### PR TITLE
ci: update CODEOWNERS for helper actions

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -14,6 +14,7 @@
 /docs/assets/observability*  @npepinpe @ChrisKujawa
 
 # C8Run by Distro team
+.github/actions/setup-c8run/* @camunda/distribution
 .github/workflows/c8run* @camunda/distribution
 /c8run/ @camunda/distribution
 
@@ -22,6 +23,12 @@
 /testing/*        @camunda/camundaex
 
 # General Automation, Unified CI and release helpers by Monorepo DevOps team
+/.github/actions/build*/*                                @camunda/monorepo-devops-team
+/.github/actions/is-fork/*                               @camunda/monorepo-devops-team
+/.github/actions/observe*/*                              @camunda/monorepo-devops-team
+/.github/actions/paths-filter/*                          @camunda/monorepo-devops-team
+/.github/actions/setup-build/*                           @camunda/monorepo-devops-team
+/.github/actions/setup-maven*/*                          @camunda/monorepo-devops-team
 /.github/workflows/add-to-projects.yml                   @camunda/monorepo-devops-team
 /.github/workflows/backport.yml                          @camunda/monorepo-devops-team
 /.github/workflows/camunda-helm-integration.yml          @camunda/monorepo-devops-team


### PR DESCRIPTION
## Description

Monorepo DevOps team also owns certain composite GHA helper actions stored under `.github/actions` (but not all, some are legacy from e.g. Optimize) and should be in the loop when they are touched - as those actions are high impact due to a high degree of reuse among the CI.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

None
