### PR TITLE
ci: fail merge queue on cancelled job in test summary

### DIFF
--- a/.github/workflows/zeebe-ci.yml
+++ b/.github/workflows/zeebe-ci.yml
@@ -638,6 +638,8 @@ jobs:
     name: Test summary
     if: always()
     runs-on: ubuntu-latest
+    timeout-minutes: 3
+    permissions: {}  # GITHUB_TOKEN unused in this job
     needs:
       - integration-tests
       - unit-tests
@@ -651,7 +653,8 @@ jobs:
       - docker-checks
       - protobuf-checks
     steps:
-      - run: exit ${{ ((contains(needs.*.result, 'skipped') || contains(needs.*.result, 'failure')) && 1) || 0 }}
+      - run: exit ${{ ((contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'failure')) && 1) || 0 }}
+
   deploy-snapshots:
     name: Deploy snapshot artifacts
     needs: [ test-summary ]


### PR DESCRIPTION
## Description

Avoids letting PRs like https://github.com/camunda/camunda/pull/33182 with [build problems](https://github.com/camunda/camunda/actions/runs/15999679898/job/45131212080) pass the merge queue.

The new condition for the test summary job is copied from the [Unified CI on main](https://github.com/camunda/camunda/blob/7690a44faf2d2abeafa198618c9e412d636b6b58/.github/workflows/ci.yml#L1273).

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

[Slack](https://camunda.slack.com/archives/C071KP5BTHB/p1751958173462109)
