### PR TITLE
Backport 34581 to stable/8.6

### DIFF
--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -721,7 +721,7 @@ jobs:
   notify-on-success:
     name: Send Slack notification on success
     runs-on: ubuntu-latest
-    needs: [release]
+    needs: [release, github, zeebe-docker, operate-docker, tasklist-docker, camunda-docker, snyk]
     if: ${{ always() && needs.release.result == 'success' }}
     timeout-minutes: 5
     permissions: {}  # GITHUB_TOKEN unused in this job
@@ -760,7 +760,7 @@ jobs:
   notify-if-failed:
     name: Send Slack notification on failure
     runs-on: ubuntu-latest
-    needs: [release]
+    needs: [release, github, zeebe-docker, operate-docker, tasklist-docker, camunda-docker, snyk]
     # if it's a dry run => no slack notification (remove noise in slack due to manual testing)
     # else => send slack notification as an actual release failed
     if: ${{ always() && needs.release.result == 'failure' && inputs.dryRun == false }}

--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -28,6 +28,30 @@ on:
         description: 'Whether to perform a dry release where no changes or artifacts are pushed, defaults to true.'
         type: boolean
         default: true
+  workflow_dispatch:
+    inputs:
+      releaseBranch:
+        description: 'The branch to perform the release on, defaults to `release-$releaseVersion`'
+        type: string
+        required: false
+        default: ''
+      releaseVersion:
+        description: 'The version to be build and released. If no releaseBranch specified, expecting `release-$releaseVersion` to already exist.'
+        type: string
+        required: true
+      nextDevelopmentVersion:
+        description: 'Next development version, e.g. 8.X.X-SNAPSHOT.'
+        type: string
+        required: true
+      isLatest:
+        description: 'Whether this is the latest release and the docker image should be tagged as camunda/{component}:latest'
+        type: boolean
+        required: false
+        default: false
+      dryRun:
+        description: 'Whether to perform a dry release where no changes or artifacts are pushed, defaults to true.'
+        type: boolean
+        default: true
 
 defaults:
   run:
@@ -693,5 +717,92 @@ jobs:
       build: ${{ inputs.dryRun }}
       dockerImage: ${{ inputs.dryRun && '' || format('camunda/zeebe:{0}', inputs.releaseVersion) }}
     secrets: inherit
+
+  notify-on-success:
+    name: Send Slack notification on success
+    runs-on: ubuntu-latest
+    needs: [release, zeebe-docker, operate-docker, tasklist-docker, camunda-docker, create-release, snyk]
+    if: ${{ always() && (needs.release.result == 'success' || needs.zeebe-docker.result == 'success' || needs.operate-docker.result == 'success' || needs.tasklist-docker.result == 'success' || needs.camunda-docker.result == 'success' || needs.create-release.result == 'success') }}
+    timeout-minutes: 5
+    permissions: {}  # GITHUB_TOKEN unused in this job
+    steps:
+      - name: Import Secrets
+        id: secrets
+        uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b # v3.4.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false # we rely on step outputs, no need for environment variables
+          secrets: |
+            secret/data/products/camunda/ci/github-actions SLACK_TOPMONOREPORELEASE_WEBHOOK_URL;
+
+      - name: Send success Slack notification
+        uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
+        with:
+          webhook: ${{ steps.secrets.outputs.SLACK_TOPMONOREPORELEASE_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          # For posting a rich message using Block Kit
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":success: *Release job for ${{ inputs.releaseVersion }}* succeeded!\n"
+                  }
+                }
+              ]
+            }
+
+  notify-if-failed:
+    name: Send Slack notification on failure
+    runs-on: ubuntu-latest
+    needs: [release, zeebe-docker, operate-docker, tasklist-docker, camunda-docker, create-release, snyk]
+    # if it's a dry run => no slack notification (remove noise in slack due to manual testing)
+    # else => send slack notification as an actual release failed
+    if: ${{ always() && (needs.release.result == 'failure' || needs.zeebe-docker.result == 'failure' || needs.operate-docker.result == 'failure' || needs.tasklist-docker.result == 'failure' || needs.camunda-docker.result == 'failure' || needs.create-release.result == 'failure') && inputs.dryRun == false }}
+    timeout-minutes: 5
+    permissions: {}  # GITHUB_TOKEN unused in this job
+    steps:
+      - name: Import Secrets
+        id: secrets
+        uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b # v3.4.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false # we rely on step outputs, no need for environment variables
+          secrets: |
+            secret/data/products/camunda/ci/github-actions SLACK_TOPMONOREPORELEASE_WEBHOOK_URL;
+
+      - name: Send failure Slack notification
+        uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
+        with:
+          webhook: ${{ steps.secrets.outputs.SLACK_TOPMONOREPORELEASE_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          # For posting a rich message using Block Kit
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":alarm: *Release job for ${{ inputs.releaseVersion }}* failed!\n"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "Please check this <https://github.com/camunda/camunda/actions/runs/${{ github.run_id }}|GHA workflow run>."
+                  }
+                }
+              ]
+            }
 
 

--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -722,7 +722,9 @@ jobs:
     name: Send Slack notification on success
     runs-on: ubuntu-latest
     needs: [release, github, zeebe-docker, operate-docker, tasklist-docker, camunda-docker, snyk]
-    if: ${{ always() && needs.release.result == 'success' }}
+    # if it's a dry run => no slack notification (remove noise in slack due to manual testing)
+    # else => send slack notification as an actual release succeeded
+    if: ${{ always() && needs.release.result == 'success' && inputs.dryRun == false }}
     timeout-minutes: 5
     permissions: {}  # GITHUB_TOKEN unused in this job
     steps:

--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -721,8 +721,8 @@ jobs:
   notify-on-success:
     name: Send Slack notification on success
     runs-on: ubuntu-latest
-    needs: [release, zeebe-docker, operate-docker, tasklist-docker, camunda-docker, create-release, snyk]
-    if: ${{ always() && (needs.release.result == 'success' || needs.zeebe-docker.result == 'success' || needs.operate-docker.result == 'success' || needs.tasklist-docker.result == 'success' || needs.camunda-docker.result == 'success' || needs.create-release.result == 'success') }}
+    needs: [release]
+    if: ${{ always() && needs.release.result == 'success' }}
     timeout-minutes: 5
     permissions: {}  # GITHUB_TOKEN unused in this job
     steps:
@@ -751,7 +751,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": ":success: *Release job for ${{ inputs.releaseVersion }}* succeeded!\n"
+                    "text": ":success: *Release job for ${{ inputs.releaseVersion }}* **succeeded!**\n"
                   }
                 }
               ]
@@ -760,10 +760,10 @@ jobs:
   notify-if-failed:
     name: Send Slack notification on failure
     runs-on: ubuntu-latest
-    needs: [release, zeebe-docker, operate-docker, tasklist-docker, camunda-docker, create-release, snyk]
+    needs: [release]
     # if it's a dry run => no slack notification (remove noise in slack due to manual testing)
     # else => send slack notification as an actual release failed
-    if: ${{ always() && (needs.release.result == 'failure' || needs.zeebe-docker.result == 'failure' || needs.operate-docker.result == 'failure' || needs.tasklist-docker.result == 'failure' || needs.camunda-docker.result == 'failure' || needs.create-release.result == 'failure') && inputs.dryRun == false }}
+    if: ${{ always() && needs.release.result == 'failure' && inputs.dryRun == false }}
     timeout-minutes: 5
     permissions: {}  # GITHUB_TOKEN unused in this job
     steps:
@@ -792,7 +792,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": ":alarm: *Release job for ${{ inputs.releaseVersion }}* failed!\n"
+                    "text": ":alarm: *Release job for ${{ inputs.releaseVersion }}* **failed!**\n"
                   }
                 },
                 {

--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -726,6 +726,7 @@ jobs:
     # else => send slack notification as an actual release succeeded
     if: ${{ always() && (
       needs.release.result == 'success' &&
+      needs.github.result == 'success' &&
       needs.zeebe-docker.result == 'success' &&
       needs.operate-docker.result == 'success' &&
       needs.tasklist-docker.result == 'success' &&
@@ -774,6 +775,7 @@ jobs:
     # else => send slack notification as an actual release failed
     if: ${{ always() && (
         needs.release.result == 'failure' ||
+        needs.github.result == 'failure' ||
         needs.zeebe-docker.result == 'failure' ||
         needs.operate-docker.result == 'failure' ||
         needs.tasklist-docker.result == 'failure' ||

--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -724,7 +724,14 @@ jobs:
     needs: [release, github, zeebe-docker, operate-docker, tasklist-docker, camunda-docker, snyk]
     # if it's a dry run => no slack notification (remove noise in slack due to manual testing)
     # else => send slack notification as an actual release succeeded
-    if: ${{ always() && needs.release.result == 'success' && inputs.dryRun == false }}
+    if: ${{ always() && (
+      needs.release.result == 'success' &&
+      needs.zeebe-docker.result == 'success' &&
+      needs.operate-docker.result == 'success' &&
+      needs.tasklist-docker.result == 'success' &&
+      needs.camunda-docker.result == 'success' &&
+      needs.snyk.result == 'success'
+      ) && inputs.dryRun == false }}
     timeout-minutes: 5
     permissions: {}  # GITHUB_TOKEN unused in this job
     steps:
@@ -765,7 +772,14 @@ jobs:
     needs: [release, github, zeebe-docker, operate-docker, tasklist-docker, camunda-docker, snyk]
     # if it's a dry run => no slack notification (remove noise in slack due to manual testing)
     # else => send slack notification as an actual release failed
-    if: ${{ always() && needs.release.result == 'failure' && inputs.dryRun == false }}
+    if: ${{ always() && (
+        needs.release.result == 'failure' ||
+        needs.zeebe-docker.result == 'failure' ||
+        needs.operate-docker.result == 'failure' ||
+        needs.tasklist-docker.result == 'failure' ||
+        needs.camunda-docker.result == 'failure' ||
+        needs.snyk.result == 'failure'
+        ) && inputs.dryRun == false }}
     timeout-minutes: 5
     permissions: {}  # GITHUB_TOKEN unused in this job
     steps:


### PR DESCRIPTION
## Description

Replace dispatch release workflows with single REST API call entry point

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
