### PR TITLE
fix: correct error usage from useApiCall to show detailed error

### DIFF
--- a/identity/client/src/pages/setup/SetupPage.tsx
+++ b/identity/client/src/pages/setup/SetupPage.tsx
@@ -73,7 +73,7 @@ const SetupForm: React.FC<SetupFormProps> = ({ onSuccess }) => {
         onSuccess();
       } else {
         const detail = (error as ErrorResponse<"detailed">)?.detail;
-        setSubmitError(detail || "");
+        setSubmitError(detail || t("setupCreateAdminUserGenericError"));
       }
     }
   };

--- a/identity/client/src/pages/setup/SetupPage.tsx
+++ b/identity/client/src/pages/setup/SetupPage.tsx
@@ -22,8 +22,9 @@ import {
   Button,
 } from "src/pages/setup/styled.ts";
 import Divider from "src/components/form/Divider";
-import { createAdminUser } from "src/utility/api/setup";
 import { useApiCall } from "src/utility/api";
+import { createAdminUser } from "src/utility/api/setup";
+import { ErrorResponse } from "src/utility/api/request";
 import { isValidEmail } from "src/utility/isValidEmail";
 
 interface SetupFormProps {
@@ -32,7 +33,9 @@ interface SetupFormProps {
 
 const SetupForm: React.FC<SetupFormProps> = ({ onSuccess }) => {
   const { t } = useTranslate();
-  const [apiCall, { error }] = useApiCall(createAdminUser);
+  const [apiCall] = useApiCall(createAdminUser, {
+    suppressErrorNotification: true,
+  });
 
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
@@ -59,7 +62,7 @@ const SetupForm: React.FC<SetupFormProps> = ({ onSuccess }) => {
 
   const handleSubmit = async () => {
     if (username && password && confirmPassword) {
-      const { success } = await apiCall({
+      const { success, error } = await apiCall({
         name,
         email,
         username,
@@ -69,7 +72,8 @@ const SetupForm: React.FC<SetupFormProps> = ({ onSuccess }) => {
       if (success) {
         onSuccess();
       } else {
-        setSubmitError(error?.detail || "");
+        const detail = (error as ErrorResponse<"detailed">)?.detail;
+        setSubmitError(detail || "");
       }
     }
   };

--- a/identity/client/src/utility/localization/en/components.json
+++ b/identity/client/src/utility/localization/en/components.json
@@ -67,5 +67,6 @@
   "setupEmailLabel": "Email",
   "setupEmailPlaceholder": "Enter email",
   "setupEmailInvalid": "Please enter a valid email",
-  "setupCreateUser": "Create user"
+  "setupCreateUser": "Create user",
+  "setupCreateAdminUserGenericError": "An error occurred while creating the admin user. Please try again."
 }


### PR DESCRIPTION
## Description

- Correct usage of error from `useApiCall` function so detailed error is immediately available upon failure to create setup admin user
- Suppress default error notifications for setup page as the feedback for the user is confusing with 2 different error messages

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #34496
