### PR TITLE
fix: a task could not be completed by another user

### DIFF
--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/es/TaskValidator.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/es/TaskValidator.java
@@ -65,7 +65,8 @@ public class TaskValidator {
     validateTaskIsAssigned(task);
 
     final UserDTO currentUser = getCurrentUser();
-    if (!task.getAssignee().equals(currentUser.getUserId())) {
+    if (!task.getAssignee().equals(currentUser.getUserId())
+        && !tasklistProperties.getFeatureFlag().getAllowNonSelfAssignment()) {
       throw new InvalidRequestException(
           createErrorMessage(
               TASK_NOT_ASSIGNED_TO_CURRENT_USER,

--- a/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/es/TaskValidatorTest.java
+++ b/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/es/TaskValidatorTest.java
@@ -78,6 +78,7 @@ public class TaskValidatorTest {
   @Test
   public void userCanNotPersistDraftTaskVariablesIfAssignedToAnotherPerson() {
     // given
+    when(tasklistProperties.getFeatureFlag()).thenReturn(new FeatureFlagProperties());
     authenticationUtil.when(TasklistAuthenticationUtil::isApiUser).thenReturn(false);
     final UserDTO user = new UserDTO().setUserId(TEST_USER).setDisplayName(TEST_USER);
     when(userReader.getCurrentUser()).thenReturn(user);
@@ -158,6 +159,7 @@ public class TaskValidatorTest {
   @Test
   public void userCanNotCompleteTaskIfAssignedToAnotherPerson() {
     // given
+    when(tasklistProperties.getFeatureFlag()).thenReturn(new FeatureFlagProperties());
     authenticationUtil.when(TasklistAuthenticationUtil::isApiUser).thenReturn(false);
     final UserDTO user = new UserDTO().setUserId(TEST_USER).setDisplayName(TEST_USER);
     when(userReader.getCurrentUser()).thenReturn(user);
@@ -196,8 +198,24 @@ public class TaskValidatorTest {
   @Test
   public void userCanCompleteTheirOwnTask() {
     // given
+
     authenticationUtil.when(TasklistAuthenticationUtil::isApiUser).thenReturn(false);
     final UserDTO user = new UserDTO().setUserId(TEST_USER).setDisplayName(TEST_USER);
+    when(userReader.getCurrentUser()).thenReturn(user);
+    final TaskEntity task = new TaskEntity().setAssignee(TEST_USER).setState(TaskState.CREATED);
+
+    // when - then
+    assertDoesNotThrow(() -> instance.validateCanComplete(task));
+  }
+
+  @Test
+  public void userCanCompleteOtherPersonTaskIfAllowNonSelfAssignment() {
+    // given
+    when(tasklistProperties.getFeatureFlag())
+        .thenReturn(new FeatureFlagProperties().setAllowNonSelfAssignment(true));
+    authenticationUtil.when(TasklistAuthenticationUtil::isApiUser).thenReturn(false);
+    final UserDTO user =
+        new UserDTO().setUserId("AnotherTestUser").setDisplayName("AnotherTestUser");
     when(userReader.getCurrentUser()).thenReturn(user);
     final TaskEntity task = new TaskEntity().setAssignee(TEST_USER).setState(TaskState.CREATED);
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR fixes an issue where a task could not be completed if the completion is done not by the assignee, despite the flag `allowNonSelfAssignment` being set to `true`.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
