### PR TITLE
fix: Set `operationReference` in REST commands (Camunda & Zeebe clients)

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/impl/command/CancelProcessInstanceCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/CancelProcessInstanceCommandImpl.java
@@ -123,6 +123,7 @@ public final class CancelProcessInstanceCommandImpl implements CancelProcessInst
   @Override
   public CancelProcessInstanceCommandStep1 operationReference(final long operationReference) {
     builder.setOperationReference(operationReference);
+    httpRequestObject.setOperationReference(operationReference);
     return this;
   }
 

--- a/clients/java/src/main/java/io/camunda/client/impl/command/JobUpdateRetriesCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/JobUpdateRetriesCommandImpl.java
@@ -128,6 +128,7 @@ public final class JobUpdateRetriesCommandImpl
   @Override
   public UpdateRetriesJobCommandStep2 operationReference(final long operationReference) {
     grpcRequestObjectBuilder.setOperationReference(operationReference);
+    httpRequestObject.setOperationReference(operationReference);
     return this;
   }
 

--- a/clients/java/src/main/java/io/camunda/client/impl/command/JobUpdateTimeoutCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/JobUpdateTimeoutCommandImpl.java
@@ -132,6 +132,7 @@ public class JobUpdateTimeoutCommandImpl
   @Override
   public UpdateTimeoutJobCommandStep2 operationReference(final long operationReference) {
     grpcRequestObjectBuilder.setOperationReference(operationReference);
+    httpRequestObject.setOperationReference(operationReference);
     return this;
   }
 

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientImpl.java
@@ -507,7 +507,8 @@ public final class ZeebeClientImpl implements ZeebeClient {
         config.getDefaultRequestTimeout(),
         credentialsProvider::shouldRetryRequest,
         httpClient,
-        config.preferRestOverGrpc());
+        config.preferRestOverGrpc(),
+        jsonMapper);
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/CancelProcessInstanceCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/CancelProcessInstanceCommandImpl.java
@@ -123,6 +123,7 @@ public final class CancelProcessInstanceCommandImpl implements CancelProcessInst
   @Override
   public CancelProcessInstanceCommandStep1 operationReference(final long operationReference) {
     builder.setOperationReference(operationReference);
+    httpRequestObject.setOperationReference(operationReference);
     return this;
   }
 

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/JobUpdateRetriesCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/JobUpdateRetriesCommandImpl.java
@@ -128,6 +128,7 @@ public final class JobUpdateRetriesCommandImpl
   @Override
   public UpdateRetriesJobCommandStep2 operationReference(final long operationReference) {
     grpcRequestObjectBuilder.setOperationReference(operationReference);
+    httpRequestObject.setOperationReference(operationReference);
     return this;
   }
 

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/JobUpdateTimeoutCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/JobUpdateTimeoutCommandImpl.java
@@ -132,6 +132,7 @@ public class JobUpdateTimeoutCommandImpl
   @Override
   public UpdateTimeoutJobCommandStep2 operationReference(final long operationReference) {
     grpcRequestObjectBuilder.setOperationReference(operationReference);
+    httpRequestObject.setOperationReference(operationReference);
     return this;
   }
 

--- a/clients/java/src/test/java/io/camunda/client/job/JobUpdateRetriesTest.java
+++ b/clients/java/src/test/java/io/camunda/client/job/JobUpdateRetriesTest.java
@@ -76,6 +76,19 @@ public final class JobUpdateRetriesTest extends ClientTest {
   }
 
   @Test
+  public void shouldSetOperationReference() {
+    // given
+    final long operationReference = 456;
+
+    // when
+    client.newUpdateRetriesCommand(123).retries(3).operationReference(operationReference).execute();
+
+    // then
+    final UpdateJobRetriesRequest request = gatewayService.getLastRequest();
+    assertThat(request.getOperationReference()).isEqualTo(operationReference);
+  }
+
+  @Test
   public void shouldNotHaveNullResponse() {
     // given
     final UpdateRetriesJobCommandStep1 command = client.newUpdateRetriesCommand(12);

--- a/clients/java/src/test/java/io/camunda/client/job/JobUpdateTimeoutTest.java
+++ b/clients/java/src/test/java/io/camunda/client/job/JobUpdateTimeoutTest.java
@@ -111,6 +111,23 @@ public class JobUpdateTimeoutTest extends ClientTest {
   }
 
   @Test
+  public void shouldSetOperationReference() {
+    // given
+    final long operationReference = 456;
+
+    // when
+    client
+        .newUpdateTimeoutCommand(123)
+        .timeout(100)
+        .operationReference(operationReference)
+        .execute();
+
+    // then
+    final UpdateJobTimeoutRequest request = gatewayService.getLastRequest();
+    assertThat(request.getOperationReference()).isEqualTo(operationReference);
+  }
+
+  @Test
   public void shouldNotHaveNullResponse() {
     // given
     final UpdateTimeoutJobCommandStep1 command = client.newUpdateTimeoutCommand(12);

--- a/clients/java/src/test/java/io/camunda/client/job/rest/JobUpdateRestTest.java
+++ b/clients/java/src/test/java/io/camunda/client/job/rest/JobUpdateRestTest.java
@@ -57,6 +57,19 @@ public class JobUpdateRestTest extends ClientRestTest {
   }
 
   @Test
+  public void shouldSetOperationReferenceForUpdateRetriesCommand() {
+    // given
+    final long operationReference = 456;
+
+    // when
+    client.newUpdateRetriesCommand(123).retries(3).operationReference(operationReference).execute();
+
+    // then
+    final JobUpdateRequest request = gatewayService.getLastRequest(JobUpdateRequest.class);
+    assertThat(request.getOperationReference()).isEqualTo(operationReference);
+  }
+
+  @Test
   public void shouldUpdateTimeoutByKeyMillis() {
     // given
     final long jobKey = 12;
@@ -112,6 +125,23 @@ public class JobUpdateRestTest extends ClientRestTest {
     // then
     final JobUpdateRequest request = gatewayService.getLastRequest(JobUpdateRequest.class);
     assertThat(request.getChangeset().getTimeout()).isEqualTo(timeout.toMillis());
+  }
+
+  @Test
+  public void shouldSetOperationReferenceForUpdateTimeoutCommand() {
+    // given
+    final long operationReference = 456;
+
+    // when
+    client
+        .newUpdateTimeoutCommand(123)
+        .timeout(100)
+        .operationReference(operationReference)
+        .execute();
+
+    // then
+    final JobUpdateRequest request = gatewayService.getLastRequest(JobUpdateRequest.class);
+    assertThat(request.getOperationReference()).isEqualTo(operationReference);
   }
 
   @Test

--- a/clients/java/src/test/java/io/camunda/client/process/CancelProcessInstanceTest.java
+++ b/clients/java/src/test/java/io/camunda/client/process/CancelProcessInstanceTest.java
@@ -64,6 +64,19 @@ public final class CancelProcessInstanceTest extends ClientTest {
   }
 
   @Test
+  public void shouldSetOperationReference() {
+    // given
+    final int operationReference = 456;
+
+    // when
+    client.newCancelInstanceCommand(123).operationReference(operationReference).execute();
+
+    // then
+    final CancelProcessInstanceRequest request = gatewayService.getLastRequest();
+    assertThat(request.getOperationReference()).isEqualTo(operationReference);
+  }
+
+  @Test
   public void shouldNotHaveNullResponse() {
     // given
     final CancelProcessInstanceCommandStep1 command = client.newCancelInstanceCommand(12);

--- a/clients/java/src/test/java/io/camunda/client/process/rest/CancelProcessInstanceRestTest.java
+++ b/clients/java/src/test/java/io/camunda/client/process/rest/CancelProcessInstanceRestTest.java
@@ -49,4 +49,18 @@ public class CancelProcessInstanceRestTest extends ClientRestTest {
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Invalid request");
   }
+
+  @Test
+  public void shouldSetOperationReference() {
+    // given
+    final int operationReference = 456;
+
+    // when
+    client.newCancelInstanceCommand(123).operationReference(operationReference).execute();
+
+    // then
+    final CancelProcessInstanceRequest request =
+        gatewayService.getLastRequest(CancelProcessInstanceRequest.class);
+    assertThat(request.getOperationReference()).isEqualTo(operationReference);
+  }
 }

--- a/clients/java/src/test/java/io/camunda/zeebe/client/job/JobUpdateRetriesTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/job/JobUpdateRetriesTest.java
@@ -76,6 +76,24 @@ public final class JobUpdateRetriesTest extends ClientTest {
   }
 
   @Test
+  public void shouldSetOperationReference() {
+    // given
+    final long operationReference = 456;
+
+    // when
+    client
+        .newUpdateRetriesCommand(123)
+        .retries(3)
+        .operationReference(operationReference)
+        .send()
+        .join();
+
+    // then
+    final UpdateJobRetriesRequest request = gatewayService.getLastRequest();
+    assertThat(request.getOperationReference()).isEqualTo(operationReference);
+  }
+
+  @Test
   public void shouldNotHaveNullResponse() {
     // given
     final UpdateRetriesJobCommandStep1 command = client.newUpdateRetriesCommand(12);

--- a/clients/java/src/test/java/io/camunda/zeebe/client/job/rest/JobUpdateRestTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/job/rest/JobUpdateRestTest.java
@@ -57,6 +57,24 @@ public class JobUpdateRestTest extends ClientRestTest {
   }
 
   @Test
+  public void shouldSetOperationReferenceForUpdateRetriesCommand() {
+    // given
+    final long operationReference = 456;
+
+    // when
+    client
+        .newUpdateRetriesCommand(123)
+        .retries(3)
+        .operationReference(operationReference)
+        .send()
+        .join();
+
+    // then
+    final JobUpdateRequest request = gatewayService.getLastRequest(JobUpdateRequest.class);
+    assertThat(request.getOperationReference()).isEqualTo(operationReference);
+  }
+
+  @Test
   public void shouldUpdateTimeoutByKeyMillis() {
     // given
     final long jobKey = 12;
@@ -112,6 +130,24 @@ public class JobUpdateRestTest extends ClientRestTest {
     // then
     final JobUpdateRequest request = gatewayService.getLastRequest(JobUpdateRequest.class);
     assertThat(request.getChangeset().getTimeout()).isEqualTo(timeout.toMillis());
+  }
+
+  @Test
+  public void shouldSetOperationReferenceForUpdateTimeoutCommand() {
+    // given
+    final long operationReference = 456;
+
+    // when
+    client
+        .newUpdateTimeoutCommand(123)
+        .timeout(100)
+        .operationReference(operationReference)
+        .send()
+        .join();
+
+    // then
+    final JobUpdateRequest request = gatewayService.getLastRequest(JobUpdateRequest.class);
+    assertThat(request.getOperationReference()).isEqualTo(operationReference);
   }
 
   @Test

--- a/clients/java/src/test/java/io/camunda/zeebe/client/process/CancelProcessInstanceTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/process/CancelProcessInstanceTest.java
@@ -64,6 +64,19 @@ public final class CancelProcessInstanceTest extends ClientTest {
   }
 
   @Test
+  public void shouldSetOperationReference() {
+    // given
+    final int operationReference = 456;
+
+    // when
+    client.newCancelInstanceCommand(123).operationReference(operationReference).send().join();
+
+    // then
+    final CancelProcessInstanceRequest request = gatewayService.getLastRequest();
+    assertThat(request.getOperationReference()).isEqualTo(operationReference);
+  }
+
+  @Test
   public void shouldNotHaveNullResponse() {
     // given
     final CancelProcessInstanceCommandStep1 command = client.newCancelInstanceCommand(12);

--- a/clients/java/src/test/java/io/camunda/zeebe/client/process/ResolveIncidentTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/process/ResolveIncidentTest.java
@@ -51,6 +51,19 @@ public final class ResolveIncidentTest extends ClientTest {
   }
 
   @Test
+  public void shouldSetOperationReference() {
+    // given
+    final long operationReference = 456;
+
+    // when
+    client.newResolveIncidentCommand(123).operationReference(operationReference).send().join();
+
+    // then
+    final ResolveIncidentRequest request = gatewayService.getLastRequest();
+    assertThat(request.getOperationReference()).isEqualTo(operationReference);
+  }
+
+  @Test
   public void shouldNotHaveNullResponse() {
     // given
     final ResolveIncidentCommandStep1 command = client.newResolveIncidentCommand(12);

--- a/clients/java/src/test/java/io/camunda/zeebe/client/process/rest/CancelProcessInstanceRestTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/process/rest/CancelProcessInstanceRestTest.java
@@ -49,4 +49,18 @@ public class CancelProcessInstanceRestTest extends ClientRestTest {
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Invalid request");
   }
+
+  @Test
+  public void shouldSetOperationReference() {
+    // given
+    final int operationReference = 456;
+
+    // when
+    client.newCancelInstanceCommand(123).operationReference(operationReference).send().join();
+
+    // then
+    final CancelProcessInstanceRequest request =
+        gatewayService.getLastRequest(CancelProcessInstanceRequest.class);
+    assertThat(request.getOperationReference()).isEqualTo(operationReference);
+  }
 }

--- a/clients/java/src/test/java/io/camunda/zeebe/client/process/rest/ResolveIncidentRestTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/process/rest/ResolveIncidentRestTest.java
@@ -18,9 +18,11 @@ package io.camunda.zeebe.client.process.rest;
 import static io.camunda.zeebe.client.util.assertions.LoggedRequestAssert.assertThat;
 
 import com.github.tomakehurst.wiremock.http.RequestMethod;
+import io.camunda.client.protocol.rest.IncidentResolutionRequest;
 import io.camunda.zeebe.client.util.ClientRestTest;
 import io.camunda.zeebe.client.util.RestGatewayPaths;
 import io.camunda.zeebe.client.util.RestGatewayService;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class ResolveIncidentRestTest extends ClientRestTest {
@@ -37,6 +39,20 @@ public class ResolveIncidentRestTest extends ClientRestTest {
     assertThat(RestGatewayService.getLastRequest())
         .hasMethod(RequestMethod.POST)
         .hasUrl(RestGatewayPaths.getIncidentResolutionUrl(incidentKey))
-        .hasEmptyBody();
+        .hasEmptyJsonObjectBody();
+  }
+
+  @Test
+  public void shouldSetOperationReference() {
+    // given
+    final long operationReference = 456;
+
+    // when
+    client.newResolveIncidentCommand(123).operationReference(operationReference).send().join();
+
+    // then
+    final IncidentResolutionRequest request =
+        gatewayService.getLastRequest(IncidentResolutionRequest.class);
+    Assertions.assertThat(request.getOperationReference()).isEqualTo(operationReference);
   }
 }

--- a/clients/java/src/test/java/io/camunda/zeebe/client/util/assertions/LoggedRequestAssert.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/util/assertions/LoggedRequestAssert.java
@@ -94,4 +94,14 @@ public class LoggedRequestAssert extends AbstractAssert<LoggedRequestAssert, Log
 
     return this;
   }
+
+  public LoggedRequestAssert hasEmptyJsonObjectBody() {
+    isNotNull();
+
+    Assertions.assertThat(actual.getBodyAsString())
+        .describedAs("Expected request body to be an empty JSON object '{}'")
+        .isEqualTo("{}");
+
+    return this;
+  }
 }


### PR DESCRIPTION
## Description
This PR fixes issues where the `operationReference` was not set on the REST request objects for various commands when using the Java client (`CamundaClient` and the deprecated `ZeebeClient`).

Previously, for some commands, the `operationReference` was only applied to the gRPC builders. As a result, REST-based requests did not propagate the reference to the broker, causing records to miss the expected metadata in scenarios like process instance termination, job retries/timeout updates.

### Changes
The following commands were adjusted to correctly propagate the `operationReference` for REST transport:

- CamundaClient
  - `CancelProcessInstanceCommandImpl`
  - `JobUpdateRetriesCommandImpl`
  - `JobUpdateTimeoutCommandImpl`

- ZeebeClient (deprecated)
  - `CancelProcessInstanceCommandImpl`
  - `JobUpdateRetriesCommandImpl`
  - `JobUpdateTimeoutCommandImpl`
  - `ResolveIncidentCommandImpl`  
    > Previously sent an empty body (REST impl); now sends a proper JSON body including the `operationReference` (if it was configure).

- Added missing tests to verify that `operationReference` is correctly propagated for both gRPC and REST requests across all commands.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #31758 
