### PR TITLE
[Backport stable/8.7] deps: remove AWS SDK v1 dependencies in favor of v2

### DIFF
--- a/operate/common/pom.xml
+++ b/operate/common/pom.xml
@@ -309,8 +309,7 @@
         <configuration>
           <usedDependencies>
             <!-- This dependency is indirectly used by the awssk auth plugin. It requires these
-     classes on the classpath in order to resolve the AWS credentials -->
-            <dependency>com.amazonaws:aws-java-sdk-sts</dependency>
+     classes on the classpath to resolve the AWS credentials -->
             <dependency>software.amazon.awssdk:sts</dependency>
           </usedDependencies>
         </configuration>

--- a/operate/common/pom.xml
+++ b/operate/common/pom.xml
@@ -130,11 +130,6 @@
     </dependency>
 
     <dependency>
-      <groupId>com.amazonaws</groupId>
-      <artifactId>aws-java-sdk-core</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>http-client-spi</artifactId>
     </dependency>
@@ -142,11 +137,6 @@
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>regions</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>com.amazonaws</groupId>
-      <artifactId>aws-java-sdk-sts</artifactId>
     </dependency>
 
     <dependency>

--- a/operate/common/src/main/java/io/camunda/operate/connect/OpensearchConnector.java
+++ b/operate/common/src/main/java/io/camunda/operate/connect/OpensearchConnector.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.operate.connect;
 
-import com.amazonaws.regions.DefaultAwsRegionProviderChain;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.camunda.operate.conditions.OpensearchCondition;
@@ -72,7 +71,7 @@ import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.http.SdkHttpClient;
 import software.amazon.awssdk.http.crt.AwsCrtHttpClient;
-import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain;
 
 @Configuration
 @Conditional(OpensearchCondition.class)
@@ -274,13 +273,13 @@ public class OpensearchConnector {
   }
 
   private OpenSearchClient getAwsClient(final OpensearchProperties osConfig) {
-    final String region = new DefaultAwsRegionProviderChain().getRegion();
+    final var region = new DefaultAwsRegionProviderChain().getRegion();
     final SdkHttpClient httpClient = AwsCrtHttpClient.builder().build();
     final AwsSdk2Transport transport =
         new AwsSdk2Transport(
             httpClient,
             osConfig.getHost(),
-            Region.of(region),
+            region,
             AwsSdk2TransportOptions.builder()
                 .setMapper(new JacksonJsonpMapper(objectMapper))
                 .build());
@@ -288,13 +287,13 @@ public class OpensearchConnector {
   }
 
   private OpenSearchAsyncClient getAwsAsyncClient(final OpensearchProperties osConfig) {
-    final String region = new DefaultAwsRegionProviderChain().getRegion();
+    final var region = new DefaultAwsRegionProviderChain().getRegion();
     final SdkHttpClient httpClient = AwsCrtHttpClient.builder().build();
     final AwsSdk2Transport transport =
         new AwsSdk2Transport(
             httpClient,
             osConfig.getHost(),
-            Region.of(region),
+            region,
             AwsSdk2TransportOptions.builder()
                 .setMapper(new JacksonJsonpMapper(objectMapper))
                 .build());

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -155,7 +155,6 @@
     <version.node>v20.12.2</version.node>
     <version.yarn>v1.22.21</version.yarn>
 
-    <version.aws-java-sdk>1.12.787</version.aws-java-sdk>
     <version.elasticsearch-test-container>1.20.6</version.elasticsearch-test-container>
     <version.postgres-test-container>1.20.6</version.postgres-test-container>
     <version.elasticsearch7>7.17.29</version.elasticsearch7>
@@ -1992,16 +1991,6 @@
         <groupId>com.nimbusds</groupId>
         <artifactId>nimbus-jose-jwt</artifactId>
         <version>${version.nimbus-jose-jwt}</version>
-      </dependency>
-
-      <!-- Start AWS -->
-
-      <dependency>
-        <groupId>com.amazonaws</groupId>
-        <artifactId>aws-java-sdk-bom</artifactId>
-        <version>${version.aws-java-sdk}</version>
-        <type>pom</type>
-        <scope>import</scope>
       </dependency>
 
       <!-- testcontainers and docker: see

--- a/search/search-client-connect/pom.xml
+++ b/search/search-client-connect/pom.xml
@@ -91,11 +91,6 @@
     </dependency>
 
     <dependency>
-      <groupId>com.amazonaws</groupId>
-      <artifactId>aws-java-sdk-core</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>http-client-spi</artifactId>
     </dependency>

--- a/search/search-client-connect/src/main/java/io/camunda/search/connect/os/OpensearchConnector.java
+++ b/search/search-client-connect/src/main/java/io/camunda/search/connect/os/OpensearchConnector.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.search.connect.os;
 
-import com.amazonaws.regions.DefaultAwsRegionProviderChain;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.search.connect.SearchClientConnectException;
 import io.camunda.search.connect.configuration.ConnectConfiguration;
@@ -37,7 +36,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.http.crt.AwsCrtHttpClient;
-import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain;
 
 public final class OpensearchConnector {
 
@@ -81,7 +80,7 @@ public final class OpensearchConnector {
     return new AwsSdk2Transport(
         httpClient,
         httpHost.getHostName(),
-        Region.of(region),
+        region,
         AwsSdk2TransportOptions.builder()
             .setMapper(new SearchRequestJacksonJsonpMapperWrapper(objectMapper))
             .build());

--- a/tasklist/common/pom.xml
+++ b/tasklist/common/pom.xml
@@ -130,11 +130,6 @@
     </dependency>
 
     <dependency>
-      <groupId>com.amazonaws</groupId>
-      <artifactId>aws-java-sdk-core</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>http-client-spi</artifactId>
     </dependency>

--- a/tasklist/common/src/main/java/io/camunda/tasklist/os/OpenSearchConnector.java
+++ b/tasklist/common/src/main/java/io/camunda/tasklist/os/OpenSearchConnector.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.tasklist.os;
 
-import com.amazonaws.regions.DefaultAwsRegionProviderChain;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.camunda.search.connect.plugin.PluginRepository;
@@ -76,7 +75,7 @@ import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.auth.signer.Aws4Signer;
 import software.amazon.awssdk.http.SdkHttpClient;
 import software.amazon.awssdk.http.crt.AwsCrtHttpClient;
-import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain;
 
 @Configuration
 @Conditional(OpenSearchCondition.class)
@@ -498,13 +497,13 @@ public class OpenSearchConnector {
   }
 
   private OpenSearchAsyncClient getAwsAsyncClient(final OpenSearchProperties osConfig) {
-    final String region = new DefaultAwsRegionProviderChain().getRegion();
+    final var region = new DefaultAwsRegionProviderChain().getRegion();
     final SdkHttpClient httpClient = AwsCrtHttpClient.builder().build();
     final AwsSdk2Transport transport =
         new AwsSdk2Transport(
             httpClient,
             osConfig.getHost(),
-            Region.of(region),
+            region,
             AwsSdk2TransportOptions.builder()
                 .setMapper(new JacksonJsonpMapper(tasklistObjectMapper))
                 .build());
@@ -512,13 +511,13 @@ public class OpenSearchConnector {
   }
 
   private OpenSearchClient getAwsClient(final OpenSearchProperties osConfig) {
-    final String region = new DefaultAwsRegionProviderChain().getRegion();
+    final var region = new DefaultAwsRegionProviderChain().getRegion();
     final SdkHttpClient httpClient = AwsCrtHttpClient.builder().build();
     final AwsSdk2Transport transport =
         new AwsSdk2Transport(
             httpClient,
             osConfig.getHost(),
-            Region.of(region),
+            region,
             AwsSdk2TransportOptions.builder()
                 .setMapper(new JacksonJsonpMapper(tasklistObjectMapper))
                 .build());

--- a/tasklist/webapp/pom.xml
+++ b/tasklist/webapp/pom.xml
@@ -221,11 +221,6 @@
     </dependency>
 
     <dependency>
-      <groupId>com.amazonaws</groupId>
-      <artifactId>aws-java-sdk-sts</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-validation</artifactId>
     </dependency>

--- a/tasklist/webapp/pom.xml
+++ b/tasklist/webapp/pom.xml
@@ -583,10 +583,9 @@
             <dependency>org.thymeleaf:thymeleaf</dependency>
             <dependency>jakarta.json:jakarta.json-api</dependency>
             <dependency>io.micrometer:micrometer-registry-prometheus</dependency>
-            <!-- Thesse dependencies are indirectly used by the awssdk auth plugin. It requires these
-     classes on the classpath in order to resolve the AWS credentials -->
+            <!-- This dependency are indirectly used by the awssdk auth plugin. It requires these
+     classes on the classpath to resolve the AWS credentials -->
             <dependency>software.amazon.awssdk:sts</dependency>
-            <dependency>com.amazonaws:aws-java-sdk-sts</dependency>
           </usedDependencies>
           <ignoredUnusedDeclaredDependencies>
             <dep>jakarta.servlet:jakarta.servlet-api</dep>


### PR DESCRIPTION
# Description
Backport of #35183 to `stable/8.7`.

relates to #29956