### PR TITLE
Fix flaky test in Job Search Endpoint Java client QA tests

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/JobSearchTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/JobSearchTest.java
@@ -50,6 +50,7 @@ public class JobSearchTest {
     startProcessInstance(camundaClient, process.getBpmnProcessId());
     waitForProcessInstancesToStart(camundaClient, 1);
 
+    // Wait until the total number of jobs in the system reaches 1
     waitUntilNewJobHasBeenCreated(1);
 
     final var executionStartListenerJob =
@@ -64,6 +65,7 @@ public class JobSearchTest {
 
     camundaClient.newCompleteCommand(executionStartListenerJob.getJobKey()).send().join();
 
+    // Wait until the total number of jobs in the system reaches 2
     waitUntilNewJobHasBeenCreated(2);
 
     final var taskABpmnJob =
@@ -80,6 +82,7 @@ public class JobSearchTest {
 
     camundaClient.newCompleteCommand(taskABpmnJob.getKey()).send().join();
 
+    // Wait until the total number of jobs in the system reaches 3
     waitUntilNewJobHasBeenCreated(3);
 
     final var executionEndListenerJob =
@@ -109,6 +112,7 @@ public class JobSearchTest {
         .assignee("testAssignee")
         .send();
 
+    // Wait until the total number of jobs in the system reaches 4
     waitUntilNewJobHasBeenCreated(4);
 
     final var userTaskListenerAssigningJob1 =
@@ -134,6 +138,7 @@ public class JobSearchTest {
 
     waitUntilNewUserTaskHasBeenCreated();
 
+    // Wait until the total number of jobs in the system reaches 5
     waitUntilNewJobHasBeenCreated(5);
 
     final var userTaskListenerAssigningJob2 =
@@ -165,6 +170,7 @@ public class JobSearchTest {
         .variable("name", "test")
         .send();
 
+    // Wait until the total number of jobs in the system reaches 6
     waitUntilNewJobHasBeenCreated(6);
 
     final var taskCBpmnJob =

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/JobSearchTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/JobSearchTest.java
@@ -50,6 +50,8 @@ public class JobSearchTest {
     startProcessInstance(camundaClient, process.getBpmnProcessId());
     waitForProcessInstancesToStart(camundaClient, 1);
 
+    waitUntilNewJobHasBeenCreated(1);
+
     final var executionStartListenerJob =
         camundaClient
             .newJobSearchRequest()


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
This PR introduces a waitUntil to ensure the job is created before assertions are executed. This resolves a timing issue observed by the release team where the test could proceed too quickly and fail intermittently.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
