### PR TITLE
[Backport stable/8.6] fix: use correct url template for cloud rest address

### DIFF
--- a/clients/java/revapi.json
+++ b/clients/java/revapi.json
@@ -66,6 +66,13 @@
           "code": "java.class.removed",
           "old": "class io.camunda.zeebe.client.protocol.rest.UserTaskUpdateRequestChangeset",
           "justification": "The classes/methods are only internal and are not user-facing, and as such does not need to maintain any backwards compatibility guarantees."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.returnTypeChanged",
+          "old": "method io.camunda.zeebe.client.ZeebeClientCloudBuilderStep1.ZeebeClientCloudBuilderStep2.ZeebeClientCloudBuilderStep3.ZeebeClientCloudBuilderStep4 io.camunda.zeebe.client.ZeebeClientCloudBuilderStep1.ZeebeClientCloudBuilderStep2.ZeebeClientCloudBuilderStep3.ZeebeClientCloudBuilderStep4::withRegion(java.lang.String)",
+          "new": "method io.camunda.zeebe.client.ZeebeClientCloudBuilderStep1.ZeebeClientCloudBuilderStep2.ZeebeClientCloudBuilderStep3.ZeebeClientCloudBuilderStep4.ZeebeClientCloudBuilderStep5 io.camunda.zeebe.client.ZeebeClientCloudBuilderStep1.ZeebeClientCloudBuilderStep2.ZeebeClientCloudBuilderStep3.ZeebeClientCloudBuilderStep4::withRegion(java.lang.String)",
+          "justification": "Added new layer to configure domain"
         }
       ]
     }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClientCloudBuilderStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClientCloudBuilderStep1.java
@@ -51,7 +51,18 @@ public interface ZeebeClientCloudBuilderStep1 {
          *
          * @param region region of the Camunda Cloud cluster
          */
-        ZeebeClientCloudBuilderStep4 withRegion(String region);
+        ZeebeClientCloudBuilderStep5 withRegion(String region);
+
+        interface ZeebeClientCloudBuilderStep5 extends ZeebeClientBuilder {
+
+          /**
+           * Sets the domain of the Camunda Cloud stage. Default is 'camunda.io', the production
+           * stage.
+           *
+           * @param domain domain of the Camunda Cloud stage
+           */
+          ZeebeClientCloudBuilderStep5 withDomain(String domain);
+        }
       }
     }
   }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientCloudBuilderImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientCloudBuilderImpl.java
@@ -289,7 +289,7 @@ public class ZeebeClientCloudBuilderImpl
     if (isNeedToSetCloudRestAddress()) {
       ensureNotNull("cluster id", clusterId);
       final String cloudRestAddress =
-          String.format("https://%s.zeebe.%s:443/%s", region, BASE_ADDRESS, clusterId);
+          String.format("https://%s.%s:443/%s", region, BASE_ADDRESS, clusterId);
       return getURIFromString(cloudRestAddress);
     } else {
       Loggers.LOGGER.debug(

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientCloudBuilderImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientCloudBuilderImpl.java
@@ -29,6 +29,7 @@ import io.camunda.zeebe.client.ZeebeClientCloudBuilderStep1;
 import io.camunda.zeebe.client.ZeebeClientCloudBuilderStep1.ZeebeClientCloudBuilderStep2;
 import io.camunda.zeebe.client.ZeebeClientCloudBuilderStep1.ZeebeClientCloudBuilderStep2.ZeebeClientCloudBuilderStep3;
 import io.camunda.zeebe.client.ZeebeClientCloudBuilderStep1.ZeebeClientCloudBuilderStep2.ZeebeClientCloudBuilderStep3.ZeebeClientCloudBuilderStep4;
+import io.camunda.zeebe.client.ZeebeClientCloudBuilderStep1.ZeebeClientCloudBuilderStep2.ZeebeClientCloudBuilderStep3.ZeebeClientCloudBuilderStep4.ZeebeClientCloudBuilderStep5;
 import io.camunda.zeebe.client.api.ExperimentalApi;
 import io.camunda.zeebe.client.api.JsonMapper;
 import io.camunda.zeebe.client.impl.oauth.OAuthCredentialsProviderBuilder;
@@ -47,12 +48,12 @@ public class ZeebeClientCloudBuilderImpl
     implements ZeebeClientCloudBuilderStep1,
         ZeebeClientCloudBuilderStep2,
         ZeebeClientCloudBuilderStep3,
-        ZeebeClientCloudBuilderStep4 {
+        ZeebeClientCloudBuilderStep4,
+        ZeebeClientCloudBuilderStep5 {
 
-  private static final String BASE_ADDRESS = "zeebe.camunda.io";
-  private static final String BASE_AUTH_URL = "https://login.cloud.camunda.io/oauth/token";
-
+  private static final String DEFAULT_DOMAIN = "camunda.io";
   private static final String DEFAULT_REGION = "bru-2";
+  private static final String ZEEBE_DOMAIN_COMPONENT = "zeebe";
 
   private final ZeebeClientBuilderImpl innerBuilder = new ZeebeClientBuilderImpl();
 
@@ -60,6 +61,7 @@ public class ZeebeClientCloudBuilderImpl
   private String clientId;
   private String clientSecret;
   private String region = DEFAULT_REGION;
+  private String domain = DEFAULT_DOMAIN;
 
   @Override
   public ZeebeClientCloudBuilderStep2 withClusterId(final String clusterId) {
@@ -80,8 +82,14 @@ public class ZeebeClientCloudBuilderImpl
   }
 
   @Override
-  public ZeebeClientCloudBuilderStep4 withRegion(final String region) {
+  public ZeebeClientCloudBuilderStep5 withRegion(final String region) {
     this.region = region;
+    return this;
+  }
+
+  @Override
+  public ZeebeClientCloudBuilderStep5 withDomain(final String domain) {
+    this.domain = domain;
     return this;
   }
 
@@ -289,7 +297,8 @@ public class ZeebeClientCloudBuilderImpl
     if (isNeedToSetCloudRestAddress()) {
       ensureNotNull("cluster id", clusterId);
       final String cloudRestAddress =
-          String.format("https://%s.%s:443/%s", region, BASE_ADDRESS, clusterId);
+          String.format(
+              "https://%s.%s.%s:443/%s", region, ZEEBE_DOMAIN_COMPONENT, domain, clusterId);
       return getURIFromString(cloudRestAddress);
     } else {
       Loggers.LOGGER.debug(
@@ -304,7 +313,8 @@ public class ZeebeClientCloudBuilderImpl
     if (isNeedToSetCloudGrpcAddress() && isNeedToSetCloudGatewayAddress()) {
       ensureNotNull("cluster id", clusterId);
       final String cloudGrpcAddress =
-          String.format("https://%s.%s.%s:443", clusterId, region, BASE_ADDRESS);
+          String.format(
+              "https://%s.%s.%s.%s:443", clusterId, region, ZEEBE_DOMAIN_COMPONENT, domain);
       return getURIFromString(cloudGrpcAddress);
     } else {
       if (!isNeedToSetCloudGrpcAddress()) {
@@ -335,10 +345,10 @@ public class ZeebeClientCloudBuilderImpl
         Loggers.LOGGER.debug("Expected setting 'usePlaintext' to be 'false', but found 'true'.");
       }
       return builder
-          .audience(String.format("%s.%s.%s", clusterId, region, BASE_ADDRESS))
+          .audience(String.format("%s.%s.%s", clusterId, region, domain))
           .clientId(clientId)
           .clientSecret(clientSecret)
-          .authorizationServerUrl(BASE_AUTH_URL)
+          .authorizationServerUrl(String.format("https://login.cloud.%s/oauth/token", domain))
           .build();
     } else {
       Loggers.LOGGER.debug(

--- a/clients/java/src/test/java/io/camunda/zeebe/client/ZeebeClientTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/ZeebeClientTest.java
@@ -378,6 +378,7 @@ public final class ZeebeClientTest extends ClientTest {
     // given
     final String clusterId = "clusterId";
     final String region = "asdf-123";
+    final String domain = "dev.ultrawombat.com";
 
     try (final ZeebeClient client =
         ZeebeClient.newCloudClientBuilder()
@@ -385,6 +386,7 @@ public final class ZeebeClientTest extends ClientTest {
             .withClientId("clientId")
             .withClientSecret("clientSecret")
             .withRegion(region)
+            .withDomain(domain)
             .build()) {
       // when
       final ZeebeClientConfiguration clientConfiguration = client.getConfiguration();
@@ -392,11 +394,11 @@ public final class ZeebeClientTest extends ClientTest {
       assertThat(clientConfiguration.getCredentialsProvider())
           .isInstanceOf(OAuthCredentialsProvider.class);
       assertThat(clientConfiguration.getGrpcAddress())
-          .hasHost(String.format("%s.%s.zeebe.camunda.io", clusterId, region))
+          .hasHost(String.format("%s.%s.zeebe.%s", clusterId, region, domain))
           .hasPort(443)
           .hasScheme("https");
       assertThat(clientConfiguration.getRestAddress())
-          .hasHost(String.format("%s.zeebe.camunda.io", region))
+          .hasHost(String.format("%s.zeebe.%s", region, domain))
           .hasPort(443)
           .hasPath("/" + clusterId)
           .hasScheme("https");
@@ -404,7 +406,7 @@ public final class ZeebeClientTest extends ClientTest {
   }
 
   @Test
-  public void shouldCloudBuilderBuildProperClientWithDefaultRegion() {
+  public void shouldCloudBuilderBuildProperClientWithDefaultRegionAndDomain() {
     // given
     final String clusterId = "clusterId";
     try (final ZeebeClient client =

--- a/clients/java/src/test/java/io/camunda/zeebe/client/ZeebeClientTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/ZeebeClientTest.java
@@ -395,6 +395,11 @@ public final class ZeebeClientTest extends ClientTest {
           .hasHost(String.format("%s.%s.zeebe.camunda.io", clusterId, region))
           .hasPort(443)
           .hasScheme("https");
+      assertThat(clientConfiguration.getRestAddress())
+          .hasHost(String.format("%s.zeebe.camunda.io", region))
+          .hasPort(443)
+          .hasPath("/" + clusterId)
+          .hasScheme("https");
     }
   }
 
@@ -417,6 +422,11 @@ public final class ZeebeClientTest extends ClientTest {
           .hasHost(String.format("%s.bru-2.zeebe.camunda.io", clusterId))
           .hasPort(443)
           .hasScheme("https");
+      assertThat(clientConfiguration.getRestAddress())
+          .hasHost("bru-2.zeebe.camunda.io")
+          .hasPort(443)
+          .hasPath("/" + clusterId)
+          .hasScheme("https");
     }
   }
 
@@ -424,6 +434,7 @@ public final class ZeebeClientTest extends ClientTest {
   public void shouldOverrideCloudProperties() {
     // given
     final String gatewayAddress = "localhost:10000";
+    final URI restAddress = URI.create("https://localhost:10001");
     final NoopCredentialsProvider credentialsProvider = new NoopCredentialsProvider();
     try (final ZeebeClient client =
         ZeebeClient.newCloudClientBuilder()
@@ -431,10 +442,12 @@ public final class ZeebeClientTest extends ClientTest {
             .withClientId("clientId")
             .withClientSecret("clientSecret")
             .gatewayAddress(gatewayAddress)
+            .restAddress(restAddress)
             .credentialsProvider(credentialsProvider)
             .build()) {
       final ZeebeClientConfiguration configuration = client.getConfiguration();
       assertThat(configuration.getGatewayAddress()).isEqualTo(gatewayAddress);
+      assertThat(configuration.getRestAddress()).isEqualTo(restAddress);
       assertThat(configuration.getCredentialsProvider()).isEqualTo(credentialsProvider);
     }
   }
@@ -461,6 +474,11 @@ public final class ZeebeClientTest extends ClientTest {
           .hasHost(String.format("clusterId.%s.zeebe.camunda.io", region))
           .hasPort(443)
           .hasScheme("https");
+      assertThat(clientConfiguration.getRestAddress())
+          .hasHost(String.format("%s.zeebe.camunda.io", region))
+          .hasPort(443)
+          .hasPath("/clusterId")
+          .hasScheme("https");
     }
   }
 
@@ -482,6 +500,11 @@ public final class ZeebeClientTest extends ClientTest {
       assertThat(clientConfiguration.getGrpcAddress())
           .hasHost(String.format("clusterId.%s.zeebe.camunda.io", defaultRegion))
           .hasPort(443)
+          .hasScheme("https");
+      assertThat(clientConfiguration.getRestAddress())
+          .hasHost(String.format("%s.zeebe.camunda.io", defaultRegion))
+          .hasPort(443)
+          .hasPath("/clusterId")
           .hasScheme("https");
     }
   }


### PR DESCRIPTION
# Description
Backport of #35093 to `stable/8.6`.

relates to #35044 #32759