### PR TITLE
refactor: move authorization and tenant strategies to SearchClients

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/search/SearchClientDatabaseConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/search/SearchClientDatabaseConfiguration.java
@@ -11,6 +11,7 @@ import io.camunda.application.commons.condition.ConditionalOnDatabaseNone;
 import io.camunda.db.rdbms.RdbmsService;
 import io.camunda.search.clients.DocumentBasedSearchClient;
 import io.camunda.search.clients.DocumentBasedSearchClients;
+import io.camunda.search.clients.SearchClientBasedQueryExecutor;
 import io.camunda.search.clients.impl.NoDBSearchClientsProxy;
 import io.camunda.search.clients.transformers.ServiceTransformers;
 import io.camunda.search.connect.configuration.ConnectConfiguration;
@@ -66,7 +67,7 @@ public class SearchClientDatabaseConfiguration {
 
   @Bean
   @ConditionalOnBean(DocumentBasedSearchClient.class)
-  public DocumentBasedSearchClients documentBasedSearchClients(
+  public SearchClientBasedQueryExecutor searchClientBasedQueryExecutor(
       final DocumentBasedSearchClient searchClient,
       final ConnectConfiguration connectConfiguration) {
     final var descriptors =
@@ -74,7 +75,14 @@ public class SearchClientDatabaseConfiguration {
             connectConfiguration.getIndexPrefix(),
             connectConfiguration.getTypeEnum().isElasticSearch());
     final var transformers = ServiceTransformers.newInstance(descriptors);
-    return new DocumentBasedSearchClients(searchClient, transformers);
+    return new SearchClientBasedQueryExecutor(searchClient, transformers);
+  }
+
+  @Bean
+  @ConditionalOnBean(DocumentBasedSearchClient.class)
+  public DocumentBasedSearchClients documentBasedSearchClients(
+      final SearchClientBasedQueryExecutor executor) {
+    return new DocumentBasedSearchClients(executor);
   }
 
   @Bean

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/SearchClientBasedQueryExecutor.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/SearchClientBasedQueryExecutor.java
@@ -8,10 +8,7 @@
 package io.camunda.search.clients;
 
 import io.camunda.search.aggregation.result.AggregationResultBase;
-import io.camunda.search.clients.auth.AuthorizationQueryStrategy;
-import io.camunda.search.clients.auth.DocumentTenantQueryStrategy;
 import io.camunda.search.clients.auth.ResourceAccessChecks;
-import io.camunda.search.clients.auth.TenantQueryStrategy;
 import io.camunda.search.clients.core.SearchQueryRequest;
 import io.camunda.search.clients.core.SearchQueryResponse;
 import io.camunda.search.clients.transformers.ServiceTransformer;
@@ -24,7 +21,6 @@ import io.camunda.search.filter.FilterBase;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.search.query.TypedSearchQuery;
 import io.camunda.search.sort.SortOption;
-import io.camunda.security.auth.SecurityContext;
 import io.camunda.zeebe.util.VisibleForTesting;
 import java.util.function.Function;
 
@@ -32,23 +28,17 @@ public final class SearchClientBasedQueryExecutor {
 
   private final DocumentBasedSearchClient searchClient;
   private final ServiceTransformers transformers;
-  private final AuthorizationQueryStrategy authorizationQueryStrategy;
-  private final TenantQueryStrategy tenantQueryStrategy;
 
   public SearchClientBasedQueryExecutor(
-      final DocumentBasedSearchClient searchClient,
-      final AuthorizationQueryStrategy authorizationQueryStrategy,
-      final ServiceTransformers transformers) {
+      final DocumentBasedSearchClient searchClient, final ServiceTransformers transformers) {
     this.searchClient = searchClient;
-    this.authorizationQueryStrategy = authorizationQueryStrategy;
-    tenantQueryStrategy = new DocumentTenantQueryStrategy();
     this.transformers = transformers;
   }
 
   public <F extends FilterBase, S extends SortOption, T, R> SearchQueryResult<R> search(
       final TypedSearchQuery<F, S> query,
       final Class<T> documentClass,
-      final SecurityContext securityContext) {
+      final ResourceAccessChecks resourceAccessChecks) {
     final SearchQueryResultTransformer<T, R> responseTransformer =
         (SearchQueryResultTransformer<T, R>) getSearchResultTransformer(documentClass);
     final var type = query.page().resultType();
@@ -58,15 +48,15 @@ public final class SearchClientBasedQueryExecutor {
     switch (type) {
       case UNLIMITED -> {
         reverse = false;
-        response = executeUnlimitedSearch(query, documentClass, securityContext);
+        response = executeUnlimitedSearch(query, documentClass, resourceAccessChecks);
       }
       case SINGLE_RESULT -> {
         reverse = false;
-        response = executeSingleResultSearch(query, documentClass, securityContext);
+        response = executeSingleResultSearch(query, documentClass, resourceAccessChecks);
       }
       default -> {
         reverse = !query.page().isNextPage();
-        response = executePaginatedSearch(query, documentClass, securityContext);
+        response = executePaginatedSearch(query, documentClass, resourceAccessChecks);
       }
     }
 
@@ -76,12 +66,12 @@ public final class SearchClientBasedQueryExecutor {
   public <F extends FilterBase, S extends SortOption, R extends AggregationResultBase> R aggregate(
       final TypedSearchQuery<F, S> query,
       final Class<R> resultClass,
-      final SecurityContext securityContext) {
+      final ResourceAccessChecks resourceAccessChecks) {
     final var searchQueryResponse =
         executeSearch(
             query,
             searchRequest -> searchClient.search(searchRequest, Object.class),
-            securityContext);
+            resourceAccessChecks);
     return transformers
         .getSearchAggregationResultTransformer(resultClass)
         .apply(searchQueryResponse.aggregations());
@@ -90,22 +80,22 @@ public final class SearchClientBasedQueryExecutor {
   <F extends FilterBase, S extends SortOption, T> SearchQueryResponse<T> executePaginatedSearch(
       final TypedSearchQuery<F, S> query,
       final Class<T> documentClass,
-      final SecurityContext securityContext) {
-    return executeSearch(query, q -> searchClient.search(q, documentClass), securityContext);
+      final ResourceAccessChecks resourceAccessChecks) {
+    return executeSearch(query, q -> searchClient.search(q, documentClass), resourceAccessChecks);
   }
 
   <F extends FilterBase, S extends SortOption, T> SearchQueryResponse<T> executeUnlimitedSearch(
       final TypedSearchQuery<F, S> query,
       final Class<T> documentClass,
-      final SecurityContext securityContext) {
-    return executeSearch(query, q -> searchClient.scroll(q, documentClass), securityContext);
+      final ResourceAccessChecks resourceAccessChecks) {
+    return executeSearch(query, q -> searchClient.scroll(q, documentClass), resourceAccessChecks);
   }
 
   <F extends FilterBase, S extends SortOption, T> SearchQueryResponse<T> executeSingleResultSearch(
       final TypedSearchQuery<F, S> query,
       final Class<T> documentClass,
-      final SecurityContext securityContext) {
-    final var response = executePaginatedSearch(query, documentClass, securityContext);
+      final ResourceAccessChecks resourceAccessChecks) {
+    final var response = executePaginatedSearch(query, documentClass, resourceAccessChecks);
     final var hits = response.hits().size();
     if (hits < 1) {
       throw new CamundaSearchException(
@@ -123,12 +113,7 @@ public final class SearchClientBasedQueryExecutor {
   <T extends FilterBase, S extends SortOption, R> R executeSearch(
       final TypedSearchQuery<T, S> query,
       final Function<SearchQueryRequest, R> searchExecutor,
-      final SecurityContext securityContext) {
-    final var authorizationCheck =
-        authorizationQueryStrategy.resolveAuthorizationCheck(securityContext);
-    final var tenantCheck = tenantQueryStrategy.resolveTenantCheck(securityContext);
-    final var resourceAccessChecks = ResourceAccessChecks.of(authorizationCheck, tenantCheck);
-
+      final ResourceAccessChecks resourceAccessChecks) {
     final var transformer = getSearchQueryRequestTransformer(query);
     final var searchRequest = transformer.apply(query, resourceAccessChecks);
     return searchExecutor.apply(searchRequest);

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/auth/TenantQueryStrategy.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/auth/TenantQueryStrategy.java
@@ -11,7 +11,7 @@ import io.camunda.security.auth.SecurityContext;
 
 public interface TenantQueryStrategy {
 
-  TenantQueryStrategy NONE = (securityContext) -> null;
+  TenantQueryStrategy NONE = (securityContext) -> TenantCheck.disabled();
 
   TenantCheck resolveTenantCheck(SecurityContext securityContext);
 }

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/DecisionInstanceSearchClientBasedQueryExecutorTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/DecisionInstanceSearchClientBasedQueryExecutorTest.java
@@ -12,8 +12,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
-import io.camunda.search.clients.auth.AuthorizationCheck;
-import io.camunda.search.clients.auth.AuthorizationQueryStrategy;
+import io.camunda.search.clients.auth.ResourceAccessChecks;
 import io.camunda.search.clients.core.SearchQueryHit;
 import io.camunda.search.clients.core.SearchQueryRequest;
 import io.camunda.search.clients.core.SearchQueryResponse;
@@ -24,7 +23,6 @@ import io.camunda.search.entities.DecisionInstanceEntity.DecisionInstanceState;
 import io.camunda.search.query.DecisionInstanceQuery;
 import io.camunda.search.query.SearchQueryBase.AbstractQueryBuilder;
 import io.camunda.search.query.SearchQueryResult;
-import io.camunda.security.auth.SecurityContext;
 import io.camunda.webapps.schema.descriptors.IndexDescriptors;
 import io.camunda.webapps.schema.entities.dmn.DecisionType;
 import java.time.OffsetDateTime;
@@ -78,7 +76,6 @@ class DecisionInstanceSearchClientBasedQueryExecutorTest {
           .setEvaluatedInputs(null);
 
   @Mock private DocumentBasedSearchClient searchClient;
-  @Mock private AuthorizationQueryStrategy authorizationQueryStrategy;
   private final ServiceTransformers serviceTransformers =
       ServiceTransformers.newInstance(new IndexDescriptors("", true));
 
@@ -86,9 +83,7 @@ class DecisionInstanceSearchClientBasedQueryExecutorTest {
 
   @BeforeEach
   void setUp() {
-    queryExecutor =
-        new SearchClientBasedQueryExecutor(
-            searchClient, authorizationQueryStrategy, serviceTransformers);
+    queryExecutor = new SearchClientBasedQueryExecutor(searchClient, serviceTransformers);
   }
 
   @Test
@@ -103,15 +98,13 @@ class DecisionInstanceSearchClientBasedQueryExecutorTest {
             any(SearchQueryRequest.class),
             eq(io.camunda.webapps.schema.entities.dmn.DecisionInstanceEntity.class)))
         .thenReturn(decisionInstanceEntityResponse);
-    when(authorizationQueryStrategy.resolveAuthorizationCheck(any(SecurityContext.class)))
-        .thenReturn(AuthorizationCheck.disabled());
 
     // When we search
     final SearchQueryResult<DecisionInstanceEntity> searchResult =
         queryExecutor.search(
             searchAllQuery,
             io.camunda.webapps.schema.entities.dmn.DecisionInstanceEntity.class,
-            SecurityContext.withoutAuthentication());
+            ResourceAccessChecks.disabled());
 
     assertThat(searchResult.total()).isEqualTo(1);
     final List<DecisionInstanceEntity> items = searchResult.items();
@@ -140,15 +133,13 @@ class DecisionInstanceSearchClientBasedQueryExecutorTest {
             any(SearchQueryRequest.class),
             eq(io.camunda.webapps.schema.entities.dmn.DecisionInstanceEntity.class)))
         .thenReturn(decisionInstanceEntityResponse);
-    when(authorizationQueryStrategy.resolveAuthorizationCheck(any(SecurityContext.class)))
-        .thenReturn(AuthorizationCheck.disabled());
 
     // When we search
     final SearchQueryResult<DecisionInstanceEntity> searchResult =
         queryExecutor.search(
             searchAllQuery,
             io.camunda.webapps.schema.entities.dmn.DecisionInstanceEntity.class,
-            SecurityContext.withoutAuthentication());
+            ResourceAccessChecks.disabled());
 
     assertThat(searchResult.items()).hasSize(1);
     assertThat(searchResult.items().getFirst()).isEqualTo(domainEntity);

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/it/util/SearchClientsUtil.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/it/util/SearchClientsUtil.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.it.util;
 import io.camunda.search.clients.DocumentBasedSearchClients;
 import io.camunda.search.clients.SearchClientBasedQueryExecutor;
 import io.camunda.search.clients.auth.AuthorizationQueryStrategy;
+import io.camunda.search.clients.auth.TenantQueryStrategy;
 import io.camunda.search.clients.transformers.ServiceTransformers;
 import io.camunda.search.connect.configuration.ConnectConfiguration;
 import io.camunda.search.connect.es.ElasticsearchConnector;
@@ -33,8 +34,9 @@ public class SearchClientsUtil {
     final var descriptors = new IndexDescriptors("", true);
     final var transformers = ServiceTransformers.newInstance(descriptors);
     return new DocumentBasedSearchClients(
-        new SearchClientBasedQueryExecutor(
-            lowLevelSearchClient, AuthorizationQueryStrategy.NONE, transformers),
+        new SearchClientBasedQueryExecutor(lowLevelSearchClient, transformers),
+        AuthorizationQueryStrategy.NONE,
+        TenantQueryStrategy.NONE,
         null);
   }
 


### PR DESCRIPTION
## Description

Moves the authorization and tenant strategies into the DocumentBasedSearchClients.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

related to #35595
