### PR TITLE
Feature/32663 (local) variable assert satisfies

### DIFF
--- a/testing/camunda-process-test-java/pom.xml
+++ b/testing/camunda-process-test-java/pom.xml
@@ -84,6 +84,12 @@
     </dependency>
 
     <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
     </dependency>

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/assertions/ProcessInstanceAssert.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/assertions/ProcessInstanceAssert.java
@@ -381,62 +381,62 @@ public interface ProcessInstanceAssert {
       ElementSelector selector, String variableName, Object variableValue);
 
   /**
-   * Verifies that the variable object satisfied the given requirements expressed as a {@link
-   * ThrowingConsumer}.
+   * Verifies that the process instance has a variable with a value that satisfies the given
+   * requirements expressed as a {@link ThrowingConsumer}. It can be used to verify a complex object
+   * partially with multiple grouped assertions. The verification fails if the variable doesn't
+   * exist or the value doesn't satisfy the requirements.
    *
-   * <p>This is useful to perform a group of assertions on a single object, each passed assertion is
-   * evaluated and all failures are reported (to be precise each assertion can lead to one failure
-   * max).
+   * <p>The assertion waits until the variable exists and the value satisfies the requirements.
    *
    * @param variableName the variable name
-   * @param jsonMappedClass the variable's deserialization target, can be a JsonNode or Map for
-   *     variables without a dedicated class
+   * @param variableValueType the variable value's deserialization type, can be a JsonNode or Map
+   *     for a generic variable
    * @param requirement the requirement that the variable must satisfy
    * @return the assertion object
    */
   <T> ProcessInstanceAssert hasVariableSatisfies(
-      String variableName, final Class<T> jsonMappedClass, final ThrowingConsumer<T> requirement);
+      String variableName, final Class<T> variableValueType, final ThrowingConsumer<T> requirement);
 
   /**
-   * Verifies that the local variable object satisfied the given requirement expressed as a {@link
-   * ThrowingConsumer}.
+   * Verifies that the process instance has a local variable with a value that satisfies the given
+   * requirements expressed as a {@link ThrowingConsumer}. It can be used to verify a complex object
+   * partially with multiple grouped assertions. The verification fails if the variable doesn't
+   * exist or the value doesn't satisfy the requirements.
    *
-   * <p>This is useful to perform a group of assertions on a single object, each passed assertion is
-   * evaluated and all failures are reported (to be precise each assertion can lead to one failure
-   * max).
+   * <p>The assertion waits until the variable exists and the value satisfies the requirements.
    *
    * @param elementId id of the element the local variable is associated with
    * @param variableName the variable name
-   * @param jsonMappedClass the variable's deserialization target, can be a JsonNode or Map for
-   *     variables without a dedicated class
+   * @param variableValueType the variable value's deserialization type, can be a JsonNode or Map
+   *     for a generic variable
    * @param requirement the requirement that the variable must satisfy
    * @return the assertion object
    */
   <T> ProcessInstanceAssert hasLocalVariableSatisfies(
       String elementId,
       String variableName,
-      Class<T> jsonMappedClass,
+      Class<T> variableValueType,
       ThrowingConsumer<T> requirement);
 
   /**
-   * Verifies that the local variable object satisfied the given requirement expressed as a {@link
-   * ThrowingConsumer}.
+   * Verifies that the process instance has a local variable with a value that satisfies the given
+   * requirements expressed as a {@link ThrowingConsumer}. It can be used to verify a complex object
+   * partially with multiple grouped assertions. The verification fails if the variable doesn't
+   * exist or the value doesn't satisfy the requirements.
    *
-   * <p>This is useful to perform a group of assertions on a single object, each passed assertion is
-   * evaluated and all failures are reported (to be precise each assertion can lead to one failure
-   * max).
+   * <p>The assertion waits until the variable exists and the value satisfies the requirements.
    *
    * @param selector the {@see ElementSelector} for the BPMN element the variable is associated with
    * @param variableName the variable name
-   * @param jsonMappedClass the variable's deserialization target, can be a JsonNode or Map for
-   *     variables without a dedicated class
+   * @param variableValueType the variable value's deserialization type, can be a JsonNode or Map
+   *     for a generic variable
    * @param requirement the requirement that the variable must satisfy
    * @return the assertion object
    */
   <T> ProcessInstanceAssert hasLocalVariableSatisfies(
       ElementSelector selector,
       String variableName,
-      Class<T> jsonMappedClass,
+      Class<T> variableValueType,
       ThrowingConsumer<T> requirement);
 
   /**

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/assertions/ProcessInstanceAssert.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/assertions/ProcessInstanceAssert.java
@@ -15,7 +15,6 @@
  */
 package io.camunda.process.test.api.assertions;
 
-import java.util.List;
 import java.util.Map;
 import org.assertj.core.api.ThrowingConsumer;
 
@@ -382,6 +381,65 @@ public interface ProcessInstanceAssert {
       ElementSelector selector, String variableName, Object variableValue);
 
   /**
+   * Verifies that the variable object satisfied the given requirements expressed as a {@link
+   * ThrowingConsumer}.
+   *
+   * <p>This is useful to perform a group of assertions on a single object, each passed assertion is
+   * evaluated and all failures are reported (to be precise each assertion can lead to one failure
+   * max).
+   *
+   * @param variableName the variable name
+   * @param jsonMappedClass the variable's deserialization target, can be a JsonNode or Map for
+   *     variables without a dedicated class
+   * @param requirement the requirement that the variable must satisfy
+   * @return the assertion object
+   */
+  <T> ProcessInstanceAssert hasVariableSatisfies(
+      String variableName, final Class<T> jsonMappedClass, final ThrowingConsumer<T> requirement);
+
+  /**
+   * Verifies that the local variable object satisfied the given requirement expressed as a {@link
+   * ThrowingConsumer}.
+   *
+   * <p>This is useful to perform a group of assertions on a single object, each passed assertion is
+   * evaluated and all failures are reported (to be precise each assertion can lead to one failure
+   * max).
+   *
+   * @param elementId id of the element the local variable is associated with
+   * @param variableName the variable name
+   * @param jsonMappedClass the variable's deserialization target, can be a JsonNode or Map for
+   *     variables without a dedicated class
+   * @param requirement the requirement that the variable must satisfy
+   * @return the assertion object
+   */
+  <T> ProcessInstanceAssert hasLocalVariableSatisfies(
+      String elementId,
+      String variableName,
+      Class<T> jsonMappedClass,
+      ThrowingConsumer<T> requirement);
+
+  /**
+   * Verifies that the local variable object satisfied the given requirement expressed as a {@link
+   * ThrowingConsumer}.
+   *
+   * <p>This is useful to perform a group of assertions on a single object, each passed assertion is
+   * evaluated and all failures are reported (to be precise each assertion can lead to one failure
+   * max).
+   *
+   * @param selector the {@see ElementSelector} for the BPMN element the variable is associated with
+   * @param variableName the variable name
+   * @param jsonMappedClass the variable's deserialization target, can be a JsonNode or Map for
+   *     variables without a dedicated class
+   * @param requirement the requirement that the variable must satisfy
+   * @return the assertion object
+   */
+  <T> ProcessInstanceAssert hasLocalVariableSatisfies(
+      ElementSelector selector,
+      String variableName,
+      Class<T> jsonMappedClass,
+      ThrowingConsumer<T> requirement);
+
+  /**
    * Verifies that the process instance has the given variables. The verification fails if at least
    * one variable doesn't exist or has a different value.
    *
@@ -391,103 +449,6 @@ public interface ProcessInstanceAssert {
    * @return the assertion object
    */
   ProcessInstanceAssert hasVariables(Map<String, Object> variables);
-
-  /**
-   * Verifies that the process instance has a variable with a value that satisfies the given
-   * requirements. The verification fails if the variable doesn't exist or the value doesn't satisfy
-   * all requirements.
-   *
-   * <p>The assertion waits until the variable exists and the value satisfies all requirements.
-   *
-   * @param variableName the variable name
-   * @param jsonMappedClass the class to map the JSON value to
-   * @param requirements the requirements that the value must satisfy
-   * @param <T> the type of the variable value
-   * @return the assertion object
-   */
-  @SuppressWarnings("unchecked")
-  <T> ProcessInstanceAssert hasVariableSatisfies(
-      String variableName, Class<T> jsonMappedClass, List<ThrowingConsumer<T>> requirements);
-
-  /**
-   * Verifies that the process instance has a variable with a value that satisfies the given
-   * requirement. The verification fails if the variable doesn't exist or the value doesn't satisfy
-   * the requirement.
-   *
-   * <p>The assertion waits until the variable exists and the value satisfies the requirement.
-   *
-   * @param variableName the variable name
-   * @param jsonMappedClass the class to map the JSON value to
-   * @param requirement the requirement that the value must satisfy
-   * @param <T> the type of the variable value
-   * @return the assertion object
-   */
-  <T> ProcessInstanceAssert hasVariableSatisfies(
-      String variableName, final Class<T> jsonMappedClass, final ThrowingConsumer<T> requirement);
-
-  /**
-   * TODO
-   *
-   * @param elementId
-   * @param variableName
-   * @param jsonMappedClass
-   * @param requirement
-   * @return
-   * @param <T>
-   */
-  <T> ProcessInstanceAssert hasLocalVariableSatisfies(
-      String elementId,
-      String variableName,
-      Class<T> jsonMappedClass,
-      ThrowingConsumer<T> requirement);
-
-  /**
-   * TODO
-   *
-   * @param elementId
-   * @param variableName
-   * @param jsonMappedClass
-   * @param requirements
-   * @return
-   * @param <T>
-   */
-  <T> ProcessInstanceAssert hasLocalVariableSatisfies(
-      String elementId,
-      String variableName,
-      Class<T> jsonMappedClass,
-      List<ThrowingConsumer<T>> requirements);
-
-  /**
-   * TODO
-   *
-   * @param selector
-   * @param variableName
-   * @param jsonMappedClass
-   * @param requirement
-   * @return
-   * @param <T>
-   */
-  <T> ProcessInstanceAssert hasLocalVariableSatisfies(
-      ElementSelector selector,
-      String variableName,
-      Class<T> jsonMappedClass,
-      ThrowingConsumer<T> requirement);
-
-  /**
-   * TODO
-   *
-   * @param selector
-   * @param variableName
-   * @param jsonMappedClass
-   * @param requirement
-   * @return
-   * @param <T>
-   */
-  <T> ProcessInstanceAssert hasLocalVariableSatisfies(
-      ElementSelector selector,
-      String variableName,
-      Class<T> jsonMappedClass,
-      List<ThrowingConsumer<T>> requirement);
 
   /**
    * Verifies that the given element associated with the process instance has the given local

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/assertions/ProcessInstanceAssert.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/assertions/ProcessInstanceAssert.java
@@ -15,7 +15,9 @@
  */
 package io.camunda.process.test.api.assertions;
 
+import java.util.List;
 import java.util.Map;
+import org.assertj.core.api.ThrowingConsumer;
 
 /** The assertion object to verify a process instance. */
 public interface ProcessInstanceAssert {
@@ -389,6 +391,103 @@ public interface ProcessInstanceAssert {
    * @return the assertion object
    */
   ProcessInstanceAssert hasVariables(Map<String, Object> variables);
+
+  /**
+   * Verifies that the process instance has a variable with a value that satisfies the given
+   * requirements. The verification fails if the variable doesn't exist or the value doesn't satisfy
+   * all requirements.
+   *
+   * <p>The assertion waits until the variable exists and the value satisfies all requirements.
+   *
+   * @param variableName the variable name
+   * @param jsonMappedClass the class to map the JSON value to
+   * @param requirements the requirements that the value must satisfy
+   * @param <T> the type of the variable value
+   * @return the assertion object
+   */
+  @SuppressWarnings("unchecked")
+  <T> ProcessInstanceAssert hasVariableSatisfies(
+      String variableName, Class<T> jsonMappedClass, List<ThrowingConsumer<T>> requirements);
+
+  /**
+   * Verifies that the process instance has a variable with a value that satisfies the given
+   * requirement. The verification fails if the variable doesn't exist or the value doesn't satisfy
+   * the requirement.
+   *
+   * <p>The assertion waits until the variable exists and the value satisfies the requirement.
+   *
+   * @param variableName the variable name
+   * @param jsonMappedClass the class to map the JSON value to
+   * @param requirement the requirement that the value must satisfy
+   * @param <T> the type of the variable value
+   * @return the assertion object
+   */
+  <T> ProcessInstanceAssert hasVariableSatisfies(
+      String variableName, final Class<T> jsonMappedClass, final ThrowingConsumer<T> requirement);
+
+  /**
+   * TODO
+   *
+   * @param elementId
+   * @param variableName
+   * @param jsonMappedClass
+   * @param requirement
+   * @return
+   * @param <T>
+   */
+  <T> ProcessInstanceAssert hasLocalVariableSatisfies(
+      String elementId,
+      String variableName,
+      Class<T> jsonMappedClass,
+      ThrowingConsumer<T> requirement);
+
+  /**
+   * TODO
+   *
+   * @param elementId
+   * @param variableName
+   * @param jsonMappedClass
+   * @param requirements
+   * @return
+   * @param <T>
+   */
+  <T> ProcessInstanceAssert hasLocalVariableSatisfies(
+      String elementId,
+      String variableName,
+      Class<T> jsonMappedClass,
+      List<ThrowingConsumer<T>> requirements);
+
+  /**
+   * TODO
+   *
+   * @param selector
+   * @param variableName
+   * @param jsonMappedClass
+   * @param requirement
+   * @return
+   * @param <T>
+   */
+  <T> ProcessInstanceAssert hasLocalVariableSatisfies(
+      ElementSelector selector,
+      String variableName,
+      Class<T> jsonMappedClass,
+      ThrowingConsumer<T> requirement);
+
+  /**
+   * TODO
+   *
+   * @param selector
+   * @param variableName
+   * @param jsonMappedClass
+   * @param requirement
+   * @return
+   * @param <T>
+   */
+  <T> ProcessInstanceAssert hasLocalVariableSatisfies(
+      ElementSelector selector,
+      String variableName,
+      Class<T> jsonMappedClass,
+      List<ThrowingConsumer<T>> requirement);
 
   /**
    * Verifies that the given element associated with the process instance has the given local

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/ProcessInstanceAssertj.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/ProcessInstanceAssertj.java
@@ -26,7 +26,6 @@ import io.camunda.process.test.api.assertions.ProcessInstanceAssert;
 import io.camunda.process.test.api.assertions.ProcessInstanceSelector;
 import io.camunda.process.test.api.assertions.ProcessInstanceSelectors;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -284,7 +283,6 @@ public class ProcessInstanceAssertj
   }
 
   @Override
-  @SuppressWarnings("unchecked")
   public <T> ProcessInstanceAssert hasLocalVariableSatisfies(
       final String elementId,
       final String variableName,
@@ -292,57 +290,18 @@ public class ProcessInstanceAssertj
       final ThrowingConsumer<T> requirement) {
 
     return hasLocalVariableSatisfies(
-        elementSelector.apply(elementId),
-        variableName,
-        jsonMappedClass,
-        Collections.singletonList(requirement));
+        elementSelector.apply(elementId), variableName, jsonMappedClass, requirement);
   }
 
   @Override
-  @SuppressWarnings("unchecked")
-  public <T> ProcessInstanceAssert hasLocalVariableSatisfies(
-      final String elementId,
-      final String variableName,
-      final Class<T> jsonMappedClass,
-      final List<ThrowingConsumer<T>> requirements) {
-
-    return hasLocalVariableSatisfies(
-        elementSelector.apply(elementId), variableName, jsonMappedClass, requirements);
-  }
-
-  @Override
-  @SuppressWarnings("unchecked")
   public <T> ProcessInstanceAssert hasLocalVariableSatisfies(
       final ElementSelector selector,
       final String variableName,
       final Class<T> jsonMappedClass,
       final ThrowingConsumer<T> requirement) {
 
-    return hasLocalVariableSatisfies(
-        selector, variableName, jsonMappedClass, Collections.singletonList(requirement));
-  }
-
-  @Override
-  @SuppressWarnings("unchecked")
-  public <T> ProcessInstanceAssert hasLocalVariableSatisfies(
-      final ElementSelector selector,
-      final String variableName,
-      final Class<T> jsonMappedClass,
-      final List<ThrowingConsumer<T>> requirements) {
     variableAssertj.hasLocalVariableSatisfies(
-        getProcessInstanceKey(), selector, variableName, jsonMappedClass, requirements);
-    return this;
-  }
-
-  @Override
-  public <T> ProcessInstanceAssert hasVariableSatisfies(
-      final String variableName,
-
-      final Class<T> jsonMappedClass,
-      final List<ThrowingConsumer<T>> requirements) {
-
-    variableAssertj.hasVariableSatisfies(
-        getProcessInstanceKey(), variableName, jsonMappedClass, requirements);
+        getProcessInstanceKey(), selector, variableName, jsonMappedClass, requirement);
     return this;
   }
 
@@ -353,10 +312,7 @@ public class ProcessInstanceAssertj
       final ThrowingConsumer<T> requirement) {
 
     variableAssertj.hasVariableSatisfies(
-        getProcessInstanceKey(),
-        variableName,
-        jsonMappedClass,
-        Collections.singletonList(requirement));
+        getProcessInstanceKey(), variableName, jsonMappedClass, requirement);
     return this;
   }
 

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/ProcessInstanceAssertj.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/ProcessInstanceAssertj.java
@@ -283,36 +283,36 @@ public class ProcessInstanceAssertj
   }
 
   @Override
+  public <T> ProcessInstanceAssert hasVariableSatisfies(
+      final String variableName,
+      final Class<T> variableValueType,
+      final ThrowingConsumer<T> requirement) {
+
+    variableAssertj.hasVariableSatisfies(
+        getProcessInstanceKey(), variableName, variableValueType, requirement);
+    return this;
+  }
+
+  @Override
   public <T> ProcessInstanceAssert hasLocalVariableSatisfies(
       final String elementId,
       final String variableName,
-      final Class<T> jsonMappedClass,
+      final Class<T> variableValueType,
       final ThrowingConsumer<T> requirement) {
 
     return hasLocalVariableSatisfies(
-        elementSelector.apply(elementId), variableName, jsonMappedClass, requirement);
+        elementSelector.apply(elementId), variableName, variableValueType, requirement);
   }
 
   @Override
   public <T> ProcessInstanceAssert hasLocalVariableSatisfies(
       final ElementSelector selector,
       final String variableName,
-      final Class<T> jsonMappedClass,
+      final Class<T> variableValueType,
       final ThrowingConsumer<T> requirement) {
 
     variableAssertj.hasLocalVariableSatisfies(
-        getProcessInstanceKey(), selector, variableName, jsonMappedClass, requirement);
-    return this;
-  }
-
-  @Override
-  public <T> ProcessInstanceAssert hasVariableSatisfies(
-      final String variableName,
-      final Class<T> jsonMappedClass,
-      final ThrowingConsumer<T> requirement) {
-
-    variableAssertj.hasVariableSatisfies(
-        getProcessInstanceKey(), variableName, jsonMappedClass, requirement);
+        getProcessInstanceKey(), selector, variableName, variableValueType, requirement);
     return this;
   }
 

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/ProcessInstanceAssertj.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/ProcessInstanceAssertj.java
@@ -26,6 +26,7 @@ import io.camunda.process.test.api.assertions.ProcessInstanceAssert;
 import io.camunda.process.test.api.assertions.ProcessInstanceSelector;
 import io.camunda.process.test.api.assertions.ProcessInstanceSelectors;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -35,6 +36,7 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import org.assertj.core.api.AbstractAssert;
+import org.assertj.core.api.ThrowingConsumer;
 import org.awaitility.Awaitility;
 import org.awaitility.core.ConditionTimeoutException;
 import org.awaitility.core.TerminalFailureException;
@@ -278,6 +280,83 @@ public class ProcessInstanceAssertj
       final ElementSelector selector, final String variableName, final Object variableValue) {
     variableAssertj.hasLocalVariable(
         getProcessInstanceKey(), selector, variableName, variableValue);
+    return this;
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public <T> ProcessInstanceAssert hasLocalVariableSatisfies(
+      final String elementId,
+      final String variableName,
+      final Class<T> jsonMappedClass,
+      final ThrowingConsumer<T> requirement) {
+
+    return hasLocalVariableSatisfies(
+        elementSelector.apply(elementId),
+        variableName,
+        jsonMappedClass,
+        Collections.singletonList(requirement));
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public <T> ProcessInstanceAssert hasLocalVariableSatisfies(
+      final String elementId,
+      final String variableName,
+      final Class<T> jsonMappedClass,
+      final List<ThrowingConsumer<T>> requirements) {
+
+    return hasLocalVariableSatisfies(
+        elementSelector.apply(elementId), variableName, jsonMappedClass, requirements);
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public <T> ProcessInstanceAssert hasLocalVariableSatisfies(
+      final ElementSelector selector,
+      final String variableName,
+      final Class<T> jsonMappedClass,
+      final ThrowingConsumer<T> requirement) {
+
+    return hasLocalVariableSatisfies(
+        selector, variableName, jsonMappedClass, Collections.singletonList(requirement));
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public <T> ProcessInstanceAssert hasLocalVariableSatisfies(
+      final ElementSelector selector,
+      final String variableName,
+      final Class<T> jsonMappedClass,
+      final List<ThrowingConsumer<T>> requirements) {
+    variableAssertj.hasLocalVariableSatisfies(
+        getProcessInstanceKey(), selector, variableName, jsonMappedClass, requirements);
+    return this;
+  }
+
+  @Override
+  public <T> ProcessInstanceAssert hasVariableSatisfies(
+      final String variableName,
+
+      final Class<T> jsonMappedClass,
+      final List<ThrowingConsumer<T>> requirements) {
+
+    variableAssertj.hasVariableSatisfies(
+        getProcessInstanceKey(), variableName, jsonMappedClass, requirements);
+    return this;
+  }
+
+  @Override
+  public <T> ProcessInstanceAssert hasVariableSatisfies(
+      final String variableName,
+      final Class<T> jsonMappedClass,
+      final ThrowingConsumer<T> requirement) {
+
+    variableAssertj.hasVariableSatisfies(
+        getProcessInstanceKey(),
+        variableName,
+        jsonMappedClass,
+        Collections.singletonList(requirement));
     return this;
   }
 

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/VariableAssertj.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/VariableAssertj.java
@@ -233,7 +233,7 @@ public class VariableAssertj extends AbstractAssert<VariableAssertj, String> {
                     AssertionJsonMapper.readJson(variables.get(variableName), jsonMappedClass);
 
                 try {
-                  assertThat(actualValue).satisfies(requirement);
+                  requirement.accept(actualValue);
                 } catch (final AssertionError e) {
                   assertionError.set(e.getMessage());
                   throw e;

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/VariableAssertj.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/VariableAssertj.java
@@ -192,7 +192,9 @@ public class VariableAssertj extends AbstractAssert<VariableAssertj, String> {
                 variableName,
                 jsonMappedClass,
                 requirement,
-                () -> findLocalVariables(processInstanceKey, instance.getElementInstanceKey())));
+                () ->
+                    getLocalProcessInstanceVariables(
+                        processInstanceKey, instance.getElementInstanceKey())));
   }
 
   public <T> void hasVariableSatisfies(

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/VariableAssertj.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/VariableAssertj.java
@@ -181,7 +181,7 @@ public class VariableAssertj extends AbstractAssert<VariableAssertj, String> {
       final long processInstanceKey,
       final ElementSelector selector,
       final String variableName,
-      final Class<T> jsonMappedClass,
+      final Class<T> variableValueType,
       final ThrowingConsumer<T> requirement) {
 
     withLocalVariableAssertion(
@@ -190,7 +190,7 @@ public class VariableAssertj extends AbstractAssert<VariableAssertj, String> {
         instance ->
             hasVariableSatisfies(
                 variableName,
-                jsonMappedClass,
+                variableValueType,
                 requirement,
                 () ->
                     getLocalProcessInstanceVariables(
@@ -200,19 +200,19 @@ public class VariableAssertj extends AbstractAssert<VariableAssertj, String> {
   public <T> void hasVariableSatisfies(
       final long processInstanceKey,
       final String variableName,
-      final Class<T> jsonMappedClass,
+      final Class<T> variableValueType,
       final ThrowingConsumer<T> requirement) {
 
     hasVariableSatisfies(
         variableName,
-        jsonMappedClass,
+        variableValueType,
         requirement,
         () -> getGlobalProcessInstanceVariables(processInstanceKey));
   }
 
   private <T> void hasVariableSatisfies(
       final String variableName,
-      final Class<T> jsonMappedClass,
+      final Class<T> variableValueType,
       final ThrowingConsumer<T> requirement,
       final Supplier<Map<String, String>> actualVariablesSupplier) {
 
@@ -230,7 +230,7 @@ public class VariableAssertj extends AbstractAssert<VariableAssertj, String> {
                 assertThat(variables).containsKey(variableName);
 
                 final T actualValue =
-                    AssertionJsonMapper.readJson(variables.get(variableName), jsonMappedClass);
+                    AssertionJsonMapper.readJson(variables.get(variableName), variableValueType);
 
                 try {
                   requirement.accept(actualValue);
@@ -262,7 +262,7 @@ public class VariableAssertj extends AbstractAssert<VariableAssertj, String> {
       final String failureMessage =
           String.format(
               "%s should have a variable '%s' of type '%s', but was: '%s'",
-              actual, variableName, jsonMappedClass.getName(), actualVariable);
+              actual, variableName, variableValueType.getName(), actualVariable);
 
       fail(failureMessage);
     }

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/util/AssertionJsonMapper.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/util/AssertionJsonMapper.java
@@ -40,7 +40,7 @@ public class AssertionJsonMapper {
     try {
       return JSON_MAPPER.readValue(value, clazz);
     } catch (final JsonProcessingException e) {
-      throw new RuntimeException(String.format("Failed to read JSON: '%s'", value), e);
+      throw new JsonMappingException(String.format("Failed to read JSON: '%s'", value), e);
     }
   }
 
@@ -48,8 +48,15 @@ public class AssertionJsonMapper {
     try {
       return JSON_MAPPER.convertValue(value, JsonNode.class);
     } catch (final IllegalArgumentException e) {
-      throw new RuntimeException(
+      throw new JsonMappingException(
           String.format("Failed to transform value to JSON: '%s'", value), e);
+    }
+  }
+
+  public static class JsonMappingException extends RuntimeException {
+
+    public JsonMappingException(final String message, final Throwable cause) {
+      super(message, cause);
     }
   }
 }

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/util/AssertionJsonMapper.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/util/AssertionJsonMapper.java
@@ -25,12 +25,20 @@ public class AssertionJsonMapper {
   private static final ObjectMapper JSON_MAPPER = new ObjectMapper();
 
   public static JsonNode readJson(final String value) {
+    return readJson(value, JsonNode.class, NullNode.getInstance());
+  }
+
+  public static <T> T readJson(final String value, final Class<T> clazz) {
+    return readJson(value, clazz, null);
+  }
+
+  public static <T> T readJson(final String value, final Class<T> clazz, final T defaultValue) {
     if (value == null) {
-      return NullNode.getInstance();
+      return defaultValue;
     }
 
     try {
-      return JSON_MAPPER.readValue(value, JsonNode.class);
+      return JSON_MAPPER.readValue(value, clazz);
     } catch (final JsonProcessingException e) {
       throw new RuntimeException(String.format("Failed to read JSON: '%s'", value), e);
     }

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/VariableAssertTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/VariableAssertTest.java
@@ -775,7 +775,7 @@ public class VariableAssertTest {
   }
 
   // Used to test assertVariableSatisfies JSON logic
-  public static class SimpleJsonObject {
+  private static final class SimpleJsonObject {
 
     @JsonProperty("string")
     private String strValue;
@@ -793,7 +793,7 @@ public class VariableAssertTest {
     private SimpleJsonNestedObject nestedObject;
   }
 
-  private static class SimpleJsonNestedObject {
+  private static final class SimpleJsonNestedObject {
 
     @JsonProperty private String key;
   }

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/VariableAssertTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/VariableAssertTest.java
@@ -105,6 +105,30 @@ public class VariableAssertTest {
         Arguments.of("{\"b\":2,\"a\":1}", CONTEXT_VARIABLE_VALUE));
   }
 
+  // Used to test assertVariableSatisfies JSON logic
+  private static final class SimpleJsonObject {
+
+    @JsonProperty("string")
+    private String strValue;
+
+    @JsonProperty("int")
+    private int intValue;
+
+    @JsonProperty("boolean")
+    private boolean boolValue;
+
+    @JsonProperty("list")
+    private List<Object> list;
+
+    @JsonProperty("object")
+    private SimpleJsonNestedObject nestedObject;
+  }
+
+  private static final class SimpleJsonNestedObject {
+
+    @JsonProperty private String key;
+  }
+
   @Nested
   class HasVariableNames {
 
@@ -692,7 +716,9 @@ public class VariableAssertTest {
                           COMPLEX_VARIABLE_KEY,
                           SimpleJsonObject.class,
                           result -> {
-                            Assertions.assertThat(result).isNull();
+                            Assertions.assertThat(result)
+                                .describedAs("Should be not null")
+                                .isNull();
                             Assertions.assertThat(result)
                                 .extracting("strValue", "intValue", "boolValue")
                                 .containsExactlyInAnyOrder("wrong", -1, false);
@@ -705,8 +731,8 @@ public class VariableAssertTest {
                                 .isEqualTo("wrong_value");
                           }))
           .hasMessageContainingAll(
-              "Multiple Failures (1 failure)",
-              "-- failure 1 --",
+              "Process instance [key: 1] should have a variable 'complex' but the following requirement was not satisfied:",
+              "[Should be not null]",
               "expected: null",
               "but was: io.camunda.process.test.api.VariableAssertTest$SimpleJsonObject");
     }
@@ -772,29 +798,5 @@ public class VariableAssertTest {
                           }))
           .hasMessage("java.lang.Exception: Error");
     }
-  }
-
-  // Used to test assertVariableSatisfies JSON logic
-  private static final class SimpleJsonObject {
-
-    @JsonProperty("string")
-    private String strValue;
-
-    @JsonProperty("int")
-    private int intValue;
-
-    @JsonProperty("boolean")
-    private boolean boolValue;
-
-    @JsonProperty("list")
-    private List<Object> list;
-
-    @JsonProperty("object")
-    private SimpleJsonNestedObject nestedObject;
-  }
-
-  private static final class SimpleJsonNestedObject {
-
-    @JsonProperty private String key;
   }
 }


### PR DESCRIPTION
## Description

Adds new assertions to assert that a process instance has a variable with a value that matches the given condition.

- New assertion: hasVariableSatisfies() with value matcher
- New assertion: hasLocalVariableSatisfies() with value matcher
- Transform the variable value (JSON) into the given class

closes https://github.com/camunda/camunda/issues/32663
