### PR TITLE
ci: add Identity team as code owners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -128,9 +128,7 @@
 # Performance  + Load testing
 /zeebe/benchmarks @camunda/zeebe-distributed-platform
 
-##############
-## Identity ##
-##############
+# Identity
 /identity/*        @camunda/identity
 /authentication/*  @camunda/identity
 /security/*        @camunda/identity

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -127,3 +127,10 @@
 
 # Performance  + Load testing
 /zeebe/benchmarks @camunda/zeebe-distributed-platform
+
+##############
+## Identity ##
+##############
+/identity/*        @camunda/identity
+/authentication/*  @camunda/identity
+/security/*        @camunda/identity


### PR DESCRIPTION
## Description

Add @camunda/identity team to CODEOWNERS for `authentication`, `security` and `identity` folders.
