### PR TITLE
docs: add demo user initialization variables to dev runtime configuration & contributing docs

### DIFF
--- a/.idea/runConfigurations/StandaloneCamunda_DEV.xml
+++ b/.idea/runConfigurations/StandaloneCamunda_DEV.xml
@@ -5,6 +5,11 @@
       <env name="ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_ARGS_CONNECT_URL" value="http://localhost:9200" />
       <env name="ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_ARGS_INDEX_SHOULDWAITFORIMPORTERS" value="false" />
       <env name="ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_CLASSNAME" value="io.camunda.exporter.CamundaExporter" />
+      <env name="CAMUNDA_SECURITY_INITIALIZATION_USERS_0_NAME" value="Demo" />
+      <env name="CAMUNDA_SECURITY_INITIALIZATION_USERS_0_USERNAME" value="demo" />
+      <env name="CAMUNDA_SECURITY_INITIALIZATION_USERS_0_EMAIL" value="demo@example.com" />
+      <env name="CAMUNDA_SECURITY_INITIALIZATION_USERS_0_PASSWORD" value="demo" />
+      <env name="CAMUNDA_SECURITY_INITIALIZATION_DEFAULTROLES_ADMIN_USERS_0_" value="demo" />
     </envs>
     <module name="camunda-zeebe" />
     <option name="SPRING_BOOT_MAIN_CLASS" value="io.camunda.application.StandaloneCamunda" />

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -240,8 +240,13 @@ You can run the Camunda distribution via IntelliJ for development purposes.
      ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_ARGS_CONNECT_URL=http://localhost:9200
      ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_ARGS_INDEX_SHOULDWAITFORIMPORTERS=false
      ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_CLASSNAME=io.camunda.exporter.CamundaExporter
+     CAMUNDA_SECURITY_INITIALIZATION_USERS_0_NAME=Demo
+     CAMUNDA_SECURITY_INITIALIZATION_USERS_0_USERNAME=demo
+     CAMUNDA_SECURITY_INITIALIZATION_USERS_0_EMAIL=demo@example.com
+     CAMUNDA_SECURITY_INITIALIZATION_USERS_0_PASSWORD=demo
+     CAMUNDA_SECURITY_INITIALIZATION_DEFAULTROLES_ADMIN_USERS_0_=demo
      ```
-6. The webapps should be available on the following URLs with default credentials (`demo`/`demo`):
+6. The webapps should be available on the following URLs with the credentials specified above (`demo`/`demo`):
    - [Tasklist](http://localhost:8080/tasklist)
    - [Operate](http://localhost:8080/operate)
    - [Identity](http://localhost:8080/identity)


### PR DESCRIPTION
## Description

Adds a demo user to the development runtime configuration and to the needed environment variables documented in the running Camunda via IntelliJ contributing docs.