### PR TITLE
ci: add `components/c8-api` to CamundaEx Board

### DIFF
--- a/.github/workflows/add-to-projects.yml
+++ b/.github/workflows/add-to-projects.yml
@@ -134,7 +134,7 @@ jobs:
           project-url: https://github.com/orgs/camunda/projects/182
           github-token: ${{ secrets.GH_PROJECT_AUTOMATION_TOKEN }}
           # any of the following labels:
-          labeled: component/clients, scope/clients-spring, scope/clients-java, scope/spring-boot-starter-camunda, component/camunda-process-test
+          labeled: component/clients, scope/clients-spring, scope/clients-java, scope/spring-boot-starter-camunda, component/camunda-process-test, components/c8-api
       # this steps needs to stay as last step to not interfer with other steps
       - id: add-to-qualityboard
         name: Add to Quality Board project

--- a/.github/workflows/add-to-projects.yml
+++ b/.github/workflows/add-to-projects.yml
@@ -134,7 +134,7 @@ jobs:
           project-url: https://github.com/orgs/camunda/projects/182
           github-token: ${{ secrets.GH_PROJECT_AUTOMATION_TOKEN }}
           # any of the following labels:
-          labeled: component/clients, scope/clients-spring, scope/clients-java, scope/spring-boot-starter-camunda, component/camunda-process-test, components/c8-api
+          labeled: component/clients, component/spring-sdk, component/camunda-process-test, component/c8-api
       # this steps needs to stay as last step to not interfer with other steps
       - id: add-to-qualityboard
         name: Add to Quality Board project


### PR DESCRIPTION
## Description

Add `components/c8-api` to CamundaEx Board.

By that change also add other missing labels.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
