### PR TITLE
[Backport stable/8.6] fix: Set missing operationReference in REST cancel process request [8.7]

### DIFF
--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/CancelProcessInstanceCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/CancelProcessInstanceCommandImpl.java
@@ -124,6 +124,7 @@ public final class CancelProcessInstanceCommandImpl implements CancelProcessInst
   @Override
   public CancelProcessInstanceCommandStep1 operationReference(final long operationReference) {
     builder.setOperationReference(operationReference);
+    httpRequestObject.setOperationReference(operationReference);
     return this;
   }
 

--- a/clients/java/src/test/java/io/camunda/zeebe/client/process/CancelProcessInstanceTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/process/CancelProcessInstanceTest.java
@@ -64,6 +64,19 @@ public final class CancelProcessInstanceTest extends ClientTest {
   }
 
   @Test
+  public void shouldSetOperationReference() {
+    // given
+    final int operationReference = 456;
+
+    // when
+    client.newCancelInstanceCommand(123).operationReference(operationReference).send().join();
+
+    // then
+    final CancelProcessInstanceRequest request = gatewayService.getLastRequest();
+    assertThat(request.getOperationReference()).isEqualTo(operationReference);
+  }
+
+  @Test
   public void shouldNotHaveNullResponse() {
     // given
     final CancelProcessInstanceCommandStep1 command = client.newCancelInstanceCommand(12);

--- a/clients/java/src/test/java/io/camunda/zeebe/client/process/rest/CancelProcessInstanceRestTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/process/rest/CancelProcessInstanceRestTest.java
@@ -49,4 +49,18 @@ public class CancelProcessInstanceRestTest extends ClientRestTest {
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Invalid request");
   }
+
+  @Test
+  public void shouldSetOperationReference() {
+    // given
+    final int operationReference = 456;
+
+    // when
+    client.newCancelInstanceCommand(123).operationReference(operationReference).send().join();
+
+    // then
+    final CancelProcessInstanceRequest request =
+        gatewayService.getLastRequest(CancelProcessInstanceRequest.class);
+    assertThat(request.getOperationReference()).isEqualTo(operationReference);
+  }
 }


### PR DESCRIPTION
# Description
Backport of #34848 to `stable/8.6`.

relates to #34847 #31758