### PR TITLE
feat: persist confirmed backup position

### DIFF
--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointBackupConfirmedApplier.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointBackupConfirmedApplier.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.backup.processing;
+
+import io.camunda.zeebe.backup.processing.state.CheckpointState;
+import io.camunda.zeebe.protocol.impl.record.value.management.CheckpointRecord;
+
+public class CheckpointBackupConfirmedApplier {
+  private final CheckpointState checkpointState;
+
+  public CheckpointBackupConfirmedApplier(final CheckpointState checkpointState) {
+    this.checkpointState = checkpointState;
+  }
+
+  public void apply(final CheckpointRecord checkpointRecord) {
+    checkpointState.setLatestBackupInfo(
+        checkpointRecord.getCheckpointId(), checkpointRecord.getCheckpointPosition());
+  }
+}

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointConfirmBackupProcessor.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointConfirmBackupProcessor.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.backup.processing;
+
+import io.camunda.zeebe.backup.processing.state.CheckpointState;
+import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
+import io.camunda.zeebe.protocol.impl.record.value.management.CheckpointRecord;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.management.CheckpointIntent;
+import io.camunda.zeebe.stream.api.ProcessingResult;
+import io.camunda.zeebe.stream.api.ProcessingResultBuilder;
+import io.camunda.zeebe.stream.api.records.TypedRecord;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class CheckpointConfirmBackupProcessor {
+
+  private static final Logger LOG = LoggerFactory.getLogger(CheckpointConfirmBackupProcessor.class);
+  private final CheckpointState checkpointState;
+
+  public CheckpointConfirmBackupProcessor(final CheckpointState checkpointState) {
+    this.checkpointState = checkpointState;
+  }
+
+  public ProcessingResult process(
+      final TypedRecord<CheckpointRecord> record, final ProcessingResultBuilder resultBuilder) {
+    final var checkpointId = record.getValue().getCheckpointId();
+    final var latestBackupId = checkpointState.getLatestBackupId();
+    if (latestBackupId < checkpointId) {
+      LOG.debug("Confirming backup for checkpoint {}", checkpointId);
+      resultBuilder.appendRecord(
+          record.getKey(),
+          record.getValue(),
+          new RecordMetadata()
+              .recordType(RecordType.EVENT)
+              .valueType(ValueType.CHECKPOINT)
+              .intent(CheckpointIntent.CONFIRMED_BACKUP));
+    } else {
+      LOG.debug(
+          "Ignoring backup for checkpoint {} as it is older than the latest backup {}",
+          checkpointId,
+          latestBackupId);
+      resultBuilder.appendRecord(
+          record.getKey(),
+          record.getValue(),
+          new RecordMetadata()
+              .recordType(RecordType.COMMAND_REJECTION)
+              .valueType(ValueType.CHECKPOINT)
+              .intent(record.getIntent()));
+    }
+
+    return resultBuilder.build();
+  }
+}

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointCreateProcessor.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointCreateProcessor.java
@@ -46,11 +46,11 @@ public final class CheckpointCreateProcessor {
 
     final var checkpointRecord = record.getValue();
     final long checkpointId = checkpointRecord.getCheckpointId();
-    if (checkpointState.getCheckpointId() < checkpointId) {
+    if (checkpointState.getLatestCheckpointId() < checkpointId) {
       // Only take a checkpoint if it is newer
       final var checkpointPosition = record.getPosition();
       backupManager.takeBackup(checkpointId, checkpointPosition);
-      checkpointState.setCheckpointInfo(checkpointId, checkpointPosition);
+      checkpointState.setLatestCheckpointInfo(checkpointId, checkpointPosition);
 
       // Notify listeners immediately
       listeners.forEach(l -> l.onNewCheckpointCreated(checkpointId));
@@ -72,8 +72,8 @@ public final class CheckpointCreateProcessor {
           record,
           CheckpointIntent.IGNORED,
           new CheckpointRecord()
-              .setCheckpointId(checkpointState.getCheckpointId())
-              .setCheckpointPosition(checkpointState.getCheckpointPosition()),
+              .setCheckpointId(checkpointState.getLatestCheckpointId())
+              .setCheckpointPosition(checkpointState.getLatestCheckpointPosition()),
           resultBuilder);
     }
   }

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointCreatedEventApplier.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointCreatedEventApplier.java
@@ -30,9 +30,9 @@ public final class CheckpointCreatedEventApplier {
   }
 
   public void apply(final CheckpointRecord checkpointRecord) {
-    checkpointState.setCheckpointInfo(
+    checkpointState.setLatestCheckpointInfo(
         checkpointRecord.getCheckpointId(), checkpointRecord.getCheckpointPosition());
     checkpointListeners.forEach(
-        listener -> listener.onNewCheckpointCreated(checkpointState.getCheckpointId()));
+        listener -> listener.onNewCheckpointCreated(checkpointState.getLatestCheckpointId()));
   }
 }

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointRecordsProcessor.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointRecordsProcessor.java
@@ -66,10 +66,10 @@ public final class CheckpointRecordsProcessor
     checkpointCreatedEventApplier =
         new CheckpointCreatedEventApplier(checkpointState, checkpointListeners, metrics);
 
-    final long checkpointId = checkpointState.getCheckpointId();
+    final long checkpointId = checkpointState.getLatestCheckpointId();
     if (checkpointId != CheckpointState.NO_CHECKPOINT) {
       checkpointListeners.forEach(listener -> listener.onNewCheckpointCreated(checkpointId));
-      metrics.setCheckpointId(checkpointId, checkpointState.getCheckpointPosition());
+      metrics.setCheckpointId(checkpointId, checkpointState.getLatestCheckpointPosition());
     }
 
     recordProcessorContext.addLifecycleListeners(List.of(this));
@@ -137,9 +137,9 @@ public final class CheckpointRecordsProcessor
       executor.runDelayed(
           Duration.ZERO,
           () -> {
-            final var checkpointId = checkpointState.getCheckpointId();
+            final var checkpointId = checkpointState.getLatestCheckpointId();
             if (checkpointId != CheckpointState.NO_CHECKPOINT) {
-              checkpointListener.onNewCheckpointCreated(checkpointState.getCheckpointId());
+              checkpointListener.onNewCheckpointCreated(checkpointState.getLatestCheckpointId());
             }
           });
     }
@@ -150,6 +150,6 @@ public final class CheckpointRecordsProcessor
     // After a leader change, the new leader will not continue taking the backup initiated by
     // previous leader. So mark them as failed, so that the users do not wait forever for it to be
     // completed.
-    backupManager.failInProgressBackup(checkpointState.getCheckpointId());
+    backupManager.failInProgressBackup(checkpointState.getLatestCheckpointId());
   }
 }

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointRecordsProcessor.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointRecordsProcessor.java
@@ -39,6 +39,7 @@ public final class CheckpointRecordsProcessor
 
   private final BackupManager backupManager;
   private CheckpointCreateProcessor checkpointCreateProcessor;
+  private CheckpointConfirmBackupProcessor checkpointConfirmBackupProcessor;
   private CheckpointCreatedEventApplier checkpointCreatedEventApplier;
 
   //  Can be accessed concurrently by other threads to add new listeners. Hence we have to use a
@@ -63,6 +64,7 @@ public final class CheckpointRecordsProcessor
 
     checkpointCreateProcessor =
         new CheckpointCreateProcessor(checkpointState, backupManager, checkpointListeners, metrics);
+    checkpointConfirmBackupProcessor = new CheckpointConfirmBackupProcessor(checkpointState);
     checkpointCreatedEventApplier =
         new CheckpointCreatedEventApplier(checkpointState, checkpointListeners, metrics);
 
@@ -103,8 +105,7 @@ public final class CheckpointRecordsProcessor
 
     if (record.getValueType() == ValueType.CHECKPOINT
         && record.getIntent() == CheckpointIntent.CONFIRM_BACKUP) {
-      // TODO: Not implemented yet
-      return resultBuilder.build();
+      return checkpointConfirmBackupProcessor.process(record, resultBuilder);
     }
 
     // Should never reach here. StreamProcessor must choose the right processor always.

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/state/CheckpointState.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/state/CheckpointState.java
@@ -32,4 +32,18 @@ public interface CheckpointState {
    * @param checkpointPosition position of the checkpoint
    */
   void setLatestCheckpointInfo(final long checkpointId, final long checkpointPosition);
+
+  /**
+   * Set id and position of the last checkpoint with a successful backup.
+   *
+   * @param backupId id of the checkpoint for this backup.
+   * @param backupPosition position of the checkpoint for this backup.
+   */
+  void setLatestBackupInfo(long backupId, long backupPosition);
+
+  /** Returns the id of the last checkpoint with a successful backup. */
+  long getLatestBackupId();
+
+  /** Returns the position of the last checkpoint with a successful backup. */
+  long getLatestBackupPosition();
 }

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/state/CheckpointState.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/state/CheckpointState.java
@@ -36,10 +36,10 @@ public interface CheckpointState {
   /**
    * Set id and position of the last checkpoint with a successful backup.
    *
-   * @param backupId id of the checkpoint for this backup.
-   * @param backupPosition position of the checkpoint for this backup.
+   * @param checkpointId id of the checkpoint for this backup.
+   * @param checkpointPosition position of the checkpoint for this backup.
    */
-  void setLatestBackupInfo(long backupId, long backupPosition);
+  void setLatestBackupInfo(long checkpointId, long checkpointPosition);
 
   /** Returns the id of the last checkpoint with a successful backup. */
   long getLatestBackupId();

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/state/CheckpointState.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/state/CheckpointState.java
@@ -16,20 +16,20 @@ public interface CheckpointState {
    *
    * @return checkpointId
    */
-  long getCheckpointId();
+  long getLatestCheckpointId();
 
   /**
    * Returns the position of the last created checkpoint
    *
    * @return checkpointPosition
    */
-  long getCheckpointPosition();
+  long getLatestCheckpointPosition();
 
   /**
-   * Set checkpointId and checkpointPosition
+   * Set id and position of the last created checkpoint
    *
    * @param checkpointId id of the checkpoint
    * @param checkpointPosition position of the checkpoint
    */
-  void setCheckpointInfo(final long checkpointId, final long checkpointPosition);
+  void setLatestCheckpointInfo(final long checkpointId, final long checkpointPosition);
 }

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/state/DbCheckpointState.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/state/DbCheckpointState.java
@@ -14,7 +14,7 @@ import io.camunda.zeebe.db.impl.DbString;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
 
 public final class DbCheckpointState implements CheckpointState {
-  private static final String CHECKPOINT_KEY = "checkpoint";
+  private static final String LATEST_CHECKPOINT_KEY = "checkpoint";
 
   private final CheckpointInfo checkpointInfo = new CheckpointInfo();
   private final ColumnFamily<DbString, CheckpointInfo> checkpointColumnFamily;
@@ -23,26 +23,29 @@ public final class DbCheckpointState implements CheckpointState {
   public DbCheckpointState(
       final ZeebeDb<ZbColumnFamilies> zeebeDb, final TransactionContext transactionContext) {
     checkpointInfoKey = new DbString();
-    checkpointInfoKey.wrapString(CHECKPOINT_KEY);
+    checkpointInfoKey.wrapString(LATEST_CHECKPOINT_KEY);
     checkpointColumnFamily =
         zeebeDb.createColumnFamily(
             ZbColumnFamilies.DEFAULT, transactionContext, checkpointInfoKey, checkpointInfo);
   }
 
   @Override
-  public long getCheckpointId() {
+  public long getLatestCheckpointId() {
+    checkpointInfoKey.wrapString(LATEST_CHECKPOINT_KEY);
     final CheckpointInfo info = checkpointColumnFamily.get(checkpointInfoKey);
     return info != null ? info.getId() : NO_CHECKPOINT;
   }
 
   @Override
-  public long getCheckpointPosition() {
+  public long getLatestCheckpointPosition() {
+    checkpointInfoKey.wrapString(LATEST_CHECKPOINT_KEY);
     final CheckpointInfo info = checkpointColumnFamily.get(checkpointInfoKey);
     return info != null ? info.getPosition() : NO_CHECKPOINT;
   }
 
   @Override
-  public void setCheckpointInfo(final long checkpointId, final long checkpointPosition) {
+  public void setLatestCheckpointInfo(final long checkpointId, final long checkpointPosition) {
+    checkpointInfoKey.wrapString(LATEST_CHECKPOINT_KEY);
     checkpointInfo.setId(checkpointId).setPosition(checkpointPosition);
     checkpointColumnFamily.upsert(checkpointInfoKey, checkpointInfo);
   }

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/state/DbCheckpointState.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/state/DbCheckpointState.java
@@ -52,9 +52,9 @@ public final class DbCheckpointState implements CheckpointState {
   }
 
   @Override
-  public void setLatestBackupInfo(final long backupId, final long backupPosition) {
+  public void setLatestBackupInfo(final long checkpointId, final long checkpointPosition) {
     checkpointInfoKey.wrapString(LATEST_BACKUP_KEY);
-    checkpointInfo.setId(backupId).setPosition(backupPosition);
+    checkpointInfo.setId(checkpointId).setPosition(checkpointPosition);
     checkpointColumnFamily.upsert(checkpointInfoKey, checkpointInfo);
   }
 

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/state/DbCheckpointState.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/state/DbCheckpointState.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.protocol.ZbColumnFamilies;
 
 public final class DbCheckpointState implements CheckpointState {
   private static final String LATEST_CHECKPOINT_KEY = "checkpoint";
+  private static final String LATEST_BACKUP_KEY = "backup";
 
   private final CheckpointInfo checkpointInfo = new CheckpointInfo();
   private final ColumnFamily<DbString, CheckpointInfo> checkpointColumnFamily;
@@ -48,5 +49,26 @@ public final class DbCheckpointState implements CheckpointState {
     checkpointInfoKey.wrapString(LATEST_CHECKPOINT_KEY);
     checkpointInfo.setId(checkpointId).setPosition(checkpointPosition);
     checkpointColumnFamily.upsert(checkpointInfoKey, checkpointInfo);
+  }
+
+  @Override
+  public void setLatestBackupInfo(final long backupId, final long backupPosition) {
+    checkpointInfoKey.wrapString(LATEST_BACKUP_KEY);
+    checkpointInfo.setId(backupId).setPosition(backupPosition);
+    checkpointColumnFamily.upsert(checkpointInfoKey, checkpointInfo);
+  }
+
+  @Override
+  public long getLatestBackupId() {
+    checkpointInfoKey.wrapString(LATEST_BACKUP_KEY);
+    final CheckpointInfo info = checkpointColumnFamily.get(checkpointInfoKey);
+    return info != null ? info.getId() : NO_CHECKPOINT;
+  }
+
+  @Override
+  public long getLatestBackupPosition() {
+    checkpointInfoKey.wrapString(LATEST_BACKUP_KEY);
+    final CheckpointInfo info = checkpointColumnFamily.get(checkpointInfoKey);
+    return info != null ? info.getPosition() : NO_CHECKPOINT;
   }
 }

--- a/zeebe/backup/src/test/java/io/camunda/zeebe/backup/processing/CheckpointRecordsProcessorTest.java
+++ b/zeebe/backup/src/test/java/io/camunda/zeebe/backup/processing/CheckpointRecordsProcessorTest.java
@@ -122,8 +122,8 @@ final class CheckpointRecordsProcessorTest {
     assertThat(followupRecord.getCheckpointPosition()).isEqualTo(checkpointPosition);
 
     // state is updated
-    assertThat(state.getCheckpointId()).isEqualTo(checkpointId);
-    assertThat(state.getCheckpointPosition()).isEqualTo(checkpointPosition);
+    assertThat(state.getLatestCheckpointId()).isEqualTo(checkpointId);
+    assertThat(state.getLatestCheckpointPosition()).isEqualTo(checkpointPosition);
   }
 
   @Test
@@ -131,7 +131,7 @@ final class CheckpointRecordsProcessorTest {
     // given
     final long checkpointId = 1;
     final long checkpointPosition = 10;
-    state.setCheckpointInfo(checkpointId, checkpointPosition);
+    state.setLatestCheckpointInfo(checkpointId, checkpointPosition);
 
     final CheckpointRecord value = new CheckpointRecord().setCheckpointId(checkpointId);
     final MockTypedCheckpointRecord record =
@@ -153,8 +153,8 @@ final class CheckpointRecordsProcessorTest {
     assertThat(followupEvent.type()).isEqualTo(RecordType.EVENT);
 
     // state not changed
-    assertThat(state.getCheckpointId()).isEqualTo(checkpointId);
-    assertThat(state.getCheckpointPosition()).isEqualTo(checkpointPosition);
+    assertThat(state.getLatestCheckpointId()).isEqualTo(checkpointId);
+    assertThat(state.getLatestCheckpointPosition()).isEqualTo(checkpointPosition);
   }
 
   @Test
@@ -162,7 +162,7 @@ final class CheckpointRecordsProcessorTest {
     // given
     final long checkpointId = 10;
     final long checkpointPosition = 10;
-    state.setCheckpointInfo(checkpointId, checkpointPosition);
+    state.setLatestCheckpointInfo(checkpointId, checkpointPosition);
 
     final int lowerCheckpointId = 1;
     final CheckpointRecord value = new CheckpointRecord().setCheckpointId(lowerCheckpointId);
@@ -190,8 +190,8 @@ final class CheckpointRecordsProcessorTest {
     assertThat(followupRecord.getCheckpointPosition()).isEqualTo(checkpointPosition);
 
     // state not changed
-    assertThat(state.getCheckpointId()).isEqualTo(checkpointId);
-    assertThat(state.getCheckpointPosition()).isEqualTo(checkpointPosition);
+    assertThat(state.getLatestCheckpointId()).isEqualTo(checkpointId);
+    assertThat(state.getLatestCheckpointPosition()).isEqualTo(checkpointPosition);
   }
 
   @Test
@@ -216,8 +216,8 @@ final class CheckpointRecordsProcessorTest {
 
     // then
     // state is updated
-    assertThat(state.getCheckpointId()).isEqualTo(checkpointId);
-    assertThat(state.getCheckpointPosition()).isEqualTo(checkpointPosition);
+    assertThat(state.getLatestCheckpointId()).isEqualTo(checkpointId);
+    assertThat(state.getLatestCheckpointPosition()).isEqualTo(checkpointPosition);
   }
 
   @Test
@@ -225,7 +225,7 @@ final class CheckpointRecordsProcessorTest {
     // given
     final long checkpointId = 2;
     final long checkpointPosition = 10;
-    state.setCheckpointInfo(checkpointId, checkpointPosition);
+    state.setLatestCheckpointInfo(checkpointId, checkpointPosition);
     final CheckpointRecord value = new CheckpointRecord().setCheckpointId(1);
     final MockTypedCheckpointRecord record =
         new MockTypedCheckpointRecord(21, 20, CheckpointIntent.IGNORED, RecordType.EVENT, value);
@@ -235,8 +235,8 @@ final class CheckpointRecordsProcessorTest {
 
     // then
     // state is not changed
-    assertThat(state.getCheckpointId()).isEqualTo(checkpointId);
-    assertThat(state.getCheckpointPosition()).isEqualTo(checkpointPosition);
+    assertThat(state.getLatestCheckpointId()).isEqualTo(checkpointId);
+    assertThat(state.getLatestCheckpointPosition()).isEqualTo(checkpointPosition);
   }
 
   @Test
@@ -293,7 +293,7 @@ final class CheckpointRecordsProcessorTest {
     processor = new CheckpointRecordsProcessor(backupManager, 1, context.getMeterRegistry());
     final long checkpointId = 3;
     final long checkpointPosition = 30;
-    state.setCheckpointInfo(checkpointId, checkpointPosition);
+    state.setLatestCheckpointInfo(checkpointId, checkpointPosition);
 
     // when
     final AtomicLong checkpoint = new AtomicLong();
@@ -309,7 +309,7 @@ final class CheckpointRecordsProcessorTest {
     // given
     final long checkpointId = 3;
     final long checkpointPosition = 30;
-    state.setCheckpointInfo(checkpointId, checkpointPosition);
+    state.setLatestCheckpointInfo(checkpointId, checkpointPosition);
 
     doAnswer(
             invocation -> {

--- a/zeebe/backup/src/test/java/io/camunda/zeebe/backup/processing/CheckpointRecordsProcessorTest.java
+++ b/zeebe/backup/src/test/java/io/camunda/zeebe/backup/processing/CheckpointRecordsProcessorTest.java
@@ -354,7 +354,7 @@ final class CheckpointRecordsProcessorTest {
   }
 
   @Test
-  void shouldRejectBackupWhenBackupIdIsOlderOrSame() {
+  void shouldRejectBackupWhenBackupIdIsOlder() {
     // given
     final var currentBackupId = 10;
     final var currentBackupPosition = 100;

--- a/zeebe/backup/src/test/java/io/camunda/zeebe/backup/processing/state/DbCheckpointStateTest.java
+++ b/zeebe/backup/src/test/java/io/camunda/zeebe/backup/processing/state/DbCheckpointStateTest.java
@@ -77,4 +77,81 @@ final class DbCheckpointStateTest {
     assertThat(state.getLatestCheckpointId()).isEqualTo(15L);
     assertThat(state.getLatestCheckpointPosition()).isEqualTo(20L);
   }
+
+  @Test
+  void shouldReturnInitialValuesWhenNoBackup() {
+    // given
+
+    // then
+    assertThat(state.getLatestBackupId()).isEqualTo(NO_CHECKPOINT);
+    assertThat(state.getLatestBackupPosition()).isEqualTo(NO_CHECKPOINT);
+  }
+
+  @Test
+  void shouldSetAndGetLatestBackupIdAndPosition() {
+    // when
+    state.setLatestBackupInfo(7L, 14L);
+
+    // then
+    assertThat(state.getLatestBackupId()).isEqualTo(7L);
+    assertThat(state.getLatestBackupPosition()).isEqualTo(14L);
+  }
+
+  @Test
+  void shouldOverwriteBackupIdAndPosition() {
+    // given
+    state.setLatestBackupInfo(7L, 14L);
+
+    // when
+    state.setLatestBackupInfo(21L, 28L);
+
+    // then
+    assertThat(state.getLatestBackupId()).isEqualTo(21L);
+    assertThat(state.getLatestBackupPosition()).isEqualTo(28L);
+  }
+
+  @Test
+  void shouldStoreCheckpointAndBackupInfoIndependently() {
+    // when
+    state.setLatestCheckpointInfo(5L, 10L);
+    state.setLatestBackupInfo(7L, 14L);
+
+    // then
+    assertThat(state.getLatestCheckpointId()).isEqualTo(5L);
+    assertThat(state.getLatestCheckpointPosition()).isEqualTo(10L);
+    assertThat(state.getLatestBackupId()).isEqualTo(7L);
+    assertThat(state.getLatestBackupPosition()).isEqualTo(14L);
+  }
+
+  @Test
+  void shouldUpdateCheckpointInfoWithoutAffectingBackupInfo() {
+    // given
+    state.setLatestCheckpointInfo(5L, 10L);
+    state.setLatestBackupInfo(7L, 14L);
+
+    // when
+    state.setLatestCheckpointInfo(15L, 20L);
+
+    // then
+    assertThat(state.getLatestCheckpointId()).isEqualTo(15L);
+    assertThat(state.getLatestCheckpointPosition()).isEqualTo(20L);
+    assertThat(state.getLatestBackupId()).isEqualTo(7L);
+    assertThat(state.getLatestBackupPosition()).isEqualTo(14L);
+  }
+
+  @Test
+  void shouldUpdateBackupInfoWithoutAffectingCheckpointInfo() {
+    // given
+    state.setLatestCheckpointInfo(5L, 10L);
+    state.setLatestBackupInfo(7L, 14L);
+
+    // when
+    state.setLatestBackupInfo(21L, 28L);
+
+    // then
+    assertThat(state.getLatestCheckpointId()).isEqualTo(5L);
+    assertThat(state.getLatestCheckpointPosition()).isEqualTo(10L);
+    assertThat(state.getLatestBackupId()).isEqualTo(21L);
+    assertThat(state.getLatestBackupPosition()).isEqualTo(28L);
+  }
 }

--- a/zeebe/backup/src/test/java/io/camunda/zeebe/backup/processing/state/DbCheckpointStateTest.java
+++ b/zeebe/backup/src/test/java/io/camunda/zeebe/backup/processing/state/DbCheckpointStateTest.java
@@ -51,30 +51,30 @@ final class DbCheckpointStateTest {
     // given
 
     // when-then
-    assertThat(state.getCheckpointId()).isEqualTo(NO_CHECKPOINT);
-    assertThat(state.getCheckpointPosition()).isEqualTo(NO_CHECKPOINT);
+    assertThat(state.getLatestCheckpointId()).isEqualTo(NO_CHECKPOINT);
+    assertThat(state.getLatestCheckpointPosition()).isEqualTo(NO_CHECKPOINT);
   }
 
   @Test
-  void shouldSetAndGetCheckpointIdAndPosition() {
+  void shouldSetAndGetLatestCheckpointIdAndPosition() {
     // when
-    state.setCheckpointInfo(5L, 10L);
+    state.setLatestCheckpointInfo(5L, 10L);
 
     // then
-    assertThat(state.getCheckpointId()).isEqualTo(5L);
-    assertThat(state.getCheckpointPosition()).isEqualTo(10L);
+    assertThat(state.getLatestCheckpointId()).isEqualTo(5L);
+    assertThat(state.getLatestCheckpointPosition()).isEqualTo(10L);
   }
 
   @Test
   void shouldOverwriteCheckpointIdAndPosition() {
     // given
-    state.setCheckpointInfo(5L, 10L);
+    state.setLatestCheckpointInfo(5L, 10L);
 
     // when
-    state.setCheckpointInfo(15L, 20L);
+    state.setLatestCheckpointInfo(15L, 20L);
 
     // then
-    assertThat(state.getCheckpointId()).isEqualTo(15L);
-    assertThat(state.getCheckpointPosition()).isEqualTo(20L);
+    assertThat(state.getLatestCheckpointId()).isEqualTo(15L);
+    assertThat(state.getLatestCheckpointPosition()).isEqualTo(20L);
   }
 }


### PR DESCRIPTION
This adds the state, command processor and event applier to persist information about the last confirmed backup.
Builds on top of #34980 
Closes #34861 