### PR TITLE
ci: removing opened from add-to-projects action initiation

### DIFF
--- a/.github/workflows/add-to-projects.yml
+++ b/.github/workflows/add-to-projects.yml
@@ -5,7 +5,7 @@ name: Assign new issues to the default projects
 
 on:
   issues:
-    types: [ opened, reopened, transferred, labeled ]
+    types: [ reopened, transferred, labeled ]
 
 jobs:
   add-to-projects:


### PR DESCRIPTION
## Description

Removing the function where add-to-projects.yml would initiate when an issue is opened. Currently, the problem is that when an issue is created with the new issue templates, the "component" labels are added later by another GHA (opened-issue-labeler) and add-to-projects action does not recognize these labels (30sec wait stage does not seem to help either). Add-to-projects.yml only works on these issues once someone adds a label manually to these issues. 

One possible fix for this could be to remove the opened initiation from this script, so it would only act on these issues once the other automated script has added the labels there.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
