### PR TITLE
ci: replace dispatch release with single REST API call entrypoint

### DIFF
--- a/.github/workflows/zeebe-release.yml
+++ b/.github/workflows/zeebe-release.yml
@@ -24,6 +24,30 @@ on:
         description: 'Whether to perform a dry release where no changes or artifacts are pushed, defaults to true.'
         type: boolean
         default: true
+  workflow_dispatch:
+    inputs:
+      releaseBranch:
+        description: 'The branch to perform the release on, defaults to `release-$releaseVersion`'
+        type: string
+        required: false
+        default: ''
+      releaseVersion:
+        description: 'The version to be build and released. If no releaseBranch specified, expecting `release-$releaseVersion` to already exist.'
+        type: string
+        required: true
+      nextDevelopmentVersion:
+        description: 'Next development version, e.g. 8.X.X-SNAPSHOT.'
+        type: string
+        required: true
+      isLatest:
+        description: 'Whether this is the latest release and the docker image should be tagged as camunda/{component}:latest'
+        type: boolean
+        required: false
+        default: false
+      dryRun:
+        description: 'Whether to perform a dry release where no changes or artifacts are pushed, defaults to true.'
+        type: boolean
+        default: true
 
 defaults:
   run:
@@ -416,3 +440,101 @@ jobs:
     secrets: inherit
 
 
+  notify-on-success:
+    name: Send Slack notification on success
+    runs-on: ubuntu-latest
+    needs: [release, github, docker, snyk]
+    # if it's a dry run => no slack notification (remove noise in slack due to manual testing)
+    # else => send slack notification as an actual release succeeded
+    if: ${{ always() && (
+      needs.release.result == 'success' &&
+      needs.github.result == 'success' &&
+      needs.docker.result == 'success' &&
+      needs.snyk.result == 'success'
+      ) && inputs.dryRun == false }}
+    timeout-minutes: 5
+    permissions: {}  # GITHUB_TOKEN unused in this job
+    steps:
+      - name: Import Secrets
+        id: secrets
+        uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b # v3.4.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false # we rely on step outputs, no need for environment variables
+          secrets: |
+            secret/data/products/camunda/ci/github-actions SLACK_TOPMONOREPORELEASE_WEBHOOK_URL;
+
+      - name: Send success Slack notification
+        uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
+        with:
+          webhook: ${{ steps.secrets.outputs.SLACK_TOPMONOREPORELEASE_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          # For posting a rich message using Block Kit
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":success: *Release job for ${{ inputs.releaseVersion }}* **succeeded!**\n"
+                  }
+                }
+              ]
+            }
+
+  notify-if-failed:
+    name: Send Slack notification on failure
+    runs-on: ubuntu-latest
+    needs: [release, github, docker, snyk]
+    # if it's a dry run => no slack notification (remove noise in slack due to manual testing)
+    # else => send slack notification as an actual release failed
+    if: ${{ always() && (
+      needs.release.result == 'failure' ||
+      needs.github.result == 'failure' ||
+      needs.docker.result == 'failure' ||
+      needs.snyk.result == 'failure'
+      ) && inputs.dryRun == false }}
+    timeout-minutes: 5
+    permissions: {}  # GITHUB_TOKEN unused in this job
+    steps:
+      - name: Import Secrets
+        id: secrets
+        uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b # v3.4.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false # we rely on step outputs, no need for environment variables
+          secrets: |
+            secret/data/products/camunda/ci/github-actions SLACK_TOPMONOREPORELEASE_WEBHOOK_URL;
+
+      - name: Send failure Slack notification
+        uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
+        with:
+          webhook: ${{ steps.secrets.outputs.SLACK_TOPMONOREPORELEASE_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          # For posting a rich message using Block Kit
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":alarm: *Release job for ${{ inputs.releaseVersion }}* **failed!**\n"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "Please check this <https://github.com/camunda/camunda/actions/runs/${{ github.run_id }}|GHA workflow run>."
+                  }
+                }
+              ]
+            }


### PR DESCRIPTION
## Description

Replace dispatch release workflows with single REST API call entry point

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
