### PR TITLE
fix: update flaky tests

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/TaskDetailsPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/TaskDetailsPage.ts
@@ -120,8 +120,13 @@ class TaskDetailsPage {
 
   async clickCompleteTaskButton() {
     await this.completeTaskButton.click({timeout: 60000});
-    await expect(this.taskCompletedBanner).toBeVisible({
-      timeout: 200000,
+    await waitForAssertion({
+      assertion: async () => {
+        await expect(this.taskCompletedBanner).toBeVisible({timeout: 120000});
+      },
+      onFailure: async () => {
+        console.log('Task completed banner not visible, retrying...');
+      },
     });
   }
 
@@ -206,10 +211,28 @@ class TaskDetailsPage {
 
   async fillTextInput(label: string, value: string): Promise<void> {
     const input = this.page.getByLabel(label, {exact: true});
-    await input.click({timeout: 60000});
-    await input.fill(value);
-    await input.blur();
-    await expect(input).toHaveValue(value, {timeout: 5000});
+    const maxRetries = 3;
+    let attempt = 0;
+    while (attempt < maxRetries) {
+      try {
+        await input.click({timeout: 120000});
+        await input.fill(value);
+        await input.blur();
+        await expect(input).toHaveValue(value);
+        return;
+      } catch (error) {
+        attempt++;
+        console.log(
+          `Attempt ${attempt} to fill input "${label}" failed with error: ${error}`,
+        );
+        if (attempt === maxRetries) {
+          throw new Error(
+            `Failed to set value "${value}" for label "${label}" after ${maxRetries} attempts.`,
+          );
+        }
+        await sleep(500);
+      }
+    }
   }
 
   async priorityAssertion(priority: string): Promise<void> {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/public-start-form.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/public-start-form.spec.ts
@@ -10,6 +10,7 @@ import {expect} from '@playwright/test';
 import {test} from 'fixtures';
 import {deploy} from 'utils/zeebeClient';
 import {captureScreenshot, captureFailureVideo} from '@setup';
+import {sleep} from 'utils/sleep';
 
 test.describe('public start process', () => {
   test.afterEach(async ({page}, testInfo) => {
@@ -22,6 +23,7 @@ test.describe('public start process', () => {
       './resources/subscribeFormProcess.bpmn',
       './resources/subscribeForm.form',
     ]);
+    await sleep(500);
     await publicFormsPage.goToPublicForm('subscribeFormProcess');
 
     await expect(publicFormsPage.nameInput).toBeVisible({timeout: 60000});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/task-details.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/task-details.spec.ts
@@ -191,10 +191,9 @@ test.describe('task details page', () => {
     });
     await taskDetailsPage.clickCompleteTaskButton();
     await expect(taskDetailsPage.taskCompletedBanner).toBeVisible();
-
     await taskPanelPage.openTask('JobWorker_user_task');
     await expect(taskDetailsPage.completeTaskButton).toBeDisabled({
-      timeout: 60000,
+      timeout: 120000,
     });
     await taskDetailsPage.clickAssignToMeButton();
     await expect(taskDetailsPage.completeTaskButton).toBeEnabled();


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
During the nightly run it has been noticed that `complete zeebe and job worker tasks` and `complete process with start node having deployed form` have been flaky on the CI. This PR adds some timeouts and extra check to make sure that the tests are reliable.

🧪 [Successful run](https://github.com/camunda/camunda/actions/runs/16168449526/job/45635843072) 
## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
