### PR TITLE
ci: use setup-yarn-cache action to follow caching strategy

### DIFF
--- a/.github/workflows/operate-a11y.yml
+++ b/.github/workflows/operate-a11y.yml
@@ -20,8 +20,9 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "18"
-          cache: "yarn"
-          cache-dependency-path: operate/client/yarn.lock
+      - uses: camunda/infra-global-github-actions/setup-yarn-cache@main
+        with:
+          directory: operate/client
       - name: Install node dependencies
         working-directory: ./operate/client
         run: yarn

--- a/.github/workflows/operate-update-browserlist-db.yml
+++ b/.github/workflows/operate-update-browserlist-db.yml
@@ -17,8 +17,9 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: "18"
-          cache: "yarn"
-          cache-dependency-path: operate/client/yarn.lock
+      - uses: camunda/infra-global-github-actions/setup-yarn-cache@main
+        with:
+          directory: operate/client
       - run: npx update-browserslist-db@latest --yes
         name: Update DB
       - uses: stefanzweifel/git-auto-commit-action@01d77ca6cb089da1360e540865f7d035c95aa199

--- a/.github/workflows/operate-update-docs-screenshots.yml
+++ b/.github/workflows/operate-update-docs-screenshots.yml
@@ -14,8 +14,9 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "20"
-          cache: "yarn"
-          cache-dependency-path: operate/client/yarn.lock
+      - uses: camunda/infra-global-github-actions/setup-yarn-cache@main
+        with:
+          directory: operate/client
       - name: Install node dependencies
         working-directory: ./operate/client
         run: yarn


### PR DESCRIPTION
## Description

Our GHA cache usage is higher than it used to be, so I was investigating where this increased usage is coming from.

Checking https://github.com/camunda/camunda/actions/caches showed a PR https://github.com/camunda/camunda/pull/32595 against `stable/operate-8.5` creating GHA cache entries related to `setup-node` and Yarn - this is something we want to avoid according to our [strategy](https://github.com/camunda/camunda/wiki/CI-&-Automation#caching-strategy). GHA cache is a shared resource and we must make best use of limited resources.

This PR uses the better `setup-yarn-cache` global action on `stable/operate-8.5` branch.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)). - only for Operate 8.5

## Related issues

Related to https://github.com/camunda/camunda/issues/34695