### PR TITLE
[Backport stable/8.7] feat(34483): Use inputs.isLatest for marking release as latest in camunda-platform-release.yml

### DIFF
--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -333,6 +333,7 @@ jobs:
           artifacts: "release-artifacts/*"
           artifactErrorsFailBuild: true
           draft: ${{ steps.gen-changelog.outputs.isDraftRelease }}
+          makeLatest: ${{ inputs.isLatest }}
           body: ${{ steps.gen-changelog.outputs.changelog }}
           token: ${{ secrets.GITHUB_TOKEN }}
           prerelease: ${{ steps.pre-release.outputs.result }}


### PR DESCRIPTION
# Description
Backport of #34509 to `stable/8.7`.

relates to camunda/camunda#34483