### PR TITLE
build: use '/' as basepath in local Operate dev env

### DIFF
--- a/operate/client/src/App/index.tsx
+++ b/operate/client/src/App/index.tsx
@@ -107,7 +107,7 @@ const routes = createRoutesFromElements(
 );
 
 const router = createBrowserRouter(routes, {
-  basename: window.clientConfig?.baseName ?? '/',
+  basename: import.meta.env.DEV ? '/' : (window.clientConfig?.baseName ?? '/'),
 });
 
 const App: React.FC = () => {


### PR DESCRIPTION
## Description

This change opens Operate with the correct path in the local vite dev env: `localhost:3000/operate`

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
