### PR TITLE
[Backport release-8.8.0-alpha6] fix: add scalingPosition to declaredProperties

### DIFF
--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/scaling/ScaleRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/scaling/ScaleRecord.java
@@ -36,11 +36,12 @@ public class ScaleRecord extends UnifiedRecordValue implements ScaleRecordValue 
   private final LongProperty scalingPosition = new LongProperty("scalingPosition", -1L);
 
   public ScaleRecord() {
-    super(4);
+    super(5);
     declareProperty(desiredPartitionCountProp)
         .declareProperty(redistributedPartitions)
         .declareProperty(relocatedPartitions)
-        .declareProperty(bootstrappedAt);
+        .declareProperty(bootstrappedAt)
+        .declareProperty(scalingPosition);
   }
 
   @Override


### PR DESCRIPTION
# Description
Backport of #34642 to `release-8.8.0-alpha6`.

relates to 