### PR TITLE
ci: Add timeout for tasklist-ci-test-reusable

### DIFF
--- a/.github/workflows/tasklist-ci-test-reusable.yml
+++ b/.github/workflows/tasklist-ci-test-reusable.yml
@@ -46,6 +46,7 @@ jobs:
   integration-tests:
     name: Test
     runs-on: gcp-perf-core-16-default
+    timeout-minutes: 40
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Description

ci: Add timeout for tasklist-ci-test-reusable

Related: https://camunda.slack.com/archives/C08MRKHJ0CD/p1751312832990709

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
