### PR TITLE
[Backport stable/8.7] 32576 avoid npe on receive task validator

### DIFF
--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/ReceiveTaskValidator.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/ReceiveTaskValidator.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.model.bpmn.instance.MessageEventDefinition;
 import io.camunda.zeebe.model.bpmn.instance.ReceiveTask;
 import io.camunda.zeebe.model.bpmn.util.ModelUtil;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Stream;
 import org.camunda.bpm.model.xml.validation.ModelElementValidator;
 import org.camunda.bpm.model.xml.validation.ValidationResultCollector;
@@ -38,6 +39,7 @@ public class ReceiveTaskValidator implements ModelElementValidator<ReceiveTask> 
     final Message message = element.getMessage();
     if (message == null) {
       validationResultCollector.addError(0, "Must reference a message");
+      return;
     }
 
     final List<EventDefinition> eventDefinitions =
@@ -46,6 +48,7 @@ public class ReceiveTaskValidator implements ModelElementValidator<ReceiveTask> 
     final Stream<String> messageNames =
         ModelUtil.getEventDefinition(eventDefinitions, MessageEventDefinition.class)
             .map(MessageEventDefinition::getMessage)
+            .filter(Objects::nonNull)
             .filter(m -> m.getName() != null && !m.getName().isEmpty())
             .map(Message::getName);
 

--- a/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeMessageValidationTest.java
+++ b/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeMessageValidationTest.java
@@ -20,6 +20,7 @@ import static java.util.Collections.singletonList;
 
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.model.bpmn.builder.AbstractCatchEventBuilder;
 import io.camunda.zeebe.model.bpmn.builder.ProcessBuilder;
 import io.camunda.zeebe.model.bpmn.instance.IntermediateThrowEvent;
 import io.camunda.zeebe.model.bpmn.instance.Message;
@@ -242,6 +243,17 @@ public class ZeebeMessageValidationTest extends AbstractZeebeValidationTest {
             expect(
                 IntermediateThrowEvent.class,
                 "Must have either one 'zeebe:publishMessage' or one 'zeebe:taskDefinition' extension element"))
+      },
+      {
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .receiveTask(
+                "receive_task",
+                r -> r.message(m -> m.name("wait").zeebeCorrelationKeyExpression("123")))
+            .boundaryEvent("boundary_event", AbstractCatchEventBuilder::messageEventDefinition)
+            .endEvent("test")
+            .done(),
+        singletonList(expect(MessageEventDefinition.class, "Must reference a message"))
       }
     };
   }


### PR DESCRIPTION
# Description
Backport of #34685 to `stable/8.7`.

relates to camunda/camunda#32576