### PR TITLE
Add client command for tenants search

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/CamundaClient.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClient.java
@@ -128,6 +128,7 @@ import io.camunda.client.api.search.request.ProcessInstanceSearchRequest;
 import io.camunda.client.api.search.request.ProcessInstanceSequenceFlowsRequest;
 import io.camunda.client.api.search.request.RolesByGroupSearchRequest;
 import io.camunda.client.api.search.request.RolesByTenantSearchRequest;
+import io.camunda.client.api.search.request.TenantsSearchRequest;
 import io.camunda.client.api.search.request.UserTaskSearchRequest;
 import io.camunda.client.api.search.request.UserTaskVariableSearchRequest;
 import io.camunda.client.api.search.request.UsersByGroupSearchRequest;
@@ -2048,6 +2049,23 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    * @return a builder for the request to get a tenant by ID
    */
   TenantGetRequest newTenantGetRequest(String tenantId);
+
+  /**
+   * Executes a search request to query tenants.
+   *
+   * <pre>
+   *
+   * camundaClient
+   *  .newTenantsSearchRequest()
+   *  .filter((f) -> f.name("tenantName"))
+   *  .sort((s) -> s.name().asc())
+   *  .page((p) -> p.limit(100))
+   *  .send();
+   * </pre>
+   *
+   * @return a builder for the tenants search request
+   */
+  TenantsSearchRequest newTenantsSearchRequest();
 
   /**
    * Command to delete a tenant.

--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/TenantFilter.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/TenantFilter.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.search.filter;
+
+import io.camunda.client.api.search.request.TypedFilterableRequest.SearchRequestFilter;
+
+public interface TenantFilter extends SearchRequestFilter {
+  /**
+   * Filter tenants by the specified tenant ID.
+   *
+   * @param tenantId the ID of the tenant
+   * @return the updated filter
+   */
+  TenantFilter tenantId(final String tenantId);
+
+  /**
+   * Filter tenants by the specified name.
+   *
+   * @param name the name of the tenant
+   * @return the updated filter
+   */
+  TenantFilter name(final String name);
+}

--- a/clients/java/src/main/java/io/camunda/client/api/search/request/SearchRequestBuilders.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/request/SearchRequestBuilders.java
@@ -29,6 +29,7 @@ import io.camunda.client.api.search.filter.MappingFilter;
 import io.camunda.client.api.search.filter.ProcessDefinitionFilter;
 import io.camunda.client.api.search.filter.ProcessInstanceFilter;
 import io.camunda.client.api.search.filter.RoleFilter;
+import io.camunda.client.api.search.filter.TenantFilter;
 import io.camunda.client.api.search.filter.UserFilter;
 import io.camunda.client.api.search.filter.UserTaskFilter;
 import io.camunda.client.api.search.filter.UserTaskVariableFilter;
@@ -50,6 +51,7 @@ import io.camunda.client.api.search.sort.ProcessDefinitionSort;
 import io.camunda.client.api.search.sort.ProcessInstanceSort;
 import io.camunda.client.api.search.sort.RoleSort;
 import io.camunda.client.api.search.sort.RoleUserSort;
+import io.camunda.client.api.search.sort.TenantSort;
 import io.camunda.client.api.search.sort.TenantUserSort;
 import io.camunda.client.api.search.sort.UserSort;
 import io.camunda.client.api.search.sort.UserTaskSort;
@@ -69,6 +71,7 @@ import io.camunda.client.impl.search.filter.MappingFilterImpl;
 import io.camunda.client.impl.search.filter.ProcessDefinitionFilterImpl;
 import io.camunda.client.impl.search.filter.ProcessInstanceFilterImpl;
 import io.camunda.client.impl.search.filter.RoleFilterImpl;
+import io.camunda.client.impl.search.filter.TenantFilterImpl;
 import io.camunda.client.impl.search.filter.UserFilterImpl;
 import io.camunda.client.impl.search.filter.UserTaskFilterImpl;
 import io.camunda.client.impl.search.filter.UserTaskVariableFilterImpl;
@@ -91,6 +94,7 @@ import io.camunda.client.impl.search.sort.ProcessDefinitionSortImpl;
 import io.camunda.client.impl.search.sort.ProcessInstanceSortImpl;
 import io.camunda.client.impl.search.sort.RoleSortImpl;
 import io.camunda.client.impl.search.sort.RoleUserSortImpl;
+import io.camunda.client.impl.search.sort.TenantSortImpl;
 import io.camunda.client.impl.search.sort.TenantUserSortImpl;
 import io.camunda.client.impl.search.sort.UserSortImpl;
 import io.camunda.client.impl.search.sort.UserTaskSortImpl;
@@ -328,6 +332,18 @@ public final class SearchRequestBuilders {
 
   public static RoleSort roleSort(final Consumer<RoleSort> fn) {
     final RoleSort sort = new RoleSortImpl();
+    fn.accept(sort);
+    return sort;
+  }
+
+  public static TenantFilter tenantFilter(final Consumer<TenantFilter> fn) {
+    final TenantFilter filter = new TenantFilterImpl();
+    fn.accept(filter);
+    return filter;
+  }
+
+  public static TenantSort tenantSort(final Consumer<TenantSort> fn) {
+    final TenantSort sort = new TenantSortImpl();
     fn.accept(sort);
     return sort;
   }

--- a/clients/java/src/main/java/io/camunda/client/api/search/request/TenantsSearchRequest.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/request/TenantsSearchRequest.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.search.request;
+
+import io.camunda.client.api.search.filter.TenantFilter;
+import io.camunda.client.api.search.response.Tenant;
+import io.camunda.client.api.search.sort.TenantSort;
+
+public interface TenantsSearchRequest
+    extends TypedSearchRequest<TenantFilter, TenantSort, TenantsSearchRequest>,
+        FinalSearchRequestStep<Tenant> {}

--- a/clients/java/src/main/java/io/camunda/client/api/search/sort/TenantSort.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/sort/TenantSort.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.search.sort;
+
+import io.camunda.client.api.search.request.TypedSortableRequest.SearchRequestSort;
+
+public interface TenantSort extends SearchRequestSort<TenantSort> {
+  TenantSort tenantId();
+
+  TenantSort name();
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
@@ -139,6 +139,7 @@ import io.camunda.client.api.search.request.ProcessInstanceSearchRequest;
 import io.camunda.client.api.search.request.ProcessInstanceSequenceFlowsRequest;
 import io.camunda.client.api.search.request.RolesByGroupSearchRequest;
 import io.camunda.client.api.search.request.RolesByTenantSearchRequest;
+import io.camunda.client.api.search.request.TenantsSearchRequest;
 import io.camunda.client.api.search.request.UserTaskSearchRequest;
 import io.camunda.client.api.search.request.UserTaskVariableSearchRequest;
 import io.camunda.client.api.search.request.UsersByGroupSearchRequest;
@@ -263,6 +264,7 @@ import io.camunda.client.impl.search.request.ProcessInstanceSequenceFlowsRequest
 import io.camunda.client.impl.search.request.RolesByGroupSearchRequestImpl;
 import io.camunda.client.impl.search.request.RolesByTenantSearchRequestImpl;
 import io.camunda.client.impl.search.request.RolesSearchRequestImpl;
+import io.camunda.client.impl.search.request.TenantsSearchRequestImpl;
 import io.camunda.client.impl.search.request.UserTaskSearchRequestImpl;
 import io.camunda.client.impl.search.request.UserTaskVariableSearchRequestImpl;
 import io.camunda.client.impl.search.request.UsersByGroupSearchRequestImpl;
@@ -1115,6 +1117,11 @@ public final class CamundaClientImpl implements CamundaClient {
   @Override
   public TenantGetRequest newTenantGetRequest(final String tenantId) {
     return new TenantGetRequestImpl(httpClient, tenantId);
+  }
+
+  @Override
+  public TenantsSearchRequest newTenantsSearchRequest() {
+    return new TenantsSearchRequestImpl(httpClient, jsonMapper);
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/TenantFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/TenantFilterImpl.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.search.filter;
+
+import io.camunda.client.api.search.filter.TenantFilter;
+import io.camunda.client.impl.search.request.TypedSearchRequestPropertyProvider;
+
+public class TenantFilterImpl
+    extends TypedSearchRequestPropertyProvider<io.camunda.client.protocol.rest.TenantFilter>
+    implements TenantFilter {
+
+  private final io.camunda.client.protocol.rest.TenantFilter filter;
+
+  public TenantFilterImpl() {
+    filter = new io.camunda.client.protocol.rest.TenantFilter();
+  }
+
+  @Override
+  public TenantFilter tenantId(final String tenantId) {
+    filter.setTenantId(tenantId);
+    return this;
+  }
+
+  @Override
+  public TenantFilter name(final String name) {
+    filter.setName(name);
+    return this;
+  }
+
+  @Override
+  protected io.camunda.client.protocol.rest.TenantFilter getSearchRequestProperty() {
+    return filter;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/search/request/TenantsSearchRequestImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/request/TenantsSearchRequestImpl.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.search.request;
+
+import static io.camunda.client.api.search.request.SearchRequestBuilders.searchRequestPage;
+import static io.camunda.client.api.search.request.SearchRequestBuilders.tenantFilter;
+import static io.camunda.client.api.search.request.SearchRequestBuilders.tenantSort;
+
+import io.camunda.client.api.CamundaFuture;
+import io.camunda.client.api.JsonMapper;
+import io.camunda.client.api.search.filter.TenantFilter;
+import io.camunda.client.api.search.request.FinalSearchRequestStep;
+import io.camunda.client.api.search.request.SearchRequestPage;
+import io.camunda.client.api.search.request.TenantsSearchRequest;
+import io.camunda.client.api.search.response.SearchResponse;
+import io.camunda.client.api.search.response.Tenant;
+import io.camunda.client.api.search.sort.TenantSort;
+import io.camunda.client.impl.http.HttpCamundaFuture;
+import io.camunda.client.impl.http.HttpClient;
+import io.camunda.client.impl.search.response.SearchResponseMapper;
+import io.camunda.client.protocol.rest.TenantSearchQueryRequest;
+import io.camunda.client.protocol.rest.TenantSearchQueryResult;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import org.apache.hc.client5.http.config.RequestConfig;
+
+public class TenantsSearchRequestImpl
+    extends TypedSearchRequestPropertyProvider<TenantSearchQueryRequest>
+    implements TenantsSearchRequest {
+
+  private final TenantSearchQueryRequest request;
+  private final HttpClient httpClient;
+  private final RequestConfig.Builder httpRequestConfig;
+  private final JsonMapper jsonMapper;
+
+  public TenantsSearchRequestImpl(final HttpClient httpClient, final JsonMapper jsonMapper) {
+    this.httpClient = httpClient;
+    this.jsonMapper = jsonMapper;
+    httpRequestConfig = httpClient.newRequestConfig();
+    request = new TenantSearchQueryRequest();
+  }
+
+  @Override
+  public FinalSearchRequestStep<Tenant> requestTimeout(final Duration requestTimeout) {
+    httpRequestConfig.setResponseTimeout(requestTimeout.toMillis(), TimeUnit.MILLISECONDS);
+    return this;
+  }
+
+  @Override
+  public CamundaFuture<SearchResponse<Tenant>> send() {
+    final HttpCamundaFuture<SearchResponse<Tenant>> result = new HttpCamundaFuture<>();
+    httpClient.post(
+        "/tenants/search",
+        jsonMapper.toJson(request),
+        httpRequestConfig.build(),
+        TenantSearchQueryResult.class,
+        SearchResponseMapper::toTenantsResponse,
+        result);
+    return result;
+  }
+
+  @Override
+  public TenantsSearchRequest filter(final TenantFilter value) {
+    request.setFilter(provideSearchRequestProperty(value));
+    return this;
+  }
+
+  @Override
+  public TenantsSearchRequest filter(final Consumer<TenantFilter> fn) {
+    return filter(tenantFilter(fn));
+  }
+
+  @Override
+  public TenantsSearchRequest page(final SearchRequestPage value) {
+    request.setPage(provideSearchRequestProperty(value));
+    return this;
+  }
+
+  @Override
+  public TenantsSearchRequest page(final Consumer<SearchRequestPage> fn) {
+    return page(searchRequestPage(fn));
+  }
+
+  @Override
+  public TenantsSearchRequest sort(final TenantSort value) {
+    request.setSort(
+        SearchRequestSortMapper.toTenantSearchQuerySortRequest(
+            provideSearchRequestProperty(value)));
+    return this;
+  }
+
+  @Override
+  public TenantsSearchRequest sort(final Consumer<TenantSort> fn) {
+    return sort(tenantSort(fn));
+  }
+
+  @Override
+  protected TenantSearchQueryRequest getSearchRequestProperty() {
+    return request;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/SearchResponseMapper.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/SearchResponseMapper.java
@@ -201,6 +201,13 @@ public final class SearchResponseMapper {
     return new SearchResponseImpl<>(instances, page);
   }
 
+  public static SearchResponse<Tenant> toTenantsResponse(final TenantSearchQueryResult response) {
+    final SearchResponsePage page = toSearchResponsePage(response.getPage());
+    final List<Tenant> instances =
+        toSearchResponseInstances(response.getItems(), SearchResponseMapper::toTenantResponse);
+    return new SearchResponseImpl<>(instances, page);
+  }
+
   public static Tenant toTenantResponse(final TenantResult response) {
     return new TenantImpl(response.getTenantId(), response.getName(), response.getDescription());
   }

--- a/clients/java/src/main/java/io/camunda/client/impl/search/sort/TenantSortImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/sort/TenantSortImpl.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.search.sort;
+
+import io.camunda.client.api.search.sort.TenantSort;
+import io.camunda.client.impl.search.request.SearchRequestSortBase;
+
+public class TenantSortImpl extends SearchRequestSortBase<TenantSort> implements TenantSort {
+
+  @Override
+  public TenantSort tenantId() {
+    return field("tenantId");
+  }
+
+  @Override
+  public TenantSort name() {
+    return field("name");
+  }
+
+  @Override
+  protected TenantSort self() {
+    return this;
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/RolesSearchTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/RolesSearchTest.java
@@ -38,7 +38,7 @@ public class RolesSearchTest {
   }
 
   @Test
-  void searchShouldReturnRoleFilteredByRoleId() {
+  void searchShouldReturnRoleFilteredByRoleName() {
     final var roleSearchResponse =
         camundaClient.newRolesSearchRequest().filter(fn -> fn.name(ROLE_NAME_1)).send().join();
 
@@ -49,7 +49,7 @@ public class RolesSearchTest {
   }
 
   @Test
-  void searchShouldReturnRolesFilteredByName() {
+  void searchShouldReturnRolesFilteredById() {
     final var roleSearchResponse =
         camundaClient.newRolesSearchRequest().filter(fn -> fn.roleId(ROLE_ID_1)).send().join();
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/TenantsSearchIntegrationTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/TenantsSearchIntegrationTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.command.ProblemException;
+import io.camunda.client.api.search.response.Tenant;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.zeebe.test.util.Strings;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+@MultiDbTest
+public class TenantsSearchIntegrationTest {
+
+  private static CamundaClient camundaClient;
+
+  private static final String TENANT_ID_1 = Strings.newRandomValidIdentityId();
+  private static final String TENANT_NAME_1 = "ATenantName";
+  private static final String TENANT_ID_2 = Strings.newRandomValidIdentityId();
+  private static final String TENANT_NAME_2 = "BTenantName";
+
+  @BeforeAll
+  static void setup() {
+    createTenant(TENANT_ID_1, TENANT_NAME_1, "description");
+    assertTenantCreated(TENANT_ID_1, TENANT_NAME_1, "description");
+
+    createTenant(TENANT_ID_2, TENANT_NAME_2, "description");
+    assertTenantCreated(TENANT_ID_2, TENANT_NAME_2, "description");
+  }
+
+  @Test
+  void searchShouldReturnTenantFilteredByTenantName() {
+    final var tenantSearchResponse =
+        camundaClient.newTenantsSearchRequest().filter(fn -> fn.name(TENANT_NAME_1)).send().join();
+
+    assertThat(tenantSearchResponse.items())
+        .hasSize(1)
+        .map(Tenant::getName)
+        .containsExactly(TENANT_NAME_1);
+  }
+
+  @Test
+  void searchShouldReturnTenantsFilteredById() {
+    final var tenantSearchResponse =
+        camundaClient
+            .newTenantsSearchRequest()
+            .filter(fn -> fn.tenantId(TENANT_ID_1))
+            .send()
+            .join();
+
+    assertThat(tenantSearchResponse.items())
+        .hasSize(1)
+        .map(Tenant::getTenantId)
+        .containsExactly(TENANT_ID_1);
+  }
+
+  @Test
+  void searchShouldReturnEmptyListWhenSearchingForNonExistingTenantId() {
+    final var tenantSearchResponse =
+        camundaClient
+            .newTenantsSearchRequest()
+            .filter(fn -> fn.tenantId("someTenantId"))
+            .send()
+            .join();
+    assertThat(tenantSearchResponse.items()).isEmpty();
+  }
+
+  @Test
+  void searchShouldReturnEmptyListWhenSearchingForNonExistingTenantName() {
+    final var tenantSearchResponse =
+        camundaClient
+            .newTenantsSearchRequest()
+            .filter(fn -> fn.name("someTenantName"))
+            .send()
+            .join();
+    assertThat(tenantSearchResponse.items()).isEmpty();
+  }
+
+  @Test
+  void searchShouldReturnTenantsSortedByName() {
+    final var tenantSearchResponse =
+        camundaClient.newTenantsSearchRequest().sort(s -> s.name().desc()).send().join();
+
+    assertThat(tenantSearchResponse.items())
+        .hasSizeGreaterThanOrEqualTo(2)
+        .map(Tenant::getName)
+        // filtering here as there is also "Default" tenant
+        .filteredOn(r -> r.equals(TENANT_NAME_1) || r.equals(TENANT_NAME_2))
+        .containsExactly(TENANT_NAME_2, TENANT_NAME_1);
+  }
+
+  private static void assertTenantCreated(
+      final String tenantId, final String tenantName, final String description) {
+    Awaitility.await("Tenant is created and exported")
+        .ignoreExceptionsInstanceOf(ProblemException.class)
+        .untilAsserted(
+            () -> {
+              final var tenant = camundaClient.newTenantGetRequest(tenantId).send().join();
+              assertThat(tenant).isNotNull();
+              assertThat(tenant.getTenantId()).isEqualTo(tenantId);
+              assertThat(tenant.getName()).isEqualTo(tenantName);
+              assertThat(tenant.getDescription()).isEqualTo(description);
+            });
+  }
+
+  private static void createTenant(
+      final String tenantId, final String tenantName, final String description) {
+    camundaClient
+        .newCreateTenantCommand()
+        .tenantId(tenantId)
+        .name(tenantName)
+        .description(description)
+        .send()
+        .join();
+  }
+}


### PR DESCRIPTION
## Description

Add client command to search Tenants.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #34645
