### PR TITLE
fix: Investigate tasklist e2e test ci failures

### DIFF
--- a/.github/workflows/tasklist-e2e-tests.yml
+++ b/.github/workflows/tasklist-e2e-tests.yml
@@ -124,6 +124,7 @@ jobs:
         # Currently, the e2e environment of tasklist conflicts with the optimize build. For the moment,
         # we're excluding optimize from the build, not to impact this tasklist's workflow.
         run: ./mvnw clean install -T1C -DskipChecks -PskipFrontendBuild -DskipTests=true -B -DskipRemoteStaging=true -Dmaven.deploy.skip=true
+
       - name: Start Tasklist
         env:
           CAMUNDA_SECURITY_INITIALIZATION_USERS_0_USERNAME: demo
@@ -148,8 +149,7 @@ jobs:
         shell: bash
         env:
           LOCAL_TEST: "false"
-          CORE_APPLICATION_TASKLIST_URL: http://localhost:8080
-          CORE_APPLICATION_OPERATE_URL: http://localhost:8081
+          CORE_APPLICATION_URL: http://localhost:8080
           CAMUNDA_AUTH_STRATEGY: "BASIC"
           CAMUNDA_BASIC_AUTH_USERNAME: "demo"
           CAMUNDA_BASIC_AUTH_PASSWORD: "demo"

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/task-details.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/task-details.spec.ts
@@ -15,6 +15,7 @@ import {sleep} from 'utils/sleep';
 import {captureScreenshot, captureFailureVideo} from '@setup';
 
 test.beforeAll(async () => {
+  // Workaround for #34322: split deployments to avoid test failures caused by bulk deployment
   await deploy([
     './resources/usertask_to_be_completed.bpmn',
     './resources/user_task_with_form.bpmn',
@@ -26,6 +27,8 @@ test.beforeAll(async () => {
     './resources/form_with_checkbox.form',
     './resources/checklist_task_with_form.bpmn',
     './resources/form_with_checklist.form',
+  ]);
+  await deploy([
     './resources/date_and_time_task_with_form.bpmn',
     './resources/form_with_date_and_time.form',
     './resources/number_task_with_form.bpmn',
@@ -36,13 +39,14 @@ test.beforeAll(async () => {
     './resources/form_with_select.form',
     './resources/tag_list_task_with_form.bpmn',
     './resources/form_with_tag_list.form',
+  ]);
+  await deploy([
     './resources/text_templating_form_task.bpmn',
     './resources/form_with_text_templating.form',
     './resources/processWithDeployedForm.bpmn',
     './resources/create_invoice.form',
     './resources/zeebe_and_job_worker_process.bpmn',
   ]);
-
   await sleep(1000);
 
   await Promise.all([


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
CI tests were failing because the env variable for the URL has changed in the  test suite and it was not updated in the `tasklist-e2e` workflow.

Also split the deployments as a workaround to [/v2/deployments endpoint fails with >10 files in multipart request](https://github.com/camunda/camunda/issues/34322)
## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
