### PR TITLE
feat: prevent log compaction until backup is confirmed

### DIFF
--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -1102,6 +1102,10 @@
       # are subject to change and can be dropped at any time.
       # It might be that also some of them are actually dangerous so be aware when you change one of these!
 
+      # Toggles continuous backups, a new feature that prevents log compaction until entries are backed up.
+      # This setting can also be overridden using the environment variable ZEEBE_BROKER_EXPERIMENTAL_CONTINUOUSBACKUPS
+      # continuousBackups = false
+
       # Toggles the version check restriction, used for migration. Useful for testing migration logic on
       # snapshot or alpha versions. Default: True, means it is not allowed to migrate to incompatible version
       # like: SNAPSHOT or alpha.

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -1015,6 +1015,10 @@
       # are subject to change and can be dropped at any time.
       # It might be that also some of them are actually dangerous so be aware when you change one of these!
 
+      # Toggles continuous backups, a new feature that prevents log compaction until entries are backed up.
+      # This setting can also be overridden using the environment variable ZEEBE_BROKER_EXPERIMENTAL_CONTINUOUSBACKUPS
+      # continuousBackups = false
+
       # Toggles the version check restriction, used for migration. Useful for testing migration logic on
       # snapshot or alpha versions. Default: True, means it is not allowed to migrate to incompatible version
       # like: SNAPSHOT or alpha.

--- a/zeebe/backup/src/test/java/io/camunda/zeebe/backup/processing/CheckpointRecordsProcessorTest.java
+++ b/zeebe/backup/src/test/java/io/camunda/zeebe/backup/processing/CheckpointRecordsProcessorTest.java
@@ -337,10 +337,17 @@ final class CheckpointRecordsProcessorTest {
 
     final var newCheckpointId = 10;
     final var newCheckpointPosition = 100;
-    final var value = new CheckpointRecord().setCheckpointId(newCheckpointId);
+    final var value =
+        new CheckpointRecord()
+            .setCheckpointId(newCheckpointId)
+            .setCheckpointPosition(newCheckpointPosition);
     final var record =
         new MockTypedCheckpointRecord(
-            newCheckpointPosition, 0, CheckpointIntent.CONFIRM_BACKUP, RecordType.COMMAND, value);
+            newCheckpointPosition + 10,
+            0,
+            CheckpointIntent.CONFIRM_BACKUP,
+            RecordType.COMMAND,
+            value);
 
     // when
     final var result = (MockProcessingResult) processor.process(record, resultBuilder);
@@ -351,6 +358,8 @@ final class CheckpointRecordsProcessorTest {
         .returns(CheckpointIntent.CONFIRMED_BACKUP, Event::intent)
         .returns(RecordType.EVENT, Event::type)
         .returns(value, Event::value);
+    assertThat(state.getLatestBackupId()).isEqualTo(newCheckpointId);
+    assertThat(state.getLatestBackupPosition()).isEqualTo(newCheckpointPosition);
   }
 
   @Test

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/logstreams/state/StatePositionSupplier.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/logstreams/state/StatePositionSupplier.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.broker.logstreams.state;
 
+import io.camunda.zeebe.backup.processing.state.DbCheckpointState;
 import io.camunda.zeebe.broker.exporter.stream.ExportersState;
 import io.camunda.zeebe.db.ZeebeDb;
 
@@ -20,5 +21,10 @@ public final class StatePositionSupplier {
     } else {
       return Long.MAX_VALUE;
     }
+  }
+
+  public static long getHighestBackupPosition(final ZeebeDb zeebeDb) {
+    final var checkpointState = new DbCheckpointState(zeebeDb, zeebeDb.createContext());
+    return checkpointState.getLatestBackupPosition();
   }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/ZeebePartitionFactory.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/ZeebePartitionFactory.java
@@ -235,6 +235,7 @@ public final class ZeebePartitionFactory {
         runtimeDirectory,
         new AtomixRecordEntrySupplierImpl(raftPartition.getServer()),
         StatePositionSupplier::getHighestExportedPosition,
+        StatePositionSupplier::getHighestBackupPosition,
         concurrencyControl);
   }
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/ZeebePartitionFactory.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/ZeebePartitionFactory.java
@@ -51,6 +51,7 @@ import io.camunda.zeebe.broker.transport.commandapi.CommandApiService;
 import io.camunda.zeebe.broker.transport.commandapi.CommandApiServiceTransitionStep;
 import io.camunda.zeebe.broker.transport.snapshotapi.SnapshotApiRequestHandler;
 import io.camunda.zeebe.db.AccessMetricsConfiguration;
+import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.db.ZeebeDbFactory;
 import io.camunda.zeebe.db.impl.rocksdb.RocksDBSnapshotCopy;
 import io.camunda.zeebe.db.impl.rocksdb.ZeebeRocksDbFactory;
@@ -77,6 +78,7 @@ import java.io.UncheckedIOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
+import java.util.function.ToLongFunction;
 
 public final class ZeebePartitionFactory {
 
@@ -229,14 +231,25 @@ public final class ZeebePartitionFactory {
     } else {
       runtimeDirectory = raftPartition.dataDirectory().toPath().resolve("runtime");
     }
+
     return new StateControllerImpl(
         zeebeRocksDbFactory,
         snapshotStore,
         runtimeDirectory,
         new AtomixRecordEntrySupplierImpl(raftPartition.getServer()),
         StatePositionSupplier::getHighestExportedPosition,
-        StatePositionSupplier::getHighestBackupPosition,
+        getBackupPositionSupplier(),
         concurrencyControl);
+  }
+
+  private ToLongFunction<ZeebeDb> getBackupPositionSupplier() {
+    if (brokerCfg.getExperimental().isContinuousBackups()) {
+      return StatePositionSupplier::getHighestBackupPosition;
+    } else {
+      // When continuous backups are disabled, act as if everything is backed up. Ensures
+      // that backups do not control compaction.
+      return (ignored) -> Long.MAX_VALUE;
+    }
   }
 
   private TypedRecordProcessorsFactory createFactory(

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ExperimentalCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ExperimentalCfg.java
@@ -24,6 +24,8 @@ public class ExperimentalCfg implements ConfigurationEntry {
   public static final boolean DEFAULT_DISABLE_EXPLICIT_RAFT_FLUSH = false;
   public static final boolean DEFAULT_VERSION_CHECK_ENABLED = true;
 
+  private boolean continuousBackups = false;
+
   /**
    * Allows to enable/disable the version check, that prevents us on migrating to alpha versions,
    * etc.
@@ -40,6 +42,14 @@ public class ExperimentalCfg implements ConfigurationEntry {
   private ConsistencyCheckCfg consistencyChecks = new ConsistencyCheckCfg();
   private EngineCfg engine = new EngineCfg();
   private FeatureFlagsCfg features = new FeatureFlagsCfg();
+
+  public boolean isContinuousBackups() {
+    return continuousBackups;
+  }
+
+  public void setContinuousBackups(final boolean continuousBackups) {
+    this.continuousBackups = continuousBackups;
+  }
 
   public boolean isVersionCheckRestrictionEnabled() {
     return versionCheckRestrictionEnabled;

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/StateControllerImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/StateControllerImpl.java
@@ -41,6 +41,7 @@ public class StateControllerImpl implements StateController {
   private final Path runtimeDirectory;
   private final ZeebeDbFactory zeebeDbFactory;
   private final ToLongFunction<ZeebeDb> exporterPositionSupplier;
+  private final ToLongFunction<ZeebeDb> backupPositionSupplier;
   private final AtomixRecordEntrySupplier entrySupplier;
   private final ConstructableSnapshotStore constructableSnapshotStore;
   private final ConcurrencyControl concurrencyControl;
@@ -54,12 +55,14 @@ public class StateControllerImpl implements StateController {
       final Path runtimeDirectory,
       final AtomixRecordEntrySupplier entrySupplier,
       final ToLongFunction<ZeebeDb> exporterPositionSupplier,
+      final ToLongFunction<ZeebeDb> backupPositionSupplier,
       final ConcurrencyControl concurrencyControl) {
     this.constructableSnapshotStore = requireNonNull(constructableSnapshotStore);
     this.runtimeDirectory = requireNonNull(runtimeDirectory);
     this.zeebeDbFactory = requireNonNull(zeebeDbFactory);
-    this.exporterPositionSupplier = requireNonNull(exporterPositionSupplier);
     this.entrySupplier = requireNonNull(entrySupplier);
+    this.exporterPositionSupplier = requireNonNull(exporterPositionSupplier);
+    this.backupPositionSupplier = backupPositionSupplier;
     this.concurrencyControl = requireNonNull(concurrencyControl);
 
     concurrencyControl.execute(this::scheduleDbMetricsExport);

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/ExperimentalCfgTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/ExperimentalCfgTest.java
@@ -216,4 +216,39 @@ final class ExperimentalCfgTest {
     // then
     assertThat(experimental.isVersionCheckRestrictionEnabled()).isFalse();
   }
+
+  @Test
+  void shouldHaveDefaultContinuousBackups() {
+    // given
+
+    // when
+    final var cfg = TestConfigReader.readConfig("empty", environment);
+    final var experimental = cfg.getExperimental();
+
+    // then
+    assertThat(experimental.isContinuousBackups()).isFalse();
+  }
+
+  @Test
+  void shouldSetContinuousBackupsFromEnv() {
+    // given
+    environment.put("zeebe.broker.experimental.continuousBackups", "true");
+
+    // when
+    final var cfg = TestConfigReader.readConfig("empty", environment);
+    final var experimental = cfg.getExperimental();
+
+    // then
+    assertThat(experimental.isContinuousBackups()).isTrue();
+  }
+
+  @Test
+  void shouldSetContinuousBackupsFromConfig() {
+    // when
+    final var cfg = TestConfigReader.readConfig("experimental-cfg", environment);
+    final var experimental = cfg.getExperimental();
+
+    // then
+    assertThat(experimental.isContinuousBackups()).isTrue();
+  }
 }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/AsyncSnapshottingTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/AsyncSnapshottingTest.java
@@ -79,6 +79,7 @@ public final class AsyncSnapshottingTest {
                     new TestIndexedRaftLogEntry(
                         l + 100, 1, new SerializedApplicationEntry(1, 10, new UnsafeBuffer()))),
             db -> Long.MAX_VALUE,
+            db -> Long.MAX_VALUE,
             new TestConcurrencyControl());
 
     snapshotController.recover().join();

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/StateControllerImplTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/StateControllerImplTest.java
@@ -46,6 +46,7 @@ public final class StateControllerImplTest {
   @Rule public final ActorSchedulerRule actorSchedulerRule = new ActorSchedulerRule();
 
   private final MutableLong exporterPosition = new MutableLong(Long.MAX_VALUE);
+  private final MutableLong backupPosition = new MutableLong(Long.MAX_VALUE);
   private StateControllerImpl snapshotController;
   private FileBasedSnapshotStore store;
   private Path runtimeDirectory;
@@ -79,6 +80,7 @@ public final class StateControllerImplTest {
             runtimeDirectory,
             l -> atomixRecordEntrySupplier.get().getPreviousIndexedEntry(l),
             db -> exporterPosition.get(),
+            db -> backupPosition.get(),
             store);
 
     autoCloseableRule.manage(snapshotController);

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/perf/LargeStateControllerPerformanceTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/perf/LargeStateControllerPerformanceTest.java
@@ -88,6 +88,7 @@ public class LargeStateControllerPerformanceTest {
             context.temporaryFolder().resolve("runtime"),
             ignored -> Optional.empty(),
             ignored -> 0L,
+            ignored -> 0L,
             context.snapshotStore());
 
     // when

--- a/zeebe/broker/src/test/resources/system/experimental-cfg.yaml
+++ b/zeebe/broker/src/test/resources/system/experimental-cfg.yaml
@@ -1,6 +1,7 @@
 zeebe:
   broker:
     experimental:
+      continuousBackups: true
       versionCheckRestrictionEnabled: false
       enablePriorityElection: true
       raft:

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/ContinuousBackupIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/ContinuousBackupIT.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.backup;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import com.google.cloud.storage.BucketInfo;
+import io.camunda.management.backups.StateCode;
+import io.camunda.zeebe.backup.gcs.GcsBackupConfig;
+import io.camunda.zeebe.backup.gcs.GcsBackupStore;
+import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
+import io.camunda.zeebe.broker.system.configuration.backup.BackupStoreCfg.BackupStoreType;
+import io.camunda.zeebe.broker.system.configuration.backup.GcsBackupStoreConfig;
+import io.camunda.zeebe.broker.system.configuration.backup.GcsBackupStoreConfig.GcsBackupStoreAuth;
+import io.camunda.zeebe.qa.util.actuator.BackupActuator;
+import io.camunda.zeebe.qa.util.actuator.PartitionsActuator;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.zeebe.snapshots.impl.FileBasedSnapshotId;
+import io.camunda.zeebe.test.testcontainers.GcsContainer;
+import java.time.Duration;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@ZeebeIntegration
+@Testcontainers
+final class ContinuousBackupIT {
+  private static final String BUCKET_NAME = RandomStringUtils.randomAlphabetic(10).toLowerCase();
+  @Container private static final GcsContainer GCS = new GcsContainer();
+
+  private final String basePath = RandomStringUtils.randomAlphabetic(10).toLowerCase();
+
+  @TestZeebe
+  private final TestStandaloneBroker broker =
+      new TestStandaloneBroker().withBrokerConfig(this::configureBroker);
+
+  private BackupActuator backupActuator;
+  private PartitionsActuator partitionsActuator;
+
+  @BeforeEach
+  void setUp() {
+    backupActuator = BackupActuator.of(broker);
+    partitionsActuator = PartitionsActuator.of(broker);
+    // Some tests stop GCS, make sure it's always started again
+    GCS.start();
+  }
+
+  @BeforeAll
+  static void setupBucket() throws Exception {
+    final var config =
+        new GcsBackupConfig.Builder()
+            .withoutAuthentication()
+            .withHost(GCS.externalEndpoint())
+            .withBucketName(BUCKET_NAME)
+            .build();
+
+    try (final var client = GcsBackupStore.buildClient(config)) {
+      client.create(BucketInfo.of(BUCKET_NAME));
+    }
+  }
+
+  @Test
+  void missingBackupPreventsSnapshotProgress() {
+    // given - some initial processing
+    processSomeData();
+    await("initial processing is done")
+        .untilAsserted(
+            () ->
+                assertThat(partitionsActuator.query().get(1).processedPosition()).isGreaterThan(0));
+
+    // when - taking a snapshot without backup
+    partitionsActuator.takeSnapshot();
+
+    // then - snapshot is for the initial index (no progress due to missing backup)
+    await("snapshot is taken but doesn't progress beyond initial position")
+        .atMost(Duration.ofSeconds(30))
+        .untilAsserted(() -> assertThat(getSnapshotIndex()).isEqualTo(0));
+  }
+
+  @Test
+  void successfulBackupEnablesSnapshotProgress() {
+    // given - some initial processing
+    processSomeData();
+    await("initial processing is done")
+        .untilAsserted(
+            () ->
+                assertThat(partitionsActuator.query().get(1).processedPosition()).isGreaterThan(0));
+
+    // when - taking a successful backup, then processing a bit more and taking a snapshot
+    final var backupId = 1L;
+    backupActuator.take(backupId);
+
+    await("backup is completed")
+        .untilAsserted(
+            () ->
+                assertThat(backupActuator.status(backupId).getState())
+                    .isEqualTo(StateCode.COMPLETED));
+
+    // then - even after a new snapshot is taken, it's index is still the backup index
+    partitionsActuator.takeSnapshot();
+    await("snapshot is taken but doesn't progress beyond initial position")
+        .untilAsserted(() -> assertThat(getSnapshotIndex()).isGreaterThan(0));
+  }
+
+  private long getSnapshotIndex() {
+    return FileBasedSnapshotId.ofFileName(partitionsActuator.query().get(1).snapshotId())
+        .orElseThrow()
+        .getIndex();
+  }
+
+  private void processSomeData() {
+    try (final var client = broker.newClientBuilder().build()) {
+      for (int i = 5; i < 10; i++) {
+        client
+            .newPublishMessageCommand()
+            .messageName("test-message")
+            .correlationKey("key-" + i)
+            .send()
+            .join();
+      }
+    }
+  }
+
+  private void configureBroker(final BrokerCfg cfg) {
+    cfg.getExperimental().setContinuousBackups(true);
+
+    final var gcsConfig = new GcsBackupStoreConfig();
+    gcsConfig.setAuth(GcsBackupStoreAuth.NONE);
+    gcsConfig.setBasePath(basePath);
+    gcsConfig.setBucketName(BUCKET_NAME);
+    gcsConfig.setHost(GCS.externalEndpoint());
+    cfg.getData().getBackup().setGcs(gcsConfig);
+    cfg.getData().getBackup().setStore(BackupStoreType.GCS);
+  }
+}

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/ContinuousBackupIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/ContinuousBackupIT.java
@@ -109,7 +109,7 @@ final class ContinuousBackupIT {
 
     // then - even after a new snapshot is taken, it's index is still the backup index
     partitionsActuator.takeSnapshot();
-    await("snapshot is taken but doesn't progress beyond initial position")
+    await("snapshot is taken with backup position")
         .untilAsserted(() -> assertThat(getSnapshotIndex()).isGreaterThan(0));
   }
 


### PR DESCRIPTION
This adds another factor to the snapshot index calculation, the backup position. When enabled via `zeebe.broker.experimental.continuousBackups`, this prevents log compaction until a backup succeeded.

closes #35157