### PR TITLE
refactor: Introduce a dedicated CamundaAuthenticationProvider

### DIFF
--- a/authentication/pom.xml
+++ b/authentication/pom.xml
@@ -76,6 +76,15 @@
       <artifactId>camunda-search-client</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-auth</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.auth0</groupId>
+      <artifactId>java-jwt</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/authentication/src/main/java/io/camunda/authentication/DefaultCamundaAuthenticationConverter.java
+++ b/authentication/src/main/java/io/camunda/authentication/DefaultCamundaAuthenticationConverter.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication;
+
+import io.camunda.authentication.entity.CamundaOAuthPrincipal;
+import io.camunda.authentication.entity.CamundaPrincipal;
+import io.camunda.search.entities.RoleEntity;
+import io.camunda.security.auth.CamundaAuthentication;
+import io.camunda.security.auth.CamundaAuthentication.Builder;
+import io.camunda.security.auth.CamundaAuthenticationConverter;
+import io.camunda.service.TenantServices.TenantDTO;
+import io.camunda.zeebe.auth.Authorization;
+import java.util.HashMap;
+import java.util.Map;
+import org.springframework.security.core.Authentication;
+
+public class DefaultCamundaAuthenticationConverter
+    implements CamundaAuthenticationConverter<Authentication> {
+
+  @Override
+  public CamundaAuthentication convert(final Authentication springBasedAuthentication) {
+    final Map<String, Object> claims = new HashMap<>();
+    final var authenticationBuilder = new Builder();
+
+    if (springBasedAuthentication != null) {
+      if (springBasedAuthentication.getPrincipal()
+          instanceof final CamundaPrincipal authenticatedPrincipal) {
+        final var authenticationContext = authenticatedPrincipal.getAuthenticationContext();
+
+        authenticationBuilder.roleIds(
+            authenticationContext.roles().stream().map(RoleEntity::roleId).toList());
+
+        authenticationBuilder.tenants(
+            authenticationContext.tenants().stream().map(TenantDTO::tenantId).toList());
+
+        authenticationBuilder.groupIds(authenticationContext.groups());
+
+        if (authenticationContext.groupsClaimEnabled()) {
+          claims.put(Authorization.USER_GROUPS_CLAIMS, authenticationContext.groups());
+        }
+
+        if (authenticationContext.username() != null) {
+          final var authenticatedUsername = authenticationContext.username();
+          claims.put(Authorization.AUTHORIZED_USERNAME, authenticatedUsername);
+          authenticationBuilder.user(authenticatedUsername);
+        } else {
+          final var authenticatedClientId = authenticationContext.clientId();
+          claims.put(Authorization.AUTHORIZED_CLIENT_ID, authenticatedClientId);
+          authenticationBuilder.clientId(authenticatedClientId);
+        }
+
+        if (authenticatedPrincipal instanceof final CamundaOAuthPrincipal principal) {
+          claims.put(Authorization.USER_TOKEN_CLAIMS, principal.getClaims());
+          authenticationBuilder.mapping(principal.getOAuthContext().mappingIds().stream().toList());
+        }
+
+        authenticationBuilder.claims(claims);
+      }
+    }
+
+    return authenticationBuilder.build();
+  }
+}

--- a/authentication/src/main/java/io/camunda/authentication/DefaultCamundaAuthenticationProvider.java
+++ b/authentication/src/main/java/io/camunda/authentication/DefaultCamundaAuthenticationProvider.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication;
+
+import io.camunda.security.auth.CamundaAuthentication;
+import io.camunda.security.auth.CamundaAuthenticationConverter;
+import io.camunda.security.auth.CamundaAuthenticationProvider;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+public class DefaultCamundaAuthenticationProvider implements CamundaAuthenticationProvider {
+
+  private final CamundaAuthenticationConverter<Authentication> converter;
+
+  public DefaultCamundaAuthenticationProvider(
+      final CamundaAuthenticationConverter<Authentication> converter) {
+    this.converter = converter;
+  }
+
+  @Override
+  public CamundaAuthentication getCamundaAuthentication() {
+    final var springBasedAuthentication = SecurityContextHolder.getContext().getAuthentication();
+    return converter.convert(springBasedAuthentication);
+  }
+}

--- a/authentication/src/test/java/io/camunda/authentication/DefaultCamundaAuthenticationProviderTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/DefaultCamundaAuthenticationProviderTest.java
@@ -1,0 +1,273 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication;
+
+import static io.camunda.zeebe.auth.Authorization.USER_TOKEN_CLAIMS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import io.camunda.authentication.entity.AuthenticationContext.AuthenticationContextBuilder;
+import io.camunda.authentication.entity.CamundaJwtUser;
+import io.camunda.authentication.entity.CamundaOidcUser;
+import io.camunda.authentication.entity.CamundaUser.CamundaUserBuilder;
+import io.camunda.authentication.entity.OAuthContext;
+import io.camunda.security.auth.CamundaAuthenticationConverter;
+import io.camunda.security.auth.CamundaAuthenticationProvider;
+import io.camunda.service.TenantServices.TenantDTO;
+import io.camunda.zeebe.auth.Authorization;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.oidc.OidcIdToken;
+import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.context.request.RequestAttributes;
+import org.springframework.web.context.request.RequestContextHolder;
+
+public class DefaultCamundaAuthenticationProviderTest {
+
+  @Mock private RequestAttributes requestAttributes;
+  private CamundaAuthenticationProvider authenticationProvider;
+  private CamundaAuthenticationConverter<Authentication> authenticationConverter;
+
+  @BeforeEach
+  void setup() throws Exception {
+    MockitoAnnotations.openMocks(this).close();
+    RequestContextHolder.setRequestAttributes(requestAttributes);
+    authenticationConverter = new DefaultCamundaAuthenticationConverter();
+    authenticationProvider = new DefaultCamundaAuthenticationProvider(authenticationConverter);
+  }
+
+  @Test
+  void tokenContainsUsernameWithBasicAuth() {
+
+    // given
+    final var username = "username";
+    setUsernamePasswordAuthenticationInContext(username);
+
+    // when
+    final var claims = authenticationProvider.getCamundaAuthentication().claims();
+
+    // then
+    assertNotNull(claims);
+    assertThat(claims).containsKey(Authorization.AUTHORIZED_USERNAME);
+    assertThat(claims.get(Authorization.AUTHORIZED_USERNAME)).isEqualTo(username);
+  }
+
+  @Test
+  void tokenContainsExtraClaimsWithOidcAuth() {
+    // given
+    final String usernameClaim = "sub";
+    final String usernameValue = "test-user";
+    setOidcAuthenticationInContext(usernameClaim, usernameValue, "aud1");
+
+    // when
+    final var authenticatedUsername =
+        authenticationProvider.getCamundaAuthentication().authenticatedUsername();
+
+    // then
+    assertThat(authenticatedUsername).isEqualTo(usernameValue);
+  }
+
+  @Test
+  void tokenContainsExtraClaimsWithJwtAuth() {
+
+    // given
+    final String sub1 = "sub1";
+    final String aud1 = "aud1";
+    setJwtAuthenticationInContext(sub1, aud1);
+
+    // when
+    final var claims =
+        (Map<String, Object>)
+            authenticationProvider.getCamundaAuthentication().claims().get(USER_TOKEN_CLAIMS);
+
+    // then
+    assertNotNull(claims);
+    assertThat(claims).containsKey("sub");
+    assertThat(claims).containsKey("aud");
+    assertThat(claims).containsKey("groups");
+    assertThat(claims.get("sub")).isEqualTo(sub1);
+    assertThat(claims.get("aud")).isEqualTo(aud1);
+    assertThat(claims.get("groups")).isEqualTo(List.of("g1", "g2"));
+  }
+
+  @Test
+  void tokenContainsTenantIdsInAuthenticationContext() {
+    // given
+    final var username = "test-user";
+    final var tenants =
+        List.of(
+            new TenantDTO(1L, "tenant-1", "Tenant One", "First"),
+            new TenantDTO(2L, "tenant-2", "Tenant Two", "Second"));
+    final var authenticationContext =
+        new AuthenticationContextBuilder().withUsername(username).withTenants(tenants).build();
+
+    final var principal =
+        new CamundaOidcUser(
+            new DefaultOidcUser(
+                Collections.emptyList(),
+                new OidcIdToken(
+                    "tokenValue",
+                    Instant.now(),
+                    Instant.now().plusSeconds(3600),
+                    Map.of("sub", username))),
+            Collections.emptySet(),
+            authenticationContext);
+
+    final var auth = new OAuth2AuthenticationToken(principal, List.of(), "oidc");
+    SecurityContextHolder.getContext().setAuthentication(auth);
+
+    // when
+    final var authContext = authenticationProvider.getCamundaAuthentication();
+
+    // then
+    assertThat(authContext.authenticatedTenantIds())
+        .containsExactlyInAnyOrder("tenant-1", "tenant-2");
+    assertThat(authContext.authenticatedUsername()).isEqualTo(username);
+  }
+
+  @Test
+  void usernameIsSetInAuthenticationWhenOnAuthenticationContext() {
+    // given
+    final var username = "test-user";
+    final var authenticationContext =
+        new AuthenticationContextBuilder().withUsername(username).build();
+
+    final var principal =
+        new CamundaOidcUser(
+            new DefaultOidcUser(
+                Collections.emptyList(),
+                new OidcIdToken(
+                    "tokenValue",
+                    Instant.now(),
+                    Instant.now().plusSeconds(3600),
+                    Map.of("sub", username))),
+            Collections.emptySet(),
+            authenticationContext);
+
+    final var auth = new OAuth2AuthenticationToken(principal, List.of(), "oidc");
+    SecurityContextHolder.getContext().setAuthentication(auth);
+
+    // when
+    final var authentication = authenticationProvider.getCamundaAuthentication();
+
+    // then
+    assertThat(authentication.authenticatedUsername()).isEqualTo(username);
+    assertThat(authentication.authenticatedClientId()).isNull();
+  }
+
+  @Test
+  void clientIdIsSetInAuthenticationWhenOnAuthenticationContext() {
+    // given
+    final var clientId = "my-application";
+    final var authenticationContext =
+        new AuthenticationContextBuilder().withClientId(clientId).build();
+
+    final var principal =
+        new CamundaOidcUser(
+            new DefaultOidcUser(
+                Collections.emptyList(),
+                new OidcIdToken(
+                    "tokenValue",
+                    Instant.now(),
+                    Instant.now().plusSeconds(3600),
+                    Map.of("sub", clientId))),
+            Collections.emptySet(),
+            authenticationContext);
+
+    final var auth = new OAuth2AuthenticationToken(principal, List.of(), "oidc");
+    SecurityContextHolder.getContext().setAuthentication(auth);
+
+    // when
+    final var authContext = authenticationProvider.getCamundaAuthentication();
+
+    // then
+    assertThat(authContext.authenticatedUsername()).isNull();
+    assertThat(authContext.authenticatedClientId()).isEqualTo(clientId);
+  }
+
+  private void setJwtAuthenticationInContext(final String sub, final String aud) {
+    final Jwt jwt =
+        new Jwt(
+            JWT.create()
+                .withIssuer("issuer1")
+                .withAudience(aud)
+                .withSubject(sub)
+                .sign(Algorithm.none()),
+            Instant.ofEpochSecond(10),
+            Instant.ofEpochSecond(100),
+            Map.of("alg", "RSA256"),
+            Map.of("sub", sub, "aud", aud, "groups", List.of("g1", "g2")));
+
+    final AbstractAuthenticationToken token =
+        new CamundaJwtAuthenticationToken(
+            jwt,
+            new CamundaJwtUser(
+                jwt,
+                new OAuthContext(
+                    new HashSet<>(),
+                    new AuthenticationContextBuilder()
+                        .withUsername(sub)
+                        .withGroups(List.of("g1", "g2"))
+                        .build())),
+            null,
+            null);
+    SecurityContextHolder.getContext().setAuthentication(token);
+  }
+
+  private void setOidcAuthenticationInContext(
+      final String usernameClaim, final String usernameValue, final String aud) {
+    final String tokenValue = "{}";
+    final Instant tokenIssuedAt = Instant.now().truncatedTo(ChronoUnit.SECONDS);
+    final Instant tokenExpiresAt = tokenIssuedAt.plus(1, ChronoUnit.DAYS);
+
+    final var oauth2Authentication =
+        new OAuth2AuthenticationToken(
+            new CamundaOidcUser(
+                new DefaultOidcUser(
+                    Collections.emptyList(),
+                    new OidcIdToken(
+                        tokenValue,
+                        tokenIssuedAt,
+                        tokenExpiresAt,
+                        Map.of("aud", aud, usernameClaim, usernameValue))),
+                Collections.emptySet(),
+                new AuthenticationContextBuilder().withUsername(usernameValue).build()),
+            List.of(),
+            "oidc");
+
+    SecurityContextHolder.getContext().setAuthentication(oauth2Authentication);
+  }
+
+  private void setUsernamePasswordAuthenticationInContext(final String username) {
+    final UsernamePasswordAuthenticationToken authenticationToken =
+        new UsernamePasswordAuthenticationToken(
+            CamundaUserBuilder.aCamundaUser()
+                .withUsername(username)
+                .withPassword("admin")
+                .withUserKey(1L)
+                .build(),
+            null);
+    SecurityContextHolder.getContext().setAuthentication(authenticationToken);
+  }
+}

--- a/dist/src/main/java/io/camunda/application/commons/rest/RestApiConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/rest/RestApiConfiguration.java
@@ -8,6 +8,10 @@
 package io.camunda.application.commons.rest;
 
 import io.camunda.application.commons.rest.RestApiConfiguration.GatewayRestProperties;
+import io.camunda.authentication.DefaultCamundaAuthenticationConverter;
+import io.camunda.authentication.DefaultCamundaAuthenticationProvider;
+import io.camunda.security.auth.CamundaAuthenticationConverter;
+import io.camunda.security.auth.CamundaAuthenticationProvider;
 import io.camunda.service.ProcessDefinitionServices;
 import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
 import io.camunda.zeebe.gateway.rest.ConditionalOnRestGatewayEnabled;
@@ -20,6 +24,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.core.Authentication;
 
 @Configuration(proxyBeanMethods = false)
 @ComponentScan(basePackages = "io.camunda.zeebe.gateway.rest")
@@ -42,6 +47,17 @@ public class RestApiConfiguration {
 
     return new ProcessCache(
         configuration, processElementProvider, brokerTopologyManager, meterRegistry);
+  }
+
+  @Bean
+  public CamundaAuthenticationConverter<Authentication> camundaAuthenticationConverter() {
+    return new DefaultCamundaAuthenticationConverter();
+  }
+
+  @Bean
+  public CamundaAuthenticationProvider camundaAuthenticationProvider(
+      final CamundaAuthenticationConverter<Authentication> converter) {
+    return new DefaultCamundaAuthenticationProvider(converter);
   }
 
   @ConfigurationProperties("camunda.rest")

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/AuthorizationMigrationHandler.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/AuthorizationMigrationHandler.java
@@ -14,7 +14,7 @@ import io.camunda.migration.identity.console.ConsoleClient;
 import io.camunda.migration.identity.console.ConsoleClient.Member;
 import io.camunda.migration.identity.dto.Authorization;
 import io.camunda.migration.identity.midentity.ManagementIdentityClient;
-import io.camunda.security.auth.Authentication;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.AuthorizationServices;
 import io.camunda.service.AuthorizationServices.CreateAuthorizationRequest;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
@@ -38,7 +38,7 @@ public class AuthorizationMigrationHandler extends MigrationHandler<Authorizatio
   private final AtomicInteger totalAuthorizationsCount = new AtomicInteger();
 
   public AuthorizationMigrationHandler(
-      final Authentication authentication,
+      final CamundaAuthentication authentication,
       final AuthorizationServices authorizationService,
       final ConsoleClient consoleClient,
       final ManagementIdentityClient managementIdentityClient) {

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/ClientMigrationHandler.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/ClientMigrationHandler.java
@@ -16,7 +16,7 @@ import io.camunda.migration.identity.console.ConsoleClient;
 import io.camunda.migration.identity.console.ConsoleClient.Client;
 import io.camunda.migration.identity.console.ConsoleClient.Members;
 import io.camunda.migration.identity.console.ConsoleClient.Permission;
-import io.camunda.security.auth.Authentication;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.AuthorizationServices;
 import io.camunda.service.AuthorizationServices.CreateAuthorizationRequest;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
@@ -43,7 +43,7 @@ public class ClientMigrationHandler extends MigrationHandler<Members> {
   public ClientMigrationHandler(
       final ConsoleClient consoleClient,
       final AuthorizationServices authorizationServices,
-      final Authentication servicesAuthentication) {
+      final CamundaAuthentication servicesAuthentication) {
     this.consoleClient = consoleClient;
     this.authorizationServices = authorizationServices.withAuthentication(servicesAuthentication);
   }

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/GroupMigrationHandler.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/GroupMigrationHandler.java
@@ -12,7 +12,7 @@ import io.camunda.migration.identity.console.ConsoleClient;
 import io.camunda.migration.identity.console.ConsoleClient.Member;
 import io.camunda.migration.identity.dto.Group;
 import io.camunda.migration.identity.midentity.ManagementIdentityClient;
-import io.camunda.security.auth.Authentication;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.GroupServices;
 import io.camunda.service.GroupServices.GroupDTO;
 import io.camunda.service.GroupServices.GroupMemberDTO;
@@ -35,7 +35,7 @@ public class GroupMigrationHandler extends MigrationHandler<Group> {
   private final AtomicInteger totalUserAssignmentAttempts = new AtomicInteger();
 
   public GroupMigrationHandler(
-      final Authentication authentication,
+      final CamundaAuthentication authentication,
       final ConsoleClient consoleClient,
       final ManagementIdentityClient managementIdentityClient,
       final GroupServices groupServices) {

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/StaticConsoleRoleAuthorizationMigrationHandler.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/StaticConsoleRoleAuthorizationMigrationHandler.java
@@ -11,7 +11,7 @@ import static io.camunda.migration.identity.config.saas.StaticEntities.ROLE_PERM
 
 import io.camunda.migration.api.MigrationException;
 import io.camunda.migration.identity.dto.NoopDTO;
-import io.camunda.security.auth.Authentication;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.AuthorizationServices;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -26,7 +26,7 @@ public class StaticConsoleRoleAuthorizationMigrationHandler extends MigrationHan
 
   public StaticConsoleRoleAuthorizationMigrationHandler(
       final AuthorizationServices authorizationServices,
-      final Authentication servicesAuthentication) {
+      final CamundaAuthentication servicesAuthentication) {
     this.authorizationServices = authorizationServices.withAuthentication(servicesAuthentication);
   }
 

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/StaticConsoleRoleMigrationHandler.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/StaticConsoleRoleMigrationHandler.java
@@ -12,7 +12,7 @@ import static io.camunda.migration.identity.config.saas.StaticEntities.ROLES;
 import io.camunda.migration.api.MigrationException;
 import io.camunda.migration.identity.console.ConsoleClient;
 import io.camunda.migration.identity.dto.NoopDTO;
-import io.camunda.security.auth.Authentication;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.RoleServices;
 import io.camunda.service.RoleServices.RoleMemberRequest;
 import io.camunda.zeebe.protocol.record.value.EntityType;
@@ -29,7 +29,7 @@ public class StaticConsoleRoleMigrationHandler extends MigrationHandler<NoopDTO>
 
   public StaticConsoleRoleMigrationHandler(
       final RoleServices roleServices,
-      final Authentication servicesAuthentication,
+      final CamundaAuthentication servicesAuthentication,
       final ConsoleClient consoleClient) {
     this.roleServices = roleServices.withAuthentication(servicesAuthentication);
     this.consoleClient = consoleClient;

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/TenantMappingRuleMigrationHandler.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/TenantMappingRuleMigrationHandler.java
@@ -13,7 +13,7 @@ import io.camunda.migration.identity.dto.TenantMappingRule;
 import io.camunda.migration.identity.midentity.ManagementIdentityClient;
 import io.camunda.migration.identity.midentity.ManagementIdentityTransformer;
 import io.camunda.search.entities.MappingEntity;
-import io.camunda.security.auth.Authentication;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.MappingServices;
 import io.camunda.service.MappingServices.MappingDTO;
 import io.camunda.service.TenantServices;
@@ -29,7 +29,7 @@ public class TenantMappingRuleMigrationHandler extends MigrationHandler<TenantMa
   private final MappingServices mappingServices;
 
   public TenantMappingRuleMigrationHandler(
-      final Authentication authentication,
+      final CamundaAuthentication authentication,
       final ManagementIdentityClient managementIdentityClient,
       final ManagementIdentityTransformer managementIdentityTransformer,
       final TenantServices tenantServices,

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/TenantMigrationHandler.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/TenantMigrationHandler.java
@@ -11,7 +11,7 @@ import io.camunda.migration.identity.dto.MigrationStatusUpdateRequest;
 import io.camunda.migration.identity.dto.Tenant;
 import io.camunda.migration.identity.midentity.ManagementIdentityClient;
 import io.camunda.migration.identity.midentity.ManagementIdentityTransformer;
-import io.camunda.security.auth.Authentication;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.TenantServices;
 import io.camunda.service.TenantServices.TenantDTO;
 import java.util.List;
@@ -23,7 +23,7 @@ public class TenantMigrationHandler extends MigrationHandler<Tenant> {
   private final TenantServices tenantServices;
 
   public TenantMigrationHandler(
-      final Authentication authentication,
+      final CamundaAuthentication authentication,
       final ManagementIdentityClient managementIdentityClient,
       final ManagementIdentityTransformer managementIdentityTransformer,
       final TenantServices tenantServices) {

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/AuthConfig.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/AuthConfig.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.migration.identity.config;
 
-import io.camunda.security.auth.Authentication;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.zeebe.auth.Authorization;
 import java.util.Map;
 import org.springframework.context.annotation.Bean;
@@ -17,8 +17,8 @@ import org.springframework.context.annotation.Configuration;
 public class AuthConfig {
 
   @Bean
-  public Authentication servicesAuthentication() {
-    return new Authentication.Builder()
+  public CamundaAuthentication servicesAuthentication() {
+    return new CamundaAuthentication.Builder()
         .claims(Map.of(Authorization.AUTHORIZED_ANONYMOUS_USER, true))
         .build();
   }

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/saas/SaaSMigrationHandlerConfig.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/saas/SaaSMigrationHandlerConfig.java
@@ -14,7 +14,7 @@ import io.camunda.migration.identity.StaticConsoleRoleAuthorizationMigrationHand
 import io.camunda.migration.identity.StaticConsoleRoleMigrationHandler;
 import io.camunda.migration.identity.console.ConsoleClient;
 import io.camunda.migration.identity.midentity.ManagementIdentityClient;
-import io.camunda.security.auth.Authentication;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.AuthorizationServices;
 import io.camunda.service.GroupServices;
 import io.camunda.service.RoleServices;
@@ -26,7 +26,7 @@ import org.springframework.context.annotation.Configuration;
 public class SaaSMigrationHandlerConfig {
   @Bean
   public GroupMigrationHandler groupMigrationHandler(
-      final Authentication authentication,
+      final CamundaAuthentication authentication,
       final ConsoleClient consoleClient,
       final ManagementIdentityClient managementIdentityClient,
       final GroupServices groupServices) {
@@ -36,7 +36,7 @@ public class SaaSMigrationHandlerConfig {
 
   @Bean
   public StaticConsoleRoleMigrationHandler roleMigrationHandler(
-      final Authentication authentication,
+      final CamundaAuthentication authentication,
       final RoleServices roleServices,
       final ConsoleClient consoleClient) {
     return new StaticConsoleRoleMigrationHandler(roleServices, authentication, consoleClient);
@@ -45,13 +45,14 @@ public class SaaSMigrationHandlerConfig {
   @Bean
   public StaticConsoleRoleAuthorizationMigrationHandler
       staticConsoleRoleAuthorizationMigrationHandler(
-          final AuthorizationServices authorizationService, final Authentication authentication) {
+          final AuthorizationServices authorizationService,
+          final CamundaAuthentication authentication) {
     return new StaticConsoleRoleAuthorizationMigrationHandler(authorizationService, authentication);
   }
 
   @Bean
   public AuthorizationMigrationHandler authorizationMigrationHandler(
-      final Authentication authentication,
+      final CamundaAuthentication authentication,
       final AuthorizationServices authorizationService,
       final ConsoleClient consoleClient,
       final ManagementIdentityClient managementIdentityClient) {
@@ -63,7 +64,7 @@ public class SaaSMigrationHandlerConfig {
   public ClientMigrationHandler clientMigrationHandler(
       final ConsoleClient consoleClient,
       final AuthorizationServices authorizationServices,
-      final Authentication servicesAuthentication) {
+      final CamundaAuthentication servicesAuthentication) {
     return new ClientMigrationHandler(consoleClient, authorizationServices, servicesAuthentication);
   }
 }

--- a/migration/identity-migration/src/test/java/io/camunda/migration/identity/AuthorizationMigrationHandlerTest.java
+++ b/migration/identity-migration/src/test/java/io/camunda/migration/identity/AuthorizationMigrationHandlerTest.java
@@ -18,7 +18,7 @@ import io.camunda.migration.identity.console.ConsoleClient.Member;
 import io.camunda.migration.identity.console.ConsoleClient.Role;
 import io.camunda.migration.identity.dto.Authorization;
 import io.camunda.migration.identity.midentity.ManagementIdentityClient;
-import io.camunda.security.auth.Authentication;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.AuthorizationServices;
 import io.camunda.service.AuthorizationServices.CreateAuthorizationRequest;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.AuthorizationRecord;
@@ -53,7 +53,10 @@ final class AuthorizationMigrationHandlerTest {
     this.consoleClient = consoleClient;
     migrationHandler =
         new AuthorizationMigrationHandler(
-            Authentication.none(), authorizationServices, consoleClient, managementIdentityClient);
+            CamundaAuthentication.none(),
+            authorizationServices,
+            consoleClient,
+            managementIdentityClient);
   }
 
   @Test

--- a/migration/identity-migration/src/test/java/io/camunda/migration/identity/ClientMigrationHandlerTest.java
+++ b/migration/identity-migration/src/test/java/io/camunda/migration/identity/ClientMigrationHandlerTest.java
@@ -18,7 +18,7 @@ import io.camunda.migration.identity.console.ConsoleClient;
 import io.camunda.migration.identity.console.ConsoleClient.Client;
 import io.camunda.migration.identity.console.ConsoleClient.Members;
 import io.camunda.migration.identity.console.ConsoleClient.Permission;
-import io.camunda.security.auth.Authentication;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.AuthorizationServices;
 import io.camunda.service.AuthorizationServices.CreateAuthorizationRequest;
 import io.camunda.zeebe.broker.client.api.BrokerRejectionException;
@@ -52,7 +52,8 @@ public class ClientMigrationHandlerTest {
     this.authorizationServices = authorizationServices;
     this.consoleClient = consoleClient;
     migrationHandler =
-        new ClientMigrationHandler(consoleClient, authorizationServices, Authentication.none());
+        new ClientMigrationHandler(
+            consoleClient, authorizationServices, CamundaAuthentication.none());
   }
 
   @Test

--- a/migration/identity-migration/src/test/java/io/camunda/migration/identity/GroupMigrationHandlerTest.java
+++ b/migration/identity-migration/src/test/java/io/camunda/migration/identity/GroupMigrationHandlerTest.java
@@ -23,7 +23,7 @@ import io.camunda.migration.identity.console.ConsoleClient.Member;
 import io.camunda.migration.identity.console.ConsoleClient.Members;
 import io.camunda.migration.identity.dto.Group;
 import io.camunda.migration.identity.midentity.ManagementIdentityClient;
-import io.camunda.security.auth.Authentication;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.GroupServices;
 import io.camunda.service.GroupServices.GroupDTO;
 import io.camunda.service.GroupServices.GroupMemberDTO;
@@ -60,7 +60,7 @@ public class GroupMigrationHandlerTest {
     this.groupService = groupService;
     migrationHandler =
         new GroupMigrationHandler(
-            Authentication.none(), consoleClient, managementIdentityClient, groupService);
+            CamundaAuthentication.none(), consoleClient, managementIdentityClient, groupService);
   }
 
   @Test

--- a/migration/identity-migration/src/test/java/io/camunda/migration/identity/StaticConsoleRoleAuthorizationMigrationHandlerTest.java
+++ b/migration/identity-migration/src/test/java/io/camunda/migration/identity/StaticConsoleRoleAuthorizationMigrationHandlerTest.java
@@ -11,7 +11,7 @@ import static io.camunda.migration.identity.config.saas.StaticEntities.ROLE_PERM
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
-import io.camunda.security.auth.Authentication;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.AuthorizationServices;
 import io.camunda.service.AuthorizationServices.CreateAuthorizationRequest;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.AuthorizationRecord;
@@ -35,7 +35,7 @@ public class StaticConsoleRoleAuthorizationMigrationHandlerTest {
     this.authorizationServices = authorizationServices;
     migrationHandler =
         new StaticConsoleRoleAuthorizationMigrationHandler(
-            authorizationServices, Authentication.none());
+            authorizationServices, CamundaAuthentication.none());
   }
 
   @Test

--- a/migration/identity-migration/src/test/java/io/camunda/migration/identity/StaticConsoleRoleMigrationHandlerTest.java
+++ b/migration/identity-migration/src/test/java/io/camunda/migration/identity/StaticConsoleRoleMigrationHandlerTest.java
@@ -18,7 +18,7 @@ import io.camunda.migration.identity.console.ConsoleClient;
 import io.camunda.migration.identity.console.ConsoleClient.Member;
 import io.camunda.migration.identity.console.ConsoleClient.Members;
 import io.camunda.migration.identity.console.ConsoleClient.Role;
-import io.camunda.security.auth.Authentication;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.RoleServices;
 import io.camunda.service.RoleServices.CreateRoleRequest;
 import io.camunda.service.RoleServices.RoleMemberRequest;
@@ -50,7 +50,8 @@ public class StaticConsoleRoleMigrationHandlerTest {
     this.roleServices = roleServices;
     this.consoleClient = consoleClient;
     migrationHandler =
-        new StaticConsoleRoleMigrationHandler(roleServices, Authentication.none(), consoleClient);
+        new StaticConsoleRoleMigrationHandler(
+            roleServices, CamundaAuthentication.none(), consoleClient);
   }
 
   @Test

--- a/migration/identity-migration/src/test/java/io/camunda/migration/identity/TenantMappingRuleMigrationHandlerTest.java
+++ b/migration/identity-migration/src/test/java/io/camunda/migration/identity/TenantMappingRuleMigrationHandlerTest.java
@@ -25,7 +25,7 @@ import io.camunda.migration.identity.dto.TenantMappingRule;
 import io.camunda.migration.identity.midentity.ManagementIdentityClient;
 import io.camunda.migration.identity.midentity.ManagementIdentityTransformer;
 import io.camunda.search.entities.TenantEntity;
-import io.camunda.security.auth.Authentication;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.MappingServices;
 import io.camunda.service.MappingServices.MappingDTO;
 import io.camunda.service.TenantServices;
@@ -63,7 +63,7 @@ final class TenantMappingRuleMigrationHandlerTest {
     this.mappingServices = mappingServices;
     migrationHandler =
         new TenantMappingRuleMigrationHandler(
-            Authentication.none(),
+            CamundaAuthentication.none(),
             managementIdentityClient,
             new ManagementIdentityTransformer(),
             tenantServices,

--- a/migration/identity-migration/src/test/java/io/camunda/migration/identity/TenantMigrationHandlerTest.java
+++ b/migration/identity-migration/src/test/java/io/camunda/migration/identity/TenantMigrationHandlerTest.java
@@ -21,7 +21,7 @@ import io.camunda.migration.identity.dto.MigrationStatusUpdateRequest;
 import io.camunda.migration.identity.dto.Tenant;
 import io.camunda.migration.identity.midentity.ManagementIdentityClient;
 import io.camunda.migration.identity.midentity.ManagementIdentityTransformer;
-import io.camunda.security.auth.Authentication;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.TenantServices;
 import io.camunda.zeebe.broker.client.api.BrokerRejectionException;
 import io.camunda.zeebe.broker.client.api.dto.BrokerRejection;
@@ -49,7 +49,7 @@ final class TenantMigrationHandlerTest {
     this.tenantServices = tenantServices;
     migrationHandler =
         new TenantMigrationHandler(
-            Authentication.none(),
+            CamundaAuthentication.none(),
             managementIdentityClient,
             new ManagementIdentityTransformer(),
             this.tenantServices);

--- a/operate/webapp/pom.xml
+++ b/operate/webapp/pom.xml
@@ -34,10 +34,6 @@
       <artifactId>camunda-search-domain</artifactId>
     </dependency>
     <dependency>
-      <groupId>io.camunda</groupId>
-      <artifactId>zeebe-gateway-rest</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.agrona</groupId>
       <artifactId>agrona</artifactId>
     </dependency>

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/security/permission/PermissionsService.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/security/permission/PermissionsService.java
@@ -11,6 +11,7 @@ import io.camunda.authentication.entity.CamundaPrincipal;
 import io.camunda.operate.webapp.security.tenant.TenantService;
 import io.camunda.search.entities.RoleEntity;
 import io.camunda.security.auth.Authorization;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.security.auth.SecurityContext;
 import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.security.impl.AuthorizationChecker;
@@ -258,12 +259,12 @@ public class PermissionsService {
     return new SecurityContext(getAuthentication(), authorization);
   }
 
-  private io.camunda.security.auth.Authentication getAuthentication() {
+  private CamundaAuthentication getAuthentication() {
     final var authenticatedUsername = getAuthenticatedUsername();
     final List<String> authenticatedRoleIds = getAuthenticatedUserRoleIds();
     final List<String> authenticatedTenantIds = getAuthenticatedUserTenantIds();
     final List<String> authenticatedGroupIds = getAuthenticatedUserGroupIds();
-    return new io.camunda.security.auth.Authentication.Builder()
+    return new CamundaAuthentication.Builder()
         .user(authenticatedUsername)
         .roleIds(authenticatedRoleIds)
         .tenants(authenticatedTenantIds)

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/zeebe/operation/adapter/ServicesBasedAdapter.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/zeebe/operation/adapter/ServicesBasedAdapter.java
@@ -12,7 +12,7 @@ import io.camunda.operate.exceptions.OperateRuntimeException;
 import io.camunda.operate.util.ConditionalOnOperateCompatibility;
 import io.camunda.operate.webapp.reader.FlowNodeInstanceReader;
 import io.camunda.operate.webapp.rest.dto.operation.ModifyProcessInstanceRequestDto.Modification;
-import io.camunda.security.auth.Authentication;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.ElementInstanceServices;
 import io.camunda.service.ElementInstanceServices.SetVariablesRequest;
 import io.camunda.service.IncidentServices;
@@ -256,13 +256,13 @@ public class ServicesBasedAdapter implements OperateServicesAdapter {
   }
 
   private <T> T executeCamundaServiceAnonymously(
-      final Function<Authentication, CompletableFuture<T>> method) {
+      final Function<CamundaAuthentication, CompletableFuture<T>> method) {
     return executeCamundaService(method, RequestMapper.getAnonymousAuthentication());
   }
 
   private <T> T executeCamundaService(
-      final Function<Authentication, CompletableFuture<T>> method,
-      final Authentication authentication) {
+      final Function<CamundaAuthentication, CompletableFuture<T>> method,
+      final CamundaAuthentication authentication) {
     return method.apply(authentication).join();
   }
 

--- a/operate/webapp/src/test/java/io/camunda/operate/webapp/security/permission/PermissionsServiceTest.java
+++ b/operate/webapp/src/test/java/io/camunda/operate/webapp/security/permission/PermissionsServiceTest.java
@@ -16,6 +16,7 @@ import io.camunda.authentication.entity.CamundaUser;
 import io.camunda.operate.webapp.security.permission.PermissionsService.ResourcesAllowed;
 import io.camunda.operate.webapp.security.tenant.TenantService;
 import io.camunda.search.entities.RoleEntity;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.security.configuration.AuthorizationsConfiguration;
 import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.security.impl.AuthorizationChecker;
@@ -91,7 +92,7 @@ public class PermissionsServiceTest {
   @Test
   public void testGetProcessDefinitionPermission() {
 
-    final io.camunda.security.auth.Authentication authentication =
+    final CamundaAuthentication authentication =
         createCamundaAuthentication(username, List.of(tenantId), List.of(roleId), List.of(groupId));
 
     when(mockAuthorizationChecker.collectPermissionTypes(
@@ -113,7 +114,7 @@ public class PermissionsServiceTest {
   @Test
   public void testGetDecisionDefinitionPermission() {
 
-    final io.camunda.security.auth.Authentication authentication =
+    final CamundaAuthentication authentication =
         createCamundaAuthentication(username, List.of(tenantId), List.of(roleId), List.of(groupId));
 
     when(mockAuthorizationChecker.collectPermissionTypes(
@@ -142,12 +143,12 @@ public class PermissionsServiceTest {
     assertThat(resourceIds.isEmpty()).isTrue();
   }
 
-  private io.camunda.security.auth.Authentication createCamundaAuthentication(
+  private CamundaAuthentication createCamundaAuthentication(
       final String username,
       final List<String> tenants,
       final List<String> roleIds,
       final List<String> groupIds) {
-    return new io.camunda.security.auth.Authentication.Builder()
+    return new CamundaAuthentication.Builder()
         .user(username)
         .tenants(tenants)
         .roleIds(roleIds)

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/SearchClientBasedQueryExecutorTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/SearchClientBasedQueryExecutorTest.java
@@ -29,7 +29,7 @@ import io.camunda.search.query.ProcessDefinitionQuery;
 import io.camunda.search.query.ProcessInstanceQuery;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.search.query.UserQuery;
-import io.camunda.security.auth.Authentication;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.security.auth.SecurityContext;
 import io.camunda.webapps.schema.descriptors.IndexDescriptors;
 import io.camunda.webapps.schema.descriptors.index.ProcessIndex;
@@ -140,7 +140,7 @@ class SearchClientBasedQueryExecutorTest {
             SecurityContext.of(
                 builder ->
                     builder.withAuthentication(
-                        Authentication.of(a -> a.user("foo").tenants(tenantIds)))));
+                        CamundaAuthentication.of(a -> a.user("foo").tenants(tenantIds)))));
 
     final var query =
         new ProcessDefinitionQuery.Builder()
@@ -185,7 +185,7 @@ class SearchClientBasedQueryExecutorTest {
             SecurityContext.of(
                 builder ->
                     builder.withAuthentication(
-                        Authentication.of(a -> a.user("foo").tenants(tenantIds)))));
+                        CamundaAuthentication.of(a -> a.user("foo").tenants(tenantIds)))));
 
     final var query =
         new UserQuery.Builder().filter(new UserFilter.Builder().usernames("x").build()).build();

--- a/security/security-core/pom.xml
+++ b/security/security-core/pom.xml
@@ -39,6 +39,10 @@
       <artifactId>zeebe-util</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-auth</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.jayway.jsonpath</groupId>
       <artifactId>json-path</artifactId>
     </dependency>

--- a/security/security-core/src/main/java/io/camunda/security/auth/CamundaAuthentication.java
+++ b/security/security-core/src/main/java/io/camunda/security/auth/CamundaAuthentication.java
@@ -11,6 +11,7 @@ import static java.util.Collections.unmodifiableList;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.camunda.zeebe.auth.Authorization;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -28,7 +29,11 @@ public record CamundaAuthentication(
     @JsonProperty("claims") Map<String, Object> claims) {
 
   public static CamundaAuthentication none() {
-    return new Builder().build();
+    return of(b -> b);
+  }
+
+  public static CamundaAuthentication anonymous() {
+    return of(b -> b.claims(Map.of(Authorization.AUTHORIZED_ANONYMOUS_USER, true)));
   }
 
   public static CamundaAuthentication of(final Function<Builder, Builder> builderFunction) {

--- a/security/security-core/src/main/java/io/camunda/security/auth/CamundaAuthentication.java
+++ b/security/security-core/src/main/java/io/camunda/security/auth/CamundaAuthentication.java
@@ -18,7 +18,7 @@ import java.util.Map;
 import java.util.function.Function;
 
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
-public record Authentication(
+public record CamundaAuthentication(
     @JsonProperty("authenticated_username") String authenticatedUsername,
     @JsonProperty("authenticated_client_id") String authenticatedClientId,
     @JsonProperty("authenticated_group_ids") List<String> authenticatedGroupIds,
@@ -27,11 +27,11 @@ public record Authentication(
     @JsonProperty("authenticated_mapping_ids") List<String> authenticatedMappingIds,
     @JsonProperty("claims") Map<String, Object> claims) {
 
-  public static Authentication none() {
+  public static CamundaAuthentication none() {
     return new Builder().build();
   }
 
-  public static Authentication of(final Function<Builder, Builder> builderFunction) {
+  public static CamundaAuthentication of(final Function<Builder, Builder> builderFunction) {
     return builderFunction.apply(new Builder()).build();
   }
 
@@ -104,8 +104,8 @@ public record Authentication(
       return this;
     }
 
-    public Authentication build() {
-      return new Authentication(
+    public CamundaAuthentication build() {
+      return new CamundaAuthentication(
           username,
           clientId,
           unmodifiableList(groupIds),

--- a/security/security-core/src/main/java/io/camunda/security/auth/CamundaAuthenticationConverter.java
+++ b/security/security-core/src/main/java/io/camunda/security/auth/CamundaAuthenticationConverter.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.security.auth;
+
+@FunctionalInterface
+public interface CamundaAuthenticationConverter<T> {
+
+  CamundaAuthentication convert(final T containerBasedAuthentication);
+}

--- a/security/security-core/src/main/java/io/camunda/security/auth/CamundaAuthenticationProvider.java
+++ b/security/security-core/src/main/java/io/camunda/security/auth/CamundaAuthenticationProvider.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.security.auth;
+
+public interface CamundaAuthenticationProvider {
+
+  CamundaAuthentication getCamundaAuthentication();
+
+  default CamundaAuthentication getAnonymousCamundaAuthentication() {
+    return CamundaAuthentication.anonymous();
+  }
+}

--- a/security/security-core/src/main/java/io/camunda/security/auth/SecurityContext.java
+++ b/security/security-core/src/main/java/io/camunda/security/auth/SecurityContext.java
@@ -21,7 +21,7 @@ import java.util.function.Function;
  */
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
 public record SecurityContext(
-    @JsonProperty("authentication") Authentication authentication,
+    @JsonProperty("authentication") CamundaAuthentication authentication,
     @JsonProperty("authorization") Authorization authorization) {
 
   public boolean requiresAuthorizationChecks() {
@@ -37,17 +37,18 @@ public record SecurityContext(
   }
 
   public static class Builder {
-    private Authentication authentication;
+    private CamundaAuthentication authentication;
     private Authorization authorization;
 
-    public Builder withAuthentication(final Authentication authentication) {
+    public Builder withAuthentication(final CamundaAuthentication authentication) {
       this.authentication = authentication;
       return this;
     }
 
     public Builder withAuthentication(
-        final Function<Authentication.Builder, Authentication.Builder> builderFunction) {
-      return withAuthentication(Authentication.of(builderFunction));
+        final Function<CamundaAuthentication.Builder, CamundaAuthentication.Builder>
+            builderFunction) {
+      return withAuthentication(CamundaAuthentication.of(builderFunction));
     }
 
     public Builder withAuthorization(final Authorization authorization) {

--- a/security/security-services/src/main/java/io/camunda/security/impl/AuthorizationChecker.java
+++ b/security/security-services/src/main/java/io/camunda/security/impl/AuthorizationChecker.java
@@ -12,7 +12,7 @@ import static io.camunda.security.auth.Authorization.WILDCARD;
 import io.camunda.search.clients.AuthorizationSearchClient;
 import io.camunda.search.entities.AuthorizationEntity;
 import io.camunda.search.query.AuthorizationQuery;
-import io.camunda.security.auth.Authentication;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.security.auth.SecurityContext;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
@@ -102,7 +102,7 @@ public class AuthorizationChecker {
   public Set<PermissionType> collectPermissionTypes(
       final String resourceId,
       final AuthorizationResourceType resourceType,
-      final Authentication authentication) {
+      final CamundaAuthentication authentication) {
     final var ownerIds = collectOwnerIds(authentication);
     final var authorizationEntities =
         authorizationSearchClient.findAllAuthorizations(
@@ -124,7 +124,7 @@ public class AuthorizationChecker {
         .collect(Collectors.toSet());
   }
 
-  private List<String> collectOwnerIds(final Authentication authentication) {
+  private List<String> collectOwnerIds(final CamundaAuthentication authentication) {
     final List<String> ownerIds = new ArrayList<>();
     if (authentication.authenticatedUsername() != null) {
       ownerIds.add(authentication.authenticatedUsername());

--- a/service/src/main/java/io/camunda/service/AdHocSubProcessActivityServices.java
+++ b/service/src/main/java/io/camunda/service/AdHocSubProcessActivityServices.java
@@ -14,7 +14,7 @@ import io.camunda.search.exception.CamundaSearchException;
 import io.camunda.search.exception.ErrorMessages;
 import io.camunda.search.query.AdHocSubProcessActivityQuery;
 import io.camunda.search.query.SearchQueryResult;
-import io.camunda.security.auth.Authentication;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.AdHocSubProcessActivityServices.AdHocSubProcessActivateActivitiesRequest.AdHocSubProcessActivateActivityReference;
 import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
@@ -39,13 +39,14 @@ public class AdHocSubProcessActivityServices extends ApiServices<AdHocSubProcess
       final BrokerClient brokerClient,
       final SecurityContextProvider securityContextProvider,
       final ProcessDefinitionServices processDefinitionServices,
-      final Authentication authentication) {
+      final CamundaAuthentication authentication) {
     super(brokerClient, securityContextProvider, authentication);
     this.processDefinitionServices = processDefinitionServices;
   }
 
   @Override
-  public AdHocSubProcessActivityServices withAuthentication(final Authentication authentication) {
+  public AdHocSubProcessActivityServices withAuthentication(
+      final CamundaAuthentication authentication) {
     return new AdHocSubProcessActivityServices(
         brokerClient,
         securityContextProvider,

--- a/service/src/main/java/io/camunda/service/ApiServices.java
+++ b/service/src/main/java/io/camunda/service/ApiServices.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.service;
 
-import io.camunda.security.auth.Authentication;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.exception.CamundaBrokerException;
 import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
@@ -25,21 +25,22 @@ public abstract class ApiServices<T extends ApiServices<T>> {
 
   protected final BrokerClient brokerClient;
   protected final SecurityContextProvider securityContextProvider;
-  protected final Authentication authentication;
+  protected final CamundaAuthentication authentication;
 
   protected ApiServices(
       final BrokerClient brokerClient,
       final SecurityContextProvider securityContextProvider,
-      final Authentication authentication) {
+      final CamundaAuthentication authentication) {
     this.brokerClient = brokerClient;
     this.securityContextProvider = securityContextProvider;
     this.authentication = authentication;
   }
 
-  public abstract T withAuthentication(final Authentication authentication);
+  public abstract T withAuthentication(final CamundaAuthentication authentication);
 
-  public T withAuthentication(final Function<Authentication.Builder, Authentication.Builder> fn) {
-    return withAuthentication(fn.apply(new Authentication.Builder()).build());
+  public T withAuthentication(
+      final Function<CamundaAuthentication.Builder, CamundaAuthentication.Builder> fn) {
+    return withAuthentication(fn.apply(new CamundaAuthentication.Builder()).build());
   }
 
   protected <R> CompletableFuture<R> sendBrokerRequest(final BrokerRequest<R> brokerRequest) {

--- a/service/src/main/java/io/camunda/service/AuthorizationServices.java
+++ b/service/src/main/java/io/camunda/service/AuthorizationServices.java
@@ -14,8 +14,8 @@ import io.camunda.search.exception.ErrorMessages;
 import io.camunda.search.query.AuthorizationQuery;
 import io.camunda.search.query.SearchQueryBuilders;
 import io.camunda.search.query.SearchQueryResult;
-import io.camunda.security.auth.Authentication;
 import io.camunda.security.auth.Authorization;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.service.search.core.SearchQueryService;
 import io.camunda.service.security.SecurityContextProvider;
@@ -45,7 +45,7 @@ public class AuthorizationServices
       final BrokerClient brokerClient,
       final SecurityContextProvider securityContextProvider,
       final AuthorizationSearchClient authorizationSearchClient,
-      final Authentication authentication,
+      final CamundaAuthentication authentication,
       final SecurityConfiguration securityConfiguration) {
     super(brokerClient, securityContextProvider, authentication);
     this.authorizationSearchClient = authorizationSearchClient;
@@ -53,7 +53,7 @@ public class AuthorizationServices
   }
 
   @Override
-  public AuthorizationServices withAuthentication(final Authentication authentication) {
+  public AuthorizationServices withAuthentication(final CamundaAuthentication authentication) {
     return new AuthorizationServices(
         brokerClient,
         securityContextProvider,

--- a/service/src/main/java/io/camunda/service/BatchOperationServices.java
+++ b/service/src/main/java/io/camunda/service/BatchOperationServices.java
@@ -16,8 +16,8 @@ import io.camunda.search.entities.BatchOperationEntity.BatchOperationItemEntity;
 import io.camunda.search.query.BatchOperationItemQuery;
 import io.camunda.search.query.BatchOperationQuery;
 import io.camunda.search.query.SearchQueryResult;
-import io.camunda.security.auth.Authentication;
 import io.camunda.security.auth.Authorization;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.search.core.SearchQueryService;
 import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
@@ -40,13 +40,13 @@ public final class BatchOperationServices
       final BrokerClient brokerClient,
       final SecurityContextProvider securityContextProvider,
       final BatchOperationSearchClient batchOperationSearchClient,
-      final Authentication authentication) {
+      final CamundaAuthentication authentication) {
     super(brokerClient, securityContextProvider, authentication);
     this.batchOperationSearchClient = batchOperationSearchClient;
   }
 
   @Override
-  public BatchOperationServices withAuthentication(final Authentication authentication) {
+  public BatchOperationServices withAuthentication(final CamundaAuthentication authentication) {
     return new BatchOperationServices(
         brokerClient, securityContextProvider, batchOperationSearchClient, authentication);
   }

--- a/service/src/main/java/io/camunda/service/ClockServices.java
+++ b/service/src/main/java/io/camunda/service/ClockServices.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.service;
 
-import io.camunda.security.auth.Authentication;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerClockPinRequest;
@@ -20,12 +20,12 @@ public final class ClockServices extends ApiServices<ClockServices> {
   public ClockServices(
       final BrokerClient brokerClient,
       final SecurityContextProvider securityContextProvider,
-      final Authentication authentication) {
+      final CamundaAuthentication authentication) {
     super(brokerClient, securityContextProvider, authentication);
   }
 
   @Override
-  public ClockServices withAuthentication(final Authentication authentication) {
+  public ClockServices withAuthentication(final CamundaAuthentication authentication) {
     return new ClockServices(brokerClient, securityContextProvider, authentication);
   }
 

--- a/service/src/main/java/io/camunda/service/DecisionDefinitionServices.java
+++ b/service/src/main/java/io/camunda/service/DecisionDefinitionServices.java
@@ -15,8 +15,8 @@ import io.camunda.search.clients.DecisionRequirementSearchClient;
 import io.camunda.search.entities.DecisionDefinitionEntity;
 import io.camunda.search.query.DecisionDefinitionQuery;
 import io.camunda.search.query.SearchQueryResult;
-import io.camunda.security.auth.Authentication;
 import io.camunda.security.auth.Authorization;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.exception.ForbiddenException;
 import io.camunda.service.search.core.SearchQueryService;
 import io.camunda.service.security.SecurityContextProvider;
@@ -41,14 +41,14 @@ public final class DecisionDefinitionServices
       final SecurityContextProvider securityContextProvider,
       final DecisionDefinitionSearchClient decisionDefinitionSearchClient,
       final DecisionRequirementSearchClient decisionRequirementSearchClient,
-      final Authentication authentication) {
+      final CamundaAuthentication authentication) {
     super(brokerClient, securityContextProvider, authentication);
     this.decisionDefinitionSearchClient = decisionDefinitionSearchClient;
     this.decisionRequirementSearchClient = decisionRequirementSearchClient;
   }
 
   @Override
-  public DecisionDefinitionServices withAuthentication(final Authentication authentication) {
+  public DecisionDefinitionServices withAuthentication(final CamundaAuthentication authentication) {
     return new DecisionDefinitionServices(
         brokerClient,
         securityContextProvider,

--- a/service/src/main/java/io/camunda/service/DecisionInstanceServices.java
+++ b/service/src/main/java/io/camunda/service/DecisionInstanceServices.java
@@ -15,8 +15,8 @@ import io.camunda.search.exception.CamundaSearchException;
 import io.camunda.search.query.DecisionInstanceQuery;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.search.result.DecisionInstanceQueryResultConfig.Builder;
-import io.camunda.security.auth.Authentication;
 import io.camunda.security.auth.Authorization;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.exception.ForbiddenException;
 import io.camunda.service.search.core.SearchQueryService;
 import io.camunda.service.security.SecurityContextProvider;
@@ -32,13 +32,13 @@ public final class DecisionInstanceServices
       final BrokerClient brokerClient,
       final SecurityContextProvider securityHandler,
       final DecisionInstanceSearchClient decisionInstanceSearchClient,
-      final Authentication authentication) {
+      final CamundaAuthentication authentication) {
     super(brokerClient, securityHandler, authentication);
     this.decisionInstanceSearchClient = decisionInstanceSearchClient;
   }
 
   @Override
-  public DecisionInstanceServices withAuthentication(final Authentication authentication) {
+  public DecisionInstanceServices withAuthentication(final CamundaAuthentication authentication) {
     return new DecisionInstanceServices(
         brokerClient, securityContextProvider, decisionInstanceSearchClient, authentication);
   }

--- a/service/src/main/java/io/camunda/service/DecisionRequirementsServices.java
+++ b/service/src/main/java/io/camunda/service/DecisionRequirementsServices.java
@@ -13,8 +13,8 @@ import io.camunda.search.clients.DecisionRequirementSearchClient;
 import io.camunda.search.entities.DecisionRequirementsEntity;
 import io.camunda.search.query.DecisionRequirementsQuery;
 import io.camunda.search.query.SearchQueryResult;
-import io.camunda.security.auth.Authentication;
 import io.camunda.security.auth.Authorization;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.exception.ForbiddenException;
 import io.camunda.service.search.core.SearchQueryService;
 import io.camunda.service.security.SecurityContextProvider;
@@ -32,13 +32,14 @@ public final class DecisionRequirementsServices
       final BrokerClient brokerClient,
       final SecurityContextProvider securityContextProvider,
       final DecisionRequirementSearchClient decisionRequirementSearchClient,
-      final Authentication authentication) {
+      final CamundaAuthentication authentication) {
     super(brokerClient, securityContextProvider, authentication);
     this.decisionRequirementSearchClient = decisionRequirementSearchClient;
   }
 
   @Override
-  public DecisionRequirementsServices withAuthentication(final Authentication authentication) {
+  public DecisionRequirementsServices withAuthentication(
+      final CamundaAuthentication authentication) {
     return new DecisionRequirementsServices(
         brokerClient, securityContextProvider, decisionRequirementSearchClient, authentication);
   }

--- a/service/src/main/java/io/camunda/service/DocumentServices.java
+++ b/service/src/main/java/io/camunda/service/DocumentServices.java
@@ -17,7 +17,7 @@ import io.camunda.document.api.DocumentReference;
 import io.camunda.document.api.DocumentStore;
 import io.camunda.document.api.DocumentStoreRecord;
 import io.camunda.document.store.SimpleDocumentStoreRegistry;
-import io.camunda.security.auth.Authentication;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.util.Either;
@@ -38,14 +38,14 @@ public class DocumentServices extends ApiServices<DocumentServices> {
   public DocumentServices(
       final BrokerClient brokerClient,
       final SecurityContextProvider securityContextProvider,
-      final Authentication authentication,
+      final CamundaAuthentication authentication,
       final SimpleDocumentStoreRegistry registry) {
     super(brokerClient, securityContextProvider, authentication);
     this.registry = registry;
   }
 
   @Override
-  public DocumentServices withAuthentication(final Authentication authentication) {
+  public DocumentServices withAuthentication(final CamundaAuthentication authentication) {
     return new DocumentServices(brokerClient, securityContextProvider, authentication, registry);
   }
 

--- a/service/src/main/java/io/camunda/service/ElementInstanceServices.java
+++ b/service/src/main/java/io/camunda/service/ElementInstanceServices.java
@@ -13,8 +13,8 @@ import io.camunda.search.clients.FlowNodeInstanceSearchClient;
 import io.camunda.search.entities.FlowNodeInstanceEntity;
 import io.camunda.search.query.FlowNodeInstanceQuery;
 import io.camunda.search.query.SearchQueryResult;
-import io.camunda.security.auth.Authentication;
 import io.camunda.security.auth.Authorization;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.exception.ForbiddenException;
 import io.camunda.service.search.core.SearchQueryService;
 import io.camunda.service.security.SecurityContextProvider;
@@ -36,13 +36,13 @@ public final class ElementInstanceServices
       final BrokerClient brokerClient,
       final SecurityContextProvider securityContextProvider,
       final FlowNodeInstanceSearchClient flowNodeInstanceSearchClient,
-      final Authentication authentication) {
+      final CamundaAuthentication authentication) {
     super(brokerClient, securityContextProvider, authentication);
     this.flowNodeInstanceSearchClient = flowNodeInstanceSearchClient;
   }
 
   @Override
-  public ElementInstanceServices withAuthentication(final Authentication authentication) {
+  public ElementInstanceServices withAuthentication(final CamundaAuthentication authentication) {
     return new ElementInstanceServices(
         brokerClient, securityContextProvider, flowNodeInstanceSearchClient, authentication);
   }

--- a/service/src/main/java/io/camunda/service/FormServices.java
+++ b/service/src/main/java/io/camunda/service/FormServices.java
@@ -14,7 +14,7 @@ import io.camunda.search.exception.ErrorMessages;
 import io.camunda.search.query.FormQuery;
 import io.camunda.search.query.SearchQueryBuilders;
 import io.camunda.search.query.SearchQueryResult;
-import io.camunda.security.auth.Authentication;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.search.core.SearchQueryService;
 import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
@@ -28,13 +28,13 @@ public final class FormServices extends SearchQueryService<FormServices, FormQue
       final BrokerClient brokerClient,
       final SecurityContextProvider securityContextProvider,
       final FormSearchClient formSearchClient,
-      final Authentication authentication) {
+      final CamundaAuthentication authentication) {
     super(brokerClient, securityContextProvider, authentication);
     this.formSearchClient = formSearchClient;
   }
 
   @Override
-  public FormServices withAuthentication(final Authentication authentication) {
+  public FormServices withAuthentication(final CamundaAuthentication authentication) {
     return new FormServices(
         brokerClient, securityContextProvider, formSearchClient, authentication);
   }

--- a/service/src/main/java/io/camunda/service/GroupServices.java
+++ b/service/src/main/java/io/camunda/service/GroupServices.java
@@ -15,8 +15,8 @@ import io.camunda.search.exception.ErrorMessages;
 import io.camunda.search.query.GroupQuery;
 import io.camunda.search.query.SearchQueryBuilders;
 import io.camunda.search.query.SearchQueryResult;
-import io.camunda.security.auth.Authentication;
 import io.camunda.security.auth.Authorization;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.search.core.SearchQueryService;
 import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
@@ -40,7 +40,7 @@ public class GroupServices extends SearchQueryService<GroupServices, GroupQuery,
       final BrokerClient brokerClient,
       final SecurityContextProvider securityContextProvider,
       final GroupSearchClient groupSearchClient,
-      final Authentication authentication) {
+      final CamundaAuthentication authentication) {
     super(brokerClient, securityContextProvider, authentication);
     this.groupSearchClient = groupSearchClient;
   }
@@ -72,7 +72,7 @@ public class GroupServices extends SearchQueryService<GroupServices, GroupQuery,
   }
 
   @Override
-  public GroupServices withAuthentication(final Authentication authentication) {
+  public GroupServices withAuthentication(final CamundaAuthentication authentication) {
     return new GroupServices(
         brokerClient, securityContextProvider, groupSearchClient, authentication);
   }

--- a/service/src/main/java/io/camunda/service/IncidentServices.java
+++ b/service/src/main/java/io/camunda/service/IncidentServices.java
@@ -13,8 +13,8 @@ import io.camunda.search.clients.IncidentSearchClient;
 import io.camunda.search.entities.IncidentEntity;
 import io.camunda.search.query.IncidentQuery;
 import io.camunda.search.query.SearchQueryResult;
-import io.camunda.security.auth.Authentication;
 import io.camunda.security.auth.Authorization;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.exception.ForbiddenException;
 import io.camunda.service.search.core.SearchQueryService;
 import io.camunda.service.security.SecurityContextProvider;
@@ -34,7 +34,7 @@ public class IncidentServices
       final BrokerClient brokerClient,
       final SecurityContextProvider securityContextProvider,
       final IncidentSearchClient incidentSearchClient,
-      final Authentication authentication) {
+      final CamundaAuthentication authentication) {
     super(brokerClient, securityContextProvider, authentication);
     this.incidentSearchClient = incidentSearchClient;
   }
@@ -54,7 +54,7 @@ public class IncidentServices
   }
 
   @Override
-  public IncidentServices withAuthentication(final Authentication authentication) {
+  public IncidentServices withAuthentication(final CamundaAuthentication authentication) {
     return new IncidentServices(
         brokerClient, securityContextProvider, incidentSearchClient, authentication);
   }

--- a/service/src/main/java/io/camunda/service/JobServices.java
+++ b/service/src/main/java/io/camunda/service/JobServices.java
@@ -11,8 +11,8 @@ import io.camunda.search.clients.JobSearchClient;
 import io.camunda.search.entities.JobEntity;
 import io.camunda.search.query.JobQuery;
 import io.camunda.search.query.SearchQueryResult;
-import io.camunda.security.auth.Authentication;
 import io.camunda.security.auth.Authorization;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.search.core.SearchQueryService;
 import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
@@ -40,14 +40,14 @@ public final class JobServices<T> extends SearchQueryService<JobServices<T>, Job
       final SecurityContextProvider securityContextProvider,
       final ActivateJobsHandler<T> activateJobsHandler,
       final JobSearchClient jobSearchClient,
-      final Authentication authentication) {
+      final CamundaAuthentication authentication) {
     super(brokerClient, securityContextProvider, authentication);
     this.activateJobsHandler = activateJobsHandler;
     this.jobSearchClient = jobSearchClient;
   }
 
   @Override
-  public JobServices<T> withAuthentication(final Authentication authentication) {
+  public JobServices<T> withAuthentication(final CamundaAuthentication authentication) {
     return new JobServices<>(
         brokerClient,
         securityContextProvider,

--- a/service/src/main/java/io/camunda/service/MappingServices.java
+++ b/service/src/main/java/io/camunda/service/MappingServices.java
@@ -14,8 +14,8 @@ import io.camunda.search.exception.ErrorMessages;
 import io.camunda.search.query.MappingQuery;
 import io.camunda.search.query.SearchQueryBuilders;
 import io.camunda.search.query.SearchQueryResult;
-import io.camunda.security.auth.Authentication;
 import io.camunda.security.auth.Authorization;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.security.auth.MappingRuleMatcher;
 import io.camunda.service.search.core.SearchQueryService;
 import io.camunda.service.security.SecurityContextProvider;
@@ -39,7 +39,7 @@ public class MappingServices
       final BrokerClient brokerClient,
       final SecurityContextProvider securityContextProvider,
       final MappingSearchClient mappingSearchClient,
-      final Authentication authentication) {
+      final CamundaAuthentication authentication) {
     super(brokerClient, securityContextProvider, authentication);
     this.mappingSearchClient = mappingSearchClient;
   }
@@ -62,7 +62,7 @@ public class MappingServices
   }
 
   @Override
-  public MappingServices withAuthentication(final Authentication authentication) {
+  public MappingServices withAuthentication(final CamundaAuthentication authentication) {
     return new MappingServices(
         brokerClient, securityContextProvider, mappingSearchClient, authentication);
   }

--- a/service/src/main/java/io/camunda/service/MessageServices.java
+++ b/service/src/main/java/io/camunda/service/MessageServices.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.service;
 
-import io.camunda.security.auth.Authentication;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.broker.client.api.dto.BrokerResponse;
@@ -23,12 +23,12 @@ public final class MessageServices extends ApiServices<MessageServices> {
   public MessageServices(
       final BrokerClient brokerClient,
       final SecurityContextProvider securityContextProvider,
-      final Authentication authentication) {
+      final CamundaAuthentication authentication) {
     super(brokerClient, securityContextProvider, authentication);
   }
 
   @Override
-  public MessageServices withAuthentication(final Authentication authentication) {
+  public MessageServices withAuthentication(final CamundaAuthentication authentication) {
     return new MessageServices(brokerClient, securityContextProvider, authentication);
   }
 

--- a/service/src/main/java/io/camunda/service/ProcessDefinitionServices.java
+++ b/service/src/main/java/io/camunda/service/ProcessDefinitionServices.java
@@ -15,8 +15,8 @@ import io.camunda.search.entities.ProcessFlowNodeStatisticsEntity;
 import io.camunda.search.filter.ProcessDefinitionStatisticsFilter;
 import io.camunda.search.query.ProcessDefinitionQuery;
 import io.camunda.search.query.SearchQueryResult;
-import io.camunda.security.auth.Authentication;
 import io.camunda.security.auth.Authorization;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.exception.ForbiddenException;
 import io.camunda.service.search.core.SearchQueryService;
 import io.camunda.service.security.SecurityContextProvider;
@@ -34,7 +34,7 @@ public class ProcessDefinitionServices
       final BrokerClient brokerClient,
       final SecurityContextProvider securityContextProvider,
       final ProcessDefinitionSearchClient processDefinitionSearchClient,
-      final Authentication authentication) {
+      final CamundaAuthentication authentication) {
     super(brokerClient, securityContextProvider, authentication);
     this.processDefinitionSearchClient = processDefinitionSearchClient;
   }
@@ -60,7 +60,7 @@ public class ProcessDefinitionServices
   }
 
   @Override
-  public ProcessDefinitionServices withAuthentication(final Authentication authentication) {
+  public ProcessDefinitionServices withAuthentication(final CamundaAuthentication authentication) {
     return new ProcessDefinitionServices(
         brokerClient, securityContextProvider, processDefinitionSearchClient, authentication);
   }

--- a/service/src/main/java/io/camunda/service/ProcessInstanceServices.java
+++ b/service/src/main/java/io/camunda/service/ProcessInstanceServices.java
@@ -23,8 +23,8 @@ import io.camunda.search.query.IncidentQuery;
 import io.camunda.search.query.ProcessInstanceQuery;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.search.query.SequenceFlowQuery;
-import io.camunda.security.auth.Authentication;
 import io.camunda.security.auth.Authorization;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.exception.ForbiddenException;
 import io.camunda.service.search.core.SearchQueryService;
 import io.camunda.service.security.SecurityContextProvider;
@@ -72,7 +72,7 @@ public final class ProcessInstanceServices
       final ProcessInstanceSearchClient processInstanceSearchClient,
       final SequenceFlowSearchClient sequenceFlowSearchClient,
       final IncidentSearchClient incidentSearchClient,
-      final Authentication authentication) {
+      final CamundaAuthentication authentication) {
     super(brokerClient, securityContextProvider, authentication);
     this.processInstanceSearchClient = processInstanceSearchClient;
     this.sequenceFlowSearchClient = sequenceFlowSearchClient;
@@ -80,7 +80,7 @@ public final class ProcessInstanceServices
   }
 
   @Override
-  public ProcessInstanceServices withAuthentication(final Authentication authentication) {
+  public ProcessInstanceServices withAuthentication(final CamundaAuthentication authentication) {
     return new ProcessInstanceServices(
         brokerClient,
         securityContextProvider,

--- a/service/src/main/java/io/camunda/service/ResourceServices.java
+++ b/service/src/main/java/io/camunda/service/ResourceServices.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.service;
 
-import io.camunda.security.auth.Authentication;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerDeleteResourceRequest;
@@ -24,12 +24,12 @@ public final class ResourceServices extends ApiServices<ResourceServices> {
   public ResourceServices(
       final BrokerClient brokerClient,
       final SecurityContextProvider securityContextProvider,
-      final Authentication authentication) {
+      final CamundaAuthentication authentication) {
     super(brokerClient, securityContextProvider, authentication);
   }
 
   @Override
-  public ResourceServices withAuthentication(final Authentication authentication) {
+  public ResourceServices withAuthentication(final CamundaAuthentication authentication) {
     return new ResourceServices(brokerClient, securityContextProvider, authentication);
   }
 

--- a/service/src/main/java/io/camunda/service/RoleServices.java
+++ b/service/src/main/java/io/camunda/service/RoleServices.java
@@ -15,8 +15,8 @@ import io.camunda.search.exception.ErrorMessages;
 import io.camunda.search.query.RoleQuery;
 import io.camunda.search.query.SearchQueryBuilders;
 import io.camunda.search.query.SearchQueryResult;
-import io.camunda.security.auth.Authentication;
 import io.camunda.security.auth.Authorization;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.search.core.SearchQueryService;
 import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
@@ -42,7 +42,7 @@ public class RoleServices extends SearchQueryService<RoleServices, RoleQuery, Ro
       final BrokerClient brokerClient,
       final SecurityContextProvider securityContextProvider,
       final RoleSearchClient roleSearchClient,
-      final Authentication authentication) {
+      final CamundaAuthentication authentication) {
     super(brokerClient, securityContextProvider, authentication);
     this.roleSearchClient = roleSearchClient;
   }
@@ -115,7 +115,7 @@ public class RoleServices extends SearchQueryService<RoleServices, RoleQuery, Ro
   }
 
   @Override
-  public RoleServices withAuthentication(final Authentication authentication) {
+  public RoleServices withAuthentication(final CamundaAuthentication authentication) {
     return new RoleServices(
         brokerClient, securityContextProvider, roleSearchClient, authentication);
   }

--- a/service/src/main/java/io/camunda/service/SignalServices.java
+++ b/service/src/main/java/io/camunda/service/SignalServices.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.service;
 
-import io.camunda.security.auth.Authentication;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.broker.client.api.dto.BrokerResponse;
@@ -21,12 +21,12 @@ public class SignalServices extends ApiServices<SignalServices> {
   public SignalServices(
       final BrokerClient brokerClient,
       final SecurityContextProvider securityContextProvider,
-      final Authentication authentication) {
+      final CamundaAuthentication authentication) {
     super(brokerClient, securityContextProvider, authentication);
   }
 
   @Override
-  public SignalServices withAuthentication(final Authentication authentication) {
+  public SignalServices withAuthentication(final CamundaAuthentication authentication) {
     return new SignalServices(brokerClient, securityContextProvider, authentication);
   }
 

--- a/service/src/main/java/io/camunda/service/TenantServices.java
+++ b/service/src/main/java/io/camunda/service/TenantServices.java
@@ -14,8 +14,8 @@ import io.camunda.search.exception.CamundaSearchException;
 import io.camunda.search.exception.ErrorMessages;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.search.query.TenantQuery;
-import io.camunda.security.auth.Authentication;
 import io.camunda.security.auth.Authorization;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.exception.ForbiddenException;
 import io.camunda.service.search.core.SearchQueryService;
 import io.camunda.service.security.SecurityContextProvider;
@@ -41,7 +41,7 @@ public class TenantServices extends SearchQueryService<TenantServices, TenantQue
       final BrokerClient brokerClient,
       final SecurityContextProvider securityContextProvider,
       final TenantSearchClient tenantSearchClient,
-      final Authentication authentication) {
+      final CamundaAuthentication authentication) {
     super(brokerClient, securityContextProvider, authentication);
     this.tenantSearchClient = tenantSearchClient;
   }
@@ -72,7 +72,7 @@ public class TenantServices extends SearchQueryService<TenantServices, TenantQue
   }
 
   @Override
-  public TenantServices withAuthentication(final Authentication authentication) {
+  public TenantServices withAuthentication(final CamundaAuthentication authentication) {
     return new TenantServices(
         brokerClient, securityContextProvider, tenantSearchClient, authentication);
   }

--- a/service/src/main/java/io/camunda/service/UsageMetricsServices.java
+++ b/service/src/main/java/io/camunda/service/UsageMetricsServices.java
@@ -10,7 +10,7 @@ package io.camunda.service;
 import io.camunda.search.clients.UsageMetricsSearchClient;
 import io.camunda.search.entities.UsageMetricsCount;
 import io.camunda.search.query.UsageMetricsQuery;
-import io.camunda.security.auth.Authentication;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 
@@ -22,7 +22,7 @@ public final class UsageMetricsServices extends ApiServices<UsageMetricsServices
       final BrokerClient brokerClient,
       final SecurityContextProvider securityContextProvider,
       final UsageMetricsSearchClient usageMetricsSearchClient,
-      final Authentication authentication) {
+      final CamundaAuthentication authentication) {
     super(brokerClient, securityContextProvider, authentication);
     this.usageMetricsSearchClient = usageMetricsSearchClient;
   }
@@ -54,7 +54,7 @@ public final class UsageMetricsServices extends ApiServices<UsageMetricsServices
   }
 
   @Override
-  public UsageMetricsServices withAuthentication(final Authentication authentication) {
+  public UsageMetricsServices withAuthentication(final CamundaAuthentication authentication) {
     return new UsageMetricsServices(
         brokerClient, securityContextProvider, usageMetricsSearchClient, authentication);
   }

--- a/service/src/main/java/io/camunda/service/UserServices.java
+++ b/service/src/main/java/io/camunda/service/UserServices.java
@@ -14,8 +14,8 @@ import io.camunda.search.exception.ErrorMessages;
 import io.camunda.search.query.SearchQueryBuilders;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.search.query.UserQuery;
-import io.camunda.security.auth.Authentication;
 import io.camunda.security.auth.Authorization;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.search.core.SearchQueryService;
 import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
@@ -38,7 +38,7 @@ public class UserServices extends SearchQueryService<UserServices, UserQuery, Us
       final BrokerClient brokerClient,
       final SecurityContextProvider securityContextProvider,
       final UserSearchClient userSearchClient,
-      final Authentication authentication,
+      final CamundaAuthentication authentication,
       final PasswordEncoder passwordEncoder) {
     super(brokerClient, securityContextProvider, authentication);
     this.userSearchClient = userSearchClient;
@@ -55,7 +55,7 @@ public class UserServices extends SearchQueryService<UserServices, UserQuery, Us
   }
 
   @Override
-  public UserServices withAuthentication(final Authentication authentication) {
+  public UserServices withAuthentication(final CamundaAuthentication authentication) {
     return new UserServices(
         brokerClient, securityContextProvider, userSearchClient, authentication, passwordEncoder);
   }

--- a/service/src/main/java/io/camunda/service/UserTaskServices.java
+++ b/service/src/main/java/io/camunda/service/UserTaskServices.java
@@ -23,8 +23,8 @@ import io.camunda.search.query.SearchQueryResult;
 import io.camunda.search.query.UserTaskQuery;
 import io.camunda.search.query.UserTaskQuery.Builder;
 import io.camunda.search.query.VariableQuery;
-import io.camunda.security.auth.Authentication;
 import io.camunda.security.auth.Authorization;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.exception.ForbiddenException;
 import io.camunda.service.search.core.SearchQueryService;
 import io.camunda.service.security.SecurityContextProvider;
@@ -58,7 +58,7 @@ public final class UserTaskServices
       final FormSearchClient formSearchClient,
       final FlowNodeInstanceSearchClient flowNodeInstanceSearchClient,
       final VariableSearchClient variableSearchClient,
-      final Authentication authentication) {
+      final CamundaAuthentication authentication) {
     super(brokerClient, securityContextProvider, authentication);
     this.userTaskSearchClient = userTaskSearchClient;
     this.formSearchClient = formSearchClient;
@@ -67,7 +67,7 @@ public final class UserTaskServices
   }
 
   @Override
-  public UserTaskServices withAuthentication(final Authentication authentication) {
+  public UserTaskServices withAuthentication(final CamundaAuthentication authentication) {
     return new UserTaskServices(
         brokerClient,
         securityContextProvider,

--- a/service/src/main/java/io/camunda/service/VariableServices.java
+++ b/service/src/main/java/io/camunda/service/VariableServices.java
@@ -14,8 +14,8 @@ import io.camunda.search.entities.VariableEntity;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.search.query.VariableQuery;
 import io.camunda.search.query.VariableQuery.Builder;
-import io.camunda.security.auth.Authentication;
 import io.camunda.security.auth.Authorization;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.exception.ForbiddenException;
 import io.camunda.service.search.core.SearchQueryService;
 import io.camunda.service.security.SecurityContextProvider;
@@ -32,13 +32,13 @@ public final class VariableServices
       final BrokerClient brokerClient,
       final SecurityContextProvider securityContextProvider,
       final VariableSearchClient variableSearchClient,
-      final Authentication authentication) {
+      final CamundaAuthentication authentication) {
     super(brokerClient, securityContextProvider, authentication);
     this.variableSearchClient = variableSearchClient;
   }
 
   @Override
-  public VariableServices withAuthentication(final Authentication authentication) {
+  public VariableServices withAuthentication(final CamundaAuthentication authentication) {
     return new VariableServices(
         brokerClient, securityContextProvider, variableSearchClient, authentication);
   }

--- a/service/src/main/java/io/camunda/service/search/core/SearchQueryService.java
+++ b/service/src/main/java/io/camunda/service/search/core/SearchQueryService.java
@@ -11,7 +11,7 @@ import io.camunda.search.exception.CamundaSearchException;
 import io.camunda.search.exception.ErrorMessages;
 import io.camunda.search.query.SearchQueryBase;
 import io.camunda.search.query.SearchQueryResult;
-import io.camunda.security.auth.Authentication;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.ApiServices;
 import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
@@ -22,7 +22,7 @@ public abstract class SearchQueryService<T extends ApiServices<T>, Q extends Sea
   protected SearchQueryService(
       final BrokerClient brokerClient,
       final SecurityContextProvider securityContextProvider,
-      final Authentication authentication) {
+      final CamundaAuthentication authentication) {
     super(brokerClient, securityContextProvider, authentication);
   }
 

--- a/service/src/main/java/io/camunda/service/security/SecurityContextProvider.java
+++ b/service/src/main/java/io/camunda/service/security/SecurityContextProvider.java
@@ -7,8 +7,8 @@
  */
 package io.camunda.service.security;
 
-import io.camunda.security.auth.Authentication;
 import io.camunda.security.auth.Authorization;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.security.auth.SecurityContext;
 import io.camunda.security.auth.SecurityContext.Builder;
 import io.camunda.security.configuration.SecurityConfiguration;
@@ -27,7 +27,7 @@ public class SecurityContextProvider {
   }
 
   public SecurityContext provideSecurityContext(
-      final Authentication authentication, final Authorization authorization) {
+      final CamundaAuthentication authentication, final Authorization authorization) {
     final SecurityContext.Builder securityContextbuilder =
         new Builder().withAuthentication(authentication);
     if (securityConfiguration.getAuthorizations().isEnabled()) {
@@ -36,13 +36,13 @@ public class SecurityContextProvider {
     return securityContextbuilder.build();
   }
 
-  public SecurityContext provideSecurityContext(final Authentication authentication) {
+  public SecurityContext provideSecurityContext(final CamundaAuthentication authentication) {
     return provideSecurityContext(authentication, null);
   }
 
   public boolean isAuthorized(
       final String resourceKey,
-      final Authentication authentication,
+      final CamundaAuthentication authentication,
       final Authorization authorization) {
     final var securityContext = provideSecurityContext(authentication, authorization);
     if (securityContext.requiresAuthorizationChecks()) {

--- a/service/src/test/java/io/camunda/service/DecisionDefinitionServiceTest.java
+++ b/service/src/test/java/io/camunda/service/DecisionDefinitionServiceTest.java
@@ -24,8 +24,8 @@ import io.camunda.search.query.DecisionDefinitionQuery;
 import io.camunda.search.query.DecisionRequirementsQuery;
 import io.camunda.search.query.SearchQueryBuilders;
 import io.camunda.search.query.SearchQueryResult;
-import io.camunda.security.auth.Authentication;
 import io.camunda.security.auth.Authorization;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.exception.ForbiddenException;
 import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
@@ -40,7 +40,7 @@ public final class DecisionDefinitionServiceTest {
   private DecisionDefinitionSearchClient client;
   private DecisionRequirementSearchClient decisionRequirementSearchClient;
   private SecurityContextProvider securityContextProvider;
-  private Authentication authentication;
+  private CamundaAuthentication authentication;
 
   @BeforeEach
   public void before() {

--- a/service/src/test/java/io/camunda/service/DecisionInstanceServiceTest.java
+++ b/service/src/test/java/io/camunda/service/DecisionInstanceServiceTest.java
@@ -19,8 +19,8 @@ import io.camunda.search.entities.DecisionInstanceEntity;
 import io.camunda.search.query.DecisionInstanceQuery;
 import io.camunda.search.query.SearchQueryBuilders;
 import io.camunda.search.query.SearchQueryResult;
-import io.camunda.security.auth.Authentication;
 import io.camunda.security.auth.Authorization;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.exception.ForbiddenException;
 import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
@@ -34,14 +34,14 @@ class DecisionInstanceServiceTest {
   private DecisionInstanceServices services;
   private DecisionInstanceSearchClient client;
   private SecurityContextProvider securityContextProvider;
-  private Authentication authentication;
+  private CamundaAuthentication authentication;
 
   @BeforeEach
   public void before() {
     client = mock(DecisionInstanceSearchClient.class);
     when(client.withSecurityContext(any())).thenReturn(client);
     securityContextProvider = mock(SecurityContextProvider.class);
-    authentication = mock(Authentication.class);
+    authentication = mock(CamundaAuthentication.class);
     services =
         new DecisionInstanceServices(
             mock(BrokerClient.class), securityContextProvider, client, authentication);

--- a/service/src/test/java/io/camunda/service/DecisionRequirementsServiceTest.java
+++ b/service/src/test/java/io/camunda/service/DecisionRequirementsServiceTest.java
@@ -18,8 +18,8 @@ import io.camunda.search.entities.DecisionRequirementsEntity;
 import io.camunda.search.query.DecisionRequirementsQuery;
 import io.camunda.search.query.SearchQueryBuilders;
 import io.camunda.search.query.SearchQueryResult;
-import io.camunda.security.auth.Authentication;
 import io.camunda.security.auth.Authorization;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.exception.ForbiddenException;
 import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
@@ -32,7 +32,7 @@ public final class DecisionRequirementsServiceTest {
   private DecisionRequirementsServices services;
   private DecisionRequirementSearchClient client;
   private SecurityContextProvider securityContextProvider;
-  private Authentication authentication;
+  private CamundaAuthentication authentication;
 
   @BeforeEach
   public void before() {

--- a/service/src/test/java/io/camunda/service/DocumentServicesTest.java
+++ b/service/src/test/java/io/camunda/service/DocumentServicesTest.java
@@ -19,7 +19,7 @@ import io.camunda.document.api.DocumentReference;
 import io.camunda.document.api.DocumentStore;
 import io.camunda.document.api.DocumentStoreRecord;
 import io.camunda.document.store.SimpleDocumentStoreRegistry;
-import io.camunda.security.auth.Authentication;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.DocumentServices.DocumentCreateRequest;
 import io.camunda.service.DocumentServices.DocumentReferenceResponse;
 import io.camunda.service.security.SecurityContextProvider;
@@ -44,7 +44,7 @@ public class DocumentServicesTest {
         new DocumentServices(
             mock(BrokerClient.class),
             mock(SecurityContextProvider.class),
-            mock(Authentication.class),
+            mock(CamundaAuthentication.class),
             registry);
   }
 

--- a/service/src/test/java/io/camunda/service/ElementInstanceServiceTest.java
+++ b/service/src/test/java/io/camunda/service/ElementInstanceServiceTest.java
@@ -17,8 +17,8 @@ import io.camunda.search.clients.FlowNodeInstanceSearchClient;
 import io.camunda.search.entities.FlowNodeInstanceEntity;
 import io.camunda.search.query.SearchQueryBuilders;
 import io.camunda.search.query.SearchQueryResult;
-import io.camunda.security.auth.Authentication;
 import io.camunda.security.auth.Authorization;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.exception.ForbiddenException;
 import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
@@ -32,14 +32,14 @@ public final class ElementInstanceServiceTest {
   private ElementInstanceServices services;
   private FlowNodeInstanceSearchClient client;
   private SecurityContextProvider securityContextProvider;
-  private Authentication authentication;
+  private CamundaAuthentication authentication;
 
   @BeforeEach
   public void before() {
     client = mock(FlowNodeInstanceSearchClient.class);
     when(client.withSecurityContext(any())).thenReturn(client);
     securityContextProvider = mock(SecurityContextProvider.class);
-    authentication = mock(Authentication.class);
+    authentication = mock(CamundaAuthentication.class);
     services =
         new ElementInstanceServices(
             mock(BrokerClient.class), securityContextProvider, client, authentication);

--- a/service/src/test/java/io/camunda/service/GroupServiceTest.java
+++ b/service/src/test/java/io/camunda/service/GroupServiceTest.java
@@ -18,7 +18,7 @@ import io.camunda.search.entities.GroupEntity;
 import io.camunda.search.filter.GroupFilter;
 import io.camunda.search.query.SearchQueryBuilders;
 import io.camunda.search.query.SearchQueryResult;
-import io.camunda.security.auth.Authentication;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.GroupServices.GroupDTO;
 import io.camunda.service.GroupServices.GroupMemberDTO;
 import io.camunda.service.security.SecurityContextProvider;
@@ -41,12 +41,12 @@ public class GroupServiceTest {
 
   private GroupServices services;
   private GroupSearchClient client;
-  private Authentication authentication;
+  private CamundaAuthentication authentication;
   private StubbedBrokerClient stubbedBrokerClient;
 
   @BeforeEach
   public void before() {
-    authentication = Authentication.of(builder -> builder.user("foo"));
+    authentication = CamundaAuthentication.of(builder -> builder.user("foo"));
     stubbedBrokerClient = new StubbedBrokerClient();
     client = mock(GroupSearchClient.class);
     when(client.withSecurityContext(any())).thenReturn(client);

--- a/service/src/test/java/io/camunda/service/IncidentServiceTest.java
+++ b/service/src/test/java/io/camunda/service/IncidentServiceTest.java
@@ -17,8 +17,8 @@ import io.camunda.search.clients.IncidentSearchClient;
 import io.camunda.search.entities.IncidentEntity;
 import io.camunda.search.query.SearchQueryBuilders;
 import io.camunda.search.query.SearchQueryResult;
-import io.camunda.security.auth.Authentication;
 import io.camunda.security.auth.Authorization;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.exception.ForbiddenException;
 import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
@@ -32,14 +32,14 @@ public final class IncidentServiceTest {
   private IncidentServices services;
   private IncidentSearchClient client;
   private SecurityContextProvider securityContextProvider;
-  private Authentication authentication;
+  private CamundaAuthentication authentication;
 
   @BeforeEach
   public void before() {
     client = mock(IncidentSearchClient.class);
     when(client.withSecurityContext(any())).thenReturn(client);
     securityContextProvider = mock(SecurityContextProvider.class);
-    authentication = mock(Authentication.class);
+    authentication = mock(CamundaAuthentication.class);
     services =
         new IncidentServices(
             mock(BrokerClient.class), securityContextProvider, client, authentication);

--- a/service/src/test/java/io/camunda/service/JobServiceTest.java
+++ b/service/src/test/java/io/camunda/service/JobServiceTest.java
@@ -16,7 +16,7 @@ import io.camunda.search.clients.JobSearchClient;
 import io.camunda.search.entities.JobEntity;
 import io.camunda.search.query.SearchQueryBuilders;
 import io.camunda.search.query.SearchQueryResult;
-import io.camunda.security.auth.Authentication;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import org.junit.jupiter.api.BeforeEach;
@@ -27,14 +27,14 @@ public class JobServiceTest {
   private JobServices<SearchQueryResult<JobEntity>> services;
   private JobSearchClient client;
   private SecurityContextProvider securityContextProvider;
-  private Authentication authentication;
+  private CamundaAuthentication authentication;
 
   @BeforeEach
   public void before() {
     client = mock(JobSearchClient.class);
     when(client.withSecurityContext(any())).thenReturn(client);
     securityContextProvider = mock(SecurityContextProvider.class);
-    authentication = mock(Authentication.class);
+    authentication = mock(CamundaAuthentication.class);
     services =
         new JobServices<>(
             mock(BrokerClient.class), securityContextProvider, null, client, authentication);

--- a/service/src/test/java/io/camunda/service/MappingServicesTest.java
+++ b/service/src/test/java/io/camunda/service/MappingServicesTest.java
@@ -22,7 +22,7 @@ import io.camunda.search.filter.MappingFilter;
 import io.camunda.search.query.MappingQuery;
 import io.camunda.search.query.SearchQueryBuilders;
 import io.camunda.search.query.SearchQueryResult;
-import io.camunda.security.auth.Authentication;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.MappingServices.MappingDTO;
 import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
@@ -47,12 +47,12 @@ public class MappingServicesTest {
   ArgumentCaptor<BrokerMappingUpdateRequest> mappingUpdateRequestArgumentCaptor;
   private MappingServices services;
   private MappingSearchClient client;
-  private Authentication authentication;
+  private CamundaAuthentication authentication;
   private StubbedBrokerClient stubbedBrokerClient;
 
   @BeforeEach
   public void before() {
-    authentication = Authentication.of(builder -> builder.user("foo"));
+    authentication = CamundaAuthentication.of(builder -> builder.user("foo"));
     stubbedBrokerClient = new StubbedBrokerClient();
     client = mock(MappingSearchClient.class);
     when(client.withSecurityContext(any())).thenReturn(client);
@@ -143,7 +143,7 @@ public class MappingServicesTest {
   @Test
   public void shouldTriggerDeleteRequest() {
     // given
-    final Authentication testAuthentication = mock(Authentication.class);
+    final CamundaAuthentication testAuthentication = mock(CamundaAuthentication.class);
     when(testAuthentication.claims()).thenReturn(Map.of());
     final BrokerClient mockBrokerClient = mock(BrokerClient.class);
     final MappingServices testMappingServices =
@@ -167,7 +167,7 @@ public class MappingServicesTest {
   @Test
   public void shouldTriggerUpdateRequest() {
     // given
-    final Authentication testAuthentication = mock(Authentication.class);
+    final CamundaAuthentication testAuthentication = mock(CamundaAuthentication.class);
     when(testAuthentication.claims()).thenReturn(Map.of());
     final BrokerClient mockBrokerClient = mock(BrokerClient.class);
     final MappingServices testMappingServices =

--- a/service/src/test/java/io/camunda/service/ProcessInstanceServiceTest.java
+++ b/service/src/test/java/io/camunda/service/ProcessInstanceServiceTest.java
@@ -31,8 +31,8 @@ import io.camunda.search.query.ProcessInstanceQuery;
 import io.camunda.search.query.SearchQueryBuilders;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.search.query.SequenceFlowQuery;
-import io.camunda.security.auth.Authentication;
 import io.camunda.security.auth.Authorization;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.ProcessInstanceServices.ProcessInstanceMigrateBatchOperationRequest;
 import io.camunda.service.ProcessInstanceServices.ProcessInstanceModifyBatchOperationRequest;
 import io.camunda.service.exception.ForbiddenException;
@@ -59,14 +59,14 @@ public final class ProcessInstanceServiceTest {
   private SequenceFlowSearchClient sequenceFlowSearchClient;
   private IncidentSearchClient incidentSearchClient;
   private SecurityContextProvider securityContextProvider;
-  private Authentication authentication;
+  private CamundaAuthentication authentication;
   private BrokerClient brokerClient;
 
   @BeforeEach
   public void before() {
     processInstanceSearchClient = mock(ProcessInstanceSearchClient.class);
     sequenceFlowSearchClient = mock(SequenceFlowSearchClient.class);
-    authentication = Authentication.none();
+    authentication = CamundaAuthentication.none();
     incidentSearchClient = mock(IncidentSearchClient.class);
     when(processInstanceSearchClient.withSecurityContext(any()))
         .thenReturn(processInstanceSearchClient);
@@ -211,7 +211,7 @@ public final class ProcessInstanceServiceTest {
 
     assertThat(
             MsgPackConverter.convertToObject(
-                enrichedRecord.getAuthenticationBuffer(), Authentication.class))
+                enrichedRecord.getAuthenticationBuffer(), CamundaAuthentication.class))
         .isEqualTo(authentication);
   }
 
@@ -306,7 +306,7 @@ public final class ProcessInstanceServiceTest {
 
     assertThat(
             MsgPackConverter.convertToObject(
-                enrichedRecord.getAuthenticationBuffer(), Authentication.class))
+                enrichedRecord.getAuthenticationBuffer(), CamundaAuthentication.class))
         .isEqualTo(authentication);
   }
 
@@ -347,7 +347,7 @@ public final class ProcessInstanceServiceTest {
 
     assertThat(
             MsgPackConverter.convertToObject(
-                enrichedRecord.getAuthenticationBuffer(), Authentication.class))
+                enrichedRecord.getAuthenticationBuffer(), CamundaAuthentication.class))
         .isEqualTo(authentication);
 
     final var modificationPlan = enrichedRecord.getMigrationPlan();
@@ -394,7 +394,7 @@ public final class ProcessInstanceServiceTest {
 
     assertThat(
             MsgPackConverter.convertToObject(
-                enrichedRecord.getAuthenticationBuffer(), Authentication.class))
+                enrichedRecord.getAuthenticationBuffer(), CamundaAuthentication.class))
         .isEqualTo(authentication);
 
     final var filterBuffer = enrichedRecord.getEntityFilterBuffer();

--- a/service/src/test/java/io/camunda/service/RoleServicesTest.java
+++ b/service/src/test/java/io/camunda/service/RoleServicesTest.java
@@ -18,7 +18,7 @@ import io.camunda.search.filter.RoleFilter;
 import io.camunda.search.query.RoleQuery;
 import io.camunda.search.query.SearchQueryBuilders;
 import io.camunda.search.query.SearchQueryResult;
-import io.camunda.security.auth.Authentication;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.RoleServices.CreateRoleRequest;
 import io.camunda.service.RoleServices.RoleMemberRequest;
 import io.camunda.service.RoleServices.UpdateRoleRequest;
@@ -41,12 +41,12 @@ public class RoleServicesTest {
 
   private RoleServices services;
   private RoleSearchClient client;
-  private Authentication authentication;
+  private CamundaAuthentication authentication;
   private StubbedBrokerClient stubbedBrokerClient;
 
   @BeforeEach
   public void before() {
-    authentication = Authentication.of(builder -> builder.user("foo"));
+    authentication = CamundaAuthentication.of(builder -> builder.user("foo"));
     stubbedBrokerClient = new StubbedBrokerClient();
     client = mock(RoleSearchClient.class);
     when(client.withSecurityContext(any())).thenReturn(client);

--- a/service/src/test/java/io/camunda/service/TenantServiceTest.java
+++ b/service/src/test/java/io/camunda/service/TenantServiceTest.java
@@ -19,8 +19,8 @@ import io.camunda.search.exception.CamundaSearchException;
 import io.camunda.search.filter.TenantFilter;
 import io.camunda.search.query.SearchQueryBuilders;
 import io.camunda.search.query.SearchQueryResult;
-import io.camunda.security.auth.Authentication;
 import io.camunda.security.auth.Authorization;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.TenantServices.TenantDTO;
 import io.camunda.service.TenantServices.TenantMemberRequest;
 import io.camunda.service.exception.ForbiddenException;
@@ -51,7 +51,8 @@ public class TenantServiceTest {
   @BeforeEach
   public void before() {
     stubbedBrokerClient = new StubbedBrokerClient();
-    final Authentication authentication = Authentication.of(builder -> builder.user("foo"));
+    final CamundaAuthentication authentication =
+        CamundaAuthentication.of(builder -> builder.user("foo"));
     client = mock(TenantSearchClient.class);
     final SecurityContextProvider securityContextProvider = mock(SecurityContextProvider.class);
     when(client.withSecurityContext(any())).thenReturn(client);
@@ -235,7 +236,8 @@ public class TenantServiceTest {
 
   @Test
   public void shouldThrowForbiddenIfNotAuthorized() {
-    final Authentication auth = Authentication.of(builder -> builder.user("unauthorizedUser"));
+    final CamundaAuthentication auth =
+        CamundaAuthentication.of(builder -> builder.user("unauthorizedUser"));
     final var contextProvider = mock(SecurityContextProvider.class);
     when(contextProvider.isAuthorized(any(), any(), any())).thenReturn(false);
 

--- a/service/src/test/java/io/camunda/service/UsageMetricsServiceTest.java
+++ b/service/src/test/java/io/camunda/service/UsageMetricsServiceTest.java
@@ -17,7 +17,7 @@ import io.camunda.search.entities.UsageMetricsCount;
 import io.camunda.search.filter.UsageMetricsFilter;
 import io.camunda.search.query.SearchQueryBuilders;
 import io.camunda.search.query.UsageMetricsQuery;
-import io.camunda.security.auth.Authentication;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import java.time.OffsetDateTime;
@@ -29,7 +29,7 @@ public final class UsageMetricsServiceTest {
   private UsageMetricsServices services;
   private UsageMetricsSearchClient client;
   private SecurityContextProvider securityContextProvider;
-  private Authentication authentication;
+  private CamundaAuthentication authentication;
 
   @BeforeEach
   public void before() {

--- a/service/src/test/java/io/camunda/service/UserServiceTest.java
+++ b/service/src/test/java/io/camunda/service/UserServiceTest.java
@@ -18,7 +18,7 @@ import io.camunda.search.entities.UserEntity;
 import io.camunda.search.filter.UserFilter;
 import io.camunda.search.query.SearchQueryBuilders;
 import io.camunda.search.query.SearchQueryResult;
-import io.camunda.security.auth.Authentication;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.broker.client.api.dto.BrokerResponse;
@@ -38,14 +38,14 @@ public class UserServiceTest {
   private UserServices services;
   private UserSearchClient client;
   private BrokerClient brokerClient;
-  private Authentication authentication;
+  private CamundaAuthentication authentication;
 
   @BeforeEach
   public void before() {
     client = mock(UserSearchClient.class);
     when(client.withSecurityContext(any())).thenReturn(client);
     brokerClient = mock(BrokerClient.class);
-    authentication = mock(Authentication.class);
+    authentication = mock(CamundaAuthentication.class);
     final PasswordEncoder passwordEncoder = mock(PasswordEncoder.class);
     userDeleteRequestArgumentCaptor = ArgumentCaptor.forClass(BrokerUserDeleteRequest.class);
     services =

--- a/service/src/test/java/io/camunda/service/UserTaskServiceTest.java
+++ b/service/src/test/java/io/camunda/service/UserTaskServiceTest.java
@@ -30,8 +30,8 @@ import io.camunda.search.filter.UserTaskFilter;
 import io.camunda.search.filter.UserTaskFilter.Builder;
 import io.camunda.search.query.SearchQueryBuilders;
 import io.camunda.search.query.SearchQueryResult;
-import io.camunda.security.auth.Authentication;
 import io.camunda.security.auth.Authorization;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.exception.ForbiddenException;
 import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
@@ -48,7 +48,7 @@ public class UserTaskServiceTest {
   private FlowNodeInstanceSearchClient flowNodeInstanceSearchClient;
   private VariableSearchClient variableSearchClient;
   private SecurityContextProvider securityContextProvider;
-  private Authentication authentication;
+  private CamundaAuthentication authentication;
 
   @BeforeEach
   public void before() {
@@ -62,7 +62,7 @@ public class UserTaskServiceTest {
     variableSearchClient = mock(VariableSearchClient.class);
     when(variableSearchClient.withSecurityContext(any())).thenReturn(variableSearchClient);
     securityContextProvider = mock(SecurityContextProvider.class);
-    authentication = mock(Authentication.class);
+    authentication = mock(CamundaAuthentication.class);
     services =
         new UserTaskServices(
             mock(BrokerClient.class),

--- a/service/src/test/java/io/camunda/service/VariableServiceTest.java
+++ b/service/src/test/java/io/camunda/service/VariableServiceTest.java
@@ -19,8 +19,8 @@ import io.camunda.search.filter.VariableFilter;
 import io.camunda.search.filter.VariableFilter.Builder;
 import io.camunda.search.query.SearchQueryBuilders;
 import io.camunda.search.query.SearchQueryResult;
-import io.camunda.security.auth.Authentication;
 import io.camunda.security.auth.Authorization;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.exception.ForbiddenException;
 import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
@@ -34,14 +34,14 @@ public class VariableServiceTest {
   private VariableServices services;
   private VariableSearchClient client;
   private SecurityContextProvider securityContextProvider;
-  private Authentication authentication;
+  private CamundaAuthentication authentication;
 
   @BeforeEach
   public void before() {
     client = mock(VariableSearchClient.class);
     when(client.withSecurityContext(any())).thenReturn(client);
     securityContextProvider = mock(SecurityContextProvider.class);
-    authentication = mock(Authentication.class);
+    authentication = mock(CamundaAuthentication.class);
     services =
         new VariableServices(
             mock(BrokerClient.class), securityContextProvider, client, authentication);

--- a/service/src/test/java/io/camunda/service/security/SecurityContextProviderTest.java
+++ b/service/src/test/java/io/camunda/service/security/SecurityContextProviderTest.java
@@ -14,8 +14,8 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import io.camunda.security.auth.Authentication;
 import io.camunda.security.auth.Authorization;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.security.auth.SecurityContext;
 import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.security.impl.AuthorizationChecker;
@@ -40,7 +40,7 @@ class SecurityContextProviderTest {
   @Test
   void shouldProvideSecurityContextWithAuthorizationWhenDisabled() {
     // given
-    final var authentication = mock(Authentication.class);
+    final var authentication = mock(CamundaAuthentication.class);
     final var authorization = mock(Authorization.class);
     when(securityConfiguration.getAuthorizations().isEnabled()).thenReturn(true);
 
@@ -57,7 +57,7 @@ class SecurityContextProviderTest {
   @Test
   void shouldProvideSecurityContextWithoutAuthorizationWhenDisabled() {
     // given
-    final var authentication = mock(Authentication.class);
+    final var authentication = mock(CamundaAuthentication.class);
     final var authorization = mock(Authorization.class);
     when(securityConfiguration.getAuthorizations().isEnabled()).thenReturn(false);
 
@@ -74,7 +74,7 @@ class SecurityContextProviderTest {
   @Test
   void isAuthorizedShouldReturnTrueWhenAuthorizationIsDisabled() {
     // given
-    final var authentication = mock(Authentication.class);
+    final var authentication = mock(CamundaAuthentication.class);
     final var authorization = mock(Authorization.class);
     when(securityConfiguration.getAuthorizations().isEnabled()).thenReturn(false);
 
@@ -90,7 +90,7 @@ class SecurityContextProviderTest {
   @Test
   void isAuthorizedShouldReturnTrueWhenAuthorizationCheckerReturnsTrue() {
     // given
-    final var authentication = mock(Authentication.class);
+    final var authentication = mock(CamundaAuthentication.class);
     final var authorization = mock(Authorization.class);
     when(securityConfiguration.getAuthorizations().isEnabled()).thenReturn(true);
     when(authorizationChecker.isAuthorized(any(), any())).thenReturn(true);
@@ -111,7 +111,7 @@ class SecurityContextProviderTest {
   @Test
   void isAuthorizedShouldReturnFalseWhenAuthorizationCheckerReturnsFalse() {
     // given
-    final var authentication = mock(Authentication.class);
+    final var authentication = mock(CamundaAuthentication.class);
     final var authorization = mock(Authorization.class);
     when(securityConfiguration.getAuthorizations().isEnabled()).thenReturn(true);
     when(authorizationChecker.isAuthorized(any(), any())).thenReturn(false);

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/permission/TasklistPermissionServices.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/permission/TasklistPermissionServices.java
@@ -7,8 +7,8 @@
  */
 package io.camunda.tasklist.webapp.permission;
 
-import io.camunda.security.auth.Authentication;
 import io.camunda.security.auth.Authorization;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.security.impl.AuthorizationChecker;
 import io.camunda.service.security.SecurityContextProvider;
@@ -81,7 +81,8 @@ public class TasklistPermissionServices {
         resourceId, authenticationSupplier.get(), authorization);
   }
 
-  private boolean isAuthorizationCheckDisabled(final Supplier<Authentication> authentication) {
+  private boolean isAuthorizationCheckDisabled(
+      final Supplier<CamundaAuthentication> authentication) {
     return isAuthorizationDisabled() || isWithoutAuthenticatedUserKey(authentication.get());
   }
 
@@ -89,7 +90,7 @@ public class TasklistPermissionServices {
     return !securityConfiguration.getAuthorizations().isEnabled();
   }
 
-  private boolean isWithoutAuthenticatedUserKey(final Authentication authentication) {
+  private boolean isWithoutAuthenticatedUserKey(final CamundaAuthentication authentication) {
     // when the provided authentication does not contain a username,
     // then the authorization check cannot be performed.
     // the authorization key is only provided when running with the BASIC authentication method

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/permission/TasklistPermissionServices.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/permission/TasklistPermissionServices.java
@@ -9,13 +9,13 @@ package io.camunda.tasklist.webapp.permission;
 
 import io.camunda.security.auth.Authorization;
 import io.camunda.security.auth.CamundaAuthentication;
+import io.camunda.security.auth.CamundaAuthenticationProvider;
 import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.security.impl.AuthorizationChecker;
 import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.tasklist.property.IdentityProperties;
 import io.camunda.tasklist.util.LazySupplier;
 import io.camunda.webapps.schema.entities.usertask.TaskEntity;
-import io.camunda.zeebe.gateway.rest.RequestMapper;
 import java.util.List;
 import java.util.function.Supplier;
 import org.springframework.stereotype.Component;
@@ -35,14 +35,17 @@ public class TasklistPermissionServices {
   private final SecurityConfiguration securityConfiguration;
   private final SecurityContextProvider securityContextProvider;
   private final AuthorizationChecker authorizationChecker;
+  private final CamundaAuthenticationProvider authenticationProvider;
 
   public TasklistPermissionServices(
       final SecurityConfiguration securityConfiguration,
       final SecurityContextProvider securityContextProvider,
-      final AuthorizationChecker authorizationChecker) {
+      final AuthorizationChecker authorizationChecker,
+      final CamundaAuthenticationProvider authenticationProvider) {
     this.securityConfiguration = securityConfiguration;
     this.securityContextProvider = securityContextProvider;
     this.authorizationChecker = authorizationChecker;
+    this.authenticationProvider = authenticationProvider;
   }
 
   public boolean hasPermissionToCreateProcessInstance(final String bpmnProcessId) {
@@ -58,7 +61,8 @@ public class TasklistPermissionServices {
   }
 
   public List<String> getProcessDefinitionsWithCreateProcessInstancePermission() {
-    final var authenticationSupplier = LazySupplier.of(RequestMapper::getAuthentication);
+    final var authenticationSupplier =
+        LazySupplier.of(authenticationProvider::getCamundaAuthentication);
     if (isAuthorizationCheckDisabled(authenticationSupplier)) {
       return WILD_CARD_PERMISSION;
     }
@@ -72,7 +76,8 @@ public class TasklistPermissionServices {
   private boolean isAuthorizedForResource(
       final String resourceId, final Authorization authorization) {
 
-    final var authenticationSupplier = LazySupplier.of(RequestMapper::getAuthentication);
+    final var authenticationSupplier =
+        LazySupplier.of(authenticationProvider::getCamundaAuthentication);
     if (isAuthorizationCheckDisabled(authenticationSupplier)) {
       return true;
     }

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/service/CamundaServicesBasedAdapter.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/service/CamundaServicesBasedAdapter.java
@@ -10,7 +10,7 @@ package io.camunda.tasklist.webapp.service;
 import static io.camunda.tasklist.webapp.util.ErrorHandlingUtils.getErrorMessageFromBrokerException;
 
 import io.camunda.client.impl.command.StreamUtil;
-import io.camunda.security.auth.Authentication;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.JobServices;
 import io.camunda.service.ProcessInstanceServices;
 import io.camunda.service.ProcessInstanceServices.ProcessInstanceCreateRequest;
@@ -220,18 +220,18 @@ public class CamundaServicesBasedAdapter implements TasklistServicesAdapter {
   }
 
   private <T> T executeCamundaServiceAuthenticated(
-      final Function<Authentication, CompletableFuture<T>> method) {
+      final Function<CamundaAuthentication, CompletableFuture<T>> method) {
     return executeCamundaService(method, RequestMapper.getAuthentication());
   }
 
   private <T> T executeCamundaServiceAnonymously(
-      final Function<Authentication, CompletableFuture<T>> method) {
+      final Function<CamundaAuthentication, CompletableFuture<T>> method) {
     return executeCamundaService(method, RequestMapper.getAnonymousAuthentication());
   }
 
   private <T> T executeCamundaService(
-      final Function<Authentication, CompletableFuture<T>> method,
-      final Authentication authentication) {
+      final Function<CamundaAuthentication, CompletableFuture<T>> method,
+      final CamundaAuthentication authentication) {
     try {
       return method.apply(authentication).join();
     } catch (final Exception e) {

--- a/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/es/cache/ProcessStoreElasticSearchTest.java
+++ b/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/es/cache/ProcessStoreElasticSearchTest.java
@@ -20,6 +20,7 @@ import static org.mockito.Mockito.when;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.authentication.entity.AuthenticationContext;
 import io.camunda.authentication.entity.CamundaUser;
+import io.camunda.security.auth.CamundaAuthenticationProvider;
 import io.camunda.security.configuration.AuthorizationsConfiguration;
 import io.camunda.security.configuration.MultiTenancyConfiguration;
 import io.camunda.security.configuration.SecurityConfiguration;
@@ -73,6 +74,7 @@ class ProcessStoreElasticSearchTest {
   @Mock private io.camunda.identity.autoconfigure.IdentityProperties identityProperties;
   @Mock private SecurityContextProvider securityContextProvider;
   @Mock private AuthorizationChecker authorizationChecker;
+  @Mock private CamundaAuthenticationProvider authenticationProvider;
   @InjectMocks private TasklistPermissionServices permissionServices;
 
   @BeforeEach
@@ -81,6 +83,8 @@ class ProcessStoreElasticSearchTest {
     when(securityConfiguration.getMultiTenancy()).thenReturn(new MultiTenancyConfiguration());
     ReflectionTestUtils.setField(
         permissionServices, "securityConfiguration", securityConfiguration);
+    ReflectionTestUtils.setField(
+        permissionServices, "authenticationProvider", authenticationProvider);
   }
 
   // ** Test Get Process by BPMN Process Id ** //

--- a/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/es/cache/ProcessStoreOpenSearchTest.java
+++ b/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/es/cache/ProcessStoreOpenSearchTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.authentication.entity.CamundaUser;
+import io.camunda.security.auth.CamundaAuthenticationProvider;
 import io.camunda.security.configuration.AuthorizationsConfiguration;
 import io.camunda.security.configuration.MultiTenancyConfiguration;
 import io.camunda.security.configuration.SecurityConfiguration;
@@ -76,6 +77,7 @@ class ProcessStoreOpenSearchTest {
   @Mock private io.camunda.identity.autoconfigure.IdentityProperties identityProperties;
   @Mock private SecurityContextProvider securityContextProvider;
   @Mock private AuthorizationChecker authorizationChecker;
+  @Mock private CamundaAuthenticationProvider authenticationProvider;
   @Mock private TasklistPermissionServices permissionServices;
 
   @BeforeEach
@@ -84,6 +86,8 @@ class ProcessStoreOpenSearchTest {
     when(securityConfiguration.getMultiTenancy()).thenReturn(new MultiTenancyConfiguration());
     ReflectionTestUtils.setField(
         permissionServices, "securityConfiguration", securityConfiguration);
+    ReflectionTestUtils.setField(
+        permissionServices, "authenticationProvider", authenticationProvider);
   }
 
   // ** Test Get Process by BPMN Process Id ** //

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationItemProvider.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationItemProvider.java
@@ -16,8 +16,8 @@ import io.camunda.search.filter.ProcessInstanceFilter;
 import io.camunda.search.page.SearchQueryPageBuilders;
 import io.camunda.search.query.SearchQueryBuilders;
 import io.camunda.search.query.SearchQueryResult;
-import io.camunda.security.auth.Authentication;
 import io.camunda.security.auth.Authorization;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.security.auth.SecurityContext;
 import io.camunda.util.FilterUtil;
 import io.camunda.zeebe.engine.EngineConfiguration;
@@ -77,7 +77,7 @@ public class BatchOperationItemProvider {
   public Set<Item> fetchProcessInstanceItems(
       final int partitionId,
       final ProcessInstanceFilter filter,
-      final Authentication authentication,
+      final CamundaAuthentication authentication,
       final Supplier<Boolean> shouldAbort) {
     final var processInstanceFilter = filter.toBuilder().partitionId(partitionId).build();
 
@@ -102,7 +102,7 @@ public class BatchOperationItemProvider {
    */
   public Set<Item> fetchIncidentItems(
       final IncidentFilter filter,
-      final Authentication authentication,
+      final CamundaAuthentication authentication,
       final Supplier<Boolean> shouldAbort) {
 
     LOG.debug("Fetching incident items with filter: {}", filter);
@@ -123,7 +123,7 @@ public class BatchOperationItemProvider {
   public Set<Item> fetchIncidentItems(
       final int partitionId,
       final ProcessInstanceFilter filter,
-      final Authentication authentication,
+      final CamundaAuthentication authentication,
       final Supplier<Boolean> shouldAbort) {
     // first fetch all matching processInstances
     final var processInstanceKeys =
@@ -139,7 +139,7 @@ public class BatchOperationItemProvider {
   private <F extends FilterBase> Set<Item> fetchEntityItems(
       final ItemPageFetcher<F> itemPageFetcher,
       final F filter,
-      final Authentication authentication,
+      final CamundaAuthentication authentication,
       final Supplier<Boolean> shouldAbort) {
     final var items = new LinkedHashSet<Item>();
 
@@ -170,7 +170,7 @@ public class BatchOperationItemProvider {
 
   private Set<Item> getIncidentItemsOfProcessInstanceKeys(
       final List<Long> processInstanceKeys,
-      final Authentication authentication,
+      final CamundaAuthentication authentication,
       final Supplier<Boolean> shouldAbort) {
     final Set<Item> incidents = new LinkedHashSet<>();
 
@@ -219,7 +219,7 @@ public class BatchOperationItemProvider {
      * @param searchAfter the current searchAfter
      * @return the fetched items and pagination information
      */
-    ItemPage fetchItems(F filter, String searchAfter, Authentication authentication);
+    ItemPage fetchItems(F filter, String searchAfter, CamundaAuthentication authentication);
 
     /**
      * Creates a security context for the given authentication and authorization.
@@ -230,7 +230,7 @@ public class BatchOperationItemProvider {
      * @return the security context
      */
     default SecurityContext createSecurityContext(
-        final Authentication authentication, final Authorization authorization) {
+        final CamundaAuthentication authentication, final Authorization authorization) {
       return SecurityContext.of(
           b -> b.withAuthentication(authentication).withAuthorization(authorization));
     }
@@ -241,7 +241,7 @@ public class BatchOperationItemProvider {
     public ItemPage fetchItems(
         final ProcessInstanceFilter filter,
         final String searchAfter,
-        final Authentication authentication) {
+        final CamundaAuthentication authentication) {
       final var securityContext =
           createSecurityContext(
               authentication, Authorization.of(a -> a.processDefinition().readProcessInstance()));
@@ -271,7 +271,7 @@ public class BatchOperationItemProvider {
     public ItemPage fetchItems(
         final IncidentFilter filter,
         final String searchAfter,
-        final Authentication authentication) {
+        final CamundaAuthentication authentication) {
       final var securityContext =
           createSecurityContext(
               authentication, Authorization.of(a -> a.processDefinition().readProcessInstance()));

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/batchoperation/PersistedBatchOperation.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/batchoperation/PersistedBatchOperation.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.zeebe.engine.state.batchoperation;
 
-import io.camunda.security.auth.Authentication;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.zeebe.db.DbValue;
 import io.camunda.zeebe.msgpack.UnpackedObject;
 import io.camunda.zeebe.msgpack.property.ArrayProperty;
@@ -165,11 +165,12 @@ public class PersistedBatchOperation extends UnpackedObject implements DbValue {
     return this;
   }
 
-  public Authentication getAuthentication() {
+  public CamundaAuthentication getAuthentication() {
     if (authenticationProp.getValue() != null) {
-      return MsgPackConverter.convertToObject(authenticationProp.getValue(), Authentication.class);
+      return MsgPackConverter.convertToObject(
+          authenticationProp.getValue(), CamundaAuthentication.class);
     } else {
-      return Authentication.none();
+      return CamundaAuthentication.none();
     }
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/AbstractBatchOperationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/AbstractBatchOperationTest.java
@@ -18,7 +18,7 @@ import io.camunda.search.filter.ProcessInstanceFilter;
 import io.camunda.search.query.IncidentQuery;
 import io.camunda.search.query.ProcessInstanceQuery;
 import io.camunda.search.query.SearchQueryResult;
-import io.camunda.security.auth.Authentication;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.security.configuration.ConfiguredUser;
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
@@ -100,7 +100,7 @@ abstract class AbstractBatchOperationTest {
 
     DirectBuffer authenticationBuffer = null;
     if (claims != null) {
-      authenticationBuffer = convertToBuffer(Authentication.of(b -> b.claims(claims)));
+      authenticationBuffer = convertToBuffer(CamundaAuthentication.of(b -> b.claims(claims)));
     }
 
     return engine
@@ -139,7 +139,7 @@ abstract class AbstractBatchOperationTest {
 
     DirectBuffer authenticationBuffer = null;
     if (claims != null) {
-      authenticationBuffer = convertToBuffer(Authentication.of(b -> b.claims(claims)));
+      authenticationBuffer = convertToBuffer(CamundaAuthentication.of(b -> b.claims(claims)));
     }
 
     return engine
@@ -199,7 +199,7 @@ abstract class AbstractBatchOperationTest {
 
     DirectBuffer authenticationBuffer = null;
     if (claims != null) {
-      authenticationBuffer = convertToBuffer(Authentication.of(b -> b.claims(claims)));
+      authenticationBuffer = convertToBuffer(CamundaAuthentication.of(b -> b.claims(claims)));
     }
 
     return engine
@@ -242,7 +242,7 @@ abstract class AbstractBatchOperationTest {
 
     DirectBuffer authenticationBuffer = null;
     if (claims != null) {
-      authenticationBuffer = convertToBuffer(Authentication.of(b -> b.claims(claims)));
+      authenticationBuffer = convertToBuffer(CamundaAuthentication.of(b -> b.claims(claims)));
     }
 
     return engine

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationItemProviderTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationItemProviderTest.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.batchoperation;
 
-import static io.camunda.security.auth.Authentication.none;
+import static io.camunda.security.auth.CamundaAuthentication.none;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -21,8 +21,8 @@ import io.camunda.search.entities.ProcessInstanceEntity;
 import io.camunda.search.filter.ProcessInstanceFilter;
 import io.camunda.search.query.ProcessInstanceQuery;
 import io.camunda.search.query.SearchQueryResult;
-import io.camunda.security.auth.Authentication;
 import io.camunda.security.auth.Authorization;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.security.auth.SecurityContext;
 import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.metrics.BatchOperationMetrics;
@@ -63,7 +63,7 @@ class BatchOperationItemProviderTest {
     final var queryCaptor = ArgumentCaptor.forClass(ProcessInstanceQuery.class);
 
     // given
-    final var auth = mock(Authentication.class);
+    final var auth = mock(CamundaAuthentication.class);
     final var result =
         new SearchQueryResult.Builder<ProcessInstanceEntity>()
             .items(
@@ -239,7 +239,7 @@ class BatchOperationItemProviderTest {
     final var queryCaptor = ArgumentCaptor.forClass(ProcessInstanceQuery.class);
 
     // given
-    final var auth = mock(Authentication.class);
+    final var auth = mock(CamundaAuthentication.class);
     final var processInstanceResult =
         new SearchQueryResult.Builder<ProcessInstanceEntity>()
             .items(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/batchoperation/BatchOperationStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/batchoperation/BatchOperationStateTest.java
@@ -13,7 +13,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.search.filter.ProcessInstanceFilter;
-import io.camunda.security.auth.Authentication;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.zeebe.engine.state.batchoperation.PersistedBatchOperation.BatchOperationStatus;
 import io.camunda.zeebe.engine.state.mutable.MutableBatchOperationState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
@@ -56,7 +56,7 @@ public class BatchOperationStateTest {
             .processDefinitionVersions(1)
             .build();
     final String username = "bud spencer";
-    final var authentication = Authentication.of(b -> b.user(username));
+    final var authentication = CamundaAuthentication.of(b -> b.user(username));
     final var record =
         new BatchOperationCreationRecord()
             .setBatchOperationKey(batchOperationKey)

--- a/zeebe/gateway-rest/pom.xml
+++ b/zeebe/gateway-rest/pom.xml
@@ -75,11 +75,6 @@
 
     <dependency>
       <groupId>io.camunda</groupId>
-      <artifactId>zeebe-auth</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>io.camunda</groupId>
       <artifactId>zeebe-protocol-impl</artifactId>
     </dependency>
 
@@ -112,10 +107,12 @@
       <groupId>io.camunda</groupId>
       <artifactId>camunda-security-core</artifactId>
     </dependency>
+
     <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>camunda-security-protocol</artifactId>
     </dependency>
+
     <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>camunda-security-services</artifactId>
@@ -238,11 +235,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.springframework.security</groupId>
-      <artifactId>spring-security-core</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>com.github.ben-manes.caffeine</groupId>
       <artifactId>caffeine</artifactId>
     </dependency>
@@ -280,17 +272,6 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-test-autoconfigure</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.springframework.security</groupId>
-      <artifactId>spring-security-oauth2-client</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework.security</groupId>
-      <artifactId>spring-security-oauth2-core</artifactId>
       <scope>test</scope>
     </dependency>
 
@@ -410,22 +391,13 @@
       <artifactId>xmlunit-core</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.springframework.security</groupId>
-      <artifactId>spring-security-oauth2-jose</artifactId>
-      <scope>test</scope>
-    </dependency>
 
-    <dependency>
-      <groupId>com.auth0</groupId>
-      <artifactId>java-jwt</artifactId>
-      <scope>test</scope>
-    </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-yaml</artifactId>
     </dependency>
   </dependencies>
+
   <build>
     <resources>
       <resource>

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RequestMapper.java
@@ -40,14 +40,9 @@ import static io.camunda.zeebe.gateway.rest.validator.UserValidator.validateUser
 import static io.camunda.zeebe.gateway.rest.validator.UserValidator.validateUserUpdateRequest;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.camunda.authentication.entity.CamundaOAuthPrincipal;
-import io.camunda.authentication.entity.CamundaPrincipal;
 import io.camunda.document.api.DocumentMetadataModel;
-import io.camunda.search.entities.RoleEntity;
 import io.camunda.search.filter.AdHocSubProcessActivityFilter;
 import io.camunda.search.query.AdHocSubProcessActivityQuery;
-import io.camunda.security.auth.CamundaAuthentication;
-import io.camunda.security.auth.CamundaAuthentication.Builder;
 import io.camunda.service.AdHocSubProcessActivityServices.AdHocSubProcessActivateActivitiesRequest;
 import io.camunda.service.AdHocSubProcessActivityServices.AdHocSubProcessActivateActivitiesRequest.AdHocSubProcessActivateActivityReference;
 import io.camunda.service.AuthorizationServices.CreateAuthorizationRequest;
@@ -76,7 +71,6 @@ import io.camunda.service.RoleServices.UpdateRoleRequest;
 import io.camunda.service.TenantServices.TenantDTO;
 import io.camunda.service.TenantServices.TenantMemberRequest;
 import io.camunda.service.UserServices.UserDTO;
-import io.camunda.zeebe.auth.Authorization;
 import io.camunda.zeebe.gateway.protocol.rest.AdHocSubProcessActivateActivitiesInstruction;
 import io.camunda.zeebe.gateway.protocol.rest.AdHocSubProcessActivitySearchQuery;
 import io.camunda.zeebe.gateway.protocol.rest.AuthorizationRequest;
@@ -153,7 +147,6 @@ import org.agrona.concurrent.UnsafeBuffer;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.multipart.MultipartFile;
 
 public class RequestMapper {
@@ -608,54 +601,6 @@ public class RequestMapper {
     return validationResponse.map(
         tenantId ->
             new BroadcastSignalRequest(request.getSignalName(), request.getVariables(), tenantId));
-  }
-
-  public static CamundaAuthentication getAuthentication() {
-    final Map<String, Object> claims = new HashMap<>();
-    final var authenticationBuilder = new Builder();
-
-    final var requestAuthentication = SecurityContextHolder.getContext().getAuthentication();
-    if (requestAuthentication != null) {
-      if (requestAuthentication.getPrincipal()
-          instanceof final CamundaPrincipal authenticatedPrincipal) {
-        final var authenticationContext = authenticatedPrincipal.getAuthenticationContext();
-
-        authenticationBuilder.roleIds(
-            authenticationContext.roles().stream().map(RoleEntity::roleId).toList());
-
-        authenticationBuilder.tenants(
-            authenticationContext.tenants().stream().map(TenantDTO::tenantId).toList());
-
-        authenticationBuilder.groupIds(authenticationContext.groups());
-
-        if (authenticationContext.groupsClaimEnabled()) {
-          claims.put(Authorization.USER_GROUPS_CLAIMS, authenticationContext.groups());
-        }
-
-        if (authenticationContext.username() != null) {
-          final var authenticatedUsername = authenticationContext.username();
-          claims.put(Authorization.AUTHORIZED_USERNAME, authenticatedUsername);
-          authenticationBuilder.user(authenticatedUsername);
-        } else {
-          final var authenticatedClientId = authenticationContext.clientId();
-          claims.put(Authorization.AUTHORIZED_CLIENT_ID, authenticatedClientId);
-          authenticationBuilder.clientId(authenticatedClientId);
-        }
-
-        if (authenticatedPrincipal instanceof final CamundaOAuthPrincipal principal) {
-          claims.put(Authorization.USER_TOKEN_CLAIMS, principal.getClaims());
-          authenticationBuilder.mapping(principal.getOAuthContext().mappingIds().stream().toList());
-        }
-
-        authenticationBuilder.claims(claims);
-      }
-    }
-
-    return authenticationBuilder.build();
-  }
-
-  public static CamundaAuthentication getAnonymousAuthentication() {
-    return new Builder().claims(Map.of(Authorization.AUTHORIZED_ANONYMOUS_USER, true)).build();
   }
 
   public static <T> Either<ProblemDetail, T> getResult(

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RequestMapper.java
@@ -46,8 +46,8 @@ import io.camunda.document.api.DocumentMetadataModel;
 import io.camunda.search.entities.RoleEntity;
 import io.camunda.search.filter.AdHocSubProcessActivityFilter;
 import io.camunda.search.query.AdHocSubProcessActivityQuery;
-import io.camunda.security.auth.Authentication;
-import io.camunda.security.auth.Authentication.Builder;
+import io.camunda.security.auth.CamundaAuthentication;
+import io.camunda.security.auth.CamundaAuthentication.Builder;
 import io.camunda.service.AdHocSubProcessActivityServices.AdHocSubProcessActivateActivitiesRequest;
 import io.camunda.service.AdHocSubProcessActivityServices.AdHocSubProcessActivateActivitiesRequest.AdHocSubProcessActivateActivityReference;
 import io.camunda.service.AuthorizationServices.CreateAuthorizationRequest;
@@ -610,7 +610,7 @@ public class RequestMapper {
             new BroadcastSignalRequest(request.getSignalName(), request.getVariables(), tenantId));
   }
 
-  public static Authentication getAuthentication() {
+  public static CamundaAuthentication getAuthentication() {
     final Map<String, Object> claims = new HashMap<>();
     final var authenticationBuilder = new Builder();
 
@@ -654,7 +654,7 @@ public class RequestMapper {
     return authenticationBuilder.build();
   }
 
-  public static Authentication getAnonymousAuthentication() {
+  public static CamundaAuthentication getAnonymousAuthentication() {
     return new Builder().claims(Map.of(Authorization.AUTHORIZED_ANONYMOUS_USER, true)).build();
   }
 

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/AdHocSubProcessActivityController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/AdHocSubProcessActivityController.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.gateway.rest.controller;
 import static io.camunda.zeebe.gateway.rest.RestErrorMapper.mapErrorToResponse;
 
 import io.camunda.search.query.AdHocSubProcessActivityQuery;
+import io.camunda.security.auth.CamundaAuthenticationProvider;
 import io.camunda.service.AdHocSubProcessActivityServices;
 import io.camunda.service.AdHocSubProcessActivityServices.AdHocSubProcessActivateActivitiesRequest;
 import io.camunda.zeebe.gateway.protocol.rest.AdHocSubProcessActivateActivitiesInstruction;
@@ -30,10 +31,13 @@ import org.springframework.web.bind.annotation.RequestMapping;
 public class AdHocSubProcessActivityController {
 
   private final AdHocSubProcessActivityServices adHocSubProcessActivityServices;
+  private final CamundaAuthenticationProvider authenticationProvider;
 
   public AdHocSubProcessActivityController(
-      final AdHocSubProcessActivityServices adHocSubProcessActivityServices) {
+      final AdHocSubProcessActivityServices adHocSubProcessActivityServices,
+      final CamundaAuthenticationProvider authenticationProvider) {
     this.adHocSubProcessActivityServices = adHocSubProcessActivityServices;
+    this.authenticationProvider = authenticationProvider;
   }
 
   @CamundaPostMapping(path = "/search")
@@ -57,7 +61,7 @@ public class AdHocSubProcessActivityController {
     try {
       final var activities =
           adHocSubProcessActivityServices
-              .withAuthentication(RequestMapper.getAuthentication())
+              .withAuthentication(authenticationProvider.getCamundaAuthentication())
               .search(query);
 
       final var result = new AdHocSubProcessActivitySearchQueryResult();
@@ -77,7 +81,7 @@ public class AdHocSubProcessActivityController {
     return RequestMapper.executeServiceMethodWithNoContentResult(
         () ->
             adHocSubProcessActivityServices
-                .withAuthentication(RequestMapper.getAuthentication())
+                .withAuthentication(authenticationProvider.getCamundaAuthentication())
                 .activateActivities(request));
   }
 }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/BatchOperationController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/BatchOperationController.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.gateway.rest.controller;
 import static io.camunda.zeebe.gateway.rest.RestErrorMapper.mapErrorToResponse;
 
 import io.camunda.search.query.BatchOperationQuery;
+import io.camunda.security.auth.CamundaAuthenticationProvider;
 import io.camunda.service.BatchOperationServices;
 import io.camunda.zeebe.gateway.protocol.rest.BatchOperationResponse;
 import io.camunda.zeebe.gateway.protocol.rest.BatchOperationSearchQuery;
@@ -31,9 +32,13 @@ import org.springframework.web.bind.annotation.RequestMapping;
 public class BatchOperationController {
 
   private final BatchOperationServices batchOperationServices;
+  private final CamundaAuthenticationProvider authenticationProvider;
 
-  public BatchOperationController(final BatchOperationServices batchOperationServices) {
+  public BatchOperationController(
+      final BatchOperationServices batchOperationServices,
+      final CamundaAuthenticationProvider authenticationProvider) {
     this.batchOperationServices = batchOperationServices;
+    this.authenticationProvider = authenticationProvider;
   }
 
   @CamundaGetMapping(path = "/{batchOperationId}")
@@ -44,7 +49,7 @@ public class BatchOperationController {
           .body(
               SearchQueryResponseMapper.toBatchOperation(
                   batchOperationServices
-                      .withAuthentication(RequestMapper.getAuthentication())
+                      .withAuthentication(authenticationProvider.getCamundaAuthentication())
                       .getById(batchOperationId)));
     } catch (final Exception e) {
       return mapErrorToResponse(e);
@@ -63,7 +68,7 @@ public class BatchOperationController {
     return RequestMapper.executeServiceMethodWithNoContentResult(
             () ->
                 batchOperationServices
-                    .withAuthentication(RequestMapper.getAuthentication())
+                    .withAuthentication(authenticationProvider.getCamundaAuthentication())
                     .cancel(batchOperationId))
         .join();
   }
@@ -73,7 +78,7 @@ public class BatchOperationController {
     return RequestMapper.executeServiceMethodWithNoContentResult(
             () ->
                 batchOperationServices
-                    .withAuthentication(RequestMapper.getAuthentication())
+                    .withAuthentication(authenticationProvider.getCamundaAuthentication())
                     .suspend(batchOperationId))
         .join();
   }
@@ -83,7 +88,7 @@ public class BatchOperationController {
     return RequestMapper.executeServiceMethodWithNoContentResult(
             () ->
                 batchOperationServices
-                    .withAuthentication(RequestMapper.getAuthentication())
+                    .withAuthentication(authenticationProvider.getCamundaAuthentication())
                     .resume(batchOperationId))
         .join();
   }
@@ -92,7 +97,7 @@ public class BatchOperationController {
     try {
       final var result =
           batchOperationServices
-              .withAuthentication(RequestMapper.getAuthentication())
+              .withAuthentication(authenticationProvider.getCamundaAuthentication())
               .search(query);
       return ResponseEntity.ok(SearchQueryResponseMapper.toBatchOperationSearchQueryResult(result));
     } catch (final Exception e) {

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/BatchOperationItemsController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/BatchOperationItemsController.java
@@ -10,10 +10,10 @@ package io.camunda.zeebe.gateway.rest.controller;
 import static io.camunda.zeebe.gateway.rest.RestErrorMapper.mapErrorToResponse;
 
 import io.camunda.search.query.BatchOperationItemQuery;
+import io.camunda.security.auth.CamundaAuthenticationProvider;
 import io.camunda.service.BatchOperationServices;
 import io.camunda.zeebe.gateway.protocol.rest.BatchOperationItemSearchQuery;
 import io.camunda.zeebe.gateway.protocol.rest.BatchOperationItemSearchQueryResult;
-import io.camunda.zeebe.gateway.rest.RequestMapper;
 import io.camunda.zeebe.gateway.rest.RestErrorMapper;
 import io.camunda.zeebe.gateway.rest.SearchQueryRequestMapper;
 import io.camunda.zeebe.gateway.rest.SearchQueryResponseMapper;
@@ -27,9 +27,13 @@ import org.springframework.web.bind.annotation.RequestMapping;
 public class BatchOperationItemsController {
 
   private final BatchOperationServices batchOperationServices;
+  private final CamundaAuthenticationProvider authenticationProvider;
 
-  public BatchOperationItemsController(final BatchOperationServices batchOperationServices) {
+  public BatchOperationItemsController(
+      final BatchOperationServices batchOperationServices,
+      final CamundaAuthenticationProvider authenticationProvider) {
     this.batchOperationServices = batchOperationServices;
+    this.authenticationProvider = authenticationProvider;
   }
 
   @CamundaPostMapping(path = "/search")
@@ -44,7 +48,7 @@ public class BatchOperationItemsController {
     try {
       final var result =
           batchOperationServices
-              .withAuthentication(RequestMapper.getAuthentication())
+              .withAuthentication(authenticationProvider.getCamundaAuthentication())
               .searchItems(query);
       return ResponseEntity.ok(
           SearchQueryResponseMapper.toBatchOperationItemSearchQueryResult(result));

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ClockController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ClockController.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.gateway.rest.controller;
 
+import io.camunda.security.auth.CamundaAuthenticationProvider;
 import io.camunda.service.ClockServices;
 import io.camunda.zeebe.gateway.protocol.rest.ClockPinRequest;
 import io.camunda.zeebe.gateway.rest.RequestMapper;
@@ -24,9 +25,13 @@ import org.springframework.web.bind.annotation.RequestMapping;
 public class ClockController {
 
   private final ClockServices clockServices;
+  private final CamundaAuthenticationProvider authenticationProvider;
 
-  public ClockController(final ClockServices clockServices) {
+  public ClockController(
+      final ClockServices clockServices,
+      final CamundaAuthenticationProvider authenticationProvider) {
     this.clockServices = clockServices;
+    this.authenticationProvider = authenticationProvider;
   }
 
   @CamundaPutMapping(consumes = MediaType.APPLICATION_JSON_VALUE)
@@ -42,14 +47,17 @@ public class ClockController {
       consumes = {})
   public CompletableFuture<ResponseEntity<Object>> resetClock() {
     return RequestMapper.executeServiceMethodWithNoContentResult(
-        () -> clockServices.withAuthentication(RequestMapper.getAuthentication()).resetClock());
+        () ->
+            clockServices
+                .withAuthentication(authenticationProvider.getCamundaAuthentication())
+                .resetClock());
   }
 
   private CompletableFuture<ResponseEntity<Object>> pinClock(final long pinnedEpoch) {
     return RequestMapper.executeServiceMethodWithNoContentResult(
         () ->
             clockServices
-                .withAuthentication(RequestMapper.getAuthentication())
+                .withAuthentication(authenticationProvider.getCamundaAuthentication())
                 .pinClock(pinnedEpoch));
   }
 }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/DecisionDefinitionController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/DecisionDefinitionController.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.gateway.rest.controller;
 import static io.camunda.zeebe.gateway.rest.RestErrorMapper.mapErrorToResponse;
 
 import io.camunda.search.query.DecisionDefinitionQuery;
+import io.camunda.security.auth.CamundaAuthenticationProvider;
 import io.camunda.security.configuration.MultiTenancyConfiguration;
 import io.camunda.service.DecisionDefinitionServices;
 import io.camunda.zeebe.gateway.protocol.rest.DecisionDefinitionResult;
@@ -38,12 +39,15 @@ public class DecisionDefinitionController {
 
   private final DecisionDefinitionServices decisionDefinitionServices;
   private final MultiTenancyConfiguration multiTenancyCfg;
+  private final CamundaAuthenticationProvider authenticationProvider;
 
   public DecisionDefinitionController(
       final DecisionDefinitionServices decisionServices,
-      final MultiTenancyConfiguration multiTenancyCfg) {
+      final MultiTenancyConfiguration multiTenancyCfg,
+      final CamundaAuthenticationProvider authenticationProvider) {
     decisionDefinitionServices = decisionServices;
     this.multiTenancyCfg = multiTenancyCfg;
+    this.authenticationProvider = authenticationProvider;
   }
 
   @CamundaPostMapping(path = "/evaluation")
@@ -68,7 +72,7 @@ public class DecisionDefinitionController {
       return ResponseEntity.ok(
           SearchQueryResponseMapper.toDecisionDefinition(
               decisionDefinitionServices
-                  .withAuthentication(RequestMapper.getAuthentication())
+                  .withAuthentication(authenticationProvider.getCamundaAuthentication())
                   .getByKey(decisionDefinitionKey)));
     } catch (final Exception e) {
       return mapErrorToResponse(e);
@@ -85,7 +89,7 @@ public class DecisionDefinitionController {
           .contentType(new MediaType(MediaType.TEXT_XML, StandardCharsets.UTF_8))
           .body(
               decisionDefinitionServices
-                  .withAuthentication(RequestMapper.getAuthentication())
+                  .withAuthentication(authenticationProvider.getCamundaAuthentication())
                   .getDecisionDefinitionXml(decisionDefinitionKey));
     } catch (final Exception e) {
       return mapErrorToResponse(e);
@@ -97,7 +101,7 @@ public class DecisionDefinitionController {
     try {
       final var result =
           decisionDefinitionServices
-              .withAuthentication(RequestMapper.getAuthentication())
+              .withAuthentication(authenticationProvider.getCamundaAuthentication())
               .search(query);
       return ResponseEntity.ok(
           SearchQueryResponseMapper.toDecisionDefinitionSearchQueryResponse(result));
@@ -111,7 +115,7 @@ public class DecisionDefinitionController {
     return RequestMapper.executeServiceMethod(
         () ->
             decisionDefinitionServices
-                .withAuthentication(RequestMapper.getAuthentication())
+                .withAuthentication(authenticationProvider.getCamundaAuthentication())
                 .evaluateDecision(
                     request.decisionId(),
                     request.decisionKey(),

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/DecisionRequirementsController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/DecisionRequirementsController.java
@@ -10,10 +10,10 @@ package io.camunda.zeebe.gateway.rest.controller;
 import static io.camunda.zeebe.gateway.rest.RestErrorMapper.mapErrorToResponse;
 
 import io.camunda.search.query.DecisionRequirementsQuery;
+import io.camunda.security.auth.CamundaAuthenticationProvider;
 import io.camunda.service.DecisionRequirementsServices;
 import io.camunda.zeebe.gateway.protocol.rest.DecisionRequirementsResult;
 import io.camunda.zeebe.gateway.protocol.rest.DecisionRequirementsSearchQuery;
-import io.camunda.zeebe.gateway.rest.RequestMapper;
 import io.camunda.zeebe.gateway.rest.RestErrorMapper;
 import io.camunda.zeebe.gateway.rest.SearchQueryRequestMapper;
 import io.camunda.zeebe.gateway.rest.SearchQueryResponseMapper;
@@ -31,10 +31,13 @@ import org.springframework.web.bind.annotation.RequestMapping;
 public class DecisionRequirementsController {
 
   private final DecisionRequirementsServices decisionRequirementsServices;
+  private final CamundaAuthenticationProvider authenticationProvider;
 
   public DecisionRequirementsController(
-      final DecisionRequirementsServices decisionRequirementsServices) {
+      final DecisionRequirementsServices decisionRequirementsServices,
+      final CamundaAuthenticationProvider authenticationProvider) {
     this.decisionRequirementsServices = decisionRequirementsServices;
+    this.authenticationProvider = authenticationProvider;
   }
 
   @CamundaPostMapping(path = "/search")
@@ -48,7 +51,7 @@ public class DecisionRequirementsController {
     try {
       final var result =
           decisionRequirementsServices
-              .withAuthentication(RequestMapper.getAuthentication())
+              .withAuthentication(authenticationProvider.getCamundaAuthentication())
               .search(query);
       return ResponseEntity.ok(
           SearchQueryResponseMapper.toDecisionRequirementsSearchQueryResponse(result));
@@ -65,7 +68,7 @@ public class DecisionRequirementsController {
           .body(
               SearchQueryResponseMapper.toDecisionRequirements(
                   decisionRequirementsServices
-                      .withAuthentication(RequestMapper.getAuthentication())
+                      .withAuthentication(authenticationProvider.getCamundaAuthentication())
                       .getByKey(decisionRequirementsKey)));
     } catch (final Exception e) {
       return mapErrorToResponse(e);
@@ -82,7 +85,7 @@ public class DecisionRequirementsController {
           .contentType(new MediaType(MediaType.TEXT_XML, StandardCharsets.UTF_8))
           .body(
               decisionRequirementsServices
-                  .withAuthentication(RequestMapper.getAuthentication())
+                  .withAuthentication(authenticationProvider.getCamundaAuthentication())
                   .getDecisionRequirementsXml(decisionRequirementsKey));
     } catch (final Exception e) {
       return mapErrorToResponse(e);

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/DocumentController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/DocumentController.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.gateway.rest.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.security.auth.CamundaAuthenticationProvider;
 import io.camunda.service.DocumentServices;
 import io.camunda.service.DocumentServices.DocumentContentResponse;
 import io.camunda.service.DocumentServices.DocumentException;
@@ -42,11 +43,15 @@ public class DocumentController {
 
   private final DocumentServices documentServices;
   private final ObjectMapper objectMapper;
+  private final CamundaAuthenticationProvider authenticationProvider;
 
   public DocumentController(
-      final DocumentServices documentServices, final ObjectMapper objectMapper) {
+      final DocumentServices documentServices,
+      final ObjectMapper objectMapper,
+      final CamundaAuthenticationProvider authenticationProvider) {
     this.documentServices = documentServices;
     this.objectMapper = objectMapper;
+    this.authenticationProvider = authenticationProvider;
   }
 
   @CamundaPostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
@@ -75,7 +80,7 @@ public class DocumentController {
     return RequestMapper.executeServiceMethod(
         () ->
             documentServices
-                .withAuthentication(RequestMapper.getAuthentication())
+                .withAuthentication(authenticationProvider.getCamundaAuthentication())
                 .createDocument(request),
         ResponseMapper::toDocumentReference);
   }
@@ -86,7 +91,7 @@ public class DocumentController {
     return RequestMapper.executeServiceMethod(
         () ->
             documentServices
-                .withAuthentication(RequestMapper.getAuthentication())
+                .withAuthentication(authenticationProvider.getCamundaAuthentication())
                 .createDocumentBatch(requests),
         ResponseMapper::toDocumentReferenceBatch);
   }
@@ -149,7 +154,7 @@ public class DocumentController {
   private DocumentContentResponse getDocumentContentResponse(
       final String documentId, final String storeId, final String contentHash) {
     return documentServices
-        .withAuthentication(RequestMapper.getAuthentication())
+        .withAuthentication(authenticationProvider.getCamundaAuthentication())
         .getDocumentContent(documentId, storeId, contentHash);
   }
 
@@ -160,7 +165,7 @@ public class DocumentController {
     return RequestMapper.executeServiceMethodWithNoContentResult(
         () ->
             documentServices
-                .withAuthentication(RequestMapper.getAuthentication())
+                .withAuthentication(authenticationProvider.getCamundaAuthentication())
                 .deleteDocument(documentId, storeId));
   }
 
@@ -186,7 +191,7 @@ public class DocumentController {
     return RequestMapper.executeServiceMethod(
         () ->
             documentServices
-                .withAuthentication(RequestMapper.getAuthentication())
+                .withAuthentication(authenticationProvider.getCamundaAuthentication())
                 .createLink(documentId, storeId, contentHash, params),
         ResponseMapper::toDocumentLinkResponse);
   }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/MessageController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/MessageController.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.gateway.rest.controller;
 
+import io.camunda.security.auth.CamundaAuthenticationProvider;
 import io.camunda.security.configuration.MultiTenancyConfiguration;
 import io.camunda.service.MessageServices;
 import io.camunda.service.MessageServices.CorrelateMessageRequest;
@@ -28,11 +29,15 @@ public class MessageController {
 
   private final MessageServices messageServices;
   private final MultiTenancyConfiguration multiTenancyCfg;
+  private final CamundaAuthenticationProvider authenticationProvider;
 
   public MessageController(
-      final MessageServices messageServices, final MultiTenancyConfiguration multiTenancyCfg) {
+      final MessageServices messageServices,
+      final MultiTenancyConfiguration multiTenancyCfg,
+      final CamundaAuthenticationProvider authenticationProvider) {
     this.messageServices = messageServices;
     this.multiTenancyCfg = multiTenancyCfg;
+    this.authenticationProvider = authenticationProvider;
   }
 
   @CamundaPostMapping(path = "/publication")
@@ -56,7 +61,7 @@ public class MessageController {
     return RequestMapper.executeServiceMethod(
         () ->
             messageServices
-                .withAuthentication(RequestMapper.getAuthentication())
+                .withAuthentication(authenticationProvider.getCamundaAuthentication())
                 .correlateMessage(correlationRequest),
         ResponseMapper::toMessageCorrelationResponse);
   }
@@ -66,7 +71,7 @@ public class MessageController {
     return RequestMapper.executeServiceMethod(
         () ->
             messageServices
-                .withAuthentication(RequestMapper.getAuthentication())
+                .withAuthentication(authenticationProvider.getCamundaAuthentication())
                 .publishMessage(request),
         ResponseMapper::toMessagePublicationResponse);
   }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ProcessDefinitionController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ProcessDefinitionController.java
@@ -12,6 +12,7 @@ import static io.camunda.zeebe.gateway.rest.RestErrorMapper.mapErrorToResponse;
 import io.camunda.search.entities.ProcessDefinitionEntity;
 import io.camunda.search.filter.ProcessDefinitionStatisticsFilter;
 import io.camunda.search.query.ProcessDefinitionQuery;
+import io.camunda.security.auth.CamundaAuthenticationProvider;
 import io.camunda.service.FormServices;
 import io.camunda.service.ProcessDefinitionServices;
 import io.camunda.zeebe.gateway.protocol.rest.FormResult;
@@ -19,7 +20,6 @@ import io.camunda.zeebe.gateway.protocol.rest.ProcessDefinitionElementStatistics
 import io.camunda.zeebe.gateway.protocol.rest.ProcessDefinitionElementStatisticsQueryResult;
 import io.camunda.zeebe.gateway.protocol.rest.ProcessDefinitionSearchQuery;
 import io.camunda.zeebe.gateway.protocol.rest.ProcessDefinitionSearchQueryResult;
-import io.camunda.zeebe.gateway.rest.RequestMapper;
 import io.camunda.zeebe.gateway.rest.RestErrorMapper;
 import io.camunda.zeebe.gateway.rest.SearchQueryRequestMapper;
 import io.camunda.zeebe.gateway.rest.SearchQueryResponseMapper;
@@ -39,11 +39,15 @@ public class ProcessDefinitionController {
 
   private final ProcessDefinitionServices processDefinitionServices;
   private final FormServices formServices;
+  private final CamundaAuthenticationProvider authenticationProvider;
 
   public ProcessDefinitionController(
-      final ProcessDefinitionServices processDefinitionServices, final FormServices formServices) {
+      final ProcessDefinitionServices processDefinitionServices,
+      final FormServices formServices,
+      final CamundaAuthenticationProvider authenticationProvider) {
     this.processDefinitionServices = processDefinitionServices;
     this.formServices = formServices;
+    this.authenticationProvider = authenticationProvider;
   }
 
   @CamundaPostMapping(path = "/search")
@@ -58,7 +62,7 @@ public class ProcessDefinitionController {
     try {
       final var result =
           processDefinitionServices
-              .withAuthentication(RequestMapper.getAuthentication())
+              .withAuthentication(authenticationProvider.getCamundaAuthentication())
               .search(query);
       return ResponseEntity.ok(
           SearchQueryResponseMapper.toProcessDefinitionSearchQueryResponse(result));
@@ -77,7 +81,7 @@ public class ProcessDefinitionController {
           .body(
               SearchQueryResponseMapper.toProcessDefinition(
                   processDefinitionServices
-                      .withAuthentication(RequestMapper.getAuthentication())
+                      .withAuthentication(authenticationProvider.getCamundaAuthentication())
                       .getByKey(processDefinitionKey)));
     } catch (final Exception e) {
       return mapErrorToResponse(e);
@@ -91,7 +95,7 @@ public class ProcessDefinitionController {
       @PathVariable("processDefinitionKey") final long processDefinitionKey) {
     try {
       return processDefinitionServices
-          .withAuthentication(RequestMapper.getAuthentication())
+          .withAuthentication(authenticationProvider.getCamundaAuthentication())
           .getProcessDefinitionXml(processDefinitionKey)
           .map(
               s ->
@@ -110,7 +114,7 @@ public class ProcessDefinitionController {
     try {
       final ProcessDefinitionEntity processDefinition =
           processDefinitionServices
-              .withAuthentication(RequestMapper.getAuthentication())
+              .withAuthentication(authenticationProvider.getCamundaAuthentication())
               .getByKey(processDefinitionKey);
 
       if (processDefinition.formId() != null) {
@@ -118,7 +122,7 @@ public class ProcessDefinitionController {
             .body(
                 SearchQueryResponseMapper.toFormItem(
                     formServices
-                        .withAuthentication(RequestMapper.getAuthentication())
+                        .withAuthentication(authenticationProvider.getCamundaAuthentication())
                         .getLatestVersionByFormId(processDefinition.formId())
                         .get()));
       } else {
@@ -142,7 +146,7 @@ public class ProcessDefinitionController {
     try {
       final var result =
           processDefinitionServices
-              .withAuthentication(RequestMapper.getAuthentication())
+              .withAuthentication(authenticationProvider.getCamundaAuthentication())
               .elementStatistics(filter);
       return ResponseEntity.ok(
           SearchQueryResponseMapper.toProcessDefinitionElementStatisticsResult(result));

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceController.java
@@ -11,6 +11,7 @@ import static io.camunda.zeebe.gateway.rest.RestErrorMapper.mapErrorToResponse;
 
 import io.camunda.search.query.IncidentQuery;
 import io.camunda.search.query.ProcessInstanceQuery;
+import io.camunda.security.auth.CamundaAuthenticationProvider;
 import io.camunda.security.configuration.MultiTenancyConfiguration;
 import io.camunda.service.ProcessInstanceServices;
 import io.camunda.service.ProcessInstanceServices.ProcessInstanceCancelRequest;
@@ -50,12 +51,15 @@ public class ProcessInstanceController {
 
   private final ProcessInstanceServices processInstanceServices;
   private final MultiTenancyConfiguration multiTenancyCfg;
+  private final CamundaAuthenticationProvider authenticationProvider;
 
   public ProcessInstanceController(
       final ProcessInstanceServices processInstanceServices,
-      final MultiTenancyConfiguration multiTenancyCfg) {
+      final MultiTenancyConfiguration multiTenancyCfg,
+      final CamundaAuthenticationProvider authenticationProvider) {
     this.processInstanceServices = processInstanceServices;
     this.multiTenancyCfg = multiTenancyCfg;
+    this.authenticationProvider = authenticationProvider;
   }
 
   @CamundaPostMapping
@@ -105,7 +109,7 @@ public class ProcessInstanceController {
           .body(
               SearchQueryResponseMapper.toProcessInstance(
                   processInstanceServices
-                      .withAuthentication(RequestMapper.getAuthentication())
+                      .withAuthentication(authenticationProvider.getCamundaAuthentication())
                       .getByKey(processInstanceKey)));
     } catch (final Exception e) {
       return mapErrorToResponse(e);
@@ -120,7 +124,7 @@ public class ProcessInstanceController {
           .body(
               SearchQueryResponseMapper.toProcessInstanceCallHierarchyEntries(
                   processInstanceServices
-                      .withAuthentication(RequestMapper.getAuthentication())
+                      .withAuthentication(authenticationProvider.getCamundaAuthentication())
                       .callHierarchy(processInstanceKey)));
 
     } catch (final Exception e) {
@@ -136,7 +140,7 @@ public class ProcessInstanceController {
           .body(
               SearchQueryResponseMapper.toProcessInstanceElementStatisticsResult(
                   processInstanceServices
-                      .withAuthentication(RequestMapper.getAuthentication())
+                      .withAuthentication(authenticationProvider.getCamundaAuthentication())
                       .elementStatistics(processInstanceKey)));
     } catch (final Exception e) {
       return mapErrorToResponse(e);
@@ -151,7 +155,7 @@ public class ProcessInstanceController {
           .body(
               SearchQueryResponseMapper.toSequenceFlowsResult(
                   processInstanceServices
-                      .withAuthentication(RequestMapper.getAuthentication())
+                      .withAuthentication(authenticationProvider.getCamundaAuthentication())
                       .sequenceFlows(processInstanceKey)));
     } catch (final Exception e) {
       return mapErrorToResponse(e);
@@ -211,7 +215,7 @@ public class ProcessInstanceController {
     try {
       final var result =
           processInstanceServices
-              .withAuthentication(RequestMapper.getAuthentication())
+              .withAuthentication(authenticationProvider.getCamundaAuthentication())
               .search(query);
       return ResponseEntity.ok(
           SearchQueryResponseMapper.toProcessInstanceSearchQueryResponse(result));
@@ -225,7 +229,7 @@ public class ProcessInstanceController {
     try {
       final var result =
           processInstanceServices
-              .withAuthentication(RequestMapper.getAuthentication())
+              .withAuthentication(authenticationProvider.getCamundaAuthentication())
               .searchIncidents(processInstanceKey, query);
       return ResponseEntity.ok(SearchQueryResponseMapper.toIncidentSearchQueryResponse(result));
     } catch (final Exception e) {
@@ -238,7 +242,7 @@ public class ProcessInstanceController {
     return RequestMapper.executeServiceMethod(
         () ->
             processInstanceServices
-                .withAuthentication(RequestMapper.getAuthentication())
+                .withAuthentication(authenticationProvider.getCamundaAuthentication())
                 .cancelProcessInstanceBatchOperationWithResult(filter),
         ResponseMapper::toBatchOperationCreatedWithResultResponse);
   }
@@ -248,7 +252,7 @@ public class ProcessInstanceController {
     return RequestMapper.executeServiceMethod(
         () ->
             processInstanceServices
-                .withAuthentication(RequestMapper.getAuthentication())
+                .withAuthentication(authenticationProvider.getCamundaAuthentication())
                 .resolveIncidentsBatchOperationWithResult(filter),
         ResponseMapper::toBatchOperationCreatedWithResultResponse);
   }
@@ -258,7 +262,7 @@ public class ProcessInstanceController {
     return RequestMapper.executeServiceMethod(
         () ->
             processInstanceServices
-                .withAuthentication(RequestMapper.getAuthentication())
+                .withAuthentication(authenticationProvider.getCamundaAuthentication())
                 .migrateProcessInstancesBatchOperation(request),
         ResponseMapper::toBatchOperationCreatedWithResultResponse);
   }
@@ -268,7 +272,7 @@ public class ProcessInstanceController {
     return RequestMapper.executeServiceMethod(
         () ->
             processInstanceServices
-                .withAuthentication(RequestMapper.getAuthentication())
+                .withAuthentication(authenticationProvider.getCamundaAuthentication())
                 .modifyProcessInstancesBatchOperation(request),
         ResponseMapper::toBatchOperationCreatedWithResultResponse);
   }
@@ -279,14 +283,14 @@ public class ProcessInstanceController {
       return RequestMapper.executeServiceMethod(
           () ->
               processInstanceServices
-                  .withAuthentication(RequestMapper.getAuthentication())
+                  .withAuthentication(authenticationProvider.getCamundaAuthentication())
                   .createProcessInstanceWithResult(request),
           ResponseMapper::toCreateProcessInstanceWithResultResponse);
     }
     return RequestMapper.executeServiceMethod(
         () ->
             processInstanceServices
-                .withAuthentication(RequestMapper.getAuthentication())
+                .withAuthentication(authenticationProvider.getCamundaAuthentication())
                 .createProcessInstance(request),
         ResponseMapper::toCreateProcessInstanceResponse);
   }
@@ -296,7 +300,7 @@ public class ProcessInstanceController {
     return RequestMapper.executeServiceMethodWithNoContentResult(
         () ->
             processInstanceServices
-                .withAuthentication(RequestMapper.getAuthentication())
+                .withAuthentication(authenticationProvider.getCamundaAuthentication())
                 .cancelProcessInstance(request));
   }
 
@@ -305,7 +309,7 @@ public class ProcessInstanceController {
     return RequestMapper.executeServiceMethodWithNoContentResult(
         () ->
             processInstanceServices
-                .withAuthentication(RequestMapper.getAuthentication())
+                .withAuthentication(authenticationProvider.getCamundaAuthentication())
                 .migrateProcessInstance(request));
   }
 
@@ -314,7 +318,7 @@ public class ProcessInstanceController {
     return RequestMapper.executeServiceMethodWithNoContentResult(
         () ->
             processInstanceServices
-                .withAuthentication(RequestMapper.getAuthentication())
+                .withAuthentication(authenticationProvider.getCamundaAuthentication())
                 .modifyProcessInstance(request));
   }
 }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ResourceController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ResourceController.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.gateway.rest.controller;
 
+import io.camunda.security.auth.CamundaAuthenticationProvider;
 import io.camunda.security.configuration.MultiTenancyConfiguration;
 import io.camunda.service.ResourceServices;
 import io.camunda.service.ResourceServices.DeployResourcesRequest;
@@ -35,11 +36,15 @@ public class ResourceController {
 
   private final ResourceServices resourceServices;
   private final MultiTenancyConfiguration multiTenancyCfg;
+  private final CamundaAuthenticationProvider authenticationProvider;
 
   public ResourceController(
-      final ResourceServices resourceServices, final MultiTenancyConfiguration multiTenancyCfg) {
+      final ResourceServices resourceServices,
+      final MultiTenancyConfiguration multiTenancyCfg,
+      final CamundaAuthenticationProvider authenticationProvider) {
     this.resourceServices = resourceServices;
     this.multiTenancyCfg = multiTenancyCfg;
+    this.authenticationProvider = authenticationProvider;
   }
 
   @CamundaPostMapping(path = "/deployments", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
@@ -78,7 +83,7 @@ public class ResourceController {
     return RequestMapper.executeServiceMethod(
         () ->
             resourceServices
-                .withAuthentication(RequestMapper.getAuthentication())
+                .withAuthentication(authenticationProvider.getCamundaAuthentication())
                 .deployResources(request),
         ResponseMapper::toDeployResourceResponse);
   }
@@ -87,13 +92,13 @@ public class ResourceController {
     return RequestMapper.executeServiceMethodWithNoContentResult(
         () ->
             resourceServices
-                .withAuthentication(RequestMapper.getAuthentication())
+                .withAuthentication(authenticationProvider.getCamundaAuthentication())
                 .deleteResource(request));
   }
 
   private CompletableFuture<ResourceRecord> fetchResource(final long resourceKey) {
     return resourceServices
-        .withAuthentication(RequestMapper.getAuthentication())
+        .withAuthentication(authenticationProvider.getCamundaAuthentication())
         .fetchResource(new ResourceFetchRequest(resourceKey));
   }
 }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/SignalController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/SignalController.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.gateway.rest.controller;
 
+import io.camunda.security.auth.CamundaAuthenticationProvider;
 import io.camunda.security.configuration.MultiTenancyConfiguration;
 import io.camunda.service.SignalServices;
 import io.camunda.zeebe.gateway.protocol.rest.SignalBroadcastRequest;
@@ -27,12 +28,16 @@ public class SignalController {
 
   private final SignalServices signalServices;
   private final MultiTenancyConfiguration multiTenancyCfg;
+  private final CamundaAuthenticationProvider authenticationProvider;
 
   @Autowired
   public SignalController(
-      final SignalServices signalServices, final MultiTenancyConfiguration multiTenancyCfg) {
+      final SignalServices signalServices,
+      final MultiTenancyConfiguration multiTenancyCfg,
+      final CamundaAuthenticationProvider authenticationProvider) {
     this.signalServices = signalServices;
     this.multiTenancyCfg = multiTenancyCfg;
+    this.authenticationProvider = authenticationProvider;
   }
 
   @CamundaPostMapping(path = "/broadcast")
@@ -47,7 +52,7 @@ public class SignalController {
     return RequestMapper.executeServiceMethod(
         () ->
             signalServices
-                .withAuthentication(RequestMapper.getAuthentication())
+                .withAuthentication(authenticationProvider.getCamundaAuthentication())
                 .broadcastSignal(request.signalName(), request.variables(), request.tenantId()),
         ResponseMapper::toSignalBroadcastResponse);
   }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/UsageMetricsController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/UsageMetricsController.java
@@ -10,9 +10,9 @@ package io.camunda.zeebe.gateway.rest.controller;
 import static io.camunda.zeebe.gateway.rest.RestErrorMapper.mapErrorToResponse;
 
 import io.camunda.search.query.UsageMetricsQuery;
+import io.camunda.security.auth.CamundaAuthenticationProvider;
 import io.camunda.service.UsageMetricsServices;
 import io.camunda.zeebe.gateway.protocol.rest.UsageMetricsResponse;
-import io.camunda.zeebe.gateway.rest.RequestMapper;
 import io.camunda.zeebe.gateway.rest.RestErrorMapper;
 import io.camunda.zeebe.gateway.rest.SearchQueryRequestMapper;
 import io.camunda.zeebe.gateway.rest.SearchQueryResponseMapper;
@@ -26,9 +26,13 @@ import org.springframework.web.bind.annotation.RequestParam;
 public class UsageMetricsController {
 
   private final UsageMetricsServices usageMetricsServices;
+  private final CamundaAuthenticationProvider authenticationProvider;
 
-  public UsageMetricsController(final UsageMetricsServices usageMetricsServices) {
+  public UsageMetricsController(
+      final UsageMetricsServices usageMetricsServices,
+      final CamundaAuthenticationProvider authenticationProvider) {
     this.usageMetricsServices = usageMetricsServices;
+    this.authenticationProvider = authenticationProvider;
   }
 
   @CamundaGetMapping
@@ -43,7 +47,9 @@ public class UsageMetricsController {
   private ResponseEntity<UsageMetricsResponse> getMetrics(final UsageMetricsQuery query) {
     try {
       final var result =
-          usageMetricsServices.withAuthentication(RequestMapper.getAuthentication()).search(query);
+          usageMetricsServices
+              .withAuthentication(authenticationProvider.getCamundaAuthentication())
+              .search(query);
       return ResponseEntity.ok(SearchQueryResponseMapper.toUsageMetricsResponse(result));
     } catch (final Exception e) {
       return mapErrorToResponse(e);

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/VariableController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/VariableController.java
@@ -10,9 +10,9 @@ package io.camunda.zeebe.gateway.rest.controller;
 import static io.camunda.zeebe.gateway.rest.RestErrorMapper.mapErrorToResponse;
 
 import io.camunda.search.query.VariableQuery;
+import io.camunda.security.auth.CamundaAuthenticationProvider;
 import io.camunda.service.VariableServices;
 import io.camunda.zeebe.gateway.protocol.rest.VariableSearchQuery;
-import io.camunda.zeebe.gateway.rest.RequestMapper;
 import io.camunda.zeebe.gateway.rest.RestErrorMapper;
 import io.camunda.zeebe.gateway.rest.SearchQueryRequestMapper;
 import io.camunda.zeebe.gateway.rest.SearchQueryResponseMapper;
@@ -28,9 +28,13 @@ import org.springframework.web.bind.annotation.RequestMapping;
 public class VariableController {
 
   private final VariableServices variableServices;
+  private final CamundaAuthenticationProvider authenticationProvider;
 
-  public VariableController(final VariableServices variableServices) {
+  public VariableController(
+      final VariableServices variableServices,
+      final CamundaAuthenticationProvider authenticationProvider) {
     this.variableServices = variableServices;
+    this.authenticationProvider = authenticationProvider;
   }
 
   @CamundaPostMapping(path = "/search")
@@ -43,7 +47,9 @@ public class VariableController {
   private ResponseEntity<Object> search(final VariableQuery query) {
     try {
       final var result =
-          variableServices.withAuthentication(RequestMapper.getAuthentication()).search(query);
+          variableServices
+              .withAuthentication(authenticationProvider.getCamundaAuthentication())
+              .search(query);
       return ResponseEntity.ok(SearchQueryResponseMapper.toVariableSearchQueryResponse(result));
     } catch (final Exception e) {
       return mapErrorToResponse(e);
@@ -58,7 +64,7 @@ public class VariableController {
           .body(
               SearchQueryResponseMapper.toVariableItem(
                   variableServices
-                      .withAuthentication(RequestMapper.getAuthentication())
+                      .withAuthentication(authenticationProvider.getCamundaAuthentication())
                       .getByKey(variableKey)));
     } catch (final Exception e) {
       return mapErrorToResponse(e);

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantController.java
@@ -14,6 +14,7 @@ import io.camunda.search.query.MappingQuery;
 import io.camunda.search.query.RoleQuery;
 import io.camunda.search.query.TenantQuery;
 import io.camunda.search.query.UserQuery;
+import io.camunda.security.auth.CamundaAuthenticationProvider;
 import io.camunda.service.GroupServices;
 import io.camunda.service.MappingServices;
 import io.camunda.service.RoleServices;
@@ -60,18 +61,21 @@ public class TenantController {
   private final MappingServices mappingServices;
   private final GroupServices groupServices;
   private final RoleServices roleServices;
+  private final CamundaAuthenticationProvider authenticationProvider;
 
   public TenantController(
       final TenantServices tenantServices,
       final UserServices userServices,
       final MappingServices mappingServices,
       final GroupServices groupServices,
-      final RoleServices roleServices) {
+      final RoleServices roleServices,
+      final CamundaAuthenticationProvider authenticationProvider) {
     this.tenantServices = tenantServices;
     this.userServices = userServices;
     this.mappingServices = mappingServices;
     this.groupServices = groupServices;
     this.roleServices = roleServices;
+    this.authenticationProvider = authenticationProvider;
   }
 
   @CamundaPostMapping
@@ -88,7 +92,7 @@ public class TenantController {
           .body(
               SearchQueryResponseMapper.toTenant(
                   tenantServices
-                      .withAuthentication(RequestMapper.getAuthentication())
+                      .withAuthentication(authenticationProvider.getCamundaAuthentication())
                       .getById(tenantId)));
     } catch (final Exception exception) {
       return RestErrorMapper.mapErrorToResponse(exception);
@@ -161,7 +165,7 @@ public class TenantController {
     return RequestMapper.executeServiceMethodWithNoContentResult(
         () ->
             tenantServices
-                .withAuthentication(RequestMapper.getAuthentication())
+                .withAuthentication(authenticationProvider.getCamundaAuthentication())
                 .deleteTenant(tenantId));
   }
 
@@ -244,7 +248,7 @@ public class TenantController {
     return RequestMapper.executeServiceMethod(
         () ->
             tenantServices
-                .withAuthentication(RequestMapper.getAuthentication())
+                .withAuthentication(authenticationProvider.getCamundaAuthentication())
                 .createTenant(tenantDTO),
         ResponseMapper::toTenantCreateResponse);
   }
@@ -254,7 +258,7 @@ public class TenantController {
     return RequestMapper.executeServiceMethodWithNoContentResult(
         () ->
             tenantServices
-                .withAuthentication(RequestMapper.getAuthentication())
+                .withAuthentication(authenticationProvider.getCamundaAuthentication())
                 .addMember(request));
   }
 
@@ -263,14 +267,16 @@ public class TenantController {
     return RequestMapper.executeServiceMethodWithNoContentResult(
         () ->
             tenantServices
-                .withAuthentication(RequestMapper.getAuthentication())
+                .withAuthentication(authenticationProvider.getCamundaAuthentication())
                 .removeMember(request));
   }
 
   private ResponseEntity<TenantSearchQueryResult> search(final TenantQuery query) {
     try {
       final var result =
-          tenantServices.withAuthentication(RequestMapper.getAuthentication()).search(query);
+          tenantServices
+              .withAuthentication(authenticationProvider.getCamundaAuthentication())
+              .search(query);
       return ResponseEntity.ok(SearchQueryResponseMapper.toTenantSearchQueryResponse(result));
     } catch (final Exception e) {
       return mapErrorToResponse(e);
@@ -282,7 +288,7 @@ public class TenantController {
     try {
       final var result =
           tenantServices
-              .withAuthentication(RequestMapper.getAuthentication())
+              .withAuthentication(authenticationProvider.getCamundaAuthentication())
               .searchMembers(buildTenantMemberQuery(tenantId, EntityType.USER, tenantQuery));
       return ResponseEntity.ok(SearchQueryResponseMapper.toTenantUserSearchQueryResponse(result));
     } catch (final Exception e) {
@@ -295,7 +301,7 @@ public class TenantController {
     try {
       final var result =
           tenantServices
-              .withAuthentication(RequestMapper.getAuthentication())
+              .withAuthentication(authenticationProvider.getCamundaAuthentication())
               .searchMembers(buildTenantMemberQuery(tenantId, EntityType.CLIENT, query));
       return ResponseEntity.ok(SearchQueryResponseMapper.toTenantClientSearchQueryResponse(result));
     } catch (final Exception e) {
@@ -309,7 +315,7 @@ public class TenantController {
       final var composedMappingQuery = buildMappingQuery(tenantId, mappingQuery);
       final var result =
           mappingServices
-              .withAuthentication(RequestMapper.getAuthentication())
+              .withAuthentication(authenticationProvider.getCamundaAuthentication())
               .search(composedMappingQuery);
       return ResponseEntity.ok(SearchQueryResponseMapper.toMappingSearchQueryResponse(result));
     } catch (final Exception e) {
@@ -323,7 +329,7 @@ public class TenantController {
       final var composedUserQuery = buildUserQuery(tenantId, userQuery);
       final var result =
           userServices
-              .withAuthentication(RequestMapper.getAuthentication())
+              .withAuthentication(authenticationProvider.getCamundaAuthentication())
               .search(composedUserQuery);
       return ResponseEntity.ok(SearchQueryResponseMapper.toUserSearchQueryResponse(result));
     } catch (final Exception e) {
@@ -337,7 +343,7 @@ public class TenantController {
       final var composedGroupQuery = buildGroupQuery(tenantId, groupQuery);
       final var result =
           groupServices
-              .withAuthentication(RequestMapper.getAuthentication())
+              .withAuthentication(authenticationProvider.getCamundaAuthentication())
               .search(composedGroupQuery);
       return ResponseEntity.ok(SearchQueryResponseMapper.toGroupSearchQueryResponse(result));
     } catch (final Exception e) {
@@ -351,7 +357,7 @@ public class TenantController {
       final var composedRoleQuery = buildRoleQuery(tenantId, roleQuery);
       final var result =
           roleServices
-              .withAuthentication(RequestMapper.getAuthentication())
+              .withAuthentication(authenticationProvider.getCamundaAuthentication())
               .search(composedRoleQuery);
       return ResponseEntity.ok(SearchQueryResponseMapper.toRoleSearchQueryResponse(result));
     } catch (final Exception e) {
@@ -394,7 +400,7 @@ public class TenantController {
     return RequestMapper.executeServiceMethod(
         () ->
             tenantServices
-                .withAuthentication(RequestMapper.getAuthentication())
+                .withAuthentication(authenticationProvider.getCamundaAuthentication())
                 .updateTenant(tenantDTO),
         ResponseMapper::toTenantUpdateResponse);
   }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/AuthorizationController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/AuthorizationController.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.gateway.rest.controller.usermanagement;
 import static io.camunda.zeebe.gateway.rest.RestErrorMapper.mapErrorToResponse;
 
 import io.camunda.search.query.AuthorizationQuery;
+import io.camunda.security.auth.CamundaAuthenticationProvider;
 import io.camunda.service.AuthorizationServices;
 import io.camunda.service.AuthorizationServices.CreateAuthorizationRequest;
 import io.camunda.service.AuthorizationServices.UpdateAuthorizationRequest;
@@ -36,9 +37,13 @@ import org.springframework.web.bind.annotation.RequestMapping;
 @RequestMapping("/v2/authorizations")
 public class AuthorizationController {
   private final AuthorizationServices authorizationServices;
+  private final CamundaAuthenticationProvider authenticationProvider;
 
-  public AuthorizationController(final AuthorizationServices authorizationServices) {
+  public AuthorizationController(
+      final AuthorizationServices authorizationServices,
+      final CamundaAuthenticationProvider authenticationProvider) {
     this.authorizationServices = authorizationServices;
+    this.authenticationProvider = authenticationProvider;
   }
 
   @CamundaPostMapping()
@@ -55,7 +60,7 @@ public class AuthorizationController {
           .body(
               SearchQueryResponseMapper.toAuthorization(
                   authorizationServices
-                      .withAuthentication(RequestMapper.getAuthentication())
+                      .withAuthentication(authenticationProvider.getCamundaAuthentication())
                       .getAuthorization(authorizationKey)));
     } catch (final Exception exception) {
       return RestErrorMapper.mapErrorToResponse(exception);
@@ -68,7 +73,7 @@ public class AuthorizationController {
     return RequestMapper.executeServiceMethodWithNoContentResult(
         () ->
             authorizationServices
-                .withAuthentication(RequestMapper.getAuthentication())
+                .withAuthentication(authenticationProvider.getCamundaAuthentication())
                 .deleteAuthorization(authorizationKey));
   }
 
@@ -90,7 +95,9 @@ public class AuthorizationController {
   private ResponseEntity<AuthorizationSearchResult> search(final AuthorizationQuery query) {
     try {
       final var result =
-          authorizationServices.withAuthentication(RequestMapper.getAuthentication()).search(query);
+          authorizationServices
+              .withAuthentication(authenticationProvider.getCamundaAuthentication())
+              .search(query);
       return ResponseEntity.ok(
           SearchQueryResponseMapper.toAuthorizationSearchQueryResponse(result));
     } catch (final Exception e) {
@@ -103,7 +110,7 @@ public class AuthorizationController {
     return RequestMapper.executeServiceMethod(
         () ->
             authorizationServices
-                .withAuthentication(RequestMapper.getAuthentication())
+                .withAuthentication(authenticationProvider.getCamundaAuthentication())
                 .createAuthorization(createAuthorizationRequest),
         ResponseMapper::toAuthorizationCreateResponse);
   }
@@ -113,7 +120,7 @@ public class AuthorizationController {
     return RequestMapper.executeServiceMethodWithNoContentResult(
         () ->
             authorizationServices
-                .withAuthentication(RequestMapper.getAuthentication())
+                .withAuthentication(authenticationProvider.getCamundaAuthentication())
                 .updateAuthorization(authorizationRequest));
   }
 }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupController.java
@@ -14,6 +14,7 @@ import io.camunda.authentication.ConditionalOnInternalGroupsEnabled;
 import io.camunda.search.query.GroupQuery;
 import io.camunda.search.query.MappingQuery;
 import io.camunda.search.query.RoleQuery;
+import io.camunda.security.auth.CamundaAuthenticationProvider;
 import io.camunda.service.GroupServices;
 import io.camunda.service.GroupServices.GroupDTO;
 import io.camunda.service.GroupServices.GroupMemberDTO;
@@ -56,14 +57,17 @@ public class GroupController {
   private final GroupServices groupServices;
   private final MappingServices mappingServices;
   private final RoleServices roleServices;
+  private final CamundaAuthenticationProvider authenticationProvider;
 
   public GroupController(
       final GroupServices groupServices,
       final MappingServices mappingServices,
-      final RoleServices roleServices) {
+      final RoleServices roleServices,
+      final CamundaAuthenticationProvider authenticationProvider) {
     this.groupServices = groupServices;
     this.mappingServices = mappingServices;
     this.roleServices = roleServices;
+    this.authenticationProvider = authenticationProvider;
   }
 
   @CamundaPostMapping
@@ -86,7 +90,7 @@ public class GroupController {
     return RequestMapper.executeServiceMethodWithNoContentResult(
         () ->
             groupServices
-                .withAuthentication(RequestMapper.getAuthentication())
+                .withAuthentication(authenticationProvider.getCamundaAuthentication())
                 .deleteGroup(groupId));
   }
 
@@ -187,7 +191,7 @@ public class GroupController {
           .body(
               SearchQueryResponseMapper.toGroup(
                   groupServices
-                      .withAuthentication(RequestMapper.getAuthentication())
+                      .withAuthentication(authenticationProvider.getCamundaAuthentication())
                       .getGroup(groupId)));
     } catch (final Exception exception) {
       return RestErrorMapper.mapErrorToResponse(exception);
@@ -204,7 +208,9 @@ public class GroupController {
   private ResponseEntity<GroupSearchQueryResult> search(final GroupQuery query) {
     try {
       final var result =
-          groupServices.withAuthentication(RequestMapper.getAuthentication()).search(query);
+          groupServices
+              .withAuthentication(authenticationProvider.getCamundaAuthentication())
+              .search(query);
       return ResponseEntity.ok(SearchQueryResponseMapper.toGroupSearchQueryResponse(result));
     } catch (final Exception e) {
       return RestErrorMapper.mapErrorToResponse(e);
@@ -215,7 +221,7 @@ public class GroupController {
     return RequestMapper.executeServiceMethod(
         () ->
             groupServices
-                .withAuthentication(RequestMapper.getAuthentication())
+                .withAuthentication(authenticationProvider.getCamundaAuthentication())
                 .createGroup(groupDTO),
         ResponseMapper::toGroupCreateResponse);
   }
@@ -224,7 +230,7 @@ public class GroupController {
     return RequestMapper.executeServiceMethod(
         () ->
             groupServices
-                .withAuthentication(RequestMapper.getAuthentication())
+                .withAuthentication(authenticationProvider.getCamundaAuthentication())
                 .updateGroup(
                     updateGroupRequest.groupId(),
                     updateGroupRequest.name(),
@@ -236,7 +242,7 @@ public class GroupController {
     return RequestMapper.executeServiceMethodWithAcceptedResult(
         () ->
             groupServices
-                .withAuthentication(RequestMapper.getAuthentication())
+                .withAuthentication(authenticationProvider.getCamundaAuthentication())
                 .assignMember(request));
   }
 
@@ -245,7 +251,7 @@ public class GroupController {
     try {
       final var result =
           groupServices
-              .withAuthentication(RequestMapper.getAuthentication())
+              .withAuthentication(authenticationProvider.getCamundaAuthentication())
               .searchMembers(buildGroupMemberQuery(groupId, EntityType.USER, groupQuery));
       return ResponseEntity.ok(SearchQueryResponseMapper.toGroupUserSearchQueryResponse(result));
     } catch (final Exception e) {
@@ -258,7 +264,7 @@ public class GroupController {
     try {
       final var result =
           groupServices
-              .withAuthentication(RequestMapper.getAuthentication())
+              .withAuthentication(authenticationProvider.getCamundaAuthentication())
               .searchMembers(buildGroupMemberQuery(groupId, EntityType.CLIENT, groupQuery));
       return ResponseEntity.ok(SearchQueryResponseMapper.toGroupClientSearchQueryResponse(result));
     } catch (final Exception e) {
@@ -272,7 +278,7 @@ public class GroupController {
       final var composedMappingQuery = buildMappingQuery(groupId, mappingQuery);
       final var result =
           mappingServices
-              .withAuthentication(RequestMapper.getAuthentication())
+              .withAuthentication(authenticationProvider.getCamundaAuthentication())
               .search(composedMappingQuery);
       return ResponseEntity.ok(SearchQueryResponseMapper.toMappingSearchQueryResponse(result));
     } catch (final Exception e) {
@@ -286,7 +292,7 @@ public class GroupController {
       final var composedRoleQuery = buildRoleQuery(groupId, roleQuery);
       final var result =
           roleServices
-              .withAuthentication(RequestMapper.getAuthentication())
+              .withAuthentication(authenticationProvider.getCamundaAuthentication())
               .search(composedRoleQuery);
       return ResponseEntity.ok(SearchQueryResponseMapper.toRoleSearchQueryResponse(result));
     } catch (final Exception e) {
@@ -318,7 +324,7 @@ public class GroupController {
     return RequestMapper.executeServiceMethodWithAcceptedResult(
         () ->
             groupServices
-                .withAuthentication(RequestMapper.getAuthentication())
+                .withAuthentication(authenticationProvider.getCamundaAuthentication())
                 .removeMember(request));
   }
 }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleController.java
@@ -12,6 +12,7 @@ import static io.camunda.zeebe.gateway.rest.RestErrorMapper.mapErrorToResponse;
 import io.camunda.search.query.GroupQuery;
 import io.camunda.search.query.MappingQuery;
 import io.camunda.search.query.RoleQuery;
+import io.camunda.security.auth.CamundaAuthenticationProvider;
 import io.camunda.service.GroupServices;
 import io.camunda.service.MappingServices;
 import io.camunda.service.RoleServices;
@@ -55,16 +56,19 @@ public class RoleController {
   private final UserServices userServices;
   private final MappingServices mappingServices;
   private final GroupServices groupServices;
+  private final CamundaAuthenticationProvider authenticationProvider;
 
   public RoleController(
       final RoleServices roleServices,
       final UserServices userServices,
       final MappingServices mappingServices,
-      final GroupServices groupServices) {
+      final GroupServices groupServices,
+      final CamundaAuthenticationProvider authenticationProvider) {
     this.roleServices = roleServices;
     this.userServices = userServices;
     this.mappingServices = mappingServices;
     this.groupServices = groupServices;
+    this.authenticationProvider = authenticationProvider;
   }
 
   @CamundaPostMapping
@@ -79,7 +83,7 @@ public class RoleController {
     return RequestMapper.executeServiceMethod(
         () ->
             roleServices
-                .withAuthentication(RequestMapper.getAuthentication())
+                .withAuthentication(authenticationProvider.getCamundaAuthentication())
                 .createRole(createRoleRequest),
         ResponseMapper::toRoleCreateResponse);
   }
@@ -96,7 +100,7 @@ public class RoleController {
     return RequestMapper.executeServiceMethod(
         () ->
             roleServices
-                .withAuthentication(RequestMapper.getAuthentication())
+                .withAuthentication(authenticationProvider.getCamundaAuthentication())
                 .updateRole(updateRoleRequest),
         ResponseMapper::toRoleUpdateResponse);
   }
@@ -105,7 +109,9 @@ public class RoleController {
   public CompletableFuture<ResponseEntity<Object>> deleteRole(@PathVariable final String roleId) {
     return RequestMapper.executeServiceMethodWithNoContentResult(
         () ->
-            roleServices.withAuthentication(RequestMapper.getAuthentication()).deleteRole(roleId));
+            roleServices
+                .withAuthentication(authenticationProvider.getCamundaAuthentication())
+                .deleteRole(roleId));
   }
 
   @CamundaGetMapping(path = "/{roleId}")
@@ -115,7 +121,7 @@ public class RoleController {
           .body(
               SearchQueryResponseMapper.toRole(
                   roleServices
-                      .withAuthentication(RequestMapper.getAuthentication())
+                      .withAuthentication(authenticationProvider.getCamundaAuthentication())
                       .getRole(roleId)));
     } catch (final Exception exception) {
       return RestErrorMapper.mapErrorToResponse(exception);
@@ -132,7 +138,9 @@ public class RoleController {
   private ResponseEntity<RoleSearchQueryResult> search(final RoleQuery query) {
     try {
       final var result =
-          roleServices.withAuthentication(RequestMapper.getAuthentication()).search(query);
+          roleServices
+              .withAuthentication(authenticationProvider.getCamundaAuthentication())
+              .search(query);
       return ResponseEntity.ok(SearchQueryResponseMapper.toRoleSearchQueryResponse(result));
     } catch (final Exception e) {
       return RestErrorMapper.mapErrorToResponse(e);
@@ -154,7 +162,7 @@ public class RoleController {
     try {
       final var result =
           roleServices
-              .withAuthentication(RequestMapper.getAuthentication())
+              .withAuthentication(authenticationProvider.getCamundaAuthentication())
               .searchMembers(buildRoleMemberQuery(roleId, EntityType.USER, query));
       return ResponseEntity.ok(SearchQueryResponseMapper.toRoleUserSearchQueryResponse(result));
     } catch (final Exception e) {
@@ -177,7 +185,7 @@ public class RoleController {
     try {
       final var result =
           roleServices
-              .withAuthentication(RequestMapper.getAuthentication())
+              .withAuthentication(authenticationProvider.getCamundaAuthentication())
               .searchMembers(buildRoleMemberQuery(tenantId, EntityType.CLIENT, query));
       return ResponseEntity.ok(SearchQueryResponseMapper.toRoleClientSearchQueryResponse(result));
     } catch (final Exception e) {
@@ -208,7 +216,7 @@ public class RoleController {
       final var composedMappingQuery = buildMappingQuery(roleId, mappingQuery);
       final var result =
           mappingServices
-              .withAuthentication(RequestMapper.getAuthentication())
+              .withAuthentication(authenticationProvider.getCamundaAuthentication())
               .search(composedMappingQuery);
       return ResponseEntity.ok(SearchQueryResponseMapper.toMappingSearchQueryResponse(result));
     } catch (final Exception e) {
@@ -253,7 +261,9 @@ public class RoleController {
       final RoleMemberRequest request) {
     return RequestMapper.executeServiceMethodWithAcceptedResult(
         () ->
-            roleServices.withAuthentication(RequestMapper.getAuthentication()).addMember(request));
+            roleServices
+                .withAuthentication(authenticationProvider.getCamundaAuthentication())
+                .addMember(request));
   }
 
   @CamundaPutMapping(
@@ -310,7 +320,7 @@ public class RoleController {
       final var composedGroupQuery = buildGroupQuery(roleId, query);
       final var result =
           groupServices
-              .withAuthentication(RequestMapper.getAuthentication())
+              .withAuthentication(authenticationProvider.getCamundaAuthentication())
               .search(composedGroupQuery);
       return ResponseEntity.ok(SearchQueryResponseMapper.toGroupSearchQueryResponse(result));
     } catch (final Exception e) {
@@ -330,7 +340,7 @@ public class RoleController {
     return RequestMapper.executeServiceMethodWithAcceptedResult(
         () ->
             roleServices
-                .withAuthentication(RequestMapper.getAuthentication())
+                .withAuthentication(authenticationProvider.getCamundaAuthentication())
                 .removeMember(request));
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/RequestMapperTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/RequestMapperTest.java
@@ -7,22 +7,11 @@
  */
 package io.camunda.zeebe.gateway.rest;
 
-import static io.camunda.zeebe.auth.Authorization.USER_TOKEN_CLAIMS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
-import com.auth0.jwt.JWT;
-import com.auth0.jwt.algorithms.Algorithm;
-import io.camunda.authentication.CamundaJwtAuthenticationToken;
-import io.camunda.authentication.entity.AuthenticationContext.AuthenticationContextBuilder;
-import io.camunda.authentication.entity.CamundaJwtUser;
-import io.camunda.authentication.entity.CamundaOidcUser;
-import io.camunda.authentication.entity.CamundaUser.CamundaUserBuilder;
-import io.camunda.authentication.entity.OAuthContext;
 import io.camunda.service.ProcessInstanceServices.ProcessInstanceMigrateBatchOperationRequest;
 import io.camunda.service.ProcessInstanceServices.ProcessInstanceModifyBatchOperationRequest;
-import io.camunda.service.TenantServices.TenantDTO;
-import io.camunda.zeebe.auth.Authorization;
 import io.camunda.zeebe.gateway.protocol.rest.MigrateProcessInstanceMappingInstruction;
 import io.camunda.zeebe.gateway.protocol.rest.ProcessInstanceFilter;
 import io.camunda.zeebe.gateway.protocol.rest.ProcessInstanceMigrationBatchOperationPlan;
@@ -30,183 +19,11 @@ import io.camunda.zeebe.gateway.protocol.rest.ProcessInstanceMigrationBatchOpera
 import io.camunda.zeebe.gateway.protocol.rest.ProcessInstanceModificationBatchOperationRequest;
 import io.camunda.zeebe.gateway.protocol.rest.ProcessInstanceModificationMoveBatchOperationInstruction;
 import io.camunda.zeebe.util.Either;
-import java.time.Instant;
-import java.time.temporal.ChronoUnit;
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 import org.springframework.http.ProblemDetail;
-import org.springframework.security.authentication.AbstractAuthenticationToken;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
-import org.springframework.security.oauth2.core.oidc.OidcIdToken;
-import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser;
-import org.springframework.security.oauth2.jwt.Jwt;
-import org.springframework.web.context.request.RequestAttributes;
-import org.springframework.web.context.request.RequestContextHolder;
 
 class RequestMapperTest {
-
-  @Mock private RequestAttributes requestAttributes;
-
-  @BeforeEach
-  void setup() throws Exception {
-    MockitoAnnotations.openMocks(this).close();
-    RequestContextHolder.setRequestAttributes(requestAttributes);
-  }
-
-  @Test
-  void tokenContainsUsernameWithBasicAuth() {
-
-    // given
-    final var username = "username";
-    setUsernamePasswordAuthenticationInContext(username);
-
-    // when
-    final var claims = RequestMapper.getAuthentication().claims();
-
-    // then
-    assertNotNull(claims);
-    assertThat(claims).containsKey(Authorization.AUTHORIZED_USERNAME);
-    assertThat(claims.get(Authorization.AUTHORIZED_USERNAME)).isEqualTo(username);
-  }
-
-  @Test
-  void tokenContainsExtraClaimsWithOidcAuth() {
-    // given
-    final String usernameClaim = "sub";
-    final String usernameValue = "test-user";
-    setOidcAuthenticationInContext(usernameClaim, usernameValue, "aud1");
-
-    // when
-    final var authenticatedUsername = RequestMapper.getAuthentication().authenticatedUsername();
-
-    // then
-    assertThat(authenticatedUsername).isEqualTo(usernameValue);
-  }
-
-  @Test
-  void tokenContainsExtraClaimsWithJwtAuth() {
-
-    // given
-    final String sub1 = "sub1";
-    final String aud1 = "aud1";
-    setJwtAuthenticationInContext(sub1, aud1);
-
-    // when
-    final var claims =
-        (Map<String, Object>) RequestMapper.getAuthentication().claims().get(USER_TOKEN_CLAIMS);
-
-    // then
-    assertNotNull(claims);
-    assertThat(claims).containsKey("sub");
-    assertThat(claims).containsKey("aud");
-    assertThat(claims).containsKey("groups");
-    assertThat(claims.get("sub")).isEqualTo(sub1);
-    assertThat(claims.get("aud")).isEqualTo(aud1);
-    assertThat(claims.get("groups")).isEqualTo(List.of("g1", "g2"));
-  }
-
-  @Test
-  void tokenContainsTenantIdsInAuthenticationContext() {
-    // given
-    final var username = "test-user";
-    final var tenants =
-        List.of(
-            new TenantDTO(1L, "tenant-1", "Tenant One", "First"),
-            new TenantDTO(2L, "tenant-2", "Tenant Two", "Second"));
-    final var authenticationContext =
-        new AuthenticationContextBuilder().withUsername(username).withTenants(tenants).build();
-
-    final var principal =
-        new CamundaOidcUser(
-            new DefaultOidcUser(
-                Collections.emptyList(),
-                new OidcIdToken(
-                    "tokenValue",
-                    Instant.now(),
-                    Instant.now().plusSeconds(3600),
-                    Map.of("sub", username))),
-            Collections.emptySet(),
-            authenticationContext);
-
-    final var auth = new OAuth2AuthenticationToken(principal, List.of(), "oidc");
-    SecurityContextHolder.getContext().setAuthentication(auth);
-
-    // when
-    final var authContext = RequestMapper.getAuthentication();
-
-    // then
-    assertThat(authContext.authenticatedTenantIds())
-        .containsExactlyInAnyOrder("tenant-1", "tenant-2");
-    assertThat(authContext.authenticatedUsername()).isEqualTo(username);
-  }
-
-  @Test
-  void usernameIsSetInAuthenticationWhenOnAuthenticationContext() {
-    // given
-    final var username = "test-user";
-    final var authenticationContext =
-        new AuthenticationContextBuilder().withUsername(username).build();
-
-    final var principal =
-        new CamundaOidcUser(
-            new DefaultOidcUser(
-                Collections.emptyList(),
-                new OidcIdToken(
-                    "tokenValue",
-                    Instant.now(),
-                    Instant.now().plusSeconds(3600),
-                    Map.of("sub", username))),
-            Collections.emptySet(),
-            authenticationContext);
-
-    final var auth = new OAuth2AuthenticationToken(principal, List.of(), "oidc");
-    SecurityContextHolder.getContext().setAuthentication(auth);
-
-    // when
-    final var authentication = RequestMapper.getAuthentication();
-
-    // then
-    assertThat(authentication.authenticatedUsername()).isEqualTo(username);
-    assertThat(authentication.authenticatedClientId()).isNull();
-  }
-
-  @Test
-  void clientIdIsSetInAuthenticationWhenOnAuthenticationContext() {
-    // given
-    final var clientId = "my-application";
-    final var authenticationContext =
-        new AuthenticationContextBuilder().withClientId(clientId).build();
-
-    final var principal =
-        new CamundaOidcUser(
-            new DefaultOidcUser(
-                Collections.emptyList(),
-                new OidcIdToken(
-                    "tokenValue",
-                    Instant.now(),
-                    Instant.now().plusSeconds(3600),
-                    Map.of("sub", clientId))),
-            Collections.emptySet(),
-            authenticationContext);
-
-    final var auth = new OAuth2AuthenticationToken(principal, List.of(), "oidc");
-    SecurityContextHolder.getContext().setAuthentication(auth);
-
-    // when
-    final var authContext = RequestMapper.getAuthentication();
-
-    // then
-    assertThat(authContext.authenticatedUsername()).isNull();
-    assertThat(authContext.authenticatedClientId()).isEqualTo(clientId);
-  }
 
   @Test
   void shouldMapToProcessInstanceMigrationBatchOperationRequest() {
@@ -315,70 +132,5 @@ class RequestMapperTest {
     final var problemDetail = result.getLeft();
     assertThat(problemDetail.getStatus()).isEqualTo(400);
     assertThat(problemDetail.getDetail()).isEqualTo("No targetElementId provided.");
-  }
-
-  private void setJwtAuthenticationInContext(final String sub, final String aud) {
-    final Jwt jwt =
-        new Jwt(
-            JWT.create()
-                .withIssuer("issuer1")
-                .withAudience(aud)
-                .withSubject(sub)
-                .sign(Algorithm.none()),
-            Instant.ofEpochSecond(10),
-            Instant.ofEpochSecond(100),
-            Map.of("alg", "RSA256"),
-            Map.of("sub", sub, "aud", aud, "groups", List.of("g1", "g2")));
-
-    final AbstractAuthenticationToken token =
-        new CamundaJwtAuthenticationToken(
-            jwt,
-            new CamundaJwtUser(
-                jwt,
-                new OAuthContext(
-                    new HashSet<>(),
-                    new AuthenticationContextBuilder()
-                        .withUsername(sub)
-                        .withGroups(List.of("g1", "g2"))
-                        .build())),
-            null,
-            null);
-    SecurityContextHolder.getContext().setAuthentication(token);
-  }
-
-  private void setOidcAuthenticationInContext(
-      final String usernameClaim, final String usernameValue, final String aud) {
-    final String tokenValue = "{}";
-    final Instant tokenIssuedAt = Instant.now().truncatedTo(ChronoUnit.SECONDS);
-    final Instant tokenExpiresAt = tokenIssuedAt.plus(1, ChronoUnit.DAYS);
-
-    final var oauth2Authentication =
-        new OAuth2AuthenticationToken(
-            new CamundaOidcUser(
-                new DefaultOidcUser(
-                    Collections.emptyList(),
-                    new OidcIdToken(
-                        tokenValue,
-                        tokenIssuedAt,
-                        tokenExpiresAt,
-                        Map.of("aud", aud, usernameClaim, usernameValue))),
-                Collections.emptySet(),
-                new AuthenticationContextBuilder().withUsername(usernameValue).build()),
-            List.of(),
-            "oidc");
-
-    SecurityContextHolder.getContext().setAuthentication(oauth2Authentication);
-  }
-
-  private void setUsernamePasswordAuthenticationInContext(final String username) {
-    final UsernamePasswordAuthenticationToken authenticationToken =
-        new UsernamePasswordAuthenticationToken(
-            CamundaUserBuilder.aCamundaUser()
-                .withUsername(username)
-                .withPassword("admin")
-                .withUserKey(1L)
-                .build(),
-            null);
-    SecurityContextHolder.getContext().setAuthentication(authenticationToken);
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/RestControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/RestControllerTest.java
@@ -9,7 +9,7 @@ package io.camunda.zeebe.gateway.rest;
 
 import io.camunda.search.filter.Operation;
 import io.camunda.search.filter.Operator;
-import io.camunda.security.auth.Authentication;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.zeebe.gateway.rest.config.JacksonConfig;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
@@ -82,7 +82,8 @@ public abstract class RestControllerTest {
         Mockito.mockStatic(RequestMapper.class, Mockito.CALLS_REAL_METHODS)) {
       mockRequestMapper
           .when(RequestMapper::getAuthentication)
-          .thenReturn(Authentication.of(a -> a.user("foo").group("groupId").tenant(tenantId)));
+          .thenReturn(
+              CamundaAuthentication.of(a -> a.user("foo").group("groupId").tenant(tenantId)));
       return function.apply(webClient);
     }
   }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/RestControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/RestControllerTest.java
@@ -18,13 +18,10 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.junit.jupiter.params.provider.Arguments;
-import org.mockito.MockedStatic;
-import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.reactive.server.WebTestClient;
-import org.springframework.test.web.reactive.server.WebTestClient.ResponseSpec;
 
 @TestPropertySource(
     properties = {
@@ -74,19 +71,13 @@ public abstract class RestControllerTest {
               Operation.gte(OffsetDateTime.now().minusHours(1)),
               Operation.lte(OffsetDateTime.now())),
           List.of(Operation.in(OffsetDateTime.now(), OffsetDateTime.now().minusDays(1))));
-  @Autowired protected WebTestClient webClient;
 
-  public ResponseSpec withMultiTenancy(
-      final String tenantId, final Function<WebTestClient, ResponseSpec> function) {
-    try (final MockedStatic<RequestMapper> mockRequestMapper =
-        Mockito.mockStatic(RequestMapper.class, Mockito.CALLS_REAL_METHODS)) {
-      mockRequestMapper
-          .when(RequestMapper::getAuthentication)
-          .thenReturn(
-              CamundaAuthentication.of(a -> a.user("foo").group("groupId").tenant(tenantId)));
-      return function.apply(webClient);
-    }
-  }
+  protected static final CamundaAuthentication AUTHENTICATION_WITH_DEFAULT_TENANT =
+      CamundaAuthentication.of(a -> a.user("foo").group("groupId").tenant("<default>"));
+  protected static final CamundaAuthentication AUTHENTICATION_WITH_NON_DEFAULT_TENANT =
+      CamundaAuthentication.of(a -> a.user("foo").group("groupId").tenant("tenantId"));
+
+  @Autowired protected WebTestClient webClient;
 
   protected static <T> Arguments generateParameterizedArguments(
       final String filterKey,

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/configuration/RestApiConfigurationTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/configuration/RestApiConfigurationTest.java
@@ -14,7 +14,7 @@ import static org.mockito.Mockito.when;
 import io.camunda.search.entities.ProcessInstanceEntity;
 import io.camunda.search.query.ProcessInstanceQuery;
 import io.camunda.search.query.SearchQueryResult.Builder;
-import io.camunda.security.auth.Authentication;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.security.configuration.MultiTenancyConfiguration;
 import io.camunda.service.ProcessInstanceServices;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
@@ -36,7 +36,7 @@ abstract class RestApiConfigurationTest extends RestControllerTest {
 
   @BeforeEach
   void setupServices() {
-    when(processInstanceServices.withAuthentication(any(Authentication.class)))
+    when(processInstanceServices.withAuthentication(any(CamundaAuthentication.class)))
         .thenReturn(processInstanceServices);
     when(brokerClient.getTopologyManager()).thenReturn(topologyManager);
     when(processInstanceServices.search(any(ProcessInstanceQuery.class)))

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/configuration/RestApiDefaultConfigurationTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/configuration/RestApiDefaultConfigurationTest.java
@@ -9,15 +9,27 @@ package io.camunda.zeebe.gateway.rest.configuration;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import io.camunda.search.query.ProcessInstanceQuery;
+import io.camunda.security.auth.CamundaAuthenticationProvider;
 import io.camunda.zeebe.gateway.rest.controller.ProcessInstanceController;
 import io.camunda.zeebe.gateway.rest.controller.TopologyController;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @WebMvcTest(value = {ProcessInstanceController.class, TopologyController.class})
 public class RestApiDefaultConfigurationTest extends RestApiConfigurationTest {
+
+  @MockitoBean private CamundaAuthenticationProvider authenticationProvider;
+
+  @BeforeEach
+  void setUpServices() {
+    when(authenticationProvider.getCamundaAuthentication())
+        .thenReturn(AUTHENTICATION_WITH_DEFAULT_TENANT);
+  }
 
   @Test
   void shouldYieldOkForQueryApiRequest() {

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AdHocSubProcessActivityControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AdHocSubProcessActivityControllerTest.java
@@ -21,6 +21,7 @@ import io.camunda.search.entities.AdHocSubProcessActivityEntity.ActivityType;
 import io.camunda.search.exception.CamundaSearchException;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.auth.CamundaAuthentication;
+import io.camunda.security.auth.CamundaAuthenticationProvider;
 import io.camunda.service.AdHocSubProcessActivityServices;
 import io.camunda.service.AdHocSubProcessActivityServices.AdHocSubProcessActivateActivitiesRequest;
 import io.camunda.service.AdHocSubProcessActivityServices.AdHocSubProcessActivateActivitiesRequest.AdHocSubProcessActivateActivityReference;
@@ -50,9 +51,12 @@ class AdHocSubProcessActivityControllerTest extends RestControllerTest {
       AD_HOC_ACTIVITIES_URL + "/{adHocSubProcessInstanceKey}/activation";
 
   @MockitoBean private AdHocSubProcessActivityServices adHocSubProcessActivityServices;
+  @MockitoBean private CamundaAuthenticationProvider authenticationProvider;
 
   @BeforeEach
   void setUpServices() {
+    when(authenticationProvider.getCamundaAuthentication())
+        .thenReturn(AUTHENTICATION_WITH_DEFAULT_TENANT);
     when(adHocSubProcessActivityServices.withAuthentication(any(CamundaAuthentication.class)))
         .thenReturn(adHocSubProcessActivityServices);
   }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AdHocSubProcessActivityControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AdHocSubProcessActivityControllerTest.java
@@ -20,7 +20,7 @@ import io.camunda.search.entities.AdHocSubProcessActivityEntity;
 import io.camunda.search.entities.AdHocSubProcessActivityEntity.ActivityType;
 import io.camunda.search.exception.CamundaSearchException;
 import io.camunda.search.query.SearchQueryResult;
-import io.camunda.security.auth.Authentication;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.AdHocSubProcessActivityServices;
 import io.camunda.service.AdHocSubProcessActivityServices.AdHocSubProcessActivateActivitiesRequest;
 import io.camunda.service.AdHocSubProcessActivityServices.AdHocSubProcessActivateActivitiesRequest.AdHocSubProcessActivateActivityReference;
@@ -53,7 +53,7 @@ class AdHocSubProcessActivityControllerTest extends RestControllerTest {
 
   @BeforeEach
   void setUpServices() {
-    when(adHocSubProcessActivityServices.withAuthentication(any(Authentication.class)))
+    when(adHocSubProcessActivityServices.withAuthentication(any(CamundaAuthentication.class)))
         .thenReturn(adHocSubProcessActivityServices);
   }
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/BatchOperationControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/BatchOperationControllerTest.java
@@ -17,6 +17,7 @@ import io.camunda.search.filter.Operation;
 import io.camunda.search.query.BatchOperationQuery;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.auth.CamundaAuthentication;
+import io.camunda.security.auth.CamundaAuthenticationProvider;
 import io.camunda.service.BatchOperationServices;
 import io.camunda.zeebe.gateway.protocol.rest.BatchOperationStateEnum;
 import io.camunda.zeebe.gateway.protocol.rest.BatchOperationTypeEnum;
@@ -38,9 +39,12 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 class BatchOperationControllerTest extends RestControllerTest {
 
   @MockitoBean private BatchOperationServices batchOperationServices;
+  @MockitoBean private CamundaAuthenticationProvider authenticationProvider;
 
   @BeforeEach
   void setUpServices() {
+    when(authenticationProvider.getCamundaAuthentication())
+        .thenReturn(AUTHENTICATION_WITH_DEFAULT_TENANT);
     when(batchOperationServices.withAuthentication(any(CamundaAuthentication.class)))
         .thenReturn(batchOperationServices);
   }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/BatchOperationControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/BatchOperationControllerTest.java
@@ -16,7 +16,7 @@ import io.camunda.search.entities.BatchOperationEntity.BatchOperationState;
 import io.camunda.search.filter.Operation;
 import io.camunda.search.query.BatchOperationQuery;
 import io.camunda.search.query.SearchQueryResult;
-import io.camunda.security.auth.Authentication;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.BatchOperationServices;
 import io.camunda.zeebe.gateway.protocol.rest.BatchOperationStateEnum;
 import io.camunda.zeebe.gateway.protocol.rest.BatchOperationTypeEnum;
@@ -41,7 +41,7 @@ class BatchOperationControllerTest extends RestControllerTest {
 
   @BeforeEach
   void setUpServices() {
-    when(batchOperationServices.withAuthentication(any(Authentication.class)))
+    when(batchOperationServices.withAuthentication(any(CamundaAuthentication.class)))
         .thenReturn(batchOperationServices);
   }
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/BatchOperationItemControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/BatchOperationItemControllerTest.java
@@ -18,6 +18,7 @@ import io.camunda.search.filter.Operation;
 import io.camunda.search.query.BatchOperationItemQuery;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.auth.CamundaAuthentication;
+import io.camunda.security.auth.CamundaAuthenticationProvider;
 import io.camunda.service.BatchOperationServices;
 import io.camunda.zeebe.gateway.protocol.rest.BatchOperationItemStateEnum;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
@@ -36,9 +37,12 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 class BatchOperationItemControllerTest extends RestControllerTest {
 
   @MockitoBean private BatchOperationServices batchOperationServices;
+  @MockitoBean private CamundaAuthenticationProvider authenticationProvider;
 
   @BeforeEach
   void setUpServices() {
+    when(authenticationProvider.getCamundaAuthentication())
+        .thenReturn(AUTHENTICATION_WITH_DEFAULT_TENANT);
     when(batchOperationServices.withAuthentication(any(CamundaAuthentication.class)))
         .thenReturn(batchOperationServices);
   }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/BatchOperationItemControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/BatchOperationItemControllerTest.java
@@ -17,7 +17,7 @@ import io.camunda.search.entities.BatchOperationEntity.BatchOperationItemState;
 import io.camunda.search.filter.Operation;
 import io.camunda.search.query.BatchOperationItemQuery;
 import io.camunda.search.query.SearchQueryResult;
-import io.camunda.security.auth.Authentication;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.BatchOperationServices;
 import io.camunda.zeebe.gateway.protocol.rest.BatchOperationItemStateEnum;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
@@ -39,7 +39,7 @@ class BatchOperationItemControllerTest extends RestControllerTest {
 
   @BeforeEach
   void setUpServices() {
-    when(batchOperationServices.withAuthentication(any(Authentication.class)))
+    when(batchOperationServices.withAuthentication(any(CamundaAuthentication.class)))
         .thenReturn(batchOperationServices);
   }
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ClockControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ClockControllerTest.java
@@ -13,7 +13,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import io.camunda.security.auth.Authentication;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.ClockServices;
 import io.camunda.zeebe.gateway.protocol.rest.ClockPinRequest;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
@@ -42,7 +42,8 @@ public class ClockControllerTest extends RestControllerTest {
 
   @BeforeEach
   void setup() {
-    when(clockServices.withAuthentication(any(Authentication.class))).thenReturn(clockServices);
+    when(clockServices.withAuthentication(any(CamundaAuthentication.class)))
+        .thenReturn(clockServices);
   }
 
   @Test

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ClockControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ClockControllerTest.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.camunda.security.auth.CamundaAuthentication;
+import io.camunda.security.auth.CamundaAuthenticationProvider;
 import io.camunda.service.ClockServices;
 import io.camunda.zeebe.gateway.protocol.rest.ClockPinRequest;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
@@ -27,10 +28,10 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ProblemDetail;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @WebMvcTest(ClockController.class)
 public class ClockControllerTest extends RestControllerTest {
@@ -38,10 +39,13 @@ public class ClockControllerTest extends RestControllerTest {
   private static final String CLOCK_URL = "/v2/clock";
   private static final String RESET_CLOCK_URL = CLOCK_URL.concat("/reset");
 
-  @MockBean private ClockServices clockServices;
+  @MockitoBean private ClockServices clockServices;
+  @MockitoBean private CamundaAuthenticationProvider authenticationProvider;
 
   @BeforeEach
   void setup() {
+    when(authenticationProvider.getCamundaAuthentication())
+        .thenReturn(AUTHENTICATION_WITH_DEFAULT_TENANT);
     when(clockServices.withAuthentication(any(CamundaAuthentication.class)))
         .thenReturn(clockServices);
   }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionDefinitionControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionDefinitionControllerTest.java
@@ -13,7 +13,7 @@ import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
-import io.camunda.security.auth.Authentication;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.security.configuration.MultiTenancyConfiguration;
 import io.camunda.service.DecisionDefinitionServices;
 import io.camunda.zeebe.broker.client.api.dto.BrokerResponse;
@@ -57,7 +57,7 @@ public class DecisionDefinitionControllerTest extends RestControllerTest {
 
   @BeforeEach
   void setupServices() {
-    when(decisionServices.withAuthentication(any(Authentication.class)))
+    when(decisionServices.withAuthentication(any(CamundaAuthentication.class)))
         .thenReturn(decisionServices);
   }
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionDefinitionQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionDefinitionQueryControllerTest.java
@@ -21,6 +21,7 @@ import io.camunda.search.query.SearchQueryResult.Builder;
 import io.camunda.search.sort.DecisionDefinitionSort;
 import io.camunda.security.auth.Authorization;
 import io.camunda.security.auth.CamundaAuthentication;
+import io.camunda.security.auth.CamundaAuthenticationProvider;
 import io.camunda.security.configuration.MultiTenancyConfiguration;
 import io.camunda.service.DecisionDefinitionServices;
 import io.camunda.service.exception.ForbiddenException;
@@ -35,8 +36,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @WebMvcTest(value = DecisionDefinitionController.class)
 public class DecisionDefinitionQueryControllerTest extends RestControllerTest {
@@ -74,11 +75,14 @@ public class DecisionDefinitionQueryControllerTest extends RestControllerTest {
   static final String DECISION_DEFINITIONS_GET_URL = "/v2/decision-definitions/%d";
   static final String DECISION_DEFINITIONS_GET_XML_URL = "/v2/decision-definitions/%d/xml";
 
-  @MockBean DecisionDefinitionServices decisionDefinitionServices;
-  @MockBean MultiTenancyConfiguration multiTenancyCfg;
+  @MockitoBean DecisionDefinitionServices decisionDefinitionServices;
+  @MockitoBean MultiTenancyConfiguration multiTenancyCfg;
+  @MockitoBean CamundaAuthenticationProvider authenticationProvider;
 
   @BeforeEach
   void setupServices() {
+    when(authenticationProvider.getCamundaAuthentication())
+        .thenReturn(AUTHENTICATION_WITH_DEFAULT_TENANT);
     when(decisionDefinitionServices.withAuthentication(any(CamundaAuthentication.class)))
         .thenReturn(decisionDefinitionServices);
   }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionDefinitionQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionDefinitionQueryControllerTest.java
@@ -19,8 +19,8 @@ import io.camunda.search.query.DecisionDefinitionQuery;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.search.query.SearchQueryResult.Builder;
 import io.camunda.search.sort.DecisionDefinitionSort;
-import io.camunda.security.auth.Authentication;
 import io.camunda.security.auth.Authorization;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.security.configuration.MultiTenancyConfiguration;
 import io.camunda.service.DecisionDefinitionServices;
 import io.camunda.service.exception.ForbiddenException;
@@ -79,7 +79,7 @@ public class DecisionDefinitionQueryControllerTest extends RestControllerTest {
 
   @BeforeEach
   void setupServices() {
-    when(decisionDefinitionServices.withAuthentication(any(Authentication.class)))
+    when(decisionDefinitionServices.withAuthentication(any(CamundaAuthentication.class)))
         .thenReturn(decisionDefinitionServices);
   }
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionInstanceQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionInstanceQueryControllerTest.java
@@ -25,6 +25,7 @@ import io.camunda.search.query.SearchQueryBuilders;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.auth.Authorization;
 import io.camunda.security.auth.CamundaAuthentication;
+import io.camunda.security.auth.CamundaAuthenticationProvider;
 import io.camunda.service.DecisionInstanceServices;
 import io.camunda.service.exception.ForbiddenException;
 import io.camunda.util.ObjectBuilder;
@@ -39,8 +40,8 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @WebMvcTest(value = DecisionInstanceController.class)
 public class DecisionInstanceQueryControllerTest extends RestControllerTest {
@@ -98,10 +99,13 @@ public class DecisionInstanceQueryControllerTest extends RestControllerTest {
           .endCursor("v")
           .build();
 
-  @MockBean private DecisionInstanceServices decisionInstanceServices;
+  @MockitoBean private DecisionInstanceServices decisionInstanceServices;
+  @MockitoBean private CamundaAuthenticationProvider authenticationProvider;
 
   @BeforeEach
   void setupServices() {
+    when(authenticationProvider.getCamundaAuthentication())
+        .thenReturn(AUTHENTICATION_WITH_DEFAULT_TENANT);
     when(decisionInstanceServices.withAuthentication(any(CamundaAuthentication.class)))
         .thenReturn(decisionInstanceServices);
   }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionInstanceQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionInstanceQueryControllerTest.java
@@ -23,8 +23,8 @@ import io.camunda.search.filter.Operation;
 import io.camunda.search.query.DecisionInstanceQuery;
 import io.camunda.search.query.SearchQueryBuilders;
 import io.camunda.search.query.SearchQueryResult;
-import io.camunda.security.auth.Authentication;
 import io.camunda.security.auth.Authorization;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.DecisionInstanceServices;
 import io.camunda.service.exception.ForbiddenException;
 import io.camunda.util.ObjectBuilder;
@@ -102,7 +102,7 @@ public class DecisionInstanceQueryControllerTest extends RestControllerTest {
 
   @BeforeEach
   void setupServices() {
-    when(decisionInstanceServices.withAuthentication(any(Authentication.class)))
+    when(decisionInstanceServices.withAuthentication(any(CamundaAuthentication.class)))
         .thenReturn(decisionInstanceServices);
   }
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionRequirementsQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionRequirementsQueryControllerTest.java
@@ -20,8 +20,8 @@ import io.camunda.search.query.DecisionRequirementsQuery;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.search.query.SearchQueryResult.Builder;
 import io.camunda.search.sort.DecisionRequirementsSort;
-import io.camunda.security.auth.Authentication;
 import io.camunda.security.auth.Authorization;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.DecisionRequirementsServices;
 import io.camunda.service.exception.ForbiddenException;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
@@ -90,7 +90,7 @@ public class DecisionRequirementsQueryControllerTest extends RestControllerTest 
 
   @BeforeEach
   void setupServices() {
-    when(decisionRequirementsServices.withAuthentication(any(Authentication.class)))
+    when(decisionRequirementsServices.withAuthentication(any(CamundaAuthentication.class)))
         .thenReturn(decisionRequirementsServices);
 
     when(decisionRequirementsServices.getByKey(VALID_DECISION_REQUIREMENTS_KEY))

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionRequirementsQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionRequirementsQueryControllerTest.java
@@ -22,6 +22,7 @@ import io.camunda.search.query.SearchQueryResult.Builder;
 import io.camunda.search.sort.DecisionRequirementsSort;
 import io.camunda.security.auth.Authorization;
 import io.camunda.security.auth.CamundaAuthentication;
+import io.camunda.security.auth.CamundaAuthenticationProvider;
 import io.camunda.service.DecisionRequirementsServices;
 import io.camunda.service.exception.ForbiddenException;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
@@ -35,8 +36,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @WebMvcTest(value = DecisionRequirementsController.class)
 public class DecisionRequirementsQueryControllerTest extends RestControllerTest {
@@ -86,10 +87,13 @@ public class DecisionRequirementsQueryControllerTest extends RestControllerTest 
             "resourceName": "rN"
           }
           """;
-  @MockBean DecisionRequirementsServices decisionRequirementsServices;
+  @MockitoBean DecisionRequirementsServices decisionRequirementsServices;
+  @MockitoBean CamundaAuthenticationProvider authenticationProvider;
 
   @BeforeEach
   void setupServices() {
+    when(authenticationProvider.getCamundaAuthentication())
+        .thenReturn(AUTHENTICATION_WITH_DEFAULT_TENANT);
     when(decisionRequirementsServices.withAuthentication(any(CamundaAuthentication.class)))
         .thenReturn(decisionRequirementsServices);
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DocumentControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DocumentControllerTest.java
@@ -15,7 +15,7 @@ import static org.mockito.Mockito.when;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.document.api.DocumentMetadataModel;
-import io.camunda.security.auth.Authentication;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.DocumentServices;
 import io.camunda.service.DocumentServices.DocumentContentResponse;
 import io.camunda.service.DocumentServices.DocumentCreateRequest;
@@ -46,7 +46,7 @@ public class DocumentControllerTest extends RestControllerTest {
 
   @BeforeEach
   void setUp() {
-    when(documentServices.withAuthentication(any(Authentication.class)))
+    when(documentServices.withAuthentication(any(CamundaAuthentication.class)))
         .thenReturn(documentServices);
   }
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DocumentControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DocumentControllerTest.java
@@ -16,6 +16,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.document.api.DocumentMetadataModel;
 import io.camunda.security.auth.CamundaAuthentication;
+import io.camunda.security.auth.CamundaAuthenticationProvider;
 import io.camunda.service.DocumentServices;
 import io.camunda.service.DocumentServices.DocumentContentResponse;
 import io.camunda.service.DocumentServices.DocumentCreateRequest;
@@ -33,19 +34,22 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.http.client.MultipartBodyBuilder;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @WebMvcTest(DocumentController.class)
 public class DocumentControllerTest extends RestControllerTest {
 
   static final String DOCUMENTS_BASE_URL = "/v2/documents";
 
-  @MockBean DocumentServices documentServices;
+  @MockitoBean DocumentServices documentServices;
+  @MockitoBean CamundaAuthenticationProvider authenticationProvider;
 
   @BeforeEach
   void setUp() {
+    when(authenticationProvider.getCamundaAuthentication())
+        .thenReturn(AUTHENTICATION_WITH_DEFAULT_TENANT);
     when(documentServices.withAuthentication(any(CamundaAuthentication.class)))
         .thenReturn(documentServices);
   }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ElementInstanceControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ElementInstanceControllerTest.java
@@ -11,7 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
-import io.camunda.security.auth.Authentication;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.ElementInstanceServices;
 import io.camunda.service.ElementInstanceServices.SetVariablesRequest;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
@@ -39,7 +39,7 @@ public class ElementInstanceControllerTest extends RestControllerTest {
 
   @BeforeEach
   void setup() {
-    when(elementInstanceServices.withAuthentication(any(Authentication.class)))
+    when(elementInstanceServices.withAuthentication(any(CamundaAuthentication.class)))
         .thenReturn(elementInstanceServices);
   }
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ElementInstanceControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ElementInstanceControllerTest.java
@@ -12,6 +12,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 import io.camunda.security.auth.CamundaAuthentication;
+import io.camunda.security.auth.CamundaAuthenticationProvider;
 import io.camunda.service.ElementInstanceServices;
 import io.camunda.service.ElementInstanceServices.SetVariablesRequest;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
@@ -25,20 +26,23 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mockito;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @WebMvcTest(ElementInstanceController.class)
 public class ElementInstanceControllerTest extends RestControllerTest {
 
   static final String ELEMENTS_BASE_URL = "/v2/element-instances";
 
-  @MockBean ElementInstanceServices elementInstanceServices;
-  @MockBean ProcessCache processCache;
+  @MockitoBean ElementInstanceServices elementInstanceServices;
+  @MockitoBean ProcessCache processCache;
+  @MockitoBean CamundaAuthenticationProvider authenticationProvider;
   @Captor ArgumentCaptor<SetVariablesRequest> requestCaptor;
 
   @BeforeEach
   void setup() {
+    when(authenticationProvider.getCamundaAuthentication())
+        .thenReturn(AUTHENTICATION_WITH_DEFAULT_TENANT);
     when(elementInstanceServices.withAuthentication(any(CamundaAuthentication.class)))
         .thenReturn(elementInstanceServices);
   }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ElementInstanceQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ElementInstanceQueryControllerTest.java
@@ -23,7 +23,7 @@ import io.camunda.search.query.FlowNodeInstanceQuery;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.search.query.SearchQueryResult.Builder;
 import io.camunda.search.sort.FlowNodeInstanceSort;
-import io.camunda.security.auth.Authentication;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.ElementInstanceServices;
 import io.camunda.zeebe.gateway.protocol.rest.ElementInstanceStateEnum;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
@@ -143,7 +143,7 @@ public class ElementInstanceQueryControllerTest extends RestControllerTest {
 
   @BeforeEach
   void setupServices() {
-    when(elementInstanceServices.withAuthentication(any(Authentication.class)))
+    when(elementInstanceServices.withAuthentication(any(CamundaAuthentication.class)))
         .thenReturn(elementInstanceServices);
     when(processCache.getElementName(any())).thenReturn("elementName");
     final var processCacheItem = mock(ProcessCacheItem.class);

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ElementInstanceQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ElementInstanceQueryControllerTest.java
@@ -24,6 +24,7 @@ import io.camunda.search.query.SearchQueryResult;
 import io.camunda.search.query.SearchQueryResult.Builder;
 import io.camunda.search.sort.FlowNodeInstanceSort;
 import io.camunda.security.auth.CamundaAuthentication;
+import io.camunda.security.auth.CamundaAuthenticationProvider;
 import io.camunda.service.ElementInstanceServices;
 import io.camunda.zeebe.gateway.protocol.rest.ElementInstanceStateEnum;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
@@ -42,8 +43,8 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @WebMvcTest(value = ElementInstanceController.class)
 public class ElementInstanceQueryControllerTest extends RestControllerTest {
@@ -137,12 +138,15 @@ public class ElementInstanceQueryControllerTest extends RestControllerTest {
   static final String ELEMENT_INSTANCES_URL = "/v2/element-instances/";
   static final String ELEMENT_INSTANCES_SEARCH_URL = ELEMENT_INSTANCES_URL + "search";
 
-  @MockBean ElementInstanceServices elementInstanceServices;
-  @MockBean ProcessCache processCache;
+  @MockitoBean ElementInstanceServices elementInstanceServices;
+  @MockitoBean ProcessCache processCache;
   @Captor ArgumentCaptor<FlowNodeInstanceQuery> queryCaptor;
+  @MockitoBean CamundaAuthenticationProvider authenticationProvider;
 
   @BeforeEach
   void setupServices() {
+    when(authenticationProvider.getCamundaAuthentication())
+        .thenReturn(AUTHENTICATION_WITH_DEFAULT_TENANT);
     when(elementInstanceServices.withAuthentication(any(CamundaAuthentication.class)))
         .thenReturn(elementInstanceServices);
     when(processCache.getElementName(any())).thenReturn("elementName");

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ErrorMapperTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ErrorMapperTest.java
@@ -11,11 +11,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.core.JsonParseException;
 import io.atomix.cluster.messaging.MessagingException.ConnectionClosed;
 import io.camunda.search.exception.CamundaSearchException;
 import io.camunda.security.auth.CamundaAuthentication;
+import io.camunda.security.auth.CamundaAuthenticationProvider;
 import io.camunda.service.UserTaskServices;
 import io.camunda.service.exception.CamundaBrokerException;
 import io.camunda.zeebe.broker.client.api.PartitionNotFoundException;
@@ -40,10 +42,10 @@ import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ProblemDetail;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.web.servlet.View;
 import reactor.core.publisher.Mono;
 
@@ -52,12 +54,15 @@ public class ErrorMapperTest extends RestControllerTest {
 
   private static final String USER_TASKS_BASE_URL = "/v1/user-tasks";
 
-  @MockBean UserTaskServices userTaskServices;
-  @MockBean ProcessCache processCache;
+  @MockitoBean UserTaskServices userTaskServices;
+  @MockitoBean ProcessCache processCache;
+  @MockitoBean CamundaAuthenticationProvider authenticationProvider;
   @Autowired private View error;
 
   @BeforeEach
   void setUp() {
+    when(authenticationProvider.getCamundaAuthentication())
+        .thenReturn(AUTHENTICATION_WITH_DEFAULT_TENANT);
     Mockito.when(userTaskServices.withAuthentication(any(CamundaAuthentication.class)))
         .thenReturn(userTaskServices);
   }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ErrorMapperTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ErrorMapperTest.java
@@ -15,7 +15,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import com.fasterxml.jackson.core.JsonParseException;
 import io.atomix.cluster.messaging.MessagingException.ConnectionClosed;
 import io.camunda.search.exception.CamundaSearchException;
-import io.camunda.security.auth.Authentication;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.UserTaskServices;
 import io.camunda.service.exception.CamundaBrokerException;
 import io.camunda.zeebe.broker.client.api.PartitionNotFoundException;
@@ -58,7 +58,7 @@ public class ErrorMapperTest extends RestControllerTest {
 
   @BeforeEach
   void setUp() {
-    Mockito.when(userTaskServices.withAuthentication(any(Authentication.class)))
+    Mockito.when(userTaskServices.withAuthentication(any(CamundaAuthentication.class)))
         .thenReturn(userTaskServices);
   }
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/IncidentControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/IncidentControllerTest.java
@@ -11,7 +11,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.when;
 
-import io.camunda.security.auth.Authentication;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.IncidentServices;
 import io.camunda.service.exception.CamundaBrokerException;
 import io.camunda.zeebe.broker.client.api.dto.BrokerRejection;
@@ -36,7 +36,7 @@ public class IncidentControllerTest extends RestControllerTest {
 
   @BeforeEach
   void setUp() {
-    when(incidentServices.withAuthentication(any(Authentication.class)))
+    when(incidentServices.withAuthentication(any(CamundaAuthentication.class)))
         .thenReturn(incidentServices);
   }
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/IncidentControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/IncidentControllerTest.java
@@ -12,6 +12,7 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.when;
 
 import io.camunda.security.auth.CamundaAuthentication;
+import io.camunda.security.auth.CamundaAuthenticationProvider;
 import io.camunda.service.IncidentServices;
 import io.camunda.service.exception.CamundaBrokerException;
 import io.camunda.zeebe.broker.client.api.dto.BrokerRejection;
@@ -24,18 +25,21 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @WebMvcTest(IncidentController.class)
 public class IncidentControllerTest extends RestControllerTest {
 
   static final String INCIDENT_BASE_URL = "/v2/incidents";
 
-  @MockBean IncidentServices incidentServices;
+  @MockitoBean IncidentServices incidentServices;
+  @MockitoBean CamundaAuthenticationProvider authenticationProvider;
 
   @BeforeEach
   void setUp() {
+    when(authenticationProvider.getCamundaAuthentication())
+        .thenReturn(AUTHENTICATION_WITH_DEFAULT_TENANT);
     when(incidentServices.withAuthentication(any(CamundaAuthentication.class)))
         .thenReturn(incidentServices);
   }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/IncidentQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/IncidentQueryControllerTest.java
@@ -20,7 +20,7 @@ import io.camunda.search.query.IncidentQuery;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.search.query.SearchQueryResult.Builder;
 import io.camunda.search.sort.IncidentSort;
-import io.camunda.security.auth.Authentication;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.IncidentServices;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
 import java.time.OffsetDateTime;
@@ -124,7 +124,7 @@ public class IncidentQueryControllerTest extends RestControllerTest {
 
   @BeforeEach
   void setupIncidentServices() {
-    when(incidentServices.withAuthentication(ArgumentMatchers.any(Authentication.class)))
+    when(incidentServices.withAuthentication(ArgumentMatchers.any(CamundaAuthentication.class)))
         .thenReturn(incidentServices);
   }
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/IncidentQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/IncidentQueryControllerTest.java
@@ -21,6 +21,7 @@ import io.camunda.search.query.SearchQueryResult;
 import io.camunda.search.query.SearchQueryResult.Builder;
 import io.camunda.search.sort.IncidentSort;
 import io.camunda.security.auth.CamundaAuthentication;
+import io.camunda.security.auth.CamundaAuthenticationProvider;
 import io.camunda.service.IncidentServices;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
 import java.time.OffsetDateTime;
@@ -30,8 +31,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @WebMvcTest(value = IncidentController.class)
 public class IncidentQueryControllerTest extends RestControllerTest {
@@ -120,10 +121,13 @@ public class IncidentQueryControllerTest extends RestControllerTest {
   static final String INCIDENT_URL = "/v2/incidents/";
   static final String INCIDENT_SEARCH_URL = INCIDENT_URL + "search";
 
-  @MockBean IncidentServices incidentServices;
+  @MockitoBean IncidentServices incidentServices;
+  @MockitoBean CamundaAuthenticationProvider authenticationProvider;
 
   @BeforeEach
   void setupIncidentServices() {
+    when(authenticationProvider.getCamundaAuthentication())
+        .thenReturn(AUTHENTICATION_WITH_DEFAULT_TENANT);
     when(incidentServices.withAuthentication(ArgumentMatchers.any(CamundaAuthentication.class)))
         .thenReturn(incidentServices);
   }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerRoundRobinTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerRoundRobinTest.java
@@ -9,8 +9,10 @@ package io.camunda.zeebe.gateway.rest.controller;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
 
 import com.jayway.jsonpath.JsonPath;
+import io.camunda.security.auth.CamundaAuthenticationProvider;
 import io.camunda.security.configuration.MultiTenancyConfiguration;
 import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.service.JobServices;
@@ -42,10 +44,10 @@ import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.context.TestConfiguration;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.util.unit.DataSize;
 
 @WebMvcTest(JobController.class)
@@ -56,10 +58,13 @@ public class JobControllerRoundRobinTest extends RestControllerTest {
   @Autowired ActivateJobsHandler<JobActivationResult> activateJobsHandler;
   @Autowired StubbedBrokerClient stubbedBrokerClient;
   @SpyBean ResettableJobActivationRequestResponseObserver responseObserver;
-  @MockBean MultiTenancyConfiguration multiTenancyCfg;
+  @MockitoBean MultiTenancyConfiguration multiTenancyCfg;
+  @MockitoBean CamundaAuthenticationProvider authenticationProvider;
 
   @BeforeEach
   void setup() {
+    when(authenticationProvider.getCamundaAuthentication())
+        .thenReturn(AUTHENTICATION_WITH_DEFAULT_TENANT);
     responseObserver.reset();
   }
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerTest.java
@@ -17,6 +17,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import io.camunda.security.auth.CamundaAuthentication;
+import io.camunda.security.auth.CamundaAuthenticationProvider;
 import io.camunda.security.configuration.MultiTenancyConfiguration;
 import io.camunda.service.JobServices;
 import io.camunda.service.JobServices.UpdateJobChangeset;
@@ -38,20 +39,23 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @WebMvcTest(JobController.class)
 public class JobControllerTest extends RestControllerTest {
 
   static final String JOBS_BASE_URL = "/v2/jobs";
 
-  @MockBean JobServices<JobActivationResult> jobServices;
-  @MockBean MultiTenancyConfiguration multiTenancyCfg;
-  @MockBean ResponseObserverProvider responseObserverProvider;
+  @MockitoBean JobServices<JobActivationResult> jobServices;
+  @MockitoBean MultiTenancyConfiguration multiTenancyCfg;
+  @MockitoBean ResponseObserverProvider responseObserverProvider;
+  @MockitoBean CamundaAuthenticationProvider authenticationProvider;
 
   @BeforeEach
   void setup() {
+    when(authenticationProvider.getCamundaAuthentication())
+        .thenReturn(AUTHENTICATION_WITH_DEFAULT_TENANT);
     when(jobServices.withAuthentication(any(CamundaAuthentication.class))).thenReturn(jobServices);
   }
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerTest.java
@@ -16,7 +16,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
-import io.camunda.security.auth.Authentication;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.security.configuration.MultiTenancyConfiguration;
 import io.camunda.service.JobServices;
 import io.camunda.service.JobServices.UpdateJobChangeset;
@@ -52,7 +52,7 @@ public class JobControllerTest extends RestControllerTest {
 
   @BeforeEach
   void setup() {
-    when(jobServices.withAuthentication(any(Authentication.class))).thenReturn(jobServices);
+    when(jobServices.withAuthentication(any(CamundaAuthentication.class))).thenReturn(jobServices);
   }
 
   @Test

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobQueryControllerTest.java
@@ -19,6 +19,7 @@ import io.camunda.search.filter.JobFilter;
 import io.camunda.search.query.JobQuery;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.auth.CamundaAuthentication;
+import io.camunda.security.auth.CamundaAuthenticationProvider;
 import io.camunda.security.configuration.MultiTenancyConfiguration;
 import io.camunda.service.JobServices;
 import io.camunda.zeebe.gateway.protocol.rest.JobActivationResult;
@@ -30,8 +31,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @WebMvcTest(value = JobController.class)
 public class JobQueryControllerTest extends RestControllerTest {
@@ -105,12 +106,15 @@ public class JobQueryControllerTest extends RestControllerTest {
           .startCursor("123base64")
           .endCursor("456base64")
           .build();
-  @MockBean JobServices<JobActivationResult> jobServices;
-  @MockBean MultiTenancyConfiguration multiTenancyCfg;
-  @MockBean ResponseObserverProvider responseObserverProvider;
+  @MockitoBean JobServices<JobActivationResult> jobServices;
+  @MockitoBean MultiTenancyConfiguration multiTenancyCfg;
+  @MockitoBean ResponseObserverProvider responseObserverProvider;
+  @MockitoBean CamundaAuthenticationProvider authenticationProvider;
 
   @BeforeEach
   void setupJobServices() {
+    when(authenticationProvider.getCamundaAuthentication())
+        .thenReturn(AUTHENTICATION_WITH_DEFAULT_TENANT);
     when(jobServices.withAuthentication(ArgumentMatchers.any(CamundaAuthentication.class)))
         .thenReturn(jobServices);
   }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobQueryControllerTest.java
@@ -18,7 +18,7 @@ import io.camunda.search.entities.JobEntity.ListenerEventType;
 import io.camunda.search.filter.JobFilter;
 import io.camunda.search.query.JobQuery;
 import io.camunda.search.query.SearchQueryResult;
-import io.camunda.security.auth.Authentication;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.security.configuration.MultiTenancyConfiguration;
 import io.camunda.service.JobServices;
 import io.camunda.zeebe.gateway.protocol.rest.JobActivationResult;
@@ -111,7 +111,7 @@ public class JobQueryControllerTest extends RestControllerTest {
 
   @BeforeEach
   void setupJobServices() {
-    when(jobServices.withAuthentication(ArgumentMatchers.any(Authentication.class)))
+    when(jobServices.withAuthentication(ArgumentMatchers.any(CamundaAuthentication.class)))
         .thenReturn(jobServices);
   }
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/MessageControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/MessageControllerTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import io.camunda.security.auth.CamundaAuthentication;
+import io.camunda.security.auth.CamundaAuthenticationProvider;
 import io.camunda.security.configuration.MultiTenancyConfiguration;
 import io.camunda.service.MessageServices;
 import io.camunda.service.MessageServices.CorrelateMessageRequest;
@@ -30,8 +31,8 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mockito;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.reactive.server.WebTestClient.ResponseSpec;
 
 @WebMvcTest(MessageController.class)
@@ -46,13 +47,16 @@ public class MessageControllerTest extends RestControllerTest {
             "messageKey": "123",
             "tenantId": "<default>"
           }""";
-  @MockBean MessageServices messageServices;
-  @MockBean MultiTenancyConfiguration multiTenancyCfg;
+  @MockitoBean MessageServices messageServices;
+  @MockitoBean MultiTenancyConfiguration multiTenancyCfg;
+  @MockitoBean CamundaAuthenticationProvider authenticationProvider;
   @Captor ArgumentCaptor<CorrelateMessageRequest> correlationRequestCaptor;
   @Captor ArgumentCaptor<PublicationMessageRequest> publicationRequestCaptor;
 
   @BeforeEach
   void setup() {
+    when(authenticationProvider.getCamundaAuthentication())
+        .thenReturn(AUTHENTICATION_WITH_DEFAULT_TENANT);
     when(messageServices.withAuthentication(any(CamundaAuthentication.class)))
         .thenReturn(messageServices);
   }
@@ -113,6 +117,8 @@ public class MessageControllerTest extends RestControllerTest {
   @Test
   void shouldCorrelateMessageWithMultiTenancyEnabled() {
     // given
+    when(authenticationProvider.getCamundaAuthentication())
+        .thenReturn(AUTHENTICATION_WITH_NON_DEFAULT_TENANT);
     when(multiTenancyCfg.isEnabled()).thenReturn(true);
     when(messageServices.correlateMessage(any()))
         .thenReturn(
@@ -135,18 +141,15 @@ public class MessageControllerTest extends RestControllerTest {
 
     // when then
     final ResponseSpec response =
-        withMultiTenancy(
-            "tenantId",
-            client ->
-                client
-                    .post()
-                    .uri(CORRELATION_ENDPOINT)
-                    .accept(MediaType.APPLICATION_JSON)
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .bodyValue(request)
-                    .exchange()
-                    .expectStatus()
-                    .isOk());
+        webClient
+            .post()
+            .uri(CORRELATION_ENDPOINT)
+            .accept(MediaType.APPLICATION_JSON)
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(request)
+            .exchange()
+            .expectStatus()
+            .isOk();
 
     Mockito.verify(messageServices).correlateMessage(correlationRequestCaptor.capture());
     final var capturedRequest = correlationRequestCaptor.getValue();

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/MessageControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/MessageControllerTest.java
@@ -12,7 +12,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
-import io.camunda.security.auth.Authentication;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.security.configuration.MultiTenancyConfiguration;
 import io.camunda.service.MessageServices;
 import io.camunda.service.MessageServices.CorrelateMessageRequest;
@@ -53,7 +53,8 @@ public class MessageControllerTest extends RestControllerTest {
 
   @BeforeEach
   void setup() {
-    when(messageServices.withAuthentication(any(Authentication.class))).thenReturn(messageServices);
+    when(messageServices.withAuthentication(any(CamundaAuthentication.class)))
+        .thenReturn(messageServices);
   }
 
   @Test

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessDefinitionQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessDefinitionQueryControllerTest.java
@@ -20,8 +20,8 @@ import io.camunda.search.filter.ProcessDefinitionStatisticsFilter;
 import io.camunda.search.query.ProcessDefinitionQuery;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.search.query.SearchQueryResult.Builder;
-import io.camunda.security.auth.Authentication;
 import io.camunda.security.auth.Authorization;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.FormServices;
 import io.camunda.service.ProcessDefinitionServices;
 import io.camunda.service.exception.ForbiddenException;
@@ -121,10 +121,11 @@ public class ProcessDefinitionQueryControllerTest extends RestControllerTest {
 
   @BeforeEach
   void setupProcessDefinitionServices() {
-    when(processDefinitionServices.withAuthentication(ArgumentMatchers.any(Authentication.class)))
+    when(processDefinitionServices.withAuthentication(
+            ArgumentMatchers.any(CamundaAuthentication.class)))
         .thenReturn(processDefinitionServices);
 
-    when(formServices.withAuthentication(ArgumentMatchers.any(Authentication.class)))
+    when(formServices.withAuthentication(ArgumentMatchers.any(CamundaAuthentication.class)))
         .thenReturn(formServices);
   }
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessDefinitionQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessDefinitionQueryControllerTest.java
@@ -22,6 +22,7 @@ import io.camunda.search.query.SearchQueryResult;
 import io.camunda.search.query.SearchQueryResult.Builder;
 import io.camunda.security.auth.Authorization;
 import io.camunda.security.auth.CamundaAuthentication;
+import io.camunda.security.auth.CamundaAuthenticationProvider;
 import io.camunda.service.FormServices;
 import io.camunda.service.ProcessDefinitionServices;
 import io.camunda.service.exception.ForbiddenException;
@@ -37,8 +38,8 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentMatchers;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @WebMvcTest(value = ProcessDefinitionController.class)
 public class ProcessDefinitionQueryControllerTest extends RestControllerTest {
@@ -115,12 +116,15 @@ public class ProcessDefinitionQueryControllerTest extends RestControllerTest {
         "version": 1
       }
       """;
-  @MockBean ProcessDefinitionServices processDefinitionServices;
+  @MockitoBean ProcessDefinitionServices processDefinitionServices;
 
-  @MockBean FormServices formServices;
+  @MockitoBean FormServices formServices;
+  @MockitoBean CamundaAuthenticationProvider authenticationProvider;
 
   @BeforeEach
   void setupProcessDefinitionServices() {
+    when(authenticationProvider.getCamundaAuthentication())
+        .thenReturn(AUTHENTICATION_WITH_DEFAULT_TENANT);
     when(processDefinitionServices.withAuthentication(
             ArgumentMatchers.any(CamundaAuthentication.class)))
         .thenReturn(processDefinitionServices);

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceControllerTest.java
@@ -21,6 +21,7 @@ import io.camunda.search.filter.ProcessInstanceFilter;
 import io.camunda.search.query.IncidentQuery;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.auth.CamundaAuthentication;
+import io.camunda.security.auth.CamundaAuthenticationProvider;
 import io.camunda.security.configuration.MultiTenancyConfiguration;
 import io.camunda.service.ProcessInstanceServices;
 import io.camunda.service.ProcessInstanceServices.ProcessInstanceCancelRequest;
@@ -73,9 +74,12 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
   @Captor ArgumentCaptor<ProcessInstanceModifyRequest> modifyRequestCaptor;
   @MockitoBean ProcessInstanceServices processInstanceServices;
   @MockitoBean MultiTenancyConfiguration multiTenancyCfg;
+  @MockitoBean CamundaAuthenticationProvider authenticationProvider;
 
   @BeforeEach
   void setupServices() {
+    when(authenticationProvider.getCamundaAuthentication())
+        .thenReturn(AUTHENTICATION_WITH_DEFAULT_TENANT);
     when(processInstanceServices.withAuthentication(any(CamundaAuthentication.class)))
         .thenReturn(processInstanceServices);
   }
@@ -91,6 +95,8 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
             .setProcessInstanceKey(123L)
             .setTenantId("tenantId");
 
+    when(authenticationProvider.getCamundaAuthentication())
+        .thenReturn(AUTHENTICATION_WITH_NON_DEFAULT_TENANT);
     when(processInstanceServices.createProcessInstance(any(ProcessInstanceCreateRequest.class)))
         .thenReturn(CompletableFuture.completedFuture(mockResponse));
 
@@ -103,18 +109,15 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
 
     // when / then
     final ResponseSpec response =
-        withMultiTenancy(
-            "tenantId",
-            client ->
-                client
-                    .post()
-                    .uri(PROCESS_INSTANCES_START_URL)
-                    .accept(MediaType.APPLICATION_JSON)
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .bodyValue(request)
-                    .exchange()
-                    .expectStatus()
-                    .isOk());
+        webClient
+            .post()
+            .uri(PROCESS_INSTANCES_START_URL)
+            .accept(MediaType.APPLICATION_JSON)
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(request)
+            .exchange()
+            .expectStatus()
+            .isOk();
 
     response
         .expectHeader()
@@ -188,6 +191,8 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
             .setProcessInstanceKey(123L)
             .setTenantId("tenantId");
 
+    when(authenticationProvider.getCamundaAuthentication())
+        .thenReturn(AUTHENTICATION_WITH_NON_DEFAULT_TENANT);
     when(processInstanceServices.createProcessInstance(any(ProcessInstanceCreateRequest.class)))
         .thenReturn(CompletableFuture.completedFuture(mockResponse));
 
@@ -201,18 +206,15 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
 
     // when / then
     final ResponseSpec response =
-        withMultiTenancy(
-            "tenantId",
-            client ->
-                client
-                    .post()
-                    .uri(PROCESS_INSTANCES_START_URL)
-                    .accept(MediaType.APPLICATION_JSON)
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .bodyValue(request)
-                    .exchange()
-                    .expectStatus()
-                    .isOk());
+        webClient
+            .post()
+            .uri(PROCESS_INSTANCES_START_URL)
+            .accept(MediaType.APPLICATION_JSON)
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(request)
+            .exchange()
+            .expectStatus()
+            .isOk();
 
     response
         .expectHeader()
@@ -237,6 +239,8 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
             .setProcessInstanceKey(123L)
             .setTenantId("tenantId");
 
+    when(authenticationProvider.getCamundaAuthentication())
+        .thenReturn(AUTHENTICATION_WITH_NON_DEFAULT_TENANT);
     when(processInstanceServices.createProcessInstance(any(ProcessInstanceCreateRequest.class)))
         .thenReturn(CompletableFuture.completedFuture(mockResponse));
 
@@ -249,18 +253,15 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
 
     // when / then
     final ResponseSpec response =
-        withMultiTenancy(
-            "tenantId",
-            client ->
-                client
-                    .post()
-                    .uri(PROCESS_INSTANCES_START_URL)
-                    .accept(MediaType.APPLICATION_JSON)
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .bodyValue(request)
-                    .exchange()
-                    .expectStatus()
-                    .isOk());
+        webClient
+            .post()
+            .uri(PROCESS_INSTANCES_START_URL)
+            .accept(MediaType.APPLICATION_JSON)
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(request)
+            .exchange()
+            .expectStatus()
+            .isOk();
 
     response
         .expectHeader()
@@ -285,6 +286,8 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
             .setProcessInstanceKey(123L)
             .setTenantId("tenantId");
 
+    when(authenticationProvider.getCamundaAuthentication())
+        .thenReturn(AUTHENTICATION_WITH_NON_DEFAULT_TENANT);
     when(processInstanceServices.createProcessInstanceWithResult(
             any(ProcessInstanceCreateRequest.class)))
         .thenReturn(CompletableFuture.completedFuture(mockResponse));
@@ -299,18 +302,15 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
 
     // when / then
     final ResponseSpec response =
-        withMultiTenancy(
-            "tenantId",
-            client ->
-                client
-                    .post()
-                    .uri(PROCESS_INSTANCES_START_URL)
-                    .accept(MediaType.APPLICATION_JSON)
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .bodyValue(request)
-                    .exchange()
-                    .expectStatus()
-                    .isOk());
+        webClient
+            .post()
+            .uri(PROCESS_INSTANCES_START_URL)
+            .accept(MediaType.APPLICATION_JSON)
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(request)
+            .exchange()
+            .expectStatus()
+            .isOk();
 
     response
         .expectHeader()
@@ -335,6 +335,8 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
             .setProcessInstanceKey(123L)
             .setTenantId("tenantId");
 
+    when(authenticationProvider.getCamundaAuthentication())
+        .thenReturn(AUTHENTICATION_WITH_NON_DEFAULT_TENANT);
     when(processInstanceServices.createProcessInstanceWithResult(
             any(ProcessInstanceCreateRequest.class)))
         .thenReturn(CompletableFuture.completedFuture(mockResponse));
@@ -350,18 +352,15 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
 
     // when / then
     final ResponseSpec response =
-        withMultiTenancy(
-            "tenantId",
-            client ->
-                client
-                    .post()
-                    .uri(PROCESS_INSTANCES_START_URL)
-                    .accept(MediaType.APPLICATION_JSON)
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .bodyValue(request)
-                    .exchange()
-                    .expectStatus()
-                    .isOk());
+        webClient
+            .post()
+            .uri(PROCESS_INSTANCES_START_URL)
+            .accept(MediaType.APPLICATION_JSON)
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(request)
+            .exchange()
+            .expectStatus()
+            .isOk();
 
     response
         .expectHeader()
@@ -386,6 +385,8 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
             .setProcessInstanceKey(123L)
             .setTenantId("tenantId");
 
+    when(authenticationProvider.getCamundaAuthentication())
+        .thenReturn(AUTHENTICATION_WITH_NON_DEFAULT_TENANT);
     when(processInstanceServices.createProcessInstanceWithResult(
             any(ProcessInstanceCreateRequest.class)))
         .thenReturn(CompletableFuture.completedFuture(mockResponse));
@@ -400,18 +401,15 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
 
     // when / then
     final ResponseSpec response =
-        withMultiTenancy(
-            "tenantId",
-            client ->
-                client
-                    .post()
-                    .uri(PROCESS_INSTANCES_START_URL)
-                    .accept(MediaType.APPLICATION_JSON)
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .bodyValue(request)
-                    .exchange()
-                    .expectStatus()
-                    .isOk());
+        webClient
+            .post()
+            .uri(PROCESS_INSTANCES_START_URL)
+            .accept(MediaType.APPLICATION_JSON)
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(request)
+            .exchange()
+            .expectStatus()
+            .isOk();
 
     response
         .expectHeader()

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceControllerTest.java
@@ -20,7 +20,7 @@ import io.camunda.search.entities.SequenceFlowEntity;
 import io.camunda.search.filter.ProcessInstanceFilter;
 import io.camunda.search.query.IncidentQuery;
 import io.camunda.search.query.SearchQueryResult;
-import io.camunda.security.auth.Authentication;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.security.configuration.MultiTenancyConfiguration;
 import io.camunda.service.ProcessInstanceServices;
 import io.camunda.service.ProcessInstanceServices.ProcessInstanceCancelRequest;
@@ -76,7 +76,7 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
 
   @BeforeEach
   void setupServices() {
-    when(processInstanceServices.withAuthentication(any(Authentication.class)))
+    when(processInstanceServices.withAuthentication(any(CamundaAuthentication.class)))
         .thenReturn(processInstanceServices);
   }
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceQueryControllerTest.java
@@ -22,7 +22,7 @@ import io.camunda.search.query.ProcessInstanceQuery;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.search.query.SearchQueryResult.Builder;
 import io.camunda.search.sort.ProcessInstanceSort;
-import io.camunda.security.auth.Authentication;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.security.configuration.MultiTenancyConfiguration;
 import io.camunda.service.ProcessInstanceServices;
 import io.camunda.zeebe.gateway.protocol.rest.ProcessInstanceStateEnum;
@@ -140,7 +140,7 @@ public class ProcessInstanceQueryControllerTest extends RestControllerTest {
 
   @BeforeEach
   void setupServices() {
-    when(processInstanceServices.withAuthentication(any(Authentication.class)))
+    when(processInstanceServices.withAuthentication(any(CamundaAuthentication.class)))
         .thenReturn(processInstanceServices);
   }
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceQueryControllerTest.java
@@ -23,6 +23,7 @@ import io.camunda.search.query.SearchQueryResult;
 import io.camunda.search.query.SearchQueryResult.Builder;
 import io.camunda.search.sort.ProcessInstanceSort;
 import io.camunda.security.auth.CamundaAuthentication;
+import io.camunda.security.auth.CamundaAuthenticationProvider;
 import io.camunda.security.configuration.MultiTenancyConfiguration;
 import io.camunda.service.ProcessInstanceServices;
 import io.camunda.zeebe.gateway.protocol.rest.ProcessInstanceStateEnum;
@@ -40,8 +41,8 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @WebMvcTest(value = ProcessInstanceController.class)
 public class ProcessInstanceQueryControllerTest extends RestControllerTest {
@@ -134,12 +135,15 @@ public class ProcessInstanceQueryControllerTest extends RestControllerTest {
           .endCursor("v")
           .build();
 
-  @MockBean ProcessInstanceServices processInstanceServices;
-  @MockBean MultiTenancyConfiguration multiTenancyCfg;
+  @MockitoBean ProcessInstanceServices processInstanceServices;
+  @MockitoBean MultiTenancyConfiguration multiTenancyCfg;
+  @MockitoBean CamundaAuthenticationProvider authenticationProvider;
   @Captor ArgumentCaptor<ProcessInstanceQuery> queryCaptor;
 
   @BeforeEach
   void setupServices() {
+    when(authenticationProvider.getCamundaAuthentication())
+        .thenReturn(AUTHENTICATION_WITH_DEFAULT_TENANT);
     when(processInstanceServices.withAuthentication(any(CamundaAuthentication.class)))
         .thenReturn(processInstanceServices);
   }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ResourceControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ResourceControllerTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.camunda.security.auth.CamundaAuthentication;
+import io.camunda.security.auth.CamundaAuthenticationProvider;
 import io.camunda.security.configuration.MultiTenancyConfiguration;
 import io.camunda.service.ResourceServices;
 import io.camunda.service.ResourceServices.DeployResourcesRequest;
@@ -36,10 +37,10 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mockito;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.client.MultipartBodyBuilder;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @WebMvcTest(ResourceController.class)
 public class ResourceControllerTest extends RestControllerTest {
@@ -50,13 +51,16 @@ public class ResourceControllerTest extends RestControllerTest {
   static final String GET_RESOURCE_ENDPOINT = RESOURCES_BASE_URL + "/resources/%s";
   static final String GET_RESOURCE_CONTENT_ENDPOINT = RESOURCES_BASE_URL + "/resources/%s/content";
 
-  @MockBean ResourceServices resourceServices;
-  @MockBean MultiTenancyConfiguration multiTenancyCfg;
+  @MockitoBean ResourceServices resourceServices;
+  @MockitoBean MultiTenancyConfiguration multiTenancyCfg;
+  @MockitoBean CamundaAuthenticationProvider authenticationProvider;
   @Captor ArgumentCaptor<DeployResourcesRequest> deployRequestCaptor;
   @Captor ArgumentCaptor<ResourceDeletionRequest> deleteRequestCaptor;
 
   @BeforeEach
   void setup() {
+    when(authenticationProvider.getCamundaAuthentication())
+        .thenReturn(AUTHENTICATION_WITH_DEFAULT_TENANT);
     when(resourceServices.withAuthentication(any(CamundaAuthentication.class)))
         .thenReturn(resourceServices);
   }
@@ -189,6 +193,8 @@ public class ResourceControllerTest extends RestControllerTest {
   @Test
   void shouldDeployResourceWithMultitenancyEnabled() {
     // given
+    when(authenticationProvider.getCamundaAuthentication())
+        .thenReturn(AUTHENTICATION_WITH_NON_DEFAULT_TENANT);
     when(multiTenancyCfg.isEnabled()).thenReturn(true);
     final var filename = "process.bpmn";
     final var contentType = MediaType.APPLICATION_OCTET_STREAM;
@@ -214,18 +220,15 @@ public class ResourceControllerTest extends RestControllerTest {
 
     // when/then
     final var response =
-        withMultiTenancy(
-            "tenantId",
-            client ->
-                client
-                    .post()
-                    .uri(DEPLOY_RESOURCES_ENDPOINT)
-                    .contentType(MediaType.MULTIPART_FORM_DATA)
-                    .bodyValue(multipartBodyBuilder.build())
-                    .accept(MediaType.APPLICATION_JSON)
-                    .exchange()
-                    .expectStatus()
-                    .isOk());
+        webClient
+            .post()
+            .uri(DEPLOY_RESOURCES_ENDPOINT)
+            .contentType(MediaType.MULTIPART_FORM_DATA)
+            .bodyValue(multipartBodyBuilder.build())
+            .accept(MediaType.APPLICATION_JSON)
+            .exchange()
+            .expectStatus()
+            .isOk();
 
     verify(resourceServices).deployResources(deployRequestCaptor.capture());
     final var capturedRequest = deployRequestCaptor.getValue();

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ResourceControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ResourceControllerTest.java
@@ -12,7 +12,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import io.camunda.security.auth.Authentication;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.security.configuration.MultiTenancyConfiguration;
 import io.camunda.service.ResourceServices;
 import io.camunda.service.ResourceServices.DeployResourcesRequest;
@@ -57,7 +57,7 @@ public class ResourceControllerTest extends RestControllerTest {
 
   @BeforeEach
   void setup() {
-    when(resourceServices.withAuthentication(any(Authentication.class)))
+    when(resourceServices.withAuthentication(any(CamundaAuthentication.class)))
         .thenReturn(resourceServices);
   }
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/SignalControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/SignalControllerTest.java
@@ -12,7 +12,7 @@ import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
-import io.camunda.security.auth.Authentication;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.security.configuration.MultiTenancyConfiguration;
 import io.camunda.service.SignalServices;
 import io.camunda.zeebe.broker.client.api.dto.BrokerResponse;
@@ -46,7 +46,8 @@ public class SignalControllerTest extends RestControllerTest {
 
   @BeforeEach
   void setup() {
-    when(signalServices.withAuthentication(any(Authentication.class))).thenReturn(signalServices);
+    when(signalServices.withAuthentication(any(CamundaAuthentication.class)))
+        .thenReturn(signalServices);
   }
 
   @Test

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/SignalControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/SignalControllerTest.java
@@ -13,6 +13,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
 import io.camunda.security.auth.CamundaAuthentication;
+import io.camunda.security.auth.CamundaAuthenticationProvider;
 import io.camunda.security.configuration.MultiTenancyConfiguration;
 import io.camunda.service.SignalServices;
 import io.camunda.zeebe.broker.client.api.dto.BrokerResponse;
@@ -25,8 +26,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.reactive.server.WebTestClient.ResponseSpec;
 
 @WebMvcTest(SignalController.class)
@@ -41,11 +42,14 @@ public class SignalControllerTest extends RestControllerTest {
             "tenantId": "tenantId"
           }""";
 
-  @MockBean MultiTenancyConfiguration multiTenancyCfg;
-  @MockBean SignalServices signalServices;
+  @MockitoBean MultiTenancyConfiguration multiTenancyCfg;
+  @MockitoBean SignalServices signalServices;
+  @MockitoBean CamundaAuthenticationProvider authenticationProvider;
 
   @BeforeEach
   void setup() {
+    when(authenticationProvider.getCamundaAuthentication())
+        .thenReturn(AUTHENTICATION_WITH_DEFAULT_TENANT);
     when(signalServices.withAuthentication(any(CamundaAuthentication.class)))
         .thenReturn(signalServices);
   }
@@ -53,6 +57,8 @@ public class SignalControllerTest extends RestControllerTest {
   @Test
   void shouldBroadcastSignal() {
     // given
+    when(authenticationProvider.getCamundaAuthentication())
+        .thenReturn(AUTHENTICATION_WITH_NON_DEFAULT_TENANT);
     when(multiTenancyCfg.isEnabled()).thenReturn(true);
     when(signalServices.broadcastSignal(anyString(), anyMap(), anyString()))
         .thenReturn(buildSignalResponse("tenantId"));
@@ -69,18 +75,15 @@ public class SignalControllerTest extends RestControllerTest {
 
     // when then
     final ResponseSpec response =
-        withMultiTenancy(
-            "tenantId",
-            client ->
-                client
-                    .post()
-                    .uri(BROADCAST_SIGNAL_ENDPOINT)
-                    .accept(MediaType.APPLICATION_JSON)
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .bodyValue(request)
-                    .exchange()
-                    .expectStatus()
-                    .isOk());
+        webClient
+            .post()
+            .uri(BROADCAST_SIGNAL_ENDPOINT)
+            .accept(MediaType.APPLICATION_JSON)
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(request)
+            .exchange()
+            .expectStatus()
+            .isOk();
 
     response.expectBody().json(EXPECTED_PUBLICATION_RESPONSE);
     Mockito.verify(signalServices)
@@ -123,6 +126,8 @@ public class SignalControllerTest extends RestControllerTest {
   @Test
   void shouldBroadcastSignalWithEmptySignalName() {
     // given
+    when(authenticationProvider.getCamundaAuthentication())
+        .thenReturn(AUTHENTICATION_WITH_NON_DEFAULT_TENANT);
     when(multiTenancyCfg.isEnabled()).thenReturn(true);
     when(signalServices.broadcastSignal(anyString(), anyMap(), anyString()))
         .thenReturn(buildSignalResponse("tenantId"));
@@ -139,18 +144,15 @@ public class SignalControllerTest extends RestControllerTest {
 
     // when then
     final ResponseSpec response =
-        withMultiTenancy(
-            "tenantId",
-            client ->
-                client
-                    .post()
-                    .uri(BROADCAST_SIGNAL_ENDPOINT)
-                    .accept(MediaType.APPLICATION_JSON)
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .bodyValue(request)
-                    .exchange()
-                    .expectStatus()
-                    .isOk());
+        webClient
+            .post()
+            .uri(BROADCAST_SIGNAL_ENDPOINT)
+            .accept(MediaType.APPLICATION_JSON)
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(request)
+            .exchange()
+            .expectStatus()
+            .isOk();
 
     response.expectBody().json(EXPECTED_PUBLICATION_RESPONSE);
     Mockito.verify(signalServices).broadcastSignal("", Map.of("key", "value"), "tenantId");

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/UsageMetricsControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/UsageMetricsControllerTest.java
@@ -15,6 +15,7 @@ import io.camunda.search.entities.UsageMetricsCount;
 import io.camunda.search.filter.UsageMetricsFilter;
 import io.camunda.search.query.UsageMetricsQuery;
 import io.camunda.security.auth.CamundaAuthentication;
+import io.camunda.security.auth.CamundaAuthenticationProvider;
 import io.camunda.service.UsageMetricsServices;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
 import java.time.OffsetDateTime;
@@ -22,8 +23,8 @@ import java.time.ZoneOffset;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @WebMvcTest(UsageMetricsController.class)
 public class UsageMetricsControllerTest extends RestControllerTest {
@@ -39,10 +40,13 @@ public class UsageMetricsControllerTest extends RestControllerTest {
 
   static final UsageMetricsCount USAGE_METRICS_COUNT_ENTITY = new UsageMetricsCount(5L, 23L, 17L);
 
-  @MockBean UsageMetricsServices usageMetricsServices;
+  @MockitoBean UsageMetricsServices usageMetricsServices;
+  @MockitoBean CamundaAuthenticationProvider authenticationProvider;
 
   @BeforeEach
   void setupUsageMetricsServices() {
+    when(authenticationProvider.getCamundaAuthentication())
+        .thenReturn(AUTHENTICATION_WITH_DEFAULT_TENANT);
     when(usageMetricsServices.withAuthentication(any(CamundaAuthentication.class)))
         .thenReturn(usageMetricsServices);
   }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/UsageMetricsControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/UsageMetricsControllerTest.java
@@ -14,7 +14,7 @@ import static org.mockito.Mockito.when;
 import io.camunda.search.entities.UsageMetricsCount;
 import io.camunda.search.filter.UsageMetricsFilter;
 import io.camunda.search.query.UsageMetricsQuery;
-import io.camunda.security.auth.Authentication;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.UsageMetricsServices;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
 import java.time.OffsetDateTime;
@@ -43,7 +43,7 @@ public class UsageMetricsControllerTest extends RestControllerTest {
 
   @BeforeEach
   void setupUsageMetricsServices() {
-    when(usageMetricsServices.withAuthentication(any(Authentication.class)))
+    when(usageMetricsServices.withAuthentication(any(CamundaAuthentication.class)))
         .thenReturn(usageMetricsServices);
   }
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/UserTaskControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/UserTaskControllerTest.java
@@ -12,8 +12,10 @@ import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
 
 import io.camunda.security.auth.CamundaAuthentication;
+import io.camunda.security.auth.CamundaAuthenticationProvider;
 import io.camunda.service.UserTaskServices;
 import io.camunda.service.exception.CamundaBrokerException;
 import io.camunda.zeebe.broker.client.api.dto.BrokerRejection;
@@ -36,9 +38,9 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @WebMvcTest(UserTaskController.class)
 public class UserTaskControllerTest extends RestControllerTest {
@@ -48,8 +50,9 @@ public class UserTaskControllerTest extends RestControllerTest {
   static final String TEST_TIME =
       OffsetDateTime.of(2023, 11, 11, 11, 11, 11, 11, ZoneOffset.of("Z")).toString();
 
-  @MockBean UserTaskServices userTaskServices;
-  @MockBean ProcessCache processCache;
+  @MockitoBean UserTaskServices userTaskServices;
+  @MockitoBean ProcessCache processCache;
+  @MockitoBean CamundaAuthenticationProvider authenticationProvider;
 
   static Stream<String> urls() {
     return Stream.of("/v1/user-tasks", "/v2/user-tasks");
@@ -95,6 +98,8 @@ public class UserTaskControllerTest extends RestControllerTest {
 
   @BeforeEach
   void setupServices() {
+    when(authenticationProvider.getCamundaAuthentication())
+        .thenReturn(AUTHENTICATION_WITH_DEFAULT_TENANT);
     Mockito.when(userTaskServices.withAuthentication(any(CamundaAuthentication.class)))
         .thenReturn(userTaskServices);
   }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/UserTaskControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/UserTaskControllerTest.java
@@ -13,7 +13,7 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 
-import io.camunda.security.auth.Authentication;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.UserTaskServices;
 import io.camunda.service.exception.CamundaBrokerException;
 import io.camunda.zeebe.broker.client.api.dto.BrokerRejection;
@@ -95,7 +95,7 @@ public class UserTaskControllerTest extends RestControllerTest {
 
   @BeforeEach
   void setupServices() {
-    Mockito.when(userTaskServices.withAuthentication(any(Authentication.class)))
+    Mockito.when(userTaskServices.withAuthentication(any(CamundaAuthentication.class)))
         .thenReturn(userTaskServices);
   }
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/UserTaskQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/UserTaskQueryControllerTest.java
@@ -26,7 +26,7 @@ import io.camunda.search.query.SearchQueryResult;
 import io.camunda.search.query.SearchQueryResult.Builder;
 import io.camunda.search.query.UserTaskQuery;
 import io.camunda.search.sort.UserTaskSort;
-import io.camunda.security.auth.Authentication;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.UserTaskServices;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
 import io.camunda.zeebe.gateway.rest.cache.ProcessCache;
@@ -210,7 +210,7 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
 
   @BeforeEach
   void setupServices() throws IOException {
-    when(userTaskServices.withAuthentication(any(Authentication.class)))
+    when(userTaskServices.withAuthentication(any(CamundaAuthentication.class)))
         .thenReturn(userTaskServices);
 
     // Mock the behavior of userTaskServices for a valid key

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/UserTaskQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/UserTaskQueryControllerTest.java
@@ -27,6 +27,7 @@ import io.camunda.search.query.SearchQueryResult.Builder;
 import io.camunda.search.query.UserTaskQuery;
 import io.camunda.search.sort.UserTaskSort;
 import io.camunda.security.auth.CamundaAuthentication;
+import io.camunda.security.auth.CamundaAuthenticationProvider;
 import io.camunda.service.UserTaskServices;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
 import io.camunda.zeebe.gateway.rest.cache.ProcessCache;
@@ -46,8 +47,8 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @WebMvcTest(value = UserTaskController.class)
 public class UserTaskQueryControllerTest extends RestControllerTest {
@@ -205,11 +206,14 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
           .endCursor("1")
           .build();
 
-  @MockBean UserTaskServices userTaskServices;
-  @MockBean ProcessCache processCache;
+  @MockitoBean UserTaskServices userTaskServices;
+  @MockitoBean ProcessCache processCache;
+  @MockitoBean CamundaAuthenticationProvider authenticationProvider;
 
   @BeforeEach
   void setupServices() throws IOException {
+    when(authenticationProvider.getCamundaAuthentication())
+        .thenReturn(AUTHENTICATION_WITH_DEFAULT_TENANT);
     when(userTaskServices.withAuthentication(any(CamundaAuthentication.class)))
         .thenReturn(userTaskServices);
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/VariablesQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/VariablesQueryControllerTest.java
@@ -21,6 +21,7 @@ import io.camunda.search.query.SearchQueryResult.Builder;
 import io.camunda.search.query.VariableQuery;
 import io.camunda.search.sort.VariableSort;
 import io.camunda.security.auth.CamundaAuthentication;
+import io.camunda.security.auth.CamundaAuthenticationProvider;
 import io.camunda.service.VariableServices;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
 import java.util.List;
@@ -33,8 +34,8 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @WebMvcTest(value = VariableController.class)
 public class VariablesQueryControllerTest extends RestControllerTest {
@@ -104,11 +105,14 @@ public class VariablesQueryControllerTest extends RestControllerTest {
           .startCursor("0")
           .endCursor("1")
           .build();
-  @MockBean VariableServices variableServices;
+  @MockitoBean VariableServices variableServices;
+  @MockitoBean CamundaAuthenticationProvider authenticationProvider;
   @Captor ArgumentCaptor<VariableQuery> variableQueryCaptor;
 
   @BeforeEach
   void setupServices() {
+    when(authenticationProvider.getCamundaAuthentication())
+        .thenReturn(AUTHENTICATION_WITH_DEFAULT_TENANT);
     when(variableServices.withAuthentication(any(CamundaAuthentication.class)))
         .thenReturn(variableServices);
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/VariablesQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/VariablesQueryControllerTest.java
@@ -20,7 +20,7 @@ import io.camunda.search.query.SearchQueryResult;
 import io.camunda.search.query.SearchQueryResult.Builder;
 import io.camunda.search.query.VariableQuery;
 import io.camunda.search.sort.VariableSort;
-import io.camunda.security.auth.Authentication;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.VariableServices;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
 import java.util.List;
@@ -109,7 +109,7 @@ public class VariablesQueryControllerTest extends RestControllerTest {
 
   @BeforeEach
   void setupServices() {
-    when(variableServices.withAuthentication(any(Authentication.class)))
+    when(variableServices.withAuthentication(any(CamundaAuthentication.class)))
         .thenReturn(variableServices);
 
     when(variableServices.getByKey(VALID_VARIABLE_KEY))

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantControllerTest.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import io.camunda.security.auth.CamundaAuthentication;
+import io.camunda.security.auth.CamundaAuthenticationProvider;
 import io.camunda.service.GroupServices;
 import io.camunda.service.MappingServices;
 import io.camunda.service.RoleServices;
@@ -40,22 +41,25 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @WebMvcTest(TenantController.class)
 public class TenantControllerTest extends RestControllerTest {
 
   private static final String TENANT_BASE_URL = "/v2/tenants";
 
-  @MockBean private TenantServices tenantServices;
-  @MockBean private UserServices userServices;
-  @MockBean private MappingServices mappingServices;
-  @MockBean private GroupServices groupServices;
-  @MockBean private RoleServices roleServices;
+  @MockitoBean private TenantServices tenantServices;
+  @MockitoBean private UserServices userServices;
+  @MockitoBean private MappingServices mappingServices;
+  @MockitoBean private GroupServices groupServices;
+  @MockitoBean private RoleServices roleServices;
+  @MockitoBean private CamundaAuthenticationProvider authenticationProvider;
 
   @BeforeEach
   void setup() {
+    when(authenticationProvider.getCamundaAuthentication())
+        .thenReturn(AUTHENTICATION_WITH_DEFAULT_TENANT);
     when(tenantServices.withAuthentication(any(CamundaAuthentication.class)))
         .thenReturn(tenantServices);
   }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantControllerTest.java
@@ -13,7 +13,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
-import io.camunda.security.auth.Authentication;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.GroupServices;
 import io.camunda.service.MappingServices;
 import io.camunda.service.RoleServices;
@@ -56,7 +56,8 @@ public class TenantControllerTest extends RestControllerTest {
 
   @BeforeEach
   void setup() {
-    when(tenantServices.withAuthentication(any(Authentication.class))).thenReturn(tenantServices);
+    when(tenantServices.withAuthentication(any(CamundaAuthentication.class)))
+        .thenReturn(tenantServices);
   }
 
   @ParameterizedTest

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantQueryControllerTest.java
@@ -26,6 +26,7 @@ import io.camunda.search.query.SearchQueryResult;
 import io.camunda.search.query.TenantQuery;
 import io.camunda.search.sort.TenantSort;
 import io.camunda.security.auth.CamundaAuthentication;
+import io.camunda.security.auth.CamundaAuthenticationProvider;
 import io.camunda.service.GroupServices;
 import io.camunda.service.MappingServices;
 import io.camunda.service.RoleServices;
@@ -224,9 +225,12 @@ public class TenantQueryControllerTest extends RestControllerTest {
   @MockitoBean private MappingServices mappingServices;
   @MockitoBean private GroupServices groupServices;
   @MockitoBean private RoleServices roleServices;
+  @MockitoBean private CamundaAuthenticationProvider authenticationProvider;
 
   @BeforeEach
   void setup() {
+    when(authenticationProvider.getCamundaAuthentication())
+        .thenReturn(AUTHENTICATION_WITH_DEFAULT_TENANT);
     when(tenantServices.withAuthentication(any(CamundaAuthentication.class)))
         .thenReturn(tenantServices);
     when(userServices.withAuthentication(any(CamundaAuthentication.class)))

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantQueryControllerTest.java
@@ -25,7 +25,7 @@ import io.camunda.search.query.RoleQuery;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.search.query.TenantQuery;
 import io.camunda.search.sort.TenantSort;
-import io.camunda.security.auth.Authentication;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.GroupServices;
 import io.camunda.service.MappingServices;
 import io.camunda.service.RoleServices;
@@ -227,11 +227,16 @@ public class TenantQueryControllerTest extends RestControllerTest {
 
   @BeforeEach
   void setup() {
-    when(tenantServices.withAuthentication(any(Authentication.class))).thenReturn(tenantServices);
-    when(userServices.withAuthentication(any(Authentication.class))).thenReturn(userServices);
-    when(mappingServices.withAuthentication(any(Authentication.class))).thenReturn(mappingServices);
-    when(groupServices.withAuthentication(any(Authentication.class))).thenReturn(groupServices);
-    when(roleServices.withAuthentication(any(Authentication.class))).thenReturn(roleServices);
+    when(tenantServices.withAuthentication(any(CamundaAuthentication.class)))
+        .thenReturn(tenantServices);
+    when(userServices.withAuthentication(any(CamundaAuthentication.class)))
+        .thenReturn(userServices);
+    when(mappingServices.withAuthentication(any(CamundaAuthentication.class)))
+        .thenReturn(mappingServices);
+    when(groupServices.withAuthentication(any(CamundaAuthentication.class)))
+        .thenReturn(groupServices);
+    when(roleServices.withAuthentication(any(CamundaAuthentication.class)))
+        .thenReturn(roleServices);
   }
 
   @Test

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/AuthorizationControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/AuthorizationControllerTest.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.camunda.security.auth.CamundaAuthentication;
+import io.camunda.security.auth.CamundaAuthenticationProvider;
 import io.camunda.service.AuthorizationServices;
 import io.camunda.service.AuthorizationServices.CreateAuthorizationRequest;
 import io.camunda.service.AuthorizationServices.UpdateAuthorizationRequest;
@@ -48,9 +49,12 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 public class AuthorizationControllerTest extends RestControllerTest {
 
   @MockitoBean private AuthorizationServices authorizationServices;
+  @MockitoBean private CamundaAuthenticationProvider authenticationProvider;
 
   @BeforeEach
   void setup() {
+    when(authenticationProvider.getCamundaAuthentication())
+        .thenReturn(AUTHENTICATION_WITH_DEFAULT_TENANT);
     when(authorizationServices.withAuthentication(any(CamundaAuthentication.class)))
         .thenReturn(authorizationServices);
   }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/AuthorizationControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/AuthorizationControllerTest.java
@@ -14,7 +14,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import io.camunda.security.auth.Authentication;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.AuthorizationServices;
 import io.camunda.service.AuthorizationServices.CreateAuthorizationRequest;
 import io.camunda.service.AuthorizationServices.UpdateAuthorizationRequest;
@@ -51,7 +51,7 @@ public class AuthorizationControllerTest extends RestControllerTest {
 
   @BeforeEach
   void setup() {
-    when(authorizationServices.withAuthentication(any(Authentication.class)))
+    when(authorizationServices.withAuthentication(any(CamundaAuthentication.class)))
         .thenReturn(authorizationServices);
   }
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/AuthorizationQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/AuthorizationQueryControllerTest.java
@@ -20,6 +20,7 @@ import io.camunda.search.query.SearchQueryResult;
 import io.camunda.search.query.SearchQueryResult.Builder;
 import io.camunda.search.sort.AuthorizationSort;
 import io.camunda.security.auth.CamundaAuthentication;
+import io.camunda.security.auth.CamundaAuthenticationProvider;
 import io.camunda.service.AuthorizationServices;
 import io.camunda.zeebe.gateway.protocol.rest.OwnerTypeEnum;
 import io.camunda.zeebe.gateway.protocol.rest.ResourceTypeEnum;
@@ -78,9 +79,12 @@ public class AuthorizationQueryControllerTest extends RestControllerTest {
           .build();
 
   @MockitoBean private AuthorizationServices authorizationServices;
+  @MockitoBean private CamundaAuthenticationProvider authenticationProvider;
 
   @BeforeEach
   void setup() {
+    when(authenticationProvider.getCamundaAuthentication())
+        .thenReturn(AUTHENTICATION_WITH_DEFAULT_TENANT);
     when(authorizationServices.withAuthentication(any(CamundaAuthentication.class)))
         .thenReturn(authorizationServices);
   }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/AuthorizationQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/AuthorizationQueryControllerTest.java
@@ -19,7 +19,7 @@ import io.camunda.search.query.AuthorizationQuery;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.search.query.SearchQueryResult.Builder;
 import io.camunda.search.sort.AuthorizationSort;
-import io.camunda.security.auth.Authentication;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.AuthorizationServices;
 import io.camunda.zeebe.gateway.protocol.rest.OwnerTypeEnum;
 import io.camunda.zeebe.gateway.protocol.rest.ResourceTypeEnum;
@@ -81,7 +81,7 @@ public class AuthorizationQueryControllerTest extends RestControllerTest {
 
   @BeforeEach
   void setup() {
-    when(authorizationServices.withAuthentication(any(Authentication.class)))
+    when(authorizationServices.withAuthentication(any(CamundaAuthentication.class)))
         .thenReturn(authorizationServices);
   }
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupControllerTest.java
@@ -13,7 +13,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
-import io.camunda.security.auth.Authentication;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.GroupServices;
 import io.camunda.service.GroupServices.GroupDTO;
 import io.camunda.service.GroupServices.GroupMemberDTO;
@@ -211,7 +211,8 @@ public class GroupControllerTest {
 
     @BeforeEach
     void setup() {
-      when(groupServices.withAuthentication(any(Authentication.class))).thenReturn(groupServices);
+      when(groupServices.withAuthentication(any(CamundaAuthentication.class)))
+          .thenReturn(groupServices);
     }
 
     @ParameterizedTest

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupControllerTest.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import io.camunda.security.auth.CamundaAuthentication;
+import io.camunda.security.auth.CamundaAuthenticationProvider;
 import io.camunda.service.GroupServices;
 import io.camunda.service.GroupServices.GroupDTO;
 import io.camunda.service.GroupServices.GroupMemberDTO;
@@ -39,10 +40,10 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 public class GroupControllerTest {
 
@@ -204,13 +205,16 @@ public class GroupControllerTest {
   @WebMvcTest(GroupController.class)
   @TestPropertySource(properties = "camunda.security.authentication.oidc.groupsClaim=")
   public class InternalGroupsEnabledTest extends RestControllerTest {
-    @MockBean private GroupServices groupServices;
-    @MockBean private UserServices userServices;
-    @MockBean private RoleServices roleServices;
-    @MockBean private MappingServices mappingServices;
+    @MockitoBean private GroupServices groupServices;
+    @MockitoBean private UserServices userServices;
+    @MockitoBean private RoleServices roleServices;
+    @MockitoBean private MappingServices mappingServices;
+    @MockitoBean private CamundaAuthenticationProvider authenticationProvider;
 
     @BeforeEach
     void setup() {
+      when(authenticationProvider.getCamundaAuthentication())
+          .thenReturn(AUTHENTICATION_WITH_DEFAULT_TENANT);
       when(groupServices.withAuthentication(any(CamundaAuthentication.class)))
           .thenReturn(groupServices);
     }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupQueryControllerTest.java
@@ -25,6 +25,7 @@ import io.camunda.search.query.RoleQuery;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.search.sort.GroupSort;
 import io.camunda.security.auth.CamundaAuthentication;
+import io.camunda.security.auth.CamundaAuthenticationProvider;
 import io.camunda.service.GroupServices;
 import io.camunda.service.MappingServices;
 import io.camunda.service.RoleServices;
@@ -39,8 +40,8 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @WebMvcTest(value = GroupController.class)
 public class GroupQueryControllerTest extends RestControllerTest {
@@ -219,12 +220,15 @@ public class GroupQueryControllerTest extends RestControllerTest {
       MAPPING_RESPONSE.formatted(
           MAPPNING_ENTITIES.get(0).mappingId(), MAPPNING_ENTITIES.get(1).mappingId());
 
-  @MockBean private GroupServices groupServices;
-  @MockBean private MappingServices mappingServices;
-  @MockBean private RoleServices roleServices;
+  @MockitoBean private GroupServices groupServices;
+  @MockitoBean private MappingServices mappingServices;
+  @MockitoBean private RoleServices roleServices;
+  @MockitoBean private CamundaAuthenticationProvider authenticationProvider;
 
   @BeforeEach
   void setup() {
+    when(authenticationProvider.getCamundaAuthentication())
+        .thenReturn(AUTHENTICATION_WITH_DEFAULT_TENANT);
     when(groupServices.withAuthentication(any(CamundaAuthentication.class)))
         .thenReturn(groupServices);
     when(roleServices.withAuthentication(any(CamundaAuthentication.class)))

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupQueryControllerTest.java
@@ -24,7 +24,7 @@ import io.camunda.search.query.MappingQuery;
 import io.camunda.search.query.RoleQuery;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.search.sort.GroupSort;
-import io.camunda.security.auth.Authentication;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.GroupServices;
 import io.camunda.service.MappingServices;
 import io.camunda.service.RoleServices;
@@ -225,9 +225,12 @@ public class GroupQueryControllerTest extends RestControllerTest {
 
   @BeforeEach
   void setup() {
-    when(groupServices.withAuthentication(any(Authentication.class))).thenReturn(groupServices);
-    when(roleServices.withAuthentication(any(Authentication.class))).thenReturn(roleServices);
-    when(mappingServices.withAuthentication(any(Authentication.class))).thenReturn(mappingServices);
+    when(groupServices.withAuthentication(any(CamundaAuthentication.class)))
+        .thenReturn(groupServices);
+    when(roleServices.withAuthentication(any(CamundaAuthentication.class)))
+        .thenReturn(roleServices);
+    when(mappingServices.withAuthentication(any(CamundaAuthentication.class)))
+        .thenReturn(mappingServices);
   }
 
   @Test

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/MappingControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/MappingControllerTest.java
@@ -13,7 +13,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
-import io.camunda.security.auth.Authentication;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.MappingServices;
 import io.camunda.service.MappingServices.MappingDTO;
 import io.camunda.zeebe.gateway.protocol.rest.MappingRuleCreateRequest;
@@ -39,7 +39,8 @@ public class MappingControllerTest extends RestControllerTest {
 
   @BeforeEach
   void setup() {
-    when(mappingServices.withAuthentication(any(Authentication.class))).thenReturn(mappingServices);
+    when(mappingServices.withAuthentication(any(CamundaAuthentication.class)))
+        .thenReturn(mappingServices);
   }
 
   @ParameterizedTest

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/MappingControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/MappingControllerTest.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import io.camunda.security.auth.CamundaAuthentication;
+import io.camunda.security.auth.CamundaAuthenticationProvider;
 import io.camunda.service.MappingServices;
 import io.camunda.service.MappingServices.MappingDTO;
 import io.camunda.zeebe.gateway.protocol.rest.MappingRuleCreateRequest;
@@ -27,18 +28,21 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @WebMvcTest(MappingController.class)
 public class MappingControllerTest extends RestControllerTest {
 
   private static final String MAPPING_RULES_PATH = "/v2/mapping-rules";
 
-  @MockBean private MappingServices mappingServices;
+  @MockitoBean private MappingServices mappingServices;
+  @MockitoBean private CamundaAuthenticationProvider authenticationProvider;
 
   @BeforeEach
   void setup() {
+    when(authenticationProvider.getCamundaAuthentication())
+        .thenReturn(AUTHENTICATION_WITH_DEFAULT_TENANT);
     when(mappingServices.withAuthentication(any(CamundaAuthentication.class)))
         .thenReturn(mappingServices);
   }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/MappingQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/MappingQueryControllerTest.java
@@ -18,7 +18,7 @@ import io.camunda.search.page.SearchQueryPage;
 import io.camunda.search.query.MappingQuery;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.search.sort.MappingSort;
-import io.camunda.security.auth.Authentication;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.MappingServices;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
 import java.util.List;
@@ -36,7 +36,8 @@ public class MappingQueryControllerTest extends RestControllerTest {
 
   @BeforeEach
   void setup() {
-    when(mappingServices.withAuthentication(any(Authentication.class))).thenReturn(mappingServices);
+    when(mappingServices.withAuthentication(any(CamundaAuthentication.class)))
+        .thenReturn(mappingServices);
   }
 
   @Test

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/MappingQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/MappingQueryControllerTest.java
@@ -19,23 +19,27 @@ import io.camunda.search.query.MappingQuery;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.search.sort.MappingSort;
 import io.camunda.security.auth.CamundaAuthentication;
+import io.camunda.security.auth.CamundaAuthenticationProvider;
 import io.camunda.service.MappingServices;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @WebMvcTest(value = MappingController.class)
 public class MappingQueryControllerTest extends RestControllerTest {
   private static final String MAPPING_BASE_URL = "/v2/mapping-rules";
 
-  @MockBean private MappingServices mappingServices;
+  @MockitoBean private MappingServices mappingServices;
+  @MockitoBean private CamundaAuthenticationProvider authenticationProvider;
 
   @BeforeEach
   void setup() {
+    when(authenticationProvider.getCamundaAuthentication())
+        .thenReturn(AUTHENTICATION_WITH_DEFAULT_TENANT);
     when(mappingServices.withAuthentication(any(CamundaAuthentication.class)))
         .thenReturn(mappingServices);
   }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleControllerTest.java
@@ -13,7 +13,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
-import io.camunda.security.auth.Authentication;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.GroupServices;
 import io.camunda.service.MappingServices;
 import io.camunda.service.RoleServices;
@@ -53,10 +53,14 @@ public class RoleControllerTest extends RestControllerTest {
 
   @BeforeEach
   void setup() {
-    when(roleServices.withAuthentication(any(Authentication.class))).thenReturn(roleServices);
-    when(userServices.withAuthentication(any(Authentication.class))).thenReturn(userServices);
-    when(mappingServices.withAuthentication(any(Authentication.class))).thenReturn(mappingServices);
-    when(groupServices.withAuthentication(any(Authentication.class))).thenReturn(groupServices);
+    when(roleServices.withAuthentication(any(CamundaAuthentication.class)))
+        .thenReturn(roleServices);
+    when(userServices.withAuthentication(any(CamundaAuthentication.class)))
+        .thenReturn(userServices);
+    when(mappingServices.withAuthentication(any(CamundaAuthentication.class)))
+        .thenReturn(mappingServices);
+    when(groupServices.withAuthentication(any(CamundaAuthentication.class)))
+        .thenReturn(groupServices);
   }
 
   @ParameterizedTest

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleControllerTest.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import io.camunda.security.auth.CamundaAuthentication;
+import io.camunda.security.auth.CamundaAuthenticationProvider;
 import io.camunda.service.GroupServices;
 import io.camunda.service.MappingServices;
 import io.camunda.service.RoleServices;
@@ -38,21 +39,24 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @WebMvcTest(RoleController.class)
 public class RoleControllerTest extends RestControllerTest {
 
   private static final String ROLE_BASE_URL = "/v2/roles";
 
-  @MockBean private RoleServices roleServices;
-  @MockBean private UserServices userServices;
-  @MockBean private MappingServices mappingServices;
-  @MockBean private GroupServices groupServices;
+  @MockitoBean private RoleServices roleServices;
+  @MockitoBean private UserServices userServices;
+  @MockitoBean private MappingServices mappingServices;
+  @MockitoBean private GroupServices groupServices;
+  @MockitoBean private CamundaAuthenticationProvider authenticationProvider;
 
   @BeforeEach
   void setup() {
+    when(authenticationProvider.getCamundaAuthentication())
+        .thenReturn(AUTHENTICATION_WITH_DEFAULT_TENANT);
     when(roleServices.withAuthentication(any(CamundaAuthentication.class)))
         .thenReturn(roleServices);
     when(userServices.withAuthentication(any(CamundaAuthentication.class)))

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleQueryControllerTest.java
@@ -23,7 +23,7 @@ import io.camunda.search.query.MappingQuery;
 import io.camunda.search.query.RoleQuery;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.search.sort.RoleSort;
-import io.camunda.security.auth.Authentication;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.GroupServices;
 import io.camunda.service.MappingServices;
 import io.camunda.service.RoleServices;
@@ -49,11 +49,14 @@ public class RoleQueryControllerTest extends RestControllerTest {
 
   @BeforeEach
   void setup() {
-    when(roleServices.withAuthentication(any(Authentication.class))).thenReturn(roleServices);
-    when(userServices.withAuthentication(any(Authentication.class))).thenReturn(userServices);
-    when(mappingsServices.withAuthentication(any(Authentication.class)))
+    when(roleServices.withAuthentication(any(CamundaAuthentication.class)))
+        .thenReturn(roleServices);
+    when(userServices.withAuthentication(any(CamundaAuthentication.class)))
+        .thenReturn(userServices);
+    when(mappingsServices.withAuthentication(any(CamundaAuthentication.class)))
         .thenReturn(mappingsServices);
-    when(groupServices.withAuthentication(any(Authentication.class))).thenReturn(groupServices);
+    when(groupServices.withAuthentication(any(CamundaAuthentication.class)))
+        .thenReturn(groupServices);
   }
 
   @Test

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleQueryControllerTest.java
@@ -24,6 +24,7 @@ import io.camunda.search.query.RoleQuery;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.search.sort.RoleSort;
 import io.camunda.security.auth.CamundaAuthentication;
+import io.camunda.security.auth.CamundaAuthenticationProvider;
 import io.camunda.service.GroupServices;
 import io.camunda.service.MappingServices;
 import io.camunda.service.RoleServices;
@@ -46,9 +47,12 @@ public class RoleQueryControllerTest extends RestControllerTest {
   @MockitoBean private UserServices userServices;
   @MockitoBean private MappingServices mappingsServices;
   @MockitoBean private GroupServices groupServices;
+  @MockitoBean private CamundaAuthenticationProvider authenticationProvider;
 
   @BeforeEach
   void setup() {
+    when(authenticationProvider.getCamundaAuthentication())
+        .thenReturn(AUTHENTICATION_WITH_DEFAULT_TENANT);
     when(roleServices.withAuthentication(any(CamundaAuthentication.class)))
         .thenReturn(roleServices);
     when(userServices.withAuthentication(any(CamundaAuthentication.class)))

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/UserControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/UserControllerTest.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.when;
 
 import io.camunda.search.exception.CamundaSearchException;
 import io.camunda.security.auth.CamundaAuthentication;
+import io.camunda.security.auth.CamundaAuthenticationProvider;
 import io.camunda.service.UserServices;
 import io.camunda.service.UserServices.UserDTO;
 import io.camunda.zeebe.gateway.protocol.rest.UserRequest;
@@ -30,20 +31,23 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ProblemDetail;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @WebMvcTest(UserController.class)
 public class UserControllerTest extends RestControllerTest {
 
   private static final String USER_BASE_URL = "/v2/users";
 
-  @MockBean private UserServices userServices;
+  @MockitoBean private UserServices userServices;
+  @MockitoBean private CamundaAuthenticationProvider authenticationProvider;
 
   @BeforeEach
   void setup() {
+    when(authenticationProvider.getCamundaAuthentication())
+        .thenReturn(AUTHENTICATION_WITH_DEFAULT_TENANT);
     when(userServices.withAuthentication(any(CamundaAuthentication.class)))
         .thenReturn(userServices);
   }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/UserControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/UserControllerTest.java
@@ -14,7 +14,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import io.camunda.search.exception.CamundaSearchException;
-import io.camunda.security.auth.Authentication;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.UserServices;
 import io.camunda.service.UserServices.UserDTO;
 import io.camunda.zeebe.gateway.protocol.rest.UserRequest;
@@ -44,7 +44,8 @@ public class UserControllerTest extends RestControllerTest {
 
   @BeforeEach
   void setup() {
-    when(userServices.withAuthentication(any(Authentication.class))).thenReturn(userServices);
+    when(userServices.withAuthentication(any(CamundaAuthentication.class)))
+        .thenReturn(userServices);
   }
 
   @ParameterizedTest

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/UserQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/UserQueryControllerTest.java
@@ -19,7 +19,7 @@ import io.camunda.search.query.SearchQueryResult;
 import io.camunda.search.query.SearchQueryResult.Builder;
 import io.camunda.search.query.UserQuery;
 import io.camunda.search.sort.UserSort;
-import io.camunda.security.auth.Authentication;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.RoleServices;
 import io.camunda.service.UserServices;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
@@ -71,7 +71,8 @@ public class UserQueryControllerTest extends RestControllerTest {
 
   @BeforeEach
   void setup() {
-    when(userServices.withAuthentication(any(Authentication.class))).thenReturn(userServices);
+    when(userServices.withAuthentication(any(CamundaAuthentication.class)))
+        .thenReturn(userServices);
   }
 
   @Test

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/UserQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/UserQueryControllerTest.java
@@ -20,6 +20,7 @@ import io.camunda.search.query.SearchQueryResult.Builder;
 import io.camunda.search.query.UserQuery;
 import io.camunda.search.sort.UserSort;
 import io.camunda.security.auth.CamundaAuthentication;
+import io.camunda.security.auth.CamundaAuthenticationProvider;
 import io.camunda.service.RoleServices;
 import io.camunda.service.UserServices;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
@@ -32,9 +33,9 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @WebMvcTest(value = UserController.class)
 public class UserQueryControllerTest extends RestControllerTest {
@@ -65,12 +66,15 @@ public class UserQueryControllerTest extends RestControllerTest {
           .endCursor("v")
           .build();
 
-  @MockBean UserServices userServices;
-  @MockBean RoleServices roleServices;
-  @MockBean PasswordEncoder passwordEncoder;
+  @MockitoBean UserServices userServices;
+  @MockitoBean RoleServices roleServices;
+  @MockitoBean PasswordEncoder passwordEncoder;
+  @MockitoBean CamundaAuthenticationProvider authenticationProvider;
 
   @BeforeEach
   void setup() {
+    when(authenticationProvider.getCamundaAuthentication())
+        .thenReturn(AUTHENTICATION_WITH_DEFAULT_TENANT);
     when(userServices.withAuthentication(any(CamundaAuthentication.class)))
         .thenReturn(userServices);
   }

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerCreateBatchOperationRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerCreateBatchOperationRequest.java
@@ -8,7 +8,7 @@
 package io.camunda.zeebe.gateway.impl.broker.request;
 
 import io.camunda.search.filter.FilterBase;
-import io.camunda.security.auth.Authentication;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.zeebe.broker.client.api.dto.BrokerExecuteCommand;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationCreationRecord;
@@ -64,7 +64,8 @@ public class BrokerCreateBatchOperationRequest
     return this;
   }
 
-  public BrokerCreateBatchOperationRequest setAuthentication(final Authentication authentication) {
+  public BrokerCreateBatchOperationRequest setAuthentication(
+      final CamundaAuthentication authentication) {
     requestDto.setAuthentication(
         new UnsafeBuffer(MsgPackConverter.convertToMsgPack(authentication)));
     return this;


### PR DESCRIPTION
## Description

* Renames the class `Authentication` to `CamundaAuthentication` to clearly separate between Spring and Camunda Authentication classes
* Extracts the `RequestMapper#getAuthentication` in its own `CamundaAuthenticationProvider` and `CamundaAuthenticationConverter`
* Replaces the usage of `RequestMapper#getAuthentication` with the `CamundaAuthenticationProvider`

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
