### PR TITLE
test:Add Unauthorized API Test For Operate

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v1/operate-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v1/operate-api-tests.spec.ts
@@ -75,3 +75,9 @@ test.describe('API tests', () => {
     expect(incidentsList.status()).toBe(200);
   });
 });
+test.describe('Unauthorized API tests', () => {
+  test('Unauthorized user cannot access Operate API', async ({request}) => {
+    const response = await request.post('/v1/process-definitions/search');
+    expect(response.status()).toBe(401);
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v1/tasklist-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v1/tasklist-api-tests.spec.ts
@@ -50,3 +50,10 @@ test.describe('API tests', () => {
     expect(response.status()).toBe(200);
   });
 });
+
+test.describe('Unauthorized API tests', () => {
+  test('Unauthorized user cannot access Tasklist API', async ({request}) => {
+    const response = await request.post('/v1/tasks/search');
+    expect(response.status()).toBe(401);
+  });
+});


### PR DESCRIPTION
## Description
[Closed issue](https://github.com/camunda/camunda/issues/34559)
Implemented test cases to verify unauthorized API behavior for both Operate and Tasklist modules.

[Link to the test run ](https://github.com/camunda/camunda/actions/runs/16192002650/job/45709783586)
## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

[Extra Backslashes Escaping Variable Values in Operate](https://github.com/camunda/camunda/issues/32439)
[Variable Editing Spinner issue](https://camunda.slack.com/archives/C08MRKHJ0CD/p1750420972401329)
