### PR TITLE
[Backport stable/8.6] ci: Determine the docker version tag based on branch name

### DIFF
--- a/.github/conftest-unified-ci-rules.rego
+++ b/.github/conftest-unified-ci-rules.rego
@@ -145,6 +145,7 @@ get_jobs_not_needing_detectchanges(jobInput) = jobs_not_needing_detectchanges {
         # not enforced on Unified CI jobs that are part of change detection control flow structure
         job_id != "detect-changes"
         job_id != "check-results"
+        job_id != "get-snapshot-docker-version-tag"
 
         # not enforced on Unified CI jobs running after "check-results" job
         not startswith(job_id, "deploy-")

--- a/.github/conftest-unified-ci-rules.rego
+++ b/.github/conftest-unified-ci-rules.rego
@@ -66,6 +66,7 @@ deny[msg] {
 
         # no Unified CI jobs running after (and including) "check-results" job
         job_id != "check-results"
+        job_id != "get-snapshot-docker-version-tag"
         not startswith(job_id, "deploy-")
     }
 
@@ -111,6 +112,7 @@ get_jobs_without_cihealth(jobInput) = jobs_without_cihealth {
         job_id != "detect-changes"
         job_id != "check-results"
         job_id != "test-summary"
+        job_id != "get-snapshot-docker-version-tag"
 
         # not enforced on jobs that invoke other reusable workflows (instead enforced there)
         not job.uses

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -706,13 +706,18 @@ jobs:
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
 
+  # Dynamically generate the Docker tag (e.g., SNAPSHOT or X.Y-SNAPSHOT) based on branch name
+  get-snapshot-docker-version-tag:
+    uses: ./.github/workflows/snapshot-docker-version-tag.yml
+    secrets: inherit
+
   deploy-camunda-docker-snapshot:
     name: Deploy snapshot Camunda Docker image
-    needs: [ check-results ]
+    needs: [ check-results, get-snapshot-docker-version-tag ]
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions: {}  # GITHUB_TOKEN unused in this job
-    if: always() && needs.check-results.result == 'success' && github.repository == 'camunda/camunda' && github.ref == 'refs/heads/main'
+    if: always() && needs.check-results.result == 'success' && github.repository == 'camunda/camunda' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/stable/'))
     concurrency:
       group: deploy-camunda-docker-snapshot
       cancel-in-progress: false
@@ -744,7 +749,7 @@ jobs:
         id: build-camunda-docker
         with:
           repository: camunda/camunda
-          version: SNAPSHOT
+          version: ${{ needs.get-snapshot-docker-version-tag.outputs.version_tag }}
           distball: ${{ steps.build-camunda.outputs.distball }}
           platforms: ${{ env.DOCKER_PLATFORMS }}
           dockerfile: camunda.Dockerfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -708,6 +708,7 @@ jobs:
 
   # Dynamically generate the Docker tag (e.g., SNAPSHOT or X.Y-SNAPSHOT) based on branch name
   get-snapshot-docker-version-tag:
+    needs: [ check-results ]
     uses: ./.github/workflows/snapshot-docker-version-tag.yml
     secrets: inherit
 

--- a/.github/workflows/operate-ci-build-reusable.yml
+++ b/.github/workflows/operate-ci-build-reusable.yml
@@ -38,13 +38,20 @@ defaults:
 env:
   BRANCH_NAME: ${{ inputs.branch }}
   IS_DEFAULT_BRANCH: ${{ inputs.branch == 'main' }}
+  IS_MAIN_OR_STABLE_BRANCH: ${{ inputs.branch == 'main' || startsWith(inputs.branch, 'stable/') }}
   DOCKER_PLATFORMS: "linux/amd64,linux/arm64"
 
 jobs:
+  # Dynamically generate the Docker tag (e.g., SNAPSHOT or X.Y-SNAPSHOT) based on branch name
+  get-snapshot-docker-version-tag:
+    uses: ./.github/workflows/snapshot-docker-version-tag.yml
+    secrets: inherit
+
   build:
     name: Build
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    needs: [ get-snapshot-docker-version-tag ]
     steps:
       # Setup: checkout branch
       - name: Checkout '${{ inputs.branch }}' branch
@@ -121,11 +128,11 @@ jobs:
       #########################################################################
       # Build SNAPSHOT Docker image
       - name: Build SNAPSHOT Docker image
-        if: ${{ env.IS_DEFAULT_BRANCH == 'true' }}
+        if: ${{ env.IS_MAIN_OR_STABLE_BRANCH == 'true' }}
         uses: ./.github/actions/build-platform-docker
         with:
           repository: camunda/operate
-          version: SNAPSHOT
+          version: ${{ needs.get-snapshot-docker-version-tag.outputs.version_tag }}
           push: true
           platforms: ${{ env.DOCKER_PLATFORMS }}
           dockerfile: operate.Dockerfile

--- a/.github/workflows/snapshot-docker-version-tag.yml
+++ b/.github/workflows/snapshot-docker-version-tag.yml
@@ -19,6 +19,8 @@ env:
 jobs:
   get-snapshot-docker-version-tag:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions: {}
     outputs:
       tag: ${{ steps.set_docker_snapshot_version_tag.outputs.tag }}
     steps:

--- a/.github/workflows/snapshot-docker-version-tag.yml
+++ b/.github/workflows/snapshot-docker-version-tag.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions: {}
-    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/stable/')
+    if: github.repository == 'camunda/camunda' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/stable/'))
     outputs:
       tag: ${{ steps.set_docker_snapshot_version_tag.outputs.tag }}
     steps:

--- a/.github/workflows/snapshot-docker-version-tag.yml
+++ b/.github/workflows/snapshot-docker-version-tag.yml
@@ -11,13 +11,13 @@ on:
     outputs:
       version_tag:
         description: "Generated Docker version tag"
-        value: ${{  jobs.generate_docker_version_tag.outputs.tag }}
+        value: ${{  jobs.get-snapshot-docker-version-tag.outputs.tag }}
 
 env:
   GHA_BEST_PRACTICES_LINTER: enabled
 
 jobs:
-  generate_docker_version_tag:
+  get-snapshot-docker-version-tag:
     runs-on: ubuntu-latest
     outputs:
       tag: ${{ steps.set_docker_snapshot_version_tag.outputs.tag }}

--- a/.github/workflows/snapshot-docker-version-tag.yml
+++ b/.github/workflows/snapshot-docker-version-tag.yml
@@ -1,0 +1,31 @@
+name: Generate Docker Version Tag (SNAPSHOT)
+
+on:
+  workflow_call:
+    outputs:
+      version_tag:
+        description: "Generated Docker version tag"
+        value: ${{  jobs.generate_docker_version_tag.outputs.tag }}
+
+env:
+  GHA_BEST_PRACTICES_LINTER: enabled
+
+jobs:
+  generate_docker_version_tag:
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.set_docker_snapshot_version_tag.outputs.tag }}
+    steps:
+      - name: Determine Snapshot Docker Version Tag
+        id: set_docker_snapshot_version_tag
+        run: |
+          BRANCH="${GITHUB_REF#refs/heads/}"
+          if [[ "$BRANCH" == "main" ]]; then
+            TAG="SNAPSHOT"
+          elif [[ "$BRANCH" == stable/* ]]; then
+            TAG="${BRANCH#stable/}-SNAPSHOT"
+          else
+            echo "Unsupported branch: $BRANCH"
+            exit 1
+          fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/snapshot-docker-version-tag.yml
+++ b/.github/workflows/snapshot-docker-version-tag.yml
@@ -21,6 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions: {}
+    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/stable/')
     outputs:
       tag: ${{ steps.set_docker_snapshot_version_tag.outputs.tag }}
     steps:

--- a/.github/workflows/snapshot-docker-version-tag.yml
+++ b/.github/workflows/snapshot-docker-version-tag.yml
@@ -1,4 +1,10 @@
+# description: Generate a Docker version tag for snapshot builds based on the branch name.
+# type: CI
+# owner: @camunda/monorepo-devops-team
 name: Generate Docker Version Tag (SNAPSHOT)
+
+permissions:
+  contents: read
 
 on:
   workflow_call:

--- a/.github/workflows/snapshot-docker-version-tag.yml
+++ b/.github/workflows/snapshot-docker-version-tag.yml
@@ -32,6 +32,6 @@ jobs:
             TAG="${BRANCH#stable/}-SNAPSHOT"
           else
             echo "Unsupported branch: $BRANCH"
-            exit 1
+            exit 0
           fi
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/tasklist-ci-build-reusable.yml
+++ b/.github/workflows/tasklist-ci-build-reusable.yml
@@ -38,13 +38,20 @@ defaults:
 env:
   BRANCH_NAME: ${{ inputs.branch }}
   IS_DEFAULT_BRANCH: ${{ inputs.branch == 'main' }}
+  IS_MAIN_OR_STABLE_BRANCH: ${{ inputs.branch == 'main' || startsWith(inputs.branch, 'stable/') }}
   DOCKER_PLATFORMS: "linux/amd64,linux/arm64"
 
 jobs:
+  # Dynamically generate the Docker tag (e.g., SNAPSHOT or X.Y-SNAPSHOT) based on branch name
+  get-snapshot-docker-version-tag:
+    uses: ./.github/workflows/snapshot-docker-version-tag.yml
+    secrets: inherit
+
   build:
     name: Build
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    needs: [ get-snapshot-docker-version-tag ]
     steps:
       # Setup: checkout branch
       - name: Checkout '${{ inputs.branch }}' branch
@@ -106,11 +113,11 @@ jobs:
       #########################################################################
       # Build SNAPSHOT Docker image
       - name: Build SNAPSHOT Docker image
-        if: ${{ env.IS_DEFAULT_BRANCH == 'true' }}
+        if: ${{ env.IS_MAIN_OR_STABLE_BRANCH == 'true' }}
         uses: ./.github/actions/build-platform-docker
         with:
           repository: camunda/tasklist
-          version: SNAPSHOT
+          version: ${{ needs.get-snapshot-docker-version-tag.outputs.version_tag }}
           push: true
           platforms: ${{ env.DOCKER_PLATFORMS }}
           dockerfile: tasklist.Dockerfile

--- a/.github/workflows/zeebe-ci.yml
+++ b/.github/workflows/zeebe-ci.yml
@@ -355,13 +355,18 @@ jobs:
       - uses: actions/checkout@v4
       - run: exit ${{ ((contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'failure')) && 1) || 0 }}
 
+  # Dynamically generate the Docker tag (e.g., SNAPSHOT or X.Y-SNAPSHOT) based on branch name
+  get-snapshot-docker-version-tag:
+    uses: ./.github/workflows/snapshot-docker-version-tag.yml
+    secrets: inherit
+
   deploy-docker-snapshot:
     name: Deploy snapshot Docker image
     timeout-minutes: 15
     permissions: {}  # GITHUB_TOKEN unused in this job
-    needs: [ test-summary ]
+    needs: [ test-summary, get-snapshot-docker-version-tag ]
     runs-on: ubuntu-latest
-    if: github.repository == 'camunda/camunda' && github.ref == 'refs/heads/main'
+    if: github.repository == 'camunda/camunda' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/stable/'))
     concurrency:
       group: deploy-docker-snapshot
       cancel-in-progress: false
@@ -381,7 +386,7 @@ jobs:
         id: build-zeebe-docker
         with:
           repository: camunda/zeebe
-          version: SNAPSHOT
+          version: ${{ needs.get-snapshot-docker-version-tag.outputs.version_tag }}
           platforms: ${{ env.DOCKER_PLATFORMS }}
           push: true
           distball: ${{ steps.build-zeebe.outputs.distball }}


### PR DESCRIPTION
Backport of https://github.com/camunda/camunda/pull/34498 to stable/8.6.

relates to https://github.com/camunda/camunda/issues/30477?reload=1