### PR TITLE
ci: don't cache Docker images according to strategy

### DIFF
--- a/.github/actions/build-operate-docker/action.yml
+++ b/.github/actions/build-operate-docker/action.yml
@@ -53,8 +53,6 @@ runs:
         tags: ${{ inputs.tags }}
         load: ${{ inputs.push != 'true' }}
         push: ${{ inputs.push }}
-        cache-from: type=gha,ignore-error=true
-        cache-to: type=gha,mode=max,ignore-error=true
         no-cache-filters: build,distball,dist
         provenance: false
         platforms: ${{ inputs.platforms }}

--- a/.github/workflows/operate-weekly-internal-docker-images.yaml
+++ b/.github/workflows/operate-weekly-internal-docker-images.yaml
@@ -82,6 +82,4 @@ jobs:
           context: .
           push: true
           tags: gcr.io/zeebe-io/operate:${{ needs.operate-image-data.outputs.image }}
-          cache-from: type=gha,ignore-error=true
-          cache-to: type=gha,mode=max,ignore-error=true
           file: operate.Dockerfile


### PR DESCRIPTION
## Description

Our GHA cache usage is higher than it used to be, so I was investigating where this increased usage is coming from.

Checking https://github.com/camunda/camunda/actions/caches showed a PR https://github.com/camunda/camunda/pull/34688 against `stable/operate-8.5` creating GHA cache entries related to Docker BuildKit - this is something we want to avoid according to our [strategy](https://github.com/camunda/camunda/wiki/CI-&-Automation#caching-strategy). GHA cache is a shared resource and we must make best use of limited resources.

This PR disables caching for two GHA jobs of `stable/operate-8.5` branch.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

Related to https://github.com/camunda/camunda/issues/34695
