### PR TITLE
deps: remove AWS SDK v1 dependencies in favor of v2

### DIFF
--- a/operate/common/pom.xml
+++ b/operate/common/pom.xml
@@ -335,8 +335,7 @@
         <configuration>
           <usedDependencies>
             <!-- This dependency is indirectly used by the awssk auth plugin. It requires these
-     classes on the classpath in order to resolve the AWS credentials -->
-            <dependency>com.amazonaws:aws-java-sdk-sts</dependency>
+     classes on the classpath to resolve the AWS credentials -->
             <dependency>software.amazon.awssdk:sts</dependency>
           </usedDependencies>
         </configuration>

--- a/operate/common/pom.xml
+++ b/operate/common/pom.xml
@@ -145,11 +145,6 @@
     </dependency>
 
     <dependency>
-      <groupId>com.amazonaws</groupId>
-      <artifactId>aws-java-sdk-core</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>http-client-spi</artifactId>
     </dependency>
@@ -157,11 +152,6 @@
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>regions</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>com.amazonaws</groupId>
-      <artifactId>aws-java-sdk-sts</artifactId>
     </dependency>
 
     <dependency>

--- a/operate/common/src/main/java/io/camunda/operate/connect/OpensearchConnector.java
+++ b/operate/common/src/main/java/io/camunda/operate/connect/OpensearchConnector.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.operate.connect;
 
-import com.amazonaws.regions.DefaultAwsRegionProviderChain;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.camunda.operate.conditions.OpensearchCondition;
@@ -72,7 +71,7 @@ import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.http.SdkHttpClient;
 import software.amazon.awssdk.http.crt.AwsCrtHttpClient;
-import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain;
 
 @Configuration
 @Conditional(OpensearchCondition.class)
@@ -274,13 +273,13 @@ public class OpensearchConnector {
   }
 
   private OpenSearchClient getAwsClient(final OpensearchProperties osConfig) {
-    final String region = new DefaultAwsRegionProviderChain().getRegion();
+    final var region = new DefaultAwsRegionProviderChain().getRegion();
     final SdkHttpClient httpClient = AwsCrtHttpClient.builder().build();
     final AwsSdk2Transport transport =
         new AwsSdk2Transport(
             httpClient,
             osConfig.getHost(),
-            Region.of(region),
+            region,
             AwsSdk2TransportOptions.builder()
                 .setMapper(new JacksonJsonpMapper(objectMapper))
                 .build());
@@ -288,13 +287,13 @@ public class OpensearchConnector {
   }
 
   private OpenSearchAsyncClient getAwsAsyncClient(final OpensearchProperties osConfig) {
-    final String region = new DefaultAwsRegionProviderChain().getRegion();
+    final var region = new DefaultAwsRegionProviderChain().getRegion();
     final SdkHttpClient httpClient = AwsCrtHttpClient.builder().build();
     final AwsSdk2Transport transport =
         new AwsSdk2Transport(
             httpClient,
             osConfig.getHost(),
-            Region.of(region),
+            region,
             AwsSdk2TransportOptions.builder()
                 .setMapper(new JacksonJsonpMapper(objectMapper))
                 .build());

--- a/optimize/util/optimize-commons/pom.xml
+++ b/optimize/util/optimize-commons/pom.xml
@@ -165,12 +165,6 @@
       <artifactId>jackson-datatype-jdk8</artifactId>
     </dependency>
 
-    <dependency>
-      <groupId>com.amazonaws</groupId>
-      <artifactId>aws-java-sdk-core</artifactId>
-      <version>${version.aws-java-sdk}</version>
-    </dependency>
-
     <!-- this is necessary. Dependency:analyze error suppressed -->
     <dependency>
       <groupId>software.amazon.awssdk</groupId>

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/upgrade/os/OpenSearchClientBuilder.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/upgrade/os/OpenSearchClientBuilder.java
@@ -11,7 +11,6 @@ import static io.camunda.optimize.rest.constants.RestConstants.HTTPS_PREFIX;
 import static io.camunda.optimize.rest.constants.RestConstants.HTTP_PREFIX;
 import static io.camunda.optimize.service.db.DatabaseConstants.OPTIMIZE_DATE_FORMAT;
 
-import com.amazonaws.regions.DefaultAwsRegionProviderChain;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.MapperFeature;
@@ -91,7 +90,7 @@ import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
 import software.amazon.awssdk.http.nio.netty.NettyNioAsyncHttpClient;
-import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain;
 
 public class OpenSearchClientBuilder {
 
@@ -125,12 +124,12 @@ public class OpenSearchClientBuilder {
   }
 
   private static OpenSearchTransport getAwsTransport(final ConfigurationService osConfig) {
-    final String region = new DefaultAwsRegionProviderChain().getRegion();
+    final var region = new DefaultAwsRegionProviderChain().getRegion();
     final SdkAsyncHttpClient httpClient = NettyNioAsyncHttpClient.builder().build();
     return new AwsSdk2Transport(
         httpClient,
         osConfig.getOpenSearchConfiguration().getFirstConnectionNode().getHost(),
-        Region.of(region),
+        region,
         AwsSdk2TransportOptions.builder()
             .setMapper(new JacksonJsonpMapper(ObjectMapperFactory.OPTIMIZE_MAPPER))
             .build());

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -165,7 +165,6 @@
     <version.node>v24.2.0</version.node>
     <version.yarn>v1.22.22</version.yarn>
 
-    <version.aws-java-sdk>1.12.787</version.aws-java-sdk>
     <version.elasticsearch-test-container>1.21.3</version.elasticsearch-test-container>
     <version.postgres-test-container>1.21.3</version.postgres-test-container>
     <version.elasticsearch7>7.17.29</version.elasticsearch7>
@@ -2096,16 +2095,6 @@
         <groupId>com.nimbusds</groupId>
         <artifactId>nimbus-jose-jwt</artifactId>
         <version>${version.nimbus-jose-jwt}</version>
-      </dependency>
-
-      <!-- Start AWS -->
-
-      <dependency>
-        <groupId>com.amazonaws</groupId>
-        <artifactId>aws-java-sdk-bom</artifactId>
-        <version>${version.aws-java-sdk}</version>
-        <type>pom</type>
-        <scope>import</scope>
       </dependency>
 
       <!-- testcontainers and docker: see

--- a/qa/util/pom.xml
+++ b/qa/util/pom.xml
@@ -228,11 +228,6 @@
       <artifactId>regions</artifactId>
       <scope>compile</scope>
     </dependency>
-    <dependency>
-      <groupId>com.amazonaws</groupId>
-      <artifactId>aws-java-sdk-core</artifactId>
-      <scope>compile</scope>
-    </dependency>
 
     <dependency>
       <groupId>io.camunda</groupId>

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/AWSOpenSearchSetupHelper.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/AWSOpenSearchSetupHelper.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.qa.util.multidb;
 
-import com.amazonaws.regions.DefaultAwsRegionProviderChain;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import java.io.IOException;
@@ -27,7 +26,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.http.SdkHttpClient;
 import software.amazon.awssdk.http.apache.ApacheHttpClient;
-import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain;
 
 public class AWSOpenSearchSetupHelper implements MultiDbSetupHelper {
 
@@ -43,13 +42,13 @@ public class AWSOpenSearchSetupHelper implements MultiDbSetupHelper {
       final String endpoint, final Collection<IndexDescriptor> expectedDescriptors) {
     final URI uri = URI.create(endpoint);
     this.expectedDescriptors = expectedDescriptors;
-    final String region = new DefaultAwsRegionProviderChain().getRegion();
+    final var region = new DefaultAwsRegionProviderChain().getRegion();
     client =
         new OpenSearchClient(
             new AwsSdk2Transport(
                 httpClient,
                 uri.getHost(),
-                Region.of(region),
+                region,
                 AwsSdk2TransportOptions.builder()
                     .setMapper(new JacksonJsonpMapper(OBJECT_MAPPER))
                     .build()));

--- a/search/search-client-connect/pom.xml
+++ b/search/search-client-connect/pom.xml
@@ -81,11 +81,6 @@
     </dependency>
 
     <dependency>
-      <groupId>com.amazonaws</groupId>
-      <artifactId>aws-java-sdk-core</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>http-client-spi</artifactId>
     </dependency>

--- a/search/search-client-connect/src/main/java/io/camunda/search/connect/os/OpensearchConnector.java
+++ b/search/search-client-connect/src/main/java/io/camunda/search/connect/os/OpensearchConnector.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.search.connect.os;
 
-import com.amazonaws.regions.DefaultAwsRegionProviderChain;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.search.connect.SearchClientConnectException;
 import io.camunda.search.connect.configuration.ConnectConfiguration;
@@ -40,7 +39,7 @@ import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.http.crt.AwsCrtHttpClient;
-import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain;
 
 public final class OpensearchConnector {
 
@@ -108,7 +107,7 @@ public final class OpensearchConnector {
     return new AwsSdk2Transport(
         httpClient,
         httpHost.getHostName(),
-        Region.of(region),
+        region,
         AwsSdk2TransportOptions.builder()
             .setMapper(new SearchRequestJacksonJsonpMapperWrapper(objectMapper))
             .build());

--- a/tasklist/common/pom.xml
+++ b/tasklist/common/pom.xml
@@ -140,11 +140,6 @@
     </dependency>
 
     <dependency>
-      <groupId>com.amazonaws</groupId>
-      <artifactId>aws-java-sdk-core</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>http-client-spi</artifactId>
     </dependency>

--- a/tasklist/common/src/main/java/io/camunda/tasklist/os/OpenSearchConnector.java
+++ b/tasklist/common/src/main/java/io/camunda/tasklist/os/OpenSearchConnector.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.tasklist.os;
 
-import com.amazonaws.regions.DefaultAwsRegionProviderChain;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.camunda.search.connect.plugin.PluginRepository;
@@ -76,7 +75,7 @@ import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.http.SdkHttpClient;
 import software.amazon.awssdk.http.auth.aws.signer.AwsV4HttpSigner;
 import software.amazon.awssdk.http.crt.AwsCrtHttpClient;
-import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain;
 
 @Configuration
 @Conditional(OpenSearchCondition.class)
@@ -498,13 +497,13 @@ public class OpenSearchConnector {
   }
 
   private OpenSearchAsyncClient getAwsAsyncClient(final OpenSearchProperties osConfig) {
-    final String region = new DefaultAwsRegionProviderChain().getRegion();
+    final var region = new DefaultAwsRegionProviderChain().getRegion();
     final SdkHttpClient httpClient = AwsCrtHttpClient.builder().build();
     final AwsSdk2Transport transport =
         new AwsSdk2Transport(
             httpClient,
             osConfig.getHost(),
-            Region.of(region),
+            region,
             AwsSdk2TransportOptions.builder()
                 .setMapper(new JacksonJsonpMapper(tasklistObjectMapper))
                 .build());
@@ -512,13 +511,13 @@ public class OpenSearchConnector {
   }
 
   private OpenSearchClient getAwsClient(final OpenSearchProperties osConfig) {
-    final String region = new DefaultAwsRegionProviderChain().getRegion();
+    final var region = new DefaultAwsRegionProviderChain().getRegion();
     final SdkHttpClient httpClient = AwsCrtHttpClient.builder().build();
     final AwsSdk2Transport transport =
         new AwsSdk2Transport(
             httpClient,
             osConfig.getHost(),
-            Region.of(region),
+            region,
             AwsSdk2TransportOptions.builder()
                 .setMapper(new JacksonJsonpMapper(tasklistObjectMapper))
                 .build());

--- a/tasklist/webapp/pom.xml
+++ b/tasklist/webapp/pom.xml
@@ -531,10 +531,9 @@
             <dependency>org.thymeleaf:thymeleaf</dependency>
             <dependency>jakarta.json:jakarta.json-api</dependency>
             <dependency>io.micrometer:micrometer-registry-prometheus</dependency>
-            <!-- Thesse dependencies are indirectly used by the awssdk auth plugin. It requires these
-     classes on the classpath in order to resolve the AWS credentials -->
+            <!-- This dependency are indirectly used by the awssdk auth plugin. It requires these
+     classes on the classpath to resolve the AWS credentials -->
             <dependency>software.amazon.awssdk:sts</dependency>
-            <dependency>com.amazonaws:aws-java-sdk-sts</dependency>
           </usedDependencies>
           <ignoredUnusedDeclaredDependencies>
             <dep>jakarta.servlet:jakarta.servlet-api</dep>

--- a/tasklist/webapp/pom.xml
+++ b/tasklist/webapp/pom.xml
@@ -223,11 +223,6 @@
     </dependency>
 
     <dependency>
-      <groupId>com.amazonaws</groupId>
-      <artifactId>aws-java-sdk-sts</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-validation</artifactId>
     </dependency>

--- a/zeebe/exporters/camunda-exporter/pom.xml
+++ b/zeebe/exporters/camunda-exporter/pom.xml
@@ -263,11 +263,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.amazonaws</groupId>
-      <artifactId>aws-java-sdk-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-api</artifactId>
       <scope>test</scope>

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryIT.java
@@ -10,7 +10,6 @@ package io.camunda.exporter.tasks.archiver;
 import static io.camunda.search.test.utils.SearchDBExtension.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.amazonaws.regions.DefaultAwsRegionProviderChain;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.exporter.config.ExporterConfiguration.HistoryConfiguration;
 import io.camunda.exporter.metrics.CamundaExporterMetrics;
@@ -59,7 +58,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.http.SdkHttpClient;
 import software.amazon.awssdk.http.apache.ApacheHttpClient;
-import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain;
 
 @SuppressWarnings("resource")
 final class OpenSearchArchiverRepositoryIT {
@@ -594,12 +593,12 @@ final class OpenSearchArchiverRepositoryIT {
     } else {
       final URI uri = URI.create(isAWSRun);
       final SdkHttpClient httpClient = ApacheHttpClient.builder().build();
-      final String region = new DefaultAwsRegionProviderChain().getRegion();
+      final var region = new DefaultAwsRegionProviderChain().getRegion();
       return new OpenSearchClient(
           new AwsSdk2Transport(
               httpClient,
               uri.getHost(),
-              Region.of(region),
+              region,
               AwsSdk2TransportOptions.builder()
                   .setMapper(new JacksonJsonpMapper(new ObjectMapper()))
                   .build()));
@@ -613,12 +612,12 @@ final class OpenSearchArchiverRepositoryIT {
     } else {
       final URI uri = URI.create(isAWSRun);
       final SdkHttpClient httpClient = ApacheHttpClient.builder().build();
-      final String region = new DefaultAwsRegionProviderChain().getRegion();
+      final var region = new DefaultAwsRegionProviderChain().getRegion();
       return new OpenSearchAsyncClient(
           new AwsSdk2Transport(
               httpClient,
               uri.getHost(),
-              Region.of(region),
+              region,
               AwsSdk2TransportOptions.builder()
                   .setMapper(new JacksonJsonpMapper(new ObjectMapper()))
                   .build()));


### PR DESCRIPTION
## Description
- refactor: replace the usage of `DefaultAwsRegionProviderChain` from AWS SDK v1 to v2
- deps: remove AWS SDK v1 dependencies in favor of v2

## Related issues

closes #29956
