### PR TITLE
fix: use correct json format for token issuer auth body

### DIFF
--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/saas/ConsoleConnectorConfig.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/saas/ConsoleConnectorConfig.java
@@ -11,6 +11,7 @@ import io.camunda.migration.identity.client.ConsoleClient;
 import io.camunda.migration.identity.config.ConsoleProperties;
 import io.camunda.migration.identity.config.IdentityMigrationProperties;
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.Map;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
@@ -23,8 +24,6 @@ import org.springframework.http.MediaType;
 import org.springframework.http.client.ClientHttpRequestExecution;
 import org.springframework.http.client.ClientHttpRequestInterceptor;
 import org.springframework.http.client.ClientHttpResponse;
-import org.springframework.util.LinkedMultiValueMap;
-import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
 
 @Configuration
@@ -70,11 +69,11 @@ public class ConsoleConnectorConfig {
       final var headers = new HttpHeaders();
       headers.setContentType(MediaType.APPLICATION_JSON);
 
-      final MultiValueMap<String, String> form = new LinkedMultiValueMap<>();
-      form.add("client_id", consoleProperties.getClientId());
-      form.add("client_secret", consoleProperties.getClientSecret());
-      form.add("audience", consoleProperties.getAudience());
-      form.add("grant_type", "client_credentials");
+      final Map<String, String> form = new HashMap<>();
+      form.put("client_id", consoleProperties.getClientId());
+      form.put("client_secret", consoleProperties.getClientSecret());
+      form.put("audience", consoleProperties.getAudience());
+      form.put("grant_type", "client_credentials");
 
       final var entity = new HttpEntity<>(form, headers);
       final var response =

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/migration/SaaSIdentityMigrationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/migration/SaaSIdentityMigrationIT.java
@@ -31,6 +31,7 @@ import static org.assertj.core.api.Assertions.tuple;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import io.camunda.client.CamundaClient;
@@ -77,10 +78,23 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 @Testcontainers(parallel = true)
 public class SaaSIdentityMigrationIT {
 
+  public static final String CONSOLE_CLIENT_ID = "client-id";
+  public static final String CONSOLE_CLIENT_SECRET = "client-secret";
+  public static final String CONSOLE_AUDIENCE = "test-audience";
+
   @TestZeebe(autoStart = false)
   static final TestStandaloneBroker BROKER =
       new TestStandaloneBroker().withBasicAuth().withAuthorizationsEnabled();
 
+  private static final String AUTH_TOKEN_BODY =
+      """
+      {
+          "client_id":"%s",
+          "client_secret":"%s",
+          "audience":"%s",
+          "grant_type":"client_credentials"
+        }
+      """;
   private static final String TOKEN = loadFixture("jwt-identity-client.txt");
 
   @Container
@@ -137,9 +151,9 @@ public class SaaSIdentityMigrationIT {
     migrationProperties
         .getConsole()
         .setIssuerBackendUrl(wmRuntimeInfo.getHttpBaseUrl() + "/oauth/token");
-    migrationProperties.getConsole().setClientId("client-id");
-    migrationProperties.getConsole().setClientSecret("client-secret");
-    migrationProperties.getConsole().setAudience("test-audience");
+    migrationProperties.getConsole().setClientId(CONSOLE_CLIENT_ID);
+    migrationProperties.getConsole().setClientSecret(CONSOLE_CLIENT_SECRET);
+    migrationProperties.getConsole().setAudience(CONSOLE_AUDIENCE);
     migrationProperties.getConsole().setClusterId("cluster123");
     migrationProperties.getConsole().setInternalClientId("client123");
 
@@ -694,8 +708,28 @@ public class SaaSIdentityMigrationIT {
                 ok().withHeader("Content-Type", "application/json")
                     .withBody(loadFixture("jwks.json"))));
 
+    // console auth token
     stubFor(
         post(urlEqualTo("/oauth/token"))
+            .withHeader("Content-Type", equalTo("application/json"))
+            .withRequestBody(
+                WireMock.equalToJson(
+                    AUTH_TOKEN_BODY.formatted(
+                        CONSOLE_CLIENT_ID, CONSOLE_CLIENT_SECRET, CONSOLE_AUDIENCE)))
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withHeader("Content-Type", "application/json")
+                    .withBody("{\"access_token\": \"" + TOKEN + "\"}")));
+
+    // management identity auth token
+    stubFor(
+        post(urlEqualTo("/oauth/token"))
+            .withHeader("Content-Type", equalTo("application/json"))
+            .withRequestBody(
+                WireMock.equalToJson(
+                    AUTH_TOKEN_BODY.formatted(
+                        IDENTITY_CLIENT, IDENTITY_CLIENT_SECRET, CAMUNDA_IDENTITY_RESOURCE_SERVER)))
             .willReturn(
                 aResponse()
                     .withStatus(200)


### PR DESCRIPTION
## Description

Previously a multi-value map was used, that the token issuer accepts but that will cause failure in the underlying request to auth0 if no token was found in the token-issuer cache.

This scenario resulted in a 500 error on the token issuer.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

relates to #33340
