### PR TITLE
feat: validate a message is published to the right partition

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -174,6 +174,7 @@ public final class EngineProcessors {
         authCheckBehavior,
         routingInfo);
     addMessageProcessors(
+        typedRecordProcessorContext.getPartitionId(),
         bpmnBehaviors,
         subscriptionCommandSender,
         processingState,
@@ -184,7 +185,8 @@ public final class EngineProcessors {
         featureFlags,
         commandDistributionBehavior,
         clock,
-        authCheckBehavior);
+        authCheckBehavior,
+        routingInfo);
 
     final TypedRecordProcessor<ProcessInstanceRecord> bpmnStreamProcessor =
         addProcessProcessors(
@@ -504,6 +506,7 @@ public final class EngineProcessors {
   }
 
   private static void addMessageProcessors(
+      final int partitionId,
       final BpmnBehaviorsImpl bpmnBehaviors,
       final SubscriptionCommandSender subscriptionCommandSender,
       final MutableProcessingState processingState,
@@ -514,8 +517,10 @@ public final class EngineProcessors {
       final FeatureFlags featureFlags,
       final CommandDistributionBehavior commandDistributionBehavior,
       final InstantSource clock,
-      final AuthorizationCheckBehavior authCheckBehavior) {
+      final AuthorizationCheckBehavior authCheckBehavior,
+      final RoutingInfo routingInfo) {
     MessageEventProcessors.addMessageProcessors(
+        partitionId,
         bpmnBehaviors,
         typedRecordProcessors,
         processingState,
@@ -526,7 +531,8 @@ public final class EngineProcessors {
         featureFlags,
         commandDistributionBehavior,
         clock,
-        authCheckBehavior);
+        authCheckBehavior,
+        routingInfo);
   }
 
   private static void addDecisionProcessors(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageEventProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageEventProcessors.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.engine.state.mutable.MutableMessageStartEventSubscriptio
 import io.camunda.zeebe.engine.state.mutable.MutableMessageState;
 import io.camunda.zeebe.engine.state.mutable.MutableMessageSubscriptionState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.state.routing.RoutingInfo;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.MessageBatchIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageCorrelationIntent;
@@ -34,6 +35,7 @@ import java.util.function.Supplier;
 public final class MessageEventProcessors {
 
   public static void addMessageProcessors(
+      final int partitionId,
       final BpmnBehaviors bpmnBehaviors,
       final TypedRecordProcessors typedRecordProcessors,
       final MutableProcessingState processingState,
@@ -44,7 +46,8 @@ public final class MessageEventProcessors {
       final FeatureFlags featureFlags,
       final CommandDistributionBehavior commandDistributionBehavior,
       final InstantSource clock,
-      final AuthorizationCheckBehavior authCheckBehavior) {
+      final AuthorizationCheckBehavior authCheckBehavior,
+      final RoutingInfo routingInfo) {
 
     final MutableMessageState messageState = processingState.getMessageState();
     final MutableMessageCorrelationState messageCorrelationState =
@@ -63,6 +66,7 @@ public final class MessageEventProcessors {
             ValueType.MESSAGE,
             MessageIntent.PUBLISH,
             new MessagePublishProcessor(
+                partitionId,
                 messageState,
                 subscriptionState,
                 startEventSubscriptionState,
@@ -73,7 +77,8 @@ public final class MessageEventProcessors {
                 processState,
                 bpmnBehaviors.eventTriggerBehavior(),
                 bpmnBehaviors.stateBehavior(),
-                authCheckBehavior))
+                authCheckBehavior,
+                routingInfo))
         .onCommand(
             ValueType.MESSAGE_BATCH,
             MessageBatchIntent.EXPIRE,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/RoutingState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/RoutingState.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.engine.state.immutable;
 
+import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 public interface RoutingState {
@@ -27,6 +29,38 @@ public interface RoutingState {
    *     specified number of partitions
    */
   long bootstrappedAt(int partitionCount);
+
+  static RoutingState of(
+      final Map<Integer, Long> activePartitions,
+      final Set<Integer> desiredPartitions,
+      final MessageCorrelation messageCorrelation) {
+    return new RoutingState() {
+      @Override
+      public Set<Integer> currentPartitions() {
+        return activePartitions.keySet();
+      }
+
+      @Override
+      public Set<Integer> desiredPartitions() {
+        return desiredPartitions;
+      }
+
+      @Override
+      public MessageCorrelation messageCorrelation() {
+        return messageCorrelation;
+      }
+
+      @Override
+      public boolean isInitialized() {
+        return true;
+      }
+
+      @Override
+      public long bootstrappedAt(final int partitionCount) {
+        return Optional.of(activePartitions.get(partitionCount)).orElse(-1L);
+      }
+    };
+  }
 
   sealed interface MessageCorrelation {
     record HashMod(int partitionCount) implements MessageCorrelation {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/RoutingState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/RoutingState.java
@@ -7,8 +7,6 @@
  */
 package io.camunda.zeebe.engine.state.immutable;
 
-import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 
 public interface RoutingState {
@@ -29,38 +27,6 @@ public interface RoutingState {
    *     specified number of partitions
    */
   long bootstrappedAt(int partitionCount);
-
-  static RoutingState of(
-      final Map<Integer, Long> activePartitions,
-      final Set<Integer> desiredPartitions,
-      final MessageCorrelation messageCorrelation) {
-    return new RoutingState() {
-      @Override
-      public Set<Integer> currentPartitions() {
-        return activePartitions.keySet();
-      }
-
-      @Override
-      public Set<Integer> desiredPartitions() {
-        return desiredPartitions;
-      }
-
-      @Override
-      public MessageCorrelation messageCorrelation() {
-        return messageCorrelation;
-      }
-
-      @Override
-      public boolean isInitialized() {
-        return true;
-      }
-
-      @Override
-      public long bootstrappedAt(final int partitionCount) {
-        return Optional.of(activePartitions.get(partitionCount)).orElse(-1L);
-      }
-    };
-  }
 
   sealed interface MessageCorrelation {
     record HashMod(int partitionCount) implements MessageCorrelation {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableRoutingState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableRoutingState.java
@@ -38,4 +38,6 @@ public interface MutableRoutingState extends RoutingState {
    *     state, false otherwise
    */
   boolean activatePartition(int partitionId);
+
+  void setMessageCorrelation(MessageCorrelation messageCorrelation);
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/routing/DbRoutingState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/routing/DbRoutingState.java
@@ -126,6 +126,14 @@ public final class DbRoutingState implements MutableRoutingState {
     }
   }
 
+  @Override
+  public void setMessageCorrelation(final MessageCorrelation messageCorrelation) {
+    key.wrapString(CURRENT_KEY);
+    final var current = columnFamily.get(key);
+    current.setMessageCorrelation(messageCorrelation);
+    columnFamily.upsert(key, current);
+  }
+
   private void setBootstrappedAt(final int partitionCount, final long key) {
     partitionIdKey.wrapInt(partitionCount);
     dbLong.wrapLong(key);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessagePublishRoutingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessagePublishRoutingTest.java
@@ -28,7 +28,6 @@ import org.junit.rules.TestWatcher;
 public class MessagePublishRoutingTest {
 
   public static final String INTERMEDIATE_MSG_NAME = "intermediateMsg";
-  public static final String START_MSG_NAME = "startMsg";
   public static final String CORRELATION_KEY_VARIABLE = "correlationKey";
   private static final String PROCESS_ID = "processId";
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessagePublishRoutingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessagePublishRoutingTest.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.engine.processing.message;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.zeebe.engine.scaling.InMemoryRoutingState;
 import io.camunda.zeebe.engine.state.immutable.RoutingState;
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
@@ -36,7 +37,7 @@ public class MessagePublishRoutingTest {
       EngineRule.multiplePartition(2)
           // only partition one is included in MessageCorrelation
           .withInitialRoutingState(
-              RoutingState.of(
+              new InMemoryRoutingState(
                   Map.of(1, 0L, 2, 0L),
                   Set.of(1, 2),
                   // partition 2 is not included in message correlation

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessagePublishRoutingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessagePublishRoutingTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.message;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.state.immutable.RoutingState;
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.MessageIntent;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestWatcher;
+
+public class MessagePublishRoutingTest {
+
+  public static final String INTERMEDIATE_MSG_NAME = "intermediateMsg";
+  public static final String START_MSG_NAME = "startMsg";
+  public static final String CORRELATION_KEY_VARIABLE = "correlationKey";
+  private static final String PROCESS_ID = "processId";
+
+  @Rule
+  public final EngineRule engine =
+      EngineRule.multiplePartition(2)
+          // only partition one is included in MessageCorrelation
+          .withInitialRoutingState(
+              RoutingState.of(
+                  Map.of(1, 0L, 2, 0L),
+                  Set.of(1, 2),
+                  // partition 2 is not included in message correlation
+                  new RoutingState.MessageCorrelation.HashMod(1)));
+
+  @Rule public final TestWatcher recordingExporterTestWatcher = new RecordingExporterTestWatcher();
+
+  @Before
+  public void before() {
+    engine
+        .deployment()
+        .withXmlResource(
+            "process.bpmn",
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .intermediateCatchEvent()
+                .message(
+                    m ->
+                        m.name(INTERMEDIATE_MSG_NAME)
+                            .zeebeCorrelationKeyExpression(CORRELATION_KEY_VARIABLE))
+                .endEvent()
+                .done())
+        .deploy();
+  }
+
+  @Test
+  public void shouldPublishMessageToCorrectPartition() {
+
+    // given
+    final var correlationKey = UUID.randomUUID().toString();
+    createProcessInstance(correlationKey);
+
+    // when
+    engine.message().withName(INTERMEDIATE_MSG_NAME).withCorrelationKey(correlationKey).publish(1);
+
+    // then
+    assertThat(
+            RecordingExporter.messageRecords(MessageIntent.PUBLISH)
+                .withName(INTERMEDIATE_MSG_NAME)
+                .withCorrelationKey(correlationKey)
+                .findFirst())
+        .isPresent();
+  }
+
+  @Test
+  public void shouldRejectMessagePublishWithInvalidPartition() {
+    // given
+    final var correlationKey = UUID.randomUUID().toString();
+    createProcessInstance(correlationKey);
+
+    // when
+    engine
+        .message()
+        .withName(INTERMEDIATE_MSG_NAME)
+        .withCorrelationKey(correlationKey)
+        .expectRejection()
+        .publish(2);
+
+    // then
+    assertThat(
+            RecordingExporter.messageRecords(MessageIntent.PUBLISH)
+                .onlyCommandRejections()
+                .withName(INTERMEDIATE_MSG_NAME)
+                .withCorrelationKey(correlationKey)
+                .findFirst())
+        .isPresent()
+        .hasValueSatisfying(
+            r -> {
+              assertThat(r.getRejectionType()).isEqualTo(RejectionType.INVALID_STATE);
+              assertThat(r.getRejectionReason())
+                  .isEqualTo(
+                      "The message has not been routed to the right partition."
+                          + " This is probably a temporary issue, please retry in a few seconds");
+            });
+  }
+
+  private void createProcessInstance(final String correlationKey) {
+    engine
+        .processInstance()
+        .ofBpmnProcessId(PROCESS_ID)
+        .withVariable(CORRELATION_KEY_VARIABLE, correlationKey);
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStreamProcessorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStreamProcessorTest.java
@@ -78,13 +78,14 @@ public final class MessageStreamProcessorTest {
     spySubscriptionCommandSender =
         spy(new SubscriptionCommandSender(1, mockInterpartitionCommandSender));
     spySubscriptionCommandSender.setWriters(writers);
+    final var routingInfo = RoutingInfo.forStaticPartitions(1);
     spyCommandDistributionBehavior =
         spy(
             new CommandDistributionBehavior(
                 mockDistributionState,
                 writers,
                 1,
-                RoutingInfo.forStaticPartitions(1),
+                routingInfo,
                 mockInterpartitionCommandSender,
                 mock(DistributionMetrics.class)));
 
@@ -95,6 +96,7 @@ public final class MessageStreamProcessorTest {
           final var mockAuthCheckBehavior = mock(AuthorizationCheckBehavior.class);
           when(mockAuthCheckBehavior.isAuthorized(any())).thenReturn(Either.right(null));
           MessageEventProcessors.addMessageProcessors(
+              1,
               mock(BpmnBehaviors.class),
               typedRecordProcessors,
               processingState,
@@ -105,7 +107,8 @@ public final class MessageStreamProcessorTest {
               FeatureFlags.createDefault(),
               spyCommandDistributionBehavior,
               InstantSource.system(),
-              mockAuthCheckBehavior);
+              mockAuthCheckBehavior,
+              routingInfo);
           return typedRecordProcessors;
         });
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/scaling/InMemoryRoutingState.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/scaling/InMemoryRoutingState.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.scaling;
+
+import io.camunda.zeebe.engine.state.immutable.RoutingState;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+public record InMemoryRoutingState(
+    Map<Integer, Long> activePartitions,
+    Set<Integer> desiredPartitions,
+    MessageCorrelation messageCorrelation)
+    implements RoutingState {
+  @Override
+  public Set<Integer> currentPartitions() {
+    return activePartitions.keySet();
+  }
+
+  @Override
+  public Set<Integer> desiredPartitions() {
+    return desiredPartitions;
+  }
+
+  @Override
+  public MessageCorrelation messageCorrelation() {
+    return messageCorrelation;
+  }
+
+  @Override
+  public boolean isInitialized() {
+    return true;
+  }
+
+  @Override
+  public long bootstrappedAt(final int partitionCount) {
+    return Optional.of(activePartitions.get(partitionCount)).orElse(-1L);
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/PublishMessageClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/PublishMessageClient.java
@@ -113,6 +113,11 @@ public final class PublishMessageClient {
     return this;
   }
 
+  public Record<MessageRecordValue> publish(final int partitionId) {
+    this.partitionId = partitionId;
+    return publish();
+  }
+
   public Record<MessageRecordValue> publish() {
 
     if (partitionId == DEFAULT_VALUE) {


### PR DESCRIPTION
## Description
In `MessagePublishProcessor`, validate that all messages are sent to the right partition. 
This is necessary in case the `RoutingState` in the gateways is wrong after a restore and it's necessary anyway when relocating messages.
## Related issues

closes #34894 
