### PR TITLE
fix: stabilize flakey Batch Operation tests

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/BatchOperationLifecycleManagementTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/BatchOperationLifecycleManagementTest.java
@@ -29,6 +29,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.UUID;
 import java.util.stream.IntStream;
 import org.junit.jupiter.api.AfterEach;
@@ -147,7 +148,12 @@ public class BatchOperationLifecycleManagementTest {
     // when we resume the batch operation
     camundaClient.newResumeBatchOperationCommand(batchOperationId).send().join();
 
-    // then it's again active and can complete
-    waitForBatchOperationStatus(camundaClient, batchOperationId, BatchOperationState.ACTIVE);
+    // Then it should be activated again, and eventually completed
+    // Note: The batch operation might complete too fast, or take too long to complete. So we wait
+    // for either state.
+    waitForBatchOperationStatus(
+        camundaClient,
+        batchOperationId,
+        Set.of(BatchOperationState.ACTIVE, BatchOperationState.COMPLETED));
   }
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/util/TestHelper.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/util/TestHelper.java
@@ -32,6 +32,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import org.awaitility.Awaitility;
@@ -412,6 +413,27 @@ public final class TestHelper {
                   camundaClient.newBatchOperationGetRequest(batchOperationId).send().join();
               assertThat(batch).isNotNull();
               assertThat(batch.getStatus()).isEqualTo(expectedStatus);
+            });
+  }
+
+  public static void waitForBatchOperationStatus(
+      final CamundaClient camundaClient,
+      final String batchOperationId,
+      final Set<BatchOperationState> acceptedStates) {
+    Awaitility.await("batch operation should have state " + acceptedStates)
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .ignoreExceptions() // Ignore exceptions and continue retrying
+        .untilAsserted(
+            () -> {
+              // and
+              final var batch =
+                  camundaClient.newBatchOperationGetRequest(batchOperationId).send().join();
+              assertThat(batch).isNotNull();
+              assertThat(batch.getStatus())
+                  .withFailMessage(
+                      "Expected batch operation to have one of the states %s, but was %s",
+                      acceptedStates, batch.getStatus())
+                  .isIn(acceptedStates);
             });
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationMultiPartitionTest.java
@@ -295,7 +295,7 @@ public final class BatchOperationMultiPartitionTest {
                   .limit(record -> record.getIntent().equals(BatchOperationIntent.RESUMED))
                   .collect(Collectors.toList()))
           .extracting(Record::getIntent)
-          .containsExactly(BatchOperationIntent.RESUME, BatchOperationIntent.RESUMED);
+          .containsSequence(BatchOperationIntent.RESUME, BatchOperationIntent.RESUMED);
     }
   }
 


### PR DESCRIPTION
## Description

- `shouldResumeBatchOperation`
The batch operation might complete too fast, or take too long to complete. So we wait for either state
- `BatchOperationAuthorizationIT` tests
After https://github.com/camunda/camunda/issues/33936, items won't be exported until BO is completed or failed.
We should wait for the BO to complete before asserting the items

- `shouldResumeOnAllPartitions`
 The assert fails because it's expecting only the exact value sequence since the recording exporter has been reset. but it could be that distribution was slower and the recording exporter reset before one partition appended `suspended`

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #34600
