### PR TITLE
[Backport release-8.8.0-alpha6] Enable tag globbing in Optimize Docker builds

### DIFF
--- a/.github/workflows/optimize-release-optimize-c8-only.yml
+++ b/.github/workflows/optimize-release-optimize-c8-only.yml
@@ -348,8 +348,9 @@ jobs:
               echo "tag_arguments=$tag_arguments" >>"$GITHUB_ENV"
           fi
 
+          # shellcheck disable=SC2086
           docker buildx build \
-              "${tag_arguments}" \
+              ${tag_arguments} \
               --build-arg VERSION="${RELEASE_VERSION}" \
               --build-arg DATE="${DATE}" \
               --build-arg REVISION="${REVISION}" \


### PR DESCRIPTION
# Description
Backport of #34760 to `release-8.8.0-alpha6`.

relates to 