### PR TITLE
Add search clients in group client command

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/CamundaClient.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClient.java
@@ -113,6 +113,7 @@ import io.camunda.client.api.response.ActivatedJob;
 import io.camunda.client.api.response.DocumentReferenceResponse;
 import io.camunda.client.api.search.request.BatchOperationItemSearchRequest;
 import io.camunda.client.api.search.request.BatchOperationSearchRequest;
+import io.camunda.client.api.search.request.ClientsByGroupSearchRequest;
 import io.camunda.client.api.search.request.ClientsByRoleSearchRequest;
 import io.camunda.client.api.search.request.DecisionDefinitionSearchRequest;
 import io.camunda.client.api.search.request.DecisionInstanceSearchRequest;
@@ -1275,6 +1276,22 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    * @return a builder for the clients by role search request
    */
   ClientsByRoleSearchRequest newClientsByRoleSearchRequest(String roleId);
+
+  /**
+   * Executes a search request to query clients by group.
+   *
+   * <pre>
+   * camundaClient
+   *   .newClientsByGroupSearchRequest("groupId")
+   *   .sort((s) -> s.clientId().asc())
+   *   .page((p) -> p.limit(100))
+   *   .send();
+   * </pre>
+   *
+   * @param groupId the ID of the group
+   * @return a builder for the clients by group search request
+   */
+  ClientsByGroupSearchRequest newClientsByGroupSearchRequest(String groupId);
 
   /**
    * Command to assign a role to a tenant.

--- a/clients/java/src/main/java/io/camunda/client/api/search/request/ClientsByGroupSearchRequest.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/request/ClientsByGroupSearchRequest.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.search.request;
+
+import io.camunda.client.api.search.filter.ClientFilter;
+import io.camunda.client.api.search.response.Client;
+import io.camunda.client.api.search.sort.ClientSort;
+
+public interface ClientsByGroupSearchRequest
+    extends TypedSearchRequest<ClientFilter, ClientSort, ClientsByGroupSearchRequest>,
+        FinalSearchRequestStep<Client> {}

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
@@ -124,6 +124,7 @@ import io.camunda.client.api.response.ActivatedJob;
 import io.camunda.client.api.response.DocumentReferenceResponse;
 import io.camunda.client.api.search.request.BatchOperationItemSearchRequest;
 import io.camunda.client.api.search.request.BatchOperationSearchRequest;
+import io.camunda.client.api.search.request.ClientsByGroupSearchRequest;
 import io.camunda.client.api.search.request.ClientsByRoleSearchRequest;
 import io.camunda.client.api.search.request.DecisionDefinitionSearchRequest;
 import io.camunda.client.api.search.request.DecisionInstanceSearchRequest;
@@ -251,6 +252,7 @@ import io.camunda.client.impl.http.HttpClientFactory;
 import io.camunda.client.impl.search.request.AuthorizationsSearchRequestImpl;
 import io.camunda.client.impl.search.request.BatchOperationItemSearchRequestImpl;
 import io.camunda.client.impl.search.request.BatchOperationSearchRequestImpl;
+import io.camunda.client.impl.search.request.ClientsByGroupSearchRequestImpl;
 import io.camunda.client.impl.search.request.ClientsByRoleSearchRequestImpl;
 import io.camunda.client.impl.search.request.DecisionDefinitionSearchRequestImpl;
 import io.camunda.client.impl.search.request.DecisionInstanceSearchRequestImpl;
@@ -894,6 +896,11 @@ public final class CamundaClientImpl implements CamundaClient {
   @Override
   public ClientsByRoleSearchRequest newClientsByRoleSearchRequest(final String roleId) {
     return new ClientsByRoleSearchRequestImpl(httpClient, jsonMapper, roleId);
+  }
+
+  @Override
+  public ClientsByGroupSearchRequest newClientsByGroupSearchRequest(final String groupId) {
+    return new ClientsByGroupSearchRequestImpl(httpClient, jsonMapper, groupId);
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/client/impl/search/request/ClientsByGroupSearchRequestImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/request/ClientsByGroupSearchRequestImpl.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.search.request;
+
+import static io.camunda.client.api.search.request.SearchRequestBuilders.clientSort;
+import static io.camunda.client.api.search.request.SearchRequestBuilders.searchRequestPage;
+
+import io.camunda.client.api.CamundaFuture;
+import io.camunda.client.api.JsonMapper;
+import io.camunda.client.api.search.filter.ClientFilter;
+import io.camunda.client.api.search.request.ClientsByGroupSearchRequest;
+import io.camunda.client.api.search.request.FinalSearchRequestStep;
+import io.camunda.client.api.search.request.SearchRequestPage;
+import io.camunda.client.api.search.response.Client;
+import io.camunda.client.api.search.response.SearchResponse;
+import io.camunda.client.api.search.sort.ClientSort;
+import io.camunda.client.impl.command.ArgumentUtil;
+import io.camunda.client.impl.http.HttpCamundaFuture;
+import io.camunda.client.impl.http.HttpClient;
+import io.camunda.client.impl.search.response.SearchResponseMapper;
+import io.camunda.client.protocol.rest.GroupClientSearchQueryRequest;
+import io.camunda.client.protocol.rest.GroupClientSearchResult;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import org.apache.hc.client5.http.config.RequestConfig;
+
+public class ClientsByGroupSearchRequestImpl
+    extends TypedSearchRequestPropertyProvider<GroupClientSearchQueryRequest>
+    implements ClientsByGroupSearchRequest {
+
+  private final GroupClientSearchQueryRequest request;
+  private final String groupId;
+  private final HttpClient httpClient;
+  private final JsonMapper jsonMapper;
+  private final RequestConfig.Builder httpRequestConfig;
+
+  public ClientsByGroupSearchRequestImpl(
+      final HttpClient httpClient, final JsonMapper jsonMapper, final String groupId) {
+    this.httpClient = httpClient;
+    this.jsonMapper = jsonMapper;
+    this.groupId = groupId;
+    httpRequestConfig = httpClient.newRequestConfig();
+    request = new GroupClientSearchQueryRequest();
+  }
+
+  @Override
+  public FinalSearchRequestStep<Client> requestTimeout(final Duration requestTimeout) {
+    httpRequestConfig.setResponseTimeout(requestTimeout.toMillis(), TimeUnit.MILLISECONDS);
+    return this;
+  }
+
+  @Override
+  public CamundaFuture<SearchResponse<Client>> send() {
+    ArgumentUtil.ensureNotNullNorEmpty("groupId", groupId);
+    final HttpCamundaFuture<SearchResponse<Client>> result = new HttpCamundaFuture<>();
+    httpClient.post(
+        String.format("/groups/%s/clients/search", groupId),
+        jsonMapper.toJson(request),
+        httpRequestConfig.build(),
+        GroupClientSearchResult.class,
+        SearchResponseMapper::toGroupClientsResponse,
+        result);
+    return result;
+  }
+
+  @Override
+  public ClientsByGroupSearchRequest filter(final ClientFilter value) {
+    // This command doesn't support filtering
+    return null;
+  }
+
+  @Override
+  public ClientsByGroupSearchRequest filter(final Consumer<ClientFilter> fn) {
+    // This command doesn't support filtering
+    return null;
+  }
+
+  @Override
+  public ClientsByGroupSearchRequest page(final SearchRequestPage value) {
+    request.setPage(provideSearchRequestProperty(value));
+    return this;
+  }
+
+  @Override
+  public ClientsByGroupSearchRequest page(final Consumer<SearchRequestPage> fn) {
+    return page(searchRequestPage(fn));
+  }
+
+  @Override
+  public ClientsByGroupSearchRequest sort(final ClientSort value) {
+    request.setSort(
+        SearchRequestSortMapper.toGroupClientSearchQuerySortRequest(
+            provideSearchRequestProperty(value)));
+    return this;
+  }
+
+  @Override
+  public ClientsByGroupSearchRequest sort(final Consumer<ClientSort> fn) {
+    return sort(clientSort(fn));
+  }
+
+  @Override
+  protected GroupClientSearchQueryRequest getSearchRequestProperty() {
+    return request;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/search/request/SearchRequestSortMapper.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/request/SearchRequestSortMapper.java
@@ -217,6 +217,20 @@ public class SearchRequestSortMapper {
         .collect(Collectors.toList());
   }
 
+  public static List<GroupClientSearchQuerySortRequest> toGroupClientSearchQuerySortRequest(
+      final List<SearchRequestSort> requests) {
+    return requests.stream()
+        .map(
+            r -> {
+              final GroupClientSearchQuerySortRequest request =
+                  new GroupClientSearchQuerySortRequest();
+              request.setField(GroupClientSearchQuerySortRequest.FieldEnum.fromValue(r.getField()));
+              request.setOrder(r.getOrder());
+              return request;
+            })
+        .collect(Collectors.toList());
+  }
+
   public static List<GroupSearchQuerySortRequest> toGroupSearchQuerySortRequest(
       final List<SearchRequestSort> requests) {
     return requests.stream()

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/SearchResponseMapper.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/SearchResponseMapper.java
@@ -194,6 +194,18 @@ public final class SearchResponseMapper {
     return new SearchResponseImpl<>(instances, page);
   }
 
+  public static SearchResponse<Client> toGroupClientsResponse(
+      final GroupClientSearchResult response) {
+    final SearchResponsePage page = toSearchResponsePage(response.getPage());
+    final List<Client> instances =
+        toSearchResponseInstances(response.getItems(), SearchResponseMapper::toGroupClientResponse);
+    return new SearchResponseImpl<>(instances, page);
+  }
+
+  public static Client toGroupClientResponse(final GroupClientResult response) {
+    return new ClientImpl(response.getClientId());
+  }
+
   public static Role toRoleResponse(final RoleResult response) {
     return new RoleImpl(response.getRoleId(), response.getName(), response.getDescription());
   }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/GroupAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/GroupAuthorizationIT.java
@@ -17,8 +17,8 @@ import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ProblemException;
 import io.camunda.client.api.search.enums.PermissionType;
 import io.camunda.client.api.search.enums.ResourceType;
+import io.camunda.client.api.search.response.Client;
 import io.camunda.client.api.search.response.Group;
-import io.camunda.client.protocol.rest.GroupClientSearchResult;
 import io.camunda.qa.util.auth.Authenticated;
 import io.camunda.qa.util.auth.GroupDefinition;
 import io.camunda.qa.util.auth.Membership;
@@ -33,16 +33,8 @@ import io.camunda.qa.util.multidb.MultiDbTestApplication;
 import io.camunda.zeebe.protocol.record.value.EntityType;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import io.camunda.zeebe.test.util.Strings;
-import java.io.IOException;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
-import java.util.Base64;
 import java.util.List;
 import org.awaitility.Awaitility;
-import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
@@ -62,8 +54,6 @@ class GroupAuthorizationIT {
   private static final String RESTRICTED = "restrictedUser";
   private static final String RESTRICTED_WITH_READ = "restrictedUser2";
   private static final String DEFAULT_PASSWORD = "password";
-
-  @AutoClose private static final HttpClient HTTP_CLIENT = HttpClient.newHttpClient();
 
   @UserDefinition
   private static final TestUser ADMIN_USER =
@@ -207,12 +197,9 @@ class GroupAuthorizationIT {
         .ignoreExceptionsInstanceOf(ProblemException.class)
         .untilAsserted(
             () -> {
-              final GroupClientSearchResult result =
-                  searchClients(
-                      camundaClient.getConfiguration().getRestAddress().toString(),
-                      ADMIN,
-                      GROUP_1.id());
-              assertThat(result.getItems()).anyMatch(r -> clientId.equals(r.getClientId()));
+              final var clients =
+                  camundaClient.newClientsByGroupSearchRequest(GROUP_1.id()).send().join();
+              assertThat(clients.items()).anyMatch(r -> clientId.equals(r.getClientId()));
             });
   }
 
@@ -262,12 +249,9 @@ class GroupAuthorizationIT {
         .ignoreExceptionsInstanceOf(ProblemException.class)
         .untilAsserted(
             () -> {
-              final GroupClientSearchResult result =
-                  searchClients(
-                      camundaClient.getConfiguration().getRestAddress().toString(),
-                      ADMIN,
-                      GROUP_1.id());
-              assertThat(result.getItems()).anyMatch(r -> clientId.equals(r.getClientId()));
+              final var clients =
+                  camundaClient.newClientsByGroupSearchRequest(GROUP_1.id()).send().join();
+              assertThat(clients.items()).anyMatch(r -> clientId.equals(r.getClientId()));
             });
 
     // when
@@ -283,40 +267,49 @@ class GroupAuthorizationIT {
         .ignoreExceptionsInstanceOf(ProblemException.class)
         .untilAsserted(
             () -> {
-              final GroupClientSearchResult result =
-                  searchClients(
-                      camundaClient.getConfiguration().getRestAddress().toString(),
-                      ADMIN,
-                      GROUP_1.id());
-              assertThat(result.getItems()).noneMatch(r -> clientId.equals(r.getClientId()));
+              final var clients =
+                  camundaClient.newClientsByGroupSearchRequest(GROUP_1.id()).send().join();
+              assertThat(clients.items()).noneMatch(r -> clientId.equals(r.getClientId()));
             });
   }
 
-  // TODO once available, this test should use the client to make the request
-  private static GroupClientSearchResult searchClients(
-      final String restAddress, final String username, final String groupId)
-      throws URISyntaxException, IOException, InterruptedException {
-    final var encodedCredentials =
-        Base64.getEncoder()
-            .encodeToString("%s:%s".formatted(username, DEFAULT_PASSWORD).getBytes());
-    final HttpRequest request =
-        HttpRequest.newBuilder()
-            .uri(new URI("%s%s".formatted(restAddress, "v2/groups/" + groupId + "/clients/search")))
-            .POST(HttpRequest.BodyPublishers.ofString(""))
-            .header("Authorization", "Basic %s".formatted(encodedCredentials))
-            .build();
-
-    // Send the request and get the response
-    final HttpResponse<String> response =
-        HTTP_CLIENT.send(request, HttpResponse.BodyHandlers.ofString());
-
-    return OBJECT_MAPPER.readValue(response.body(), GroupClientSearchResult.class);
+  @Test
+  void getClientsByGroupShouldReturnEmptyListIfUnauthorized(
+      @Authenticated(RESTRICTED) final CamundaClient camundaClient) {
+    final var clients = camundaClient.newClientsByGroupSearchRequest(GROUP_1.id()).send().join();
+    assertThat(clients.items().size()).isEqualTo(0);
   }
 
   @Test
-  void getClientsByGroupShouldReturnNotFoundIfUnauthorized(
-      @Authenticated(RESTRICTED) final CamundaClient camundaClient) {
-    final var roles = camundaClient.newClientsByGroupSearchRequest(GROUP_1.id()).send().join();
-    assertThat(roles.items().size()).isEqualTo(0);
+  void getClientsByGroupShouldReturnClientsIfAuthorized(
+      @Authenticated(ADMIN) final CamundaClient camundaClient) {
+    // when
+    final String firstClientId = "someClientId";
+    camundaClient
+        .newAssignClientToGroupCommand()
+        .clientId(firstClientId)
+        .groupId(GROUP_1.id())
+        .send()
+        .join();
+
+    final String secondClientId = "otherClientId";
+    camundaClient
+        .newAssignClientToGroupCommand()
+        .clientId(secondClientId)
+        .groupId(GROUP_1.id())
+        .send()
+        .join();
+
+    // then
+    Awaitility.await("Clients are assigned to the group and can be searched")
+        .ignoreExceptionsInstanceOf(ProblemException.class)
+        .untilAsserted(
+            () -> {
+              final var clients =
+                  camundaClient.newClientsByGroupSearchRequest(GROUP_1.id()).send().join();
+              assertThat(clients.items())
+                  .map(Client::getClientId)
+                  .contains(firstClientId, secondClientId);
+            });
   }
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/GroupAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/GroupAuthorizationIT.java
@@ -312,4 +312,11 @@ class GroupAuthorizationIT {
 
     return OBJECT_MAPPER.readValue(response.body(), GroupClientSearchResult.class);
   }
+
+  @Test
+  void getClientsByGroupShouldReturnNotFoundIfUnauthorized(
+      @Authenticated(RESTRICTED) final CamundaClient camundaClient) {
+    final var roles = camundaClient.newClientsByGroupSearchRequest(GROUP_1.id()).send().join();
+    assertThat(roles.items().size()).isEqualTo(0);
+  }
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ClientsByGroupIntegrationTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ClientsByGroupIntegrationTest.java
@@ -16,8 +16,8 @@ import io.camunda.client.api.search.response.Client;
 import io.camunda.client.api.search.response.SearchResponse;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.zeebe.test.util.Strings;
-import java.util.UUID;
 import org.awaitility.Awaitility;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
@@ -26,18 +26,25 @@ import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 public class ClientsByGroupIntegrationTest {
 
   private static CamundaClient camundaClient;
+  private static final String GROUP_ID = Strings.newRandomValidIdentityId();
+
+  @BeforeAll
+  static void setup() {
+    createGroup(GROUP_ID);
+  }
 
   @Test
   void shouldAssignClientToGroup() {
     // given
     final var clientId = "clientId";
-    final var groupId = Strings.newRandomValidIdentityId();
-    final var groupName = UUID.randomUUID().toString();
-    final var description = UUID.randomUUID().toString();
-    createGroup(groupId, groupName, description);
 
     // when
-    camundaClient.newAssignClientToGroupCommand().clientId(clientId).groupId(groupId).send().join();
+    camundaClient
+        .newAssignClientToGroupCommand()
+        .clientId(clientId)
+        .groupId(GROUP_ID)
+        .send()
+        .join();
 
     // then
     Awaitility.await("Client is assigned to the group")
@@ -45,7 +52,7 @@ public class ClientsByGroupIntegrationTest {
         .untilAsserted(
             () -> {
               final SearchResponse<Client> result =
-                  camundaClient.newClientsByGroupSearchRequest(groupId).send().join();
+                  camundaClient.newClientsByGroupSearchRequest(GROUP_ID).send().join();
               assertThat(result.items()).anyMatch(r -> clientId.equals(r.getClientId()));
             });
   }
@@ -70,19 +77,20 @@ public class ClientsByGroupIntegrationTest {
   void shouldUnassignClientFromGroup() {
     // given
     final var clientId = "clientId_toRemove";
-    final var groupId = Strings.newRandomValidIdentityId();
-    final var groupName = UUID.randomUUID().toString();
-    final var description = UUID.randomUUID().toString();
-    createGroup(groupId, groupName, description);
 
-    camundaClient.newAssignClientToGroupCommand().clientId(clientId).groupId(groupId).send().join();
+    camundaClient
+        .newAssignClientToGroupCommand()
+        .clientId(clientId)
+        .groupId(GROUP_ID)
+        .send()
+        .join();
 
     Awaitility.await("Client is assigned to the group")
         .ignoreExceptionsInstanceOf(ProblemException.class)
         .untilAsserted(
             () -> {
               final SearchResponse<Client> result =
-                  camundaClient.newClientsByGroupSearchRequest(groupId).send().join();
+                  camundaClient.newClientsByGroupSearchRequest(GROUP_ID).send().join();
               assertThat(result.items()).anyMatch(r -> clientId.equals(r.getClientId()));
             });
 
@@ -90,7 +98,7 @@ public class ClientsByGroupIntegrationTest {
     camundaClient
         .newUnassignClientFromGroupCommand()
         .clientId(clientId)
-        .groupId(groupId)
+        .groupId(GROUP_ID)
         .send()
         .join();
 
@@ -100,7 +108,7 @@ public class ClientsByGroupIntegrationTest {
         .untilAsserted(
             () -> {
               final SearchResponse<Client> result =
-                  camundaClient.newClientsByGroupSearchRequest(groupId).send().join();
+                  camundaClient.newClientsByGroupSearchRequest(GROUP_ID).send().join();
               assertThat(result.items()).noneMatch(r -> clientId.equals(r.getClientId()));
             });
   }
@@ -108,9 +116,7 @@ public class ClientsByGroupIntegrationTest {
   @Test
   void shouldRejectUnassigningIfClientIsNotAssignedToGroup() {
     // given
-    final var groupId = Strings.newRandomValidIdentityId();
     final var clientId = Strings.newRandomValidIdentityId();
-    camundaClient.newCreateGroupCommand().groupId(groupId).name("groupName").send().join();
 
     // when/then
     assertThatThrownBy(
@@ -118,7 +124,7 @@ public class ClientsByGroupIntegrationTest {
                 camundaClient
                     .newUnassignClientFromGroupCommand()
                     .clientId(clientId)
-                    .groupId(groupId)
+                    .groupId(GROUP_ID)
                     .send()
                     .join())
         .isInstanceOf(ProblemException.class)
@@ -126,18 +132,109 @@ public class ClientsByGroupIntegrationTest {
             "Expected to remove entity with ID '"
                 + clientId
                 + "' from group with ID '"
-                + groupId
+                + GROUP_ID
                 + "', but the entity is not assigned to this group.");
   }
 
-  private static void createGroup(
-      final String groupId, final String groupName, final String description) {
+  @Test
+  void searchClientsShouldReturnEmptyListWhenSearchingForNonExistingGroupId() {
+    final var clientsSearchResponse =
+        camundaClient.newClientsByGroupSearchRequest("someGroupId").send().join();
+    assertThat(clientsSearchResponse.items()).isEmpty();
+  }
+
+  @Test
+  void shouldRejectClientsByGroupSearchIfMissingGroupId() {
+    // when / then
+    assertThatThrownBy(() -> camundaClient.newClientsByGroupSearchRequest(null).send().join())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("groupId must not be null");
+  }
+
+  @Test
+  void shouldRejectClientsByGroupSearchIfEmptyGroupId() {
+    // when / then
+    assertThatThrownBy(() -> camundaClient.newClientsByGroupSearchRequest("").send().join())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("groupId must not be empty");
+  }
+
+  @Test
+  void shouldReturnClientsByGroup() {
+    // given
+    final var firstClientId = "someClientId";
+    final var secondClientId = "otherClientId";
+
+    // when
     camundaClient
-        .newCreateGroupCommand()
-        .groupId(groupId)
-        .name(groupName)
-        .description(description)
+        .newAssignClientToGroupCommand()
+        .clientId(firstClientId)
+        .groupId(GROUP_ID)
         .send()
         .join();
+
+    camundaClient
+        .newAssignClientToGroupCommand()
+        .clientId(secondClientId)
+        .groupId(GROUP_ID)
+        .send()
+        .join();
+
+    // then
+    Awaitility.await("Clients are assigned to the group and can be searched")
+        .ignoreExceptionsInstanceOf(ProblemException.class)
+        .untilAsserted(
+            () -> {
+              final SearchResponse<Client> result =
+                  camundaClient.newClientsByGroupSearchRequest(GROUP_ID).send().join();
+              assertThat(result.items())
+                  .map(Client::getClientId)
+                  .contains(firstClientId, secondClientId);
+            });
+  }
+
+  @Test
+  void shouldReturnClientsByGroupSorted() {
+    // given
+    final var firstClientId = "AClientId";
+    final var secondClientId = "BClientId";
+    final var groupId = Strings.newRandomValidIdentityId();
+    createGroup(groupId);
+
+    // when
+    camundaClient
+        .newAssignClientToGroupCommand()
+        .clientId(firstClientId)
+        .groupId(groupId)
+        .send()
+        .join();
+
+    camundaClient
+        .newAssignClientToGroupCommand()
+        .clientId(secondClientId)
+        .groupId(groupId)
+        .send()
+        .join();
+
+    // then
+    Awaitility.await("Clients are assigned to the group and can be searched")
+        .ignoreExceptionsInstanceOf(ProblemException.class)
+        .untilAsserted(
+            () -> {
+              final var clients =
+                  camundaClient
+                      .newClientsByGroupSearchRequest(groupId)
+                      .sort(fn -> fn.clientId().desc())
+                      .send()
+                      .join();
+              assertThat(clients.items().size()).isEqualTo(2);
+              assertThat(clients.items())
+                  .extracting(Client::getClientId)
+                  .containsExactly(secondClientId, firstClientId);
+            });
+  }
+
+  private static void createGroup(final String groupId) {
+    camundaClient.newCreateGroupCommand().groupId(groupId).name("groupName").send().join();
   }
 }


### PR DESCRIPTION
## Description

Adding `newClientsByGroupSearchRequest` client command.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #35213
