### PR TITLE
Feat/34957 batch operation engine javadoc

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationCancelProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationCancelProcessor.java
@@ -32,6 +32,10 @@ import io.camunda.zeebe.stream.api.state.KeyGenerator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Processes commands to cancel batch operations. It validates the command and checks for
+ * authorization. The CANCEL command is then distributed to all other partitions.
+ */
 @ExcludeAuthorizationCheck
 public final class BatchOperationCancelProcessor
     implements DistributedTypedRecordProcessor<BatchOperationLifecycleManagementRecord> {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationCreateChunkProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationCreateChunkProcessor.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.stream.api.records.TypedRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/** Processes commands to create batch operation chunks. */
 @ExcludeAuthorizationCheck
 public final class BatchOperationCreateChunkProcessor
     implements TypedRecordProcessor<BatchOperationChunkRecord> {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationCreateProcessor.java
@@ -31,6 +31,10 @@ import io.camunda.zeebe.util.Either;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Processes commands to create batch operations. It validates the command and checks for
+ * authorization. This command will be distributed to all other existing partitions.
+ */
 public final class BatchOperationCreateProcessor
     implements DistributedTypedRecordProcessor<BatchOperationCreationRecord> {
 
@@ -91,6 +95,8 @@ public final class BatchOperationCreateProcessor
     final var recordWithKey = new BatchOperationCreationRecord();
     recordWithKey.wrap(recordValue);
     recordWithKey.setBatchOperationKey(key);
+    // we remember the partition ids of the batch operation, so that we can count the number of
+    // finished partitions in the end.
     recordWithKey.setPartitionIds(routingInfo.partitions());
 
     stateWriter.appendFollowUpEvent(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationItemProvider.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationItemProvider.java
@@ -111,7 +111,7 @@ public class BatchOperationItemProvider {
 
   /**
    * Fetches the incident items based on the provided process instance filter for the given
-   * partitonId. This will return <b>ALL</b> incidents of the matching processInstances. The items
+   * partitionId. This will return <b>ALL</b> incidents of the matching processInstances. The items
    * are fetched sequentially in pages. Depending on the overall size of the result, this can cause
    * multiple queries to the secondary database.
    *
@@ -136,6 +136,17 @@ public class BatchOperationItemProvider {
         new ArrayList<>(processInstanceKeys), authentication, shouldAbort);
   }
 
+  /**
+   * Fetches the entity items based on the provided filter. The items are fetched sequentially in
+   * pages. Depending on the overall size of the result, this can cause multiple queries to the
+   * secondary database.
+   *
+   * @param itemPageFetcher the fetcher to use for fetching items
+   * @param filter the filter to use
+   * @param authentication the authentication to use
+   * @param shouldAbort if the process should be aborted
+   * @return a set of all found entity items
+   */
   private <F extends FilterBase> Set<Item> fetchEntityItems(
       final ItemPageFetcher<F> itemPageFetcher,
       final F filter,
@@ -168,6 +179,16 @@ public class BatchOperationItemProvider {
     return items;
   }
 
+  /**
+   * Fetches the incident items of the given process instance keys. The items are fetched in batches
+   * to avoid hitting the potential IN clause size limit of the database. Especially Oracle has a
+   * size limit of 1000 there.
+   *
+   * @param processInstanceKeys the process instance keys to fetch incidents for
+   * @param authentication the authentication to use
+   * @param shouldAbort if the process should be aborted
+   * @return a set of all found incident items
+   */
   private Set<Item> getIncidentItemsOfProcessInstanceKeys(
       final List<Long> processInstanceKeys,
       final CamundaAuthentication authentication,
@@ -192,6 +213,13 @@ public class BatchOperationItemProvider {
     return incidents;
   }
 
+  /**
+   * Internal abstraction to hold an item of a batch operation. This is used to represent an itemKey
+   * and it's related processInstanceKey.
+   *
+   * @param itemKey the key of the item
+   * @param processInstanceKey the key of the process instance this item belongs to
+   */
   public record Item(long itemKey, long processInstanceKey) {}
 
   /**

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationLeadPartitionFailProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationLeadPartitionFailProcessor.java
@@ -89,15 +89,17 @@ public final class BatchOperationLeadPartitionFailProcessor
       } else {
 
         // we need this event for every partition that failed, so that the lead partition state can
-        // collect all of them.
-        // that's why in this case, we don't append this event in the normal FailProcessor. (Would
-        // be duplicated otherwise)
+        // collect all of them. That's why in this case, we don't append this event in the normal
+        // FailProcessor. (Would be duplicated otherwise)
+        // This information is directly applied and present in the batch operation state
         stateWriter.appendFollowUpEvent(
             batchOperationKey,
             BatchOperationIntent.PARTITION_FAILED,
             command.getValue(),
             FollowUpEventMetadata.of(b -> b.batchOperationReference(batchOperationKey)));
 
+        // after the source partition is marked as finished, we check if now all partitions are
+        // finished (either completed or failed). If yes, we can append the final COMPLETED event
         if (bo.getFinishedPartitions().size() == bo.getPartitions().size()) {
           LOGGER.debug(
               "All partitions finished, but some with errors, appending COMPLETED event with errors for batch operation {}",

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationResumeProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationResumeProcessor.java
@@ -38,6 +38,10 @@ import io.camunda.zeebe.util.VisibleForTesting;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Processes commands to resume batch operations. It validates the command and checks for
+ * authorization. The RESUME command is then distributed to all other partitions.
+ */
 @ExcludeAuthorizationCheck
 public final class BatchOperationResumeProcessor
     implements DistributedTypedRecordProcessor<BatchOperationLifecycleManagementRecord> {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationSetupProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationSetupProcessors.java
@@ -133,11 +133,7 @@ public final class BatchOperationSetupProcessors {
             ValueType.BATCH_OPERATION_PARTITION_LIFECYCLE,
             BatchOperationIntent.COMPLETE_PARTITION,
             new BatchOperationLeadPartitionCompleteProcessor(
-                writers,
-                processingState,
-                commandDistributionBehavior,
-                partitionId,
-                batchOperationMetrics))
+                writers, processingState, commandDistributionBehavior, batchOperationMetrics))
         .onCommand(
             ValueType.BATCH_OPERATION_PARTITION_LIFECYCLE,
             BatchOperationIntent.FAIL_PARTITION,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationSuspendProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationSuspendProcessor.java
@@ -32,6 +32,10 @@ import io.camunda.zeebe.stream.api.state.KeyGenerator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Processes commands to suspend batch operations. It validates the command and checks for
+ * authorization. The SUSPEND command is then distributed to all other partitions.
+ */
 @ExcludeAuthorizationCheck
 public final class BatchOperationSuspendProcessor
     implements DistributedTypedRecordProcessor<BatchOperationLifecycleManagementRecord> {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/BatchOperationPartitionFailedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/BatchOperationPartitionFailedApplier.java
@@ -13,6 +13,16 @@ import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationPartitionLifecycleRecord;
 import io.camunda.zeebe.protocol.record.intent.BatchOperationIntent;
 
+/**
+ * This applier can do two things:
+ *
+ * <ul>
+ *   <li>If the applier is running on the lead partition of the batch operation, it will mark the
+ *       <code>sourcePartitionId</code> as failed with an error message
+ *   <li>If the applier is running on a non-lead partition, it will mark the batch operation locally
+ *       as finished, which means it will delete the batch operation from the RocksDB state.
+ * </ul>
+ */
 public class BatchOperationPartitionFailedApplier
     implements TypedEventApplier<BatchOperationIntent, BatchOperationPartitionLifecycleRecord> {
 
@@ -27,11 +37,23 @@ public class BatchOperationPartitionFailedApplier
 
   @Override
   public void applyState(final long recordKey, final BatchOperationPartitionLifecycleRecord value) {
-    if (Protocol.decodePartitionId(value.getBatchOperationKey()) == partitionId) {
+    if (isOnLeadPartition(value.getBatchOperationKey())) {
+      // mark the source partition as failed with an error message
       batchOperationState.failPartition(
           value.getBatchOperationKey(), value.getSourcePartitionId(), value.getError());
     } else {
+      // mark the batch operation as completed locally => delete it from rocksDb
       batchOperationState.complete(value.getBatchOperationKey());
     }
+  }
+
+  /**
+   * Check, if this applier is running on the lead partition of the batch operation.
+   *
+   * @param batchOperationKey the key of the batch operation
+   * @return true if this applier is running on the lead partition, false otherwise
+   */
+  private boolean isOnLeadPartition(final long batchOperationKey) {
+    return Protocol.decodePartitionId(batchOperationKey) == partitionId;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/batchoperation/PersistedBatchOperation.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/batchoperation/PersistedBatchOperation.java
@@ -33,29 +33,88 @@ import java.util.List;
 import org.agrona.DirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
 
+/** The persisted record for a batch operation in the rocksDb state. */
 public class PersistedBatchOperation extends UnpackedObject implements DbValue {
 
+  /** The key of the batch operation. This is a unique identifier for the batch operation. */
   private final LongProperty keyProp = new LongProperty("key");
+
+  /**
+   * The type of the batch operation. This indicates what kind of operation is being performed in
+   * the executor.
+   */
   private final EnumProperty<BatchOperationType> batchOperationTypeProp =
       new EnumProperty<>("batchOperationType", BatchOperationType.class);
+
+  /** The status of the batch operation. */
   private final EnumProperty<BatchOperationStatus> statusProp =
       new EnumProperty<>("status", BatchOperationStatus.class);
+
+  /**
+   * The entity filter for the batch operation. This is a binary property that contains the
+   * serialized form of the filter. It needs to be deserialized before it can be used.
+   */
   private final BinaryProperty entityFilterProp = new BinaryProperty("entityFilter");
+
+  /**
+   * An optional migration plan for the batch operation. Usually only filled for the batch operation
+   * type <code>MIGRATE_PROCESS_INSTANCE</code>.
+   */
   private final ObjectProperty<BatchOperationProcessInstanceMigrationPlan> migrationPlanProp =
       new ObjectProperty<>("migrationPlan", new BatchOperationProcessInstanceMigrationPlan());
+
+  /**
+   * An optional modification plan for the batch operation. Usually only filled for the batch
+   * operation type <code>MODIFY_PROCESS_INSTANCE</code>.
+   */
   private final ObjectProperty<BatchOperationProcessInstanceModificationPlan> modificationPlanProp =
       new ObjectProperty<>("modificationPlan", new BatchOperationProcessInstanceModificationPlan());
+
+  /**
+   * A flag indicating whether the batch operation has been initialized. This flag should be true
+   * when the batch operation has been set to the status STARTED at least once. This is used on
+   * resumption to mark a batch operation as pending or not pending.
+   */
   private final BooleanProperty initializedProp = new BooleanProperty("initialized", false);
+
+  /** The number of total items that are part of the batch operation. */
   private final IntegerProperty numTotalItemsProp = new IntegerProperty("numTotalItems", 0);
+
+  /**
+   * The number of items that have been executed so far in the batch operation. This is used for a
+   * heartbeat logging in the BatchOperationExecuteProcessor.
+   */
   private final IntegerProperty numExecutedItemsProp = new IntegerProperty("numExecutedItems", 0);
+
+  /**
+   * The keys of the chunks that are part of the batch operation. A chunk key is a local id
+   * (starting from 0) for the chunks related to the batch operation. The combination of
+   * batchOperationKey and chunkKey is unique.
+   */
   private final ArrayProperty<LongValue> chunkKeysProp =
       new ArrayProperty<>("chunkKeys", LongValue::new);
-  // Authentication claims, needed for query + command auth
+
+  /**
+   * The authentication claims for the batch operation. This is used to track the original
+   * authentication claims of the user which has created the batch operation. This authentication is
+   * used for querying the relevant itemKeys.
+   */
   private final DocumentProperty authenticationProp = new DocumentProperty("authentication");
+
+  /**
+   * The partition ids that are part of the batch operation. This is used to track which partitions
+   * existed when the batch operation was created and on which partitions the batch operation runs.
+   */
   private final ArrayProperty<IntegerValue> partitionsProp =
       new ArrayProperty<>("partitions", IntegerValue::new);
+
+  /**
+   * The partition ids that have been finished (completed or failed). This is used to track the
+   * distributed progress sof the whole batch operations.
+   */
   private final ArrayProperty<IntegerValue> finishedPartitionsProp =
       new ArrayProperty<>("finishedPartitions", IntegerValue::new);
+
   private final ArrayProperty<BatchOperationError> errorsProp =
       new ArrayProperty<>("errors", BatchOperationError::new);
 
@@ -109,15 +168,32 @@ public class PersistedBatchOperation extends UnpackedObject implements DbValue {
         || getStatus() == BatchOperationStatus.SUSPENDED;
   }
 
+  /**
+   * Checks if the batch operation can be suspended. A batch operation can be suspended if it is
+   * actively running.
+   *
+   * @return true if the batch operation can be suspended, false otherwise
+   */
   public boolean canSuspend() {
     return getStatus() == BatchOperationStatus.CREATED
         || getStatus() == BatchOperationStatus.STARTED;
   }
 
+  /**
+   * Checks if the batch operation can be resumed. A batch operation can be resumed if it is
+   * currently suspended.
+   *
+   * @return true if the batch operation can be resumed, false otherwise
+   */
   public boolean canResume() {
     return isSuspended();
   }
 
+  /**
+   * Checks if the batch operation is currently suspended.
+   *
+   * @return true if the batch operation is currently suspended, false otherwise
+   */
   public boolean isSuspended() {
     return getStatus() == BatchOperationStatus.SUSPENDED;
   }
@@ -245,15 +321,34 @@ public class PersistedBatchOperation extends UnpackedObject implements DbValue {
     return this;
   }
 
+  /**
+   * Returns the next chunk key for this batch operation. If there are no chunks yet, <code>0</code>
+   * will be returned.
+   *
+   * @return the next chunk key
+   */
   public long nextChunkKey() {
     return getMaxChunkKey() + 1;
   }
 
+  /**
+   * Adds a chunk key to the batch operation. Usually that key has been returned from <code>
+   * nextChunkKey()</code> before.
+   *
+   * @param chunkKey the chunk key to add
+   * @return this instance for method chaining
+   */
   public PersistedBatchOperation addChunkKey(final Long chunkKey) {
     chunkKeysProp.add().setValue(chunkKey);
     return this;
   }
 
+  /**
+   * Removes a chunk key from the batch operation. If the chunk key does not exist, nothing happens.
+   *
+   * @param chunkKey the chunk key to remove
+   * @return this instance for method chaining
+   */
   public PersistedBatchOperation removeChunkKey(final Long chunkKey) {
     final var newKeys =
         chunkKeysProp.stream().map(LongValue::getValue).filter(k -> !k.equals(chunkKey)).toList();
@@ -267,6 +362,12 @@ public class PersistedBatchOperation extends UnpackedObject implements DbValue {
     return this;
   }
 
+  /**
+   * Returns the smallest chunk key for this batch operation. If there are no chunks, <code>-1
+   * </code> will be returned.
+   *
+   * @return the minimum chunk key or <code>-1</code> if there are no chunks
+   */
   public long getMinChunkKey() {
     return chunkKeysProp.stream()
         .min(Comparator.comparing(LongValue::getValue))
@@ -274,6 +375,16 @@ public class PersistedBatchOperation extends UnpackedObject implements DbValue {
         .orElse(-1L);
   }
 
+  public boolean hasChunks() {
+    return getMinChunkKey() != -1L;
+  }
+
+  /**
+   * Returns the latest chunk key for this batch operation. If there are no chunks, <code>-1</code>
+   * will be returned.
+   *
+   * @return the maximum chunk key or <code>-1</code> if there are no chunks
+   */
   public long getMaxChunkKey() {
     return chunkKeysProp.stream()
         .max(Comparator.comparing(LongValue::getValue))

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/batchoperation/PersistedBatchOperationChunk.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/batchoperation/PersistedBatchOperationChunk.java
@@ -15,10 +15,19 @@ import io.camunda.zeebe.msgpack.value.LongValue;
 import java.util.List;
 import java.util.Set;
 
+/** Represents a chunk of itemKeys of a batch operation that is persisted in the database. */
 public class PersistedBatchOperationChunk extends UnpackedObject implements DbValue {
 
+  /** The key of the chunk. This key os unique just for the batch operation it belongs to. */
   private final LongProperty keyProp = new LongProperty("key");
+
+  /** The key of the batch operation this chunk belongs to. */
   private final LongProperty batchOperationKeyProp = new LongProperty("batchOperationKey");
+
+  /**
+   * The itemKeys of the batch operation chunk. This is an array of itemKeys that are part of the
+   * batch operation.
+   */
   private final ArrayProperty<LongValue> itemKeysProp =
       new ArrayProperty<>("itemKeys", LongValue::new);
 
@@ -54,6 +63,7 @@ public class PersistedBatchOperationChunk extends UnpackedObject implements DbVa
     return this;
   }
 
+  /** Removes the given itemKeys from the chunk. */
   public PersistedBatchOperationChunk removeItemKeys(final Set<Long> itemKeys) {
     final var newKeys =
         itemKeysProp.stream().map(LongValue::getValue).filter(k -> !itemKeys.contains(k)).toList();

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/BatchOperationState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/BatchOperationState.java
@@ -13,17 +13,46 @@ import java.util.Optional;
 
 public interface BatchOperationState {
 
-  boolean exists(long batchKey);
-
-  Optional<PersistedBatchOperation> get(final long batchKey);
+  /**
+   * Checks if a batch operation with the given key exists.
+   *
+   * @param batchOperationKey the key of the batch operation to check
+   * @return true if the batch operation exists, false otherwise
+   */
+  boolean exists(long batchOperationKey);
 
   /**
-   * returns the next pending batch operation, or an empty <code>Optional</code> if there are no
+   * Retrieves a batch operation by its key.
+   *
+   * @param batchOperationKey the key of the batch operation to retrieve
+   * @return an Optional containing the batch operation if it exists, or an empty Optional if it
+   *     does not
+   */
+  Optional<PersistedBatchOperation> get(final long batchOperationKey);
+
+  /**
+   * Returns the next pending batch operation, or an empty <code>Optional</code> if there are no
    * pending batch operations.
    *
    * @return the next pending batch operation
    */
   Optional<PersistedBatchOperation> getNextPendingBatchOperation();
 
+  /**
+   * Retrieves the next <code>batchSize</code> unprocessed itemKeys for a given batch operation.
+   * This method is usually called by the BatchOperationExecuteProcessor to execute the next X
+   * items.<br>
+   * <br>
+   * This method can return fewer than <code>batchSize</code> itemKeys. This does not mean that
+   * there are no more itemKeys but depends on the internal structure of the batch operation state.
+   * <br>
+   * <br>
+   * If the returned list is empty, it means that there are no more itemKeys to process for the
+   * given batch operation.
+   *
+   * @param batchOperationKey the key of the batch operation
+   * @param batchSize the maximum number of itemKeys to retrieve
+   * @return a list of itemKeys for the batch operations, up to the specified batch size
+   */
   List<Long> getNextItemKeys(long batchOperationKey, int batchSize);
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableBatchOperationState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableBatchOperationState.java
@@ -21,20 +21,64 @@ public interface MutableBatchOperationState extends BatchOperationState {
    */
   void create(final long batchOperationKey, final BatchOperationCreationRecord record);
 
+  /**
+   * Marks a batch operation as started.
+   *
+   * @param batchOperationKey the key of the batch operation to mark as started
+   */
   void start(final long batchOperationKey);
 
+  /**
+   * Marks a batch operation as failed.
+   *
+   * @param batchOperationKey the key of the batch operation to mark as failed
+   */
   void fail(final long batchOperationKey);
 
+  /**
+   * Adds the given itemKeys to the given batch operation. The itemKeys are added to the end of the
+   * pending itemKeys.
+   *
+   * @param batchOperationKey the key of the batch operation to which the itemKeys should be added
+   * @param itemKeys the set of itemKeys to add to the batch operation
+   */
   void appendItemKeys(final long batchOperationKey, final Set<Long> itemKeys);
 
+  /**
+   * Removes the given itemKeys from the given batch operation. The itemKeys are removed from the
+   * pending itemKeys.
+   *
+   * @param batchOperationKey the key of the batch operation
+   * @param itemKeys the set of itemKeys to remove from the batch operation
+   */
   void removeItemKeys(final long batchOperationKey, final Set<Long> itemKeys);
 
+  /**
+   * Marks a batch operation as cancelled.
+   *
+   * @param batchOperationKey the key of the batch operation to mark as canceled
+   */
   void cancel(final long batchOperationKey);
 
+  /**
+   * Marks a batch operation as suspended.
+   *
+   * @param batchOperationKey the key of the batch operation
+   */
   void suspend(final long batchOperationKey);
 
+  /**
+   * Marks a batch operation as resumed.
+   *
+   * @param batchOperationKey the key of the batch operation
+   */
   void resume(final long batchOperationKey);
 
+  /**
+   * Marks a batch operation as completed. This will delete the batch operation from the state.
+   *
+   * @param batchOperationKey the key of the batch operation
+   */
   void complete(final long batchOperationKey);
 
   void failPartition(
@@ -45,7 +89,7 @@ public interface MutableBatchOperationState extends BatchOperationState {
    * completed or failed.
    *
    * @param batchOperationKey the batch operation key
-   * @param partitionId the partition ID
+   * @param partitionId the partition ID to mark as finished
    */
   void finishPartition(final long batchOperationKey, int partitionId);
 }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/BatchOperationChunkRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/BatchOperationChunkRecordValue.java
@@ -20,6 +20,13 @@ import io.camunda.zeebe.protocol.record.RecordValue;
 import java.util.List;
 import org.immutables.value.Value;
 
+/**
+ * A record value that represents a chunk of items for a batch operation. It contains a list of
+ * itemKeys and their related processInstanceKey.<br>
+ * <br>
+ * A Zeebe record has a limited size (default 4MB). To overcome this limitation for large batch
+ * operations, the total set of items is split into multiple chunk records.
+ */
 @Value.Immutable
 @ImmutableProtocol(builder = ImmutableBatchOperationChunkRecordValue.Builder.class)
 public interface BatchOperationChunkRecordValue extends BatchOperationRelated, RecordValue {

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/BatchOperationCreationRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/BatchOperationCreationRecordValue.java
@@ -21,6 +21,11 @@ import io.camunda.zeebe.protocol.record.value.ProcessInstanceMigrationRecordValu
 import java.util.List;
 import org.immutables.value.Value;
 
+/**
+ * A record value that represents the creation of a batch operation. It contains the type of the
+ * batch operation, a filter to specify the entities to operate on and optionally a migrationPlan
+ * and a modification plan (depending on the type of the batch operation)
+ */
 @Value.Immutable
 @ImmutableProtocol(builder = ImmutableBatchOperationCreationRecordValue.Builder.class)
 public interface BatchOperationCreationRecordValue extends BatchOperationRelated, RecordValue {
@@ -48,7 +53,7 @@ public interface BatchOperationCreationRecordValue extends BatchOperationRelated
 
   /**
    * The list of partitions this batch operation is executed on. THis list will be filled by the
-   * engine.
+   * engine and is only available after the batch operation was created.
    *
    * @return the list of partitions
    */

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/BatchOperationExecutionRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/BatchOperationExecutionRecordValue.java
@@ -20,6 +20,10 @@ import io.camunda.zeebe.protocol.record.RecordValue;
 import java.util.Set;
 import org.immutables.value.Value;
 
+/**
+ * A record value that represents the execution of a batch operation. It contains a set of item keys
+ * that are being or were processed as part of the batch operation.
+ */
 @Value.Immutable
 @ImmutableProtocol(builder = ImmutableBatchOperationExecutionRecordValue.Builder.class)
 public interface BatchOperationExecutionRecordValue extends BatchOperationRelated, RecordValue {

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/BatchOperationPartitionLifecycleRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/BatchOperationPartitionLifecycleRecordValue.java
@@ -25,5 +25,10 @@ import org.immutables.value.Value;
 public interface BatchOperationPartitionLifecycleRecordValue
     extends BatchOperationRelated, RecordValue {
 
+  /**
+   * Returns the partition id of the source partition where this record was created.
+   *
+   * @return the source partition id
+   */
   Integer getSourcePartitionId();
 }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/BatchOperationRelated.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/BatchOperationRelated.java
@@ -15,6 +15,7 @@
  */
 package io.camunda.zeebe.protocol.record.value;
 
+/** Marks a record as related to a batch operation. */
 public interface BatchOperationRelated {
 
   /**


### PR DESCRIPTION
## Description

Enrich various classes for the Zeebe batch operation engine with more javadoc.
Also gave some parameters and variables more meaningful names and extracted some conditionals to separate methods.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #34957
