### PR TITLE
ci: update tasklist-e2e workflow stable/8.6

### DIFF
--- a/.github/workflows/tasklist-e2e-tests.yml
+++ b/.github/workflows/tasklist-e2e-tests.yml
@@ -15,6 +15,7 @@ on:
       - "tasklist/**"
       - "tasklist.Dockerfile"
       - "webapps-common/**"
+      - "qa/c8-orchestration-cluster-e2e-test-suite/**"
   pull_request:
     paths:
       - ".github/actions/**"
@@ -25,9 +26,10 @@ on:
       - "tasklist/**"
       - "tasklist.Dockerfile"
       - "webapps-common/**"
+      - "qa/c8-orchestration-cluster-e2e-test-suite/**"
 
 # Limit workflow to 1 concurrent run per ref (branch): new commit -> old runs are canceled to save costs
-# Exception for main branch: complete builds for every commit needed for confidenence
+# Exception for main branch: complete builds for every commit needed for confidence
 concurrency:
   cancel-in-progress: true
   group: ${{ format('{0}-{1}', github.workflow, github.ref == 'refs/heads/main' && github.sha || github.ref) }}
@@ -59,9 +61,11 @@ jobs:
         ports:
           - 26500:26500
           - 8089:8080
+
     steps:
       - name: Check out repository code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
       - name: Import Secrets
         id: secrets
         uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b
@@ -73,31 +77,34 @@ jobs:
           secrets: |
             secret/data/github.com/organizations/camunda NEXUS_USR;
             secret/data/github.com/organizations/camunda NEXUS_PSW;
+
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
           node-version: "20"
-      - name: Setup yarn
-        run: npm install -g yarn
+
       - name: Install node dependencies
+        working-directory: qa/c8-orchestration-cluster-e2e-test-suite
+        run: yarn install
+
+      - name: Install frontend dependencies
         working-directory: ./tasklist/client
         run: yarn install
-      - name: Add Yarn binaries to Path
-        working-directory: ./tasklist/client
-        run: |
-          echo "$(yarn bin)" >> $GITHUB_PATH
-          echo "$(yarn global bin)" >> $GITHUB_PATH
+
       - name: Install Playwright
+        working-directory: qa/c8-orchestration-cluster-e2e-test-suite
         run: yarn exec playwright install -- --with-deps chromium
-        working-directory: ./tasklist/client
+
       - name: Build frontend
         working-directory: ./tasklist/client
         run: yarn build
+
       - name: Setup Java
         uses: actions/setup-java@v4
         with:
           distribution: "adopt"
           java-version: "21"
+
       - name: Setup Maven
         uses: ./.github/actions/setup-maven-dist
         with:
@@ -115,28 +122,40 @@ jobs:
               "password": "${{ steps.secrets.outputs.NEXUS_PSW }}"
             }]
           mirrors: '[{"url": "https://repository.nexus.camunda.cloud/content/groups/internal/", "id": "camunda-nexus", "mirrorOf": "*", "name": "camunda Nexus"}]'
+
       - name: Build backend
         # Currently, the e2e environment of tasklist conflicts with the optimize build. For the moment,
         # we're excluding optimize from the build, not to impact this tasklist's workflow.
         run: ./mvnw clean install -T1C -DskipChecks -PskipFrontendBuild -DskipTests=true -B -DskipRemoteStaging=true -Dmaven.deploy.skip=true
+
       - name: Start Tasklist
         run: ./mvnw -q -B spring-boot:start -pl dist -Dspring-boot.run.main-class=io.camunda.application.StandaloneTasklist -Dspring-boot.run.fork=true -Dspring-boot.run.profiles=e2e-test -Dspring-boot.run.arguments="--camunda.tasklist.cloud.clusterId=449ac2ad-d3c6-4c73-9c68-7752e39ae616 --camunda.tasklist.csrfPreventionEnabled=false"
+
       - name: Python setup
         if: always()
         uses: actions/setup-python@v5
         with:
           python-version: "3.x"
+
       - name: Run tests
-        working-directory: ./tasklist/client
-        run: yarn run test:e2e:ci
+        shell: bash
         env:
-          ZEEBE_GATEWAY_ADDRESS: localhost:26500
+          LOCAL_TEST: "false"
+          CORE_APPLICATION_TASKLIST_URL: http://localhost:8080
+          CORE_APPLICATION_OPERATE_URL: http://localhost:8081
+          CAMUNDA_AUTH_STRATEGY: "BASIC"
+          CAMUNDA_BASIC_AUTH_USERNAME: "demo"
+          CAMUNDA_BASIC_AUTH_PASSWORD: "demo"
+          ZEEBE_REST_ADDRESS: "http://localhost:8089"
+        run: npm run test -- --project=tasklist-e2e
+        working-directory: qa/c8-orchestration-cluster-e2e-test-suite
       - uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: Playwright report
-          path: tasklist/client/playwright-report/
+          name: C8 Orchestration Cluster E2E Test Result
+          path: qa/c8-orchestration-cluster-e2e-test-suite/html-report
           retention-days: 30
+
       - name: Observe build status
         if: always()
         continue-on-error: true

--- a/qa/c8-orchestration-cluster-e2e-test-suite/playwright.config.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/playwright.config.ts
@@ -94,6 +94,13 @@ export default defineConfig({
       testMatch: 'task-panel.spec.ts',
       use: devices['Desktop Edge'],
     },
+    {
+      name: 'tasklist-e2e',
+      testMatch: ['tests/tasklist/*.spec.ts'],
+      use: devices['Desktop Edge'],
+      testIgnore: 'task-panel.spec.ts',
+      teardown: 'chromium-subset',
+    },
   ],
   reporter:
     process.env.INCLUDE_SLACK_REPORTER === 'true'

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/task-details.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/task-details.spec.ts
@@ -15,6 +15,7 @@ import {sleep} from 'utils/sleep';
 import {captureScreenshot, captureFailureVideo} from '@setup';
 
 test.beforeAll(async () => {
+  // Workaround for #34322: split deployments to avoid test failures caused by bulk deployment
   await deploy([
     './resources/usertask_to_be_completed.bpmn',
     './resources/user_task_with_form.bpmn',
@@ -26,6 +27,8 @@ test.beforeAll(async () => {
     './resources/form_with_checkbox.form',
     './resources/checklist_task_with_form.bpmn',
     './resources/form_with_checklist.form',
+  ]);
+  await deploy([
     './resources/date_and_time_task_with_form.bpmn',
     './resources/form_with_date_and_time.form',
     './resources/number_task_with_form.bpmn',
@@ -36,13 +39,14 @@ test.beforeAll(async () => {
     './resources/form_with_select.form',
     './resources/tag_list_task_with_form.bpmn',
     './resources/form_with_tag_list.form',
+  ]);
+  await deploy([
     './resources/text_templating_form_task.bpmn',
     './resources/form_with_text_templating.form',
     './resources/processWithDeployedForm.bpmn',
     './resources/create_invoice.form',
     './resources/zeebe_and_job_worker_process.bpmn',
   ]);
-
   await sleep(1000);
 
   await Promise.all([


### PR DESCRIPTION
As part of the migration of Tasklist E2E tests to the centralized  `C8 Orchestration cluster` test suite, this PR updates the GitHub Actions workflow triggers to reflect the new location. Also applied some refactoring.

### ✅ Summary of Changes:

* Updated workflow triggers to include paths under `qa/c8-orchestration-cluster-e2e-test-suite`.
* Removed references to the old `tasklist/client/e2e/tests` directory.
* Split deployments to avoid test failures caused by bulk deployment as a workaround to #34322 

🧪 **Testing**
- Successful Test run [here](https://github.com/camunda/camunda/actions/runs/16072917732)
## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
