### PR TITLE
feat: user tasks data migration

### DIFF
--- a/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/v2/Details/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/v2/Details/index.test.tsx
@@ -138,4 +138,139 @@ describe('MetadataPopover <Details />', () => {
     expect(screen.getByText('Execution Duration')).toBeInTheDocument();
     expect(screen.getByText(calculatedExecutionDuration)).toBeInTheDocument();
   });
+
+  it('should display user task metadata in modal when available', async () => {
+    const userTaskMetaData: V2MetaDataDto = {
+      ...baseMetaData,
+      instanceMetadata: {
+        ...baseMetaData.instanceMetadata!,
+        type: 'USER_TASK',
+        assignee: 'john.doe',
+        dueDate: '2023-12-31T23:59:59.000Z',
+        followUpDate: '2023-12-30T12:00:00.000Z',
+        formKey: 'user-form-key',
+        userTaskKey: 'ut-123456',
+        candidateGroups: ['managers', 'admins'],
+        candidateUsers: ['user1', 'user2'],
+        externalFormReference: 'external-form-ref-123',
+        creationDate: '2023-12-01T09:00:00.000Z',
+        completionDate: '2023-12-31T18:00:00.000Z',
+        customHeaders: {custom1: 'value1', custom2: 2},
+        priority: 10,
+      },
+    };
+
+    const {user} = render(
+      <Details metaData={userTaskMetaData} elementId="UserTask_1" />,
+      {wrapper: TestWrapper},
+    );
+
+    await user.click(screen.getByRole('button', {name: 'Show more metadata'}));
+
+    expect(
+      screen.getByText(/Element "UserTask_1" 123456789 Metadata/),
+    ).toBeInTheDocument();
+
+    expect(screen.getByText(/"assignee": "john.doe"/)).toBeInTheDocument();
+    expect(
+      screen.getByText(/"dueDate": "2023-12-31T23:59:59.000Z"/),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/"followUpDate": "2023-12-30T12:00:00.000Z"/),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/"formKey": "user-form-key"/)).toBeInTheDocument();
+    expect(screen.getByText(/"userTaskKey": "ut-123456"/)).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        (content) =>
+          content.includes('"candidateGroups":') &&
+          content.includes('"managers"') &&
+          content.includes('"admins"'),
+      ),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByText(
+        (content) =>
+          content.includes('"candidateUsers":') &&
+          content.includes('"user1"') &&
+          content.includes('"user2"'),
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/"externalFormReference": "external-form-ref-123"/),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/"creationDate": "2023-12-01T09:00:00.000Z"/),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/"completionDate": "2023-12-31T18:00:00.000Z"/),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/"priority": 10/)).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        (content) =>
+          content.includes('"customHeaders":') &&
+          content.includes('"custom1": "value1"') &&
+          content.includes('"custom2": 2'),
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it('should display partial user task metadata when some fields are missing', async () => {
+    const partialUserTaskMetaData: V2MetaDataDto = {
+      ...baseMetaData,
+      instanceMetadata: {
+        ...baseMetaData.instanceMetadata!,
+        type: 'USER_TASK',
+        assignee: 'jane.smith',
+        formKey: 'simple-form',
+        userTaskKey: 'ut-789',
+        dueDate: undefined,
+        followUpDate: undefined,
+        candidateGroups: undefined,
+        candidateUsers: undefined,
+        externalFormReference: undefined,
+      },
+    };
+
+    const {user} = render(
+      <Details metaData={partialUserTaskMetaData} elementId="UserTask_2" />,
+      {wrapper: TestWrapper},
+    );
+
+    await user.click(screen.getByRole('button', {name: 'Show more metadata'}));
+
+    expect(screen.getByText(/"assignee": "jane.smith"/)).toBeInTheDocument();
+    expect(screen.getByText(/"formKey": "simple-form"/)).toBeInTheDocument();
+    expect(screen.getByText(/"userTaskKey": "ut-789"/)).toBeInTheDocument();
+  });
+
+  it('should not display user task fields for non-user task types', async () => {
+    const serviceTaskMetaData: V2MetaDataDto = {
+      ...baseMetaData,
+      instanceMetadata: {
+        ...baseMetaData.instanceMetadata!,
+        type: 'SERVICE_TASK',
+      },
+    };
+
+    const {user} = render(
+      <Details metaData={serviceTaskMetaData} elementId="ServiceTask_1" />,
+      {wrapper: TestWrapper},
+    );
+
+    await user.click(screen.getByRole('button', {name: 'Show more metadata'}));
+
+    expect(screen.queryByText(/"assignee"/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/"dueDate"/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/"followUpDate"/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/"formKey"/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/"userTaskKey"/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/"candidateGroups"/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/"candidateUsers"/)).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/"externalFormReference"/),
+    ).not.toBeInTheDocument();
+  });
 });

--- a/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/v2/Details/mocks.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/v2/Details/mocks.tsx
@@ -42,7 +42,7 @@ const baseMetaData: V2MetaDataDto = {
     jobType: 'httpService',
     jobWorker: 'worker-1',
     jobDeadline: '2023-01-15T10:10:00.000Z',
-    jobCustomHeaders: '{"timeout": "30s"}',
+    jobCustomHeaders: {timeout: '30s'},
     jobId: '555666777',
   },
   incident: null,

--- a/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/v2/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/v2/index.test.tsx
@@ -308,7 +308,7 @@ describe('MetadataPopover', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('should render metadata for multi instance flow nodes', async () => {
+  it('should render metadata for multi instance elements', async () => {
     mockFetchFlowNodeMetadata().withSuccess(multiInstancesMetadata);
     mockFetchFlowNodeMetadata().withSuccess(multiInstancesMetadata);
     flowNodeMetaDataStore.setMetaData(multiInstancesMetadata);

--- a/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/v2/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/v2/index.test.tsx
@@ -238,6 +238,11 @@ describe('MetadataPopover', () => {
   it('should render meta data modal', async () => {
     mockFetchFlowNodeMetadata().withSuccess(calledInstanceMetadata);
     mockFetchFlowNodeMetadata().withSuccess(calledInstanceMetadata);
+    mockFetchElementInstance('2251799813699889').withSuccess({
+      ...mockElementInstance,
+      startDate: '2018-12-12 00:00:00',
+      endDate: '2018-12-12 00:00:00',
+    });
     flowNodeMetaDataStore.setMetaData(calledInstanceMetadata);
 
     processInstanceDetailsStore.setProcessInstance(
@@ -303,7 +308,7 @@ describe('MetadataPopover', () => {
     await user.click(screen.getByRole('button', {name: /close/i}));
     expect(
       screen.queryByText(
-        /Flow Node "Activity_0zqism7" 2251799813699889 Metadata/,
+        /Element "Activity_0zqism7" 2251799813699889 Metadata/,
       ),
     ).not.toBeInTheDocument();
   });

--- a/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/v2/index.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/v2/index.tsx
@@ -23,6 +23,7 @@ import {useFlownodeInstancesStatistics} from 'modules/queries/flownodeInstancesS
 import {useMemo} from 'react';
 import {Details} from './Details';
 import {createV2InstanceMetadata} from './types';
+import {useGetUserTaskByElementInstance} from 'modules/queries/userTasks/useUserTasksSearch';
 
 type Props = {
   selectedFlowNodeRef?: SVGGraphicsElement | null;
@@ -96,11 +97,22 @@ const MetadataPopover = observer(({selectedFlowNodeRef}: Props) => {
     elementInstancesSearchResult,
   ]);
 
+  const {data: userTask, isLoading: isSearchingUserTasks} =
+    useGetUserTaskByElementInstance(
+      elementInstanceMetadata?.elementInstanceKey ?? '',
+      {
+        enabled:
+          !!elementInstanceMetadata?.elementInstanceKey &&
+          elementInstanceMetadata?.type === 'USER_TASK',
+      },
+    );
+
   if (
     elementId === undefined ||
     metaData === null ||
     (shouldFetchElementInstances && isSearchingInstances) ||
-    (!!elementInstanceId && isFetchingInstance)
+    (!!elementInstanceId && isFetchingInstance) ||
+    isSearchingUserTasks
   ) {
     return null;
   }
@@ -139,6 +151,9 @@ const MetadataPopover = observer(({selectedFlowNodeRef}: Props) => {
                 instanceMetadata: createV2InstanceMetadata(
                   instanceMetadata,
                   elementInstanceMetadata,
+                  elementInstanceMetadata.type === 'USER_TASK'
+                    ? userTask
+                    : undefined,
                 ),
               }}
               elementId={elementInstanceMetadata.elementId}

--- a/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/v2/types.ts
+++ b/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/v2/types.ts
@@ -6,8 +6,11 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {type MetaDataDto} from 'modules/api/processInstances/fetchFlowNodeMetaData';
-import {type ElementInstance} from '@vzeta/camunda-api-zod-schemas/8.8';
+import type {MetaDataDto} from 'modules/api/processInstances/fetchFlowNodeMetaData';
+import type {
+  ElementInstance,
+  UserTask,
+} from '@vzeta/camunda-api-zod-schemas/8.8';
 
 // V2 Element Instance Metadata - extends the old structure but with v2 element instance fields will be removed after other components migration
 type V2InstanceMetadata = {
@@ -15,7 +18,7 @@ type V2InstanceMetadata = {
   elementId: string;
   elementName?: string;
   type: ElementInstance['type'];
-  state?: ElementInstance['state'];
+  state?: ElementInstance['state'] | UserTask['state'];
   startDate: string;
   endDate: string | null;
   processDefinitionId?: string;
@@ -38,17 +41,51 @@ type V2InstanceMetadata = {
   jobDeadline?: string | null;
   jobCustomHeaders?: string | null;
   jobId?: string | null;
-};
+} & Partial<UserTask>;
 
 type V2MetaDataDto = Omit<MetaDataDto, 'instanceMetadata'> & {
   instanceMetadata: V2InstanceMetadata | null;
 };
 
+type UserTaskSubset = Pick<
+  UserTask,
+  | 'dueDate'
+  | 'followUpDate'
+  | 'formKey'
+  | 'assignee'
+  | 'userTaskKey'
+  | 'candidateGroups'
+  | 'candidateUsers'
+  | 'state'
+  | 'externalFormReference'
+  | 'creationDate'
+  | 'completionDate'
+  | 'customHeaders'
+  | 'priority'
+>;
+
 // Utility function to create V2 instance metadata from old metadata + migrated element instance
 function createV2InstanceMetadata(
   oldMetadata: MetaDataDto['instanceMetadata'],
   elementInstance: ElementInstance,
+  userTask: Partial<UserTaskSubset> = {},
 ): V2InstanceMetadata {
+  const {
+    creationDate,
+    completionDate,
+    customHeaders,
+    priority,
+    userTaskKey,
+    state: userTaskState,
+    dueDate,
+    followUpDate,
+    formKey,
+    assignee,
+    candidateGroups,
+    candidateUsers,
+    externalFormReference,
+  } = userTask;
+
   return {
     calledProcessInstanceId: oldMetadata?.calledProcessInstanceId ?? null,
     calledProcessDefinitionName:
@@ -61,7 +98,8 @@ function createV2InstanceMetadata(
     elementId: elementInstance.elementId,
     elementName: elementInstance.elementName,
     type: elementInstance.type,
-    state: elementInstance.state,
+    state: (userTaskState ??
+      elementInstance.state) as V2InstanceMetadata['state'],
     startDate: elementInstance.startDate || '',
     endDate: elementInstance.endDate || null,
     processDefinitionId: elementInstance.processDefinitionId,
@@ -73,8 +111,22 @@ function createV2InstanceMetadata(
     flowNodeInstanceId: elementInstance.elementInstanceKey,
     flowNodeId: elementInstance.elementId,
     flowNodeType: elementInstance.type,
+
+    creationDate,
+    completionDate,
+    customHeaders,
+    priority,
+    userTaskKey,
+    dueDate,
+    followUpDate,
+    formKey,
+    assignee,
+    candidateGroups,
+    candidateUsers,
+    externalFormReference,
   };
 }
 
-export type {V2InstanceMetadata, V2MetaDataDto};
+export type {V2InstanceMetadata, V2MetaDataDto, UserTaskSubset};
+
 export {createV2InstanceMetadata};

--- a/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/v2/types.ts
+++ b/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/v2/types.ts
@@ -39,7 +39,7 @@ type V2InstanceMetadata = {
   jobType?: string | null;
   jobWorker?: string | null;
   jobDeadline?: string | null;
-  jobCustomHeaders?: string | null;
+  jobCustomHeaders: {[key: string]: string} | null;
   jobId?: string | null;
 } & Partial<UserTask>;
 
@@ -94,6 +94,11 @@ function createV2InstanceMetadata(
     calledDecisionDefinitionName:
       oldMetadata?.calledDecisionDefinitionName ?? null,
     jobRetries: oldMetadata?.jobRetries ?? null,
+    jobDeadline: oldMetadata?.jobDeadline ?? null,
+    jobId: oldMetadata?.jobId ?? null,
+    jobType: oldMetadata?.jobType ?? null,
+    jobWorker: oldMetadata?.jobWorker ?? null,
+    jobCustomHeaders: oldMetadata?.jobCustomHeaders ?? null,
     elementInstanceKey: elementInstance.elementInstanceKey,
     elementId: elementInstance.elementId,
     elementName: elementInstance.elementName,
@@ -110,7 +115,7 @@ function createV2InstanceMetadata(
     tenantId: elementInstance.tenantId,
     flowNodeInstanceId: elementInstance.elementInstanceKey,
     flowNodeId: elementInstance.elementId,
-    flowNodeType: elementInstance.type,
+    flowNodeType: oldMetadata?.flowNodeType,
 
     creationDate,
     completionDate,

--- a/operate/client/src/modules/queries/userTasks/useUserTasksSearch.ts
+++ b/operate/client/src/modules/queries/userTasks/useUserTasksSearch.ts
@@ -8,28 +8,26 @@
 
 import {useQuery} from '@tanstack/react-query';
 import {searchUserTasks} from 'modules/api/v2/userTasks/searchUserTasks';
+import type {QueryUserTasksRequestBody} from '@vzeta/camunda-api-zod-schemas/8.8';
 
-const USER_TASKS_SEARCH_QUERY_KEY = 'userTasksSearch';
+const USER_TASKS_BY_ELEMENT_INSTANCE_QUERY_KEY =
+  'useGetUserTaskByElementInstance';
 
-type UseUserTasksSearchParams = {
-  elementInstanceKey: string;
-  limit?: number;
-};
-
-const useUserTasksSearch = (
-  {elementInstanceKey, limit = 1}: UseUserTasksSearchParams,
-  options?: {enabled?: boolean},
+const useGetUserTaskByElementInstance = (
+  elementInstanceKey: string,
+  options: {enabled: boolean} = {enabled: true},
 ) => {
   return useQuery({
-    queryKey: [USER_TASKS_SEARCH_QUERY_KEY, elementInstanceKey, limit],
+    queryKey: [USER_TASKS_BY_ELEMENT_INSTANCE_QUERY_KEY, elementInstanceKey],
     queryFn: async () => {
-      const {response, error} = await searchUserTasks({
+      const payload: QueryUserTasksRequestBody = {
         filter: {elementInstanceKey},
-        page: {limit},
-      });
+        page: {limit: 1},
+      };
 
+      const {response, error} = await searchUserTasks(payload);
       if (response !== null) {
-        return response;
+        return response.items?.[0];
       }
 
       throw error;
@@ -38,4 +36,4 @@ const useUserTasksSearch = (
   });
 };
 
-export {useUserTasksSearch};
+export {useGetUserTaskByElementInstance};


### PR DESCRIPTION
## Description

This PR migrates the user tasks data of MetadataPopover component.

- Migrates MetadataPopover to use v2 user tasks search endpoint

## Related issues

closes #33216 
