### PR TITLE
[Backport stable/8.5] fix: use correct url template for cloud rest address

### DIFF
--- a/zeebe/clients/java/revapi.json
+++ b/zeebe/clients/java/revapi.json
@@ -34,6 +34,13 @@
           "code": "java.annotation.removed",
           "annotationType": "io.camunda.zeebe.client.api.ExperimentalApi",
           "justification": "The ExperimentalApi annotation is used to mark methods as 'in-development'. It is okay to remove it after a feature is implemented"
+        },
+        {
+          "ignore": true,
+          "code": "java.method.returnTypeChanged",
+          "old": "method io.camunda.zeebe.client.ZeebeClientCloudBuilderStep1.ZeebeClientCloudBuilderStep2.ZeebeClientCloudBuilderStep3.ZeebeClientCloudBuilderStep4 io.camunda.zeebe.client.ZeebeClientCloudBuilderStep1.ZeebeClientCloudBuilderStep2.ZeebeClientCloudBuilderStep3.ZeebeClientCloudBuilderStep4::withRegion(java.lang.String)",
+          "new": "method io.camunda.zeebe.client.ZeebeClientCloudBuilderStep1.ZeebeClientCloudBuilderStep2.ZeebeClientCloudBuilderStep3.ZeebeClientCloudBuilderStep4.ZeebeClientCloudBuilderStep5 io.camunda.zeebe.client.ZeebeClientCloudBuilderStep1.ZeebeClientCloudBuilderStep2.ZeebeClientCloudBuilderStep3.ZeebeClientCloudBuilderStep4::withRegion(java.lang.String)",
+          "justification": "Added new layer to configure domain"
         }
       ]
     }

--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClientCloudBuilderStep1.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClientCloudBuilderStep1.java
@@ -51,7 +51,18 @@ public interface ZeebeClientCloudBuilderStep1 {
          *
          * @param region region of the Camunda Cloud cluster
          */
-        ZeebeClientCloudBuilderStep4 withRegion(String region);
+        ZeebeClientCloudBuilderStep5 withRegion(String region);
+
+        interface ZeebeClientCloudBuilderStep5 extends ZeebeClientBuilder {
+
+          /**
+           * Sets the domain of the Camunda Cloud stage. Default is 'camunda.io', the production
+           * stage.
+           *
+           * @param domain domain of the Camunda Cloud stage
+           */
+          ZeebeClientCloudBuilderStep5 withDomain(String domain);
+        }
       }
     }
   }

--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientCloudBuilderImpl.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientCloudBuilderImpl.java
@@ -282,7 +282,7 @@ public class ZeebeClientCloudBuilderImpl
     if (isNeedToSetCloudRestAddress()) {
       ensureNotNull("cluster id", clusterId);
       final String cloudRestAddress =
-          String.format("https://%s.zeebe.%s:443/%s", region, BASE_ADDRESS, clusterId);
+          String.format("https://%s.%s:443/%s", region, BASE_ADDRESS, clusterId);
       return getURIFromString(cloudRestAddress);
     } else {
       Loggers.LOGGER.debug(

--- a/zeebe/clients/java/src/test/java/io/camunda/zeebe/client/ZeebeClientTest.java
+++ b/zeebe/clients/java/src/test/java/io/camunda/zeebe/client/ZeebeClientTest.java
@@ -420,6 +420,11 @@ public final class ZeebeClientTest extends ClientTest {
           .hasHost(String.format("%s.%s.zeebe.camunda.io", clusterId, region))
           .hasPort(443)
           .hasScheme("https");
+      assertThat(clientConfiguration.getRestAddress())
+          .hasHost(String.format("%s.zeebe.camunda.io", region))
+          .hasPort(443)
+          .hasPath("/" + clusterId)
+          .hasScheme("https");
     }
   }
 
@@ -442,6 +447,11 @@ public final class ZeebeClientTest extends ClientTest {
           .hasHost(String.format("%s.bru-2.zeebe.camunda.io", clusterId))
           .hasPort(443)
           .hasScheme("https");
+      assertThat(clientConfiguration.getRestAddress())
+          .hasHost("bru-2.zeebe.camunda.io")
+          .hasPort(443)
+          .hasPath("/" + clusterId)
+          .hasScheme("https");
     }
   }
 
@@ -449,6 +459,7 @@ public final class ZeebeClientTest extends ClientTest {
   public void shouldOverrideCloudProperties() {
     // given
     final String gatewayAddress = "localhost:10000";
+    final URI restAddress = URI.create("https://localhost:10001");
     final NoopCredentialsProvider credentialsProvider = new NoopCredentialsProvider();
     try (final ZeebeClient client =
         ZeebeClient.newCloudClientBuilder()
@@ -456,10 +467,12 @@ public final class ZeebeClientTest extends ClientTest {
             .withClientId("clientId")
             .withClientSecret("clientSecret")
             .gatewayAddress(gatewayAddress)
+            .restAddress(restAddress)
             .credentialsProvider(credentialsProvider)
             .build()) {
       final ZeebeClientConfiguration configuration = client.getConfiguration();
       assertThat(configuration.getGatewayAddress()).isEqualTo(gatewayAddress);
+      assertThat(configuration.getRestAddress()).isEqualTo(restAddress);
       assertThat(configuration.getCredentialsProvider()).isEqualTo(credentialsProvider);
     }
   }
@@ -486,6 +499,11 @@ public final class ZeebeClientTest extends ClientTest {
           .hasHost(String.format("clusterId.%s.zeebe.camunda.io", region))
           .hasPort(443)
           .hasScheme("https");
+      assertThat(clientConfiguration.getRestAddress())
+          .hasHost(String.format("%s.zeebe.camunda.io", region))
+          .hasPort(443)
+          .hasPath("/clusterId")
+          .hasScheme("https");
     }
   }
 
@@ -507,6 +525,11 @@ public final class ZeebeClientTest extends ClientTest {
       assertThat(clientConfiguration.getGrpcAddress())
           .hasHost(String.format("clusterId.%s.zeebe.camunda.io", defaultRegion))
           .hasPort(443)
+          .hasScheme("https");
+      assertThat(clientConfiguration.getRestAddress())
+          .hasHost(String.format("%s.zeebe.camunda.io", defaultRegion))
+          .hasPort(443)
+          .hasPath("/clusterId")
           .hasScheme("https");
     }
   }

--- a/zeebe/clients/java/src/test/java/io/camunda/zeebe/client/ZeebeClientTest.java
+++ b/zeebe/clients/java/src/test/java/io/camunda/zeebe/client/ZeebeClientTest.java
@@ -403,6 +403,7 @@ public final class ZeebeClientTest extends ClientTest {
     // given
     final String clusterId = "clusterId";
     final String region = "asdf-123";
+    final String domain = "dev.ultrawombat.com";
 
     try (final ZeebeClient client =
         ZeebeClient.newCloudClientBuilder()
@@ -410,6 +411,7 @@ public final class ZeebeClientTest extends ClientTest {
             .withClientId("clientId")
             .withClientSecret("clientSecret")
             .withRegion(region)
+            .withDomain(domain)
             .build()) {
       // when
       final ZeebeClientConfiguration clientConfiguration = client.getConfiguration();
@@ -417,11 +419,11 @@ public final class ZeebeClientTest extends ClientTest {
       assertThat(clientConfiguration.getCredentialsProvider())
           .isInstanceOf(OAuthCredentialsProvider.class);
       assertThat(clientConfiguration.getGrpcAddress())
-          .hasHost(String.format("%s.%s.zeebe.camunda.io", clusterId, region))
+          .hasHost(String.format("%s.%s.zeebe.%s", clusterId, region, domain))
           .hasPort(443)
           .hasScheme("https");
       assertThat(clientConfiguration.getRestAddress())
-          .hasHost(String.format("%s.zeebe.camunda.io", region))
+          .hasHost(String.format("%s.zeebe.%s", region, domain))
           .hasPort(443)
           .hasPath("/" + clusterId)
           .hasScheme("https");
@@ -429,7 +431,7 @@ public final class ZeebeClientTest extends ClientTest {
   }
 
   @Test
-  public void shouldCloudBuilderBuildProperClientWithDefaultRegion() {
+  public void shouldCloudBuilderBuildProperClientWithDefaultRegionAndDomain() {
     // given
     final String clusterId = "clusterId";
     try (final ZeebeClient client =


### PR DESCRIPTION
# Description
Backport of #35093 to `stable/8.5`.

relates to #35044 #32759