### PR TITLE
Console ping: Add retry configuration and IT test.

### DIFF
--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -713,6 +713,29 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>com.squareup.okhttp3</groupId>
+      <artifactId>mockwebserver</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.squareup.okhttp3</groupId>
+      <artifactId>okhttp</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.squareup.okio</groupId>
+      <artifactId>okio-jvm</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -714,26 +714,14 @@
     </dependency>
 
     <dependency>
-      <groupId>com.squareup.okhttp3</groupId>
-      <artifactId>mockwebserver</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>com.squareup.okhttp3</groupId>
-      <artifactId>okhttp</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>com.squareup.okio</groupId>
-      <artifactId>okio-jvm</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.wiremock</groupId>
+      <artifactId>wiremock-standalone</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/dist/src/main/java/io/camunda/application/commons/console/ping/PingConsoleRunner.java
+++ b/dist/src/main/java/io/camunda/application/commons/console/ping/PingConsoleRunner.java
@@ -88,6 +88,18 @@ public class PingConsoleRunner implements ApplicationRunner {
     if (pingConfiguration.pingPeriod().isZero() || pingConfiguration.pingPeriod().isNegative()) {
       throw new IllegalArgumentException("Ping period must be greater than zero.");
     }
+    if (pingConfiguration.retryConfiguration != null) {
+      if (pingConfiguration.retryConfiguration().numberOfMaxRetries() <= 0) {
+        throw new IllegalArgumentException("Number of max retries must be greater than zero.");
+      }
+      if (pingConfiguration.retryConfiguration().retryDelayMultiplier() <= 0) {
+        throw new IllegalArgumentException("Retry delay multiplier must be greater than zero.");
+      }
+      if (pingConfiguration.retryConfiguration().maxRetryDelay().isZero()
+          || pingConfiguration.retryConfiguration().maxRetryDelay().isNegative()) {
+        throw new IllegalArgumentException("Max retry delay must be greater than zero.");
+      }
+    }
     if (licensePayload.isLeft()) {
       throw new IllegalArgumentException(
           "Failed to parse license payload for Console ping task.", licensePayload.getLeft());
@@ -138,5 +150,9 @@ public class PingConsoleRunner implements ApplicationRunner {
       String clusterId,
       String clusterName,
       Duration pingPeriod,
-      Map<String, String> properties) {}
+      RetryConfiguration retryConfiguration,
+      Map<String, String> properties) {
+    public record RetryConfiguration(
+        int numberOfMaxRetries, int retryDelayMultiplier, Duration maxRetryDelay) {}
+  }
 }

--- a/dist/src/main/java/io/camunda/application/commons/console/ping/PingConsoleRunner.java
+++ b/dist/src/main/java/io/camunda/application/commons/console/ping/PingConsoleRunner.java
@@ -56,7 +56,7 @@ public class PingConsoleRunner implements ApplicationRunner {
     try {
       validateConfiguration();
       LOGGER.info(
-          "Console ping is enabled with endpoint: {}, and delay: {} " + "minutes",
+          "Console ping is enabled with endpoint: {}, and delay of {}.",
           pingConfiguration.endpoint(),
           pingConfiguration.pingPeriod());
       final var executor = createTaskExecutor();

--- a/dist/src/main/java/io/camunda/application/commons/console/ping/PingConsoleTask.java
+++ b/dist/src/main/java/io/camunda/application/commons/console/ping/PingConsoleTask.java
@@ -10,25 +10,19 @@ package io.camunda.application.commons.console.ping;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.camunda.application.commons.console.ping.PingConsoleRunner.ConsolePingConfiguration;
 import io.camunda.zeebe.util.VisibleForTesting;
-import io.camunda.zeebe.util.retry.RetryConfiguration;
 import io.camunda.zeebe.util.retry.RetryDecorator;
 import java.io.IOException;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.net.http.HttpResponse.BodyHandlers;
-import java.time.Duration;
 import java.util.Map;
-import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class PingConsoleTask implements Runnable {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(PingConsoleTask.class);
-  private static final int NUMBER_OF_MAX_RETRIES = 10;
-  private static final int RETRY_DELAY_MULTIPLIER = 2;
-  private static final Duration MAX_RETRY_DELAY = Duration.ofMinutes(2);
   private static final int MAX_RESPONSE_BODY_LENGTH = 1000;
   private final HttpClient client;
   private final ConsolePingConfiguration pingConfiguration;
@@ -42,17 +36,7 @@ public class PingConsoleTask implements Runnable {
       final String licensePayload) {
     this.pingConfiguration = pingConfiguration;
     this.client = client;
-    final var retryConfiguration = new RetryConfiguration();
-    retryConfiguration.setMaxRetries(
-        Optional.ofNullable(pingConfiguration.retryConfiguration().numberOfMaxRetries())
-            .orElse(NUMBER_OF_MAX_RETRIES));
-    retryConfiguration.setRetryDelayMultiplier(
-        Optional.ofNullable(pingConfiguration.retryConfiguration().retryDelayMultiplier())
-            .orElse(RETRY_DELAY_MULTIPLIER));
-    retryConfiguration.setMaxRetryDelay(
-        Optional.ofNullable(pingConfiguration.retryConfiguration().maxRetryDelay())
-            .orElse(MAX_RETRY_DELAY));
-    retryDecorator = new RetryDecorator();
+    retryDecorator = new RetryDecorator(pingConfiguration.retry());
     this.licensePayload = licensePayload;
   }
 

--- a/dist/src/main/java/io/camunda/application/commons/console/ping/PingConsoleTask.java
+++ b/dist/src/main/java/io/camunda/application/commons/console/ping/PingConsoleTask.java
@@ -19,6 +19,7 @@ import java.net.http.HttpResponse;
 import java.net.http.HttpResponse.BodyHandlers;
 import java.time.Duration;
 import java.util.Map;
+import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -42,9 +43,15 @@ public class PingConsoleTask implements Runnable {
     this.pingConfiguration = pingConfiguration;
     this.client = client;
     final var retryConfiguration = new RetryConfiguration();
-    retryConfiguration.setMaxRetries(NUMBER_OF_MAX_RETRIES);
-    retryConfiguration.setRetryDelayMultiplier(RETRY_DELAY_MULTIPLIER);
-    retryConfiguration.setMaxRetryDelay(MAX_RETRY_DELAY);
+    retryConfiguration.setMaxRetries(
+        Optional.ofNullable(pingConfiguration.retryConfiguration().numberOfMaxRetries())
+            .orElse(NUMBER_OF_MAX_RETRIES));
+    retryConfiguration.setRetryDelayMultiplier(
+        Optional.ofNullable(pingConfiguration.retryConfiguration().retryDelayMultiplier())
+            .orElse(RETRY_DELAY_MULTIPLIER));
+    retryConfiguration.setMaxRetryDelay(
+        Optional.ofNullable(pingConfiguration.retryConfiguration().maxRetryDelay())
+            .orElse(MAX_RETRY_DELAY));
     retryDecorator = new RetryDecorator();
     this.licensePayload = licensePayload;
   }

--- a/dist/src/test/java/io/camunda/application/commons/console/ping/PingConsoleRunnerIT.java
+++ b/dist/src/test/java/io/camunda/application/commons/console/ping/PingConsoleRunnerIT.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.application.commons.console.ping;
+
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.AssertionsKt.assertNotNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.application.commons.console.ping.PingConsoleRunner.ConsolePingConfiguration;
+import io.camunda.application.commons.console.ping.PingConsoleRunner.ConsolePingConfiguration.RetryConfiguration;
+import io.camunda.service.ManagementServices;
+import io.camunda.service.license.LicenseType;
+import java.io.IOException;
+import java.net.URI;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class PingConsoleRunnerIT {
+
+  private MockWebServer mockWebServer;
+  private ManagementServices managementServices;
+  private final boolean validLicense = true;
+  private final boolean isCommercial = true;
+  private final LicenseType licenseType = LicenseType.SAAS;
+  private final String clusterId = "test-cluster-id";
+  private final String clusterName = "test-cluster-name";
+  private final String expectedBody =
+      String.format(
+          """
+    {
+      "license": {
+        "validLicense": %s,
+        "licenseType": "%s",
+        "isCommercial": %s
+      },
+      "clusterId": "%s",
+      "clusterName": "%s"
+    }
+  """,
+          validLicense, licenseType, isCommercial, clusterId, clusterName);
+
+  @BeforeEach
+  void setup() throws IOException {
+    mockWebServer = new MockWebServer();
+    mockWebServer.start();
+    managementServices = mock(ManagementServices.class);
+    when(managementServices.getCamundaLicenseType()).thenReturn(licenseType);
+    when(managementServices.isCommercialCamundaLicense()).thenReturn(isCommercial);
+    when(managementServices.isCamundaLicenseValid()).thenReturn(validLicense);
+  }
+
+  @AfterEach
+  void tearDown() throws IOException {
+    mockWebServer.shutdown();
+  }
+
+  @Test
+  void shouldSendCorrectPayload() throws InterruptedException, JsonProcessingException {
+    // given
+    final String mockUrl = mockWebServer.url("/ping").toString();
+
+    // we have the server answer with a valid response for 3 times.
+    mockWebServer.enqueue(new MockResponse().setResponseCode(200).setBody("PONG"));
+    mockWebServer.enqueue(new MockResponse().setResponseCode(200).setBody("PONG"));
+    mockWebServer.enqueue(new MockResponse().setResponseCode(200).setBody("PONG"));
+
+    final Duration pingPeriod = Duration.ofMillis(200);
+    final ConsolePingConfiguration.RetryConfiguration retryConfig =
+        new RetryConfiguration(1, 1, Duration.ofMillis(100));
+
+    final ConsolePingConfiguration config =
+        new ConsolePingConfiguration(
+            true, URI.create(mockUrl), clusterId, clusterName, pingPeriod, retryConfig, null);
+
+    final PingConsoleRunner pingConsoleRunner = new PingConsoleRunner(config, managementServices);
+
+    // when
+    pingConsoleRunner.run(null);
+
+    // then
+    await().atMost(10, TimeUnit.SECONDS).until(() -> mockWebServer.getRequestCount() >= 3);
+
+    // we validate the first request received by the mock server
+    final RecordedRequest request = mockWebServer.takeRequest(1, TimeUnit.SECONDS);
+    assertNotNull(request);
+    assertEquals("POST", request.getMethod());
+
+    final String body = request.getBody().readUtf8();
+
+    final ObjectMapper mapper = new ObjectMapper();
+    final JsonNode expected = mapper.readTree(expectedBody);
+
+    assertEquals(expected.toString(), body, "JSON payload did not match expected structure");
+  }
+}

--- a/dist/src/test/java/io/camunda/application/commons/console/ping/PingConsoleRunnerIT.java
+++ b/dist/src/test/java/io/camunda/application/commons/console/ping/PingConsoleRunnerIT.java
@@ -37,25 +37,6 @@ public class PingConsoleRunnerIT {
 
   private WireMockServer wireMockServer;
   private ManagementServices managementServices;
-  private final boolean validLicense = true;
-  private final boolean isCommercial = true;
-  private final LicenseType licenseType = LicenseType.SAAS;
-  private final String clusterId = "test-cluster-id";
-  private final String clusterName = "test-cluster-name";
-  private final String expectedBody =
-      String.format(
-          """
-    {
-      "license": {
-        "validLicense": %s,
-        "licenseType": "%s",
-        "isCommercial": %s
-      },
-      "clusterId": "%s",
-      "clusterName": "%s"
-    }
-  """,
-          validLicense, licenseType, isCommercial, clusterId, clusterName);
 
   @BeforeEach
   void setup() {
@@ -63,11 +44,6 @@ public class PingConsoleRunnerIT {
     wireMockServer.start();
     configureFor("localhost", wireMockServer.port());
     stubFor(post(urlEqualTo("/ping")).willReturn(aResponse().withStatus(200).withBody("PONG")));
-
-    managementServices = mock(ManagementServices.class);
-    when(managementServices.getCamundaLicenseType()).thenReturn(licenseType);
-    when(managementServices.isCommercialCamundaLicense()).thenReturn(isCommercial);
-    when(managementServices.isCamundaLicenseValid()).thenReturn(validLicense);
   }
 
   @AfterEach
@@ -81,10 +57,32 @@ public class PingConsoleRunnerIT {
     final String mockUrl = "http://localhost:" + wireMockServer.port() + "/ping";
     final Duration pingPeriod = Duration.ofMillis(200);
     final RetryConfiguration retryConfig = new RetryConfiguration();
+    final String expectedBody =
+        """
+      {
+        "license": {
+          "validLicense": true,
+          "licenseType": "saas",
+          "isCommercial": true
+        },
+        "clusterId": "test-cluster-id",
+        "clusterName": "test-cluster-name"
+      }
+    """;
+    managementServices = mock(ManagementServices.class);
+    when(managementServices.getCamundaLicenseType()).thenReturn(LicenseType.SAAS);
+    when(managementServices.isCommercialCamundaLicense()).thenReturn(true);
+    when(managementServices.isCamundaLicenseValid()).thenReturn(true);
 
     final ConsolePingConfiguration config =
         new ConsolePingConfiguration(
-            true, URI.create(mockUrl), clusterId, clusterName, pingPeriod, retryConfig, null);
+            true,
+            URI.create(mockUrl),
+            "test-cluster-id",
+            "test-cluster-name",
+            pingPeriod,
+            retryConfig,
+            null);
 
     final PingConsoleRunner pingConsoleRunner = new PingConsoleRunner(config, managementServices);
 

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -169,7 +169,6 @@
     <version.elasticsearch-test-container>1.21.3</version.elasticsearch-test-container>
     <version.postgres-test-container>1.21.3</version.postgres-test-container>
     <version.elasticsearch7>7.17.29</version.elasticsearch7>
-    <version.com.squareup.okhttp3>4.12.0</version.com.squareup.okhttp3>
     <!-- the lucene version must be coupled with version.elasticsearch7 -->
     <version.lucene>8.11.3</version.lucene>
     <version.hdr-histogram>2.2.2</version.hdr-histogram>
@@ -1329,20 +1328,6 @@
         <groupId>org.instancio</groupId>
         <artifactId>instancio-core</artifactId>
         <version>${version.instancio}</version>
-        <scope>test</scope>
-      </dependency>
-
-      <dependency>
-        <groupId>com.squareup.okhttp3</groupId>
-        <artifactId>mockwebserver</artifactId>
-        <version>${version.com.squareup.okhttp3}</version>
-        <scope>test</scope>
-      </dependency>
-
-      <dependency>
-        <groupId>com.squareup.okhttp3</groupId>
-        <artifactId>okhttp</artifactId>
-        <version>${version.com.squareup.okhttp3}</version>
         <scope>test</scope>
       </dependency>
 

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -169,6 +169,7 @@
     <version.elasticsearch-test-container>1.21.3</version.elasticsearch-test-container>
     <version.postgres-test-container>1.21.3</version.postgres-test-container>
     <version.elasticsearch7>7.17.29</version.elasticsearch7>
+    <version.com.squareup.okhttp3>4.12.0</version.com.squareup.okhttp3>
     <!-- the lucene version must be coupled with version.elasticsearch7 -->
     <version.lucene>8.11.3</version.lucene>
     <version.hdr-histogram>2.2.2</version.hdr-histogram>
@@ -1328,6 +1329,20 @@
         <groupId>org.instancio</groupId>
         <artifactId>instancio-core</artifactId>
         <version>${version.instancio}</version>
+        <scope>test</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>com.squareup.okhttp3</groupId>
+        <artifactId>mockwebserver</artifactId>
+        <version>${version.com.squareup.okhttp3}</version>
+        <scope>test</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>com.squareup.okhttp3</groupId>
+        <artifactId>okhttp</artifactId>
+        <version>${version.com.squareup.okhttp3}</version>
         <scope>test</scope>
       </dependency>
 


### PR DESCRIPTION
## Description

This PR adds retry configuration to the `ConsolePingConfiguration`, such as a normal config could be:

```
console:
  ping:
    enabled:
    endpoint:
    clusterName:
    clusterId:
    pingPeriod:
    retry:
      maxRetries:
      minRetryDelay:
      maxRetryDelay:
      retryDelayMultiplier:
    properties:
      (properties set by the customer ... )
```

Aditionally this ads an IT test to a mock server to check that the payload is sent correctly.
## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
