### PR TITLE
[Backport stable/8.6] fix: build cloud audience correctly

### DIFF
--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientCloudBuilderImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientCloudBuilderImpl.java
@@ -345,7 +345,7 @@ public class ZeebeClientCloudBuilderImpl
         Loggers.LOGGER.debug("Expected setting 'usePlaintext' to be 'false', but found 'true'.");
       }
       return builder
-          .audience(String.format("%s.%s.%s", clusterId, region, domain))
+          .audience(String.format("%s.%s", ZEEBE_DOMAIN_COMPONENT, domain))
           .clientId(clientId)
           .clientSecret(clientSecret)
           .authorizationServerUrl(String.format("https://login.cloud.%s/oauth/token", domain))


### PR DESCRIPTION
# Description
Backport of #35103 to `stable/8.6`.

relates to 