### PR TITLE
fix: refresh indices before submitting delete-by-query

### DIFF
--- a/schema-manager/src/main/java/io/camunda/search/schema/elasticsearch/ElasticsearchEngineClient.java
+++ b/schema-manager/src/main/java/io/camunda/search/schema/elasticsearch/ElasticsearchEngineClient.java
@@ -292,6 +292,8 @@ public class ElasticsearchEngineClient implements SearchEngineClient {
             .refresh(true)
             .build();
     try {
+      client.indices().refresh(r -> r.index(indexName));
+      LOG.debug("Refreshed index {}", indexName);
       final DeleteByQueryResponse response = client.deleteByQuery(deleteByQueryRequest);
       LOG.debug("Deleted {} documents from index {}", response.deleted(), indexName);
     } catch (final IOException e) {

--- a/schema-manager/src/main/java/io/camunda/search/schema/opensearch/OpensearchEngineClient.java
+++ b/schema-manager/src/main/java/io/camunda/search/schema/opensearch/OpensearchEngineClient.java
@@ -309,6 +309,8 @@ public class OpensearchEngineClient implements SearchEngineClient {
             .refresh(true)
             .build();
     try {
+      client.indices().refresh(r -> r.index(indexName));
+      LOG.debug("Refreshed index {}", indexName);
       final DeleteByQueryResponse response = client.deleteByQuery(request);
       LOG.debug("Deleted {} documents from index {}", response.deleted(), indexName);
     } catch (final IOException ioe) {


### PR DESCRIPTION
## Description

In ES and OS, deleting by query will delete all documents matching the defined query. However, as ES and OS are, by definition, near real-time, any segments that have not been refreshed/flushed to disk yet won't be considered. Meaning, after the delete by query request, any documents stored in memory may be flushed.

This PR ensures that the index will be refreshed before executing the delete-by-query. That way, it will ensure that everything will be deleted by the delete by query request.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
