### PR TITLE
Add unassign client from group command to java client

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/CamundaClient.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClient.java
@@ -66,6 +66,7 @@ import io.camunda.client.api.command.ResumeBatchOperationStep1;
 import io.camunda.client.api.command.SetVariablesCommandStep1;
 import io.camunda.client.api.command.SuspendBatchOperationStep1;
 import io.camunda.client.api.command.TopologyRequestStep1;
+import io.camunda.client.api.command.UnassignClientFromGroupCommandStep1;
 import io.camunda.client.api.command.UnassignGroupFromTenantCommandStep1;
 import io.camunda.client.api.command.UnassignMappingFromGroupStep1;
 import io.camunda.client.api.command.UnassignRoleFromClientCommandStep1;
@@ -2194,6 +2195,25 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    * @return a builder to configure and send the assign client to group command
    */
   AssignClientToGroupCommandStep1 newAssignClientToGroupCommand();
+
+  /**
+   * Command to unassign a client from a group.
+   *
+   * <p>Example usage:
+   *
+   * <pre>
+   * camundaClient
+   *   .newUnassignClientFromGroupCommand()
+   *   .clientId("clientId")
+   *   .groupId("groupId")
+   *   .send();
+   * </pre>
+   *
+   * <p>This command is only sent via REST over HTTP, not via gRPC <br>
+   *
+   * @return a builder for the unassign client from group command
+   */
+  UnassignClientFromGroupCommandStep1 newUnassignClientFromGroupCommand();
 
   /**
    * Command to create an authorization

--- a/clients/java/src/main/java/io/camunda/client/api/command/UnassignClientFromGroupCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/UnassignClientFromGroupCommandStep1.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.command;
+
+import io.camunda.client.api.response.UnassignClientFromGroupResponse;
+
+public interface UnassignClientFromGroupCommandStep1 {
+
+  /**
+   * Sets the client ID.
+   *
+   * @param clientId the id of the client
+   * @return the builder for this command
+   */
+  UnassignClientFromGroupCommandStep2 clientId(String clientId);
+
+  interface UnassignClientFromGroupCommandStep2
+      extends FinalCommandStep<UnassignClientFromGroupResponse> {
+
+    /**
+     * Sets the group ID.
+     *
+     * @param groupId the id of the group
+     * @return the builder for this command. Call {@link #send()} to complete the command and send
+     *     it to the broker.
+     */
+    UnassignClientFromGroupCommandStep2 groupId(String groupId);
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/api/response/UnassignClientFromGroupResponse.java
+++ b/clients/java/src/main/java/io/camunda/client/api/response/UnassignClientFromGroupResponse.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.response;
+
+public interface UnassignClientFromGroupResponse {}

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
@@ -77,6 +77,7 @@ import io.camunda.client.api.command.StreamJobsCommandStep1;
 import io.camunda.client.api.command.SuspendBatchOperationStep1;
 import io.camunda.client.api.command.ThrowErrorCommandStep1;
 import io.camunda.client.api.command.TopologyRequestStep1;
+import io.camunda.client.api.command.UnassignClientFromGroupCommandStep1;
 import io.camunda.client.api.command.UnassignGroupFromTenantCommandStep1;
 import io.camunda.client.api.command.UnassignMappingFromGroupStep1;
 import io.camunda.client.api.command.UnassignRoleFromClientCommandStep1;
@@ -208,6 +209,7 @@ import io.camunda.client.impl.command.SetVariablesCommandImpl;
 import io.camunda.client.impl.command.StreamJobsCommandImpl;
 import io.camunda.client.impl.command.SuspendBatchOperationCommandImpl;
 import io.camunda.client.impl.command.TopologyRequestImpl;
+import io.camunda.client.impl.command.UnassignClientFromGroupCommandImpl;
 import io.camunda.client.impl.command.UnassignGroupFromTenantCommandImpl;
 import io.camunda.client.impl.command.UnassignMappingFromGroupCommandImpl;
 import io.camunda.client.impl.command.UnassignRoleFromClientCommandImpl;
@@ -1164,6 +1166,11 @@ public final class CamundaClientImpl implements CamundaClient {
   @Override
   public AssignClientToGroupCommandStep1 newAssignClientToGroupCommand() {
     return new AssignClientToGroupCommandImpl(httpClient);
+  }
+
+  @Override
+  public UnassignClientFromGroupCommandStep1 newUnassignClientFromGroupCommand() {
+    return new UnassignClientFromGroupCommandImpl(httpClient);
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/client/impl/command/UnassignClientFromGroupCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/UnassignClientFromGroupCommandImpl.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.command;
+
+import io.camunda.client.api.CamundaFuture;
+import io.camunda.client.api.command.FinalCommandStep;
+import io.camunda.client.api.command.UnassignClientFromGroupCommandStep1;
+import io.camunda.client.api.command.UnassignClientFromGroupCommandStep1.UnassignClientFromGroupCommandStep2;
+import io.camunda.client.api.response.UnassignClientFromGroupResponse;
+import io.camunda.client.impl.http.HttpCamundaFuture;
+import io.camunda.client.impl.http.HttpClient;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import org.apache.hc.client5.http.config.RequestConfig;
+
+public class UnassignClientFromGroupCommandImpl
+    implements UnassignClientFromGroupCommandStep1, UnassignClientFromGroupCommandStep2 {
+
+  private final HttpClient httpClient;
+  private final RequestConfig.Builder httpRequestConfig;
+  private String clientId;
+  private String groupId;
+
+  public UnassignClientFromGroupCommandImpl(final HttpClient httpClient) {
+    this.httpClient = httpClient;
+    httpRequestConfig = httpClient.newRequestConfig();
+  }
+
+  @Override
+  public UnassignClientFromGroupCommandStep2 clientId(final String clientId) {
+    this.clientId = clientId;
+    return this;
+  }
+
+  @Override
+  public UnassignClientFromGroupCommandStep2 groupId(final String groupId) {
+    this.groupId = groupId;
+    return this;
+  }
+
+  @Override
+  public FinalCommandStep<UnassignClientFromGroupResponse> requestTimeout(
+      final Duration requestTimeout) {
+    httpRequestConfig.setResponseTimeout(requestTimeout.toMillis(), TimeUnit.MILLISECONDS);
+    return this;
+  }
+
+  @Override
+  public CamundaFuture<UnassignClientFromGroupResponse> send() {
+    ArgumentUtil.ensureNotNullNorEmpty("clientId", clientId);
+    ArgumentUtil.ensureNotNullNorEmpty("groupId", groupId);
+    final HttpCamundaFuture<UnassignClientFromGroupResponse> result = new HttpCamundaFuture<>();
+    httpClient.delete(
+        "/groups/" + groupId + "/clients/" + clientId,
+        null, // No request body needed
+        httpRequestConfig.build(),
+        result);
+    return result;
+  }
+}

--- a/clients/java/src/test/java/io/camunda/client/group/UnassignMemberGroupTest.java
+++ b/clients/java/src/test/java/io/camunda/client/group/UnassignMemberGroupTest.java
@@ -31,6 +31,7 @@ public class UnassignMemberGroupTest extends ClientRestTest {
   public static final String GROUP_ID = "groupId";
   public static final String USERNAME = "username";
   public static final String MAPPING_ID = "mappingId";
+  public static final String CLIENT_ID = "clientId";
 
   @Test
   void shouldUnassignUserFromGroup() {
@@ -259,5 +260,76 @@ public class UnassignMemberGroupTest extends ClientRestTest {
                     .join())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("mappingId must not be empty");
+  }
+
+  @Test
+  void shouldUnassignClientFromGroup() {
+    // when
+    client.newUnassignClientFromGroupCommand().clientId(CLIENT_ID).groupId(GROUP_ID).send().join();
+
+    // then
+    final String requestPath = RestGatewayService.getLastRequest().getUrl();
+    assertThat(requestPath)
+        .isEqualTo(REST_API_PATH + "/groups/" + GROUP_ID + "/clients/" + CLIENT_ID);
+  }
+
+  @Test
+  void shouldRaiseExceptionOnEmptyClientIdWhenUnassigningClientFromGroup() {
+    // when / then
+    assertThatThrownBy(
+            () ->
+                client
+                    .newUnassignClientFromGroupCommand()
+                    .clientId("")
+                    .groupId(GROUP_ID)
+                    .send()
+                    .join())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("clientId must not be empty");
+  }
+
+  @Test
+  void shouldRaiseExceptionOnNullClientIdWhenUnassigningClientFromGroup() {
+    // when / then
+    assertThatThrownBy(
+            () ->
+                client
+                    .newUnassignClientFromGroupCommand()
+                    .clientId(null)
+                    .groupId(GROUP_ID)
+                    .send()
+                    .join())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("clientId must not be null");
+  }
+
+  @Test
+  void shouldRaiseExceptionOnEmptyGroupIdWhenUnassigningClientFromGroup() {
+    // when / then
+    assertThatThrownBy(
+            () ->
+                client
+                    .newUnassignClientFromGroupCommand()
+                    .clientId(CLIENT_ID)
+                    .groupId("")
+                    .send()
+                    .join())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("groupId must not be empty");
+  }
+
+  @Test
+  void shouldRaiseExceptionOnNullGroupIdWhenUnassigningClientFromGroup() {
+    // when / then
+    assertThatThrownBy(
+            () ->
+                client
+                    .newUnassignClientFromGroupCommand()
+                    .clientId(CLIENT_ID)
+                    .groupId(null)
+                    .send()
+                    .join())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("groupId must not be null");
   }
 }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupController.java
@@ -129,7 +129,7 @@ public class GroupController {
   }
 
   @CamundaDeleteMapping(path = "/{groupId}/clients/{clientId}")
-  public CompletableFuture<ResponseEntity<Object>> unassignApplicationFromGroup(
+  public CompletableFuture<ResponseEntity<Object>> unassignClientFromGroup(
       @PathVariable final String groupId, @PathVariable final String clientId) {
     return RequestMapper.toGroupMemberRequest(groupId, clientId, EntityType.CLIENT)
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::unassignMember);


### PR DESCRIPTION
## Description

Add command to unassign client from the group.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #35038
