### PR TITLE
Alow assigning and removing non-camunda groups

### DIFF
--- a/identity/client/src/components/global/useEnrichGroups.tsx
+++ b/identity/client/src/components/global/useEnrichGroups.tsx
@@ -7,7 +7,7 @@
  */
 
 import { useCallback, useEffect, useState } from "react";
-import { isInternalGroupsEnabled } from "src/configuration";
+import { isCamundaGroupsEnabled } from "src/configuration";
 import { SearchResponse } from "src/utility/api";
 import { useApiCall } from "src/utility/api/hooks";
 import { MemberGroup } from "src/utility/api/groups";
@@ -46,7 +46,7 @@ export function useEnrichedGroups<P>(
         return;
       }
 
-      if (!isInternalGroupsEnabled) {
+      if (!isCamundaGroupsEnabled) {
         setGroups(
           members.map(({ groupId }) => ({
             groupId,

--- a/identity/client/src/components/global/useGlobalRoutes.tsx
+++ b/identity/client/src/components/global/useGlobalRoutes.tsx
@@ -14,7 +14,7 @@ import Roles from "src/pages/roles";
 import Tenants from "src/pages/tenants";
 import MappingRules from "src/pages/mapping-rules";
 import Authorizations from "src/pages/authorizations";
-import { isOIDC, isInternalGroupsEnabled } from "src/configuration";
+import { isOIDC, isCamundaGroupsEnabled } from "src/configuration";
 import { Paths } from "src/components/global/routePaths";
 
 export const useGlobalRoutes = () => {
@@ -39,7 +39,7 @@ export const useGlobalRoutes = () => {
         },
       ];
 
-  const internalGroupsDependentRoutes = isInternalGroupsEnabled
+  const camundaGroupsDependentRoutes = isCamundaGroupsEnabled
     ? [
         {
           path: `${Paths.groups()}/*`,
@@ -52,7 +52,7 @@ export const useGlobalRoutes = () => {
 
   const routes = [
     ...OIDCDependentRoutes,
-    ...internalGroupsDependentRoutes,
+    ...camundaGroupsDependentRoutes,
     {
       path: `${Paths.roles()}/*`,
       key: Paths.roles(),

--- a/identity/client/src/configuration/index.ts
+++ b/identity/client/src/configuration/index.ts
@@ -15,8 +15,8 @@ const apiBaseUrl = "/v2";
 const loginApiUrl = "/login";
 
 export const isOIDC = getEnvBoolean("IS_OIDC", false);
-export const isInternalGroupsEnabled = getEnvBoolean(
-  "INTERNAL_GROUPS_ENABLED",
+export const isCamundaGroupsEnabled = getEnvBoolean(
+  "CAMUNDA_GROUPS_ENABLED",
   true,
 );
 

--- a/identity/client/src/pages/authorizations/modals/OwnerSelection/index.tsx
+++ b/identity/client/src/pages/authorizations/modals/OwnerSelection/index.tsx
@@ -15,7 +15,7 @@ import { searchRoles } from "src/utility/api/roles";
 import useTranslate from "src/utility/localization";
 import OwnerSelection from "./OwnerSelection";
 import TextField from "src/components/form/TextField";
-import { isOIDC } from "src/configuration";
+import { isCamundaGroupsEnabled, isOIDC } from "src/configuration";
 
 type SelectionProps = {
   type: OwnerType;
@@ -49,13 +49,24 @@ const Selection: FC<SelectionProps> = ({ type, ownerId, onChange }) => {
         />
       );
     case OwnerType.GROUP:
+      if (isCamundaGroupsEnabled) {
+        return (
+          <OwnerSelection
+            id="groupSelection"
+            onChange={onChange}
+            searchFn={searchGroups}
+            getId={(group) => group.groupId}
+            itemToString={(group) => group.name || group.groupId}
+          />
+        );
+      }
       return (
-        <OwnerSelection
-          id="groupSelection"
+        <TextField
+          value={ownerId}
+          label={t("groupId")}
           onChange={onChange}
-          searchFn={searchGroups}
-          getId={(group) => group.groupId}
-          itemToString={(group) => group.name || group.groupId}
+          placeholder={t("enterGroupId")}
+          type="text"
         />
       );
     case OwnerType.MAPPING:

--- a/identity/client/src/pages/roles/detail/groups/AssignGroupModal.tsx
+++ b/identity/client/src/pages/roles/detail/groups/AssignGroupModal.tsx
@@ -1,0 +1,74 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import { FC, useEffect, useState } from "react";
+import { UseEntityModalCustomProps } from "src/components/modal";
+import { assignRoleGroup, Role } from "src/utility/api/roles";
+import useTranslate from "src/utility/localization";
+import { useApiCall } from "src/utility/api/hooks";
+import { Group } from "src/utility/api/groups";
+import FormModal from "src/components/modal/FormModal";
+import TextField from "src/components/form/TextField";
+
+const AssignGroupModal: FC<
+  UseEntityModalCustomProps<
+    { roleId: Role["roleId"] },
+    { assignedGroups: Group[] }
+  >
+> = ({ entity: { roleId }, onSuccess, open, onClose }) => {
+  const { t } = useTranslate("roles");
+  const [groupId, setGroupId] = useState("");
+  const [loadingAssignGroup, setLoadingAssignGroup] = useState(false);
+
+  const [callAssignGroup] = useApiCall(assignRoleGroup);
+
+  const canSubmit = roleId && groupId;
+
+  const handleSubmit = async () => {
+    if (!canSubmit) return;
+
+    setLoadingAssignGroup(true);
+    const { success } = await callAssignGroup({ groupId, roleId });
+    setLoadingAssignGroup(false);
+
+    if (success) {
+      onSuccess();
+    }
+  };
+
+  useEffect(() => {
+    if (open) {
+      setGroupId("");
+    }
+  }, [open]);
+
+  return (
+    <FormModal
+      headline={t("assignGroup")}
+      confirmLabel={t("assignGroup")}
+      loading={loadingAssignGroup}
+      loadingDescription={t("assigningGroup")}
+      open={open}
+      onSubmit={handleSubmit}
+      submitDisabled={!canSubmit}
+      onClose={onClose}
+      overflowVisible
+    >
+      <p>{t("assignGroupsToRole")}</p>
+      <TextField
+        label={t("groupId")}
+        placeholder={t("typeGroup")}
+        onChange={setGroupId}
+        value={groupId}
+        autoFocus
+      />
+    </FormModal>
+  );
+};
+
+export default AssignGroupModal;

--- a/identity/client/src/pages/roles/detail/groups/AssignGroupsModal.tsx
+++ b/identity/client/src/pages/roles/detail/groups/AssignGroupsModal.tsx
@@ -17,7 +17,7 @@ import { TranslatedErrorInlineNotification } from "src/components/notifications/
 import DropdownSearch from "src/components/form/DropdownSearch";
 import FormModal from "src/components/modal/FormModal";
 import { assignRoleGroup, Role } from "src/utility/api/roles";
-import { isInternalGroupsEnabled } from "src/configuration";
+import { isCamundaGroupsEnabled } from "src/configuration";
 
 const SelectedGroups = styled.div`
   margin-top: 0;
@@ -41,7 +41,7 @@ const AssignGroupsModal: FC<
   const [callAssignGroup] = useApiCall(assignRoleGroup);
 
   const getDynamicGroup = (): Group | null => {
-    if (!isInternalGroupsEnabled || !currentInputValue.trim()) return null;
+    if (!isCamundaGroupsEnabled || !currentInputValue.trim()) return null;
 
     const trimmedValue = currentInputValue.trim();
     const groupId = trimmedValue.replace(/\s+/g, "").toLowerCase();

--- a/identity/client/src/pages/roles/detail/groups/index.tsx
+++ b/identity/client/src/pages/roles/detail/groups/index.tsx
@@ -7,17 +7,18 @@
  */
 
 import { FC } from "react";
+import { TrashCan } from "@carbon/react/icons";
 import { C3EmptyState } from "@camunda/camunda-composite-components";
 import useTranslate from "src/utility/localization";
 import { getGroupsByRoleId } from "src/utility/api/roles";
 import EntityList from "src/components/entityList";
 import { useEntityModal } from "src/components/modal";
-import { TrashCan } from "@carbon/react/icons";
-import DeleteModal from "src/pages/roles/detail/groups/DeleteModal";
 import AssignGroupsModal from "src/pages/roles/detail/groups/AssignGroupsModal";
+import AssignGroupModal from "src/pages/roles/detail/groups/AssignGroupModal";
+import DeleteModal from "src/pages/roles/detail/groups/DeleteModal";
 import { isCamundaGroupsEnabled } from "src/configuration";
-import { useEnrichedGroups } from "src/components/global/useEnrichGroups";
 import { GroupKeys } from "src/utility/api/groups";
+import { useEnrichedGroups } from "src/components/global/useEnrichGroups";
 
 type GroupsProps = {
   roleId: string;
@@ -25,7 +26,6 @@ type GroupsProps = {
 
 const Groups: FC<GroupsProps> = ({ roleId }) => {
   const { t } = useTranslate("roles");
-
   const { groups, loading, success, reload } = useEnrichedGroups(
     getGroupsByRoleId,
     {
@@ -34,15 +34,14 @@ const Groups: FC<GroupsProps> = ({ roleId }) => {
   );
 
   const isGroupsEmpty = !groups || groups.length === 0;
-
   const [assignGroups, assignGroupsModal] = useEntityModal(
-    AssignGroupsModal,
+    isCamundaGroupsEnabled ? AssignGroupsModal : AssignGroupModal,
     reload,
     {
       assignedGroups: groups,
     },
   );
-  const openAssignModal = () => assignGroups({ id: roleId });
+  const openAssignModal = () => assignGroups({ roleId });
   const [unassignGroup, unassignGroupModal] = useEntityModal(
     DeleteModal,
     reload,

--- a/identity/client/src/pages/roles/detail/groups/index.tsx
+++ b/identity/client/src/pages/roles/detail/groups/index.tsx
@@ -15,7 +15,7 @@ import { useEntityModal } from "src/components/modal";
 import { TrashCan } from "@carbon/react/icons";
 import DeleteModal from "src/pages/roles/detail/groups/DeleteModal";
 import AssignGroupsModal from "src/pages/roles/detail/groups/AssignGroupsModal";
-import { isInternalGroupsEnabled } from "src/configuration";
+import { isCamundaGroupsEnabled } from "src/configuration";
 import { useEnrichedGroups } from "src/components/global/useEnrichGroups";
 import { GroupKeys } from "src/utility/api/groups";
 
@@ -84,7 +84,7 @@ const Groups: FC<GroupsProps> = ({ roleId }) => {
     key: GroupKeys;
   }[];
 
-  const groupsListHeaders: GroupsListHeaders = isInternalGroupsEnabled
+  const groupsListHeaders: GroupsListHeaders = isCamundaGroupsEnabled
     ? [
         { header: t("groupId"), key: "groupId" },
         { header: t("groupName"), key: "name" },

--- a/identity/client/src/pages/roles/detail/index.tsx
+++ b/identity/client/src/pages/roles/detail/index.tsx
@@ -100,7 +100,7 @@ const Details: FC = () => {
                   ? [
                       {
                         key: "mapping-rules",
-                        label: t("mapping-rules"),
+                        label: t("mappingRules"),
                         content: <MappingRules roleId={role.roleId} />,
                       },
                       {

--- a/identity/client/src/pages/roles/detail/mapping-rules/index.tsx
+++ b/identity/client/src/pages/roles/detail/mapping-rules/index.tsx
@@ -65,7 +65,7 @@ const MappingRules: FC<MappingRulesProps> = ({ roleId }) => {
     return (
       <>
         <C3EmptyState
-          heading={t("assignMappingsToRole")}
+          heading={t("assignMappingRulesToRole")}
           description={t("accessDisclaimer")}
           button={{
             label: t("assignMapping"),

--- a/identity/client/src/pages/tenants/detail/groups/AssignGroupModal.tsx
+++ b/identity/client/src/pages/tenants/detail/groups/AssignGroupModal.tsx
@@ -1,0 +1,74 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import { FC, useEffect, useState } from "react";
+import { UseEntityModalCustomProps } from "src/components/modal";
+import { assignTenantGroup, Tenant } from "src/utility/api/tenants";
+import useTranslate from "src/utility/localization";
+import { useApiCall } from "src/utility/api/hooks";
+import { Group } from "src/utility/api/groups";
+import FormModal from "src/components/modal/FormModal";
+import TextField from "src/components/form/TextField";
+
+const AssignGroupModal: FC<
+  UseEntityModalCustomProps<
+    { tenantId: Tenant["tenantId"] },
+    { assignedGroups: Group[] }
+  >
+> = ({ entity: { tenantId }, onSuccess, open, onClose }) => {
+  const { t } = useTranslate("tenants");
+  const [groupId, setGroupId] = useState("");
+  const [loadingAssignGroup, setLoadingAssignGroup] = useState(false);
+
+  const [callAssignGroup] = useApiCall(assignTenantGroup);
+
+  const canSubmit = tenantId && groupId;
+
+  const handleSubmit = async () => {
+    if (!canSubmit) return;
+
+    setLoadingAssignGroup(true);
+    const { success } = await callAssignGroup({ groupId, tenantId });
+    setLoadingAssignGroup(false);
+
+    if (success) {
+      onSuccess();
+    }
+  };
+
+  useEffect(() => {
+    if (open) {
+      setGroupId("");
+    }
+  }, [open]);
+
+  return (
+    <FormModal
+      headline={t("assignGroup")}
+      confirmLabel={t("assignGroup")}
+      loading={loadingAssignGroup}
+      loadingDescription={t("assigningGroup")}
+      open={open}
+      onSubmit={handleSubmit}
+      submitDisabled={!canSubmit}
+      onClose={onClose}
+      overflowVisible
+    >
+      <p>{t("assignGroupsToTenant")}</p>
+      <TextField
+        label={t("groupId")}
+        placeholder={t("typeGroup")}
+        onChange={setGroupId}
+        value={groupId}
+        autoFocus
+      />
+    </FormModal>
+  );
+};
+
+export default AssignGroupModal;

--- a/identity/client/src/pages/tenants/detail/groups/index.tsx
+++ b/identity/client/src/pages/tenants/detail/groups/index.tsx
@@ -7,17 +7,18 @@
  */
 
 import { FC } from "react";
+import { TrashCan } from "@carbon/react/icons";
 import { C3EmptyState } from "@camunda/camunda-composite-components";
 import useTranslate from "src/utility/localization";
 import { getGroupsByTenantId } from "src/utility/api/tenants";
 import EntityList from "src/components/entityList";
 import { useEntityModal } from "src/components/modal";
-import { TrashCan } from "@carbon/react/icons";
-import DeleteModal from "src/pages/tenants/detail/groups/DeleteModal";
 import AssignGroupsModal from "src/pages/tenants/detail/groups/AssignGroupsModal";
+import AssignGroupModal from "src/pages/tenants/detail/groups/AssignGroupModal";
+import DeleteModal from "src/pages/tenants/detail/groups/DeleteModal";
 import { isCamundaGroupsEnabled } from "src/configuration";
-import { useEnrichedGroups } from "src/components/global/useEnrichGroups";
 import { GroupKeys } from "src/utility/api/groups";
+import { useEnrichedGroups } from "src/components/global/useEnrichGroups";
 
 type GroupsProps = {
   tenantId: string;
@@ -34,15 +35,14 @@ const Groups: FC<GroupsProps> = ({ tenantId }) => {
   );
 
   const isGroupsEmpty = !groups || groups.length === 0;
-
   const [assignGroups, assignGroupsModal] = useEntityModal(
-    AssignGroupsModal,
+    isCamundaGroupsEnabled ? AssignGroupsModal : AssignGroupModal,
     reload,
     {
       assignedGroups: groups,
     },
   );
-  const openAssignModal = () => assignGroups({ id: tenantId });
+  const openAssignModal = () => assignGroups({ tenantId });
   const [unassignGroup, unassignGroupModal] = useEntityModal(
     DeleteModal,
     reload,

--- a/identity/client/src/pages/tenants/detail/groups/index.tsx
+++ b/identity/client/src/pages/tenants/detail/groups/index.tsx
@@ -15,7 +15,7 @@ import { useEntityModal } from "src/components/modal";
 import { TrashCan } from "@carbon/react/icons";
 import DeleteModal from "src/pages/tenants/detail/groups/DeleteModal";
 import AssignGroupsModal from "src/pages/tenants/detail/groups/AssignGroupsModal";
-import { isInternalGroupsEnabled } from "src/configuration";
+import { isCamundaGroupsEnabled } from "src/configuration";
 import { useEnrichedGroups } from "src/components/global/useEnrichGroups";
 import { GroupKeys } from "src/utility/api/groups";
 
@@ -84,7 +84,7 @@ const Groups: FC<GroupsProps> = ({ tenantId }) => {
     key: GroupKeys;
   }[];
 
-  const groupsListHeaders: GroupsListHeaders = isInternalGroupsEnabled
+  const groupsListHeaders: GroupsListHeaders = isCamundaGroupsEnabled
     ? [
         { header: t("groupId"), key: "groupId" },
         { header: t("groupName"), key: "name" },

--- a/identity/client/src/utility/localization/en/components.json
+++ b/identity/client/src/utility/localization/en/components.json
@@ -51,6 +51,8 @@
   "searchByClientId": "Search by client ID",
   "typeUsername": "Type a username",
   "typeGroup": "Type a group",
+  "groupId": "Group ID",
+  "enterGroupId": "Enter your Group ID",
   "setupCreateAdminUser": "Create admin user",
   "setupUsernameLabel": "Username *",
   "setupUsernamePlaceholder": "Enter username",

--- a/identity/client/src/utility/localization/en/components.json
+++ b/identity/client/src/utility/localization/en/components.json
@@ -50,6 +50,7 @@
   "unableToLoadClients": "Unable to load clients",
   "searchByClientId": "Search by client ID",
   "typeUsername": "Type a username",
+  "typeGroup": "Type a group",
   "setupCreateAdminUser": "Create admin user",
   "setupUsernameLabel": "Username *",
   "setupUsernamePlaceholder": "Enter username",


### PR DESCRIPTION
## Description

- Allow assigning non-camunda (local) groups to Roles, Tenants and Authorizations
   - For Roles and Tenants a new modal is created to replicate what was done previously for Users in OIDC mode
   - For Authorizations a simple conditional was added to make the Owner selection a text field with no restrictions to Group ID added
- Refactors Dropdown usage to include filtering based on value types on dropdown search input
- Renames `isInternalGroupsEnabled` to `isCamundaGroupsEnabled`
- Fix a few translation keys that were wrongly translated from the Mapping Rules renaming across UI

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #34282 
