### PR TITLE
Add config option to disable the Tenants API

### DIFF
--- a/security/security-core/src/main/java/io/camunda/security/configuration/MultiTenancyConfiguration.java
+++ b/security/security-core/src/main/java/io/camunda/security/configuration/MultiTenancyConfiguration.java
@@ -10,8 +10,10 @@ package io.camunda.security.configuration;
 public class MultiTenancyConfiguration {
 
   private static final boolean DEFAULT_MULTITENANCY_ENABLED = false;
+  private static final boolean DEFAULT_API_ENABLED = true;
 
   private boolean enabled = DEFAULT_MULTITENANCY_ENABLED;
+  private boolean apiEnabled = DEFAULT_API_ENABLED;
 
   public boolean isEnabled() {
     return enabled;
@@ -19,5 +21,13 @@ public class MultiTenancyConfiguration {
 
   public void setEnabled(final boolean enabled) {
     this.enabled = enabled;
+  }
+
+  public boolean isApiEnabled() {
+    return apiEnabled;
+  }
+
+  public void setApiEnabled(final boolean apiEnabled) {
+    this.apiEnabled = apiEnabled;
   }
 }

--- a/security/security-core/src/main/java/io/camunda/security/configuration/MultiTenancyConfiguration.java
+++ b/security/security-core/src/main/java/io/camunda/security/configuration/MultiTenancyConfiguration.java
@@ -9,6 +9,7 @@ package io.camunda.security.configuration;
 
 public class MultiTenancyConfiguration {
 
+  public static final String API_ENABLED_PROPERTY = "camunda.security.multiTenancy.apiEnabled";
   private static final boolean DEFAULT_MULTITENANCY_ENABLED = false;
   private static final boolean DEFAULT_API_ENABLED = true;
 

--- a/security/security-core/src/main/java/io/camunda/security/configuration/OidcAuthenticationConfiguration.java
+++ b/security/security-core/src/main/java/io/camunda/security/configuration/OidcAuthenticationConfiguration.java
@@ -13,6 +13,9 @@ import java.util.List;
 import java.util.Set;
 
 public class OidcAuthenticationConfiguration {
+  public static final String GROUPS_CLAIM_PROPERTY =
+      "camunda.security.authentication.oidc.groupsClaim";
+
   private String issuerUri;
   private String clientId;
   private String clientSecret;
@@ -96,7 +99,7 @@ public class OidcAuthenticationConfiguration {
     return tokenUri;
   }
 
-  public void setTokenUri(String tokenUri) {
+  public void setTokenUri(final String tokenUri) {
     this.tokenUri = tokenUri;
   }
 

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/ApiFiltersConfiguration.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/ApiFiltersConfiguration.java
@@ -12,6 +12,7 @@ import static io.camunda.security.configuration.OidcAuthenticationConfiguration.
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.zeebe.gateway.rest.controller.EndpointAccessErrorFilter;
+import io.camunda.zeebe.util.VisibleForTesting;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
@@ -20,10 +21,12 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class ApiFiltersConfiguration {
 
-  private static final String GROUPS_API_DISABLED_ERROR_MESSAGE =
+  @VisibleForTesting
+  public static final String GROUPS_API_DISABLED_ERROR_MESSAGE =
       "Groups API is disabled because the application is configured in group claim mode. To use the Groups API, reconfigure the application to to manage group mode removing the '%s' property."
           .formatted(GROUPS_CLAIM_PROPERTY);
-  private static final String TENANTS_API_DISABLED_ERROR_MESSAGE =
+
+  public static final String TENANTS_API_DISABLED_ERROR_MESSAGE =
       "Tenants API is disabled. Enable the API by setting '%s' to true."
           .formatted(API_ENABLED_PROPERTY);
 

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/ApiFiltersConfiguration.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/ApiFiltersConfiguration.java
@@ -26,6 +26,7 @@ public class ApiFiltersConfiguration {
       "Groups API is disabled because the application is configured in group claim mode. To use the Groups API, reconfigure the application to to manage group mode removing the '%s' property."
           .formatted(GROUPS_CLAIM_PROPERTY);
 
+  @VisibleForTesting
   public static final String TENANTS_API_DISABLED_ERROR_MESSAGE =
       "Tenants API is disabled. Enable the API by setting '%s' to true."
           .formatted(API_ENABLED_PROPERTY);

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/ApiFiltersConfiguration.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/ApiFiltersConfiguration.java
@@ -7,6 +7,9 @@
  */
 package io.camunda.zeebe.gateway.rest.config;
 
+import static io.camunda.security.configuration.MultiTenancyConfiguration.API_ENABLED_PROPERTY;
+import static io.camunda.security.configuration.OidcAuthenticationConfiguration.GROUPS_CLAIM_PROPERTY;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.zeebe.gateway.rest.controller.EndpointAccessErrorFilter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
@@ -17,13 +20,21 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class ApiFiltersConfiguration {
 
+  private static final String GROUPS_API_DISABLED_ERROR_MESSAGE =
+      "Groups API is disabled because the application is configured in group claim mode. To use the Groups API, reconfigure the application to to manage group mode removing the '%s' property."
+          .formatted(GROUPS_CLAIM_PROPERTY);
+  private static final String TENANTS_API_DISABLED_ERROR_MESSAGE =
+      "Tenants API is disabled. Enable the API by setting '%s' to true."
+          .formatted(API_ENABLED_PROPERTY);
+
   @ConditionalOnExpression("'${camunda.security.authentication.oidc.groupsClaim:}' != ''")
   @Bean
   public FilterRegistrationBean<EndpointAccessErrorFilter> registerFilter(
       final ObjectMapper objectMapper) {
     final FilterRegistrationBean<EndpointAccessErrorFilter> registration =
         new FilterRegistrationBean<>();
-    registration.setFilter(new EndpointAccessErrorFilter(objectMapper));
+    registration.setFilter(
+        new EndpointAccessErrorFilter(objectMapper, GROUPS_API_DISABLED_ERROR_MESSAGE));
     registration.addUrlPatterns("/v2/groups/*");
     registration.setOrder(1);
     return registration;
@@ -35,7 +46,8 @@ public class ApiFiltersConfiguration {
       final ObjectMapper objectMapper) {
     final FilterRegistrationBean<EndpointAccessErrorFilter> registration =
         new FilterRegistrationBean<>();
-    registration.setFilter(new EndpointAccessErrorFilter(objectMapper));
+    registration.setFilter(
+        new EndpointAccessErrorFilter(objectMapper, TENANTS_API_DISABLED_ERROR_MESSAGE));
     registration.addUrlPatterns("/v2/tenants/*");
     registration.setOrder(1);
     return registration;

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/ApiFiltersConfiguration.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/ApiFiltersConfiguration.java
@@ -28,4 +28,16 @@ public class ApiFiltersConfiguration {
     registration.setOrder(1);
     return registration;
   }
+
+  @ConditionalOnExpression("'${camunda.security.multiTenancy.apiEnabled:}' == 'false'")
+  @Bean
+  public FilterRegistrationBean<EndpointAccessErrorFilter> disableMultiTenancyApiFilter(
+      final ObjectMapper objectMapper) {
+    final FilterRegistrationBean<EndpointAccessErrorFilter> registration =
+        new FilterRegistrationBean<>();
+    registration.setFilter(new EndpointAccessErrorFilter(objectMapper));
+    registration.addUrlPatterns("/v2/tenants/*");
+    registration.setOrder(1);
+    return registration;
+  }
 }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/EndpointAccessErrorFilter.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/EndpointAccessErrorFilter.java
@@ -21,9 +21,12 @@ import org.springframework.http.MediaType;
 
 public class EndpointAccessErrorFilter extends HttpFilter {
   private final ObjectMapper objectMapper;
+  private final String errorMessage;
 
-  public EndpointAccessErrorFilter(@Autowired final ObjectMapper objectMapper) {
+  public EndpointAccessErrorFilter(
+      @Autowired final ObjectMapper objectMapper, final String errorMessage) {
     this.objectMapper = objectMapper;
+    this.errorMessage = errorMessage;
   }
 
   @Override
@@ -35,9 +38,7 @@ public class EndpointAccessErrorFilter extends HttpFilter {
     final var detail =
         RestErrorMapper.createProblemDetail(
             HttpStatusCode.valueOf(HttpServletResponse.SC_FORBIDDEN),
-            String.format(
-                "Due to security configuration, %s endpoint is not accessible",
-                req.getRequestURI()),
+            String.format("%s endpoint is not accessible: %s", req.getRequestURI(), errorMessage),
             "Access issue");
     detail.setInstance(URI.create(req.getRequestURI()));
     res.getWriter().write(objectMapper.writeValueAsString(detail));

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantControllerTest.java
@@ -35,6 +35,7 @@ import io.camunda.zeebe.protocol.record.value.EntityType;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -44,91 +45,97 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
-@WebMvcTest(TenantController.class)
-public class TenantControllerTest extends RestControllerTest {
+public class TenantControllerTest {
 
   private static final String TENANT_BASE_URL = "/v2/tenants";
 
-  @MockitoBean private TenantServices tenantServices;
-  @MockitoBean private UserServices userServices;
-  @MockitoBean private MappingServices mappingServices;
-  @MockitoBean private GroupServices groupServices;
-  @MockitoBean private RoleServices roleServices;
-  @MockitoBean private CamundaAuthenticationProvider authenticationProvider;
+  @Nested
+  @WebMvcTest(TenantController.class)
+  public class TenantsApiEnabledTest extends RestControllerTest {
+    @MockitoBean private TenantServices tenantServices;
+    @MockitoBean private UserServices userServices;
+    @MockitoBean private MappingServices mappingServices;
+    @MockitoBean private GroupServices groupServices;
+    @MockitoBean private RoleServices roleServices;
+    @MockitoBean private CamundaAuthenticationProvider authenticationProvider;
 
-  @BeforeEach
-  void setup() {
-    when(authenticationProvider.getCamundaAuthentication())
-        .thenReturn(AUTHENTICATION_WITH_DEFAULT_TENANT);
-    when(tenantServices.withAuthentication(any(CamundaAuthentication.class)))
-        .thenReturn(tenantServices);
-  }
+    @BeforeEach
+    void setup() {
+      when(authenticationProvider.getCamundaAuthentication())
+          .thenReturn(AUTHENTICATION_WITH_DEFAULT_TENANT);
+      when(tenantServices.withAuthentication(any(CamundaAuthentication.class)))
+          .thenReturn(tenantServices);
+    }
 
-  @ParameterizedTest
-  @ValueSource(strings = {"foo", "Foo", "foo123", "foo_", "foo.", "foo@"})
-  void createTenantShouldReturnAccepted(final String id) {
-    // given
-    final var tenantName = "Test Tenant";
-    final var tenantDescription = "Test description";
-    when(tenantServices.createTenant(new TenantDTO(null, id, tenantName, tenantDescription)))
-        .thenReturn(
-            CompletableFuture.completedFuture(
-                new TenantRecord()
-                    .setTenantKey(100L)
-                    .setName(tenantName)
-                    .setDescription(tenantDescription)
-                    .setTenantId(id)));
+    @ParameterizedTest
+    @ValueSource(strings = {"foo", "Foo", "foo123", "foo_", "foo.", "foo@"})
+    void createTenantShouldReturnAccepted(final String id) {
+      // given
+      final var tenantName = "Test Tenant";
+      final var tenantDescription = "Test description";
+      when(tenantServices.createTenant(new TenantDTO(null, id, tenantName, tenantDescription)))
+          .thenReturn(
+              CompletableFuture.completedFuture(
+                  new TenantRecord()
+                      .setTenantKey(100L)
+                      .setName(tenantName)
+                      .setDescription(tenantDescription)
+                      .setTenantId(id)));
 
-    // when
-    webClient
-        .post()
-        .uri(TENANT_BASE_URL)
-        .accept(MediaType.APPLICATION_JSON)
-        .contentType(MediaType.APPLICATION_JSON)
-        .bodyValue(
-            new TenantCreateRequest().name(tenantName).description(tenantDescription).tenantId(id))
-        .exchange()
-        .expectStatus()
-        .isCreated();
+      // when
+      webClient
+          .post()
+          .uri(TENANT_BASE_URL)
+          .accept(MediaType.APPLICATION_JSON)
+          .contentType(MediaType.APPLICATION_JSON)
+          .bodyValue(
+              new TenantCreateRequest()
+                  .name(tenantName)
+                  .description(tenantDescription)
+                  .tenantId(id))
+          .exchange()
+          .expectStatus()
+          .isCreated();
 
-    // then
-    verify(tenantServices, times(1))
-        .createTenant(new TenantDTO(null, id, tenantName, tenantDescription));
-  }
+      // then
+      verify(tenantServices, times(1))
+          .createTenant(new TenantDTO(null, id, tenantName, tenantDescription));
+    }
 
-  @Test
-  void createTenantShouldReturnAllDetails() {
-    // given
-    final var tenantName = "Test Tenant";
-    final var tenantId = "tenantId";
-    final var tenantDescription = "Test description";
-    final var tenantKey = 100L;
-    when(tenantServices.createTenant(new TenantDTO(null, tenantId, tenantName, tenantDescription)))
-        .thenReturn(
-            CompletableFuture.completedFuture(
-                new TenantRecord()
-                    .setTenantKey(tenantKey)
-                    .setName(tenantName)
-                    .setDescription(tenantDescription)
-                    .setTenantId(tenantId)));
+    @Test
+    void createTenantShouldReturnAllDetails() {
+      // given
+      final var tenantName = "Test Tenant";
+      final var tenantId = "tenantId";
+      final var tenantDescription = "Test description";
+      final var tenantKey = 100L;
+      when(tenantServices.createTenant(
+              new TenantDTO(null, tenantId, tenantName, tenantDescription)))
+          .thenReturn(
+              CompletableFuture.completedFuture(
+                  new TenantRecord()
+                      .setTenantKey(tenantKey)
+                      .setName(tenantName)
+                      .setDescription(tenantDescription)
+                      .setTenantId(tenantId)));
 
-    // when
-    webClient
-        .post()
-        .uri(TENANT_BASE_URL)
-        .accept(MediaType.APPLICATION_JSON)
-        .contentType(MediaType.APPLICATION_JSON)
-        .bodyValue(
-            new TenantCreateRequest()
-                .name(tenantName)
-                .tenantId(tenantId)
-                .description(tenantDescription))
-        .exchange()
-        .expectStatus()
-        .isCreated()
-        .expectBody()
-        .json(
-            """
+      // when
+      webClient
+          .post()
+          .uri(TENANT_BASE_URL)
+          .accept(MediaType.APPLICATION_JSON)
+          .contentType(MediaType.APPLICATION_JSON)
+          .bodyValue(
+              new TenantCreateRequest()
+                  .name(tenantName)
+                  .tenantId(tenantId)
+                  .description(tenantDescription))
+          .exchange()
+          .expectStatus()
+          .isCreated()
+          .expectBody()
+          .json(
+              """
             {
               "tenantKey": "%d",
               "tenantId": "%s",
@@ -136,31 +143,31 @@ public class TenantControllerTest extends RestControllerTest {
               "description": "%s"
             }
             """
-                .formatted(tenantKey, tenantId, tenantName, tenantDescription));
+                  .formatted(tenantKey, tenantId, tenantName, tenantDescription));
 
-    // then
-    verify(tenantServices, times(1))
-        .createTenant(new TenantDTO(null, tenantId, tenantName, tenantDescription));
-  }
+      // then
+      verify(tenantServices, times(1))
+          .createTenant(new TenantDTO(null, tenantId, tenantName, tenantDescription));
+    }
 
-  @Test
-  void createTenantWithEmptyTenantIdShouldFail() {
-    // given
-    final var tenantName = "Tenant Name";
+    @Test
+    void createTenantWithEmptyTenantIdShouldFail() {
+      // given
+      final var tenantName = "Tenant Name";
 
-    // when
-    webClient
-        .post()
-        .uri(TENANT_BASE_URL)
-        .accept(MediaType.APPLICATION_JSON)
-        .contentType(MediaType.APPLICATION_JSON)
-        .bodyValue(new TenantCreateRequest().name(tenantName))
-        .exchange()
-        .expectStatus()
-        .isBadRequest()
-        .expectBody()
-        .json(
-            """
+      // when
+      webClient
+          .post()
+          .uri(TENANT_BASE_URL)
+          .accept(MediaType.APPLICATION_JSON)
+          .contentType(MediaType.APPLICATION_JSON)
+          .bodyValue(new TenantCreateRequest().name(tenantName))
+          .exchange()
+          .expectStatus()
+          .isBadRequest()
+          .expectBody()
+          .json(
+              """
             {
               "type": "about:blank",
               "status": 400,
@@ -168,37 +175,37 @@ public class TenantControllerTest extends RestControllerTest {
               "detail": "No tenantId provided.",
               "instance": "%s"
             }"""
-                .formatted(TENANT_BASE_URL));
+                  .formatted(TENANT_BASE_URL));
 
-    // then
-    verifyNoInteractions(tenantServices);
-  }
+      // then
+      verifyNoInteractions(tenantServices);
+    }
 
-  @ParameterizedTest
-  @ValueSource(
-      strings = {
-        "foo~", "foo!", "foo#", "foo$", "foo%", "foo^", "foo&", "foo*", "foo(", "foo)", "foo=",
-        "foo+", "foo{", "foo[", "foo}", "foo]", "foo|", "foo\\", "foo:", "foo;", "foo\"", "foo'",
-        "foo<", "foo>", "foo,", "foo?", "foo/", "foo ", "foo\t", "foo\n", "foo\r"
-      })
-  void shouldRejectTenantCreationWithIllegalCharactersInId(final String id) {
-    // given
-    final var tenantName = "Tenant Name";
-    final var request = new TenantCreateRequest().tenantId(id).name(tenantName);
+    @ParameterizedTest
+    @ValueSource(
+        strings = {
+          "foo~", "foo!", "foo#", "foo$", "foo%", "foo^", "foo&", "foo*", "foo(", "foo)", "foo=",
+          "foo+", "foo{", "foo[", "foo}", "foo]", "foo|", "foo\\", "foo:", "foo;", "foo\"", "foo'",
+          "foo<", "foo>", "foo,", "foo?", "foo/", "foo ", "foo\t", "foo\n", "foo\r"
+        })
+    void shouldRejectTenantCreationWithIllegalCharactersInId(final String id) {
+      // given
+      final var tenantName = "Tenant Name";
+      final var request = new TenantCreateRequest().tenantId(id).name(tenantName);
 
-    // when
-    webClient
-        .post()
-        .uri(TENANT_BASE_URL)
-        .accept(MediaType.APPLICATION_JSON)
-        .contentType(MediaType.APPLICATION_JSON)
-        .bodyValue(request)
-        .exchange()
-        .expectStatus()
-        .isBadRequest()
-        .expectBody()
-        .json(
-            """
+      // when
+      webClient
+          .post()
+          .uri(TENANT_BASE_URL)
+          .accept(MediaType.APPLICATION_JSON)
+          .contentType(MediaType.APPLICATION_JSON)
+          .bodyValue(request)
+          .exchange()
+          .expectStatus()
+          .isBadRequest()
+          .expectBody()
+          .json(
+              """
             {
               "type": "about:blank",
               "status": 400,
@@ -206,31 +213,31 @@ public class TenantControllerTest extends RestControllerTest {
               "detail": "The provided tenantId contains illegal characters. It must match the pattern '%s'.",
               "instance": "%s"
             }"""
-                .formatted(IdentifierPatterns.ID_PATTERN, TENANT_BASE_URL));
+                  .formatted(IdentifierPatterns.ID_PATTERN, TENANT_BASE_URL));
 
-    // then
-    verifyNoInteractions(tenantServices);
-  }
+      // then
+      verifyNoInteractions(tenantServices);
+    }
 
-  @Test
-  void shouldRejectTenantWithTooLongId() {
-    // given
-    final var id = "x".repeat(257);
-    final var request = new TenantCreateRequest().tenantId(id).name("Tenant name");
+    @Test
+    void shouldRejectTenantWithTooLongId() {
+      // given
+      final var id = "x".repeat(257);
+      final var request = new TenantCreateRequest().tenantId(id).name("Tenant name");
 
-    // when
-    webClient
-        .post()
-        .uri(TENANT_BASE_URL)
-        .accept(MediaType.APPLICATION_JSON)
-        .contentType(MediaType.APPLICATION_JSON)
-        .bodyValue(request)
-        .exchange()
-        .expectStatus()
-        .isBadRequest()
-        .expectBody()
-        .json(
-            """
+      // when
+      webClient
+          .post()
+          .uri(TENANT_BASE_URL)
+          .accept(MediaType.APPLICATION_JSON)
+          .contentType(MediaType.APPLICATION_JSON)
+          .bodyValue(request)
+          .exchange()
+          .expectStatus()
+          .isBadRequest()
+          .expectBody()
+          .json(
+              """
             {
               "type": "about:blank",
               "status": 400,
@@ -238,41 +245,42 @@ public class TenantControllerTest extends RestControllerTest {
               "detail": "The provided tenantId exceeds the limit of 256 characters.",
               "instance": "%s"
             }"""
-                .formatted(TENANT_BASE_URL));
+                  .formatted(TENANT_BASE_URL));
 
-    // then
-    verifyNoInteractions(tenantServices);
-  }
+      // then
+      verifyNoInteractions(tenantServices);
+    }
 
-  @Test
-  void updateTenantShouldReturnUpdatedResponse() {
-    // given
-    final var tenantKey = 100L;
-    final var tenantName = "Updated Tenant Name";
-    final var tenantId = "tenant-test-id";
-    final var tenantDescription = "Updated description";
-    when(tenantServices.updateTenant(new TenantDTO(null, tenantId, tenantName, tenantDescription)))
-        .thenReturn(
-            CompletableFuture.completedFuture(
-                new TenantRecord()
-                    .setName(tenantName)
-                    .setDescription(tenantDescription)
-                    .setTenantKey(tenantKey)
-                    .setTenantId(tenantId)));
+    @Test
+    void updateTenantShouldReturnUpdatedResponse() {
+      // given
+      final var tenantKey = 100L;
+      final var tenantName = "Updated Tenant Name";
+      final var tenantId = "tenant-test-id";
+      final var tenantDescription = "Updated description";
+      when(tenantServices.updateTenant(
+              new TenantDTO(null, tenantId, tenantName, tenantDescription)))
+          .thenReturn(
+              CompletableFuture.completedFuture(
+                  new TenantRecord()
+                      .setName(tenantName)
+                      .setDescription(tenantDescription)
+                      .setTenantKey(tenantKey)
+                      .setTenantId(tenantId)));
 
-    // when
-    webClient
-        .put()
-        .uri("%s/%s".formatted(TENANT_BASE_URL, tenantId))
-        .accept(MediaType.APPLICATION_JSON)
-        .contentType(MediaType.APPLICATION_JSON)
-        .bodyValue(new TenantUpdateRequest().name(tenantName).description(tenantDescription))
-        .exchange()
-        .expectStatus()
-        .isOk()
-        .expectBody()
-        .json(
-            """
+      // when
+      webClient
+          .put()
+          .uri("%s/%s".formatted(TENANT_BASE_URL, tenantId))
+          .accept(MediaType.APPLICATION_JSON)
+          .contentType(MediaType.APPLICATION_JSON)
+          .bodyValue(new TenantUpdateRequest().name(tenantName).description(tenantDescription))
+          .exchange()
+          .expectStatus()
+          .isOk()
+          .expectBody()
+          .json(
+              """
             {
               "tenantKey": "%d",
               "tenantId": "%s",
@@ -280,33 +288,33 @@ public class TenantControllerTest extends RestControllerTest {
               "description": "%s"
             }
             """
-                .formatted(tenantKey, tenantId, tenantName, tenantDescription));
+                  .formatted(tenantKey, tenantId, tenantName, tenantDescription));
 
-    // then
-    verify(tenantServices, times(1))
-        .updateTenant(new TenantDTO(null, tenantId, tenantName, tenantDescription));
-  }
+      // then
+      verify(tenantServices, times(1))
+          .updateTenant(new TenantDTO(null, tenantId, tenantName, tenantDescription));
+    }
 
-  @Test
-  void updateTenantWithoutDescriptionShouldFail() {
-    // given
-    final var tenantId = 100L;
-    final var tenantName = "tenant name";
-    final var uri = "%s/%s".formatted(TENANT_BASE_URL, tenantId);
+    @Test
+    void updateTenantWithoutDescriptionShouldFail() {
+      // given
+      final var tenantId = 100L;
+      final var tenantName = "tenant name";
+      final var uri = "%s/%s".formatted(TENANT_BASE_URL, tenantId);
 
-    // when / then
-    webClient
-        .put()
-        .uri(uri)
-        .accept(MediaType.APPLICATION_JSON)
-        .contentType(MediaType.APPLICATION_JSON)
-        .bodyValue(new TenantUpdateRequest().name(tenantName))
-        .exchange()
-        .expectStatus()
-        .isBadRequest()
-        .expectBody()
-        .json(
-            """
+      // when / then
+      webClient
+          .put()
+          .uri(uri)
+          .accept(MediaType.APPLICATION_JSON)
+          .contentType(MediaType.APPLICATION_JSON)
+          .bodyValue(new TenantUpdateRequest().name(tenantName))
+          .exchange()
+          .expectStatus()
+          .isBadRequest()
+          .expectBody()
+          .json(
+              """
             {
               "type": "about:blank",
               "status": 400,
@@ -314,31 +322,31 @@ public class TenantControllerTest extends RestControllerTest {
               "detail": "No description provided.",
               "instance": "%s"
             }"""
-                .formatted(uri));
+                  .formatted(uri));
 
-    verifyNoInteractions(tenantServices);
-  }
+      verifyNoInteractions(tenantServices);
+    }
 
-  @Test
-  void updateTenantWithoutNameShouldFail() {
-    // given
-    final var tenantId = 100L;
-    final var tenantDescription = "Tenant description";
-    final var uri = "%s/%s".formatted(TENANT_BASE_URL, tenantId);
+    @Test
+    void updateTenantWithoutNameShouldFail() {
+      // given
+      final var tenantId = 100L;
+      final var tenantDescription = "Tenant description";
+      final var uri = "%s/%s".formatted(TENANT_BASE_URL, tenantId);
 
-    // when / then
-    webClient
-        .put()
-        .uri(uri)
-        .accept(MediaType.APPLICATION_JSON)
-        .contentType(MediaType.APPLICATION_JSON)
-        .bodyValue(new TenantUpdateRequest().description(tenantDescription))
-        .exchange()
-        .expectStatus()
-        .isBadRequest()
-        .expectBody()
-        .json(
-            """
+      // when / then
+      webClient
+          .put()
+          .uri(uri)
+          .accept(MediaType.APPLICATION_JSON)
+          .contentType(MediaType.APPLICATION_JSON)
+          .bodyValue(new TenantUpdateRequest().description(tenantDescription))
+          .exchange()
+          .expectStatus()
+          .isBadRequest()
+          .expectBody()
+          .json(
+              """
             {
               "type": "about:blank",
               "status": 400,
@@ -346,113 +354,114 @@ public class TenantControllerTest extends RestControllerTest {
               "detail": "No name provided.",
               "instance": "%s"
             }"""
-                .formatted(uri));
+                  .formatted(uri));
 
-    verifyNoInteractions(tenantServices);
-  }
+      verifyNoInteractions(tenantServices);
+    }
 
-  @Test
-  void updateNonExistingTenantShouldReturnError() {
-    // given
-    final var tenantId = "tenant-id";
-    final var tenantName = "My tenant";
-    final var tenantDescription = "My tenant description";
-    final var tenantKey = 100L;
-    final var path = "%s/%s".formatted(TENANT_BASE_URL, tenantId);
-    when(tenantServices.updateTenant(new TenantDTO(null, tenantId, tenantName, tenantDescription)))
-        .thenReturn(
-            CompletableFuture.failedFuture(
-                ErrorMapper.mapBrokerRejection(
-                    new BrokerRejection(
-                        TenantIntent.UPDATE,
-                        tenantKey,
-                        RejectionType.NOT_FOUND,
-                        "Tenant not found"))));
+    @Test
+    void updateNonExistingTenantShouldReturnError() {
+      // given
+      final var tenantId = "tenant-id";
+      final var tenantName = "My tenant";
+      final var tenantDescription = "My tenant description";
+      final var tenantKey = 100L;
+      final var path = "%s/%s".formatted(TENANT_BASE_URL, tenantId);
+      when(tenantServices.updateTenant(
+              new TenantDTO(null, tenantId, tenantName, tenantDescription)))
+          .thenReturn(
+              CompletableFuture.failedFuture(
+                  ErrorMapper.mapBrokerRejection(
+                      new BrokerRejection(
+                          TenantIntent.UPDATE,
+                          tenantKey,
+                          RejectionType.NOT_FOUND,
+                          "Tenant not found"))));
 
-    // when / then
-    webClient
-        .put()
-        .uri(path)
-        .accept(MediaType.APPLICATION_JSON)
-        .contentType(MediaType.APPLICATION_JSON)
-        .bodyValue(new TenantUpdateRequest().name(tenantName).description(tenantDescription))
-        .exchange()
-        .expectStatus()
-        .isNotFound();
+      // when / then
+      webClient
+          .put()
+          .uri(path)
+          .accept(MediaType.APPLICATION_JSON)
+          .contentType(MediaType.APPLICATION_JSON)
+          .bodyValue(new TenantUpdateRequest().name(tenantName).description(tenantDescription))
+          .exchange()
+          .expectStatus()
+          .isNotFound();
 
-    verify(tenantServices, times(1))
-        .updateTenant(new TenantDTO(null, tenantId, tenantName, tenantDescription));
-  }
+      verify(tenantServices, times(1))
+          .updateTenant(new TenantDTO(null, tenantId, tenantName, tenantDescription));
+    }
 
-  @Test
-  void deleteTenantShouldReturnNoContent() {
-    // given
-    final String tenantId = "tenant-to-delete-id";
+    @Test
+    void deleteTenantShouldReturnNoContent() {
+      // given
+      final String tenantId = "tenant-to-delete-id";
 
-    final var tenantRecord = new TenantRecord().setTenantId(tenantId);
+      final var tenantRecord = new TenantRecord().setTenantId(tenantId);
 
-    when(tenantServices.deleteTenant(tenantId))
-        .thenReturn(CompletableFuture.completedFuture(tenantRecord));
+      when(tenantServices.deleteTenant(tenantId))
+          .thenReturn(CompletableFuture.completedFuture(tenantRecord));
 
-    // when
-    webClient
-        .delete()
-        .uri(TENANT_BASE_URL + "/{tenantId}", tenantId)
-        .accept(MediaType.APPLICATION_JSON)
-        .exchange()
-        .expectStatus()
-        .isNoContent();
+      // when
+      webClient
+          .delete()
+          .uri(TENANT_BASE_URL + "/{tenantId}", tenantId)
+          .accept(MediaType.APPLICATION_JSON)
+          .exchange()
+          .expectStatus()
+          .isNoContent();
 
-    // then
-    verify(tenantServices, times(1)).deleteTenant(tenantId);
-  }
+      // then
+      verify(tenantServices, times(1)).deleteTenant(tenantId);
+    }
 
-  @ParameterizedTest
-  @MethodSource("provideAddMemberByIdTestCases")
-  void testAddMemberToTenantById(final EntityType entityType, final String entityPath) {
-    // given
-    final var tenantId = "some-tenant-id";
-    final var entityId = "some-entity-id";
-    final var request = new TenantMemberRequest(tenantId, entityId, entityType);
+    @ParameterizedTest
+    @MethodSource("provideAddMemberByIdTestCases")
+    void testAddMemberToTenantById(final EntityType entityType, final String entityPath) {
+      // given
+      final var tenantId = "some-tenant-id";
+      final var entityId = "some-entity-id";
+      final var request = new TenantMemberRequest(tenantId, entityId, entityType);
 
-    when(tenantServices.addMember(request)).thenReturn(CompletableFuture.completedFuture(null));
+      when(tenantServices.addMember(request)).thenReturn(CompletableFuture.completedFuture(null));
 
-    // when
-    webClient
-        .put()
-        .uri("%s/%s/%s/%s".formatted(TENANT_BASE_URL, tenantId, entityPath, entityId))
-        .accept(MediaType.APPLICATION_JSON)
-        .exchange()
-        .expectStatus()
-        .isNoContent();
+      // when
+      webClient
+          .put()
+          .uri("%s/%s/%s/%s".formatted(TENANT_BASE_URL, tenantId, entityPath, entityId))
+          .accept(MediaType.APPLICATION_JSON)
+          .exchange()
+          .expectStatus()
+          .isNoContent();
 
-    // then
-    verify(tenantServices, times(1)).addMember(request);
-  }
+      // then
+      verify(tenantServices, times(1)).addMember(request);
+    }
 
-  @ParameterizedTest
-  @MethodSource("provideAddMemberByIdTestCases")
-  void testAddMemberToTenantWithInvalidTenantId(
-      final EntityType entityType, final String entityPath) {
-    // given
-    final var tenantId = "invalidTenantId!";
-    final var entityId = "some-entity-id";
-    final var request = new TenantMemberRequest(tenantId, entityId, entityType);
+    @ParameterizedTest
+    @MethodSource("provideAddMemberByIdTestCases")
+    void testAddMemberToTenantWithInvalidTenantId(
+        final EntityType entityType, final String entityPath) {
+      // given
+      final var tenantId = "invalidTenantId!";
+      final var entityId = "some-entity-id";
+      final var request = new TenantMemberRequest(tenantId, entityId, entityType);
 
-    when(tenantServices.addMember(request)).thenReturn(CompletableFuture.completedFuture(null));
+      when(tenantServices.addMember(request)).thenReturn(CompletableFuture.completedFuture(null));
 
-    // when
-    final var uri = "%s/%s/%s/%s".formatted(TENANT_BASE_URL, tenantId, entityPath, entityId);
-    webClient
-        .put()
-        .uri(uri)
-        .accept(MediaType.APPLICATION_JSON)
-        .exchange()
-        .expectStatus()
-        .isBadRequest()
-        .expectBody()
-        .json(
-            """
+      // when
+      final var uri = "%s/%s/%s/%s".formatted(TENANT_BASE_URL, tenantId, entityPath, entityId);
+      webClient
+          .put()
+          .uri(uri)
+          .accept(MediaType.APPLICATION_JSON)
+          .exchange()
+          .expectStatus()
+          .isBadRequest()
+          .expectBody()
+          .json(
+              """
             {
               "type": "about:blank",
               "status": 400,
@@ -460,35 +469,35 @@ public class TenantControllerTest extends RestControllerTest {
               "detail": "The provided tenantId contains illegal characters. It must match the pattern '%s'.",
               "instance": "%s"
             }"""
-                .formatted(IdentifierPatterns.ID_PATTERN, uri));
+                  .formatted(IdentifierPatterns.ID_PATTERN, uri));
 
-    // then
-    verifyNoInteractions(tenantServices);
-  }
+      // then
+      verifyNoInteractions(tenantServices);
+    }
 
-  @ParameterizedTest
-  @MethodSource("provideAddMemberByIdTestCases")
-  void testAddMemberToTenantWithInvalidEntityId(
-      final EntityType entityType, final String entityPath, final String entityIdName) {
-    // given
-    final var tenantId = "some-tenant-id";
-    final var entityId = "invalidEntityId!";
-    final var request = new TenantMemberRequest(tenantId, entityId, entityType);
+    @ParameterizedTest
+    @MethodSource("provideAddMemberByIdTestCases")
+    void testAddMemberToTenantWithInvalidEntityId(
+        final EntityType entityType, final String entityPath, final String entityIdName) {
+      // given
+      final var tenantId = "some-tenant-id";
+      final var entityId = "invalidEntityId!";
+      final var request = new TenantMemberRequest(tenantId, entityId, entityType);
 
-    when(tenantServices.addMember(request)).thenReturn(CompletableFuture.completedFuture(null));
+      when(tenantServices.addMember(request)).thenReturn(CompletableFuture.completedFuture(null));
 
-    // when
-    final var uri = "%s/%s/%s/%s".formatted(TENANT_BASE_URL, tenantId, entityPath, entityId);
-    webClient
-        .put()
-        .uri(uri)
-        .accept(MediaType.APPLICATION_JSON)
-        .exchange()
-        .expectStatus()
-        .isBadRequest()
-        .expectBody()
-        .json(
-            """
+      // when
+      final var uri = "%s/%s/%s/%s".formatted(TENANT_BASE_URL, tenantId, entityPath, entityId);
+      webClient
+          .put()
+          .uri(uri)
+          .accept(MediaType.APPLICATION_JSON)
+          .exchange()
+          .expectStatus()
+          .isBadRequest()
+          .expectBody()
+          .json(
+              """
             {
               "type": "about:blank",
               "status": 400,
@@ -496,59 +505,60 @@ public class TenantControllerTest extends RestControllerTest {
               "detail": "The provided %s contains illegal characters. It must match the pattern '%s'.",
               "instance": "%s"
             }"""
-                .formatted(entityIdName, IdentifierPatterns.ID_PATTERN, uri));
+                  .formatted(entityIdName, IdentifierPatterns.ID_PATTERN, uri));
 
-    // then
-    verifyNoInteractions(tenantServices);
-  }
+      // then
+      verifyNoInteractions(tenantServices);
+    }
 
-  @ParameterizedTest
-  @MethodSource("provideRemoveMemberByIdTestCases")
-  void testRemoveMemberByIdFromTenant(final EntityType entityType, final String entityPath) {
-    // given
-    final var tenantId = "some-tenant-id";
-    final var entityId = "entity-id";
-    final var tenantMemberRequest = new TenantMemberRequest(tenantId, entityId, entityType);
+    @ParameterizedTest
+    @MethodSource("provideRemoveMemberByIdTestCases")
+    void testRemoveMemberByIdFromTenant(final EntityType entityType, final String entityPath) {
+      // given
+      final var tenantId = "some-tenant-id";
+      final var entityId = "entity-id";
+      final var tenantMemberRequest = new TenantMemberRequest(tenantId, entityId, entityType);
 
-    when(tenantServices.removeMember(tenantMemberRequest))
-        .thenReturn(CompletableFuture.completedFuture(null));
+      when(tenantServices.removeMember(tenantMemberRequest))
+          .thenReturn(CompletableFuture.completedFuture(null));
 
-    // when
-    webClient
-        .delete()
-        .uri("%s/%s/%s/%s".formatted(TENANT_BASE_URL, tenantId, entityPath, entityId))
-        .accept(MediaType.APPLICATION_JSON)
-        .exchange()
-        .expectStatus()
-        .isNoContent();
+      // when
+      webClient
+          .delete()
+          .uri("%s/%s/%s/%s".formatted(TENANT_BASE_URL, tenantId, entityPath, entityId))
+          .accept(MediaType.APPLICATION_JSON)
+          .exchange()
+          .expectStatus()
+          .isNoContent();
 
-    // then
-    verify(tenantServices, times(1)).removeMember(tenantMemberRequest);
-  }
+      // then
+      verify(tenantServices, times(1)).removeMember(tenantMemberRequest);
+    }
 
-  @ParameterizedTest
-  @MethodSource("provideAddMemberByIdTestCases")
-  void testRemoveMemberToTenantWithInvalidTenantId(
-      final EntityType entityType, final String entityPath) {
-    // given
-    final var tenantId = "invalidTenantId!";
-    final var entityId = "some-entity-id";
-    final var request = new TenantMemberRequest(tenantId, entityId, entityType);
+    @ParameterizedTest
+    @MethodSource("provideAddMemberByIdTestCases")
+    void testRemoveMemberToTenantWithInvalidTenantId(
+        final EntityType entityType, final String entityPath) {
+      // given
+      final var tenantId = "invalidTenantId!";
+      final var entityId = "some-entity-id";
+      final var request = new TenantMemberRequest(tenantId, entityId, entityType);
 
-    when(tenantServices.removeMember(request)).thenReturn(CompletableFuture.completedFuture(null));
+      when(tenantServices.removeMember(request))
+          .thenReturn(CompletableFuture.completedFuture(null));
 
-    // when
-    final var uri = "%s/%s/%s/%s".formatted(TENANT_BASE_URL, tenantId, entityPath, entityId);
-    webClient
-        .put()
-        .uri(uri)
-        .accept(MediaType.APPLICATION_JSON)
-        .exchange()
-        .expectStatus()
-        .isBadRequest()
-        .expectBody()
-        .json(
-            """
+      // when
+      final var uri = "%s/%s/%s/%s".formatted(TENANT_BASE_URL, tenantId, entityPath, entityId);
+      webClient
+          .put()
+          .uri(uri)
+          .accept(MediaType.APPLICATION_JSON)
+          .exchange()
+          .expectStatus()
+          .isBadRequest()
+          .expectBody()
+          .json(
+              """
             {
               "type": "about:blank",
               "status": 400,
@@ -556,35 +566,36 @@ public class TenantControllerTest extends RestControllerTest {
               "detail": "The provided tenantId contains illegal characters. It must match the pattern '%s'.",
               "instance": "%s"
             }"""
-                .formatted(IdentifierPatterns.ID_PATTERN, uri));
+                  .formatted(IdentifierPatterns.ID_PATTERN, uri));
 
-    // then
-    verifyNoInteractions(tenantServices);
-  }
+      // then
+      verifyNoInteractions(tenantServices);
+    }
 
-  @ParameterizedTest
-  @MethodSource("provideAddMemberByIdTestCases")
-  void testRemoveMemberToTenantWithInvalidEntityId(
-      final EntityType entityType, final String entityPath, final String entityIdName) {
-    // given
-    final var tenantId = "some-tenant-id";
-    final var entityId = "invalidEntityId!";
-    final var request = new TenantMemberRequest(tenantId, entityId, entityType);
+    @ParameterizedTest
+    @MethodSource("provideAddMemberByIdTestCases")
+    void testRemoveMemberToTenantWithInvalidEntityId(
+        final EntityType entityType, final String entityPath, final String entityIdName) {
+      // given
+      final var tenantId = "some-tenant-id";
+      final var entityId = "invalidEntityId!";
+      final var request = new TenantMemberRequest(tenantId, entityId, entityType);
 
-    when(tenantServices.removeMember(request)).thenReturn(CompletableFuture.completedFuture(null));
+      when(tenantServices.removeMember(request))
+          .thenReturn(CompletableFuture.completedFuture(null));
 
-    // when
-    final var uri = "%s/%s/%s/%s".formatted(TENANT_BASE_URL, tenantId, entityPath, entityId);
-    webClient
-        .put()
-        .uri(uri)
-        .accept(MediaType.APPLICATION_JSON)
-        .exchange()
-        .expectStatus()
-        .isBadRequest()
-        .expectBody()
-        .json(
-            """
+      // when
+      final var uri = "%s/%s/%s/%s".formatted(TENANT_BASE_URL, tenantId, entityPath, entityId);
+      webClient
+          .put()
+          .uri(uri)
+          .accept(MediaType.APPLICATION_JSON)
+          .exchange()
+          .expectStatus()
+          .isBadRequest()
+          .expectBody()
+          .json(
+              """
             {
               "type": "about:blank",
               "status": 400,
@@ -592,27 +603,28 @@ public class TenantControllerTest extends RestControllerTest {
               "detail": "The provided %s contains illegal characters. It must match the pattern '%s'.",
               "instance": "%s"
             }"""
-                .formatted(entityIdName, IdentifierPatterns.ID_PATTERN, uri));
+                  .formatted(entityIdName, IdentifierPatterns.ID_PATTERN, uri));
 
-    // then
-    verifyNoInteractions(tenantServices);
-  }
+      // then
+      verifyNoInteractions(tenantServices);
+    }
 
-  private static Stream<Arguments> provideAddMemberByIdTestCases() {
-    return Stream.of(
-        Arguments.of(EntityType.USER, "users", "username"),
-        Arguments.of(EntityType.MAPPING, "mapping-rules", "mappingId"),
-        Arguments.of(EntityType.GROUP, "groups", "groupId"),
-        Arguments.of(EntityType.ROLE, "roles", "roleId"),
-        Arguments.of(EntityType.CLIENT, "clients", "clientId"));
-  }
+    private static Stream<Arguments> provideAddMemberByIdTestCases() {
+      return Stream.of(
+          Arguments.of(EntityType.USER, "users", "username"),
+          Arguments.of(EntityType.MAPPING, "mapping-rules", "mappingId"),
+          Arguments.of(EntityType.GROUP, "groups", "groupId"),
+          Arguments.of(EntityType.ROLE, "roles", "roleId"),
+          Arguments.of(EntityType.CLIENT, "clients", "clientId"));
+    }
 
-  private static Stream<Arguments> provideRemoveMemberByIdTestCases() {
-    return Stream.of(
-        Arguments.of(EntityType.USER, "users", "username"),
-        Arguments.of(EntityType.MAPPING, "mapping-rules", "mappingId"),
-        Arguments.of(EntityType.GROUP, "groups", "groupId"),
-        Arguments.of(EntityType.ROLE, "roles", "roleId"),
-        Arguments.of(EntityType.CLIENT, "clients", "clientId"));
+    private static Stream<Arguments> provideRemoveMemberByIdTestCases() {
+      return Stream.of(
+          Arguments.of(EntityType.USER, "users", "username"),
+          Arguments.of(EntityType.MAPPING, "mapping-rules", "mappingId"),
+          Arguments.of(EntityType.GROUP, "groups", "groupId"),
+          Arguments.of(EntityType.ROLE, "roles", "roleId"),
+          Arguments.of(EntityType.CLIENT, "clients", "clientId"));
+    }
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupControllerTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.gateway.rest.controller.usermanagement;
 
+import static io.camunda.zeebe.gateway.rest.config.ApiFiltersConfiguration.GROUPS_API_DISABLED_ERROR_MESSAGE;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -61,9 +62,10 @@ public class GroupControllerTest {
           "type": "about:blank",
           "status": 403,
           "title": "Access issue",
-          "detail": "Due to security configuration, %s endpoint is not accessible",
-          "instance": "%s"
-        }""";
+          "detail": "%%s endpoint is not accessible: %s",
+          "instance": "%%s"
+        }"""
+            .formatted(GROUPS_API_DISABLED_ERROR_MESSAGE);
 
     @Test
     void shouldReturnErrorOnCreate() {


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR adds a config option that can be used to disable the Tenants API. If the value is set to `true` any requests to `/v2/tenants` gets filtered and we respond with a `403 Forbidden` response. I've also slightly refactored the groups one we already have with a more descriptive error message, heklping users pinpoint what config option they can change to enable the API.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

related to #31911 
