### PR TITLE
deps: upgrade spring version to fix CVE-2025-41234

### DIFF
--- a/identity/client/pom.xml
+++ b/identity/client/pom.xml
@@ -87,4 +87,14 @@
     </profile>
   </profiles>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-web</artifactId>
+        <version>6.1.21</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
 </project>

--- a/identity/migration/pom.xml
+++ b/identity/migration/pom.xml
@@ -47,6 +47,11 @@
         <artifactId>commons-lang3</artifactId>
         <version>3.18.0</version>
       </dependency>
+      <dependency>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-web</artifactId>
+        <version>6.1.21</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 

--- a/optimize/pom.xml
+++ b/optimize/pom.xml
@@ -51,7 +51,7 @@
     <apache.http5-client.version>5.4</apache.http5-client.version>
     <apache.http5-core.version>5.3.1</apache.http5-core.version>
     <guava.version>33.3.1-jre</guava.version>
-    <spring.boot.version>3.3.11</spring.boot.version>
+    <spring.boot.version>3.3.13</spring.boot.version>
     <spring.version>6.1.21</spring.version>
     <spring.security.version>6.4.7</spring.security.version>
     <version.tomcat>10.1.43</version.tomcat>


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Fixes CVE-2025-41234

`${version.spring}` does not work for the identity modules. (In the `mvn dependency:tree` they will still use the vulnerable version of Spring). Also using `dependencyManagement` in the `identity-parent` for `spring-web` does not force the identity modules to use the correct spring version

Using a specific version in `dependencyManagement` forces the identity modules to use the correct version of spring
## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes https://github.com/camunda/camunda/issues/35544
