### PR TITLE
Console Ping: provide default in case retry config is null.

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/console/ping/PingConsoleTask.java
+++ b/dist/src/main/java/io/camunda/application/commons/console/ping/PingConsoleTask.java
@@ -10,6 +10,7 @@ package io.camunda.application.commons.console.ping;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.camunda.application.commons.console.ping.PingConsoleRunner.ConsolePingConfiguration;
 import io.camunda.zeebe.util.VisibleForTesting;
+import io.camunda.zeebe.util.retry.RetryConfiguration;
 import io.camunda.zeebe.util.retry.RetryDecorator;
 import java.io.IOException;
 import java.net.http.HttpClient;
@@ -36,7 +37,11 @@ public class PingConsoleTask implements Runnable {
       final String licensePayload) {
     this.pingConfiguration = pingConfiguration;
     this.client = client;
-    retryDecorator = new RetryDecorator(pingConfiguration.retry());
+    retryDecorator =
+        new RetryDecorator(
+            pingConfiguration.retry() != null
+                ? pingConfiguration.retry()
+                : new RetryConfiguration());
     this.licensePayload = licensePayload;
   }
 


### PR DESCRIPTION
## Description

We should provide the default retry config in case this was not set up instead of failing during the start.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

