### PR TITLE
fix: moved default port of camunda to 8088

### DIFF
--- a/c8run/cmd/c8run/main.go
+++ b/c8run/cmd/c8run/main.go
@@ -157,7 +157,7 @@ func createStartFlagSet(settings *types.C8RunSettings) *flag.FlagSet {
 	startFlagSet := flag.NewFlagSet("start", flag.ExitOnError)
 	startFlagSet.StringVar(&settings.Config, "config", "", "Applies the specified configuration file.")
 	startFlagSet.BoolVar(&settings.Detached, "detached", false, "Starts Camunda Run as a detached process")
-	startFlagSet.IntVar(&settings.Port, "port", 8080, "Port to run Camunda on")
+	startFlagSet.IntVar(&settings.Port, "port", 8088, "Port to run Camunda on")
 	startFlagSet.StringVar(&settings.Keystore, "keystore", "", "Provide a JKS filepath to enable TLS")
 	startFlagSet.StringVar(&settings.KeystorePassword, "keystorePassword", "", "Provide a password to unlock your JKS keystore")
 	startFlagSet.StringVar(&settings.LogLevel, "log-level", "", "Adjust the log level of Camunda")

--- a/c8run/cmd/c8run/main_test.go
+++ b/c8run/cmd/c8run/main_test.go
@@ -8,110 +8,111 @@
 package main
 
 import (
-	"strings"
-	"testing"
+    "strings"
+    "testing"
 
-	"context"
+    "context"
+    "strconv"
 
-	"github.com/camunda/camunda/c8run/internal/overrides"
-	"github.com/camunda/camunda/c8run/internal/types"
-	"github.com/stretchr/testify/assert"
+    "github.com/camunda/camunda/c8run/internal/overrides"
+    "github.com/camunda/camunda/c8run/internal/types"
+    "github.com/stretchr/testify/assert"
 )
 
 func TestCamundaCmdWithKeystoreSettings(t *testing.T) {
-	settings := types.C8RunSettings{
-		Config:           "",
-		Detached:         false,
-		Port:             8080,
-		Keystore:         "/tmp/camundatest/certs/secret.jks",
-		KeystorePassword: "changeme",
-	}
-	expectedJavaOpts := "JAVA_OPTS= -Dserver.ssl.keystore=file:" + settings.Keystore + " -Dserver.ssl.enabled=true" + " -Dserver.ssl.key-password=" + settings.KeystorePassword + " -Dcamunda.security.authentication.unprotected-api=true" + " -Dcamunda.security.authorizations.enabled=false" + " -Dspring.profiles.active=operate,tasklist,broker,identity,consolidated-auth"
+    settings := types.C8RunSettings{
+        Config:           "",
+        Detached:         false,
+        Port:             8088,
+        Keystore:         "/tmp/camundatest/certs/secret.jks",
+        KeystorePassword: "changeme",
+    }
+    expectedJavaOpts := "JAVA_OPTS= -Dserver.ssl.keystore=file:" + settings.Keystore + " -Dserver.ssl.enabled=true" + " -Dserver.ssl.key-password=" + settings.KeystorePassword + " -Dserver.port=" + strconv.Itoa(settings.Port) + " -Dcamunda.security.authentication.unprotected-api=true" + " -Dcamunda.security.authorizations.enabled=false" + " -Dspring.profiles.active=operate,tasklist,broker,identity,consolidated-auth"
 
-	javaOpts := overrides.AdjustJavaOpts("", settings)
-	c8runPlatform := getC8RunPlatform()
-	err := validateKeystore(settings, "/tmp/camundatest/")
-	assert.Nil(t, err)
+    javaOpts := overrides.AdjustJavaOpts("", settings)
+    c8runPlatform := getC8RunPlatform()
+    err := validateKeystore(settings, "/tmp/camundatest/")
+    assert.Nil(t, err)
 
-	cmd := c8runPlatform.CamundaCmd(context.Background(), "8.7.0", "/tmp/camundatest/", "", javaOpts)
+    cmd := c8runPlatform.CamundaCmd(context.Background(), "8.7.0", "/tmp/camundatest/", "", javaOpts)
 
-	foundVar := ""
-	for _, envVar := range cmd.Env {
-		if strings.Contains(envVar, "JAVA_OPTS") {
-			foundVar = envVar
-			break
-		}
-	}
-	assert.Equal(t, expectedJavaOpts, foundVar)
+    foundVar := ""
+    for _, envVar := range cmd.Env {
+        if strings.Contains(envVar, "JAVA_OPTS") {
+            foundVar = envVar
+            break
+        }
+    }
+    assert.Equal(t, expectedJavaOpts, foundVar)
 }
 
 func TestCamundaCmdKeystoreRequiresPassword(t *testing.T) {
-	settings := types.C8RunSettings{
-		Config:           "",
-		Detached:         false,
-		Port:             8080,
-		Keystore:         "/tmp/camundatest/certs/secret.jks",
-		KeystorePassword: "",
-	}
-	err := validateKeystore(settings, "/tmp/camundatest/")
+    settings := types.C8RunSettings{
+        Config:           "",
+        Detached:         false,
+        Port:             8088,
+        Keystore:         "/tmp/camundatest/certs/secret.jks",
+        KeystorePassword: "",
+    }
+    err := validateKeystore(settings, "/tmp/camundatest/")
 
-	assert.NotNil(t, err)
-	assert.Error(t, err, "You must provide a password with --keystorePassword to unlock your keystore.")
+    assert.NotNil(t, err)
+    assert.Error(t, err, "You must provide a password with --keystorePassword to unlock your keystore.")
 }
 
 func TestCamundaCmdDifferentPort(t *testing.T) {
-	settings := types.C8RunSettings{
-		Port: 8087,
-	}
-	javaOpts := overrides.AdjustJavaOpts("", settings)
-	c8runPlatform := getC8RunPlatform()
+    settings := types.C8RunSettings{
+        Port: 8087,
+    }
+    javaOpts := overrides.AdjustJavaOpts("", settings)
+    c8runPlatform := getC8RunPlatform()
 
-	cmd := c8runPlatform.CamundaCmd(context.Background(), "8.7.0", "/tmp/camundatest/", "", javaOpts)
+    cmd := c8runPlatform.CamundaCmd(context.Background(), "8.7.0", "/tmp/camundatest/", "", javaOpts)
 
-	javaOptsEnvVar := ""
-	for _, envVar := range cmd.Env {
-		if strings.Contains(envVar, "JAVA_OPTS") {
-			javaOptsEnvVar = envVar
-			break
-		}
-	}
-	assert.Contains(t, javaOptsEnvVar, "-Dserver.port=8087")
+    javaOptsEnvVar := ""
+    for _, envVar := range cmd.Env {
+        if strings.Contains(envVar, "JAVA_OPTS") {
+            javaOptsEnvVar = envVar
+            break
+        }
+    }
+    assert.Contains(t, javaOptsEnvVar, "-Dserver.port=8087")
 }
 
 func TestCamundaCmdUsername(t *testing.T) {
-	settings := types.C8RunSettings{
-		Username: "admin",
-	}
-	javaOpts := overrides.AdjustJavaOpts("", settings)
-	c8runPlatform := getC8RunPlatform()
+    settings := types.C8RunSettings{
+        Username: "admin",
+    }
+    javaOpts := overrides.AdjustJavaOpts("", settings)
+    c8runPlatform := getC8RunPlatform()
 
-	cmd := c8runPlatform.CamundaCmd(context.Background(), "8.7.0", "/tmp/camundatest/", "", javaOpts)
+    cmd := c8runPlatform.CamundaCmd(context.Background(), "8.7.0", "/tmp/camundatest/", "", javaOpts)
 
-	javaOptsEnvVar := ""
-	for _, envVar := range cmd.Env {
-		if strings.Contains(envVar, "JAVA_OPTS") {
-			javaOptsEnvVar = envVar
-			break
-		}
-	}
-	assert.Contains(t, javaOptsEnvVar, "-Dcamunda.security.initialization.users[0].username=admin")
+    javaOptsEnvVar := ""
+    for _, envVar := range cmd.Env {
+        if strings.Contains(envVar, "JAVA_OPTS") {
+            javaOptsEnvVar = envVar
+            break
+        }
+    }
+    assert.Contains(t, javaOptsEnvVar, "-Dcamunda.security.initialization.users[0].username=admin")
 }
 
 func TestCamundaCmdPassword(t *testing.T) {
-	settings := types.C8RunSettings{
-		Password: "changeme",
-	}
-	javaOpts := overrides.AdjustJavaOpts("", settings)
-	c8runPlatform := getC8RunPlatform()
+    settings := types.C8RunSettings{
+        Password: "changeme",
+    }
+    javaOpts := overrides.AdjustJavaOpts("", settings)
+    c8runPlatform := getC8RunPlatform()
 
-	cmd := c8runPlatform.CamundaCmd(context.Background(), "8.7.0", "/tmp/camundatest/", "", javaOpts)
+    cmd := c8runPlatform.CamundaCmd(context.Background(), "8.7.0", "/tmp/camundatest/", "", javaOpts)
 
-	javaOptsEnvVar := ""
-	for _, envVar := range cmd.Env {
-		if strings.Contains(envVar, "JAVA_OPTS") {
-			javaOptsEnvVar = envVar
-			break
-		}
-	}
-	assert.Contains(t, javaOptsEnvVar, "-Dcamunda.security.initialization.users[0].password=changeme")
+    javaOptsEnvVar := ""
+    for _, envVar := range cmd.Env {
+        if strings.Contains(envVar, "JAVA_OPTS") {
+            javaOptsEnvVar = envVar
+            break
+        }
+    }
+    assert.Contains(t, javaOptsEnvVar, "-Dcamunda.security.initialization.users[0].password=changeme")
 }

--- a/c8run/connectors-application.properties
+++ b/c8run/connectors-application.properties
@@ -1,6 +1,6 @@
 zeebe.client.broker.gateway-address=http://127.0.0.1:26500
 zeebe.client.security.plaintext=true
-camunda.operate.client.url=http://localhost:8080
+camunda.operate.client.url=http://localhost:8088
 camunda.operate.client.username=demo
 camunda.operate.client.password=demo
 server.port=8086

--- a/c8run/connectors-application.properties
+++ b/c8run/connectors-application.properties
@@ -1,6 +1,4 @@
-zeebe.client.broker.gateway-address=http://127.0.0.1:26500
-zeebe.client.security.plaintext=true
-camunda.operate.client.url=http://localhost:8088
-camunda.operate.client.username=demo
-camunda.operate.client.password=demo
+camunda.client.grpc-address=http://127.0.0.1:26500
+camunda.client.rest-address=http://127.0.0.1:26500
+camunda.client.auth.method=basic
 server.port=8086

--- a/c8run/connectors-application.properties
+++ b/c8run/connectors-application.properties
@@ -1,4 +1,4 @@
 camunda.client.grpc-address=http://127.0.0.1:26500
-camunda.client.rest-address=http://127.0.0.1:26500
+camunda.client.rest-address=http://127.0.0.1:8088
 camunda.client.auth.method=basic
 server.port=8086

--- a/c8run/e2e_tests/api_tests.sh
+++ b/c8run/e2e_tests/api_tests.sh
@@ -2,7 +2,7 @@
 
 printf "\nTest: Operate process instance api\n"
 
-curl -f -L -X POST 'http://localhost:8080/v2/process-instances/search' \
+curl -f -L -X POST 'http://localhost:8088/v2/process-instances/search' \
         -H 'Content-Type: application/json' \
         -H 'Accept: application/json' \
         --data-raw '{
@@ -20,7 +20,7 @@ if [[ "$returnCode" != 0 ]]; then
 fi
 
 printf "\nTest: Tasklist user task\n"
-curl -f -L -X POST 'http://localhost:8080/v2/user-tasks/search' \
+curl -f -L -X POST 'http://localhost:8088/v2/user-tasks/search' \
         -H 'Content-Type: application/json' \
         -H 'Accept: application/json' \
         --data-raw '{}'
@@ -33,7 +33,7 @@ if [[ "$returnCode" != 0 ]]; then
 fi
 
 printf "\nTest: Zeebe topology endpoint\n"
-curl localhost:8080/v2/topology
+curl localhost:8088/v2/topology
 
 returnCode=$?
 if [[ "$returnCode" != 0 ]]; then

--- a/c8run/e2e_tests/tests/operate_login.spec.ts
+++ b/c8run/e2e_tests/tests/operate_login.spec.ts
@@ -3,7 +3,7 @@ const playwright = require('playwright');
 
 test('test', async ({ page }) => {
   test.setTimeout(60000);
-  await page.goto('http://localhost:8080/operate');
+  await page.goto('http://localhost:8088/operate');
   await page.getByPlaceholder('Username').click();
   await page.getByPlaceholder('Username').fill('demo');
   await page.getByPlaceholder('Username').press('Tab');

--- a/c8run/e2e_tests/tests/tasklist_login.spec.ts
+++ b/c8run/e2e_tests/tests/tasklist_login.spec.ts
@@ -3,7 +3,7 @@ const playwright = require('playwright');
 
 test('test', async ({ page }) => {
   test.setTimeout(60000);
-  await page.goto('http://localhost:8080/tasklist');
+  await page.goto('http://localhost:8088/tasklist');
   await page.getByPlaceholder('Username').click();
   await page.getByPlaceholder('Username').fill('demo');
   await page.getByPlaceholder('Username').press('Tab');

--- a/c8run/internal/health/camunda.go
+++ b/c8run/internal/health/camunda.go
@@ -88,7 +88,7 @@ func isRunning(ctx context.Context, name, url string, retries int, delay time.Du
 }
 
 func PrintStatus(settings types.C8RunSettings) error {
-	operatePort, tasklistPort, identityPort, camundaPort := 8080, 8080, 8080, 8080
+	operatePort, tasklistPort, identityPort, camundaPort := 8088, 8088, 8088, 8088
 
 	// Overwrite ports if Docker is enabled
 	if settings.Docker {

--- a/clients/camunda-spring-boot-starter/src/test/java/io/camunda/spring/client/config/CamundaClientConfigurationDefaultPropertiesTest.java
+++ b/clients/camunda-spring-boot-starter/src/test/java/io/camunda/spring/client/config/CamundaClientConfigurationDefaultPropertiesTest.java
@@ -68,7 +68,7 @@ public class CamundaClientConfigurationDefaultPropertiesTest {
     assertThat(configuration.getMaxMetadataSize()).isEqualTo(16 * ONE_KB);
     assertThat(configuration.getNumJobWorkerExecutionThreads()).isEqualTo(1);
     assertThat(configuration.getOverrideAuthority()).isNull();
-    assertThat(configuration.getRestAddress()).isEqualTo(new URI("http://0.0.0.0:8080"));
+    assertThat(configuration.getRestAddress()).isEqualTo(new URI("http://0.0.0.0:8088"));
     assertThat(configuration.preferRestOverGrpc()).isTrue();
   }
 }

--- a/clients/camunda-spring-boot-starter/src/test/java/io/camunda/spring/client/config/legacy/CamundaClientStarterAutoConfigurationCustomJsonMapperTest.java
+++ b/clients/camunda-spring-boot-starter/src/test/java/io/camunda/spring/client/config/legacy/CamundaClientStarterAutoConfigurationCustomJsonMapperTest.java
@@ -46,7 +46,7 @@ import org.springframework.test.util.ReflectionTestUtils;
     properties = {
       "zeebe.client.broker.gatewayAddress=localhost:1234",
       "zeebe.client.broker.grpcAddress=https://localhost:1234",
-      "zeebe.client.broker.restAddress=https://localhost:8080",
+      "zeebe.client.broker.restAddress=https://localhost:8088",
       "zeebe.client.requestTimeout=99s",
       "zeebe.client.job.timeout=99s",
       "zeebe.client.job.pollInterval=99s",
@@ -110,7 +110,7 @@ public class CamundaClientStarterAutoConfigurationCustomJsonMapperTest {
     assertThat(clientJsonMapper).isSameAs(applicationContext.getBean("overridingJsonMapper"));
     assertThat(configuration.getGatewayAddress()).isEqualTo("localhost:1234");
     assertThat(configuration.getGrpcAddress().toString()).isEqualTo("https://localhost:1234");
-    assertThat(configuration.getRestAddress().toString()).isEqualTo("https://localhost:8080");
+    assertThat(configuration.getRestAddress().toString()).isEqualTo("https://localhost:8088");
     assertThat(configuration.getDefaultRequestTimeout()).isEqualTo(Duration.ofSeconds(99));
     assertThat(configuration.getCaCertificatePath()).isEqualTo("aPath");
     assertThat(configuration.isPlaintextConnectionEnabled())

--- a/clients/camunda-spring-boot-starter/src/test/java/io/camunda/spring/client/config/legacy/CamundaClientStarterAutoConfigurationTest.java
+++ b/clients/camunda-spring-boot-starter/src/test/java/io/camunda/spring/client/config/legacy/CamundaClientStarterAutoConfigurationTest.java
@@ -45,7 +45,7 @@ import org.springframework.test.util.ReflectionTestUtils;
     properties = {
       "zeebe.client.broker.gatewayAddress=localhost:1234",
       "zeebe.client.broker.grpcAddress=https://localhost:1234",
-      "zeebe.client.broker.restAddress=https://localhost:8080",
+      "zeebe.client.broker.restAddress=https://localhost:8088",
       "zeebe.client.requestTimeout=99s",
       "zeebe.client.job.timeout=99s",
       "zeebe.client.job.pollInterval=99s",
@@ -104,7 +104,7 @@ public class CamundaClientStarterAutoConfigurationTest {
         applicationContext.getBean(CamundaClientConfiguration.class);
     assertThat(configuration.getGatewayAddress()).isEqualTo("localhost:1234");
     assertThat(configuration.getGrpcAddress().toString()).isEqualTo("https://localhost:1234");
-    assertThat(configuration.getRestAddress().toString()).isEqualTo("https://localhost:8080");
+    assertThat(configuration.getRestAddress().toString()).isEqualTo("https://localhost:8088");
     assertThat(configuration.getDefaultRequestTimeout()).isEqualTo(Duration.ofSeconds(99));
     assertThat(configuration.getCaCertificatePath()).isEqualTo("aPath");
     assertThat(configuration.isPlaintextConnectionEnabled()).isFalse(); // grpc address is https

--- a/clients/camunda-spring-boot-starter/src/test/java/io/camunda/spring/client/properties/CamundaClientPropertiesPostProcessorTest.java
+++ b/clients/camunda-spring-boot-starter/src/test/java/io/camunda/spring/client/properties/CamundaClientPropertiesPostProcessorTest.java
@@ -159,7 +159,7 @@ public class CamundaClientPropertiesPostProcessorTest {
             "zeebe.client.cloud.clientSecret=your-client-secret",
             "zeebe.client.cloud.authUrl=http://localhost:18081/auth/realms/your-realm/protocol/openid-connect/token",
             "zeebe.client.broker.grpcAddress=http://localhost:26500",
-            "zeebe.client.broker.restAddress=http://localhost:8080",
+            "zeebe.client.broker.restAddress=http://localhost:8088",
             "zeebe.client.security.plaintext=true"
           })
       @Nested
@@ -180,7 +180,7 @@ public class CamundaClientPropertiesPostProcessorTest {
         @Test
         void shouldReadClientRestAddress() {
           assertThat(camundaClientProperties.getRestAddress())
-              .isEqualTo(URI.create("http://localhost:8080"));
+              .isEqualTo(URI.create("http://localhost:8088"));
         }
 
         @Test
@@ -480,7 +480,7 @@ public class CamundaClientPropertiesPostProcessorTest {
         "camunda.client.auth.issuer=http://localhost:18081/auth/realms/camunda-platform/protocol/openid-connect/token",
         "camunda.client.zeebe.enabled=false",
         "camunda.client.zeebe.grpc-address=http://localhostaaa:26500",
-        "camunda.client.zeebe.rest-address=http://localhostaaa:8080",
+        "camunda.client.zeebe.rest-address=http://localhostaaa:8088",
         "camunda.client.zeebe.prefer-rest-over-grpc=true",
         "camunda.client.zeebe.audience=zeebe-api-lulu",
         "camunda.client.zeebe.scope=scope"
@@ -527,7 +527,7 @@ public class CamundaClientPropertiesPostProcessorTest {
         @Test
         void shouldReadZeebeRestAddress() {
           assertThat(camundaClientProperties.getRestAddress())
-              .isEqualTo(URI.create("http://localhostaaa:8080"));
+              .isEqualTo(URI.create("http://localhostaaa:8088"));
         }
 
         @Test
@@ -757,7 +757,7 @@ public class CamundaClientPropertiesPostProcessorTest {
         }
       }
 
-      @SpringBootTest({"camunda.client.zeebe.rest-address=http://localhostaaa:8080"})
+      @SpringBootTest({"camunda.client.zeebe.rest-address=http://localhostaaa:8088"})
       @Nested
       class RestAddress {
         @Autowired CamundaClientProperties camundaClientProperties;
@@ -765,7 +765,7 @@ public class CamundaClientPropertiesPostProcessorTest {
         @Test
         void shouldReadGrpcAddress() {
           assertThat(camundaClientProperties.getRestAddress())
-              .isEqualTo(URI.create("http://localhostaaa:8080"));
+              .isEqualTo(URI.create("http://localhostaaa:8088"));
         }
       }
     }
@@ -877,7 +877,7 @@ public class CamundaClientPropertiesPostProcessorTest {
         @Test
         void shouldReadZeebeRestAddress() {
           assertThat(camundaClientProperties.getRestAddress())
-              .isEqualTo(URI.create("http://localhost:8080"));
+              .isEqualTo(URI.create("http://localhost:8088"));
         }
 
         @Test

--- a/clients/camunda-spring-boot-starter/src/test/java/io/camunda/spring/client/properties/JavaClientPropertiesTest.java
+++ b/clients/camunda-spring-boot-starter/src/test/java/io/camunda/spring/client/properties/JavaClientPropertiesTest.java
@@ -39,7 +39,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
     properties = {
       "zeebe.client.gateway.address=localhost12345",
       "zeebe.client.broker.grpcAddress=https://localhost:1234",
-      "zeebe.client.broker.restAddress=https://localhost:8080",
+      "zeebe.client.broker.restAddress=https://localhost:8088",
       "zeebe.client.job.pollinterval=99s",
       "zeebe.client.worker.name=testName",
       "zeebe.client.cloud.secret=processOrchestration"
@@ -56,7 +56,7 @@ public class JavaClientPropertiesTest {
 
   @Test
   public void hasRestAddress() {
-    assertThat(properties.getRestAddress().toString()).isEqualTo("https://localhost:8080");
+    assertThat(properties.getRestAddress().toString()).isEqualTo("https://localhost:8088");
   }
 
   @Test
@@ -103,7 +103,7 @@ public class JavaClientPropertiesTest {
     void shouldThrowExceptionOnInvalidRestURI() {
       assertThatThrownBy(
               () -> {
-                new CamundaClientProperties().setRestAddress(new URI("invalid:8080"));
+                new CamundaClientProperties().setRestAddress(new URI("invalid:8088"));
               })
           .isInstanceOf(IllegalArgumentException.class)
           .hasMessageContaining("'restAddress' must be an absolute URI");

--- a/clients/camunda-spring-boot-starter/src/test/resources/properties/8.7/self-managed-extended.yaml
+++ b/clients/camunda-spring-boot-starter/src/test/resources/properties/8.7/self-managed-extended.yaml
@@ -9,7 +9,7 @@ camunda:
     zeebe:
       enabled: true
       grpc-address: http://localhost:26500
-      rest-address: http://localhost:8080
+      rest-address: http://localhost:8088
       prefer-rest-over-grpc: false
       scope: scope # optional
       audience: zeebe-api

--- a/clients/java/src/main/java/io/camunda/client/CamundaClientBuilder.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClientBuilder.java
@@ -61,14 +61,14 @@ public interface CamundaClientBuilder {
   /**
    * @param restAddress the REST API address of a gateway that the client can connect to. The
    *     address must be an absolute URL, including the scheme.
-   *     <p>The default value is {@code https://0.0.0.0:8080}.
+   *     <p>The default value is {@code http://0.0.0.0:8088}.
    */
   CamundaClientBuilder restAddress(URI restAddress);
 
   /**
    * @param grpcAddress the gRPC address of a gateway that the client can connect to. The address
    *     must be an absolute URL, including the scheme.
-   *     <p>The default value is {@code https://0.0.0.0:26500}.
+   *     <p>The default value is {@code http://0.0.0.0:26500}.
    */
   CamundaClientBuilder grpcAddress(URI grpcAddress);
 

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientBuilderImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientBuilderImpl.java
@@ -78,7 +78,7 @@ public final class CamundaClientBuilderImpl
   public static final String DEFAULT_GATEWAY_ADDRESS = "0.0.0.0:26500";
   public static final URI DEFAULT_GRPC_ADDRESS =
       getURIFromString("http://" + DEFAULT_GATEWAY_ADDRESS);
-  public static final URI DEFAULT_REST_ADDRESS = getURIFromString("http://0.0.0.0:8080");
+  public static final URI DEFAULT_REST_ADDRESS = getURIFromString("http://0.0.0.0:8088");
   public static final String DEFAULT_JOB_WORKER_NAME_VAR = "default";
   public static final Duration DEFAULT_MESSAGE_TTL = Duration.ofHours(1);
   public static final boolean DEFAULT_PREFER_REST_OVER_GRPC = true;

--- a/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClientBuilder.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClientBuilder.java
@@ -65,14 +65,14 @@ public interface ZeebeClientBuilder {
   /**
    * @param restAddress the REST API address of a gateway that the client can connect to. The
    *     address must be an absolute URL, including the scheme.
-   *     <p>The default value is {@code https://0.0.0.0:8080}.
+   *     <p>The default value is {@code http://0.0.0.0:8088}.
    */
   ZeebeClientBuilder restAddress(URI restAddress);
 
   /**
    * @param grpcAddress the gRPC address of a gateway that the client can connect to. The address
    *     must be an absolute URL, including the scheme.
-   *     <p>The default value is {@code https://0.0.0.0:26500}.
+   *     <p>The default value is {@code http://0.0.0.0:26500}.
    */
   ZeebeClientBuilder grpcAddress(URI grpcAddress);
 

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientBuilderImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientBuilderImpl.java
@@ -80,7 +80,7 @@ public final class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeCl
   public static final String DEFAULT_GATEWAY_ADDRESS = "0.0.0.0:26500";
   public static final URI DEFAULT_GRPC_ADDRESS =
       getURIFromString("http://" + DEFAULT_GATEWAY_ADDRESS);
-  public static final URI DEFAULT_REST_ADDRESS = getURIFromString("http://0.0.0.0:8080");
+  public static final URI DEFAULT_REST_ADDRESS = getURIFromString("http://0.0.0.0:8088");
   public static final String DEFAULT_JOB_WORKER_NAME_VAR = "default";
   public static final Duration DEFAULT_MESSAGE_TTL = Duration.ofHours(1);
   private static final String TENANT_ID_LIST_SEPARATOR = ",";


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR changes the default port of c8run to 8088 and also adjusts the default port of the java client.

Reason: There should only be 1 port to be used by all distributions for the same component.

The only question now is: Would it make sense to define a dedicated port for the application itself in the application.properties of the dist?

PS: I am flexible with the port number itself. This is just an alignment with what we started in 8.5 :)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
