### PR TITLE
feat: add REST management endpoint to update `RoutingState`

### DIFF
--- a/dist/src/main/resources/api/cluster/cluster-api.yaml
+++ b/dist/src/main/resources/api/cluster/cluster-api.yaml
@@ -157,7 +157,12 @@ paths:
 
   /routing-state:
     patch:
-      summary: Force an update of the routing state
+      summary:
+        Force an update of the routing state using the user provided routing state
+        or by fetching the routing state from the engine first and then
+        applying it to the configuration.
+        No validation is performed on the user provided routing state, so it must be
+        used only in the rare circumstances when it's not possible to fetch it from the engine.
       requestBody:
         content:
           application/json:

--- a/dist/src/main/resources/api/cluster/cluster-api.yaml
+++ b/dist/src/main/resources/api/cluster/cluster-api.yaml
@@ -155,6 +155,30 @@ paths:
         '504':
           $ref: 'components.yaml#/responses/TimeoutError'
 
+  /routing-state:
+    patch:
+      summary: Force an update of the routing state
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "components.yaml#/schemas/RoutingState"
+      parameters:
+        - $ref: '#/components/parameters/DryRunParameter'
+      responses:
+        '202':
+          description: Accepted
+        '400':
+          $ref: 'components.yaml#/responses/InvalidRequest'
+        '409':
+          $ref: 'components.yaml#/responses/ConcurrentChangeError'
+        '500':
+          $ref: 'components.yaml#/responses/InternalError'
+        '502':
+          $ref: 'components.yaml#/responses/GatewayError'
+        '504':
+          $ref: 'components.yaml#/responses/TimeoutError'
+
 components:
   parameters:
     BrokerId:

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementApi.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementApi.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.PurgeRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ReassignPartitionsRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RemoveMembersRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.UpdateRoutingStateRequest;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 
@@ -56,6 +57,9 @@ public interface ClusterConfigurationManagementApi {
 
   ActorFuture<ClusterConfigurationChangeResponse> patchCluster(
       ClusterPatchRequest clusterPatchRequest);
+
+  ActorFuture<ClusterConfigurationChangeResponse> updateRoutingState(
+      UpdateRoutingStateRequest updateRoutingStateRequest);
 
   ActorFuture<ClusterConfigurationChangeResponse> purge(PurgeRequest purgeRequest);
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequest.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequest.java
@@ -61,7 +61,7 @@ public sealed interface ClusterConfigurationManagementRequest {
       boolean dryRun)
       implements ClusterConfigurationManagementRequest {}
 
-  record UpdateRoutingStateRequest(RoutingState routingState, boolean dryRun)
+  record UpdateRoutingStateRequest(Optional<RoutingState> routingState, boolean dryRun)
       implements ClusterConfigurationManagementRequest {}
 
   record ForceRemoveBrokersRequest(Set<MemberId> membersToRemove, boolean dryRun)

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestSender.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestSender.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.PurgeRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ReassignPartitionsRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RemoveMembersRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.UpdateRoutingStateRequest;
 import io.camunda.zeebe.dynamic.config.serializer.ClusterConfigurationRequestsSerializer;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.util.Either;
@@ -204,6 +205,17 @@ public final class ClusterConfigurationManagementRequestSender {
         request,
         serializer::encodeCancelChangeRequest,
         serializer::decodeClusterTopologyResponse,
+        coordinatorSupplier.getDefaultCoordinator(),
+        TIMEOUT);
+  }
+
+  public CompletableFuture<Either<ErrorResponse, ClusterConfigurationChangeResponse>>
+      updateRoutingState(final UpdateRoutingStateRequest updateRoutingStateRequest) {
+    return communicationService.send(
+        ClusterConfigurationRequestTopics.UPDATE_ROUTING_STATE.topic(),
+        updateRoutingStateRequest,
+        serializer::encodeUpdateRoutingStateRequest,
+        serializer::decodeTopologyChangeResponse,
         coordinatorSupplier.getDefaultCoordinator(),
         TIMEOUT);
   }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestsHandler.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestsHandler.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.PurgeRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ReassignPartitionsRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RemoveMembersRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.UpdateRoutingStateRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedException.InvalidRequest;
 import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeCoordinator;
 import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeCoordinator.ConfigurationChangeRequest;
@@ -174,6 +175,15 @@ public final class ClusterConfigurationManagementRequestsHandler
             clusterPatchRequest.membersToRemove(),
             clusterPatchRequest.newPartitionCount(),
             clusterPatchRequest.newReplicationFactor()));
+  }
+
+  @Override
+  public ActorFuture<ClusterConfigurationChangeResponse> updateRoutingState(
+      final UpdateRoutingStateRequest updateRoutingStateRequest) {
+    return handleRequest(
+        updateRoutingStateRequest.dryRun(),
+        new UpdateRoutingStateTransformer(
+            enablePartitionScaling, updateRoutingStateRequest.routingState()));
   }
 
   @Override

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationRequestServer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationRequestServer.java
@@ -48,6 +48,7 @@ public final class ClusterConfigurationRequestServer implements AutoCloseable {
     registerEnableExporterHandler();
     registerClusterScaleRequestHandler();
     registerClusterPatchRequestHandler();
+    registerUpdateRoutingStateHandler();
     registerForceRemoveBrokersRequestHandler();
     registerPurgeRequestHandler();
   }
@@ -186,6 +187,14 @@ public final class ClusterConfigurationRequestServer implements AutoCloseable {
         ClusterConfigurationRequestTopics.PATCH_CLUSTER.topic(),
         serializer::decodeClusterPatchRequest,
         request -> mapResponse(clusterConfigurationManagementApi.patchCluster(request)),
+        this::encodeResponse);
+  }
+
+  private void registerUpdateRoutingStateHandler() {
+    communicationService.replyTo(
+        ClusterConfigurationRequestTopics.UPDATE_ROUTING_STATE.topic(),
+        serializer::decodeUpdateRoutingStateRequest,
+        request -> mapResponse(clusterConfigurationManagementApi.updateRoutingState(request)),
         this::encodeResponse);
   }
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationRequestTopics.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationRequestTopics.java
@@ -23,7 +23,8 @@ public enum ClusterConfigurationRequestTopics {
   SCALE_CLUSTER("topology-cluster-scale"),
   PATCH_CLUSTER("topology-cluster-patch"),
   PURGE("topology-cluster-purge"),
-  FORCE_REMOVE_BROKERS("topology-broker-force-remove");
+  FORCE_REMOVE_BROKERS("topology-broker-force-remove"),
+  UPDATE_ROUTING_STATE("topology-cluster-update-routing-state");
 
   private final String topic;
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/UpdateRoutingStateApplier.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/UpdateRoutingStateApplier.java
@@ -41,11 +41,16 @@ public class UpdateRoutingStateApplier implements ClusterOperationApplier {
             : executor.getRoutingState();
 
     return routingState.thenApply(
-        state ->
-            config -> {
+        state -> {
+          if (state == null) {
+            return UnaryOperator.identity();
+          } else {
+            return config -> {
               final var previousVersion =
                   config.routingState().map(RoutingState::version).orElse(0L);
               return config.setRoutingState(state.withVersion(previousVersion + 1));
-            });
+            };
+          }
+        });
   }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ClusterConfigurationRequestsSerializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ClusterConfigurationRequestsSerializer.java
@@ -52,6 +52,8 @@ public interface ClusterConfigurationRequestsSerializer {
   byte[] encodeForceRemoveBrokersRequest(
       ClusterConfigurationManagementRequest.ForceRemoveBrokersRequest forceRemoveBrokersRequest);
 
+  byte[] encodeUpdateRoutingStateRequest(UpdateRoutingStateRequest updateRoutingStateRequest);
+
   ClusterConfigurationManagementRequest.AddMembersRequest decodeAddMembersRequest(
       byte[] encodedState);
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/ClusterRoutingEndpointIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/ClusterRoutingEndpointIT.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.clustering.dynamic;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.management.cluster.MessageCorrelationHashMod;
+import io.camunda.zeebe.management.cluster.RequestHandlingAllPartitions;
+import io.camunda.zeebe.management.cluster.RoutingState;
+import io.camunda.zeebe.qa.util.actuator.ClusterActuator;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+@ZeebeIntegration
+public class ClusterRoutingEndpointIT {
+
+  @TestZeebe(initMethod = "initTestStandaloneBroker")
+  static TestStandaloneBroker broker;
+
+  @SuppressWarnings("unused")
+  static void initTestStandaloneBroker() {
+    broker =
+        new TestStandaloneBroker()
+            .withBrokerConfig(
+                cfg -> cfg.getExperimental().getFeatures().setEnablePartitionScaling(true));
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  public void shouldPatchRoutingStateFromEngineState(final boolean dryRun) {
+    //    broker.awaitCompleteTopology();
+    final var actuator = ClusterActuator.of(broker);
+    actuator.patchRoutingState(dryRun);
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  public void shouldPatchRoutingStateFromRequestBody(final boolean dryRun) {
+    broker.awaitCompleteTopology();
+    final var actuator = ClusterActuator.of(broker);
+    final var routingState =
+        new RoutingState()
+            .requestHandling(new RequestHandlingAllPartitions(2).strategy("AllPartitions"))
+            .messageCorrelation(new MessageCorrelationHashMod("HashMod", 2))
+            .version(2L);
+    actuator.patchRoutingState(routingState, dryRun);
+
+    if (!dryRun) {
+      Awaitility.await("Until routing state is updated)")
+          .untilAsserted(
+              () -> assertThat(actuator.getTopology().getRouting()).isEqualTo(routingState));
+    }
+  }
+}

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/ClusterActuator.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/ClusterActuator.java
@@ -21,6 +21,7 @@ import feign.jackson.JacksonEncoder;
 import io.camunda.zeebe.management.cluster.ClusterConfigPatchRequest;
 import io.camunda.zeebe.management.cluster.GetTopologyResponse;
 import io.camunda.zeebe.management.cluster.PlannedOperationsResponse;
+import io.camunda.zeebe.management.cluster.RoutingState;
 import io.camunda.zeebe.qa.util.cluster.TestApplication;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.zeebe.containers.ZeebeNode;
@@ -203,4 +204,12 @@ public interface ClusterActuator {
   @RequestLine("POST /purge?dryRun={dryRun}")
   @Headers({"Content-Type: application/json"})
   PlannedOperationsResponse purge(@Param boolean dryRun);
+
+  @RequestLine("PATCH /routing-state?dryRun={dryRun}&force={force}")
+  @Headers({"Content-Type: application/json", "accept: application/json"})
+  void patchRoutingState(@RequestBody final RoutingState routingState, @Param boolean dryRun);
+
+  @RequestLine("PATCH /routing-state?dryRun={dryRun}&force={force}")
+  @Headers({"Content-Type: application/json", "accept: application/json"})
+  void patchRoutingState(@Param boolean dryRun);
 }


### PR DESCRIPTION
## Description
A new rest endpoint `PATCH /cluster/routing-state` has been added to the Cluster Actuator. 

The endpoint can be used to update the `RoutingState` from the `dynamic-config` module  in two ways:
- no body: the `RoutingState` is fetched from the brokers from partition 1
- `RoutingState` in body: it's updated in the configuration without checking if it's compatibile with the broker. Should we keep it or hide it behind an experimental flag?

This API does not update in any way the `RoutingState` inside the engine.

The API is intended to be used only in case some unexpected error happens and the gateways have an invalid configuration that must be patched.


## Related issues

closes #34768 
