### PR TITLE
chore: remove unnecessary properties from rdbms mapper files

### DIFF
--- a/db/rdbms/src/main/resources/mapper/AuthorizationsMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/AuthorizationsMapper.xml
@@ -88,8 +88,7 @@
     </collection>
   </resultMap>
 
-  <insert id="insert" parameterType="io.camunda.db.rdbms.write.domain.AuthorizationDbModel"
-    flushCache="true">
+  <insert id="insert" parameterType="io.camunda.db.rdbms.write.domain.AuthorizationDbModel">
     INSERT INTO ${prefix}AUTHORIZATIONS (AUTHORIZATION_KEY, OWNER_ID, OWNER_TYPE, RESOURCE_TYPE, RESOURCE_ID, PERMISSION_TYPE)
     VALUES
     <foreach collection="permissionTypes" item="permissionType" separator=",">
@@ -97,8 +96,7 @@
     </foreach>
   </insert>
 
-  <delete id="delete" parameterType="io.camunda.db.rdbms.write.domain.AuthorizationDbModel"
-    flushCache="true">
+  <delete id="delete" parameterType="io.camunda.db.rdbms.write.domain.AuthorizationDbModel">
     DELETE
     FROM ${prefix}AUTHORIZATIONS
     WHERE AUTHORIZATION_KEY = #{authorizationKey}

--- a/db/rdbms/src/main/resources/mapper/BatchOperationMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/BatchOperationMapper.xml
@@ -116,8 +116,7 @@
 
   <select id="search"
     parameterType="io.camunda.db.rdbms.read.domain.BatchOperationDbQuery"
-    resultMap="BatchOperationResultMap"
-    statementType="PREPARED">
+    resultMap="BatchOperationResultMap">
 
   SELECT * FROM (
     SELECT
@@ -171,8 +170,7 @@
 
   <select id="searchItems"
     parameterType="io.camunda.db.rdbms.read.domain.BatchOperationItemDbQuery"
-    resultMap="BatchOperationItemResultMap"
-    statementType="PREPARED">
+    resultMap="BatchOperationItemResultMap">
 
     SELECT * FROM (
     SELECT BATCH_OPERATION_ID, ITEM_KEY, PROCESS_INSTANCE_KEY, STATE, PROCESSED_DATE, ERROR_MESSAGE

--- a/db/rdbms/src/main/resources/mapper/DecisionDefinitionMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/DecisionDefinitionMapper.xml
@@ -92,10 +92,7 @@
     </constructor>
   </resultMap>
 
-  <insert
-    id="insert"
-    parameterType="io.camunda.db.rdbms.write.domain.DecisionDefinitionDbModel"
-    flushCache="true">
+  <insert id="insert" parameterType="io.camunda.db.rdbms.write.domain.DecisionDefinitionDbModel">
     INSERT INTO ${prefix}DECISION_DEFINITION (DECISION_DEFINITION_KEY, DECISION_DEFINITION_ID, NAME, TENANT_ID, VERSION, DECISION_REQUIREMENTS_ID, DECISION_REQUIREMENTS_KEY)
     VALUES (#{decisionDefinitionKey}, #{decisionDefinitionId}, #{name},
             #{tenantId}, #{version}, #{decisionRequirementsId}, #{decisionRequirementsKey})

--- a/db/rdbms/src/main/resources/mapper/DecisionInstanceMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/DecisionInstanceMapper.xml
@@ -173,10 +173,7 @@
     </constructor>
   </resultMap>
 
-  <insert
-    id="insert"
-    parameterType="io.camunda.db.rdbms.write.domain.DecisionInstanceDbModel"
-    flushCache="true">
+  <insert id="insert" parameterType="io.camunda.db.rdbms.write.domain.DecisionInstanceDbModel">
     INSERT INTO ${prefix}DECISION_INSTANCE (DECISION_INSTANCE_ID,
                                    DECISION_INSTANCE_KEY,
                                    PROCESS_INSTANCE_KEY,
@@ -210,10 +207,7 @@
             #{historyCleanupDate, jdbcType=TIMESTAMP})
   </insert>
 
-  <insert
-    id="insertInput"
-    parameterType="io.camunda.db.rdbms.write.domain.DecisionInstanceDbModel"
-    flushCache="true">
+  <insert id="insertInput" parameterType="io.camunda.db.rdbms.write.domain.DecisionInstanceDbModel">
     INSERT INTO ${prefix}DECISION_INSTANCE_INPUT (DECISION_INSTANCE_ID, INPUT_ID, INPUT_NAME,
     INPUT_VALUE)
     VALUES
@@ -245,10 +239,8 @@
     </constructor>
   </resultMap>
 
-  <insert
-    id="insertOutput"
-    parameterType="io.camunda.db.rdbms.write.domain.DecisionInstanceDbModel"
-    flushCache="true">
+  <insert id="insertOutput"
+    parameterType="io.camunda.db.rdbms.write.domain.DecisionInstanceDbModel">
     INSERT INTO ${prefix}DECISION_INSTANCE_OUTPUT
     (DECISION_INSTANCE_ID, OUTPUT_ID, OUTPUT_NAME, OUTPUT_VALUE, RULE_ID, RULE_INDEX) VALUES
     <foreach collection="evaluatedOutputs" item="item" separator=", ">
@@ -283,19 +275,13 @@
     </constructor>
   </resultMap>
 
-  <update
-    flushCache="true"
-    id="updateHistoryCleanupDate"
-    statementType="PREPARED">
+  <update id="updateHistoryCleanupDate">
     UPDATE ${prefix}DECISION_INSTANCE
     SET HISTORY_CLEANUP_DATE = #{historyCleanupDate, jdbcType=TIMESTAMP}
     WHERE PROCESS_INSTANCE_KEY = #{processInstanceKey}
   </update>
 
-  <delete
-    flushCache="true"
-    id="cleanupHistory"
-    statementType="PREPARED">
+  <delete id="cleanupHistory">
     <bind name="tableName" value="'DECISION_INSTANCE'"/>
     <include refid="io.camunda.db.rdbms.sql.Commons.historyCleanup"/>
   </delete>

--- a/db/rdbms/src/main/resources/mapper/DecisionRequirementsMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/DecisionRequirementsMapper.xml
@@ -87,10 +87,7 @@
     </constructor>
   </resultMap>
 
-  <insert
-    id="insert"
-    parameterType="io.camunda.db.rdbms.write.domain.DecisionRequirementsDbModel"
-    flushCache="true">
+  <insert id="insert" parameterType="io.camunda.db.rdbms.write.domain.DecisionRequirementsDbModel">
     INSERT INTO ${prefix}DECISION_REQUIREMENTS (DECISION_REQUIREMENTS_KEY, DECISION_REQUIREMENTS_ID,
                                                 NAME, TENANT_ID, VERSION, RESOURCE_NAME, XML)
     VALUES (#{decisionRequirementsKey}, #{decisionRequirementsId}, #{name},

--- a/db/rdbms/src/main/resources/mapper/ExporterPositionMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/ExporterPositionMapper.xml
@@ -10,7 +10,6 @@
 <mapper namespace="io.camunda.db.rdbms.sql.ExporterPositionMapper">
 
   <select id="findOne"
-    statementType="PREPARED"
     parameterType="java.lang.Integer"
     resultType="io.camunda.db.rdbms.write.domain.ExporterPositionModel">
       SELECT
@@ -24,18 +23,12 @@
       WHERE PARTITION_ID = #{partitionId}
   </select>
 
-  <insert
-    id="insert"
-    statementType="PREPARED"
-    parameterType="io.camunda.db.rdbms.write.domain.ExporterPositionModel">
+  <insert id="insert" parameterType="io.camunda.db.rdbms.write.domain.ExporterPositionModel">
       INSERT INTO ${prefix}EXPORTER_POSITION (PARTITION_ID, EXPORTER, LAST_EXPORTED_POSITION, CREATED, LAST_UPDATED)
       VALUES (#{partitionId}, #{exporter}, #{lastExportedPosition}, #{created}, #{lastUpdated})
   </insert>
 
-  <update
-    id="update"
-    statementType="PREPARED"
-    parameterType="io.camunda.db.rdbms.write.domain.ExporterPositionModel">
+  <update id="update" parameterType="io.camunda.db.rdbms.write.domain.ExporterPositionModel">
       UPDATE ${prefix}EXPORTER_POSITION
       SET LAST_EXPORTED_POSITION = #{lastExportedPosition}, LAST_UPDATED = #{lastUpdated}
       WHERE PARTITION_ID = #{partitionId}

--- a/db/rdbms/src/main/resources/mapper/FlowNodeInstanceMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/FlowNodeInstanceMapper.xml
@@ -138,10 +138,7 @@
     </constructor>
   </resultMap>
 
-  <insert
-    id="insert"
-    parameterType="io.camunda.db.rdbms.write.domain.FlowNodeInstanceDbModel"
-    flushCache="true">
+  <insert id="insert" parameterType="io.camunda.db.rdbms.write.domain.FlowNodeInstanceDbModel">
     INSERT INTO ${prefix}FLOW_NODE_INSTANCE (FLOW_NODE_INSTANCE_KEY, FLOW_NODE_ID, FLOW_NODE_NAME, PROCESS_INSTANCE_KEY,
                                     PROCESS_DEFINITION_ID, PROCESS_DEFINITION_KEY, TYPE, STATE,
                                              START_DATE, END_DATE, TENANT_ID, TREE_PATH,
@@ -152,10 +149,7 @@
             #{treePath}, #{incidentKey}, #{numSubprocessIncidents}, #{partitionId}, #{historyCleanupDate, jdbcType=TIMESTAMP})
   </insert>
 
-  <update
-    id="update"
-    parameterType="io.camunda.db.rdbms.write.domain.FlowNodeInstanceDbModel"
-    flushCache="true">
+  <update id="update" parameterType="io.camunda.db.rdbms.write.domain.FlowNodeInstanceDbModel">
     UPDATE FLOW_NODE_INSTANCE
     SET FLOW_NODE_ID             = #{flowNodeId},
         FLOW_NODE_NAME           = #{flowNodeName},
@@ -171,60 +165,40 @@
     WHERE FLOW_NODE_INSTANCE_KEY = #{flowNodeInstanceKey}
   </update>
 
-  <update
-    id="updateStateAndEndDate"
-    statementType="PREPARED"
-    parameterType="io.camunda.db.rdbms.sql.FlowNodeInstanceMapper$EndFlowNodeDto"
-    flushCache="true">
+  <update id="updateStateAndEndDate"
+    parameterType="io.camunda.db.rdbms.sql.FlowNodeInstanceMapper$EndFlowNodeDto">
     UPDATE ${prefix}FLOW_NODE_INSTANCE
     SET STATE = #{state},
         END_DATE = #{endDate}
     WHERE FLOW_NODE_INSTANCE_KEY = #{flowNodeInstanceKey}
   </update>
 
-  <update
-    id="updateIncident"
-    statementType="PREPARED"
-    parameterType="io.camunda.db.rdbms.sql.FlowNodeInstanceMapper$UpdateIncidentDto"
-    flushCache="true">
+  <update id="updateIncident"
+    parameterType="io.camunda.db.rdbms.sql.FlowNodeInstanceMapper$UpdateIncidentDto">
     UPDATE ${prefix}FLOW_NODE_INSTANCE
     SET INCIDENT_KEY = #{incidentKey}
     WHERE FLOW_NODE_INSTANCE_KEY = #{flowNodeInstanceKey}
   </update>
 
-  <update
-    id="incrementSubprocessIncidentCount"
-    statementType="PREPARED"
-    parameterType="java.lang.Long"
-    flushCache="true">
+  <update id="incrementSubprocessIncidentCount" parameterType="java.lang.Long">
     UPDATE ${prefix}FLOW_NODE_INSTANCE
     SET NUM_SUBPROCESS_INCIDENTS = NUM_SUBPROCESS_INCIDENTS + 1
     WHERE FLOW_NODE_INSTANCE_KEY = #{flowNodeInstanceKey}
   </update>
 
-  <update
-    id="decrementSubprocessIncidentCount"
-    statementType="PREPARED"
-    parameterType="java.lang.Long"
-    flushCache="true">
+  <update id="decrementSubprocessIncidentCount" parameterType="java.lang.Long">
     UPDATE ${prefix}FLOW_NODE_INSTANCE
     SET NUM_SUBPROCESS_INCIDENTS = NUM_SUBPROCESS_INCIDENTS - 1
     WHERE FLOW_NODE_INSTANCE_KEY = #{flowNodeInstanceKey}
   </update>
 
-  <update
-    flushCache="true"
-    id="updateHistoryCleanupDate"
-    statementType="PREPARED">
+  <update id="updateHistoryCleanupDate">
     UPDATE ${prefix}FLOW_NODE_INSTANCE SET
       HISTORY_CLEANUP_DATE = #{historyCleanupDate, jdbcType=TIMESTAMP}
     WHERE PROCESS_INSTANCE_KEY = #{processInstanceKey}
   </update>
 
-  <delete
-    flushCache="true"
-    id="cleanupHistory"
-    statementType="PREPARED">
+  <delete id="cleanupHistory">
     <bind name="tableName" value="'FLOW_NODE_INSTANCE'"/>
     <include refid="io.camunda.db.rdbms.sql.Commons.historyCleanup"/>
   </delete>

--- a/db/rdbms/src/main/resources/mapper/GroupMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/GroupMapper.xml
@@ -76,42 +76,30 @@
     </collection>
   </resultMap>
 
-  <insert
-    id="insert"
-    parameterType="io.camunda.db.rdbms.write.domain.GroupDbModel"
-    flushCache="true">
+  <insert id="insert" parameterType="io.camunda.db.rdbms.write.domain.GroupDbModel">
     INSERT INTO ${prefix}GROUPS (GROUP_KEY, GROUP_ID, NAME, DESCRIPTION)
     VALUES (#{groupKey}, #{groupId}, #{name}, #{description})
   </insert>
 
-  <update
-    id="update"
-    parameterType="io.camunda.db.rdbms.write.domain.GroupDbModel"
-    flushCache="true">
+  <update id="update" parameterType="io.camunda.db.rdbms.write.domain.GroupDbModel">
     UPDATE ${prefix}GROUPS SET
                     NAME = #{name},
                     DESCRIPTION = #{description}
     WHERE GROUP_ID = #{groupId}
   </update>
 
-  <delete id="delete" parameterType="java.lang.String" flushCache="true">
+  <delete id="delete" parameterType="java.lang.String">
     DELETE
     FROM ${prefix}GROUPS
     WHERE GROUP_ID = #{groupId}
   </delete>
 
-  <insert
-    id="insertMember"
-    parameterType="io.camunda.db.rdbms.write.domain.GroupMemberDbModel"
-    flushCache="true">
+  <insert id="insertMember" parameterType="io.camunda.db.rdbms.write.domain.GroupMemberDbModel">
     INSERT INTO ${prefix}GROUP_MEMBER (GROUP_ID, ENTITY_ID, ENTITY_TYPE)
     VALUES (#{groupId}, #{entityId}, #{entityType})
   </insert>
 
-  <delete
-    id="deleteMember"
-    parameterType="io.camunda.db.rdbms.write.domain.GroupMemberDbModel"
-    flushCache="true">
+  <delete id="deleteMember" parameterType="io.camunda.db.rdbms.write.domain.GroupMemberDbModel">
     DELETE
     FROM ${prefix}GROUP_MEMBER
     WHERE GROUP_ID = #{groupId}

--- a/db/rdbms/src/main/resources/mapper/IncidentMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/IncidentMapper.xml
@@ -145,10 +145,7 @@
 
   </resultMap>
 
-  <insert
-    id="insert"
-    parameterType="io.camunda.db.rdbms.write.domain.IncidentDbModel"
-    flushCache="true">
+  <insert id="insert" parameterType="io.camunda.db.rdbms.write.domain.IncidentDbModel">
     INSERT INTO ${prefix}INCIDENT (INCIDENT_KEY,
                           FLOW_NODE_INSTANCE_KEY,
                           FLOW_NODE_ID,
@@ -171,11 +168,7 @@
             #{historyCleanupDate, jdbcType=TIMESTAMP})
   </insert>
 
-  <update
-    id="update"
-    statementType="PREPARED"
-    parameterType="io.camunda.db.rdbms.write.domain.IncidentDbModel"
-    flushCache="true">
+  <update id="update" parameterType="io.camunda.db.rdbms.write.domain.IncidentDbModel">
     UPDATE INCIDENT
     SET FLOW_NODE_INSTANCE_KEY = #{flowNodeInstanceKey},
         FLOW_NODE_ID           = #{flowNodeId},
@@ -194,11 +187,7 @@
     WHERE INCIDENT_KEY = #{incidentKey}
   </update>
 
-  <update
-    id="updateState"
-    statementType="PREPARED"
-    parameterType="io.camunda.db.rdbms.sql.IncidentMapper$IncidentStateDto"
-    flushCache="true">
+  <update id="updateState" parameterType="io.camunda.db.rdbms.sql.IncidentMapper$IncidentStateDto">
     UPDATE ${prefix}INCIDENT i
     SET STATE         = #{state},
         ERROR_MESSAGE = #{errorMessage},
@@ -206,19 +195,13 @@
     WHERE INCIDENT_KEY = #{incidentKey}
   </update>
 
-  <update
-    flushCache="true"
-    id="updateHistoryCleanupDate"
-    statementType="PREPARED">
+  <update id="updateHistoryCleanupDate">
     UPDATE ${prefix}INCIDENT SET
       HISTORY_CLEANUP_DATE = #{historyCleanupDate, jdbcType=TIMESTAMP}
     WHERE PROCESS_INSTANCE_KEY = #{processInstanceKey}
   </update>
 
-  <delete
-    flushCache="true"
-    id="cleanupHistory"
-    statementType="PREPARED">
+  <delete id="cleanupHistory">
     <bind name="tableName" value="'INCIDENT'"/>
     <include refid="io.camunda.db.rdbms.sql.Commons.historyCleanup"/>
   </delete>

--- a/db/rdbms/src/main/resources/mapper/JobMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/JobMapper.xml
@@ -27,19 +27,13 @@
     WHERE JOB_KEY = #{jobKey}
   </update>
 
-  <update
-    flushCache="true"
-    id="updateHistoryCleanupDate"
-    statementType="PREPARED">
+  <update id="updateHistoryCleanupDate">
     UPDATE ${prefix}JOB SET
       HISTORY_CLEANUP_DATE = #{historyCleanupDate, jdbcType=TIMESTAMP}
     WHERE PROCESS_INSTANCE_KEY = #{processInstanceKey}
   </update>
 
-  <delete
-    flushCache="true"
-    id="cleanupHistory"
-    statementType="PREPARED">
+  <delete id="cleanupHistory">
     <bind name="tableName" value="'JOB'"/>
     <include refid="io.camunda.db.rdbms.sql.Commons.historyCleanup"/>
   </delete>

--- a/db/rdbms/src/main/resources/mapper/ProcessDefinitionMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/ProcessDefinitionMapper.xml
@@ -271,10 +271,7 @@
     </trim>
   </sql>
 
-  <insert
-    id="insert"
-    parameterType="io.camunda.db.rdbms.write.domain.ProcessDefinitionDbModel"
-    flushCache="true">
+  <insert id="insert" parameterType="io.camunda.db.rdbms.write.domain.ProcessDefinitionDbModel">
     INSERT INTO ${prefix}PROCESS_DEFINITION (PROCESS_DEFINITION_KEY, PROCESS_DEFINITION_ID, RESOURCE_NAME,
                                     BPMN_XML, NAME, TENANT_ID, VERSION_TAG, VERSION, FORM_ID)
     VALUES (#{processDefinitionKey}, #{processDefinitionId}, #{resourceName}, #{bpmnXml}, #{name},

--- a/db/rdbms/src/main/resources/mapper/ProcessInstanceMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/ProcessInstanceMapper.xml
@@ -45,7 +45,8 @@
   </select>
 
   <!-- default search statement for databases supporting LIMIT/OFFSET-->
-  <select id="search" parameterType="io.camunda.db.rdbms.read.domain.ProcessInstanceDbQuery" resultMap="io.camunda.db.rdbms.sql.ProcessInstanceMapper.searchResultMap">
+  <select id="search" parameterType="io.camunda.db.rdbms.read.domain.ProcessInstanceDbQuery"
+    resultMap="io.camunda.db.rdbms.sql.ProcessInstanceMapper.searchResultMap">
     SELECT * FROM (
     SELECT
     pi.PROCESS_INSTANCE_KEY,
@@ -292,20 +293,21 @@
     GROUP BY fni.FLOW_NODE_ID
   </select>
 
-  <insert
-    id="insert"
-    parameterType="io.camunda.db.rdbms.write.domain.ProcessInstanceDbModel"
-    flushCache="true">
-    INSERT INTO ${prefix}PROCESS_INSTANCE (PROCESS_INSTANCE_KEY, PROCESS_DEFINITION_ID, PROCESS_DEFINITION_KEY, STATE, START_DATE, END_DATE, TENANT_ID, PARENT_PROCESS_INSTANCE_KEY, PARENT_ELEMENT_INSTANCE_KEY,
-                                           NUM_INCIDENTS, VERSION, PARTITION_ID, TREE_PATH, HISTORY_CLEANUP_DATE)
-    VALUES (#{processInstanceKey}, #{processDefinitionId}, #{processDefinitionKey}, #{state}, #{startDate, jdbcType=TIMESTAMP}, #{endDate, jdbcType=TIMESTAMP}, #{tenantId}, #{parentProcessInstanceKey},
-            #{parentElementInstanceKey}, #{numIncidents}, #{version}, #{partitionId}, #{treePath}, #{historyCleanupDate, jdbcType=TIMESTAMP})
+  <insert id="insert" parameterType="io.camunda.db.rdbms.write.domain.ProcessInstanceDbModel">
+    INSERT INTO ${prefix}PROCESS_INSTANCE (PROCESS_INSTANCE_KEY, PROCESS_DEFINITION_ID,
+                                           PROCESS_DEFINITION_KEY, STATE, START_DATE, END_DATE,
+                                           TENANT_ID, PARENT_PROCESS_INSTANCE_KEY,
+                                           PARENT_ELEMENT_INSTANCE_KEY,
+                                           NUM_INCIDENTS, VERSION, PARTITION_ID, TREE_PATH,
+                                           HISTORY_CLEANUP_DATE)
+    VALUES (#{processInstanceKey}, #{processDefinitionId}, #{processDefinitionKey}, #{state},
+            #{startDate, jdbcType=TIMESTAMP}, #{endDate, jdbcType=TIMESTAMP}, #{tenantId},
+            #{parentProcessInstanceKey},
+            #{parentElementInstanceKey}, #{numIncidents}, #{version}, #{partitionId}, #{treePath},
+            #{historyCleanupDate, jdbcType=TIMESTAMP})
   </insert>
 
-  <update
-    id="update"
-    parameterType="io.camunda.db.rdbms.write.domain.ProcessInstanceDbModel"
-    flushCache="true">
+  <update id="update" parameterType="io.camunda.db.rdbms.write.domain.ProcessInstanceDbModel">
     UPDATE PROCESS_INSTANCE
     SET PROCESS_DEFINITION_ID       = #{processDefinitionId},
         PROCESS_DEFINITION_KEY      = #{processDefinitionKey},
@@ -322,50 +324,33 @@
     WHERE PROCESS_INSTANCE_KEY = #{processInstanceKey}
   </update>
 
-  <update
-    id="updateStateAndEndDate"
-    statementType="PREPARED"
-    parameterType="io.camunda.db.rdbms.sql.ProcessInstanceMapper$EndProcessInstanceDto"
-    flushCache="true">
+  <update id="updateStateAndEndDate"
+    parameterType="io.camunda.db.rdbms.sql.ProcessInstanceMapper$EndProcessInstanceDto">
     UPDATE ${prefix}PROCESS_INSTANCE p
     SET STATE    = #{state},
         END_DATE = #{endDate}
     WHERE PROCESS_INSTANCE_KEY = #{processInstanceKey}
   </update>
 
-  <update
-    id="incrementIncidentCount"
-    statementType="PREPARED"
-    parameterType="java.lang.Long"
-    flushCache="true">
+  <update id="incrementIncidentCount" parameterType="java.lang.Long">
     UPDATE ${prefix}PROCESS_INSTANCE
     SET NUM_INCIDENTS = NUM_INCIDENTS + 1
     WHERE PROCESS_INSTANCE_KEY = #{id}
   </update>
 
-  <update
-    id="decrementIncidentCount"
-    statementType="PREPARED"
-    parameterType="java.lang.Long"
-    flushCache="true">
+  <update id="decrementIncidentCount" parameterType="java.lang.Long">
     UPDATE ${prefix}PROCESS_INSTANCE
     SET NUM_INCIDENTS = NUM_INCIDENTS - 1
     WHERE PROCESS_INSTANCE_KEY = #{id}
   </update>
 
-  <update
-    flushCache="true"
-    id="updateHistoryCleanupDate"
-    statementType="PREPARED">
-    UPDATE ${prefix}PROCESS_INSTANCE SET
-      HISTORY_CLEANUP_DATE = #{historyCleanupDate, jdbcType=TIMESTAMP}
+  <update id="updateHistoryCleanupDate">
+    UPDATE ${prefix}PROCESS_INSTANCE
+    SET HISTORY_CLEANUP_DATE = #{historyCleanupDate, jdbcType=TIMESTAMP}
     WHERE PROCESS_INSTANCE_KEY = #{processInstanceKey}
   </update>
 
-  <delete
-    flushCache="true"
-    id="cleanupHistory"
-    statementType="PREPARED">
+  <delete id="cleanupHistory">
     <bind name="tableName" value="'PROCESS_INSTANCE'"/>
     <include refid="io.camunda.db.rdbms.sql.Commons.historyCleanup"/>
   </delete>

--- a/db/rdbms/src/main/resources/mapper/RoleMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/RoleMapper.xml
@@ -77,42 +77,30 @@
     </collection>
   </resultMap>
 
-  <insert
-    id="insert"
-    parameterType="io.camunda.db.rdbms.write.domain.RoleDbModel"
-    flushCache="true">
+  <insert id="insert" parameterType="io.camunda.db.rdbms.write.domain.RoleDbModel">
     INSERT INTO ${prefix}ROLES (ROLE_KEY, ROLE_ID, NAME, DESCRIPTION)
     VALUES (#{roleKey}, #{roleId}, #{name}, #{description})
   </insert>
 
-  <update
-    id="update"
-    parameterType="io.camunda.db.rdbms.write.domain.RoleDbModel"
-    flushCache="true">
+  <update id="update" parameterType="io.camunda.db.rdbms.write.domain.RoleDbModel">
     UPDATE ${prefix}ROLES
     SET NAME = #{name},
         DESCRIPTION = #{description}
     WHERE ROLE_ID = #{roleId}
   </update>
 
-  <delete id="delete" parameterType="java.lang.String" flushCache="true">
+  <delete id="delete" parameterType="java.lang.String">
     DELETE
     FROM ${prefix}ROLES
     WHERE ROLE_ID = #{roleId}
   </delete>
 
-  <insert
-    id="insertMember"
-    parameterType="io.camunda.db.rdbms.write.domain.RoleMemberDbModel"
-    flushCache="true">
+  <insert id="insertMember" parameterType="io.camunda.db.rdbms.write.domain.RoleMemberDbModel">
     INSERT INTO ${prefix}ROLE_MEMBER (ROLE_ID, ENTITY_ID, ENTITY_TYPE)
     VALUES (#{roleId}, #{entityId}, #{entityType})
   </insert>
 
-  <delete
-    id="deleteMember"
-    parameterType="io.camunda.db.rdbms.write.domain.RoleMemberDbModel"
-    flushCache="true">
+  <delete id="deleteMember" parameterType="io.camunda.db.rdbms.write.domain.RoleMemberDbModel">
     DELETE
     FROM ${prefix}ROLE_MEMBER
     WHERE ROLE_ID = #{roleId}

--- a/db/rdbms/src/main/resources/mapper/SequenceFlowMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/SequenceFlowMapper.xml
@@ -23,8 +23,7 @@
 
   <select id="search"
     parameterType="io.camunda.search.query.SequenceFlowQuery"
-    resultMap="SequenceFlowResultMap"
-    statementType="PREPARED">
+    resultMap="SequenceFlowResultMap">
     SELECT distinct
       sf.FLOW_NODE_ID,
       sf.PROCESS_INSTANCE_KEY,
@@ -52,7 +51,8 @@
             #{historyCleanupDate, jdbcType=TIMESTAMP})
   </insert>
 
-  <insert id="createIfNotExists" parameterType="io.camunda.db.rdbms.write.domain.SequenceFlowDbModel" databaseId="postgresql">
+  <insert id="createIfNotExists"
+    parameterType="io.camunda.db.rdbms.write.domain.SequenceFlowDbModel" databaseId="postgresql">
     INSERT INTO ${prefix}SEQUENCE_FLOW (FLOW_NODE_ID,
                                         PROCESS_INSTANCE_KEY,
                                         PROCESS_DEFINITION_KEY,
@@ -70,7 +70,8 @@
     ON CONFLICT DO NOTHING
   </insert>
 
-  <insert id="createIfNotExists" parameterType="io.camunda.db.rdbms.write.domain.SequenceFlowDbModel" databaseId="mariadb">
+  <insert id="createIfNotExists"
+    parameterType="io.camunda.db.rdbms.write.domain.SequenceFlowDbModel" databaseId="mariadb">
     INSERT INTO ${prefix}SEQUENCE_FLOW (FLOW_NODE_ID,
                                         PROCESS_INSTANCE_KEY,
                                         PROCESS_DEFINITION_KEY,
@@ -88,7 +89,8 @@
     ON DUPLICATE KEY UPDATE FLOW_NODE_ID = FLOW_NODE_ID -- this will not trigger an update
   </insert>
 
-  <insert id="createIfNotExists" parameterType="io.camunda.db.rdbms.write.domain.SequenceFlowDbModel" databaseId="h2">
+  <insert id="createIfNotExists"
+    parameterType="io.camunda.db.rdbms.write.domain.SequenceFlowDbModel" databaseId="h2">
     MERGE INTO ${prefix}SEQUENCE_FLOW sf
       USING dual
       ON (sf.FLOW_NODE_ID = #{flowNodeId} AND sf.PROCESS_INSTANCE_KEY = #{processInstanceKey})
@@ -109,7 +111,8 @@
             #{historyCleanupDate, jdbcType=TIMESTAMP})
   </insert>
 
-  <insert id="createIfNotExists" parameterType="io.camunda.db.rdbms.write.domain.SequenceFlowDbModel" databaseId="oracle">
+  <insert id="createIfNotExists"
+    parameterType="io.camunda.db.rdbms.write.domain.SequenceFlowDbModel" databaseId="oracle">
     MERGE INTO ${prefix}SEQUENCE_FLOW sf
       USING dual
       ON (sf.FLOW_NODE_ID = #{flowNodeId} AND sf.PROCESS_INSTANCE_KEY = #{processInstanceKey})
@@ -130,19 +133,13 @@
             #{historyCleanupDate, jdbcType=TIMESTAMP})
   </insert>
 
-  <update
-    flushCache="true"
-    id="updateHistoryCleanupDate"
-    statementType="PREPARED">
+  <update id="updateHistoryCleanupDate">
     UPDATE ${prefix}SEQUENCE_FLOW
     SET HISTORY_CLEANUP_DATE = #{historyCleanupDate, jdbcType=TIMESTAMP}
     WHERE PROCESS_INSTANCE_KEY = #{processInstanceKey}
   </update>
 
-  <delete
-    flushCache="true"
-    id="cleanupHistory"
-    statementType="PREPARED">
+  <delete id="cleanupHistory">
     <bind name="tableName" value="'SEQUENCE_FLOW'"/>
     <include refid="io.camunda.db.rdbms.sql.Commons.historyCleanup"/>
   </delete>

--- a/db/rdbms/src/main/resources/mapper/TenantMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/TenantMapper.xml
@@ -46,42 +46,30 @@
     <result column="DESCRIPTION" property="description"/>
   </resultMap>
 
-  <insert
-    id="insert"
-    parameterType="io.camunda.db.rdbms.write.domain.TenantDbModel"
-    flushCache="true">
+  <insert id="insert" parameterType="io.camunda.db.rdbms.write.domain.TenantDbModel">
     INSERT INTO ${prefix}TENANT (TENANT_KEY, TENANT_ID, NAME, DESCRIPTION)
     VALUES (#{tenantKey}, #{tenantId}, #{name}, #{description})
   </insert>
 
-  <update
-    id="update"
-    parameterType="io.camunda.db.rdbms.write.domain.TenantDbModel"
-    flushCache="true">
+  <update id="update" parameterType="io.camunda.db.rdbms.write.domain.TenantDbModel">
     UPDATE ${prefix}TENANT SET
                     NAME = #{name},
                     DESCRIPTION = #{description}
     WHERE TENANT_ID = #{tenantId}
   </update>
 
-  <delete id="delete" parameterType="java.lang.String" flushCache="true">
+  <delete id="delete" parameterType="java.lang.String">
     DELETE
     FROM ${prefix}TENANT
     WHERE TENANT_ID = #{tenantId}
   </delete>
 
-  <insert
-    id="insertMember"
-    parameterType="io.camunda.db.rdbms.write.domain.TenantMemberDbModel"
-    flushCache="true">
+  <insert id="insertMember" parameterType="io.camunda.db.rdbms.write.domain.TenantMemberDbModel">
     INSERT INTO ${prefix}TENANT_MEMBER (TENANT_ID, ENTITY_ID, ENTITY_TYPE)
     VALUES (#{tenantId}, #{entityId}, #{entityType})
   </insert>
 
-  <delete
-    id="deleteMember"
-    parameterType="io.camunda.db.rdbms.write.domain.TenantMemberDbModel"
-    flushCache="true">
+  <delete id="deleteMember" parameterType="io.camunda.db.rdbms.write.domain.TenantMemberDbModel">
     DELETE
     FROM ${prefix}TENANT_MEMBER
     WHERE TENANT_ID = #{tenantId}

--- a/db/rdbms/src/main/resources/mapper/UserMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/UserMapper.xml
@@ -94,18 +94,12 @@
     </constructor>
   </resultMap>
 
-  <insert
-    id="insert"
-    parameterType="io.camunda.db.rdbms.write.domain.UserDbModel"
-    flushCache="true">
+  <insert id="insert" parameterType="io.camunda.db.rdbms.write.domain.UserDbModel">
     INSERT INTO ${prefix}USERS (USER_KEY, USERNAME, NAME, EMAIL, PASSWORD)
     VALUES (#{userKey}, #{username}, #{name}, #{email}, #{password})
   </insert>
 
-  <update
-    id="update"
-    parameterType="io.camunda.db.rdbms.write.domain.UserDbModel"
-    flushCache="true">
+  <update id="update" parameterType="io.camunda.db.rdbms.write.domain.UserDbModel">
     UPDATE ${prefix}USERS
     SET NAME     = #{name},
         EMAIL    = #{email},
@@ -113,7 +107,7 @@
     WHERE USERNAME = #{username}
   </update>
 
-  <delete id="delete" parameterType="java.lang.String" flushCache="true">
+  <delete id="delete" parameterType="java.lang.String">
     DELETE FROM ${prefix}USERS
     WHERE USERNAME = #{username}
   </delete>

--- a/db/rdbms/src/main/resources/mapper/UserTaskMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/UserTaskMapper.xml
@@ -10,11 +10,7 @@
   "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="io.camunda.db.rdbms.sql.UserTaskMapper">
 
-  <insert
-    flushCache="true"
-    id="insert"
-    parameterType="io.camunda.db.rdbms.write.domain.UserTaskDbModel"
-    statementType="PREPARED">
+  <insert id="insert" parameterType="io.camunda.db.rdbms.write.domain.UserTaskDbModel">
     INSERT INTO ${prefix}USER_TASK (USER_TASK_KEY, ELEMENT_ID, NAME, PROCESS_DEFINITION_ID, CREATION_DATE,
                            COMPLETION_DATE, ASSIGNEE, STATE,
                            FORM_KEY,
@@ -31,10 +27,7 @@
             #{priority}, #{partitionId}, #{historyCleanupDate})
   </insert>
 
-  <insert flushCache="true"
-    id="insertCandidateUsers"
-    parameterType="io.camunda.db.rdbms.write.domain.UserTaskDbModel"
-    statementType="PREPARED">
+  <insert id="insertCandidateUsers" parameterType="io.camunda.db.rdbms.write.domain.UserTaskDbModel">
     INSERT INTO ${prefix}CANDIDATE_USER (USER_TASK_KEY, CANDIDATE_USER)
     VALUES
     <foreach collection="candidateUsers" item="candidateUser" separator=", ">
@@ -42,10 +35,7 @@
     </foreach>
   </insert>
 
-  <insert flushCache="true"
-    id="insertCandidateGroups"
-    parameterType="io.camunda.db.rdbms.write.domain.UserTaskDbModel"
-    statementType="PREPARED">
+  <insert id="insertCandidateGroups" parameterType="io.camunda.db.rdbms.write.domain.UserTaskDbModel">
     INSERT INTO ${prefix}CANDIDATE_GROUP (USER_TASK_KEY, CANDIDATE_GROUP)
     VALUES
     <foreach collection="candidateGroups" item="candidateGroup" separator=", ">
@@ -92,8 +82,7 @@
   <!-- default search statement for databases supporting LIMIT/OFFSET-->
   <select id="search"
     parameterType="io.camunda.db.rdbms.read.domain.UserTaskDbQuery"
-    resultMap="io.camunda.db.rdbms.sql.UserTaskMapper.searchResultMap"
-    statementType="PREPARED">
+    resultMap="io.camunda.db.rdbms.sql.UserTaskMapper.searchResultMap">
     SELECT * FROM (
     SELECT
     ut.*,
@@ -135,9 +124,7 @@
     <include refid="io.camunda.db.rdbms.sql.Commons.orderBy"/>
   </select>
 
-  <select id="count"
-    resultType="java.lang.Long"
-    statementType="PREPARED">
+  <select id="count" resultType="java.lang.Long">
     SELECT COUNT(*)
     FROM ${prefix}USER_TASK ut
     <include refid="io.camunda.db.rdbms.sql.UserTaskMapper.searchFilter"/>
@@ -305,11 +292,7 @@
 
   </sql>
 
-  <update
-    flushCache="true"
-    id="update"
-    parameterType="io.camunda.db.rdbms.write.domain.UserTaskDbModel"
-    statementType="PREPARED">
+  <update id="update" parameterType="io.camunda.db.rdbms.write.domain.UserTaskDbModel">
     UPDATE ${prefix}USER_TASK
     SET
     COMPLETION_DATE = #{completionDate},
@@ -325,40 +308,25 @@
     WHERE USER_TASK_KEY = #{userTaskKey}
   </update>
 
-  <delete
-    flushCache="true"
-    id="deleteCandidateUsers"
-    parameterType="java.lang.Long"
-    statementType="PREPARED">
+  <delete id="deleteCandidateUsers" parameterType="java.lang.Long">
     DELETE
     FROM ${prefix}CANDIDATE_USER
     WHERE USER_TASK_KEY = #{userTaskKey}
   </delete>
 
-  <delete
-    flushCache="true"
-    id="deleteCandidateGroups"
-    parameterType="java.lang.Long"
-    statementType="PREPARED">
+  <delete id="deleteCandidateGroups" parameterType="java.lang.Long">
     DELETE
     FROM ${prefix}CANDIDATE_GROUP
     WHERE USER_TASK_KEY = #{userTaskKey}
   </delete>
 
-  <update
-    flushCache="true"
-    id="updateHistoryCleanupDate"
-    statementType="PREPARED">
+  <update id="updateHistoryCleanupDate">
     UPDATE ${prefix}USER_TASK SET
     HISTORY_CLEANUP_DATE = #{historyCleanupDate, jdbcType=TIMESTAMP}
     WHERE PROCESS_INSTANCE_KEY = #{processInstanceKey}
   </update>
 
-  <update
-    flushCache="true"
-    id="migrateToProcess"
-    parameterType="java.util.Map"
-    statementType="PREPARED">
+  <update id="migrateToProcess" parameterType="java.util.Map">
     UPDATE ${prefix}USER_TASK SET
     ELEMENT_ID = #{elementId},
     NAME = #{name},
@@ -368,10 +336,7 @@
     WHERE USER_TASK_KEY = #{userTaskKey}
   </update>
 
-  <delete
-    flushCache="true"
-    id="cleanupHistory"
-    statementType="PREPARED">
+  <delete id="cleanupHistory">
     <bind name="tableName" value="'USER_TASK'"/>
     <include refid="io.camunda.db.rdbms.sql.Commons.historyCleanup"/>
   </delete>

--- a/db/rdbms/src/main/resources/mapper/VariableMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/VariableMapper.xml
@@ -119,11 +119,7 @@
     </constructor>
   </resultMap>
 
-  <insert
-    id="insert"
-    statementType="PREPARED"
-    parameterType="io.camunda.db.rdbms.write.domain.VariableDbModel"
-    flushCache="true">
+  <insert id="insert" parameterType="io.camunda.db.rdbms.write.domain.VariableDbModel">
     INSERT INTO ${prefix}VARIABLE (VAR_KEY, PROCESS_INSTANCE_KEY, PROCESS_DEFINITION_ID, SCOPE_KEY, TYPE, VAR_NAME, DOUBLE_VALUE,
                                    LONG_VALUE, VAR_VALUE, VAR_FULL_VALUE, TENANT_ID, IS_PREVIEW,
                                    PARTITION_ID, HISTORY_CLEANUP_DATE)
@@ -131,11 +127,7 @@
             #{longValue}, #{value}, #{fullValue}, #{tenantId}, #{isPreview}, #{partitionId}, #{historyCleanupDate, jdbcType=TIMESTAMP})
   </insert>
 
-  <update
-    id="update"
-    statementType="PREPARED"
-    parameterType="io.camunda.db.rdbms.write.domain.VariableDbModel"
-    flushCache="true">
+  <update id="update" parameterType="io.camunda.db.rdbms.write.domain.VariableDbModel">
       UPDATE ${prefix}VARIABLE
       SET TYPE         = #{type},
           DOUBLE_VALUE = #{doubleValue},
@@ -147,28 +139,18 @@
       WHERE VAR_KEY = #{variableKey}
   </update>
 
-  <update
-    flushCache="true"
-    id="updateHistoryCleanupDate"
-    statementType="PREPARED">
+  <update id="updateHistoryCleanupDate">
     UPDATE ${prefix}VARIABLE SET
       HISTORY_CLEANUP_DATE = #{historyCleanupDate, jdbcType=TIMESTAMP}
     WHERE PROCESS_INSTANCE_KEY = #{processInstanceKey}
   </update>
 
-  <delete
-    flushCache="true"
-    id="cleanupHistory"
-    statementType="PREPARED">
+  <delete id="cleanupHistory">
     <bind name="tableName" value="'VARIABLE'"/>
     <include refid="io.camunda.db.rdbms.sql.Commons.historyCleanup"/>
   </delete>
 
-  <update
-    id="migrateToProcess"
-    statementType="PREPARED"
-    parameterType="java.util.Map"
-    flushCache="true">
+  <update id="migrateToProcess" parameterType="java.util.Map">
       UPDATE ${prefix}VARIABLE
       SET PROCESS_DEFINITION_ID = #{processDefinitionId}
       WHERE VAR_KEY = #{variableKey}


### PR DESCRIPTION
## Description

Based on a [finding](https://github.com/camunda/camunda/pull/33689#discussion_r2179361647) in PR #33689, this PR cleans up the `rdbms` mapper files by removing unnecessary properties:
- `flushCache` => We don't use a cache and will probably never do: Since we also don't have queries like getById() but always more complicated filter queries, a cache hit would be quite rare.
- `statementType="PREPARED"` => this is actually the default and can be omitted

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).
