### PR TITLE
test: add schema update integration test

### DIFF
--- a/schema-manager/src/main/java/io/camunda/search/schema/IndexMappingDifference.java
+++ b/schema-manager/src/main/java/io/camunda/search/schema/IndexMappingDifference.java
@@ -11,6 +11,7 @@ import com.google.common.base.Equivalence;
 import com.google.common.collect.HashMultiset;
 import com.google.common.collect.MapDifference;
 import com.google.common.collect.Maps;
+import io.camunda.zeebe.util.VisibleForTesting;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Map;
@@ -97,9 +98,6 @@ public record IndexMappingDifference(
         isRightDynamic);
   }
 
-  record PropertyDifference(
-      String name, IndexMappingProperty leftValue, IndexMappingProperty rightValue) {}
-
   /**
    * A recursive equivalence for comparing Elasticsearch/Opensearch index mappings, specifically
    * required to handle nested structures and ignore list ordering.
@@ -125,9 +123,12 @@ public record IndexMappingDifference(
    *       differences) are treated as equivalent.
    * </ul>
    */
-  private static final class OrderInsensitiveEquivalence extends Equivalence<Object> {
+  @VisibleForTesting
+  public static final class OrderInsensitiveEquivalence extends Equivalence<Object> {
 
     private static final OrderInsensitiveEquivalence INSTANCE = new OrderInsensitiveEquivalence();
+
+    private OrderInsensitiveEquivalence() {}
 
     public static OrderInsensitiveEquivalence equals() {
       return INSTANCE;
@@ -156,4 +157,7 @@ public record IndexMappingDifference(
       }
     }
   }
+
+  record PropertyDifference(
+      String name, IndexMappingProperty leftValue, IndexMappingProperty rightValue) {}
 }

--- a/schema-manager/src/test/java/io/camunda/search/schema/SchemaUpdateIT.java
+++ b/schema-manager/src/test/java/io/camunda/search/schema/SchemaUpdateIT.java
@@ -1,0 +1,216 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.schema;
+
+import static io.camunda.search.schema.utils.SchemaManagerITInvocationProvider.ELASTICSEARCH_NETWORK_ALIAS;
+import static io.camunda.search.schema.utils.SchemaManagerITInvocationProvider.OPENSEARCH_NETWORK_ALIAS;
+import static io.camunda.search.schema.utils.SchemaTestUtil.assertMappingsMatch;
+import static io.camunda.search.schema.utils.SchemaTestUtil.createSchemaManager;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.collect.Maps;
+import io.camunda.search.schema.config.SearchEngineConfiguration;
+import io.camunda.search.schema.utils.SchemaManagerITInvocationProvider;
+import io.camunda.search.test.utils.SearchClientAdapter;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
+import io.camunda.webapps.schema.descriptors.IndexDescriptors;
+import io.camunda.zeebe.util.VersionUtil;
+import io.zeebe.containers.ZeebeContainer;
+import java.io.IOException;
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.Network;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+@Testcontainers
+@ExtendWith(SchemaManagerITInvocationProvider.class)
+class SchemaUpdateIT {
+
+  private static final Logger LOG = LoggerFactory.getLogger(SchemaUpdateIT.class);
+
+  private static String currentMinorVersion; // e.g. "8.8"
+
+  private static final String PREVIOUS_VERSION =
+      VersionUtil.getPreviousVersion(); // e.g. "8.7-0-SNAPSHOT"
+
+  @BeforeAll
+  static void beforeAll() {
+    final var semanticVersion = VersionUtil.getSemanticVersion().get();
+    currentMinorVersion = "%d.%d".formatted(semanticVersion.major(), semanticVersion.minor());
+  }
+
+  @BeforeEach
+  void setup(final SearchEngineConfiguration config, final SearchClientAdapter ignored) {
+    // startupWithPreviousVersionSchema
+    final var databaseType = config.connect().getTypeEnum();
+    final var indexPrefix = config.connect().getIndexPrefix();
+    final var url =
+        "http://%s:%d"
+            .formatted(
+                databaseType.isElasticSearch()
+                    ? ELASTICSEARCH_NETWORK_ALIAS
+                    : OPENSEARCH_NETWORK_ALIAS,
+                9200);
+    try (final var previousVersionContainer =
+        new ZeebeContainer(DockerImageName.parse("camunda/camunda:%s".formatted(PREVIOUS_VERSION)))
+            .withNetwork(Network.SHARED)
+            .withEnv("CAMUNDA_OPERATE_DATABASE", databaseType.toString())
+            .withEnv("CAMUNDA_OPERATE_%s_URL".formatted(databaseType.name()), url)
+            .withEnv("CAMUNDA_OPERATE_%s_NUMBEROFREPLICAS".formatted(databaseType.name()), "1")
+            .withEnv(
+                "CAMUNDA_OPERATE_%s_INDEXPREFIX".formatted(databaseType.name()),
+                "%s-operate".formatted(indexPrefix))
+            .withEnv("CAMUNDA_OPERATE_ZEEBE%s_URL".formatted(databaseType.name()), url)
+            .withEnv("CAMUNDA_OPERATE_ARCHIVER_ILMENABLED", "true")
+            .withEnv("CAMUNDA_TASKLIST_DATABASE", databaseType.toString())
+            .withEnv("CAMUNDA_TASKLIST_%s_URL".formatted(databaseType.name()), url)
+            .withEnv("CAMUNDA_TASKLIST_%s_NUMBEROFREPLICAS".formatted(databaseType.name()), "1")
+            .withEnv(
+                "CAMUNDA_TASKLIST_%s_INDEXPREFIX".formatted(databaseType.name()),
+                "%s-tasklist".formatted(indexPrefix))
+            .withEnv("CAMUNDA_TASKLIST_ZEEBE%s_URL".formatted(databaseType.name()), url)
+            .withEnv("CAMUNDA_TASKLIST_ARCHIVER_ILMENABLED", "true")) {
+      previousVersionContainer.start();
+      previousVersionContainer.followOutput(new Slf4jLogConsumer(LOG));
+    }
+  }
+
+  @TestTemplate
+  void shouldRunConcurrentUpdates(
+      final SearchEngineConfiguration config, final SearchClientAdapter searchClientAdapter)
+      throws InterruptedException, IOException {
+    // given
+    // enable retention policy for the test and set replicas to 1
+    config.retention().setEnabled(true);
+    config.index().setNumberOfReplicas(1);
+    final var indexDescriptors =
+        new IndexDescriptors(
+            config.connect().getIndexPrefix(), config.connect().getTypeEnum().isElasticSearch());
+    final int numberOfDatedIndices =
+        createDatedIndices(config, searchClientAdapter, indexDescriptors);
+    final SchemaManager schemaManager =
+        createSchemaManager(indexDescriptors.indices(), indexDescriptors.templates(), config);
+    final var exceptions = new ConcurrentLinkedQueue<Throwable>();
+
+    // when
+    final int numberOfThreads = 12;
+    final var threads =
+        IntStream.range(0, numberOfThreads)
+            .mapToObj(
+                i ->
+                    Thread.ofVirtual()
+                        .start(
+                            () -> {
+                              try {
+                                schemaManager.startup();
+                              } catch (final Throwable e) {
+                                exceptions.add(e);
+                              }
+                            }))
+            .toList();
+    for (final var thread : threads) {
+      thread.join(Duration.ofSeconds(10));
+    }
+
+    // then
+    assertThat(exceptions).isEmpty();
+    assertThat(schemaManager.isSchemaReadyForUse()).isTrue();
+    assertThat(
+            searchClientAdapter.getPolicyAsNode(config.retention().getPolicyName()).get("policy"))
+        .isNotNull();
+    final var allIndices =
+        Maps.filterKeys( // filter out legacy tasklist and operate indices
+            searchClientAdapter.getAllIndicesAsNode(config.connect().getIndexPrefix()),
+            indexName -> getMatchingIndexDescriptor(indexName, indexDescriptors).isPresent());
+
+    assertThat(allIndices).hasSize(indexDescriptors.all().size() + numberOfDatedIndices);
+
+    allIndices.forEach(
+        (indexName, index) -> {
+          final var matchingIndexDescriptor =
+              getMatchingIndexDescriptor(indexName, indexDescriptors)
+                  .orElseThrow(
+                      () ->
+                          new IllegalStateException(
+                              "No matching index descriptor found for index: " + indexName));
+
+          // validate index settings
+          final var settings = index.get("settings").get("index");
+          assertThat(settings.get("number_of_shards").asText()).isEqualTo("1");
+          assertThat(settings.get("number_of_replicas").asText()).isEqualTo("1");
+
+          // validate index mappings
+          assertMappingsMatch(index.get("mappings"), matchingIndexDescriptor);
+
+          // validate index aliases
+          assertThat(index.get("aliases").fieldNames().next())
+              .isEqualTo(matchingIndexDescriptor.getAlias());
+        });
+  }
+
+  private static Optional<IndexDescriptor> getMatchingIndexDescriptor(
+      final String indexName, final IndexDescriptors indexDescriptors) {
+    return indexDescriptors.all().stream()
+        .filter(descriptor -> indexName.startsWith(descriptor.getFullQualifiedName()))
+        .findFirst();
+  }
+
+  private static int createDatedIndices(
+      final SearchEngineConfiguration config,
+      final SearchClientAdapter searchClientAdapter,
+      final IndexDescriptors indexDescriptors) {
+    final int archivePeriodInDays = 30;
+    final LocalDate today = LocalDate.now();
+    for (final var indexTemplate :
+        indexDescriptors.templates().stream()
+            .filter(template -> !template.getVersion().startsWith(currentMinorVersion))
+            .toList()) {
+      IntStream.range(0, archivePeriodInDays)
+          .mapToObj(i -> today.minusDays(i).format(DateTimeFormatter.ISO_DATE))
+          .map(date -> indexTemplate.getIndexPattern().replace("*", date))
+          .forEach(
+              indexName -> {
+                try {
+                  searchClientAdapter.createIndex(indexName, config.index().getNumberOfReplicas());
+                } catch (final IOException e) {
+                  throw new RuntimeException(e);
+                }
+              });
+    }
+    return archivePeriodInDays * indexDescriptors.templates().size();
+  }
+
+  @AfterEach
+  void tearDown(
+      final SearchEngineConfiguration config, final SearchClientAdapter searchClientAdapter)
+      throws IOException {
+    if (config.connect().getTypeEnum().isElasticSearch()) {
+      // Delete the data streams to allow removal of associated index templates.
+      // Note: These stream is auto-created by Elasticsearch with the use of deprecated APIs in 8.7
+      // (ES client 7.x).
+      searchClientAdapter
+          .getElsClient()
+          .indices()
+          .deleteDataStream(
+              req -> req.name(".logs-deprecation.elasticsearch-default", "ilm-history-7"));
+    }
+  }
+}

--- a/schema-manager/src/test/java/io/camunda/search/schema/utils/SchemaManagerITInvocationProvider.java
+++ b/schema-manager/src/test/java/io/camunda/search/schema/utils/SchemaManagerITInvocationProvider.java
@@ -32,6 +32,7 @@ import org.junit.jupiter.api.extension.TestTemplateInvocationContext;
 import org.junit.jupiter.api.extension.TestTemplateInvocationContextProvider;
 import org.opensearch.client.opensearch.OpenSearchClient;
 import org.opensearch.testcontainers.OpensearchContainer;
+import org.testcontainers.containers.Network;
 import org.testcontainers.elasticsearch.ElasticsearchContainer;
 
 public class SchemaManagerITInvocationProvider
@@ -41,12 +42,18 @@ public class SchemaManagerITInvocationProvider
         AfterEachCallback {
 
   public static final String CONFIG_PREFIX = "custom-prefix";
+  public static final String OPENSEARCH_NETWORK_ALIAS = "test-opensearch";
+  public static final String ELASTICSEARCH_NETWORK_ALIAS = "test-elasticsearch";
   protected SearchClientAdapter elsClientAdapter;
   protected SearchClientAdapter osClientAdapter;
   private final ElasticsearchContainer elsContainer =
-      TestSearchContainers.createDefeaultElasticsearchContainer();
+      TestSearchContainers.createDefeaultElasticsearchContainer()
+          .withNetwork(Network.SHARED)
+          .withNetworkAliases(ELASTICSEARCH_NETWORK_ALIAS);
   private final OpensearchContainer<?> osContainer =
-      TestSearchContainers.createDefaultOpensearchContainer();
+      TestSearchContainers.createDefaultOpensearchContainer()
+          .withNetwork(Network.SHARED)
+          .withNetworkAliases(OPENSEARCH_NETWORK_ALIAS);
   private ElasticsearchClient elsClient;
   private OpenSearchClient osClient;
   private final List<AutoCloseable> closeables = new ArrayList<>();

--- a/schema-manager/src/test/java/io/camunda/search/schema/utils/SchemaTestUtil.java
+++ b/schema-manager/src/test/java/io/camunda/search/schema/utils/SchemaTestUtil.java
@@ -13,7 +13,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import co.elastic.clients.elasticsearch._types.mapping.TypeMapping;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.google.common.collect.MapDifference;
 import com.google.common.collect.Maps;
 import io.camunda.search.connect.es.ElasticsearchConnector;
 import io.camunda.search.connect.os.OpensearchConnector;
@@ -102,14 +101,14 @@ public final class SchemaTestUtil {
                   Map.class);
       final var actualMappingsTree =
           TestObjectMapper.objectMapper().convertValue(mappings, Map.class);
-      final MapDifference difference =
-          Maps.difference(
-              actualMappingsTree, expectedMappingsTree, OrderInsensitiveEquivalence.equals());
       if (parseBoolean(actualMappingsTree.getOrDefault("dynamic", "false").toString())
           && parseBoolean(expectedMappingsTree.getOrDefault("dynamic", "false").toString())) {
         // if dynamic is true, skip mappings validation
         return;
       }
+      final var difference =
+          Maps.difference(
+              actualMappingsTree, expectedMappingsTree, OrderInsensitiveEquivalence.equals());
       assertThat(difference.areEqual())
           .isTrue()
           .withFailMessage("Mappings did not match: %s", difference);

--- a/search/search-test-utils/src/main/java/io/camunda/search/test/utils/SearchClientAdapter.java
+++ b/search/search-test-utils/src/main/java/io/camunda/search/test/utils/SearchClientAdapter.java
@@ -51,6 +51,10 @@ public class SearchClientAdapter {
     schemaResourceSerializer = new SchemaResourceSerializer(objectMapper);
   }
 
+  public ElasticsearchClient getElsClient() {
+    return elsClient;
+  }
+
   private JsonNode opensearchIndexToNode(final IndexState index) {
     final Map<String, Object> indexAsMap;
     try {
@@ -189,6 +193,32 @@ public class SearchClientAdapter {
       return osClient.index(i -> i.index(index).id(id).document(document)).result().jsonValue();
     }
     return "";
+  }
+
+  public void createIndex(final String indexName, final int numberOfReplicas) throws IOException {
+    if (elsClient != null) {
+      elsClient
+          .indices()
+          .create(
+              c ->
+                  c.index(indexName)
+                      .settings(
+                          settings ->
+                              settings
+                                  .numberOfShards("1")
+                                  .numberOfReplicas(String.valueOf(numberOfReplicas))));
+    } else if (osClient != null) {
+      osClient
+          .indices()
+          .create(
+              c ->
+                  c.index(indexName)
+                      .settings(
+                          settings ->
+                              settings
+                                  .numberOfShards("1")
+                                  .numberOfReplicas(String.valueOf(numberOfReplicas))));
+    }
   }
 
   public void refresh() throws IOException {


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Integration test that test schema updates from 8.7 to 8.8 with "real" indices and index templates and a set of dated indices.
Schema update is executed by multiple concurrent schema manager runs, to check the idempotency and the concurrency tolerance.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
