### PR TITLE
Console Ping: send version in the payload.

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/console/ping/PingConsoleRunner.java
+++ b/dist/src/main/java/io/camunda/application/commons/console/ping/PingConsoleRunner.java
@@ -13,6 +13,7 @@ import io.camunda.application.commons.console.ping.PingConsoleRunner.ConsolePing
 import io.camunda.application.commons.console.ping.PingConsoleTask.LicensePayload;
 import io.camunda.service.ManagementServices;
 import io.camunda.zeebe.util.Either;
+import io.camunda.zeebe.util.VersionUtil;
 import io.camunda.zeebe.util.VisibleForTesting;
 import io.camunda.zeebe.util.error.FatalErrorHandler;
 import io.camunda.zeebe.util.retry.RetryConfiguration;
@@ -148,6 +149,7 @@ public class PingConsoleRunner implements ApplicationRunner {
             license,
             pingConfiguration.clusterId(),
             pingConfiguration.clusterName(),
+            VersionUtil.getVersion(),
             pingConfiguration.properties());
     try {
       return Either.right(objectMapper.writeValueAsString(payload));

--- a/dist/src/main/java/io/camunda/application/commons/console/ping/PingConsoleTask.java
+++ b/dist/src/main/java/io/camunda/application/commons/console/ping/PingConsoleTask.java
@@ -88,7 +88,11 @@ public class PingConsoleTask implements Runnable {
 
   @JsonInclude(JsonInclude.Include.NON_NULL)
   public record LicensePayload(
-      License license, String clusterId, String clusterName, Map<String, String> properties) {
+      License license,
+      String clusterId,
+      String clusterName,
+      String version,
+      Map<String, String> properties) {
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public record License(
         boolean validLicense, String licenseType, boolean isCommercial, String expiresAt) {}

--- a/dist/src/test/java/io/camunda/application/commons/console/ping/PingConsoleRunnerIT.java
+++ b/dist/src/test/java/io/camunda/application/commons/console/ping/PingConsoleRunnerIT.java
@@ -24,6 +24,7 @@ import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
 import io.camunda.application.commons.console.ping.PingConsoleRunner.ConsolePingConfiguration;
 import io.camunda.service.ManagementServices;
 import io.camunda.service.license.LicenseType;
+import io.camunda.zeebe.util.VersionUtil;
 import io.camunda.zeebe.util.retry.RetryConfiguration;
 import java.net.URI;
 import java.time.Duration;
@@ -66,9 +67,11 @@ public class PingConsoleRunnerIT {
           "isCommercial": true
         },
         "clusterId": "test-cluster-id",
-        "clusterName": "test-cluster-name"
+        "clusterName": "test-cluster-name",
+        "version":"%s"
       }
-    """;
+    """
+            .formatted(VersionUtil.getVersion());
     managementServices = mock(ManagementServices.class);
     when(managementServices.getCamundaLicenseType()).thenReturn(LicenseType.SAAS);
     when(managementServices.isCommercialCamundaLicense()).thenReturn(true);


### PR DESCRIPTION
## Description

This PR adds the version of the cluster to the payload sent to the console.
```
{
 "license": {
  "validLicense": boolean,
  "licenseType": string,
  "isCommercial": boolean,
  "expiresAt": string (optional)
 },
 "clusterId": string,
 "clusterName": string,
 "version": string,
 "properties": Record<string, string> (optional)
}
```

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes https://github.com/camunda/camunda/issues/35084
