### PR TITLE
[Backport stable/8.6] fix: typo in camunda-bpm repo name

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -158,7 +158,7 @@
       <snapshots>
         <enabled>false</enabled>
       </snapshots>
-      <id>camunda-cpm</id>
+      <id>camunda-bpm</id>
       <name>Camunda BPM Repository</name>
       <url>https://artifacts.camunda.com/artifactory/camunda-bpm/</url>
     </repository>


### PR DESCRIPTION
# Description
Backport of #34871 to `stable/8.6`.

relates to 