### PR TITLE
fix: fetch complete variable data instead of asserting on truncated variables

### DIFF
--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/CamundaDataSource.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/CamundaDataSource.java
@@ -73,6 +73,10 @@ public class CamundaDataSource {
         .items();
   }
 
+  public Variable getVariable(final long variableKey) {
+    return client.newVariableGetRequest(variableKey).send().join();
+  }
+
   public List<ProcessInstance> findProcessInstances() {
     return findProcessInstances(filter -> {});
   }

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/LargeVariableIT.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/LargeVariableIT.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.api;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.response.ProcessInstanceEvent;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+@CamundaProcessTest
+public class LargeVariableIT {
+
+  // to be injected
+  private CamundaClient client;
+  private CamundaProcessTestContext processTestContext;
+
+  @Test
+  void shouldHandleTruncatedVariables() {
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .name("start")
+            .endEvent()
+            .name("end")
+            .done();
+
+    client.newDeployResourceCommand().addProcessModel(process, "process.bpmn").send().join();
+
+    final Map<String, Object> variables = new HashMap<>();
+    variables.put("small", "smallValue");
+    variables.put("large", createLargeString(100));
+
+    final ProcessInstanceEvent processInstance =
+        client
+            .newCreateInstanceCommand()
+            .bpmnProcessId("process")
+            .latestVersion()
+            .variables(variables)
+            .send()
+            .join();
+
+    CamundaAssert.assertThat(processInstance).isCompleted().hasVariables(variables);
+  }
+
+  private String createLargeString(final long sizeKb) {
+    final StringBuilder sb = new StringBuilder();
+    for (long i = 0; i < sizeKb * 1024; i++) {
+      sb.append('a');
+    }
+
+    return sb.toString();
+  }
+}


### PR DESCRIPTION
## Description

When asserting a variable with a value large enough to be truncated, CPT will run into JSON parsing errors in VariableAssertj.readJson. This PR fixes this bug by checking the `isTruncated` flag and fetching the complete variable.

## Related issues

closes https://github.com/camunda/camunda/issues/32755
