### PR TITLE
deps: downgrade zeebe-test-container

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -91,7 +91,7 @@
     <version.asm>9.3</version.asm>
     <version.testcontainers>1.19.8</version.testcontainers>
     <version.netflix.concurrency>0.4.2</version.netflix.concurrency>
-    <version.zeebe-test-container>3.6.6</version.zeebe-test-container>
+    <version.zeebe-test-container>3.6.5</version.zeebe-test-container>
     <version.feel-scala>1.17.11</version.feel-scala>
     <version.dmn-scala>1.9.0</version.dmn-scala>
     <version.rest-assured>5.4.0</version.rest-assured>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -91,7 +91,7 @@
     <version.asm>9.3</version.asm>
     <version.testcontainers>1.19.8</version.testcontainers>
     <version.netflix.concurrency>0.4.2</version.netflix.concurrency>
-    <version.zeebe-test-container>3.6.7</version.zeebe-test-container>
+    <version.zeebe-test-container>3.6.6</version.zeebe-test-container>
     <version.feel-scala>1.17.11</version.feel-scala>
     <version.dmn-scala>1.9.0</version.dmn-scala>
     <version.rest-assured>5.4.0</version.rest-assured>


### PR DESCRIPTION
This resolves the failure to start containers in `RollingUpdateTest`. The problem was that https://github.com/camunda-community-hub/zeebe-test-container/pull/812 introduced a breaking change for 8.4 where we do not yet expose the REST port 8080, thus failing the default port readiness check.

Thread with more context: https://camunda.slack.com/archives/C071KP5BTHB/p1751958173462109