### PR TITLE
fix: skip generating commit info in docker build 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -81,7 +81,7 @@ WORKDIR /zeebe
 ENV MAVEN_OPTS -XX:MaxRAMPercentage=80
 COPY --link . ./
 RUN --mount=type=cache,target=/root/.m2,rw \
-    ./mvnw -B -am -pl dist package -T1C -D skipChecks -D skipTests && \
+    ./mvnw -B -am -pl dist package -T1C -D skipChecks -D skipTests -D maven.gitcommitid.skip=true && \
     mv dist/target/camunda-zeebe .
 
 ### Extract zeebe from distball ###


### PR DESCRIPTION
## Description

Git info is not available in when building from scratch.

```
 > [build 3/3] RUN --mount=type=cache,target=/root/.m2,rw     ./mvnw -B -am -pl dist package -T1C -D skipChecks -D skipTests &&     mv dist/target/camunda-zeebe .:
Error: ERROR] Failed to execute goal io.github.git-commit-id:git-commit-id-maven-plugin:9.0.2:revision (resolve-git-info) on project camunda-zeebe: .git directory is not found! Please specify a valid [dotGitDirectory] in your project -> [Help 1]
```

This breaks the `zeebe-benchmark` workflow in stable/8.5 because the workflow builds zeebe from scratch in docker. This was not affecting benchmarks of later versions, because there the docker image is build from distball.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
