### PR TITLE
fix: use correct url template for cloud rest address

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/CamundaClientCloudBuilderStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClientCloudBuilderStep1.java
@@ -51,7 +51,18 @@ public interface CamundaClientCloudBuilderStep1 {
          *
          * @param region region of the Camunda Cloud cluster
          */
-        CamundaClientCloudBuilderStep4 withRegion(String region);
+        CamundaClientCloudBuilderStep5 withRegion(String region);
+
+        interface CamundaClientCloudBuilderStep5 extends CamundaClientBuilder {
+
+          /**
+           * Sets the domain of the Camunda Cloud stage. Default is 'camunda.io', the production
+           * stage.
+           *
+           * @param domain domain of the Camunda Cloud stage
+           */
+          CamundaClientCloudBuilderStep5 withDomain(String domain);
+        }
       }
     }
   }

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientCloudBuilderImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientCloudBuilderImpl.java
@@ -28,6 +28,7 @@ import io.camunda.client.CamundaClientCloudBuilderStep1;
 import io.camunda.client.CamundaClientCloudBuilderStep1.CamundaClientCloudBuilderStep2;
 import io.camunda.client.CamundaClientCloudBuilderStep1.CamundaClientCloudBuilderStep2.CamundaClientCloudBuilderStep3;
 import io.camunda.client.CamundaClientCloudBuilderStep1.CamundaClientCloudBuilderStep2.CamundaClientCloudBuilderStep3.CamundaClientCloudBuilderStep4;
+import io.camunda.client.CamundaClientCloudBuilderStep1.CamundaClientCloudBuilderStep2.CamundaClientCloudBuilderStep3.CamundaClientCloudBuilderStep4.CamundaClientCloudBuilderStep5;
 import io.camunda.client.CredentialsProvider;
 import io.camunda.client.api.ExperimentalApi;
 import io.camunda.client.api.JsonMapper;
@@ -47,12 +48,12 @@ public class CamundaClientCloudBuilderImpl
     implements CamundaClientCloudBuilderStep1,
         CamundaClientCloudBuilderStep2,
         CamundaClientCloudBuilderStep3,
-        CamundaClientCloudBuilderStep4 {
+        CamundaClientCloudBuilderStep4,
+        CamundaClientCloudBuilderStep5 {
 
-  private static final String BASE_ADDRESS = "zeebe.camunda.io";
-  private static final String BASE_AUTH_URL = "https://login.cloud.camunda.io/oauth/token";
-
+  private static final String DEFAULT_DOMAIN = "camunda.io";
   private static final String DEFAULT_REGION = "bru-2";
+  private static final String ZEEBE_DOMAIN_COMPONENT = "zeebe";
 
   private final CamundaClientBuilderImpl innerBuilder = new CamundaClientBuilderImpl();
 
@@ -60,6 +61,7 @@ public class CamundaClientCloudBuilderImpl
   private String clientId;
   private String clientSecret;
   private String region = DEFAULT_REGION;
+  private String domain = DEFAULT_DOMAIN;
 
   @Override
   public CamundaClientCloudBuilderStep2 withClusterId(final String clusterId) {
@@ -80,8 +82,14 @@ public class CamundaClientCloudBuilderImpl
   }
 
   @Override
-  public CamundaClientCloudBuilderStep4 withRegion(final String region) {
+  public CamundaClientCloudBuilderStep5 withRegion(final String region) {
     this.region = region;
+    return this;
+  }
+
+  @Override
+  public CamundaClientCloudBuilderStep5 withDomain(final String domain) {
+    this.domain = domain;
     return this;
   }
 
@@ -312,7 +320,8 @@ public class CamundaClientCloudBuilderImpl
     if (isNeedToSetCloudRestAddress()) {
       ensureNotNull("cluster id", clusterId);
       final String cloudRestAddress =
-          String.format("https://%s.%s:443/%s", region, BASE_ADDRESS, clusterId);
+          String.format(
+              "https://%s.%s.%s:443/%s", region, ZEEBE_DOMAIN_COMPONENT, domain, clusterId);
       return getURIFromString(cloudRestAddress);
     } else {
       Loggers.LOGGER.debug(
@@ -327,7 +336,8 @@ public class CamundaClientCloudBuilderImpl
     if (isNeedToSetCloudGrpcAddress() && isNeedToSetCloudGatewayAddress()) {
       ensureNotNull("cluster id", clusterId);
       final String cloudGrpcAddress =
-          String.format("https://%s.%s.%s:443", clusterId, region, BASE_ADDRESS);
+          String.format(
+              "https://%s.%s.%s.%s:443", clusterId, region, ZEEBE_DOMAIN_COMPONENT, domain);
       return getURIFromString(cloudGrpcAddress);
     } else {
       if (!isNeedToSetCloudGrpcAddress()) {
@@ -358,10 +368,10 @@ public class CamundaClientCloudBuilderImpl
         Loggers.LOGGER.debug("Expected setting 'usePlaintext' to be 'false', but found 'true'.");
       }
       return builder
-          .audience(String.format("%s.%s.%s", clusterId, region, BASE_ADDRESS))
+          .audience(String.format("%s.%s.%s", clusterId, region, domain))
           .clientId(clientId)
           .clientSecret(clientSecret)
-          .authorizationServerUrl(BASE_AUTH_URL)
+          .authorizationServerUrl(String.format("https://login.cloud.%s/oauth/token", domain))
           .build();
     } else {
       Loggers.LOGGER.debug(

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientCloudBuilderImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientCloudBuilderImpl.java
@@ -312,7 +312,7 @@ public class CamundaClientCloudBuilderImpl
     if (isNeedToSetCloudRestAddress()) {
       ensureNotNull("cluster id", clusterId);
       final String cloudRestAddress =
-          String.format("https://%s.zeebe.%s:443/%s", region, BASE_ADDRESS, clusterId);
+          String.format("https://%s.%s:443/%s", region, BASE_ADDRESS, clusterId);
       return getURIFromString(cloudRestAddress);
     } else {
       Loggers.LOGGER.debug(

--- a/clients/java/src/test/java/io/camunda/client/CamundaClientTest.java
+++ b/clients/java/src/test/java/io/camunda/client/CamundaClientTest.java
@@ -451,6 +451,11 @@ public final class CamundaClientTest {
           .hasHost(String.format("%s.%s.zeebe.camunda.io", clusterId, region))
           .hasPort(443)
           .hasScheme("https");
+      assertThat(clientConfiguration.getRestAddress())
+          .hasHost(String.format("%s.zeebe.camunda.io", region))
+          .hasPort(443)
+          .hasPath("/" + clusterId)
+          .hasScheme("https");
     }
   }
 
@@ -473,6 +478,11 @@ public final class CamundaClientTest {
           .hasHost(String.format("%s.bru-2.zeebe.camunda.io", clusterId))
           .hasPort(443)
           .hasScheme("https");
+      assertThat(clientConfiguration.getRestAddress())
+          .hasHost("bru-2.zeebe.camunda.io")
+          .hasPort(443)
+          .hasPath("/" + clusterId)
+          .hasScheme("https");
     }
   }
 
@@ -480,6 +490,7 @@ public final class CamundaClientTest {
   public void shouldOverrideCloudProperties() {
     // given
     final String gatewayAddress = "localhost:10000";
+    final URI restAddress = URI.create("https://localhost:10001");
     final NoopCredentialsProvider credentialsProvider = new NoopCredentialsProvider();
     try (final CamundaClient client =
         CamundaClient.newCloudClientBuilder()
@@ -487,10 +498,12 @@ public final class CamundaClientTest {
             .withClientId("clientId")
             .withClientSecret("clientSecret")
             .gatewayAddress(gatewayAddress)
+            .restAddress(restAddress)
             .credentialsProvider(credentialsProvider)
             .build()) {
       final CamundaClientConfiguration configuration = client.getConfiguration();
       assertThat(configuration.getGatewayAddress()).isEqualTo(gatewayAddress);
+      assertThat(configuration.getRestAddress()).isEqualTo(restAddress);
       assertThat(configuration.getCredentialsProvider()).isEqualTo(credentialsProvider);
     }
   }
@@ -519,6 +532,11 @@ public final class CamundaClientTest {
           .hasHost(String.format("clusterId.%s.zeebe.camunda.io", region))
           .hasPort(443)
           .hasScheme("https");
+      assertThat(clientConfiguration.getRestAddress())
+          .hasHost(String.format("%s.zeebe.camunda.io", region))
+          .hasPort(443)
+          .hasPath("/clusterId")
+          .hasScheme("https");
     }
   }
 
@@ -540,6 +558,11 @@ public final class CamundaClientTest {
       assertThat(clientConfiguration.getGrpcAddress())
           .hasHost(String.format("clusterId.%s.zeebe.camunda.io", defaultRegion))
           .hasPort(443)
+          .hasScheme("https");
+      assertThat(clientConfiguration.getRestAddress())
+          .hasHost(String.format("%s.zeebe.camunda.io", defaultRegion))
+          .hasPort(443)
+          .hasPath("/clusterId")
           .hasScheme("https");
     }
   }

--- a/clients/java/src/test/java/io/camunda/client/CamundaClientTest.java
+++ b/clients/java/src/test/java/io/camunda/client/CamundaClientTest.java
@@ -434,6 +434,7 @@ public final class CamundaClientTest {
     // given
     final String clusterId = "clusterId";
     final String region = "asdf-123";
+    final String domain = "dev.ultrawombat.com";
 
     try (final CamundaClient client =
         CamundaClient.newCloudClientBuilder()
@@ -441,6 +442,7 @@ public final class CamundaClientTest {
             .withClientId("clientId")
             .withClientSecret("clientSecret")
             .withRegion(region)
+            .withDomain(domain)
             .build()) {
       // when
       final CamundaClientConfiguration clientConfiguration = client.getConfiguration();
@@ -448,11 +450,11 @@ public final class CamundaClientTest {
       assertThat(clientConfiguration.getCredentialsProvider())
           .isInstanceOf(OAuthCredentialsProvider.class);
       assertThat(clientConfiguration.getGrpcAddress())
-          .hasHost(String.format("%s.%s.zeebe.camunda.io", clusterId, region))
+          .hasHost(String.format("%s.%s.zeebe.%s", clusterId, region, domain))
           .hasPort(443)
           .hasScheme("https");
       assertThat(clientConfiguration.getRestAddress())
-          .hasHost(String.format("%s.zeebe.camunda.io", region))
+          .hasHost(String.format("%s.zeebe.%s", region, domain))
           .hasPort(443)
           .hasPath("/" + clusterId)
           .hasScheme("https");
@@ -460,7 +462,7 @@ public final class CamundaClientTest {
   }
 
   @Test
-  public void shouldCloudBuilderBuildProperClientWithDefaultRegion() {
+  public void shouldCloudBuilderBuildProperClientWithDefaultRegionAndDomain() {
     // given
     final String clusterId = "clusterId";
     try (final CamundaClient client =

--- a/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/spring/client/properties/CamundaClientCloudProperties.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/spring/client/properties/CamundaClientCloudProperties.java
@@ -15,11 +15,14 @@
  */
 package io.camunda.spring.client.properties;
 
+import org.springframework.boot.context.properties.DeprecatedConfigurationProperty;
+
 public class CamundaClientCloudProperties {
   private String region;
   private String clusterId;
-  private String baseUrl;
+  @Deprecated private String baseUrl;
   private Integer port;
+  private String domain;
 
   public Integer getPort() {
     return port;
@@ -45,12 +48,23 @@ public class CamundaClientCloudProperties {
     this.clusterId = clusterId;
   }
 
+  @Deprecated
+  @DeprecatedConfigurationProperty(replacement = "camunda.client.cloud.domain")
   public String getBaseUrl() {
     return baseUrl;
   }
 
+  @Deprecated
   public void setBaseUrl(final String baseUrl) {
     this.baseUrl = baseUrl;
+  }
+
+  public String getDomain() {
+    return domain;
+  }
+
+  public void setDomain(final String domain) {
+    this.domain = domain;
   }
 
   @Override
@@ -62,8 +76,8 @@ public class CamundaClientCloudProperties {
         + ", clusterId='"
         + clusterId
         + '\''
-        + ", baseUrl='"
-        + baseUrl
+        + ", domain='"
+        + domain
         + '\''
         + ", port="
         + port

--- a/clients/spring-boot-starter-camunda-sdk/src/main/resources/camunda-client-legacy-property-mappings.properties
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/resources/camunda-client-legacy-property-mappings.properties
@@ -21,7 +21,7 @@ camunda.client.prefer-rest-over-grpc=camunda.client.zeebe.prefer-rest-over-grpc
 # Cloud properties
 camunda.client.cloud.cluster-id=camunda.client.cluster-id, zeebe.client.cloud.cluster-id
 camunda.client.cloud.region=camunda.client.region, zeebe.client.cloud.region
-camunda.client.cloud.base-url=zeebe.client.cloud.base-url
+camunda.client.cloud.domain=camunda.client.cloud.base-url, zeebe.client.cloud.base-url
 camunda.client.cloud.port=zeebe.client.cloud.port
 # Worker defaults
 camunda.client.worker.defaults.max-jobs-active=camunda.client.zeebe.defaults.max-jobs-active, zeebe.client.worker.max-jobs-active

--- a/clients/spring-boot-starter-camunda-sdk/src/main/resources/modes/saas.yaml
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/resources/modes/saas.yaml
@@ -2,12 +2,12 @@ camunda:
   client:
     mode: saas
     cloud:
-      base-url: camunda.io
+      domain: camunda.io
       region: bru-2
       port: 443
     auth:
       method: oidc
-      token-url: https://login.cloud.${camunda.client.cloud.base-url}/oauth/token
-      audience: zeebe.${camunda.client.cloud.base-url}
-    grpc-address: https://${camunda.client.cloud.cluster-id}.${camunda.client.cloud.region}.zeebe.${camunda.client.cloud.base-url}:${camunda.client.cloud.port}
-    rest-address: https://${camunda.client.cloud.region}.zeebe.${camunda.client.cloud.base-url}:${camunda.client.cloud.port}/${camunda.client.cloud.cluster-id}
+      token-url: https://login.cloud.${camunda.client.cloud.domain}/oauth/token
+      audience: zeebe.${camunda.client.cloud.domain}
+    grpc-address: https://${camunda.client.cloud.cluster-id}.${camunda.client.cloud.region}.zeebe.${camunda.client.cloud.domain}:${camunda.client.cloud.port}
+    rest-address: https://${camunda.client.cloud.region}.zeebe.${camunda.client.cloud.domain}:${camunda.client.cloud.port}/${camunda.client.cloud.cluster-id}

--- a/docs/spring-sdk.md
+++ b/docs/spring-sdk.md
@@ -2,7 +2,7 @@
 
 ## Spring SDK usage in Camunda Saas staging environments
 
-To use a staging environment, the `camunda.client.cloud.base-url` can be updated to match the base url of the desired cloud environment.
+To use a staging environment, the `camunda.client.cloud.domain` can be updated to match the domain of the desired cloud environment.
 
 Example:
 
@@ -10,7 +10,7 @@ Example:
 camunda:
   client:
     cloud:
-      base-url: ultrawombat.com
+      domain: ultrawombat.com
 ```
 
 By default, the client will always point to the production Saas instance:
@@ -19,6 +19,6 @@ By default, the client will always point to the production Saas instance:
 camunda:
   client:
     cloud:
-      base-url: camunda.io
+      domain: camunda.io
 ```
 

--- a/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/impl/CamundaSpringProcessTestRuntimeBuilderTest.java
+++ b/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/impl/CamundaSpringProcessTestRuntimeBuilderTest.java
@@ -238,7 +238,7 @@ public class CamundaSpringProcessTestRuntimeBuilderTest {
         getCamundaClientConfiguration(remoteClientBuilder);
 
     assertThat(configuration.getRestAddress())
-        .isEqualTo(URI.create("https://my-region.zeebe.zeebe.camunda.io:443/my-cluster"));
+        .isEqualTo(URI.create("https://my-region.zeebe.camunda.io:443/my-cluster"));
     assertThat(configuration.getGrpcAddress())
         .isEqualTo(URI.create("https://my-cluster.my-region.zeebe.camunda.io:443"));
 


### PR DESCRIPTION
## Description

Current URL template resulted in invalid host names with a duplicated `zeebe` element as `BASE_ADDRESS` is already `zeebe.camunda.io`.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #32759
