### PR TITLE
fix: map missing ClusterChangeOperation added by scaling in response

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterApiUtils.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterApiUtils.java
@@ -157,7 +157,7 @@ final class ClusterApiUtils {
     return operations.stream().map(ClusterApiUtils::mapOperation).toList();
   }
 
-  private static Operation mapOperation(final ClusterConfigurationChangeOperation operation) {
+  static Operation mapOperation(final ClusterConfigurationChangeOperation operation) {
     return switch (operation) {
       case final MemberJoinOperation join ->
           new Operation()

--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterApiUtils.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterApiUtils.java
@@ -30,6 +30,9 @@ import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionJoinOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionLeaveOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionReconfigurePriorityOperation;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.ScaleUpOperation.AwaitRedistributionCompletion;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.ScaleUpOperation.AwaitRelocationCompletion;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.UpdateRoutingState;
 import io.camunda.zeebe.dynamic.config.state.CompletedChange;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.ExporterState;
@@ -216,6 +219,18 @@ final class ClusterApiUtils {
               .priority(bootstrapOperation.priority());
       case final DeleteHistoryOperation deleteHistoryOperation ->
           new Operation().operation(OperationEnum.DELETE_HISTORY);
+      case final AwaitRedistributionCompletion redistributionCompletion ->
+          new Operation()
+              .operation(OperationEnum.AWAIT_REDISTRIBUTION)
+              .brokerId(Integer.parseInt(redistributionCompletion.memberId().id()));
+      case final AwaitRelocationCompletion relocationCompletion ->
+          new Operation()
+              .operation(OperationEnum.AWAIT_RELOCATION)
+              .brokerId(Integer.parseInt(relocationCompletion.memberId().id()));
+      case final UpdateRoutingState updateRoutingState ->
+          new Operation()
+              .operation(OperationEnum.UPDATE_ROUTING_STATE)
+              .brokerId(Integer.parseInt(updateRoutingState.memberId().id()));
       default -> new Operation().operation(OperationEnum.UNKNOWN);
     };
   }

--- a/dist/src/main/resources/api/cluster/components.yaml
+++ b/dist/src/main/resources/api/cluster/components.yaml
@@ -318,6 +318,9 @@ schemas:
           - PARTITION_DISABLE_EXPORTER
           - PARTITION_ENABLE_EXPORTER
           - PARTITION_BOOTSTRAP
+          - AWAIT_REDISTRIBUTION
+          - AWAIT_RELOCATION
+          - UPDATE_ROUTING_STATE
           - DELETE_HISTORY
       brokerId:
         $ref: "components.yaml#/schemas/BrokerId"

--- a/dist/src/test/java/io/camunda/zeebe/shared/management/ClusterApiUtilsTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/shared/management/ClusterApiUtilsTest.java
@@ -11,22 +11,44 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.DeleteHistoryOperation;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.MemberJoinOperation;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.MemberLeaveOperation;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.MemberRemoveOperation;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionBootstrapOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionDisableExporterOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionEnableExporterOperation;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionForceReconfigureOperation;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionJoinOperation;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionLeaveOperation;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionReconfigurePriorityOperation;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.ScaleUpOperation.AwaitRedistributionCompletion;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.ScaleUpOperation.AwaitRelocationCompletion;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.ScaleUpOperation.StartPartitionScaleUp;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.UpdateRoutingState;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.ExporterState;
 import io.camunda.zeebe.dynamic.config.state.ExporterState.State;
 import io.camunda.zeebe.dynamic.config.state.ExportersConfig;
 import io.camunda.zeebe.dynamic.config.state.MemberState;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
+import io.camunda.zeebe.dynamic.config.state.RoutingState;
 import io.camunda.zeebe.management.cluster.ExporterStatus;
 import io.camunda.zeebe.management.cluster.ExporterStatus.StatusEnum;
+import io.camunda.zeebe.management.cluster.Operation.OperationEnum;
+import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
 import java.util.function.UnaryOperator;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Named;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -41,6 +63,79 @@ final class ClusterApiUtilsTest {
 
     // then
     assertThat(result).containsExactlyInAnyOrderElementsOf(param.expectedResult());
+  }
+
+  @ParameterizedTest
+  @MethodSource("generateAllClusterConfigurationChangeOperationsAsArguments")
+  void shouldMapClusterChangeOperation(final ClusterConfigurationChangeOperation operation) {
+    final var encoded = ClusterApiUtils.mapOperation(operation);
+    assertThat(encoded).isNotNull();
+    assertThat(OperationEnum.values())
+        .as("Operation " + operation + "is not mapped correctly")
+        .contains(encoded.getOperation());
+  }
+
+  @Test
+  void shouldGenerateAllClusterConfigurationChangeOperationImplementations() {
+    // when
+    final var allOperations = generateAllClusterConfigurationChangeOperations();
+
+    // Get all concrete implementation classes from generated operations
+    final Set<Class<?>> actualImplementationClasses = new HashSet<>();
+    for (final var operation : allOperations) {
+      actualImplementationClasses.add(operation.getClass());
+    }
+
+    // Dynamically discover all implementations using reflection
+    final Set<Class<?>> discoveredImplementationClasses = discoverAllImplementations();
+
+    // This is the key test - verify that our generator includes ALL discovered implementations
+    assertThat(actualImplementationClasses)
+        .as(
+            "Generator method must include ALL ClusterConfigurationChangeOperation implementations. "
+                + "Missing implementations: %s. "
+                + "If you added a new implementation, make sure to add it to generateAllClusterConfigurationChangeOperations()",
+            discoveredImplementationClasses.stream()
+                .filter(clazz -> !actualImplementationClasses.contains(clazz))
+                .map(Class::getSimpleName)
+                .toList())
+        .containsExactlyInAnyOrderElementsOf(discoveredImplementationClasses);
+  }
+
+  /**
+   * Discovers all concrete implementations of ClusterConfigurationChangeOperation using reflection.
+   * This method automatically finds all nested classes that implement the interface.
+   */
+  private Set<Class<?>> discoverAllImplementations() {
+    final Set<Class<?>> implementations = new HashSet<>();
+
+    // Get all nested classes from the ClusterConfigurationChangeOperation interface
+    final Class<?>[] nestedClasses = ClusterConfigurationChangeOperation.class.getDeclaredClasses();
+    if (!ClusterConfigurationChangeOperation.class.isSealed()) {
+      throw new AssertionError("ClusterConfigurationChangeOperation must be sealed");
+    }
+
+    for (final Class<?> nestedClass : nestedClasses) {
+      // Check if it's a record that implements ClusterConfigurationChangeOperation
+      if (nestedClass.isRecord()
+          && ClusterConfigurationChangeOperation.class.isAssignableFrom(nestedClass)) {
+        implementations.add(nestedClass);
+      }
+
+      // Also check nested classes within nested interfaces (like ScaleUpOperation,
+      // PartitionChangeOperation)
+      if (nestedClass.isInterface()) {
+        final Class<?>[] subNestedClasses = nestedClass.getDeclaredClasses();
+        for (final Class<?> subNestedClass : subNestedClasses) {
+          if (subNestedClass.isRecord()
+              && ClusterConfigurationChangeOperation.class.isAssignableFrom(subNestedClass)) {
+            implementations.add(subNestedClass);
+          }
+        }
+      }
+    }
+
+    return implementations;
   }
 
   public static Stream<Arguments> provideClusterConfigurationWithExporters() {
@@ -157,6 +252,53 @@ final class ClusterApiUtilsTest {
 
   private static MemberId member(final int id) {
     return MemberId.from(String.valueOf(id));
+  }
+
+  /**
+   * Generates all implementations of ClusterConfigurationChangeOperation interface. This method
+   * creates instances of all concrete record implementations with sample data.
+   *
+   * @return a list containing one instance of each ClusterConfigurationChangeOperation
+   *     implementation
+   */
+  public static List<ClusterConfigurationChangeOperation>
+      generateAllClusterConfigurationChangeOperations() {
+    final MemberId memberId1 = member(1);
+    final MemberId memberId2 = member(2);
+    final SortedSet<Integer> partitionSet = new TreeSet<>(Set.of(1, 2, 3));
+    final Collection<MemberId> memberCollection = List.of(memberId1, memberId2);
+    final Optional<RoutingState> emptyRoutingState = Optional.empty();
+    final Optional<String> emptyExporterId = Optional.empty();
+    final Optional<DynamicPartitionConfig> emptyConfig = Optional.empty();
+
+    return List.of(
+        // Basic member operations
+        new MemberJoinOperation(memberId1),
+        new MemberLeaveOperation(memberId1),
+        new MemberRemoveOperation(memberId1, memberId2),
+        new DeleteHistoryOperation(memberId1),
+        new UpdateRoutingState(memberId1, emptyRoutingState),
+
+        // Scale up operations
+        new StartPartitionScaleUp(memberId1, 8),
+        new AwaitRedistributionCompletion(memberId1, 8, partitionSet),
+        new AwaitRelocationCompletion(memberId1, 8, partitionSet),
+
+        // Partition change operations
+        new PartitionJoinOperation(memberId1, 1, 1),
+        new PartitionLeaveOperation(memberId1, 1, 3),
+        new PartitionReconfigurePriorityOperation(memberId1, 1, 2),
+        new PartitionForceReconfigureOperation(memberId1, 1, memberCollection),
+        new PartitionDisableExporterOperation(memberId1, 1, "test-exporter"),
+        new PartitionEnableExporterOperation(memberId1, 1, "test-exporter", emptyExporterId),
+        new PartitionBootstrapOperation(memberId1, 1, 1, emptyConfig, false),
+        new PartitionBootstrapOperation(memberId1, 2, 1, true) // Alternative constructor
+        );
+  }
+
+  /** Provides all ClusterConfigurationChangeOperation implementations as test arguments. */
+  public static Stream<Arguments> generateAllClusterConfigurationChangeOperationsAsArguments() {
+    return generateAllClusterConfigurationChangeOperations().stream().map(Arguments::of);
   }
 
   private record ExporterConfigParam(


### PR DESCRIPTION
## Description
Newly added operations were not serialized correctly, but just as `UNKNOWN`.

I don't think there is a test for this yet.