### PR TITLE
Username and email are optional fields

### DIFF
--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/UserValidator.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/UserValidator.java
@@ -27,8 +27,7 @@ import org.springframework.http.ProblemDetail;
 public final class UserValidator {
 
   public static Optional<ProblemDetail> validateUserUpdateRequest(final UserUpdateRequest request) {
-    return validate(
-        violations -> violations.addAll(validateUserEmail(request.getName(), request.getEmail())));
+    return validate(violations -> violations.addAll(validateUserEmail(request.getEmail())));
   }
 
   public static Optional<ProblemDetail> validateUserCreateRequest(final UserRequest request) {
@@ -38,7 +37,7 @@ public final class UserValidator {
           if (request.getPassword() == null || request.getPassword().isBlank()) {
             violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("password"));
           }
-          violations.addAll(validateUserEmail(request.getName(), request.getEmail()));
+          violations.addAll(validateUserEmail(request.getEmail()));
         });
   }
 
@@ -53,7 +52,7 @@ public final class UserValidator {
     }
   }
 
-  private static List<String> validateUserEmail(final String name, final String email) {
+  private static List<String> validateUserEmail(final String email) {
     final List<String> violations = new ArrayList<>();
     if (email != null && !email.isBlank() && !EmailValidator.getInstance().isValid(email)) {
       violations.add(ERROR_MESSAGE_INVALID_EMAIL.formatted(email));

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/UserValidator.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/UserValidator.java
@@ -28,9 +28,7 @@ public final class UserValidator {
 
   public static Optional<ProblemDetail> validateUserUpdateRequest(final UserUpdateRequest request) {
     return validate(
-        violations -> {
-          violations.addAll(validateUserNameAndEmail(request.getName(), request.getEmail()));
-        });
+        violations -> violations.addAll(validateUserEmail(request.getName(), request.getEmail())));
   }
 
   public static Optional<ProblemDetail> validateUserCreateRequest(final UserRequest request) {
@@ -40,7 +38,7 @@ public final class UserValidator {
           if (request.getPassword() == null || request.getPassword().isBlank()) {
             violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("password"));
           }
-          violations.addAll(validateUserNameAndEmail(request.getName(), request.getEmail()));
+          violations.addAll(validateUserEmail(request.getName(), request.getEmail()));
         });
   }
 
@@ -55,15 +53,9 @@ public final class UserValidator {
     }
   }
 
-  private static List<String> validateUserNameAndEmail(final String name, final String email) {
+  private static List<String> validateUserEmail(final String name, final String email) {
     final List<String> violations = new ArrayList<>();
-    if (name == null || name.isBlank()) {
-      violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("name"));
-    }
-
-    if (email == null || email.isBlank()) {
-      violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("email"));
-    } else if (!EmailValidator.getInstance().isValid(email)) {
+    if (email != null && !email.isBlank() && !EmailValidator.getInstance().isValid(email)) {
       violations.add(ERROR_MESSAGE_INVALID_EMAIL.formatted(email));
     }
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/UserControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/UserControllerTest.java
@@ -158,46 +158,6 @@ public class UserControllerTest extends RestControllerTest {
   }
 
   @Test
-  void shouldRejectUserCreationWithEmptyName() {
-    // given
-    final var request = validUserWithPasswordRequest().name(null);
-
-    // when then
-    assertRequestRejectedExceptionally(
-        request,
-        """
-            {
-              "type": "about:blank",
-              "status": 400,
-              "title": "INVALID_ARGUMENT",
-              "detail": "No name provided.",
-              "instance": "%s"
-            }"""
-            .formatted(USER_BASE_URL));
-    verifyNoInteractions(userServices);
-  }
-
-  @Test
-  void shouldRejectUserCreationWithBlankName() {
-    // given
-    final var request = validUserWithPasswordRequest().name("");
-
-    // when then
-    assertRequestRejectedExceptionally(
-        request,
-        """
-            {
-              "type": "about:blank",
-              "status": 400,
-              "title": "INVALID_ARGUMENT",
-              "detail": "No name provided.",
-              "instance": "%s"
-            }"""
-            .formatted(USER_BASE_URL));
-    verifyNoInteractions(userServices);
-  }
-
-  @Test
   void shouldRejectUserCreationWithEmptyPassword() {
     // given
     final var request = validUserWithPasswordRequest().password(null);
@@ -238,43 +198,36 @@ public class UserControllerTest extends RestControllerTest {
   }
 
   @Test
-  void shouldRejectUserCreationWithEmptyEmail() {
+  void shouldCreateUserWithEmptyNameAndEmail() {
     // given
-    final var request = validUserWithPasswordRequest().email(null);
+    final var dto = new UserDTO("foo", null, null, "zabraboof");
+    final var userRecord = new UserRecord().setUsername(dto.username()).setPassword(dto.password());
+    when(userServices.createUser(dto)).thenReturn(CompletableFuture.completedFuture(userRecord));
 
-    // when then
-    assertRequestRejectedExceptionally(
-        request,
+    // when
+    webClient
+        .post()
+        .uri(USER_BASE_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(dto)
+        .exchange()
+        .expectStatus()
+        .isCreated()
+        .expectBody()
+        .json(
+            """
+          {
+            "userKey": "-1",
+            "username": "%s",
+            "name": "",
+            "email": ""
+          }
         """
-            {
-              "type": "about:blank",
-              "status": 400,
-              "title": "INVALID_ARGUMENT",
-              "detail": "No email provided.",
-              "instance": "%s"
-            }"""
-            .formatted(USER_BASE_URL));
-    verifyNoInteractions(userServices);
-  }
+                .formatted(dto.username()));
 
-  @Test
-  void shouldRejectUserCreationWithBlankEmail() {
-    // given
-    final var request = validUserWithPasswordRequest().email("");
-
-    // when then
-    assertRequestRejectedExceptionally(
-        request,
-        """
-            {
-              "type": "about:blank",
-              "status": 400,
-              "title": "INVALID_ARGUMENT",
-              "detail": "No email provided.",
-              "instance": "%s"
-            }"""
-            .formatted(USER_BASE_URL));
-    verifyNoInteractions(userServices);
+    // then
+    verify(userServices, times(1)).createUser(dto);
   }
 
   @Test


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Email are name are optional fields. We should ensure they can be null. If they are set to null we automatically fill them with an empty string. This also means we shouldn't check if it's empty, because if someone wants to update a user with the API response, they'd add an empty name and email.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #34463 
