### PR TITLE
Delete persisted snapshot if it's a snapshot for bootstrap before fetching a new one 

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/steps/SnapshotStoreStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/steps/SnapshotStoreStep.java
@@ -17,9 +17,9 @@ import io.camunda.zeebe.scheduler.SchedulingHints;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.scheduler.startup.StartupStep;
-import io.camunda.zeebe.snapshots.impl.FileBasedSnapshotId;
 import io.camunda.zeebe.snapshots.impl.FileBasedSnapshotStore;
 import io.camunda.zeebe.snapshots.transfer.SnapshotTransferImpl;
+import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -55,11 +55,10 @@ public class SnapshotStoreStep implements StartupStep<PartitionStartupContext> {
       // It's not possible to persist the same snapshot twice, so we must delete it first
       if (snapshotStore.getLatestSnapshot().isPresent()) {
         final var latestSnapshot = snapshotStore.getLatestSnapshot().get();
-        final var isBootstrap =
-            FileBasedSnapshotId.ofFileName(latestSnapshot.getId())
-                .map(FileBasedSnapshotId::isForBootstrap)
-                .orElse(false);
+        final var isBootstrap = latestSnapshot.getMetadata().isBootstrap();
         if (isBootstrap) {
+          LOG.info(
+              "A bootstrapped snapshot is present, deleting it in order to be able to fetch it again and bootstrap cleanly.");
           result =
               result.andThen(
                   ctx -> snapshotStore.delete().thenApply(empty -> ctx),
@@ -95,7 +94,8 @@ public class SnapshotStoreStep implements StartupStep<PartitionStartupContext> {
                             context.concurrencyControl());
                   },
                   context.concurrencyControl())
-              .andThen(this::initializeFromBootstrapSnapshot, context.concurrencyControl());
+              .andThen(this::initializeFromBootstrapSnapshot, context.concurrencyControl())
+              .andThen(this::deleteBootstrapSnapshot, context.concurrencyControl());
     }
     return result;
   }
@@ -107,7 +107,26 @@ public class SnapshotStoreStep implements StartupStep<PartitionStartupContext> {
         .thenApply(ignored -> context.snapshotStore(null), context.concurrencyControl());
   }
 
-  ActorFuture<PartitionStartupContext> initializeFromBootstrapSnapshot(
+  /** Deletes the snapshot for bootstrap, even if an error was raised. */
+  private ActorFuture<PartitionStartupContext> deleteBootstrapSnapshot(
+      final PartitionStartupContext context, final Throwable error) {
+    final var result =
+        Optional.ofNullable(context.snapshotStore())
+            .map(FileBasedSnapshotStore::deleteBootstrapSnapshots)
+            .orElse(CompletableActorFuture.completed());
+
+    return result.andThen(
+        ignored -> {
+          if (error != null) {
+            return CompletableActorFuture.completedExceptionally(error);
+          } else {
+            return CompletableActorFuture.completed(context);
+          }
+        },
+        context.concurrencyControl());
+  }
+
+  private ActorFuture<PartitionStartupContext> initializeFromBootstrapSnapshot(
       final PartitionStartupContext context) {
     final var fut = context.snapshotTransfer().getLatestSnapshot(Protocol.DEPLOYMENT_PARTITION);
     return fut.andThen(
@@ -118,10 +137,7 @@ public class SnapshotStoreStep implements StartupStep<PartitionStartupContext> {
               } else {
                 LOG.info(
                     "Received snapshot {} from leader, restoring from snapshot", snapshot.getId());
-                return context
-                    .snapshotStore()
-                    .restore(snapshot)
-                    .andThen(ignore -> context.snapshotStore().deleteBootstrapSnapshots());
+                return context.snapshotStore().restore(snapshot);
               }
             },
             context.concurrencyControl())

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/steps/SnapshotStoreStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/steps/SnapshotStoreStep.java
@@ -90,7 +90,10 @@ public class SnapshotStoreStep implements StartupStep<PartitionStartupContext> {
               } else {
                 LOG.info(
                     "Received snapshot {} from leader, restoring from snapshot", snapshot.getId());
-                return context.snapshotStore().restore(snapshot);
+                return context
+                    .snapshotStore()
+                    .restore(snapshot)
+                    .andThen(ignore -> context.snapshotStore().deleteBootstrapSnapshots());
               }
             },
             context.concurrencyControl())

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedReceivedSnapshot.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedReceivedSnapshot.java
@@ -272,10 +272,6 @@ public class FileBasedReceivedSnapshot implements ReceivedSnapshot {
                 snapshotId.getExportedPosition(),
                 Long.MAX_VALUE,
                 false);
-      } else {
-        // received snapshot are not considered "for bootstrap", they need to be saved in the
-        // usual snapshot directory
-        metadata = metadata.notBootstrap();
       }
       final PersistedSnapshot value =
           snapshotStore.persistNewSnapshot(directory, snapshotId, checksumCollection, metadata);

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshot.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshot.java
@@ -157,7 +157,6 @@ public final class FileBasedSnapshot implements PersistedSnapshot {
   }
 
   void delete() {
-    LOGGER.debug("Deleting snapshot {}", snapshotId);
     // the checksum, as a mark file, should be deleted first
     try {
       Files.deleteIfExists(checksumFile);

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotId.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotId.java
@@ -52,6 +52,10 @@ public final class FileBasedSnapshotId implements SnapshotId {
     brokerId = Optional.empty();
   }
 
+  static FileBasedSnapshotId forBoostrap(final int brokerId) {
+    return new FileBasedSnapshotId(1, 1, 0, 0, brokerId);
+  }
+
   // TODO(npepinpe): using Either here would improve readability and observability, as validation
   //  can have better error messages, and the return type better expresses what we attempt to do,
   //  i.e. either it failed (with an error) or it succeeded

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotMetadata.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotMetadata.java
@@ -38,11 +38,6 @@ public record FileBasedSnapshotMetadata(
     return new FileBasedSnapshotMetadata(version, 0L, 0L, 0L, true);
   }
 
-  public FileBasedSnapshotMetadata notBootstrap() {
-    return new FileBasedSnapshotMetadata(
-        version, processedPosition, exportedPosition, lastFollowupEventPosition, false);
-  }
-
   public void encode(final OutputStream output) throws IOException {
     OBJECTMAPPER.writeValue(output, this);
   }

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStoreImpl.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStoreImpl.java
@@ -116,7 +116,6 @@ public final class FileBasedSnapshotStoreImpl {
   }
 
   public void close() {
-    LOGGER.debug("Closing snapshot store {}", snapshotsDirectory);
     listeners.clear();
     deleteBootstrapSnapshotsInternal();
   }
@@ -512,7 +511,7 @@ public final class FileBasedSnapshotStoreImpl {
       // it's important to persist the checksum file only after the move is finished, since we use
       // it as a marker file to guarantee the move was complete and not partial
       final var checksumPath =
-          computeChecksum(destination, snapshotId, immutableChecksumsSFV, destination);
+          computeChecksum(snapshotId, immutableChecksumsSFV, destination, isBootstrap);
 
       final var newPersistedSnapshot =
           new FileBasedSnapshot(
@@ -562,11 +561,11 @@ public final class FileBasedSnapshotStoreImpl {
   }
 
   private Path computeChecksum(
-      final Path source,
       final FileBasedSnapshotId snapshotId,
       final ImmutableChecksumsSFV immutableChecksumsSFV,
-      final Path destination) {
-    final var checksumPath = buildSnapshotsChecksumPath(source, snapshotId);
+      final Path destination,
+      final boolean isBootstrap) {
+    final var checksumPath = buildSnapshotsChecksumPath(snapshotId, isBootstrap);
     final var tmpChecksumPath =
         checksumPath.resolveSibling(checksumPath.getFileName().toString() + TMP_CHECKSUM_SUFFIX);
     try {
@@ -625,6 +624,12 @@ public final class FileBasedSnapshotStoreImpl {
 
   private Path buildSnapshotsChecksumPath(final Path snapshotPath, final SnapshotId snapshotId) {
     return snapshotPath.getParent().resolve(snapshotId.getSnapshotIdAsString() + CHECKSUM_SUFFIX);
+  }
+
+  private Path buildSnapshotsChecksumPath(
+      final FileBasedSnapshotId snapshotId, final boolean isBoostrap) {
+    final var directory = isBoostrap ? bootstrapSnapshotsDirectory : snapshotsDirectory;
+    return directory.resolve(snapshotId.getSnapshotIdAsString() + CHECKSUM_SUFFIX);
   }
 
   private boolean isChecksumFile(final String name) {

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStoreImpl.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStoreImpl.java
@@ -116,6 +116,7 @@ public final class FileBasedSnapshotStoreImpl {
   }
 
   public void close() {
+    LOGGER.debug("Closing snapshot store {}", snapshotsDirectory);
     listeners.clear();
     deleteBootstrapSnapshotsInternal();
   }
@@ -511,7 +512,7 @@ public final class FileBasedSnapshotStoreImpl {
       // it's important to persist the checksum file only after the move is finished, since we use
       // it as a marker file to guarantee the move was complete and not partial
       final var checksumPath =
-          computeChecksum(snapshotId, immutableChecksumsSFV, destination, isBootstrap);
+          computeChecksum(destination, snapshotId, immutableChecksumsSFV, destination);
 
       final var newPersistedSnapshot =
           new FileBasedSnapshot(
@@ -561,11 +562,11 @@ public final class FileBasedSnapshotStoreImpl {
   }
 
   private Path computeChecksum(
+      final Path source,
       final FileBasedSnapshotId snapshotId,
       final ImmutableChecksumsSFV immutableChecksumsSFV,
-      final Path destination,
-      final boolean isBootstrap) {
-    final var checksumPath = buildSnapshotsChecksumPath(snapshotId, isBootstrap);
+      final Path destination) {
+    final var checksumPath = buildSnapshotsChecksumPath(source, snapshotId);
     final var tmpChecksumPath =
         checksumPath.resolveSibling(checksumPath.getFileName().toString() + TMP_CHECKSUM_SUFFIX);
     try {
@@ -624,12 +625,6 @@ public final class FileBasedSnapshotStoreImpl {
 
   private Path buildSnapshotsChecksumPath(final Path snapshotPath, final SnapshotId snapshotId) {
     return snapshotPath.getParent().resolve(snapshotId.getSnapshotIdAsString() + CHECKSUM_SUFFIX);
-  }
-
-  private Path buildSnapshotsChecksumPath(
-      final FileBasedSnapshotId snapshotId, final boolean isBoostrap) {
-    final var directory = isBoostrap ? bootstrapSnapshotsDirectory : snapshotsDirectory;
-    return directory.resolve(snapshotId.getSnapshotIdAsString() + CHECKSUM_SUFFIX);
   }
 
   private boolean isChecksumFile(final String name) {

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStoreImpl.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStoreImpl.java
@@ -738,7 +738,7 @@ public final class FileBasedSnapshotStoreImpl {
   public ActorFuture<PersistedSnapshot> copyForBootstrap(
       final PersistedSnapshot persistedSnapshot, final BiConsumer<Path, Path> copySnapshot) {
     final var snapshotPath = persistedSnapshot.getPath();
-    final var zeroedSnapshotId = new FileBasedSnapshotId(1, 1, 0, 0, brokerId);
+    final var zeroedSnapshotId = FileBasedSnapshotId.forBoostrap(brokerId);
 
     final var destinationFolder = buildSnapshotDirectory(zeroedSnapshotId, true);
 

--- a/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/transfer/SnapshotTransferTest.java
+++ b/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/transfer/SnapshotTransferTest.java
@@ -112,7 +112,8 @@ public class SnapshotTransferTest {
             snapshot -> {
               assertThat(snapshot.getId()).isEqualTo("1-1-0-0-0");
               assertThat(snapshot.getMetadata())
-                  .isEqualTo(FileBasedSnapshotMetadata.forBootstrap(1).notBootstrap());
+                  .isEqualTo(FileBasedSnapshotMetadata.forBootstrap(1));
+              assertThat(snapshot.isBootstrap()).isTrue();
               assertThat(snapshot.files()).isNotEmpty();
             });
     assertThat(snapshotMetrics.getTransferDuration(true).mean(TimeUnit.MILLISECONDS))


### PR DESCRIPTION
## Description
The issue is fixed by checking if the `SnapshotStore` has found a snapshot before fetching the snapshot for bootstrap.
If the snapshot found is a snapshot for bootstrap, then it's deleted for safety and it will be fetched again.
If the snapshot is not for bootstrap, then manual intervention is required to fix the issue.

To make checking if a snapshot is for bootstrap I reverted the commit that set `isBootstrap=false` when a snapshot was persisted. In this way, we can check if it was made for bootstrap by only checking the metadata and not by matching the file pattern.

Moreover, the snapshot for bootstrap (in the `bootstrap-snapshots/`) is deleted before the `start` method returns, regardless if it terminated with an error or not.


## Related issues

closes #35152
