### PR TITLE
deps: upgrade spring to 6.2.8

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -102,7 +102,7 @@
     <version.feel-scala>1.19.3</version.feel-scala>
     <version.dmn-scala>1.10.1</version.dmn-scala>
     <version.rest-assured>5.5.5</version.rest-assured>
-    <version.spring>6.2.6</version.spring>
+    <version.spring>6.2.8</version.spring>
     <version.spring-security>6.5.1</version.spring-security>
     <version.spring-boot>3.4.7</version.spring-boot>
     <version.concurrentunit>0.4.6</version.concurrentunit>


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Fixes CVE-2025-22233 by upgrading spring to 6.2.8 (most recent spring version)

https://spring.io/blog/2025/05/15/spring-framework-6-1-20-and-6-2-7-releases-fix-cve-2025-22233

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
