### PR TITLE
[Backport stable/optimize-8.7] deps: upgrade dependencies vulnerable to CVEs

### DIFF
--- a/optimize/backend/pom.xml
+++ b/optimize/backend/pom.xml
@@ -288,6 +288,10 @@
           <groupId>commons-logging</groupId>
           <artifactId>commons-logging</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>commons-beanutils</groupId>
+          <artifactId>commons-beanutils</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
 

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/cleanup/OptimizeProcessCleanupServiceTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/cleanup/OptimizeProcessCleanupServiceTest.java
@@ -40,7 +40,7 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-import org.apache.commons.collections.ListUtils;
+import org.apache.commons.collections4.ListUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/optimize/pom.xml
+++ b/optimize/pom.xml
@@ -51,9 +51,9 @@
     <apache.http5-client.version>5.4</apache.http5-client.version>
     <apache.http5-core.version>5.3.1</apache.http5-core.version>
     <guava.version>33.3.1-jre</guava.version>
-    <spring.boot.version>3.3.10</spring.boot.version>
-    <spring.version>6.1.17</spring.version>
-    <spring.security.version>6.4.6</spring.security.version>
+    <spring.boot.version>3.3.11</spring.boot.version>
+    <spring.version>6.1.21</spring.version>
+    <spring.security.version>6.4.7</spring.security.version>
     <httpclient.version>4.5.14</httpclient.version>
     <quartz.version>2.3.2</quartz.version>
     <jakarta.rs-api.version>4.0.0</jakarta.rs-api.version>

--- a/optimize/pom.xml
+++ b/optimize/pom.xml
@@ -380,6 +380,10 @@
           <groupId>commons-logging</groupId>
           <artifactId>commons-logging</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>commons-beanutils</groupId>
+          <artifactId>commons-beanutils</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -98,9 +98,9 @@
     <version.feel-scala>1.18.0</version.feel-scala>
     <version.dmn-scala>1.10.0</version.dmn-scala>
     <version.rest-assured>5.5.0</version.rest-assured>
-    <version.spring>6.1.13</version.spring>
-    <version.spring-security>6.4.6</version.spring-security>
-    <version.spring-boot>3.3.4</version.spring-boot>
+    <version.spring>6.1.21</version.spring>
+    <version.spring-security>6.4.7</version.spring-security>
+    <version.spring-boot>3.3.11</version.spring-boot>
     <version.concurrentunit>0.4.6</version.concurrentunit>
     <version.kryo>5.6.0</version.kryo>
     <version.failsafe>2.4.4</version.failsafe>


### PR DESCRIPTION
# Description
Backport of #34506 to `stable/optimize-8.7`.

relates to 
original author: @matthewBearCamunda