### PR TITLE
test: add UsageMetricClient & fix flaky tests

### DIFF
--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/randomized/ProcessExecutionRandomizedPropertyTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/randomized/ProcessExecutionRandomizedPropertyTest.java
@@ -13,6 +13,8 @@ import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.engine.util.ProcessExecutor;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.UsageMetricRecordValue.EventType;
+import io.camunda.zeebe.protocol.record.value.UsageMetricRecordValue.IntervalType;
 import io.camunda.zeebe.test.util.bpmn.random.ExecutionPath;
 import io.camunda.zeebe.test.util.bpmn.random.ScheduledExecutionStep;
 import io.camunda.zeebe.test.util.bpmn.random.TestDataGenerator;
@@ -65,6 +67,13 @@ public class ProcessExecutionRandomizedPropertyTest {
    */
   @Test
   public void shouldExecuteProcessToEnd() {
+    engineRule
+        .usageMetrics()
+        .withEventType(EventType.NONE)
+        .withIntervalType(IntervalType.ACTIVE)
+        .withResetTime(engineRule.getClock().getCurrentTimeInMillis())
+        .export();
+
     final var deployment = engineRule.deployment();
     record.getBpmnModels().forEach(deployment::withXmlResource);
     deployment.deploy();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/randomized/ReplayStateRandomizedPropertyTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/randomized/ReplayStateRandomizedPropertyTest.java
@@ -14,6 +14,8 @@ import io.camunda.zeebe.engine.util.ProcessExecutor;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.UsageMetricRecordValue.EventType;
+import io.camunda.zeebe.protocol.record.value.UsageMetricRecordValue.IntervalType;
 import io.camunda.zeebe.stream.impl.StreamProcessorMode;
 import io.camunda.zeebe.test.util.bpmn.random.ExecutionPath;
 import io.camunda.zeebe.test.util.bpmn.random.ScheduledExecutionStep;
@@ -66,6 +68,13 @@ public class ReplayStateRandomizedPropertyTest {
    */
   @Test
   public void shouldRestoreStateAtEachStepInExecution() {
+    engineRule
+        .usageMetrics()
+        .withEventType(EventType.NONE)
+        .withIntervalType(IntervalType.ACTIVE)
+        .withResetTime(engineRule.getClock().getCurrentTimeInMillis())
+        .export();
+
     final var deployment = engineRule.deployment();
     record.getBpmnModels().forEach(deployment::withXmlResource);
     deployment.deploy();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/ReplayStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/ReplayStateTest.java
@@ -22,6 +22,8 @@ import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.JobBatchRecordValue;
 import io.camunda.zeebe.protocol.record.value.JobRecordValue;
+import io.camunda.zeebe.protocol.record.value.UsageMetricRecordValue.EventType;
+import io.camunda.zeebe.protocol.record.value.UsageMetricRecordValue.IntervalType;
 import io.camunda.zeebe.protocol.record.value.UserTaskRecordValue;
 import io.camunda.zeebe.stream.impl.StreamProcessorMode;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
@@ -393,6 +395,12 @@ public final class ReplayStateTest {
   @Test
   public void shouldRestoreState() {
     // given
+    engine
+        .usageMetrics()
+        .withEventType(EventType.NONE)
+        .withIntervalType(IntervalType.ACTIVE)
+        .withResetTime(engine.getClock().getCurrentTimeInMillis())
+        .export();
     testCase.processes.forEach(process -> engine.deployment().withXmlResource(process).deploy());
     testCase.forms.forEach(form -> engine.deployment().withJsonClasspathResource(form).deploy());
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
@@ -45,6 +45,7 @@ import io.camunda.zeebe.engine.util.client.RoleClient;
 import io.camunda.zeebe.engine.util.client.ScaleClient;
 import io.camunda.zeebe.engine.util.client.SignalClient;
 import io.camunda.zeebe.engine.util.client.TenantClient;
+import io.camunda.zeebe.engine.util.client.UsageMetricClient;
 import io.camunda.zeebe.engine.util.client.UserClient;
 import io.camunda.zeebe.engine.util.client.UserTaskClient;
 import io.camunda.zeebe.engine.util.client.VariableClient;
@@ -471,6 +472,10 @@ public final class EngineRule extends ExternalResource {
 
   public BatchOperationClient batchOperation() {
     return new BatchOperationClient(environmentRule);
+  }
+
+  public UsageMetricClient usageMetrics() {
+    return new UsageMetricClient(environmentRule);
   }
 
   public Record<JobRecordValue> createJob(final String type, final String processId) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/UsageMetricClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/UsageMetricClient.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.util.client;
+
+import io.camunda.zeebe.protocol.impl.record.value.metrics.UsageMetricRecord;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.UsageMetricIntent;
+import io.camunda.zeebe.protocol.record.value.UsageMetricRecordValue;
+import io.camunda.zeebe.protocol.record.value.UsageMetricRecordValue.EventType;
+import io.camunda.zeebe.protocol.record.value.UsageMetricRecordValue.IntervalType;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import java.util.function.Function;
+
+public class UsageMetricClient {
+
+  private static final Function<Long, Record<UsageMetricRecordValue>> SUCCESS_EXPECTATION =
+      (sourceRecordPosition) ->
+          RecordingExporter.usageMetricsRecords(UsageMetricIntent.EXPORTED)
+              .withSourceRecordPosition(sourceRecordPosition)
+              .getFirst();
+
+  private final CommandWriter writer;
+  private final UsageMetricRecord usageMetricRecord = new UsageMetricRecord();
+
+  public UsageMetricClient(final CommandWriter writer) {
+    this.writer = writer;
+  }
+
+  public UsageMetricClient withEventType(final EventType eventType) {
+    usageMetricRecord.setEventType(eventType);
+    return this;
+  }
+
+  public UsageMetricClient withIntervalType(final IntervalType intervalType) {
+    usageMetricRecord.setIntervalType(intervalType);
+    return this;
+  }
+
+  public UsageMetricClient withResetTime(final long resetTime) {
+    usageMetricRecord.setResetTime(resetTime);
+    return this;
+  }
+
+  public Record<UsageMetricRecordValue> export() {
+    final var pos = writer.writeCommand(UsageMetricIntent.EXPORT, usageMetricRecord);
+    return SUCCESS_EXPECTATION.apply(pos);
+  }
+}

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordingExporter.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordingExporter.java
@@ -43,6 +43,7 @@ import io.camunda.zeebe.protocol.record.intent.SignalIntent;
 import io.camunda.zeebe.protocol.record.intent.SignalSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.TenantIntent;
 import io.camunda.zeebe.protocol.record.intent.TimerIntent;
+import io.camunda.zeebe.protocol.record.intent.UsageMetricIntent;
 import io.camunda.zeebe.protocol.record.intent.UserIntent;
 import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
 import io.camunda.zeebe.protocol.record.intent.VariableDocumentIntent;
@@ -88,6 +89,7 @@ import io.camunda.zeebe.protocol.record.value.SignalRecordValue;
 import io.camunda.zeebe.protocol.record.value.SignalSubscriptionRecordValue;
 import io.camunda.zeebe.protocol.record.value.TenantRecordValue;
 import io.camunda.zeebe.protocol.record.value.TimerRecordValue;
+import io.camunda.zeebe.protocol.record.value.UsageMetricRecordValue;
 import io.camunda.zeebe.protocol.record.value.UserRecordValue;
 import io.camunda.zeebe.protocol.record.value.UserTaskRecordValue;
 import io.camunda.zeebe.protocol.record.value.VariableDocumentRecordValue;
@@ -239,6 +241,14 @@ public final class RecordingExporter implements Exporter {
 
   public static DeploymentRecordStream deploymentRecords(final DeploymentIntent intent) {
     return deploymentRecords().withIntent(intent);
+  }
+
+  public static UsageMetricsStream usageMetricsRecords() {
+    return new UsageMetricsStream(records(ValueType.USAGE_METRIC, UsageMetricRecordValue.class));
+  }
+
+  public static UsageMetricsStream usageMetricsRecords(final UsageMetricIntent intent) {
+    return usageMetricsRecords().withIntent(intent);
   }
 
   public static CommandDistributionRecordStream commandDistributionRecords() {

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/UsageMetricsStream.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/UsageMetricsStream.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.test.util.record;
+
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.value.UsageMetricRecordValue;
+import io.camunda.zeebe.protocol.record.value.UsageMetricRecordValue.EventType;
+import java.util.stream.Stream;
+
+public class UsageMetricsStream
+    extends ExporterRecordStream<UsageMetricRecordValue, UsageMetricsStream> {
+
+  public UsageMetricsStream(final Stream<Record<UsageMetricRecordValue>> wrappedStream) {
+    super(wrappedStream);
+  }
+
+  @Override
+  protected UsageMetricsStream supply(final Stream<Record<UsageMetricRecordValue>> wrappedStream) {
+    return new UsageMetricsStream(wrappedStream);
+  }
+
+  public UsageMetricsStream withEventType(final EventType eventType) {
+    return valueFilter(v -> v.getEventType() == eventType);
+  }
+}


### PR DESCRIPTION
## Description

- Add UsageMetricClient
- Adjust `ReplayStateTest` to export metrics first
- Adjust `ProcessExecutionRandomizedPropertyTest` to export metrics first
- Adjust `ReplayStateRandomizedPropertyTest` to export metrics first

## Related issues

related to https://github.com/camunda/camunda/issues/31070
