### PR TITLE
fix: fix deserialization issue occurs on ci tests

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/impl/http/HttpClientFactory.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/http/HttpClientFactory.java
@@ -15,6 +15,7 @@
  */
 package io.camunda.client.impl.http;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.client.CamundaClientConfiguration;
 import io.camunda.client.CredentialsProvider;
@@ -68,7 +69,8 @@ public class HttpClientFactory {
   /** The versioned base REST API context path the client uses for requests */
   public static final String REST_API_PATH = "/v2";
 
-  private static final ObjectMapper JSON_MAPPER = new ObjectMapper();
+  private static final ObjectMapper JSON_MAPPER =
+      new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
   private final CamundaClientConfiguration config;
 


### PR DESCRIPTION
## Description

Deserialization issue occurs on ci tests due to `camunda-client-java` artifact mismatch, between integration system's latest outdated image e.g. `camunda/connectors-bundle` vs `camunda/camunda` updated image.

```
Integration Test
   │
   ├──> CamundaClient (outdated) 
   │     │
   │     └──> Sends /v2 search query
   │
   └──<── Receives response with new field `hasMoreTotalItems`
         └──> Jackson fails: FAIL_ON_UNKNOWN_PROPERTIES = true
              └──> JsonApiEntityConsumer
                    └──> ApiEntityConsumer
                          └──> HttpClient (from HttpClientFactory)
```

More info on related issue.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #34704
