### PR TITLE
[Backport stable/8.5] ci: Determine the docker version tag based on branch name

### DIFF
--- a/.github/workflows/snapshot-docker-version-tag.yml
+++ b/.github/workflows/snapshot-docker-version-tag.yml
@@ -19,6 +19,8 @@ env:
 jobs:
   get-snapshot-docker-version-tag:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions: {}
     outputs:
       tag: ${{ steps.set_docker_snapshot_version_tag.outputs.tag }}
     steps:

--- a/.github/workflows/snapshot-docker-version-tag.yml
+++ b/.github/workflows/snapshot-docker-version-tag.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions: {}
-    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/stable/')
+    if: github.repository == 'camunda/camunda' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/stable/'))
     outputs:
       tag: ${{ steps.set_docker_snapshot_version_tag.outputs.tag }}
     steps:

--- a/.github/workflows/snapshot-docker-version-tag.yml
+++ b/.github/workflows/snapshot-docker-version-tag.yml
@@ -11,13 +11,13 @@ on:
     outputs:
       version_tag:
         description: "Generated Docker version tag"
-        value: ${{  jobs.generate_docker_version_tag.outputs.tag }}
+        value: ${{  jobs.get-snapshot-docker-version-tag.outputs.tag }}
 
 env:
   GHA_BEST_PRACTICES_LINTER: enabled
 
 jobs:
-  generate_docker_version_tag:
+  get-snapshot-docker-version-tag:
     runs-on: ubuntu-latest
     outputs:
       tag: ${{ steps.set_docker_snapshot_version_tag.outputs.tag }}

--- a/.github/workflows/snapshot-docker-version-tag.yml
+++ b/.github/workflows/snapshot-docker-version-tag.yml
@@ -1,0 +1,31 @@
+name: Generate Docker Version Tag (SNAPSHOT)
+
+on:
+  workflow_call:
+    outputs:
+      version_tag:
+        description: "Generated Docker version tag"
+        value: ${{  jobs.generate_docker_version_tag.outputs.tag }}
+
+env:
+  GHA_BEST_PRACTICES_LINTER: enabled
+
+jobs:
+  generate_docker_version_tag:
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.set_docker_snapshot_version_tag.outputs.tag }}
+    steps:
+      - name: Determine Snapshot Docker Version Tag
+        id: set_docker_snapshot_version_tag
+        run: |
+          BRANCH="${GITHUB_REF#refs/heads/}"
+          if [[ "$BRANCH" == "main" ]]; then
+            TAG="SNAPSHOT"
+          elif [[ "$BRANCH" == stable/* ]]; then
+            TAG="${BRANCH#stable/}-SNAPSHOT"
+          else
+            echo "Unsupported branch: $BRANCH"
+            exit 1
+          fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/snapshot-docker-version-tag.yml
+++ b/.github/workflows/snapshot-docker-version-tag.yml
@@ -21,6 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions: {}
+    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/stable/')
     outputs:
       tag: ${{ steps.set_docker_snapshot_version_tag.outputs.tag }}
     steps:

--- a/.github/workflows/snapshot-docker-version-tag.yml
+++ b/.github/workflows/snapshot-docker-version-tag.yml
@@ -1,4 +1,10 @@
+# description: Generate a Docker version tag for snapshot builds based on the branch name.
+# type: CI
+# owner: @camunda/monorepo-devops-team
 name: Generate Docker Version Tag (SNAPSHOT)
+
+permissions:
+  contents: read
 
 on:
   workflow_call:

--- a/.github/workflows/snapshot-docker-version-tag.yml
+++ b/.github/workflows/snapshot-docker-version-tag.yml
@@ -32,6 +32,6 @@ jobs:
             TAG="${BRANCH#stable/}-SNAPSHOT"
           else
             echo "Unsupported branch: $BRANCH"
-            exit 1
+            exit 0
           fi
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/zeebe-ci.yml
+++ b/.github/workflows/zeebe-ci.yml
@@ -695,12 +695,19 @@ jobs:
         env:
           MAVEN_USERNAME: ${{ steps.secrets.outputs.ARTIFACTS_USR }}
           MAVEN_PASSWORD: ${{ steps.secrets.outputs.ARTIFACTS_PSW }}
+
+  # Dynamically generate the Docker tag (e.g., SNAPSHOT or X.Y-SNAPSHOT) based on branch name
+  get-snapshot-docker-version-tag:
+    uses: ./.github/workflows/snapshot-docker-version-tag.yml
+    secrets: inherit
+
   deploy-docker-snapshot:
     name: Deploy snapshot Docker image
     timeout-minutes: 15
-    needs: [ test-summary ]
+    permissions: {}  # GITHUB_TOKEN unused in this job
+    needs: [ test-summary, get-snapshot-docker-version-tag ]
     runs-on: ubuntu-latest
-    if: github.repository == 'camunda/camunda' && github.ref == 'refs/heads/main'
+    if: github.repository == 'camunda/camunda' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/stable/'))
     concurrency:
       group: deploy-docker-snapshot
       cancel-in-progress: false
@@ -718,7 +725,7 @@ jobs:
         id: build-zeebe-docker
         with:
           repository: camunda/zeebe
-          version: SNAPSHOT
+          version: ${{ needs.get-snapshot-docker-version-tag.outputs.version_tag }}
           platforms: ${{ env.DOCKER_PLATFORMS }}
           push: true
           distball: ${{ steps.build-zeebe.outputs.distball }}


### PR DESCRIPTION
# Description
Backport of #34498 to `stable/8.5`.

relates to 