### PR TITLE
test: stabilize flaky BatchOperationLifecycleManagementTest

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/BatchOperationLifecycleManagementTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/BatchOperationLifecycleManagementTest.java
@@ -53,7 +53,7 @@ public class BatchOperationLifecycleManagementTest {
                 b.getExperimental()
                     .getEngine()
                     .getBatchOperations()
-                    .setSchedulerInterval(Duration.ofSeconds(3));
+                    .setSchedulerInterval(Duration.ofDays(1));
               });
 
   String testScopeId;


### PR DESCRIPTION
## Description

Increase scheduling interval to minimize the possibility of moving the BO too fast before performing the tested actions

## Related issues

closes #34600
