### PR TITLE
ci: adding additional wait stages into add-to-projects

### DIFF
--- a/.github/workflows/add-to-projects.yml
+++ b/.github/workflows/add-to-projects.yml
@@ -12,6 +12,8 @@ jobs:
     name: Add issue to team projects if no project assigned and by corresponding component label
     runs-on: ubuntu-latest
     steps:
+      - name: Wait
+        run: sleep 30s
       - id: get_project_count
         uses: octokit/graphql-action@v2.3.2
         with:


### PR DESCRIPTION
## Description

Adding a 30sec wait stage at the beginning of the script as well, since when an issue is created via the new templates (e.g. bug report), the kind/bug label is added immediately, which triggers this script. If there is no wait stage at the beginning as well, the script does not recognize the automatically added component labels that are added by another script about 10 - 15 seconds later.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
