### PR TITLE
feat: Support intermediate user task lifecycle states in secondary storage (`rdbms-exporter`)

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/UserTaskDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/UserTaskDbModel.java
@@ -500,6 +500,7 @@ public class UserTaskDbModel implements Copyable<UserTaskDbModel> {
   }
 
   public enum UserTaskState {
+    CREATING,
     CREATED,
     COMPLETED,
     CANCELED,

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/UserTaskDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/UserTaskDbModel.java
@@ -502,7 +502,11 @@ public class UserTaskDbModel implements Copyable<UserTaskDbModel> {
   public enum UserTaskState {
     CREATING,
     CREATED,
+    ASSIGNING,
+    UPDATING,
+    COMPLETING,
     COMPLETED,
+    CANCELING,
     CANCELED,
     FAILED
   }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/UserTaskWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/UserTaskWriter.java
@@ -11,6 +11,7 @@ import io.camunda.db.rdbms.sql.HistoryCleanupMapper;
 import io.camunda.db.rdbms.sql.HistoryCleanupMapper.CleanupHistoryDto;
 import io.camunda.db.rdbms.sql.UserTaskMapper;
 import io.camunda.db.rdbms.write.domain.UserTaskDbModel;
+import io.camunda.db.rdbms.write.domain.UserTaskDbModel.UserTaskState;
 import io.camunda.db.rdbms.write.domain.UserTaskMigrationDbModel;
 import io.camunda.db.rdbms.write.queue.ContextType;
 import io.camunda.db.rdbms.write.queue.ExecutionQueue;
@@ -96,6 +97,16 @@ public class UserTaskWriter {
               "io.camunda.db.rdbms.sql.UserTaskMapper.insertCandidateGroups",
               userTaskDbModel));
     }
+  }
+
+  public void updateState(final long userTaskKey, final UserTaskState state) {
+    executionQueue.executeInQueue(
+        new QueueItem(
+            ContextType.USER_TASK,
+            WriteStatementType.UPDATE,
+            userTaskKey,
+            "io.camunda.db.rdbms.sql.UserTaskMapper.updateState",
+            new UserTaskDbModel.Builder().userTaskKey(userTaskKey).state(state).build()));
   }
 
   public void scheduleForHistoryCleanup(

--- a/db/rdbms/src/main/resources/mapper/UserTaskMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/UserTaskMapper.xml
@@ -297,9 +297,7 @@
     SET
     COMPLETION_DATE = #{completionDate},
     DUE_DATE = #{dueDate},
-    <if test="state != null">
-      STATE = #{state},
-    </if>
+    STATE = #{state},
     FOLLOW_UP_DATE = #{followUpDate},
     CUSTOM_HEADERS = #{serializedCustomHeaders},
     PRIORITY = #{priority},

--- a/db/rdbms/src/main/resources/mapper/UserTaskMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/UserTaskMapper.xml
@@ -306,6 +306,12 @@
     WHERE USER_TASK_KEY = #{userTaskKey}
   </update>
 
+  <update id="updateState" parameterType="io.camunda.db.rdbms.write.domain.UserTaskDbModel">
+    UPDATE ${prefix}USER_TASK
+    SET STATE = #{state}
+    WHERE USER_TASK_KEY = #{userTaskKey}
+  </update>
+
   <delete id="deleteCandidateUsers" parameterType="java.lang.Long">
     DELETE
     FROM ${prefix}CANDIDATE_USER

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsExporterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsExporterIT.java
@@ -24,7 +24,7 @@ import static io.camunda.it.rdbms.exporter.RecordFixtures.getProcessInstanceStar
 import static io.camunda.it.rdbms.exporter.RecordFixtures.getRoleRecord;
 import static io.camunda.it.rdbms.exporter.RecordFixtures.getTenantRecord;
 import static io.camunda.it.rdbms.exporter.RecordFixtures.getUserRecord;
-import static io.camunda.it.rdbms.exporter.RecordFixtures.getUserTaskCreatedRecord;
+import static io.camunda.it.rdbms.exporter.RecordFixtures.getUserTaskCreatingRecord;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.db.rdbms.RdbmsService;
@@ -264,7 +264,7 @@ class RdbmsExporterIT {
   @Test
   public void shouldExportUserTask() {
     // given
-    final var userTaskRecord = getUserTaskCreatedRecord(1L);
+    final var userTaskRecord = getUserTaskCreatingRecord(1L);
 
     // when
     exporter.export(userTaskRecord);
@@ -586,8 +586,8 @@ class RdbmsExporterIT {
 
     // then
     final var formKey = ((Form) formCreatedRecord.getValue()).getFormKey();
-    final var userTask = rdbmsService.getFormReader().findOne(formKey);
-    assertThat(userTask).isNotNull();
+    final var formEntity = rdbmsService.getFormReader().findOne(formKey);
+    assertThat(formEntity).isNotNull();
   }
 
   @Test

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RecordFixtures.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RecordFixtures.java
@@ -249,12 +249,12 @@ public class RecordFixtures {
         .build();
   }
 
-  protected static ImmutableRecord<RecordValue> getUserTaskCreatedRecord(final Long position) {
+  protected static ImmutableRecord<RecordValue> getUserTaskCreatingRecord(final Long position) {
     final Record<RecordValue> recordValueRecord = FACTORY.generateRecord(ValueType.USER_TASK);
 
     return ImmutableRecord.builder()
         .from(recordValueRecord)
-        .withIntent(UserTaskIntent.CREATED)
+        .withIntent(UserTaskIntent.CREATING)
         .withPosition(position)
         .withTimestamp(System.currentTimeMillis())
         .withPartitionId(1)

--- a/zeebe/exporters/rdbms-exporter/pom.xml
+++ b/zeebe/exporters/rdbms-exporter/pom.xml
@@ -104,13 +104,26 @@
     </dependency>
 
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
+
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/UserTaskExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/UserTaskExportHandler.java
@@ -77,9 +77,10 @@ public class UserTaskExportHandler implements RdbmsExportHandler<UserTaskRecordV
       case UserTaskIntent.CREATING ->
           userTaskWriter.create(
               map(record, UserTaskState.CREATING, null).toBuilder()
-                  // Clear assignee as it may be initialized later during the assignment transition
-                  // (if defined via the BPMN model) or modified by 'creating' task listeners, in
-                  // which case the final value will be reflected in the subsequent CREATED event.
+                  // Clear assignee as it shouldn't be persisted yet. While the CREATING event may
+                  // contain it (if defined in the BPMN model), it's only used internally to trigger
+                  // the assignment transition after the CREATED event. Externally, the task should
+                  // remain unassigned until the ASSIGNED event is exported.
                   .assignee(null)
                   .build());
       case UserTaskIntent.ASSIGNING, CLAIMING ->

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/UserTaskExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/UserTaskExportHandler.java
@@ -28,6 +28,7 @@ import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
 import io.camunda.zeebe.protocol.record.value.UserTaskRecordValue;
 import java.time.OffsetDateTime;
+import java.util.EnumSet;
 import java.util.Set;
 import org.apache.commons.lang3.StringUtils;
 
@@ -35,13 +36,13 @@ import org.apache.commons.lang3.StringUtils;
 public class UserTaskExportHandler implements RdbmsExportHandler<UserTaskRecordValue> {
 
   private static final Set<UserTaskIntent> EXPORTABLE_INTENTS =
-      Set.of(
+      EnumSet.of(
           UserTaskIntent.CREATING,
           UserTaskIntent.CREATED,
-          UserTaskIntent.UPDATED,
-          UserTaskIntent.CANCELED,
           UserTaskIntent.ASSIGNED,
+          UserTaskIntent.UPDATED,
           UserTaskIntent.COMPLETED,
+          UserTaskIntent.CANCELED,
           UserTaskIntent.MIGRATED);
 
   private final UserTaskWriter userTaskWriter;

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/UserTaskExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/UserTaskExportHandler.java
@@ -29,9 +29,13 @@ import java.time.OffsetDateTime;
 import java.util.EnumSet;
 import java.util.Set;
 import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** Based on UserTaskRecordToTaskEntityMapper */
 public class UserTaskExportHandler implements RdbmsExportHandler<UserTaskRecordValue> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(UserTaskExportHandler.class);
 
   private static final Set<UserTaskIntent> EXPORTABLE_INTENTS =
       EnumSet.of(
@@ -120,11 +124,11 @@ public class UserTaskExportHandler implements RdbmsExportHandler<UserTaskRecordV
                   .build());
       case UserTaskIntent.ASSIGNMENT_DENIED, UPDATE_DENIED, COMPLETION_DENIED ->
           userTaskWriter.updateState(value.getUserTaskKey(), UserTaskState.CREATED);
-      default -> {
-        // All currently supported intents are handled explicitly above.
-        // If new intent is added to EXPORTABLE_INTENTS but not handled here,
-        // this default case ensures it is ignored until explicitly supported.
-      }
+      default ->
+          // All currently supported intents are handled explicitly above.
+          // If new intent is added to EXPORTABLE_INTENTS but not handled here,
+          // this default case ensures it is ignored until explicitly supported.
+          LOG.warn("Unexpected intent {} for user task record", record.getIntent());
     }
   }
 

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/UserTaskExportHandlerTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/UserTaskExportHandlerTest.java
@@ -145,8 +145,8 @@ class UserTaskExportHandlerTest {
         .satisfies(
             model -> {
               assertThat(model.state())
-                  .as("State should be null for record with ASSIGNED intent")
-                  .isNull();
+                  .as("State should be CREATED for record with ASSIGNED intent")
+                  .isEqualTo(UserTaskState.CREATED);
               assertThat(model.assignee())
                   .as("Assignee should be same as in the record")
                   .isNotNull()
@@ -179,8 +179,8 @@ class UserTaskExportHandlerTest {
         .satisfies(
             model -> {
               assertThat(model.state())
-                  .as("State should be null for record with UPDATED intent")
-                  .isNull();
+                  .as("State should be CREATED for record with UPDATED intent")
+                  .isEqualTo(UserTaskState.CREATED);
               assertThat(model.assignee())
                   .as("Assignee should be same as in the record")
                   .isNotNull()

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/UserTaskExportHandlerTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/UserTaskExportHandlerTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.rdbms.handlers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.db.rdbms.write.service.UserTaskWriter;
+import io.camunda.zeebe.exporter.common.cache.ExporterEntityCache;
+import io.camunda.zeebe.exporter.common.cache.process.CachedProcessEntity;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
+import io.camunda.zeebe.protocol.record.value.UserTaskRecordValue;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class UserTaskExportHandlerTest {
+
+  private final ProtocolFactory factory = new ProtocolFactory();
+
+  @Mock private UserTaskWriter userTaskWriter;
+  @Mock private ExporterEntityCache<Long, CachedProcessEntity> processCache;
+
+  private UserTaskExportHandler handler;
+
+  @BeforeEach
+  void setUp() {
+    handler = new UserTaskExportHandler(userTaskWriter, processCache);
+  }
+
+  @ParameterizedTest(name = "should be able to export record with intent: {0}")
+  @EnumSource(
+      value = UserTaskIntent.class,
+      names = {"CREATED", "ASSIGNED", "UPDATED", "COMPLETED", "CANCELED", "MIGRATED"})
+  void shouldExportRecord(final UserTaskIntent intent) {
+    // given
+    final Record<UserTaskRecordValue> record =
+        factory.generateRecord(ValueType.USER_TASK, r -> r.withIntent(intent));
+
+    // when - then
+    assertThat(handler.canExport(record))
+        .as("Handler should be able to export record with intent: %s", intent)
+        .isTrue();
+  }
+
+  @ParameterizedTest(name = "should not export record with unsupported intent: {0}")
+  @EnumSource(
+      value = UserTaskIntent.class,
+      // Exclude the intents that are supported by the handler
+      mode = EnumSource.Mode.EXCLUDE,
+      names = {"CREATED", "ASSIGNED", "UPDATED", "COMPLETED", "CANCELED", "MIGRATED"})
+  void shouldNotExportRecord(final UserTaskIntent intent) {
+    // given
+    final Record<UserTaskRecordValue> record =
+        factory.generateRecord(ValueType.USER_TASK, r -> r.withIntent(intent));
+
+    // when - then
+    assertThat(handler.canExport(record))
+        .as("Handler should not be able to export record with unsupported intent: %s", intent)
+        // If this assertion fails, it means that the given intent was recently added to
+        // `UserTaskExportHandler#EXPORTABLE_INTENTS`.
+        // In that case:
+        // - Add it to the supported intents list in both this test and the one above
+        // - Review whether it needs custom handling in `UserTaskExportHandler#export`:
+        //   - If so, add a dedicated handling in `UserTaskExportHandler#export`
+        //   - Add a dedicated test for the new intent in this class
+        .isFalse();
+  }
+}

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/UserTaskExportHandlerTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/UserTaskExportHandlerTest.java
@@ -8,7 +8,13 @@
 package io.camunda.exporter.rdbms.handlers;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 
+import io.camunda.db.rdbms.write.domain.UserTaskDbModel;
+import io.camunda.db.rdbms.write.domain.UserTaskDbModel.UserTaskState;
+import io.camunda.db.rdbms.write.domain.UserTaskMigrationDbModel;
 import io.camunda.db.rdbms.write.service.UserTaskWriter;
 import io.camunda.zeebe.exporter.common.cache.ExporterEntityCache;
 import io.camunda.zeebe.exporter.common.cache.process.CachedProcessEntity;
@@ -17,9 +23,16 @@ import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
 import io.camunda.zeebe.protocol.record.value.UserTaskRecordValue;
 import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import io.camunda.zeebe.util.DateUtil;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -30,6 +43,8 @@ class UserTaskExportHandlerTest {
 
   @Mock private UserTaskWriter userTaskWriter;
   @Mock private ExporterEntityCache<Long, CachedProcessEntity> processCache;
+
+  @Captor private ArgumentCaptor<UserTaskDbModel> taskDbModelCaptor;
 
   private UserTaskExportHandler handler;
 
@@ -75,5 +90,251 @@ class UserTaskExportHandlerTest {
         //   - If so, add a dedicated handling in `UserTaskExportHandler#export`
         //   - Add a dedicated test for the new intent in this class
         .isFalse();
+  }
+
+  @Test
+  @DisplayName("Should handle user task record with CREATED intent")
+  void shouldHandleCreatedUserTaskRecord() {
+    // given
+    final Record<UserTaskRecordValue> record =
+        factory.generateRecord(ValueType.USER_TASK, r -> r.withIntent(UserTaskIntent.CREATED));
+    final var recordValue = record.getValue();
+    when(processCache.get(recordValue.getProcessDefinitionKey())).thenReturn(Optional.empty());
+
+    // when
+    handler.export(record);
+
+    // then
+    verify(userTaskWriter).create(taskDbModelCaptor.capture());
+    assertThat(taskDbModelCaptor.getValue())
+        .satisfies(
+            model -> {
+              assertThat(model.state())
+                  .as("State should be CREATED for record with CREATED intent")
+                  .isEqualTo(UserTaskState.CREATED);
+              assertThat(model.assignee())
+                  .as("Assignee should be same as in the record")
+                  .isNotNull()
+                  .isEqualTo(recordValue.getAssignee());
+              assertThat(model.completionDate())
+                  .as("Completion date should be null for CREATED intent")
+                  .isNull();
+
+              assertUserTaskModelFieldsEqualToRecord(model, record);
+            });
+
+    // ensure no other methods are called
+    verifyNoMoreInteractions(userTaskWriter);
+  }
+
+  @Test
+  @DisplayName("Should handle user task record with ASSIGNED intent")
+  void shouldHandleAssignedUserTaskRecord() {
+    // given
+    final Record<UserTaskRecordValue> record =
+        factory.generateRecord(ValueType.USER_TASK, r -> r.withIntent(UserTaskIntent.ASSIGNED));
+    final var recordValue = record.getValue();
+    when(processCache.get(recordValue.getProcessDefinitionKey())).thenReturn(Optional.empty());
+
+    // when
+    handler.export(record);
+
+    // then
+    verify(userTaskWriter).update(taskDbModelCaptor.capture());
+    assertThat(taskDbModelCaptor.getValue())
+        .satisfies(
+            model -> {
+              assertThat(model.state())
+                  .as("State should be null for record with ASSIGNED intent")
+                  .isNull();
+              assertThat(model.assignee())
+                  .as("Assignee should be same as in the record")
+                  .isNotNull()
+                  .isEqualTo(recordValue.getAssignee());
+              assertThat(model.completionDate())
+                  .as("Completion date should be null for ASSIGNED intent")
+                  .isNull();
+              assertUserTaskModelFieldsEqualToRecord(model, record);
+            });
+
+    // ensure no other methods are called
+    verifyNoMoreInteractions(userTaskWriter);
+  }
+
+  @Test
+  @DisplayName("Should handle user task record with UPDATED intent")
+  void shouldHandleUpdatedUserTaskRecord() {
+    // given
+    final Record<UserTaskRecordValue> record =
+        factory.generateRecord(ValueType.USER_TASK, r -> r.withIntent(UserTaskIntent.UPDATED));
+    final var recordValue = record.getValue();
+    when(processCache.get(recordValue.getProcessDefinitionKey())).thenReturn(Optional.empty());
+
+    // when
+    handler.export(record);
+
+    // then
+    verify(userTaskWriter).update(taskDbModelCaptor.capture());
+    assertThat(taskDbModelCaptor.getValue())
+        .satisfies(
+            model -> {
+              assertThat(model.state())
+                  .as("State should be null for record with UPDATED intent")
+                  .isNull();
+              assertThat(model.assignee())
+                  .as("Assignee should be same as in the record")
+                  .isNotNull()
+                  .isEqualTo(recordValue.getAssignee());
+              assertThat(model.completionDate())
+                  .as("Completion date should be null for UPDATED intent")
+                  .isNull();
+
+              assertUserTaskModelFieldsEqualToRecord(model, record);
+            });
+
+    // ensure no other methods are called
+    verifyNoMoreInteractions(userTaskWriter);
+  }
+
+  @Test
+  @DisplayName("Should handle user task record with COMPLETED intent")
+  void shouldHandleCompletedUserTaskRecord() {
+    // given
+    final Record<UserTaskRecordValue> record =
+        factory.generateRecord(ValueType.USER_TASK, r -> r.withIntent(UserTaskIntent.COMPLETED));
+    final var recordValue = record.getValue();
+    when(processCache.get(recordValue.getProcessDefinitionKey())).thenReturn(Optional.empty());
+
+    // when
+    handler.export(record);
+
+    // then
+    verify(userTaskWriter).update(taskDbModelCaptor.capture());
+    assertThat(taskDbModelCaptor.getValue())
+        .satisfies(
+            model -> {
+              assertThat(model.state())
+                  .as("State should be COMPLETED for record with COMPLETED intent")
+                  .isEqualTo(UserTaskState.COMPLETED);
+              assertThat(model.assignee())
+                  .as("Assignee should be same as in the record")
+                  .isNotNull()
+                  .isEqualTo(recordValue.getAssignee());
+              assertThat(model.completionDate())
+                  .as("Completion date should be not null for COMPLETED intent")
+                  .isNotNull()
+                  .isEqualTo(DateUtil.toOffsetDateTime(record.getTimestamp()));
+
+              assertUserTaskModelFieldsEqualToRecord(model, record);
+            });
+
+    // ensure no other methods are called
+    verifyNoMoreInteractions(userTaskWriter);
+  }
+
+  @Test
+  @DisplayName("Should handle user task record with CANCELED intent")
+  void shouldHandleCanceledUserTaskRecord() {
+    // given
+    final Record<UserTaskRecordValue> record =
+        factory.generateRecord(ValueType.USER_TASK, r -> r.withIntent(UserTaskIntent.CANCELED));
+    final var recordValue = record.getValue();
+    when(processCache.get(recordValue.getProcessDefinitionKey())).thenReturn(Optional.empty());
+
+    // when
+    handler.export(record);
+
+    // then
+    verify(userTaskWriter).update(taskDbModelCaptor.capture());
+    assertThat(taskDbModelCaptor.getValue())
+        .satisfies(
+            model -> {
+              assertThat(model.state())
+                  .as("State should be CANCELED for record with CANCELED intent")
+                  .isEqualTo(UserTaskState.CANCELED);
+              assertThat(model.assignee())
+                  .as("Assignee should be same as in the record")
+                  .isNotNull()
+                  .isEqualTo(recordValue.getAssignee());
+              assertThat(model.completionDate())
+                  .as("Completion date should be not null for CANCELED intent")
+                  .isNotNull()
+                  .isEqualTo(DateUtil.toOffsetDateTime(record.getTimestamp()));
+
+              assertUserTaskModelFieldsEqualToRecord(model, record);
+            });
+
+    // ensure no other methods are called
+    verifyNoMoreInteractions(userTaskWriter);
+  }
+
+  @Test
+  @DisplayName("Should handle user task record with MIGRATED intent")
+  void shouldHandleMigratedUserTaskRecord() {
+    // given
+    final Record<UserTaskRecordValue> record =
+        factory.generateRecord(ValueType.USER_TASK, r -> r.withIntent(UserTaskIntent.MIGRATED));
+    final var recordValue = record.getValue();
+    when(processCache.get(recordValue.getProcessDefinitionKey())).thenReturn(Optional.empty());
+
+    // when
+    handler.export(record);
+
+    // then
+    final var taskMigrationDbModelCaptor = ArgumentCaptor.forClass(UserTaskMigrationDbModel.class);
+    verify(userTaskWriter).migrateToProcess(taskMigrationDbModelCaptor.capture());
+    assertThat(taskMigrationDbModelCaptor.getValue())
+        .satisfies(
+            migrationModel -> {
+              assertThat(migrationModel.userTaskKey())
+                  .as("User task key should be same as in the record")
+                  .isEqualTo(recordValue.getUserTaskKey());
+              assertThat(migrationModel.processDefinitionKey())
+                  .as("Process definition key should be same as in the record")
+                  .isEqualTo(recordValue.getProcessDefinitionKey());
+              assertThat(migrationModel.processDefinitionId())
+                  .as("Process definition ID should be same as in the record")
+                  .isEqualTo(recordValue.getBpmnProcessId());
+              assertThat(migrationModel.elementId())
+                  .as("Element ID should be same as in the record")
+                  .isEqualTo(recordValue.getElementId());
+              assertThat(migrationModel.name()).isNull();
+              assertThat(migrationModel.processDefinitionVersion())
+                  .as("Process definition version should be same as in the record")
+                  .isEqualTo(recordValue.getProcessDefinitionVersion());
+            });
+
+    // ensure no other methods are called
+    verifyNoMoreInteractions(userTaskWriter);
+  }
+
+  private static void assertUserTaskModelFieldsEqualToRecord(
+      final UserTaskDbModel model, final Record<UserTaskRecordValue> record) {
+    final var recordValue = record.getValue();
+    assertThat(model.userTaskKey()).isEqualTo(recordValue.getUserTaskKey());
+    assertThat(model.elementId()).isEqualTo(recordValue.getElementId());
+    assertThat(model.processDefinitionId()).isEqualTo(recordValue.getBpmnProcessId());
+    assertThat(model.creationDate())
+        .isNotNull()
+        .isEqualTo(DateUtil.toOffsetDateTime(recordValue.getCreationTimestamp()));
+    assertThat(model.formKey()).isEqualTo(recordValue.getFormKey());
+    assertThat(model.processDefinitionKey()).isEqualTo(recordValue.getProcessDefinitionKey());
+    assertThat(model.processInstanceKey()).isEqualTo(recordValue.getProcessInstanceKey());
+    assertThat(model.elementInstanceKey()).isEqualTo(recordValue.getElementInstanceKey());
+    assertThat(model.tenantId()).isEqualTo(recordValue.getTenantId());
+    assertThat(model.candidateGroups()).isEqualTo(recordValue.getCandidateGroupsList());
+    assertThat(model.candidateUsers()).isEqualTo(recordValue.getCandidateUsersList());
+    assertThat(model.externalFormReference()).isEqualTo(recordValue.getExternalFormReference());
+    assertThat(model.processDefinitionVersion())
+        .isEqualTo(recordValue.getProcessDefinitionVersion());
+    assertThat(model.customHeaders()).isEqualTo(recordValue.getCustomHeaders());
+    assertThat(model.priority()).isEqualTo(recordValue.getPriority());
+    assertThat(model.partitionId()).isEqualTo(record.getPartitionId());
+    // ProtocolFactory used in tests - generates random strings for due/follow-up dates,
+    // which aren't in a valid ISO-8601 format. As a result, the conversion
+    // to OffsetDateTime fails and those fields are intentionally mapped to null
+    // during model mapping.
+    assertThat(model.dueDate()).isNull();
+    assertThat(model.followUpDate()).isNull();
   }
 }

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/UserTaskExportHandlerTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/UserTaskExportHandlerTest.java
@@ -308,6 +308,9 @@ class UserTaskExportHandlerTest {
     verifyNoMoreInteractions(userTaskWriter);
   }
 
+  // Helper method to assert that the fields of a UserTaskDbModel match the values in a Record and
+  // RecordValue, except for the 'state', 'assignee', and 'completionDate' fields,
+  // which are handled separately
   private static void assertUserTaskModelFieldsEqualToRecord(
       final UserTaskDbModel model, final Record<UserTaskRecordValue> record) {
     final var recordValue = record.getValue();
@@ -330,11 +333,7 @@ class UserTaskExportHandlerTest {
     assertThat(model.customHeaders()).isEqualTo(recordValue.getCustomHeaders());
     assertThat(model.priority()).isEqualTo(recordValue.getPriority());
     assertThat(model.partitionId()).isEqualTo(record.getPartitionId());
-    // ProtocolFactory used in tests - generates random strings for due/follow-up dates,
-    // which aren't in a valid ISO-8601 format. As a result, the conversion
-    // to OffsetDateTime fails and those fields are intentionally mapped to null
-    // during model mapping.
-    assertThat(model.dueDate()).isNull();
-    assertThat(model.followUpDate()).isNull();
+    assertThat(model.dueDate()).isNotNull().isEqualTo(recordValue.getDueDate());
+    assertThat(model.followUpDate()).isNotNull().isEqualTo(recordValue.getFollowUpDate());
   }
 }

--- a/zeebe/protocol-test-util/src/main/java/io/camunda/zeebe/test/broker/protocol/ProtocolFactory.java
+++ b/zeebe/protocol-test-util/src/main/java/io/camunda/zeebe/test/broker/protocol/ProtocolFactory.java
@@ -22,6 +22,9 @@ import io.github.classgraph.ClassGraph;
 import io.github.classgraph.ClassInfo;
 import io.github.classgraph.ClassInfoList;
 import java.lang.reflect.Field;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.EnumSet;
 import java.util.Objects;
 import java.util.concurrent.ThreadLocalRandom;
@@ -304,6 +307,19 @@ public final class ProtocolFactory {
               .withRequestStreamId(random.nextInt())
               .withOperationReference(random.nextLong())
               .build();
+        });
+
+    // A randomizer for any String property whose name ends with the "Date" suffix,
+    // generating a random date between now - 2 years and now + 2 years
+    randomizerRegistry.registerRandomizer(
+        field -> field.getType() == String.class && field.getName().endsWith("Date"),
+        () -> {
+          final var now = OffsetDateTime.now();
+          final var min = now.minusYears(2).toEpochSecond();
+          final var max = now.plusYears(2).toEpochSecond();
+          final var randomEpoch = min + Math.abs(random.nextLong()) % (max - min + 1);
+          return OffsetDateTime.ofInstant(Instant.ofEpochSecond(randomEpoch), now.getOffset())
+              .format(DateTimeFormatter.ISO_ZONED_DATE_TIME);
         });
   }
 


### PR DESCRIPTION
## Description

This PR handles more user task intents in the `rdbms-exporter` to support intermediate lifecycle states (e.g. `CREATING`, `ASSIGNING`, `COMPLETING`...), complementing [camunda-exporter PR#32733](https://github.com/camunda/camunda/pull/32733).

The exporter now explicitly handles records with intents:
- Transition started intents: `CREATING`, `ASSIGNING`, `CLAIMING`, `UPDATING`, `COMPLETING`, `CANCELING` - all new
- Transition denied: `ASSIGNMENT_DENIED`, `UPDATE_DENIED`, `COMPLETION_DENIED` - all new.
- Terminal intents: `CREATED`, `ASSIGNED`, `UPDATED`, `COMPLETED`, `CANCELED`, `MIGRATED`

This ensures accurate, fine-grained tracking of user task lifecycle, making transitional states available via secondary storage.

#### Key changes
- Explicit handling of a wider range of `UserTaskIntent` values in `UserTaskExportHandler`
- Added transitional states (`ASSIGNING`, `UPDATING`, etc.) to the `rdbms-exporter` internal API (`UserTaskDbModel.UserTaskState`)
- Handling denied intents now rollback task state to `CREATED`
- Added dedicated test suite to cover handling of `UserTaskIntent`-s.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #32562
complements PR #32733
