### PR TITLE
fix: :switch mapping API to mapping-rule

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/impl/command/AssignMappingToTenantCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/AssignMappingToTenantCommandImpl.java
@@ -61,7 +61,7 @@ public final class AssignMappingToTenantCommandImpl
   @Override
   public CamundaFuture<AssignMappingToTenantResponse> send() {
     final HttpCamundaFuture<AssignMappingToTenantResponse> result = new HttpCamundaFuture<>();
-    final String endpoint = String.format("/tenants/%s/mappings/%s", tenantId, mappingId);
+    final String endpoint = String.format("/tenants/%s/mapping-rules/%s", tenantId, mappingId);
     httpClient.put(endpoint, null, httpRequestConfig.build(), result);
     return result;
   }

--- a/clients/java/src/main/java/io/camunda/client/impl/command/AssignRoleToMappingCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/AssignRoleToMappingCommandImpl.java
@@ -63,7 +63,7 @@ public class AssignRoleToMappingCommandImpl
     ArgumentUtil.ensureNotNullNorEmpty("mappingId", mappingId);
     final HttpCamundaFuture<AssignRoleToMappingResponse> result = new HttpCamundaFuture<>();
     httpClient.put(
-        "/roles/" + roleId + "/mappings/" + mappingId,
+        "/roles/" + roleId + "/mapping-rules/" + mappingId,
         null, // No request body needed
         httpRequestConfig.build(),
         result);

--- a/clients/java/src/main/java/io/camunda/client/impl/command/CreateMappingCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/CreateMappingCommandImpl.java
@@ -63,7 +63,7 @@ public class CreateMappingCommandImpl implements CreateMappingCommandStep1 {
 
   @Override
   public CreateMappingCommandStep1 mappingId(final String mappingId) {
-    mappingRequest.mappingId(mappingId);
+    mappingRequest.mappingRuleId(mappingId);
     return this;
   }
 
@@ -78,7 +78,7 @@ public class CreateMappingCommandImpl implements CreateMappingCommandStep1 {
     ArgumentUtil.ensureNotNull("claimName", mappingRequest.getClaimName());
     ArgumentUtil.ensureNotNull("claimValue", mappingRequest.getClaimValue());
     ArgumentUtil.ensureNotNull("name", mappingRequest.getName());
-    ArgumentUtil.ensureNotNull("mappingId", mappingRequest.getMappingId());
+    ArgumentUtil.ensureNotNull("mappingRuleId", mappingRequest.getMappingRuleId());
     final HttpCamundaFuture<CreateMappingResponse> result = new HttpCamundaFuture<>();
     final CreateMappingResponseImpl response = new CreateMappingResponseImpl();
     httpClient.post(

--- a/clients/java/src/main/java/io/camunda/client/impl/command/UnassignRoleFromMappingCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/UnassignRoleFromMappingCommandImpl.java
@@ -64,7 +64,7 @@ public class UnassignRoleFromMappingCommandImpl
     ArgumentUtil.ensureNotNullNorEmpty("mappingId", mappingId);
     final HttpCamundaFuture<UnassignRoleFromMappingResponse> result = new HttpCamundaFuture<>();
     httpClient.delete(
-        "/roles/" + roleId + "/mappings/" + mappingId,
+        "/roles/" + roleId + "/mapping-rules/" + mappingId,
         null, // No request body needed
         httpRequestConfig.build(),
         result);

--- a/clients/java/src/main/java/io/camunda/client/impl/response/CreateMappingResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/CreateMappingResponseImpl.java
@@ -28,7 +28,7 @@ public class CreateMappingResponseImpl implements CreateMappingResponse {
   }
 
   public CreateMappingResponseImpl setResponse(final MappingRuleCreateResult response) {
-    mappingId = response.getMappingId();
+    mappingId = response.getMappingRuleId();
     return this;
   }
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/MappingFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/MappingFilterImpl.java
@@ -19,18 +19,18 @@ import io.camunda.client.api.search.filter.MappingFilter;
 import io.camunda.client.impl.search.request.TypedSearchRequestPropertyProvider;
 
 public class MappingFilterImpl
-    extends TypedSearchRequestPropertyProvider<io.camunda.client.protocol.rest.MappingFilter>
+    extends TypedSearchRequestPropertyProvider<io.camunda.client.protocol.rest.MappingRuleFilter>
     implements MappingFilter {
 
-  private final io.camunda.client.protocol.rest.MappingFilter filter;
+  private final io.camunda.client.protocol.rest.MappingRuleFilter filter;
 
   public MappingFilterImpl() {
-    filter = new io.camunda.client.protocol.rest.MappingFilter();
+    filter = new io.camunda.client.protocol.rest.MappingRuleFilter();
   }
 
   @Override
   public MappingFilter mappingId(final String mappingId) {
-    filter.setMappingId(mappingId);
+    filter.setMappingRuleId(mappingId);
     return this;
   }
 
@@ -53,7 +53,7 @@ public class MappingFilterImpl
   }
 
   @Override
-  protected io.camunda.client.protocol.rest.MappingFilter getSearchRequestProperty() {
+  protected io.camunda.client.protocol.rest.MappingRuleFilter getSearchRequestProperty() {
     return filter;
   }
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/search/request/MappingsByGroupSearchRequestImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/request/MappingsByGroupSearchRequestImpl.java
@@ -32,18 +32,18 @@ import io.camunda.client.impl.command.ArgumentUtil;
 import io.camunda.client.impl.http.HttpCamundaFuture;
 import io.camunda.client.impl.http.HttpClient;
 import io.camunda.client.impl.search.response.SearchResponseMapper;
-import io.camunda.client.protocol.rest.MappingSearchQueryRequest;
-import io.camunda.client.protocol.rest.MappingSearchQueryResult;
+import io.camunda.client.protocol.rest.MappingRuleSearchQueryRequest;
+import io.camunda.client.protocol.rest.MappingRuleSearchQueryResult;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import org.apache.hc.client5.http.config.RequestConfig;
 
 public class MappingsByGroupSearchRequestImpl
-    extends TypedSearchRequestPropertyProvider<MappingSearchQueryRequest>
+    extends TypedSearchRequestPropertyProvider<MappingRuleSearchQueryRequest>
     implements MappingsByGroupSearchRequest {
 
-  private final MappingSearchQueryRequest request;
+  private final MappingRuleSearchQueryRequest request;
   private final String groupId;
   private final HttpClient httpClient;
   private final JsonMapper jsonMapper;
@@ -55,7 +55,7 @@ public class MappingsByGroupSearchRequestImpl
     this.jsonMapper = jsonMapper;
     this.groupId = groupId;
     httpRequestConfig = httpClient.newRequestConfig();
-    request = new MappingSearchQueryRequest();
+    request = new MappingRuleSearchQueryRequest();
   }
 
   @Override
@@ -72,7 +72,7 @@ public class MappingsByGroupSearchRequestImpl
         String.format("/groups/%s/mapping-rules/search", groupId),
         jsonMapper.toJson(request),
         httpRequestConfig.build(),
-        MappingSearchQueryResult.class,
+        MappingRuleSearchQueryResult.class,
         SearchResponseMapper::toMappingsResponse,
         result);
     return result;
@@ -114,7 +114,7 @@ public class MappingsByGroupSearchRequestImpl
   }
 
   @Override
-  protected MappingSearchQueryRequest getSearchRequestProperty() {
+  protected MappingRuleSearchQueryRequest getSearchRequestProperty() {
     return request;
   }
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/search/request/MappingsByRoleSearchRequestImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/request/MappingsByRoleSearchRequestImpl.java
@@ -32,18 +32,18 @@ import io.camunda.client.impl.command.ArgumentUtil;
 import io.camunda.client.impl.http.HttpCamundaFuture;
 import io.camunda.client.impl.http.HttpClient;
 import io.camunda.client.impl.search.response.SearchResponseMapper;
-import io.camunda.client.protocol.rest.MappingSearchQueryRequest;
-import io.camunda.client.protocol.rest.MappingSearchQueryResult;
+import io.camunda.client.protocol.rest.MappingRuleSearchQueryRequest;
+import io.camunda.client.protocol.rest.MappingRuleSearchQueryResult;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import org.apache.hc.client5.http.config.RequestConfig;
 
 public class MappingsByRoleSearchRequestImpl
-    extends TypedSearchRequestPropertyProvider<MappingSearchQueryRequest>
+    extends TypedSearchRequestPropertyProvider<MappingRuleSearchQueryRequest>
     implements MappingsByRoleSearchRequest {
 
-  private final MappingSearchQueryRequest request;
+  private final MappingRuleSearchQueryRequest request;
   private final String roleId;
   private final HttpClient httpClient;
   private final JsonMapper jsonMapper;
@@ -54,8 +54,8 @@ public class MappingsByRoleSearchRequestImpl
     this.httpClient = httpClient;
     this.jsonMapper = jsonMapper;
     this.roleId = roleId;
-    this.httpRequestConfig = httpClient.newRequestConfig();
-    this.request = new MappingSearchQueryRequest();
+    httpRequestConfig = httpClient.newRequestConfig();
+    request = new MappingRuleSearchQueryRequest();
   }
 
   @Override
@@ -72,7 +72,7 @@ public class MappingsByRoleSearchRequestImpl
         String.format("/roles/%s/mapping-rules/search", roleId),
         jsonMapper.toJson(request),
         httpRequestConfig.build(),
-        MappingSearchQueryResult.class,
+        MappingRuleSearchQueryResult.class,
         SearchResponseMapper::toMappingsResponse,
         result);
     return result;
@@ -114,7 +114,7 @@ public class MappingsByRoleSearchRequestImpl
   }
 
   @Override
-  protected MappingSearchQueryRequest getSearchRequestProperty() {
+  protected MappingRuleSearchQueryRequest getSearchRequestProperty() {
     return request;
   }
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/search/request/SearchRequestSortMapper.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/request/SearchRequestSortMapper.java
@@ -16,6 +16,7 @@
 package io.camunda.client.impl.search.request;
 
 import io.camunda.client.protocol.rest.*;
+import io.camunda.client.protocol.rest.MappingRuleSearchQuerySortRequest.FieldEnum;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -249,7 +250,13 @@ public class SearchRequestSortMapper {
             r -> {
               final MappingRuleSearchQuerySortRequest request =
                   new MappingRuleSearchQuerySortRequest();
-              request.setField(MappingRuleSearchQuerySortRequest.FieldEnum.fromValue(r.getField()));
+              // Remove when https://github.com/camunda/camunda/issues/32586 is done
+              if (r.getField() != null && r.getField().equals("mappingId")) {
+                request.setField(FieldEnum.MAPPING_RULE_ID);
+              } else {
+                request.setField(
+                    MappingRuleSearchQuerySortRequest.FieldEnum.fromValue(r.getField()));
+              }
               request.setOrder(r.getOrder());
               return request;
             })

--- a/clients/java/src/main/java/io/camunda/client/impl/search/request/SearchRequestSortMapper.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/request/SearchRequestSortMapper.java
@@ -57,7 +57,7 @@ public class SearchRequestSortMapper {
   }
 
   public static List<SearchRequestSort> fromMappingSearchQuerySortRequest(
-      final List<MappingSearchQuerySortRequest> requests) {
+      final List<MappingRuleSearchQuerySortRequest> requests) {
     return requests.stream()
         .map(r -> createFrom(r.getField(), r.getOrder()))
         .collect(Collectors.toList());
@@ -242,13 +242,14 @@ public class SearchRequestSortMapper {
         .collect(Collectors.toList());
   }
 
-  public static List<MappingSearchQuerySortRequest> toMappingSearchQuerySortRequest(
+  public static List<MappingRuleSearchQuerySortRequest> toMappingSearchQuerySortRequest(
       final List<SearchRequestSort> requests) {
     return requests.stream()
         .map(
             r -> {
-              final MappingSearchQuerySortRequest request = new MappingSearchQuerySortRequest();
-              request.setField(MappingSearchQuerySortRequest.FieldEnum.fromValue(r.getField()));
+              final MappingRuleSearchQuerySortRequest request =
+                  new MappingRuleSearchQuerySortRequest();
+              request.setField(MappingRuleSearchQuerySortRequest.FieldEnum.fromValue(r.getField()));
               request.setOrder(r.getOrder());
               return request;
             })

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/SearchResponseMapper.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/SearchResponseMapper.java
@@ -276,9 +276,9 @@ public final class SearchResponseMapper {
     return new TenantUserImpl(response.getUsername());
   }
 
-  public static Mapping toMappingResponse(final MappingResult response) {
+  public static Mapping toMappingResponse(final MappingRuleResult response) {
     return new MappingImpl(
-        response.getMappingId(),
+        response.getMappingRuleId(),
         response.getClaimName(),
         response.getClaimValue(),
         response.getName());
@@ -299,7 +299,7 @@ public final class SearchResponseMapper {
   }
 
   public static SearchResponse<Mapping> toMappingsResponse(
-      final MappingSearchQueryResult response) {
+      final MappingRuleSearchQueryResult response) {
     final SearchResponsePage page = toSearchResponsePage(response.getPage());
     final List<Mapping> instances =
         toSearchResponseInstances(response.getItems(), SearchResponseMapper::toMappingResponse);

--- a/clients/java/src/test/java/io/camunda/client/mapping/CreateMappingTest.java
+++ b/clients/java/src/test/java/io/camunda/client/mapping/CreateMappingTest.java
@@ -47,7 +47,7 @@ public class CreateMappingTest extends ClientRestTest {
     assertThat(request.getClaimName()).isEqualTo(CLAIM_NAME);
     assertThat(request.getClaimValue()).isEqualTo(CLAIM_VALUE);
     assertThat(request.getName()).isEqualTo(NAME);
-    assertThat(request.getMappingId()).isEqualTo(MAPPING_ID);
+    assertThat(request.getMappingRuleId()).isEqualTo(MAPPING_ID);
   }
 
   @Test

--- a/clients/java/src/test/java/io/camunda/client/role/AssignRoleToMappingTest.java
+++ b/clients/java/src/test/java/io/camunda/client/role/AssignRoleToMappingTest.java
@@ -36,7 +36,7 @@ public class AssignRoleToMappingTest extends ClientRestTest {
     // then
     final String requestPath = RestGatewayService.getLastRequest().getUrl();
     assertThat(requestPath)
-        .isEqualTo(REST_API_PATH + "/roles/" + ROLE_ID + "/mappings/" + MAPPING_ID);
+        .isEqualTo(REST_API_PATH + "/roles/" + ROLE_ID + "/mapping-rules/" + MAPPING_ID);
   }
 
   @Test

--- a/clients/java/src/test/java/io/camunda/client/role/UnassignRoleFromMappingTest.java
+++ b/clients/java/src/test/java/io/camunda/client/role/UnassignRoleFromMappingTest.java
@@ -35,7 +35,7 @@ public class UnassignRoleFromMappingTest extends ClientRestTest {
     // then
     final String requestPath = RestGatewayService.getLastRequest().getUrl();
     assertThat(requestPath)
-        .isEqualTo(REST_API_PATH + "/roles/" + ROLE_ID + "/mappings/" + MAPPING_ID);
+        .isEqualTo(REST_API_PATH + "/roles/" + ROLE_ID + "/mapping-rules/" + MAPPING_ID);
   }
 
   @Test

--- a/clients/java/src/test/java/io/camunda/client/tenant/AssignMappingToTenantTest.java
+++ b/clients/java/src/test/java/io/camunda/client/tenant/AssignMappingToTenantTest.java
@@ -43,14 +43,14 @@ public class AssignMappingToTenantTest extends ClientRestTest {
     // then
     final String requestPath = RestGatewayService.getLastRequest().getUrl();
     assertThat(requestPath)
-        .isEqualTo(REST_API_PATH + "/tenants/" + TENANT_ID + "/mappings/" + MAPPING_ID);
+        .isEqualTo(REST_API_PATH + "/tenants/" + TENANT_ID + "/mapping-rules/" + MAPPING_ID);
   }
 
   @Test
   void shouldRaiseExceptionOnNotFoundTenant() {
     // given
     gatewayService.errorOnRequest(
-        REST_API_PATH + "/tenants/" + TENANT_ID + "/mappings/" + MAPPING_ID,
+        REST_API_PATH + "/tenants/" + TENANT_ID + "/mapping-rules/" + MAPPING_ID,
         () -> new ProblemDetail().title("Not Found").status(404));
 
     // when / then
@@ -70,7 +70,7 @@ public class AssignMappingToTenantTest extends ClientRestTest {
   void shouldRaiseExceptionOnNotFoundMapping() {
     // given
     gatewayService.errorOnRequest(
-        REST_API_PATH + "/tenants/" + TENANT_ID + "/mappings/" + MAPPING_ID,
+        REST_API_PATH + "/tenants/" + TENANT_ID + "/mapping-rules/" + MAPPING_ID,
         () -> new ProblemDetail().title("Not Found").status(404));
 
     // when / then
@@ -90,7 +90,7 @@ public class AssignMappingToTenantTest extends ClientRestTest {
   void shouldHandleServerError() {
     // given
     gatewayService.errorOnRequest(
-        REST_API_PATH + "/tenants/" + TENANT_ID + "/mappings/" + MAPPING_ID,
+        REST_API_PATH + "/tenants/" + TENANT_ID + "/mapping-rules/" + MAPPING_ID,
         () -> new ProblemDetail().title("Internal Server Error").status(500));
 
     // when / then
@@ -110,7 +110,7 @@ public class AssignMappingToTenantTest extends ClientRestTest {
   void shouldRaiseExceptionOnForbiddenRequest() {
     // given
     gatewayService.errorOnRequest(
-        REST_API_PATH + "/tenants/" + TENANT_ID + "/mappings/" + MAPPING_ID,
+        REST_API_PATH + "/tenants/" + TENANT_ID + "/mapping-rules/" + MAPPING_ID,
         () -> new ProblemDetail().title("Forbidden").status(403));
 
     // when / then

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -775,7 +775,7 @@ paths:
                 $ref: "#/components/schemas/ProblemDetail"
         "500":
           $ref: "#/components/responses/InternalServerError"
-  /tenants/{tenantId}/mappings/{mappingId}:
+  /tenants/{tenantId}/mapping-rules/{mappingRuleId}:
     put:
       tags:
         - Tenant
@@ -789,7 +789,7 @@ paths:
           description: The unique identifier of the tenant.
           schema:
             type: string
-        - name: mappingId
+        - name: mappingRuleId
           in: path
           required: true
           description: The unique identifier of the mapping rule.
@@ -824,7 +824,7 @@ paths:
           description: The unique identifier of the tenant.
           schema:
             type: string
-        - name: mappingId
+        - name: mappingRuleId
           in: path
           required: true
           description: The unique identifier of the mapping rule.
@@ -845,13 +845,13 @@ paths:
                 $ref: "#/components/schemas/ProblemDetail"
         "500":
           $ref: "#/components/responses/InternalServerError"
-  /tenants/{tenantId}/mappings/search:
+  /tenants/{tenantId}/mapping-rules/search:
     post:
       tags:
         - Tenant
       operationId: searchMappingsForTenant
-      summary: Search mappings for tenant
-      description: Retrieves a filtered and sorted list of mappings for a specified tenant.
+      summary: Search mapping rules for tenant
+      description: Retrieves a filtered and sorted list of MappingRules for a specified tenant.
       parameters:
         - name: tenantId
           in: path
@@ -864,14 +864,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/MappingSearchQueryRequest"
+              $ref: "#/components/schemas/MappingRuleSearchQueryRequest"
       responses:
         "200":
-          description: The search result of mappings for the tenant.
+          description: The search result of MappingRules for the tenant.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/MappingSearchQueryResult"
+                $ref: "#/components/schemas/MappingRuleSearchQueryResult"
 
   /tenants/{tenantId}/groups/{groupId}:
     put:
@@ -3294,14 +3294,14 @@ paths:
                 $ref: "#/components/schemas/ProblemDetail"
         "500":
           $ref: "#/components/responses/InternalServerError"
-  /roles/{roleId}/mappings/{mappingId}:
+  /roles/{roleId}/mapping-rules/{mappingRuleId}:
     put:
       tags:
         - Role
-      operationId: addMappingToRole
-      summary: Assign a mapping to a role
+      operationId: addMappingRuleToRole
+      summary: Assign a mapping rule to a role
       description: |
-        Assigns a mapping to a role.
+        Assigns a mapping rule to a role.
       parameters:
         - name: roleId
           in: path
@@ -3309,27 +3309,27 @@ paths:
           description: The role ID.
           schema:
             type: string
-        - name: mappingId
+        - name: mappingRuleId
           in: path
           required: true
-          description: The mapping ID.
+          description: The mapping rule ID.
           schema:
             type: string
       responses:
         "202":
-          description: The mapping was assigned successfully to the role.
+          description: The mapping rule was assigned successfully to the role.
         "400":
           $ref: "#/components/responses/InvalidData"
         "403":
           $ref: "#/components/responses/Forbidden"
         "404":
-          description: The role or mapping with the given ID was not found.
+          description: The role or mapping rule with the given ID was not found.
           content:
             application/problem+json:
               schema:
                 $ref: "#/components/schemas/ProblemDetail"
         "409":
-          description: The mapping with the given ID is already assigned to the role.
+          description: The mapping rule with the given ID is already assigned to the role.
           content:
             application/problem+json:
               schema:
@@ -3339,7 +3339,7 @@ paths:
     delete:
       tags:
         - Role
-      operationId: removeMappingFromRole
+      operationId: removeMappingRuleFromRole
       summary: Unassign a mapping from a role
       description: |
         Unassigns a mapping from a role.
@@ -3350,15 +3350,15 @@ paths:
           description: The role ID.
           schema:
             type: string
-        - name: mappingId
+        - name: mappingRuleId
           in: path
           required: true
-          description: The mapping ID.
+          description: The mapping rule ID.
           schema:
             type: string
       responses:
         "202":
-          description: The mapping was unassigned successfully from the role.
+          description: The mapping rule was unassigned successfully from the role.
         "400":
           $ref: "#/components/responses/InvalidData"
         "403":
@@ -3391,14 +3391,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/MappingSearchQueryRequest"
+              $ref: "#/components/schemas/MappingRuleSearchQueryRequest"
       responses:
         "200":
           description: The mapping rules assigned to the role.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/MappingSearchQueryResult"
+                $ref: "#/components/schemas/MappingRuleSearchQueryResult"
         "400":
           $ref: "#/components/responses/InvalidData"
         "401":
@@ -3604,14 +3604,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/MappingSearchQueryRequest"
+              $ref: "#/components/schemas/MappingRuleSearchQueryRequest"
       responses:
         "200":
           description: The mapping rules assigned to the group.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/MappingSearchQueryResult"
+                $ref: "#/components/schemas/MappingRuleSearchQueryResult"
         "400":
           $ref: "#/components/responses/InvalidData"
         "401":
@@ -3864,11 +3864,11 @@ paths:
                 $ref: "#/components/schemas/ProblemDetail"
         "500":
           $ref: "#/components/responses/InternalServerError"
-  /groups/{groupId}/mapping-rules/{mappingId}:
+  /groups/{groupId}/mapping-rules/{mappingRuleId}:
     put:
       tags:
         - Group
-      operationId: assignMappingToGroup
+      operationId: assignMappingRuleToGroup
       summary: Assign a mapping rule to a group
       description: |
         Assigns a mapping rule to a group.
@@ -3879,7 +3879,7 @@ paths:
           description: The group ID.
           schema:
             type: string
-        - name: mappingId
+        - name: mappingRuleId
           in: path
           required: true
           description: The mapping rule ID.
@@ -3909,7 +3909,7 @@ paths:
     delete:
       tags:
         - Group
-      operationId: unassignMappingFromGroup
+      operationId: unassignMappingRuleFromGroup
       summary: Unassign a mapping rule from a group
       description: |
         Unassigns a mapping rule from a group.
@@ -3920,7 +3920,7 @@ paths:
           description: The group ID.
           schema:
             type: string
-        - name: mappingId
+        - name: mappingRuleId
           in: path
           required: true
           description: The mapping rule ID.
@@ -4013,7 +4013,7 @@ paths:
                 $ref: "#/components/schemas/ProblemDetail"
         "500":
           $ref: "#/components/responses/InternalServerError"
-  /mapping-rules/{mappingId}:
+  /mapping-rules/{mappingRuleId}:
     put:
       tags:
         - Mapping rule
@@ -4022,7 +4022,7 @@ paths:
       description: |
         Update a mapping rule.
       parameters:
-        - name: mappingId
+        - name: mappingRuleId
           in: path
           required: true
           description: The ID of the mapping rule to update.
@@ -4066,7 +4066,7 @@ paths:
       description: |
         Deletes the mapping rule with the given ID.
       parameters:
-        - name: mappingId
+        - name: mappingRuleId
           in: path
           required: true
           description: The ID of the mapping rule to delete.
@@ -4078,7 +4078,7 @@ paths:
         "401":
           $ref: "#/components/responses/Unauthorized"
         "404":
-          description: The mapping rule with the mappingId was not found.
+          description: The mapping rule with the mappingRuleId was not found.
           content:
             application/problem+json:
               schema:
@@ -4093,7 +4093,7 @@ paths:
       description: |
         Gets the mapping rule with the given ID.
       parameters:
-        - name: mappingId
+        - name: mappingRuleId
           in: path
           required: true
           description: The ID of the mapping rule to get.
@@ -4105,7 +4105,7 @@ paths:
         "401":
           $ref: "#/components/responses/Unauthorized"
         "404":
-          description: The mapping rule with the mappingId was not found.
+          description: The mapping rule with the mappingRuleId was not found.
           content:
             application/problem+json:
               schema:
@@ -4117,15 +4117,15 @@ paths:
     post:
       tags:
         - Mapping rule
-      operationId: searchMappings
-      summary: Search mappings
+      operationId: searchMappingRule
+      summary: Search mapping rules
       description: |
         Search for mapping rules based on given criteria.
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/MappingSearchQueryRequest"
+              $ref: "#/components/schemas/MappingRuleSearchQueryRequest"
         required: true
       responses:
         "200":
@@ -4133,7 +4133,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/MappingSearchQueryResult"
+                $ref: "#/components/schemas/MappingRuleSearchQueryResult"
         "400":
           $ref: "#/components/responses/InvalidData"
         "401":
@@ -7315,14 +7315,14 @@ components:
           description: The user search filters.
           allOf:
             - $ref: "#/components/schemas/UserFilter"
-    MappingSearchQuerySortRequest:
+    MappingRuleSearchQuerySortRequest:
       type: object
       properties:
         field:
           description: The field to sort by.
           type: string
           enum:
-            - mappingId
+            - mappingRuleId
             - claimName
             - claimValue
             - name
@@ -7330,7 +7330,7 @@ components:
           $ref: "#/components/schemas/SortOrderEnum"
       required:
         - field
-    MappingSearchQueryRequest:
+    MappingRuleSearchQueryRequest:
       allOf:
         - $ref: "#/components/schemas/SearchQueryRequest"
       type: object
@@ -7339,11 +7339,11 @@ components:
           description: Sort field criteria.
           type: array
           items:
-            $ref: "#/components/schemas/MappingSearchQuerySortRequest"
+            $ref: "#/components/schemas/MappingRuleSearchQuerySortRequest"
         filter:
           description: The mapping search filters.
           allOf:
-            - $ref: "#/components/schemas/MappingFilter"
+            - $ref: "#/components/schemas/MappingRuleFilter"
     UserFilter:
       description: User search filter.
       type: object
@@ -7360,8 +7360,8 @@ components:
           description: The email of the user.
           allOf:
             - $ref: "#/components/schemas/StringFilterProperty"
-    MappingFilter:
-      description: Mapping search filter.
+    MappingRuleFilter:
+      description: Mapping rule search filter.
       type: object
       properties:
         claimName:
@@ -7373,7 +7373,7 @@ components:
         name:
           type: string
           description: The name of the mapping.
-        mappingId:
+        mappingRuleId:
           type: string
           description: The ID of the mapping.
     CamundaUserResult:
@@ -8025,11 +8025,11 @@ components:
       allOf:
         - $ref: "#/components/schemas/MappingRuleCreateUpdateRequest"
       properties:
-        mappingId:
+        mappingRuleId:
           type: string
           description: The unique ID of the mapping.
       required:
-        - mappingId
+        - mappingRuleId
     MappingRuleUpdateRequest:
       type: object
       allOf:
@@ -8046,7 +8046,7 @@ components:
         name:
           type: string
           description: The name of the mapping.
-        mappingId:
+        mappingRuleId:
           type: string
           description: The unique ID of the mapping.
     MappingRuleCreateResult:
@@ -8057,7 +8057,7 @@ components:
       type: object
       allOf:
         - $ref: "#/components/schemas/MappingRuleCreateUpdateResult"
-    MappingSearchQueryResult:
+    MappingRuleSearchQueryResult:
       type: object
       allOf:
         - $ref: "#/components/schemas/SearchQueryResponse"
@@ -8066,8 +8066,8 @@ components:
           description: The matching mapping rules.
           type: array
           items:
-            $ref: "#/components/schemas/MappingResult"
-    MappingResult:
+            $ref: "#/components/schemas/MappingRuleResult"
+    MappingRuleResult:
       type: "object"
       properties:
         claimName:
@@ -8079,7 +8079,7 @@ components:
         name:
           type: string
           description: The name of the mapping.
-        mappingId:
+        mappingRuleId:
           type: string
           description: The ID of the mapping.
 

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RequestMapper.java
@@ -495,7 +495,7 @@ public class RequestMapper {
                 request.getClaimName(),
                 request.getClaimValue(),
                 request.getName(),
-                request.getMappingId()));
+                request.getMappingRuleId()));
   }
 
   public static Either<ProblemDetail, MappingDTO> toMappingDTO(

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/ResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/ResponseMapper.java
@@ -637,7 +637,7 @@ public final class ResponseMapper {
         new MappingRuleCreateResult()
             .claimName(record.getClaimName())
             .claimValue(record.getClaimValue())
-            .mappingId(record.getMappingId())
+            .mappingRuleId(record.getMappingId())
             .name(record.getName());
     return new ResponseEntity<>(response, HttpStatus.CREATED);
   }
@@ -647,7 +647,7 @@ public final class ResponseMapper {
         new MappingRuleUpdateResult()
             .claimName(record.getClaimName())
             .claimValue(record.getClaimValue())
-            .mappingId(record.getMappingId())
+            .mappingRuleId(record.getMappingId())
             .name(record.getName());
     return new ResponseEntity<>(response, HttpStatus.OK);
   }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
@@ -515,7 +515,7 @@ public final class SearchQueryRequestMapper {
   }
 
   public static Either<ProblemDetail, MappingQuery> toMappingQuery(
-      final MappingSearchQueryRequest request) {
+      final MappingRuleSearchQueryRequest request) {
     if (request == null) {
       return Either.right(SearchQueryBuilders.mappingSearchQuery().build());
     }
@@ -1061,13 +1061,13 @@ public final class SearchQueryRequestMapper {
   }
 
   private static MappingFilter toMappingFilter(
-      final io.camunda.zeebe.gateway.protocol.rest.MappingFilter filter) {
+      final io.camunda.zeebe.gateway.protocol.rest.MappingRuleFilter filter) {
     final var builder = FilterBuilders.mapping();
     if (filter != null) {
       ofNullable(filter.getClaimName()).ifPresent(builder::claimName);
       ofNullable(filter.getClaimValue()).ifPresent(builder::claimValue);
       ofNullable(filter.getName()).ifPresent(builder::name);
-      ofNullable(filter.getMappingId()).ifPresent(builder::mappingId);
+      ofNullable(filter.getMappingRuleId()).ifPresent(builder::mappingId);
     }
     return builder.build();
   }
@@ -1489,13 +1489,13 @@ public final class SearchQueryRequestMapper {
   }
 
   private static List<String> applyMappingSortField(
-      final MappingSearchQuerySortRequest.FieldEnum field, final MappingSort.Builder builder) {
+      final MappingRuleSearchQuerySortRequest.FieldEnum field, final MappingSort.Builder builder) {
     final List<String> validationErrors = new ArrayList<>();
     if (field == null) {
       validationErrors.add(ERROR_SORT_FIELD_MUST_NOT_BE_NULL);
     } else {
       switch (field) {
-        case MAPPING_ID -> builder.mappingId();
+        case MAPPING_RULE_ID -> builder.mappingId();
         case CLAIM_NAME -> builder.claimName();
         case CLAIM_VALUE -> builder.claimValue();
         case NAME -> builder.name();

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
@@ -77,8 +77,8 @@ import io.camunda.zeebe.gateway.protocol.rest.JobListenerEventTypeEnum;
 import io.camunda.zeebe.gateway.protocol.rest.JobSearchQueryResult;
 import io.camunda.zeebe.gateway.protocol.rest.JobSearchResult;
 import io.camunda.zeebe.gateway.protocol.rest.JobStateEnum;
-import io.camunda.zeebe.gateway.protocol.rest.MappingResult;
-import io.camunda.zeebe.gateway.protocol.rest.MappingSearchQueryResult;
+import io.camunda.zeebe.gateway.protocol.rest.MappingRuleResult;
+import io.camunda.zeebe.gateway.protocol.rest.MappingRuleSearchQueryResult;
 import io.camunda.zeebe.gateway.protocol.rest.MatchedDecisionRuleItem;
 import io.camunda.zeebe.gateway.protocol.rest.OwnerTypeEnum;
 import io.camunda.zeebe.gateway.protocol.rest.PermissionTypeEnum;
@@ -333,10 +333,10 @@ public final class SearchQueryResponseMapper {
                 .orElseGet(List::of));
   }
 
-  public static MappingSearchQueryResult toMappingSearchQueryResponse(
+  public static MappingRuleSearchQueryResult toMappingSearchQueryResponse(
       final SearchQueryResult<MappingEntity> result) {
     final var page = toSearchQueryPageResponse(result);
-    return new MappingSearchQueryResult()
+    return new MappingRuleSearchQueryResult()
         .page(page)
         .items(
             ofNullable(result.items())
@@ -662,15 +662,15 @@ public final class SearchQueryResponseMapper {
     return new RoleClientResult().clientId(roleMember.id());
   }
 
-  private static List<MappingResult> toMappings(final List<MappingEntity> mappings) {
+  private static List<MappingRuleResult> toMappings(final List<MappingEntity> mappings) {
     return mappings.stream().map(SearchQueryResponseMapper::toMapping).toList();
   }
 
-  public static MappingResult toMapping(final MappingEntity mappingEntity) {
-    return new MappingResult()
+  public static MappingRuleResult toMapping(final MappingEntity mappingEntity) {
+    return new MappingRuleResult()
         .claimName(mappingEntity.claimName())
         .claimValue(mappingEntity.claimValue())
-        .mappingId(mappingEntity.mappingId())
+        .mappingRuleId(mappingEntity.mappingId())
         .name(mappingEntity.name());
   }
 

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQuerySortRequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQuerySortRequestMapper.java
@@ -89,8 +89,8 @@ public class SearchQuerySortRequestMapper {
     return requests.stream().map(r -> createFrom(r.getField(), r.getOrder())).toList();
   }
 
-  public static List<SearchQuerySortRequest<MappingSearchQuerySortRequest.FieldEnum>>
-      fromMappingSearchQuerySortRequest(final List<MappingSearchQuerySortRequest> requests) {
+  public static List<SearchQuerySortRequest<MappingRuleSearchQuerySortRequest.FieldEnum>>
+      fromMappingSearchQuerySortRequest(final List<MappingRuleSearchQuerySortRequest> requests) {
     return requests.stream().map(r -> createFrom(r.getField(), r.getOrder())).toList();
   }
 

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantController.java
@@ -139,7 +139,7 @@ public class TenantController {
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::addMemberToTenant);
   }
 
-  @CamundaPutMapping(path = "/{tenantId}/mappings/{mappingId}")
+  @CamundaPutMapping(path = "/{tenantId}/mapping-rules/{mappingId}")
   public CompletableFuture<ResponseEntity<Object>> assignMappingToTenant(
       @PathVariable final String tenantId, @PathVariable final String mappingId) {
     return RequestMapper.toTenantMemberRequest(tenantId, mappingId, EntityType.MAPPING)
@@ -184,7 +184,7 @@ public class TenantController {
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::removeMemberFromTenant);
   }
 
-  @CamundaPostMapping(path = "/{tenantId}/mappings/search")
+  @CamundaPostMapping(path = "/{tenantId}/mapping-rules/search")
   public ResponseEntity<MappingRuleSearchQueryResult> searchMappingsInTenant(
       @PathVariable final String tenantId,
       @RequestBody(required = false) final MappingRuleSearchQueryRequest query) {
@@ -194,7 +194,7 @@ public class TenantController {
             mappingQuery -> searchMappingsInTenant(tenantId, mappingQuery));
   }
 
-  @CamundaDeleteMapping(path = "/{tenantId}/mappings/{mappingId}")
+  @CamundaDeleteMapping(path = "/{tenantId}/mapping-rules/{mappingId}")
   public CompletableFuture<ResponseEntity<Object>> removeMappingFromTenant(
       @PathVariable final String tenantId, @PathVariable final String mappingId) {
     return RequestMapper.toTenantMemberRequest(tenantId, mappingId, EntityType.MAPPING)

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantController.java
@@ -23,8 +23,8 @@ import io.camunda.service.TenantServices.TenantDTO;
 import io.camunda.service.TenantServices.TenantMemberRequest;
 import io.camunda.service.UserServices;
 import io.camunda.zeebe.gateway.protocol.rest.GroupSearchQueryResult;
-import io.camunda.zeebe.gateway.protocol.rest.MappingSearchQueryRequest;
-import io.camunda.zeebe.gateway.protocol.rest.MappingSearchQueryResult;
+import io.camunda.zeebe.gateway.protocol.rest.MappingRuleSearchQueryRequest;
+import io.camunda.zeebe.gateway.protocol.rest.MappingRuleSearchQueryResult;
 import io.camunda.zeebe.gateway.protocol.rest.RoleSearchQueryRequest;
 import io.camunda.zeebe.gateway.protocol.rest.RoleSearchQueryResult;
 import io.camunda.zeebe.gateway.protocol.rest.TenantClientSearchQueryRequest;
@@ -185,9 +185,9 @@ public class TenantController {
   }
 
   @CamundaPostMapping(path = "/{tenantId}/mappings/search")
-  public ResponseEntity<MappingSearchQueryResult> searchMappingsInTenant(
+  public ResponseEntity<MappingRuleSearchQueryResult> searchMappingsInTenant(
       @PathVariable final String tenantId,
-      @RequestBody(required = false) final MappingSearchQueryRequest query) {
+      @RequestBody(required = false) final MappingRuleSearchQueryRequest query) {
     return SearchQueryRequestMapper.toMappingQuery(query)
         .fold(
             RestErrorMapper::mapProblemToResponse,
@@ -323,7 +323,7 @@ public class TenantController {
     }
   }
 
-  private ResponseEntity<MappingSearchQueryResult> searchMappingsInTenant(
+  private ResponseEntity<MappingRuleSearchQueryResult> searchMappingsInTenant(
       final String tenantId, final MappingQuery mappingQuery) {
     try {
       final var composedMappingQuery = buildMappingQuery(tenantId, mappingQuery);

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupController.java
@@ -28,8 +28,8 @@ import io.camunda.zeebe.gateway.protocol.rest.GroupSearchQueryResult;
 import io.camunda.zeebe.gateway.protocol.rest.GroupUpdateRequest;
 import io.camunda.zeebe.gateway.protocol.rest.GroupUserSearchQueryRequest;
 import io.camunda.zeebe.gateway.protocol.rest.GroupUserSearchResult;
-import io.camunda.zeebe.gateway.protocol.rest.MappingSearchQueryRequest;
-import io.camunda.zeebe.gateway.protocol.rest.MappingSearchQueryResult;
+import io.camunda.zeebe.gateway.protocol.rest.MappingRuleSearchQueryRequest;
+import io.camunda.zeebe.gateway.protocol.rest.MappingRuleSearchQueryResult;
 import io.camunda.zeebe.gateway.protocol.rest.RoleSearchQueryRequest;
 import io.camunda.zeebe.gateway.protocol.rest.RoleSearchQueryResult;
 import io.camunda.zeebe.gateway.rest.RequestMapper;
@@ -155,9 +155,9 @@ public class GroupController {
   }
 
   @CamundaPostMapping(path = "/{groupId}/mapping-rules/search")
-  public ResponseEntity<MappingSearchQueryResult> mappingsByGroup(
+  public ResponseEntity<MappingRuleSearchQueryResult> mappingsByGroup(
       @PathVariable final String groupId,
-      @RequestBody(required = false) final MappingSearchQueryRequest query) {
+      @RequestBody(required = false) final MappingRuleSearchQueryRequest query) {
     return SearchQueryRequestMapper.toMappingQuery(query)
         .fold(
             RestErrorMapper::mapProblemToResponse,
@@ -272,7 +272,7 @@ public class GroupController {
     }
   }
 
-  private ResponseEntity<MappingSearchQueryResult> searchMappingsInGroup(
+  private ResponseEntity<MappingRuleSearchQueryResult> searchMappingsInGroup(
       final String groupId, final MappingQuery mappingQuery) {
     try {
       final var composedMappingQuery = buildMappingQuery(groupId, mappingQuery);

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/MappingController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/MappingController.java
@@ -13,11 +13,11 @@ import io.camunda.search.query.MappingQuery;
 import io.camunda.security.auth.CamundaAuthenticationProvider;
 import io.camunda.service.MappingServices;
 import io.camunda.service.MappingServices.MappingDTO;
-import io.camunda.zeebe.gateway.protocol.rest.MappingResult;
 import io.camunda.zeebe.gateway.protocol.rest.MappingRuleCreateRequest;
+import io.camunda.zeebe.gateway.protocol.rest.MappingRuleResult;
+import io.camunda.zeebe.gateway.protocol.rest.MappingRuleSearchQueryRequest;
+import io.camunda.zeebe.gateway.protocol.rest.MappingRuleSearchQueryResult;
 import io.camunda.zeebe.gateway.protocol.rest.MappingRuleUpdateRequest;
-import io.camunda.zeebe.gateway.protocol.rest.MappingSearchQueryRequest;
-import io.camunda.zeebe.gateway.protocol.rest.MappingSearchQueryResult;
 import io.camunda.zeebe.gateway.rest.RequestMapper;
 import io.camunda.zeebe.gateway.rest.ResponseMapper;
 import io.camunda.zeebe.gateway.rest.RestErrorMapper;
@@ -72,8 +72,8 @@ public class MappingController {
                 .deleteMapping(mappingId));
   }
 
-  @CamundaGetMapping(path = "/{mappingId}")
-  public ResponseEntity<MappingResult> getMapping(@PathVariable final String mappingId) {
+  @CamundaGetMapping(path = "/{mappingRuleId}")
+  public ResponseEntity<MappingRuleResult> getMappingRule(@PathVariable final String mappingId) {
     try {
       return ResponseEntity.ok()
           .body(
@@ -87,8 +87,8 @@ public class MappingController {
   }
 
   @CamundaPostMapping(path = "/search")
-  public ResponseEntity<MappingSearchQueryResult> searchMappings(
-      @RequestBody(required = false) final MappingSearchQueryRequest query) {
+  public ResponseEntity<MappingRuleSearchQueryResult> searchMappings(
+      @RequestBody(required = false) final MappingRuleSearchQueryRequest query) {
     return SearchQueryRequestMapper.toMappingQuery(query)
         .fold(RestErrorMapper::mapProblemToResponse, this::search);
   }
@@ -111,7 +111,7 @@ public class MappingController {
         ResponseMapper::toMappingUpdateResponse);
   }
 
-  private ResponseEntity<MappingSearchQueryResult> search(final MappingQuery query) {
+  private ResponseEntity<MappingRuleSearchQueryResult> search(final MappingQuery query) {
     try {
       final var result =
           mappingServices

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/MappingRuleController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/MappingRuleController.java
@@ -36,11 +36,11 @@ import org.springframework.web.bind.annotation.RequestMapping;
 
 @CamundaRestController
 @RequestMapping("/v2/mapping-rules")
-public class MappingController {
+public class MappingRuleController {
   private final MappingServices mappingServices;
   private final CamundaAuthenticationProvider authenticationProvider;
 
-  public MappingController(
+  public MappingRuleController(
       final MappingServices mappingServices,
       final CamundaAuthenticationProvider authenticationProvider) {
     this.mappingServices = mappingServices;
@@ -54,40 +54,41 @@ public class MappingController {
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::createMapping);
   }
 
-  @CamundaPutMapping(path = "/{mappingId}")
+  @CamundaPutMapping(path = "/{mappingRuleId}")
   public CompletableFuture<ResponseEntity<Object>> update(
-      @PathVariable final String mappingId,
+      @PathVariable final String mappingRuleId,
       @RequestBody final MappingRuleUpdateRequest mappingRequest) {
-    return RequestMapper.toMappingDTO(mappingId, mappingRequest)
+    return RequestMapper.toMappingDTO(mappingRuleId, mappingRequest)
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::updateMapping);
   }
 
-  @CamundaDeleteMapping(path = "/{mappingId}")
+  @CamundaDeleteMapping(path = "/{mappingRuleId}")
   public CompletableFuture<ResponseEntity<Object>> deleteMapping(
-      @PathVariable final String mappingId) {
+      @PathVariable final String mappingRuleId) {
     return RequestMapper.executeServiceMethodWithNoContentResult(
         () ->
             mappingServices
                 .withAuthentication(authenticationProvider.getCamundaAuthentication())
-                .deleteMapping(mappingId));
+                .deleteMapping(mappingRuleId));
   }
 
   @CamundaGetMapping(path = "/{mappingRuleId}")
-  public ResponseEntity<MappingRuleResult> getMappingRule(@PathVariable final String mappingId) {
+  public ResponseEntity<MappingRuleResult> getMappingRule(
+      @PathVariable final String mappingRuleId) {
     try {
       return ResponseEntity.ok()
           .body(
               SearchQueryResponseMapper.toMapping(
                   mappingServices
                       .withAuthentication(authenticationProvider.getCamundaAuthentication())
-                      .getMapping(mappingId)));
+                      .getMapping(mappingRuleId)));
     } catch (final Exception exception) {
       return RestErrorMapper.mapErrorToResponse(exception);
     }
   }
 
   @CamundaPostMapping(path = "/search")
-  public ResponseEntity<MappingRuleSearchQueryResult> searchMappings(
+  public ResponseEntity<MappingRuleSearchQueryResult> searchMappingRules(
       @RequestBody(required = false) final MappingRuleSearchQueryRequest query) {
     return SearchQueryRequestMapper.toMappingQuery(query)
         .fold(RestErrorMapper::mapProblemToResponse, this::search);

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/MappingRuleController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/MappingRuleController.java
@@ -88,7 +88,7 @@ public class MappingRuleController {
   }
 
   @CamundaPostMapping(path = "/search")
-  public ResponseEntity<MappingRuleSearchQueryResult> searchMappingRules(
+  public ResponseEntity<MappingRuleSearchQueryResult> searchMappings(
       @RequestBody(required = false) final MappingRuleSearchQueryRequest query) {
     return SearchQueryRequestMapper.toMappingQuery(query)
         .fold(RestErrorMapper::mapProblemToResponse, this::search);

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleController.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.gateway.rest.controller.usermanagement;
 
 import static io.camunda.zeebe.gateway.rest.RestErrorMapper.mapErrorToResponse;
 
+import io.camunda.search.query.GroupQuery;
 import io.camunda.search.query.MappingQuery;
 import io.camunda.search.query.RoleQuery;
 import io.camunda.security.auth.CamundaAuthenticationProvider;
@@ -19,6 +20,10 @@ import io.camunda.service.RoleServices.CreateRoleRequest;
 import io.camunda.service.RoleServices.RoleMemberRequest;
 import io.camunda.service.RoleServices.UpdateRoleRequest;
 import io.camunda.service.UserServices;
+import io.camunda.zeebe.gateway.protocol.rest.GroupSearchQueryRequest;
+import io.camunda.zeebe.gateway.protocol.rest.GroupSearchQueryResult;
+import io.camunda.zeebe.gateway.protocol.rest.MappingRuleSearchQueryRequest;
+import io.camunda.zeebe.gateway.protocol.rest.MappingRuleSearchQueryResult;
 import io.camunda.zeebe.gateway.protocol.rest.MappingSearchQueryRequest;
 import io.camunda.zeebe.gateway.protocol.rest.MappingSearchQueryResult;
 import io.camunda.zeebe.gateway.protocol.rest.RoleClientSearchQueryRequest;
@@ -200,16 +205,16 @@ public class RoleController {
   }
 
   @CamundaPostMapping(path = "/{roleId}/mapping-rules/search")
-  public ResponseEntity<MappingSearchQueryResult> searchMappingRulesByRole(
+  public ResponseEntity<MappingRuleSearchQueryResult> searchMappingRulesByRole(
       @PathVariable final String roleId,
-      @RequestBody(required = false) final MappingSearchQueryRequest query) {
+      @RequestBody(required = false) final MappingRuleSearchQueryRequest query) {
     return SearchQueryRequestMapper.toMappingQuery(query)
         .fold(
             RestErrorMapper::mapProblemToResponse,
             mappingQuery -> searchMappingRulesInRole(roleId, mappingQuery));
   }
 
-  private ResponseEntity<MappingSearchQueryResult> searchMappingRulesInRole(
+  private ResponseEntity<MappingRuleSearchQueryResult> searchMappingRulesInRole(
       final String roleId, final MappingQuery mappingQuery) {
     try {
       final var composedMappingQuery = buildMappingQuery(roleId, mappingQuery);

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleController.java
@@ -9,7 +9,6 @@ package io.camunda.zeebe.gateway.rest.controller.usermanagement;
 
 import static io.camunda.zeebe.gateway.rest.RestErrorMapper.mapErrorToResponse;
 
-import io.camunda.search.query.GroupQuery;
 import io.camunda.search.query.MappingQuery;
 import io.camunda.search.query.RoleQuery;
 import io.camunda.security.auth.CamundaAuthenticationProvider;
@@ -20,12 +19,8 @@ import io.camunda.service.RoleServices.CreateRoleRequest;
 import io.camunda.service.RoleServices.RoleMemberRequest;
 import io.camunda.service.RoleServices.UpdateRoleRequest;
 import io.camunda.service.UserServices;
-import io.camunda.zeebe.gateway.protocol.rest.GroupSearchQueryRequest;
-import io.camunda.zeebe.gateway.protocol.rest.GroupSearchQueryResult;
 import io.camunda.zeebe.gateway.protocol.rest.MappingRuleSearchQueryRequest;
 import io.camunda.zeebe.gateway.protocol.rest.MappingRuleSearchQueryResult;
-import io.camunda.zeebe.gateway.protocol.rest.MappingSearchQueryRequest;
-import io.camunda.zeebe.gateway.protocol.rest.MappingSearchQueryResult;
 import io.camunda.zeebe.gateway.protocol.rest.RoleClientSearchQueryRequest;
 import io.camunda.zeebe.gateway.protocol.rest.RoleClientSearchResult;
 import io.camunda.zeebe.gateway.protocol.rest.RoleCreateRequest;
@@ -271,18 +266,18 @@ public class RoleController {
   }
 
   @CamundaPutMapping(
-      path = "/{roleId}/mappings/{mappingId}",
+      path = "/{roleId}/mapping-rules/{mappingRuleId}",
       consumes = {})
   public CompletableFuture<ResponseEntity<Object>> assignMappingToRole(
-      @PathVariable final String roleId, @PathVariable final String mappingId) {
-    return RequestMapper.toRoleMemberRequest(roleId, mappingId, EntityType.MAPPING)
+      @PathVariable final String roleId, @PathVariable final String mappingRuleId) {
+    return RequestMapper.toRoleMemberRequest(roleId, mappingRuleId, EntityType.MAPPING)
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::addMemberToRole);
   }
 
-  @CamundaDeleteMapping(path = "/{roleId}/mappings/{mappingId}")
+  @CamundaDeleteMapping(path = "/{roleId}/mapping-rules/{mappingRuleId}")
   public CompletableFuture<ResponseEntity<Object>> removeMappingFromRole(
-      @PathVariable final String roleId, @PathVariable final String mappingId) {
-    return RequestMapper.toRoleMemberRequest(roleId, mappingId, EntityType.MAPPING)
+      @PathVariable final String roleId, @PathVariable final String mappingRuleId) {
+    return RequestMapper.toRoleMemberRequest(roleId, mappingRuleId, EntityType.MAPPING)
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::removeMemberFromRole);
   }
 

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/MappingValidator.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/MappingValidator.java
@@ -39,7 +39,7 @@ public class MappingValidator {
         violations -> {
           violations.addAll(validateClaims(request.getClaimName(), request.getClaimValue()));
           violations.addAll(validateName(request.getName()));
-          violations.addAll(validateId(request.getMappingId()));
+          violations.addAll(validateId(request.getMappingRuleId()));
         });
   }
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantControllerTest.java
@@ -601,7 +601,7 @@ public class TenantControllerTest extends RestControllerTest {
   private static Stream<Arguments> provideAddMemberByIdTestCases() {
     return Stream.of(
         Arguments.of(EntityType.USER, "users", "username"),
-        Arguments.of(EntityType.MAPPING, "mappings", "mappingId"),
+        Arguments.of(EntityType.MAPPING, "mapping-rules", "mappingId"),
         Arguments.of(EntityType.GROUP, "groups", "groupId"),
         Arguments.of(EntityType.ROLE, "roles", "roleId"),
         Arguments.of(EntityType.CLIENT, "clients", "clientId"));
@@ -610,7 +610,7 @@ public class TenantControllerTest extends RestControllerTest {
   private static Stream<Arguments> provideRemoveMemberByIdTestCases() {
     return Stream.of(
         Arguments.of(EntityType.USER, "users", "username"),
-        Arguments.of(EntityType.MAPPING, "mappings", "mappingId"),
+        Arguments.of(EntityType.MAPPING, "mapping-rules", "mappingId"),
         Arguments.of(EntityType.GROUP, "groups", "groupId"),
         Arguments.of(EntityType.ROLE, "roles", "roleId"),
         Arguments.of(EntityType.CLIENT, "clients", "clientId"));

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantQueryControllerTest.java
@@ -124,13 +124,13 @@ public class TenantQueryControllerTest extends RestControllerTest {
              "name": "%s",
              "claimName": "%s",
              "claimValue": "%s",
-             "mappingId": %s
+             "mappingRuleId": %s
            },
            {
              "name": "%s",
              "claimName": "%s",
              "claimValue": "%s",
-             "mappingId": "%s"
+             "mappingRuleId": "%s"
            }
          ],
          "page": {
@@ -389,13 +389,13 @@ public class TenantQueryControllerTest extends RestControllerTest {
     // when / then
     webClient
         .post()
-        .uri("%s/%s/mappings/search".formatted(TENANT_BASE_URL, "tenantId"))
+        .uri("%s/%s/mapping-rules/search".formatted(TENANT_BASE_URL, "tenantId"))
         .accept(MediaType.APPLICATION_JSON)
         .contentType(MediaType.APPLICATION_JSON)
         .bodyValue(
             """
             {
-              "sort": [{"field": "mappingId", "order": "ASC"}]
+              "sort": [{"field": "mappingRuleId", "order": "ASC"}]
             }
             """)
         .exchange()
@@ -422,7 +422,7 @@ public class TenantQueryControllerTest extends RestControllerTest {
     // when / then
     webClient
         .post()
-        .uri("%s/%s/mappings/search".formatted(TENANT_BASE_URL, "tenantId"))
+        .uri("%s/%s/mapping-rules/search".formatted(TENANT_BASE_URL, "tenantId"))
         .accept(MediaType.APPLICATION_JSON)
         .contentType(MediaType.APPLICATION_JSON)
         .bodyValue(

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupQueryControllerTest.java
@@ -198,13 +198,13 @@ public class GroupQueryControllerTest extends RestControllerTest {
         "items":[
           {
             "name":"name",
-            "mappingId":"%s",
+            "mappingRuleId":"%s",
             "claimName":"claimName1",
             "claimValue":"claimValue1"
           },
           {
             "name":"name",
-            "mappingId":"%s",
+            "mappingRuleId":"%s",
             "claimName":"claimName2",
             "claimValue":"claimValue2"
           }
@@ -612,7 +612,7 @@ public class GroupQueryControllerTest extends RestControllerTest {
         .bodyValue(
             """
             {
-              "sort": [{"field": "mappingId", "order": "ASC"}]
+              "sort": [{"field": "mappingRuleId", "order": "ASC"}]
             }
             """)
         .exchange()

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/MappingControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/MappingControllerTest.java
@@ -31,7 +31,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
-@WebMvcTest(MappingController.class)
+@WebMvcTest(MappingRuleController.class)
 public class MappingControllerTest extends RestControllerTest {
 
   private static final String MAPPING_RULES_PATH = "/v2/mapping-rules";

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/MappingControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/MappingControllerTest.java
@@ -55,7 +55,6 @@ public class MappingControllerTest extends RestControllerTest {
     final var request =
         new MappingRuleCreateRequest(
             dto.mappingId(), dto.claimName(), dto.claimValue(), dto.name());
-    ;
     final var mappingRecord =
         new MappingRecord()
             .setMappingKey(1L)

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/MappingControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/MappingControllerTest.java
@@ -107,7 +107,7 @@ public class MappingControllerTest extends RestControllerTest {
             .claimName("claim")
             .claimValue("claimValue")
             .name("name")
-            .mappingId("");
+            .mappingRuleId("");
 
     // when then
     assertRequestRejectedExceptionally(
@@ -128,7 +128,7 @@ public class MappingControllerTest extends RestControllerTest {
   void shouldRejectMappingCreationWithMissingClaimName() {
     // given
     final var request =
-        new MappingRuleCreateRequest().claimValue("claimValue").name("name").mappingId("id");
+        new MappingRuleCreateRequest().claimValue("claimValue").name("name").mappingRuleId("id");
 
     // when then
     assertRequestRejectedExceptionally(
@@ -153,7 +153,7 @@ public class MappingControllerTest extends RestControllerTest {
             .claimName("")
             .claimValue("claimValue")
             .name("name")
-            .mappingId("id");
+            .mappingRuleId("id");
 
     // when then
     assertRequestRejectedExceptionally(
@@ -174,7 +174,7 @@ public class MappingControllerTest extends RestControllerTest {
   void shouldRejectMappingCreationWithMissingClaimValue() {
     // given
     final var request =
-        new MappingRuleCreateRequest().claimName("claimName").name("name").mappingId("id");
+        new MappingRuleCreateRequest().claimName("claimName").name("name").mappingRuleId("id");
 
     // when then
     assertRequestRejectedExceptionally(
@@ -199,7 +199,7 @@ public class MappingControllerTest extends RestControllerTest {
             .claimName("claimName")
             .claimValue("")
             .name("name")
-            .mappingId("id");
+            .mappingRuleId("id");
 
     // when then
     assertRequestRejectedExceptionally(
@@ -223,7 +223,7 @@ public class MappingControllerTest extends RestControllerTest {
         new MappingRuleCreateRequest()
             .claimName("claimName")
             .claimValue("claimValue")
-            .mappingId("id");
+            .mappingRuleId("id");
 
     // when then
     assertRequestRejectedExceptionally(
@@ -251,7 +251,7 @@ public class MappingControllerTest extends RestControllerTest {
     // given
     final var request =
         new MappingRuleCreateRequest()
-            .mappingId(id)
+            .mappingRuleId(id)
             .claimName("claimName")
             .claimValue("claimValue")
             .name("name");
@@ -277,7 +277,7 @@ public class MappingControllerTest extends RestControllerTest {
     final var id = "x".repeat(257);
     final var request =
         new MappingRuleCreateRequest()
-            .mappingId(id)
+            .mappingRuleId(id)
             .claimName("claimName")
             .claimValue("claimValue")
             .name("name");

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/MappingControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/MappingControllerTest.java
@@ -51,7 +51,11 @@ public class MappingControllerTest extends RestControllerTest {
   @ValueSource(strings = {"foo", "Foo", "foo123", "foo_", "foo.", "foo@"})
   void createMappingShouldReturnCreated(final String id) {
     // given
-    final var dto = validCreateMappingRequest();
+    final var dto = validCreateMappingDTO();
+    final var request =
+        new MappingRuleCreateRequest(
+            dto.mappingId(), dto.claimName(), dto.claimValue(), dto.name());
+    ;
     final var mappingRecord =
         new MappingRecord()
             .setMappingKey(1L)
@@ -69,7 +73,7 @@ public class MappingControllerTest extends RestControllerTest {
         .uri(MAPPING_RULES_PATH)
         .accept(MediaType.APPLICATION_JSON)
         .contentType(MediaType.APPLICATION_JSON)
-        .bodyValue(dto)
+        .bodyValue(request)
         .exchange()
         .expectStatus()
         .isCreated();
@@ -459,7 +463,7 @@ public class MappingControllerTest extends RestControllerTest {
     verifyNoInteractions(mappingServices);
   }
 
-  private MappingDTO validCreateMappingRequest() {
+  private MappingDTO validCreateMappingDTO() {
     return new MappingDTO("newClaimName", "newClaimValue", "mapName", "mapId");
   }
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/MappingQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/MappingQueryControllerTest.java
@@ -29,7 +29,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
-@WebMvcTest(value = MappingController.class)
+@WebMvcTest(value = MappingRuleController.class)
 public class MappingQueryControllerTest extends RestControllerTest {
   private static final String MAPPING_BASE_URL = "/v2/mapping-rules";
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleControllerTest.java
@@ -445,7 +445,7 @@ public class RoleControllerTest extends RestControllerTest {
     // when
     webClient
         .put()
-        .uri("%s/%s/mappings/%s".formatted(ROLE_BASE_URL, roleId, mappingId))
+        .uri("%s/%s/mapping-rules/%s".formatted(ROLE_BASE_URL, roleId, mappingId))
         .accept(MediaType.APPLICATION_JSON)
         .exchange()
         .expectStatus()
@@ -460,7 +460,7 @@ public class RoleControllerTest extends RestControllerTest {
     // given
     final var roleId = Strings.newRandomValidIdentityId();
     final var mappingId = Strings.newRandomValidIdentityId();
-    final var path = "%s/%s/mappings/%s".formatted(ROLE_BASE_URL, roleId, mappingId);
+    final var path = "%s/%s/mapping-rules/%s".formatted(ROLE_BASE_URL, roleId, mappingId);
     final var request = new RoleMemberRequest(roleId, mappingId, EntityType.MAPPING);
     when(roleServices.addMember(request))
         .thenReturn(
@@ -490,7 +490,7 @@ public class RoleControllerTest extends RestControllerTest {
     // given
     final var roleId = Strings.newRandomValidIdentityId();
     final var mappingId = Strings.newRandomValidIdentityId();
-    final var path = "%s/%s/mappings/%s".formatted(ROLE_BASE_URL, roleId, mappingId);
+    final var path = "%s/%s/mapping-rules/%s".formatted(ROLE_BASE_URL, roleId, mappingId);
     final var request = new RoleMemberRequest(roleId, mappingId, EntityType.MAPPING);
     when(roleServices.addMember(request))
         .thenReturn(
@@ -517,7 +517,7 @@ public class RoleControllerTest extends RestControllerTest {
     // given
     final var roleId = Strings.newRandomValidIdentityId();
     final var mappingId = "mappingId!";
-    final var path = "%s/%s/mappings/%s".formatted(ROLE_BASE_URL, roleId, mappingId);
+    final var path = "%s/%s/mapping-rules/%s".formatted(ROLE_BASE_URL, roleId, mappingId);
 
     // when
     webClient
@@ -547,7 +547,7 @@ public class RoleControllerTest extends RestControllerTest {
     // given
     final String roleId = "roleId!";
     final String mappingId = Strings.newRandomValidIdentityId();
-    final var path = "%s/%s/mappings/%s".formatted(ROLE_BASE_URL, roleId, mappingId);
+    final var path = "%s/%s/mapping-rules/%s".formatted(ROLE_BASE_URL, roleId, mappingId);
 
     // when
     webClient
@@ -584,7 +584,7 @@ public class RoleControllerTest extends RestControllerTest {
     // when
     webClient
         .delete()
-        .uri("%s/%s/mappings/%s".formatted(ROLE_BASE_URL, roleId, mappingId))
+        .uri("%s/%s/mapping-rules/%s".formatted(ROLE_BASE_URL, roleId, mappingId))
         .accept(MediaType.APPLICATION_JSON)
         .exchange()
         .expectStatus()
@@ -599,7 +599,7 @@ public class RoleControllerTest extends RestControllerTest {
     // given
     final var roleId = Strings.newRandomValidIdentityId();
     final var mappingId = Strings.newRandomValidIdentityId();
-    final var path = "%s/%s/mappings/%s".formatted(ROLE_BASE_URL, roleId, mappingId);
+    final var path = "%s/%s/mapping-rules/%s".formatted(ROLE_BASE_URL, roleId, mappingId);
     final var request = new RoleMemberRequest(roleId, mappingId, EntityType.MAPPING);
     when(roleServices.removeMember(request))
         .thenReturn(
@@ -629,7 +629,7 @@ public class RoleControllerTest extends RestControllerTest {
     // given
     final var roleId = Strings.newRandomValidIdentityId();
     final var mappingId = Strings.newRandomValidIdentityId();
-    final var path = "%s/%s/mappings/%s".formatted(ROLE_BASE_URL, roleId, mappingId);
+    final var path = "%s/%s/mapping-rules/%s".formatted(ROLE_BASE_URL, roleId, mappingId);
     final var request = new RoleMemberRequest(roleId, mappingId, EntityType.MAPPING);
     when(roleServices.removeMember(request))
         .thenReturn(

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleQueryControllerTest.java
@@ -306,19 +306,19 @@ public class RoleQueryControllerTest extends RestControllerTest {
           {
              "items": [
                {
-                 "mappingId": "mapping1",
+                 "mappingRuleId": "mapping1",
                  "claimName": "claim1",
                  "claimValue": "value1",
                  "name": "Mapping 1"
                },
                 {
-                  "mappingId": "mapping2",
+                  "mappingRuleId": "mapping2",
                   "claimName": "claim2",
                   "claimValue": "value2",
                   "name": "Mapping 2"
                 },
                 {
-                  "mappingId": "mapping3",
+                  "mappingRuleId": "mapping3",
                   "claimName": "claim3",
                   "claimValue": "value3",
                   "name": "Mapping 3"

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/CreateMappingTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/CreateMappingTest.java
@@ -92,7 +92,7 @@ public class CreateMappingTest {
                     .send()
                     .join())
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("mappingId");
+        .hasMessageContaining("mappingRuleId");
   }
 
   @Test


### PR DESCRIPTION
## Description

Rename `mappings` to `mapping-rules` in the URL and in api requests/responses.

## Related issues

closes #32583 
