### PR TITLE
Ensure unique Identity ES/OS index IDs

### DIFF
--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/index/GroupIndex.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/index/GroupIndex.java
@@ -25,8 +25,8 @@ public class GroupIndex extends AbstractIndexDescriptor implements Prio5Backup {
   public static final String JOIN = "join";
   public static final String MEMBER_TYPE = "memberType";
 
-  public static final EntityJoinRelationFactory<String> JOIN_RELATION_FACTORY =
-      new EntityJoinRelationFactory<>(
+  public static final EntityJoinRelationFactory JOIN_RELATION_FACTORY =
+      new EntityJoinRelationFactory(
           IdentityJoinRelationshipType.GROUP, IdentityJoinRelationshipType.MEMBER);
 
   public GroupIndex(final String indexPrefix, final boolean isElasticsearch) {

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/index/RoleIndex.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/index/RoleIndex.java
@@ -24,8 +24,8 @@ public class RoleIndex extends AbstractIndexDescriptor implements Prio5Backup {
   public static final String MEMBER_TYPE = "memberType";
   public static final String JOIN = "join";
 
-  public static final EntityJoinRelationFactory<String> JOIN_RELATION_FACTORY =
-      new EntityJoinRelationFactory<>(
+  public static final EntityJoinRelationFactory JOIN_RELATION_FACTORY =
+      new EntityJoinRelationFactory(
           IdentityJoinRelationshipType.ROLE, IdentityJoinRelationshipType.MEMBER);
 
   public RoleIndex(final String indexPrefix, final boolean isElasticsearch) {

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/index/TenantIndex.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/index/TenantIndex.java
@@ -26,8 +26,8 @@ public class TenantIndex extends AbstractIndexDescriptor implements Prio5Backup 
   public static final String MEMBER_ID = "memberId";
   public static final String PARENT = "parent";
 
-  public static final EntityJoinRelationFactory<String> JOIN_RELATION_FACTORY =
-      new EntityJoinRelationFactory<>(
+  public static final EntityJoinRelationFactory JOIN_RELATION_FACTORY =
+      new EntityJoinRelationFactory(
           EntityJoinRelation.IdentityJoinRelationshipType.TENANT,
           EntityJoinRelation.IdentityJoinRelationshipType.MEMBER);
 

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/index/TenantIndex.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/index/TenantIndex.java
@@ -24,7 +24,6 @@ public class TenantIndex extends AbstractIndexDescriptor implements Prio5Backup 
   public static final String JOIN = "join";
   public static final String MEMBER_TYPE = "memberType";
   public static final String MEMBER_ID = "memberId";
-  public static final String PARENT = "parent";
 
   public static final EntityJoinRelationFactory JOIN_RELATION_FACTORY =
       new EntityJoinRelationFactory(

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/EntityJoinRelation.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/EntityJoinRelation.java
@@ -7,9 +7,9 @@
  */
 package io.camunda.webapps.schema.entities.usermanagement;
 
-public record EntityJoinRelation<T>(String name, T parent) {
+public record EntityJoinRelation(String name, String parent) {
 
-  public static class EntityJoinRelationFactory<T> {
+  public static class EntityJoinRelationFactory {
 
     private final IdentityJoinRelationshipType parent;
     private final IdentityJoinRelationshipType child;
@@ -20,12 +20,20 @@ public record EntityJoinRelation<T>(String name, T parent) {
       this.child = child;
     }
 
-    public EntityJoinRelation<T> createParent() {
-      return new EntityJoinRelation<>(parent.getType(), null);
+    public EntityJoinRelation createParent() {
+      return new EntityJoinRelation(parent.getType(), null);
     }
 
-    public EntityJoinRelation<T> createChild(final T parentId) {
-      return new EntityJoinRelation<>(child.getType(), parentId);
+    public EntityJoinRelation createChild(final String parentId) {
+      return new EntityJoinRelation(child.getType(), createParentId(parentId));
+    }
+
+    public String createParentId(final String parentId) {
+      return parent.getType() + "-" + parentId;
+    }
+
+    public String createChildId(final String parentId, final String childId) {
+      return child.getType() + "-" + parentId + "-" + childId;
     }
   }
 

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/GroupEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/GroupEntity.java
@@ -16,7 +16,7 @@ public class GroupEntity extends AbstractExporterEntity<GroupEntity> {
   private String name;
   private String description;
 
-  private EntityJoinRelation<String> join;
+  private EntityJoinRelation join;
 
   public Long getKey() {
     return key;
@@ -54,11 +54,11 @@ public class GroupEntity extends AbstractExporterEntity<GroupEntity> {
     return this;
   }
 
-  public EntityJoinRelation<String> getJoin() {
+  public EntityJoinRelation getJoin() {
     return join;
   }
 
-  public GroupEntity setJoin(final EntityJoinRelation<String> join) {
+  public GroupEntity setJoin(final EntityJoinRelation join) {
     this.join = join;
     return this;
   }

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/GroupEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/GroupEntity.java
@@ -62,8 +62,4 @@ public class GroupEntity extends AbstractExporterEntity<GroupEntity> {
     this.join = join;
     return this;
   }
-
-  public static String getChildKey(final String groupId, final String memberId) {
-    return String.format("%s-%s", groupId, memberId);
-  }
 }

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/GroupMemberEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/GroupMemberEntity.java
@@ -15,7 +15,7 @@ public class GroupMemberEntity extends AbstractExporterEntity<GroupMemberEntity>
   private String memberId;
   private EntityType memberType;
 
-  private EntityJoinRelation<String> join;
+  private EntityJoinRelation join;
 
   public String getMemberId() {
     return memberId;
@@ -35,11 +35,11 @@ public class GroupMemberEntity extends AbstractExporterEntity<GroupMemberEntity>
     return this;
   }
 
-  public EntityJoinRelation<String> getJoin() {
+  public EntityJoinRelation getJoin() {
     return join;
   }
 
-  public GroupMemberEntity setJoin(final EntityJoinRelation<String> join) {
+  public GroupMemberEntity setJoin(final EntityJoinRelation join) {
     this.join = join;
     return this;
   }

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/GroupMemberEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/GroupMemberEntity.java
@@ -43,8 +43,4 @@ public class GroupMemberEntity extends AbstractExporterEntity<GroupMemberEntity>
     this.join = join;
     return this;
   }
-
-  public static String getChildKey(final String tenantId, final String memberId) {
-    return String.format("%s-%s", tenantId, memberId);
-  }
 }

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/RoleEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/RoleEntity.java
@@ -61,8 +61,4 @@ public class RoleEntity extends AbstractExporterEntity<RoleEntity> {
     this.join = join;
     return this;
   }
-
-  public static String getChildKey(final String roleId, final String memberId) {
-    return "%s-%s".formatted(roleId, memberId);
-  }
 }

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/RoleEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/RoleEntity.java
@@ -15,7 +15,7 @@ public class RoleEntity extends AbstractExporterEntity<RoleEntity> {
   private String roleId;
   private String name;
   private String description;
-  private EntityJoinRelation<String> join;
+  private EntityJoinRelation join;
 
   public Long getKey() {
     return key;
@@ -53,11 +53,11 @@ public class RoleEntity extends AbstractExporterEntity<RoleEntity> {
     return this;
   }
 
-  public EntityJoinRelation<String> getJoin() {
+  public EntityJoinRelation getJoin() {
     return join;
   }
 
-  public RoleEntity setJoin(final EntityJoinRelation<String> join) {
+  public RoleEntity setJoin(final EntityJoinRelation join) {
     this.join = join;
     return this;
   }

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/RoleMemberEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/RoleMemberEntity.java
@@ -14,7 +14,7 @@ public class RoleMemberEntity extends AbstractExporterEntity<RoleMemberEntity> {
   private String memberId;
   private EntityType memberType;
 
-  private EntityJoinRelation<String> join;
+  private EntityJoinRelation join;
 
   public String getMemberId() {
     return memberId;
@@ -34,11 +34,11 @@ public class RoleMemberEntity extends AbstractExporterEntity<RoleMemberEntity> {
     return this;
   }
 
-  public EntityJoinRelation<String> getJoin() {
+  public EntityJoinRelation getJoin() {
     return join;
   }
 
-  public RoleMemberEntity setJoin(final EntityJoinRelation<String> join) {
+  public RoleMemberEntity setJoin(final EntityJoinRelation join) {
     this.join = join;
     return this;
   }

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/RoleMemberEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/RoleMemberEntity.java
@@ -42,8 +42,4 @@ public class RoleMemberEntity extends AbstractExporterEntity<RoleMemberEntity> {
     this.join = join;
     return this;
   }
-
-  public static String getChildKey(final String roleId, final String memberId) {
-    return String.format("%s-%s", roleId, memberId);
-  }
 }

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/TenantEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/TenantEntity.java
@@ -54,11 +54,11 @@ public class TenantEntity extends AbstractExporterEntity<TenantEntity> {
     return this;
   }
 
-  public EntityJoinRelation<String> getJoin() {
+  public EntityJoinRelation getJoin() {
     return join;
   }
 
-  public TenantEntity setJoin(final EntityJoinRelation<String> join) {
+  public TenantEntity setJoin(final EntityJoinRelation join) {
     this.join = join;
     return this;
   }

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/TenantEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/TenantEntity.java
@@ -16,7 +16,7 @@ public class TenantEntity extends AbstractExporterEntity<TenantEntity> {
   private String name;
   private String description;
 
-  private EntityJoinRelation<String> join;
+  private EntityJoinRelation join;
 
   public Long getKey() {
     return key;

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/TenantMemberEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/TenantMemberEntity.java
@@ -43,8 +43,4 @@ public class TenantMemberEntity extends AbstractExporterEntity<TenantMemberEntit
     this.join = join;
     return this;
   }
-
-  public static String getChildKey(final String tenantId, final String memberId) {
-    return String.format("%s-%s", tenantId, memberId);
-  }
 }

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/TenantMemberEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/TenantMemberEntity.java
@@ -15,7 +15,7 @@ public class TenantMemberEntity extends AbstractExporterEntity<TenantMemberEntit
   private String memberId;
   private EntityType memberType;
 
-  private EntityJoinRelation<String> join;
+  private EntityJoinRelation join;
 
   public String getMemberId() {
     return memberId;
@@ -35,11 +35,11 @@ public class TenantMemberEntity extends AbstractExporterEntity<TenantMemberEntit
     return this;
   }
 
-  public EntityJoinRelation<String> getJoin() {
+  public EntityJoinRelation getJoin() {
     return join;
   }
 
-  public TenantMemberEntity setJoin(final EntityJoinRelation<String> join) {
+  public TenantMemberEntity setJoin(final EntityJoinRelation join) {
     this.join = join;
     return this;
   }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/GroupCreatedUpdatedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/GroupCreatedUpdatedHandler.java
@@ -47,7 +47,7 @@ public class GroupCreatedUpdatedHandler implements ExportHandler<GroupEntity, Gr
 
   @Override
   public List<String> generateIds(final Record<GroupRecordValue> record) {
-    return List.of(record.getValue().getGroupId());
+    return List.of(GroupIndex.JOIN_RELATION_FACTORY.createParentId(record.getValue().getGroupId()));
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/GroupDeletedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/GroupDeletedHandler.java
@@ -43,7 +43,7 @@ public class GroupDeletedHandler implements ExportHandler<GroupEntity, GroupReco
 
   @Override
   public List<String> generateIds(final Record<GroupRecordValue> record) {
-    return List.of(record.getValue().getGroupId());
+    return List.of(GroupIndex.JOIN_RELATION_FACTORY.createParentId(record.getValue().getGroupId()));
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/GroupEntityAddedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/GroupEntityAddedHandler.java
@@ -45,7 +45,8 @@ public class GroupEntityAddedHandler implements ExportHandler<GroupMemberEntity,
   public List<String> generateIds(final Record<GroupRecordValue> record) {
     final var groupRecord = record.getValue();
     return List.of(
-        GroupMemberEntity.getChildKey(groupRecord.getGroupId(), groupRecord.getEntityId()));
+        GroupIndex.JOIN_RELATION_FACTORY.createChildId(
+            groupRecord.getGroupId(), groupRecord.getEntityId()));
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/GroupEntityRemovedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/GroupEntityRemovedHandler.java
@@ -46,7 +46,8 @@ public class GroupEntityRemovedHandler
   public List<String> generateIds(final Record<GroupRecordValue> record) {
     final var groupRecord = record.getValue();
     return List.of(
-        GroupMemberEntity.getChildKey(groupRecord.getGroupId(), groupRecord.getEntityId()));
+        GroupIndex.JOIN_RELATION_FACTORY.createChildId(
+            groupRecord.getGroupId(), groupRecord.getEntityId()));
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/RoleCreateUpdateHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/RoleCreateUpdateHandler.java
@@ -43,7 +43,7 @@ public class RoleCreateUpdateHandler implements ExportHandler<RoleEntity, RoleRe
 
   @Override
   public List<String> generateIds(final Record<RoleRecordValue> record) {
-    return List.of(record.getValue().getRoleId());
+    return List.of(RoleIndex.JOIN_RELATION_FACTORY.createParentId(record.getValue().getRoleId()));
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/RoleDeletedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/RoleDeletedHandler.java
@@ -9,6 +9,7 @@ package io.camunda.exporter.handlers;
 
 import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.index.RoleIndex;
 import io.camunda.webapps.schema.entities.usermanagement.RoleEntity;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
@@ -44,7 +45,7 @@ public class RoleDeletedHandler implements ExportHandler<RoleEntity, RoleRecordV
 
   @Override
   public List<String> generateIds(final Record<RoleRecordValue> record) {
-    return List.of(record.getValue().getRoleId());
+    return List.of(RoleIndex.JOIN_RELATION_FACTORY.createParentId(record.getValue().getRoleId()));
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/RoleMemberAddedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/RoleMemberAddedHandler.java
@@ -10,7 +10,6 @@ package io.camunda.exporter.handlers;
 import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.descriptors.index.RoleIndex;
-import io.camunda.webapps.schema.entities.usermanagement.RoleEntity;
 import io.camunda.webapps.schema.entities.usermanagement.RoleMemberEntity;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
@@ -45,7 +44,8 @@ public class RoleMemberAddedHandler implements ExportHandler<RoleMemberEntity, R
   @Override
   public List<String> generateIds(final Record<RoleRecordValue> record) {
     final RoleRecordValue value = record.getValue();
-    return List.of(RoleEntity.getChildKey(value.getRoleId(), value.getEntityId()));
+    return List.of(
+        RoleIndex.JOIN_RELATION_FACTORY.createChildId(value.getRoleId(), value.getEntityId()));
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/RoleMemberRemovedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/RoleMemberRemovedHandler.java
@@ -10,7 +10,6 @@ package io.camunda.exporter.handlers;
 import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.descriptors.index.RoleIndex;
-import io.camunda.webapps.schema.entities.usermanagement.RoleEntity;
 import io.camunda.webapps.schema.entities.usermanagement.RoleMemberEntity;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
@@ -44,7 +43,8 @@ public class RoleMemberRemovedHandler implements ExportHandler<RoleMemberEntity,
   @Override
   public List<String> generateIds(final Record<RoleRecordValue> record) {
     final RoleRecordValue value = record.getValue();
-    return List.of(RoleEntity.getChildKey(value.getRoleId(), value.getEntityId()));
+    return List.of(
+        RoleIndex.JOIN_RELATION_FACTORY.createChildId(value.getRoleId(), value.getEntityId()));
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/TenantCreateUpdateHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/TenantCreateUpdateHandler.java
@@ -46,7 +46,8 @@ public class TenantCreateUpdateHandler implements ExportHandler<TenantEntity, Te
 
   @Override
   public List<String> generateIds(final Record<TenantRecordValue> record) {
-    return List.of(record.getValue().getTenantId());
+    return List.of(
+        TenantIndex.JOIN_RELATION_FACTORY.createParentId(record.getValue().getTenantId()));
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/TenantDeletedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/TenantDeletedHandler.java
@@ -9,6 +9,7 @@ package io.camunda.exporter.handlers;
 
 import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.index.TenantIndex;
 import io.camunda.webapps.schema.entities.usermanagement.TenantEntity;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
@@ -44,7 +45,8 @@ public class TenantDeletedHandler implements ExportHandler<TenantEntity, TenantR
 
   @Override
   public List<String> generateIds(final Record<TenantRecordValue> record) {
-    return List.of(record.getValue().getTenantId());
+    return List.of(
+        TenantIndex.JOIN_RELATION_FACTORY.createParentId(record.getValue().getTenantId()));
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/TenantEntityAddedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/TenantEntityAddedHandler.java
@@ -45,7 +45,8 @@ public class TenantEntityAddedHandler
   public List<String> generateIds(final Record<TenantRecordValue> record) {
     final var tenantRecord = record.getValue();
     return List.of(
-        TenantMemberEntity.getChildKey(tenantRecord.getTenantId(), tenantRecord.getEntityId()));
+        TenantIndex.JOIN_RELATION_FACTORY.createChildId(
+            tenantRecord.getTenantId(), tenantRecord.getEntityId()));
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/TenantEntityRemovedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/TenantEntityRemovedHandler.java
@@ -46,7 +46,8 @@ public class TenantEntityRemovedHandler
   public List<String> generateIds(final Record<TenantRecordValue> record) {
     final var tenantRecord = record.getValue();
     return List.of(
-        TenantMemberEntity.getChildKey(tenantRecord.getTenantId(), tenantRecord.getEntityId()));
+        TenantIndex.JOIN_RELATION_FACTORY.createChildId(
+            tenantRecord.getTenantId(), tenantRecord.getEntityId()));
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/RoleMemberRemovedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/RoleMemberRemovedHandlerTest.java
@@ -61,7 +61,8 @@ public class RoleMemberRemovedHandlerTest {
     // then
     final var value = roleRecord.getValue();
     assertThat(idList)
-        .containsExactly(RoleMemberEntity.getChildKey(value.getRoleId(), value.getEntityId()));
+        .containsExactly(
+            RoleIndex.JOIN_RELATION_FACTORY.createChildId(value.getRoleId(), value.getEntityId()));
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/GroupCreatedUpdatedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/GroupCreatedUpdatedHandlerTest.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.verify;
 
 import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.index.GroupIndex;
 import io.camunda.webapps.schema.entities.usermanagement.GroupEntity;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
@@ -65,12 +66,14 @@ public class GroupCreatedUpdatedHandlerTest {
     // given
     final Record<GroupRecordValue> groupRecord =
         factory.generateRecordWithIntent(ValueType.GROUP, intent);
+    final String groupId = groupRecord.getValue().getGroupId();
+    final String uniqueExporterId = GroupIndex.JOIN_RELATION_FACTORY.createParentId(groupId);
 
     // when
     final var idList = underTest.generateIds(groupRecord);
 
     // then
-    assertThat(idList).containsExactly(String.valueOf(groupRecord.getValue().getGroupId()));
+    assertThat(idList).containsExactly(uniqueExporterId);
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/GroupDeletedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/GroupDeletedHandlerTest.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.verify;
 
 import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.index.GroupIndex;
 import io.camunda.webapps.schema.entities.usermanagement.GroupEntity;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
@@ -53,12 +54,14 @@ public class GroupDeletedHandlerTest {
     // given
     final Record<GroupRecordValue> groupRecord =
         factory.generateRecordWithIntent(ValueType.GROUP, GroupIntent.DELETED);
+    final String groupId = groupRecord.getValue().getGroupId();
+    final String uniqueExporterId = GroupIndex.JOIN_RELATION_FACTORY.createParentId(groupId);
 
     // when
     final var idList = underTest.generateIds(groupRecord);
 
     // then
-    assertThat(idList).containsExactly(String.valueOf(groupRecord.getValue().getGroupId()));
+    assertThat(idList).containsExactly(uniqueExporterId);
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/GroupEntityAddedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/GroupEntityAddedHandlerTest.java
@@ -62,7 +62,9 @@ public class GroupEntityAddedHandlerTest {
     // then
     final var value = groupRecord.getValue();
     assertThat(idList)
-        .containsExactly(GroupMemberEntity.getChildKey(value.getGroupId(), value.getEntityId()));
+        .containsExactly(
+            GroupIndex.JOIN_RELATION_FACTORY.createChildId(
+                value.getGroupId(), value.getEntityId()));
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/GroupEntityRemovedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/GroupEntityRemovedHandlerTest.java
@@ -62,7 +62,9 @@ public class GroupEntityRemovedHandlerTest {
     // then
     final var value = groupRecord.getValue();
     assertThat(idList)
-        .containsExactly(GroupMemberEntity.getChildKey(value.getGroupId(), value.getEntityId()));
+        .containsExactly(
+            GroupIndex.JOIN_RELATION_FACTORY.createChildId(
+                value.getGroupId(), value.getEntityId()));
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/RoleCreateUpdateHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/RoleCreateUpdateHandlerTest.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.verify;
 
 import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.index.RoleIndex;
 import io.camunda.webapps.schema.entities.usermanagement.RoleEntity;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
@@ -56,12 +57,14 @@ public class RoleCreateUpdateHandlerTest {
     // given
     final Record<RoleRecordValue> roleRecord =
         factory.generateRecordWithIntent(ValueType.ROLE, RoleIntent.CREATED);
+    final String roleId = roleRecord.getValue().getRoleId();
+    final String uniqueExporterId = RoleIndex.JOIN_RELATION_FACTORY.createParentId(roleId);
 
     // when
     final var idList = underTest.generateIds(roleRecord);
 
     // then
-    assertThat(idList).containsExactly(roleRecord.getValue().getRoleId());
+    assertThat(idList).containsExactly(uniqueExporterId);
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/RoleDeletedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/RoleDeletedHandlerTest.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.verify;
 
 import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.index.RoleIndex;
 import io.camunda.webapps.schema.entities.usermanagement.RoleEntity;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
@@ -52,12 +53,14 @@ public class RoleDeletedHandlerTest {
     // given
     final Record<RoleRecordValue> roleRecord =
         factory.generateRecordWithIntent(ValueType.ROLE, RoleIntent.DELETED);
+    final String roleId = roleRecord.getValue().getRoleId();
+    final String uniqueExporterId = RoleIndex.JOIN_RELATION_FACTORY.createParentId(roleId);
 
     // when
     final var idList = underTest.generateIds(roleRecord);
 
     // then
-    assertThat(idList).containsExactly(String.valueOf(roleRecord.getValue().getRoleId()));
+    assertThat(idList).containsExactly(uniqueExporterId);
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/RoleMemberAddedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/RoleMemberAddedHandlerTest.java
@@ -60,7 +60,8 @@ public class RoleMemberAddedHandlerTest {
     // then
     final var value = roleRecord.getValue();
     assertThat(idList)
-        .containsExactly(RoleMemberEntity.getChildKey(value.getRoleId(), value.getEntityId()));
+        .containsExactly(
+            RoleIndex.JOIN_RELATION_FACTORY.createChildId(value.getRoleId(), value.getEntityId()));
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/TenantCreateUpdateHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/TenantCreateUpdateHandlerTest.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.verify;
 
 import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.index.TenantIndex;
 import io.camunda.webapps.schema.entities.usermanagement.TenantEntity;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
@@ -56,12 +57,14 @@ public class TenantCreateUpdateHandlerTest {
     // given
     final Record<TenantRecordValue> tenantRecord =
         factory.generateRecordWithIntent(ValueType.TENANT, TenantIntent.CREATED);
+    final String tenantId = tenantRecord.getValue().getTenantId();
+    final String uniqueExporterId = TenantIndex.JOIN_RELATION_FACTORY.createParentId(tenantId);
 
     // when
     final var idList = underTest.generateIds(tenantRecord);
 
     // then
-    assertThat(idList).containsExactly(tenantRecord.getValue().getTenantId());
+    assertThat(idList).containsExactly(uniqueExporterId);
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/TenantDeletedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/TenantDeletedHandlerTest.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.verify;
 
 import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.index.TenantIndex;
 import io.camunda.webapps.schema.entities.usermanagement.TenantEntity;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
@@ -52,12 +53,14 @@ public class TenantDeletedHandlerTest {
     // given
     final Record<TenantRecordValue> tenantRecord =
         factory.generateRecordWithIntent(ValueType.TENANT, TenantIntent.DELETED);
+    final String tenantId = tenantRecord.getValue().getTenantId();
+    final String uniqueExporterId = TenantIndex.JOIN_RELATION_FACTORY.createParentId(tenantId);
 
     // when
     final var idList = underTest.generateIds(tenantRecord);
 
     // then
-    assertThat(idList).containsExactly(String.valueOf(tenantRecord.getValue().getTenantId()));
+    assertThat(idList).containsExactly(uniqueExporterId);
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/TenantEntityAddedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/TenantEntityAddedHandlerTest.java
@@ -59,7 +59,9 @@ public class TenantEntityAddedHandlerTest {
     // then
     final var value = tenantRecord.getValue();
     assertThat(idList)
-        .containsExactly(TenantMemberEntity.getChildKey(value.getTenantId(), value.getEntityId()));
+        .containsExactly(
+            TenantIndex.JOIN_RELATION_FACTORY.createChildId(
+                value.getTenantId(), value.getEntityId()));
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/TenantEntityRemovedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/TenantEntityRemovedHandlerTest.java
@@ -61,7 +61,9 @@ public class TenantEntityRemovedHandlerTest {
     // then
     final var value = tenantRecord.getValue();
     assertThat(idList)
-        .containsExactly(TenantMemberEntity.getChildKey(value.getTenantId(), value.getEntityId()));
+        .containsExactly(
+            TenantIndex.JOIN_RELATION_FACTORY.createChildId(
+                value.getTenantId(), value.getEntityId()));
   }
 
   @Test


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Ensure that Identity-related IDs provided by users are unique when persisted to secondary storage.

ℹ️ Note: I didn't add any new tests for this change as we extensively test the Tenant, Role, and Group APIs in the QA acceptance tests suite. Both retrieval by ID, as well as searching member entities are tested.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #32252
