### PR TITLE
feat: optimize batch operation scheduler to execute bo per run #34969

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationExecutionScheduler.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationExecutionScheduler.java
@@ -87,12 +87,20 @@ public class BatchOperationExecutionScheduler implements StreamProcessorLifecycl
     }
   }
 
+  /**
+   * Executes the next pending batch operation in the queue. If more than one batch operation is
+   * pending, the following one will be executed in the next scheduled run.
+   *
+   * @param taskResultBuilder the task result builder to append the commands to
+   * @return the task result containing the commands to be executed
+   */
   private TaskResult execute(final TaskResultBuilder taskResultBuilder) {
     try {
-      LOG.trace("Looking for pending batch operations to execute (scheduled).");
+      LOG.trace("Looking for the next pending batch operation to execute (scheduled).");
       executing.set(true);
-      batchOperationState.foreachPendingBatchOperation(
-          bo -> executeBatchOperation(bo, taskResultBuilder));
+      batchOperationState
+          .getNextPendingBatchOperation()
+          .ifPresent(bo -> executeBatchOperation(bo, taskResultBuilder));
       return taskResultBuilder.build();
     } finally {
       executing.set(false);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/BatchOperationState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/BatchOperationState.java
@@ -17,13 +17,13 @@ public interface BatchOperationState {
 
   Optional<PersistedBatchOperation> get(final long batchKey);
 
-  void foreachPendingBatchOperation(BatchOperationVisitor visitor);
+  /**
+   * returns the next pending batch operation, or an empty <code>Optional</code> if there are no
+   * pending batch operations.
+   *
+   * @return the next pending batch operation
+   */
+  Optional<PersistedBatchOperation> getNextPendingBatchOperation();
 
   List<Long> getNextItemKeys(long batchOperationKey, int batchSize);
-
-  @FunctionalInterface
-  interface BatchOperationVisitor {
-
-    void visit(PersistedBatchOperation batchOperation);
-  }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationExecutionSchedulerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationExecutionSchedulerTest.java
@@ -22,7 +22,6 @@ import io.camunda.zeebe.engine.metrics.BatchOperationMetrics;
 import io.camunda.zeebe.engine.processing.batchoperation.BatchOperationItemProvider.Item;
 import io.camunda.zeebe.engine.state.batchoperation.PersistedBatchOperation;
 import io.camunda.zeebe.engine.state.immutable.BatchOperationState;
-import io.camunda.zeebe.engine.state.immutable.BatchOperationState.BatchOperationVisitor;
 import io.camunda.zeebe.engine.state.immutable.ScheduledTaskState;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationChunkRecord;
@@ -39,6 +38,7 @@ import io.camunda.zeebe.stream.api.scheduling.TaskResultBuilder;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -80,14 +80,8 @@ public class BatchOperationExecutionSchedulerTest {
     lenient()
         .when(batchOperation.getEntityFilter(eq(ProcessInstanceFilter.class)))
         .thenReturn(filter);
-    doAnswer(
-            invocation -> {
-              final BatchOperationVisitor visitor = invocation.getArgument(0);
-              visitor.visit(batchOperation);
-              return null;
-            })
-        .when(batchOperationState)
-        .foreachPendingBatchOperation(any(BatchOperationVisitor.class));
+    when(batchOperationState.getNextPendingBatchOperation())
+        .thenReturn(Optional.of(batchOperation));
     lenient().when(batchOperationState.exists(anyLong())).thenReturn(true);
 
     final var engineConfiguration = mock(EngineConfiguration.class);
@@ -113,7 +107,7 @@ public class BatchOperationExecutionSchedulerTest {
     execute();
 
     // then
-    verify(batchOperationState).foreachPendingBatchOperation(any());
+    verify(batchOperationState).getNextPendingBatchOperation();
     verify(taskResultBuilder)
         .appendCommandRecord(
             anyLong(),
@@ -146,7 +140,7 @@ public class BatchOperationExecutionSchedulerTest {
     execute();
 
     // then
-    verify(batchOperationState).foreachPendingBatchOperation(any());
+    verify(batchOperationState).getNextPendingBatchOperation();
     verify(taskResultBuilder)
         .appendCommandRecord(
             anyLong(),
@@ -248,7 +242,7 @@ public class BatchOperationExecutionSchedulerTest {
     execute();
 
     // then
-    verify(batchOperationState).foreachPendingBatchOperation(any());
+    verify(batchOperationState).getNextPendingBatchOperation();
     verify(taskResultBuilder)
         .appendCommandRecord(
             anyLong(),
@@ -276,7 +270,7 @@ public class BatchOperationExecutionSchedulerTest {
     execute();
 
     // then
-    verify(batchOperationState).foreachPendingBatchOperation(any());
+    verify(batchOperationState).getNextPendingBatchOperation();
     verify(taskResultBuilder)
         .appendCommandRecord(
             anyLong(),
@@ -304,7 +298,7 @@ public class BatchOperationExecutionSchedulerTest {
     execute();
 
     // then
-    verify(batchOperationState).foreachPendingBatchOperation(any());
+    verify(batchOperationState).getNextPendingBatchOperation();
     verify(taskResultBuilder)
         .appendCommandRecord(
             anyLong(),

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/batchoperation/BatchOperationStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/batchoperation/BatchOperationStateTest.java
@@ -176,10 +176,7 @@ public class BatchOperationStateTest {
     state.create(batchOperationKey, batchRecord);
 
     // then
-    final var pendingKeys = new ArrayList<>();
-    state.foreachPendingBatchOperation(bo -> pendingKeys.add(bo.getKey()));
-
-    assertThat(pendingKeys).containsExactly(batchOperationKey);
+    assertThat(state.getNextPendingBatchOperation().get().getKey()).isEqualTo(batchOperationKey);
   }
 
   @Test
@@ -196,10 +193,7 @@ public class BatchOperationStateTest {
     state.start(batchOperationKey);
 
     // then
-    final var pendingKeys = new ArrayList<>();
-    state.foreachPendingBatchOperation(bo -> pendingKeys.add(bo.getKey()));
-
-    assertThat(pendingKeys).isEmpty();
+    assertThat(state.getNextPendingBatchOperation()).isEmpty();
 
     // and should have status STARTED
     final var persistedBatchOperation = state.get(batchOperationKey).get();
@@ -238,10 +232,7 @@ public class BatchOperationStateTest {
     state.fail(batchOperationKey);
 
     // then
-    final var pendingKeys = new ArrayList<>();
-    state.foreachPendingBatchOperation(bo -> pendingKeys.add(bo.getKey()));
-
-    assertThat(pendingKeys).isEmpty();
+    assertThat(state.getNextPendingBatchOperation()).isEmpty();
 
     // and should have status STARTED
     final var persistedBatchOperation = state.get(batchOperationKey).get();


### PR DESCRIPTION
## Description

This PR optimizes the batch operation scheduler to execute only one batch operation per run.

## Related issues

closes #34969 
