### PR TITLE
fix: inconsistent behavior when `exportItemsOnCreation` config changes while a BO is ongoing - rdbms

### DIFF
--- a/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.8.0.xml
+++ b/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.8.0.xml
@@ -496,6 +496,7 @@
       <column name="OPERATIONS_TOTAL_COUNT" type="INT"/>
       <column name="OPERATIONS_FAILED_COUNT" type="INT"/>
       <column name="OPERATIONS_COMPLETED_COUNT" type="INT"/>
+      <column name="EXPORT_ITEMS_ON_CREATION" type="BOOLEAN"/>
     </createTable>
 
     <createTable tableName="${prefix}BATCH_OPERATION_ITEM">

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/BatchOperationReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/BatchOperationReader.java
@@ -11,6 +11,7 @@ import io.camunda.db.rdbms.read.domain.BatchOperationDbQuery;
 import io.camunda.db.rdbms.read.mapper.BatchOperationEntityMapper;
 import io.camunda.db.rdbms.sql.BatchOperationMapper;
 import io.camunda.db.rdbms.sql.columns.BatchOperationSearchColumn;
+import io.camunda.db.rdbms.write.domain.BatchOperationDbModel;
 import io.camunda.search.entities.BatchOperationEntity;
 import io.camunda.search.query.BatchOperationQuery;
 import io.camunda.search.query.SearchQueryResult;
@@ -42,6 +43,11 @@ public class BatchOperationReader extends AbstractEntityReader<BatchOperationEnt
     final var result =
         search(BatchOperationQuery.of(b -> b.filter(f -> f.batchOperationIds(batchOperationId))));
     return Optional.ofNullable(result.items()).flatMap(it -> it.stream().findFirst());
+  }
+
+  // TODO better name?
+  public Optional<BatchOperationDbModel> findOneDbModel(final String batchOperationId) {
+    return batchOperationMapper.findById(batchOperationId);
   }
 
   public SearchQueryResult<BatchOperationEntity> search(final BatchOperationQuery query) {

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/BatchOperationMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/BatchOperationMapper.java
@@ -16,8 +16,11 @@ import io.camunda.search.entities.BatchOperationEntity.BatchOperationItemEntity;
 import io.camunda.search.entities.BatchOperationEntity.BatchOperationState;
 import java.time.OffsetDateTime;
 import java.util.List;
+import java.util.Optional;
 
 public interface BatchOperationMapper {
+
+  Optional<BatchOperationDbModel> findById(String batchOperationId);
 
   void insert(BatchOperationDbModel batchOperationDbModel);
 
@@ -27,11 +30,11 @@ public interface BatchOperationMapper {
 
   void updateItemsWithState(BatchOperationItemStatusUpdateDto dto);
 
-  void incrementOperationsTotalCount(BatchOperationUpdateTotalCountDto dto);
+  void incrementOperationsTotalCount(BatchOperationUpdateCountDto dto);
 
-  void incrementFailedOperationsCount(String batchOperationId);
+  void incrementFailedOperationsCount(BatchOperationUpdateCountDto dto);
 
-  void incrementCompletedOperationsCount(String batchOperationId);
+  void incrementCompletedOperationsCount(BatchOperationUpdateCountDto dto);
 
   Long count(BatchOperationDbQuery query);
 
@@ -44,9 +47,7 @@ public interface BatchOperationMapper {
   record BatchOperationUpdateDto(
       String batchOperationId, BatchOperationState state, OffsetDateTime endDate) {}
 
-  record BatchOperationUpdateTotalCountDto(String batchOperationId, int operationsTotalCount) {}
-
-  record BatchOperationUpdateCountsDto(String batchOperationId, long itemKey) {}
+  record BatchOperationUpdateCountDto(String batchOperationId, int count) {}
 
   record BatchOperationItemsDto(String batchOperationId, List<BatchOperationItemDbModel> items) {}
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriterConfig.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriterConfig.java
@@ -17,13 +17,7 @@ public record RdbmsWriterConfig(
     Duration minHistoryCleanupInterval,
     Duration maxHistoryCleanupInterval,
     int historyCleanupBatchSize,
-    int batchOperationItemInsertBlockSize,
-    /*
-     * Export the batch operation items when the initial chunk records are processed. If set to
-     * <code>false</code>, the batch operation items will be exported only when they have been
-     * processed and are completed or failed.
-     */
-    boolean exportBatchOperationItemsOnCreation) {
+    int batchOperationItemInsertBlockSize) {
 
   public static final int DEFAULT_QUEUE_SIZE = -1;
   public static final Duration DEFAULT_HISTORY_TTL = Duration.ofDays(30);
@@ -31,7 +25,6 @@ public record RdbmsWriterConfig(
   public static final Duration DEFAULT_MAX_HISTORY_CLEANUP_INTERVAL = Duration.ofMinutes(60);
   public static final int DEFAULT_HISTORY_CLEANUP_BATCH_SIZE = 1000;
   public static final int DEFAULT_BATCH_OPERATION_ITEM_INSERT_BLOCK_SIZE = 10000;
-  public static final boolean DEFAULT_EXPORT_BATCH_OPERATION_ITEMS_ON_CREATION = true;
 
   public static Builder builder() {
     return new Builder();
@@ -46,8 +39,6 @@ public record RdbmsWriterConfig(
     private Duration maxHistoryCleanupInterval = DEFAULT_MAX_HISTORY_CLEANUP_INTERVAL;
     private int historyCleanupBatchSize = DEFAULT_HISTORY_CLEANUP_BATCH_SIZE;
     private int batchOperationItemInsertBlockSize = DEFAULT_BATCH_OPERATION_ITEM_INSERT_BLOCK_SIZE;
-    private boolean exportBatchOperationItemsOnCreation =
-        DEFAULT_EXPORT_BATCH_OPERATION_ITEMS_ON_CREATION;
 
     public Builder partitionId(final int partitionId) {
       this.partitionId = partitionId;
@@ -84,12 +75,6 @@ public record RdbmsWriterConfig(
       return this;
     }
 
-    public Builder exportBatchOperationItemsOnCreation(
-        final boolean exportBatchOperationItemsOnCreation) {
-      this.exportBatchOperationItemsOnCreation = exportBatchOperationItemsOnCreation;
-      return this;
-    }
-
     @Override
     public RdbmsWriterConfig build() {
       return new RdbmsWriterConfig(
@@ -99,8 +84,7 @@ public record RdbmsWriterConfig(
           minHistoryCleanupInterval,
           maxHistoryCleanupInterval,
           historyCleanupBatchSize,
-          batchOperationItemInsertBlockSize,
-          exportBatchOperationItemsOnCreation);
+          batchOperationItemInsertBlockSize);
     }
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/BatchOperationDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/BatchOperationDbModel.java
@@ -19,7 +19,21 @@ public record BatchOperationDbModel(
     OffsetDateTime endDate,
     Integer operationsTotalCount,
     Integer operationsFailedCount,
-    Integer operationsCompletedCount) {
+    Integer operationsCompletedCount,
+    Boolean exportItemsOnCreation) {
+
+  public Builder toBuilder() {
+    return new Builder()
+        .batchOperationId(batchOperationId)
+        .state(state)
+        .operationType(operationType)
+        .startDate(startDate)
+        .endDate(endDate)
+        .operationsTotalCount(operationsTotalCount)
+        .operationsFailedCount(operationsFailedCount)
+        .operationsCompletedCount(operationsCompletedCount)
+        .exportItemsOnCreation(exportItemsOnCreation);
+  }
 
   // Builder class
   public static class Builder implements ObjectBuilder<BatchOperationDbModel> {
@@ -32,6 +46,7 @@ public record BatchOperationDbModel(
     private Integer operationsTotalCount = 0;
     private Integer operationsFailedCount = 0;
     private Integer operationsCompletedCount = 0;
+    private Boolean exportItemsOnCreation = false;
 
     public Builder() {}
 
@@ -75,6 +90,11 @@ public record BatchOperationDbModel(
       return this;
     }
 
+    public Builder exportItemsOnCreation(final Boolean exportItemsOnCreation) {
+      this.exportItemsOnCreation = exportItemsOnCreation;
+      return this;
+    }
+
     @Override
     public BatchOperationDbModel build() {
       return new BatchOperationDbModel(
@@ -85,7 +105,8 @@ public record BatchOperationDbModel(
           endDate,
           operationsTotalCount,
           operationsFailedCount,
-          operationsCompletedCount);
+          operationsCompletedCount,
+          exportItemsOnCreation);
     }
   }
 }

--- a/db/rdbms/src/main/resources/mapper/BatchOperationMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/BatchOperationMapper.xml
@@ -17,6 +17,7 @@
       <arg column="OPERATIONS_TOTAL_COUNT" javaType="int"/>
       <arg column="OPERATIONS_FAILED_COUNT" javaType="int"/>
       <arg column="OPERATIONS_COMPLETED_COUNT" javaType="int"/>
+      <arg column="EXPORT_ITEMS_ON_CREATION" javaType="boolean"/>
     </constructor>
   </resultMap>
 
@@ -35,13 +36,14 @@
 
   <insert id="insert" parameterType="io.camunda.db.rdbms.write.domain.BatchOperationDbModel">
     INSERT INTO ${prefix}BATCH_OPERATION (BATCH_OPERATION_ID,
-                                 STATE,
-                                 OPERATION_TYPE,
-                                 START_DATE,
-                                 END_DATE,
-                                 OPERATIONS_TOTAL_COUNT,
-                                 OPERATIONS_FAILED_COUNT,
-                                 OPERATIONS_COMPLETED_COUNT)
+                                          STATE,
+                                          OPERATION_TYPE,
+                                          START_DATE,
+                                          END_DATE,
+                                          OPERATIONS_TOTAL_COUNT,
+                                          OPERATIONS_FAILED_COUNT,
+                                          OPERATIONS_COMPLETED_COUNT,
+                                          EXPORT_ITEMS_ON_CREATION)
     VALUES (#{batchOperationId},
             #{state},
             #{operationType},
@@ -49,12 +51,14 @@
             #{endDate},
             #{operationsTotalCount},
             #{operationsFailedCount},
-            #{operationsCompletedCount})
+            #{operationsCompletedCount},
+            #{exportItemsOnCreation})
   </insert>
 
   <insert id="insertItems"
     parameterType="io.camunda.db.rdbms.sql.BatchOperationMapper$BatchOperationItemsDto">
-    INSERT INTO ${prefix}BATCH_OPERATION_ITEM (BATCH_OPERATION_ID, ITEM_KEY, PROCESS_INSTANCE_KEY, STATE)
+    INSERT INTO ${prefix}BATCH_OPERATION_ITEM (BATCH_OPERATION_ID, ITEM_KEY, PROCESS_INSTANCE_KEY,
+    STATE)
     VALUES
     <foreach collection="items" item="item" separator=",">
       (#{batchOperationId}, #{item.itemKey}, #{item.processInstanceKey}, #{item.state})
@@ -64,7 +68,7 @@
   <update id="updateCompleted"
     parameterType="io.camunda.db.rdbms.sql.BatchOperationMapper$BatchOperationUpdateDto">
     UPDATE ${prefix}BATCH_OPERATION
-    SET STATE = #{state},
+    SET STATE    = #{state},
         END_DATE = #{endDate}
     WHERE BATCH_OPERATION_ID = #{batchOperationId}
   </update>
@@ -72,9 +76,9 @@
   <update id="updateItem"
     parameterType="io.camunda.db.rdbms.sql.BatchOperationMapper$BatchOperationItemDto">
     UPDATE ${prefix}BATCH_OPERATION_ITEM
-    SET STATE = #{state},
+    SET STATE          = #{state},
         PROCESSED_DATE = #{processedDate},
-        ERROR_MESSAGE = #{errorMessage}
+        ERROR_MESSAGE  = #{errorMessage}
     WHERE BATCH_OPERATION_ID = #{batchOperationId}
       AND ITEM_KEY = #{itemKey}
   </update>
@@ -88,25 +92,41 @@
   </update>
 
   <update id="incrementOperationsTotalCount"
-    parameterType="io.camunda.db.rdbms.sql.BatchOperationMapper$BatchOperationUpdateTotalCountDto">
+    parameterType="io.camunda.db.rdbms.sql.BatchOperationMapper$BatchOperationUpdateCountDto">
     UPDATE ${prefix}BATCH_OPERATION
-    SET OPERATIONS_TOTAL_COUNT = OPERATIONS_TOTAL_COUNT + #{operationsTotalCount}
+    SET OPERATIONS_TOTAL_COUNT = OPERATIONS_TOTAL_COUNT + #{count}
     WHERE BATCH_OPERATION_ID = #{batchOperationId}
   </update>
 
   <update id="incrementFailedOperationsCount"
-    parameterType="java.lang.String">
+    parameterType="io.camunda.db.rdbms.sql.BatchOperationMapper$BatchOperationUpdateCountDto">
     UPDATE ${prefix}BATCH_OPERATION t
-    SET OPERATIONS_FAILED_COUNT = OPERATIONS_FAILED_COUNT + 1
-    WHERE BATCH_OPERATION_ID = #{id}
+    SET OPERATIONS_FAILED_COUNT = OPERATIONS_FAILED_COUNT + #{count}
+    WHERE BATCH_OPERATION_ID = #{batchOperationId}
   </update>
 
   <update id="incrementCompletedOperationsCount"
-    parameterType="java.lang.String">
+    parameterType="io.camunda.db.rdbms.sql.BatchOperationMapper$BatchOperationUpdateCountDto">
     UPDATE ${prefix}BATCH_OPERATION t
-    SET OPERATIONS_COMPLETED_COUNT = OPERATIONS_COMPLETED_COUNT + 1
-    WHERE BATCH_OPERATION_ID = #{id}
+    SET OPERATIONS_COMPLETED_COUNT = OPERATIONS_COMPLETED_COUNT + #{count}
+    WHERE BATCH_OPERATION_ID = #{batchOperationId}
   </update>
+
+  <select id="findById" parameterType="java.lang.String"
+    resultMap="BatchOperationResultMap"
+    statementType="PREPARED">
+    SELECT BATCH_OPERATION_ID,
+           STATE,
+           OPERATION_TYPE,
+           START_DATE,
+           END_DATE,
+           OPERATIONS_TOTAL_COUNT,
+           OPERATIONS_FAILED_COUNT,
+           OPERATIONS_COMPLETED_COUNT,
+           EXPORT_ITEMS_ON_CREATION
+    FROM ${prefix}BATCH_OPERATION
+    WHERE BATCH_OPERATION_ID = #{id}
+  </select>
 
   <select id="count" resultType="java.lang.Long">
     SELECT COUNT(*)
@@ -119,7 +139,7 @@
     resultMap="BatchOperationResultMap"
     statementType="PREPARED">
 
-  SELECT * FROM (
+    SELECT * FROM (
     SELECT
     bo.BATCH_OPERATION_ID,
     bo.STATE,
@@ -128,7 +148,8 @@
     bo.END_DATE,
     bo.OPERATIONS_TOTAL_COUNT,
     bo.OPERATIONS_FAILED_COUNT,
-    bo.OPERATIONS_COMPLETED_COUNT
+    bo.OPERATIONS_COMPLETED_COUNT,
+    bo.EXPORT_ITEMS_ON_CREATION
     FROM ${prefix}BATCH_OPERATION bo
     <include refid="io.camunda.db.rdbms.sql.BatchOperationMapper.searchFilter"/>
     ) filtered

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/template/BatchOperationTemplate.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/template/BatchOperationTemplate.java
@@ -32,6 +32,7 @@ public class BatchOperationTemplate extends AbstractTemplateDescriptor implement
   public static final String STATE = "state";
   public static final String OPERATIONS_FAILED_COUNT = "operationsFailedCount";
   public static final String OPERATIONS_COMPLETED_COUNT = "operationsCompletedCount";
+  public static final String EXPORT_ITEMS_ON_CREATION = "exportItemsOnCreation";
 
   public BatchOperationTemplate(final String indexPrefix, final boolean isElasticsearch) {
     super(indexPrefix, isElasticsearch);

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/operation/BatchOperationEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/operation/BatchOperationEntity.java
@@ -30,6 +30,7 @@ public class BatchOperationEntity extends AbstractExporterEntity<BatchOperationE
   private BatchOperationState state;
   private Integer operationsFailedCount = 0; // Just failed / rejected operations
   private Integer operationsCompletedCount = 0; // Just successfully completed operations
+  private Boolean exportItemsOnCreation = false;
 
   @JsonIgnore private Object[] sortValues;
 
@@ -129,6 +130,15 @@ public class BatchOperationEntity extends AbstractExporterEntity<BatchOperationE
 
   public BatchOperationEntity setOperationsCompletedCount(final Integer operationsCompletedCount) {
     this.operationsCompletedCount = operationsCompletedCount;
+    return this;
+  }
+
+  public Boolean isExportItemsOnCreation() {
+    return exportItemsOnCreation;
+  }
+
+  public BatchOperationEntity setExportItemsOnCreation(final Boolean exportItemsOnCreation) {
+    this.exportItemsOnCreation = exportItemsOnCreation;
     return this;
   }
 

--- a/webapps-schema/src/main/resources/schema/elasticsearch/create/template/operate-batch-operation.json
+++ b/webapps-schema/src/main/resources/schema/elasticsearch/create/template/operate-batch-operation.json
@@ -39,6 +39,9 @@
       },
       "operationsCompletedCount": {
         "type": "long"
+      },
+      "exportItemsOnCreation": {
+        "type": "boolean"
       }
     }
 	}

--- a/webapps-schema/src/main/resources/schema/opensearch/create/template/operate-batch-operation.json
+++ b/webapps-schema/src/main/resources/schema/opensearch/create/template/operate-batch-operation.json
@@ -39,6 +39,9 @@
       },
       "operationsCompletedCount": {
         "type": "long"
+      },
+      "exportItemsOnCreation": {
+        "type": "boolean"
       }
 		}
 	}

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/cache/batchoperation/CachedBatchOperationEntity.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/cache/batchoperation/CachedBatchOperationEntity.java
@@ -9,4 +9,5 @@ package io.camunda.zeebe.exporter.common.cache.batchoperation;
 
 import io.camunda.webapps.schema.entities.operation.OperationType;
 
-public record CachedBatchOperationEntity(String batchOperationId, OperationType type) {}
+public record CachedBatchOperationEntity(
+    String batchOperationId, OperationType type, boolean exportItemsOnCreation) {}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
@@ -282,7 +282,8 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
             // Batch Operation Handler
             new BatchOperationCreatedHandler(
                 indexDescriptors.get(BatchOperationTemplate.class).getFullQualifiedName(),
-                batchOperationCache),
+                batchOperationCache,
+                configuration.getBatchOperation().isExportItemsOnCreation()),
             new BatchOperationStartedHandler(
                 indexDescriptors.get(BatchOperationTemplate.class).getFullQualifiedName()),
             new BatchOperationLifecycleManagementHandler(

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/cache/batchoperation/ElasticSearchBatchOperationCacheLoader.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/cache/batchoperation/ElasticSearchBatchOperationCacheLoader.java
@@ -38,7 +38,10 @@ public class ElasticSearchBatchOperationCacheLoader
     final var termQuery = QueryBuilders.ids(i -> i.values(batchOperationId));
     final var sourceFilter =
         SourceConfigBuilders.filter()
-            .includes(BatchOperationTemplate.ID, BatchOperationTemplate.TYPE)
+            .includes(
+                BatchOperationTemplate.ID,
+                BatchOperationTemplate.TYPE,
+                BatchOperationTemplate.EXPORT_ITEMS_ON_CREATION)
             .build();
     final var response =
         client.search(
@@ -51,7 +54,8 @@ public class ElasticSearchBatchOperationCacheLoader
             BatchOperationEntity.class);
     if (response.hits() != null && !response.hits().hits().isEmpty()) {
       final var entity = response.hits().hits().getFirst().source();
-      return new CachedBatchOperationEntity(entity.getId(), entity.getType());
+      return new CachedBatchOperationEntity(
+          entity.getId(), entity.getType(), entity.isExportItemsOnCreation());
     } else {
       LOG.debug("BatchOperation '{}' not found in Elasticsearch", batchOperationId);
       return null;

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/cache/batchoperation/OpenSearchBatchOperationCacheLoader.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/cache/batchoperation/OpenSearchBatchOperationCacheLoader.java
@@ -37,7 +37,10 @@ public class OpenSearchBatchOperationCacheLoader
     final var idQuery = QueryBuilders.ids().values(batchOperationId).build();
     final var sourceFilter =
         SourceConfigBuilders.filter()
-            .includes(BatchOperationTemplate.ID, BatchOperationTemplate.TYPE)
+            .includes(
+                BatchOperationTemplate.ID,
+                BatchOperationTemplate.TYPE,
+                BatchOperationTemplate.EXPORT_ITEMS_ON_CREATION)
             .build();
     final var response =
         client.search(
@@ -50,7 +53,8 @@ public class OpenSearchBatchOperationCacheLoader
             BatchOperationEntity.class);
     if (response.hits() != null && !response.hits().hits().isEmpty()) {
       final var entity = response.hits().hits().getFirst().source();
-      return new CachedBatchOperationEntity(entity.getId(), entity.getType());
+      return new CachedBatchOperationEntity(
+          entity.getId(), entity.getType(), entity.isExportItemsOnCreation());
     } else {
       LOG.debug("BatchOperation '{}' not found in OpenSearch", batchOperationId);
       return null;

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/BatchOperationCreatedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/BatchOperationCreatedHandler.java
@@ -26,12 +26,15 @@ public class BatchOperationCreatedHandler
 
   private final String indexName;
   private final ExporterEntityCache<String, CachedBatchOperationEntity> batchOperationCache;
+  private final boolean exportItemsOnCreation;
 
   public BatchOperationCreatedHandler(
       final String indexName,
-      final ExporterEntityCache<String, CachedBatchOperationEntity> batchOperationCache) {
+      final ExporterEntityCache<String, CachedBatchOperationEntity> batchOperationCache,
+      final boolean exportItemsOnCreation) {
     this.indexName = indexName;
     this.batchOperationCache = batchOperationCache;
+    this.exportItemsOnCreation = exportItemsOnCreation;
   }
 
   @Override
@@ -66,11 +69,14 @@ public class BatchOperationCreatedHandler
     entity
         .setId(String.valueOf(value.getBatchOperationKey()))
         .setType(OperationType.valueOf(value.getBatchOperationType().name()))
-        .setState(BatchOperationState.CREATED);
+        .setState(BatchOperationState.CREATED)
+        .setExportItemsOnCreation(exportItemsOnCreation);
 
     // update local cache so that the batch operation info is available immediately to operation
     // status handlers
-    final var cachedEntity = new CachedBatchOperationEntity(entity.getId(), entity.getType());
+    final var cachedEntity =
+        new CachedBatchOperationEntity(
+            entity.getId(), entity.getType(), entity.isExportItemsOnCreation());
     batchOperationCache.put(cachedEntity.batchOperationId(), cachedEntity);
   }
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/cache/BatchOperationCacheIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/cache/BatchOperationCacheIT.java
@@ -83,7 +83,10 @@ class BatchOperationCacheIT {
       final BatchOperationCacheArgument batchOperationCacheArgument) throws IOException {
     // given
     final var batchOperationEntity =
-        new BatchOperationEntity().setId("3").setType(OperationType.RESOLVE_INCIDENT);
+        new BatchOperationEntity()
+            .setId("3")
+            .setType(OperationType.RESOLVE_INCIDENT)
+            .setExportItemsOnCreation(true);
     batchOperationCacheArgument.indexer().accept(batchOperationEntity);
 
     // when
@@ -91,7 +94,7 @@ class BatchOperationCacheIT {
 
     // then
     final var expectedCachedBatchOperationEntity =
-        new CachedBatchOperationEntity("3", OperationType.RESOLVE_INCIDENT);
+        new CachedBatchOperationEntity("3", OperationType.RESOLVE_INCIDENT, true);
     assertThat(batchOperation).isPresent().get().isEqualTo(expectedCachedBatchOperationEntity);
   }
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/BatchOperationCreatedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/BatchOperationCreatedHandlerTest.java
@@ -34,7 +34,7 @@ class BatchOperationCreatedHandlerTest {
 
   private final ExporterEntityCache batchOperationCache = mock(ExporterEntityCache.class);
   private final BatchOperationCreatedHandler underTest =
-      new BatchOperationCreatedHandler(indexName, batchOperationCache);
+      new BatchOperationCreatedHandler(indexName, batchOperationCache, true);
 
   @Test
   void testGetHandledValueType() {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/BatchOperationStatusHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/BatchOperationStatusHandlerTest.java
@@ -63,7 +63,7 @@ class BatchOperationStatusHandlerTest {
           .thenReturn(
               Optional.of(
                   new CachedBatchOperationEntity(
-                      String.valueOf(batchOperationKey), handler.relevantOperationType)));
+                      String.valueOf(batchOperationKey), handler.relevantOperationType, false)));
     }
 
     @Test
@@ -97,7 +97,7 @@ class BatchOperationStatusHandlerTest {
           .thenReturn(
               Optional.of(
                   new CachedBatchOperationEntity(
-                      String.valueOf(batchOperationKey), otherOperationType)));
+                      String.valueOf(batchOperationKey), otherOperationType, false)));
 
       final var record =
           ImmutableRecord.<T>builder()
@@ -139,7 +139,7 @@ class BatchOperationStatusHandlerTest {
           .thenReturn(
               Optional.of(
                   new CachedBatchOperationEntity(
-                      String.valueOf(batchOperationKey), otherOperationType)));
+                      String.valueOf(batchOperationKey), otherOperationType, false)));
 
       final var record =
           ImmutableRecord.<T>builder()

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/cache/RdbmsBatchOperationCacheLoader.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/cache/RdbmsBatchOperationCacheLoader.java
@@ -27,12 +27,13 @@ public class RdbmsBatchOperationCacheLoader
 
   @Override
   public CachedBatchOperationEntity load(final @NotNull String key) throws Exception {
-    final var response = reader.findOne(key);
+    final var response = reader.findOneDbModel(key);
     if (response.isPresent()) {
-      final var batchOperationEntity = response.get();
+      final var batchOperation = response.get();
       return new CachedBatchOperationEntity(
-          batchOperationEntity.batchOperationId(),
-          OperationType.valueOf(batchOperationEntity.operationType()));
+          batchOperation.batchOperationId(),
+          OperationType.valueOf(batchOperation.operationType()),
+          batchOperation.exportItemsOnCreation());
     }
     LOG.debug("BatchOperation '{}' not found in RDBMS", key);
     return null;

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/BatchOperationChunkExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/BatchOperationChunkExportHandler.java
@@ -11,6 +11,8 @@ import io.camunda.db.rdbms.write.domain.BatchOperationItemDbModel;
 import io.camunda.db.rdbms.write.service.BatchOperationWriter;
 import io.camunda.exporter.rdbms.RdbmsExportHandler;
 import io.camunda.search.entities.BatchOperationEntity.BatchOperationItemState;
+import io.camunda.zeebe.exporter.common.cache.ExporterEntityCache;
+import io.camunda.zeebe.exporter.common.cache.batchoperation.CachedBatchOperationEntity;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.BatchOperationChunkIntent;
@@ -18,15 +20,23 @@ import io.camunda.zeebe.protocol.record.value.BatchOperationChunkRecordValue;
 import io.camunda.zeebe.protocol.record.value.BatchOperationChunkRecordValue.BatchOperationItemValue;
 import java.util.Collection;
 import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** Exports a batch operation chunk record, which contains all the item keys, to the database. */
 public class BatchOperationChunkExportHandler
     implements RdbmsExportHandler<BatchOperationChunkRecordValue> {
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(BatchOperationChunkExportHandler.class);
 
   private final BatchOperationWriter batchOperationWriter;
+  private final ExporterEntityCache<String, CachedBatchOperationEntity> batchOperationCache;
 
-  public BatchOperationChunkExportHandler(final BatchOperationWriter batchOperationWriter) {
+  public BatchOperationChunkExportHandler(
+      final BatchOperationWriter batchOperationWriter,
+      final ExporterEntityCache<String, CachedBatchOperationEntity> batchOperationCache) {
     this.batchOperationWriter = batchOperationWriter;
+    this.batchOperationCache = batchOperationCache;
   }
 
   @Override
@@ -38,20 +48,38 @@ public class BatchOperationChunkExportHandler
   @Override
   public void export(final Record<BatchOperationChunkRecordValue> record) {
     final var value = record.getValue();
-    batchOperationWriter.updateBatchAndInsertItems(
-        String.valueOf(value.getBatchOperationKey()),
-        mapItems(value.getItems(), record.getValue().getBatchOperationKey()));
+    final var batchOperationId = Long.toString(value.getBatchOperationKey());
+
+    final var exportItemsOnCreation =
+        batchOperationCache
+            .get(batchOperationId)
+            .map(CachedBatchOperationEntity::exportItemsOnCreation)
+            .orElseGet(
+                () -> {
+                  LOGGER.warn(
+                      "Batch operation with key {} not found in cache, using default 'true'.",
+                      batchOperationId);
+                  return true;
+                });
+
+    // either insert items (counts are incremented automatically) or increment the total item count
+    if (exportItemsOnCreation) {
+      batchOperationWriter.insertItems(
+          batchOperationId, mapItems(value.getItems(), batchOperationId));
+    } else {
+      batchOperationWriter.incrementTotalItemCount(batchOperationId, value.getItems().size());
+    }
   }
 
   private List<BatchOperationItemDbModel> mapItems(
-      final Collection<BatchOperationItemValue> items, final long batchOperationId) {
+      final Collection<BatchOperationItemValue> items, final String batchOperationId) {
     return items.stream().map(item -> mapItem(item, batchOperationId)).toList();
   }
 
   private BatchOperationItemDbModel mapItem(
-      final BatchOperationItemValue value, final long batchOperationId) {
+      final BatchOperationItemValue value, final String batchOperationId) {
     return new BatchOperationItemDbModel(
-        Long.toString(batchOperationId),
+        batchOperationId,
         value.getItemKey(),
         value.getProcessInstanceKey(),
         BatchOperationItemState.ACTIVE,

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/BatchOperationCreatedExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/BatchOperationCreatedExportHandler.java
@@ -29,12 +29,15 @@ public class BatchOperationCreatedExportHandler
 
   private final BatchOperationWriter batchOperationWriter;
   private final ExporterEntityCache<String, CachedBatchOperationEntity> batchOperationCache;
+  private final boolean exportItemsOnCreation;
 
   public BatchOperationCreatedExportHandler(
       final BatchOperationWriter batchOperationWriter,
-      final ExporterEntityCache<String, CachedBatchOperationEntity> batchOperationCache) {
+      final ExporterEntityCache<String, CachedBatchOperationEntity> batchOperationCache,
+      final boolean exportItemsOnCreation) {
     this.batchOperationWriter = batchOperationWriter;
     this.batchOperationCache = batchOperationCache;
+    this.exportItemsOnCreation = exportItemsOnCreation;
   }
 
   @Override
@@ -50,7 +53,8 @@ public class BatchOperationCreatedExportHandler
         String.valueOf(record.getKey()),
         new CachedBatchOperationEntity(
             String.valueOf(record.getValue().getBatchOperationKey()),
-            OperationType.valueOf(record.getValue().getBatchOperationType().name())));
+            OperationType.valueOf(record.getValue().getBatchOperationType().name()),
+            exportItemsOnCreation));
   }
 
   private BatchOperationDbModel map(final Record<BatchOperationCreationRecordValue> record) {
@@ -61,6 +65,7 @@ public class BatchOperationCreatedExportHandler
         .state(BatchOperationState.ACTIVE)
         .operationType(value.getBatchOperationType().name())
         .startDate(DateUtil.toOffsetDateTime(record.getTimestamp()))
+        .exportItemsOnCreation(exportItemsOnCreation)
         .build();
   }
 }


### PR DESCRIPTION
## Description

Fixes a problem in RDBMS, when the exporter setting `exportBatchOperationItemsOnCreation` is changed while a batch operation is running. As a solution, the persisted BatchOperation now also persists the setting of `exportBatchOperationItemsOnCreation` when the batch operation is stored. Afterwards on chunk records or monitoring records, that setting is read and used to decide if an update or an insert has to be performed.

Changes made:
- extended the `CachedBatchOperationEntity` by `exportItemsOnCreation`
- store the `exportItemsOnCreation` setting also in `CamundaExporter`. It is not really needed (ES can perform `upsert`) but then it is consistent with RDBMS and also the cached entity must not be filled with a wrong default value.
- move the `exportBatchOperationItemsOnCreation` config from the `RdbmsWriterConfig` to the exporter level
- refactor the `RdbmsExporter` and `RdbmsWriter` so that the exporter handlers always read the `exportBatchOperationItemsOnCreation` value and decide what to do and not the writer. 
  - this was done because the writer does not have access to the used ExporterEntityCache used to cache the batch operation

## Related issues

closes #34541 
