### PR TITLE
fix: change Opensearch snapshot status from STARTED to IN_PROGRESS in Tasklist

### DIFF
--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/es/backup/os/BackupManagerOpenSearch.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/es/backup/os/BackupManagerOpenSearch.java
@@ -638,7 +638,7 @@ public class BackupManagerOpenSearch extends BackupManager {
         // No need to continue
         return false;
       }
-      if (currentSnapshot.state().equals(SnapshotState.STARTED.name())) {
+      if (currentSnapshot.state().equals(SnapshotState.IN_PROGRESS.name())) {
         ThreadUtil.sleepFor(100);
         count++;
         if (count % 600 == 0) { // approx. 1 minute, depending on how long findSnapshots takes

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/es/backup/os/response/SnapshotState.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/es/backup/os/response/SnapshotState.java
@@ -8,18 +8,8 @@
 package io.camunda.tasklist.webapp.es.backup.os.response;
 
 public enum SnapshotState {
-  FAILED("FAILED"),
-  PARTIAL("PARTIAL"),
-  STARTED("STARTED"),
-  SUCCESS("SUCCESS");
-  private final String state;
-
-  SnapshotState(final String state) {
-    this.state = state;
-  }
-
-  @Override
-  public String toString() {
-    return state;
-  }
+  FAILED,
+  PARTIAL,
+  IN_PROGRESS,
+  SUCCESS;
 }

--- a/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/es/backup/os/BackupManagerOpenSearchTest.java
+++ b/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/es/backup/os/BackupManagerOpenSearchTest.java
@@ -191,7 +191,7 @@ class BackupManagerOpenSearchTest {
   public void shouldWaitForSnapshotWithTimeout() throws IOException {
     // given
     final int timeout = 1;
-    final SnapshotState snapshotState = SnapshotState.STARTED;
+    final SnapshotState snapshotState = SnapshotState.IN_PROGRESS;
 
     final SnapshotInfo snapshotInfo = mock(SnapshotInfo.class, RETURNS_DEEP_STUBS);
     when(snapshotInfo.state()).thenReturn(snapshotState.name());
@@ -231,8 +231,8 @@ class BackupManagerOpenSearchTest {
     for (int i = 0; i < numberOfSnapshots; i++) {
       final SnapshotInfo snapshotInfo = mock(SnapshotInfo.class, RETURNS_DEEP_STUBS);
       when(snapshotInfo.state())
-          .thenReturn(SnapshotState.STARTED.name())
-          .thenReturn(SnapshotState.STARTED.name())
+          .thenReturn(SnapshotState.IN_PROGRESS.name())
+          .thenReturn(SnapshotState.IN_PROGRESS.name())
           .thenReturn(SnapshotState.SUCCESS.name());
       when(snapshotInfo.snapshot()).thenReturn(metadata.get(i).buildSnapshotName());
       snapshotInfos.add(snapshotInfo);


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Same as was done in https://github.com/camunda/camunda/pull/33520, it was forgotten to do the same for the SnapshotStatus enum in Tasklist
The good news is that Tasklist does not use this enum for OS response deserialization, but there is a retry logic on snapshot creation that is not triggered, as the `IN_PROGRESS` status is not correctly handled

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

relates to https://github.com/camunda/camunda/issues/33516
