### PR TITLE
fix: make max cell size customizable, increase value, adapt for authorizations

### DIFF
--- a/identity/client/src/components/entityList/EntityList.tsx
+++ b/identity/client/src/components/entityList/EntityList.tsx
@@ -108,12 +108,12 @@ type EntityListProps<D extends EntityData> = {
     onSelectAll: (selected: D[]) => unknown;
     isSelected: (selected: D) => boolean;
   };
+  maxDisplayCellLength?: number;
 };
 
 const MAX_ICON_ACTIONS = 2;
 const PAGINATION_HIDE_LIMIT = 15;
 const PAGINATION_MAX_PAGE_SIZE = 15;
-const MAX_DISPLAY_CELL_LENGTH = 20;
 
 const EntityList = <D extends EntityData>({
   title,
@@ -131,6 +131,7 @@ const EntityList = <D extends EntityData>({
   loading,
   batchSelection,
   searchPlaceholder,
+  maxDisplayCellLength = 50,
 }: EntityListProps<D>): ReturnType<FC> => {
   const debounce = useDebounce(300);
   const { t } = useTranslate("components");
@@ -324,7 +325,7 @@ const EntityList = <D extends EntityData>({
                           const truncatedValue =
                             displayValue &&
                             displayValue.toString().length >
-                              MAX_DISPLAY_CELL_LENGTH ? (
+                              maxDisplayCellLength ? (
                               <StyledToolTip
                                 label={displayValue}
                                 autoAlign
@@ -332,7 +333,7 @@ const EntityList = <D extends EntityData>({
                               >
                                 <TooltipTrigger>
                                   {displayValue
-                                    .substring(0, MAX_DISPLAY_CELL_LENGTH)
+                                    .substring(0, maxDisplayCellLength)
                                     .concat("…")}
                                 </TooltipTrigger>
                               </StyledToolTip>

--- a/identity/client/src/pages/authorizations/AuthorizationsList.tsx
+++ b/identity/client/src/pages/authorizations/AuthorizationsList.tsx
@@ -75,6 +75,7 @@ const AuthorizationList: FC<AuthorizationListProps> = ({
               onClick: deleteAuthorization,
             },
           ]}
+          maxDisplayCellLength={25}
         />
       ) : (
         <C3EmptyState


### PR DESCRIPTION
## Description

- Turn constant for max cell size on `EntityList` component a prop, increase default value
- Adapt value to make it smaller for authorizations table as it is smaller than the others and due to the authorizations it's prone to have very long text.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #33772
