### PR TITLE
Improve Docker build resiliency against apt failures

### DIFF
--- a/.github/actions/build-platform-docker/99apt-timeout-and-retries
+++ b/.github/actions/build-platform-docker/99apt-timeout-and-retries
@@ -1,9 +1,8 @@
-/* The purpose of this APT configuration file is to make Docker image builds
-   more resilient against package mirror or network problems.
-   The file can be copied into /etc/apt/apt.conf.d/ during the build process.
-   Original request: https://github.com/camunda/camunda/issues/32264
-*/
+// The purpose of this APT configuration file is to make Docker image builds
+// more resilient against package mirror or network problems.
+// The file can be copied into /etc/apt/apt.conf.d/ during the build process.
+// Original request: https://github.com/camunda/camunda/issues/32264
 
-Acquire::Retries "6"
-Acquire::http::Timeout "10"
-Acquire::https::Timeout "10"
+Acquire::Retries "6";
+Acquire::http::Timeout "10";
+Acquire::https::Timeout "10";

--- a/.github/actions/build-platform-docker/99apt-timeout-and-retries
+++ b/.github/actions/build-platform-docker/99apt-timeout-and-retries
@@ -1,6 +1,7 @@
 // The purpose of this APT configuration file is to make Docker image builds
 // more resilient against package mirror or network problems.
 // The file can be copied into /etc/apt/apt.conf.d/ during the build process.
+// The default APT retries value is 3, so doubling it gives more chance for a successfull build.
 // Original request: https://github.com/camunda/camunda/issues/32264
 
 Acquire::Retries "6";

--- a/.github/actions/build-platform-docker/99apt-timeout-and-retries
+++ b/.github/actions/build-platform-docker/99apt-timeout-and-retries
@@ -1,0 +1,9 @@
+/* The purpose of this APT configuration file is to make Docker image builds
+   more resilient against package mirror or network problems.
+   The file can be copied into /etc/apt/apt.conf.d/ during the build process.
+   Original request: https://github.com/camunda/camunda/issues/32264
+*/
+
+Acquire::Retries "6"
+Acquire::http::Timeout "10"
+Acquire::https::Timeout "10"

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,9 @@ ARG DIST="distball"
 FROM ${BASE_IMAGE}@${BASE_DIGEST} AS base
 WORKDIR /
 
+# Use custom APT timeout and retry values for more resilient builds
+COPY .github/actions/build-pplatform-docker/99apt-timeout-and-retries /etc/apt/apt.conf.d/
+
 # Upgrade all outdated packages and install missing ones (e.g. locales, tini)
 # This breaks reproducibility of builds, but is acceptable to gain access to security patches faster
 # than the base image releases

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ FROM ${BASE_IMAGE}@${BASE_DIGEST} AS base
 WORKDIR /
 
 # Use custom APT timeout and retry values for more resilient builds
-COPY .github/actions/build-pplatform-docker/99apt-timeout-and-retries /etc/apt/apt.conf.d/
+COPY .github/actions/build-platform-docker/99apt-timeout-and-retries /etc/apt/apt.conf.d/
 
 # Upgrade all outdated packages and install missing ones (e.g. locales, tini)
 # This breaks reproducibility of builds, but is acceptable to gain access to security patches faster

--- a/camunda.Dockerfile
+++ b/camunda.Dockerfile
@@ -18,6 +18,9 @@ ARG DIST="distball"
 FROM ${BASE_IMAGE}@${BASE_DIGEST} AS base
 WORKDIR /
 
+# Use custom APT timeout and retry values for more resilient builds
+COPY .github/actions/build-pplatform-docker/99apt-timeout-and-retries /etc/apt/apt.conf.d/
+
 # Upgrade all outdated packages and install missing ones (e.g. locales, tini)
 # This breaks reproducibility of builds, but is acceptable to gain access to security patches faster
 # than the base image releases

--- a/camunda.Dockerfile
+++ b/camunda.Dockerfile
@@ -19,7 +19,7 @@ FROM ${BASE_IMAGE}@${BASE_DIGEST} AS base
 WORKDIR /
 
 # Use custom APT timeout and retry values for more resilient builds
-COPY .github/actions/build-pplatform-docker/99apt-timeout-and-retries /etc/apt/apt.conf.d/
+COPY .github/actions/build-platform-docker/99apt-timeout-and-retries /etc/apt/apt.conf.d/
 
 # Upgrade all outdated packages and install missing ones (e.g. locales, tini)
 # This breaks reproducibility of builds, but is acceptable to gain access to security patches faster


### PR DESCRIPTION
## Description

This PR implements custom APT timeout and retry values to make Docker image builds more resilient against package mirror or network problems.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

https://github.com/camunda/camunda/issues/32264
