### PR TITLE
ci: moving the wait stage in add-to-projects

### DIFF
--- a/.github/workflows/add-to-projects.yml
+++ b/.github/workflows/add-to-projects.yml
@@ -12,8 +12,6 @@ jobs:
     name: Add issue to team projects if no project assigned and by corresponding component label
     runs-on: ubuntu-latest
     steps:
-      - name: Wait
-        run: sleep 30s
       - id: get_project_count
         uses: octokit/graphql-action@v2.3.2
         with:
@@ -135,7 +133,9 @@ jobs:
           github-token: ${{ secrets.GH_PROJECT_AUTOMATION_TOKEN }}
           # any of the following labels:
           labeled: component/clients, component/spring-sdk, component/camunda-process-test, component/c8-api
-      # this steps needs to stay as last step to not interfer with other steps
+      - name: Wait
+        run: sleep 30s
+          # this steps needs to stay as last step to not interfer with other steps
       - id: add-to-qualityboard
         name: Add to Quality Board project
         uses: actions/add-to-project@v1.0.2


### PR DESCRIPTION
## Description

Moving the wait stage in add-to-projects.yml to right before the adding to Quality Board project. 

This is because currently the script is triggered by the "kind/bug" -label and the component labels are added a bit later by another automation. Because of this, the issue is added to the Quality Board project first and the issue is then not added to any other project, since the criteria for adding the issue into component specific project is that it is not included in any other project before that.

With this fix I try to give the automated labeler enough time so it can add the component label before the addition to Quality Board happens.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
