### PR TITLE
ci: remove typePrerelease from c8run release workflow

### DIFF
--- a/.github/workflows/c8run-release.yaml
+++ b/.github/workflows/c8run-release.yaml
@@ -29,10 +29,6 @@ on:
         description: "Publish C8Run artifact to Camunda Download Center"
         type: boolean
         default: true
-      typePrerelease:
-        description: "Mark the GitHub release as prerelease (used for alphas only)"
-        type: boolean
-        default: false
       artifactVersionSuffix:
         description: 'Add extra suffix for release artifacts like "-rc" (Note: the dash should be included)'
         type: string
@@ -207,13 +203,6 @@ jobs:
             "${{ env.C8RUN_NAME_ARTIFACT_WITH_PATCH_VERSION }}"
         env:
           GH_TOKEN: ${{ github.token }}
-
-      - name: Set GitHub release type
-        if: inputs.typePrerelease
-        env:
-          GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-        run: |
-          gh release edit "${{ inputs.camundaAppsRelease }}" --prerelease
 
       - name: Camunda Download Center - Upload artifact in own release
         if: inputs.publishToCamundaDownloadCenter


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Related to https://github.com/camunda/team-distribution/issues/576

Removes the `typePrerelease` input as its not needed anymore. C8Run -rcs are added to the release and we should not switch/ control the prerelease of the monorepo releases.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
