### PR TITLE
[Backport stable/8.7] Add console ping scheduler and task.

### DIFF
--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -549,6 +549,11 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
 
   </dependencies>
 

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -555,6 +555,29 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>com.squareup.okhttp3</groupId>
+      <artifactId>mockwebserver</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.squareup.okhttp3</groupId>
+      <artifactId>okhttp</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.squareup.okio</groupId>
+      <artifactId>okio-jvm</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -566,6 +566,11 @@
       <artifactId>wiremock-standalone</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.wiremock</groupId>
+      <artifactId>wiremock</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -560,12 +560,6 @@
       <artifactId>awaitility</artifactId>
       <scope>test</scope>
     </dependency>
-
-    <dependency>
-      <groupId>org.wiremock</groupId>
-      <artifactId>wiremock-standalone</artifactId>
-      <scope>test</scope>
-    </dependency>
     <dependency>
       <groupId>org.wiremock</groupId>
       <artifactId>wiremock</artifactId>

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -556,26 +556,14 @@
     </dependency>
 
     <dependency>
-      <groupId>com.squareup.okhttp3</groupId>
-      <artifactId>mockwebserver</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>com.squareup.okhttp3</groupId>
-      <artifactId>okhttp</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>com.squareup.okio</groupId>
-      <artifactId>okio-jvm</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.wiremock</groupId>
+      <artifactId>wiremock-standalone</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/dist/src/main/config/application.yaml
+++ b/dist/src/main/config/application.yaml
@@ -96,7 +96,7 @@ camunda:
   # Operate configuration properties
   operate:
     # Set operate username and password.
-    # If user with <username> does not exists it will be created.
+    # If user with <username> does not exist it will be created.
     # Default: demo/demo
     #username:
     #password:
@@ -121,7 +121,7 @@ camunda:
   # Tasklist configuration properties
   tasklist:
     # Set Tasklist username and password.
-    # If user with <username> does not exists it will be created.
+    # If user with <username> does not exist it will be created.
     # Default: demo/demo
     #username:
     #password:

--- a/dist/src/main/java/io/camunda/application/commons/console/ping/PingConsoleConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/console/ping/PingConsoleConfiguration.java
@@ -9,6 +9,7 @@ package io.camunda.application.commons.console.ping;
 
 import io.camunda.application.commons.console.ping.PingConsoleConfiguration.ConsolePingConfiguration;
 import io.camunda.service.ManagementServices;
+import io.camunda.zeebe.util.VisibleForTesting;
 import io.camunda.zeebe.util.error.FatalErrorHandler;
 import java.util.Map;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
@@ -42,18 +43,7 @@ public class PingConsoleConfiguration implements ApplicationRunner {
   public void run(final ApplicationArguments args) {
     try {
       if (pingConfiguration.enabled) {
-        if (pingConfiguration.endpoint() == null || pingConfiguration.endpoint().isBlank()) {
-          throw new IllegalArgumentException("Ping endpoint must not be null or empty.");
-        }
-        if (pingConfiguration.clusterId() == null || pingConfiguration.clusterId().isBlank()) {
-          throw new IllegalArgumentException("Cluster ID must not be null or empty.");
-        }
-        if (pingConfiguration.clusterName() == null || pingConfiguration.clusterName().isBlank()) {
-          throw new IllegalArgumentException("Cluster name must not be null or empty.");
-        }
-        if (pingConfiguration.pingPeriod() <= 0) {
-          throw new IllegalArgumentException("Ping period must be greater than zero.");
-        }
+        validateConfiguration();
 
         LOGGER.info(
             "Console ping is enabled with endpoint: {}, and delay: {} " + "minutes",
@@ -71,6 +61,22 @@ public class PingConsoleConfiguration implements ApplicationRunner {
       }
     } catch (final Exception exception) {
       LOGGER.error("Failed to initialize PingConsoleTask: {}", exception.getMessage(), exception);
+    }
+  }
+
+  @VisibleForTesting
+  protected void validateConfiguration() {
+    if (pingConfiguration.endpoint() == null || pingConfiguration.endpoint().isBlank()) {
+      throw new IllegalArgumentException("Ping endpoint must not be null or empty.");
+    }
+    if (pingConfiguration.clusterId() == null || pingConfiguration.clusterId().isBlank()) {
+      throw new IllegalArgumentException("Cluster ID must not be null or empty.");
+    }
+    if (pingConfiguration.clusterName() == null || pingConfiguration.clusterName().isBlank()) {
+      throw new IllegalArgumentException("Cluster name must not be null or empty.");
+    }
+    if (pingConfiguration.pingPeriod() <= 0) {
+      throw new IllegalArgumentException("Ping period must be greater than zero.");
     }
   }
 

--- a/dist/src/main/java/io/camunda/application/commons/console/ping/PingConsoleConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/console/ping/PingConsoleConfiguration.java
@@ -39,34 +39,38 @@ public class PingConsoleConfiguration implements ApplicationRunner {
   }
 
   @Override
-  public void run(final ApplicationArguments args) throws Exception {
-    if (pingConfiguration.enabled) {
-      if (pingConfiguration.endpoint() == null || pingConfiguration.endpoint().isBlank()) {
-        throw new IllegalArgumentException("Ping endpoint must not be null or empty.");
-      }
-      if (pingConfiguration.clusterId() == null || pingConfiguration.clusterId().isBlank()) {
-        throw new IllegalArgumentException("Cluster ID must not be null or empty.");
-      }
-      if (pingConfiguration.clusterName() == null || pingConfiguration.clusterName().isBlank()) {
-        throw new IllegalArgumentException("Cluster name must not be null or empty.");
-      }
-      if (pingConfiguration.pingPeriod() <= 0) {
-        throw new IllegalArgumentException("Ping period must be greater than zero.");
-      }
+  public void run(final ApplicationArguments args) {
+    try {
+      if (pingConfiguration.enabled) {
+        if (pingConfiguration.endpoint() == null || pingConfiguration.endpoint().isBlank()) {
+          throw new IllegalArgumentException("Ping endpoint must not be null or empty.");
+        }
+        if (pingConfiguration.clusterId() == null || pingConfiguration.clusterId().isBlank()) {
+          throw new IllegalArgumentException("Cluster ID must not be null or empty.");
+        }
+        if (pingConfiguration.clusterName() == null || pingConfiguration.clusterName().isBlank()) {
+          throw new IllegalArgumentException("Cluster name must not be null or empty.");
+        }
+        if (pingConfiguration.pingPeriod() <= 0) {
+          throw new IllegalArgumentException("Ping period must be greater than zero.");
+        }
 
-      LOGGER.info(
-          "Console ping is enabled with endpoint: {}, and delay: {} " + "minutes",
-          pingConfiguration.endpoint(),
-          pingConfiguration.pingPeriod());
-      final var executor = createTaskExecutor();
-      executor.schedule(
-          new SelfSchedulingTask(
-              executor,
-              new PingConsoleTask(managementServices, pingConfiguration),
-              // pingPeriod is given in minutes.
-              pingConfiguration.pingPeriod * 60 * 1000L),
-          1000,
-          TimeUnit.MILLISECONDS);
+        LOGGER.info(
+            "Console ping is enabled with endpoint: {}, and delay: {} " + "minutes",
+            pingConfiguration.endpoint(),
+            pingConfiguration.pingPeriod());
+        final var executor = createTaskExecutor();
+        executor.schedule(
+            new SelfSchedulingTask(
+                executor,
+                new PingConsoleTask(managementServices, pingConfiguration),
+                // pingPeriod is given in minutes.
+                pingConfiguration.pingPeriod * 60 * 1000L),
+            1000,
+            TimeUnit.MILLISECONDS);
+      }
+    } catch (final Exception exception) {
+      LOGGER.error("Failed to initialize PingConsoleTask: {}", exception.getMessage(), exception);
     }
   }
 

--- a/dist/src/main/java/io/camunda/application/commons/console/ping/PingConsoleConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/console/ping/PingConsoleConfiguration.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.application.commons.console.ping;
+
+import io.camunda.application.commons.console.ping.PingConsoleConfiguration.ConsolePingConfiguration;
+import io.camunda.service.ManagementServices;
+import io.camunda.zeebe.util.error.FatalErrorHandler;
+import java.util.Map;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties({ConsolePingConfiguration.class})
+public class PingConsoleConfiguration implements ApplicationRunner {
+  public static final Logger LOGGER = LoggerFactory.getLogger(PingConsoleConfiguration.class);
+
+  private final ConsolePingConfiguration pingConfiguration;
+  private final ManagementServices managementServices;
+
+  @Autowired
+  public PingConsoleConfiguration(
+      final ConsolePingConfiguration pingConfigurationProperties,
+      final ManagementServices managementServices) {
+    pingConfiguration = pingConfigurationProperties;
+    this.managementServices = managementServices;
+  }
+
+  @Override
+  public void run(final ApplicationArguments args) throws Exception {
+    if (pingConfiguration.enabled) {
+      if (pingConfiguration.endpoint() == null || pingConfiguration.endpoint().isBlank()) {
+        throw new IllegalArgumentException("Ping endpoint must not be null or empty.");
+      }
+      if (pingConfiguration.clusterId() == null || pingConfiguration.clusterId().isBlank()) {
+        throw new IllegalArgumentException("Cluster ID must not be null or empty.");
+      }
+      if (pingConfiguration.clusterName() == null || pingConfiguration.clusterName().isBlank()) {
+        throw new IllegalArgumentException("Cluster name must not be null or empty.");
+      }
+      if (pingConfiguration.pingPeriod() <= 0) {
+        throw new IllegalArgumentException("Ping period must be greater than zero.");
+      }
+
+      LOGGER.info(
+          "Console ping is enabled with endpoint: {}, and delay: {} " + "minutes",
+          pingConfiguration.endpoint(),
+          pingConfiguration.pingPeriod());
+      final var executor = createTaskExecutor();
+      executor.schedule(
+          new SelfSchedulingTask(
+              executor,
+              new PingConsoleTask(managementServices, pingConfiguration),
+              // pingPeriod is given in minutes.
+              pingConfiguration.pingPeriod * 60 * 1000L),
+          1000,
+          TimeUnit.MILLISECONDS);
+    }
+  }
+
+  public ScheduledThreadPoolExecutor createTaskExecutor() {
+    final var threadFactory =
+        Thread.ofPlatform()
+            .name("console-license-ping-", 0)
+            .uncaughtExceptionHandler(FatalErrorHandler.uncaughtExceptionHandler(LOGGER))
+            .factory();
+    final var executor = new ScheduledThreadPoolExecutor(1, threadFactory);
+    executor.setContinueExistingPeriodicTasksAfterShutdownPolicy(false);
+    executor.setExecuteExistingDelayedTasksAfterShutdownPolicy(false);
+    executor.setRemoveOnCancelPolicy(true);
+    return executor;
+  }
+
+  @ConfigurationProperties("camunda.console.ping")
+  public record ConsolePingConfiguration(
+      boolean enabled,
+      String endpoint,
+      String clusterId,
+      String clusterName,
+      int pingPeriod,
+      Map<String, String> properties) {}
+
+  static final class SelfSchedulingTask implements Runnable {
+
+    private final ScheduledThreadPoolExecutor executor;
+    private final Runnable task;
+    private final long delay;
+
+    SelfSchedulingTask(
+        final ScheduledThreadPoolExecutor executor, final Runnable task, final long delay) {
+      this.executor = executor;
+      this.task = task;
+      this.delay = delay;
+    }
+
+    @Override
+    public void run() {
+      task.run();
+      executor.schedule(this, delay, TimeUnit.MILLISECONDS);
+    }
+  }
+}

--- a/dist/src/main/java/io/camunda/application/commons/console/ping/PingConsoleRunner.java
+++ b/dist/src/main/java/io/camunda/application/commons/console/ping/PingConsoleRunner.java
@@ -54,7 +54,7 @@ public class PingConsoleRunner implements ApplicationRunner {
     try {
       validateConfiguration();
       LOGGER.info(
-          "Console ping is enabled with endpoint: {}, and delay: {} " + "minutes",
+          "Console ping is enabled with endpoint: {}, and delay of {}.",
           pingConfiguration.endpoint(),
           pingConfiguration.pingPeriod());
       final var executor = createTaskExecutor();

--- a/dist/src/main/java/io/camunda/application/commons/console/ping/PingConsoleRunner.java
+++ b/dist/src/main/java/io/camunda/application/commons/console/ping/PingConsoleRunner.java
@@ -15,6 +15,7 @@ import io.camunda.service.ManagementServices;
 import io.camunda.zeebe.util.Either;
 import io.camunda.zeebe.util.VisibleForTesting;
 import io.camunda.zeebe.util.error.FatalErrorHandler;
+import io.camunda.zeebe.util.retry.RetryConfiguration;
 import java.net.URI;
 import java.time.Duration;
 import java.util.Map;
@@ -86,16 +87,28 @@ public class PingConsoleRunner implements ApplicationRunner {
     if (pingConfiguration.pingPeriod().isZero() || pingConfiguration.pingPeriod().isNegative()) {
       throw new IllegalArgumentException("Ping period must be greater than zero.");
     }
-    if (pingConfiguration.retryConfiguration != null) {
-      if (pingConfiguration.retryConfiguration().numberOfMaxRetries() <= 0) {
+    if (pingConfiguration.retry() != null) {
+      if (pingConfiguration.retry().getMaxRetries() <= 0) {
         throw new IllegalArgumentException("Number of max retries must be greater than zero.");
       }
-      if (pingConfiguration.retryConfiguration().retryDelayMultiplier() <= 0) {
+      if (pingConfiguration.retry().getRetryDelayMultiplier() <= 0) {
         throw new IllegalArgumentException("Retry delay multiplier must be greater than zero.");
       }
-      if (pingConfiguration.retryConfiguration().maxRetryDelay().isZero()
-          || pingConfiguration.retryConfiguration().maxRetryDelay().isNegative()) {
+      if (pingConfiguration.retry().getMaxRetryDelay().isZero()
+          || pingConfiguration.retry().getMinRetryDelay().isNegative()) {
         throw new IllegalArgumentException("Max retry delay must be greater than zero.");
+      }
+      if (pingConfiguration.retry().getMinRetryDelay().isZero()
+          || pingConfiguration.retry().getMinRetryDelay().isNegative()) {
+        throw new IllegalArgumentException("Min retry delay must be greater than zero.");
+      }
+      if (pingConfiguration
+              .retry()
+              .getMaxRetryDelay()
+              .compareTo(pingConfiguration.retry().getMinRetryDelay())
+          < 0) {
+        throw new IllegalArgumentException(
+            "Max retry delay must be greater than or equal to min retry delay.");
       }
     }
     if (licensePayload.isLeft()) {
@@ -144,9 +157,6 @@ public class PingConsoleRunner implements ApplicationRunner {
       String clusterId,
       String clusterName,
       Duration pingPeriod,
-      RetryConfiguration retryConfiguration,
-      Map<String, String> properties) {
-    public record RetryConfiguration(
-        int numberOfMaxRetries, int retryDelayMultiplier, Duration maxRetryDelay) {}
-  }
+      RetryConfiguration retry,
+      Map<String, String> properties) {}
 }

--- a/dist/src/main/java/io/camunda/application/commons/console/ping/PingConsoleRunner.java
+++ b/dist/src/main/java/io/camunda/application/commons/console/ping/PingConsoleRunner.java
@@ -17,7 +17,6 @@ import io.camunda.zeebe.util.VisibleForTesting;
 import io.camunda.zeebe.util.error.FatalErrorHandler;
 import java.net.URI;
 import java.time.Duration;
-import java.time.format.DateTimeFormatter;
 import java.util.Map;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -36,7 +35,6 @@ import org.springframework.stereotype.Component;
 @ConditionalOnProperty(prefix = "camunda.console.ping", name = "enabled", havingValue = "true")
 public class PingConsoleRunner implements ApplicationRunner {
   private static final Logger LOGGER = LoggerFactory.getLogger(PingConsoleRunner.class);
-  private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ISO_DATE_TIME;
   private final ConsolePingConfiguration pingConfiguration;
   private final ManagementServices managementServices;
   private final Either<Exception, String> licensePayload;
@@ -113,11 +111,7 @@ public class PingConsoleRunner implements ApplicationRunner {
     final LicensePayload.License license =
         new LicensePayload.License(
             managementServices.isCamundaLicenseValid(),
-            managementServices.getCamundaLicenseType().toString(),
-            managementServices.isCommercialCamundaLicense(),
-            managementServices.getCamundaLicenseExpiresAt() == null
-                ? null
-                : DATE_TIME_FORMATTER.format(managementServices.getCamundaLicenseExpiresAt()));
+            managementServices.getCamundaLicenseType().toString());
     final LicensePayload payload =
         new LicensePayload(
             license,

--- a/dist/src/main/java/io/camunda/application/commons/console/ping/PingConsoleRunner.java
+++ b/dist/src/main/java/io/camunda/application/commons/console/ping/PingConsoleRunner.java
@@ -86,6 +86,18 @@ public class PingConsoleRunner implements ApplicationRunner {
     if (pingConfiguration.pingPeriod().isZero() || pingConfiguration.pingPeriod().isNegative()) {
       throw new IllegalArgumentException("Ping period must be greater than zero.");
     }
+    if (pingConfiguration.retryConfiguration != null) {
+      if (pingConfiguration.retryConfiguration().numberOfMaxRetries() <= 0) {
+        throw new IllegalArgumentException("Number of max retries must be greater than zero.");
+      }
+      if (pingConfiguration.retryConfiguration().retryDelayMultiplier() <= 0) {
+        throw new IllegalArgumentException("Retry delay multiplier must be greater than zero.");
+      }
+      if (pingConfiguration.retryConfiguration().maxRetryDelay().isZero()
+          || pingConfiguration.retryConfiguration().maxRetryDelay().isNegative()) {
+        throw new IllegalArgumentException("Max retry delay must be greater than zero.");
+      }
+    }
     if (licensePayload.isLeft()) {
       throw new IllegalArgumentException(
           "Failed to parse license payload for Console ping task.", licensePayload.getLeft());
@@ -132,5 +144,9 @@ public class PingConsoleRunner implements ApplicationRunner {
       String clusterId,
       String clusterName,
       Duration pingPeriod,
-      Map<String, String> properties) {}
+      RetryConfiguration retryConfiguration,
+      Map<String, String> properties) {
+    public record RetryConfiguration(
+        int numberOfMaxRetries, int retryDelayMultiplier, Duration maxRetryDelay) {}
+  }
 }

--- a/dist/src/main/java/io/camunda/application/commons/console/ping/PingConsoleTask.java
+++ b/dist/src/main/java/io/camunda/application/commons/console/ping/PingConsoleTask.java
@@ -99,8 +99,7 @@ public class PingConsoleTask implements Runnable {
   public record LicensePayload(
       License license, String clusterId, String clusterName, Map<String, String> properties) {
     @JsonInclude(JsonInclude.Include.NON_NULL)
-    public record License(
-        boolean validLicense, String licenseType, boolean isCommercial, String expiresAt) {}
+    public record License(boolean validLicense, String licenseType) {}
   }
 
   @VisibleForTesting

--- a/dist/src/main/java/io/camunda/application/commons/console/ping/PingConsoleTask.java
+++ b/dist/src/main/java/io/camunda/application/commons/console/ping/PingConsoleTask.java
@@ -10,25 +10,19 @@ package io.camunda.application.commons.console.ping;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.camunda.application.commons.console.ping.PingConsoleRunner.ConsolePingConfiguration;
 import io.camunda.zeebe.util.VisibleForTesting;
-import io.camunda.zeebe.util.retry.RetryConfiguration;
 import io.camunda.zeebe.util.retry.RetryDecorator;
 import java.io.IOException;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.net.http.HttpResponse.BodyHandlers;
-import java.time.Duration;
 import java.util.Map;
-import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class PingConsoleTask implements Runnable {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(PingConsoleTask.class);
-  private static final int NUMBER_OF_MAX_RETRIES = 10;
-  private static final int RETRY_DELAY_MULTIPLIER = 2;
-  private static final Duration MAX_RETRY_DELAY = Duration.ofMinutes(2);
   private static final int MAX_RESPONSE_BODY_LENGTH = 1000;
   private final HttpClient client;
   private final ConsolePingConfiguration pingConfiguration;
@@ -42,17 +36,7 @@ public class PingConsoleTask implements Runnable {
       final String licensePayload) {
     this.pingConfiguration = pingConfiguration;
     this.client = client;
-    final var retryConfiguration = new RetryConfiguration();
-    retryConfiguration.setMaxRetries(
-        Optional.ofNullable(pingConfiguration.retryConfiguration().numberOfMaxRetries())
-            .orElse(NUMBER_OF_MAX_RETRIES));
-    retryConfiguration.setRetryDelayMultiplier(
-        Optional.ofNullable(pingConfiguration.retryConfiguration().retryDelayMultiplier())
-            .orElse(RETRY_DELAY_MULTIPLIER));
-    retryConfiguration.setMaxRetryDelay(
-        Optional.ofNullable(pingConfiguration.retryConfiguration().maxRetryDelay())
-            .orElse(MAX_RETRY_DELAY));
-    retryDecorator = new RetryDecorator();
+    retryDecorator = new RetryDecorator(pingConfiguration.retry());
     this.licensePayload = licensePayload;
   }
 

--- a/dist/src/main/java/io/camunda/application/commons/console/ping/PingConsoleTask.java
+++ b/dist/src/main/java/io/camunda/application/commons/console/ping/PingConsoleTask.java
@@ -19,6 +19,7 @@ import java.net.http.HttpResponse;
 import java.net.http.HttpResponse.BodyHandlers;
 import java.time.Duration;
 import java.util.Map;
+import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -42,9 +43,15 @@ public class PingConsoleTask implements Runnable {
     this.pingConfiguration = pingConfiguration;
     this.client = client;
     final var retryConfiguration = new RetryConfiguration();
-    retryConfiguration.setMaxRetries(NUMBER_OF_MAX_RETRIES);
-    retryConfiguration.setRetryDelayMultiplier(RETRY_DELAY_MULTIPLIER);
-    retryConfiguration.setMaxRetryDelay(MAX_RETRY_DELAY);
+    retryConfiguration.setMaxRetries(
+        Optional.ofNullable(pingConfiguration.retryConfiguration().numberOfMaxRetries())
+            .orElse(NUMBER_OF_MAX_RETRIES));
+    retryConfiguration.setRetryDelayMultiplier(
+        Optional.ofNullable(pingConfiguration.retryConfiguration().retryDelayMultiplier())
+            .orElse(RETRY_DELAY_MULTIPLIER));
+    retryConfiguration.setMaxRetryDelay(
+        Optional.ofNullable(pingConfiguration.retryConfiguration().maxRetryDelay())
+            .orElse(MAX_RETRY_DELAY));
     retryDecorator = new RetryDecorator();
     this.licensePayload = licensePayload;
   }

--- a/dist/src/main/java/io/camunda/application/commons/console/ping/PingConsoleTask.java
+++ b/dist/src/main/java/io/camunda/application/commons/console/ping/PingConsoleTask.java
@@ -10,6 +10,7 @@ package io.camunda.application.commons.console.ping;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.camunda.application.commons.console.ping.PingConsoleRunner.ConsolePingConfiguration;
 import io.camunda.zeebe.util.VisibleForTesting;
+import io.camunda.zeebe.util.retry.RetryConfiguration;
 import io.camunda.zeebe.util.retry.RetryDecorator;
 import java.io.IOException;
 import java.net.http.HttpClient;
@@ -36,7 +37,11 @@ public class PingConsoleTask implements Runnable {
       final String licensePayload) {
     this.pingConfiguration = pingConfiguration;
     this.client = client;
-    retryDecorator = new RetryDecorator(pingConfiguration.retry());
+    retryDecorator =
+        new RetryDecorator(
+            pingConfiguration.retry() != null
+                ? pingConfiguration.retry()
+                : new RetryConfiguration());
     this.licensePayload = licensePayload;
   }
 

--- a/dist/src/test/java/io/camunda/application/commons/console/ping/PingConsoleConfigurationTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/console/ping/PingConsoleConfigurationTest.java
@@ -51,8 +51,6 @@ class PingConsoleConfigurationTest {
   static void setUp() {
     when(MANAGEMENT_SERVICES.getCamundaLicenseType()).thenReturn(LicenseType.SAAS);
     when(MANAGEMENT_SERVICES.isCamundaLicenseValid()).thenReturn(true);
-    when(MANAGEMENT_SERVICES.isCommercialCamundaLicense()).thenReturn(true);
-    when(MANAGEMENT_SERVICES.getCamundaLicenseExpiresAt()).thenReturn(null);
   }
 
   @Test

--- a/dist/src/test/java/io/camunda/application/commons/console/ping/PingConsoleConfigurationTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/console/ping/PingConsoleConfigurationTest.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.camunda.application.commons.console.ping.PingConsoleRunner.ConsolePingConfiguration;
+import io.camunda.application.commons.console.ping.PingConsoleRunner.ConsolePingConfiguration.RetryConfiguration;
 import io.camunda.service.ManagementServices;
 import io.camunda.service.license.LicenseType;
 import java.io.IOException;
@@ -42,6 +43,7 @@ class PingConsoleConfigurationTest {
           "clusterId",
           "clusterName",
           Duration.ofMillis(1000),
+          new RetryConfiguration(3, 2, Duration.ofMillis(5000)),
           null);
   private final String licensePayload =
       "{\"type\":\"SAAS\",\"valid\":true,\"expiresAt\":null,\"commercial\":true}";
@@ -58,7 +60,13 @@ class PingConsoleConfigurationTest {
     // given
     final ConsolePingConfiguration consolePingConfiguration =
         new ConsolePingConfiguration(
-            true, null, "clusterId", "clusterName", Duration.ofMillis(5000), null);
+            true,
+            null,
+            "clusterId",
+            "clusterName",
+            Duration.ofMillis(5000),
+            new RetryConfiguration(3, 2, Duration.ofMillis(5000)),
+            null);
 
     // then
     final IllegalArgumentException exception =
@@ -74,7 +82,13 @@ class PingConsoleConfigurationTest {
     // given
     final ConsolePingConfiguration consolePingConfiguration =
         new ConsolePingConfiguration(
-            true, URI.create("123"), "clusterId", "clusterName", Duration.ofMillis(5000), null);
+            true,
+            URI.create("123"),
+            "clusterId",
+            "clusterName",
+            Duration.ofMillis(5000),
+            new RetryConfiguration(3, 2, Duration.ofMillis(5000)),
+            null);
 
     // then
     final IllegalArgumentException exception =
@@ -95,6 +109,7 @@ class PingConsoleConfigurationTest {
             null,
             "clusterName",
             Duration.ofMillis(5000),
+            new RetryConfiguration(3, 2, Duration.ofMillis(5000)),
             null);
 
     // then
@@ -116,6 +131,7 @@ class PingConsoleConfigurationTest {
             "clusterId",
             "",
             Duration.ofMillis(5000),
+            new RetryConfiguration(3, 2, Duration.ofMillis(5000)),
             null);
 
     // then
@@ -137,6 +153,7 @@ class PingConsoleConfigurationTest {
             "clusterId",
             "clusterName",
             Duration.ofMillis(-333),
+            new RetryConfiguration(3, 2, Duration.ofMillis(5000)),
             null);
 
     // then
@@ -149,6 +166,89 @@ class PingConsoleConfigurationTest {
   }
 
   @Test
+  void numberOfMaxRetriesMustBePositive() {
+    // given
+    final ConsolePingConfiguration consolePingConfiguration =
+        new ConsolePingConfiguration(
+            true,
+            URI.create("http://localhost:8080"),
+            "clusterId",
+            "clusterName",
+            Duration.ofMillis(5000),
+            new RetryConfiguration(0, 2, Duration.ofMillis(5000)),
+            null);
+
+    // then
+    final IllegalArgumentException exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            new PingConsoleRunner(consolePingConfiguration, MANAGEMENT_SERVICES)
+                ::validateConfiguration);
+    assertEquals("Number of max retries must be greater than zero.", exception.getMessage());
+  }
+
+  @Test
+  void retryDelayMultiplierMustBePositive() {
+    // given
+    final ConsolePingConfiguration consolePingConfiguration =
+        new ConsolePingConfiguration(
+            true,
+            URI.create("http://localhost:8080"),
+            "clusterId",
+            "clusterName",
+            Duration.ofMillis(5000),
+            new RetryConfiguration(3, 0, Duration.ofMillis(5000)),
+            null);
+
+    // then
+    final IllegalArgumentException exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            new PingConsoleRunner(consolePingConfiguration, MANAGEMENT_SERVICES)
+                ::validateConfiguration);
+    assertEquals("Retry delay multiplier must be greater than zero.", exception.getMessage());
+  }
+
+  @Test
+  void retryConfigurationCanBeNull() {
+    // given
+    final ConsolePingConfiguration consolePingConfiguration =
+        new ConsolePingConfiguration(
+            true,
+            URI.create("http://localhost:8080"),
+            "clusterId",
+            "clusterName",
+            Duration.ofMillis(5000),
+            null,
+            null);
+
+    // then
+    assertDoesNotThrow(() -> new PingConsoleRunner(consolePingConfiguration, MANAGEMENT_SERVICES));
+  }
+
+  @Test
+  void maxRetryDelayMustBePositive() {
+    // given
+    final ConsolePingConfiguration consolePingConfiguration =
+        new ConsolePingConfiguration(
+            true,
+            URI.create("http://localhost:8080"),
+            "clusterId",
+            "clusterName",
+            Duration.ofMillis(5000),
+            new RetryConfiguration(3, 2, Duration.ZERO),
+            null);
+
+    // then
+    final IllegalArgumentException exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            new PingConsoleRunner(consolePingConfiguration, MANAGEMENT_SERVICES)
+                ::validateConfiguration);
+    assertEquals("Max retry delay must be greater than zero.", exception.getMessage());
+  }
+
+  @Test
   void shouldSucceedToStartConsolePingForValidConfig() {
     // given
     final ConsolePingConfiguration consolePingConfiguration =
@@ -158,6 +258,7 @@ class PingConsoleConfigurationTest {
             "clusterId",
             "clusterName",
             Duration.ofMillis(5000),
+            new RetryConfiguration(3, 2, Duration.ofMillis(5000)),
             null);
     // then
     assertDoesNotThrow(() -> new PingConsoleRunner(consolePingConfiguration, MANAGEMENT_SERVICES));
@@ -168,7 +269,13 @@ class PingConsoleConfigurationTest {
     // given an invalid config
     final ConsolePingConfiguration consolePingConfiguration =
         new ConsolePingConfiguration(
-            false, URI.create("123"), "", null, Duration.ofMillis(-300), null);
+            false,
+            URI.create("123"),
+            "",
+            null,
+            Duration.ofMillis(-300),
+            new RetryConfiguration(3, 2, Duration.ofMillis(5000)),
+            null);
 
     // then we assert that it is not throwing an exception due to the feature being disabled
     assertDoesNotThrow(() -> new PingConsoleRunner(consolePingConfiguration, MANAGEMENT_SERVICES));

--- a/dist/src/test/java/io/camunda/application/commons/console/ping/PingConsoleConfigurationTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/console/ping/PingConsoleConfigurationTest.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.application.commons.console.ping;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.application.commons.console.ping.PingConsoleConfiguration.ConsolePingConfiguration;
+import io.camunda.service.ManagementServices;
+import io.camunda.service.license.LicenseType;
+import java.io.IOException;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class PingConsoleConfigurationTest {
+
+  @Mock private ManagementServices managementServices;
+  @Mock private ConsolePingConfiguration pingConfiguration;
+  @Mock private HttpClient mockClient;
+
+  @Test
+  void shouldFailToStartConsolePing() {
+    IllegalArgumentException exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            new PingConsoleConfiguration(
+                    new ConsolePingConfiguration(true, null, "clusterId", "clusterName", 5, null),
+                    managementServices)
+                ::validateConfiguration);
+    assertEquals("Ping endpoint must not be null or empty.", exception.getMessage());
+
+    exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            new PingConsoleConfiguration(
+                    new ConsolePingConfiguration(
+                        true, "http://localhost:8080", null, "clusterName", 5, null),
+                    managementServices)
+                ::validateConfiguration);
+    assertEquals("Cluster ID must not be null or empty.", exception.getMessage());
+
+    exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            new PingConsoleConfiguration(
+                    new ConsolePingConfiguration(
+                        true, "http://localhost:8080", "clusterId", "", 5, null),
+                    managementServices)
+                ::validateConfiguration);
+    assertEquals("Cluster name must not be null or empty.", exception.getMessage());
+
+    exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            new PingConsoleConfiguration(
+                    new ConsolePingConfiguration(
+                        true, "http" + "://localhost:8080", "clusterId", "clusterName", 0, null),
+                    managementServices)
+                ::validateConfiguration);
+    assertEquals("Ping period must be greater than zero.", exception.getMessage());
+  }
+
+  @Test
+  void shouldSucceedToStartConsolePing() {
+    assertDoesNotThrow(
+        () ->
+            new PingConsoleConfiguration(
+                new ConsolePingConfiguration(
+                    true, "http://localhost:8080", "clusterId", "clusterName", 1, null),
+                managementServices));
+
+    // does not throw if the feature is disabled
+    assertDoesNotThrow(
+        () ->
+            new PingConsoleConfiguration(
+                new ConsolePingConfiguration(false, "", "", null, -32, null), managementServices));
+  }
+
+  @Test
+  void doesNotRetryOnSuccess() throws Exception {
+    final HttpResponse<String> mockResponse = mock(HttpResponse.class);
+    // Simulate a successful response
+    when(mockResponse.statusCode()).thenReturn(200);
+    when(pingConfiguration.endpoint()).thenReturn("http://fake-endpoint.com");
+
+    when(mockClient.send(
+            ArgumentMatchers.<HttpRequest>any(),
+            ArgumentMatchers.<HttpResponse.BodyHandler<String>>any()))
+        .thenReturn(mockResponse);
+
+    when(managementServices.getCamundaLicenseType()).thenReturn(LicenseType.SAAS);
+    when(managementServices.isCamundaLicenseValid()).thenReturn(true);
+    when(managementServices.isCommercialCamundaLicense()).thenReturn(true);
+    when(managementServices.getCamundaLicenseExpiresAt()).thenReturn(null);
+
+    final PingConsoleTask realTask =
+        new PingConsoleTask(managementServices, pingConfiguration, mockClient);
+
+    final PingConsoleTask spyTask = Mockito.spy(realTask);
+
+    spyTask.run();
+
+    verify(spyTask, times(1)).tryPingConsole(any(HttpRequest.class));
+  }
+
+  @Test
+  void shouldRetryOnSendException() throws Exception {
+    final HttpResponse<String> mockResponse = mock(HttpResponse.class);
+    when(mockResponse.statusCode()).thenReturn(200);
+    when(pingConfiguration.endpoint()).thenReturn("http://fake-endpoint.com");
+
+    // when we simulate 2 failures and 1 success
+    when(mockClient.send(
+            ArgumentMatchers.<HttpRequest>any(),
+            ArgumentMatchers.<HttpResponse.BodyHandler<String>>any()))
+        .thenThrow(new IOException("IO error"))
+        .thenThrow(new InterruptedException("Interrupted connection error"))
+        .thenReturn(mockResponse); // 3rd try succeeds
+
+    when(managementServices.getCamundaLicenseType()).thenReturn(LicenseType.SAAS);
+    when(managementServices.isCamundaLicenseValid()).thenReturn(true);
+    when(managementServices.isCommercialCamundaLicense()).thenReturn(true);
+    when(managementServices.getCamundaLicenseExpiresAt()).thenReturn(null);
+
+    final PingConsoleTask realTask =
+        new PingConsoleTask(managementServices, pingConfiguration, mockClient);
+
+    final PingConsoleTask spyTask = Mockito.spy(realTask);
+
+    spyTask.run();
+
+    // then
+    verify(spyTask, times(3)).tryPingConsole(any(HttpRequest.class));
+  }
+
+  @Test
+  void shouldRetryOnSpecificStatusCodes() throws Exception {
+    final HttpResponse<String> firstMockResponse = mock(HttpResponse.class);
+    final HttpResponse<String> secondMockResponse = mock(HttpResponse.class);
+    final HttpResponse<String> thirdMockResponse = mock(HttpResponse.class);
+
+    when(firstMockResponse.statusCode()).thenReturn(500); // server error
+    when(secondMockResponse.statusCode()).thenReturn(429); // timeout
+    when(thirdMockResponse.statusCode()).thenReturn(200); // successful request
+
+    when(pingConfiguration.endpoint()).thenReturn("http://fake-endpoint.com");
+
+    when(managementServices.getCamundaLicenseType()).thenReturn(LicenseType.SAAS);
+    when(managementServices.isCamundaLicenseValid()).thenReturn(true);
+    when(managementServices.isCommercialCamundaLicense()).thenReturn(true);
+    when(managementServices.getCamundaLicenseExpiresAt()).thenReturn(null);
+
+    when(mockClient.send(
+            ArgumentMatchers.<HttpRequest>any(),
+            ArgumentMatchers.<HttpResponse.BodyHandler<String>>any()))
+        .thenReturn(firstMockResponse)
+        .thenReturn(secondMockResponse)
+        .thenReturn(thirdMockResponse);
+
+    final PingConsoleTask realTask =
+        new PingConsoleTask(managementServices, pingConfiguration, mockClient);
+
+    final PingConsoleTask spyTask = Mockito.spy(realTask);
+
+    spyTask.run();
+
+    // then
+    verify(spyTask, times(3)).tryPingConsole(any(HttpRequest.class));
+  }
+}

--- a/dist/src/test/java/io/camunda/application/commons/console/ping/PingConsoleRunnerIT.java
+++ b/dist/src/test/java/io/camunda/application/commons/console/ping/PingConsoleRunnerIT.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.application.commons.console.ping;
+
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.AssertionsKt.assertNotNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.application.commons.console.ping.PingConsoleRunner.ConsolePingConfiguration;
+import io.camunda.application.commons.console.ping.PingConsoleRunner.ConsolePingConfiguration.RetryConfiguration;
+import io.camunda.service.ManagementServices;
+import io.camunda.service.license.LicenseType;
+import java.io.IOException;
+import java.net.URI;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class PingConsoleRunnerIT {
+
+  private MockWebServer mockWebServer;
+  private ManagementServices managementServices;
+  private final boolean validLicense = true;
+  private final boolean isCommercial = true;
+  private final LicenseType licenseType = LicenseType.SAAS;
+  private final String clusterId = "test-cluster-id";
+  private final String clusterName = "test-cluster-name";
+  private final String expectedBody =
+      String.format(
+          """
+    {
+      "license": {
+        "validLicense": %s,
+        "licenseType": "%s",
+        "isCommercial": %s
+      },
+      "clusterId": "%s",
+      "clusterName": "%s"
+    }
+  """,
+          validLicense, licenseType, isCommercial, clusterId, clusterName);
+
+  @BeforeEach
+  void setup() throws IOException {
+    mockWebServer = new MockWebServer();
+    mockWebServer.start();
+    managementServices = mock(ManagementServices.class);
+    when(managementServices.getCamundaLicenseType()).thenReturn(licenseType);
+    when(managementServices.isCommercialCamundaLicense()).thenReturn(isCommercial);
+    when(managementServices.isCamundaLicenseValid()).thenReturn(validLicense);
+  }
+
+  @AfterEach
+  void tearDown() throws IOException {
+    mockWebServer.shutdown();
+  }
+
+  @Test
+  void shouldSendCorrectPayload() throws InterruptedException, JsonProcessingException {
+    // given
+    final String mockUrl = mockWebServer.url("/ping").toString();
+
+    // we have the server answer with a valid response for 3 times.
+    mockWebServer.enqueue(new MockResponse().setResponseCode(200).setBody("PONG"));
+    mockWebServer.enqueue(new MockResponse().setResponseCode(200).setBody("PONG"));
+    mockWebServer.enqueue(new MockResponse().setResponseCode(200).setBody("PONG"));
+
+    final Duration pingPeriod = Duration.ofMillis(200);
+    final ConsolePingConfiguration.RetryConfiguration retryConfig =
+        new RetryConfiguration(1, 1, Duration.ofMillis(100));
+
+    final ConsolePingConfiguration config =
+        new ConsolePingConfiguration(
+            true, URI.create(mockUrl), clusterId, clusterName, pingPeriod, retryConfig, null);
+
+    final PingConsoleRunner pingConsoleRunner = new PingConsoleRunner(config, managementServices);
+
+    // when
+    pingConsoleRunner.run(null);
+
+    // then
+    await().atMost(10, TimeUnit.SECONDS).until(() -> mockWebServer.getRequestCount() >= 3);
+
+    // we validate the first request received by the mock server
+    final RecordedRequest request = mockWebServer.takeRequest(1, TimeUnit.SECONDS);
+    assertNotNull(request);
+    assertEquals("POST", request.getMethod());
+
+    final String body = request.getBody().readUtf8();
+
+    final ObjectMapper mapper = new ObjectMapper();
+    final JsonNode expected = mapper.readTree(expectedBody);
+
+    assertEquals(expected.toString(), body, "JSON payload did not match expected structure");
+  }
+}

--- a/zeebe/util/pom.xml
+++ b/zeebe/util/pom.xml
@@ -92,6 +92,16 @@
     </dependency>
 
     <dependency>
+      <groupId>io.github.resilience4j</groupId>
+      <artifactId>resilience4j-retry</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.github.resilience4j</groupId>
+      <artifactId>resilience4j-core</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>provided</scope>

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/retry/RetryConfiguration.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/retry/RetryConfiguration.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.util.retry;
+
+import static io.github.resilience4j.core.IntervalFunction.DEFAULT_INITIAL_INTERVAL;
+import static io.github.resilience4j.core.IntervalFunction.DEFAULT_MULTIPLIER;
+import static io.github.resilience4j.retry.RetryConfig.DEFAULT_MAX_ATTEMPTS;
+import static java.util.Optional.ofNullable;
+
+import java.time.Duration;
+
+public class RetryConfiguration {
+
+  private static final Duration DEFAULT_MAX_RETRY_DELAY = Duration.ofMillis(30_000);
+  private Integer maxRetries;
+  private Duration minRetryDelay;
+  private Duration maxRetryDelay;
+  private Double retryDelayMultiplier;
+
+  public int getMaxRetries() {
+    return ofNullable(maxRetries).orElseGet(this::defaultMaxRetries);
+  }
+
+  public void setMaxRetries(final int maxRetries) {
+    this.maxRetries = maxRetries;
+  }
+
+  public Duration getMinRetryDelay() {
+    return ofNullable(minRetryDelay).orElseGet(this::defaultMinRetryDelay);
+  }
+
+  public void setMinRetryDelay(final Duration minRetryDelay) {
+    this.minRetryDelay = minRetryDelay;
+  }
+
+  public Duration getMaxRetryDelay() {
+    return ofNullable(maxRetryDelay).orElseGet(this::defaultMaxRetryDelay);
+  }
+
+  public void setMaxRetryDelay(final Duration maxRetryDelay) {
+    this.maxRetryDelay = maxRetryDelay;
+  }
+
+  public double getRetryDelayMultiplier() {
+    return ofNullable(retryDelayMultiplier).orElseGet(this::defaultRetryDelayMultiplier);
+  }
+
+  public void setRetryDelayMultiplier(final double retryDelayMultiplier) {
+    this.retryDelayMultiplier = retryDelayMultiplier;
+  }
+
+  protected int defaultMaxRetries() {
+    return DEFAULT_MAX_ATTEMPTS;
+  }
+
+  protected Duration defaultMinRetryDelay() {
+    return Duration.ofMillis(DEFAULT_INITIAL_INTERVAL);
+  }
+
+  protected Duration defaultMaxRetryDelay() {
+    return DEFAULT_MAX_RETRY_DELAY;
+  }
+
+  protected double defaultRetryDelayMultiplier() {
+    return DEFAULT_MULTIPLIER;
+  }
+}

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/retry/RetryDecorator.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/retry/RetryDecorator.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.util.retry;
+
+import static java.util.Optional.ofNullable;
+
+import io.github.resilience4j.core.IntervalBiFunction;
+import io.github.resilience4j.core.IntervalFunction;
+import io.github.resilience4j.core.functions.CheckedRunnable;
+import io.github.resilience4j.retry.Retry;
+import io.github.resilience4j.retry.RetryConfig;
+import java.util.UUID;
+import java.util.concurrent.Callable;
+import java.util.function.Predicate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class RetryDecorator {
+
+  private static final Logger LOG = LoggerFactory.getLogger(RetryDecorator.class);
+  private final RetryConfiguration retryConfiguration;
+  private final Predicate<Throwable> retryOnExceptionPredicate;
+
+  public RetryDecorator(
+      final RetryConfiguration retryConfiguration,
+      final Predicate<Throwable> retryOnExceptionPredicate) {
+    this.retryConfiguration = retryConfiguration;
+    this.retryOnExceptionPredicate = retryOnExceptionPredicate;
+  }
+
+  public RetryDecorator(final RetryConfiguration retryConfiguration) {
+    this(retryConfiguration, e -> true);
+  }
+
+  public RetryDecorator() {
+    this(new RetryConfiguration());
+  }
+
+  public RetryDecorator withRetryOnException(final Predicate<Throwable> retryOnExceptionPredicate) {
+    return new RetryDecorator(retryConfiguration, retryOnExceptionPredicate);
+  }
+
+  public RetryDecorator withRetryOnExceptions(
+      final Class<? extends Throwable>... exceptionClasses) {
+    return new RetryDecorator(
+        retryConfiguration,
+        e -> {
+          for (final var exceptionClass : exceptionClasses) {
+            if (exceptionClass.isAssignableFrom(e.getClass())) {
+              return true;
+            }
+          }
+          return false;
+        });
+  }
+
+  public <T> T decorate(
+      final String operationName, final Callable<T> callable, final Predicate<T> retryPredicate)
+      throws Exception {
+    final Retry retry = buildRetry(operationName, retryPredicate);
+    return Retry.decorateCallable(retry, callable).call();
+  }
+
+  public void decorate(final String operationName, final Runnable runnable) {
+    final Retry retry = buildRetry(operationName, null);
+    Retry.decorateRunnable(retry, runnable).run();
+  }
+
+  public void decorateCheckedRunnable(final String operationName, final CheckedRunnable runnable) {
+    final Retry retry = buildRetry(operationName, null);
+    Retry.decorateCheckedRunnable(retry, runnable).unchecked().run();
+  }
+
+  private <T> Retry buildRetry(final String operationName, final Predicate<T> retryPredicate) {
+    final var retryConfigBuilder =
+        RetryConfig.<T>custom()
+            .maxAttempts(retryConfiguration.getMaxRetries())
+            .intervalBiFunction(
+                IntervalBiFunction.ofIntervalFunction(
+                    IntervalFunction.ofExponentialRandomBackoff(
+                        retryConfiguration.getMinRetryDelay(),
+                        retryConfiguration.getRetryDelayMultiplier(),
+                        retryConfiguration.getMaxRetryDelay())))
+            .retryOnException(retryOnExceptionPredicate);
+    if (retryPredicate != null) {
+      retryConfigBuilder.retryOnResult(retryPredicate);
+    }
+    final var config = retryConfigBuilder.build();
+    final Retry retry = Retry.of(UUID.randomUUID().toString(), config);
+
+    retry
+        .getEventPublisher()
+        .onError(
+            event ->
+                ofNullable(event.getLastThrowable())
+                    .ifPresentOrElse(
+                        t -> LOG.error("Retry failed for '{}': {}", operationName, t.getMessage()),
+                        () -> LOG.error("Retry failed for '{}'", operationName)))
+        .onRetry(
+            event -> {
+              ofNullable(event.getLastThrowable())
+                  .ifPresentOrElse(
+                      t -> {
+                        LOG.warn(
+                            "Retrying operation for '{}': attempt {}. Message: {}.",
+                            operationName,
+                            event.getNumberOfRetryAttempts(),
+                            t.getMessage());
+                        LOG.debug("Stacktrace:", t);
+                      },
+                      () ->
+                          LOG.warn(
+                              "Retrying operation for '{}': attempt {}.",
+                              operationName,
+                              event.getNumberOfRetryAttempts()));
+            });
+    return retry;
+  }
+}


### PR DESCRIPTION
# Description
Backport of #34370 and https://github.com/camunda/camunda/pull/34776 to `stable/8.7`.

I decided to try to backport both PRs at the same time to be less confusing since both of them add changes in two files, namelly `PingConsoleRunner` , and `PingConsoleConfiguration`, plus the tests. 

Unlike the latest version, the `stable/8.7` management services do not provide the `expiresAt` and `isComertial` fields for the license, so this in the only difference in the implementation of the feature in 8.7.

This PR also backports the Retry decorator util that is used in this feature.

The last commit `fix: provide default in case retry config is null.` is new and is something I noticed while testing again. We should provide the default retry config in case this was not set up instead of failing during the start. I will also add this commit to `main`.

relates to camunda/camunda#34259 and https://github.com/camunda/camunda/pull/34776