### PR TITLE
Enable tag globbing in Optimize Docker builds

### DIFF
--- a/.github/workflows/optimize-release-optimize-c8-only.yml
+++ b/.github/workflows/optimize-release-optimize-c8-only.yml
@@ -349,8 +349,9 @@ jobs:
               echo "tag_arguments=$tag_arguments" >>"$GITHUB_ENV"
           fi
 
+          # shellcheck disable=SC2086
           docker buildx build \
-              "${tag_arguments}" \
+              ${tag_arguments} \
               --build-arg VERSION="${RELEASE_VERSION}" \
               --build-arg DATE="${DATE}" \
               --build-arg REVISION="${REVISION}" \


### PR DESCRIPTION
## Description

The PR fixes Docker tagging by enabling globbing. It also instructs `shellcheck` to ignore it.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

https://camunda.slack.com/archives/C08NZ7E9ZT2/p1751409745193159
