### PR TITLE
feat: write a command to confirm the latest backup position

### DIFF
--- a/zeebe/backup/pom.xml
+++ b/zeebe/backup/pom.xml
@@ -43,6 +43,11 @@
 
     <dependency>
       <groupId>io.camunda</groupId>
+      <artifactId>zeebe-logstreams</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
       <artifactId>zeebe-protocol-impl</artifactId>
     </dependency>
     <dependency>

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/management/BackupService.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/management/BackupService.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.backup.api.BackupStore;
 import io.camunda.zeebe.backup.common.BackupIdentifierImpl;
 import io.camunda.zeebe.backup.common.BackupStatusImpl;
 import io.camunda.zeebe.backup.metrics.BackupManagerMetrics;
+import io.camunda.zeebe.logstreams.log.LogStreamWriter;
 import io.camunda.zeebe.scheduler.Actor;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
@@ -46,14 +47,15 @@ public final class BackupService extends Actor implements BackupManager {
       final PersistedSnapshotStore snapshotStore,
       final Path segmentsDirectory,
       final JournalInfoProvider raftMetadataProvider,
-      final MeterRegistry partitionRegistry) {
+      final MeterRegistry partitionRegistry,
+      final LogStreamWriter logStreamWriter) {
     this.nodeId = nodeId;
     this.partitionId = partitionId;
     this.numberOfPartitions = numberOfPartitions;
     this.snapshotStore = snapshotStore;
     this.segmentsDirectory = segmentsDirectory;
     metrics = new BackupManagerMetrics(partitionRegistry);
-    internalBackupManager = new BackupServiceImpl(backupStore);
+    internalBackupManager = new BackupServiceImpl(backupStore, logStreamWriter);
     actorName = buildActorName("BackupService", partitionId);
     journalInfoProvider = raftMetadataProvider;
   }

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointRecordsProcessor.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointRecordsProcessor.java
@@ -100,6 +100,13 @@ public final class CheckpointRecordsProcessor
         && record.getIntent() == CheckpointIntent.CREATE) {
       return checkpointCreateProcessor.process(record, resultBuilder);
     }
+
+    if (record.getValueType() == ValueType.CHECKPOINT
+        && record.getIntent() == CheckpointIntent.CONFIRM_BACKUP) {
+      // TODO: Not implemented yet
+      return resultBuilder.build();
+    }
+
     // Should never reach here. StreamProcessor must choose the right processor always.
     throw new IllegalArgumentException("Unknown record");
   }

--- a/zeebe/backup/src/test/java/io/camunda/zeebe/backup/management/BackupServiceImplTest.java
+++ b/zeebe/backup/src/test/java/io/camunda/zeebe/backup/management/BackupServiceImplTest.java
@@ -26,9 +26,11 @@ import io.camunda.zeebe.backup.api.BackupStore;
 import io.camunda.zeebe.backup.common.BackupIdentifierImpl;
 import io.camunda.zeebe.backup.common.BackupIdentifierWildcardImpl;
 import io.camunda.zeebe.backup.common.BackupStatusImpl;
+import io.camunda.zeebe.logstreams.log.LogStreamWriter.WriteFailure;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.testing.TestActorFuture;
 import io.camunda.zeebe.scheduler.testing.TestConcurrencyControl;
+import io.camunda.zeebe.util.Either;
 import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
@@ -54,7 +56,9 @@ class BackupServiceImplTest {
 
   @BeforeEach
   void setup() {
-    backupService = new BackupServiceImpl(backupStore);
+    backupService =
+        new BackupServiceImpl(
+            backupStore, (context, entries, source) -> Either.left(WriteFailure.CLOSED));
 
     lenient()
         .when(notExistingBackupStatus.statusCode())

--- a/zeebe/backup/src/test/java/io/camunda/zeebe/backup/management/BackupServiceImplTest.java
+++ b/zeebe/backup/src/test/java/io/camunda/zeebe/backup/management/BackupServiceImplTest.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.backup.management;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.assertArg;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
@@ -26,7 +27,13 @@ import io.camunda.zeebe.backup.api.BackupStore;
 import io.camunda.zeebe.backup.common.BackupIdentifierImpl;
 import io.camunda.zeebe.backup.common.BackupIdentifierWildcardImpl;
 import io.camunda.zeebe.backup.common.BackupStatusImpl;
+import io.camunda.zeebe.logstreams.log.LogAppendEntry;
+import io.camunda.zeebe.logstreams.log.LogStreamWriter;
 import io.camunda.zeebe.logstreams.log.LogStreamWriter.WriteFailure;
+import io.camunda.zeebe.logstreams.log.WriteContext;
+import io.camunda.zeebe.protocol.impl.record.value.management.CheckpointRecord;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.intent.management.CheckpointIntent;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.testing.TestActorFuture;
 import io.camunda.zeebe.scheduler.testing.TestConcurrencyControl;
@@ -51,14 +58,14 @@ class BackupServiceImplTest {
 
   @Mock BackupStatus notExistingBackupStatus;
 
+  @Mock LogStreamWriter logStreamWriter;
+
   private BackupServiceImpl backupService;
   private final TestConcurrencyControl concurrencyControl = new TestConcurrencyControl();
 
   @BeforeEach
   void setup() {
-    backupService =
-        new BackupServiceImpl(
-            backupStore, (context, entries, source) -> Either.left(WriteFailure.CLOSED));
+    backupService = new BackupServiceImpl(backupStore, logStreamWriter);
 
     lenient()
         .when(notExistingBackupStatus.statusCode())
@@ -72,6 +79,10 @@ class BackupServiceImplTest {
                 new BackupIdentifierWildcardImpl(
                     Optional.empty(), Optional.of(2), Optional.of(3L))))
         .thenReturn(CompletableFuture.completedFuture(List.of()));
+
+    lenient()
+        .when(logStreamWriter.tryWrite(any(), any(LogAppendEntry.class)))
+        .thenReturn(Either.right(-1L));
   }
 
   @Test
@@ -410,6 +421,68 @@ class BackupServiceImplTest {
 
     // then
     assertThat(backups).containsExactlyInAnyOrder(backup1, backup2);
+  }
+
+  @Test
+  void confirmsSuccessfulBackup() {
+    // given
+    final var inProgressBackup = new ControllableInProgressBackup();
+    mockSaveBackup();
+
+    // when
+    backupService.takeBackup(inProgressBackup, concurrencyControl).join();
+
+    // then
+    verify(logStreamWriter)
+        .tryWrite(
+            eq(WriteContext.internal()),
+            assertArg(
+                (final LogAppendEntry entry) -> {
+                  assertThat(entry.recordMetadata().getRecordType()).isEqualTo(RecordType.COMMAND);
+                  assertThat(entry.recordMetadata().getIntent())
+                      .isEqualTo(CheckpointIntent.CONFIRM_BACKUP);
+                  assertThat(entry.recordValue())
+                      .isInstanceOfSatisfying(
+                          CheckpointRecord.class,
+                          checkpointRecord -> {
+                            assertThat(checkpointRecord.getCheckpointId())
+                                .isEqualTo(inProgressBackup.checkpointId());
+                            assertThat(checkpointRecord.getCheckpointPosition())
+                                .isEqualTo(inProgressBackup.checkpointPosition());
+                          });
+                }));
+  }
+
+  @Test
+  void doesNotConfirmUnsuccessfulBackup() {
+    // given
+    final var inProgressBackup = new ControllableInProgressBackup();
+    when(backupStore.save(any()))
+        .thenReturn(CompletableFuture.failedFuture(new RuntimeException("Expected")));
+
+    // when
+    final var result = backupService.takeBackup(inProgressBackup, concurrencyControl);
+
+    // then
+    assertThat(result).failsWithin(Duration.ofMillis(100));
+
+    verify(logStreamWriter, never()).tryWrite(any(), any(LogAppendEntry.class));
+  }
+
+  @Test
+  void backupConfirmationWriteErrorIsIgnored() {
+    // given
+    when(logStreamWriter.tryWrite(any(), any(LogAppendEntry.class)))
+        .thenReturn(Either.left(WriteFailure.WRITE_LIMIT_EXHAUSTED));
+    mockSaveBackup();
+
+    // when
+    final var result =
+        backupService.takeBackup(new ControllableInProgressBackup(), concurrencyControl);
+
+    // then
+    assertThat(result).succeedsWithin(Duration.ofMillis(100));
+    verify(logStreamWriter).tryWrite(any(), any(LogAppendEntry.class));
   }
 
   private ActorFuture<Void> failedFuture() {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/BackupServiceTransitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/BackupServiceTransitionStep.java
@@ -108,7 +108,8 @@ public final class BackupServiceTransitionStep implements PartitionTransitionSte
             context.getPersistedSnapshotStore(),
             context.getRaftPartition().dataDirectory().toPath(),
             index -> context.getRaftPartition().getServer().getTailSegments(index),
-            context.getPartitionTransitionMeterRegistry());
+            context.getPartitionTransitionMeterRegistry(),
+            context.getLogStream().newLogStreamWriter());
 
     final ActorFuture<Void> installed = context.getConcurrencyControl().createFuture();
     context

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/backup/ConcurrentBackupCompactionTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/backup/ConcurrentBackupCompactionTest.java
@@ -25,12 +25,14 @@ import io.camunda.zeebe.backup.management.BackupService;
 import io.camunda.zeebe.broker.utils.InlineThreadContext;
 import io.camunda.zeebe.journal.JournalMetaStore;
 import io.camunda.zeebe.journal.file.SegmentedJournal;
+import io.camunda.zeebe.logstreams.log.LogStreamWriter.WriteFailure;
 import io.camunda.zeebe.scheduler.ActorScheduler;
 import io.camunda.zeebe.scheduler.SchedulingHints;
 import io.camunda.zeebe.snapshots.PersistedSnapshot;
 import io.camunda.zeebe.snapshots.impl.FileBasedSnapshotStore;
 import io.camunda.zeebe.snapshots.impl.FileBasedSnapshotStoreImpl;
 import io.camunda.zeebe.test.DynamicAutoCloseable;
+import io.camunda.zeebe.util.Either;
 import io.camunda.zeebe.util.FileUtil;
 import io.camunda.zeebe.util.buffer.DirectBufferWriter;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -121,7 +123,8 @@ public class ConcurrentBackupCompactionTest extends DynamicAutoCloseable {
                 dataDirectory,
                 // RaftPartitions implements this interface, but the RaftServer is not started
                 index -> CompletableFuture.completedFuture(journal.getTailSegments(index).values()),
-                meterRegistry));
+                meterRegistry,
+                (context, entries, source) -> Either.left(WriteFailure.CLOSED)));
     actorScheduler.submitActor(backupService);
   }
 

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/management/CheckpointIntent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/management/CheckpointIntent.java
@@ -20,7 +20,9 @@ import io.camunda.zeebe.protocol.record.intent.Intent;
 public enum CheckpointIntent implements Intent {
   CREATE(0),
   CREATED(1),
-  IGNORED(2);
+  IGNORED(2),
+  CONFIRM_BACKUP(3),
+  CONFIRMED_BACKUP(4);
 
   private final short value;
 
@@ -38,6 +40,7 @@ public enum CheckpointIntent implements Intent {
     switch (this) {
       case CREATED:
       case IGNORED:
+      case CONFIRMED_BACKUP:
         return true;
       default:
         return false;
@@ -52,6 +55,10 @@ public enum CheckpointIntent implements Intent {
         return CREATED;
       case 2:
         return IGNORED;
+      case 3:
+        return CONFIRM_BACKUP;
+      case 4:
+        return CONFIRMED_BACKUP;
       default:
         return UNKNOWN;
     }

--- a/zeebe/restore/pom.xml
+++ b/zeebe/restore/pom.xml
@@ -74,6 +74,12 @@
     </dependency>
 
     <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-logstreams</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>

--- a/zeebe/restore/src/test/java/io/camunda/zeebe/restore/PartitionRestoreServiceTest.java
+++ b/zeebe/restore/src/test/java/io/camunda/zeebe/restore/PartitionRestoreServiceTest.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.backup.common.BackupIdentifierImpl;
 import io.camunda.zeebe.backup.management.BackupService;
 import io.camunda.zeebe.journal.JournalMetaStore;
 import io.camunda.zeebe.journal.file.SegmentedJournal;
+import io.camunda.zeebe.logstreams.log.LogStreamWriter.WriteFailure;
 import io.camunda.zeebe.restore.PartitionRestoreService.BackupValidator;
 import io.camunda.zeebe.restore.PartitionRestoreService.BackupValidator.BackupNotValidException;
 import io.camunda.zeebe.restore.RestoreManager.ValidatePartitionCount;
@@ -28,6 +29,7 @@ import io.camunda.zeebe.scheduler.SchedulingHints;
 import io.camunda.zeebe.snapshots.PersistedSnapshot;
 import io.camunda.zeebe.snapshots.SnapshotException.CorruptedSnapshotException;
 import io.camunda.zeebe.snapshots.impl.FileBasedSnapshotStore;
+import io.camunda.zeebe.util.Either;
 import io.camunda.zeebe.util.FileUtil;
 import io.camunda.zeebe.util.buffer.DirectBufferWriter;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -116,7 +118,8 @@ class PartitionRestoreServiceTest {
             dataDirectory,
             // RaftPartitions implements this interface, but the RaftServer is not started
             index -> CompletableFuture.completedFuture(journal.getTailSegments(index).values()),
-            meterRegistry);
+            meterRegistry,
+            (context, entries, source) -> Either.left(WriteFailure.CLOSED));
     actorScheduler.submitActor(backupService);
   }
 


### PR DESCRIPTION
When a backup was successfully taken, we now write a new `Checkpoint/ConfirmBackup` command. It is currently unimplemented but will later be used to persist the the backup position in the state.

Relates to #34861