### PR TITLE
fix: typo in camunda-bpm repo name

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -158,7 +158,7 @@
       <snapshots>
         <enabled>false</enabled>
       </snapshots>
-      <id>camunda-cpm</id>
+      <id>camunda-bpm</id>
       <name>Camunda BPM Repository</name>
       <url>https://artifacts.camunda.com/artifactory/camunda-bpm/</url>
     </repository>


### PR DESCRIPTION
## Description

This was introduced accidentally in https://github.com/camunda/camunda/commit/e1bd31ae6e3335ce04893fe09497904ad4d95331 and does not have any impact, besides being confusing in human-readable logs.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

None
