### PR TITLE
fix: allow reading over raft entries of unknown type

### DIFF
--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/storage/log/entry/UnknownEntry.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/storage/log/entry/UnknownEntry.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.atomix.raft.storage.log.entry;
+
+import io.atomix.raft.storage.serializer.RaftEntrySerializer;
+import io.camunda.zeebe.util.buffer.BufferWriter;
+
+/**
+ * Represents a Raft entry of an unknown type. This entry doesn't provide any information about the
+ * entry and can't be serialized again. This type is used when a newer version introduced a new
+ * entry type that isn't supported yet.
+ */
+public record UnknownEntry() implements RaftEntry {
+
+  @Override
+  public BufferWriter toSerializable(final long term, final RaftEntrySerializer serializer) {
+    throw new UnsupportedOperationException("Can't serialize unknown entry");
+  }
+}

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/storage/serializer/RaftEntrySBESerializer.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/storage/serializer/RaftEntrySBESerializer.java
@@ -26,6 +26,7 @@ import io.atomix.raft.storage.log.entry.ConfigurationEntry;
 import io.atomix.raft.storage.log.entry.InitialEntry;
 import io.atomix.raft.storage.log.entry.RaftLogEntry;
 import io.atomix.raft.storage.log.entry.SerializedApplicationEntry;
+import io.atomix.raft.storage.log.entry.UnknownEntry;
 import io.atomix.raft.storage.serializer.ConfigurationEntryDecoder.NewMembersDecoder;
 import io.atomix.raft.storage.serializer.ConfigurationEntryDecoder.OldMembersDecoder;
 import io.camunda.zeebe.journal.file.RecordDataEncoder;
@@ -187,7 +188,7 @@ public class RaftEntrySBESerializer implements RaftEntrySerializer {
             yield readConfigurationEntry(buffer, entryOffset);
           }
           case InitialEntry -> new InitialEntry();
-          default -> throw new IllegalStateException("Unexpected entry type " + type);
+          default -> new UnknownEntry();
         };
 
     return new RaftLogEntry(term, entry);


### PR DESCRIPTION
Rather than failing to read newly introduced raft entries written by an updated leader, we ignore them and use `UnknownEntry` as a placeholder.

closes #34687
