### PR TITLE
refactor: allow unlimited search queries without calling findAll

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/session/WebSessionRepository.java
+++ b/authentication/src/main/java/io/camunda/authentication/session/WebSessionRepository.java
@@ -74,7 +74,7 @@ public class WebSessionRepository implements SessionRepository<WebSession> {
   }
 
   public void deleteExpiredWebSessions() {
-    Optional.ofNullable(persistentWebSessionClient.getAllPersistentWebSessions())
+    Optional.ofNullable(persistentWebSessionClient.getAllPersistentWebSessions().items())
         .ifPresent(
             persistentWebSessionEntities ->
                 persistentWebSessionEntities.forEach(this::deletePersistentWebSessionIfExpired));

--- a/authentication/src/test/java/io/camunda/authentication/session/WebSessionRepositoryTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/session/WebSessionRepositoryTest.java
@@ -12,10 +12,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.camunda.authentication.session.WebSessionMapper.SpringBasedWebSessionAttributeConverter;
 import io.camunda.search.clients.PersistentWebSessionClient;
 import io.camunda.search.entities.PersistentWebSessionEntity;
+import io.camunda.search.query.SearchQueryResult;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -126,13 +126,13 @@ class WebSessionRepositoryTest {
             MapSession.DEFAULT_MAX_INACTIVE_INTERVAL.toSeconds(),
             Map.of()));
 
-    assertThat(persistentWebSessionClient.getAllPersistentWebSessions()).hasSize(3);
+    assertThat(persistentWebSessionClient.getAllPersistentWebSessions().items()).hasSize(3);
 
     // when
     webSessionRepository.deleteExpiredWebSessions();
 
     // then
-    assertThat(persistentWebSessionClient.getAllPersistentWebSessions()).isEmpty();
+    assertThat(persistentWebSessionClient.getAllPersistentWebSessions().items()).isEmpty();
   }
 
   static final class PersistentWebSessionClientStub implements PersistentWebSessionClient {
@@ -160,8 +160,8 @@ class WebSessionRepositoryTest {
     }
 
     @Override
-    public List<PersistentWebSessionEntity> getAllPersistentWebSessions() {
-      return new ArrayList<>(persistentWebSessions.values());
+    public SearchQueryResult<PersistentWebSessionEntity> getAllPersistentWebSessions() {
+      return SearchQueryResult.of(b -> b.items(new ArrayList<>(persistentWebSessions.values())));
     }
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/SequenceFlowReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/SequenceFlowReader.java
@@ -10,8 +10,8 @@ package io.camunda.db.rdbms.read.service;
 import io.camunda.db.rdbms.read.mapper.SequenceFlowEntityMapper;
 import io.camunda.db.rdbms.sql.SequenceFlowMapper;
 import io.camunda.search.entities.SequenceFlowEntity;
+import io.camunda.search.query.SearchQueryResult;
 import io.camunda.search.query.SequenceFlowQuery;
-import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -26,10 +26,10 @@ public class SequenceFlowReader extends AbstractEntityReader<SequenceFlowEntity>
     this.sequenceFlowMapper = sequenceFlowMapper;
   }
 
-  public List<SequenceFlowEntity> search(final SequenceFlowQuery filter) {
+  public SearchQueryResult<SequenceFlowEntity> search(final SequenceFlowQuery filter) {
     LOG.trace("[RDBMS DB] Search for sequence flows with {}", filter);
-    return sequenceFlowMapper.search(filter).stream()
-        .map(SequenceFlowEntityMapper::toEntity)
-        .toList();
+    final var hits =
+        sequenceFlowMapper.search(filter).stream().map(SequenceFlowEntityMapper::toEntity).toList();
+    return buildSearchQueryResult(hits.size(), hits, null);
   }
 }

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/AbstractEntityReaderTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/AbstractEntityReaderTest.java
@@ -69,7 +69,7 @@ class AbstractEntityReaderTest {
             b ->
                 b.addEntry(ProcessInstanceSearchColumn.PROCESS_DEFINITION_NAME, SortOrder.ASC)
                     .addEntry(ProcessInstanceSearchColumn.PROCESS_INSTANCE_KEY, SortOrder.ASC));
-    final SearchQueryPage page = new SearchQueryPage(0, 10, null, null);
+    final SearchQueryPage page = SearchQueryPage.of(p -> p.from(0).size(10));
 
     final DbQueryPage result = reader.convertPaging(sort, page);
 
@@ -91,7 +91,8 @@ class AbstractEntityReaderTest {
 
     final SearchQueryResult result = reader.buildSearchQueryResult(1L, List.of(entity), sort);
 
-    final SearchQueryPage page = new SearchQueryPage(0, 10, result.endCursor(), null);
+    final SearchQueryPage page =
+        SearchQueryPage.of(p -> p.from(0).size(10).after(result.endCursor()));
 
     final DbQueryPage dbPage = reader.convertPaging(sort, page);
 
@@ -135,7 +136,8 @@ class AbstractEntityReaderTest {
 
     final SearchQueryResult result = reader.buildSearchQueryResult(1L, List.of(entity), sort);
 
-    final SearchQueryPage page = new SearchQueryPage(0, 10, null, result.startCursor());
+    final SearchQueryPage page =
+        SearchQueryPage.of(p -> p.from(0).size(10).before(result.startCursor()));
 
     final DbQueryPage dbPage = reader.convertPaging(sort, page);
 

--- a/dist/src/main/java/io/camunda/application/commons/search/SearchClientDatabaseConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/search/SearchClientDatabaseConfiguration.java
@@ -48,8 +48,8 @@ public class SearchClientDatabaseConfiguration {
       havingValue = DatabaseConfig.OPENSEARCH)
   public OpensearchSearchClient opensearchSearchClient(final ConnectConfiguration configuration) {
     final var connector = new OpensearchConnector(configuration);
-    final var elasticsearch = connector.createClient();
-    return new OpensearchSearchClient(elasticsearch);
+    final var opensearch = connector.createClient();
+    return new OpensearchSearchClient(opensearch);
   }
 
   @Bean

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/sequenceflow/SequenceFlowIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/sequenceflow/SequenceFlowIT.java
@@ -50,8 +50,9 @@ public class SequenceFlowIT {
 
     // then
     final var items =
-        sequenceFlowReader.search(
-            SequenceFlowQuery.of(q -> q.filter(f -> f.processInstanceKey(1L))));
+        sequenceFlowReader
+            .search(SequenceFlowQuery.of(q -> q.filter(f -> f.processInstanceKey(1L))))
+            .items();
     assertThat(items)
         .containsExactly(
             new SequenceFlowEntity.Builder()
@@ -95,8 +96,9 @@ public class SequenceFlowIT {
 
     // when
     final var actual =
-        sequenceFlowReader.search(
-            SequenceFlowQuery.of(q -> q.filter(f -> f.processInstanceKey(22L))));
+        sequenceFlowReader
+            .search(SequenceFlowQuery.of(q -> q.filter(f -> f.processInstanceKey(22L))))
+            .items();
 
     // then
     assertThat(actual)
@@ -135,8 +137,9 @@ public class SequenceFlowIT {
 
     // then
     final var items =
-        sequenceFlowReader.search(
-            SequenceFlowQuery.of(q -> q.filter(f -> f.processInstanceKey(3L))));
+        sequenceFlowReader
+            .search(SequenceFlowQuery.of(q -> q.filter(f -> f.processInstanceKey(3L))))
+            .items();
     assertThat(items)
         .containsExactly(
             new SequenceFlowEntity.Builder()
@@ -176,8 +179,9 @@ public class SequenceFlowIT {
 
     // then
     final var items =
-        sequenceFlowReader.search(
-            SequenceFlowQuery.of(q -> q.filter(f -> f.processInstanceKey(4L))));
+        sequenceFlowReader
+            .search(SequenceFlowQuery.of(q -> q.filter(f -> f.processInstanceKey(4L))))
+            .items();
     assertThat(items)
         .containsExactly(
             new SequenceFlowEntity.Builder()

--- a/search/search-client-elasticsearch/src/test/java/io/camunda/search/es/clients/ElasticsearchSearchClientTest.java
+++ b/search/search-client-elasticsearch/src/test/java/io/camunda/search/es/clients/ElasticsearchSearchClientTest.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.search.es.clients;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -16,29 +15,20 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
-import co.elastic.clients.elasticsearch.core.ScrollResponse;
 import co.elastic.clients.elasticsearch.core.SearchRequest;
-import co.elastic.clients.elasticsearch.core.SearchResponse;
-import co.elastic.clients.elasticsearch.core.search.Hit;
 import io.camunda.search.clients.core.SearchQueryRequest;
 import io.camunda.search.es.transformers.ElasticsearchTransformers;
 import io.camunda.search.exception.CamundaSearchException;
 import java.io.IOException;
-import java.util.List;
 import java.util.function.Function;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentCaptor;
 
 class ElasticsearchSearchClientTest {
 
-  private static final String SCROLL_ID = "scrollId123";
   private ElasticsearchClient client;
   private ElasticsearchSearchClient searchClient;
   private SearchQueryRequest searchRequest;
-  private SearchResponse<Object> searchResponse;
-  private ScrollResponse<Object> scrollResponse;
-  private ScrollResponse<Object> emptyScrollResponse;
 
   @BeforeEach
   void setUp() {
@@ -46,50 +36,6 @@ class ElasticsearchSearchClientTest {
     searchClient = new ElasticsearchSearchClient(client, new ElasticsearchTransformers());
     searchRequest = mock(SearchQueryRequest.class);
     when(searchRequest.size()).thenReturn(null);
-    searchResponse =
-        SearchResponse.of(
-            f ->
-                f.scrollId(SCROLL_ID)
-                    .hits(
-                        h -> h.hits(Hit.of(hit -> hit.id("id").index("idx").source(new Object()))))
-                    .shards((s) -> s.failed(0).successful(1).total(1))
-                    .took(1L)
-                    .timedOut(false));
-    scrollResponse =
-        ScrollResponse.of(
-            f ->
-                f.scrollId(SCROLL_ID)
-                    .hits(
-                        h -> h.hits(Hit.of(hit -> hit.id("id").index("idx").source(new Object()))))
-                    .shards((s) -> s.failed(0).successful(1).total(1))
-                    .took(1L)
-                    .timedOut(false));
-    emptyScrollResponse =
-        ScrollResponse.of(
-            f ->
-                f.scrollId(SCROLL_ID)
-                    .hits(h -> h.hits(List.of()))
-                    .shards((s) -> s.failed(0).successful(0).total(0))
-                    .took(1L)
-                    .timedOut(false));
-  }
-
-  @Test
-  void findAllShouldReturnResultsWhenSearchIsSuccessful() throws IOException {
-    // given
-    final var searchRequestCaptor = ArgumentCaptor.forClass(SearchRequest.class);
-    when(client.search(searchRequestCaptor.capture(), any())).thenReturn(searchResponse);
-    when(client.scroll(any(Function.class), any()))
-        .thenReturn(scrollResponse)
-        .thenReturn(emptyScrollResponse);
-
-    // when
-    final List<Object> result = searchClient.findAll(searchRequest, Object.class);
-
-    // then
-    assertThat(result).hasSize(2);
-    assertThat(searchRequestCaptor.getValue().scroll().time()).isEqualTo("1m");
-    verify(client).clearScroll(any(Function.class));
   }
 
   @Test
@@ -99,20 +45,8 @@ class ElasticsearchSearchClientTest {
 
     // when & Assert
     assertThrows(
-        CamundaSearchException.class, () -> searchClient.findAll(searchRequest, Object.class));
+        CamundaSearchException.class, () -> searchClient.scroll(searchRequest, Object.class));
     verify(client, never()).scroll(any(Function.class), any());
     verify(client, never()).clearScroll(any(Function.class));
-  }
-
-  @Test
-  void findAllShouldClearScrollOnException() throws IOException {
-    // given
-    when(client.search(any(SearchRequest.class), any())).thenReturn(searchResponse);
-    when(client.scroll(any(Function.class), any())).thenThrow(IOException.class);
-
-    // when & Assert
-    assertThrows(
-        CamundaSearchException.class, () -> searchClient.findAll(searchRequest, Object.class));
-    verify(client).clearScroll(any(Function.class));
   }
 }

--- a/search/search-client-opensearch/src/test/java/io/camunda/search/os/clients/OpensearchSearchClientTest.java
+++ b/search/search-client-opensearch/src/test/java/io/camunda/search/os/clients/OpensearchSearchClientTest.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.search.os.clients;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -19,26 +18,17 @@ import io.camunda.search.clients.core.SearchQueryRequest;
 import io.camunda.search.exception.CamundaSearchException;
 import io.camunda.search.os.transformers.OpensearchTransformers;
 import java.io.IOException;
-import java.util.List;
 import java.util.function.Function;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentCaptor;
 import org.opensearch.client.opensearch.OpenSearchClient;
-import org.opensearch.client.opensearch.core.ScrollResponse;
 import org.opensearch.client.opensearch.core.SearchRequest;
-import org.opensearch.client.opensearch.core.SearchResponse;
-import org.opensearch.client.opensearch.core.search.Hit;
 
 public class OpensearchSearchClientTest {
 
-  private static final String SCROLL_ID = "scrollId123";
   private OpenSearchClient client;
   private OpensearchSearchClient searchClient;
   private SearchQueryRequest searchRequest;
-  private SearchResponse<Object> searchResponse;
-  private ScrollResponse<Object> scrollResponse;
-  private ScrollResponse<Object> emptyScrollResponse;
 
   @BeforeEach
   void setUp() {
@@ -46,50 +36,6 @@ public class OpensearchSearchClientTest {
     searchClient = new OpensearchSearchClient(client, new OpensearchTransformers());
     searchRequest = mock(SearchQueryRequest.class);
     when(searchRequest.size()).thenReturn(null);
-    searchResponse =
-        SearchResponse.searchResponseOf(
-            f ->
-                f.scrollId(SCROLL_ID)
-                    .hits(
-                        h -> h.hits(Hit.of(hit -> hit.id("id").index("idx").source(new Object()))))
-                    .shards((s) -> s.failed(0).successful(1).total(1))
-                    .took(1L)
-                    .timedOut(false));
-    scrollResponse =
-        ScrollResponse.of(
-            f ->
-                f.scrollId(SCROLL_ID)
-                    .hits(
-                        h -> h.hits(Hit.of(hit -> hit.id("id").index("idx").source(new Object()))))
-                    .shards((s) -> s.failed(0).successful(1).total(1))
-                    .took(1L)
-                    .timedOut(false));
-    emptyScrollResponse =
-        ScrollResponse.of(
-            f ->
-                f.scrollId(SCROLL_ID)
-                    .hits(h -> h.hits(List.of()))
-                    .shards((s) -> s.failed(0).successful(0).total(0))
-                    .took(1L)
-                    .timedOut(false));
-  }
-
-  @Test
-  void findAllShouldReturnResultsWhenSearchIsSuccessful() throws IOException {
-    // given
-    final var searchRequestCaptor = ArgumentCaptor.forClass(SearchRequest.class);
-    when(client.search(searchRequestCaptor.capture(), any())).thenReturn(searchResponse);
-    when(client.scroll(any(Function.class), any()))
-        .thenReturn(scrollResponse)
-        .thenReturn(emptyScrollResponse);
-
-    // when
-    final List<Object> result = searchClient.findAll(searchRequest, Object.class);
-
-    // then
-    assertThat(result).hasSize(2);
-    assertThat(searchRequestCaptor.getValue().scroll().time()).isEqualTo("1m");
-    verify(client).clearScroll(any(Function.class));
   }
 
   @Test
@@ -99,20 +45,8 @@ public class OpensearchSearchClientTest {
 
     // when & Assert
     assertThrows(
-        CamundaSearchException.class, () -> searchClient.findAll(searchRequest, Object.class));
+        CamundaSearchException.class, () -> searchClient.scroll(searchRequest, Object.class));
     verify(client, never()).scroll(any(Function.class), any());
     verify(client, never()).clearScroll(any(Function.class));
-  }
-
-  @Test
-  void findAllShouldClearScrollOnException() throws IOException {
-    // given
-    when(client.search(any(SearchRequest.class), any())).thenReturn(searchResponse);
-    when(client.scroll(any(Function.class), any())).thenThrow(IOException.class);
-
-    // when & Assert
-    assertThrows(
-        CamundaSearchException.class, () -> searchClient.findAll(searchRequest, Object.class));
-    verify(client).clearScroll(any(Function.class));
   }
 }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/DocumentBasedSearchClient.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/DocumentBasedSearchClient.java
@@ -16,7 +16,6 @@ import io.camunda.search.clients.core.SearchQueryRequest.Builder;
 import io.camunda.search.clients.core.SearchQueryResponse;
 import io.camunda.util.ObjectBuilder;
 import io.camunda.zeebe.util.CloseableSilently;
-import java.util.List;
 import java.util.function.Function;
 
 public interface DocumentBasedSearchClient extends CloseableSilently {
@@ -29,7 +28,8 @@ public interface DocumentBasedSearchClient extends CloseableSilently {
     return search(searchRequest(fn), documentClass);
   }
 
-  <T> List<T> findAll(final SearchQueryRequest searchRequest, final Class<T> documentClass);
+  <T> SearchQueryResponse<T> scroll(
+      final SearchQueryRequest searchRequest, final Class<T> documentClass);
 
   <T> SearchGetResponse<T> get(final SearchGetRequest getRequest, final Class<T> documentClass);
 }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/DocumentBasedSearchClients.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/DocumentBasedSearchClients.java
@@ -47,7 +47,6 @@ import io.camunda.search.filter.Operation;
 import io.camunda.search.filter.Operator;
 import io.camunda.search.filter.ProcessDefinitionStatisticsFilter;
 import io.camunda.search.filter.ProcessInstanceStatisticsFilter;
-import io.camunda.search.filter.UsageMetricsFilter;
 import io.camunda.search.query.AuthorizationQuery;
 import io.camunda.search.query.BatchOperationItemQuery;
 import io.camunda.search.query.BatchOperationQuery;
@@ -119,16 +118,9 @@ public class DocumentBasedSearchClients implements SearchClientsProxy, Closeable
   }
 
   @Override
-  public List<AuthorizationEntity> findAllAuthorizations(final AuthorizationQuery filter) {
+  public SearchQueryResult<SequenceFlowEntity> searchSequenceFlows(final SequenceFlowQuery filter) {
     return getSearchExecutor()
-        .findAll(
-            filter, io.camunda.webapps.schema.entities.usermanagement.AuthorizationEntity.class);
-  }
-
-  @Override
-  public List<SequenceFlowEntity> findAllSequenceFlows(final SequenceFlowQuery filter) {
-    return getSearchExecutor()
-        .findAll(filter, io.camunda.webapps.schema.entities.SequenceFlowEntity.class);
+        .search(filter, io.camunda.webapps.schema.entities.SequenceFlowEntity.class);
   }
 
   @Override
@@ -141,12 +133,6 @@ public class DocumentBasedSearchClients implements SearchClientsProxy, Closeable
     final var query = applyFilters(mappingQuery);
     return getSearchExecutor()
         .search(query, io.camunda.webapps.schema.entities.usermanagement.MappingEntity.class);
-  }
-
-  @Override
-  public List<MappingEntity> findAllMappings(final MappingQuery query) {
-    return getSearchExecutor()
-        .findAll(query, io.camunda.webapps.schema.entities.usermanagement.MappingEntity.class);
   }
 
   @Override
@@ -335,12 +321,6 @@ public class DocumentBasedSearchClients implements SearchClientsProxy, Closeable
   }
 
   @Override
-  public List<RoleEntity> findAllRoles(final RoleQuery filter) {
-    return getSearchExecutor()
-        .findAll(filter, io.camunda.webapps.schema.entities.usermanagement.RoleEntity.class);
-  }
-
-  @Override
   public SearchQueryResult<TenantEntity> searchTenants(final TenantQuery filter) {
     return getSearchExecutor()
         .search(filter, io.camunda.webapps.schema.entities.usermanagement.TenantEntity.class);
@@ -350,12 +330,6 @@ public class DocumentBasedSearchClients implements SearchClientsProxy, Closeable
   public SearchQueryResult<TenantMemberEntity> searchTenantMembers(final TenantQuery query) {
     return getSearchExecutor()
         .search(query, io.camunda.webapps.schema.entities.usermanagement.TenantMemberEntity.class);
-  }
-
-  @Override
-  public List<TenantEntity> findAllTenants(final TenantQuery query) {
-    return getSearchExecutor()
-        .findAll(query, io.camunda.webapps.schema.entities.usermanagement.TenantEntity.class);
   }
 
   @Override
@@ -375,12 +349,6 @@ public class DocumentBasedSearchClients implements SearchClientsProxy, Closeable
   public SearchQueryResult<GroupMemberEntity> searchGroupMembers(final GroupQuery query) {
     return getSearchExecutor()
         .search(query, io.camunda.webapps.schema.entities.usermanagement.GroupMemberEntity.class);
-  }
-
-  @Override
-  public List<GroupEntity> findAllGroups(final GroupQuery query) {
-    return getSearchExecutor()
-        .findAll(query, io.camunda.webapps.schema.entities.usermanagement.GroupEntity.class);
   }
 
   @Override
@@ -431,22 +399,18 @@ public class DocumentBasedSearchClients implements SearchClientsProxy, Closeable
    */
   private Long distinctCountUsageMetricsFor(final String event, final UsageMetricsQuery query) {
     final var filter =
-        new UsageMetricsQuery.Builder()
-            .filter(
-                new UsageMetricsFilter.Builder()
-                    .startTime(query.filter().startTime())
-                    .endTime(query.filter().endTime())
-                    .events(event)
-                    .build())
-            .build();
-    final List<UsageMetricsEntity> metrics =
-        new SearchClientBasedQueryExecutor(
-                searchClient,
-                transformers,
-                new DocumentAuthorizationQueryStrategy(this),
-                securityContext)
-            .findAll(filter, io.camunda.webapps.schema.entities.UsageMetricsEntity.class);
-    return metrics.stream().map(UsageMetricsEntity::value).distinct().count();
+        UsageMetricsQuery.of(
+            b ->
+                b.filter(
+                        f ->
+                            f.startTime(query.filter().startTime())
+                                .endTime(query.filter().endTime())
+                                .events(event))
+                    .unlimited());
+    final SearchQueryResult<UsageMetricsEntity> result =
+        getSearchExecutor()
+            .search(filter, io.camunda.webapps.schema.entities.UsageMetricsEntity.class);
+    return result.items().stream().map(UsageMetricsEntity::value).distinct().count();
   }
 
   private MappingQuery applyFilters(final MappingQuery mappingQuery) {
@@ -520,25 +484,24 @@ public class DocumentBasedSearchClients implements SearchClientsProxy, Closeable
   }
 
   private Set<String> getTenantMembers(final String tenantId, final EntityType entityType) {
-    final List<TenantMemberEntity> tenantMembers =
+    final SearchQueryResult<TenantMemberEntity> tenantMembers =
         getSearchExecutor()
-            .findAll(
-                new TenantQuery.Builder()
-                    .filter(f -> f.joinParentId(tenantId).memberType(entityType))
-                    .build(),
+            .search(
+                TenantQuery.of(
+                    b ->
+                        b.filter(f -> f.joinParentId(tenantId).memberType(entityType)).unlimited()),
                 io.camunda.webapps.schema.entities.usermanagement.TenantMemberEntity.class);
-    return tenantMembers.stream().map(TenantMemberEntity::id).collect(Collectors.toSet());
+    return tenantMembers.items().stream().map(TenantMemberEntity::id).collect(Collectors.toSet());
   }
 
   private Set<String> getGroupMembers(final String groupId, final EntityType entityType) {
-    final List<GroupMemberEntity> groupMembers =
+    final SearchQueryResult<GroupMemberEntity> groupMembers =
         getSearchExecutor()
-            .findAll(
-                new GroupQuery.Builder()
-                    .filter(f -> f.joinParentId(groupId).memberType(entityType))
-                    .build(),
+            .search(
+                GroupQuery.of(
+                    b -> b.filter(f -> f.joinParentId(groupId).memberType(entityType)).unlimited()),
                 io.camunda.webapps.schema.entities.usermanagement.GroupMemberEntity.class);
-    return groupMembers.stream().map(GroupMemberEntity::id).collect(Collectors.toSet());
+    return groupMembers.items().stream().map(GroupMemberEntity::id).collect(Collectors.toSet());
   }
 
   private UserQuery expandRoleFilter(final UserQuery userQuery) {
@@ -563,14 +526,13 @@ public class DocumentBasedSearchClients implements SearchClientsProxy, Closeable
   }
 
   public Set<String> getRoleMemberIds(final String roleId, final EntityType memberType) {
-    final List<RoleMemberEntity> roleMembers =
+    final SearchQueryResult<RoleMemberEntity> roleMembers =
         getSearchExecutor()
-            .findAll(
-                new RoleQuery.Builder()
-                    .filter(f -> f.joinParentId(roleId).memberType(memberType))
-                    .build(),
+            .search(
+                RoleQuery.of(
+                    b -> b.filter(f -> f.joinParentId(roleId).memberType(memberType)).unlimited()),
                 io.camunda.webapps.schema.entities.usermanagement.RoleMemberEntity.class);
-    return roleMembers.stream().map(RoleMemberEntity::id).collect(Collectors.toSet());
+    return roleMembers.items().stream().map(RoleMemberEntity::id).collect(Collectors.toSet());
   }
 
   @Override

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/PersistentWebSessionSearchImpl.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/PersistentWebSessionSearchImpl.java
@@ -10,10 +10,11 @@ package io.camunda.search.clients;
 import io.camunda.search.clients.core.SearchDeleteRequest;
 import io.camunda.search.clients.core.SearchGetRequest;
 import io.camunda.search.clients.core.SearchIndexRequest;
+import io.camunda.search.clients.core.SearchQueryHit;
 import io.camunda.search.clients.core.SearchQueryRequest;
 import io.camunda.search.entities.PersistentWebSessionEntity;
+import io.camunda.search.query.SearchQueryResult;
 import io.camunda.webapps.schema.descriptors.index.PersistentWebSessionIndexDescriptor;
-import java.util.List;
 
 public class PersistentWebSessionSearchImpl implements PersistentWebSessionClient {
 
@@ -58,9 +59,12 @@ public class PersistentWebSessionSearchImpl implements PersistentWebSessionClien
   }
 
   @Override
-  public List<PersistentWebSessionEntity> getAllPersistentWebSessions() {
-    return readClient.findAll(
-        SearchQueryRequest.of(b -> b.index(persistentWebSessionIndex.getFullQualifiedName())),
-        PersistentWebSessionEntity.class);
+  public SearchQueryResult<PersistentWebSessionEntity> getAllPersistentWebSessions() {
+    final var response =
+        readClient.scroll(
+            SearchQueryRequest.of(b -> b.index(persistentWebSessionIndex.getFullQualifiedName())),
+            PersistentWebSessionEntity.class);
+    return SearchQueryResult.of(
+        r -> r.items(response.hits().stream().map(SearchQueryHit::source).toList()));
   }
 }

--- a/search/search-client-rdbms/src/main/java/io/camunda/search/rdbms/RdbmsSearchClient.java
+++ b/search/search-client-rdbms/src/main/java/io/camunda/search/rdbms/RdbmsSearchClient.java
@@ -95,23 +95,7 @@ public class RdbmsSearchClient implements SearchClientsProxy {
   }
 
   @Override
-  public List<AuthorizationEntity> findAllAuthorizations(final AuthorizationQuery query) {
-    LOG.debug("[RDBMS Search Client] Search for all authorizations: {}", query);
-
-    // search without size boundary to find all items
-    return rdbmsService
-        .getAuthorizationReader()
-        .search(
-            AuthorizationQuery.of(
-                b ->
-                    b.filter(query.filter())
-                        .sort(query.sort())
-                        .page(p -> p.size(Integer.MAX_VALUE))))
-        .items();
-  }
-
-  @Override
-  public List<SequenceFlowEntity> findAllSequenceFlows(final SequenceFlowQuery query) {
+  public SearchQueryResult<SequenceFlowEntity> searchSequenceFlows(final SequenceFlowQuery query) {
     LOG.debug("[RDBMS Search Client] Search for sequence flow: {}", query);
     return rdbmsService.getSequenceFlowReader().search(query);
   }
@@ -144,22 +128,6 @@ public class RdbmsSearchClient implements SearchClientsProxy {
     LOG.debug("[RDBMS Search Client] Search for mappings: {}", filter);
 
     return rdbmsService.getMappingReader().search(filter);
-  }
-
-  @Override
-  public List<MappingEntity> findAllMappings(final MappingQuery query) {
-    LOG.debug("[RDBMS Search Client] Search for all mappings: {}", query);
-
-    // search without size boundary to find all items
-    return rdbmsService
-        .getMappingReader()
-        .search(
-            MappingQuery.of(
-                b ->
-                    b.filter(query.filter())
-                        .sort(query.sort())
-                        .page(p -> p.size(Integer.MAX_VALUE))))
-        .items();
   }
 
   @Override
@@ -224,22 +192,6 @@ public class RdbmsSearchClient implements SearchClientsProxy {
   }
 
   @Override
-  public List<GroupEntity> findAllGroups(final GroupQuery query) {
-    LOG.debug("[RDBMS Search Client] Search for all groups: {}", query);
-
-    // search without size boundary to find all items
-    return rdbmsService
-        .getGroupReader()
-        .search(
-            GroupQuery.of(
-                b ->
-                    b.filter(query.filter())
-                        .sort(query.sort())
-                        .page(p -> p.size(Integer.MAX_VALUE))))
-        .items();
-  }
-
-  @Override
   public SearchQueryResult<UserTaskEntity> searchUserTasks(final UserTaskQuery query) {
     return rdbmsService
         .getUserTaskReader()
@@ -267,11 +219,6 @@ public class RdbmsSearchClient implements SearchClientsProxy {
   }
 
   @Override
-  public List<RoleEntity> findAllRoles(final RoleQuery filter) {
-    return List.of();
-  }
-
-  @Override
   public SearchQueryResult<TenantEntity> searchTenants(final TenantQuery query) {
     LOG.debug("[RDBMS Search Client] Search for tenants: {}", query);
 
@@ -281,22 +228,6 @@ public class RdbmsSearchClient implements SearchClientsProxy {
   @Override
   public SearchQueryResult<TenantMemberEntity> searchTenantMembers(final TenantQuery filter) {
     throw new UnsupportedOperationException("Tenant member search not implemented on RDBMS");
-  }
-
-  @Override
-  public List<TenantEntity> findAllTenants(final TenantQuery query) {
-    LOG.debug("[RDBMS Search Client] Search for all tenants: {}", query);
-
-    // search without size boundary to find all items
-    return rdbmsService
-        .getTenantReader()
-        .search(
-            TenantQuery.of(
-                b ->
-                    b.filter(query.filter())
-                        .sort(query.sort())
-                        .page(p -> p.size(Integer.MAX_VALUE))))
-        .items();
   }
 
   @Override

--- a/search/search-client/src/main/java/io/camunda/search/clients/AuthorizationSearchClient.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/AuthorizationSearchClient.java
@@ -11,13 +11,10 @@ import io.camunda.search.entities.AuthorizationEntity;
 import io.camunda.search.query.AuthorizationQuery;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.auth.SecurityContext;
-import java.util.List;
 
 public interface AuthorizationSearchClient {
 
   SearchQueryResult<AuthorizationEntity> searchAuthorizations(AuthorizationQuery filter);
-
-  List<AuthorizationEntity> findAllAuthorizations(AuthorizationQuery filter);
 
   AuthorizationSearchClient withSecurityContext(SecurityContext securityContext);
 }

--- a/search/search-client/src/main/java/io/camunda/search/clients/GroupSearchClient.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/GroupSearchClient.java
@@ -12,15 +12,12 @@ import io.camunda.search.entities.GroupMemberEntity;
 import io.camunda.search.query.GroupQuery;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.auth.SecurityContext;
-import java.util.List;
 
 public interface GroupSearchClient {
 
   SearchQueryResult<GroupEntity> searchGroups(final GroupQuery query);
 
   SearchQueryResult<GroupMemberEntity> searchGroupMembers(GroupQuery query);
-
-  List<GroupEntity> findAllGroups(final GroupQuery query);
 
   GroupSearchClient withSecurityContext(SecurityContext securityContext);
 }

--- a/search/search-client/src/main/java/io/camunda/search/clients/MappingSearchClient.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/MappingSearchClient.java
@@ -11,13 +11,10 @@ import io.camunda.search.entities.MappingEntity;
 import io.camunda.search.query.MappingQuery;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.auth.SecurityContext;
-import java.util.List;
 
 public interface MappingSearchClient {
 
   SearchQueryResult<MappingEntity> searchMappings(MappingQuery filter);
-
-  List<MappingEntity> findAllMappings(MappingQuery query);
 
   MappingSearchClient withSecurityContext(SecurityContext securityContext);
 }

--- a/search/search-client/src/main/java/io/camunda/search/clients/PersistentWebSessionClient.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/PersistentWebSessionClient.java
@@ -8,7 +8,7 @@
 package io.camunda.search.clients;
 
 import io.camunda.search.entities.PersistentWebSessionEntity;
-import java.util.List;
+import io.camunda.search.query.SearchQueryResult;
 
 public interface PersistentWebSessionClient {
 
@@ -18,5 +18,5 @@ public interface PersistentWebSessionClient {
 
   void deletePersistentWebSession(final String sessionId);
 
-  List<PersistentWebSessionEntity> getAllPersistentWebSessions();
+  SearchQueryResult<PersistentWebSessionEntity> getAllPersistentWebSessions();
 }

--- a/search/search-client/src/main/java/io/camunda/search/clients/RoleSearchClient.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/RoleSearchClient.java
@@ -12,15 +12,12 @@ import io.camunda.search.entities.RoleMemberEntity;
 import io.camunda.search.query.RoleQuery;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.auth.SecurityContext;
-import java.util.List;
 
 public interface RoleSearchClient {
 
   SearchQueryResult<RoleEntity> searchRoles(RoleQuery filter);
 
   SearchQueryResult<RoleMemberEntity> searchRoleMembers(RoleQuery filter);
-
-  List<RoleEntity> findAllRoles(RoleQuery filter);
 
   RoleSearchClient withSecurityContext(SecurityContext securityContext);
 }

--- a/search/search-client/src/main/java/io/camunda/search/clients/SequenceFlowSearchClient.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/SequenceFlowSearchClient.java
@@ -8,13 +8,13 @@
 package io.camunda.search.clients;
 
 import io.camunda.search.entities.SequenceFlowEntity;
+import io.camunda.search.query.SearchQueryResult;
 import io.camunda.search.query.SequenceFlowQuery;
 import io.camunda.security.auth.SecurityContext;
-import java.util.List;
 
 public interface SequenceFlowSearchClient {
 
-  List<SequenceFlowEntity> findAllSequenceFlows(SequenceFlowQuery filter);
+  SearchQueryResult<SequenceFlowEntity> searchSequenceFlows(SequenceFlowQuery filter);
 
   SequenceFlowSearchClient withSecurityContext(SecurityContext securityContext);
 }

--- a/search/search-client/src/main/java/io/camunda/search/clients/TenantSearchClient.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/TenantSearchClient.java
@@ -12,14 +12,11 @@ import io.camunda.search.entities.TenantMemberEntity;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.search.query.TenantQuery;
 import io.camunda.security.auth.SecurityContext;
-import java.util.List;
 
 public interface TenantSearchClient {
   SearchQueryResult<TenantEntity> searchTenants(TenantQuery filter);
 
   SearchQueryResult<TenantMemberEntity> searchTenantMembers(TenantQuery filter);
-
-  List<TenantEntity> findAllTenants(TenantQuery query);
 
   TenantSearchClient withSecurityContext(SecurityContext securityContext);
 }

--- a/search/search-client/src/main/java/io/camunda/search/clients/impl/NoopSearchClientsProxy.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/impl/NoopSearchClientsProxy.java
@@ -69,11 +69,6 @@ public class NoopSearchClientsProxy implements SearchClientsProxy {
   }
 
   @Override
-  public List<AuthorizationEntity> findAllAuthorizations(final AuthorizationQuery filter) {
-    return List.of();
-  }
-
-  @Override
   public SearchQueryResult<BatchOperationEntity> searchBatchOperations(
       final BatchOperationQuery query) {
     return SearchQueryResult.empty();
@@ -125,11 +120,6 @@ public class NoopSearchClientsProxy implements SearchClientsProxy {
   }
 
   @Override
-  public List<GroupEntity> findAllGroups(final GroupQuery query) {
-    return List.of();
-  }
-
-  @Override
   public SearchQueryResult<IncidentEntity> searchIncidents(final IncidentQuery filter) {
     return SearchQueryResult.empty();
   }
@@ -137,11 +127,6 @@ public class NoopSearchClientsProxy implements SearchClientsProxy {
   @Override
   public SearchQueryResult<MappingEntity> searchMappings(final MappingQuery filter) {
     return SearchQueryResult.empty();
-  }
-
-  @Override
-  public List<MappingEntity> findAllMappings(final MappingQuery query) {
-    return List.of();
   }
 
   @Override
@@ -179,11 +164,6 @@ public class NoopSearchClientsProxy implements SearchClientsProxy {
   }
 
   @Override
-  public List<RoleEntity> findAllRoles(final RoleQuery filter) {
-    return List.of();
-  }
-
-  @Override
   public SearchQueryResult<TenantEntity> searchTenants(final TenantQuery filter) {
     return SearchQueryResult.empty();
   }
@@ -191,11 +171,6 @@ public class NoopSearchClientsProxy implements SearchClientsProxy {
   @Override
   public SearchQueryResult<TenantMemberEntity> searchTenantMembers(final TenantQuery filter) {
     return SearchQueryResult.empty();
-  }
-
-  @Override
-  public List<TenantEntity> findAllTenants(final TenantQuery query) {
-    return List.of();
   }
 
   @Override
@@ -214,8 +189,8 @@ public class NoopSearchClientsProxy implements SearchClientsProxy {
   }
 
   @Override
-  public List<SequenceFlowEntity> findAllSequenceFlows(final SequenceFlowQuery filter) {
-    return List.of();
+  public SearchQueryResult<SequenceFlowEntity> searchSequenceFlows(final SequenceFlowQuery filter) {
+    return SearchQueryResult.empty();
   }
 
   @Override

--- a/search/search-domain/src/main/java/io/camunda/search/exception/ErrorMessages.java
+++ b/search/search-domain/src/main/java/io/camunda/search/exception/ErrorMessages.java
@@ -33,4 +33,7 @@ public class ErrorMessages {
   public static final String ERROR_NOT_UNIQUE_ENTITY = "Found %s with key %s more than once";
   public static final String ERROR_NOT_UNIQUE_FORM = "Found form with key %d more than once";
   public static final String ERROR_NOT_UNIQUE_TENANT = "Found multiple tenants matching %s";
+
+  public static final String ERROR_QUERY_MAX_BATCH_SIZE_EXCEEDS_LIMIT =
+      "Given query max batch %d exceeds the limit of %d";
 }

--- a/search/search-domain/src/main/java/io/camunda/search/page/SearchQueryPage.java
+++ b/search/search-domain/src/main/java/io/camunda/search/page/SearchQueryPage.java
@@ -10,13 +10,15 @@ package io.camunda.search.page;
 import io.camunda.util.ObjectBuilder;
 import java.util.function.Function;
 
-public record SearchQueryPage(Integer from, Integer size, String after, String before) {
+public record SearchQueryPage(
+    Integer from, Integer size, String after, String before, SearchQueryResultType resultType) {
 
   public static final Integer DEFAULT_FROM = 0;
   public static final Integer DEFAULT_SIZE = 100;
 
-  public static final SearchQueryPage DEFAULT = new Builder().build();
-  public static final SearchQueryPage NO_ENTITIES_QUERY = new SearchQueryPage(0, 0, null, null);
+  public static final SearchQueryPage DEFAULT = of(b -> b);
+  public static final SearchQueryPage NO_ENTITIES_QUERY =
+      of(b -> b.from(0).size(0).after(null).before(null));
 
   public boolean isNextPage() {
     return after != null || !isPreviousPage();
@@ -74,7 +76,13 @@ public record SearchQueryPage(Integer from, Integer size, String after, String b
     public SearchQueryPage build() {
       final var sanitizedFrom = (from == null) ? DEFAULT_FROM : Math.max(0, from);
       final var sanitizedSize = (size == null) ? DEFAULT_SIZE : Math.max(0, size);
-      return new SearchQueryPage(sanitizedFrom, sanitizedSize, after, before);
+      return new SearchQueryPage(
+          sanitizedFrom, sanitizedSize, after, before, SearchQueryResultType.PAGINATED);
     }
+  }
+
+  public enum SearchQueryResultType {
+    UNLIMITED,
+    PAGINATED
   }
 }

--- a/search/search-domain/src/main/java/io/camunda/search/query/SearchQueryBase.java
+++ b/search/search-domain/src/main/java/io/camunda/search/query/SearchQueryBase.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.search.query;
 
+import static io.camunda.search.page.SearchQueryPage.SearchQueryResultType.UNLIMITED;
+
 import io.camunda.search.page.SearchQueryPage;
 import io.camunda.search.page.SearchQueryPageBuilders;
 import io.camunda.util.ObjectBuilder;
@@ -27,6 +29,11 @@ public interface SearchQueryBase {
 
     protected SearchQueryPage page() {
       return Objects.requireNonNullElse(page, DEFAULT_PAGE);
+    }
+
+    public T unlimited() {
+      page(new SearchQueryPage(0, 0, null, null, UNLIMITED));
+      return self();
     }
 
     public T page(final SearchQueryPage value) {

--- a/search/search-domain/src/main/java/io/camunda/search/query/SearchQueryResult.java
+++ b/search/search-domain/src/main/java/io/camunda/search/query/SearchQueryResult.java
@@ -11,9 +11,15 @@ import io.camunda.util.ObjectBuilder;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.function.Function;
 
 public record SearchQueryResult<T>(
     long total, boolean hasMoreTotalItems, List<T> items, String startCursor, String endCursor) {
+
+  public static <T> SearchQueryResult<T> of(
+      final Function<SearchQueryResult.Builder<T>, SearchQueryResult.Builder<T>> builderFunction) {
+    return builderFunction.apply(new Builder<>()).build();
+  }
 
   public static <T> SearchQueryResult<T> empty() {
     return new SearchQueryResult<>(0, false, Collections.emptyList(), null, null);

--- a/service/src/main/java/io/camunda/service/GroupServices.java
+++ b/service/src/main/java/io/camunda/service/GroupServices.java
@@ -47,11 +47,13 @@ public class GroupServices extends SearchQueryService<GroupServices, GroupQuery,
 
   public List<GroupEntity> getGroupsByMemberTypeAndMemberIds(
       final Map<EntityType, Set<String>> memberTypesToMemberIds) {
-    return findAll(
-        GroupQuery.of(
-            groupQuery ->
-                groupQuery.filter(
-                    groupFilter -> groupFilter.memberIdsByType(memberTypesToMemberIds))));
+    return search(
+            GroupQuery.of(
+                groupQuery ->
+                    groupQuery
+                        .filter(groupFilter -> groupFilter.memberIdsByType(memberTypesToMemberIds))
+                        .unlimited()))
+        .items();
   }
 
   @Override
@@ -61,14 +63,6 @@ public class GroupServices extends SearchQueryService<GroupServices, GroupQuery,
             securityContextProvider.provideSecurityContext(
                 authentication, Authorization.of(a -> a.group().read())))
         .searchGroups(query);
-  }
-
-  public List<GroupEntity> findAll(final GroupQuery query) {
-    return groupSearchClient
-        .withSecurityContext(
-            securityContextProvider.provideSecurityContext(
-                authentication, Authorization.of(a -> a.group().read())))
-        .findAllGroups(query);
   }
 
   @Override
@@ -111,18 +105,18 @@ public class GroupServices extends SearchQueryService<GroupServices, GroupQuery,
   }
 
   public List<GroupEntity> getGroupsByMemberId(final String memberId, final EntityType memberType) {
-    return findAll(
-        SearchQueryBuilders.groupSearchQuery()
-            .filter(f -> f.memberId(memberId).childMemberType(memberType))
-            .build());
+    return search(
+            GroupQuery.of(
+                b -> b.filter(f -> f.memberId(memberId).childMemberType(memberType)).unlimited()))
+        .items();
   }
 
   public List<GroupEntity> getGroupsByMemberIds(
       final Set<String> memberIds, final EntityType memberType) {
-    return findAll(
-        SearchQueryBuilders.groupSearchQuery()
-            .filter(f -> f.memberIds(memberIds).childMemberType(memberType))
-            .build());
+    return search(
+            GroupQuery.of(
+                b -> b.filter(f -> f.memberIds(memberIds).childMemberType(memberType)).unlimited()))
+        .items();
   }
 
   public Optional<GroupEntity> findGroup(final String groupId) {

--- a/service/src/main/java/io/camunda/service/MappingServices.java
+++ b/service/src/main/java/io/camunda/service/MappingServices.java
@@ -24,7 +24,6 @@ import io.camunda.zeebe.gateway.impl.broker.request.BrokerMappingCreateRequest;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerMappingDeleteRequest;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerMappingUpdateRequest;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.MappingRecord;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -51,14 +50,6 @@ public class MappingServices
             securityContextProvider.provideSecurityContext(
                 authentication, Authorization.of(a -> a.mapping().read())))
         .searchMappings(query);
-  }
-
-  public List<MappingEntity> findAll(final MappingQuery query) {
-    return mappingSearchClient
-        .withSecurityContext(
-            securityContextProvider.provideSecurityContext(
-                authentication, Authorization.of(a -> a.mapping().read())))
-        .findAllMappings(query);
   }
 
   @Override
@@ -118,7 +109,8 @@ public class MappingServices
   }
 
   public Stream<MappingEntity> getMatchingMappings(final Map<String, Object> claims) {
-    return MappingRuleMatcher.matchingRules(findAll(MappingQuery.of(q -> q)).stream(), claims);
+    return MappingRuleMatcher.matchingRules(
+        search(MappingQuery.of(q -> q.unlimited())).items().stream(), claims);
   }
 
   public record MappingDTO(String claimName, String claimValue, String name, String mappingId) {}

--- a/service/src/main/java/io/camunda/service/ProcessInstanceServices.java
+++ b/service/src/main/java/io/camunda/service/ProcessInstanceServices.java
@@ -147,8 +147,10 @@ public final class ProcessInstanceServices
         .withSecurityContext(
             securityContextProvider.provideSecurityContext(
                 authentication, Authorization.of(a -> a.processDefinition().readProcessInstance())))
-        .findAllSequenceFlows(
-            SequenceFlowQuery.of(b -> b.filter(f -> f.processInstanceKey(processInstanceKey))));
+        .searchSequenceFlows(
+            SequenceFlowQuery.of(
+                b -> b.filter(f -> f.processInstanceKey(processInstanceKey)).unlimited()))
+        .items();
   }
 
   public ProcessInstanceEntity getByKey(final Long processInstanceKey) {

--- a/service/src/main/java/io/camunda/service/RoleServices.java
+++ b/service/src/main/java/io/camunda/service/RoleServices.java
@@ -79,22 +79,28 @@ public class RoleServices extends SearchQueryService<RoleServices, RoleQuery, Ro
 
   public List<RoleEntity> getRolesByMemberIds(
       final Set<String> memberIds, final EntityType entityType) {
-    return findAll(
-        RoleQuery.of(q -> q.filter(f -> f.memberIds(memberIds).childMemberType(entityType))));
+    return search(
+            RoleQuery.of(
+                q -> q.filter(f -> f.memberIds(memberIds).childMemberType(entityType)).unlimited()))
+        .items();
   }
 
   public List<RoleEntity> getRolesByMemberId(final String memberId, final EntityType entityType) {
-    return findAll(
-        RoleQuery.of(q -> q.filter(f -> f.memberId(memberId).childMemberType(entityType))));
+    return search(
+            RoleQuery.of(
+                q -> q.filter(f -> f.memberId(memberId).childMemberType(entityType)).unlimited()))
+        .items();
   }
 
   public List<RoleEntity> getRolesByMemberTypeAndMemberIds(
       final Map<EntityType, Set<String>> memberTypesToMemberIds) {
-    return findAll(
-        RoleQuery.of(
-            roleQuery ->
-                roleQuery.filter(
-                    roleFilter -> roleFilter.memberIdsByType(memberTypesToMemberIds))));
+    return search(
+            RoleQuery.of(
+                roleQuery ->
+                    roleQuery
+                        .filter(roleFilter -> roleFilter.memberIdsByType(memberTypesToMemberIds))
+                        .unlimited()))
+        .items();
   }
 
   public List<RoleEntity> getRolesByUserAndGroups(
@@ -104,14 +110,6 @@ public class RoleServices extends SearchQueryService<RoleServices, RoleQuery, Ro
 
     roles.addAll(groupRoles);
     return roles.stream().distinct().toList();
-  }
-
-  public List<RoleEntity> findAll(final RoleQuery query) {
-    return roleSearchClient
-        .withSecurityContext(
-            securityContextProvider.provideSecurityContext(
-                authentication, Authorization.of(a -> a.role().read())))
-        .findAllRoles(query);
   }
 
   @Override

--- a/service/src/main/java/io/camunda/service/TenantServices.java
+++ b/service/src/main/java/io/camunda/service/TenantServices.java
@@ -63,14 +63,6 @@ public class TenantServices extends SearchQueryService<TenantServices, TenantQue
         .searchTenantMembers(query);
   }
 
-  public List<TenantEntity> findAll(final TenantQuery query) {
-    return tenantSearchClient
-        .withSecurityContext(
-            securityContextProvider.provideSecurityContext(
-                authentication, Authorization.of(a -> a.tenant().read())))
-        .findAllTenants(query);
-  }
-
   @Override
   public TenantServices withAuthentication(final CamundaAuthentication authentication) {
     return new TenantServices(
@@ -112,8 +104,10 @@ public class TenantServices extends SearchQueryService<TenantServices, TenantQue
 
   public List<TenantEntity> getTenantsByMemberIds(
       final Set<String> memberIds, final EntityType memberType) {
-    return findAll(
-        TenantQuery.of(q -> q.filter(b -> b.memberIds(memberIds).childMemberType(memberType))));
+    return search(
+            TenantQuery.of(
+                q -> q.filter(b -> b.memberIds(memberIds).childMemberType(memberType)).unlimited()))
+        .items();
   }
 
   public List<TenantEntity> getTenantsByUserAndGroupsAndRoles(
@@ -140,7 +134,10 @@ public class TenantServices extends SearchQueryService<TenantServices, TenantQue
 
   public List<TenantEntity> getTenantsByMemberTypeAndMemberIds(
       final Map<EntityType, Set<String>> memberTypesToMemberIds) {
-    return findAll(TenantQuery.of(q -> q.filter(f -> f.memberIdsByType(memberTypesToMemberIds))));
+    return search(
+            TenantQuery.of(
+                q -> q.filter(f -> f.memberIdsByType(memberTypesToMemberIds)).unlimited()))
+        .items();
   }
 
   public TenantEntity getById(final String tenantId) {

--- a/service/src/test/java/io/camunda/service/MappingServicesTest.java
+++ b/service/src/test/java/io/camunda/service/MappingServicesTest.java
@@ -49,13 +49,16 @@ public class MappingServicesTest {
   private MappingSearchClient client;
   private CamundaAuthentication authentication;
   private StubbedBrokerClient stubbedBrokerClient;
+  private SearchQueryResult<MappingEntity> result;
 
   @BeforeEach
   public void before() {
     authentication = CamundaAuthentication.of(builder -> builder.user("foo"));
     stubbedBrokerClient = new StubbedBrokerClient();
     client = mock(MappingSearchClient.class);
+    result = mock(SearchQueryResult.class);
     when(client.withSecurityContext(any())).thenReturn(client);
+    when(client.searchMappings(any())).thenReturn(result);
     mappingDeleteRequestArgumentCaptor = ArgumentCaptor.forClass(BrokerMappingDeleteRequest.class);
     mappingUpdateRequestArgumentCaptor = ArgumentCaptor.forClass(BrokerMappingUpdateRequest.class);
     services =
@@ -206,7 +209,7 @@ public class MappingServicesTest {
     services.getMatchingMappings(claims);
     // then
     final ArgumentCaptor<MappingQuery> queryCaptor = ArgumentCaptor.forClass(MappingQuery.class);
-    verify(client, times(1)).findAllMappings(queryCaptor.capture());
+    verify(client, times(1)).searchMappings(queryCaptor.capture());
     final MappingQuery query = queryCaptor.getValue();
     assertThat(query.filter().claimName()).isNull();
     assertThat(query.filter().claimValue()).isNull();

--- a/service/src/test/java/io/camunda/service/ProcessInstanceServiceTest.java
+++ b/service/src/test/java/io/camunda/service/ProcessInstanceServiceTest.java
@@ -103,19 +103,24 @@ public final class ProcessInstanceServiceTest {
   @Test
   public void shouldReturnProcessInstanceSequenceFlows() {
     // given
-    final var result =
-        List.of(
-            new SequenceFlowEntity("pi1_sequenceFlow1", "node1", 1L, 1L, "pd1", "<default>"),
-            new SequenceFlowEntity("pi1_sequenceFlow2", "node1", 1L, 1L, "pd1", "<default>"));
-    when(sequenceFlowSearchClient.findAllSequenceFlows(any())).thenReturn(result);
+    final SearchQueryResult<SequenceFlowEntity> result =
+        SearchQueryResult.of(
+            r ->
+                r.items(
+                    List.of(
+                        new SequenceFlowEntity(
+                            "pi1_sequenceFlow1", "node1", 1L, 1L, "pd1", "<default>"),
+                        new SequenceFlowEntity(
+                            "pi1_sequenceFlow2", "node1", 1L, 1L, "pd1", "<default>"))));
+    when(sequenceFlowSearchClient.searchSequenceFlows(any())).thenReturn(result);
 
     // when
     final var actual = services.sequenceFlows(123L);
 
     // then
     verify(sequenceFlowSearchClient)
-        .findAllSequenceFlows(SequenceFlowQuery.of(q -> q.filter(f -> f.processInstanceKey(123L))));
-    assertThat(actual).isEqualTo(result);
+        .searchSequenceFlows(SequenceFlowQuery.of(q -> q.filter(f -> f.processInstanceKey(123L))));
+    assertThat(actual).isEqualTo(result.items());
   }
 
   @Test

--- a/service/src/test/java/io/camunda/service/RoleServicesTest.java
+++ b/service/src/test/java/io/camunda/service/RoleServicesTest.java
@@ -190,14 +190,20 @@ public class RoleServicesTest {
     final var memberId = "memberId";
     final var memberType = EntityType.USER;
     final var roleEntity = mock(RoleEntity.class);
-    when(client.findAllRoles(
-            RoleQuery.of(q -> q.filter(f -> f.memberId(memberId).childMemberType(memberType)))))
-        .thenReturn(List.of(roleEntity));
+    when(client.searchRoles(
+            RoleQuery.of(
+                q -> q.filter(f -> f.memberId(memberId).childMemberType(memberType)).unlimited())))
+        .thenReturn(SearchQueryResult.of(r -> r.items(List.of(roleEntity))));
 
     // when
     final var result =
-        services.findAll(
-            RoleQuery.of(q -> q.filter(f -> f.memberId(memberId).childMemberType(memberType))));
+        services
+            .search(
+                RoleQuery.of(
+                    q ->
+                        q.filter(f -> f.memberId(memberId).childMemberType(memberType))
+                            .unlimited()))
+            .items();
 
     // then
     assertThat(result).isEqualTo(List.of(roleEntity));


### PR DESCRIPTION
## Description

* Replaces the `DocumentBasedSearchClient#findAll()` with a dedicated `#unlimited()` flag provided with the actual query.
* Meaning, when constructing a search query, either `#page()` can specify which page to load, or `#unlimited()` can load all entities at once.
```
RoleQuery.of(q -> q
  .filter(f -> f.memberId(memberId).childMemberType(entityType))
  .unlimited())
```
* That way, it is no longer necessary to implement a `#findAll()` handling for any entity.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

related to #34975
