### PR TITLE
feat: show loading spinner until cancel operation is completed

### DIFF
--- a/operate/client/src/App/ProcessInstance/FlowNodeInstanceLog/v2/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/FlowNodeInstanceLog/v2/index.test.tsx
@@ -94,6 +94,7 @@ describe('FlowNodeInstanceLog', () => {
     );
     mockFetchProcessInstance().withSuccess(mockProcessInstance);
     mockFetchProcessInstance().withSuccess(mockProcessInstance);
+    mockFetchFlownodeInstancesStatistics().withSuccess({items: []});
 
     processInstanceDetailsStore.init({id: '1'});
   });

--- a/operate/client/src/App/ProcessInstance/ProcessInstanceHeader/v2/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/ProcessInstanceHeader/v2/index.test.tsx
@@ -30,6 +30,7 @@ import {mockApplyOperation} from 'modules/mocks/api/processInstances/operations'
 import {notificationsStore} from 'modules/stores/notifications';
 import {mockFetchProcessDefinitionXml} from 'modules/mocks/api/v2/processDefinitions/fetchProcessDefinitionXml';
 import {mockFetchCallHierarchy} from 'modules/mocks/api/v2/processInstances/fetchCallHierarchy';
+import {mockCancelProcessInstance} from 'modules/mocks/api/v2/processInstances/cancelProcessInstance';
 
 vi.mock('modules/stores/notifications', () => ({
   notificationsStore: {
@@ -43,6 +44,7 @@ describe('InstanceHeader', () => {
   });
 
   it('should render process instance data', async () => {
+    // TODO: remove mockFetchProcessInstance once useHasActiveOperations is refactored
     mockFetchProcessInstance().withSuccess(mockInstanceDeprecated);
     mockFetchProcessDefinitionXml().withSuccess(mockProcessXML);
 
@@ -378,6 +380,50 @@ describe('InstanceHeader', () => {
 
     expect(
       screen.queryByRole('button', {name: /Modify Instance/}),
+    ).not.toBeInTheDocument();
+  });
+
+  it('should show spinner on process instance cancellation', async () => {
+    // TODO: remove mockFetchProcessInstance once useHasActiveOperations is refactored
+    mockFetchProcessInstance().withSuccess({
+      ...mockInstanceDeprecated,
+      operations: [],
+    });
+    mockFetchProcessDefinitionXml().withSuccess(mockProcessXML);
+    mockCancelProcessInstance().withSuccess({});
+
+    const {user, rerender} = render(
+      <ProcessInstanceHeader processInstance={mockInstance} />,
+      {
+        wrapper: Wrapper,
+      },
+    );
+
+    expect(screen.getByTestId('instance-header-skeleton')).toBeInTheDocument();
+
+    await waitForElementToBeRemoved(
+      screen.queryByTestId('instance-header-skeleton'),
+    );
+
+    await user.click(screen.getByRole('button', {name: /cancel instance/i}));
+    await user.click(screen.getByRole('button', {name: /apply/i}));
+
+    expect(screen.getByTestId('operation-spinner')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', {name: /cancel instance/i}),
+    ).toBeDisabled();
+
+    rerender(
+      <ProcessInstanceHeader
+        processInstance={{...mockInstance, state: 'TERMINATED'}}
+      />,
+    );
+
+    await waitFor(() =>
+      expect(screen.queryByTestId('operation-spinner')).not.toBeInTheDocument(),
+    );
+    expect(
+      screen.queryByRole('button', {name: /cancel instance/i}),
     ).not.toBeInTheDocument();
   });
 });

--- a/operate/client/src/App/ProcessInstance/ProcessInstanceHeader/v2/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/ProcessInstanceHeader/v2/index.test.tsx
@@ -44,7 +44,7 @@ describe('InstanceHeader', () => {
   });
 
   it('should render process instance data', async () => {
-    // TODO: remove mockFetchProcessInstance once useHasActiveOperations is refactored
+    // TODO: remove mockFetchProcessInstance once useHasActiveOperations is refactored https://github.com/camunda/camunda/issues/33512
     mockFetchProcessInstance().withSuccess(mockInstanceDeprecated);
     mockFetchProcessDefinitionXml().withSuccess(mockProcessXML);
 
@@ -90,7 +90,7 @@ describe('InstanceHeader', () => {
   });
 
   it('should render "View All" link for call activity process', async () => {
-    // TODO: remove mockFetchProcessInstance once useHasActiveOperations is refactored
+    // TODO: remove mockFetchProcessInstance once useHasActiveOperations is refactored https://github.com/camunda/camunda/issues/33512
     mockFetchProcessInstance().withSuccess(mockInstanceDeprecated);
     mockFetchProcessDefinitionXml().withSuccess(mockCallActivityProcessXML);
 
@@ -110,7 +110,7 @@ describe('InstanceHeader', () => {
   it('should navigate to Instances Page and expand Filters Panel on "View All" click', async () => {
     panelStatesStore.toggleFiltersPanel();
 
-    // TODO: remove mockFetchProcessInstance once useHasActiveOperations is refactored
+    // TODO: remove mockFetchProcessInstance once useHasActiveOperations is refactored https://github.com/camunda/camunda/issues/33512
     mockFetchProcessInstance().withSuccess(mockInstanceDeprecated);
     mockFetchProcessDefinitionXml().withSuccess(mockCallActivityProcessXML);
 
@@ -135,7 +135,7 @@ describe('InstanceHeader', () => {
   });
 
   it('should render parent Process Instance Key', async () => {
-    // TODO: remove mockFetchProcessInstance once useHasActiveOperations is refactored
+    // TODO: remove mockFetchProcessInstance once useHasActiveOperations is refactored https://github.com/camunda/camunda/issues/33512
     mockFetchProcessInstance().withSuccess(mockInstanceDeprecated);
     mockFetchProcessDefinitionXml().withSuccess(mockProcessXML);
 
@@ -163,7 +163,7 @@ describe('InstanceHeader', () => {
   });
 
   it('should show spinner when instance has active operations', async () => {
-    // TODO: remove mockFetchProcessInstance once useHasActiveOperations is refactored
+    // TODO: remove mockFetchProcessInstance once useHasActiveOperations is refactored https://github.com/camunda/camunda/issues/33512
     mockFetchProcessInstance().withSuccess(mockInstanceDeprecated);
     mockFetchProcessDefinitionXml().withSuccess(mockProcessXML);
 
@@ -179,7 +179,7 @@ describe('InstanceHeader', () => {
   });
 
   it('should not show spinner when instance has no active operations', async () => {
-    // TODO: remove mockFetchProcessInstance once useHasActiveOperations is refactored
+    // TODO: remove mockFetchProcessInstance once useHasActiveOperations is refactored https://github.com/camunda/camunda/issues/33512
     mockFetchProcessInstance().withSuccess({
       ...mockInstanceDeprecated,
       operations: [],
@@ -384,7 +384,7 @@ describe('InstanceHeader', () => {
   });
 
   it('should show spinner on process instance cancellation', async () => {
-    // TODO: remove mockFetchProcessInstance once useHasActiveOperations is refactored
+    // TODO: remove mockFetchProcessInstance once useHasActiveOperations is refactored https://github.com/camunda/camunda/issues/33512
     mockFetchProcessInstance().withSuccess({
       ...mockInstanceDeprecated,
       operations: [],

--- a/operate/client/src/App/ProcessInstance/ProcessInstanceHeader/v2/processInstanceOperationsContext.ts
+++ b/operate/client/src/App/ProcessInstance/ProcessInstanceHeader/v2/processInstanceOperationsContext.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {createContext, useContext} from 'react';
+
+type ProcessInstanceOperationsContextType = {
+  cancellation: {
+    onMutate: () => void;
+    onError: (error: Error) => void;
+    isPending: boolean;
+  };
+};
+
+const ProcessInstanceOperationsContext = createContext<
+  ProcessInstanceOperationsContextType | undefined
+>(undefined);
+
+const useProcessInstanceOperationsContext = () => {
+  return useContext(ProcessInstanceOperationsContext);
+};
+
+export {ProcessInstanceOperationsContext, useProcessInstanceOperationsContext};
+export type {ProcessInstanceOperationsContextType};

--- a/operate/client/src/App/ProcessInstance/v2/index.tsx
+++ b/operate/client/src/App/ProcessInstance/v2/index.tsx
@@ -73,7 +73,6 @@ const ProcessInstance: React.FC = observer(() => {
   const {data: processTitle} = useProcessTitle();
   const {data: callHierarchy} = useCallHierarchy();
   const {processInstanceId = ''} = useProcessInstancePageParams();
-  const {data: processInstanceData} = useProcessInstance();
   const isRootNodeSelected = useIsRootNodeSelected();
   const rootNode = useRootNode();
   const navigate = useNavigate();
@@ -108,14 +107,14 @@ const ProcessInstance: React.FC = observer(() => {
           stopPolling();
         } else {
           instanceHistoryModificationStore.reset();
-          startPolling(processInstanceData);
+          startPolling(processInstance);
         }
       },
     );
 
     const handleVisibilityChange = () => {
       if (document.visibilityState === 'visible') {
-        startPolling(processInstanceData);
+        startPolling(processInstance);
       } else {
         stopPolling();
       }
@@ -127,7 +126,7 @@ const ProcessInstance: React.FC = observer(() => {
       disposer();
       document.removeEventListener('visibilitychange', handleVisibilityChange);
     };
-  }, [processInstanceData]);
+  }, [processInstance]);
 
   const isInitialized = useRef(false);
   useEffect(() => {

--- a/operate/client/src/modules/components/Operations/v2/Cancel.test.tsx
+++ b/operate/client/src/modules/components/Operations/v2/Cancel.test.tsx
@@ -14,13 +14,11 @@ import {mockFetchCallHierarchy} from 'modules/mocks/api/v2/processInstances/fetc
 import {mockCancelProcessInstance} from 'modules/mocks/api/v2/processInstances/cancelProcessInstance';
 import {notificationsStore} from 'modules/stores/notifications';
 
-jest.mock('modules/stores/notifications', () => {
-  return {
-    notificationsStore: {
-      displayNotification: jest.fn(),
-    },
-  };
-});
+vi.mock('modules/stores/notifications', () => ({
+  notificationsStore: {
+    displayNotification: vi.fn(() => () => {}),
+  },
+}));
 
 describe('Cancel component', () => {
   beforeEach(() => {

--- a/operate/client/src/modules/components/Operations/v2/Cancel.test.tsx
+++ b/operate/client/src/modules/components/Operations/v2/Cancel.test.tsx
@@ -1,0 +1,49 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {screen, waitFor} from '@testing-library/react';
+import {Cancel} from './Cancel';
+import {render} from 'modules/testing-library';
+import {getWrapper} from './mocks';
+import {mockFetchCallHierarchy} from 'modules/mocks/api/v2/processInstances/fetchCallHierarchy';
+import {mockCancelProcessInstance} from 'modules/mocks/api/v2/processInstances/cancelProcessInstance';
+import {notificationsStore} from 'modules/stores/notifications';
+
+jest.mock('modules/stores/notifications', () => {
+  return {
+    notificationsStore: {
+      displayNotification: jest.fn(),
+    },
+  };
+});
+
+describe('Cancel component', () => {
+  beforeEach(() => {
+    mockFetchCallHierarchy().withSuccess([]);
+  });
+
+  it('should show notification on server error', async () => {
+    mockCancelProcessInstance().withServerError();
+
+    const {user} = render(<Cancel processInstanceKey="809213809132809" />, {
+      wrapper: getWrapper(),
+    });
+
+    await user.click(screen.getByRole('button', {name: /cancel instance/i}));
+    await user.click(screen.getByRole('button', {name: /apply/i}));
+
+    await waitFor(() =>
+      expect(notificationsStore.displayNotification).toHaveBeenCalledWith({
+        kind: 'error',
+        title: 'Failed to cancel process instance',
+        isDismissable: true,
+        subtitle: 'Internal Server Error',
+      }),
+    );
+  });
+});

--- a/operate/client/src/modules/components/Operations/v2/Cancel.test.tsx
+++ b/operate/client/src/modules/components/Operations/v2/Cancel.test.tsx
@@ -21,11 +21,8 @@ vi.mock('modules/stores/notifications', () => ({
 }));
 
 describe('Cancel component', () => {
-  beforeEach(() => {
-    mockFetchCallHierarchy().withSuccess([]);
-  });
-
   it('should show notification on server error', async () => {
+    mockFetchCallHierarchy().withSuccess([]);
     mockCancelProcessInstance().withServerError();
 
     const {user} = render(<Cancel processInstanceKey="809213809132809" />, {

--- a/operate/client/src/modules/components/Operations/v2/Cancel.tsx
+++ b/operate/client/src/modules/components/Operations/v2/Cancel.tsx
@@ -15,6 +15,7 @@ import {OperationItem} from 'modules/components/OperationItem';
 import {Link} from 'modules/components/Link';
 import {useRootInstanceId} from 'modules/queries/callHierarchy/useRootInstanceId';
 import {notificationsStore} from 'modules/stores/notifications';
+import {useProcessInstanceOperationsContext} from 'App/ProcessInstance/ProcessInstanceHeader/v2/processInstanceOperationsContext';
 
 type Props = {
   processInstanceKey: ProcessInstance['processInstanceKey'];
@@ -28,15 +29,25 @@ const Cancel: React.FC<Props> = ({processInstanceKey}) => {
     enabled: isCancellationModalVisible,
   });
 
+  const processInstanceOperationsContext =
+    useProcessInstanceOperationsContext();
+  const {isPending, onMutate, onError} =
+    processInstanceOperationsContext?.cancellation ?? {};
+
   const cancelProcessInstanceMutation = useCancelProcessInstance(
     processInstanceKey,
-    (error) =>
-      notificationsStore.displayNotification({
-        kind: 'error',
-        title: 'Failed to cancel process instance',
-        subtitle: error.message,
-        isDismissable: true,
-      }),
+    {
+      onError: (error) => {
+        notificationsStore.displayNotification({
+          kind: 'error',
+          title: 'Failed to cancel process instance',
+          subtitle: error.message,
+          isDismissable: true,
+        });
+        onError?.(error);
+      },
+      onMutate,
+    },
   );
 
   return (
@@ -45,7 +56,7 @@ const Cancel: React.FC<Props> = ({processInstanceKey}) => {
         type="CANCEL_PROCESS_INSTANCE"
         onClick={() => setIsCancellationModalVisible(true)}
         title={`Cancel Instance ${processInstanceKey}`}
-        disabled={cancelProcessInstanceMutation.isPending}
+        disabled={isPending}
         size="sm"
       />
 

--- a/operate/client/src/modules/hooks/useProcessInstanceOperations.ts
+++ b/operate/client/src/modules/hooks/useProcessInstanceOperations.ts
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {ProcessInstance} from '@vzeta/camunda-api-zod-schemas';
+import {type ProcessInstance} from '@vzeta/camunda-api-zod-schemas';
 import {useEffect, useState} from 'react';
 
 const useProcessInstanceOperations = (

--- a/operate/client/src/modules/hooks/useProcessInstanceOperations.ts
+++ b/operate/client/src/modules/hooks/useProcessInstanceOperations.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {ProcessInstance} from '@vzeta/camunda-api-zod-schemas';
+import {useEffect, useState} from 'react';
+
+const useProcessInstanceOperations = (
+  processInstanceState: ProcessInstance['state'],
+) => {
+  const [isCancelOperationPending, setIsCancelOperationPending] =
+    useState(false);
+
+  useEffect(() => {
+    if (processInstanceState === 'TERMINATED' && isCancelOperationPending) {
+      setIsCancelOperationPending(false);
+    }
+  }, [isCancelOperationPending, processInstanceState]);
+
+  return {
+    cancellation: {
+      isPending: isCancelOperationPending,
+      setIsPending: setIsCancelOperationPending,
+    },
+  };
+};
+
+export {useProcessInstanceOperations};

--- a/operate/client/src/modules/mutations/processInstance/useCancelProcessInstance.tsx
+++ b/operate/client/src/modules/mutations/processInstance/useCancelProcessInstance.tsx
@@ -6,12 +6,12 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {useMutation} from '@tanstack/react-query';
+import {useMutation, UseMutationOptions} from '@tanstack/react-query';
 import {cancelProcessInstance} from 'modules/api/v2/processInstances/cancelProcessInstance';
 
 function useCancelProcessInstance(
   processInstanceKey: string,
-  onError?: (error: Error) => void,
+  options?: Partial<UseMutationOptions>,
 ) {
   return useMutation({
     mutationFn: async () => {
@@ -21,7 +21,7 @@ function useCancelProcessInstance(
       }
       return response;
     },
-    onError,
+    ...options,
   });
 }
 

--- a/operate/client/src/modules/mutations/processInstance/useCancelProcessInstance.tsx
+++ b/operate/client/src/modules/mutations/processInstance/useCancelProcessInstance.tsx
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {useMutation, UseMutationOptions} from '@tanstack/react-query';
+import {useMutation, type UseMutationOptions} from '@tanstack/react-query';
 import {cancelProcessInstance} from 'modules/api/v2/processInstances/cancelProcessInstance';
 
 function useCancelProcessInstance(

--- a/operate/client/src/modules/queries/flownodeInstancesStatistics/useExecutedFlowNode.test.tsx
+++ b/operate/client/src/modules/queries/flownodeInstancesStatistics/useExecutedFlowNode.test.tsx
@@ -12,11 +12,15 @@ import {useExecutedFlowNodes} from './useExecutedFlowNodes';
 import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
 import {mockFetchFlownodeInstancesStatistics} from 'modules/mocks/api/v2/flownodeInstances/fetchFlownodeInstancesStatistics';
 import {type GetProcessInstanceStatisticsResponseBody} from '@vzeta/camunda-api-zod-schemas';
-import {mockProcessWithInputOutputMappingsXML} from 'modules/testUtils';
+import {
+  createProcessInstance,
+  mockProcessWithInputOutputMappingsXML,
+} from 'modules/testUtils';
 import {ProcessDefinitionKeyContext} from 'App/Processes/ListView/processDefinitionKeyContext';
 import {MemoryRouter, Route, Routes} from 'react-router-dom';
 import {Paths} from 'modules/Routes';
 import {mockFetchProcessDefinitionXml} from 'modules/mocks/api/v2/processDefinitions/fetchProcessDefinitionXml';
+import {mockFetchProcessInstance} from 'modules/mocks/api/v2/processInstances/fetchProcessInstance';
 
 describe('useExecutedFlowNodes', () => {
   const Wrapper = ({children}: {children: React.ReactNode}) => {
@@ -37,6 +41,7 @@ describe('useExecutedFlowNodes', () => {
     mockFetchProcessDefinitionXml().withSuccess(
       mockProcessWithInputOutputMappingsXML,
     );
+    mockFetchProcessInstance().withSuccess(createProcessInstance());
   });
 
   it('should fetch executed flow nodes successfully', async () => {

--- a/operate/client/src/modules/queries/flownodeInstancesStatistics/useFlownodeInstancesStatistics.test.tsx
+++ b/operate/client/src/modules/queries/flownodeInstancesStatistics/useFlownodeInstancesStatistics.test.tsx
@@ -12,11 +12,15 @@ import {useFlownodeInstancesStatistics} from './useFlownodeInstancesStatistics';
 import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
 import {mockFetchFlownodeInstancesStatistics} from 'modules/mocks/api/v2/flownodeInstances/fetchFlownodeInstancesStatistics';
 import {type GetProcessInstanceStatisticsResponseBody} from '@vzeta/camunda-api-zod-schemas';
-import {mockProcessWithInputOutputMappingsXML} from 'modules/testUtils';
+import {
+  createProcessInstance,
+  mockProcessWithInputOutputMappingsXML,
+} from 'modules/testUtils';
 import {ProcessDefinitionKeyContext} from 'App/Processes/ListView/processDefinitionKeyContext';
 import {MemoryRouter, Route, Routes} from 'react-router-dom';
 import {Paths} from 'modules/Routes';
 import {mockFetchProcessDefinitionXml} from 'modules/mocks/api/v2/processDefinitions/fetchProcessDefinitionXml';
+import {mockFetchProcessInstance} from 'modules/mocks/api/v2/processInstances/fetchProcessInstance';
 
 describe('useFlownodeInstancesStatistics', () => {
   const Wrapper = ({children}: {children: React.ReactNode}) => {
@@ -37,6 +41,7 @@ describe('useFlownodeInstancesStatistics', () => {
     mockFetchProcessDefinitionXml().withSuccess(
       mockProcessWithInputOutputMappingsXML,
     );
+    mockFetchProcessInstance().withSuccess(createProcessInstance());
   });
 
   it('should fetch flownode instances statistics successfully', async () => {

--- a/operate/client/src/modules/queries/flownodeInstancesStatistics/useFlownodeInstancesStatistics.ts
+++ b/operate/client/src/modules/queries/flownodeInstancesStatistics/useFlownodeInstancesStatistics.ts
@@ -13,6 +13,7 @@ import {fetchFlownodeInstancesStatistics} from 'modules/api/v2/flownodeInstances
 import {useProcessInstancePageParams} from 'App/ProcessInstance/useProcessInstancePageParams';
 import isEmpty from 'lodash/isEmpty';
 import {useBusinessObjects} from '../processDefinitions/useBusinessObjects';
+import {useIsProcessInstanceRunning} from '../processInstance/useIsProcessInstanceRunning';
 
 const FLOWNODE_INSTANCES_STATISTICS_QUERY_KEY = 'flownodeInstancesStatistics';
 
@@ -28,6 +29,7 @@ const useFlownodeInstancesStatistics = <
 ): UseQueryResult<T, RequestError> => {
   const {processInstanceId} = useProcessInstancePageParams();
   const {data: businessObjects} = useBusinessObjects();
+  const {data: isProcessInstanceRunning} = useIsProcessInstanceRunning();
 
   return useQuery({
     queryKey: getQueryKey(processInstanceId),
@@ -45,6 +47,11 @@ const useFlownodeInstancesStatistics = <
           }
         : skipToken,
     select,
+    refetchInterval: () => {
+      if (isProcessInstanceRunning) {
+        return 5000;
+      }
+    },
   });
 };
 

--- a/operate/client/src/modules/queries/flownodeInstancesStatistics/useFlownodeStatistics.test.tsx
+++ b/operate/client/src/modules/queries/flownodeInstancesStatistics/useFlownodeStatistics.test.tsx
@@ -12,11 +12,15 @@ import {useFlownodeStatistics} from './useFlownodeStatistics';
 import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
 import {mockFetchFlownodeInstancesStatistics} from 'modules/mocks/api/v2/flownodeInstances/fetchFlownodeInstancesStatistics';
 import {type GetProcessInstanceStatisticsResponseBody} from '@vzeta/camunda-api-zod-schemas';
-import {mockProcessWithInputOutputMappingsXML} from 'modules/testUtils';
+import {
+  createProcessInstance,
+  mockProcessWithInputOutputMappingsXML,
+} from 'modules/testUtils';
 import {ProcessDefinitionKeyContext} from 'App/Processes/ListView/processDefinitionKeyContext';
 import {mockFetchProcessDefinitionXml} from 'modules/mocks/api/v2/processDefinitions/fetchProcessDefinitionXml';
 import {MemoryRouter, Route, Routes} from 'react-router-dom';
 import {Paths} from 'modules/Routes';
+import {mockFetchProcessInstance} from 'modules/mocks/api/v2/processInstances/fetchProcessInstance';
 
 describe('useFlownodeStatistics', () => {
   const Wrapper = ({children}: {children: React.ReactNode}) => {
@@ -37,6 +41,7 @@ describe('useFlownodeStatistics', () => {
     mockFetchProcessDefinitionXml().withSuccess(
       mockProcessWithInputOutputMappingsXML,
     );
+    mockFetchProcessInstance().withSuccess(createProcessInstance());
   });
 
   it('should fetch parsed flownode statistics successfully', async () => {

--- a/operate/client/src/modules/queries/flownodeInstancesStatistics/useSelectableFlowNodes.test.tsx
+++ b/operate/client/src/modules/queries/flownodeInstancesStatistics/useSelectableFlowNodes.test.tsx
@@ -12,11 +12,15 @@ import {useSelectableFlowNodes} from './useSelectableFlowNodes';
 import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
 import {mockFetchFlownodeInstancesStatistics} from 'modules/mocks/api/v2/flownodeInstances/fetchFlownodeInstancesStatistics';
 import {type GetProcessInstanceStatisticsResponseBody} from '@vzeta/camunda-api-zod-schemas';
-import {mockProcessWithInputOutputMappingsXML} from 'modules/testUtils';
+import {
+  createProcessInstance,
+  mockProcessWithInputOutputMappingsXML,
+} from 'modules/testUtils';
 import {mockFetchProcessDefinitionXml} from 'modules/mocks/api/v2/processDefinitions/fetchProcessDefinitionXml';
 import {MemoryRouter, Route, Routes} from 'react-router-dom';
 import {Paths} from 'modules/Routes';
 import {ProcessDefinitionKeyContext} from 'App/Processes/ListView/processDefinitionKeyContext';
+import {mockFetchProcessInstance} from 'modules/mocks/api/v2/processInstances/fetchProcessInstance';
 
 describe('useSelectableFlowNodes', () => {
   const Wrapper = ({children}: {children: React.ReactNode}) => {
@@ -37,6 +41,7 @@ describe('useSelectableFlowNodes', () => {
     mockFetchProcessDefinitionXml().withSuccess(
       mockProcessWithInputOutputMappingsXML,
     );
+    mockFetchProcessInstance().withSuccess(createProcessInstance());
   });
 
   it('should fetch selectable flow nodes successfully', async () => {

--- a/operate/client/src/modules/queries/flownodeInstancesStatistics/useTotalRunningInstancesForFlowNode.test.tsx
+++ b/operate/client/src/modules/queries/flownodeInstancesStatistics/useTotalRunningInstancesForFlowNode.test.tsx
@@ -17,11 +17,15 @@ import {
 import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
 import {mockFetchFlownodeInstancesStatistics} from 'modules/mocks/api/v2/flownodeInstances/fetchFlownodeInstancesStatistics';
 import {type GetProcessInstanceStatisticsResponseBody} from '@vzeta/camunda-api-zod-schemas';
-import {mockProcessWithInputOutputMappingsXML} from 'modules/testUtils';
+import {
+  createProcessInstance,
+  mockProcessWithInputOutputMappingsXML,
+} from 'modules/testUtils';
 import {ProcessDefinitionKeyContext} from 'App/Processes/ListView/processDefinitionKeyContext';
 import {Paths} from 'modules/Routes';
 import {MemoryRouter, Route, Routes} from 'react-router-dom';
 import {mockFetchProcessDefinitionXml} from 'modules/mocks/api/v2/processDefinitions/fetchProcessDefinitionXml';
+import {mockFetchProcessInstance} from 'modules/mocks/api/v2/processInstances/fetchProcessInstance';
 
 describe('useTotalRunningInstancesForFlowNode hooks', () => {
   const Wrapper = ({children}: {children: React.ReactNode}) => {
@@ -42,6 +46,7 @@ describe('useTotalRunningInstancesForFlowNode hooks', () => {
     mockFetchProcessDefinitionXml().withSuccess(
       mockProcessWithInputOutputMappingsXML,
     );
+    mockFetchProcessInstance().withSuccess(createProcessInstance());
   });
 
   it('should fetch total running instances for a single flow node', async () => {

--- a/operate/client/src/modules/queries/processInstance/useProcessInstance.ts
+++ b/operate/client/src/modules/queries/processInstance/useProcessInstance.ts
@@ -11,6 +11,7 @@ import type {RequestError} from 'modules/request';
 import type {ProcessInstance} from '@vzeta/camunda-api-zod-schemas';
 import {useProcessInstancePageParams} from 'App/ProcessInstance/useProcessInstancePageParams';
 import {fetchProcessInstance} from 'modules/api/v2/processInstances/fetchProcessInstance';
+import {isInstanceRunning} from 'modules/utils/instance';
 
 const PROCESS_INSTANCE_QUERY_KEY = 'processInstance';
 
@@ -38,6 +39,13 @@ const useProcessInstance = <T = ProcessInstance>(
         }
       : skipToken,
     select,
+
+    refetchInterval: (query) => {
+      const processInstance = query.state.data;
+      if (processInstance !== undefined && isInstanceRunning(processInstance)) {
+        return 5000;
+      }
+    },
   });
 };
 


### PR DESCRIPTION
## Description

This PR implements a pending state between starting a process instance cancellation mutation and fetching the terminated process instance. During this time the Cancel button is disabled and a spinner is shown.

To achieve this, the process instance is refetched every 5s until it reaches a `TERMINATED` or `COMPLETED` state. 

In addition refetching is enabled for element instance statistics as long as the process instance is active, to keep diagram statistics consistent with the process instance state.

I decided to rely on polling/refetching over optimistic updates, because we would need to update data for multiple endpoints to keep data consistent in the UI. In my opinion polling was the most straight forward approach similar to what we had before. 

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #34476 


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210735566176312