### PR TITLE
test: remove deprecated CloseableResource in favour of AutoCloseable

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/util/CamundaRdbmsInvocationContextProviderExtension.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/util/CamundaRdbmsInvocationContextProviderExtension.java
@@ -25,9 +25,7 @@ import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.oracle.OracleContainer;
 
 public class CamundaRdbmsInvocationContextProviderExtension
-    implements TestTemplateInvocationContextProvider,
-        BeforeAllCallback,
-        ExtensionContext.Store.CloseableResource {
+    implements TestTemplateInvocationContextProvider, BeforeAllCallback, AutoCloseable {
 
   private static boolean started = false;
 
@@ -138,7 +136,7 @@ public class CamundaRdbmsInvocationContextProviderExtension
    * surefire.rerunFailingTestsCount
    */
   @Override
-  public void close() throws Throwable {
+  public void close() {
     LOGGER.info("Resource closed - Close CamundaRdbmsInvocationContextProviderExtension");
     started = false;
   }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/util/CamundaRdbmsTestApplication.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/util/CamundaRdbmsTestApplication.java
@@ -12,15 +12,13 @@ import io.camunda.db.rdbms.RdbmsService;
 import io.camunda.zeebe.qa.util.actuator.HealthActuator;
 import io.camunda.zeebe.qa.util.cluster.TestSpringApplication;
 import org.awaitility.Awaitility;
-import org.junit.jupiter.api.extension.ExtensionContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.JdbcDatabaseContainer;
 
 public final class CamundaRdbmsTestApplication
-    extends TestSpringApplication<CamundaRdbmsTestApplication>
-    implements ExtensionContext.Store.CloseableResource {
+    extends TestSpringApplication<CamundaRdbmsTestApplication> implements AutoCloseable {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(CamundaRdbmsTestApplication.class);
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/ProcessingStateExtension.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/ProcessingStateExtension.java
@@ -35,7 +35,6 @@ import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
 import org.junit.jupiter.api.extension.ExtensionContext.Store;
-import org.junit.jupiter.api.extension.ExtensionContext.Store.CloseableResource;
 import org.junit.platform.commons.util.ExceptionUtils;
 import org.junit.platform.commons.util.ReflectionUtils;
 import org.junit.platform.commons.util.ReflectionUtils.HierarchyTraversalMode;
@@ -144,7 +143,7 @@ public class ProcessingStateExtension implements BeforeEachCallback {
     return context.getStore(Namespace.create(getClass(), context.getUniqueId()));
   }
 
-  private static final class ProcessingStateExtensionState implements CloseableResource {
+  private static final class ProcessingStateExtensionState implements AutoCloseable {
 
     private Path tempFolder;
     private ZeebeDb<ZbColumnFamilies> zeebeDb;
@@ -176,7 +175,7 @@ public class ProcessingStateExtension implements BeforeEachCallback {
     }
 
     @Override
-    public void close() throws Throwable {
+    public void close() throws Exception {
       transactionContext.getCurrentTransaction().rollback();
       zeebeDb.close();
 

--- a/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/ContainerState.java
+++ b/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/ContainerState.java
@@ -24,7 +24,6 @@ import net.jodah.failsafe.Failsafe;
 import net.jodah.failsafe.RetryPolicy;
 import org.agrona.LangUtil;
 import org.agrona.Strings;
-import org.junit.jupiter.api.extension.ExtensionContext.Store.CloseableResource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.ContainerFetchException;
@@ -32,7 +31,7 @@ import org.testcontainers.containers.ContainerLaunchException;
 import org.testcontainers.containers.Network;
 import org.testcontainers.utility.DockerImageName;
 
-final class ContainerState implements CloseableResource {
+final class ContainerState implements AutoCloseable {
 
   private static final RetryPolicy<Void> CONTAINER_START_RETRY_POLICY =
       new RetryPolicy<Void>().withMaxRetries(5).withBackoff(3, 30, ChronoUnit.SECONDS);

--- a/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/ContainerStateExtension.java
+++ b/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/ContainerStateExtension.java
@@ -12,7 +12,6 @@ import org.junit.jupiter.api.extension.AfterTestExecutionCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
 import org.junit.jupiter.api.extension.ExtensionContext.Store;
-import org.junit.jupiter.api.extension.ExtensionContext.Store.CloseableResource;
 import org.junit.jupiter.api.extension.ParameterContext;
 import org.junit.jupiter.api.extension.ParameterResolutionException;
 import org.junit.jupiter.api.extension.ParameterResolver;
@@ -20,7 +19,7 @@ import org.junit.jupiter.api.extension.ParameterResolver;
 /**
  * This extension injects a new {@link ContainerState} at runtime into any test which adds a {@link
  * ContainerState} parameter, and stores it in a {@link Store}. This ensures that the resource is
- * properly closed (since {@link ContainerState} implements {@link CloseableResource}).
+ * properly closed (since {@link ContainerState} implements {@link AutoCloseable}).
  *
  * <p>Note however that it currently only supports injecting a single state, since the stored state
  * will get overwritten.

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/junit/ZeebeIntegrationExtension.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/junit/ZeebeIntegrationExtension.java
@@ -31,7 +31,6 @@ import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
 import org.junit.jupiter.api.extension.ExtensionContext.Store;
-import org.junit.jupiter.api.extension.ExtensionContext.Store.CloseableResource;
 import org.junit.jupiter.api.extension.TestWatcher;
 import org.junit.platform.commons.support.AnnotationSupport;
 import org.junit.platform.commons.support.HierarchyTraversalMode;
@@ -266,7 +265,7 @@ final class ZeebeIntegrationExtension
   }
 
   private record ClusterResource(Object testInstance, Field field, TestZeebe annotation)
-      implements TestZeebeResource, CloseableResource {
+      implements TestZeebeResource, AutoCloseable {
 
     public TestCluster cluster() {
       try {
@@ -316,7 +315,7 @@ final class ZeebeIntegrationExtension
   }
 
   private record ApplicationResource(Object testInstance, Field field, TestZeebe annotation)
-      implements TestZeebeResource, CloseableResource {
+      implements TestZeebeResource, AutoCloseable {
 
     public TestApplication<?> app() {
       try {
@@ -361,7 +360,7 @@ final class ZeebeIntegrationExtension
     }
   }
 
-  private record DirectoryResource(Path directory) implements CloseableResource {
+  private record DirectoryResource(Path directory) implements AutoCloseable {
 
     @Override
     public void close() {

--- a/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamPlatformExtension.java
+++ b/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamPlatformExtension.java
@@ -23,7 +23,6 @@ import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
 import org.junit.jupiter.api.extension.ExtensionContext.Store;
-import org.junit.jupiter.api.extension.ExtensionContext.Store.CloseableResource;
 import org.junit.platform.commons.util.ExceptionUtils;
 import org.junit.platform.commons.util.ReflectionUtils;
 import org.junit.platform.commons.util.ReflectionUtils.HierarchyTraversalMode;
@@ -95,7 +94,7 @@ public class StreamPlatformExtension implements BeforeEachCallback {
             });
   }
 
-  private static final class StreamProcessorTestContext implements CloseableResource {
+  private static final class StreamProcessorTestContext implements AutoCloseable {
     private final ControlledActorClock clock = new ControlledActorClock();
     private StreamPlatform streamPlatform;
     private final ArrayList<AutoCloseable> closables;


### PR DESCRIPTION
## Description
Since junit 5.13 `CloseableResource` has been deprecated in favour of `AutoCloseable`  from the java standard library.

From Junit's [release notes](https://docs.junit.org/5.13.0-RC1/release-notes/)
> By default, AutoCloseable objects put into ExtensionContext.Store are now treated like instances of CloseableResource (which has been deprecated) and are closed automatically when the store is closed at the end of the test lifecycle. It’s possible to [revert to the old behavior](https://docs.junit.org/5.13.0-RC1/user-guide/index.html#extensions-keeping-state-autocloseable-support) via a configuration parameter. Please also see the [migration note](https://docs.junit.org/5.13.0-RC1/user-guide/index.html#extensions-keeping-state-autocloseable-migration) for third-party extensions wanting to support both JUnit 5.13 and earlier versions.

