### PR TITLE
feat: unified config: override OperateProperties bean with its UC version

### DIFF
--- a/configuration/pom.xml
+++ b/configuration/pom.xml
@@ -35,5 +35,10 @@
       <groupId>io.camunda</groupId>
       <artifactId>tasklist-common</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>operate-common</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/OperatePropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/OperatePropertiesOverride.java
@@ -5,39 +5,40 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-
 package io.camunda.configuration.beanoverrides;
 
 import io.camunda.configuration.UnifiedConfiguration;
-import io.camunda.tasklist.property.TasklistProperties;
+import io.camunda.operate.property.OperateProperties;
 import org.springframework.beans.BeanUtils;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.DependsOn;
 import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.Profile;
 import org.springframework.context.annotation.PropertySource;
 
 @Configuration
-@EnableConfigurationProperties(TasklistProperties.class)
-@PropertySource("classpath:tasklist-version.properties")
-@Profile("tasklist | test")
-public class TasklistPropertiesOverride {
+@EnableConfigurationProperties(OperateProperties.class)
+@PropertySource("classpath:operate-version.properties")
+@DependsOn("databaseInfo")
+@Profile("operate | test")
+public class OperatePropertiesOverride {
 
   private final UnifiedConfiguration unifiedConfiguration;
-  private final TasklistProperties legacyTasklistProperties;
+  private final OperateProperties legacyOperateProperties;
 
-  public TasklistPropertiesOverride(
-      UnifiedConfiguration unifiedConfiguration, TasklistProperties legacyTasklistProperties) {
+  public OperatePropertiesOverride(
+      UnifiedConfiguration unifiedConfiguration, OperateProperties legacyOperateProperties) {
     this.unifiedConfiguration = unifiedConfiguration;
-    this.legacyTasklistProperties = legacyTasklistProperties;
+    this.legacyOperateProperties = legacyOperateProperties;
   }
 
   @Bean
   @Primary
-  public TasklistProperties tasklistProperties() {
-    final TasklistProperties override = new TasklistProperties();
-    BeanUtils.copyProperties(legacyTasklistProperties, override);
+  public OperateProperties operateProperties() {
+    final OperateProperties override = new OperateProperties();
+    BeanUtils.copyProperties(legacyOperateProperties, override);
 
     // TODO: Populate the bean using unifiedConfiguration
     //  override.setSampleField(unifiedConfiguration.getSampleField());

--- a/dist/src/main/java/io/camunda/application/StandaloneCamunda.java
+++ b/dist/src/main/java/io/camunda/application/StandaloneCamunda.java
@@ -15,6 +15,7 @@ import io.camunda.application.initializers.HealthConfigurationInitializer;
 import io.camunda.application.initializers.WebappsConfigurationInitializer;
 import io.camunda.application.listeners.ApplicationErrorListener;
 import io.camunda.configuration.UnifiedConfiguration;
+import io.camunda.configuration.beanoverrides.OperatePropertiesOverride;
 import io.camunda.configuration.beanoverrides.TasklistPropertiesOverride;
 import io.camunda.identity.IdentityModuleConfiguration;
 import io.camunda.operate.OperateModuleConfiguration;
@@ -48,8 +49,11 @@ public class StandaloneCamunda {
     final var standaloneCamundaApplication =
         MainSupport.createDefaultApplicationBuilder()
             .sources(
+                // Unified Configuration classes
                 UnifiedConfiguration.class,
                 TasklistPropertiesOverride.class,
+                OperatePropertiesOverride.class,
+                // ---
                 CommonsModuleConfiguration.class,
                 OperateModuleConfiguration.class,
                 TasklistModuleConfiguration.class,

--- a/dist/src/main/java/io/camunda/application/StandaloneOperate.java
+++ b/dist/src/main/java/io/camunda/application/StandaloneOperate.java
@@ -11,6 +11,8 @@ import io.camunda.application.commons.CommonsModuleConfiguration;
 import io.camunda.application.initializers.DefaultAuthenticationInitializer;
 import io.camunda.application.initializers.WebappsConfigurationInitializer;
 import io.camunda.application.listeners.ApplicationErrorListener;
+import io.camunda.configuration.UnifiedConfiguration;
+import io.camunda.configuration.beanoverrides.OperatePropertiesOverride;
 import io.camunda.operate.OperateModuleConfiguration;
 import io.camunda.webapps.WebappsModuleConfiguration;
 import java.util.HashMap;
@@ -39,6 +41,10 @@ public class StandaloneOperate {
     final var standaloneOperateApplication =
         MainSupport.createDefaultApplicationBuilder()
             .sources(
+                // Unified Configuration classes
+                UnifiedConfiguration.class,
+                OperatePropertiesOverride.class,
+                // ---
                 CommonsModuleConfiguration.class,
                 OperateModuleConfiguration.class,
                 WebappsModuleConfiguration.class)

--- a/operate/common/src/main/java/io/camunda/operate/property/OperateProperties.java
+++ b/operate/common/src/main/java/io/camunda/operate/property/OperateProperties.java
@@ -13,18 +13,11 @@ import java.util.List;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.DependsOn;
 import org.springframework.context.annotation.PropertySource;
-import org.springframework.stereotype.Component;
 
 /** This class contains all project configuration parameters. */
-@Component
-@Configuration
 @ConfigurationProperties(OperateProperties.PREFIX)
 @PropertySource("classpath:operate-version.properties")
-@DependsOn(
-    "databaseInfo") // as DatabaseInfo is used in #getIndexPrefix(), it should be loaded first
 public class OperateProperties {
 
   public static final String PREFIX = "camunda.operate";

--- a/operate/qa/integration-tests/pom.xml
+++ b/operate/qa/integration-tests/pom.xml
@@ -12,7 +12,6 @@
   <name>Operate QA Integration Tests</name>
 
   <dependencies>
-
     <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>operate-webapp</artifactId>
@@ -521,6 +520,13 @@
       <groupId>org.apache.tomcat</groupId>
       <artifactId>tomcat-annotations-api</artifactId>
       <version>11.0.9</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>configuration</artifactId>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/elasticsearch/DecisionIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/elasticsearch/DecisionIT.java
@@ -12,8 +12,6 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.core.type.TypeReference;
-import io.camunda.configuration.UnifiedConfiguration;
-import io.camunda.configuration.beanoverrides.OperatePropertiesOverride;
 import io.camunda.operate.property.OperateProperties;
 import io.camunda.operate.util.OperateAbstractIT;
 import io.camunda.operate.util.SearchTestRule;
@@ -41,9 +39,6 @@ import org.springframework.test.web.servlet.MvcResult;
 @SpringBootTest(
     classes = {
       TestApplication.class,
-      // Unified Configuration classes
-      UnifiedConfiguration.class,
-      OperatePropertiesOverride.class
     },
     properties = {
       OperateProperties.PREFIX + ".importer.startLoadingDataOnStartup = false",

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/elasticsearch/DecisionIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/elasticsearch/DecisionIT.java
@@ -12,6 +12,8 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.core.type.TypeReference;
+import io.camunda.configuration.UnifiedConfiguration;
+import io.camunda.configuration.beanoverrides.OperatePropertiesOverride;
 import io.camunda.operate.property.OperateProperties;
 import io.camunda.operate.util.OperateAbstractIT;
 import io.camunda.operate.util.SearchTestRule;
@@ -37,7 +39,12 @@ import org.springframework.test.web.servlet.MvcResult;
 
 /** Tests Elasticsearch queries for decision. */
 @SpringBootTest(
-    classes = {TestApplication.class},
+    classes = {
+      TestApplication.class,
+      // Unified Configuration classes
+      UnifiedConfiguration.class,
+      OperatePropertiesOverride.class
+    },
     properties = {
       OperateProperties.PREFIX + ".importer.startLoadingDataOnStartup = false",
       OperateProperties.PREFIX + ".archiver.rolloverEnabled = false",

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/metric/UsageMetricIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/metric/UsageMetricIT.java
@@ -12,6 +12,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
+import io.camunda.configuration.UnifiedConfiguration;
+import io.camunda.configuration.beanoverrides.OperatePropertiesOverride;
 import io.camunda.operate.property.OperateProperties;
 import io.camunda.operate.qa.util.DependencyInjectionTestExecutionListener;
 import io.camunda.operate.store.MetricsStore;
@@ -33,7 +35,12 @@ import org.springframework.test.context.junit4.SpringRunner;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(
-    classes = {TestApplication.class},
+    classes = {
+      TestApplication.class,
+      // Unified Configuration classes
+      UnifiedConfiguration.class,
+      OperatePropertiesOverride.class
+    },
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
     properties = {
       OperateProperties.PREFIX + ".importer.startLoadingDataOnStartup = false",

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/metric/UsageMetricIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/metric/UsageMetricIT.java
@@ -12,8 +12,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
-import io.camunda.configuration.UnifiedConfiguration;
-import io.camunda.configuration.beanoverrides.OperatePropertiesOverride;
 import io.camunda.operate.property.OperateProperties;
 import io.camunda.operate.qa.util.DependencyInjectionTestExecutionListener;
 import io.camunda.operate.store.MetricsStore;
@@ -37,9 +35,6 @@ import org.springframework.test.context.junit4.SpringRunner;
 @SpringBootTest(
     classes = {
       TestApplication.class,
-      // Unified Configuration classes
-      UnifiedConfiguration.class,
-      OperatePropertiesOverride.class
     },
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
     properties = {

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/OperateAbstractIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/OperateAbstractIT.java
@@ -15,8 +15,6 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import io.camunda.configuration.UnifiedConfiguration;
-import io.camunda.configuration.beanoverrides.OperatePropertiesOverride;
 import io.camunda.operate.property.OperateProperties;
 import io.camunda.operate.qa.util.DependencyInjectionTestExecutionListener;
 import io.camunda.operate.webapp.rest.exception.NotAuthorizedException;
@@ -46,9 +44,6 @@ import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilde
 @SpringBootTest(
     classes = {
       TestApplication.class,
-      // Unified Configuration classes
-      UnifiedConfiguration.class,
-      OperatePropertiesOverride.class
     },
     properties = {
       OperateProperties.PREFIX + ".importer.startLoadingDataOnStartup = false",

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/OperateAbstractIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/OperateAbstractIT.java
@@ -15,6 +15,8 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import io.camunda.configuration.UnifiedConfiguration;
+import io.camunda.configuration.beanoverrides.OperatePropertiesOverride;
 import io.camunda.operate.property.OperateProperties;
 import io.camunda.operate.qa.util.DependencyInjectionTestExecutionListener;
 import io.camunda.operate.webapp.rest.exception.NotAuthorizedException;
@@ -42,7 +44,12 @@ import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilde
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(
-    classes = {TestApplication.class},
+    classes = {
+      TestApplication.class,
+      // Unified Configuration classes
+      UnifiedConfiguration.class,
+      OperatePropertiesOverride.class
+    },
     properties = {
       OperateProperties.PREFIX + ".importer.startLoadingDataOnStartup = false",
       OperateProperties.PREFIX + ".archiver.rolloverEnabled = false",

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/TestApplication.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/TestApplication.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.operate.util;
 
+import io.camunda.configuration.UnifiedConfiguration;
+import io.camunda.configuration.beanoverrides.OperatePropertiesOverride;
 import io.camunda.operate.OperateModuleConfiguration;
 import io.camunda.webapps.WebappsModuleConfiguration;
 import org.springframework.boot.SpringApplication;
@@ -28,7 +30,12 @@ import org.springframework.context.annotation.Import;
           value = OperateModuleConfiguration.class),
     },
     nameGenerator = FullyQualifiedAnnotationBeanNameGenerator.class)
-@Import(WebappsModuleConfiguration.class)
+@Import({
+  WebappsModuleConfiguration.class,
+  // Unified Configuration classes
+  UnifiedConfiguration.class,
+  OperatePropertiesOverride.class
+})
 public class TestApplication {
 
   public static void main(final String[] args) throws Exception {

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/apps/modules/ModulesTestApplication.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/apps/modules/ModulesTestApplication.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.operate.util.apps.modules;
 
+import io.camunda.configuration.UnifiedConfiguration;
+import io.camunda.configuration.beanoverrides.OperatePropertiesOverride;
 import io.camunda.operate.OperateModuleConfiguration;
 import io.camunda.operate.util.TestApplication;
 import io.camunda.webapps.WebappsModuleConfiguration;
@@ -40,7 +42,12 @@ import org.springframework.context.annotation.Import;
           value = OperateModuleConfiguration.class)
     },
     nameGenerator = FullyQualifiedAnnotationBeanNameGenerator.class)
-@Import(WebappsModuleConfiguration.class)
+@Import({
+  WebappsModuleConfiguration.class,
+  // Unified Configuration classes
+  UnifiedConfiguration.class,
+  OperatePropertiesOverride.class
+})
 public class ModulesTestApplication {
 
   public static void main(final String[] args) throws Exception {

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/BackupControllerIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/BackupControllerIT.java
@@ -35,6 +35,8 @@ import co.elastic.clients.transport.TransportException;
 import co.elastic.clients.util.ObjectBuilder;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import io.camunda.configuration.UnifiedConfiguration;
+import io.camunda.configuration.beanoverrides.OperatePropertiesOverride;
 import io.camunda.management.backups.Error;
 import io.camunda.management.backups.HistoryBackupDetail;
 import io.camunda.management.backups.HistoryBackupInfo;
@@ -77,7 +79,12 @@ anymore, it will be done in a follow-up PR
 */
 @RunWith(SpringRunner.class)
 @SpringBootTest(
-    classes = {TestApplication.class},
+    classes = {
+      TestApplication.class,
+      // Unified Configuration classes
+      UnifiedConfiguration.class,
+      OperatePropertiesOverride.class
+    },
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
     properties = {
       OperateProperties.PREFIX + ".importer.startLoadingDataOnStartup = false",

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/BackupControllerIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/BackupControllerIT.java
@@ -35,8 +35,6 @@ import co.elastic.clients.transport.TransportException;
 import co.elastic.clients.util.ObjectBuilder;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import io.camunda.configuration.UnifiedConfiguration;
-import io.camunda.configuration.beanoverrides.OperatePropertiesOverride;
 import io.camunda.management.backups.Error;
 import io.camunda.management.backups.HistoryBackupDetail;
 import io.camunda.management.backups.HistoryBackupInfo;
@@ -81,9 +79,6 @@ anymore, it will be done in a follow-up PR
 @SpringBootTest(
     classes = {
       TestApplication.class,
-      // Unified Configuration classes
-      UnifiedConfiguration.class,
-      OperatePropertiesOverride.class
     },
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
     properties = {

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/security/AuthorizationIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/security/AuthorizationIT.java
@@ -16,8 +16,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
-import io.camunda.configuration.UnifiedConfiguration;
-import io.camunda.configuration.beanoverrides.OperatePropertiesOverride;
 import io.camunda.operate.property.OperateProperties;
 import io.camunda.operate.util.TestApplication;
 import io.camunda.operate.webapp.elasticsearch.reader.ProcessInstanceReader;
@@ -42,9 +40,6 @@ import org.springframework.test.context.web.WebAppConfiguration;
 @SpringBootTest(
     classes = {
       TestApplication.class,
-      // Unified Configuration classes
-      UnifiedConfiguration.class,
-      OperatePropertiesOverride.class
     },
     properties = {
       OperateProperties.PREFIX + ".importer.startLoadingDataOnStartup = false",

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/security/AuthorizationIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/security/AuthorizationIT.java
@@ -16,6 +16,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import io.camunda.configuration.UnifiedConfiguration;
+import io.camunda.configuration.beanoverrides.OperatePropertiesOverride;
 import io.camunda.operate.property.OperateProperties;
 import io.camunda.operate.util.TestApplication;
 import io.camunda.operate.webapp.elasticsearch.reader.ProcessInstanceReader;
@@ -38,7 +40,12 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.web.WebAppConfiguration;
 
 @SpringBootTest(
-    classes = {TestApplication.class},
+    classes = {
+      TestApplication.class,
+      // Unified Configuration classes
+      UnifiedConfiguration.class,
+      OperatePropertiesOverride.class
+    },
     properties = {
       OperateProperties.PREFIX + ".importer.startLoadingDataOnStartup = false",
       OperateProperties.PREFIX + ".zeebe.compatibility.enabled = true",

--- a/qa/util/src/main/java/io/camunda/qa/util/cluster/TestCamundaApplication.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/cluster/TestCamundaApplication.java
@@ -19,6 +19,7 @@ import io.camunda.application.commons.security.CamundaSecurityConfiguration.Camu
 import io.camunda.application.initializers.WebappsConfigurationInitializer;
 import io.camunda.authentication.config.AuthenticationProperties;
 import io.camunda.configuration.UnifiedConfiguration;
+import io.camunda.configuration.beanoverrides.OperatePropertiesOverride;
 import io.camunda.configuration.beanoverrides.TasklistPropertiesOverride;
 import io.camunda.identity.IdentityModuleConfiguration;
 import io.camunda.operate.OperateModuleConfiguration;
@@ -65,8 +66,11 @@ public final class TestCamundaApplication extends TestSpringApplication<TestCamu
 
   public TestCamundaApplication() {
     super(
+        // Unified Configuration classes
         UnifiedConfiguration.class,
         TasklistPropertiesOverride.class,
+        OperatePropertiesOverride.class,
+        // ---
         CommonsModuleConfiguration.class,
         OperateModuleConfiguration.class,
         TasklistModuleConfiguration.class,


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Context:
https://github.com/camunda/camunda/issues/34814

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes https://github.com/camunda/camunda/issues/34814
