### PR TITLE
fix: avoid overloading of owner ids during auth check

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/BatchOperationAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/BatchOperationAuthorizationIT.java
@@ -74,6 +74,7 @@ class BatchOperationAuthorizationIT {
           List.of(
               new Permissions(RESOURCE, CREATE, List.of("*")),
               new Permissions(PROCESS_DEFINITION, READ_PROCESS_DEFINITION, List.of("*")),
+              new Permissions(PROCESS_DEFINITION, READ_PROCESS_INSTANCE, List.of("*")),
               new Permissions(PROCESS_DEFINITION, CREATE_PROCESS_INSTANCE, List.of("*")),
               new Permissions(
                   BATCH_OPERATION, CREATE_BATCH_OPERATION_CANCEL_PROCESS_INSTANCE, List.of("*")),

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/UserTaskAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/UserTaskAuthorizationIT.java
@@ -52,6 +52,8 @@ class UserTaskAuthorizationIT {
           List.of(
               new Permissions(RESOURCE, CREATE, List.of("*")),
               new Permissions(PROCESS_DEFINITION, CREATE_PROCESS_INSTANCE, List.of("*")),
+              new Permissions(PROCESS_DEFINITION, READ_PROCESS_DEFINITION, List.of("*")),
+              new Permissions(PROCESS_DEFINITION, READ_PROCESS_INSTANCE, List.of("*")),
               new Permissions(PROCESS_DEFINITION, READ_USER_TASK, List.of("*"))));
 
   @UserDefinition

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/operate/OperateInternalApiGroupPermissionsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/operate/OperateInternalApiGroupPermissionsIT.java
@@ -9,6 +9,7 @@ package io.camunda.it.operate;
 
 import static io.camunda.client.api.search.enums.PermissionType.CREATE;
 import static io.camunda.client.api.search.enums.PermissionType.CREATE_PROCESS_INSTANCE;
+import static io.camunda.client.api.search.enums.PermissionType.READ_PROCESS_INSTANCE;
 import static io.camunda.client.api.search.enums.PermissionType.UPDATE;
 import static io.camunda.client.api.search.enums.ResourceType.AUTHORIZATION;
 import static io.camunda.client.api.search.enums.ResourceType.GROUP;
@@ -78,7 +79,8 @@ public class OperateInternalApiGroupPermissionsIT {
               new Permissions(GROUP, UPDATE, List.of("*")),
               new Permissions(AUTHORIZATION, CREATE, List.of("*")),
               new Permissions(RESOURCE, CREATE, List.of("*")),
-              new Permissions(PROCESS_DEFINITION, CREATE_PROCESS_INSTANCE, List.of("*"))));
+              new Permissions(PROCESS_DEFINITION, CREATE_PROCESS_INSTANCE, List.of("*")),
+              new Permissions(PROCESS_DEFINITION, READ_PROCESS_INSTANCE, List.of("*"))));
 
   @UserDefinition
   private static final TestUser AUTHORIZED_USER =

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/operate/OperateInternalApiRolePermissionsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/operate/OperateInternalApiRolePermissionsIT.java
@@ -9,6 +9,7 @@ package io.camunda.it.operate;
 
 import static io.camunda.client.api.search.enums.PermissionType.CREATE;
 import static io.camunda.client.api.search.enums.PermissionType.CREATE_PROCESS_INSTANCE;
+import static io.camunda.client.api.search.enums.PermissionType.READ_PROCESS_INSTANCE;
 import static io.camunda.client.api.search.enums.PermissionType.UPDATE;
 import static io.camunda.client.api.search.enums.ResourceType.AUTHORIZATION;
 import static io.camunda.client.api.search.enums.ResourceType.PROCESS_DEFINITION;
@@ -78,7 +79,8 @@ public class OperateInternalApiRolePermissionsIT {
               new Permissions(ROLE, UPDATE, List.of("*")),
               new Permissions(AUTHORIZATION, CREATE, List.of("*")),
               new Permissions(RESOURCE, CREATE, List.of("*")),
-              new Permissions(PROCESS_DEFINITION, CREATE_PROCESS_INSTANCE, List.of("*"))));
+              new Permissions(PROCESS_DEFINITION, CREATE_PROCESS_INSTANCE, List.of("*")),
+              new Permissions(PROCESS_DEFINITION, READ_PROCESS_INSTANCE, List.of("*"))));
 
   @UserDefinition
   private static final TestUser AUTHORIZED_USER =

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/tasklist/v1/groups/TasklistV1ApiGroupPermissionsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/tasklist/v1/groups/TasklistV1ApiGroupPermissionsIT.java
@@ -9,6 +9,7 @@ package io.camunda.it.tasklist.v1.groups;
 
 import static io.camunda.client.api.search.enums.PermissionType.CREATE;
 import static io.camunda.client.api.search.enums.PermissionType.CREATE_PROCESS_INSTANCE;
+import static io.camunda.client.api.search.enums.PermissionType.READ_USER_TASK;
 import static io.camunda.client.api.search.enums.PermissionType.UPDATE;
 import static io.camunda.client.api.search.enums.ResourceType.AUTHORIZATION;
 import static io.camunda.client.api.search.enums.ResourceType.GROUP;
@@ -70,7 +71,8 @@ public class TasklistV1ApiGroupPermissionsIT {
               new Permissions(GROUP, UPDATE, List.of("*")),
               new Permissions(AUTHORIZATION, CREATE, List.of("*")),
               new Permissions(RESOURCE, CREATE, List.of("*")),
-              new Permissions(PROCESS_DEFINITION, CREATE_PROCESS_INSTANCE, List.of("*"))));
+              new Permissions(PROCESS_DEFINITION, CREATE_PROCESS_INSTANCE, List.of("*")),
+              new Permissions(PROCESS_DEFINITION, READ_USER_TASK, List.of("*"))));
 
   @UserDefinition
   private static final TestUser AUTHORIZED_USER =

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/tasklist/v1/roles/TasklistV1ApiRolePermissionsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/tasklist/v1/roles/TasklistV1ApiRolePermissionsIT.java
@@ -9,6 +9,7 @@ package io.camunda.it.tasklist.v1.roles;
 
 import static io.camunda.client.api.search.enums.PermissionType.CREATE;
 import static io.camunda.client.api.search.enums.PermissionType.CREATE_PROCESS_INSTANCE;
+import static io.camunda.client.api.search.enums.PermissionType.READ_USER_TASK;
 import static io.camunda.client.api.search.enums.PermissionType.UPDATE;
 import static io.camunda.client.api.search.enums.ResourceType.AUTHORIZATION;
 import static io.camunda.client.api.search.enums.ResourceType.PROCESS_DEFINITION;
@@ -70,7 +71,8 @@ public class TasklistV1ApiRolePermissionsIT {
               new Permissions(ROLE, UPDATE, List.of("*")),
               new Permissions(AUTHORIZATION, CREATE, List.of("*")),
               new Permissions(RESOURCE, CREATE, List.of("*")),
-              new Permissions(PROCESS_DEFINITION, CREATE_PROCESS_INSTANCE, List.of("*"))));
+              new Permissions(PROCESS_DEFINITION, CREATE_PROCESS_INSTANCE, List.of("*")),
+              new Permissions(PROCESS_DEFINITION, READ_USER_TASK, List.of("*"))));
 
   @UserDefinition
   private static final TestUser AUTHORIZED_USER =

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/auth/DocumentAuthorizationQueryStrategyTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/auth/DocumentAuthorizationQueryStrategyTest.java
@@ -29,7 +29,9 @@ import io.camunda.search.query.AuthorizationQuery;
 import io.camunda.search.query.ProcessDefinitionQuery;
 import io.camunda.search.query.SearchQueryBase;
 import io.camunda.security.auth.SecurityContext;
+import io.camunda.zeebe.protocol.record.value.EntityType;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -174,7 +176,7 @@ class DocumentAuthorizationQueryStrategyTest {
                 q ->
                     q.filter(
                         f ->
-                            f.ownerIds(List.of("foo"))
+                            f.ownerTypeToOwnerIds(Map.of(EntityType.USER, Set.of("foo")))
                                 .resourceType("PROCESS_DEFINITION")
                                 .permissionTypes(READ_PROCESS_DEFINITION))));
   }

--- a/security/security-services/src/main/java/io/camunda/security/impl/AuthorizationChecker.java
+++ b/security/security-services/src/main/java/io/camunda/security/impl/AuthorizationChecker.java
@@ -15,9 +15,12 @@ import io.camunda.search.query.AuthorizationQuery;
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.security.auth.SecurityContext;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
+import io.camunda.zeebe.protocol.record.value.EntityType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
-import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -44,7 +47,7 @@ public class AuthorizationChecker {
    * @return a list of authorized resource keys for the user or group in the SecurityContext
    */
   public List<String> retrieveAuthorizedResourceKeys(final SecurityContext securityContext) {
-    final var ownerIds = collectOwnerIds(securityContext.authentication());
+    final var ownerIds = collectOwnerTypeToOwnerIds(securityContext.authentication());
     final var resourceType = securityContext.authorization().resourceType();
     final var permissionType = securityContext.authorization().permissionType();
     final var authorizationEntities =
@@ -53,7 +56,7 @@ public class AuthorizationChecker {
                 q ->
                     q.filter(
                         f ->
-                            f.ownerIds(ownerIds)
+                            f.ownerTypeToOwnerIds(ownerIds)
                                 .resourceType(resourceType.name())
                                 .permissionTypes(permissionType))));
     return authorizationEntities.stream()
@@ -72,7 +75,7 @@ public class AuthorizationChecker {
    * @return true if the resource key is authorized, false otherwise
    */
   public boolean isAuthorized(final String resourceId, final SecurityContext securityContext) {
-    final var ownerIds = collectOwnerIds(securityContext.authentication());
+    final var ownerIds = collectOwnerTypeToOwnerIds(securityContext.authentication());
     final var resourceType = securityContext.authorization().resourceType();
     final var permissionType = securityContext.authorization().permissionType();
     return authorizationSearchClient
@@ -81,7 +84,7 @@ public class AuthorizationChecker {
                     q ->
                         q.filter(
                                 f ->
-                                    f.ownerIds(ownerIds)
+                                    f.ownerTypeToOwnerIds(ownerIds)
                                         .resourceType(resourceType.name())
                                         .permissionTypes(permissionType)
                                         .resourceIds(List.of(WILDCARD, resourceId)))
@@ -103,14 +106,14 @@ public class AuthorizationChecker {
       final String resourceId,
       final AuthorizationResourceType resourceType,
       final CamundaAuthentication authentication) {
-    final var ownerIds = collectOwnerIds(authentication);
+    final var ownerIds = collectOwnerTypeToOwnerIds(authentication);
     final var authorizationEntities =
         authorizationSearchClient.findAllAuthorizations(
             AuthorizationQuery.of(
                 q ->
                     q.filter(
                         f ->
-                            f.ownerIds(ownerIds)
+                            f.ownerTypeToOwnerIds(ownerIds)
                                 .resourceType(resourceType.name())
                                 .resourceIds(List.of(WILDCARD, resourceId)))));
 
@@ -124,17 +127,31 @@ public class AuthorizationChecker {
         .collect(Collectors.toSet());
   }
 
-  private List<String> collectOwnerIds(final CamundaAuthentication authentication) {
-    final List<String> ownerIds = new ArrayList<>();
+  private Map<EntityType, Set<String>> collectOwnerTypeToOwnerIds(
+      final CamundaAuthentication authentication) {
+    final var ownerTypeToOwnerIds = new HashMap<EntityType, Set<String>>();
     if (authentication.authenticatedUsername() != null) {
-      ownerIds.add(authentication.authenticatedUsername());
+      ownerTypeToOwnerIds.put(EntityType.USER, Set.of(authentication.authenticatedUsername()));
     }
     if (authentication.authenticatedClientId() != null) {
-      ownerIds.add(authentication.authenticatedClientId());
+      ownerTypeToOwnerIds.put(EntityType.CLIENT, Set.of(authentication.authenticatedClientId()));
     }
-    ownerIds.addAll(authentication.authenticatedMappingIds());
-    ownerIds.addAll(authentication.authenticatedGroupIds());
-    ownerIds.addAll(authentication.authenticatedRoleIds());
-    return ownerIds;
+
+    final var authenticatedGroupIds = authentication.authenticatedGroupIds();
+    if (authenticatedGroupIds != null && !authenticatedGroupIds.isEmpty()) {
+      ownerTypeToOwnerIds.put(EntityType.GROUP, new HashSet<>(authenticatedGroupIds));
+    }
+
+    final var authenticatedRoleIds = authentication.authenticatedRoleIds();
+    if (authenticatedRoleIds != null && !authenticatedRoleIds.isEmpty()) {
+      ownerTypeToOwnerIds.put(EntityType.ROLE, new HashSet<>(authenticatedRoleIds));
+    }
+
+    final var authenticatedMappingIds = authentication.authenticatedMappingIds();
+    if (authenticatedMappingIds != null && !authenticatedMappingIds.isEmpty()) {
+      ownerTypeToOwnerIds.put(EntityType.MAPPING, new HashSet<>(authenticatedMappingIds));
+    }
+
+    return ownerTypeToOwnerIds;
   }
 }


### PR DESCRIPTION
## Description

Ensures that the authorization check includes the owner type to apply the correct authorizations.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #34677
