### PR TITLE
fix: reset flow node instance and selection on pi key change

### DIFF
--- a/operate/client/src/App/ProcessInstance/v2/index.tsx
+++ b/operate/client/src/App/ProcessInstance/v2/index.tsx
@@ -149,6 +149,7 @@ const ProcessInstance: React.FC = observer(() => {
       flowNodeTimeStampStore.reset();
       flowNodeSelectionStore.reset();
       modificationsStore.reset();
+      isInitialized.current = false;
     };
   }, [processInstanceId]);
 


### PR DESCRIPTION
## Description

This fixes a bug where instance history and variables were not fetched when the process instance key changed without leaving the page (e.g. navigating to a called/parent process instance).

This PR sets a flag (isInitialized) to false, which allows re-initializing the flow node instance and selection stores.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes https://github.com/camunda/camunda/issues/34147
