### PR TITLE
Make client commands and controller endpoints naming consistent

### DIFF
--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -3299,7 +3299,7 @@ paths:
       tags:
         - Role
       operationId: addRoleToMappingRule
-      summary: Assign a role to a mapping rule.
+      summary: Assign a role to a mapping rule
       description: |
         Assigns a role to a mapping rule.
       parameters:
@@ -3340,7 +3340,7 @@ paths:
       tags:
         - Role
       operationId: removeRoleFromMappingRule
-      summary: Unassign a role from a mapping rule.
+      summary: Unassign a role from a mapping rule
       description: |
         Unassigns a role from a mapping rule.
       parameters:

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -3591,7 +3591,7 @@ paths:
       operationId: searchMappingRulesForGroup
       summary: Search group mapping rules
       description: |
-        Search mapping rules to a group.
+        Search mapping rules assigned to a group.
       parameters:
         - name: groupId
           in: path

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -2911,7 +2911,7 @@ paths:
       operationId: searchUsersForRole
       summary: Search role users
       description: |
-        Search users assigned to a role.
+        Search users with assigned role.
       parameters:
         - name: roleId
           in: path
@@ -2927,7 +2927,7 @@ paths:
               $ref: "#/components/schemas/RoleUserSearchQueryRequest"
       responses:
         "200":
-          description: The users assigned to the role.
+          description: The users with the assigned role.
           content:
             application/json:
               schema:
@@ -2953,7 +2953,7 @@ paths:
       operationId: searchClientsForRole
       summary: Search role clients
       description: |
-        Search clients assigned to a role.
+        Search clients with assigned role.
       parameters:
         - name: roleId
           in: path
@@ -2969,7 +2969,7 @@ paths:
               $ref: "#/components/schemas/RoleClientSearchQueryRequest"
       responses:
         "200":
-          description: The clients assigned to the role.
+          description: The clients with the assigned role.
           content:
             application/json:
               schema:
@@ -2992,10 +2992,10 @@ paths:
     put:
       tags:
         - Role
-      operationId: addUserToRole
-      summary: Assign a user to a role
+      operationId: addRoleToUser
+      summary: Assign a role to a user
       description: |
-        Assigns a user to a role.
+        Assigns a role to a user.
       parameters:
         - name: roleId
           in: path
@@ -3011,7 +3011,7 @@ paths:
             type: string
       responses:
         "202":
-          description: The user was assigned successfully to the role.
+          description: The role was assigned successfully to the user.
         "400":
           $ref: "#/components/responses/InvalidData"
         "403":
@@ -3023,7 +3023,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/ProblemDetail"
         "409":
-          description: The user with the given ID is already assigned to the role.
+          description: The role is already assigned to the user with the given ID.
           content:
             application/problem+json:
               schema:
@@ -3069,10 +3069,10 @@ paths:
     put:
       tags:
         - Role
-      operationId: addClientToRole
-      summary: Assign a client to a role
+      operationId: addRoleToClient
+      summary: Assign a role to a client
       description: |
-        Assigns a client to a role.
+        Assigns a role to a client.
       parameters:
         - name: roleId
           in: path
@@ -3088,7 +3088,7 @@ paths:
             type: string
       responses:
         "202":
-          description: The client was assigned successfully to the role.
+          description: The role was assigned successfully to the client.
         "400":
           $ref: "#/components/responses/InvalidData"
         "403":
@@ -3100,7 +3100,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/ProblemDetail"
         "409":
-          description: The client with the given ID is already assigned to the role.
+          description: The role was already assigned to the client with the given ID.
           content:
             application/problem+json:
               schema:
@@ -3110,10 +3110,10 @@ paths:
     delete:
       tags:
         - Role
-      operationId: removeClientFromRole
-      summary: Unassign a client from a role
+      operationId: removeRoleFromClient
+      summary: Unassign a role from a client
       description: |
-        Unassigns a client from a role.
+        Unassigns a role from a client.
       parameters:
         - name: roleId
           in: path
@@ -3129,7 +3129,7 @@ paths:
             type: string
       responses:
         "202":
-          description: The client was unassigned successfully from the role.
+          description: The role was unassigned successfully from the client.
         "400":
           $ref: "#/components/responses/InvalidData"
         "403":
@@ -3179,10 +3179,10 @@ paths:
     put:
       tags:
         - Role
-      operationId: addGroupToRole
-      summary: Assign a group to a role
+      operationId: addRoleToGroup
+      summary: Assign a role to a group
       description: |
-        Assigns a group to a role.
+        Assigns a role to a group.
       parameters:
         - name: roleId
           in: path
@@ -3198,7 +3198,7 @@ paths:
             type: string
       responses:
         "202":
-          description: The group was assigned successfully to the role.
+          description: The role was assigned successfully to the group.
         "400":
           $ref: "#/components/responses/InvalidData"
         "403":
@@ -3210,7 +3210,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/ProblemDetail"
         "409":
-          description: The group with the given ID is already assigned to the role.
+          description: The role is already assigned to the group with the given ID.
           content:
             application/problem+json:
               schema:
@@ -3220,10 +3220,10 @@ paths:
     delete:
       tags:
         - Role
-      operationId: removeGroupFromRole
-      summary: Unassign a group from a role
+      operationId: removeRoleFromGroup
+      summary: Unassign a role from a group
       description: |
-        Unassigns a group from a role.
+        Unassigns a role from a group.
       parameters:
         - name: roleId
           in: path
@@ -3239,7 +3239,7 @@ paths:
             type: string
       responses:
         "202":
-          description: The group was unassigned successfully from the role.
+          description: The role was unassigned successfully from the group.
         "400":
           $ref: "#/components/responses/InvalidData"
         "403":
@@ -3259,7 +3259,7 @@ paths:
       operationId: searchGroupsForRole
       summary: Search role groups
       description: |
-        Search groups assigned to a role.
+        Search groups with assigned role.
       parameters:
         - name: roleId
           in: path
@@ -3275,7 +3275,7 @@ paths:
               $ref: "#/components/schemas/RoleGroupSearchQueryRequest"
       responses:
         "200":
-          description: The groups assigned to the role.
+          description: The groups with assigned role.
           content:
             application/json:
               schema:
@@ -3298,10 +3298,10 @@ paths:
     put:
       tags:
         - Role
-      operationId: addMappingRuleToRole
-      summary: Assign a mapping rule to a role
+      operationId: addRoleToMappingRule
+      summary: Assign a role to a mapping rule.
       description: |
-        Assigns a mapping rule to a role.
+        Assigns a role to a mapping rule.
       parameters:
         - name: roleId
           in: path
@@ -3317,7 +3317,7 @@ paths:
             type: string
       responses:
         "202":
-          description: The mapping rule was assigned successfully to the role.
+          description: The role was assigned successfully to the mapping rule.
         "400":
           $ref: "#/components/responses/InvalidData"
         "403":
@@ -3329,7 +3329,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/ProblemDetail"
         "409":
-          description: The mapping rule with the given ID is already assigned to the role.
+          description: The role is already assigned to the mapping rule with the given ID.
           content:
             application/problem+json:
               schema:
@@ -3339,10 +3339,10 @@ paths:
     delete:
       tags:
         - Role
-      operationId: removeMappingRuleFromRole
-      summary: Unassign a mapping from a role
+      operationId: removeRoleFromMappingRule
+      summary: Unassign a role from a mapping rule.
       description: |
-        Unassigns a mapping from a role.
+        Unassigns a role from a mapping rule.
       parameters:
         - name: roleId
           in: path
@@ -3358,7 +3358,7 @@ paths:
             type: string
       responses:
         "202":
-          description: The mapping rule was unassigned successfully from the role.
+          description: The role was unassigned successfully from the mapping rule.
         "400":
           $ref: "#/components/responses/InvalidData"
         "403":
@@ -3378,7 +3378,7 @@ paths:
       operationId: searchMappingRulesForRole
       summary: Search role mapping rules
       description: |
-        Search mapping rules assigned to a role.
+        Search mapping rules with assigned role.
       parameters:
         - name: roleId
           in: path
@@ -3394,7 +3394,7 @@ paths:
               $ref: "#/components/schemas/MappingRuleSearchQueryRequest"
       responses:
         "200":
-          description: The mapping rules assigned to the role.
+          description: The mapping rules with assigned role.
           content:
             application/json:
               schema:

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupController.java
@@ -138,7 +138,7 @@ public class GroupController {
   @CamundaDeleteMapping(
       path = "/{groupId}/mapping-rules/{mappingId}",
       consumes = {})
-  public CompletableFuture<ResponseEntity<Object>> unassignMappingToGroup(
+  public CompletableFuture<ResponseEntity<Object>> unassignMappingFromGroup(
       @PathVariable final String groupId, @PathVariable final String mappingId) {
     return RequestMapper.toGroupMemberRequest(groupId, mappingId, EntityType.MAPPING)
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::unassignMember);

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleController.java
@@ -275,7 +275,7 @@ public class RoleController {
   }
 
   @CamundaDeleteMapping(path = "/{roleId}/mapping-rules/{mappingRuleId}")
-  public CompletableFuture<ResponseEntity<Object>> removeMappingFromRole(
+  public CompletableFuture<ResponseEntity<Object>> removeRoleFromMapping(
       @PathVariable final String roleId, @PathVariable final String mappingRuleId) {
     return RequestMapper.toRoleMemberRequest(roleId, mappingRuleId, EntityType.MAPPING)
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::removeMemberFromRole);
@@ -296,7 +296,7 @@ public class RoleController {
   }
 
   @CamundaDeleteMapping(path = "/{roleId}/groups/{groupId}")
-  public CompletableFuture<ResponseEntity<Object>> removeGroupFromRole(
+  public CompletableFuture<ResponseEntity<Object>> removeRoleFromGroup(
       @PathVariable final String roleId, @PathVariable final String groupId) {
     return RequestMapper.toRoleMemberRequest(roleId, groupId, EntityType.GROUP)
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::removeMemberFromRole);

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleController.java
@@ -268,14 +268,14 @@ public class RoleController {
   @CamundaPutMapping(
       path = "/{roleId}/mapping-rules/{mappingRuleId}",
       consumes = {})
-  public CompletableFuture<ResponseEntity<Object>> assignRoleToMapping(
+  public CompletableFuture<ResponseEntity<Object>> addRoleToMappingRule(
       @PathVariable final String roleId, @PathVariable final String mappingRuleId) {
     return RequestMapper.toRoleMemberRequest(roleId, mappingRuleId, EntityType.MAPPING)
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::addMemberToRole);
   }
 
   @CamundaDeleteMapping(path = "/{roleId}/mapping-rules/{mappingRuleId}")
-  public CompletableFuture<ResponseEntity<Object>> removeRoleFromMapping(
+  public CompletableFuture<ResponseEntity<Object>> removeRoleFromMappingRule(
       @PathVariable final String roleId, @PathVariable final String mappingRuleId) {
     return RequestMapper.toRoleMemberRequest(roleId, mappingRuleId, EntityType.MAPPING)
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::removeMemberFromRole);

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleController.java
@@ -232,7 +232,7 @@ public class RoleController {
   @CamundaPutMapping(
       path = "/{roleId}/users/{username}",
       consumes = {})
-  public CompletableFuture<ResponseEntity<Object>> addUserToRole(
+  public CompletableFuture<ResponseEntity<Object>> addRoleToUser(
       @PathVariable final String roleId, @PathVariable final String username) {
     return RequestMapper.toRoleMemberRequest(roleId, username, EntityType.USER)
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::addMemberToRole);
@@ -241,7 +241,7 @@ public class RoleController {
   @CamundaPutMapping(
       path = "/{roleId}/clients/{clientId}",
       consumes = {})
-  public CompletableFuture<ResponseEntity<Object>> addClientToRole(
+  public CompletableFuture<ResponseEntity<Object>> addRoleToClient(
       @PathVariable final String roleId, @PathVariable final String clientId) {
     return RequestMapper.toRoleMemberRequest(roleId, clientId, EntityType.CLIENT)
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::addMemberToRole);
@@ -250,7 +250,7 @@ public class RoleController {
   @CamundaPutMapping(
       path = "/{roleId}/groups/{groupId}",
       consumes = {})
-  public CompletableFuture<ResponseEntity<Object>> addGroupToRole(
+  public CompletableFuture<ResponseEntity<Object>> addRoleToGroup(
       @PathVariable final String roleId, @PathVariable final String groupId) {
     return RequestMapper.toRoleMemberRequest(roleId, groupId, EntityType.GROUP)
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::addMemberToRole);
@@ -268,7 +268,7 @@ public class RoleController {
   @CamundaPutMapping(
       path = "/{roleId}/mapping-rules/{mappingRuleId}",
       consumes = {})
-  public CompletableFuture<ResponseEntity<Object>> assignMappingToRole(
+  public CompletableFuture<ResponseEntity<Object>> assignRoleToMapping(
       @PathVariable final String roleId, @PathVariable final String mappingRuleId) {
     return RequestMapper.toRoleMemberRequest(roleId, mappingRuleId, EntityType.MAPPING)
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::addMemberToRole);
@@ -282,14 +282,14 @@ public class RoleController {
   }
 
   @CamundaDeleteMapping(path = "/{roleId}/users/{username}")
-  public CompletableFuture<ResponseEntity<Object>> removeUserFromRole(
+  public CompletableFuture<ResponseEntity<Object>> removeRoleFromUser(
       @PathVariable final String roleId, @PathVariable final String username) {
     return RequestMapper.toRoleMemberRequest(roleId, username, EntityType.USER)
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::removeMemberFromRole);
   }
 
   @CamundaDeleteMapping(path = "/{roleId}/clients/{clientId}")
-  public CompletableFuture<ResponseEntity<Object>> removeClientFromRole(
+  public CompletableFuture<ResponseEntity<Object>> removeRoleFromClient(
       @PathVariable final String roleId, @PathVariable final String clientId) {
     return RequestMapper.toRoleMemberRequest(roleId, clientId, EntityType.CLIENT)
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::removeMemberFromRole);


### PR DESCRIPTION
Reasoning:
As per team decision, naming should be:

- Assigning a role to a group/user/mapping
- Assigning a user/mapping to a group
- Assigning a role/group/user/mapping to a tenant

This PR will also bring consistency with the client commands we have. For example:
`newAssignRoleToUserCommand` command  and `addRoleToUser` endpoint.

💭  I believe we wanted to keep `assign` in client and `add` in REST but if any objections, please let me know

## Description

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #32138
