### PR TITLE
[Backport stable/8.7] fix: use correct url template for cloud rest address

### DIFF
--- a/clients/java/revapi.json
+++ b/clients/java/revapi.json
@@ -438,6 +438,13 @@
           "old": "field io.camunda.zeebe.client.protocol.rest.IncidentItem.ErrorTypeEnum.UNKNOWN_DEFAULT_OPEN_API",
           "new": "field io.camunda.zeebe.client.protocol.rest.IncidentItem.ErrorTypeEnum.UNKNOWN_DEFAULT_OPEN_API",
           "justification": "Added a missing enum EXECUTION_LISTENER_NO_RETRIES. The UNKNOWN_DEFAULT_OPEN_API enum is automatically added at the end of the list."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.returnTypeChanged",
+          "old": "method io.camunda.zeebe.client.ZeebeClientCloudBuilderStep1.ZeebeClientCloudBuilderStep2.ZeebeClientCloudBuilderStep3.ZeebeClientCloudBuilderStep4 io.camunda.zeebe.client.ZeebeClientCloudBuilderStep1.ZeebeClientCloudBuilderStep2.ZeebeClientCloudBuilderStep3.ZeebeClientCloudBuilderStep4::withRegion(java.lang.String)",
+          "new": "method io.camunda.zeebe.client.ZeebeClientCloudBuilderStep1.ZeebeClientCloudBuilderStep2.ZeebeClientCloudBuilderStep3.ZeebeClientCloudBuilderStep4.ZeebeClientCloudBuilderStep5 io.camunda.zeebe.client.ZeebeClientCloudBuilderStep1.ZeebeClientCloudBuilderStep2.ZeebeClientCloudBuilderStep3.ZeebeClientCloudBuilderStep4::withRegion(java.lang.String)",
+          "justification": "Added new layer to configure domain"
         }
       ]
     }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClientCloudBuilderStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClientCloudBuilderStep1.java
@@ -51,7 +51,18 @@ public interface ZeebeClientCloudBuilderStep1 {
          *
          * @param region region of the Camunda Cloud cluster
          */
-        ZeebeClientCloudBuilderStep4 withRegion(String region);
+        ZeebeClientCloudBuilderStep5 withRegion(String region);
+
+        interface ZeebeClientCloudBuilderStep5 extends ZeebeClientBuilder {
+
+          /**
+           * Sets the domain of the Camunda Cloud stage. Default is 'camunda.io', the production
+           * stage.
+           *
+           * @param domain domain of the Camunda Cloud stage
+           */
+          ZeebeClientCloudBuilderStep5 withDomain(String domain);
+        }
       }
     }
   }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientCloudBuilderImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientCloudBuilderImpl.java
@@ -289,7 +289,7 @@ public class ZeebeClientCloudBuilderImpl
     if (isNeedToSetCloudRestAddress()) {
       ensureNotNull("cluster id", clusterId);
       final String cloudRestAddress =
-          String.format("https://%s.zeebe.%s:443/%s", region, BASE_ADDRESS, clusterId);
+          String.format("https://%s.%s:443/%s", region, BASE_ADDRESS, clusterId);
       return getURIFromString(cloudRestAddress);
     } else {
       Loggers.LOGGER.debug(

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientCloudBuilderImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientCloudBuilderImpl.java
@@ -29,6 +29,7 @@ import io.camunda.zeebe.client.ZeebeClientCloudBuilderStep1;
 import io.camunda.zeebe.client.ZeebeClientCloudBuilderStep1.ZeebeClientCloudBuilderStep2;
 import io.camunda.zeebe.client.ZeebeClientCloudBuilderStep1.ZeebeClientCloudBuilderStep2.ZeebeClientCloudBuilderStep3;
 import io.camunda.zeebe.client.ZeebeClientCloudBuilderStep1.ZeebeClientCloudBuilderStep2.ZeebeClientCloudBuilderStep3.ZeebeClientCloudBuilderStep4;
+import io.camunda.zeebe.client.ZeebeClientCloudBuilderStep1.ZeebeClientCloudBuilderStep2.ZeebeClientCloudBuilderStep3.ZeebeClientCloudBuilderStep4.ZeebeClientCloudBuilderStep5;
 import io.camunda.zeebe.client.api.ExperimentalApi;
 import io.camunda.zeebe.client.api.JsonMapper;
 import io.camunda.zeebe.client.impl.oauth.OAuthCredentialsProviderBuilder;
@@ -47,12 +48,12 @@ public class ZeebeClientCloudBuilderImpl
     implements ZeebeClientCloudBuilderStep1,
         ZeebeClientCloudBuilderStep2,
         ZeebeClientCloudBuilderStep3,
-        ZeebeClientCloudBuilderStep4 {
+        ZeebeClientCloudBuilderStep4,
+        ZeebeClientCloudBuilderStep5 {
 
-  private static final String BASE_ADDRESS = "zeebe.camunda.io";
-  private static final String BASE_AUTH_URL = "https://login.cloud.camunda.io/oauth/token";
-
+  private static final String DEFAULT_DOMAIN = "camunda.io";
   private static final String DEFAULT_REGION = "bru-2";
+  private static final String ZEEBE_DOMAIN_COMPONENT = "zeebe";
 
   private final ZeebeClientBuilderImpl innerBuilder = new ZeebeClientBuilderImpl();
 
@@ -60,6 +61,7 @@ public class ZeebeClientCloudBuilderImpl
   private String clientId;
   private String clientSecret;
   private String region = DEFAULT_REGION;
+  private String domain = DEFAULT_DOMAIN;
 
   @Override
   public ZeebeClientCloudBuilderStep2 withClusterId(final String clusterId) {
@@ -80,8 +82,14 @@ public class ZeebeClientCloudBuilderImpl
   }
 
   @Override
-  public ZeebeClientCloudBuilderStep4 withRegion(final String region) {
+  public ZeebeClientCloudBuilderStep5 withRegion(final String region) {
     this.region = region;
+    return this;
+  }
+
+  @Override
+  public ZeebeClientCloudBuilderStep5 withDomain(final String domain) {
+    this.domain = domain;
     return this;
   }
 
@@ -289,7 +297,8 @@ public class ZeebeClientCloudBuilderImpl
     if (isNeedToSetCloudRestAddress()) {
       ensureNotNull("cluster id", clusterId);
       final String cloudRestAddress =
-          String.format("https://%s.%s:443/%s", region, BASE_ADDRESS, clusterId);
+          String.format(
+              "https://%s.%s.%s:443/%s", region, ZEEBE_DOMAIN_COMPONENT, domain, clusterId);
       return getURIFromString(cloudRestAddress);
     } else {
       Loggers.LOGGER.debug(
@@ -304,7 +313,8 @@ public class ZeebeClientCloudBuilderImpl
     if (isNeedToSetCloudGrpcAddress() && isNeedToSetCloudGatewayAddress()) {
       ensureNotNull("cluster id", clusterId);
       final String cloudGrpcAddress =
-          String.format("https://%s.%s.%s:443", clusterId, region, BASE_ADDRESS);
+          String.format(
+              "https://%s.%s.%s.%s:443", clusterId, region, ZEEBE_DOMAIN_COMPONENT, domain);
       return getURIFromString(cloudGrpcAddress);
     } else {
       if (!isNeedToSetCloudGrpcAddress()) {
@@ -335,10 +345,10 @@ public class ZeebeClientCloudBuilderImpl
         Loggers.LOGGER.debug("Expected setting 'usePlaintext' to be 'false', but found 'true'.");
       }
       return builder
-          .audience(String.format("%s.%s.%s", clusterId, region, BASE_ADDRESS))
+          .audience(String.format("%s.%s.%s", clusterId, region, domain))
           .clientId(clientId)
           .clientSecret(clientSecret)
-          .authorizationServerUrl(BASE_AUTH_URL)
+          .authorizationServerUrl(String.format("https://login.cloud.%s/oauth/token", domain))
           .build();
     } else {
       Loggers.LOGGER.debug(

--- a/clients/java/src/test/java/io/camunda/zeebe/client/ZeebeClientTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/ZeebeClientTest.java
@@ -378,6 +378,7 @@ public final class ZeebeClientTest extends ClientTest {
     // given
     final String clusterId = "clusterId";
     final String region = "asdf-123";
+    final String domain = "dev.ultrawombat.com";
 
     try (final ZeebeClient client =
         ZeebeClient.newCloudClientBuilder()
@@ -385,6 +386,7 @@ public final class ZeebeClientTest extends ClientTest {
             .withClientId("clientId")
             .withClientSecret("clientSecret")
             .withRegion(region)
+            .withDomain(domain)
             .build()) {
       // when
       final ZeebeClientConfiguration clientConfiguration = client.getConfiguration();
@@ -392,11 +394,11 @@ public final class ZeebeClientTest extends ClientTest {
       assertThat(clientConfiguration.getCredentialsProvider())
           .isInstanceOf(OAuthCredentialsProvider.class);
       assertThat(clientConfiguration.getGrpcAddress())
-          .hasHost(String.format("%s.%s.zeebe.camunda.io", clusterId, region))
+          .hasHost(String.format("%s.%s.zeebe.%s", clusterId, region, domain))
           .hasPort(443)
           .hasScheme("https");
       assertThat(clientConfiguration.getRestAddress())
-          .hasHost(String.format("%s.zeebe.camunda.io", region))
+          .hasHost(String.format("%s.zeebe.%s", region, domain))
           .hasPort(443)
           .hasPath("/" + clusterId)
           .hasScheme("https");
@@ -404,7 +406,7 @@ public final class ZeebeClientTest extends ClientTest {
   }
 
   @Test
-  public void shouldCloudBuilderBuildProperClientWithDefaultRegion() {
+  public void shouldCloudBuilderBuildProperClientWithDefaultRegionAndDomain() {
     // given
     final String clusterId = "clusterId";
     try (final ZeebeClient client =

--- a/clients/java/src/test/java/io/camunda/zeebe/client/ZeebeClientTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/ZeebeClientTest.java
@@ -395,6 +395,11 @@ public final class ZeebeClientTest extends ClientTest {
           .hasHost(String.format("%s.%s.zeebe.camunda.io", clusterId, region))
           .hasPort(443)
           .hasScheme("https");
+      assertThat(clientConfiguration.getRestAddress())
+          .hasHost(String.format("%s.zeebe.camunda.io", region))
+          .hasPort(443)
+          .hasPath("/" + clusterId)
+          .hasScheme("https");
     }
   }
 
@@ -417,6 +422,11 @@ public final class ZeebeClientTest extends ClientTest {
           .hasHost(String.format("%s.bru-2.zeebe.camunda.io", clusterId))
           .hasPort(443)
           .hasScheme("https");
+      assertThat(clientConfiguration.getRestAddress())
+          .hasHost("bru-2.zeebe.camunda.io")
+          .hasPort(443)
+          .hasPath("/" + clusterId)
+          .hasScheme("https");
     }
   }
 
@@ -424,6 +434,7 @@ public final class ZeebeClientTest extends ClientTest {
   public void shouldOverrideCloudProperties() {
     // given
     final String gatewayAddress = "localhost:10000";
+    final URI restAddress = URI.create("https://localhost:10001");
     final NoopCredentialsProvider credentialsProvider = new NoopCredentialsProvider();
     try (final ZeebeClient client =
         ZeebeClient.newCloudClientBuilder()
@@ -431,10 +442,12 @@ public final class ZeebeClientTest extends ClientTest {
             .withClientId("clientId")
             .withClientSecret("clientSecret")
             .gatewayAddress(gatewayAddress)
+            .restAddress(restAddress)
             .credentialsProvider(credentialsProvider)
             .build()) {
       final ZeebeClientConfiguration configuration = client.getConfiguration();
       assertThat(configuration.getGatewayAddress()).isEqualTo(gatewayAddress);
+      assertThat(configuration.getRestAddress()).isEqualTo(restAddress);
       assertThat(configuration.getCredentialsProvider()).isEqualTo(credentialsProvider);
     }
   }
@@ -461,6 +474,11 @@ public final class ZeebeClientTest extends ClientTest {
           .hasHost(String.format("clusterId.%s.zeebe.camunda.io", region))
           .hasPort(443)
           .hasScheme("https");
+      assertThat(clientConfiguration.getRestAddress())
+          .hasHost(String.format("%s.zeebe.camunda.io", region))
+          .hasPort(443)
+          .hasPath("/clusterId")
+          .hasScheme("https");
     }
   }
 
@@ -482,6 +500,11 @@ public final class ZeebeClientTest extends ClientTest {
       assertThat(clientConfiguration.getGrpcAddress())
           .hasHost(String.format("clusterId.%s.zeebe.camunda.io", defaultRegion))
           .hasPort(443)
+          .hasScheme("https");
+      assertThat(clientConfiguration.getRestAddress())
+          .hasHost(String.format("%s.zeebe.camunda.io", defaultRegion))
+          .hasPort(443)
+          .hasPath("/clusterId")
           .hasScheme("https");
     }
   }

--- a/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/properties/CamundaClientCloudProperties.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/properties/CamundaClientCloudProperties.java
@@ -15,11 +15,14 @@
  */
 package io.camunda.zeebe.spring.client.properties;
 
+import org.springframework.boot.context.properties.DeprecatedConfigurationProperty;
+
 public class CamundaClientCloudProperties {
   private String region;
   private String clusterId;
-  private String baseUrl;
+  @Deprecated private String baseUrl;
   private Integer port;
+  private String domain;
 
   public Integer getPort() {
     return port;
@@ -45,12 +48,23 @@ public class CamundaClientCloudProperties {
     this.clusterId = clusterId;
   }
 
+  @Deprecated
+  @DeprecatedConfigurationProperty(replacement = "camunda.client.cloud.domain")
   public String getBaseUrl() {
     return baseUrl;
   }
 
+  @Deprecated
   public void setBaseUrl(final String baseUrl) {
     this.baseUrl = baseUrl;
+  }
+
+  public String getDomain() {
+    return domain;
+  }
+
+  public void setDomain(final String domain) {
+    this.domain = domain;
   }
 
   @Override
@@ -62,8 +76,8 @@ public class CamundaClientCloudProperties {
         + ", clusterId='"
         + clusterId
         + '\''
-        + ", baseUrl='"
-        + baseUrl
+        + ", domain='"
+        + domain
         + '\''
         + ", port="
         + port

--- a/clients/spring-boot-starter-camunda-sdk/src/main/resources/modes/saas.yaml
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/resources/modes/saas.yaml
@@ -2,15 +2,15 @@ camunda:
   client:
     mode: saas
     cloud:
-      base-url: camunda.io
+      domain: camunda.io
       region: bru-2
       port: 443
     tenant-id: <default>
     auth:
-      token-url: https://login.cloud.${camunda.client.cloud.base-url}/oauth/token
+      token-url: https://login.cloud.${camunda.client.cloud.domain}/oauth/token
     zeebe:
       enabled: true
-      audience: zeebe.${camunda.client.cloud.base-url}
-      rest-address: https://${camunda.client.cloud.region}.zeebe.${camunda.client.cloud.base-url}:${camunda.client.cloud.port}/${camunda.client.cloud.cluster-id}
-      grpc-address: https://${camunda.client.cloud.cluster-id}.${camunda.client.cloud.region}.zeebe.${camunda.client.cloud.base-url}:${camunda.client.cloud.port}
+      audience: zeebe.${camunda.client.cloud.domain}
+      rest-address: https://${camunda.client.cloud.region}.zeebe.${camunda.client.cloud.domain}:${camunda.client.cloud.port}/${camunda.client.cloud.cluster-id}
+      grpc-address: https://${camunda.client.cloud.cluster-id}.${camunda.client.cloud.region}.zeebe.${camunda.client.cloud.domain}:${camunda.client.cloud.port}
       prefer-rest-over-grpc: false

--- a/clients/spring-boot-starter-camunda-sdk/src/main/resources/zeebe-client-legacy-property-mappings.properties
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/resources/zeebe-client-legacy-property-mappings.properties
@@ -19,7 +19,7 @@ camunda.client.zeebe.max-message-size=zeebe.client.message.max-message-size
 # Cloud properties
 camunda.client.cloud.cluster-id=camunda.client.cluster-id, zeebe.client.cloud.cluster-id
 camunda.client.cloud.region=camunda.client.region, zeebe.client.cloud.region
-camunda.client.cloud.base-url=zeebe.client.cloud.base-url
+camunda.client.cloud.domain=camunda.client.cloud.base-url, zeebe.client.cloud.base-url
 camunda.client.cloud.port=zeebe.client.cloud.port
 # Worker defaults
 camunda.client.zeebe.defaults.max-jobs-active=zeebe.client.worker.max-jobs-active

--- a/docs/spring-sdk.md
+++ b/docs/spring-sdk.md
@@ -2,7 +2,7 @@
 
 ## Spring SDK usage in Camunda Saas staging environments
 
-To use a staging environment, the `camunda.client.cloud.base-url` can be updated to match the base url of the desired cloud environment.
+To use a staging environment, the `camunda.client.cloud.domain` can be updated to match the domain of the desired cloud environment.
 
 Example:
 
@@ -10,7 +10,7 @@ Example:
 camunda:
   client:
     cloud:
-      base-url: ultrawombat.com
+      domain: ultrawombat.com
 ```
 
 By default, the client will always point to the production Saas instance:
@@ -19,6 +19,6 @@ By default, the client will always point to the production Saas instance:
 camunda:
   client:
     cloud:
-      base-url: camunda.io
+      domain: camunda.io
 ```
 


### PR DESCRIPTION
# Description
Backport of #35044 to `stable/8.7`.

relates to #32759