### PR TITLE
Process instance suspension instruction in the Java client

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/command/CreateProcessInstanceCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/CreateProcessInstanceCommandStep1.java
@@ -132,6 +132,17 @@ public interface CreateProcessInstanceCommandStep1
     CreateProcessInstanceCommandStep3 startBeforeElement(final String elementId);
 
     /**
+     * Adds a runtime instruction to suspend the process instance after the given element is
+     * completed or terminated.
+     *
+     * @param elementId the id of the BPMN element after which the process instance should be
+     *     suspended
+     * @return the builder for this command. Call {@link #send()} to complete the command and send
+     *     it to the broker
+     */
+    CreateProcessInstanceCommandStep3 suspendAfterElement(final String elementId);
+
+    /**
      * When this method is called, the response to the command will be received after the process is
      * completed. The response consists of a set of variables.
      *

--- a/clients/java/src/main/java/io/camunda/client/api/command/CreateProcessInstanceCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/CreateProcessInstanceCommandStep1.java
@@ -126,7 +126,7 @@ public interface CreateProcessInstanceCommandStep1
      * than once to simultaneously start at different elements in different branches of the process.
      *
      * @param elementId the id of the BPMN element where to start the process instance
-     * @return the builder for this command. Call {@link #send()} to complete the command and send *
+     * @return the builder for this command. Call {@link #send()} to complete the command and send
      *     it to the broker.
      */
     CreateProcessInstanceCommandStep3 startBeforeElement(final String elementId);

--- a/clients/java/src/main/java/io/camunda/client/api/command/CreateProcessInstanceCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/CreateProcessInstanceCommandStep1.java
@@ -133,7 +133,8 @@ public interface CreateProcessInstanceCommandStep1
 
     /**
      * Adds a runtime instruction to suspend the process instance after the given element is
-     * completed or terminated.
+     * completed or terminated. This method can be called more than once to add multiple runtime
+     * instructions.
      *
      * @param elementId the id of the BPMN element after which the process instance should be
      *     suspended

--- a/clients/java/src/main/java/io/camunda/client/impl/command/CreateProcessInstanceCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/CreateProcessInstanceCommandImpl.java
@@ -32,14 +32,14 @@ import io.camunda.client.impl.response.CreateProcessInstanceResponseImpl;
 import io.camunda.client.impl.util.ParseUtil;
 import io.camunda.client.protocol.rest.CreateProcessInstanceResult;
 import io.camunda.client.protocol.rest.ProcessInstanceCreationInstruction;
+import io.camunda.client.protocol.rest.ProcessInstanceCreationSuspendInstruction;
 import io.camunda.zeebe.gateway.protocol.GatewayGrpc.GatewayStub;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.CreateProcessInstanceRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.CreateProcessInstanceRequest.Builder;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.CreateProcessInstanceResponse;
-import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ProcessInstanceCreationRuntimeInstruction;
-import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ProcessInstanceCreationRuntimeInstruction.RuntimeInstructionType;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ProcessInstanceCreationStartInstruction;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.SuspendProcessInstanceInstruction;
 import io.grpc.stub.StreamObserver;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
@@ -137,13 +137,13 @@ public final class CreateProcessInstanceCommandImpl
   @Override
   public CreateProcessInstanceCommandStep3 suspendAfterElement(final String elementId) {
     grpcRequestObjectBuilder.addRuntimeInstructions(
-        ProcessInstanceCreationRuntimeInstruction.newBuilder()
-            .setType(RuntimeInstructionType.SUSPEND_PROCESS_INSTANCE)
-            .setAfterElementId(elementId)
-            .build());
+        GatewayOuterClass.ProcessInstanceCreationRuntimeInstruction.newBuilder()
+            .setSuspend(
+                SuspendProcessInstanceInstruction.newBuilder()
+                    .setAfterElementId(elementId)
+                    .build()));
     httpRequestObject.addRuntimeInstructionsItem(
-        new io.camunda.client.protocol.rest.ProcessInstanceCreationSuspendInstruction()
-            .afterElementId(elementId));
+        new ProcessInstanceCreationSuspendInstruction().afterElementId(elementId));
     return this;
   }
 

--- a/clients/java/src/main/java/io/camunda/client/impl/command/CreateProcessInstanceCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/CreateProcessInstanceCommandImpl.java
@@ -37,6 +37,8 @@ import io.camunda.zeebe.gateway.protocol.GatewayOuterClass;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.CreateProcessInstanceRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.CreateProcessInstanceRequest.Builder;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.CreateProcessInstanceResponse;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ProcessInstanceCreationRuntimeInstruction;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ProcessInstanceCreationRuntimeInstruction.RuntimeInstructionType;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ProcessInstanceCreationStartInstruction;
 import io.grpc.stub.StreamObserver;
 import java.time.Duration;
@@ -129,6 +131,19 @@ public final class CreateProcessInstanceCommandImpl
     httpRequestObject.addStartInstructionsItem(
         new io.camunda.client.protocol.rest.ProcessInstanceCreationStartInstruction()
             .elementId(elementId));
+    return this;
+  }
+
+  @Override
+  public CreateProcessInstanceCommandStep3 suspendAfterElement(final String elementId) {
+    grpcRequestObjectBuilder.addRuntimeInstructions(
+        ProcessInstanceCreationRuntimeInstruction.newBuilder()
+            .setType(RuntimeInstructionType.SUSPEND_PROCESS_INSTANCE)
+            .setAfterElementId(elementId)
+            .build());
+    httpRequestObject.addRuntimeInstructionsItem(
+        new io.camunda.client.protocol.rest.ProcessInstanceCreationSuspendInstruction()
+            .afterElementId(elementId));
     return this;
   }
 

--- a/clients/java/src/main/java/io/camunda/client/impl/command/CreateProcessInstanceCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/CreateProcessInstanceCommandImpl.java
@@ -139,9 +139,7 @@ public final class CreateProcessInstanceCommandImpl
     grpcRequestObjectBuilder.addRuntimeInstructions(
         GatewayOuterClass.ProcessInstanceCreationRuntimeInstruction.newBuilder()
             .setSuspend(
-                SuspendProcessInstanceInstruction.newBuilder()
-                    .setAfterElementId(elementId)
-                    .build()));
+                SuspendProcessInstanceInstruction.newBuilder().setAfterElementId(elementId)));
     httpRequestObject.addRuntimeInstructionsItem(
         new ProcessInstanceCreationSuspendInstruction().afterElementId(elementId));
     return this;

--- a/clients/java/src/test/java/io/camunda/client/process/CreateProcessInstanceTest.java
+++ b/clients/java/src/test/java/io/camunda/client/process/CreateProcessInstanceTest.java
@@ -26,7 +26,6 @@ import io.camunda.client.api.response.ProcessInstanceEvent;
 import io.camunda.client.util.ClientTest;
 import io.camunda.client.util.JsonUtil;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.CreateProcessInstanceRequest;
-import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ProcessInstanceCreationRuntimeInstruction.RuntimeInstructionType;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ProcessInstanceCreationStartInstruction;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
@@ -330,8 +329,10 @@ public final class CreateProcessInstanceTest extends ClientTest {
         .hasSize(1)
         .allSatisfy(
             instruction ->
-                assertThat(instruction.getType())
-                    .isEqualTo(RuntimeInstructionType.SUSPEND_PROCESS_INSTANCE));
+                assertThat(instruction.getSuspend())
+                    .satisfies(
+                        suspend ->
+                            assertThat(suspend.getAfterElementId()).isEqualTo("elementId_A")));
   }
 
   @Test
@@ -351,8 +352,11 @@ public final class CreateProcessInstanceTest extends ClientTest {
         .hasSize(2)
         .allSatisfy(
             instruction ->
-                assertThat(instruction.getType())
-                    .isEqualTo(RuntimeInstructionType.SUSPEND_PROCESS_INSTANCE));
+                assertThat(instruction.getSuspend())
+                    .satisfies(
+                        suspend ->
+                            assertThat(suspend.getAfterElementId())
+                                .isIn("elementId_A", "elementId_B")));
   }
 
   public static class VariableDocument {

--- a/service/src/main/java/io/camunda/service/ProcessInstanceServices.java
+++ b/service/src/main/java/io/camunda/service/ProcessInstanceServices.java
@@ -205,7 +205,7 @@ public final class ProcessInstanceServices
             .setTenantId(request.tenantId())
             .setVariables(getDocumentOrEmpty(request.variables()))
             .setStartInstructionsFromRecord(request.startInstructions())
-            .setRuntimeInstructions(request.runtimeInstructions());
+            .setRuntimeInstructionsFromRecord(request.runtimeInstructions());
 
     if (request.operationReference() != null) {
       brokerRequest.setOperationReference(request.operationReference());

--- a/zeebe/gateway-protocol/src/main/proto/gateway.proto
+++ b/zeebe/gateway-protocol/src/main/proto/gateway.proto
@@ -263,14 +263,13 @@ message ProcessInstanceCreationStartInstruction {
 }
 
 message ProcessInstanceCreationRuntimeInstruction {
-  enum RuntimeInstructionType {
-    SUSPEND_PROCESS_INSTANCE = 0;
+  oneof instruction {
+    SuspendProcessInstanceInstruction suspend = 1;
   }
+}
 
-  // discriminator
-  RuntimeInstructionType type = 1;
-  // necessary for SUSPEND_PROCESS_INSTANCE instruction
-  optional string afterElementId = 2;
+message SuspendProcessInstanceInstruction {
+  string afterElementId = 1;
 }
 
 message CreateProcessInstanceResponse {

--- a/zeebe/gateway-protocol/src/main/proto/gateway.proto
+++ b/zeebe/gateway-protocol/src/main/proto/gateway.proto
@@ -239,11 +239,14 @@ message CreateProcessInstanceRequest {
   // will start at the start event. If non-empty the process instance will apply start
   // instructions after it has been created
   repeated ProcessInstanceCreationStartInstruction startInstructions = 5;
+
   // the tenant id of the process definition
   string tenantId = 6;
 
   // a reference key chosen by the user and will be part of all records resulted from this operation
   optional uint64 operationReference = 7;
+
+  repeated ProcessInstanceCreationRuntimeInstruction runtimeInstructions = 8;
 }
 
 message ProcessInstanceCreationStartInstruction {
@@ -257,6 +260,17 @@ message ProcessInstanceCreationStartInstruction {
 
   // element ID
   string elementId = 1;
+}
+
+message ProcessInstanceCreationRuntimeInstruction {
+  enum RuntimeInstructionType {
+    SUSPEND_PROCESS_INSTANCE = 0;
+  }
+
+  // discriminator
+  RuntimeInstructionType type = 1;
+  // necessary for SUSPEND_PROCESS_INSTANCE instruction
+  optional string afterElementId = 2;
 }
 
 message CreateProcessInstanceResponse {

--- a/zeebe/gateway-protocol/src/main/proto/gateway.proto
+++ b/zeebe/gateway-protocol/src/main/proto/gateway.proto
@@ -246,6 +246,9 @@ message CreateProcessInstanceRequest {
   // a reference key chosen by the user and will be part of all records resulted from this operation
   optional uint64 operationReference = 7;
 
+  // a list of runtime instruction that can modify the behavior of the process
+  // instance during its execution
+  // if empty (default), the process instance will be executed normally
   repeated ProcessInstanceCreationRuntimeInstruction runtimeInstructions = 8;
 }
 
@@ -269,6 +272,8 @@ message ProcessInstanceCreationRuntimeInstruction {
 }
 
 message SuspendProcessInstanceInstruction {
+  // the ID of the process element after which the process instance should be
+  // suspended
   string afterElementId = 1;
 }
 

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerCreateProcessInstanceRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerCreateProcessInstanceRequest.java
@@ -75,14 +75,15 @@ public class BrokerCreateProcessInstanceRequest
     runtimeInstructions.stream()
         .map(
             instruction ->
-                switch (instruction.getType()) {
-                  case SUSPEND_PROCESS_INSTANCE ->
+                switch (instruction.getInstructionCase()) {
+                  case SUSPEND ->
                       new ProcessInstanceCreationRuntimeInstruction()
                           .setType(RuntimeInstructionType.SUSPEND_PROCESS_INSTANCE)
-                          .setAfterElementId(instruction.getAfterElementId());
-                  case UNRECOGNIZED ->
+                          .setAfterElementId(instruction.getSuspend().getAfterElementId());
+                  case INSTRUCTION_NOT_SET ->
                       throw new IllegalArgumentException(
-                          "Unsupported runtime instruction type: " + instruction.getType().name());
+                          "Unsupported runtime instruction type: "
+                              + instruction.getInstructionCase().name());
                 })
         .forEach(requestDto::addRuntimeInstruction);
     return this;

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerCreateProcessInstanceRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerCreateProcessInstanceRequest.java
@@ -8,9 +8,11 @@
 package io.camunda.zeebe.gateway.impl.broker.request;
 
 import io.camunda.zeebe.broker.client.api.dto.BrokerExecuteCommand;
-import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ProcessInstanceCreationStartInstruction;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceCreationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceCreationRuntimeInstruction;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceCreationStartInstruction;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.RuntimeInstructionType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
 import java.util.List;
@@ -51,12 +53,11 @@ public class BrokerCreateProcessInstanceRequest
   }
 
   public BrokerCreateProcessInstanceRequest setStartInstructions(
-      final List<ProcessInstanceCreationStartInstruction> startInstructionsList) {
+      final List<GatewayOuterClass.ProcessInstanceCreationStartInstruction> startInstructionsList) {
     startInstructionsList.stream()
         .map(
             startInstructionReq ->
-                new io.camunda.zeebe.protocol.impl.record.value.processinstance
-                        .ProcessInstanceCreationStartInstruction()
+                new ProcessInstanceCreationStartInstruction()
                     .setElementId(startInstructionReq.getElementId()))
         .forEach(requestDto::addStartInstruction);
 
@@ -64,15 +65,30 @@ public class BrokerCreateProcessInstanceRequest
   }
 
   public BrokerCreateProcessInstanceRequest setStartInstructionsFromRecord(
-      final List<
-              io.camunda.zeebe.protocol.impl.record.value.processinstance
-                  .ProcessInstanceCreationStartInstruction>
-          instructions) {
+      final List<ProcessInstanceCreationStartInstruction> instructions) {
     requestDto.addStartInstructions(instructions);
     return this;
   }
 
   public BrokerCreateProcessInstanceRequest setRuntimeInstructions(
+      final List<GatewayOuterClass.ProcessInstanceCreationRuntimeInstruction> runtimeInstructions) {
+    runtimeInstructions.stream()
+        .map(
+            instruction ->
+                switch (instruction.getType()) {
+                  case SUSPEND_PROCESS_INSTANCE ->
+                      new ProcessInstanceCreationRuntimeInstruction()
+                          .setType(RuntimeInstructionType.SUSPEND_PROCESS_INSTANCE)
+                          .setAfterElementId(instruction.getAfterElementId());
+                  case UNRECOGNIZED ->
+                      throw new IllegalArgumentException(
+                          "Unsupported runtime instruction type: " + instruction.getType().name());
+                })
+        .forEach(requestDto::addRuntimeInstruction);
+    return this;
+  }
+
+  public BrokerCreateProcessInstanceRequest setRuntimeInstructionsFromRecord(
       final List<ProcessInstanceCreationRuntimeInstruction> runtimeInstructions) {
     requestDto.addRuntimeInstructions(runtimeInstructions);
     return this;


### PR DESCRIPTION
## Description

This PR contains the Java client changes that allow users to add process instance suspension instructions when creating an instance.

Additionally, gRPC API is extended to support runtime instructions.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #35108
closes #34632 
