### PR TITLE
feat: add UsageMetricState with methods to track eDI metrics

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/metrics/DbUsageMetricState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/metrics/DbUsageMetricState.java
@@ -61,6 +61,11 @@ public class DbUsageMetricState implements MutableUsageMetricState {
   }
 
   @Override
+  public void recordEDIMetric(final String tenantId) {
+    updateActiveBucket(getActiveBucket().recordEDI(tenantId));
+  }
+
+  @Override
   public void resetActiveBucket(final long resetTime) {
     setActiveBucketKeys();
     metricsBucketColumnFamily.deleteIfExists(metricsBucketKey);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/metrics/PersistedUsageMetrics.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/metrics/PersistedUsageMetrics.java
@@ -21,10 +21,12 @@ public class PersistedUsageMetrics extends UnpackedObject implements DbValue {
   private final LongProperty fromTimeProp = new LongProperty("fromTime");
   private final LongProperty toTimeProp = new LongProperty("toTime");
   private final DocumentProperty tenantRPIMapProp = new DocumentProperty("tenantRPI");
+  private final DocumentProperty tenantEDIMapProp = new DocumentProperty("tenantEDI");
 
   public PersistedUsageMetrics() {
-    super(3);
-    declareProperty(fromTimeProp).declareProperty(toTimeProp).declareProperty(tenantRPIMapProp);
+    super(4);
+    declareProperty(fromTimeProp).declareProperty(toTimeProp).declareProperty(tenantRPIMapProp)
+        .declareProperty(tenantEDIMapProp);
   }
 
   public long getFromTime() {
@@ -59,10 +61,30 @@ public class PersistedUsageMetrics extends UnpackedObject implements DbValue {
     return this;
   }
 
+  public DirectBuffer getTenantEDIMapValue() {
+    return tenantRPIMapProp.getValue();
+  }
+
+  public Map<String, Long> getTenantEDIMap() {
+    return MsgPackConverter.convertToLongMap(tenantEDIMapProp.getValue());
+  }
+
+  public void setTenantEDIMap(final Map<String, Long> tenantEDIMap) {
+    tenantEDIMapProp.setValue(
+        BufferUtil.wrapArray(MsgPackConverter.convertToMsgPack(tenantEDIMap)));
+  }
+
   public PersistedUsageMetrics recordRPI(final String tenantId) {
     final var tenantRPIMap = getTenantRPIMap();
     tenantRPIMap.merge(tenantId, 1L, Long::sum);
     setTenantRPIMap(tenantRPIMap);
+    return this;
+  }
+
+  public PersistedUsageMetrics recordEDI(final String tenantId) {
+    final var tenantEDIMap = getTenantEDIMap();
+    tenantEDIMap.merge(tenantId, 1L, Long::sum);
+    setTenantEDIMap(tenantEDIMap);
     return this;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/metrics/PersistedUsageMetrics.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/metrics/PersistedUsageMetrics.java
@@ -25,7 +25,9 @@ public class PersistedUsageMetrics extends UnpackedObject implements DbValue {
 
   public PersistedUsageMetrics() {
     super(4);
-    declareProperty(fromTimeProp).declareProperty(toTimeProp).declareProperty(tenantRPIMapProp)
+    declareProperty(fromTimeProp)
+        .declareProperty(toTimeProp)
+        .declareProperty(tenantRPIMapProp)
         .declareProperty(tenantEDIMapProp);
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableUsageMetricState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableUsageMetricState.java
@@ -13,5 +13,7 @@ public interface MutableUsageMetricState extends UsageMetricState {
 
   void recordRPIMetric(final String tenantId);
 
+  void recordEDIMetric(final String tenantId);
+
   void resetActiveBucket(final long fromTime);
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/metrics/DbUsageMetricStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/metrics/DbUsageMetricStateTest.java
@@ -77,4 +77,28 @@ public class DbUsageMetricStateTest {
         .containsExactlyInAnyOrderEntriesOf(
             Map.of(TenantOwned.DEFAULT_TENANT_IDENTIFIER, 2L, "tenant1", 3L, "tenant2", 1L));
   }
+
+  @Test
+  public void shouldRecordEDIMetrics() {
+    // given
+    final var eventTime = InstantSource.system().millis();
+    when(mockClock.millis()).thenReturn(eventTime);
+    state.resetActiveBucket(1L);
+
+    // when
+    state.recordEDIMetric(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+    state.recordEDIMetric(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+    state.recordEDIMetric("tenant1");
+    state.recordEDIMetric("tenant1");
+    state.recordEDIMetric("tenant1");
+    state.recordEDIMetric("tenant2");
+
+    // then
+    final var actual = state.getActiveBucket();
+    assertThat(actual.getFromTime()).isEqualTo(1L);
+    assertThat(actual.getToTime()).isEqualTo(1001L);
+    assertThat(actual.getTenantEDIMap())
+        .containsExactlyInAnyOrderEntriesOf(
+            Map.of(TenantOwned.DEFAULT_TENANT_IDENTIFIER, 2L, "tenant1", 3L, "tenant2", 1L));
+  }
 }


### PR DESCRIPTION
## Description

- Add UsageMetricState with methods to track eDI metrics
- Tests

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #31120 
