### PR TITLE
fix: ensure that `TestActorFuture` times out properly

### DIFF
--- a/zeebe/scheduler/src/test/java/io/camunda/zeebe/scheduler/testing/TestActorFuture.java
+++ b/zeebe/scheduler/src/test/java/io/camunda/zeebe/scheduler/testing/TestActorFuture.java
@@ -207,8 +207,15 @@ public final class TestActorFuture<V> implements ActorFuture<V> {
   @Override
   public V get(final long timeout, final TimeUnit unit)
       throws InterruptedException, ExecutionException, TimeoutException {
-    countDownLatch.await(timeout, unit);
-    return get();
+    if (!countDownLatch.await(timeout, unit)) {
+      throw new TimeoutException("Timeout waiting for future to complete");
+    }
+
+    if (result.isRight()) {
+      return result.get();
+    } else {
+      throw new ExecutionException(result.getLeft());
+    }
   }
 
   public static <U> ActorFuture<U> completedFuture(final U value) {


### PR DESCRIPTION
Previously, `TestActorFuture#get(long, java.util.concurrent.TimeUnit)` was implemented incorrectly, first awaiting _with_ timeout but a second time _without_ timeout. This could lead to blocked tests.