### PR TITLE
ci: log context info on FOSSA PR check timeout

### DIFF
--- a/.github/workflows/check-licenses.yml
+++ b/.github/workflows/check-licenses.yml
@@ -23,9 +23,13 @@ env:
 jobs:
   analyze:
     name: "Analyze ${{ matrix.project.name }} dependencies"
-    permissions: {}
+    permissions:
+      # Needed for camunda/infra-global-github-actions/fossa/info
+      actions: read
+      contents: read
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    # If you change the job timeout, update the timeout in camunda/infra-global-github-actions/fossa/pr-check accordingly.
+    timeout-minutes: 21
     strategy:
       fail-fast: false
       # The matrix is necessary to run separate analyses
@@ -78,11 +82,11 @@ jobs:
         echo "${MAVEN_CONFIG}" | tee ./.mvn/maven.config
 
     - name: Setup fossa-cli
-      uses: camunda/infra-global-github-actions/fossa/setup@415155f7c608854a13c36a2f13b770c56507ab95
+      uses: camunda/infra-global-github-actions/fossa/setup@e10093ca1459892b5cc37bef06a0605e5774a02b
 
     - name: Get context info
       id: info
-      uses: camunda/infra-global-github-actions/fossa/info@415155f7c608854a13c36a2f13b770c56507ab95
+      uses: camunda/infra-global-github-actions/fossa/info@e10093ca1459892b5cc37bef06a0605e5774a02b
 
     - name: Adjust pom.xml files for FOSSA
       if: contains(fromJson('["optimize", "single-app"]'), matrix.project.name)
@@ -105,7 +109,7 @@ jobs:
           optimize/pom.xml
 
     - name: Analyze project
-      uses: camunda/infra-global-github-actions/fossa/analyze@415155f7c608854a13c36a2f13b770c56507ab95
+      uses: camunda/infra-global-github-actions/fossa/analyze@e10093ca1459892b5cc37bef06a0605e5774a02b
       with:
         api-key: ${{ steps.secrets.outputs.FOSSA_API_KEY }}
         branch: ${{  steps.info.outputs.head-ref }}
@@ -117,7 +121,7 @@ jobs:
     # It does not fail for pre-existing issues already present in the base branch.
     - name: Check Pull Request for new License Issues
       if: steps.info.outputs.is-pull-request == 'true'
-      uses: camunda/infra-global-github-actions/fossa/pr-check@415155f7c608854a13c36a2f13b770c56507ab95
+      uses: camunda/infra-global-github-actions/fossa/pr-check@e10093ca1459892b5cc37bef06a0605e5774a02b
       with:
         api-key: ${{ steps.secrets.outputs.FOSSA_API_KEY }}
         base-ref: ${{ steps.info.outputs.base-ref }}
@@ -131,7 +135,8 @@ jobs:
         path: ${{ matrix.project.path }}
         project: ${{ matrix.project.name }}
         revision: ${{ steps.info.outputs.head-revision }}
-
+        timeout: 20 # must be less than overall job timeout
+        timeout-start-time: ${{ steps.info.outputs.job-start-time }}
     - name: Observe build status
       if: always()
       continue-on-error: true


### PR DESCRIPTION
## Description

Related to:
- https://camunda.slack.com/archives/C071KP5BTHB/p1751550213039139
- https://github.com/camunda/infra-global-github-actions/pull/440

Introduce a dedicated timeout for the `fossa test` command (PR check) to provide users with helpful context when it occurs.

Before merging:
- [x] https://github.com/camunda/infra-global-github-actions/pull/440 is merged
- [x] `check-licenses.yml` uses the last versions of the fossa actions

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).
