### PR TITLE
refactor: wait for EXPORTED instead of writing

### DIFF
--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/randomized/ProcessExecutionRandomizedPropertyTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/randomized/ProcessExecutionRandomizedPropertyTest.java
@@ -12,7 +12,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.engine.util.ProcessExecutor;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.intent.UsageMetricIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.UsageMetricRecordValue.EventType;
 import io.camunda.zeebe.test.util.bpmn.random.ExecutionPath;
 import io.camunda.zeebe.test.util.bpmn.random.ScheduledExecutionStep;
 import io.camunda.zeebe.test.util.bpmn.random.TestDataGenerator;
@@ -65,6 +67,10 @@ public class ProcessExecutionRandomizedPropertyTest {
    */
   @Test
   public void shouldExecuteProcessToEnd() {
+    RecordingExporter.usageMetricsRecords(UsageMetricIntent.EXPORTED)
+        .withEventType(EventType.NONE)
+        .await();
+
     final var deployment = engineRule.deployment();
     record.getBpmnModels().forEach(deployment::withXmlResource);
     deployment.deploy();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/ReplayStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/ReplayStateTest.java
@@ -18,12 +18,12 @@ import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.intent.UsageMetricIntent;
 import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.JobBatchRecordValue;
 import io.camunda.zeebe.protocol.record.value.JobRecordValue;
 import io.camunda.zeebe.protocol.record.value.UsageMetricRecordValue.EventType;
-import io.camunda.zeebe.protocol.record.value.UsageMetricRecordValue.IntervalType;
 import io.camunda.zeebe.protocol.record.value.UserTaskRecordValue;
 import io.camunda.zeebe.stream.impl.StreamProcessorMode;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
@@ -395,12 +395,10 @@ public final class ReplayStateTest {
   @Test
   public void shouldRestoreState() {
     // given
-    engine
-        .usageMetrics()
+    RecordingExporter.usageMetricsRecords(UsageMetricIntent.EXPORTED)
         .withEventType(EventType.NONE)
-        .withIntervalType(IntervalType.ACTIVE)
-        .withResetTime(engine.getClock().getCurrentTimeInMillis())
-        .export();
+        .await();
+
     testCase.processes.forEach(process -> engine.deployment().withXmlResource(process).deploy());
     testCase.forms.forEach(form -> engine.deployment().withJsonClasspathResource(form).deploy());
 


### PR DESCRIPTION
## Description

- Await EXPORTED in ProcessExecutionRandomizedPropertyTest
- Await EXPORTED in ReplayStateTest

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
