### PR TITLE
[Backport stable/8.7] feat(34483): Use inputs.isLatest for marking release as latest in camunda-platform-release.yml

### DIFF
--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -332,7 +332,11 @@ jobs:
           name: ${{ inputs.releaseVersion }}
           artifacts: "release-artifacts/*"
           artifactErrorsFailBuild: true
+<<<<<<< HEAD
           draft: ${{ steps.gen-changelog.outputs.isDraftRelease }}
+=======
+          draft: false
+>>>>>>> 37b637ca (feat: Use inputs.isLatest for marking release as latest in camunda-platform-release.yml (#34483))
           makeLatest: ${{ inputs.isLatest }}
           body: ${{ steps.gen-changelog.outputs.changelog }}
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Description
Backport of #34509 to `stable/8.7`.

relates to camunda/camunda#34483