### PR TITLE
feat: insecure development springboot

### DIFF
--- a/.idea/runConfigurations/StandaloneCamunda_DEV.xml
+++ b/.idea/runConfigurations/StandaloneCamunda_DEV.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="StandaloneCamunda DEV" type="SpringBootApplicationConfigurationType" factoryName="Spring Boot">
-    <option name="ACTIVE_PROFILES" value="identity,tasklist,operate,broker,consolidated-auth,dev" />
+    <option name="ACTIVE_PROFILES" value="identity,tasklist,operate,broker,consolidated-auth,dev,insecure" />
     <envs>
       <env name="ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_ARGS_CONNECT_URL" value="http://localhost:9200" />
       <env name="ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_ARGS_INDEX_SHOULDWAITFORIMPORTERS" value="false" />

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -233,7 +233,7 @@ You can run the Camunda distribution via IntelliJ for development purposes.
    and start a new Spring Boot run configuration with the following settings:
    - **Module**: `camunda-zeebe`
    - **Main class**: `io.camunda.application.StandaloneCamunda`
-   - **Active profiles**: `identity,tasklist,operate,broker,consolidated-auth,dev`
+   - **Active profiles**: `identity,tasklist,operate,broker,consolidated-auth,dev,insecure`
    - **Environment variables**:
 
      ```

--- a/dist/README.txt
+++ b/dist/README.txt
@@ -28,6 +28,13 @@ zeebe:
 Local Development only
 ==========
 
+# How to disable security checks
+
+By default, authentication and authorizations are enabled in the Camunda distribution.
+To disable these security checks for local development, you can use the `insecure` profile.
+
+So e.g. `rdbmsH2,insecure`
+
 # With Elasticsearch (Camunda Exporter)
 
 ## Prerequisites:
@@ -107,4 +114,5 @@ docker-compose up -d oracle
 ## Start Camunda:
 
 Run camunda with `rdbmsOracle` profile
+
 

--- a/dist/src/main/resources/application-elasticsearch.yaml
+++ b/dist/src/main/resources/application-elasticsearch.yaml
@@ -37,17 +37,6 @@ zeebe:
         # This setting can also be overridden using the environment variable ZEEBE_BROKER_GATEWAY_NETWORK_PORT.
         port: 26500
 
-      security:
-        # Enables TLS authentication between clients and the gateway
-        # This setting can also be overridden using the environment variable ZEEBE_BROKER_GATEWAY_SECURITY_ENABLED.
-        enabled: false
-        authentication:
-          # Controls which authentication mode is active, supported modes are 'none' and 'identity'.
-          # If 'identity' is set, authentication will be done using camunda-identity, which needs to
-          # be configured in the corresponding subsection. See also https://docs.camunda.io/docs/self-managed/identity/what-is-identity/ .
-          # This setting can also be overridden using the environment variable ZEEBE_BROKER_GATEWAY_SECURITY_AUTHENTICATION_MODE.
-          mode: none
-
     data:
       # Specify a directory in which data is stored.
       # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_DIRECTORY.

--- a/dist/src/main/resources/application-insecure.yaml
+++ b/dist/src/main/resources/application-insecure.yaml
@@ -1,0 +1,17 @@
+# Zeebe additional configuration to disable authentication and authorizations.
+# This configuration should only be used for development purposes and not in production environments!
+
+zeebe:
+  broker:
+    gateway:
+      security:
+        # Enables TLS authentication between clients and the gateway
+        # This setting can also be overridden using the environment variable ZEEBE_BROKER_GATEWAY_SECURITY_ENABLED.
+        enabled: false
+
+camunda:
+  security:
+    authentication:
+      unprotected-api: true
+    authorizations:
+      enabled: false

--- a/dist/src/main/resources/application-opensearch.yaml
+++ b/dist/src/main/resources/application-opensearch.yaml
@@ -37,17 +37,6 @@ zeebe:
         # This setting can also be overridden using the environment variable ZEEBE_BROKER_GATEWAY_NETWORK_PORT.
         port: 26500
 
-      security:
-        # Enables TLS authentication between clients and the gateway
-        # This setting can also be overridden using the environment variable ZEEBE_BROKER_GATEWAY_SECURITY_ENABLED.
-        enabled: false
-        authentication:
-          # Controls which authentication mode is active, supported modes are 'none' and 'identity'.
-          # If 'identity' is set, authentication will be done using camunda-identity, which needs to
-          # be configured in the corresponding subsection. See also https://docs.camunda.io/docs/self-managed/identity/what-is-identity/ .
-          # This setting can also be overridden using the environment variable ZEEBE_BROKER_GATEWAY_SECURITY_AUTHENTICATION_MODE.
-          mode: none
-
     data:
       # Specify a directory in which data is stored.
       # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_DIRECTORY.

--- a/dist/src/main/resources/application-rdbmsH2.yaml
+++ b/dist/src/main/resources/application-rdbmsH2.yaml
@@ -37,17 +37,6 @@ zeebe:
         # This setting can also be overridden using the environment variable ZEEBE_BROKER_GATEWAY_NETWORK_PORT.
         port: 26500
 
-      security:
-        # Enables TLS authentication between clients and the gateway
-        # This setting can also be overridden using the environment variable ZEEBE_BROKER_GATEWAY_SECURITY_ENABLED.
-        enabled: false
-        authentication:
-          # Controls which authentication mode is active, supported modes are 'none' and 'identity'.
-          # If 'identity' is set, authentication will be done using camunda-identity, which needs to
-          # be configured in the corresponding subsection. See also https://docs.camunda.io/docs/self-managed/identity/what-is-identity/ .
-          # This setting can also be overridden using the environment variable ZEEBE_BROKER_GATEWAY_SECURITY_AUTHENTICATION_MODE.
-          mode: none
-
     data:
       # Specify a directory in which data is stored.
       # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_DIRECTORY.

--- a/dist/src/main/resources/application-rdbmsMariaDB.yaml
+++ b/dist/src/main/resources/application-rdbmsMariaDB.yaml
@@ -37,17 +37,6 @@ zeebe:
         # This setting can also be overridden using the environment variable ZEEBE_BROKER_GATEWAY_NETWORK_PORT.
         port: 26500
 
-      security:
-        # Enables TLS authentication between clients and the gateway
-        # This setting can also be overridden using the environment variable ZEEBE_BROKER_GATEWAY_SECURITY_ENABLED.
-        enabled: false
-        authentication:
-          # Controls which authentication mode is active, supported modes are 'none' and 'identity'.
-          # If 'identity' is set, authentication will be done using camunda-identity, which needs to
-          # be configured in the corresponding subsection. See also https://docs.camunda.io/docs/self-managed/identity/what-is-identity/ .
-          # This setting can also be overridden using the environment variable ZEEBE_BROKER_GATEWAY_SECURITY_AUTHENTICATION_MODE.
-          mode: none
-
     data:
       # Specify a directory in which data is stored.
       # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_DIRECTORY.

--- a/dist/src/main/resources/application-rdbmsOracle.yaml
+++ b/dist/src/main/resources/application-rdbmsOracle.yaml
@@ -37,17 +37,6 @@ zeebe:
         # This setting can also be overridden using the environment variable ZEEBE_BROKER_GATEWAY_NETWORK_PORT.
         port: 26500
 
-      security:
-        # Enables TLS authentication between clients and the gateway
-        # This setting can also be overridden using the environment variable ZEEBE_BROKER_GATEWAY_SECURITY_ENABLED.
-        enabled: false
-        authentication:
-          # Controls which authentication mode is active, supported modes are 'none' and 'identity'.
-          # If 'identity' is set, authentication will be done using camunda-identity, which needs to
-          # be configured in the corresponding subsection. See also https://docs.camunda.io/docs/self-managed/identity/what-is-identity/ .
-          # This setting can also be overridden using the environment variable ZEEBE_BROKER_GATEWAY_SECURITY_AUTHENTICATION_MODE.
-          mode: none
-
     data:
       # Specify a directory in which data is stored.
       # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_DIRECTORY.

--- a/dist/src/main/resources/application-rdbmsPostgres.yaml
+++ b/dist/src/main/resources/application-rdbmsPostgres.yaml
@@ -37,17 +37,6 @@ zeebe:
         # This setting can also be overridden using the environment variable ZEEBE_BROKER_GATEWAY_NETWORK_PORT.
         port: 26500
 
-      security:
-        # Enables TLS authentication between clients and the gateway
-        # This setting can also be overridden using the environment variable ZEEBE_BROKER_GATEWAY_SECURITY_ENABLED.
-        enabled: false
-        authentication:
-          # Controls which authentication mode is active, supported modes are 'none' and 'identity'.
-          # If 'identity' is set, authentication will be done using camunda-identity, which needs to
-          # be configured in the corresponding subsection. See also https://docs.camunda.io/docs/self-managed/identity/what-is-identity/ .
-          # This setting can also be overridden using the environment variable ZEEBE_BROKER_GATEWAY_SECURITY_AUTHENTICATION_MODE.
-          mode: none
-
     data:
       # Specify a directory in which data is stored.
       # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_DIRECTORY.


### PR DESCRIPTION
## Description

This PR adds a new spring profile `insecure` to disable the security checks (authentication/authorizations) for local development with the standalone broker. (They are enabled by default)
It can be used together with other profiles like rdbmsH2 or elasticsearch when starting the. 
E.g. `elasticsearch,insecure`

It also cleans up the other config files. 
