### PR TITLE
ci: exclude optimize profile when setting compat versions during release

### DIFF
--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -196,8 +196,8 @@ jobs:
             exit 0
           fi
 
-          ./mvnw -B versions:set-property -DgenerateBackupPoms=false -Dproperty=backwards.compat.version -DnewVersion="${RELEASE_VERSION}"
-          FILE=$(./mvnw -B help:evaluate -Dexpression=ignored.changes.file -q -DforceStdout)
+          ./mvnw -B versions:set-property -DgenerateBackupPoms=false -Dproperty=backwards.compat.version -DnewVersion="${RELEASE_VERSION}" -P\!include-optimize
+          FILE=$(./mvnw -B help:evaluate -Dexpression=ignored.changes.file -q -DforceStdout -P\!include-optimize)
           rm -f "clients/java/${FILE}" "test/${FILE}" "exporter-api/${FILE}" "protocol/${FILE}" "bpmn-model/${FILE}"
           git commit -am "build(project): update java compat versions"
       - name: Delete version-specific allowed API breaking changes


### PR DESCRIPTION
## Description

The release dry run job is failing (for patch releases only, dry run alphas are fine): https://github.com/camunda/camunda/actions/runs/16105546347/job/45440450420

In the "Update Compat Version" step there is a new fatal error: `[FATAL] Non-resolvable parent POM for io.camunda.optimize:optimize-parent:8.8.0-SNAPSHOT: The following artifacts could not be resolved: io.camunda:zeebe-parent:pom:8.8.0-SNAPSHOT (absent): Could not find artifact io.camunda:zeebe-parent:pom:8.8.0-SNAPSHOT and 'parent.relativePath' points at wrong local POM @ line 5, column 11`

The change from https://github.com/camunda/camunda/pull/34714 needs to be extended to also cover steps relevant only for non-alpha releases (e.g. patch releases), which is what this PR is about.

Tested in dry-run: https://github.com/camunda/camunda/actions/runs/16117691901/job/45475327756

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

None