### PR TITLE
[Backport stable/8.7] ci: Add timeout for tasklist-ci-test-reusable

### DIFF
--- a/.github/workflows/tasklist-ci-test-reusable.yml
+++ b/.github/workflows/tasklist-ci-test-reusable.yml
@@ -41,6 +41,7 @@ jobs:
   integration-tests:
     name: Test
     runs-on: gcp-perf-core-16-default
+    timeout-minutes: 40
     if: ${{ !startsWith(inputs.branch, 'fe-') && !startsWith(inputs.branch, 'renovate/') }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
# Description
Backport of #34582 to `stable/8.7`.

relates to 