### PR TITLE
feat: the thread pool is renamed, but kept backwards-compatible tag-wise

### DIFF
--- a/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/spring/client/configuration/ExecutorServiceConfiguration.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/spring/client/configuration/ExecutorServiceConfiguration.java
@@ -20,6 +20,7 @@ import static io.camunda.spring.client.configuration.CamundaClientConfigurationI
 import io.camunda.spring.client.jobhandling.CamundaClientExecutorService;
 import io.camunda.spring.client.properties.CamundaClientProperties;
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.binder.MeterBinder;
 import io.micrometer.core.instrument.binder.jvm.ExecutorServiceMetrics;
 import java.util.Collections;
@@ -51,7 +52,9 @@ public class ExecutorServiceConfiguration {
     if (meterRegistry != null) {
       final MeterBinder threadPoolMetrics =
           new ExecutorServiceMetrics(
-              threadPool, "zeebe_client_thread_pool", Collections.emptyList());
+              threadPool,
+              "camundaClientExecutor",
+              Collections.singleton(Tag.of("name", "zeebe_client_thread_pool")));
       threadPoolMetrics.bindTo(meterRegistry);
     }
     return new CamundaClientExecutorService(threadPool, true);


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR changes the name of the thread pool while keeping it backwards-compatible.

What I realized during working on that is that we have no proper IT to verify that our metrics integration works, it's always manual effort.

Maybe this point would be a good starting point to verify that the actuator/metrics endpoint actually delivers the expected metrics.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
