### PR TITLE
[Backport stable/8.5] fix: ensure that `TestActorFuture` times out properly

### DIFF
--- a/zeebe/scheduler/src/test/java/io/camunda/zeebe/scheduler/testing/TestActorFuture.java
+++ b/zeebe/scheduler/src/test/java/io/camunda/zeebe/scheduler/testing/TestActorFuture.java
@@ -176,8 +176,15 @@ public final class TestActorFuture<V> implements ActorFuture<V> {
   @Override
   public V get(final long timeout, final TimeUnit unit)
       throws InterruptedException, ExecutionException, TimeoutException {
-    countDownLatch.await(timeout, unit);
-    return get();
+    if (!countDownLatch.await(timeout, unit)) {
+      throw new TimeoutException("Timeout waiting for future to complete");
+    }
+
+    if (result.isRight()) {
+      return result.get();
+    } else {
+      throw new ExecutionException(result.getLeft());
+    }
   }
 
   public static <U> ActorFuture<U> completedFuture(final U value) {


### PR DESCRIPTION
# Description
Backport of #34977 to `stable/8.5`.

relates to 