### PR TITLE
refactor: avoid mentioning default limitation from ES/OS results

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/search/response/SearchResponsePage.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/response/SearchResponsePage.java
@@ -21,17 +21,20 @@ public interface SearchResponsePage {
   Long totalItems();
 
   /**
-   * Whether more than 10,000 results exist in Elasticsearch (ES) or OpenSearch (OS) searches.
+   * Whether the total items count exceeds the maximum limit in Elasticsearch (ES) or OpenSearch
+   * (OS).
    *
-   * <p>In ES or OS, total hits are capped at 10,000. If the result set is greater than or equal to
-   * this, this method returns {@code true}; otherwise, it returns {@code false}.
+   * <p>In ES or OS, total items are often capped by a predefined configurable limit. If the result
+   * set is greater than or equal to this, this method returns {@code true}; otherwise, it returns
+   * {@code false}.
    *
    * <p>For RDBMS-backed searches, this is always {@code false} because there is no such limitation.
    *
    * <p>This helps clients understand when total item counts may be incomplete due to ES or OS
    * limits.
    *
-   * @return {@code true} if more than 10,000 items exist in ES or OS; {@code false} otherwise.
+   * @return {@code true} if the total result count exceeds the cap in ES or OS; {@code false}
+   *     otherwise.
    */
   default Boolean hasMoreTotalItems() {
     return false;

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/SearchResponseMapper.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/SearchResponseMapper.java
@@ -150,7 +150,7 @@ public final class SearchResponseMapper {
       final SearchQueryPageResponse pageResponse) {
     return new SearchResponsePageImpl(
         pageResponse.getTotalItems(),
-        Boolean.TRUE.equals(pageResponse.getHasMoreTotalItems()),
+        pageResponse.getHasMoreTotalItems(),
         pageResponse.getStartCursor(),
         pageResponse.getEndCursor());
   }

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/SearchResponsePageImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/SearchResponsePageImpl.java
@@ -25,17 +25,17 @@ public class SearchResponsePageImpl implements SearchResponsePage {
   private final String endCursor;
 
   public SearchResponsePageImpl(
-      final long totalItems, final String startCursor, final String endCursor) {
+      final Long totalItems, final String startCursor, final String endCursor) {
     this(totalItems, false, startCursor, endCursor);
   }
 
   public SearchResponsePageImpl(
-      final long totalItems,
-      final boolean hasMoreTotalItems,
+      final Long totalItems,
+      final Boolean hasMoreTotalItems,
       final String startCursor,
       final String endCursor) {
-    this.totalItems = totalItems;
-    this.hasMoreTotalItems = hasMoreTotalItems;
+    this.totalItems = totalItems != null ? totalItems : 0L;
+    this.hasMoreTotalItems = Boolean.TRUE.equals(hasMoreTotalItems);
     this.startCursor = startCursor;
     this.endCursor = endCursor;
   }

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -9236,7 +9236,7 @@ components:
           format: int64
         hasMoreTotalItems:
           description: |
-            Indicates if more results exist beyond the reported totalItems value. If ElasticSearch or OpenSearch is used, the totalItems value is capped at 10,000 due to search limitations. This field is true if additional results exist beyond this cap; otherwise, it is false.
+            Indicates if more results exist beyond the reported totalItems value. Due to system limitations, the totalItems value can be capped.
           type: boolean
         startCursor:
           description: The cursor value for getting the previous page of results. Use this in the `before` field of an ensuing request.


### PR DESCRIPTION
## Description

add `hasMoreTotalItems` property to v2 responses [issue](https://github.com/camunda/camunda/issues/33885)
Handling some comments after merge of https://github.com/camunda/camunda/pull/34387
