### PR TITLE
feat: provide a clearer set of assertion names and deprecate the old ones

### DIFF
--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/CamundaAssert.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/CamundaAssert.java
@@ -105,8 +105,6 @@ public class CamundaAssert {
     Awaitility.setDefaultPollInterval(assertionInterval);
   }
 
-  // ======== Assertions ========
-
   /**
    * Configures the element selector used for BPMN element assertions with a string identifier.
    *
@@ -116,6 +114,8 @@ public class CamundaAssert {
   public static void setElementSelector(final Function<String, ElementSelector> elementSelector) {
     CamundaAssert.elementSelector = elementSelector;
   }
+
+  // ======== Assertions ========
 
   /**
    * To verify a process instance.
@@ -140,6 +140,25 @@ public class CamundaAssert {
   /**
    * To verify a process instance.
    *
+   * @param processInstanceEvent the event of the process instance to verify
+   * @return the assertion object
+   */
+  public static ProcessInstanceAssert assertThat(final ProcessInstanceEvent processInstanceEvent) {
+    return assertThatProcessInstance(processInstanceEvent);
+  }
+
+  /**
+   * @deprecated, for removal, use {@link #assertThatProcessInstance(ProcessInstanceEvent)} instead
+   */
+  @Deprecated
+  public static ProcessInstanceAssert assertThat(
+      final io.camunda.zeebe.client.api.response.ProcessInstanceEvent processInstanceEvent) {
+    return assertThatProcessInstance(processInstanceEvent);
+  }
+
+  /**
+   * To verify a process instance.
+   *
    * @param processInstanceResult the result of the process instance to verify
    * @return the assertion object
    */
@@ -155,75 +174,6 @@ public class CamundaAssert {
   public static ProcessInstanceAssert assertThatProcessInstance(
       final io.camunda.zeebe.client.api.response.ProcessInstanceResult processInstanceResult) {
     return createProcessInstanceAssertj(processInstanceResult.getProcessInstanceKey());
-  }
-
-  private static ProcessInstanceAssertj createProcessInstanceAssertj(
-      final long processInstanceKey) {
-    return new ProcessInstanceAssertj(getDataSource(), processInstanceKey, elementSelector);
-  }
-
-  /**
-   * To verify a process instance.
-   *
-   * @param processInstanceSelector the selector of the process instance to verify
-   * @return the assertion object
-   * @see io.camunda.process.test.api.assertions.ProcessInstanceSelectors
-   */
-  public static ProcessInstanceAssert assertThatProcessInstance(
-      final ProcessInstanceSelector processInstanceSelector) {
-    return new ProcessInstanceAssertj(getDataSource(), processInstanceSelector, elementSelector);
-  }
-
-  /**
-   * To verify a user task.
-   *
-   * @param userTaskSelector the selector of the user task to verify
-   * @return the assertion object
-   * @see io.camunda.process.test.api.assertions.UserTaskSelectors
-   */
-  public static UserTaskAssert assertThatUserTask(final UserTaskSelector userTaskSelector) {
-    return new UserTaskAssertj(getDataSource(), userTaskSelector);
-  }
-
-  /**
-   * To verify a decision instance (via business rule task).
-   *
-   * @param decisionSelector the selector of the decision instance to verify
-   * @return the assertion object
-   * @see io.camunda.process.test.api.assertions.DecisionSelectors
-   */
-  public static DecisionInstanceAssert assertThatDecision(final DecisionSelector decisionSelector) {
-    return new DecisionInstanceAssertj(getDataSource(), decisionSelector);
-  }
-
-  /**
-   * To verify an evaluated decision response (via API).
-   *
-   * @param response the evaluated decision response to assert
-   * @return the assertion object
-   */
-  public static DecisionInstanceAssertj assertThatDecision(
-      final EvaluateDecisionResponse response) {
-    return new DecisionInstanceAssertj(getDataSource(), DecisionSelectors.byResponse(response));
-  }
-
-  /**
-   * To verify a process instance.
-   *
-   * @param processInstanceEvent the event of the process instance to verify
-   * @return the assertion object
-   */
-  public static ProcessInstanceAssert assertThat(final ProcessInstanceEvent processInstanceEvent) {
-    return assertThatProcessInstance(processInstanceEvent);
-  }
-
-  /**
-   * @deprecated, for removal, use {@link #assertThatProcessInstance(ProcessInstanceEvent)} instead
-   */
-  @Deprecated
-  public static ProcessInstanceAssert assertThat(
-      final io.camunda.zeebe.client.api.response.ProcessInstanceEvent processInstanceEvent) {
-    return assertThatProcessInstance(processInstanceEvent);
   }
 
   /**
@@ -253,9 +203,37 @@ public class CamundaAssert {
    * @return the assertion object
    * @see io.camunda.process.test.api.assertions.ProcessInstanceSelectors
    */
+  public static ProcessInstanceAssert assertThatProcessInstance(
+      final ProcessInstanceSelector processInstanceSelector) {
+    return new ProcessInstanceAssertj(getDataSource(), processInstanceSelector, elementSelector);
+  }
+
+  /**
+   * To verify a process instance.
+   *
+   * @param processInstanceSelector the selector of the process instance to verify
+   * @return the assertion object
+   * @see io.camunda.process.test.api.assertions.ProcessInstanceSelectors
+   */
   public static ProcessInstanceAssert assertThat(
       final ProcessInstanceSelector processInstanceSelector) {
     return assertThatProcessInstance(processInstanceSelector);
+  }
+
+  private static ProcessInstanceAssertj createProcessInstanceAssertj(
+      final long processInstanceKey) {
+    return new ProcessInstanceAssertj(getDataSource(), processInstanceKey, elementSelector);
+  }
+
+  /**
+   * To verify a user task.
+   *
+   * @param userTaskSelector the selector of the user task to verify
+   * @return the assertion object
+   * @see io.camunda.process.test.api.assertions.UserTaskSelectors
+   */
+  public static UserTaskAssert assertThatUserTask(final UserTaskSelector userTaskSelector) {
+    return new UserTaskAssertj(getDataSource(), userTaskSelector);
   }
 
   /**
@@ -276,8 +254,30 @@ public class CamundaAssert {
    * @return the assertion object
    * @see io.camunda.process.test.api.assertions.DecisionSelectors
    */
+  public static DecisionInstanceAssert assertThatDecision(final DecisionSelector decisionSelector) {
+    return new DecisionInstanceAssertj(getDataSource(), decisionSelector);
+  }
+
+  /**
+   * To verify a decision instance (via business rule task).
+   *
+   * @param decisionSelector the selector of the decision instance to verify
+   * @return the assertion object
+   * @see io.camunda.process.test.api.assertions.DecisionSelectors
+   */
   public static DecisionInstanceAssert assertThat(final DecisionSelector decisionSelector) {
     return assertThatDecision(decisionSelector);
+  }
+
+  /**
+   * To verify an evaluated decision response (via API).
+   *
+   * @param response the evaluated decision response to assert
+   * @return the assertion object
+   */
+  public static DecisionInstanceAssertj assertThatDecision(
+      final EvaluateDecisionResponse response) {
+    return new DecisionInstanceAssertj(getDataSource(), DecisionSelectors.byResponse(response));
   }
 
   /**

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/CamundaAssert.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/CamundaAssert.java
@@ -123,15 +123,16 @@ public class CamundaAssert {
    * @param processInstanceEvent the event of the process instance to verify
    * @return the assertion object
    */
-  public static ProcessInstanceAssert assertThat(final ProcessInstanceEvent processInstanceEvent) {
+  public static ProcessInstanceAssert assertThatProcessInstance(
+      final ProcessInstanceEvent processInstanceEvent) {
     return createProcessInstanceAssertj(processInstanceEvent.getProcessInstanceKey());
   }
 
   /**
-   * @deprecated, for removal, use {@link #assertThat(ProcessInstanceEvent)} instead
+   * @deprecated, for removal, use {@link #assertThatProcessInstance(ProcessInstanceEvent)} instead
    */
   @Deprecated
-  public static ProcessInstanceAssert assertThat(
+  public static ProcessInstanceAssert assertThatProcessInstance(
       final io.camunda.zeebe.client.api.response.ProcessInstanceEvent processInstanceEvent) {
     return createProcessInstanceAssertj(processInstanceEvent.getProcessInstanceKey());
   }
@@ -142,16 +143,16 @@ public class CamundaAssert {
    * @param processInstanceResult the result of the process instance to verify
    * @return the assertion object
    */
-  public static ProcessInstanceAssert assertThat(
+  public static ProcessInstanceAssert assertThatProcessInstance(
       final ProcessInstanceResult processInstanceResult) {
     return createProcessInstanceAssertj(processInstanceResult.getProcessInstanceKey());
   }
 
   /**
-   * @deprecated, for removal, use {@link #assertThat(ProcessInstanceResult)} instead
+   * @deprecated, for removal, use {@link #assertThatProcessInstance(ProcessInstanceResult)} instead
    */
   @Deprecated
-  public static ProcessInstanceAssert assertThat(
+  public static ProcessInstanceAssert assertThatProcessInstance(
       final io.camunda.zeebe.client.api.response.ProcessInstanceResult processInstanceResult) {
     return createProcessInstanceAssertj(processInstanceResult.getProcessInstanceKey());
   }
@@ -168,7 +169,7 @@ public class CamundaAssert {
    * @return the assertion object
    * @see io.camunda.process.test.api.assertions.ProcessInstanceSelectors
    */
-  public static ProcessInstanceAssert assertThat(
+  public static ProcessInstanceAssert assertThatProcessInstance(
       final ProcessInstanceSelector processInstanceSelector) {
     return new ProcessInstanceAssertj(getDataSource(), processInstanceSelector, elementSelector);
   }
@@ -180,7 +181,7 @@ public class CamundaAssert {
    * @return the assertion object
    * @see io.camunda.process.test.api.assertions.UserTaskSelectors
    */
-  public static UserTaskAssert assertThat(final UserTaskSelector userTaskSelector) {
+  public static UserTaskAssert assertThatUserTask(final UserTaskSelector userTaskSelector) {
     return new UserTaskAssertj(getDataSource(), userTaskSelector);
   }
 
@@ -191,7 +192,7 @@ public class CamundaAssert {
    * @return the assertion object
    * @see io.camunda.process.test.api.assertions.DecisionSelectors
    */
-  public static DecisionInstanceAssert assertThat(final DecisionSelector decisionSelector) {
+  public static DecisionInstanceAssert assertThatDecision(final DecisionSelector decisionSelector) {
     return new DecisionInstanceAssertj(getDataSource(), decisionSelector);
   }
 
@@ -201,8 +202,92 @@ public class CamundaAssert {
    * @param response the evaluated decision response to assert
    * @return the assertion object
    */
-  public static DecisionInstanceAssertj assertThat(final EvaluateDecisionResponse response) {
+  public static DecisionInstanceAssertj assertThatDecision(
+      final EvaluateDecisionResponse response) {
     return new DecisionInstanceAssertj(getDataSource(), DecisionSelectors.byResponse(response));
+  }
+
+  /**
+   * To verify a process instance.
+   *
+   * @param processInstanceEvent the event of the process instance to verify
+   * @return the assertion object
+   */
+  public static ProcessInstanceAssert assertThat(final ProcessInstanceEvent processInstanceEvent) {
+    return assertThatProcessInstance(processInstanceEvent);
+  }
+
+  /**
+   * @deprecated, for removal, use {@link #assertThatProcessInstance(ProcessInstanceEvent)} instead
+   */
+  @Deprecated
+  public static ProcessInstanceAssert assertThat(
+      final io.camunda.zeebe.client.api.response.ProcessInstanceEvent processInstanceEvent) {
+    return assertThatProcessInstance(processInstanceEvent);
+  }
+
+  /**
+   * To verify a process instance.
+   *
+   * @param processInstanceResult the result of the process instance to verify
+   * @return the assertion object
+   */
+  public static ProcessInstanceAssert assertThat(
+      final ProcessInstanceResult processInstanceResult) {
+    return assertThatProcessInstance(processInstanceResult);
+  }
+
+  /**
+   * @deprecated, for removal, use {@link #assertThat(ProcessInstanceEvent)} instead
+   */
+  @Deprecated
+  public static ProcessInstanceAssert assertThat(
+      final io.camunda.zeebe.client.api.response.ProcessInstanceResult processInstanceResult) {
+    return assertThatProcessInstance(processInstanceResult);
+  }
+
+  /**
+   * To verify a process instance.
+   *
+   * @param processInstanceSelector the selector of the process instance to verify
+   * @return the assertion object
+   * @see io.camunda.process.test.api.assertions.ProcessInstanceSelectors
+   */
+  public static ProcessInstanceAssert assertThat(
+      final ProcessInstanceSelector processInstanceSelector) {
+    return assertThatProcessInstance(processInstanceSelector);
+  }
+
+  /**
+   * To verify a user task.
+   *
+   * @param userTaskSelector the selector of the user task to verify
+   * @return the assertion object
+   * @see io.camunda.process.test.api.assertions.UserTaskSelectors
+   */
+  public static UserTaskAssert assertThat(final UserTaskSelector userTaskSelector) {
+    return assertThatUserTask(userTaskSelector);
+  }
+
+  /**
+   * To verify a decision instance (via business rule task).
+   *
+   * @param decisionSelector the selector of the decision instance to verify
+   * @return the assertion object
+   * @see io.camunda.process.test.api.assertions.DecisionSelectors
+   */
+  public static DecisionInstanceAssert assertThat(final DecisionSelector decisionSelector) {
+    return assertThatDecision(decisionSelector);
+  }
+
+  /**
+   * To verify an evaluated decision response (via API).
+   *
+   * @param response the evaluated decision response to assert
+   * @return the assertion object
+   */
+  public static DecisionInstanceAssertj assertThat(final EvaluateDecisionResponse response) {
+    return assertThatDecision(response);
   }
 
   // ======== Internal ========


### PR DESCRIPTION
## Description

Added separate `CamundaAssert.assertThatX` methods to help distinguish assertion contexts.

```$java
// with separate assertThat methods
assertThatProcessInstance(byKey(processInstanceKey)).isCompleted();
assertThatUserTask(byTaskName("User Task")).isCompleted();
assertThatDecision(byName("Language Happiness")).hasOutput(90);
```
closes #32739 