### PR TITLE
feat: set the clock to a specific time but don't pin it

### DIFF
--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/CamundaProcessTestContext.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/CamundaProcessTestContext.java
@@ -94,8 +94,19 @@ public interface CamundaProcessTestContext {
    * waiting until a due date is reached, for example, of a BPMN timer event.
    *
    * @param timeToAdd the duration to add to the current time
+   * @throws ArithmeticException if numeric overflow occurs
    */
   void increaseTime(final Duration timeToAdd);
+
+  /**
+   * Sets the current time and date for the process tests. It can be used to jump to a specific date
+   * to avoid waiting until a due date is reached, for example, or start the process from a specific
+   * date.
+   *
+   * @param timeToSet the time to set
+   * @throws ArithmeticException if numeric overflow occurs
+   */
+  void setTime(final Instant timeToSet);
 
   /**
    * Creates a mock job worker for the specified job type.

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/client/CamundaManagementClient.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/client/CamundaManagementClient.java
@@ -85,6 +85,13 @@ public class CamundaManagementClient {
     }
   }
 
+  public void setTime(final Instant timeToSet) {
+    final Instant now = getCurrentTime();
+    final Duration timeOffset = Duration.between(now, timeToSet);
+
+    increaseTime(timeOffset);
+  }
+
   public void resetTime() {
     final HttpDelete request = new HttpDelete(camundaManagementApi + CLOCK_ENDPOINT);
 

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/extension/CamundaProcessTestContextImpl.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/extension/CamundaProcessTestContextImpl.java
@@ -149,6 +149,12 @@ public class CamundaProcessTestContextImpl implements CamundaProcessTestContext 
   }
 
   @Override
+  public void setTime(final Instant timeToSet) {
+    LOGGER.debug("Setting the time to {}", timeToSet);
+    camundaManagementClient.setTime(timeToSet);
+  }
+
+  @Override
   public JobWorkerMock mockJobWorker(final String jobType) {
     final CamundaClient client = createClient();
     return new JobWorkerMockImpl(jobType, client);

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/CamundaProcessContextClockIT.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/CamundaProcessContextClockIT.java
@@ -16,16 +16,21 @@
 package io.camunda.process.test.api;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
 
 import io.camunda.client.CamundaClient;
 import java.time.Duration;
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
 
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 @CamundaProcessTest
-public class CamundaProcessTestClockResetIT {
+public class CamundaProcessContextClockIT {
 
   private static final Duration TIMER_DURATION = Duration.ofHours(1);
 
@@ -60,5 +65,35 @@ public class CamundaProcessTestClockResetIT {
 
     assertThat(Duration.between(testStartTime, currentTime))
         .isCloseTo(Duration.ofSeconds(10), Duration.ofMinutes(1));
+  }
+
+  @Test
+  @Order(3)
+  public void shouldSetTheTime() {
+    // when
+    final Instant timeToSet = Instant.parse("2025-05-28T13:30:00Z");
+    processTestContext.setTime(timeToSet);
+
+    // then
+    final Instant processTime = processTestContext.getCurrentTime();
+
+    assertThat(processTime).isCloseTo(timeToSet, within(10, ChronoUnit.SECONDS));
+  }
+
+  @Test
+  @Order(3)
+  public void shouldSetTheTimeMultipleTimes() {
+    // given
+    final Instant timeToSet = Instant.parse("2025-05-28T13:30:00Z");
+
+    // when
+    processTestContext.increaseTime(Duration.ofHours(4));
+
+    processTestContext.setTime(timeToSet);
+
+    // then
+    final Instant processTime = processTestContext.getCurrentTime();
+
+    assertThat(processTime).isCloseTo(timeToSet, within(10, ChronoUnit.SECONDS));
   }
 }


### PR DESCRIPTION
## Description

Adds a new method to the CamundaProcessTestContext `setTime` allowing a user to set, but not pin, the time. This is in addition to `increaseTime` which allows a user to advance the time.

## Related issues

closes [#32666](https://github.com/camunda/camunda/issues/32666)
