### PR TITLE
feat: Allow to return a single result by query

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/AbstractEntityReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/AbstractEntityReader.java
@@ -15,9 +15,12 @@ import io.camunda.db.rdbms.read.domain.DbQueryPage.KeySetPaginationFieldEntry;
 import io.camunda.db.rdbms.read.domain.DbQueryPage.Operator;
 import io.camunda.db.rdbms.read.domain.DbQuerySorting;
 import io.camunda.db.rdbms.sql.columns.SearchColumn;
+import io.camunda.search.exception.CamundaSearchException;
+import io.camunda.search.exception.ErrorMessages;
 import io.camunda.search.page.SearchQueryPage;
 import io.camunda.search.page.SearchQueryPage.SearchQueryResultType;
 import io.camunda.search.query.SearchQueryResult;
+import io.camunda.search.query.TypedSearchQuery;
 import io.camunda.search.sort.SortOption;
 import io.camunda.search.sort.SortOption.FieldSorting;
 import io.camunda.search.sort.SortOrder;
@@ -132,6 +135,23 @@ abstract class AbstractEntityReader<T> {
     }
 
     return keySetPagination;
+  }
+
+  protected void ensureSingleResultIfRequired(final List<T> hits, final TypedSearchQuery query) {
+    if (!SearchQueryResultType.SINGLE_RESULT.equals(query.page().resultType())) {
+      return;
+    }
+
+    // Requires some refactoring to move this check into a single place later
+    if (hits.isEmpty()) {
+      throw new CamundaSearchException(
+          ErrorMessages.ERROR_SINGLE_RESULT_NOT_FOUND.formatted(query),
+          CamundaSearchException.Reason.NOT_FOUND);
+    } else if (hits.size() > 1) {
+      throw new CamundaSearchException(
+          ErrorMessages.ERROR_SINGLE_RESULT_NOT_UNIQUE.formatted(query),
+          CamundaSearchException.Reason.NOT_UNIQUE);
+    }
   }
 
   protected final SearchQueryResult<T> buildSearchQueryResult(

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/AuthorizationReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/AuthorizationReader.java
@@ -55,6 +55,7 @@ public class AuthorizationReader extends AbstractEntityReader<AuthorizationEntit
     LOG.trace("[RDBMS DB] Search for authorizations with filter {}", dbQuery);
     final var totalHits = authorizationMapper.count(dbQuery);
     final var hits = authorizationMapper.search(dbQuery).stream().map(this::map).toList();
+    ensureSingleResultIfRequired(hits, query);
     return buildSearchQueryResult(totalHits, hits, dbSort);
   }
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/BatchOperationItemReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/BatchOperationItemReader.java
@@ -40,6 +40,7 @@ public class BatchOperationItemReader extends AbstractEntityReader<BatchOperatio
     LOG.trace("[RDBMS DB] Search for batch operation items with filter {}", dbQuery);
     final var totalHits = batchOperationMapper.countItems(dbQuery);
     final var hits = batchOperationMapper.searchItems(dbQuery);
+    ensureSingleResultIfRequired(hits, query);
     return buildSearchQueryResult(totalHits, hits, dbSort);
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/BatchOperationReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/BatchOperationReader.java
@@ -56,6 +56,7 @@ public class BatchOperationReader extends AbstractEntityReader<BatchOperationEnt
         batchOperationMapper.search(dbQuery).stream()
             .map(BatchOperationEntityMapper::toEntity)
             .toList();
+    ensureSingleResultIfRequired(hits, query);
     return buildSearchQueryResult(totalHits, hits, dbSort);
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/DecisionDefinitionReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/DecisionDefinitionReader.java
@@ -46,6 +46,7 @@ public class DecisionDefinitionReader extends AbstractEntityReader<DecisionDefin
     LOG.trace("[RDBMS DB] Search for decision definition with filter {}", dbQuery);
     final var totalHits = decisionDefinitionMapper.count(dbQuery);
     final var hits = decisionDefinitionMapper.search(dbQuery);
+    ensureSingleResultIfRequired(hits, query);
     return buildSearchQueryResult(totalHits, hits, dbSort);
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/DecisionInstanceReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/DecisionInstanceReader.java
@@ -59,6 +59,7 @@ public class DecisionInstanceReader extends AbstractEntityReader<DecisionInstanc
     final var totalHits = decisionInstanceMapper.count(dbQuery);
     final var hits = enhanceEntities(decisionInstanceMapper.search(dbQuery), query.resultConfig());
 
+    ensureSingleResultIfRequired(hits, query);
     return buildSearchQueryResult(totalHits, hits, dbSort);
   }
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/DecisionRequirementsReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/DecisionRequirementsReader.java
@@ -53,6 +53,7 @@ public class DecisionRequirementsReader extends AbstractEntityReader<DecisionReq
     LOG.trace("[RDBMS DB] Search for decision requirements with filter {}", dbQuery);
     final var totalHits = decisionRequirementsMapper.count(dbQuery);
     final var hits = decisionRequirementsMapper.search(dbQuery);
+    ensureSingleResultIfRequired(hits, query);
     return buildSearchQueryResult(totalHits, hits, dbSort);
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/FlowNodeInstanceReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/FlowNodeInstanceReader.java
@@ -44,6 +44,7 @@ public class FlowNodeInstanceReader extends AbstractEntityReader<FlowNodeInstanc
     LOG.trace("[RDBMS DB] Search for process instance with filter {}", dbQuery);
     final var totalHits = flowNodeInstanceMapper.count(dbQuery);
     final var hits = flowNodeInstanceMapper.search(dbQuery);
+    ensureSingleResultIfRequired(hits, query);
     return buildSearchQueryResult(totalHits, hits, dbSort);
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/FormReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/FormReader.java
@@ -44,6 +44,7 @@ public class FormReader extends AbstractEntityReader<FormEntity> {
     LOG.trace("[RDBMS DB] Search for form with filter {}", dbQuery);
     final var totalHits = formMapper.count(dbQuery);
     final var hits = formMapper.search(dbQuery);
+    ensureSingleResultIfRequired(hits, query);
     return buildSearchQueryResult(totalHits, hits, dbSort);
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/GroupReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/GroupReader.java
@@ -43,6 +43,7 @@ public class GroupReader extends AbstractEntityReader<GroupEntity> {
     LOG.trace("[RDBMS DB] Search for groups with filter {}", dbQuery);
     final var totalHits = groupMapper.count(dbQuery);
     final var hits = groupMapper.search(dbQuery).stream().map(this::map).toList();
+    ensureSingleResultIfRequired(hits, query);
     return buildSearchQueryResult(totalHits, hits, dbSort);
   }
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/IncidentReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/IncidentReader.java
@@ -42,6 +42,7 @@ public class IncidentReader extends AbstractEntityReader<IncidentEntity> {
     LOG.trace("[RDBMS DB] Search for incident with filter {}", dbQuery);
     final var totalHits = incidentMapper.count(dbQuery);
     final var hits = incidentMapper.search(dbQuery);
+    ensureSingleResultIfRequired(hits, query);
     return buildSearchQueryResult(totalHits, hits, dbSort);
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/JobReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/JobReader.java
@@ -43,6 +43,7 @@ public class JobReader extends AbstractEntityReader<JobEntity> {
     LOG.trace("[RDBMS DB] Search for jobs with filter {}", dbQuery);
     final var totalHits = jobMapper.count(dbQuery);
     final var hits = jobMapper.search(dbQuery).stream().map(JobEntityMapper::toEntity).toList();
+    ensureSingleResultIfRequired(hits, query);
     return buildSearchQueryResult(totalHits, hits, dbSort);
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/MappingReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/MappingReader.java
@@ -44,6 +44,7 @@ public class MappingReader extends AbstractEntityReader<MappingEntity> {
     LOG.trace("[RDBMS DB] Search for mapping with filter {}", dbQuery);
     final var totalHits = mappingMapper.count(dbQuery);
     final var hits = mappingMapper.search(dbQuery);
+    ensureSingleResultIfRequired(hits, query);
     return buildSearchQueryResult(totalHits, hits, dbSort);
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/ProcessDefinitionReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/ProcessDefinitionReader.java
@@ -53,6 +53,7 @@ public class ProcessDefinitionReader extends AbstractEntityReader<ProcessDefinit
     LOG.trace("[RDBMS DB] Search for process instance with filter {}", dbQuery);
     final var totalHits = processDefinitionMapper.count(dbQuery);
     final var hits = processDefinitionMapper.search(dbQuery);
+    ensureSingleResultIfRequired(hits, query);
     return buildSearchQueryResult(totalHits, hits, dbSort);
   }
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/ProcessInstanceReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/ProcessInstanceReader.java
@@ -44,6 +44,7 @@ public class ProcessInstanceReader extends AbstractEntityReader<ProcessInstanceE
     LOG.trace("[RDBMS DB] Search for process instance with filter {}", dbQuery);
     final var totalHits = processInstanceMapper.count(dbQuery);
     final var hits = processInstanceMapper.search(dbQuery);
+    ensureSingleResultIfRequired(hits, query);
     return buildSearchQueryResult(totalHits, hits, dbSort);
   }
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/RoleReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/RoleReader.java
@@ -43,6 +43,7 @@ public class RoleReader extends AbstractEntityReader<RoleEntity> {
     LOG.trace("[RDBMS DB] Search for roles with filter {}", dbQuery);
     final var totalHits = roleMapper.count(dbQuery);
     final var hits = roleMapper.search(dbQuery).stream().map(this::map).toList();
+    ensureSingleResultIfRequired(hits, query);
     return buildSearchQueryResult(totalHits, hits, dbSort);
   }
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/TenantReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/TenantReader.java
@@ -43,6 +43,7 @@ public class TenantReader extends AbstractEntityReader<TenantEntity> {
     LOG.trace("[RDBMS DB] Search for tenants with filter {}", dbQuery);
     final var totalHits = tenantMapper.count(dbQuery);
     final var hits = tenantMapper.search(dbQuery).stream().map(this::map).toList();
+    ensureSingleResultIfRequired(hits, query);
     return buildSearchQueryResult(totalHits, hits, dbSort);
   }
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/UserReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/UserReader.java
@@ -42,6 +42,7 @@ public class UserReader extends AbstractEntityReader<UserEntity> {
     LOG.trace("[RDBMS DB] Search for users with filter {}", dbQuery);
     final var totalHits = userMapper.count(dbQuery);
     final var hits = userMapper.search(dbQuery);
+    ensureSingleResultIfRequired(hits, query);
     return buildSearchQueryResult(totalHits, hits, dbSort);
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/UserTaskReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/UserTaskReader.java
@@ -46,6 +46,7 @@ public class UserTaskReader extends AbstractEntityReader<UserTaskEntity> {
     final var totalHits = userTaskMapper.count(dbQuery);
     final var hits =
         userTaskMapper.search(dbQuery).stream().map(UserTaskEntityMapper::toEntity).toList();
+    ensureSingleResultIfRequired(hits, query);
     return buildSearchQueryResult(totalHits, hits, dbSort);
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/VariableReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/VariableReader.java
@@ -49,6 +49,7 @@ public class VariableReader extends AbstractEntityReader<VariableEntity> {
     LOG.trace("[RDBMS DB] Search for variables with filter {}", query);
     final var totalHits = variableMapper.count(dbQuery);
     final var hits = variableMapper.search(dbQuery);
+    ensureSingleResultIfRequired(hits, query);
     return buildSearchQueryResult(totalHits, hits, dbSort);
   }
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/AuthorizationIntegrationTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/AuthorizationIntegrationTest.java
@@ -80,9 +80,7 @@ public class AuthorizationIntegrationTest {
                 camundaClient.newAuthorizationGetRequest(nonExistingAuthorizationKey).send().join())
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 404: 'Not Found'")
-        .hasMessageContaining(
-            "Authorization with authorization key %d not found"
-                .formatted(nonExistingAuthorizationKey));
+        .hasMessageContaining("A single result was expected, but none was found matching");
   }
 
   @Test

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/DecisionInstanceSearchTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/DecisionInstanceSearchTest.java
@@ -340,7 +340,7 @@ class DecisionInstanceSearchTest {
     // then
     assertThat(problemException.code()).isEqualTo(404);
     assertThat(problemException.details().getDetail())
-        .isEqualTo("Decision instance with key %s not found".formatted(decisionInstanceId));
+        .contains("A single result was expected, but none was found matching");
   }
 
   private static DeploymentEvent deployResource(

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/DecisionSearchTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/DecisionSearchTest.java
@@ -179,7 +179,7 @@ class DecisionSearchTest {
     // then
     assertThat(problemException.code()).isEqualTo(404);
     assertThat(problemException.details().getDetail())
-        .isEqualTo("Decision definition with key %d not found".formatted(decisionKey));
+        .contains("A single result was expected, but none was found matching");
   }
 
   @Test
@@ -203,7 +203,7 @@ class DecisionSearchTest {
     // then
     assertThat(problemException.code()).isEqualTo(404);
     assertThat(problemException.details().getDetail())
-        .isEqualTo("Decision definition with key %d not found".formatted(decisionKey));
+        .contains("A single result was expected, but none was found matching");
   }
 
   @Test
@@ -580,8 +580,7 @@ class DecisionSearchTest {
     // then
     assertThat(problemException.code()).isEqualTo(404);
     assertThat(problemException.details().getDetail())
-        .isEqualTo(
-            "Decision requirements with key %d not found".formatted(decisionRequirementsKey));
+        .contains("A single result was expected, but none was found matching");
   }
 
   @Test

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/IncidentSearchTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/IncidentSearchTest.java
@@ -115,7 +115,8 @@ class IncidentSearchTest {
     assertThat(exception.details()).isNotNull();
     assertThat(exception.details().getTitle()).isEqualTo("NOT_FOUND");
     assertThat(exception.details().getStatus()).isEqualTo(404);
-    assertThat(exception.details().getDetail()).isEqualTo("Incident with key 51966 not found");
+    assertThat(exception.details().getDetail())
+        .contains("A single result was expected, but none was found matching");
   }
 
   @Test

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessDefinitionSearchTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessDefinitionSearchTest.java
@@ -209,7 +209,7 @@ public class ProcessDefinitionSearchTest {
     assertThat(exception.details().getTitle()).isEqualTo("NOT_FOUND");
     assertThat(exception.details().getStatus()).isEqualTo(404);
     assertThat(exception.details().getDetail())
-        .isEqualTo("Process definition with key 3072 not found");
+        .contains("A single result was expected, but none was found matching");
   }
 
   @Test

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceIncidentSearchTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceIncidentSearchTest.java
@@ -108,7 +108,7 @@ class ProcessInstanceIncidentSearchTest {
     assertThat(exception.details().getTitle()).isEqualTo("NOT_FOUND");
     assertThat(exception.details().getStatus()).isEqualTo(404);
     assertThat(exception.details().getDetail())
-        .isEqualTo("Process instance with key 1234567890 not found");
+        .contains("A single result was expected, but none was found matching");
   }
 
   @ParameterizedTest

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceSearchTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceSearchTest.java
@@ -160,7 +160,7 @@ public class ProcessInstanceSearchTest {
     assertThat(exception.details().getTitle()).isEqualTo("NOT_FOUND");
     assertThat(exception.details().getStatus()).isEqualTo(404);
     assertThat(exception.details().getDetail())
-        .isEqualTo("Process instance with key 100 not found");
+        .contains("A single result was expected, but none was found matching");
   }
 
   @Test

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/RoleIntegrationTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/RoleIntegrationTest.java
@@ -116,7 +116,7 @@ public class RoleIntegrationTest {
     assertThatThrownBy(() -> camundaClient.newRoleGetRequest("someRoleId").send().join())
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 404: 'Not Found'")
-        .hasMessageContaining("Role with role ID someRoleId not found");
+        .hasMessageContaining("A single result was expected, but none was found matching");
   }
 
   @Test

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/UserTaskSearchTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/UserTaskSearchTest.java
@@ -619,7 +619,7 @@ class UserTaskSearchTest {
     // then
     assertThat(problemException.code()).isEqualTo(404);
     assertThat(problemException.details().getDetail())
-        .isEqualTo("User task with key %d not found".formatted(userTaskKey));
+        .contains("A single result was expected, but none was found matching");
   }
 
   @Test

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/UsersSearchIntegrationTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/UsersSearchIntegrationTest.java
@@ -69,7 +69,7 @@ public class UsersSearchIntegrationTest {
     assertThatThrownBy(() -> camundaClient.newUserGetRequest("testUsername").send().join())
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 404: 'Not Found'")
-        .hasMessageContaining("User with username testUsername not found");
+        .hasMessageContaining("A single result was expected, but none was found matching");
   }
 
   @Test

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/VariableSearchTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/VariableSearchTest.java
@@ -315,7 +315,7 @@ class VariableSearchTest {
     // then
     assertThat(problemException.code()).isEqualTo(404);
     assertThat(problemException.details().getDetail())
-        .isEqualTo("Variable with key %d not found".formatted(variableKey));
+        .contains("A single result was expected, but none was found matching");
   }
 
   @Test

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/SearchClientBasedQueryExecutor.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/SearchClientBasedQueryExecutor.java
@@ -13,14 +13,16 @@ import io.camunda.search.aggregation.AggregationBase;
 import io.camunda.search.aggregation.result.AggregationResultBase;
 import io.camunda.search.clients.auth.AuthorizationQueryStrategy;
 import io.camunda.search.clients.core.SearchQueryRequest;
+import io.camunda.search.clients.core.SearchQueryResponse;
 import io.camunda.search.clients.query.SearchQuery;
 import io.camunda.search.clients.query.SearchQueryBuilders;
 import io.camunda.search.clients.transformers.ServiceTransformer;
 import io.camunda.search.clients.transformers.ServiceTransformers;
 import io.camunda.search.clients.transformers.query.SearchQueryResultTransformer;
 import io.camunda.search.clients.transformers.query.TypedSearchQueryTransformer;
+import io.camunda.search.exception.CamundaSearchException;
+import io.camunda.search.exception.ErrorMessages;
 import io.camunda.search.filter.FilterBase;
-import io.camunda.search.page.SearchQueryPage.SearchQueryResultType;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.search.query.TypedSearchAggregationQuery;
 import io.camunda.search.query.TypedSearchQuery;
@@ -53,16 +55,25 @@ public final class SearchClientBasedQueryExecutor {
     final SearchQueryResultTransformer<T, R> responseTransformer =
         (SearchQueryResultTransformer<T, R>) getSearchResultTransformer(documentClass);
     final var type = query.page().resultType();
-    return executeSearch(
-        query,
-        q -> {
-          if (SearchQueryResultType.UNLIMITED.equals(type)) {
-            return responseTransformer.apply(searchClient.scroll(q, documentClass), false);
-          } else {
-            return responseTransformer.apply(
-                searchClient.search(q, documentClass), !query.page().isNextPage());
-          }
-        });
+    final boolean reverse;
+    final SearchQueryResponse<T> response;
+
+    switch (type) {
+      case UNLIMITED -> {
+        reverse = false;
+        response = executeUnlimitedSearch(query, documentClass);
+      }
+      case SINGLE_RESULT -> {
+        reverse = false;
+        response = executeSingleResultSearch(query, documentClass);
+      }
+      default -> {
+        reverse = !query.page().isNextPage();
+        response = executePaginatedSearch(query, documentClass);
+      }
+    }
+
+    return responseTransformer.apply(response, reverse);
   }
 
   public <F extends FilterBase, A extends AggregationBase, R extends AggregationResultBase>
@@ -72,6 +83,32 @@ public final class SearchClientBasedQueryExecutor {
     return transformers
         .getSearchAggregationResultTransformer(resultClass)
         .apply(searchQueryResponse.aggregations());
+  }
+
+  <F extends FilterBase, S extends SortOption, T> SearchQueryResponse<T> executePaginatedSearch(
+      final TypedSearchQuery<F, S> query, final Class<T> documentClass) {
+    return executeSearch(query, q -> searchClient.search(q, documentClass));
+  }
+
+  <F extends FilterBase, S extends SortOption, T> SearchQueryResponse<T> executeUnlimitedSearch(
+      final TypedSearchQuery<F, S> query, final Class<T> documentClass) {
+    return executeSearch(query, q -> searchClient.scroll(q, documentClass));
+  }
+
+  <F extends FilterBase, S extends SortOption, T> SearchQueryResponse<T> executeSingleResultSearch(
+      final TypedSearchQuery<F, S> query, final Class<T> documentClass) {
+    final var response = executePaginatedSearch(query, documentClass);
+    final var hits = response.hits().size();
+    if (hits < 1) {
+      throw new CamundaSearchException(
+          ErrorMessages.ERROR_SINGLE_RESULT_NOT_FOUND.formatted(query),
+          CamundaSearchException.Reason.NOT_FOUND);
+    } else if (hits > 1) {
+      throw new CamundaSearchException(
+          ErrorMessages.ERROR_SINGLE_RESULT_NOT_UNIQUE.formatted(query),
+          CamundaSearchException.Reason.NOT_UNIQUE);
+    }
+    return response;
   }
 
   @VisibleForTesting

--- a/search/search-domain/src/main/java/io/camunda/search/exception/ErrorMessages.java
+++ b/search/search-domain/src/main/java/io/camunda/search/exception/ErrorMessages.java
@@ -19,21 +19,8 @@ public class ErrorMessages {
 
   public static final String ERROR_NOT_FOUND_AD_HOC_SUB_PROCESS =
       "Failed to find ad-hoc sub-process with ID '%s'";
-  public static final String ERROR_NOT_FOUND_AUTHORIZATION_BY_KEY =
-      "Authorization with authorization key %d not found";
-  public static final String ERROR_NOT_FOUND_ENTITY_BY_KEY = "%s with key %s not found";
-  public static final String ERROR_NOT_FOUND_FORM_BY_KEY = "Form with formKey %d not found";
-  public static final String ERROR_NOT_FOUND_GROUP_BY_ID = "Group with ID %s not found";
-  public static final String ERROR_NOT_FOUND_GROUP_BY_NAME = "Group with group name %s not found";
-  public static final String ERROR_NOT_FOUND_MAPPING_BY_ID = "Mapping with mappingId %s not found";
-  public static final String ERROR_NOT_FOUND_ROLE_BY_ID = "Role with role ID %s not found";
-  public static final String ERROR_NOT_FOUND_USER_BY_USERNAME = "User with username %s not found";
-  public static final String ERROR_NOT_FOUND_TENANT = "Tenant matching %s not found";
-
-  public static final String ERROR_NOT_UNIQUE_ENTITY = "Found %s with key %s more than once";
-  public static final String ERROR_NOT_UNIQUE_FORM = "Found form with key %d more than once";
-  public static final String ERROR_NOT_UNIQUE_TENANT = "Found multiple tenants matching %s";
-
-  public static final String ERROR_QUERY_MAX_BATCH_SIZE_EXCEEDS_LIMIT =
-      "Given query max batch %d exceeds the limit of %d";
+  public static final String ERROR_SINGLE_RESULT_NOT_UNIQUE =
+      "A single result was expected, but multiple results were found matching %s";
+  public static final String ERROR_SINGLE_RESULT_NOT_FOUND =
+      "A single result was expected, but none was found matching %s";
 }

--- a/search/search-domain/src/main/java/io/camunda/search/page/SearchQueryPage.java
+++ b/search/search-domain/src/main/java/io/camunda/search/page/SearchQueryPage.java
@@ -83,6 +83,7 @@ public record SearchQueryPage(
 
   public enum SearchQueryResultType {
     UNLIMITED,
-    PAGINATED
+    PAGINATED,
+    SINGLE_RESULT
   }
 }

--- a/search/search-domain/src/main/java/io/camunda/search/query/SearchQueryBase.java
+++ b/search/search-domain/src/main/java/io/camunda/search/query/SearchQueryBase.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.search.query;
 
+import static io.camunda.search.page.SearchQueryPage.SearchQueryResultType.SINGLE_RESULT;
 import static io.camunda.search.page.SearchQueryPage.SearchQueryResultType.UNLIMITED;
 
 import io.camunda.search.page.SearchQueryPage;
@@ -19,7 +20,7 @@ public interface SearchQueryBase {
 
   SearchQueryPage page();
 
-  public abstract static class AbstractQueryBuilder<T extends AbstractQueryBuilder<T>> {
+  abstract class AbstractQueryBuilder<T extends AbstractQueryBuilder<T>> {
 
     private static final SearchQueryPage DEFAULT_PAGE = SearchQueryPage.of((b) -> b);
 
@@ -29,6 +30,11 @@ public interface SearchQueryBase {
 
     protected SearchQueryPage page() {
       return Objects.requireNonNullElse(page, DEFAULT_PAGE);
+    }
+
+    public T singleResult() {
+      page(new SearchQueryPage(0, 2, null, null, SINGLE_RESULT));
+      return self();
     }
 
     public T unlimited() {

--- a/service/src/main/java/io/camunda/service/AuthorizationServices.java
+++ b/service/src/main/java/io/camunda/service/AuthorizationServices.java
@@ -9,8 +9,6 @@ package io.camunda.service;
 
 import io.camunda.search.clients.AuthorizationSearchClient;
 import io.camunda.search.entities.AuthorizationEntity;
-import io.camunda.search.exception.CamundaSearchException;
-import io.camunda.search.exception.ErrorMessages;
 import io.camunda.search.query.AuthorizationQuery;
 import io.camunda.search.query.SearchQueryBuilders;
 import io.camunda.search.query.SearchQueryResult;
@@ -30,7 +28,6 @@ import io.camunda.zeebe.protocol.record.value.EntityType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
@@ -116,22 +113,13 @@ public class AuthorizationServices
   }
 
   public AuthorizationEntity getAuthorization(final long authorizationKey) {
-    return findAuthorization(authorizationKey)
-        .orElseThrow(
-            () ->
-                new CamundaSearchException(
-                    ErrorMessages.ERROR_NOT_FOUND_AUTHORIZATION_BY_KEY.formatted(authorizationKey),
-                    CamundaSearchException.Reason.NOT_FOUND));
-  }
-
-  public Optional<AuthorizationEntity> findAuthorization(final long authorizationKey) {
     return search(
             SearchQueryBuilders.authorizationSearchQuery()
                 .filter(f -> f.authorizationKey(authorizationKey))
+                .singleResult()
                 .build())
         .items()
-        .stream()
-        .findFirst();
+        .getFirst();
   }
 
   public CompletableFuture<AuthorizationRecord> deleteAuthorization(final long authorizationKey) {

--- a/service/src/main/java/io/camunda/service/BatchOperationServices.java
+++ b/service/src/main/java/io/camunda/service/BatchOperationServices.java
@@ -70,14 +70,15 @@ public final class BatchOperationServices
   }
 
   public BatchOperationEntity getById(final String batchOperationId) {
-    final var result =
-        batchOperationSearchClient
-            .withSecurityContext(
-                securityContextProvider.provideSecurityContext(
-                    authentication, Authorization.of(a -> a.batchOperation().read())))
-            .searchBatchOperations(
-                batchOperationQuery(q -> q.filter(f -> f.batchOperationIds(batchOperationId))));
-    return getSingleResultOrThrow(result, batchOperationId, "BatchOperation");
+    return batchOperationSearchClient
+        .withSecurityContext(
+            securityContextProvider.provideSecurityContext(
+                authentication, Authorization.of(a -> a.batchOperation().read())))
+        .searchBatchOperations(
+            batchOperationQuery(
+                q -> q.filter(f -> f.batchOperationIds(batchOperationId)).singleResult()))
+        .items()
+        .getFirst();
   }
 
   public CompletableFuture<BatchOperationLifecycleManagementRecord> cancel(

--- a/service/src/main/java/io/camunda/service/DecisionInstanceServices.java
+++ b/service/src/main/java/io/camunda/service/DecisionInstanceServices.java
@@ -77,14 +77,15 @@ public final class DecisionInstanceServices
                 decisionInstanceSearchQuery(
                     q ->
                         q.filter(f -> f.decisionInstanceIds(decisionInstanceId))
-                            .resultConfig(Builder::includeAll)));
-    final var decisionInstanceEntity =
-        getSingleResultOrThrow(result, decisionInstanceId, "Decision instance");
+                            .resultConfig(Builder::includeAll)
+                            .singleResult()))
+            .items()
+            .getFirst();
     final var authorization = Authorization.of(a -> a.decisionDefinition().readDecisionInstance());
     if (!securityContextProvider.isAuthorized(
-        decisionInstanceEntity.decisionDefinitionId(), authentication, authorization)) {
+        result.decisionDefinitionId(), authentication, authorization)) {
       throw new ForbiddenException(authorization);
     }
-    return decisionInstanceEntity;
+    return result;
   }
 }

--- a/service/src/main/java/io/camunda/service/DecisionRequirementsServices.java
+++ b/service/src/main/java/io/camunda/service/DecisionRequirementsServices.java
@@ -68,15 +68,16 @@ public final class DecisionRequirementsServices
                 decisionRequirementsSearchQuery(
                     q ->
                         q.filter(f -> f.decisionRequirementsKeys(key))
-                            .resultConfig(r -> r.includeXml(includeXml))));
-    final var decisionRequirementsEntity =
-        getSingleResultOrThrow(result, key, "Decision requirements");
+                            .resultConfig(r -> r.includeXml(includeXml))
+                            .singleResult()))
+            .items()
+            .getFirst();
     final var authorization = Authorization.of(a -> a.decisionRequirementsDefinition().read());
     if (!securityContextProvider.isAuthorized(
-        decisionRequirementsEntity.decisionRequirementsId(), authentication, authorization)) {
+        result.decisionRequirementsId(), authentication, authorization)) {
       throw new ForbiddenException(authorization);
     }
-    return decisionRequirementsEntity;
+    return result;
   }
 
   public SearchQueryResult<DecisionRequirementsEntity> search(

--- a/service/src/main/java/io/camunda/service/ElementInstanceServices.java
+++ b/service/src/main/java/io/camunda/service/ElementInstanceServices.java
@@ -66,14 +66,16 @@ public final class ElementInstanceServices
         flowNodeInstanceSearchClient
             .withSecurityContext(securityContextProvider.provideSecurityContext(authentication))
             .searchFlowNodeInstances(
-                flownodeInstanceSearchQuery(q -> q.filter(f -> f.flowNodeInstanceKeys(key))));
-    final var flowNodeInstance = getSingleResultOrThrow(result, key, "Flow node instance");
+                flownodeInstanceSearchQuery(
+                    q -> q.filter(f -> f.flowNodeInstanceKeys(key)).singleResult()))
+            .items()
+            .getFirst();
     final var authorization = Authorization.of(a -> a.processDefinition().readProcessInstance());
     if (!securityContextProvider.isAuthorized(
-        flowNodeInstance.processDefinitionId(), authentication, authorization)) {
+        result.processDefinitionId(), authentication, authorization)) {
       throw new ForbiddenException(authorization);
     }
-    return flowNodeInstance;
+    return result;
   }
 
   public CompletableFuture<VariableDocumentRecord> setVariables(

--- a/service/src/main/java/io/camunda/service/FormServices.java
+++ b/service/src/main/java/io/camunda/service/FormServices.java
@@ -9,8 +9,6 @@ package io.camunda.service;
 
 import io.camunda.search.clients.FormSearchClient;
 import io.camunda.search.entities.FormEntity;
-import io.camunda.search.exception.CamundaSearchException;
-import io.camunda.search.exception.ErrorMessages;
 import io.camunda.search.query.FormQuery;
 import io.camunda.search.query.SearchQueryBuilders;
 import io.camunda.search.query.SearchQueryResult;
@@ -47,20 +45,9 @@ public final class FormServices extends SearchQueryService<FormServices, FormQue
   }
 
   public FormEntity getByKey(final Long key) {
-    final SearchQueryResult<FormEntity> result =
-        search(SearchQueryBuilders.formSearchQuery().filter(f -> f.formKeys(key)).build());
-
-    if (result.total() < 1) {
-      throw new CamundaSearchException(
-          ErrorMessages.ERROR_NOT_FOUND_FORM_BY_KEY.formatted(key),
-          CamundaSearchException.Reason.NOT_FOUND);
-    } else if (result.total() > 1) {
-      throw new CamundaSearchException(
-          ErrorMessages.ERROR_NOT_UNIQUE_FORM.formatted(key),
-          CamundaSearchException.Reason.NOT_UNIQUE);
-    } else {
-      return result.items().stream().findFirst().orElseThrow();
-    }
+    return search(FormQuery.of(b -> b.filter(f -> f.formKeys(key)).singleResult()))
+        .items()
+        .getFirst();
   }
 
   public Optional<FormEntity> getLatestVersionByFormId(final String formId) {

--- a/service/src/main/java/io/camunda/service/GroupServices.java
+++ b/service/src/main/java/io/camunda/service/GroupServices.java
@@ -10,10 +10,7 @@ package io.camunda.service;
 import io.camunda.search.clients.GroupSearchClient;
 import io.camunda.search.entities.GroupEntity;
 import io.camunda.search.entities.GroupMemberEntity;
-import io.camunda.search.exception.CamundaSearchException;
-import io.camunda.search.exception.ErrorMessages;
 import io.camunda.search.query.GroupQuery;
-import io.camunda.search.query.SearchQueryBuilders;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.auth.Authorization;
 import io.camunda.security.auth.CamundaAuthentication;
@@ -28,7 +25,6 @@ import io.camunda.zeebe.protocol.impl.record.value.group.GroupRecord;
 import io.camunda.zeebe.protocol.record.value.EntityType;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
@@ -80,28 +76,15 @@ public class GroupServices extends SearchQueryService<GroupServices, GroupQuery,
   }
 
   public GroupEntity getGroup(final String groupId) {
-    return findGroup(groupId)
-        .orElseThrow(
-            () ->
-                new CamundaSearchException(
-                    ErrorMessages.ERROR_NOT_FOUND_GROUP_BY_ID.formatted(groupId),
-                    CamundaSearchException.Reason.NOT_FOUND));
-  }
-
-  public Optional<GroupEntity> findGroupByName(final String name) {
-    return search(SearchQueryBuilders.groupSearchQuery().filter(f -> f.name(name)).build())
+    return search(GroupQuery.of(b -> b.filter(f -> f.groupIds(groupId)).singleResult()))
         .items()
-        .stream()
-        .findFirst();
+        .getFirst();
   }
 
   public GroupEntity getGroupByName(final String name) {
-    return findGroupByName(name)
-        .orElseThrow(
-            () ->
-                new CamundaSearchException(
-                    ErrorMessages.ERROR_NOT_FOUND_GROUP_BY_NAME.formatted(name),
-                    CamundaSearchException.Reason.NOT_FOUND));
+    return search(GroupQuery.of(b -> b.filter(f -> f.name(name)).singleResult()))
+        .items()
+        .getFirst();
   }
 
   public List<GroupEntity> getGroupsByMemberId(final String memberId, final EntityType memberType) {
@@ -117,13 +100,6 @@ public class GroupServices extends SearchQueryService<GroupServices, GroupQuery,
             GroupQuery.of(
                 b -> b.filter(f -> f.memberIds(memberIds).childMemberType(memberType)).unlimited()))
         .items();
-  }
-
-  public Optional<GroupEntity> findGroup(final String groupId) {
-    return search(SearchQueryBuilders.groupSearchQuery().filter(f -> f.groupIds(groupId)).build())
-        .items()
-        .stream()
-        .findFirst();
   }
 
   public CompletableFuture<GroupRecord> updateGroup(

--- a/service/src/main/java/io/camunda/service/IncidentServices.java
+++ b/service/src/main/java/io/camunda/service/IncidentServices.java
@@ -63,14 +63,16 @@ public class IncidentServices
     final var result =
         incidentSearchClient
             .withSecurityContext(securityContextProvider.provideSecurityContext(authentication))
-            .searchIncidents(incidentSearchQuery(q -> q.filter(f -> f.incidentKeys(key))));
-    final var incidentEntity = getSingleResultOrThrow(result, key, "Incident");
+            .searchIncidents(
+                incidentSearchQuery(q -> q.filter(f -> f.incidentKeys(key)).singleResult()))
+            .items()
+            .getFirst();
     final var authorization = Authorization.of(a -> a.processDefinition().readProcessInstance());
     if (!securityContextProvider.isAuthorized(
-        incidentEntity.processDefinitionId(), authentication, authorization)) {
+        result.processDefinitionId(), authentication, authorization)) {
       throw new ForbiddenException(authorization);
     }
-    return incidentEntity;
+    return result;
   }
 
   public CompletableFuture<IncidentRecord> resolveIncident(

--- a/service/src/main/java/io/camunda/service/MappingServices.java
+++ b/service/src/main/java/io/camunda/service/MappingServices.java
@@ -9,8 +9,6 @@ package io.camunda.service;
 
 import io.camunda.search.clients.MappingSearchClient;
 import io.camunda.search.entities.MappingEntity;
-import io.camunda.search.exception.CamundaSearchException;
-import io.camunda.search.exception.ErrorMessages;
 import io.camunda.search.query.MappingQuery;
 import io.camunda.search.query.SearchQueryBuilders;
 import io.camunda.search.query.SearchQueryResult;
@@ -77,20 +75,13 @@ public class MappingServices
   }
 
   public MappingEntity getMapping(final String mappingId) {
-    return findMapping(mappingId)
-        .orElseThrow(
-            () ->
-                new CamundaSearchException(
-                    ErrorMessages.ERROR_NOT_FOUND_MAPPING_BY_ID.formatted(mappingId),
-                    CamundaSearchException.Reason.NOT_FOUND));
-  }
-
-  public Optional<MappingEntity> findMapping(final String mappingId) {
     return search(
-            SearchQueryBuilders.mappingSearchQuery().filter(f -> f.mappingId(mappingId)).build())
+            SearchQueryBuilders.mappingSearchQuery()
+                .filter(f -> f.mappingId(mappingId))
+                .singleResult()
+                .build())
         .items()
-        .stream()
-        .findFirst();
+        .getFirst();
   }
 
   public Optional<MappingEntity> findMapping(final MappingDTO request) {

--- a/service/src/main/java/io/camunda/service/ProcessDefinitionServices.java
+++ b/service/src/main/java/io/camunda/service/ProcessDefinitionServices.java
@@ -71,15 +71,17 @@ public class ProcessDefinitionServices
             .withSecurityContext(securityContextProvider.provideSecurityContext(authentication))
             .searchProcessDefinitions(
                 processDefinitionSearchQuery(
-                    q -> q.filter(f -> f.processDefinitionKeys(processDefinitionKey))));
-    final var processDefinitionEntity =
-        getSingleResultOrThrow(result, processDefinitionKey, "Process definition");
+                    q ->
+                        q.filter(f -> f.processDefinitionKeys(processDefinitionKey))
+                            .singleResult()))
+            .items()
+            .getFirst();
     final var authorization = Authorization.of(a -> a.processDefinition().readProcessDefinition());
     if (!securityContextProvider.isAuthorized(
-        processDefinitionEntity.processDefinitionId(), authentication, authorization)) {
+        result.processDefinitionId(), authentication, authorization)) {
       throw new ForbiddenException(authorization);
     }
-    return processDefinitionEntity;
+    return result;
   }
 
   public Optional<String> getProcessDefinitionXml(final Long processDefinitionKey) {

--- a/service/src/main/java/io/camunda/service/ProcessInstanceServices.java
+++ b/service/src/main/java/io/camunda/service/ProcessInstanceServices.java
@@ -159,15 +159,15 @@ public final class ProcessInstanceServices
             .withSecurityContext(securityContextProvider.provideSecurityContext(authentication))
             .searchProcessInstances(
                 processInstanceSearchQuery(
-                    q -> q.filter(f -> f.processInstanceKeys(processInstanceKey))));
-    final var processInstanceEntity =
-        getSingleResultOrThrow(result, processInstanceKey, "Process instance");
+                    q -> q.filter(f -> f.processInstanceKeys(processInstanceKey)).singleResult()))
+            .items()
+            .getFirst();
     final var authorization = Authorization.of(a -> a.processDefinition().readProcessInstance());
     if (!securityContextProvider.isAuthorized(
-        processInstanceEntity.processDefinitionId(), authentication, authorization)) {
+        result.processDefinitionId(), authentication, authorization)) {
       throw new ForbiddenException(authorization);
     }
-    return processInstanceEntity;
+    return result;
   }
 
   public CompletableFuture<ProcessInstanceCreationRecord> createProcessInstance(

--- a/service/src/main/java/io/camunda/service/RoleServices.java
+++ b/service/src/main/java/io/camunda/service/RoleServices.java
@@ -10,8 +10,6 @@ package io.camunda.service;
 import io.camunda.search.clients.RoleSearchClient;
 import io.camunda.search.entities.RoleEntity;
 import io.camunda.search.entities.RoleMemberEntity;
-import io.camunda.search.exception.CamundaSearchException;
-import io.camunda.search.exception.ErrorMessages;
 import io.camunda.search.query.RoleQuery;
 import io.camunda.search.query.SearchQueryBuilders;
 import io.camunda.search.query.SearchQueryResult;
@@ -30,7 +28,6 @@ import io.camunda.zeebe.protocol.record.value.EntityType;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
@@ -134,19 +131,13 @@ public class RoleServices extends SearchQueryService<RoleServices, RoleQuery, Ro
   }
 
   public RoleEntity getRole(final String roleId) {
-    return findRole(roleId)
-        .orElseThrow(
-            () ->
-                new CamundaSearchException(
-                    ErrorMessages.ERROR_NOT_FOUND_ROLE_BY_ID.formatted(roleId),
-                    CamundaSearchException.Reason.NOT_FOUND));
-  }
-
-  public Optional<RoleEntity> findRole(final String roleId) {
-    return search(SearchQueryBuilders.roleSearchQuery().filter(f -> f.roleId(roleId)).build())
+    return search(
+            SearchQueryBuilders.roleSearchQuery()
+                .filter(f -> f.roleId(roleId))
+                .singleResult()
+                .build())
         .items()
-        .stream()
-        .findFirst();
+        .getFirst();
   }
 
   public CompletableFuture<RoleRecord> deleteRole(final String roleId) {

--- a/service/src/main/java/io/camunda/service/TenantServices.java
+++ b/service/src/main/java/io/camunda/service/TenantServices.java
@@ -10,8 +10,6 @@ package io.camunda.service;
 import io.camunda.search.clients.TenantSearchClient;
 import io.camunda.search.entities.TenantEntity;
 import io.camunda.search.entities.TenantMemberEntity;
-import io.camunda.search.exception.CamundaSearchException;
-import io.camunda.search.exception.ErrorMessages;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.search.query.TenantQuery;
 import io.camunda.security.auth.Authorization;
@@ -141,31 +139,18 @@ public class TenantServices extends SearchQueryService<TenantServices, TenantQue
   }
 
   public TenantEntity getById(final String tenantId) {
-    return getSingle(TenantQuery.of(q -> q.filter(f -> f.tenantId(tenantId))));
-  }
-
-  private TenantEntity getSingle(final TenantQuery query) {
     final var result =
         tenantSearchClient
             .withSecurityContext(securityContextProvider.provideSecurityContext(authentication))
-            .searchTenants(query);
-    if (result.total() < 1) {
-      throw new CamundaSearchException(
-          ErrorMessages.ERROR_NOT_FOUND_TENANT.formatted(query),
-          CamundaSearchException.Reason.NOT_FOUND);
-    } else if (result.total() > 1) {
-      throw new CamundaSearchException(
-          ErrorMessages.ERROR_NOT_UNIQUE_TENANT.formatted(query),
-          CamundaSearchException.Reason.NOT_UNIQUE);
-    }
+            .searchTenants(TenantQuery.of(q -> q.filter(f -> f.tenantId(tenantId)).singleResult()))
+            .items()
+            .getFirst();
 
-    final var tenantEntity = result.items().stream().findFirst().orElseThrow();
     final var authorization = Authorization.of(a -> a.tenant().read());
-    if (!securityContextProvider.isAuthorized(
-        tenantEntity.tenantId(), authentication, authorization)) {
+    if (!securityContextProvider.isAuthorized(result.tenantId(), authentication, authorization)) {
       throw new ForbiddenException(authorization);
     }
-    return tenantEntity;
+    return result;
   }
 
   public record TenantDTO(Long key, String tenantId, String name, String description)

--- a/service/src/main/java/io/camunda/service/UserServices.java
+++ b/service/src/main/java/io/camunda/service/UserServices.java
@@ -9,8 +9,6 @@ package io.camunda.service;
 
 import io.camunda.search.clients.UserSearchClient;
 import io.camunda.search.entities.UserEntity;
-import io.camunda.search.exception.CamundaSearchException;
-import io.camunda.search.exception.ErrorMessages;
 import io.camunda.search.query.SearchQueryBuilders;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.search.query.UserQuery;
@@ -24,7 +22,6 @@ import io.camunda.zeebe.gateway.impl.broker.request.BrokerUserDeleteRequest;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerUserUpdateRequest;
 import io.camunda.zeebe.protocol.impl.record.value.user.UserRecord;
 import io.camunda.zeebe.protocol.record.intent.UserIntent;
-import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -81,19 +78,13 @@ public class UserServices extends SearchQueryService<UserServices, UserQuery, Us
   }
 
   public UserEntity getUser(final String username) {
-    return findUser(username)
-        .orElseThrow(
-            () ->
-                new CamundaSearchException(
-                    ErrorMessages.ERROR_NOT_FOUND_USER_BY_USERNAME.formatted(username),
-                    CamundaSearchException.Reason.NOT_FOUND));
-  }
-
-  public Optional<UserEntity> findUser(final String username) {
-    return search(SearchQueryBuilders.userSearchQuery().filter(f -> f.usernames(username)).build())
+    return search(
+            SearchQueryBuilders.userSearchQuery()
+                .filter(f -> f.usernames(username))
+                .singleResult()
+                .build())
         .items()
-        .stream()
-        .findFirst();
+        .getFirst();
   }
 
   public CompletableFuture<UserRecord> updateUser(final UserDTO request) {

--- a/service/src/main/java/io/camunda/service/VariableServices.java
+++ b/service/src/main/java/io/camunda/service/VariableServices.java
@@ -61,13 +61,15 @@ public final class VariableServices
     final var result =
         variableSearchClient
             .withSecurityContext(securityContextProvider.provideSecurityContext(authentication))
-            .searchVariables(variableSearchQuery(q -> q.filter(f -> f.variableKeys(key))));
-    final var variableEntity = getSingleResultOrThrow(result, key, "Variable");
+            .searchVariables(
+                variableSearchQuery(q -> q.filter(f -> f.variableKeys(key)).singleResult()))
+            .items()
+            .getFirst();
     final var authorization = Authorization.of(a -> a.processDefinition().readProcessInstance());
     if (!securityContextProvider.isAuthorized(
-        variableEntity.processDefinitionId(), authentication, authorization)) {
+        result.processDefinitionId(), authentication, authorization)) {
       throw new ForbiddenException(authorization);
     }
-    return variableEntity;
+    return result;
   }
 }

--- a/service/src/main/java/io/camunda/service/search/core/SearchQueryService.java
+++ b/service/src/main/java/io/camunda/service/search/core/SearchQueryService.java
@@ -7,8 +7,6 @@
  */
 package io.camunda.service.search.core;
 
-import io.camunda.search.exception.CamundaSearchException;
-import io.camunda.search.exception.ErrorMessages;
 import io.camunda.search.query.SearchQueryBase;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.auth.CamundaAuthentication;
@@ -27,22 +25,4 @@ public abstract class SearchQueryService<T extends ApiServices<T>, Q extends Sea
   }
 
   public abstract SearchQueryResult<D> search(final Q query);
-
-  protected <E> E getSingleResultOrThrow(
-      final SearchQueryResult<E> searchQueryResult,
-      final Object key,
-      final String entityTypeLabel) {
-    if (searchQueryResult.total() < 1) {
-      throw new CamundaSearchException(
-          ErrorMessages.ERROR_NOT_FOUND_ENTITY_BY_KEY.formatted(entityTypeLabel, key),
-          CamundaSearchException.Reason.NOT_FOUND);
-    } else if (searchQueryResult.total() > 1) {
-      throw new CamundaSearchException(
-          ErrorMessages.ERROR_NOT_UNIQUE_ENTITY.formatted(entityTypeLabel, key),
-          CamundaSearchException.Reason.NOT_UNIQUE);
-
-    } else {
-      return searchQueryResult.items().stream().findFirst().orElseThrow();
-    }
-  }
 }

--- a/service/src/test/java/io/camunda/service/AuthorizationServiceTest.java
+++ b/service/src/test/java/io/camunda/service/AuthorizationServiceTest.java
@@ -117,20 +117,9 @@ public class AuthorizationServiceTest {
     when(client.searchAuthorizations(any())).thenReturn(result);
 
     // when
-    final var searchQueryResult = services.findAuthorization(entity.authorizationKey());
+    final var searchQueryResult = services.getAuthorization(entity.authorizationKey());
 
     // then
-    assertThat(searchQueryResult).contains(entity);
-  }
-
-  @Test
-  public void shouldThrownExceptionIfAuthorizationNotFound() {
-    // given
-    final var authorizationKey = 100L;
-    when(client.searchAuthorizations(any()))
-        .thenReturn(new SearchQueryResult<>(0, false, List.of(), null, null));
-
-    // when / then
-    assertThat(services.findAuthorization(authorizationKey)).isEmpty();
+    assertThat(searchQueryResult).isEqualTo(entity);
   }
 }

--- a/service/src/test/java/io/camunda/service/DecisionInstanceServiceTest.java
+++ b/service/src/test/java/io/camunda/service/DecisionInstanceServiceTest.java
@@ -91,7 +91,8 @@ class DecisionInstanceServiceTest {
                 q ->
                     q.filter(f -> f.decisionInstanceIds(decisionInstanceId))
                         .resultConfig(
-                            c -> c.includeEvaluatedInputs(true).includeEvaluatedOutputs(true))));
+                            c -> c.includeEvaluatedInputs(true).includeEvaluatedOutputs(true))
+                        .singleResult()));
   }
 
   @Test

--- a/service/src/test/java/io/camunda/service/GroupServiceTest.java
+++ b/service/src/test/java/io/camunda/service/GroupServiceTest.java
@@ -111,21 +111,10 @@ public class GroupServiceTest {
     when(client.searchGroups(any())).thenReturn(result);
 
     // when
-    final var searchQueryResult = services.findGroup("groupId");
+    final var searchQueryResult = services.getGroup("groupId");
 
     // then
-    assertThat(searchQueryResult).contains(entity);
-  }
-
-  @Test
-  public void shouldThrowExceptionIfGroupNotFoundById() {
-    // given
-    final var id = "groupId";
-    when(client.searchGroups(any()))
-        .thenReturn(new SearchQueryResult<>(0, false, List.of(), null, null));
-
-    // when / then
-    assertThat(services.findGroup(id)).isEmpty();
+    assertThat(searchQueryResult).isEqualTo(entity);
   }
 
   @Test

--- a/service/src/test/java/io/camunda/service/MappingServicesTest.java
+++ b/service/src/test/java/io/camunda/service/MappingServicesTest.java
@@ -8,7 +8,6 @@
 package io.camunda.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -17,7 +16,6 @@ import static org.mockito.Mockito.when;
 
 import io.camunda.search.clients.MappingSearchClient;
 import io.camunda.search.entities.MappingEntity;
-import io.camunda.search.exception.CamundaSearchException;
 import io.camunda.search.filter.MappingFilter;
 import io.camunda.search.query.MappingQuery;
 import io.camunda.search.query.SearchQueryBuilders;
@@ -117,32 +115,10 @@ public class MappingServicesTest {
     when(client.searchMappings(any())).thenReturn(result);
 
     // when
-    final var searchQueryResult = services.findMapping("mappingId");
+    final var searchQueryResult = services.getMapping("mappingId");
 
     // then
-    assertThat(searchQueryResult).contains(entity);
-  }
-
-  @Test
-  public void shouldReturnEmptyWhenNotFoundByFind() {
-    // given
-    when(client.searchMappings(any()))
-        .thenReturn(new SearchQueryResult(0, false, List.of(), null, null));
-
-    // when / then
-    assertThat(services.findMapping("mappingId")).isEmpty();
-  }
-
-  @Test
-  public void shouldThrowExceptionWhenNotFoundByGet() {
-    // given
-    when(client.searchMappings(any()))
-        .thenReturn(new SearchQueryResult(0, false, List.of(), null, null));
-
-    // when / then
-    final var exception =
-        assertThrows(CamundaSearchException.class, () -> services.getMapping("mappingId"));
-    assertThat(exception.getReason()).isEqualTo(CamundaSearchException.Reason.NOT_FOUND);
+    assertThat(searchQueryResult).isEqualTo(entity);
   }
 
   @Test

--- a/service/src/test/java/io/camunda/service/ProcessInstanceServiceTest.java
+++ b/service/src/test/java/io/camunda/service/ProcessInstanceServiceTest.java
@@ -22,7 +22,6 @@ import io.camunda.search.entities.IncidentEntity;
 import io.camunda.search.entities.ProcessInstanceEntity;
 import io.camunda.search.entities.ProcessInstanceEntity.ProcessInstanceState;
 import io.camunda.search.entities.SequenceFlowEntity;
-import io.camunda.search.exception.CamundaSearchException;
 import io.camunda.search.filter.FilterBuilders;
 import io.camunda.search.filter.Operation;
 import io.camunda.search.filter.ProcessInstanceFilter;
@@ -139,36 +138,6 @@ public final class ProcessInstanceServiceTest {
 
     // then
     assertThat(searchQueryResult.processInstanceKey()).isEqualTo(key);
-  }
-
-  @Test
-  public void shouldThrownExceptionIfNotFoundByKey() {
-    // given
-    final var key = 100L;
-    when(processInstanceSearchClient.searchProcessInstances(any()))
-        .thenReturn(new SearchQueryResult<>(0, false, List.of(), null, null));
-
-    // when / then
-    final var exception =
-        assertThrowsExactly(CamundaSearchException.class, () -> services.getByKey(key));
-    assertThat(exception.getMessage()).isEqualTo("Process instance with key 100 not found");
-    assertThat(exception.getReason()).isEqualTo(CamundaSearchException.Reason.NOT_FOUND);
-  }
-
-  @Test
-  public void shouldThrownExceptionIfDuplicateFoundByKey() {
-    // given
-    final var key = 200L;
-    final var entity1 = mock(ProcessInstanceEntity.class);
-    final var entity2 = mock(ProcessInstanceEntity.class);
-    when(processInstanceSearchClient.searchProcessInstances(any()))
-        .thenReturn(new SearchQueryResult<>(2, false, List.of(entity1, entity2), null, null));
-
-    // when / then
-    final var exception =
-        assertThrowsExactly(CamundaSearchException.class, () -> services.getByKey(key));
-    assertThat(exception.getMessage())
-        .isEqualTo("Found Process instance with key 200 more than once");
   }
 
   @Test

--- a/service/src/test/java/io/camunda/service/RoleServicesTest.java
+++ b/service/src/test/java/io/camunda/service/RoleServicesTest.java
@@ -108,21 +108,10 @@ public class RoleServicesTest {
     when(client.searchRoles(any())).thenReturn(result);
 
     // when
-    final var searchQueryResult = services.findRole(entity.roleId());
+    final var searchQueryResult = services.getRole(entity.roleId());
 
     // then
-    assertThat(searchQueryResult).contains(entity);
-  }
-
-  @Test
-  public void shouldThrownExceptionIfNotFoundById() {
-    // given
-    final var roleId = "roleId";
-    when(client.searchRoles(any()))
-        .thenReturn(new SearchQueryResult(0, false, List.of(), null, null));
-
-    // when / then
-    assertThat(services.findRole(roleId)).isEmpty();
+    assertThat(searchQueryResult).isEqualTo(entity);
   }
 
   @Test

--- a/service/src/test/java/io/camunda/service/TenantServiceTest.java
+++ b/service/src/test/java/io/camunda/service/TenantServiceTest.java
@@ -15,7 +15,6 @@ import static org.mockito.Mockito.when;
 
 import io.camunda.search.clients.TenantSearchClient;
 import io.camunda.search.entities.TenantEntity;
-import io.camunda.search.exception.CamundaSearchException;
 import io.camunda.search.filter.TenantFilter;
 import io.camunda.search.query.SearchQueryBuilders;
 import io.camunda.search.query.SearchQueryResult;
@@ -103,21 +102,6 @@ public class TenantServiceTest {
 
     // then
     assertThat(searchQueryResult).isEqualTo(tenantEntity);
-  }
-
-  @Test
-  public void shouldThrowExceptionIfNotFoundByKey() {
-    // given
-    when(client.searchTenants(any()))
-        .thenReturn(new SearchQueryResult(0, false, List.of(), null, null));
-
-    // when / then
-
-    assertThatCode(() -> services.getById("non-existent-tenant-id"))
-        .isInstanceOf(CamundaSearchException.class)
-        .hasMessageMatching("Tenant matching TenantQuery\\[.*] not found")
-        .extracting(e -> ((CamundaSearchException) e).getReason())
-        .isEqualTo(CamundaSearchException.Reason.NOT_FOUND);
   }
 
   @Test

--- a/service/src/test/java/io/camunda/service/UserServiceTest.java
+++ b/service/src/test/java/io/camunda/service/UserServiceTest.java
@@ -99,20 +99,9 @@ public class UserServiceTest {
     when(client.searchUsers(any())).thenReturn(result);
 
     // when
-    final var searchQueryResult = services.findUser(entity.username());
+    final var searchQueryResult = services.getUser(entity.username());
 
     // then
-    assertThat(searchQueryResult).contains(entity);
-  }
-
-  @Test
-  public void shouldThrownExceptionIfUserNotFoundByUsername() {
-    // given
-    final var username = "username";
-    when(client.searchUsers(any()))
-        .thenReturn(new SearchQueryResult<>(0, false, List.of(), null, null));
-
-    // when / then
-    assertThat(services.findUser(username)).isEmpty();
+    assertThat(searchQueryResult).isEqualTo(entity);
   }
 }

--- a/service/src/test/java/io/camunda/service/UserTaskServiceTest.java
+++ b/service/src/test/java/io/camunda/service/UserTaskServiceTest.java
@@ -113,7 +113,8 @@ public class UserTaskServiceTest {
     when(entity.processDefinitionId()).thenReturn("bpid");
     when(entity.formKey()).thenReturn(formKey);
     final var form = mock(FormEntity.class);
-    when(formSearchClient.searchForms(formSearchQuery(q -> q.filter(f -> f.formKeys(formKey)))))
+    when(formSearchClient.searchForms(
+            formSearchQuery(q -> q.filter(f -> f.formKeys(formKey)).singleResult())))
         .thenReturn(wrapWithSearchQueryResult(form));
     when(client.searchUserTasks(any())).thenReturn(wrapWithSearchQueryResult(entity));
     authorizeReadUserTasksForProcess(true, "bpid");
@@ -197,7 +198,7 @@ public class UserTaskServiceTest {
     when(client.searchUserTasks(any())).thenReturn(wrapWithSearchQueryResult(entity));
     when(flowNodeInstanceSearchClient.searchFlowNodeInstances(
             flownodeInstanceSearchQuery(
-                q -> q.filter(f -> f.flowNodeInstanceKeys(flowNodeInstanceKey)))))
+                q -> q.filter(f -> f.flowNodeInstanceKeys(flowNodeInstanceKey)).singleResult())))
         .thenReturn(wrapWithSearchQueryResult(flowNodeInstanceEntity));
     final var variable = mock(VariableEntity.class);
     when(variableSearchClient.searchVariables(


### PR DESCRIPTION
## Description

* Introduces a `#singleResult()` flag to be used when creating a query.
* If `#singleResult()` is called, it will ensure that a "unique" item is returned.
  * If the query returns nothing, it throws a not found exception.
  * If the query returns more than 1, it throws a not unique exception.
  * Otherwise, it returns a `SearchQueryResult` containing the single item/result as an item.
* Usage example.
```
RoleQuery.of(q -> q
  .filter(f -> f.memberId(memberId).childMemberType(entityType))
  .singleResult()) 
```
* This is to be used when querying a unique resource by a complex query, in other words, the resource key/id is not present, only a query that "identifies" the unique resource.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

related to #34975
