### PR TITLE
Feat/34541 bo fix configuragtion change in rdbms upsert

### DIFF
--- a/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.8.0.xml
+++ b/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.8.0.xml
@@ -188,7 +188,8 @@
       <column name="CANDIDATE_GROUP" type="VARCHAR(255)"/>
     </createTable>
 
-    <createIndex tableName="${prefix}CANDIDATE_USER" indexName="${prefix}IDX_CANDIDATE_USER_USER_TASK_KEY">
+    <createIndex tableName="${prefix}CANDIDATE_USER"
+      indexName="${prefix}IDX_CANDIDATE_USER_USER_TASK_KEY">
       <column name="USER_TASK_KEY"/>
     </createIndex>
 
@@ -501,23 +502,21 @@
     <createTable tableName="${prefix}BATCH_OPERATION_ITEM">
       <column name="BATCH_OPERATION_ID" type="VARCHAR(255)">
         <constraints
+          primaryKey="true"
+          nullable="false"
           foreignKeyName="${prefix}FK_BATCH_OPERATION_ITEM_BATCH_OPERATION"
           referencedTableName="${prefix}BATCH_OPERATION"
           referencedColumnNames="BATCH_OPERATION_ID"
           deleteCascade="true"/>
-        />
       </column>
-      <column name="ITEM_KEY" type="BIGINT"/>
+      <column name="ITEM_KEY" type="BIGINT">
+        <constraints primaryKey="true" nullable="false"/>
+      </column>
       <column name="PROCESS_INSTANCE_KEY" type="BIGINT"/>
       <column name="PROCESSED_DATE" type="TIMESTAMP WITH TIME ZONE(3)"/>
       <column name="ERROR_MESSAGE" type="VARCHAR(4000)"/>
       <column name="STATE" type="VARCHAR(20)" defaultValue="ACTIVE"/>
     </createTable>
-
-    <createIndex tableName="${prefix}BATCH_OPERATION_ITEM"
-      indexName="${prefix}IDX_BATCH_OPERATION_ITEM_KEY">
-      <column name="BATCH_OPERATION_ID"/>
-    </createIndex>
 
     <modifySql dbms="mariadb">
       <!-- MariaDB doesn't support TIMESTAMP WITH TIME ZONE, but its TIMESTAMP type has already a time zone -->

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/RdbmsService.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/RdbmsService.java
@@ -29,7 +29,9 @@ import io.camunda.db.rdbms.read.service.UserTaskReader;
 import io.camunda.db.rdbms.read.service.VariableReader;
 import io.camunda.db.rdbms.write.RdbmsWriter;
 import io.camunda.db.rdbms.write.RdbmsWriterConfig;
+import io.camunda.db.rdbms.write.RdbmsWriterConfig.Builder;
 import io.camunda.db.rdbms.write.RdbmsWriterFactory;
+import java.util.function.Consumer;
 
 /** A holder for all rdbms services */
 public class RdbmsService {
@@ -187,5 +189,11 @@ public class RdbmsService {
 
   public RdbmsWriter createWriter(final RdbmsWriterConfig config) {
     return rdbmsWriterFactory.createWriter(config);
+  }
+
+  public RdbmsWriter createWriter(final Consumer<Builder> configBuilder) {
+    final RdbmsWriterConfig.Builder builder = new RdbmsWriterConfig.Builder();
+    configBuilder.accept(builder);
+    return rdbmsWriterFactory.createWriter(builder.build());
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/BatchOperationWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/BatchOperationWriter.java
@@ -81,17 +81,13 @@ public class BatchOperationWriter {
   }
 
   public void updateItem(final BatchOperationItemDbModel item) {
-    if (exportPendingBatchOperationItems) {
-      executionQueue.executeInQueue(
-          new QueueItem(
-              ContextType.BATCH_OPERATION,
-              WriteStatementType.UPDATE,
-              item.batchOperationId(),
-              "io.camunda.db.rdbms.sql.BatchOperationMapper.updateItem",
-              item));
-    } else {
-      insertItems(new BatchOperationItemsDto(item.batchOperationId(), List.of(item)));
-    }
+    executionQueue.executeInQueue(
+        new QueueItem(
+            ContextType.BATCH_OPERATION,
+            WriteStatementType.UPDATE,
+            item.batchOperationId(),
+            "io.camunda.db.rdbms.sql.BatchOperationMapper.upsertItem",
+            item));
 
     if (item.state() == BatchOperationItemState.FAILED) {
       executionQueue.executeInQueue(

--- a/db/rdbms/src/main/resources/mapper/BatchOperationMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/BatchOperationMapper.xml
@@ -69,15 +69,84 @@
     WHERE BATCH_OPERATION_ID = #{batchOperationId}
   </update>
 
-  <update id="updateItem"
-    parameterType="io.camunda.db.rdbms.sql.BatchOperationMapper$BatchOperationItemDto">
-    UPDATE ${prefix}BATCH_OPERATION_ITEM
-    SET STATE = #{state},
-        PROCESSED_DATE = #{processedDate},
-        ERROR_MESSAGE = #{errorMessage}
-    WHERE BATCH_OPERATION_ID = #{batchOperationId}
-      AND ITEM_KEY = #{itemKey}
-  </update>
+
+  <insert id="upsertItem"
+    parameterType="io.camunda.db.rdbms.sql.BatchOperationMapper$BatchOperationItemDto"
+    databaseId="postgresql">
+    INSERT INTO ${prefix}BATCH_OPERATION_ITEM
+    (BATCH_OPERATION_ID, ITEM_KEY, PROCESS_INSTANCE_KEY, PROCESSED_DATE, STATE)
+    VALUES (#{batchOperationId},
+            #{itemKey},
+            #{processInstanceKey},
+            #{processedDate},
+            #{state})
+    ON CONFLICT (BATCH_OPERATION_ID, ITEM_KEY) DO UPDATE SET
+                                                           STATE          = #{state},
+                                                             PROCESSED_DATE = #{processedDate},
+                                                             ERROR_MESSAGE  = #{errorMessage}
+  </insert>
+
+  <insert id="upsertItem"
+    parameterType="io.camunda.db.rdbms.sql.BatchOperationMapper$BatchOperationItemDto"
+    databaseId="mariadb">
+    INSERT INTO ${prefix}BATCH_OPERATION_ITEM
+    (BATCH_OPERATION_ID, ITEM_KEY, PROCESS_INSTANCE_KEY, PROCESSED_DATE, STATE)
+    VALUES (#{batchOperationId},
+            #{itemKey},
+            #{processInstanceKey},
+            #{processedDate},
+            #{state})
+    ON DUPLICATE KEY UPDATE
+      STATE = #{state}, PROCESSED_DATE = #{processedDate}, ERROR_MESSAGE = #{errorMessage}
+  </insert>
+
+  <insert id="upsertItem"
+    parameterType="io.camunda.db.rdbms.sql.BatchOperationMapper$BatchOperationItemDto"
+    databaseId="oracle">
+    MERGE INTO ${prefix}BATCH_OPERATION_ITEM target
+    USING (SELECT #{batchOperationId}   AS BATCH_OPERATION_ID,
+                  #{itemKey}            AS ITEM_KEY,
+                  #{processInstanceKey} AS PROCESS_INSTANCE_KEY,
+                  #{processedDate}      AS PROCESSED_DATE,
+                  #{state}              AS STATE,
+                  #{errorMessage}       AS ERROR_MESSAGE
+           FROM dual) source
+    ON (target.BATCH_OPERATION_ID = source.BATCH_OPERATION_ID AND target.ITEM_KEY = source.ITEM_KEY)
+    WHEN MATCHED THEN
+      UPDATE
+      SET STATE          = source.STATE,
+          PROCESSED_DATE = source.PROCESSED_DATE,
+          ERROR_MESSAGE  = source.ERROR_MESSAGE
+    WHEN NOT MATCHED THEN
+      INSERT (BATCH_OPERATION_ID, ITEM_KEY, PROCESS_INSTANCE_KEY, PROCESSED_DATE, STATE,
+              ERROR_MESSAGE)
+      VALUES (source.BATCH_OPERATION_ID, source.ITEM_KEY, source.PROCESS_INSTANCE_KEY,
+              source.PROCESSED_DATE, source.STATE, source.ERROR_MESSAGE)
+  </insert>
+
+  <insert id="upsertItem"
+    parameterType="io.camunda.db.rdbms.sql.BatchOperationMapper$BatchOperationItemDto"
+    databaseId="h2">
+MERGE INTO ${prefix}BATCH_OPERATION_ITEM target
+USING (SELECT CAST(#{batchOperationId} AS VARCHAR)   AS BATCH_OPERATION_ID,
+              CAST(#{itemKey} AS BIGINT)            AS ITEM_KEY,
+              CAST(#{processInstanceKey} AS BIGINT) AS PROCESS_INSTANCE_KEY,
+              CAST(#{processedDate} AS TIMESTAMP)   AS PROCESSED_DATE,
+              CAST(#{state} AS VARCHAR)            AS STATE,
+              CAST(#{errorMessage} AS VARCHAR)     AS ERROR_MESSAGE) source
+ON (target.BATCH_OPERATION_ID = source.BATCH_OPERATION_ID AND target.ITEM_KEY = source.ITEM_KEY)
+WHEN MATCHED THEN
+  UPDATE
+  SET STATE          = source.STATE,
+      PROCESSED_DATE = source.PROCESSED_DATE,
+      ERROR_MESSAGE  = source.ERROR_MESSAGE
+WHEN NOT MATCHED THEN
+  INSERT (BATCH_OPERATION_ID, ITEM_KEY, PROCESS_INSTANCE_KEY, PROCESSED_DATE, STATE,
+          ERROR_MESSAGE)
+  VALUES (source.BATCH_OPERATION_ID, source.ITEM_KEY, source.PROCESS_INSTANCE_KEY,
+          source.PROCESSED_DATE, source.STATE, source.ERROR_MESSAGE)
+  </insert>
+
 
   <update id="updateItemsWithState"
     parameterType="io.camunda.db.rdbms.sql.BatchOperationMapper$BatchOperationItemStatusUpdateDto">

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/BatchOperationFixtures.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/BatchOperationFixtures.java
@@ -38,9 +38,9 @@ public final class BatchOperationFixtures {
             .operationType("some-operation" + RANDOM.nextInt(1000))
             .startDate(OffsetDateTime.now())
             .endDate(OffsetDateTime.now().plusSeconds(1))
-            .operationsTotalCount(RANDOM.nextInt(1000))
-            .operationsFailedCount(RANDOM.nextInt(1000))
-            .operationsCompletedCount(RANDOM.nextInt(1000));
+            .operationsTotalCount(0)
+            .operationsFailedCount(0)
+            .operationsCompletedCount(0);
     return builderFunction.apply(builder).build();
   }
 


### PR DESCRIPTION
## Description

Alternative approach for PR #34596.

This one solves the issue by adding vendor specific upsert statements to dynamically upsert the batch operation item when it already exists.

## Related issues

closes #34541 
