### PR TITLE
ci: disable cache of golangci-lint

### DIFF
--- a/.github/workflows/c8run-build.yaml
+++ b/.github/workflows/c8run-build.yaml
@@ -57,6 +57,7 @@ jobs:
         uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84 # v6.5.2
         with:
           working-directory: ./c8run
+          skip-cache: true
 
   test_c8run_unittests:
     strategy:


### PR DESCRIPTION
## Description

Creating GHA cache entries on builds for Pull Requests or in the merge queue has very limited use, which is [why we have the caching strategy](https://github.com/camunda/camunda/wiki/CI-&-Automation#caching-strategy). While the usage by `golangci-lint` is rather small, we shoud avoid creating caches outside of builds on `main` or a `stable/*` branch.

This PR takes the easy way by [disabling caching](https://github.com/golangci/golangci-lint-action/tree/main#skip-cache) for golangci-lint completely.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

Related to https://github.com/camunda/camunda/issues/34695
