### PR TITLE
fix: add error banner to create tenant failure

### DIFF
--- a/identity/client/src/pages/tenants/modals/AddModal.tsx
+++ b/identity/client/src/pages/tenants/modals/AddModal.tsx
@@ -15,6 +15,7 @@ import { createTenant } from "src/utility/api/tenants";
 import { useNotifications } from "src/components/notifications";
 import { Stack } from "@carbon/react";
 import { spacing06 } from "@carbon/elements";
+import { ErrorResponse } from "src/utility/api/request";
 
 const AddTenantModal: FC<UseModalProps> = ({ open, onClose, onSuccess }) => {
   const { t } = useTranslate("tenants");
@@ -29,7 +30,7 @@ const AddTenantModal: FC<UseModalProps> = ({ open, onClose, onSuccess }) => {
   const submitDisabled = loading || !name || !tenantId;
 
   const handleSubmit = async () => {
-    const { success } = await apiCall({
+    const { success, error } = await apiCall({
       name,
       tenantId,
       description,
@@ -44,6 +45,14 @@ const AddTenantModal: FC<UseModalProps> = ({ open, onClose, onSuccess }) => {
         }),
       });
       onSuccess();
+    } else {
+      const detail = (error as ErrorResponse<"detailed">)?.detail;
+
+      enqueueNotification({
+        kind: "error",
+        title: t("failedToCreateTenant"),
+        subtitle: detail,
+      });
     }
   };
 

--- a/identity/client/src/utility/localization/en/tenants.json
+++ b/identity/client/src/utility/localization/en/tenants.json
@@ -78,5 +78,6 @@
   "assignClientToTenant": "Assign client to tenant",
   "tenantClientRemoved": "Tenant client removed",
   "removeClientFromTenant": "Are you sure you want to remove <strong>{{clientId}}</strong> from this tenant?",
-  "assignClientsToTenant": "Assign clients to this Tenant"
+  "assignClientsToTenant": "Assign clients to this Tenant",
+  "failedToCreateTenant": "Failed to create tenant"
 }


### PR DESCRIPTION
## Description

Add toast notification for failed attempts of creating a tenant

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #34479 
