### PR TITLE
fix: Zeebe Benchmark deploy step only done after corresponding images are built

### DIFF
--- a/.github/workflows/zeebe-benchmark.yml
+++ b/.github/workflows/zeebe-benchmark.yml
@@ -213,6 +213,8 @@ jobs:
     name: Deploy
     needs:
       - calculate-image-tag
+      - build-benchmark-images
+      - build-zeebe-image
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:

--- a/.github/workflows/zeebe-benchmark.yml
+++ b/.github/workflows/zeebe-benchmark.yml
@@ -215,10 +215,8 @@ jobs:
       - calculate-image-tag
       - build-zeebe-image
       - build-benchmark-images
-    # Deploy will be run:
-    # - after build jobs if they are not skipped
-    # - after calculate-image-tag if build jobs are skipped
-    # this is to have the possibility to re-deploy the benchmarks without rebuilding the images
+    # To have the possibility to re-deploy the benchmarks without rebuilding the images,
+    # the deploy will be run, when build is skipped or successful.
     if: |
       always() &&
       (needs.build-zeebe-image.result == 'success' || needs.build-zeebe-image.result == 'skipped') &&

--- a/.github/workflows/zeebe-benchmark.yml
+++ b/.github/workflows/zeebe-benchmark.yml
@@ -213,8 +213,16 @@ jobs:
     name: Deploy
     needs:
       - calculate-image-tag
-      - build-benchmark-images
       - build-zeebe-image
+      - build-benchmark-images
+    # Deploy will be run:
+    # - after build jobs if they are not skipped
+    # - after calculate-image-tag if build jobs are skipped
+    # this is to have the possibility to re-deploy the benchmarks without rebuilding the images
+    if: |
+      always() &&
+      (needs.build-zeebe-image.result == 'success' || needs.build-zeebe-image.result == 'skipped') &&
+      (needs.build-benchmark-images.result == 'success' || needs.build-benchmark-images.result == 'skipped')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:


### PR DESCRIPTION
## Description

fix: Zeebe Benchmark deploy step should only be done after the corresponding Docker images are pushed.

Otherwise, `helm install` kicks in and updates the StatefulSet to use images that do not exist yet.
That works due to k8s self-healing mode eventually, but can be easily prevented from being a problem at all.

Example:
- https://github.com/camunda/camunda/actions/runs/15978905178/job/45068425763

<img width="632" alt="Screenshot 2025-06-30 at 19 41 49" src="https://github.com/user-attachments/assets/d26e4f9d-6690-4636-bd94-14280b44b4b1" />

(_Deploy_ step run at the same time as the _Build_ steps prior to this change)

If the existing image is used (build steps skipped), deploy will run too, not breaking the current functionality.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
