### PR TITLE
fix: spring sdk legacy property mappings

### DIFF
--- a/clients/spring-boot-starter-camunda-sdk/src/main/resources/zeebe-client-legacy-property-mappings.properties
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/resources/zeebe-client-legacy-property-mappings.properties
@@ -32,7 +32,7 @@ camunda.client.zeebe.defaults.type=zeebe.client.worker.default-type
 # Auth
 camunda.client.auth.client-id=zeebe.client.cloud.client-id, zeebe.client.id
 camunda.client.auth.client-secret=zeebe.client.cloud.client-secret, zeebe.client.secret, zeebe.client.cloud.secret
-camunda.client.auth.audience=camunda.client.zeebe.audience, zeebe.client.cloud.audience
-camunda.client.auth.scope=camunda.client.zeebe.scope, zeebe.client.cloud.scope, zeebe.token.scope
+camunda.client.zeebe.audience=zeebe.client.cloud.audience
+camunda.client.zeebe.scope=zeebe.client.cloud.scope, zeebe.token.scope
 camunda.client.auth.token-url=camunda.client.auth.issuer, zeebe.client.cloud.auth-url, zeebe.authorization.server.url
 camunda.client.auth.credentials-cache-path=zeebe.client.cloud.credentials-cache-path, zeebe.client.config.path


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR fixes some unintentional mappings.

The scope and audience still reside with `camunda.client.zeebe.` with the 8.7 release and are added to the credentials provider here: 

https://github.com/camunda/camunda/blob/stable/8.7/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/configuration/CredentialsProviderConfiguration.java#L47-L48

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
