### PR TITLE
ci: Update camunda-platform-release.yml

### DIFF
--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -759,7 +759,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": ":success: *Release job for ${{ inputs.releaseVersion }}* **succeeded!**\n"
+                    "text": ":success: *Release job for ${{ inputs.releaseVersion }}* **succeeded!** (excluding Maven Central publishing - this is done separately)\n"
                   }
                 }
               ]


### PR DESCRIPTION
Specify deployment does not include Maven Central deployment

Otherwise the notification is confusing (we can assume Maven Central deployment is done - but it's not the case: it's a manual approval process, that also takes time)

## Description

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
