### PR TITLE
CI: allow concurrent stable branch builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,11 +18,11 @@ on:
     - cron: '0 6 * * *' # daily full build in the morning to re-populate GHA caches
 
 # Limit workflow to 1 concurrent run per ref (branch): new commit -> old runs are canceled to save costs
-# Exception for main branch: complete builds for every commit needed for confidenence
+# Exception for main + stable/* branches: complete builds for every commit needed for confidenence
 # Exception for deploy jobs that have to wait for each other to avoid overwriting
 concurrency:
   cancel-in-progress: true
-  group: ${{ format('{0}-{1}', github.workflow, github.ref == 'refs/heads/main' && github.sha || github.ref) }}
+  group: ${{ format('{0}-{1}', github.workflow, (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/stable/')) && github.sha || github.ref) }}
 
 defaults:
   run:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,12 +17,12 @@ on:
   schedule:
     - cron: '0 6 * * *' # daily full build in the morning to re-populate GHA caches
 
-# Limit workflow to 1 concurrent run per ref (branch): new commit -> old runs are canceled to save costs
+# Limit workflow to 1 concurrent run per ref (branch) and trigger event (push/schedule/etc): new commit -> old runs are canceled to save costs
 # Exception for main + stable/* branches: complete builds for every commit needed for confidenence
 # Exception for deploy jobs that have to wait for each other to avoid overwriting
 concurrency:
   cancel-in-progress: true
-  group: ${{ format('{0}-{1}', github.workflow, (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/stable/')) && github.sha || github.ref) }}
+  group: ${{ format('{0}-{1}-{2}', github.workflow, github.event_name, (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/stable/')) && github.sha || github.ref) }}
 
 defaults:
   run:


### PR DESCRIPTION
## Description

This PR includes two changes:

1. We allow concurrent Unified CI builds on the same `stable/*` branch to complete, in order to address https://github.com/camunda/camunda/issues/28236 and have complete SNAPSHOT artifact uploads
2. (Not directly related to the ticket) We include the [`github.event_name`](https://docs.github.com/en/actions/reference/contexts-reference#github-context) (push/schedule/etc) in the `concurrency` group name to allow concurrent builds with different triggers but the same branch (most likely `main`) to complete:
    * Scenario: nightly `schedule`d build on `main` starts and someone `push`es to `main` at the same time -> one build will be cancelled (only ref+workflow name were relevant in the past) but we want both to continue (now ref+workflow name+event name are relevant)
    * Examples of the new `concurrency` group names for illustration of the desired effect:
        * `CI-push-8639485743985931` for Unified CI workflow `ci.yml` and commit SHA `8639485743985931` on `push` event
        * `CI-pull_request-mycoolbranchname` for Unified CI workflow `ci.yml` on a PR of `mycoolbranchname`
        * `Legacy Optimize E2E-push-8639485743985931` etc

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)). - for all branches with Unified CI

## Related issues

Related to https://github.com/camunda/camunda/issues/28236
