### PR TITLE
Get details for Groups based on isInternalGroupsEnabled flag

### DIFF
--- a/identity/client/src/components/global/useEnrichGroups.tsx
+++ b/identity/client/src/components/global/useEnrichGroups.tsx
@@ -1,0 +1,83 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import { useCallback, useEffect, useState } from "react";
+import { isInternalGroupsEnabled } from "src/configuration";
+import { SearchResponse } from "src/utility/api";
+import { useApiCall } from "src/utility/api/hooks";
+import { MemberGroup } from "src/utility/api/groups";
+import { ApiDefinition } from "src/utility/api/request";
+import { searchGroups, Group } from "src/utility/api/groups";
+
+type UseEnrichedGroupsResult = {
+  groups: Group[];
+  loading: boolean;
+  success: boolean;
+  reload: () => void;
+};
+
+export function useEnrichedGroups<P>(
+  apiDefinition: ApiDefinition<SearchResponse<MemberGroup>, P>,
+  params: P,
+): UseEnrichedGroupsResult {
+  const [callSearchMembers] = useApiCall(apiDefinition);
+  const [callSearchGroups] = useApiCall(searchGroups);
+
+  const [groups, setGroups] = useState<Group[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [success, setSuccess] = useState(false);
+
+  const fetch = useCallback(async () => {
+    setLoading(true);
+    setSuccess(false);
+
+    try {
+      const result = await callSearchMembers(params);
+      const members = result.data?.items || [];
+
+      if (members.length === 0) {
+        setGroups([]);
+        setSuccess(true);
+        return;
+      }
+
+      if (!isInternalGroupsEnabled) {
+        setGroups(
+          members.map(({ groupId }) => ({
+            groupId,
+            name: "",
+            description: "",
+          })),
+        );
+        setSuccess(true);
+        return;
+      }
+
+      const groupIds = members.map(({ groupId }) => groupId);
+      const groupResult = await callSearchGroups({ groupIds });
+      setGroups(groupResult.data?.items || []);
+      setSuccess(true);
+    } catch {
+      setGroups([]);
+      setSuccess(false);
+    } finally {
+      setLoading(false);
+    }
+  }, [callSearchMembers, callSearchGroups, JSON.stringify(params)]);
+
+  useEffect(() => {
+    void fetch();
+  }, [fetch]);
+
+  return {
+    groups,
+    loading,
+    success,
+    reload: fetch,
+  };
+}

--- a/identity/client/src/pages/roles/detail/groups/AssignGroupsModal.tsx
+++ b/identity/client/src/pages/roles/detail/groups/AssignGroupsModal.tsx
@@ -1,0 +1,136 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import { FC, useEffect, useState } from "react";
+import styled from "styled-components";
+import { Tag } from "@carbon/react";
+import { UseEntityModalCustomProps } from "src/components/modal";
+import useTranslate from "src/utility/localization";
+import { useApi, useApiCall } from "src/utility/api/hooks";
+import { searchGroups, Group } from "src/utility/api/groups";
+import { TranslatedErrorInlineNotification } from "src/components/notifications/InlineNotification";
+import DropdownSearch from "src/components/form/DropdownSearch";
+import FormModal from "src/components/modal/FormModal";
+import { assignRoleGroup, Role } from "src/utility/api/roles";
+
+const SelectedGroups = styled.div`
+  margin-top: 0;
+`;
+
+const AssignGroupsModal: FC<
+  UseEntityModalCustomProps<{ id: Role["roleId"] }, { assignedGroups: Group[] }>
+> = ({ entity: role, assignedGroups, onSuccess, open, onClose }) => {
+  const { t, Translate } = useTranslate("roles");
+  const [selectedGroups, setSelectedGroups] = useState<Group[]>([]);
+  const [loadingAssignGroup, setLoadingAssignGroup] = useState(false);
+
+  const {
+    data: groupSearchResults,
+    loading,
+    reload,
+    error,
+  } = useApi(searchGroups);
+
+  const [callAssignGroup] = useApiCall(assignRoleGroup);
+
+  const unassignedGroups =
+    groupSearchResults?.items.filter(
+      ({ groupId }) =>
+        !assignedGroups.some((group) => group.groupId === groupId) &&
+        !selectedGroups.some((group) => group.groupId === groupId),
+    ) || [];
+
+  const onSelectGroup = (group: Group) => {
+    setSelectedGroups([...selectedGroups, group]);
+  };
+
+  const onUnselectGroup =
+    ({ groupId }: Group) =>
+    () => {
+      setSelectedGroups(
+        selectedGroups.filter((group) => group.groupId !== groupId),
+      );
+    };
+
+  const canSubmit = role && selectedGroups.length;
+
+  const handleSubmit = async () => {
+    if (!canSubmit) return;
+
+    setLoadingAssignGroup(true);
+
+    const results = await Promise.all(
+      selectedGroups.map(({ groupId }) =>
+        callAssignGroup({ groupId, roleId: role.id }),
+      ),
+    );
+
+    setLoadingAssignGroup(false);
+
+    if (results.every(({ success }) => success)) {
+      onSuccess();
+    }
+  };
+
+  useEffect(() => {
+    if (open) {
+      setSelectedGroups([]);
+    }
+  }, [open]);
+
+  return (
+    <FormModal
+      headline={t("assignGroup")}
+      confirmLabel={t("assignGroup")}
+      loading={loadingAssignGroup}
+      loadingDescription={t("assigningGroup")}
+      open={open}
+      onSubmit={handleSubmit}
+      submitDisabled={!canSubmit}
+      onClose={onClose}
+      overflowVisible
+    >
+      <p>
+        <Translate i18nKey="searchAndAssignGroupToRole">
+          Search and assign group to role
+        </Translate>
+      </p>
+      {selectedGroups.length > 0 && (
+        <SelectedGroups>
+          {selectedGroups.map((group) => (
+            <Tag
+              key={group.groupId}
+              onClose={onUnselectGroup(group)}
+              size="md"
+              type="blue"
+              filter
+            >
+              {group.groupId}
+            </Tag>
+          ))}
+        </SelectedGroups>
+      )}
+      <DropdownSearch
+        autoFocus
+        items={unassignedGroups}
+        itemTitle={({ groupId }) => groupId}
+        itemSubTitle={({ name }) => name}
+        placeholder={t("searchByGroupId")}
+        onSelect={onSelectGroup}
+      />
+      {!loading && error && (
+        <TranslatedErrorInlineNotification
+          title={t("groupsCouldNotLoad")}
+          actionButton={{ label: t("retry"), onClick: reload }}
+        />
+      )}
+    </FormModal>
+  );
+};
+
+export default AssignGroupsModal;

--- a/identity/client/src/pages/roles/detail/groups/DeleteModal.tsx
+++ b/identity/client/src/pages/roles/detail/groups/DeleteModal.tsx
@@ -1,0 +1,79 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import { FC } from "react";
+import { useApiCall } from "src/utility/api";
+import useTranslate from "src/utility/localization";
+import {
+  DeleteModal as Modal,
+  UseEntityModalCustomProps,
+} from "src/components/modal";
+import { useNotifications } from "src/components/notifications";
+import { Group } from "src/utility/api/groups";
+import { unassignRoleGroup } from "src/utility/api/roles";
+
+type RemoveRoleGroupModalProps = UseEntityModalCustomProps<
+  Group,
+  {
+    role: string;
+  }
+>;
+
+const DeleteModal: FC<RemoveRoleGroupModalProps> = ({
+  entity: group,
+  open,
+  onClose,
+  onSuccess,
+  role,
+}) => {
+  const { t, Translate } = useTranslate("roles");
+  const { enqueueNotification } = useNotifications();
+
+  const [callUnassignGroup, { loading }] = useApiCall(unassignRoleGroup);
+
+  const handleSubmit = async () => {
+    if (role && group) {
+      const { success } = await callUnassignGroup({
+        roleId: role,
+        groupId: group.groupId,
+      });
+
+      if (success) {
+        enqueueNotification({
+          kind: "success",
+          title: t("roleGroupRemoved"),
+        });
+        onSuccess();
+      }
+    }
+  };
+
+  return (
+    <Modal
+      open={open}
+      headline={t("removeGroup")}
+      onSubmit={handleSubmit}
+      loading={loading}
+      loadingDescription={t("removingGroup")}
+      onClose={onClose}
+      confirmLabel={t("removeGroup")}
+    >
+      <p>
+        <Translate
+          i18nKey="removeGroupFromRole"
+          values={{ groupId: group.groupId }}
+        >
+          Are you sure you want to remove <strong>{group.groupId}</strong> from
+          this role?
+        </Translate>
+      </p>
+    </Modal>
+  );
+};
+
+export default DeleteModal;

--- a/identity/client/src/pages/roles/detail/groups/index.tsx
+++ b/identity/client/src/pages/roles/detail/groups/index.tsx
@@ -1,0 +1,119 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import { FC } from "react";
+import { C3EmptyState } from "@camunda/camunda-composite-components";
+import useTranslate from "src/utility/localization";
+import { getGroupsByRoleId } from "src/utility/api/roles";
+import EntityList from "src/components/entityList";
+import { useEntityModal } from "src/components/modal";
+import { TrashCan } from "@carbon/react/icons";
+import DeleteModal from "src/pages/roles/detail/groups/DeleteModal";
+import AssignGroupsModal from "src/pages/roles/detail/groups/AssignGroupsModal";
+import { isInternalGroupsEnabled } from "src/configuration";
+import { useEnrichedGroups } from "src/components/global/useEnrichGroups";
+import { GroupKeys } from "src/utility/api/groups";
+
+type GroupsProps = {
+  roleId: string;
+};
+
+const Groups: FC<GroupsProps> = ({ roleId }) => {
+  const { t } = useTranslate("roles");
+
+  const { groups, loading, success, reload } = useEnrichedGroups(
+    getGroupsByRoleId,
+    {
+      roleId,
+    },
+  );
+
+  const isGroupsEmpty = !groups || groups.length === 0;
+
+  const [assignGroups, assignGroupsModal] = useEntityModal(
+    AssignGroupsModal,
+    reload,
+    {
+      assignedGroups: groups,
+    },
+  );
+  const openAssignModal = () => assignGroups({ id: roleId });
+  const [unassignGroup, unassignGroupModal] = useEntityModal(
+    DeleteModal,
+    reload,
+    {
+      role: roleId,
+    },
+  );
+
+  if (!loading && !success)
+    return (
+      <C3EmptyState
+        heading={t("somethingsWrong")}
+        description={t("unableToLoadGroups")}
+        button={{ label: t("retry"), onClick: reload }}
+      />
+    );
+
+  if (success && isGroupsEmpty)
+    return (
+      <>
+        <C3EmptyState
+          heading={t("assignGroupsToRole")}
+          description={t("roleMemberAccessDisclaimer")}
+          button={{
+            label: t("assignGroup"),
+            onClick: openAssignModal,
+          }}
+          link={{
+            label: t("learnMoreAboutRoles"),
+            href: "https://docs.camunda.io/",
+          }}
+        />
+        {assignGroupsModal}
+      </>
+    );
+
+  type GroupsListHeaders = {
+    header: string;
+    key: GroupKeys;
+  }[];
+
+  const groupsListHeaders: GroupsListHeaders = isInternalGroupsEnabled
+    ? [
+        { header: t("groupId"), key: "groupId" },
+        { header: t("groupName"), key: "name" },
+      ]
+    : [{ header: t("groupId"), key: "groupId" }];
+
+  return (
+    <>
+      <EntityList
+        data={groups}
+        headers={groupsListHeaders}
+        sortProperty="groupId"
+        loading={loading}
+        addEntityLabel={t("assignGroup")}
+        onAddEntity={openAssignModal}
+        searchPlaceholder={t("searchByGroupId")}
+        menuItems={[
+          {
+            label: t("remove"),
+            icon: TrashCan,
+            isDangerous: true,
+            onClick: unassignGroup,
+          },
+        ]}
+      />
+      {assignGroupsModal}
+      {unassignGroupModal}
+    </>
+  );
+};
+
+export default Groups;

--- a/identity/client/src/pages/roles/detail/index.tsx
+++ b/identity/client/src/pages/roles/detail/index.tsx
@@ -24,6 +24,7 @@ import DeleteModal from "src/pages/roles/modals/DeleteModal";
 import { Description } from "src/components/layout/DetailsPageDescription";
 import Members from "src/pages/roles/detail/members";
 import Mappings from "src/pages/roles/detail/mappings";
+import Groups from "src/pages/roles/detail/groups";
 import Clients from "src/pages/roles/detail/clients";
 import { isOIDC } from "src/configuration";
 
@@ -83,31 +84,36 @@ const Details: FC = () => {
         </Stack>
         {role && (
           <Section>
-            {!isOIDC ? (
-              <Members roleId={role.roleId} />
-            ) : (
-              <Tabs
-                tabs={[
-                  {
-                    key: "users",
-                    label: t("users"),
-                    content: <Members roleId={role.roleId} />,
-                  },
-                  {
-                    key: "mappings",
-                    label: t("mappings"),
-                    content: <Mappings roleId={role.roleId} />,
-                  },
-                  {
-                    key: "clients",
-                    label: t("clients"),
-                    content: <Clients roleId={role.roleId} />,
-                  },
-                ]}
-                selectedTabKey={tab}
-                path={`../${id}`}
-              />
-            )}
+            <Tabs
+              tabs={[
+                {
+                  key: "users",
+                  label: t("users"),
+                  content: <Members roleId={role.roleId} />,
+                },
+                {
+                  key: "groups",
+                  label: t("groups"),
+                  content: <Groups roleId={role.roleId} />,
+                },
+                ...(isOIDC
+                  ? [
+                      {
+                        key: "mappings",
+                        label: t("mappings"),
+                        content: <Mappings roleId={role.roleId} />,
+                      },
+                      {
+                        key: "clients",
+                        label: t("clients"),
+                        content: <Clients roleId={role.roleId} />,
+                      },
+                    ]
+                  : []),
+              ]}
+              selectedTabKey={tab}
+              path={`../${id}`}
+            />
           </Section>
         )}
       </>

--- a/identity/client/src/pages/tenants/detail/index.tsx
+++ b/identity/client/src/pages/tenants/detail/index.tsx
@@ -27,7 +27,7 @@ import Groups from "src/pages/tenants/detail/groups";
 import Roles from "src/pages/tenants/detail/roles";
 import Mappings from "src/pages/tenants/detail/mappings";
 import Clients from "src/pages/tenants/detail/clients";
-import { isInternalGroupsEnabled, isOIDC } from "src/configuration";
+import { isOIDC } from "src/configuration";
 
 const Details: FC = () => {
   const { t } = useTranslate("tenants");
@@ -89,15 +89,11 @@ const Details: FC = () => {
                   label: t("users"),
                   content: <Members tenantId={tenant.tenantId} />,
                 },
-                ...(isInternalGroupsEnabled
-                  ? [
-                      {
-                        key: "groups",
-                        label: t("groups"),
-                        content: <Groups tenantId={tenant.tenantId} />,
-                      },
-                    ]
-                  : []),
+                {
+                  key: "groups",
+                  label: t("groups"),
+                  content: <Groups tenantId={tenant.tenantId} />,
+                },
                 {
                   key: "roles",
                   label: t("roles"),

--- a/identity/client/src/utility/api/groups/index.ts
+++ b/identity/client/src/utility/api/groups/index.ts
@@ -13,14 +13,29 @@ import { Mapping } from "src/utility/api/mappings";
 
 export const GROUPS_ENDPOINT = "/groups";
 
+export type GroupKeys = "groupId" | "name" | "description";
+
 export type Group = {
   groupId: string;
   name: string;
   description?: string;
 };
 
-export const searchGroups: ApiDefinition<SearchResponse<Group>> = () =>
-  apiPost(`${GROUPS_ENDPOINT}/search`);
+export type MemberGroup = Pick<Group, "groupId">;
+
+type SearchGroupsParams = {
+  groupIds: string[];
+};
+
+export const searchGroups: ApiDefinition<
+  SearchResponse<Group>,
+  SearchGroupsParams | undefined
+> = (filterParams) => {
+  const params = filterParams?.groupIds
+    ? { filter: { groupId: { $in: filterParams.groupIds } } }
+    : undefined;
+  return apiPost(`${GROUPS_ENDPOINT}/search`, params);
+};
 
 export type GetGroupParams = {
   groupId: string;

--- a/identity/client/src/utility/api/roles/index.ts
+++ b/identity/client/src/utility/api/roles/index.ts
@@ -14,6 +14,7 @@ import {
   apiPut,
 } from "src/utility/api/request";
 import { SearchResponse } from "src/utility/api";
+import { Group } from "src/utility/api/groups";
 import { Mapping } from "src/utility/api/mappings";
 
 export const ROLES_ENDPOINT = "/roles";
@@ -69,6 +70,32 @@ export const unassignRoleMapping: ApiDefinition<
   UnassignRoleMappingParams
 > = ({ roleId, mappingId }) =>
   apiDelete(`${ROLES_ENDPOINT}/${roleId}/mappings/${mappingId}`);
+
+// ----------------- Groups within a Role -----------------
+
+type GetRoleGroupsParams = {
+  roleId: string;
+};
+
+export const getGroupsByRoleId: ApiDefinition<
+  SearchResponse<Group>,
+  GetRoleGroupsParams
+> = ({ roleId }) => apiPost(`${ROLES_ENDPOINT}/${roleId}/groups/search`);
+
+type AssignRoleGroupParams = GetRoleGroupsParams & Pick<Group, "groupId">;
+export const assignRoleGroup: ApiDefinition<
+  undefined,
+  AssignRoleGroupParams
+> = ({ roleId, groupId }) => {
+  return apiPut(`${ROLES_ENDPOINT}/${roleId}/groups/${groupId}`);
+};
+
+type UnassignRoleGroupParams = AssignRoleGroupParams;
+export const unassignRoleGroup: ApiDefinition<
+  undefined,
+  UnassignRoleGroupParams
+> = ({ roleId, groupId }) =>
+  apiDelete(`${ROLES_ENDPOINT}/${roleId}/groups/${groupId}`);
 
 // ----------------- Clients within a Role -----------------
 

--- a/identity/client/src/utility/localization/en/roles.json
+++ b/identity/client/src/utility/localization/en/roles.json
@@ -52,5 +52,18 @@
   "assignClientToRole": "Assign client to role",
   "roleClientRemoved": "Role client removed",
   "removeClientFromRole": "Are you sure you want to remove <strong>{{clientId}}</strong> from this role?",
-  "assignClientsToRole": "Assign clients to this role"
+  "assignClientsToRole": "Assign clients to this role",
+  "searchByGroupId": "Search by group ID",
+  "assignGroupsToRole": "Assign groups to this Role",
+  "assignGroup": "Assign group",
+  "assigningGroup": "Assigning group",
+  "removeGroup": "Remove group",
+  "removingGroup": "Removing group",
+  "roleGroupRemoved": "Role group has been removed.",
+  "groupsCouldNotLoad": "Groups could not be loaded.",
+  "unableToLoadGroups": "We were unable to load the groups. Click \"Retry\" to try again.",
+  "groupId": "Group ID",
+  "groupName": "Group name",
+  "roleMemberAccessDisclaimer": "Members of this Group will be given access to the data within the Role.",
+  "searchAndAssignGroupToRole": "Search and assign group to role"
 }


### PR DESCRIPTION
## Description

- Creates `useEnrichedGroups` hook to (just like `useEnrichedUsers` query the base groups search for more details about each group based on the `isInternalGroupsEnabled` flag.
- Implements `useEnrichedGroups` hook in the Groups tab of the Tenants details page
- Creates new Group tab under Roles details page and use same logic of `useEnrichedGroups` hook that was implemented in the tab for Tenants details page
- Adds appropriate translation keys
- Adjust API definitions accordingly (especially for the `searchGroups` endpoint to allow for filtering)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #34548
