### PR TITLE
ci: Disable Optimize build in benchmarks

### DIFF
--- a/.github/actions/build-zeebe/action.yml
+++ b/.github/actions/build-zeebe/action.yml
@@ -23,7 +23,20 @@ runs:
       shell: bash
       id: build-java
       run: |
+        set -euo pipefail
+
         ./mvnw -B -T1C -DskipTests -DskipChecks install ${{ inputs.maven-extra-args }}
-        export BUILD_DIR=$(./mvnw -pl dist/ help:evaluate -Dexpression=project.build.directory -q -DforceStdout)
-        export ARTIFACT=$(./mvnw -pl dist/ help:evaluate -Dexpression=project.build.finalName -q -DforceStdout)
+
+        BUILD_DIR=$(
+          ./mvnw -q -N -f dist/pom.xml help:evaluate \
+                -Dexpression=project.build.directory \
+                -DforceStdout
+        ) || { echo "::error::could not evaluate project.build.directory"; exit 1; }
+
+        ARTIFACT=$(
+          ./mvnw -q -N -f dist/pom.xml help:evaluate \
+                -Dexpression=project.build.finalName \
+                -DforceStdout
+        ) || { echo "::error::could not evaluate project.build.finalName"; exit 1; }
+
         echo "distball=${BUILD_DIR}/${ARTIFACT}.tar.gz" >> $GITHUB_OUTPUT

--- a/.github/workflows/zeebe-benchmark.yml
+++ b/.github/workflows/zeebe-benchmark.yml
@@ -129,21 +129,25 @@ jobs:
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
       - uses: ./.github/actions/build-frontend
+        name: Build Operate Frontend
         id: build-operate-fe
         with:
           directory: ./operate/client
       - uses: ./.github/actions/build-frontend
+        name: Build Tasklist Frontend
         id: build-tasklist-fe
         with:
           directory: ./tasklist/client
       - uses: ./.github/actions/build-frontend
+        name: Build Identity Frontend
         id: build-identity-fe
         with:
           directory: ./identity/client
       - uses: ./.github/actions/build-zeebe
+        name: Build Zeebe
         id: build-zeebe
         with:
-          maven-extra-args: -PskipFrontendBuild -Dmaven.test.skip=true
+          maven-extra-args: -PskipFrontendBuild -P\!include-optimize -Dmaven.test.skip=true
       - uses: google-github-actions/auth@v2
         id: auth
         with:
@@ -157,6 +161,7 @@ jobs:
           username: oauth2accesstoken
           password: ${{ steps.auth.outputs.access_token }}
       - uses: ./.github/actions/build-platform-docker
+        name: Build Camunda Docker Image
         with:
           repository: 'gcr.io/zeebe-io/zeebe'
           revision: ${{ inputs.ref }}
@@ -197,11 +202,11 @@ jobs:
           vault-address: ${{ secrets.VAULT_ADDR }}
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
-      - run: ./mvnw -B -D skipTests -D skipChecks -pl zeebe/benchmarks/project -am install
+      - run: ./mvnw -B -D skipTests -D skipChecks -P\!include-optimize -pl zeebe/benchmarks/project -am install
       - name: Build Starter Image
-        run: ./mvnw -pl zeebe/benchmarks/project jib:build -P starter -D image="gcr.io/zeebe-io/starter:${{ needs.calculate-image-tag.outputs.image-tag }}"
+        run: ./mvnw -pl zeebe/benchmarks/project jib:build -P starter -P\!include-optimize -D image="gcr.io/zeebe-io/starter:${{ needs.calculate-image-tag.outputs.image-tag }}"
       - name: Build Worker Image
-        run: ./mvnw -pl zeebe/benchmarks/project jib:build -P worker -D image="gcr.io/zeebe-io/worker:${{ needs.calculate-image-tag.outputs.image-tag }}"
+        run: ./mvnw -pl zeebe/benchmarks/project jib:build -P worker -P\!include-optimize -D image="gcr.io/zeebe-io/worker:${{ needs.calculate-image-tag.outputs.image-tag }}"
 
   deploy-benchmark-cluster:
     name: Deploy


### PR DESCRIPTION
## Description

ci: Disable Optimize build in benchmarks

Fix is similar to https://github.com/camunda/camunda/pull/34714/files but for the benchmark.

Otherwise, when running the workflow against the release tag (e.g. `8.8.0-alpha6`), the following error happens (example [workflow](https://github.com/camunda/camunda/actions/runs/16059778630)):

```
Error:    
Error:    The project io.camunda.optimize:optimize-parent:8.8.0-SNAPSHOT (/home/runner/work/camunda/camunda/optimize/pom.xml) has 1 error
Error:      Non-resolvable parent POM for io.camunda.optimize:optimize-parent:8.8.0-SNAPSHOT: The following artifacts could not be resolved: io.camunda:zeebe-parent:pom:8.8.0-SNAPSHOT (absent): Could not find artifact io.camunda:zeebe-parent:pom:8.8.0-SNAPSHOT and 'parent.relativePath' points at wrong local POM @ line 5, column 11 -> [Help 2]
```

How to reproduce the error:
- `git checkout 8.8.0-alpha6` <- not the release branch, release tag
- `./mvnw -B -D skipTests -D skipChecks -pl zeebe/benchmarks/project -am install`

(Maven will also try to build Optimize and will fail on the parent resolution step).

The fix:

- Disables building Optimize for the benchmark builds
- Fixed the maven command to get the build-dist path (maven was falling with the same `Non-resolvable parent POM` otherwise)
- Additionally make the maven command to get the build-dist path fail explicitly and not to swallow the error with the subshell.

The fixed workflow [run](https://github.com/camunda/camunda/actions/runs/16069734170) - against a test branch `8.8.0-alpha6-test` that contains this fix commit on top of the `8.8.0-alpha6` tag.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
