### PR TITLE
refactor: remove usage of the deprecated `DefaultCredentialsProvider:create`

### DIFF
--- a/operate/common/src/main/java/io/camunda/operate/connect/OpensearchConnector.java
+++ b/operate/common/src/main/java/io/camunda/operate/connect/OpensearchConnector.java
@@ -68,7 +68,6 @@ import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
 import org.springframework.util.StringUtils;
-import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.http.SdkHttpClient;
 import software.amazon.awssdk.http.crt.AwsCrtHttpClient;
@@ -215,8 +214,7 @@ public class OpensearchConnector {
       LOGGER.info("AWS Credentials are disabled. Using basic auth.");
       return false;
     }
-    final AwsCredentialsProvider credentialsProvider = DefaultCredentialsProvider.create();
-    try {
+    try (final var credentialsProvider = DefaultCredentialsProvider.builder().build()) {
       credentialsProvider.resolveCredentials();
       LOGGER.info("AWS Credentials can be resolved. Use AWS Opensearch");
       return true;

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/upgrade/os/OpenSearchClientBuilder.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/upgrade/os/OpenSearchClientBuilder.java
@@ -87,7 +87,6 @@ import org.opensearch.client.transport.httpclient5.ApacheHttpClient5TransportBui
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
-import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
 import software.amazon.awssdk.http.nio.netty.NettyNioAsyncHttpClient;
@@ -166,8 +165,7 @@ public class OpenSearchClientBuilder {
 
   private static boolean useAwsCredentials(final ConfigurationService configurationService) {
     if (configurationService.getOpenSearchConfiguration().getConnection().getAwsEnabled()) {
-      final AwsCredentialsProvider credentialsProvider = DefaultCredentialsProvider.create();
-      try {
+      try (final var credentialsProvider = DefaultCredentialsProvider.builder().build()) {
         credentialsProvider.resolveCredentials();
         LOG.info("AWS Credentials can be resolved. Use AWS OpenSearch");
         return true;

--- a/search/search-client-connect/src/main/java/io/camunda/search/connect/os/OpensearchConnector.java
+++ b/search/search-client-connect/src/main/java/io/camunda/search/connect/os/OpensearchConnector.java
@@ -56,7 +56,7 @@ public final class OpensearchConnector {
     this(
         configuration,
         new JacksonConfiguration(configuration).createObjectMapper(),
-        DefaultCredentialsProvider.create(),
+        DefaultCredentialsProvider.builder().build(),
         new PluginRepository());
   }
 

--- a/tasklist/common/src/main/java/io/camunda/tasklist/os/OpenSearchConnector.java
+++ b/tasklist/common/src/main/java/io/camunda/tasklist/os/OpenSearchConnector.java
@@ -486,8 +486,7 @@ public class OpenSearchConnector {
     if (!tasklistProperties.getOpenSearch().isAwsEnabled()) {
       return false;
     }
-    final AwsCredentialsProvider credentialsProvider = DefaultCredentialsProvider.create();
-    try {
+    try (final var credentialsProvider = DefaultCredentialsProvider.builder().build()) {
       credentialsProvider.resolveCredentials();
       LOGGER.info("AWS Credentials can be resolved. Use AWS Opensearch");
       return true;
@@ -545,7 +544,7 @@ public class OpenSearchConnector {
 
   private void configureAwsSigningForApacheHttpClient(
       final org.apache.http.impl.nio.client.HttpAsyncClientBuilder builder) {
-    final AwsCredentialsProvider credentialsProvider = DefaultCredentialsProvider.create();
+    final AwsCredentialsProvider credentialsProvider = DefaultCredentialsProvider.builder().build();
     credentialsProvider.resolveCredentials();
     final AwsV4HttpSigner signer = AwsV4HttpSigner.create();
     final HttpRequestInterceptor signInterceptor =

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/RestClientFactory.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/RestClientFactory.java
@@ -139,7 +139,7 @@ final class RestClientFactory {
    */
   public void configureAws(
       final HttpAsyncClientBuilder builder, final AwsConfiguration awsConfiguration) {
-    final AwsCredentialsProvider credentialsProvider = DefaultCredentialsProvider.create();
+    final AwsCredentialsProvider credentialsProvider = DefaultCredentialsProvider.builder().build();
     credentialsProvider.resolveCredentials();
     final AwsV4HttpSigner signer = AwsV4HttpSigner.create();
 


### PR DESCRIPTION
## Description

As the [javadocs](https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/auth/credentials/DefaultCredentialsProvider.html#create()) suggests:
The create() method that returns a singleton instance which can cause issues if one client closes the provider while others are still using it. Use `builder().build()` to create independent instances, which is the safer approach and recommended for most use cases.