### PR TITLE
feat: Search endpoint for message subscription

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
@@ -20,6 +20,7 @@ import io.camunda.search.clients.GroupSearchClient;
 import io.camunda.search.clients.IncidentSearchClient;
 import io.camunda.search.clients.JobSearchClient;
 import io.camunda.search.clients.MappingSearchClient;
+import io.camunda.search.clients.MessageSubscriptionSearchClient;
 import io.camunda.search.clients.ProcessDefinitionSearchClient;
 import io.camunda.search.clients.ProcessInstanceSearchClient;
 import io.camunda.search.clients.RoleSearchClient;
@@ -46,6 +47,7 @@ import io.camunda.service.IncidentServices;
 import io.camunda.service.JobServices;
 import io.camunda.service.MappingServices;
 import io.camunda.service.MessageServices;
+import io.camunda.service.MessageSubscriptionServices;
 import io.camunda.service.ProcessDefinitionServices;
 import io.camunda.service.ProcessInstanceServices;
 import io.camunda.service.ResourceServices;
@@ -302,6 +304,15 @@ public class CamundaServicesConfiguration {
       final SecurityContextProvider securityContextProvider,
       final MappingSearchClient mappingSearchClient) {
     return new MappingServices(brokerClient, securityContextProvider, mappingSearchClient, null);
+  }
+
+  @Bean
+  public MessageSubscriptionServices messageSubscriptionServices(
+      final BrokerClient brokerClient,
+      final SecurityContextProvider securityContextProvider,
+      final MessageSubscriptionSearchClient messageSubscriptionSearchClient) {
+    return new MessageSubscriptionServices(
+        brokerClient, securityContextProvider, messageSubscriptionSearchClient, null);
   }
 
   @Bean

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/DocumentBasedSearchClients.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/DocumentBasedSearchClients.java
@@ -30,6 +30,7 @@ import io.camunda.search.entities.IncidentEntity;
 import io.camunda.search.entities.IncidentEntity.IncidentState;
 import io.camunda.search.entities.JobEntity;
 import io.camunda.search.entities.MappingEntity;
+import io.camunda.search.entities.MessageSubscriptionEntity;
 import io.camunda.search.entities.ProcessDefinitionEntity;
 import io.camunda.search.entities.ProcessFlowNodeStatisticsEntity;
 import io.camunda.search.entities.ProcessInstanceEntity;
@@ -59,6 +60,7 @@ import io.camunda.search.query.GroupQuery;
 import io.camunda.search.query.IncidentQuery;
 import io.camunda.search.query.JobQuery;
 import io.camunda.search.query.MappingQuery;
+import io.camunda.search.query.MessageSubscriptionQuery;
 import io.camunda.search.query.ProcessDefinitionFlowNodeStatisticsQuery;
 import io.camunda.search.query.ProcessDefinitionQuery;
 import io.camunda.search.query.ProcessInstanceFlowNodeStatisticsQuery;
@@ -75,6 +77,7 @@ import io.camunda.security.auth.SecurityContext;
 import io.camunda.util.FilterUtil;
 import io.camunda.webapps.schema.descriptors.IndexDescriptors;
 import io.camunda.webapps.schema.entities.ProcessEntity;
+import io.camunda.webapps.schema.entities.event.EventEntity;
 import io.camunda.webapps.schema.entities.listview.ProcessInstanceForListViewEntity;
 import io.camunda.webapps.schema.entities.usertask.TaskEntity;
 import io.camunda.zeebe.protocol.record.value.EntityType;
@@ -121,6 +124,12 @@ public class DocumentBasedSearchClients implements SearchClientsProxy, Closeable
   public SearchQueryResult<SequenceFlowEntity> searchSequenceFlows(final SequenceFlowQuery filter) {
     return getSearchExecutor()
         .search(filter, io.camunda.webapps.schema.entities.SequenceFlowEntity.class);
+  }
+
+  @Override
+  public SearchQueryResult<MessageSubscriptionEntity> searchMessageSubscriptions(
+      final MessageSubscriptionQuery filter) {
+    return getSearchExecutor().search(filter, EventEntity.class);
   }
 
   @Override

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/ServiceTransformers.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/ServiceTransformers.java
@@ -36,6 +36,7 @@ import io.camunda.search.clients.transformers.entity.GroupMemberEntityTransforme
 import io.camunda.search.clients.transformers.entity.IncidentEntityTransformer;
 import io.camunda.search.clients.transformers.entity.JobEntityTransformer;
 import io.camunda.search.clients.transformers.entity.MappingEntityTransformer;
+import io.camunda.search.clients.transformers.entity.MessageSubscriptionEntityTransformer;
 import io.camunda.search.clients.transformers.entity.ProcessDefinitionEntityTransfomer;
 import io.camunda.search.clients.transformers.entity.ProcessInstanceEntityTransformer;
 import io.camunda.search.clients.transformers.entity.RoleEntityTransformer;
@@ -61,6 +62,7 @@ import io.camunda.search.clients.transformers.filter.GroupFilterTransformer;
 import io.camunda.search.clients.transformers.filter.IncidentFilterTransformer;
 import io.camunda.search.clients.transformers.filter.JobFilterTransformer;
 import io.camunda.search.clients.transformers.filter.MappingFilterTransformer;
+import io.camunda.search.clients.transformers.filter.MessageSubscriptionFilterTransformer;
 import io.camunda.search.clients.transformers.filter.ProcessDefinitionFilterTransformer;
 import io.camunda.search.clients.transformers.filter.ProcessDefinitionStatisticsFilterTransformer;
 import io.camunda.search.clients.transformers.filter.ProcessInstanceFilterTransformer;
@@ -90,6 +92,7 @@ import io.camunda.search.clients.transformers.sort.GroupFieldSortingTransformer;
 import io.camunda.search.clients.transformers.sort.IncidentFieldSortingTransformer;
 import io.camunda.search.clients.transformers.sort.JobFieldSortingTransformer;
 import io.camunda.search.clients.transformers.sort.MappingFieldSortingTransformer;
+import io.camunda.search.clients.transformers.sort.MessageSubscriptionFieldSortingTransformer;
 import io.camunda.search.clients.transformers.sort.ProcessDefinitionFieldSortingTransformer;
 import io.camunda.search.clients.transformers.sort.ProcessInstanceFieldSortingTransformer;
 import io.camunda.search.clients.transformers.sort.RoleFieldSortingTransformer;
@@ -112,6 +115,7 @@ import io.camunda.search.filter.GroupFilter;
 import io.camunda.search.filter.IncidentFilter;
 import io.camunda.search.filter.JobFilter;
 import io.camunda.search.filter.MappingFilter;
+import io.camunda.search.filter.MessageSubscriptionFilter;
 import io.camunda.search.filter.ProcessDefinitionFilter;
 import io.camunda.search.filter.ProcessDefinitionStatisticsFilter;
 import io.camunda.search.filter.ProcessInstanceFilter;
@@ -136,6 +140,7 @@ import io.camunda.search.query.GroupQuery;
 import io.camunda.search.query.IncidentQuery;
 import io.camunda.search.query.JobQuery;
 import io.camunda.search.query.MappingQuery;
+import io.camunda.search.query.MessageSubscriptionQuery;
 import io.camunda.search.query.ProcessDefinitionFlowNodeStatisticsQuery;
 import io.camunda.search.query.ProcessDefinitionQuery;
 import io.camunda.search.query.ProcessInstanceFlowNodeStatisticsQuery;
@@ -163,6 +168,7 @@ import io.camunda.search.sort.GroupSort;
 import io.camunda.search.sort.IncidentSort;
 import io.camunda.search.sort.JobSort;
 import io.camunda.search.sort.MappingSort;
+import io.camunda.search.sort.MessageSubscriptionSort;
 import io.camunda.search.sort.ProcessDefinitionSort;
 import io.camunda.search.sort.ProcessInstanceSort;
 import io.camunda.search.sort.RoleSort;
@@ -187,6 +193,7 @@ import io.camunda.webapps.schema.descriptors.index.TenantIndex;
 import io.camunda.webapps.schema.descriptors.index.UserIndex;
 import io.camunda.webapps.schema.descriptors.template.BatchOperationTemplate;
 import io.camunda.webapps.schema.descriptors.template.DecisionInstanceTemplate;
+import io.camunda.webapps.schema.descriptors.template.EventTemplate;
 import io.camunda.webapps.schema.descriptors.template.FlowNodeInstanceTemplate;
 import io.camunda.webapps.schema.descriptors.template.IncidentTemplate;
 import io.camunda.webapps.schema.descriptors.template.JobTemplate;
@@ -203,6 +210,7 @@ import io.camunda.webapps.schema.entities.VariableEntity;
 import io.camunda.webapps.schema.entities.dmn.DecisionInstanceEntity;
 import io.camunda.webapps.schema.entities.dmn.definition.DecisionDefinitionEntity;
 import io.camunda.webapps.schema.entities.dmn.definition.DecisionRequirementsEntity;
+import io.camunda.webapps.schema.entities.event.EventEntity;
 import io.camunda.webapps.schema.entities.flownode.FlowNodeInstanceEntity;
 import io.camunda.webapps.schema.entities.form.FormEntity;
 import io.camunda.webapps.schema.entities.incident.IncidentEntity;
@@ -305,7 +313,8 @@ public final class ServiceTransformers {
             VariableQuery.class,
             UsageMetricsQuery.class,
             SequenceFlowQuery.class,
-            JobQuery.class)
+            JobQuery.class,
+            MessageSubscriptionQuery.class)
         .forEach(cls -> mappers.put(cls, searchQueryTransformer));
 
     // document entity -> domain entity
@@ -333,6 +342,7 @@ public final class ServiceTransformers {
     mappers.put(OperationEntity.class, new BatchOperationItemEntityTransformer());
     mappers.put(SequenceFlowEntity.class, new SequenceFlowEntityTransformer());
     mappers.put(JobEntity.class, new JobEntityTransformer());
+    mappers.put(EventEntity.class, new MessageSubscriptionEntityTransformer());
 
     // domain field sorting -> database field sorting
     mappers.put(DecisionDefinitionSort.class, new DecisionDefinitionFieldSortingTransformer());
@@ -356,6 +366,7 @@ public final class ServiceTransformers {
     mappers.put(BatchOperationSort.class, new BatchOperationFieldSortingTransformer());
     mappers.put(BatchOperationItemSort.class, new BatchOperationItemFieldSortingTransformer());
     mappers.put(JobSort.class, new JobFieldSortingTransformer());
+    mappers.put(MessageSubscriptionSort.class, new MessageSubscriptionFieldSortingTransformer());
 
     // filters -> search query
     mappers.put(
@@ -428,6 +439,9 @@ public final class ServiceTransformers {
         SequenceFlowFilter.class,
         new SequenceFlowFilterTransformer(indexDescriptors.get(SequenceFlowTemplate.class)));
     mappers.put(JobFilter.class, new JobFilterTransformer(indexDescriptors.get(JobTemplate.class)));
+    mappers.put(
+        MessageSubscriptionFilter.class,
+        new MessageSubscriptionFilterTransformer(indexDescriptors.get(EventTemplate.class)));
 
     // result config -> source config
     mappers.put(

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/MessageSubscriptionEntityTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/MessageSubscriptionEntityTransformer.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.entity;
+
+import io.camunda.search.clients.transformers.ServiceTransformer;
+import io.camunda.search.entities.MessageSubscriptionEntity;
+import io.camunda.search.entities.MessageSubscriptionEntity.MessageSubscriptionType;
+import io.camunda.webapps.schema.entities.event.EventEntity;
+import io.camunda.webapps.schema.entities.event.EventType;
+
+public class MessageSubscriptionEntityTransformer
+    implements ServiceTransformer<EventEntity, MessageSubscriptionEntity> {
+
+  @Override
+  public MessageSubscriptionEntity apply(final EventEntity value) {
+    return new MessageSubscriptionEntity(
+        value.getKey(),
+        value.getBpmnProcessId(),
+        value.getProcessDefinitionKey(),
+        value.getProcessInstanceKey(),
+        value.getFlowNodeId(),
+        value.getFlowNodeInstanceKey(),
+        toMessageSubscriptionType(value.getEventType()),
+        value.getDateTime(),
+        value.getMetadata().getMessageName(),
+        value.getMetadata().getCorrelationKey(),
+        value.getTenantId());
+  }
+
+  private MessageSubscriptionType toMessageSubscriptionType(final EventType value) {
+    if (value == null) {
+      return null;
+    }
+    return switch (value) {
+      case CREATED -> MessageSubscriptionType.CREATED;
+      case MIGRATED -> MessageSubscriptionType.MIGRATED;
+      case CORRELATED -> MessageSubscriptionType.CORRELATED;
+      default -> throw new IllegalArgumentException("Unknown EventType: " + value);
+    };
+  }
+}

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/MessageSubscriptionFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/MessageSubscriptionFilterTransformer.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.filter;
+
+import static io.camunda.search.clients.query.SearchQueryBuilders.and;
+import static io.camunda.search.clients.query.SearchQueryBuilders.dateTimeOperations;
+import static io.camunda.search.clients.query.SearchQueryBuilders.longOperations;
+import static io.camunda.search.clients.query.SearchQueryBuilders.stringOperations;
+import static io.camunda.search.clients.query.SearchQueryBuilders.stringTerms;
+import static io.camunda.webapps.schema.descriptors.IndexDescriptor.TENANT_ID;
+import static io.camunda.webapps.schema.descriptors.template.EventTemplate.BPMN_PROCESS_ID;
+import static io.camunda.webapps.schema.descriptors.template.EventTemplate.DATE_TIME;
+import static io.camunda.webapps.schema.descriptors.template.EventTemplate.EVENT_SOURCE_TYPE;
+import static io.camunda.webapps.schema.descriptors.template.EventTemplate.EVENT_TYPE;
+import static io.camunda.webapps.schema.descriptors.template.EventTemplate.FLOW_NODE_ID;
+import static io.camunda.webapps.schema.descriptors.template.EventTemplate.FLOW_NODE_INSTANCE_KEY;
+import static io.camunda.webapps.schema.descriptors.template.EventTemplate.KEY;
+import static io.camunda.webapps.schema.descriptors.template.EventTemplate.PROCESS_KEY;
+
+import io.camunda.search.clients.query.SearchQuery;
+import io.camunda.search.filter.MessageSubscriptionFilter;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
+import java.util.List;
+
+public class MessageSubscriptionFilterTransformer
+    extends IndexFilterTransformer<MessageSubscriptionFilter> {
+
+  public MessageSubscriptionFilterTransformer(final IndexDescriptor indexDescriptor) {
+    super(indexDescriptor);
+  }
+
+  @Override
+  public SearchQuery toSearchQuery(final MessageSubscriptionFilter filter) {
+    final var messageSubscriptionTerm =
+        stringTerms(EVENT_SOURCE_TYPE, List.of("PROCESS_MESSAGE_SUBSCRIPTION"));
+    return and(
+        List.of(messageSubscriptionTerm),
+        longOperations(KEY, filter.messageSubscriptionKeyOperations()),
+        stringOperations(BPMN_PROCESS_ID, filter.processDefinitionIdOperations()),
+        longOperations(PROCESS_KEY, filter.processDefinitionKeyOperations()),
+        longOperations("processInstanceKey", filter.processInstanceKeyOperations()),
+        stringOperations(FLOW_NODE_ID, filter.flowNodeIdOperations()),
+        longOperations(FLOW_NODE_INSTANCE_KEY, filter.flowNodeInstanceKeyOperations()),
+        stringOperations(EVENT_TYPE, filter.messageSubscriptionTypeOperations()),
+        dateTimeOperations(DATE_TIME, filter.dateTimeOperations()),
+        stringOperations("metadata.messageName", filter.messageNameOperations()),
+        stringOperations("metadata.correlationKey", filter.correlationKeyOperations()),
+        stringOperations(TENANT_ID, filter.tenantIdOperations()));
+  }
+}

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/sort/MessageSubscriptionFieldSortingTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/sort/MessageSubscriptionFieldSortingTransformer.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.sort;
+
+import static io.camunda.webapps.schema.descriptors.IndexDescriptor.TENANT_ID;
+import static io.camunda.webapps.schema.descriptors.template.EventTemplate.BPMN_PROCESS_ID;
+import static io.camunda.webapps.schema.descriptors.template.EventTemplate.DATE_TIME;
+import static io.camunda.webapps.schema.descriptors.template.EventTemplate.EVENT_TYPE;
+import static io.camunda.webapps.schema.descriptors.template.EventTemplate.FLOW_NODE_ID;
+import static io.camunda.webapps.schema.descriptors.template.EventTemplate.FLOW_NODE_INSTANCE_KEY;
+import static io.camunda.webapps.schema.descriptors.template.EventTemplate.KEY;
+import static io.camunda.webapps.schema.descriptors.template.EventTemplate.PROCESS_KEY;
+
+public class MessageSubscriptionFieldSortingTransformer implements FieldSortingTransformer {
+
+  @Override
+  public String apply(final String domainField) {
+    return switch (domainField) {
+      case "messageSubscriptionKey" -> KEY;
+      case "processDefinitionId" -> BPMN_PROCESS_ID;
+      case "processDefinitionKey" -> PROCESS_KEY;
+      case "processInstanceKey" -> "processInstanceKey";
+      case "flowNodeId" -> FLOW_NODE_ID;
+      case "flowNodeInstanceKey" -> FLOW_NODE_INSTANCE_KEY;
+      case "messageSubscriptionType" -> EVENT_TYPE;
+      case "dateTime" -> DATE_TIME;
+      case "messageName" -> "metadata.messageName";
+      case "correlationKey" -> "metadata.correlationKey";
+      case "tenantId" -> TENANT_ID;
+      default -> throw new IllegalArgumentException("Unknown field: " + domainField);
+    };
+  }
+}

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/sort/MessageSubscriptionFieldSortingTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/sort/MessageSubscriptionFieldSortingTransformer.java
@@ -8,6 +8,7 @@
 package io.camunda.search.clients.transformers.sort;
 
 import static io.camunda.webapps.schema.descriptors.IndexDescriptor.TENANT_ID;
+import static io.camunda.webapps.schema.descriptors.ProcessInstanceDependant.PROCESS_INSTANCE_KEY;
 import static io.camunda.webapps.schema.descriptors.template.EventTemplate.BPMN_PROCESS_ID;
 import static io.camunda.webapps.schema.descriptors.template.EventTemplate.DATE_TIME;
 import static io.camunda.webapps.schema.descriptors.template.EventTemplate.EVENT_TYPE;
@@ -24,7 +25,7 @@ public class MessageSubscriptionFieldSortingTransformer implements FieldSortingT
       case "messageSubscriptionKey" -> KEY;
       case "processDefinitionId" -> BPMN_PROCESS_ID;
       case "processDefinitionKey" -> PROCESS_KEY;
-      case "processInstanceKey" -> "processInstanceKey";
+      case "processInstanceKey" -> PROCESS_INSTANCE_KEY;
       case "flowNodeId" -> FLOW_NODE_ID;
       case "flowNodeInstanceKey" -> FLOW_NODE_INSTANCE_KEY;
       case "messageSubscriptionType" -> EVENT_TYPE;

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/MessageSubscriptionQueryTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/MessageSubscriptionQueryTransformerTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.filter;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import io.camunda.search.clients.query.SearchBoolQuery;
+import io.camunda.search.clients.query.SearchTermQuery;
+import io.camunda.search.filter.FilterBuilders;
+import io.camunda.search.filter.MessageSubscriptionFilter;
+import io.camunda.util.ObjectBuilder;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.function.Function;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class MessageSubscriptionQueryTransformerTest extends AbstractTransformerTest {
+
+  @ParameterizedTest
+  @MethodSource("queryFilterParameters")
+  void shouldQueryByMessageSubscriptionKey(
+      final Function<MessageSubscriptionFilter.Builder, ObjectBuilder<MessageSubscriptionFilter>>
+          filterFunction,
+      final String expectedFieldName,
+      final Object expectedValue) {
+    // Given
+    final var filter = FilterBuilders.messageSubscription(filterFunction);
+
+    // When
+    final var searchQuery = transformQuery(filter);
+
+    // Then
+    final var queryVariant = searchQuery.queryOption();
+
+    assertThat(queryVariant)
+        .isNotNull()
+        .isInstanceOfSatisfying(
+            SearchBoolQuery.class,
+            query -> {
+              assertThat(query.must().size()).isEqualTo(2);
+              assertThat(query.must().getFirst().queryOption())
+                  .isInstanceOfSatisfying(
+                      SearchTermQuery.class,
+                      termQuery -> {
+                        assertThat(termQuery.field()).isEqualTo("eventSourceType");
+                        assertThat(termQuery.value().stringValue())
+                            .isEqualTo("PROCESS_MESSAGE_SUBSCRIPTION");
+                      });
+              assertThat(query.must().get(1).queryOption())
+                  .isInstanceOfSatisfying(
+                      SearchTermQuery.class,
+                      termQuery -> {
+                        assertThat(termQuery.field()).isEqualTo(expectedFieldName);
+                        assertThat(termQuery.value().value()).isEqualTo(expectedValue);
+                      });
+            });
+  }
+
+  private static Stream<Arguments> queryFilterParameters() {
+    return Stream.of(
+        Arguments.of(
+            (Function<MessageSubscriptionFilter.Builder, ObjectBuilder<MessageSubscriptionFilter>>)
+                b -> b.messageSubscriptionKeys(123L),
+            "key",
+            123L),
+        Arguments.of(
+            (Function<MessageSubscriptionFilter.Builder, ObjectBuilder<MessageSubscriptionFilter>>)
+                b -> b.processDefinitionIds("abcd"),
+            "bpmnProcessId",
+            "abcd"),
+        Arguments.of(
+            (Function<MessageSubscriptionFilter.Builder, ObjectBuilder<MessageSubscriptionFilter>>)
+                b -> b.processDefinitionKeys(456L),
+            "processDefinitionKey",
+            456L),
+        Arguments.of(
+            (Function<MessageSubscriptionFilter.Builder, ObjectBuilder<MessageSubscriptionFilter>>)
+                b -> b.processInstanceKeys(999L),
+            "processInstanceKey",
+            999L),
+        Arguments.of(
+            (Function<MessageSubscriptionFilter.Builder, ObjectBuilder<MessageSubscriptionFilter>>)
+                b -> b.flowNodeIds("abcd"),
+            "flowNodeId",
+            "abcd"),
+        Arguments.of(
+            (Function<MessageSubscriptionFilter.Builder, ObjectBuilder<MessageSubscriptionFilter>>)
+                b -> b.flowNodeInstanceKeys(784L),
+            "flowNodeInstanceKey",
+            784L),
+        Arguments.of(
+            (Function<MessageSubscriptionFilter.Builder, ObjectBuilder<MessageSubscriptionFilter>>)
+                b -> b.messageSubscriptionTypes("CREATED"),
+            "eventType",
+            "CREATED"),
+        Arguments.of(
+            (Function<MessageSubscriptionFilter.Builder, ObjectBuilder<MessageSubscriptionFilter>>)
+                b -> b.dateTimes(OffsetDateTime.parse("2024-07-24T00:00Z")),
+            "dateTime",
+            OffsetDateTime.parse("2024-07-24T00:00Z")
+                .format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSZ"))),
+        Arguments.of(
+            (Function<MessageSubscriptionFilter.Builder, ObjectBuilder<MessageSubscriptionFilter>>)
+                b -> b.messageNames("msg_name"),
+            "metadata.messageName",
+            "msg_name"),
+        Arguments.of(
+            (Function<MessageSubscriptionFilter.Builder, ObjectBuilder<MessageSubscriptionFilter>>)
+                b -> b.correlationKeys("key1"),
+            "metadata.correlationKey",
+            "key1"),
+        Arguments.of(
+            (Function<MessageSubscriptionFilter.Builder, ObjectBuilder<MessageSubscriptionFilter>>)
+                b -> b.tenantIds("tnt1"),
+            "tenantId",
+            "tnt1"));
+  }
+}

--- a/search/search-client-rdbms/src/main/java/io/camunda/search/rdbms/RdbmsSearchClient.java
+++ b/search/search-client-rdbms/src/main/java/io/camunda/search/rdbms/RdbmsSearchClient.java
@@ -22,6 +22,7 @@ import io.camunda.search.entities.GroupMemberEntity;
 import io.camunda.search.entities.IncidentEntity;
 import io.camunda.search.entities.JobEntity;
 import io.camunda.search.entities.MappingEntity;
+import io.camunda.search.entities.MessageSubscriptionEntity;
 import io.camunda.search.entities.ProcessDefinitionEntity;
 import io.camunda.search.entities.ProcessFlowNodeStatisticsEntity;
 import io.camunda.search.entities.ProcessInstanceEntity;
@@ -46,6 +47,7 @@ import io.camunda.search.query.GroupQuery;
 import io.camunda.search.query.IncidentQuery;
 import io.camunda.search.query.JobQuery;
 import io.camunda.search.query.MappingQuery;
+import io.camunda.search.query.MessageSubscriptionQuery;
 import io.camunda.search.query.ProcessDefinitionQuery;
 import io.camunda.search.query.ProcessInstanceQuery;
 import io.camunda.search.query.RoleQuery;
@@ -98,6 +100,12 @@ public class RdbmsSearchClient implements SearchClientsProxy {
   public SearchQueryResult<SequenceFlowEntity> searchSequenceFlows(final SequenceFlowQuery query) {
     LOG.debug("[RDBMS Search Client] Search for sequence flow: {}", query);
     return rdbmsService.getSequenceFlowReader().search(query);
+  }
+
+  @Override
+  public SearchQueryResult<MessageSubscriptionEntity> searchMessageSubscriptions(
+      final MessageSubscriptionQuery filter) {
+    return SearchQueryResult.empty();
   }
 
   @Override

--- a/search/search-client/src/main/java/io/camunda/search/clients/MessageSubscriptionSearchClient.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/MessageSubscriptionSearchClient.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients;
+
+import io.camunda.search.entities.MessageSubscriptionEntity;
+import io.camunda.search.query.MessageSubscriptionQuery;
+import io.camunda.search.query.SearchQueryResult;
+import io.camunda.security.auth.SecurityContext;
+
+public interface MessageSubscriptionSearchClient {
+  SearchQueryResult<MessageSubscriptionEntity> searchMessageSubscriptions(
+      MessageSubscriptionQuery filter);
+
+  MessageSubscriptionSearchClient withSecurityContext(SecurityContext securityContext);
+}

--- a/search/search-client/src/main/java/io/camunda/search/clients/SearchClientsProxy.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/SearchClientsProxy.java
@@ -30,7 +30,8 @@ public interface SearchClientsProxy
         UsageMetricsSearchClient,
         BatchOperationSearchClient,
         SequenceFlowSearchClient,
-        JobSearchClient {
+        JobSearchClient,
+        MessageSubscriptionSearchClient {
 
   @Override
   SearchClientsProxy withSecurityContext(SecurityContext securityContext);

--- a/search/search-client/src/main/java/io/camunda/search/clients/impl/NoopSearchClientsProxy.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/impl/NoopSearchClientsProxy.java
@@ -23,6 +23,7 @@ import io.camunda.search.entities.GroupMemberEntity;
 import io.camunda.search.entities.IncidentEntity;
 import io.camunda.search.entities.JobEntity;
 import io.camunda.search.entities.MappingEntity;
+import io.camunda.search.entities.MessageSubscriptionEntity;
 import io.camunda.search.entities.ProcessDefinitionEntity;
 import io.camunda.search.entities.ProcessFlowNodeStatisticsEntity;
 import io.camunda.search.entities.ProcessInstanceEntity;
@@ -47,6 +48,7 @@ import io.camunda.search.query.GroupQuery;
 import io.camunda.search.query.IncidentQuery;
 import io.camunda.search.query.JobQuery;
 import io.camunda.search.query.MappingQuery;
+import io.camunda.search.query.MessageSubscriptionQuery;
 import io.camunda.search.query.ProcessDefinitionQuery;
 import io.camunda.search.query.ProcessInstanceQuery;
 import io.camunda.search.query.RoleQuery;
@@ -190,6 +192,12 @@ public class NoopSearchClientsProxy implements SearchClientsProxy {
 
   @Override
   public SearchQueryResult<SequenceFlowEntity> searchSequenceFlows(final SequenceFlowQuery filter) {
+    return SearchQueryResult.empty();
+  }
+
+  @Override
+  public SearchQueryResult<MessageSubscriptionEntity> searchMessageSubscriptions(
+      final MessageSubscriptionQuery filter) {
     return SearchQueryResult.empty();
   }
 

--- a/search/search-domain/src/main/java/io/camunda/search/entities/MessageSubscriptionEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/MessageSubscriptionEntity.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.entities;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.time.OffsetDateTime;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record MessageSubscriptionEntity(
+    Long messageSubscriptionKey,
+    String processDefinitionId,
+    Long processDefinitionKey,
+    Long processInstanceKey,
+    String flowNodeId,
+    Long flowNodeInstanceKey,
+    MessageSubscriptionType messageSubscriptionType,
+    OffsetDateTime dateTime,
+    String messageName,
+    String correlationKey,
+    String tenantId) {
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private Long messageSubscriptionKey;
+    private String processDefinitionId;
+    private Long processDefinitionKey;
+    private Long processInstanceKey;
+    private String flowNodeId;
+    private Long flowNodeInstanceKey;
+    private MessageSubscriptionType messageSubscriptionType;
+    private OffsetDateTime dateTime;
+    private String messageName;
+    private String correlationKey;
+    private String tenantId;
+
+    public Builder messageSubscriptionKey(final Long messageSubscriptionKey) {
+      this.messageSubscriptionKey = messageSubscriptionKey;
+      return this;
+    }
+
+    public Builder processDefinitionId(final String processDefinitionId) {
+      this.processDefinitionId = processDefinitionId;
+      return this;
+    }
+
+    public Builder processDefinitionKey(final Long processDefinitionKey) {
+      this.processDefinitionKey = processDefinitionKey;
+      return this;
+    }
+
+    public Builder processInstanceKey(final Long processInstanceKey) {
+      this.processInstanceKey = processInstanceKey;
+      return this;
+    }
+
+    public Builder flowNodeId(final String flowNodeId) {
+      this.flowNodeId = flowNodeId;
+      return this;
+    }
+
+    public Builder flowNodeInstanceKey(final Long flowNodeInstanceKey) {
+      this.flowNodeInstanceKey = flowNodeInstanceKey;
+      return this;
+    }
+
+    public Builder messageSubscriptionType(final MessageSubscriptionType messageSubscriptionType) {
+      this.messageSubscriptionType = messageSubscriptionType;
+      return this;
+    }
+
+    public Builder dateTime(final OffsetDateTime dateTime) {
+      this.dateTime = dateTime;
+      return this;
+    }
+
+    public Builder messageName(final String messageName) {
+      this.messageName = messageName;
+      return this;
+    }
+
+    public Builder correlationKey(final String correlationKey) {
+      this.correlationKey = correlationKey;
+      return this;
+    }
+
+    public Builder tenantId(final String tenantId) {
+      this.tenantId = tenantId;
+      return this;
+    }
+
+    public MessageSubscriptionEntity build() {
+      return new MessageSubscriptionEntity(
+          messageSubscriptionKey,
+          processDefinitionId,
+          processDefinitionKey,
+          processInstanceKey,
+          flowNodeId,
+          flowNodeInstanceKey,
+          messageSubscriptionType,
+          dateTime,
+          messageName,
+          correlationKey,
+          tenantId);
+    }
+  }
+
+  public enum MessageSubscriptionType {
+    CREATED,
+    MIGRATED,
+    CORRELATED,
+  }
+}

--- a/search/search-domain/src/main/java/io/camunda/search/entities/MessageSubscriptionEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/MessageSubscriptionEntity.java
@@ -112,8 +112,8 @@ public record MessageSubscriptionEntity(
   }
 
   public enum MessageSubscriptionType {
+    CORRELATED,
     CREATED,
     MIGRATED,
-    CORRELATED,
   }
 }

--- a/search/search-domain/src/main/java/io/camunda/search/filter/FilterBuilders.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/FilterBuilders.java
@@ -233,4 +233,14 @@ public final class FilterBuilders {
   public static JobFilter job(final Function<JobFilter.Builder, ObjectBuilder<JobFilter>> fn) {
     return fn.apply(job()).build();
   }
+
+  public static MessageSubscriptionFilter.Builder messageSubscription() {
+    return new MessageSubscriptionFilter.Builder();
+  }
+
+  public static MessageSubscriptionFilter messageSubscription(
+      final Function<MessageSubscriptionFilter.Builder, ObjectBuilder<MessageSubscriptionFilter>>
+          fn) {
+    return fn.apply(messageSubscription()).build();
+  }
 }

--- a/search/search-domain/src/main/java/io/camunda/search/filter/MessageSubscriptionFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/MessageSubscriptionFilter.java
@@ -1,0 +1,230 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.filter;
+
+import static io.camunda.util.CollectionUtil.addValuesToList;
+import static io.camunda.util.CollectionUtil.collectValues;
+
+import io.camunda.util.FilterUtil;
+import io.camunda.util.ObjectBuilder;
+import java.time.OffsetDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+public record MessageSubscriptionFilter(
+    List<Operation<Long>> messageSubscriptionKeyOperations,
+    List<Operation<String>> processDefinitionIdOperations,
+    List<Operation<Long>> processDefinitionKeyOperations,
+    List<Operation<Long>> processInstanceKeyOperations,
+    List<Operation<String>> flowNodeIdOperations,
+    List<Operation<Long>> flowNodeInstanceKeyOperations,
+    List<Operation<String>> messageSubscriptionTypeOperations,
+    List<Operation<OffsetDateTime>> dateTimeOperations,
+    List<Operation<String>> messageNameOperations,
+    List<Operation<String>> correlationKeyOperations,
+    List<Operation<String>> tenantIdOperations)
+    implements FilterBase {
+
+  public static final class Builder implements ObjectBuilder<MessageSubscriptionFilter> {
+
+    private List<Operation<Long>> messageSubscriptionKeyOperations;
+    private List<Operation<String>> processDefinitionIdOperations;
+    private List<Operation<Long>> processDefinitionKeyOperations;
+    private List<Operation<Long>> processInstanceKeyOperations;
+    private List<Operation<String>> flowNodeIdOperations;
+    private List<Operation<Long>> flowNodeInstanceKeyOperations;
+    private List<Operation<String>> messageSubscriptionTypeOperations;
+    private List<Operation<OffsetDateTime>> dateTimeOperations;
+    private List<Operation<String>> messageNameOperations;
+    private List<Operation<String>> correlationKeyOperations;
+    private List<Operation<String>> tenantIdOperations;
+
+    public Builder messageSubscriptionKeys(final Long value, final Long... values) {
+      return messageSubscriptionKeyOperations(FilterUtil.mapDefaultToOperation(value, values));
+    }
+
+    @SafeVarargs
+    public final Builder messageSubscriptionKeyOperations(
+        final Operation<Long> operation, final Operation<Long>... operations) {
+      return messageSubscriptionKeyOperations(collectValues(operation, operations));
+    }
+
+    public Builder messageSubscriptionKeyOperations(final List<Operation<Long>> operations) {
+      messageSubscriptionKeyOperations = operations;
+      return this;
+    }
+
+    public Builder processDefinitionIds(final String value, final String... values) {
+      return processDefinitionIdOperations(FilterUtil.mapDefaultToOperation(value, values));
+    }
+
+    @SafeVarargs
+    public final Builder processDefinitionIdOperations(
+        final Operation<String> operation, final Operation<String>... operations) {
+      return processDefinitionIdOperations(collectValues(operation, operations));
+    }
+
+    public Builder processDefinitionIdOperations(final List<Operation<String>> operations) {
+      processDefinitionIdOperations = operations;
+      return this;
+    }
+
+    public Builder processDefinitionKeys(final Long value, final Long... values) {
+      return processDefinitionKeyOperations(FilterUtil.mapDefaultToOperation(value, values));
+    }
+
+    @SafeVarargs
+    public final Builder processDefinitionKeyOperations(
+        final Operation<Long> operation, final Operation<Long>... operations) {
+      return processDefinitionKeyOperations(collectValues(operation, operations));
+    }
+
+    public Builder processDefinitionKeyOperations(final List<Operation<Long>> operations) {
+      processDefinitionKeyOperations = operations;
+      return this;
+    }
+
+    public Builder processInstanceKeys(final Long value, final Long... values) {
+      return processInstanceKeyOperations(FilterUtil.mapDefaultToOperation(value, values));
+    }
+
+    @SafeVarargs
+    public final Builder processInstanceKeyOperations(
+        final Operation<Long> operation, final Operation<Long>... operations) {
+      return processInstanceKeyOperations(collectValues(operation, operations));
+    }
+
+    public Builder processInstanceKeyOperations(final List<Operation<Long>> operations) {
+      processInstanceKeyOperations = addValuesToList(processInstanceKeyOperations, operations);
+      return this;
+    }
+
+    public Builder flowNodeIds(final String value, final String... values) {
+      return flowNodeIdOperations(FilterUtil.mapDefaultToOperation(value, values));
+    }
+
+    @SafeVarargs
+    public final Builder flowNodeIdOperations(
+        final Operation<String> operation, final Operation<String>... operations) {
+      return flowNodeIdOperations(collectValues(operation, operations));
+    }
+
+    public Builder flowNodeIdOperations(final List<Operation<String>> operations) {
+      flowNodeIdOperations = addValuesToList(flowNodeIdOperations, operations);
+      return this;
+    }
+
+    public Builder flowNodeInstanceKeys(final Long value, final Long... values) {
+      return flowNodeInstanceKeyOperations(FilterUtil.mapDefaultToOperation(value, values));
+    }
+
+    @SafeVarargs
+    public final Builder flowNodeInstanceKeyOperations(
+        final Operation<Long> operation, final Operation<Long>... operations) {
+      return flowNodeInstanceKeyOperations(collectValues(operation, operations));
+    }
+
+    public Builder flowNodeInstanceKeyOperations(final List<Operation<Long>> operations) {
+      flowNodeInstanceKeyOperations = addValuesToList(flowNodeInstanceKeyOperations, operations);
+      return this;
+    }
+
+    public Builder messageSubscriptionTypes(final String value, final String... values) {
+      return messageSubscriptionTypeOperations(FilterUtil.mapDefaultToOperation(value, values));
+    }
+
+    @SafeVarargs
+    public final Builder messageSubscriptionTypeOperations(
+        final Operation<String> operation, final Operation<String>... operations) {
+      return messageSubscriptionTypeOperations(collectValues(operation, operations));
+    }
+
+    public Builder messageSubscriptionTypeOperations(final List<Operation<String>> operations) {
+      messageSubscriptionTypeOperations =
+          addValuesToList(messageSubscriptionTypeOperations, operations);
+      return this;
+    }
+
+    public Builder dateTimes(final OffsetDateTime value, final OffsetDateTime... values) {
+      return dateTimeOperations(FilterUtil.mapDefaultToOperation(value, values));
+    }
+
+    @SafeVarargs
+    public final Builder dateTimeOperations(
+        final Operation<OffsetDateTime> operation, final Operation<OffsetDateTime>... operations) {
+      return dateTimeOperations(collectValues(operation, operations));
+    }
+
+    public Builder dateTimeOperations(final List<Operation<OffsetDateTime>> operations) {
+      dateTimeOperations = addValuesToList(dateTimeOperations, operations);
+      return this;
+    }
+
+    public Builder tenantIdOperations(final List<Operation<String>> operations) {
+      tenantIdOperations = addValuesToList(tenantIdOperations, operations);
+      return this;
+    }
+
+    public Builder tenantIds(final String value, final String... values) {
+      return tenantIdOperations(FilterUtil.mapDefaultToOperation(value, values));
+    }
+
+    @SafeVarargs
+    public final Builder tenantIdOperations(
+        final Operation<String> operation, final Operation<String>... operations) {
+      return tenantIdOperations(collectValues(operation, operations));
+    }
+
+    public Builder messageNameOperations(final List<Operation<String>> operations) {
+      messageNameOperations = addValuesToList(messageNameOperations, operations);
+      return this;
+    }
+
+    public Builder messageNames(final String value, final String... values) {
+      return messageNameOperations(FilterUtil.mapDefaultToOperation(value, values));
+    }
+
+    @SafeVarargs
+    public final Builder messageNameOperations(
+        final Operation<String> operation, final Operation<String>... operations) {
+      return messageNameOperations(collectValues(operation, operations));
+    }
+
+    public Builder correlationKeyOperations(final List<Operation<String>> operations) {
+      correlationKeyOperations = addValuesToList(correlationKeyOperations, operations);
+      return this;
+    }
+
+    public Builder correlationKeys(final String value, final String... values) {
+      return correlationKeyOperations(FilterUtil.mapDefaultToOperation(value, values));
+    }
+
+    @SafeVarargs
+    public final Builder correlationKeyOperations(
+        final Operation<String> operation, final Operation<String>... operations) {
+      return correlationKeyOperations(collectValues(operation, operations));
+    }
+
+    @Override
+    public MessageSubscriptionFilter build() {
+      return new MessageSubscriptionFilter(
+          Objects.requireNonNullElse(messageSubscriptionKeyOperations, Collections.emptyList()),
+          Objects.requireNonNullElse(processDefinitionIdOperations, Collections.emptyList()),
+          Objects.requireNonNullElse(processDefinitionKeyOperations, Collections.emptyList()),
+          Objects.requireNonNullElse(processInstanceKeyOperations, Collections.emptyList()),
+          Objects.requireNonNullElse(flowNodeIdOperations, Collections.emptyList()),
+          Objects.requireNonNullElse(flowNodeInstanceKeyOperations, Collections.emptyList()),
+          Objects.requireNonNullElse(messageSubscriptionTypeOperations, Collections.emptyList()),
+          Objects.requireNonNullElse(dateTimeOperations, Collections.emptyList()),
+          Objects.requireNonNullElse(messageNameOperations, Collections.emptyList()),
+          Objects.requireNonNullElse(correlationKeyOperations, Collections.emptyList()),
+          Objects.requireNonNullElse(tenantIdOperations, Collections.emptyList()));
+    }
+  }
+}

--- a/search/search-domain/src/main/java/io/camunda/search/query/MessageSubscriptionQuery.java
+++ b/search/search-domain/src/main/java/io/camunda/search/query/MessageSubscriptionQuery.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.query;
+
+import io.camunda.search.filter.FilterBuilders;
+import io.camunda.search.filter.MessageSubscriptionFilter;
+import io.camunda.search.page.SearchQueryPage;
+import io.camunda.search.sort.MessageSubscriptionSort;
+import io.camunda.search.sort.SortOptionBuilders;
+import io.camunda.util.ObjectBuilder;
+import java.util.Objects;
+import java.util.function.Function;
+
+public record MessageSubscriptionQuery(
+    MessageSubscriptionFilter filter, MessageSubscriptionSort sort, SearchQueryPage page)
+    implements TypedSearchQuery<MessageSubscriptionFilter, MessageSubscriptionSort> {
+
+  public static MessageSubscriptionQuery of(
+      final Function<MessageSubscriptionQuery.Builder, ObjectBuilder<MessageSubscriptionQuery>>
+          fn) {
+    return fn.apply(new MessageSubscriptionQuery.Builder()).build();
+  }
+
+  public static final class Builder
+      extends SearchQueryBase.AbstractQueryBuilder<MessageSubscriptionQuery.Builder>
+      implements TypedSearchQueryBuilder<
+          MessageSubscriptionQuery,
+          MessageSubscriptionQuery.Builder,
+          MessageSubscriptionFilter,
+          MessageSubscriptionSort> {
+
+    private static final MessageSubscriptionFilter EMPTY_FILTER =
+        FilterBuilders.messageSubscription().build();
+    private static final MessageSubscriptionSort EMPTY_SORT =
+        SortOptionBuilders.messageSubscription().build();
+
+    private MessageSubscriptionFilter filter;
+    private MessageSubscriptionSort sort;
+
+    @Override
+    protected Builder self() {
+      return this;
+    }
+
+    @Override
+    public Builder filter(final MessageSubscriptionFilter value) {
+      filter = value;
+      return this;
+    }
+
+    @Override
+    public Builder sort(final MessageSubscriptionSort value) {
+      sort = value;
+      return this;
+    }
+
+    public Builder filter(
+        final Function<MessageSubscriptionFilter.Builder, ObjectBuilder<MessageSubscriptionFilter>>
+            fn) {
+      return filter(FilterBuilders.messageSubscription(fn));
+    }
+
+    public Builder sort(
+        final Function<MessageSubscriptionSort.Builder, ObjectBuilder<MessageSubscriptionSort>>
+            fn) {
+      return sort(SortOptionBuilders.messageSubscription(fn));
+    }
+
+    @Override
+    public MessageSubscriptionQuery build() {
+      filter = Objects.requireNonNullElse(filter, EMPTY_FILTER);
+      sort = Objects.requireNonNullElse(sort, EMPTY_SORT);
+      return new MessageSubscriptionQuery(filter, sort, page());
+    }
+  }
+}

--- a/search/search-domain/src/main/java/io/camunda/search/query/SearchQueryBuilders.java
+++ b/search/search-domain/src/main/java/io/camunda/search/query/SearchQueryBuilders.java
@@ -194,4 +194,8 @@ public final class SearchQueryBuilders {
       final Function<JobQuery.Builder, ObjectBuilder<JobQuery>> fn) {
     return fn.apply(jobSearchQuery()).build();
   }
+
+  public static MessageSubscriptionQuery.Builder messageSubscriptionSearchQuery() {
+    return new MessageSubscriptionQuery.Builder();
+  }
 }

--- a/search/search-domain/src/main/java/io/camunda/search/sort/MessageSubscriptionSort.java
+++ b/search/search-domain/src/main/java/io/camunda/search/sort/MessageSubscriptionSort.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.sort;
+
+import io.camunda.util.ObjectBuilder;
+import java.util.List;
+import java.util.function.Function;
+
+public record MessageSubscriptionSort(List<FieldSorting> orderings) implements SortOption {
+
+  @Override
+  public List<FieldSorting> getFieldSortings() {
+    return orderings;
+  }
+
+  public static MessageSubscriptionSort of(
+      final Function<MessageSubscriptionSort.Builder, ObjectBuilder<MessageSubscriptionSort>> fn) {
+    return SortOptionBuilders.messageSubscription(fn);
+  }
+
+  public static final class Builder
+      extends SortOption.AbstractBuilder<MessageSubscriptionSort.Builder>
+      implements ObjectBuilder<MessageSubscriptionSort> {
+
+    public Builder messageSubscriptionKey() {
+      currentOrdering = new FieldSorting("messageSubscriptionKey", null);
+      return this;
+    }
+
+    public Builder processDefinitionId() {
+      currentOrdering = new FieldSorting("processDefinitionId", null);
+      return this;
+    }
+
+    public Builder processDefinitionKey() {
+      currentOrdering = new FieldSorting("processDefinitionKey", null);
+      return this;
+    }
+
+    public Builder processInstanceKey() {
+      currentOrdering = new FieldSorting("processInstanceKey", null);
+      return this;
+    }
+
+    public Builder flowNodeId() {
+      currentOrdering = new FieldSorting("flowNodeId", null);
+      return this;
+    }
+
+    public Builder flowNodeInstanceKey() {
+      currentOrdering = new FieldSorting("flowNodeInstanceKey", null);
+      return this;
+    }
+
+    public Builder messageSubscriptionType() {
+      currentOrdering = new FieldSorting("messageSubscriptionType", null);
+      return this;
+    }
+
+    public Builder dateTime() {
+      currentOrdering = new FieldSorting("dateTime", null);
+      return this;
+    }
+
+    public Builder messageName() {
+      currentOrdering = new FieldSorting("messageName", null);
+      return this;
+    }
+
+    public Builder correlationKey() {
+      currentOrdering = new FieldSorting("correlationKey", null);
+      return this;
+    }
+
+    public Builder tenantId() {
+      currentOrdering = new FieldSorting("tenantId", null);
+      return this;
+    }
+
+    @Override
+    protected MessageSubscriptionSort.Builder self() {
+      return this;
+    }
+
+    @Override
+    public MessageSubscriptionSort build() {
+      return new MessageSubscriptionSort(orderings);
+    }
+  }
+}

--- a/search/search-domain/src/main/java/io/camunda/search/sort/SortOptionBuilders.java
+++ b/search/search-domain/src/main/java/io/camunda/search/sort/SortOptionBuilders.java
@@ -189,4 +189,13 @@ public final class SortOptionBuilders {
   public static JobSort job(final Function<JobSort.Builder, ObjectBuilder<JobSort>> fn) {
     return fn.apply(job()).build();
   }
+
+  public static MessageSubscriptionSort.Builder messageSubscription() {
+    return new MessageSubscriptionSort.Builder();
+  }
+
+  public static MessageSubscriptionSort messageSubscription(
+      final Function<MessageSubscriptionSort.Builder, ObjectBuilder<MessageSubscriptionSort>> fn) {
+    return fn.apply(messageSubscription()).build();
+  }
 }

--- a/service/src/main/java/io/camunda/service/MessageSubscriptionServices.java
+++ b/service/src/main/java/io/camunda/service/MessageSubscriptionServices.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service;
+
+import io.camunda.search.clients.MessageSubscriptionSearchClient;
+import io.camunda.search.entities.MessageSubscriptionEntity;
+import io.camunda.search.query.MessageSubscriptionQuery;
+import io.camunda.search.query.SearchQueryResult;
+import io.camunda.security.auth.Authorization;
+import io.camunda.security.auth.CamundaAuthentication;
+import io.camunda.service.search.core.SearchQueryService;
+import io.camunda.service.security.SecurityContextProvider;
+import io.camunda.zeebe.broker.client.api.BrokerClient;
+
+public class MessageSubscriptionServices
+    extends SearchQueryService<
+        MessageSubscriptionServices, MessageSubscriptionQuery, MessageSubscriptionEntity> {
+
+  private final MessageSubscriptionSearchClient searchClient;
+
+  public MessageSubscriptionServices(
+      final BrokerClient brokerClient,
+      final SecurityContextProvider securityContextProvider,
+      final MessageSubscriptionSearchClient searchClient,
+      final CamundaAuthentication authentication) {
+    super(brokerClient, securityContextProvider, authentication);
+    this.searchClient = searchClient;
+  }
+
+  @Override
+  public SearchQueryResult<MessageSubscriptionEntity> search(final MessageSubscriptionQuery query) {
+    return searchClient
+        .withSecurityContext(
+            securityContextProvider.provideSecurityContext(
+                authentication, Authorization.of(a -> a.processDefinition().readProcessInstance())))
+        .searchMessageSubscriptions(query);
+  }
+
+  @Override
+  public MessageSubscriptionServices withAuthentication(
+      final CamundaAuthentication authentication) {
+    return new MessageSubscriptionServices(
+        brokerClient, securityContextProvider, searchClient, authentication);
+  }
+}

--- a/service/src/test/java/io/camunda/service/MessageSubscriptionServiceTest.java
+++ b/service/src/test/java/io/camunda/service/MessageSubscriptionServiceTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.camunda.search.clients.MessageSubscriptionSearchClient;
+import io.camunda.search.query.SearchQueryBuilders;
+import io.camunda.search.query.SearchQueryResult;
+import io.camunda.security.auth.CamundaAuthentication;
+import io.camunda.service.security.SecurityContextProvider;
+import io.camunda.zeebe.broker.client.api.BrokerClient;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class MessageSubscriptionServiceTest {
+
+  private MessageSubscriptionServices services;
+  private MessageSubscriptionSearchClient client;
+
+  @BeforeEach
+  public void before() {
+    client = mock(MessageSubscriptionSearchClient.class);
+    when(client.withSecurityContext(any())).thenReturn(client);
+    final SecurityContextProvider securityContextProvider = mock(SecurityContextProvider.class);
+    final CamundaAuthentication authentication = mock(CamundaAuthentication.class);
+    services =
+        new MessageSubscriptionServices(
+            mock(BrokerClient.class), securityContextProvider, client, authentication);
+  }
+
+  @Test
+  void shouldReturnMessageSubscriptions() {
+    // given
+    final var result = mock(SearchQueryResult.class);
+    when(client.searchMessageSubscriptions(any())).thenReturn(result);
+
+    final var searchQuery = SearchQueryBuilders.messageSubscriptionSearchQuery().build();
+
+    // when
+    final var searchQueryResult = services.search(searchQuery);
+
+    // then
+    assertThat(searchQueryResult).isEqualTo(result);
+  }
+
+  @Test
+  void shouldReturnAuthenticatedInstance() {
+    // given
+    final var authentication = mock(CamundaAuthentication.class);
+
+    // when
+    final var authenticatedServices = services.withAuthentication(authentication);
+
+    // then
+    assertThat(authenticatedServices).isNotNull();
+    assertThat(authenticatedServices).isInstanceOf(MessageSubscriptionServices.class);
+  }
+}

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -41,6 +41,7 @@ tags:
   - name: License
   - name: Mapping rule
   - name: Message
+  - name: Message subscription
   - name: Process definition
   - name: Process instance
   - name: Resource
@@ -4209,6 +4210,35 @@ paths:
                 $ref: "#/components/schemas/ProblemDetail"
         "500":
           $ref: "#/components/responses/InternalServerError"
+  /message-subscriptions/search:
+    post:
+      tags:
+        - Message subscription
+      operationId: searchMessageSubscriptions
+      summary: Search message subscriptions
+      description: |
+        Search for message subscriptions based on given criteria.
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/MessageSubscriptionSearchQuery"
+      responses:
+        "200":
+          description: The message subscription search result.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MessageSubscriptionSearchQueryResult"
+        "400":
+          $ref: "#/components/responses/InvalidData"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
 
   /documents:
     post:
@@ -6959,6 +6989,176 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/IncidentResult"
+    MessageSubscriptionSearchQueryResult:
+      type: object
+      allOf:
+        - $ref: "#/components/schemas/SearchQueryResponse"
+      properties:
+        items:
+          description: The matching message subscriptions.
+          type: array
+          items:
+            $ref: "#/components/schemas/MessageSubscriptionResult"
+    MessageSubscriptionResult:
+      type: object
+      properties:
+        messageSubscriptionKey:
+          description: The message subscription key associated with this message subscription.
+          type: string
+        processDefinitionId:
+          description: The process definition ID associated with this message subscription.
+          type: string
+        processDefinitionKey:
+          description: The process definition key associated with this message subscription.
+          type: string
+        processInstanceKey:
+          description: The process instance key associated with this message subscription.
+          type: string
+        elementId:
+          description: The element ID associated with this message subscription.
+          type: string
+        elementInstanceKey:
+          description: The element instance key associated with this message subscription.
+          type: string
+        messageSubscriptionType:
+          $ref: "#/components/schemas/MessageSubscriptionTypeEnum"
+        lastUpdatedDate:
+          description: The last updated date of the message subscription.
+          type: string
+          format: date-time
+        messageName:
+          description: The name of the message associated with the message subscription.
+          type: string
+        correlationKey:
+          description: The correlation key of the message subscription.
+          type: string
+        tenantId:
+          description: The unique external tenant ID.
+          type: string
+    MessageSubscriptionSearchQuerySortRequest:
+      type: object
+      properties:
+        field:
+          description: The field to sort by.
+          type: string
+          enum:
+            - messageSubscriptionKey
+            - processDefinitionId
+            - processDefinitionKey
+            - processInstanceKey
+            - elementId
+            - elementInstanceKey
+            - messageSubscriptionType
+            - lastUpdatedDate
+            - messageName
+            - correlationKey
+            - tenantId
+        order:
+          $ref: "#/components/schemas/SortOrderEnum"
+      required:
+        - field
+    MessageSubscriptionSearchQuery:
+      type: object
+      allOf:
+        - $ref: "#/components/schemas/SearchQueryRequest"
+      properties:
+        sort:
+          description: Sort field criteria.
+          type: array
+          items:
+            $ref: "#/components/schemas/MessageSubscriptionSearchQuerySortRequest"
+        filter:
+          description: The incident search filters.
+          allOf:
+            - $ref: "#/components/schemas/MessageSubscriptionFilter"
+    MessageSubscriptionFilter:
+      description: Message subscription search filter.
+      type: object
+      properties:
+        messageSubscriptionKey:
+          description: The message subscription key associated with this message subscription.
+          allOf:
+            - $ref: "#/components/schemas/StringFilterProperty"
+        processDefinitionId:
+          description: The process definition ID associated with this message subscription.
+          allOf:
+            - $ref: "#/components/schemas/StringFilterProperty"
+        processDefinitionKey:
+          description: The process definition key associated with this message subscription.
+          allOf:
+            - $ref: "#/components/schemas/BasicStringFilterProperty"
+        processInstanceKey:
+          description: The process instance key associated with this message subscription.
+          allOf:
+            - $ref: "#/components/schemas/StringFilterProperty"
+        elementId:
+          description: The element ID associated with this message subscription.
+          allOf:
+            - $ref: "#/components/schemas/StringFilterProperty"
+        elementInstanceKey:
+          description: The element instance key associated with this message subscription.
+          allOf:
+            - $ref: "#/components/schemas/StringFilterProperty"
+        messageSubscriptionType:
+          description: The message subscription type.
+          allOf:
+            - $ref: "#/components/schemas/MessageSubscriptionTypeFilterProperty"
+        lastUpdatedDate:
+          description: The last updated date of the message subscription.
+          allOf:
+            - $ref: "#/components/schemas/DateTimeFilterProperty"
+        messageName:
+          description: The name of the message associated with the message subscription.
+          allOf:
+            - $ref: "#/components/schemas/StringFilterProperty"
+        correlationKey:
+          description: The correlation key of the message subscription.
+          allOf:
+            - $ref: "#/components/schemas/StringFilterProperty"
+        tenantId:
+          description: The unique external tenant ID.
+          allOf:
+            - $ref: "#/components/schemas/StringFilterProperty"
+    MessageSubscriptionTypeFilterProperty:
+      description: MessageSubscriptionTypeEnum with full advanced search capabilities.
+      type: object
+      oneOf:
+        - type: string
+          title: Exact match
+          description: Matches the value exactly.
+          allOf:
+            - $ref: "#/components/schemas/MessageSubscriptionTypeEnum"
+        - $ref: "#/components/schemas/AdvancedMessageSubscriptionTypeFilter"
+    MessageSubscriptionTypeEnum:
+      description: The type of message subscription.
+      type: string
+      enum:
+        - CREATED
+        - MIGRATED
+        - CORRELATED
+    AdvancedMessageSubscriptionTypeFilter:
+      title: Advanced filter
+      description: Advanced MessageSubscriptionTypeEnum filter
+      type: object
+      properties:
+        $eq:
+          description: Checks for equality with the provided value.
+          allOf:
+            - $ref: "#/components/schemas/MessageSubscriptionTypeEnum"
+        $neq:
+          description: Checks for inequality with the provided value.
+          allOf:
+            - $ref: "#/components/schemas/MessageSubscriptionTypeEnum"
+        $exists:
+          description: Checks if the current property exists.
+          type: boolean
+        $in:
+          description: Checks if the property matches any of the provided values.
+          type: array
+          items:
+            $ref: "#/components/schemas/MessageSubscriptionTypeEnum"
+        $like:
+          $ref: "#/components/schemas/LikeFilterProperty"
     IncidentResult:
       type: object
       properties:

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -4213,6 +4213,7 @@ paths:
   /message-subscriptions/search:
     post:
       tags:
+        - Message
         - Message subscription
       operationId: searchMessageSubscriptions
       summary: Search message subscriptions

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
@@ -28,6 +28,7 @@ import io.camunda.search.entities.GroupMemberEntity;
 import io.camunda.search.entities.IncidentEntity;
 import io.camunda.search.entities.JobEntity;
 import io.camunda.search.entities.MappingEntity;
+import io.camunda.search.entities.MessageSubscriptionEntity;
 import io.camunda.search.entities.ProcessDefinitionEntity;
 import io.camunda.search.entities.ProcessFlowNodeStatisticsEntity;
 import io.camunda.search.entities.ProcessInstanceEntity;
@@ -80,6 +81,9 @@ import io.camunda.zeebe.gateway.protocol.rest.JobStateEnum;
 import io.camunda.zeebe.gateway.protocol.rest.MappingRuleResult;
 import io.camunda.zeebe.gateway.protocol.rest.MappingRuleSearchQueryResult;
 import io.camunda.zeebe.gateway.protocol.rest.MatchedDecisionRuleItem;
+import io.camunda.zeebe.gateway.protocol.rest.MessageSubscriptionResult;
+import io.camunda.zeebe.gateway.protocol.rest.MessageSubscriptionSearchQueryResult;
+import io.camunda.zeebe.gateway.protocol.rest.MessageSubscriptionTypeEnum;
 import io.camunda.zeebe.gateway.protocol.rest.OwnerTypeEnum;
 import io.camunda.zeebe.gateway.protocol.rest.PermissionTypeEnum;
 import io.camunda.zeebe.gateway.protocol.rest.ProcessDefinitionElementStatisticsQueryResult;
@@ -444,6 +448,17 @@ public final class SearchQueryResponseMapper {
                 .orElseGet(Collections::emptyList));
   }
 
+  public static MessageSubscriptionSearchQueryResult toMessageSubscriptionSearchQueryResponse(
+      final SearchQueryResult<MessageSubscriptionEntity> result) {
+    final var page = toSearchQueryPageResponse(result);
+    return new MessageSubscriptionSearchQueryResult()
+        .page(page)
+        .items(
+            ofNullable(result.items())
+                .map(SearchQueryResponseMapper::toMessageSubscriptions)
+                .orElseGet(Collections::emptyList));
+  }
+
   private static SearchQueryPageResponse toSearchQueryPageResponse(
       final SearchQueryResult<?> result) {
 
@@ -784,6 +799,31 @@ public final class SearchQueryResponseMapper {
         .state(IncidentResult.StateEnum.fromValue(t.state().name()))
         .jobKey(KeyUtil.keyToString(t.jobKey()))
         .tenantId(t.tenantId());
+  }
+
+  public static List<MessageSubscriptionResult> toMessageSubscriptions(
+      final List<MessageSubscriptionEntity> messageSubscriptions) {
+    return messageSubscriptions.stream()
+        .map(SearchQueryResponseMapper::toMessageSubscription)
+        .toList();
+  }
+
+  public static MessageSubscriptionResult toMessageSubscription(
+      final MessageSubscriptionEntity messageSubscription) {
+    return new MessageSubscriptionResult()
+        .messageSubscriptionKey(KeyUtil.keyToString(messageSubscription.messageSubscriptionKey()))
+        .processDefinitionId(messageSubscription.processDefinitionId())
+        .processDefinitionKey(KeyUtil.keyToString(messageSubscription.processDefinitionKey()))
+        .processInstanceKey(KeyUtil.keyToString(messageSubscription.processInstanceKey()))
+        .elementId(messageSubscription.flowNodeId())
+        .elementInstanceKey(KeyUtil.keyToString(messageSubscription.flowNodeInstanceKey()))
+        .messageSubscriptionType(
+            MessageSubscriptionTypeEnum.fromValue(
+                messageSubscription.messageSubscriptionType().name()))
+        .lastUpdatedDate(formatDate(messageSubscription.dateTime()))
+        .messageName(messageSubscription.messageName())
+        .correlationKey(messageSubscription.correlationKey())
+        .tenantId(messageSubscription.tenantId());
   }
 
   public static UserTaskResult toUserTask(final UserTaskEntity t, final String name) {

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQuerySortRequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQuerySortRequestMapper.java
@@ -162,6 +162,12 @@ public class SearchQuerySortRequestMapper {
     return requests.stream().map(r -> createFrom(r.getField(), r.getOrder())).toList();
   }
 
+  public static List<SearchQuerySortRequest<MessageSubscriptionSearchQuerySortRequest.FieldEnum>>
+      fromMessageSubscriptionSearchQuerySortRequest(
+          final List<MessageSubscriptionSearchQuerySortRequest> requests) {
+    return requests.stream().map(r -> createFrom(r.getField(), r.getOrder())).toList();
+  }
+
   private static <T> SearchQuerySortRequest<T> createFrom(
       final T field, final SortOrderEnum order) {
     return new SearchQuerySortRequest<T>(field, order);

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/JacksonConfig.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/JacksonConfig.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.gateway.protocol.rest.IntegerFilterProperty;
 import io.camunda.zeebe.gateway.protocol.rest.JobKindFilterProperty;
 import io.camunda.zeebe.gateway.protocol.rest.JobListenerEventTypeFilterProperty;
 import io.camunda.zeebe.gateway.protocol.rest.JobStateFilterProperty;
+import io.camunda.zeebe.gateway.protocol.rest.MessageSubscriptionTypeFilterProperty;
 import io.camunda.zeebe.gateway.protocol.rest.ProcessInstanceStateFilterProperty;
 import io.camunda.zeebe.gateway.protocol.rest.StringFilterProperty;
 import io.camunda.zeebe.gateway.rest.deserializer.BasicStringFilterPropertyDeserializer;
@@ -31,6 +32,7 @@ import io.camunda.zeebe.gateway.rest.deserializer.IntegerFilterPropertyDeseriali
 import io.camunda.zeebe.gateway.rest.deserializer.JobKindFilterPropertyDeserializer;
 import io.camunda.zeebe.gateway.rest.deserializer.JobListenerEventTypeFilterPropertyDeserializer;
 import io.camunda.zeebe.gateway.rest.deserializer.JobStateFilterPropertyDeserializer;
+import io.camunda.zeebe.gateway.rest.deserializer.MessageSubscriptionTypePropertyDeserializer;
 import io.camunda.zeebe.gateway.rest.deserializer.ProcessInstanceStateFilterPropertyDeserializer;
 import io.camunda.zeebe.gateway.rest.deserializer.StringFilterPropertyDeserializer;
 import java.util.function.Consumer;
@@ -68,6 +70,9 @@ public class JacksonConfig {
     module.addDeserializer(
         JobListenerEventTypeFilterProperty.class,
         new JobListenerEventTypeFilterPropertyDeserializer());
+    module.addDeserializer(
+        MessageSubscriptionTypeFilterProperty.class,
+        new MessageSubscriptionTypePropertyDeserializer());
     return builder -> builder.modulesToInstall(modules -> modules.add(module));
   }
 

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/MessageSubscriptionController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/MessageSubscriptionController.java
@@ -18,8 +18,6 @@ import io.camunda.zeebe.gateway.rest.RestErrorMapper;
 import io.camunda.zeebe.gateway.rest.SearchQueryRequestMapper;
 import io.camunda.zeebe.gateway.rest.SearchQueryResponseMapper;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaPostMapping;
-import jakarta.validation.ValidationException;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -54,13 +52,6 @@ public class MessageSubscriptionController {
               .search(query);
       return ResponseEntity.ok(
           SearchQueryResponseMapper.toMessageSubscriptionSearchQueryResponse(result));
-    } catch (final ValidationException e) {
-      final var problemDetail =
-          RestErrorMapper.createProblemDetail(
-              HttpStatus.BAD_REQUEST,
-              e.getMessage(),
-              "Validation failed for Message Subscription Search Query");
-      return RestErrorMapper.mapProblemToResponse(problemDetail);
     } catch (final Exception e) {
       return mapErrorToResponse(e);
     }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/MessageSubscriptionController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/MessageSubscriptionController.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.controller;
+
+import static io.camunda.zeebe.gateway.rest.RestErrorMapper.mapErrorToResponse;
+
+import io.camunda.search.query.MessageSubscriptionQuery;
+import io.camunda.security.auth.CamundaAuthenticationProvider;
+import io.camunda.service.MessageSubscriptionServices;
+import io.camunda.zeebe.gateway.protocol.rest.MessageSubscriptionSearchQuery;
+import io.camunda.zeebe.gateway.protocol.rest.MessageSubscriptionSearchQueryResult;
+import io.camunda.zeebe.gateway.rest.RestErrorMapper;
+import io.camunda.zeebe.gateway.rest.SearchQueryRequestMapper;
+import io.camunda.zeebe.gateway.rest.SearchQueryResponseMapper;
+import io.camunda.zeebe.gateway.rest.annotation.CamundaPostMapping;
+import jakarta.validation.ValidationException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@CamundaRestController
+@RequestMapping("/v2/message-subscriptions")
+public class MessageSubscriptionController {
+
+  private final CamundaAuthenticationProvider authenticationProvider;
+  private final MessageSubscriptionServices messageSubscriptionServices;
+
+  public MessageSubscriptionController(
+      final CamundaAuthenticationProvider authenticationProvider,
+      final MessageSubscriptionServices messageSubscriptionServices) {
+    this.authenticationProvider = authenticationProvider;
+    this.messageSubscriptionServices = messageSubscriptionServices;
+  }
+
+  @CamundaPostMapping(path = "/search")
+  public ResponseEntity<MessageSubscriptionSearchQueryResult> searchMessageSubscriptions(
+      @RequestBody(required = false) final MessageSubscriptionSearchQuery searchRequest) {
+    return SearchQueryRequestMapper.toMessageSubscriptionQuery(searchRequest)
+        .fold(RestErrorMapper::mapProblemToResponse, this::search);
+  }
+
+  private ResponseEntity<MessageSubscriptionSearchQueryResult> search(
+      final MessageSubscriptionQuery query) {
+    try {
+      final var result =
+          messageSubscriptionServices
+              .withAuthentication(authenticationProvider.getCamundaAuthentication())
+              .search(query);
+      return ResponseEntity.ok(
+          SearchQueryResponseMapper.toMessageSubscriptionSearchQueryResponse(result));
+    } catch (final ValidationException e) {
+      final var problemDetail =
+          RestErrorMapper.createProblemDetail(
+              HttpStatus.BAD_REQUEST,
+              e.getMessage(),
+              "Validation failed for Message Subscription Search Query");
+      return RestErrorMapper.mapProblemToResponse(problemDetail);
+    } catch (final Exception e) {
+      return mapErrorToResponse(e);
+    }
+  }
+}

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/deserializer/MessageSubscriptionTypePropertyDeserializer.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/deserializer/MessageSubscriptionTypePropertyDeserializer.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.deserializer;
+
+import io.camunda.zeebe.gateway.protocol.rest.AdvancedMessageSubscriptionTypeFilter;
+import io.camunda.zeebe.gateway.protocol.rest.MessageSubscriptionTypeEnum;
+import io.camunda.zeebe.gateway.protocol.rest.MessageSubscriptionTypeFilterProperty;
+
+public class MessageSubscriptionTypePropertyDeserializer
+    extends FilterDeserializer<MessageSubscriptionTypeFilterProperty, MessageSubscriptionTypeEnum> {
+
+  @Override
+  protected Class<? extends MessageSubscriptionTypeFilterProperty> getFinalType() {
+    return AdvancedMessageSubscriptionTypeFilter.class;
+  }
+
+  @Override
+  protected Class<MessageSubscriptionTypeEnum> getImplicitValueType() {
+    return MessageSubscriptionTypeEnum.class;
+  }
+
+  @Override
+  protected MessageSubscriptionTypeFilterProperty createFromImplicitValue(
+      final MessageSubscriptionTypeEnum value) {
+    final var filter = new AdvancedMessageSubscriptionTypeFilter();
+    filter.set$Eq(value);
+    return filter;
+  }
+}

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/MessageSubscriptionQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/MessageSubscriptionQueryControllerTest.java
@@ -1,0 +1,286 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.search.entities.MessageSubscriptionEntity;
+import io.camunda.search.query.MessageSubscriptionQuery;
+import io.camunda.search.query.SearchQueryResult;
+import io.camunda.security.auth.CamundaAuthentication;
+import io.camunda.security.auth.CamundaAuthenticationProvider;
+import io.camunda.service.MessageSubscriptionServices;
+import io.camunda.zeebe.gateway.rest.RestControllerTest;
+import java.time.OffsetDateTime;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+@WebMvcTest(value = MessageSubscriptionController.class)
+public class MessageSubscriptionQueryControllerTest extends RestControllerTest {
+
+  private static final String EXPECTED_SEARCH_RESPONSE =
+      """
+        {
+            "items": [
+                {
+                  "messageSubscriptionKey": "2251799813685854",
+                  "processDefinitionId": "gg_msg_receive_id",
+                  "processDefinitionKey": "948",
+                  "processInstanceKey": "2251799813685849",
+                  "elementId": "Activity_1ludhs2",
+                  "elementInstanceKey": "2251799813685853",
+                  "messageSubscriptionType": "CREATED",
+                  "lastUpdatedDate": "2025-07-05T12:11:00.975Z",
+                  "messageName": "Message_1f8cu1e",
+                  "correlationKey": "test",
+                  "tenantId": "test-tenant"
+                }
+            ],
+            "page": {
+                "totalItems": 1,
+                "startCursor": "WzIyNTE3OTk4MTM2ODU4Mjld",
+                "endCursor": "WzIyNTE3OTk4MTM2ODU4NjZd"
+            }
+        }
+      """;
+  private static final String MESSAGE_SUBSCRIPTIONS_SEARCH_URL = "/v2/message-subscriptions/search";
+  private static final SearchQueryResult<MessageSubscriptionEntity> SEARCH_QUERY_RESULT =
+      new SearchQueryResult.Builder<MessageSubscriptionEntity>()
+          .total(1L)
+          .items(
+              List.of(
+                  new MessageSubscriptionEntity.Builder()
+                      .messageSubscriptionKey(2251799813685854L)
+                      .processDefinitionId("gg_msg_receive_id")
+                      .processDefinitionKey(948L)
+                      .processInstanceKey(2251799813685849L)
+                      .flowNodeId("Activity_1ludhs2")
+                      .flowNodeInstanceKey(2251799813685853L)
+                      .messageSubscriptionType(
+                          MessageSubscriptionEntity.MessageSubscriptionType.CREATED)
+                      .dateTime(OffsetDateTime.parse("2025-07-05T12:11:00.975Z"))
+                      .messageName("Message_1f8cu1e")
+                      .correlationKey("test")
+                      .tenantId("test-tenant")
+                      .build()))
+          .startCursor("WzIyNTE3OTk4MTM2ODU4Mjld")
+          .endCursor("WzIyNTE3OTk4MTM2ODU4NjZd")
+          .build();
+  @MockitoBean MessageSubscriptionServices services;
+  @MockitoBean CamundaAuthenticationProvider authenticationProvider;
+
+  @BeforeEach
+  void setUp() {
+    when(authenticationProvider.getCamundaAuthentication())
+        .thenReturn(AUTHENTICATION_WITH_DEFAULT_TENANT);
+    when(services.withAuthentication(any(CamundaAuthentication.class))).thenReturn(services);
+  }
+
+  @Test
+  public void shouldSearchMessageSubscriptionsWithEmptyBody() {
+    // given
+    when(services.search(any())).thenReturn(SEARCH_QUERY_RESULT);
+
+    // when / then
+    webClient
+        .post()
+        .uri(MESSAGE_SUBSCRIPTIONS_SEARCH_URL)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_JSON)
+        .expectBody()
+        .json(EXPECTED_SEARCH_RESPONSE);
+
+    verify(services).search(new MessageSubscriptionQuery.Builder().build());
+  }
+
+  @Test
+  public void shouldSearchMessageSubscriptionsWithEmptyQuery() {
+    // given
+    when(services.search(any())).thenReturn(SEARCH_QUERY_RESULT);
+
+    // when / then
+    webClient
+        .post()
+        .uri(MESSAGE_SUBSCRIPTIONS_SEARCH_URL)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue("{}")
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_JSON)
+        .expectBody()
+        .json(EXPECTED_SEARCH_RESPONSE);
+
+    verify(services).search(new MessageSubscriptionQuery.Builder().build());
+  }
+
+  @Test
+  public void shouldSearchMessageSubscriptionsWithFilters() {
+    // given
+    when(services.search(any())).thenReturn(SEARCH_QUERY_RESULT);
+
+    // when / then
+    webClient
+        .post()
+        .uri(MESSAGE_SUBSCRIPTIONS_SEARCH_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(
+            """
+            {
+              "filter": {
+                "messageSubscriptionKey": 123,
+                "processDefinitionId": "gg_msg_receive_id",
+                "processDefinitionKey": 948,
+                "processInstanceKey": 2251799813685849,
+                "elementId": "Activity_1ludhs2",
+                "elementInstanceKey": 2251799813685853,
+                "messageSubscriptionType": "CREATED",
+                "lastUpdatedDate": "2025-07-05T12:11:00.975Z",
+                "correlationKey": "test",
+                "messageName": "test-message",
+                "tenantId": "test-tenant"
+              }
+            }""")
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_JSON)
+        .expectBody()
+        .json(EXPECTED_SEARCH_RESPONSE);
+
+    verify(services)
+        .search(
+            new MessageSubscriptionQuery.Builder()
+                .filter(
+                    f ->
+                        f.messageSubscriptionKeys(123L)
+                            .processDefinitionIds("gg_msg_receive_id")
+                            .processDefinitionKeys(948L)
+                            .processInstanceKeys(2251799813685849L)
+                            .flowNodeIds("Activity_1ludhs2")
+                            .flowNodeInstanceKeys(2251799813685853L)
+                            .messageSubscriptionTypes(
+                                MessageSubscriptionEntity.MessageSubscriptionType.CREATED.name())
+                            .dateTimes(OffsetDateTime.parse("2025-07-05T12:11:00.975Z"))
+                            .correlationKeys("test")
+                            .messageNames("test-message")
+                            .tenantIds("test-tenant"))
+                .build());
+  }
+
+  @Test
+  public void shouldSearchMessageSubscriptionsWithSorting() {
+    // given
+    when(services.search(any())).thenReturn(SEARCH_QUERY_RESULT);
+
+    // when / then
+    webClient
+        .post()
+        .uri(MESSAGE_SUBSCRIPTIONS_SEARCH_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(
+            """
+            {
+              "sort": [
+                {
+                  "field": "messageSubscriptionKey",
+                  "order": "asc"
+                },
+                {
+                  "field": "processDefinitionId",
+                  "order": "desc"
+                },
+                {
+                  "field": "processDefinitionKey",
+                  "order": "asc"
+                },
+                {
+                  "field": "processInstanceKey",
+                  "order": "desc"
+                },
+                {
+                  "field": "elementId",
+                  "order": "asc"
+                },
+                {
+                  "field": "elementInstanceKey",
+                  "order": "desc"
+                },
+                {
+                  "field": "messageSubscriptionType",
+                  "order": "asc"
+                },
+                {
+                  "field": "lastUpdatedDate",
+                  "order": "desc"
+                },
+                {
+                  "field": "correlationKey",
+                  "order": "asc"
+                },
+                {
+                  "field": "messageName",
+                  "order": "desc"
+                },
+                {
+                  "field": "tenantId",
+                  "order": "asc"
+                }
+              ]
+            }""")
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_JSON)
+        .expectBody()
+        .json(EXPECTED_SEARCH_RESPONSE);
+
+    verify(services)
+        .search(
+            new MessageSubscriptionQuery.Builder()
+                .sort(
+                    s ->
+                        s.messageSubscriptionKey()
+                            .asc()
+                            .processDefinitionId()
+                            .desc()
+                            .processDefinitionKey()
+                            .asc()
+                            .processInstanceKey()
+                            .desc()
+                            .flowNodeId()
+                            .asc()
+                            .flowNodeInstanceKey()
+                            .desc()
+                            .messageSubscriptionType()
+                            .asc()
+                            .dateTime()
+                            .desc()
+                            .correlationKey()
+                            .asc()
+                            .messageName()
+                            .desc()
+                            .tenantId()
+                            .asc())
+                .build());
+  }
+}


### PR DESCRIPTION
## Testing

Besides the unit tests I focused on manual testing of the API. The Java client will be extended in a future PR and that PR will include QA acceptance tests.
<details>

<summary>Click here to see the manual test</summary>

### Request

```
{
    "sort": [
        {
            "field": "messageSubscriptionKey",
            "order": "DESC"
        },
        {
            "field": "processDefinitionId",
            "order": "DESC"
        },
        {
            "field": "processDefinitionKey",
            "order": "DESC"
        },
        {
            "field": "processInstanceKey",
            "order": "DESC"
        },
        {
            "field": "elementId",
            "order": "DESC"
        },
        {
            "field": "elementInstanceKey",
            "order": "DESC"
        },
        {
            "field": "messageSubscriptionType",
            "order": "DESC"
        },
        {
            "field": "lastUpdatedDate",
            "order": "DESC"
        },
        {
            "field": "messageName",
            "order": "DESC"
        },
        {
            "field": "correlationKey",
            "order": "DESC"
        },
        {
            "field": "tenantId",
            "order": "DESC"
        }
    ],
    "page": {
        "limit": 2,
        "from": 0
    },
    "filter": {
        "messageSubscriptionKey": {
            "$neq": "2251299813685866"
        },
        "processDefinitionId": {
            "$eq": "gg_msg_receive_id"
        },
        "processDefinitionKey": {
            "$neq": "2251799813685403"
        },
        "processInstanceKey": {
            "$neq": "2251799813685861"
        },
        "elementId": {
            "$eq": "Activity_1ludhs2"
        },
        "elementInstanceKey": {
            "$neq": "2251799813685865"
        },
        "messageSubscriptionType": {
            "$eq": "CREATED"
        },
        "lastUpdatedDate": {
            "$neq": "2025-07-05T12:11:02.778Z"
        },
        "messageName": {
            "$eq": "Message_1f8cu1e"
        },
        "correlationKey": {
            "$eq": "test"
        },
        "tenantId": {
            "$eq": "<default>"
        }
    }
}
```

### Response

```
{
    "items": [
        {
            "messageSubscriptionKey": "2251799813685854",
            "processDefinitionId": "gg_msg_receive_id",
            "processInstanceKey": "2251799813685849",
            "elementId": "Activity_1ludhs2",
            "elementInstanceKey": "2251799813685853",
            "messageSubscriptionType": "CREATED",
            "lastUpdatedDate": "2025-07-05T12:11:00.975Z",
            "messageName": "Message_1f8cu1e",
            "correlationKey": "test",
            "tenantId": "<default>"
        },
        {
            "messageSubscriptionKey": "2251799813685829",
            "processDefinitionId": "gg_msg_receive_id",
            "processInstanceKey": "2251799813685824",
            "elementId": "Activity_1ludhs2",
            "elementInstanceKey": "2251799813685828",
            "messageSubscriptionType": "CREATED",
            "lastUpdatedDate": "2025-07-05T12:10:58.769Z",
            "messageName": "Message_1f8cu1e",
            "correlationKey": "test",
            "tenantId": "<default>"
        }
    ],
    "page": {
        "totalItems": 2,
        "startCursor": "WzIyNTE3OTk4MTM2ODU4NTQsImdnX21zZ19yZWNlaXZlX2lkIiwtOTIyMzM3MjAzNjg1NDc3NTgwOCwyMjUxNzk5ODEzNjg1ODQ5LCJBY3Rpdml0eV8xbHVkaHMyIiwyMjUxNzk5ODEzNjg1ODUzLCJDUkVBVEVEIiwxNzUxNzE3NDYwOTc1LCJNZXNzYWdlXzFmOGN1MWUiLCJ0ZXN0IiwiPGRlZmF1bHQ+IiwyMjUxNzk5ODEzNjg1ODU0XQ==",
        "endCursor": "WzIyNTE3OTk4MTM2ODU4MjksImdnX21zZ19yZWNlaXZlX2lkIiwtOTIyMzM3MjAzNjg1NDc3NTgwOCwyMjUxNzk5ODEzNjg1ODI0LCJBY3Rpdml0eV8xbHVkaHMyIiwyMjUxNzk5ODEzNjg1ODI4LCJDUkVBVEVEIiwxNzUxNzE3NDU4NzY5LCJNZXNzYWdlXzFmOGN1MWUiLCJ0ZXN0IiwiPGRlZmF1bHQ+IiwyMjUxNzk5ODEzNjg1ODI5XQ=="
    }
}
```

`processDefinitionKey` does not appear in the requests because it is `null` in the ES data.

</details>

## Description

This PR includes a REST endpoint that allows clients to search for message subscriptions with optional filtering, sorting and pagination.

## Related issues

closes https://github.com/camunda/camunda/issues/34442
