### PR TITLE
[Backport stable/8.6] ci: update CODEOWNERS for helper actions

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,9 +2,16 @@
 /zeebe/gateway-protocol/src/main/proto/rest-api.yaml @camunda/docs-api-reviewers
 
 # C8Run by Distro team
+.github/actions/setup-c8run/* @camunda/distribution
 .github/workflows/c8run* @camunda/distribution
 
 # General Automation, Unified CI and release helpers by Monorepo DevOps team
+/.github/actions/build*/*                                @camunda/monorepo-devops-team
+/.github/actions/is-fork/*                               @camunda/monorepo-devops-team
+/.github/actions/observe*/*                              @camunda/monorepo-devops-team
+/.github/actions/paths-filter/*                          @camunda/monorepo-devops-team
+/.github/actions/setup-build/*                           @camunda/monorepo-devops-team
+/.github/actions/setup-maven*/*                          @camunda/monorepo-devops-team
 /.github/workflows/add-to-projects.yml                   @camunda/monorepo-devops-team
 /.github/workflows/backport.yml                          @camunda/monorepo-devops-team
 /.github/workflows/camunda-helm-integration.yml          @camunda/monorepo-devops-team


### PR DESCRIPTION
# Description
Backport of #35073 to `stable/8.6`.

relates to 