### PR TITLE
test: add IT verifying that message correlation works with scaling

### DIFF
--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/ScaleUpPartitionsTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/ScaleUpPartitionsTest.java
@@ -544,7 +544,8 @@ public class ScaleUpPartitionsTest {
                               .correlationKey(String.valueOf(key))
                               .send()
                               .toCompletableFuture())
-                      .succeedsWithin(Duration.ofSeconds(5));
+                      .succeedsWithin(Duration.ofSeconds(5))
+                      .satisfies(r -> assertThat(r.getMessageKey()).isNotNull().isPositive());
                 });
       }
     }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/ScaleUpPartitionsTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/ScaleUpPartitionsTest.java
@@ -334,9 +334,7 @@ public class ScaleUpPartitionsTest {
   public void shouldNotBreakMessageCorrelation() {
     // given
     cluster.awaitHealthyTopology();
-    final var messageId = new AtomicInteger();
     final var correlationKeyVariable = "correlationKey";
-    final var correlationKeys = new ArrayBlockingQueue<Integer>(1024);
     final var processId = "PROCESS_WITH_MESSAGE";
     final var process =
         Bpmn.createExecutableProcess(processId)
@@ -386,7 +384,7 @@ public class ScaleUpPartitionsTest {
 
   @ParameterizedTest
   @EnumSource(value = TestCase.class)
-  public void shouldNotBreakProcessWIthStartEvents(final TestCase testCase) {
+  public void shouldNotBreakProcessWithStartEvents(final TestCase testCase) {
     // given
     cluster.awaitHealthyTopology();
     final var correlationKeyVariable = "correlationKey";

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/ScaleUpPartitionsTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/ScaleUpPartitionsTest.java
@@ -376,6 +376,7 @@ public class ScaleUpPartitionsTest {
     // After creating instances, wait for subscriptions to be established
     variableProvider.correlateAllMessages(camundaClient, "message");
   }
+
   @ParameterizedTest
   @EnumSource(value = TestCase.class)
   public void shouldNotBreakMessageStartEvents(final TestCase testCase) {
@@ -426,6 +427,7 @@ public class ScaleUpPartitionsTest {
     // then - verify that message start events work and intermediate messages can be correlated
     correlationKeyProvider.correlateAllMessages(camundaClient, continueMessageName);
   }
+
   public void assertThatRoutingStateMatches(final RoutingState routingState) {
     Awaitility.await("until topology is restored correctly")
         .atMost(Duration.ofSeconds(30))
@@ -481,6 +483,7 @@ public class ScaleUpPartitionsTest {
         false,
         false);
   }
+
   private void awaitScaleUpCompletion(final int desiredPartitionCount) {
     Awaitility.await("until scaling is done")
         .atMost(Duration.ofMinutes(2))
@@ -509,6 +512,7 @@ public class ScaleUpPartitionsTest {
       };
     }
   }
+
   static class CorrelationKeyVariableProvider {
 
     final AtomicInteger messageId = new AtomicInteger();
@@ -586,6 +590,7 @@ public class ScaleUpPartitionsTest {
         case SIGNAL ->
             startProcessInstancesWithSignals(
                 camundaClient, messageName(), count, correlationKeyProvider);
+        default -> throw new IllegalArgumentException("Invalid enum case " + this);
       }
     }
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/ScaleUpPartitionsTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/ScaleUpPartitionsTest.java
@@ -44,7 +44,6 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Map;
 import java.util.concurrent.ArrayBlockingQueue;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 import org.apache.commons.lang3.RandomStringUtils;
@@ -359,14 +358,7 @@ public class ScaleUpPartitionsTest {
     new ZeebeResourcesHelper(camundaClient).waitUntilDeploymentIsDone(deploymentKey);
     final var targetPartitionCount = PARTITIONS_COUNT + 1;
 
-    final Supplier<Map<String, Object>> variableProvider =
-        () -> {
-          final var key = messageId.incrementAndGet();
-          if (!correlationKeys.add(key)) {
-            throw new IllegalStateException("Too many correlation keys created");
-          }
-          return Map.of(correlationKeyVariable, key);
-        };
+    final var variableProvider = new CorrelationKeyVariableProvider();
 
     createInstanceWithAJobOnAllPartitions(
         camundaClient, JOB_TYPE, PARTITIONS_COUNT, false, processId, variableProvider);
@@ -380,27 +372,7 @@ public class ScaleUpPartitionsTest {
 
     // then
     // After creating instances, wait for subscriptions to be established
-    Awaitility.await("until all messages can be correlated successfully")
-        .timeout(Duration.ofSeconds(30))
-        .pollInterval(Duration.ofMillis(100))
-        .untilAsserted(
-            () -> {
-              // Try to correlate one message to verify subscriptions are ready
-              final var testKey = correlationKeys.peek();
-              if (testKey != null) {
-                try {
-                  camundaClient
-                      .newCorrelateMessageCommand()
-                      .messageName("message")
-                      .correlationKey(String.valueOf(testKey))
-                      .send()
-                      .join(1, TimeUnit.SECONDS);
-                  correlationKeys.poll(); // Remove the successfully correlated key
-                } catch (final Exception e) {
-                  throw new AssertionError("Message subscriptions not ready yet", e);
-                }
-              }
-            });
+    variableProvider.correlateAllMessages(camundaClient, "message");
   }
   @Test
   public void shouldNotBreakMessageStartEvents() {
@@ -411,7 +383,7 @@ public class ScaleUpPartitionsTest {
     final var correlationKeys = new ArrayBlockingQueue<Integer>(1024);
     final var processId = "PROCESS_WITH_MESSAGE_START";
     final var startMessageName = "startMessage";
-
+    final var continueMessageName = "continueMessage";
     // Create process with message start event and intermediate message event
     final var process =
         Bpmn.createExecutableProcess(processId)
@@ -423,7 +395,7 @@ public class ScaleUpPartitionsTest {
                 b ->
                     b.message(
                         m ->
-                            m.name("continueMessage")
+                            m.name(continueMessageName)
                                 .zeebeCorrelationKeyExpression(correlationKeyVariable)))
             .endEvent()
             .done();
@@ -439,18 +411,13 @@ public class ScaleUpPartitionsTest {
 
     final var targetPartitionCount = PARTITIONS_COUNT + 1;
 
-    final Supplier<String> correlationKeyProvider =
-        () -> {
-          final var key = messageId.incrementAndGet();
-          if (!correlationKeys.add(key)) {
-            throw new IllegalStateException("Too many correlation keys created");
-          }
-          return String.valueOf(key);
-        };
-
+    final var correlationKeyProvider = new CorrelationKeyVariableProvider();
     // Start some instances before scaling by publishing messages
     startProcessInstancesWithMessages(
-        startMessageName, correlationKeyVariable, correlationKeyProvider, PARTITIONS_COUNT * 5);
+        startMessageName,
+        correlationKeyVariable,
+        correlationKeyProvider.supplier(correlationKeyVariable),
+        PARTITIONS_COUNT * 5);
 
     // when
     scaleToPartitions(targetPartitionCount);
@@ -458,47 +425,96 @@ public class ScaleUpPartitionsTest {
 
     // Start instances after scaling by publishing messages
     startProcessInstancesWithMessages(
-        startMessageName, correlationKeyVariable, correlationKeyProvider, targetPartitionCount * 5);
+        startMessageName,
+        correlationKeyVariable,
+        correlationKeyProvider.supplier(correlationKeyVariable),
+        targetPartitionCount * 5);
 
     // then - verify that message start events work and intermediate messages can be correlated
-    Awaitility.await("until all intermediate message events can be correlated")
-        .timeout(Duration.ofSeconds(30))
-        .pollInterval(Duration.ofMillis(100))
-        .untilAsserted(
-            () -> {
-              // Try to correlate messages to the intermediate catch events
-              final var testKey = correlationKeys.peek();
-              if (testKey != null) {
-                try {
-                  camundaClient
-                      .newCorrelateMessageCommand()
-                      .messageName("continueMessage")
-                      .correlationKey(String.valueOf(testKey))
-                      .send()
-                      .join(1, TimeUnit.SECONDS);
-                  correlationKeys.poll(); // Remove the successfully correlated key
-                } catch (final Exception e) {
-                  throw new AssertionError("Message subscriptions not ready yet", e);
-                }
-              }
-            });
+    correlationKeyProvider.correlateAllMessages(camundaClient, continueMessageName);
   }
 
+  @Test
+  public void shouldNotBreakSignalStartEvents() {
+    // given
+    cluster.awaitHealthyTopology();
+    final var processId = "PROCESS_WITH_SIGNAL_START";
+    final var startSignalName = "startSignal";
+    final var correlationKeyVariable = "correlationKey";
 
+    final var variableProvider = new CorrelationKeyVariableProvider();
+    // Create process with signal start event and intermediate signal event
+    final var process =
+        Bpmn.createExecutableProcess(processId)
+            .startEvent("start-signal")
+            .signal(startSignalName)
+            .intermediateCatchEvent(
+                "continueMessage",
+                b ->
+                    b.message(
+                        mb ->
+                            mb.name("message")
+                                .zeebeCorrelationKeyExpression(correlationKeyVariable)))
+            .endEvent()
+            .done();
+
+    final var deploymentKey =
+        camundaClient
+            .newDeployResourceCommand()
+            .addProcessModel(process, "process-with-signal-start.bpmn")
+            .send()
+            .join()
+            .getKey();
+    new ZeebeResourcesHelper(camundaClient).waitUntilDeploymentIsDone(deploymentKey);
+
+    final var targetPartitionCount = PARTITIONS_COUNT + 1;
+
+    // Start some instances before scaling by broadcasting signals
+    startProcessInstancesWithSignals(
+        startSignalName, PARTITIONS_COUNT * 5, variableProvider.supplier(correlationKeyVariable));
+
+    // when
+    scaleToPartitions(targetPartitionCount);
+    awaitScaleUpCompletion(targetPartitionCount);
+
+    // Start instances after scaling by broadcasting signals
+    startProcessInstancesWithSignals(
+        startSignalName,
+        targetPartitionCount * 5,
+        variableProvider.supplier(correlationKeyVariable));
+
+    // then
+    // verify that the messages can be correlated, indicating that the process instances
+    // were started by the signal
+    variableProvider.correlateAllMessages(camundaClient, "continueMessage");
+  }
+
+  private void startProcessInstancesWithSignals(
+      final String signalName,
+      final int instanceCount,
+      final Supplier<Map<String, Object>> correlationKeyProvider) {
+    for (int i = 0; i < instanceCount; i++) {
+      camundaClient
+          .newBroadcastSignalCommand()
+          .signalName(signalName)
+          .variables(correlationKeyProvider.get())
+          .send()
+          .join();
+    }
+  }
 
   private void startProcessInstancesWithMessages(
       final String messageName,
       final String correlationKeyVariable,
-      final Supplier<String> correlationKeyProvider,
+      final Supplier<Map<String, Object>> correlationKeyProvider,
       final int instanceCount) {
 
     for (int i = 0; i < instanceCount; i++) {
-      final var correlationKey = correlationKeyProvider.get();
       camundaClient
           .newPublishMessageCommand()
           .messageName(messageName)
-          .correlationKey(correlationKey)
-          .variables(Map.of(correlationKeyVariable, correlationKey))
+          .correlationKey(correlationKeyVariable)
+          .variables(correlationKeyProvider.get())
           .send()
           .join();
     }
@@ -558,7 +574,6 @@ public class ScaleUpPartitionsTest {
         false,
         false);
   }
-
   private void awaitScaleUpCompletion(final int desiredPartitionCount) {
     Awaitility.await("until scaling is done")
         .atMost(Duration.ofMinutes(2))
@@ -585,6 +600,42 @@ public class ScaleUpPartitionsTest {
         case PARTITION_1_LEADER -> cluster.leaderForPartition(1);
         case BOOTSTRAP_NODE -> cluster.brokers().get(MEMBER_0);
       };
+    }
+  }
+  static class CorrelationKeyVariableProvider {
+
+    final AtomicInteger messageId = new AtomicInteger();
+    final ArrayBlockingQueue<Integer> correlationKeys = new ArrayBlockingQueue<>(1024);
+
+    Supplier<Map<String, Object>> supplier(final String name) {
+      return () -> {
+        final var key = messageId.incrementAndGet();
+        if (!correlationKeys.add(key)) {
+          throw new IllegalStateException("Too many correlation keys created");
+        }
+        return Map.of(name, key);
+      };
+    }
+
+    void correlateAllMessages(final CamundaClient camundaClient, final String messageName) {
+      while (!correlationKeys.isEmpty()) {
+        final var key = correlationKeys.poll();
+        Awaitility.await("until all signal start events are processed")
+            .timeout(Duration.ofSeconds(5))
+            .pollInterval(Duration.ofMillis(100))
+            .untilAsserted(
+                () -> {
+                  // Broadcast continue signal to verify subscriptions are ready
+                  assertThat(
+                          camundaClient
+                              .newCorrelateMessageCommand()
+                              .messageName(messageName)
+                              .correlationKey(String.valueOf(key))
+                              .send()
+                              .toCompletableFuture())
+                      .succeedsWithin(Duration.ofSeconds(5));
+                });
+      }
     }
   }
 }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/Utils.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/Utils.java
@@ -150,10 +150,18 @@ final class Utils {
       final boolean deployProcess,
       final String processId,
       final Supplier<Map<String, Object>> variables) {
-
     if (deployProcess) {
       deployProcessModel(camundaClient, jobType, processId);
     }
+    return createInstanceOnAllPartitions(camundaClient, partitionsCount, processId, variables);
+  }
+
+  static List<Long> createInstanceOnAllPartitions(
+      final CamundaClient camundaClient,
+      final int partitionsCount,
+      final String processId,
+      final Supplier<Map<String, Object>> variables) {
+
     final List<Long> createdProcessInstances = new ArrayList<>();
     Awaitility.await("Process instances are created in all partitions")
         // Might throw exception when a partition has not yet received deployment distribution


### PR DESCRIPTION
## Description
A simple process is created with an intermediate catch event.
Process instances created before and after scaling can be correlated successfully.

Added test case for :
    - message start event
    - signal start event

to make sure that processes that start with those events can be started before and after scaling up

## Related issues

relates #31653 
