### PR TITLE
feat: disable webapps components in no-db mode

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/backup/ConditionalOnBackupWebappsEnabled.java
+++ b/dist/src/main/java/io/camunda/application/commons/backup/ConditionalOnBackupWebappsEnabled.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.application.commons.backup;
 
+import io.camunda.application.commons.utils.DatabaseTypeUtils;
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -31,8 +32,8 @@ public @interface ConditionalOnBackupWebappsEnabled {
     public boolean matches(final ConditionContext context, final AnnotatedTypeMetadata metadata) {
       final Environment env = context.getEnvironment();
       final String backupEnabled = env.getProperty(BACKUP_WEBAPPS_ENABLED);
-      final String dbType = env.getProperty("camunda.database.type");
-      return "true".equalsIgnoreCase(backupEnabled) && !"none".equalsIgnoreCase(dbType);
+      return "true".equalsIgnoreCase(backupEnabled)
+          && DatabaseTypeUtils.isSecondaryStorageEnabled(env);
     }
   }
 }

--- a/dist/src/main/java/io/camunda/application/commons/condition/ConditionalOnDatabaseNone.java
+++ b/dist/src/main/java/io/camunda/application/commons/condition/ConditionalOnDatabaseNone.java
@@ -5,7 +5,7 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.application.commons.search.condition;
+package io.camunda.application.commons.condition;
 
 import io.camunda.search.connect.configuration.DatabaseConfig;
 import java.lang.annotation.*;

--- a/dist/src/main/java/io/camunda/application/commons/condition/ConditionalOnSecondaryStorage.java
+++ b/dist/src/main/java/io/camunda/application/commons/condition/ConditionalOnSecondaryStorage.java
@@ -5,34 +5,41 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.application.commons.backup;
+package io.camunda.application.commons.condition;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Condition;
 import org.springframework.context.annotation.ConditionContext;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.core.env.Environment;
 import org.springframework.core.type.AnnotatedTypeMetadata;
 
-/** This condition is used to enable or disable the webapps backup functionality */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE, ElementType.METHOD})
 @Documented
-@Conditional(ConditionalOnBackupWebappsEnabled.BackupWebappsEnabledAndDatabaseTypeCondition.class)
-public @interface ConditionalOnBackupWebappsEnabled {
-  String BACKUP_WEBAPPS_ENABLED = "camunda.backup.webapps.enabled";
+@Conditional(ConditionalOnSecondaryStorage.DatabaseTypeNotNone.class)
+public @interface ConditionalOnSecondaryStorage {
 
-  class BackupWebappsEnabledAndDatabaseTypeCondition implements Condition {
+  class DatabaseTypeNotNone implements Condition {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DatabaseTypeNotNone.class);
+
     @Override
     public boolean matches(final ConditionContext context, final AnnotatedTypeMetadata metadata) {
       final Environment env = context.getEnvironment();
-      final String backupEnabled = env.getProperty(BACKUP_WEBAPPS_ENABLED);
       final String dbType = env.getProperty("camunda.database.type");
-      return "true".equalsIgnoreCase(backupEnabled) && !"none".equalsIgnoreCase(dbType);
+      if ("none".equalsIgnoreCase(dbType)) {
+        LOG.warn(
+            "Secondary storage is disabled (camunda.database.type=none). Some features such as webapps will not start unless a secondary storage is configured. See camunda.database.type config.");
+        return false;
+      }
+      return true;
     }
   }
 }

--- a/dist/src/main/java/io/camunda/application/commons/condition/ConditionalOnSecondaryStorage.java
+++ b/dist/src/main/java/io/camunda/application/commons/condition/ConditionalOnSecondaryStorage.java
@@ -7,8 +7,8 @@
  */
 package io.camunda.application.commons.condition;
 
-import static io.camunda.application.commons.utils.DatabaseTypeUtils.PROPERTY_CAMUNDA_DATABASE_TYPE;
-
+import io.camunda.application.commons.utils.DatabaseTypeUtils;
+import io.camunda.search.connect.configuration.DatabaseType;
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -35,10 +35,11 @@ public @interface ConditionalOnSecondaryStorage {
     @Override
     public boolean matches(final ConditionContext context, final AnnotatedTypeMetadata metadata) {
       final Environment env = context.getEnvironment();
-      final String dbType = env.getProperty(PROPERTY_CAMUNDA_DATABASE_TYPE);
-      if ("none".equalsIgnoreCase(dbType)) {
+      if (!DatabaseTypeUtils.isSecondaryStorageEnabled(env)) {
         LOG.warn(
-            "Secondary storage is disabled (camunda.database.type=none). Some features such as webapps will not start unless a secondary storage is configured. See camunda.database.type config.");
+            "Secondary storage is disabled ({}={}). Some features such as webapps will not start unless a secondary storage is configured. See camunda.database.type config.",
+            DatabaseTypeUtils.PROPERTY_CAMUNDA_DATABASE_TYPE,
+            DatabaseType.NONE);
         return false;
       }
       return true;

--- a/dist/src/main/java/io/camunda/application/commons/condition/ConditionalOnSecondaryStorage.java
+++ b/dist/src/main/java/io/camunda/application/commons/condition/ConditionalOnSecondaryStorage.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.application.commons.condition;
 
+import static io.camunda.application.commons.utils.DatabaseTypeUtils.PROPERTY_CAMUNDA_DATABASE_TYPE;
+
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -33,7 +35,7 @@ public @interface ConditionalOnSecondaryStorage {
     @Override
     public boolean matches(final ConditionContext context, final AnnotatedTypeMetadata metadata) {
       final Environment env = context.getEnvironment();
-      final String dbType = env.getProperty("camunda.database.type");
+      final String dbType = env.getProperty(PROPERTY_CAMUNDA_DATABASE_TYPE);
       if ("none".equalsIgnoreCase(dbType)) {
         LOG.warn(
             "Secondary storage is disabled (camunda.database.type=none). Some features such as webapps will not start unless a secondary storage is configured. See camunda.database.type config.");

--- a/dist/src/main/java/io/camunda/application/commons/search/SearchClientDatabaseConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/search/SearchClientDatabaseConfiguration.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.application.commons.search;
 
-import io.camunda.application.commons.search.condition.ConditionalOnDatabaseNone;
+import io.camunda.application.commons.condition.ConditionalOnDatabaseNone;
 import io.camunda.db.rdbms.RdbmsService;
 import io.camunda.search.clients.DocumentBasedSearchClient;
 import io.camunda.search.clients.DocumentBasedSearchClients;

--- a/dist/src/main/java/io/camunda/application/commons/utils/DatabaseTypeUtils.java
+++ b/dist/src/main/java/io/camunda/application/commons/utils/DatabaseTypeUtils.java
@@ -9,7 +9,7 @@ package io.camunda.application.commons.utils;
 
 import org.springframework.core.env.Environment;
 
-public class DatabaseTypeUtils {
+public final class DatabaseTypeUtils {
   public static final String PROPERTY_CAMUNDA_DATABASE_TYPE = "camunda.database.type";
 
   private DatabaseTypeUtils() {}

--- a/dist/src/main/java/io/camunda/application/commons/utils/DatabaseTypeUtils.java
+++ b/dist/src/main/java/io/camunda/application/commons/utils/DatabaseTypeUtils.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.application.commons.utils;
+
+import org.springframework.core.env.Environment;
+
+public class DatabaseTypeUtils {
+  public static final String PROPERTY_CAMUNDA_DATABASE_TYPE = "camunda.database.type";
+
+  private DatabaseTypeUtils() {}
+
+  public static boolean isSecondaryStorageEnabled(final Environment env) {
+    final String dbType = env.getProperty(PROPERTY_CAMUNDA_DATABASE_TYPE);
+    return !"none".equalsIgnoreCase(dbType);
+  }
+}

--- a/dist/src/main/java/io/camunda/application/initializers/HealthConfigurationInitializer.java
+++ b/dist/src/main/java/io/camunda/application/initializers/HealthConfigurationInitializer.java
@@ -8,6 +8,7 @@
 package io.camunda.application.initializers;
 
 import io.camunda.application.Profile;
+import io.camunda.application.commons.utils.DatabaseTypeUtils;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -83,17 +84,11 @@ public class HealthConfigurationInitializer
                 ::contains);
   }
 
-  /**
-   * Returns a list of health indicators which will be member of the readiness group
-   *
-   * @param activeProfiles
-   * @param env
-   * @return
-   */
+  /** Returns a list of health indicators which will be member of the readiness group */
   protected List<String> collectHealthIndicators(
       final List<String> activeProfiles, final Environment env) {
     final var healthIndicators = new ArrayList<String>();
-    final boolean secondaryStorageEnabled = isSecondaryStorageEnabled(env);
+    final boolean secondaryStorageEnabled = DatabaseTypeUtils.isSecondaryStorageEnabled(env);
 
     if (activeProfiles.contains(Profile.BROKER.getId())) {
       healthIndicators.add(INDICATOR_BROKER_READY);
@@ -117,10 +112,5 @@ public class HealthConfigurationInitializer
     }
 
     return healthIndicators;
-  }
-
-  private static boolean isSecondaryStorageEnabled(final Environment env) {
-    final String dbType = env.getProperty("camunda.database.type");
-    return !"none".equalsIgnoreCase(dbType);
   }
 }

--- a/dist/src/main/java/io/camunda/application/initializers/StandaloneSchemaManagerInitializer.java
+++ b/dist/src/main/java/io/camunda/application/initializers/StandaloneSchemaManagerInitializer.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.application.initializers;
 
+import static io.camunda.application.commons.utils.DatabaseTypeUtils.PROPERTY_CAMUNDA_DATABASE_TYPE;
 import static io.camunda.search.connect.configuration.ConnectConfiguration.DATABASE_TYPE_DEFAULT;
 import static io.camunda.search.connect.configuration.DatabaseType.ELASTICSEARCH;
 import static java.util.Optional.ofNullable;
@@ -22,7 +23,7 @@ public class StandaloneSchemaManagerInitializer
   @Override
   public void initialize(final ConfigurableApplicationContext applicationContext) {
     final String databaseTypeProperty =
-        applicationContext.getEnvironment().getProperty("camunda.database.type");
+        applicationContext.getEnvironment().getProperty(PROPERTY_CAMUNDA_DATABASE_TYPE);
     if (ELASTICSEARCH
         != ofNullable(databaseTypeProperty).map(DatabaseType::from).orElse(DATABASE_TYPE_DEFAULT)) {
       throw new IllegalArgumentException(

--- a/dist/src/main/java/io/camunda/identity/IdentityModuleConfiguration.java
+++ b/dist/src/main/java/io/camunda/identity/IdentityModuleConfiguration.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.identity;
 
+import io.camunda.application.commons.condition.ConditionalOnSecondaryStorage;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.FullyQualifiedAnnotationBeanNameGenerator;
@@ -17,4 +18,5 @@ import org.springframework.context.annotation.Profile;
     basePackages = "io.camunda.identity.webapp",
     nameGenerator = FullyQualifiedAnnotationBeanNameGenerator.class)
 @Profile("identity")
+@ConditionalOnSecondaryStorage
 public class IdentityModuleConfiguration {}

--- a/dist/src/main/java/io/camunda/operate/OperateModuleConfiguration.java
+++ b/dist/src/main/java/io/camunda/operate/OperateModuleConfiguration.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.operate;
 
+import io.camunda.application.commons.condition.ConditionalOnSecondaryStorage;
 import io.camunda.zeebe.broker.Broker;
 import io.camunda.zeebe.gateway.Gateway;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -36,6 +37,7 @@ import org.springframework.context.annotation.Profile;
     // versions of importer
     nameGenerator = FullyQualifiedAnnotationBeanNameGenerator.class)
 @Profile("operate")
+@ConditionalOnSecondaryStorage
 public class OperateModuleConfiguration {
 
   // if present, then it will ensure

--- a/dist/src/main/java/io/camunda/tasklist/TasklistModuleConfiguration.java
+++ b/dist/src/main/java/io/camunda/tasklist/TasklistModuleConfiguration.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.tasklist;
 
+import io.camunda.application.commons.condition.ConditionalOnSecondaryStorage;
 import io.camunda.tasklist.webapp.management.WebappManagementModuleConfiguration;
 import io.camunda.tasklist.webapp.security.WebappSecurityModuleConfiguration;
 import io.camunda.tasklist.zeebeimport.security.ImporterSecurityModuleConfiguration;
@@ -46,6 +47,7 @@ import org.springframework.context.annotation.Profile;
     // versions of importer
     nameGenerator = FullyQualifiedAnnotationBeanNameGenerator.class)
 @Profile("tasklist")
+@ConditionalOnSecondaryStorage
 public class TasklistModuleConfiguration {
   // if present, then it will ensure
   // that the broker is started first

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/nodb/NoSecondaryStorageTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/nodb/NoSecondaryStorageTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.it.nodb;
 
+import static io.camunda.application.commons.utils.DatabaseTypeUtils.PROPERTY_CAMUNDA_DATABASE_TYPE;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.client.CamundaClient;
@@ -31,7 +32,7 @@ public class NoSecondaryStorageTest {
   private final TestStandaloneBroker broker =
       new TestStandaloneBroker()
           .withUnauthenticatedAccess()
-          .withProperty("camunda.database.type", "none")
+          .withProperty(PROPERTY_CAMUNDA_DATABASE_TYPE, "none")
           .withProperty("spring.profiles.active", "broker");
 
   @AutoClose private CamundaClient camundaClient;

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/util/CamundaRdbmsTestApplication.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/util/CamundaRdbmsTestApplication.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.it.rdbms.db.util;
 
+import static io.camunda.application.commons.utils.DatabaseTypeUtils.PROPERTY_CAMUNDA_DATABASE_TYPE;
+
 import io.atomix.cluster.MemberId;
 import io.camunda.db.rdbms.RdbmsService;
 import io.camunda.zeebe.qa.util.actuator.HealthActuator;
@@ -35,7 +37,7 @@ public final class CamundaRdbmsTestApplication
   }
 
   public CamundaRdbmsTestApplication withRdbms() {
-    super.withProperty("camunda.database.type", "rdbms")
+    super.withProperty(PROPERTY_CAMUNDA_DATABASE_TYPE, "rdbms")
         .withProperty("logging.level.io.camunda.db.rdbms", "DEBUG")
         .withProperty("logging.level.org.mybatis", "DEBUG");
     return this;

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/MultiDbConfigurator.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/MultiDbConfigurator.java
@@ -8,6 +8,7 @@
 package io.camunda.qa.util.multidb;
 
 import static io.camunda.application.commons.search.SearchEngineDatabaseConfiguration.SearchEngineSchemaManagerProperties.CREATE_SCHEMA_PROPERTY;
+import static io.camunda.application.commons.utils.DatabaseTypeUtils.PROPERTY_CAMUNDA_DATABASE_TYPE;
 
 import io.camunda.exporter.CamundaExporter;
 import io.camunda.search.connect.configuration.DatabaseType;
@@ -71,7 +72,7 @@ public class MultiDbConfigurator {
 
     /* Camunda */
     elasticsearchProperties.put(
-        "camunda.database.type",
+        PROPERTY_CAMUNDA_DATABASE_TYPE,
         io.camunda.search.connect.configuration.DatabaseType.ELASTICSEARCH);
     elasticsearchProperties.put("camunda.database.indexPrefix", indexPrefix);
     elasticsearchProperties.put("camunda.database.url", elasticsearchUrl);
@@ -180,7 +181,8 @@ public class MultiDbConfigurator {
 
     /* Camunda */
     opensearchProperties.put(
-        "camunda.database.type", io.camunda.search.connect.configuration.DatabaseType.OPENSEARCH);
+        PROPERTY_CAMUNDA_DATABASE_TYPE,
+        io.camunda.search.connect.configuration.DatabaseType.OPENSEARCH);
     opensearchProperties.put("camunda.operate.database", "opensearch");
     opensearchProperties.put("camunda.tasklist.database", "opensearch");
     opensearchProperties.put("camunda.database.indexPrefix", indexPrefix);
@@ -235,7 +237,7 @@ public class MultiDbConfigurator {
   }
 
   public void configureRDBMSSupport(final boolean retentionEnabled) {
-    testApplication.withProperty("camunda.database.type", DatabaseType.RDBMS);
+    testApplication.withProperty(PROPERTY_CAMUNDA_DATABASE_TYPE, DatabaseType.RDBMS);
     testApplication.withProperty(
         "spring.datasource.url",
         "jdbc:h2:mem:testdb+" + UUID.randomUUID() + ";DB_CLOSE_DELAY=-1;MODE=PostgreSQL");

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/smoke/NoSecondaryStorageSmokeIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/smoke/NoSecondaryStorageSmokeIT.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.it.smoke;
 
+import static io.camunda.application.commons.utils.DatabaseTypeUtils.PROPERTY_CAMUNDA_DATABASE_TYPE;
 import static io.restassured.RestAssured.given;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
@@ -39,7 +40,7 @@ final class NoSecondaryStorageSmokeIT {
   private final TestStandaloneBroker broker =
       new TestStandaloneBroker()
           .withUnauthenticatedAccess()
-          .withProperty("camunda.database.type", "none");
+          .withProperty(PROPERTY_CAMUNDA_DATABASE_TYPE, "none");
 
   @AutoClose private CamundaClient client;
 

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestSpringApplication.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestSpringApplication.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.qa.util.cluster;
 
 import static io.camunda.application.commons.search.SearchEngineDatabaseConfiguration.SearchEngineSchemaManagerProperties.CREATE_SCHEMA_PROPERTY;
+import static io.camunda.application.commons.utils.DatabaseTypeUtils.PROPERTY_CAMUNDA_DATABASE_TYPE;
 
 import io.camunda.application.MainSupport;
 import io.camunda.application.Profile;
@@ -250,7 +251,7 @@ public abstract class TestSpringApplication<T extends TestSpringApplication<T>>
   }
 
   private String databaseType() {
-    return property("camunda.database.type", String.class, "es");
+    return property(PROPERTY_CAMUNDA_DATABASE_TYPE, String.class, "es");
   }
 
   private int monitoringPort() {

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneBroker.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneBroker.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.qa.util.cluster;
 
+import static io.camunda.application.commons.utils.DatabaseTypeUtils.PROPERTY_CAMUNDA_DATABASE_TYPE;
+
 import io.atomix.cluster.MemberId;
 import io.camunda.application.Profile;
 import io.camunda.application.commons.CommonsModuleConfiguration;
@@ -302,7 +304,7 @@ public final class TestStandaloneBroker extends TestSpringApplication<TestStanda
   }
 
   public TestStandaloneBroker withRdbmsExporter() {
-    withProperty("camunda.database.type", "rdbms");
+    withProperty(PROPERTY_CAMUNDA_DATABASE_TYPE, "rdbms");
     withProperty(
         "camunda.database.url",
         "jdbc:h2:mem:testdb+" + UUID.randomUUID() + ";DB_CLOSE_DELAY=-1;MODE=PostgreSQL");


### PR DESCRIPTION
## Description

This PR updates the webapps condition to only start webapps when database type is not NONE, this prevents conflicting configs/profiles. For example, if a user sets Operate profile and no-db mode at the same time, we won't run the operate webapp

## Related issues

related to #34467
