### PR TITLE
ci: disable scheduled automation for stable/8.4

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,7 +6,7 @@
   ],
   "commitMessagePrefix": "deps:",
   "baseBranches": [
-    "/^stable\\/8\\..*/",
+    "/^stable\\/8\\.([5-9]|[1-9][0-9])/",
     "stable/operate-8.5",
     "main"
   ],

--- a/.github/workflows/zeebe-daily-qa.yml
+++ b/.github/workflows/zeebe-daily-qa.yml
@@ -31,7 +31,6 @@ jobs:
       latest-version: ${{ env.LATEST_VERSION }}
       second-last-version: ${{ env.SECOND_LAST_VERSION }}
       third-last-version: ${{ env.THIRD_LAST_VERSION }}
-      fourth-last-version: ${{ env.FOURTH_LAST_VERSION }}
     steps:
       - uses: actions/checkout@v4
       - run: git fetch --tags
@@ -41,9 +40,8 @@ jobs:
           latest="${versions[0]}"
           second_last="${versions[1]}"
           third_last="${versions[2]}"
-          fourth_last="${versions[3]}"
-          if [ -n "$latest" ] && [ -n "$second_last" ] && [ -n "$third_last" ] && [ -n "$fourth_last" ]; then
-            echo "Successfully computed latest versions: ${latest} and ${second_last} and ${third_last} and ${fourth_last}"
+          if [ -n "$latest" ] && [ -n "$second_last" ] && [ -n "$third_last" ]; then
+            echo "Successfully computed latest versions: ${latest} and ${second_last} and ${third_last}"
           else
             echo "Failed to compute latest versions"
           fi
@@ -51,7 +49,6 @@ jobs:
             echo "LATEST_VERSION=${latest}"
             echo "SECOND_LAST_VERSION=${second_last}"
             echo "THIRD_LAST_VERSION=${third_last}"
-            echo "FOURTH_LAST_VERSION=${fourth_last}"
           } >> "$GITHUB_ENV"
   # Runs the qa-testbench workflow against the stable branches. It assumes that branches follow the
   # pattern of `stable/VERSION`, and generations of `Camunda VERSION`.
@@ -70,7 +67,6 @@ jobs:
           - ${{ format('stable/{0}', needs.get-versions.outputs.latest-version) }}
           - ${{ format('stable/{0}', needs.get-versions.outputs.second-last-version) }}
           - ${{ format('stable/{0}', needs.get-versions.outputs.third-last-version) }}
-          - ${{ format('stable/{0}', needs.get-versions.outputs.fourth-last-version) }}
         include:
           - branch: 'main'
             generation_template: 'Zeebe SNAPSHOT'
@@ -80,8 +76,6 @@ jobs:
             generation_template: ${{ format('Camunda {0}+gen1', needs.get-versions.outputs.second-last-version) }}
           - branch: ${{ format('stable/{0}', needs.get-versions.outputs.third-last-version) }}
             generation_template: ${{ format('Camunda {0}.0', needs.get-versions.outputs.third-last-version) }}
-          - branch: ${{ format('stable/{0}', needs.get-versions.outputs.fourth-last-version) }}
-            generation_template: ${{ format('Camunda {0}.0', needs.get-versions.outputs.fourth-last-version) }}
     runs-on: ubuntu-latest
     name: Daily QA
     steps:

--- a/.github/workflows/zeebe-release-stable-dry-run.yml
+++ b/.github/workflows/zeebe-release-stable-dry-run.yml
@@ -101,7 +101,7 @@ jobs:
   notify-zeebe:
     name: Send Slack notification for Zeebe up to 8.5
     runs-on: ubuntu-latest
-    needs: [dry-run-release-83, dry-run-release-84, dry-run-release-85]
+    needs: [dry-run-release-85]
     if: always()
     timeout-minutes: 5
     permissions: {}  # GITHUB_TOKEN unused in this job
@@ -109,7 +109,7 @@ jobs:
       - id: slack-notify-failure
         name: Send failure slack notification
         uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
-        if: ${{ always() && (needs.dry-run-release-83.result != 'success' || needs.dry-run-release-84.result != 'success' || needs.dry-run-release-85.result != 'success') }}
+        if: ${{ always() && needs.dry-run-release-85.result != 'success' }}
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook
@@ -136,7 +136,7 @@ jobs:
       - id: slack-notify-success
         name: Send success slack notification
         uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
-        if: ${{ always() && needs.dry-run-release-83.result == 'success' && needs.dry-run-release-84.result == 'success' && needs.dry-run-release-85.result == 'success' }}
+        if: ${{ always() && needs.dry-run-release-85.result == 'success' }}
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook

--- a/.github/workflows/zeebe-release-stable-dry-run.yml
+++ b/.github/workflows/zeebe-release-stable-dry-run.yml
@@ -50,30 +50,6 @@ jobs:
       nextDevelopmentVersion: 0.0.0-SNAPSHOT
       isLatest: true
       dryRun: true
-  dry-run-release-84:
-    name: "Release from stable/8.4"
-    uses: camunda/camunda/.github/workflows/zeebe-release.yml@stable/8.4
-    secrets: inherit
-    strategy:
-      fail-fast: false
-    with:
-      releaseBranch: stable/8.4
-      releaseVersion: 0.8.4
-      nextDevelopmentVersion: 0.0.0-SNAPSHOT
-      isLatest: true
-      dryRun: true
-  dry-run-release-83:
-    name: "Release from stable/8.3"
-    uses: camunda/camunda/.github/workflows/zeebe-release.yml@stable/8.3
-    secrets: inherit
-    strategy:
-      fail-fast: false
-    with:
-      releaseBranch: stable/8.3
-      releaseVersion: 0.8.3
-      nextDevelopmentVersion: 0.0.0-SNAPSHOT
-      isLatest: true
-      dryRun: true
 
   notify-camunda:
     name: Send Slack notification for 8.6+

--- a/.github/workflows/zeebe-weekly-e2e.yml
+++ b/.github/workflows/zeebe-weekly-e2e.yml
@@ -24,7 +24,6 @@ jobs:
       latest-version: ${{ env.LATEST_VERSION }}
       second-last-version: ${{ env.SECOND_LAST_VERSION }}
       third-last-version: ${{ env.THIRD_LAST_VERSION }}
-      fourth-last-version: ${{ env.FOURTH_LAST_VERSION }}
     steps:
       - uses: actions/checkout@v4
       - run: git fetch --tags
@@ -34,9 +33,8 @@ jobs:
           latest="${versions[0]}"
           second_last="${versions[1]}"
           third_last="${versions[2]}"
-          fourth_last="${versions[3]}"
-          if [ -n "$latest" ] && [ -n "$second_last" ] && [ -n "$third_last" ] && [ -n "$fourth_last" ]; then
-            echo "Successfully computed latest versions: ${latest} and ${second_last} and ${third_last} and ${fourth_last}"
+          if [ -n "$latest" ] && [ -n "$second_last" ] && [ -n "$third_last" ]; then
+            echo "Successfully computed latest versions: ${latest} and ${second_last} and ${third_last}"
           else
             echo "Failed to compute latest versions"
           fi
@@ -44,7 +42,6 @@ jobs:
             echo "LATEST_VERSION=${latest}"
             echo "SECOND_LAST_VERSION=${second_last}"
             echo "THIRD_LAST_VERSION=${third_last}"
-            echo "FOURTH_LAST_VERSION=${fourth_last}"
           } >> "$GITHUB_ENV"
 
   e2e:
@@ -59,7 +56,6 @@ jobs:
           - ${{ format('stable/{0}', needs.get-versions.outputs.latest-version) }}
           - ${{ format('stable/{0}', needs.get-versions.outputs.second-last-version) }}
           - ${{ format('stable/{0}', needs.get-versions.outputs.third-last-version) }}
-          - ${{ format('stable/{0}', needs.get-versions.outputs.fourth-last-version) }}
         include:
           - branch: 'main'
             generation_template: 'Zeebe SNAPSHOT'
@@ -69,8 +65,6 @@ jobs:
             generation_template: ${{ format('Camunda {0}+gen1', needs.get-versions.outputs.second-last-version) }}
           - branch: ${{ format('stable/{0}', needs.get-versions.outputs.third-last-version) }}
             generation_template: ${{ format('Camunda {0}.0', needs.get-versions.outputs.third-last-version) }}
-          - branch: ${{ format('stable/{0}', needs.get-versions.outputs.fourth-last-version) }}
-            generation_template: ${{ format('Camunda {0}.0', needs.get-versions.outputs.fourth-last-version) }}
     runs-on: ubuntu-latest
     name: Weekly E2E
     steps:


### PR DESCRIPTION
## Description

The 8.4 version will go out of regular maintenance and we want to avoid running scheduled automation (CI jobs, Renovate) for it.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

[Slack](https://camunda.slack.com/archives/C08F5RD5X8B/p1751446133909409)
