### PR TITLE
build: downgrade camunda-xml-model to 7.19 in java client

### DIFF
--- a/clients/java/pom.xml
+++ b/clients/java/pom.xml
@@ -26,12 +26,28 @@
     <version.java>8</version.java>
     <license.header>com/mycila/maven/plugin/license/templates/APACHE-2.txt</license.header>
     <openapi.dir>${maven.multiModuleProjectDirectory}/zeebe/gateway-protocol/src/main/proto</openapi.dir>
+    <!-- needed as newer model releases don't support jdk 8 -->
+    <dependency.camundamodel.version>7.19.0</dependency.camundamodel.version>
   </properties>
 
   <dependencies>
     <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>zeebe-bpmn-model</artifactId>
+      <exclusions>
+        <!-- we override the model version explicitly to maintain jdk 8 compatibility -->
+        <exclusion>
+          <groupId>org.camunda.bpm.model</groupId>
+          <artifactId>camunda-xml-model</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <!-- we override the model version explicitly to maintain jdk 8 compatibility -->
+    <dependency>
+      <groupId>org.camunda.bpm.model</groupId>
+      <artifactId>camunda-xml-model</artifactId>
+      <version>${dependency.camundamodel.version}</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
## Description

The client is offering jdk 8 compatibility, thus only the last jdk8 compatible model can be used.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
