### PR TITLE
Initialize `RoutingState` with a cluster operation

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImpl.java
@@ -34,6 +34,7 @@ import io.camunda.zeebe.broker.transport.snapshotapi.SnapshotApiRequestHandler;
 import io.camunda.zeebe.dynamic.config.changes.PartitionChangeExecutor;
 import io.camunda.zeebe.dynamic.config.changes.PartitionScalingChangeExecutor;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
+import io.camunda.zeebe.dynamic.config.state.RoutingState;
 import io.camunda.zeebe.engine.processing.streamprocessor.JobStreamer;
 import io.camunda.zeebe.protocol.impl.encoding.BrokerInfo;
 import io.camunda.zeebe.scheduler.ActorSchedulingService;
@@ -591,6 +592,11 @@ public final class PartitionManagerImpl
   @Override
   public ActorFuture<Void> notifyPartitionBootstrapped(final int partitionId) {
     return scalingExecutor.notifyPartitionBootstrapped(partitionId);
+  }
+
+  @Override
+  public ActorFuture<RoutingState> getRoutingState() {
+    return scalingExecutor.getRoutingState();
   }
 
   private ActorFuture<Void> stopPartition(final int partitionId) {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/scaling/RoutingStateConverter.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/scaling/RoutingStateConverter.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker.partitioning.scaling;
+
+import io.camunda.zeebe.dynamic.config.state.RoutingState;
+import io.camunda.zeebe.dynamic.config.state.RoutingState.MessageCorrelation;
+import io.camunda.zeebe.dynamic.config.state.RoutingState.RequestHandling;
+import io.camunda.zeebe.protocol.impl.record.value.scaling.ScaleRecord;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+public final class RoutingStateConverter {
+
+  public static RoutingState fromScaleRecord(final ScaleRecord record) {
+    final RequestHandling requestHandling;
+    if (record.getDesiredPartitionCount() <= 0) {
+      throw new IllegalArgumentException(
+          "desired partition count must be greater than 0, was "
+              + record.getDesiredPartitionCount());
+    }
+    if (record.getRedistributedPartitions().size() == record.getDesiredPartitionCount()) {
+      requestHandling = new RequestHandling.AllPartitions(record.getDesiredPartitionCount());
+    } else {
+      if (record.getMessageCorrelationPartitions() > record.getRedistributedPartitions().size()) {
+        throw new IllegalArgumentException(
+            "partitions in message correlation cannot be more than partitions in request handling: %d > %d"
+                .formatted(
+                    record.getMessageCorrelationPartitions(),
+                    record.getRedistributedPartitions().size()));
+      }
+      if (record.getRedistributedPartitions().size() > record.getDesiredPartitionCount()) {
+        throw new IllegalArgumentException(
+            "redistributed partitions cannot be more than desired partitions: %d > %d"
+                .formatted(
+                    record.getRedistributedPartitions().size(), record.getDesiredPartitionCount()));
+      }
+      requestHandling =
+          new RequestHandling.ActivePartitions(
+              record.getRedistributedPartitions().size(),
+              Set.of(),
+              IntStream.rangeClosed(
+                      record.getRedistributedPartitions().size() + 1,
+                      record.getDesiredPartitionCount())
+                  .boxed()
+                  .collect(Collectors.toSet()));
+    }
+    final var messageCorrelation =
+        new MessageCorrelation.HashMod(record.getMessageCorrelationPartitions());
+    return new RoutingState(0L, requestHandling, messageCorrelation);
+  }
+}

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/ZeebePartitionFactory.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/ZeebePartitionFactory.java
@@ -230,7 +230,6 @@ public final class ZeebePartitionFactory {
       runtimeDirectory = raftPartition.dataDirectory().toPath().resolve("runtime");
     }
     return new StateControllerImpl(
-        partitionId,
         zeebeRocksDbFactory,
         snapshotStore,
         runtimeDirectory,

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/StateController.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/StateController.java
@@ -10,9 +10,8 @@ package io.camunda.zeebe.broker.system.partitions;
 import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.snapshots.TransientSnapshot;
-import io.camunda.zeebe.snapshots.transfer.SnapshotTransferService;
 
-public interface StateController extends AutoCloseable, SnapshotTransferService.TakeSnapshot {
+public interface StateController extends AutoCloseable {
   /**
    * Takes a snapshot based on the given position. The position is a last processed lower bound
    * event position. When the returned future completes successfully the transient snapshot will be

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/StateControllerImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/StateControllerImpl.java
@@ -19,9 +19,7 @@ import io.camunda.zeebe.logstreams.impl.Loggers;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.ScheduledTimer;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
-import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.snapshots.ConstructableSnapshotStore;
-import io.camunda.zeebe.snapshots.PersistableSnapshot;
 import io.camunda.zeebe.snapshots.PersistedSnapshot;
 import io.camunda.zeebe.snapshots.SnapshotException.StateClosedException;
 import io.camunda.zeebe.snapshots.TransientSnapshot;
@@ -44,7 +42,6 @@ public class StateControllerImpl implements StateController {
   private final ZeebeDbFactory zeebeDbFactory;
   private final ToLongFunction<ZeebeDb> exporterPositionSupplier;
   private final AtomixRecordEntrySupplier entrySupplier;
-  private final int partitionId;
   private final ConstructableSnapshotStore constructableSnapshotStore;
   private final ConcurrencyControl concurrencyControl;
 
@@ -52,14 +49,12 @@ public class StateControllerImpl implements StateController {
   private ScheduledTimer metricsExportTimer;
 
   public StateControllerImpl(
-      final int partitionId,
       final ZeebeDbFactory zeebeDbFactory,
       final ConstructableSnapshotStore constructableSnapshotStore,
       final Path runtimeDirectory,
       final AtomixRecordEntrySupplier entrySupplier,
       final ToLongFunction<ZeebeDb> exporterPositionSupplier,
       final ConcurrencyControl concurrencyControl) {
-    this.partitionId = partitionId;
     this.constructableSnapshotStore = requireNonNull(constructableSnapshotStore);
     this.runtimeDirectory = requireNonNull(runtimeDirectory);
     this.zeebeDbFactory = requireNonNull(zeebeDbFactory);
@@ -282,20 +277,6 @@ public class StateControllerImpl implements StateController {
             transientSnapshotFuture.complete(snapshot);
           }
         });
-  }
-
-  @Override
-  public ActorFuture<PersistedSnapshot> takeSnapshot(
-      final int partition, final long lastProcessedPosition, final ConcurrencyControl control) {
-    if (partition != partitionId) {
-      return CompletableActorFuture.completedExceptionally(
-          new IllegalArgumentException(
-              String.format(
-                  "Expected to take snapshot for partition %d, but was called for partition %d",
-                  partitionId, partition)));
-    }
-    return takeTransientSnapshot(lastProcessedPosition)
-        .andThen(PersistableSnapshot::persist, control);
   }
 
   private record NextSnapshotId(

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/SnapshotApiHandlerTransitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/SnapshotApiHandlerTransitionStep.java
@@ -35,7 +35,7 @@ public class SnapshotApiHandlerTransitionStep implements PartitionTransitionStep
       final var service =
           new SnapshotTransferServiceImpl(
               context.getPersistedSnapshotStore(),
-              context.getStateController(),
+              context.getSnapshotDirector(),
               context.getPartitionId(),
               (from, to) ->
                   context.snapshotCopy().copySnapshot(from, to, Set.of(ColumnFamilyScope.GLOBAL)),

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/scaling/RoutingStateConverterTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/scaling/RoutingStateConverterTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker.partitioning.scaling;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.zeebe.dynamic.config.state.RoutingState;
+import io.camunda.zeebe.dynamic.config.state.RoutingState.MessageCorrelation;
+import io.camunda.zeebe.dynamic.config.state.RoutingState.RequestHandling;
+import io.camunda.zeebe.dynamic.config.state.RoutingState.RequestHandling.AllPartitions;
+import io.camunda.zeebe.protocol.impl.record.value.scaling.ScaleRecord;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+public class RoutingStateConverterTest {
+
+  @Test
+  void shouldConvertAllPartitionsHandling() {
+    final ScaleRecord record = new ScaleRecord();
+    record.setDesiredPartitionCount(3);
+    record.setRedistributedPartitions(List.of(1, 2, 3));
+    record.setMessageCorrelationPartitions(2);
+
+    final RoutingState state = RoutingStateConverter.fromScaleRecord(record);
+
+    assertThat(state.requestHandling()).isInstanceOf(RequestHandling.AllPartitions.class);
+    final var allPartitions = (RequestHandling.AllPartitions) state.requestHandling();
+    assertThat(allPartitions).isEqualTo(new AllPartitions(3));
+    assertThat(state.messageCorrelation()).isInstanceOf(MessageCorrelation.HashMod.class);
+    assertThat(((MessageCorrelation.HashMod) state.messageCorrelation()).partitionCount())
+        .isEqualTo(2);
+  }
+
+  @Test
+  void shouldConvertActivePartitionsHandling() {
+    final ScaleRecord record = new ScaleRecord();
+    record.setDesiredPartitionCount(5);
+    record.setRedistributedPartitions(List.of(1, 2, 3));
+    record.setMessageCorrelationPartitions(3);
+
+    final RoutingState state = RoutingStateConverter.fromScaleRecord(record);
+
+    assertThat(state.requestHandling()).isInstanceOf(RequestHandling.ActivePartitions.class);
+    final RequestHandling.ActivePartitions active =
+        (RequestHandling.ActivePartitions) state.requestHandling();
+    assertThat(active.activePartitions().size()).isEqualTo(3);
+    assertThat(active.inactivePartitions()).containsExactlyInAnyOrder(4, 5);
+    assertThat(state.messageCorrelation()).isInstanceOf(MessageCorrelation.HashMod.class);
+    assertThat(((MessageCorrelation.HashMod) state.messageCorrelation()).partitionCount())
+        .isEqualTo(3);
+  }
+
+  @Test
+  void shouldRejectInvalidRecord() {
+    final var scaleRecord = new ScaleRecord();
+
+    assertThatThrownBy(() -> RoutingStateConverter.fromScaleRecord(scaleRecord))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("desired partition count must be greater than 0, was -1");
+
+    scaleRecord.setDesiredPartitionCount(0);
+    assertThatThrownBy(() -> RoutingStateConverter.fromScaleRecord(scaleRecord))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("desired partition count must be greater than 0, was 0");
+
+    scaleRecord.setDesiredPartitionCount(1);
+    scaleRecord.setMessageCorrelationPartitions(1);
+    assertThatThrownBy(() -> RoutingStateConverter.fromScaleRecord(scaleRecord))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(
+            "partitions in message correlation cannot be more than partitions in request handling: 1 > 0");
+  }
+}

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/AsyncSnapshottingTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/AsyncSnapshottingTest.java
@@ -71,7 +71,6 @@ public final class AsyncSnapshottingTest {
 
     snapshotController =
         new StateControllerImpl(
-            1,
             DefaultZeebeDbFactory.defaultFactory(),
             persistedSnapshotStore,
             rootDirectory.resolve("runtime"),

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/RandomizedPartitionTransitionTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/RandomizedPartitionTransitionTest.java
@@ -28,10 +28,8 @@ import io.camunda.zeebe.broker.system.partitions.impl.steps.ZeebeDbPartitionTran
 import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.scheduler.Actor;
 import io.camunda.zeebe.scheduler.ActorScheduler;
-import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
-import io.camunda.zeebe.snapshots.PersistedSnapshot;
 import io.camunda.zeebe.snapshots.TransientSnapshot;
 import io.camunda.zeebe.stream.impl.StreamProcessor;
 import io.camunda.zeebe.util.health.HealthMonitor;
@@ -471,12 +469,6 @@ public class RandomizedPartitionTransitionTest {
     @Override
     public void close() throws Exception {
       throw new IllegalStateException("Not implemented");
-    }
-
-    @Override
-    public ActorFuture<PersistedSnapshot> takeSnapshot(
-        final int partition, final long lastProcessedPosition, final ConcurrencyControl control) {
-      return CompletableActorFuture.completed(null);
     }
   }
 

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/StateControllerImplTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/StateControllerImplTest.java
@@ -74,7 +74,6 @@ public final class StateControllerImplTest {
     runtimeDirectory = tempFolderRule.getRoot().toPath().resolve("runtime");
     snapshotController =
         new StateControllerImpl(
-            1,
             DefaultZeebeDbFactory.defaultFactory(),
             store,
             runtimeDirectory,

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/perf/LargeStateControllerPerformanceTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/perf/LargeStateControllerPerformanceTest.java
@@ -83,7 +83,6 @@ public class LargeStateControllerPerformanceTest {
     // given
     final var controller =
         new StateControllerImpl(
-            1,
             context.dbFactory(),
             context.snapshotStore(),
             context.temporaryFolder().resolve("runtime"),

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/snapshotapi/SnapshotApiRequestHandlerTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/snapshotapi/SnapshotApiRequestHandlerTest.java
@@ -215,7 +215,7 @@ public class SnapshotApiRequestHandlerTest {
           final var writer =
               new CommandResponseWriterImpl(output)
                   .partitionId(partitionId)
-                  .valueWriter(new ScaleRecord().statusResponse(3, List.of(), position))
+                  .valueWriter(new ScaleRecord().statusResponse(3, List.of(), 2, position))
                   .recordType(RecordType.COMMAND)
                   .valueType(ValueType.SCALE);
           output.sendResponse(

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/snapshotapi/SnapshotApiRequestHandlerTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/snapshotapi/SnapshotApiRequestHandlerTest.java
@@ -8,7 +8,6 @@
 package io.camunda.zeebe.broker.transport.snapshotapi;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -167,8 +166,7 @@ public class SnapshotApiRequestHandlerTest {
     scheduler.workUntilDone();
     assertThat(takeFuture).succeedsWithin(Duration.ofSeconds(30));
     if (position > snapshotProcessedPosition) {
-      when(takeSnapshotMock.takeSnapshot(eq(1), eq(position), any()))
-          .thenReturn(takePersistedSnapshot(position));
+      when(takeSnapshotMock.takeSnapshot(eq(position))).thenReturn(takePersistedSnapshot(position));
     }
     mockBootstrappedAtWith(position);
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerService.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerService.java
@@ -45,10 +45,10 @@ import java.util.Optional;
 
 public final class ClusterConfigurationManagerService
     implements ClusterConfigurationUpdateNotifier, AsyncClosable {
+  public static final String TOPOLOGY_FILE_NAME = ".topology.meta";
   // Use a node 0 as always the coordinator. Later we can make it configurable or allow changing it
   // dynamically.
   private static final String COORDINATOR_ID = "0";
-  private static final String TOPOLOGY_FILE_NAME = ".topology.meta";
   private final ClusterConfigurationManagerImpl clusterConfigurationManager;
   private final ClusterConfigurationGossiper clusterConfigurationGossiper;
   private final ClusterMembershipService memberShipService;

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/PersistedClusterConfiguration.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/PersistedClusterConfiguration.java
@@ -23,7 +23,7 @@ import java.util.zip.CRC32C;
  * a fixed-size header containing a version and a checksum, followed by the serialized
  * configuration.
  */
-final class PersistedClusterConfiguration {
+public final class PersistedClusterConfiguration {
   // Header is a single byte for the version, followed by a long for the checksum.
   public static final int HEADER_LENGTH = Byte.BYTES + Long.BYTES;
   // Constant version, to be incremented if the format changes.
@@ -53,7 +53,7 @@ final class PersistedClusterConfiguration {
    * @throws ChecksumMismatch if the file exists but the checksum does not match.
    * @throws MissingHeader if the file exists but is too small to contain the header.
    */
-  static PersistedClusterConfiguration ofFile(
+  public static PersistedClusterConfiguration ofFile(
       final Path topologyFile, final ClusterConfigurationSerializer serializer) {
     final ClusterConfiguration currentlyPersisted;
     try {
@@ -68,7 +68,7 @@ final class PersistedClusterConfiguration {
     return clusterConfiguration;
   }
 
-  void update(final ClusterConfiguration clusterConfiguration) throws IOException {
+  public void update(final ClusterConfiguration clusterConfiguration) throws IOException {
     if (this.clusterConfiguration.equals(clusterConfiguration)) {
       return;
     }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequest.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequest.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.dynamic.config.api;
 
 import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.state.RoutingState;
 import java.util.Optional;
 import java.util.Set;
 
@@ -58,6 +59,9 @@ public sealed interface ClusterConfigurationManagementRequest {
       Optional<Integer> newPartitionCount,
       Optional<Integer> newReplicationFactor,
       boolean dryRun)
+      implements ClusterConfigurationManagementRequest {}
+
+  record UpdateRoutingStateRequest(RoutingState routingState, boolean dryRun)
       implements ClusterConfigurationManagementRequest {}
 
   record ForceRemoveBrokersRequest(Set<MemberId> membersToRemove, boolean dryRun)

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/UpdateRoutingStateTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/UpdateRoutingStateTransformer.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.api;
+
+public class UpdateRoutingStateTransformer {
+}

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/ConfigurationChangeAppliersImpl.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/ConfigurationChangeAppliersImpl.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionReconfigurePriorityOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.ScaleUpOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.ScaleUpOperation.*;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.UpdateRoutingState;
 
 public class ConfigurationChangeAppliersImpl implements ConfigurationChangeAppliers {
 
@@ -106,6 +107,8 @@ public class ConfigurationChangeAppliersImpl implements ConfigurationChangeAppli
             case final AwaitRelocationCompletion relocation ->
                 new AwaitRelocationCompletionApplier(partitionScalingChangeExecutor, relocation);
           };
+      case final UpdateRoutingState updateRoutingState ->
+          new UpdateRoutingStateApplier(updateRoutingState, partitionScalingChangeExecutor);
     };
   }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/PartitionScalingChangeExecutor.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/PartitionScalingChangeExecutor.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.dynamic.config.changes;
 
+import io.camunda.zeebe.dynamic.config.state.RoutingState;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import java.time.Duration;
@@ -30,6 +31,8 @@ public interface PartitionScalingChangeExecutor {
 
   ActorFuture<Void> notifyPartitionBootstrapped(int partitionId);
 
+  ActorFuture<RoutingState> getRoutingState();
+
   final class NoopPartitionScalingChangeExecutor implements PartitionScalingChangeExecutor {
     @Override
     public ActorFuture<Void> initiateScaleUp(final int desiredPartitionCount) {
@@ -47,6 +50,11 @@ public interface PartitionScalingChangeExecutor {
     @Override
     public ActorFuture<Void> notifyPartitionBootstrapped(final int partitionId) {
       return CompletableActorFuture.completed();
+    }
+
+    @Override
+    public ActorFuture<RoutingState> getRoutingState() {
+      return CompletableActorFuture.completed(null);
     }
   }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/UpdateRoutingStateApplier.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/UpdateRoutingStateApplier.java
@@ -7,5 +7,38 @@
  */
 package io.camunda.zeebe.dynamic.config.changes;
 
-public class UpdateRoutingStateApplier {
+import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeAppliers.ClusterOperationApplier;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.UpdateRoutingState;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import io.camunda.zeebe.util.Either;
+import java.util.function.UnaryOperator;
+
+public class UpdateRoutingStateApplier implements ClusterOperationApplier {
+
+  private final UpdateRoutingState updateRoutingState;
+  private final PartitionScalingChangeExecutor executor;
+
+  public UpdateRoutingStateApplier(
+      final UpdateRoutingState updateRoutingState, final PartitionScalingChangeExecutor executor) {
+    this.updateRoutingState = updateRoutingState;
+    this.executor = executor;
+  }
+
+  @Override
+  public Either<Exception, UnaryOperator<ClusterConfiguration>> init(
+      final ClusterConfiguration currentClusterConfiguration) {
+    return Either.right(UnaryOperator.identity());
+  }
+
+  @Override
+  public ActorFuture<UnaryOperator<ClusterConfiguration>> apply() {
+    final var routingState =
+        updateRoutingState.routingState().isPresent()
+            ? CompletableActorFuture.completed(updateRoutingState.routingState().get())
+            : executor.getRoutingState();
+
+    return routingState.thenApply(state -> config -> config.setRoutingState(state));
+  }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/UpdateRoutingStateApplier.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/UpdateRoutingStateApplier.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.changes;
+
+public class UpdateRoutingStateApplier {
+}

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ClusterConfigurationRequestsSerializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ClusterConfigurationRequestsSerializer.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationChangeResponse;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.BrokerScaleRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.PurgeRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.UpdateRoutingStateRequest;
 import io.camunda.zeebe.dynamic.config.api.ErrorResponse;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.util.Either;
@@ -98,4 +99,6 @@ public interface ClusterConfigurationRequestsSerializer {
       byte[] encodedResponse);
 
   Either<ErrorResponse, ClusterConfiguration> decodeClusterTopologyResponse(byte[] encodedResponse);
+
+  UpdateRoutingStateRequest decodeUpdateRoutingStateRequest(byte[] bytes);
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
@@ -24,6 +24,7 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.PurgeRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ReassignPartitionsRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RemoveMembersRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.UpdateRoutingStateRequest;
 import io.camunda.zeebe.dynamic.config.api.ErrorResponse;
 import io.camunda.zeebe.dynamic.config.gossip.ClusterConfigurationGossipState;
 import io.camunda.zeebe.dynamic.config.protocol.Requests;
@@ -51,6 +52,7 @@ import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionLeaveOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionReconfigurePriorityOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.ScaleUpOperation.*;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.UpdateRoutingState;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.ExporterState;
 import io.camunda.zeebe.dynamic.config.state.ExportersConfig;
@@ -62,7 +64,6 @@ import io.camunda.zeebe.dynamic.config.state.RoutingState.RequestHandling;
 import io.camunda.zeebe.util.Either;
 import java.nio.ByteBuffer;
 import java.time.Instant;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
@@ -447,6 +448,11 @@ public class ProtoBufSerializer
                   .setDesiredPartitionCount(msg.desiredPartitionCount())
                   .addAllPartitionsToRelocate(msg.partitionsToRelocate())
                   .build());
+      case final UpdateRoutingState msg -> {
+        final var b = Topology.UpdateRoutingState.newBuilder();
+        msg.routingState().ifPresent(s -> b.setRoutingState(encodeRoutingState(s)));
+        builder.setUpdateRoutingState(b);
+      }
     }
     return builder.build();
   }
@@ -521,9 +527,9 @@ public class ProtoBufSerializer
       case ACTIVEPARTITIONS ->
           new RequestHandling.ActivePartitions(
               requestHandling.getActivePartitions().getBasePartitionCount(),
-              new HashSet<>(
+              new TreeSet<>(
                   requestHandling.getActivePartitions().getAdditionalActivePartitionsList()),
-              new HashSet<>(requestHandling.getActivePartitions().getInactivePartitionsList()));
+              new TreeSet<>(requestHandling.getActivePartitions().getInactivePartitionsList()));
       case STRATEGY_NOT_SET -> throw new IllegalArgumentException("Unknown request handling type");
     };
   }
@@ -672,6 +678,14 @@ public class ProtoBufSerializer
           memberId,
           relocation.getDesiredPartitionCount(),
           new TreeSet<>(relocation.getPartitionsToRelocateList()));
+    } else if (topologyChangeOperation.hasUpdateRoutingState()) {
+      final var protoRoutingState =
+          topologyChangeOperation.getUpdateRoutingState().getRoutingState();
+      final var routingState =
+          protoRoutingState.equals(Topology.RoutingState.getDefaultInstance())
+              ? null
+              : decodeRoutingState(protoRoutingState);
+      return new UpdateRoutingState(memberId, Optional.ofNullable(routingState));
     } else {
       // If the node does not know of a type, the exception thrown will prevent
       // ClusterTopologyGossiper from processing the incoming topology. This helps to prevent any
@@ -1087,6 +1101,18 @@ public class ProtoBufSerializer
     } catch (final InvalidProtocolBufferException e) {
       throw new DecodingFailed(e);
     }
+  }
+
+  @Override
+  public UpdateRoutingStateRequest decodeUpdateRoutingStateRequest(final byte[] bytes) {
+    final Requests.UpdateRoutingStateRequest proto;
+    try {
+      proto = Requests.UpdateRoutingStateRequest.parseFrom(bytes);
+    } catch (final InvalidProtocolBufferException e) {
+      throw new DecodingFailed(e);
+    }
+    final RoutingState routingState = decodeRoutingState(proto.getRoutingState());
+    return new UpdateRoutingStateRequest(routingState, proto.getDryRun());
   }
 
   public Builder encodeTopologyChangeResponse(

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ClusterConfiguration.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ClusterConfiguration.java
@@ -69,6 +69,11 @@ public record ClusterConfiguration(
     return new ClusterConfiguration(version, newMembers, lastChange, pendingChanges, routingState);
   }
 
+  public ClusterConfiguration setRoutingState(final RoutingState updatedRoutingState) {
+    return new ClusterConfiguration(
+        version, members, lastChange, pendingChanges, Optional.of(updatedRoutingState));
+  }
+
   /**
    * Adds or updates a member in the configuration.
    *

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ClusterConfigurationChangeOperation.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ClusterConfigurationChangeOperation.java
@@ -51,6 +51,17 @@ public sealed interface ClusterConfigurationChangeOperation {
    */
   record DeleteHistoryOperation(MemberId memberId) implements ClusterConfigurationChangeOperation {}
 
+  /**
+   * Represents an operation to update the routing state of a member in the cluster configuration.
+   *
+   * @param memberId the identifier of the member for which the routing state is being updated
+   * @param routingState the new routing state to be applied to the member, or {@link
+   *     Optional#empty()} if the routing state is to be fetched from the runtime state of {@link
+   *     io.camunda.zeebe.protocol.Protocol.DEPLOYMENT_PARTITION} leader
+   */
+  record UpdateRoutingState(MemberId memberId, Optional<RoutingState> routingState)
+      implements ClusterConfigurationChangeOperation {}
+
   sealed interface ScaleUpOperation extends ClusterConfigurationChangeOperation {
     /**
      * Operation to initiate partition scale up. This instructs the cluster to redistribute

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ClusterConfigurationChangeOperation.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ClusterConfigurationChangeOperation.java
@@ -54,7 +54,7 @@ public sealed interface ClusterConfigurationChangeOperation {
   /**
    * Represents an operation to update the routing state of a member in the cluster configuration.
    *
-   * @param memberId the identifier of the member for which the routing state is being updated
+   * @param memberId the identifier of the member who will update the routing state
    * @param routingState the new routing state to be applied to the member, or {@link
    *     Optional#empty()} if the routing state is to be fetched from the runtime state of {@link
    *     io.camunda.zeebe.protocol.Protocol.DEPLOYMENT_PARTITION} leader

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/RoutingState.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/RoutingState.java
@@ -38,6 +38,10 @@ public record RoutingState(
     return new RoutingState(version + 1, update.apply(requestHandling), messageCorrelation);
   }
 
+  public RoutingState withVersion(final long version) {
+    return new RoutingState(version, requestHandling, messageCorrelation);
+  }
+
   public RoutingState merge(final RoutingState other) {
     if (equals(other)) {
       return this;

--- a/zeebe/dynamic-config/src/main/resources/proto/requests.proto
+++ b/zeebe/dynamic-config/src/main/resources/proto/requests.proto
@@ -53,6 +53,11 @@ message ClusterPatchRequest {
   bool dryRun = 5;
 }
 
+message UpdateRoutingStateRequest{
+  topology_protocol.RoutingState routing_state = 1;
+  bool dryRun = 2;
+}
+
 message ForceRemoveBrokersRequest {
   repeated string membersToRemove = 1;
   bool dryRun = 2;

--- a/zeebe/dynamic-config/src/main/resources/proto/topology.proto
+++ b/zeebe/dynamic-config/src/main/resources/proto/topology.proto
@@ -97,6 +97,7 @@ message TopologyChangeOperation {
     DeleteHistoryOperation deleteHistory = 13;
     AwaitRedistributionCompletion awaitRedistributionCompletion = 14;
     AwaitRelocationCompletion awaitRelocationCompletion = 15;
+    UpdateRoutingState updateRoutingState = 16;
   }
 }
 
@@ -153,6 +154,10 @@ message AwaitRedistributionCompletion {
 message AwaitRelocationCompletion {
   int32 desiredPartitionCount = 1;
   repeated int32 partitionsToRelocate = 2;
+}
+
+message UpdateRoutingState{
+  RoutingState routing_state = 1;
 }
 
 message DeleteHistoryOperation { int32 memberId = 1; }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/UpdateRoutingStateTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/UpdateRoutingStateTransformerTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.UpdateRoutingState;
+import io.camunda.zeebe.dynamic.config.state.MemberState;
+import io.camunda.zeebe.dynamic.config.state.RoutingState;
+import io.camunda.zeebe.test.util.asserts.EitherAssert;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class UpdateRoutingStateTransformerTest {
+
+  private final ClusterConfiguration currentTopology =
+      ClusterConfiguration.init()
+          .addMember(MemberId.from("1"), MemberState.initializeAsActive(Map.of()));
+
+  @Test
+  void shouldReturnErrorWhenPartitionScalingIsDisabled() {
+    // given
+    final var transformer =
+        new UpdateRoutingStateTransformer(
+            false, // partition scaling disabled
+            Optional.empty());
+
+    // when
+    final var result = transformer.operations(currentTopology);
+
+    // then
+    EitherAssert.assertThat(result).isLeft();
+    assertThat(result.getLeft())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Partition scaling is disabled. Cannot update routing state.");
+  }
+
+  @Test
+  void shouldGenerateUpdateRoutingStateOperationWhenEnabled() {
+    // given
+    final var routingState =
+        Optional.of(
+            new RoutingState(
+                1L,
+                new RoutingState.RequestHandling.AllPartitions(3),
+                new RoutingState.MessageCorrelation.HashMod(3)));
+    final var transformer =
+        new UpdateRoutingStateTransformer(
+            true, // partition scaling enabled
+            routingState);
+
+    // when
+    final var result = transformer.operations(currentTopology);
+
+    // then
+    EitherAssert.assertThat(result).isRight();
+    assertThat(result.get()).hasSize(1);
+    assertThat(result.get().get(0)).isInstanceOf(UpdateRoutingState.class);
+    final var operation = (UpdateRoutingState) result.get().get(0);
+    assertThat(operation.routingState()).isEqualTo(routingState);
+  }
+
+  @Test
+  void shouldGenerateUpdateRoutingStateOperationWithEmptyRoutingState() {
+    // given
+    final var transformer =
+        new UpdateRoutingStateTransformer(
+            true, // partition scaling enabled
+            Optional.empty());
+
+    // when
+    final var result = transformer.operations(currentTopology);
+
+    // then
+    EitherAssert.assertThat(result).isRight();
+    assertThat(result.get()).hasSize(1);
+    assertThat(result.get().get(0)).isInstanceOf(UpdateRoutingState.class);
+    final var operation = (UpdateRoutingState) result.get().get(0);
+    assertThat(operation.routingState()).isEmpty();
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/scaling/ScaleUpStatusProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/scaling/ScaleUpStatusProcessor.java
@@ -40,6 +40,7 @@ public class ScaleUpStatusProcessor implements TypedRecordProcessor<ScaleRecord>
     response.statusResponse(
         desiredPartitions.size(),
         routingState.currentPartitions(),
+        routingState.messageCorrelation().partitionCount(),
         routingState.bootstrappedAt(desiredPartitionCount));
     writers.state().appendFollowUpEvent(key, ScaleIntent.STATUS_RESPONSE, response);
     writers.response().writeEventOnCommand(key, ScaleIntent.STATUS_RESPONSE, response, command);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/RoutingState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/RoutingState.java
@@ -29,10 +29,13 @@ public interface RoutingState {
   long bootstrappedAt(int partitionCount);
 
   sealed interface MessageCorrelation {
+    int partitionCount();
+
     record HashMod(int partitionCount) implements MessageCorrelation {
       public HashMod {
         if (partitionCount <= 0) {
-          throw new IllegalArgumentException("Partition count must be positive");
+          throw new IllegalArgumentException(
+              "Partition count must be positive, was " + partitionCount);
         }
       }
     }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/scaling/ScaleUpTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/scaling/ScaleUpTest.java
@@ -200,7 +200,7 @@ public class ScaleUpTest {
   }
 
   @Test
-  public void shouldRespondWithTheCurrentNumberOfRedistributedPartitions() {
+  public void shouldRespondWithTheCurrentNumberOfRedistributedPartitionsAndMessageCorrelation() {
     // given
     final var scaleUpCommand =
         RecordToWrite.command()
@@ -219,8 +219,9 @@ public class ScaleUpTest {
             .getLast();
     assertThat(record.getValue().getDesiredPartitionCount()).isEqualTo(4);
     assertThat(record.getValue().getRedistributedPartitions()).containsExactly(1, 2);
-    // SCALE_UP command is the first command after usage metrics export
-    assertThat(record.getValue().getBootstrappedAt()).isEqualTo(3);
+    // SCALE_UP command is the first command
+    assertThat(record.getValue().getBootstrappedAt()).isEqualTo(1);
+    assertThat(record.getValue().getMessageCorrelationPartitions()).isEqualTo(2);
 
     // when the partitions are marked as bootstrapped
     final var bootstrapPartition3 =
@@ -243,6 +244,7 @@ public class ScaleUpTest {
             .getLast();
     assertThat(finalResponse.getValue().getDesiredPartitionCount()).isEqualTo(4);
     assertThat(finalResponse.getValue().getRedistributedPartitions()).containsExactly(1, 2, 3, 4);
+    assertThat(record.getValue().getMessageCorrelationPartitions()).isEqualTo(2);
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/scaling/ScaleUpTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/scaling/ScaleUpTest.java
@@ -220,7 +220,7 @@ public class ScaleUpTest {
     assertThat(record.getValue().getDesiredPartitionCount()).isEqualTo(4);
     assertThat(record.getValue().getRedistributedPartitions()).containsExactly(1, 2);
     // SCALE_UP command is the first command
-    assertThat(record.getValue().getBootstrappedAt()).isEqualTo(1);
+    assertThat(record.getValue().getBootstrappedAt()).isEqualTo(3);
     assertThat(record.getValue().getMessageCorrelationPartitions()).isEqualTo(2);
 
     // when the partitions are marked as bootstrapped

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/scaling/ScaleRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/scaling/ScaleRecord.java
@@ -34,6 +34,11 @@ public class ScaleRecord extends UnifiedRecordValue implements ScaleRecordValue 
 
   private final LongProperty bootstrappedAt = new LongProperty("bootstrappedAt", -1L);
   private final LongProperty scalingPosition = new LongProperty("scalingPosition", -1L);
+
+  /**
+   * Represent the number of partitions that participate in message correlation. The set of
+   * partitions is in the range [1, messageCorrelationPartitions]
+   */
   private final IntegerProperty messageCorrelationPartitions =
       new IntegerProperty("messageCorrelationPartitions", -1);
 

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/scaling/ScaleRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/scaling/ScaleRecord.java
@@ -34,12 +34,15 @@ public class ScaleRecord extends UnifiedRecordValue implements ScaleRecordValue 
 
   private final LongProperty bootstrappedAt = new LongProperty("bootstrappedAt", -1L);
   private final LongProperty scalingPosition = new LongProperty("scalingPosition", -1L);
+  private final IntegerProperty messageCorrelationPartitions =
+      new IntegerProperty("messageCorrelationPartitions", -1);
 
   public ScaleRecord() {
-    super(5);
+    super(6);
     declareProperty(desiredPartitionCountProp)
         .declareProperty(redistributedPartitions)
         .declareProperty(relocatedPartitions)
+        .declareProperty(messageCorrelationPartitions)
         .declareProperty(bootstrappedAt)
         .declareProperty(scalingPosition);
   }
@@ -75,6 +78,11 @@ public class ScaleRecord extends UnifiedRecordValue implements ScaleRecordValue 
   }
 
   @Override
+  public int getMessageCorrelationPartitions() {
+    return messageCorrelationPartitions.getValue();
+  }
+
+  @Override
   public long getBootstrappedAt() {
     return bootstrappedAt.getValue();
   }
@@ -91,6 +99,11 @@ public class ScaleRecord extends UnifiedRecordValue implements ScaleRecordValue 
 
   public ScaleRecord setScalingPosition(final long position) {
     scalingPosition.setValue(position);
+    return this;
+  }
+
+  public ScaleRecord setMessageCorrelationPartitions(final int messageCorrelationPartitions) {
+    this.messageCorrelationPartitions.setValue(messageCorrelationPartitions);
     return this;
   }
 
@@ -115,9 +128,11 @@ public class ScaleRecord extends UnifiedRecordValue implements ScaleRecordValue 
   public ScaleRecord statusResponse(
       final int desiredPartitionCount,
       final Collection<Integer> redistributedPartitions,
+      final int messageCorrelationPartitions,
       final long bootstrappedAt) {
     setDesiredPartitionCount(desiredPartitionCount);
     setRedistributedPartitions(redistributedPartitions);
+    setMessageCorrelationPartitions(messageCorrelationPartitions);
     setBootstrappedAt(bootstrappedAt);
     return this;
   }

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -2932,6 +2932,7 @@ final class JsonSerializableToJsonTest {
           "desiredPartitionCount": -1,
           "redistributedPartitions": [],
           "relocatedPartitions": [],
+          "messageCorrelationPartitions": -1,
           "bootstrappedAt": -1,
           "scalingPosition": -1
         }
@@ -2945,6 +2946,7 @@ final class JsonSerializableToJsonTest {
          "desiredPartitionCount": 5,
           "redistributedPartitions": [],
           "relocatedPartitions": [],
+          "messageCorrelationPartitions": -1,
           "bootstrappedAt": -1,
           "scalingPosition": -1
         }
@@ -2958,6 +2960,7 @@ final class JsonSerializableToJsonTest {
                     .setDesiredPartitionCount(5)
                     .setRelocatedPartitions(List.of(4, 5))
                     .setRedistributedPartitions(List.of(4, 5))
+                    .setMessageCorrelationPartitions(5)
                     .setBootstrappedAt(123L)
                     .setScalingPosition(199L),
         """
@@ -2965,6 +2968,7 @@ final class JsonSerializableToJsonTest {
          "desiredPartitionCount": 5,
           "redistributedPartitions": [4,5],
           "relocatedPartitions": [4,5],
+          "messageCorrelationPartitions": 5,
           "bootstrappedAt": 123,
           "scalingPosition": 199
         }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/scaling/ScaleRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/scaling/ScaleRecordValue.java
@@ -29,6 +29,11 @@ public interface ScaleRecordValue extends RecordValue {
 
   Collection<Integer> getRelocatedPartitions();
 
+  /**
+   * @return The number of partitions taking part in the message correlation
+   */
+  int getMessageCorrelationPartitions();
+
   long getBootstrappedAt();
 
   long getScalingPosition();

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/ScaleUpPartitionsTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/ScaleUpPartitionsTest.java
@@ -11,29 +11,48 @@ import static io.camunda.zeebe.it.clustering.dynamic.Utils.DEFAULT_PROCESS_ID;
 import static io.camunda.zeebe.it.clustering.dynamic.Utils.createInstanceWithAJobOnAllPartitions;
 import static io.camunda.zeebe.it.clustering.dynamic.Utils.deployProcessModel;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import io.camunda.application.commons.configuration.BrokerBasedConfiguration.BrokerBasedProperties;
 import io.camunda.client.CamundaClient;
+import io.camunda.management.backups.StateCode;
+import io.camunda.zeebe.broker.system.configuration.backup.BackupStoreCfg.BackupStoreType;
 import io.camunda.zeebe.management.cluster.ClusterConfigPatchRequest;
 import io.camunda.zeebe.management.cluster.ClusterConfigPatchRequestPartitions;
+import io.camunda.zeebe.management.cluster.MessageCorrelationHashMod;
 import io.camunda.zeebe.management.cluster.PlannedOperationsResponse;
 import io.camunda.zeebe.management.cluster.RequestHandlingAllPartitions;
+import io.camunda.zeebe.management.cluster.RoutingState;
+import io.camunda.zeebe.qa.util.actuator.BackupActuator;
 import io.camunda.zeebe.qa.util.actuator.ClusterActuator;
 import io.camunda.zeebe.qa.util.cluster.TestCluster;
+import io.camunda.zeebe.qa.util.cluster.TestRestoreApp;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.zeebe.test.testcontainers.AzuriteContainer;
+import io.camunda.zeebe.util.FileUtil;
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Objects;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
 
+@Testcontainers
 @ZeebeIntegration
 public class ScaleUpPartitionsTest {
   private static final Logger LOG = LoggerFactory.getLogger(ScaleUpPartitionsTest.class);
@@ -41,9 +60,16 @@ public class ScaleUpPartitionsTest {
   private static final int PARTITIONS_COUNT = 3;
   private static final String JOB_TYPE = "job";
   private static final String PROCESS_ID = DEFAULT_PROCESS_ID;
-  @AutoClose CamundaClient camundaClient;
+  // must be static so that it's initialized before the cluster
+  @TempDir private static Path backupPath;
 
+  @Container private static final AzuriteContainer AZURITE_CONTAINER = new AzuriteContainer();
+  @AutoClose CamundaClient camundaClient;
   private ClusterActuator clusterActuator;
+  private BackupActuator backupActuator;
+
+  private final String containerName =
+      RandomStringUtils.insecure().nextAlphabetic(10).toLowerCase();
 
   @TestZeebe
   private final TestCluster cluster =
@@ -55,20 +81,32 @@ public class ScaleUpPartitionsTest {
           .withReplicationFactor(3)
           .withBrokerConfig(
               b ->
-                  b.withBrokerConfig(
-                      bb -> {
-                        bb.getExperimental().getFeatures().setEnablePartitionScaling(true);
-                        bb.getCluster()
-                            .getMembership()
-                            .setSyncInterval(Duration.ofSeconds(1))
-                            .setGossipInterval(Duration.ofSeconds(1));
-                      }))
+                  b.withBrokerConfig(this::configureBackupStore)
+                      .withBrokerConfig(
+                          bb -> {
+                            bb.getExperimental().getFeatures().setEnablePartitionScaling(true);
+                            bb.getCluster()
+                                .getMembership()
+                                .setSyncInterval(Duration.ofSeconds(1))
+                                .setGossipInterval(Duration.ofMillis(500));
+                          }))
           .build();
 
   @BeforeEach
   void createClient() {
     camundaClient = cluster.availableGateway().newClientBuilder().build();
     clusterActuator = ClusterActuator.of(cluster.availableGateway());
+    backupActuator = BackupActuator.of(cluster.availableGateway());
+  }
+
+  private void configureBackupStore(final BrokerBasedProperties bb) {
+    final var backup = bb.getData().getBackup();
+    backup.setStore(BackupStoreType.AZURE);
+    final var azure = backup.getAzure();
+
+    backup.setStore(BackupStoreType.AZURE);
+    azure.setBasePath(containerName);
+    azure.setConnectionString(AZURITE_CONTAINER.getConnectString());
   }
 
   @Test
@@ -188,6 +226,47 @@ public class ScaleUpPartitionsTest {
             });
   }
 
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  public void shouldBePossibleToRestoreAsAfterScalingUp(final boolean backupBeforeScaling)
+      throws IOException {
+    // given
+    final var desiredPartitionCount = PARTITIONS_COUNT + 1;
+    cluster.awaitHealthyTopology();
+    final var backupId = 1L;
+
+    // when
+    if (backupBeforeScaling) {
+      backupActuator.take(backupId);
+      assertBackupIsCompleted(backupId);
+    }
+    scaleToPartitions(desiredPartitionCount);
+    awaitScaleUpCompletion(desiredPartitionCount);
+
+    final var routingStateAfterScaling = clusterActuator.getTopology().getRouting();
+
+    if (!backupBeforeScaling) {
+      backupActuator.take(backupId);
+      assertBackupIsCompleted(backupId);
+    }
+
+    cluster.close();
+
+    restoreAllBrokers(backupId);
+
+    // then
+    // the topology is restored to the desired partition count and message correlation
+    cluster.start();
+    if (backupBeforeScaling) {
+      assertThatRoutingStateMatches(
+          new RoutingState()
+              .requestHandling(new RequestHandlingAllPartitions(3).strategy("AllPartitions"))
+              .messageCorrelation(new MessageCorrelationHashMod("HashMod", 3)));
+    } else {
+      assertThatRoutingStateMatches(routingStateAfterScaling);
+    }
+  }
+
   private void awaitScaleUpCompletion(final int desiredPartitionCount) {
     Awaitility.await("until scaling is done")
         .timeout(Duration.ofMinutes(5))
@@ -203,6 +282,51 @@ public class ScaleUpPartitionsTest {
                         + topology.getRouting().getRequestHandling());
               }
             });
+  }
+
+  public void assertThatRoutingStateMatches(final RoutingState routingState) {
+    Awaitility.await("until topology is restored correctly")
+        .atMost(Duration.ofSeconds(30))
+        .untilAsserted(
+            () -> {
+              final var topology = clusterActuator.getTopology();
+              assertNotNull(topology.getRouting());
+              assertThat(topology.getRouting().getRequestHandling())
+                  .isEqualTo(routingState.getRequestHandling());
+              assertThat(topology.getRouting().getMessageCorrelation())
+                  .isEqualTo(routingState.getMessageCorrelation());
+            });
+  }
+
+  private void assertBackupIsCompleted(final long backupId) {
+    Awaitility.await("until backup is ready")
+        .timeout(Duration.ofMinutes(1))
+        .pollInterval(Duration.ofMillis(500))
+        .untilAsserted(
+            () -> {
+              try {
+                final var backupInfo = backupActuator.status(backupId);
+                assertThat(backupInfo.getState()).isEqualTo(StateCode.COMPLETED);
+              } catch (final Exception e) {
+                LOG.error("Failed to get backup status for backupId: {}", backupId, e);
+                fail(e);
+              }
+            });
+  }
+
+  private void restoreAllBrokers(final long backupId) throws IOException {
+    for (final var broker : cluster.brokers().values()) {
+      LOG.debug("Restoring broker: {}", broker.nodeId());
+      final var dataFolder = Path.of(broker.brokerConfig().getData().getDirectory());
+      FileUtil.deleteFolderIfExists(dataFolder);
+
+      Files.createDirectories(dataFolder);
+      try (final var restoreApp =
+          new TestRestoreApp(broker.brokerConfig()).withBackupId(backupId)) {
+        assertThatNoException().isThrownBy(restoreApp::start);
+      }
+      FileUtil.flushDirectory(dataFolder);
+    }
   }
 
   private PlannedOperationsResponse scaleToPartitions(final int desiredPartitionCount) {

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/ScaleUpPartitionsTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/ScaleUpPartitionsTest.java
@@ -251,12 +251,15 @@ public class ScaleUpPartitionsTest {
     }
 
     cluster.close();
+    LOG.info("Cluster stopped, restoring all brokers");
 
     restoreAllBrokers(backupId);
 
+    LOG.info("All brokers restored, starting cluster");
     // then
     // the topology is restored to the desired partition count and message correlation
     cluster.start();
+    cluster.awaitCompleteTopology();
     if (backupBeforeScaling) {
       assertThatRoutingStateMatches(
           new RoutingState()

--- a/zeebe/restore/src/main/java/io/camunda/zeebe/restore/RestoreManager.java
+++ b/zeebe/restore/src/main/java/io/camunda/zeebe/restore/RestoreManager.java
@@ -72,37 +72,6 @@ public class RestoreManager {
       return CompletableFuture.failedFuture(e);
     }
 
-    // restore Topology file
-    if (configuration.getCluster().getNodeId() == 0) {
-      final var coordinatorId = MemberId.from("0");
-      LOG.info("Restoring topology file");
-      final var file =
-          Path.of(configuration.getData().getDirectory())
-              .resolve(ClusterConfigurationManagerService.TOPOLOGY_FILE_NAME);
-      final var staticConfiguration =
-          StaticConfigurationGenerator.getStaticConfiguration(configuration, coordinatorId);
-      final var initializer = new StaticInitializer(staticConfiguration);
-      try {
-        // it's ok to block, it's not really async
-        final var base = initializer.initialize().get();
-        final var configuration =
-            new ClusterConfiguration(
-                base.version(),
-                base.members(),
-                base.lastChange(),
-                Optional.of(
-                    ClusterChangePlan.init(
-                        1L, List.of(new UpdateRoutingState(coordinatorId, Optional.empty())))),
-                Optional.empty());
-        final var persistedConfiguration =
-            PersistedClusterConfiguration.ofFile(file, new ProtoBufSerializer());
-        persistedConfiguration.update(configuration);
-        LOG.info("Successfully restored topology file {}", base);
-      } catch (final Exception e) {
-        throw new RuntimeException(e);
-      }
-    }
-
     final var partitionToRestore = collectPartitions();
 
     final var partitionIds = partitionToRestore.stream().map(p -> p.partition().id().id()).toList();
@@ -112,7 +81,45 @@ public class RestoreManager {
             partitionToRestore.stream()
                 .map(partition -> restorePartition(partition, backupId, validateConfig))
                 .toArray(CompletableFuture[]::new))
+        .<Void>thenApply(
+            ignored -> {
+              // restore Topology file
+              if (configuration.getCluster().getNodeId() == 0) {
+                restoreTopologyFile();
+              }
+              return null;
+            })
         .exceptionallyComposeAsync(error -> logFailureAndDeleteDataDirectory(dataDirectory, error));
+  }
+
+  private void restoreTopologyFile() {
+    final var coordinatorId = MemberId.from("0");
+    LOG.info("Restoring topology file");
+    final var file =
+        Path.of(configuration.getData().getDirectory())
+            .resolve(ClusterConfigurationManagerService.TOPOLOGY_FILE_NAME);
+    final var staticConfiguration =
+        StaticConfigurationGenerator.getStaticConfiguration(configuration, coordinatorId);
+    final var initializer = new StaticInitializer(staticConfiguration);
+    try {
+      // it's ok to block, it's not really async
+      final var base = initializer.initialize().get();
+      final var configuration =
+          new ClusterConfiguration(
+              base.version(),
+              base.members(),
+              base.lastChange(),
+              Optional.of(
+                  ClusterChangePlan.init(
+                      1L, List.of(new UpdateRoutingState(coordinatorId, Optional.empty())))),
+              base.routingState());
+      final var persistedConfiguration =
+          PersistedClusterConfiguration.ofFile(file, new ProtoBufSerializer());
+      persistedConfiguration.update(configuration);
+      LOG.info("Successfully restored topology file {}", base);
+    } catch (final Exception e) {
+      throw new RuntimeException(e);
+    }
   }
 
   private CompletableFuture<Void> logFailureAndDeleteDataDirectory(

--- a/zeebe/restore/src/main/java/io/camunda/zeebe/restore/RestoreManager.java
+++ b/zeebe/restore/src/main/java/io/camunda/zeebe/restore/RestoreManager.java
@@ -18,6 +18,13 @@ import io.camunda.zeebe.broker.partitioning.topology.PartitionDistribution;
 import io.camunda.zeebe.broker.partitioning.topology.StaticConfigurationGenerator;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.db.impl.rocksdb.ChecksumProviderRocksDBImpl;
+import io.camunda.zeebe.dynamic.config.ClusterConfigurationInitializer.StaticInitializer;
+import io.camunda.zeebe.dynamic.config.ClusterConfigurationManagerService;
+import io.camunda.zeebe.dynamic.config.PersistedClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.serializer.ProtoBufSerializer;
+import io.camunda.zeebe.dynamic.config.state.ClusterChangePlan;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.UpdateRoutingState;
 import io.camunda.zeebe.restore.PartitionRestoreService.BackupValidator;
 import io.camunda.zeebe.util.FileUtil;
 import io.camunda.zeebe.util.micrometer.MicrometerUtil;
@@ -28,6 +35,8 @@ import java.io.IOException;
 import java.nio.file.DirectoryNotEmptyException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
@@ -61,6 +70,37 @@ public class RestoreManager {
       }
     } catch (final IOException e) {
       return CompletableFuture.failedFuture(e);
+    }
+
+    // restore Topology file
+    if (configuration.getCluster().getNodeId() == 0) {
+      final var coordinatorId = MemberId.from("0");
+      LOG.info("Restoring topology file");
+      final var file =
+          Path.of(configuration.getData().getDirectory())
+              .resolve(ClusterConfigurationManagerService.TOPOLOGY_FILE_NAME);
+      final var staticConfiguration =
+          StaticConfigurationGenerator.getStaticConfiguration(configuration, coordinatorId);
+      final var initializer = new StaticInitializer(staticConfiguration);
+      try {
+        // it's ok to block, it's not really async
+        final var base = initializer.initialize().get();
+        final var configuration =
+            new ClusterConfiguration(
+                base.version(),
+                base.members(),
+                base.lastChange(),
+                Optional.of(
+                    ClusterChangePlan.init(
+                        1L, List.of(new UpdateRoutingState(coordinatorId, Optional.empty())))),
+                Optional.empty());
+        final var persistedConfiguration =
+            PersistedClusterConfiguration.ofFile(file, new ProtoBufSerializer());
+        persistedConfiguration.update(configuration);
+        LOG.info("Successfully restored topology file {}", base);
+      } catch (final Exception e) {
+        throw new RuntimeException(e);
+      }
     }
 
     final var partitionToRestore = collectPartitions();

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/transfer/SnapshotTransferService.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/transfer/SnapshotTransferService.java
@@ -8,7 +8,6 @@
 package io.camunda.zeebe.snapshots.transfer;
 
 import io.camunda.zeebe.scheduler.AsyncClosable;
-import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.snapshots.PersistedSnapshot;
 import io.camunda.zeebe.snapshots.SnapshotChunk;
@@ -47,11 +46,9 @@ public interface SnapshotTransferService extends AsyncClosable {
      * Take a snapshot of a partition. The snapshot returned must have processed at least {@param
      * lastProcessedPosition}
      *
-     * @param partition the partition to take the snapshot for
      * @param lastProcessedPosition the minimum value for lastProcessedPosition in the snapshot
-     * @return
+     * @return a future with the persisted snapshot
      */
-    ActorFuture<PersistedSnapshot> takeSnapshot(
-        int partition, long lastProcessedPosition, ConcurrencyControl control);
+    ActorFuture<PersistedSnapshot> takeSnapshot(long lastProcessedPosition);
   }
 }

--- a/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/transfer/SnapshotTransferTest.java
+++ b/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/transfer/SnapshotTransferTest.java
@@ -9,7 +9,6 @@ package io.camunda.zeebe.snapshots.transfer;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -127,13 +126,13 @@ public class SnapshotTransferTest {
   public void shouldTakeSnapshotIfNoneIsPresent() {
     // given
     final int partitionId = 1;
-    when(takeSnapshotMock.takeSnapshot(anyInt(), anyLong(), any()))
+    when(takeSnapshotMock.takeSnapshot(anyLong()))
         .thenReturn(CompletableActorFuture.completed(null));
 
     // when
     final var persistedSnapshotFuture = snapshotTransfer.getLatestSnapshot(partitionId);
 
     // then
-    verify(takeSnapshotMock, timeout(5000)).takeSnapshot(eq(1), eq(-1L), any());
+    verify(takeSnapshotMock, timeout(5000)).takeSnapshot(eq(-1L));
   }
 }


### PR DESCRIPTION
## Description
In this PR we introduce a new `ClusterChangeOperation`: `UpdateRoutingState`.
This operation is used to update the `RoutingState` in the `ClusterConfiguration` with the provided values or by fetching these values from partition 1, which contains the latest data.

In case of restoring from a backup, the latest values from partition 1 are fetched and used to update the `RoutingState`.
In order to do that, I had to add a new field to `ScaleRecord` so that the messageCorrelation field of `RoutingState` can be filled correctly. 
Currently we have only 1 implementation (`HashMod`) so an enum to discern between different implementations is not needed yet and can be easily added in the future.

When the `RoutingState` is set in `UpdateRoutingState`, then it will be "updated" directly with that value in `ClusterConfiguration`. This is meant to be done mainly from a REST endpoint in order to fix a broken `RoutingState` (which will be done in a follow up PR)

### BugFix
When running the IT I noticed that a couple of fields where not initialized correctly in the backups and the reason was that `StateController` was used for taking the snapshots This is wrong as `AsyncSnapshotDirector` is the component that takes snapshots.

## Related issues

closes #34146 
