### PR TITLE
pg-fix-backup-history-actuator

### DIFF
--- a/dist/src/main/java/io/camunda/webapps/controllers/BackupController.java
+++ b/dist/src/main/java/io/camunda/webapps/controllers/BackupController.java
@@ -23,8 +23,7 @@ import io.camunda.webapps.backup.TakeBackupRequestDto;
 import io.camunda.webapps.backup.repository.BackupRepositoryProps;
 import io.camunda.webapps.profiles.ProfileWebApp;
 import io.camunda.zeebe.util.VisibleForTesting;
-import io.micrometer.common.lang.NonNull;
-import io.micrometer.common.lang.Nullable;
+import jakarta.annotation.Nullable;
 import java.math.BigDecimal;
 import java.util.Arrays;
 import org.slf4j.Logger;
@@ -72,7 +71,7 @@ public class BackupController {
   }
 
   @ReadOperation
-  public WebEndpointResponse<?> getBackupState(@Selector @NonNull final long backupId) {
+  public WebEndpointResponse<?> getBackupState(@Selector final long backupId) {
     try {
       validateBackupId(backupId);
       validateRepositoryNameIsConfigured();
@@ -102,7 +101,7 @@ public class BackupController {
   }
 
   @DeleteOperation
-  public WebEndpointResponse<?> deleteBackup(@Selector @NonNull final long backupId) {
+  public WebEndpointResponse<?> deleteBackup(@Selector final long backupId) {
     try {
       validateBackupId(backupId);
       validateRepositoryNameIsConfigured();

--- a/dist/src/main/java/io/camunda/webapps/controllers/BackupController.java
+++ b/dist/src/main/java/io/camunda/webapps/controllers/BackupController.java
@@ -24,6 +24,7 @@ import io.camunda.webapps.backup.repository.BackupRepositoryProps;
 import io.camunda.webapps.profiles.ProfileWebApp;
 import io.camunda.zeebe.util.VisibleForTesting;
 import io.micrometer.common.lang.NonNull;
+import io.micrometer.common.lang.Nullable;
 import java.math.BigDecimal;
 import java.util.Arrays;
 import org.slf4j.Logger;
@@ -36,7 +37,6 @@ import org.springframework.boot.actuate.endpoint.annotation.WriteOperation;
 import org.springframework.boot.actuate.endpoint.web.WebEndpointResponse;
 import org.springframework.boot.actuate.endpoint.web.annotation.WebEndpoint;
 import org.springframework.stereotype.Component;
-import org.springframework.web.bind.annotation.RequestParam;
 
 @Component
 @WebEndpoint(id = "backupHistory")
@@ -87,12 +87,12 @@ public class BackupController {
 
   @ReadOperation
   public WebEndpointResponse<?> getBackups(
-      @RequestParam(value = "verbose", defaultValue = "true", required = false)
-          final boolean verbose,
-      @RequestParam(value = "pattern", defaultValue = "*", required = false) final String pattern) {
+      @Nullable final Boolean verbose, @Nullable final String pattern) {
     try {
+      final boolean verboseValue = verbose != null ? verbose : true;
+      final String patternValue = pattern != null ? pattern : "*";
       validateRepositoryNameIsConfigured();
-      final var respDTO = backupService.getBackups(verbose, pattern);
+      final var respDTO = backupService.getBackups(verboseValue, patternValue);
       final var resp = respDTO.stream().map(this::mapTo).toList();
       return new WebEndpointResponse<>(resp);
     } catch (final Exception e) {

--- a/dist/src/main/java/io/camunda/webapps/controllers/BackupController.java
+++ b/dist/src/main/java/io/camunda/webapps/controllers/BackupController.java
@@ -23,7 +23,6 @@ import io.camunda.webapps.backup.TakeBackupRequestDto;
 import io.camunda.webapps.backup.repository.BackupRepositoryProps;
 import io.camunda.webapps.profiles.ProfileWebApp;
 import io.camunda.zeebe.util.VisibleForTesting;
-import jakarta.annotation.Nullable;
 import java.math.BigDecimal;
 import java.util.Arrays;
 import org.slf4j.Logger;
@@ -35,6 +34,7 @@ import org.springframework.boot.actuate.endpoint.annotation.Selector;
 import org.springframework.boot.actuate.endpoint.annotation.WriteOperation;
 import org.springframework.boot.actuate.endpoint.web.WebEndpointResponse;
 import org.springframework.boot.actuate.endpoint.web.annotation.WebEndpoint;
+import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Component;
 
 @Component

--- a/dist/src/main/java/io/camunda/webapps/controllers/BackupControllerStandalone.java
+++ b/dist/src/main/java/io/camunda/webapps/controllers/BackupControllerStandalone.java
@@ -9,7 +9,7 @@ package io.camunda.webapps.controllers;
 
 import io.camunda.application.commons.backup.ConditionalOnBackupWebappsEnabled;
 import io.camunda.webapps.profiles.ProfileWebAppStandalone;
-import io.micrometer.common.lang.NonNull;
+import jakarta.annotation.Nullable;
 import org.springframework.boot.actuate.endpoint.annotation.DeleteOperation;
 import org.springframework.boot.actuate.endpoint.annotation.ReadOperation;
 import org.springframework.boot.actuate.endpoint.annotation.Selector;
@@ -17,7 +17,6 @@ import org.springframework.boot.actuate.endpoint.annotation.WriteOperation;
 import org.springframework.boot.actuate.endpoint.web.WebEndpointResponse;
 import org.springframework.boot.actuate.endpoint.web.annotation.WebEndpoint;
 import org.springframework.stereotype.Component;
-import org.springframework.web.bind.annotation.RequestParam;
 
 @Component
 @WebEndpoint(id = "backups")
@@ -36,20 +35,18 @@ public class BackupControllerStandalone {
   }
 
   @ReadOperation
-  public WebEndpointResponse<?> getBackupState(@Selector @NonNull final long backupId) {
+  public WebEndpointResponse<?> getBackupState(@Selector final long backupId) {
     return backupController.getBackupState(backupId);
   }
 
   @ReadOperation
   public WebEndpointResponse<?> getBackups(
-      @RequestParam(value = "verbose", defaultValue = "true", required = false)
-          final boolean verbose,
-      @RequestParam(value = "pattern", defaultValue = "*", required = false) final String pattern) {
+      @Nullable final Boolean verbose, @Nullable final String pattern) {
     return backupController.getBackups(verbose, pattern);
   }
 
   @DeleteOperation
-  public WebEndpointResponse<?> deleteBackup(@Selector @NonNull final long backupId) {
+  public WebEndpointResponse<?> deleteBackup(@Selector final long backupId) {
     return backupController.deleteBackup(backupId);
   }
 }

--- a/dist/src/main/resources/api/backup-management-api.yaml
+++ b/dist/src/main/resources/api/backup-management-api.yaml
@@ -149,6 +149,13 @@ paths:
             Set to false to improve the query performance. However, the response will not contain
             fields startTime, failures, failureReason.
             This parameter is forwarded to Elasticsearch/Opensearch /_snapshot/ API.
+        - in: query
+          name: pattern
+          schema:
+            type: string
+            default: '*'
+          description: |
+            Provide a possible prefix number for filtering the backups, can end with a wildcard('*').
       responses:
         '200':
           description: OK

--- a/dist/src/main/resources/api/backup-management-api.yaml
+++ b/dist/src/main/resources/api/backup-management-api.yaml
@@ -155,7 +155,8 @@ paths:
             type: string
             default: '*'
           description: |
-            Provide a possible prefix number for filtering the backups, can end with a wildcard('*').
+            Provide a possible prefix for filtering the backups. Since the backupId is a number,
+            this pattern can only contain digits and the wildcard '*'.
       responses:
         '200':
           description: OK

--- a/dist/src/test/java/io/camunda/webapps/controllers/BackupControllerTest.java
+++ b/dist/src/test/java/io/camunda/webapps/controllers/BackupControllerTest.java
@@ -166,6 +166,21 @@ public abstract sealed class BackupControllerTest {
     assertThat(response.getBody()).isEqualTo(List.of(EXPECTED_INFO));
   }
 
+  @Test
+  public void shouldGetBackupsWithNullParameters() {
+    when(backupService.getBackups(anyBoolean(), any()))
+        .thenReturn(
+            List.of(
+                new GetBackupStateResponseDto()
+                    .setBackupId(1L)
+                    .setState(BackupStateDto.FAILED)
+                    .setFailureReason("Out of disk space")
+                    .setDetails(List.of(DETAIL_DTO))));
+    final var response = backupController.getBackups(null, null);
+    assertThat(response.getStatus()).isEqualTo(200);
+    assertThat(response.getBody()).isEqualTo(List.of(EXPECTED_INFO));
+  }
+
   @EnumSource(BackupStateDto.class)
   @ParameterizedTest
   public void testEnumConversion(final BackupStateDto backupStateDto) {

--- a/dist/src/test/java/io/camunda/webapps/controllers/BackupControllerTest.java
+++ b/dist/src/test/java/io/camunda/webapps/controllers/BackupControllerTest.java
@@ -168,7 +168,7 @@ public abstract sealed class BackupControllerTest {
 
   @Test
   public void shouldGetBackupsWithNullParameters() {
-    when(backupService.getBackups(anyBoolean(), any()))
+    when(backupService.getBackups(true, "*"))
         .thenReturn(
             List.of(
                 new GetBackupStateResponseDto()


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Actuator endpoint `/backupHistory` was not able to correctly parse the request params using the conventional REST `@RequestParam` mapping. Resulting in `400` response status codes when passing no parameters.

This pr fixes the endpoint to the required behavior of being able to handle null & no request parameters passed to the endpoint.

Ref discussion thread: https://camunda.slack.com/archives/C08MRKHJ0CD/p1751968205527279

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes:
