### PR TITLE
fix: Set missing operationReference in REST cancel process request [8.7]

### DIFF
--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/CancelProcessInstanceCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/CancelProcessInstanceCommandImpl.java
@@ -124,6 +124,7 @@ public final class CancelProcessInstanceCommandImpl implements CancelProcessInst
   @Override
   public CancelProcessInstanceCommandStep1 operationReference(final long operationReference) {
     builder.setOperationReference(operationReference);
+    httpRequestObject.setOperationReference(operationReference);
     return this;
   }
 

--- a/clients/java/src/test/java/io/camunda/zeebe/client/process/CancelProcessInstanceTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/process/CancelProcessInstanceTest.java
@@ -64,6 +64,19 @@ public final class CancelProcessInstanceTest extends ClientTest {
   }
 
   @Test
+  public void shouldSetOperationReference() {
+    // given
+    final int operationReference = 456;
+
+    // when
+    client.newCancelInstanceCommand(123).operationReference(operationReference).send().join();
+
+    // then
+    final CancelProcessInstanceRequest request = gatewayService.getLastRequest();
+    assertThat(request.getOperationReference()).isEqualTo(operationReference);
+  }
+
+  @Test
   public void shouldNotHaveNullResponse() {
     // given
     final CancelProcessInstanceCommandStep1 command = client.newCancelInstanceCommand(12);

--- a/clients/java/src/test/java/io/camunda/zeebe/client/process/rest/CancelProcessInstanceRestTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/process/rest/CancelProcessInstanceRestTest.java
@@ -49,4 +49,18 @@ public class CancelProcessInstanceRestTest extends ClientRestTest {
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Invalid request");
   }
+
+  @Test
+  public void shouldSetOperationReference() {
+    // given
+    final int operationReference = 456;
+
+    // when
+    client.newCancelInstanceCommand(123).operationReference(operationReference).send().join();
+
+    // then
+    final CancelProcessInstanceRequest request =
+        gatewayService.getLastRequest(CancelProcessInstanceRequest.class);
+    assertThat(request.getOperationReference()).isEqualTo(operationReference);
+  }
 }


### PR DESCRIPTION
## Description

This PR fixes a bug where the `operationReference` was not set on the REST request object when cancelling a process instance via the Java client.

Previously, the `operationReference` was only applied to the gRPC request builder. As a result, REST-based cancellation requests did not propagate the reference to the broker, causing records like `ProcessInstance:ELEMENT_TERMINATED` to miss the expected reference.


### Changes
- Updated `CancelProcessInstanceCommandImpl` to correctly set the `operationReference` field on the REST request object, in addition to the gRPC builder.
- Added missing tests to verify that `operationReference` is correctly propagated in both gRPC and REST requests.


> [!NOTE]
> This is the same fix as for the `main` #34847 (CancelProcessInstance command), but applied manually (not via backport action) because prior to 8.8 we only had the `ZeebeClient`. Backporting the changes made to the new `CamundaClient` would lead to conflicts.


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #31758
