### PR TITLE
ci: cache binfmt image only on persistent branches

### DIFF
--- a/.github/actions/build-platform-docker/action.yml
+++ b/.github/actions/build-platform-docker/action.yml
@@ -52,8 +52,19 @@ outputs:
 runs:
   using: composite
   steps:
+    - name: Detect branch type
+      id: branch-detect
+      shell: bash
+      env:
+        IS_MAIN_OR_STABLE_BRANCH: ${{ startsWith(github.ref_name, 'stable/') || github.ref_name == 'main' }}
+      run: |
+        echo is-main-or-stable-branch="$IS_MAIN_OR_STABLE_BRANCH" | tee -a $GITHUB_OUTPUT
+
     - name: Set up multi-platform support
       uses: docker/setup-qemu-action@v3
+      with:
+        # only cache on persistent branches where reuse is likely
+        cache-image: ${{ steps.branch-detect.outputs.is-main-or-stable-branch == 'true' }}
 
     # Creating a context is required when installing buildx on self-hosted runners
     - name: Create context


### PR DESCRIPTION
## Description

The `docker/setup-qemu-action` does download a Docker image for `binfmt` under the hood and persists that by default in GHA cache for every branch/PR/merge queue and other builds - this is something we want to avoid according to our [strategy](https://github.com/camunda/camunda/wiki/CI-&-Automation#caching-strategy). GHA cache is a shared resource and we must make best use of limited resources.

This PR enables caching only on persistent branches where likelihood of reuse is high.

See [Slack discussion for details](https://camunda.slack.com/archives/C08F5RD5X8B/p1751456494312519).

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

Related to https://github.com/camunda/camunda/issues/34695
