### PR TITLE
fix: add scalingPosition to declaredProperties

### DIFF
--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/scaling/ScaleRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/scaling/ScaleRecord.java
@@ -36,11 +36,12 @@ public class ScaleRecord extends UnifiedRecordValue implements ScaleRecordValue 
   private final LongProperty scalingPosition = new LongProperty("scalingPosition", -1L);
 
   public ScaleRecord() {
-    super(4);
+    super(5);
     declareProperty(desiredPartitionCountProp)
         .declareProperty(redistributedPartitions)
         .declareProperty(relocatedPartitions)
-        .declareProperty(bootstrappedAt);
+        .declareProperty(bootstrappedAt)
+        .declareProperty(scalingPosition);
   }
 
   @Override


### PR DESCRIPTION
## Description
in `ScaleRecord` `scalingPosition` was not included in the `declaredProperties`

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [X] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
