### PR TITLE
ci: disable golang cache in stable/8.5

### DIFF
--- a/.github/actions/setup-zeebe/action.yml
+++ b/.github/actions/setup-zeebe/action.yml
@@ -178,5 +178,4 @@ runs:
       uses: actions/setup-go@v5
       with:
         go-version: '1.22'
-        cache: true
-        cache-dependency-path: 'clients/go/go.sum'
+        cache: false

--- a/.github/workflows/zeebe-ci.yml
+++ b/.github/workflows/zeebe-ci.yml
@@ -460,6 +460,7 @@ jobs:
           # fixed to avoid triggering false positive; see https://github.com/golangci/golangci-lint-action/issues/535
           version: v1.55.2
           working-directory: clients/go
+          skip-cache: true
       - name: Observe build status
         if: always()
         continue-on-error: true


### PR DESCRIPTION
## Description

Our GHA cache usage is higher than it used to be, so I was investigating where this increased usage is coming from.

Checking https://github.com/camunda/camunda/actions/caches showed a PR https://github.com/camunda/camunda/pull/34716 against `stable/8.5` creating GHA cache entries related to `setup-go` and `golangci-lint` - this is something we want to avoid according to our [strategy](https://github.com/camunda/camunda/wiki/CI-&-Automation#caching-strategy). GHA cache is a shared resource and we must make best use of limited resources.

This PR disables the cache.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

Related to #34695 
