### PR TITLE
fix: fix css transition component warning

### DIFF
--- a/operate/client/src/App/ProcessInstance/IncidentsWrapper/IncidentsOverlay/index.tsx
+++ b/operate/client/src/App/ProcessInstance/IncidentsWrapper/IncidentsOverlay/index.tsx
@@ -10,11 +10,17 @@ import React from 'react';
 import {Overlay} from './styled';
 
 type Props = {
-  children?: React.ReactNode | React.ReactNode[];
+  children?: React.ReactNode;
 };
 
-const IncidentsOverlay: React.FC<Props> = (props) => {
-  return <Overlay {...props}>{props.children}</Overlay>;
-};
+const IncidentsOverlay = React.forwardRef<HTMLDivElement, Props>(
+  (props, ref) => {
+    return (
+      <Overlay ref={ref} {...props}>
+        {props.children}
+      </Overlay>
+    );
+  },
+);
 
 export {IncidentsOverlay};

--- a/operate/client/src/modules/components/Transition/index.tsx
+++ b/operate/client/src/modules/components/Transition/index.tsx
@@ -6,17 +6,21 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import React, {Children} from 'react';
+import React, {Children, useRef} from 'react';
 import {CSSTransition, TransitionGroup} from 'react-transition-group';
 
 type Props = {
-  children: React.ReactNode;
+  children: React.ReactElement;
 } & React.ComponentProps<typeof CSSTransition>;
 
-const Transition: React.FC<Props> = (props) => {
+const Transition: React.FC<Props> = ({children, ...props}) => {
+  const nodeRef = useRef<HTMLDivElement | null>(null);
+
   return (
-    <CSSTransition classNames="transition" {...props}>
-      {Children.only(props.children)}
+    <CSSTransition classNames="transition" nodeRef={nodeRef} {...props}>
+      {React.cloneElement(Children.only(children), {
+        ref: nodeRef,
+      })}
     </CSSTransition>
   );
 };


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Fixes the warning below

![image](https://github.com/user-attachments/assets/d83f23d1-f429-4a8b-af5f-8f962d678e1e)

