### PR TITLE
ci: add missing Camunda Experience components to issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/1. bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/1. bug_report.yml
@@ -13,11 +13,14 @@ body:
         - <!-- Not sure- -->
         - <!-- C8-API- -->
         - <!-- C8Run- -->
+        - <!-- Camunda Process Test- -->
+        - <!-- Clients- -->
         - <!-- Data Layer- -->
         - <!-- Feel- -->
         - <!-- Identity- -->
         - <!-- Operate- -->
         - <!-- Optimize- -->
+        - <!-- Spring SDK- -->
         - <!-- Tasklist- -->
         - <!-- Zeebe- -->
       default: null

--- a/.github/ISSUE_TEMPLATE/2. feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/2. feature_request.yml
@@ -13,11 +13,14 @@ body:
         - <!-- Not sure- -->
         - <!-- C8-API- -->
         - <!-- C8Run- -->
+        - <!-- Camunda Process Test- -->
+        - <!-- Clients- -->
         - <!-- Data Layer- -->
         - <!-- Feel- -->
         - <!-- Identity- -->
         - <!-- Operate- -->
         - <!-- Optimize- -->
+        - <!-- Spring SDK- -->
         - <!-- Tasklist- -->
         - <!-- Zeebe- -->
       default: null

--- a/.github/ISSUE_TEMPLATE/3. task.yml
+++ b/.github/ISSUE_TEMPLATE/3. task.yml
@@ -13,11 +13,14 @@ body:
         - <!-- Not sure- -->
         - <!-- C8-API- -->
         - <!-- C8Run- -->
+        - <!-- Camunda Process Test- -->
+        - <!-- Clients- -->
         - <!-- Data Layer- -->
         - <!-- Feel- -->
         - <!-- Identity- -->
         - <!-- Operate- -->
         - <!-- Optimize- -->
+        - <!-- Spring SDK- -->
         - <!-- Tasklist- -->
         - <!-- Zeebe- -->
       default: null

--- a/.github/ISSUE_TEMPLATE/4. epic breakdown.yml
+++ b/.github/ISSUE_TEMPLATE/4. epic breakdown.yml
@@ -13,11 +13,14 @@ body:
       options:
         - <!-- C8-API- -->
         - <!-- C8Run- -->
+        - <!-- Camunda Process Test- -->
+        - <!-- Clients- -->
         - <!-- Data Layer- -->
         - <!-- Feel- -->
         - <!-- Identity- -->
         - <!-- Operate- -->
         - <!-- Optimize- -->
+        - <!-- Spring SDK- -->
         - <!-- Tasklist- -->
         - <!-- Zeebe- -->
       default: 0

--- a/.github/opened_issue_labeler.yml
+++ b/.github/opened_issue_labeler.yml
@@ -2,6 +2,10 @@ component/c8-api:
   '(C8-API-)'
 component/C8Run:
   '(C8Run-)'
+component/camunda-process-test:
+  '(Camunda Process Test-)'
+component/clients:
+  '(Clients-)'
 component/data-layer:
   '(Data Layer-)'
 component/feel-js:
@@ -14,6 +18,8 @@ component/operate:
   '(Operate-)'
 component/optimize:
   '(Optimize-)'
+component/spring-sdk:
+  '(Spring SDK-)'
 component/tasklist:
   '(Tasklist-)'
 component/zeebe:


### PR DESCRIPTION
## Description

They are picked up [by this workflow](https://github.com/camunda/camunda/blob/main/.github/workflows/add-to-projects.yml#L137) to add those issues to the CamundaEx Project board.