### PR TITLE
Remove test dependency io.zeebe:zeebe-test-container

### DIFF
--- a/schema-manager/pom.xml
+++ b/schema-manager/pom.xml
@@ -169,8 +169,8 @@
     </dependency>
 
     <dependency>
-      <groupId>io.zeebe</groupId>
-      <artifactId>zeebe-test-container</artifactId>
+      <groupId>com.github.docker-java</groupId>
+      <artifactId>docker-java-api</artifactId>
       <scope>test</scope>
     </dependency>
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
[Slack discussion](https://camunda.slack.com/archives/C08F5RD5X8B/p1751625742046039)
We need to remove `io.zeebe:zeebe-test-container` test dependecy from schema manager module as it depends on an artifact from the mono-repo itself, and it causes failure or mvn release perform


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
