### PR TITLE
feat: PoC for storing web session attributes as a string

### DIFF
--- a/authentication/pom.xml
+++ b/authentication/pom.xml
@@ -61,6 +61,10 @@
       <artifactId>jackson-databind</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+    </dependency>
+    <dependency>
       <groupId>jakarta.servlet</groupId>
       <artifactId>jakarta.servlet-api</artifactId>
     </dependency>

--- a/authentication/src/test/java/io/camunda/authentication/session/WebSessionMapperTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/session/WebSessionMapperTest.java
@@ -9,6 +9,9 @@ package io.camunda.authentication.session;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.authentication.entity.CamundaUser.CamundaUserBuilder;
 import io.camunda.authentication.session.WebSessionMapper.SpringBasedWebSessionAttributeConverter;
 import io.camunda.search.entities.PersistentWebSessionEntity;
@@ -28,16 +31,18 @@ public class WebSessionMapperTest {
 
   private WebSessionMapper webSessionMapper;
   private WebSessionAttributeConverter webSessionAttributeConverter;
+  private ObjectMapper objectMapper;
 
   @BeforeEach
   void setUp() {
     final var conversionService = new GenericConversionService();
     webSessionAttributeConverter = new SpringBasedWebSessionAttributeConverter(conversionService);
-    webSessionMapper = new WebSessionMapper(webSessionAttributeConverter);
+    objectMapper = new ObjectMapper();
+    webSessionMapper = new WebSessionMapper(webSessionAttributeConverter, objectMapper);
   }
 
   @Test
-  void toPersistentSessionWithCamundaPrincipal() {
+  void toPersistentSessionWithCamundaPrincipal() throws JsonProcessingException {
     // given
     final var securityContext = new SecurityContextImpl();
     final UsernamePasswordAuthenticationToken authenticationToken =
@@ -59,13 +64,19 @@ public class WebSessionMapperTest {
 
     assertThat(persistentWebSession).isNotNull();
     assertThat(persistentWebSession.id()).isEqualTo("sessionId");
-    assertThat(persistentWebSession.attributes()).hasSize(1);
-    assertThat(persistentWebSession.attributes().get("securityContext"))
+    assertThat(persistentWebSession.attributesAsJson()).isNotNull();
+    assertThat(persistentWebSession.attributesAsJson())
+        .isEqualTo(
+            "{\"securityContext\":\"rO0ABXNyAD1vcmcuc3ByaW5nZnJhbWV3b3JrLnNlY3VyaXR5LmNvcmUuY29udGV4dC5TZWN1cml0eUNvbnRleHRJbXBsAAAAAAAAAmwCAAFMAA5hdXRoZW50aWNhdGlvbnQAMkxvcmcvc3ByaW5nZnJhbWV3b3JrL3NlY3VyaXR5L2NvcmUvQXV0aGVudGljYXRpb247eHBzcgBPb3JnLnNwcmluZ2ZyYW1ld29yay5zZWN1cml0eS5hdXRoZW50aWNhdGlvbi5Vc2VybmFtZVBhc3N3b3JkQXV0aGVudGljYXRpb25Ub2tlbgAAAAAAAAJsAgACTAALY3JlZGVudGlhbHN0ABJMamF2YS9sYW5nL09iamVjdDtMAAlwcmluY2lwYWxxAH4ABHhyAEdvcmcuc3ByaW5nZnJhbWV3b3JrLnNlY3VyaXR5LmF1dGhlbnRpY2F0aW9uLkFic3RyYWN0QXV0aGVudGljYXRpb25Ub2tlbtOqKH5uR2QOAgADWgANYXV0aGVudGljYXRlZEwAC2F1dGhvcml0aWVzdAAWTGphdmEvdXRpbC9Db2xsZWN0aW9uO0wAB2RldGFpbHNxAH4ABHhwAHNyAB9qYXZhLnV0aWwuQ29sbGVjdGlvbnMkRW1wdHlMaXN0ergXtDynnt4CAAB4cHBwc3IALGlvLmNhbXVuZGEuYXV0aGVudGljYXRpb24uZW50aXR5LkNhbXVuZGFVc2Vy0Mj+PYgzt8gCAAdaAAljYW5Mb2dvdXRMAA5hdXRoZW50aWNhdGlvbnQAOExpby9jYW11bmRhL2F1dGhlbnRpY2F0aW9uL2VudGl0eS9BdXRoZW50aWNhdGlvbkNvbnRleHQ7TAAHYzhMaW5rc3QAD0xqYXZhL3V0aWwvTWFwO0wAC2Rpc3BsYXlOYW1ldAASTGphdmEvbGFuZy9TdHJpbmc7TAAFZW1haWxxAH4ADUwADXNhbGVzUGxhblR5cGVxAH4ADUwAB3VzZXJLZXl0ABBMamF2YS9sYW5nL0xvbmc7eHIAMm9yZy5zcHJpbmdmcmFtZXdvcmsuc2VjdXJpdHkuY29yZS51c2VyZGV0YWlscy5Vc2VyAAAAAAAAAmwCAAdaABFhY2NvdW50Tm9uRXhwaXJlZFoAEGFjY291bnROb25Mb2NrZWRaABVjcmVkZW50aWFsc05vbkV4cGlyZWRaAAdlbmFibGVkTAALYXV0aG9yaXRpZXN0AA9MamF2YS91dGlsL1NldDtMAAhwYXNzd29yZHEAfgANTAAIdXNlcm5hbWVxAH4ADXhwAQEBAXNyACVqYXZhLnV0aWwuQ29sbGVjdGlvbnMkVW5tb2RpZmlhYmxlU2V0gB2S0Y+bgFUCAAB4cgAsamF2YS51dGlsLkNvbGxlY3Rpb25zJFVubW9kaWZpYWJsZUNvbGxlY3Rpb24ZQgCAy173HgIAAUwAAWNxAH4ABnhwc3IAEWphdmEudXRpbC5UcmVlU2V03ZhQk5Xth1sDAAB4cHNyAEZvcmcuc3ByaW5nZnJhbWV3b3JrLnNlY3VyaXR5LmNvcmUudXNlcmRldGFpbHMuVXNlciRBdXRob3JpdHlDb21wYXJhdG9yAAAAAAAAAmwCAAB4cHcEAAAAAHh0AAVhZG1pbnQABHRlc3QAc3IANmlvLmNhbXVuZGEuYXV0aGVudGljYXRpb24uZW50aXR5LkF1dGhlbnRpY2F0aW9uQ29udGV4dAAAAAAAAAAAAgAHWgASZ3JvdXBzQ2xhaW1FbmFibGVkTAAWYXV0aG9yaXplZEFwcGxpY2F0aW9uc3QAEExqYXZhL3V0aWwvTGlzdDtMAAhjbGllbnRJZHEAfgANTAAGZ3JvdXBzcQB+ABxMAAVyb2xlc3EAfgAcTAAHdGVuYW50c3EAfgAcTAAIdXNlcm5hbWVxAH4ADXhwAHNyABFqYXZhLnV0aWwuQ29sbFNlcleOq7Y6G6gRAwABSQADdGFneHAAAAABdwQAAAAAeHBxAH4AH3NxAH4AHgAAAAF3BAAAAAFzcgAlaW8uY2FtdW5kYS5zZWFyY2guZW50aXRpZXMuUm9sZUVudGl0eQAAAAAAAAAAAgAETAALZGVzY3JpcHRpb25xAH4ADUwABG5hbWVxAH4ADUwABnJvbGVJZHEAfgANTAAHcm9sZUtleXEAfgAOeHB0AAtkZXNjcmlwdGlvbnQACHRlc3RSb2xlcQB+ACRzcgAOamF2YS5sYW5nLkxvbmc7i+SQzI8j3wIAAUoABXZhbHVleHIAEGphdmEubGFuZy5OdW1iZXKGrJUdC5TgiwIAAHhwAAAAAAAAAAF4cQB+AB9xAH4AGnNxAH4AHgAAAAN3BAAAAAB4cHBwcQB+ACc=\"}");
+    final Map<String, byte[]> attributes =
+        objectMapper.readValue(persistentWebSession.attributesAsJson(), new TypeReference<>() {});
+    assertThat(attributes).containsKey("securityContext");
+    assertThat(attributes.get("securityContext"))
         .isEqualTo(webSessionAttributeConverter.serialize(securityContext));
   }
 
   @Test
-  void toPersistentSession() {
+  void toPersistentSession() throws JsonProcessingException {
     // given
     final var now = Instant.now();
     final var maxInactiveInterval = Duration.ofSeconds(1800);
@@ -77,6 +88,7 @@ public class WebSessionMapperTest {
     webSession.setMaxInactiveInterval(maxInactiveInterval);
     webSession.setAttribute("attribute1", "value1");
     webSession.setAttribute("attribute2", testAttribute);
+    webSession.setAttribute("attribute3", null);
 
     // when
     final var persistentWebSession = webSessionMapper.toPersistentWebSession(webSession);
@@ -87,19 +99,34 @@ public class WebSessionMapperTest {
     assertThat(persistentWebSession.lastAccessedTime()).isEqualTo(now.toEpochMilli());
     assertThat(persistentWebSession.maxInactiveIntervalInSeconds())
         .isEqualTo(maxInactiveInterval.getSeconds());
-    assertThat(persistentWebSession.attributes()).hasSize(2);
-    assertThat(persistentWebSession.attributes().get("attribute1"))
+    assertThat(persistentWebSession.attributesAsJson()).isNotNull();
+    assertThat(persistentWebSession.attributesAsJson())
+        .isEqualTo(
+            "{\"attribute1\":\"rO0ABXQABnZhbHVlMQ==\",\"attribute2\":\"rO0ABXNyAERpby5jYW11bmRhLmF1dGhlbnRpY2F0aW9uLnNlc3Npb24uV2ViU2Vzc2lvbk1hcHBlclRlc3QkVGVzdEF0dHJpYnV0ZQAAAAAAAAAAAgACTAAJYXR0cmlidXRldAASTGphdmEvbGFuZy9TdHJpbmc7TAAFdmFsdWVxAH4AAXhwdAADZm9vdAADYmFy\"}");
+    final Map<String, byte[]> attributes =
+        objectMapper.readValue(persistentWebSession.attributesAsJson(), new TypeReference<>() {});
+    assertThat(attributes.size()).isEqualTo(2);
+    assertThat(attributes).containsKey("attribute1");
+    assertThat(attributes.get("attribute1"))
         .isEqualTo(webSessionAttributeConverter.serialize("value1"));
-    assertThat(persistentWebSession.attributes().get("attribute2"))
+    assertThat(attributes).containsKey("attribute2");
+    assertThat(attributes.get("attribute2"))
         .isEqualTo(webSessionAttributeConverter.serialize(testAttribute));
   }
 
   @Test
-  void fromPersistentSession() {
+  void fromPersistentSession() throws JsonProcessingException {
     // given
     final var now = Instant.now();
     final var maxInactiveInterval = Duration.ofSeconds(1800);
     final var testAttribute = new TestAttribute("foo", "bar");
+
+    final var attributeMap =
+        Map.of(
+            "attribute1",
+            webSessionAttributeConverter.serialize("value1"),
+            "attribute2",
+            webSessionAttributeConverter.serialize(testAttribute));
 
     final var persistentSession =
         new PersistentWebSessionEntity(
@@ -107,11 +134,7 @@ public class WebSessionMapperTest {
             now.toEpochMilli(),
             now.toEpochMilli(),
             maxInactiveInterval.toSeconds(),
-            Map.of(
-                "attribute1",
-                webSessionAttributeConverter.serialize("value1"),
-                "attribute2",
-                webSessionAttributeConverter.serialize(testAttribute)));
+            objectMapper.writeValueAsString(attributeMap));
 
     // when
     final var webSession = webSessionMapper.fromPersistentWebSession(persistentSession);
@@ -127,7 +150,25 @@ public class WebSessionMapperTest {
   }
 
   @Test
-  void fromPersistentSessionWithCamundaPrincipal() {
+  void fromPersistentSessionReturnsNullDueToInvalidAttributes() {
+    // given
+    final var persistentSession =
+        new PersistentWebSessionEntity(
+            "sessionId",
+            Instant.now().toEpochMilli(),
+            Instant.now().toEpochMilli(),
+            500L,
+            "invalidAttributes");
+
+    // when
+    final var webSession = webSessionMapper.fromPersistentWebSession(persistentSession);
+
+    // then
+    assertThat(webSession).isNull();
+  }
+
+  @Test
+  void fromPersistentSessionWithCamundaPrincipal() throws JsonProcessingException {
     // given
     final var now = Instant.now();
     final var maxInactiveInterval = Duration.ofSeconds(1800);
@@ -149,7 +190,9 @@ public class WebSessionMapperTest {
             now.toEpochMilli(),
             now.toEpochMilli(),
             maxInactiveInterval.toSeconds(),
-            Map.of("securityContext", webSessionAttributeConverter.serialize(securityContext)));
+            objectMapper.writeValueAsString(
+                Map.of(
+                    "securityContext", webSessionAttributeConverter.serialize(securityContext))));
 
     // when
     final var webSession = webSessionMapper.fromPersistentWebSession(persistentSession);

--- a/authentication/src/test/java/io/camunda/authentication/session/WebSessionRepositoryTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/session/WebSessionRepositoryTest.java
@@ -9,6 +9,7 @@ package io.camunda.authentication.session;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.authentication.session.WebSessionMapper.SpringBasedWebSessionAttributeConverter;
 import io.camunda.search.clients.PersistentWebSessionClient;
 import io.camunda.search.entities.PersistentWebSessionEntity;
@@ -30,11 +31,13 @@ class WebSessionRepositoryTest {
   @BeforeEach
   void setUp() {
     persistentWebSessionClient = new PersistentWebSessionClientStub();
+    final ObjectMapper objectMapper = new ObjectMapper();
     webSessionRepository =
         new WebSessionRepository(
             persistentWebSessionClient,
             new WebSessionMapper(
-                new SpringBasedWebSessionAttributeConverter(new GenericConversionService())),
+                new SpringBasedWebSessionAttributeConverter(new GenericConversionService()),
+                objectMapper),
             null);
   }
 
@@ -110,21 +113,21 @@ class WebSessionRepositoryTest {
             expiredLastAccessedTime.toEpochMilli(),
             expiredLastAccessedTime.toEpochMilli(),
             MapSession.DEFAULT_MAX_INACTIVE_INTERVAL.toSeconds(),
-            Map.of()));
+            ""));
     persistentWebSessionClient.upsertPersistentWebSession(
         new PersistentWebSessionEntity(
             "s2",
             expiredLastAccessedTime.toEpochMilli(),
             expiredLastAccessedTime.toEpochMilli(),
             MapSession.DEFAULT_MAX_INACTIVE_INTERVAL.toSeconds(),
-            Map.of()));
+            ""));
     persistentWebSessionClient.upsertPersistentWebSession(
         new PersistentWebSessionEntity(
             "s3",
             expiredLastAccessedTime.toEpochMilli(),
             expiredLastAccessedTime.toEpochMilli(),
             MapSession.DEFAULT_MAX_INACTIVE_INTERVAL.toSeconds(),
-            Map.of()));
+            null));
 
     assertThat(persistentWebSessionClient.getAllPersistentWebSessions().items()).hasSize(3);
 

--- a/dist/src/main/java/io/camunda/application/commons/identity/WebSessionRepositoryConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/identity/WebSessionRepositoryConfiguration.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.application.commons.identity;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.authentication.session.ConditionalOnPersistentWebSessionEnabled;
 import io.camunda.authentication.session.WebSessionDeletionTask;
 import io.camunda.authentication.session.WebSessionMapper;
@@ -67,7 +68,8 @@ public class WebSessionRepositoryConfiguration {
       final HttpServletRequest request) {
     final var webSessionAttributeConverter =
         new SpringBasedWebSessionAttributeConverter(conversionService);
-    final var webSessionMapper = new WebSessionMapper(webSessionAttributeConverter);
+    final var webSessionMapper =
+        new WebSessionMapper(webSessionAttributeConverter, new ObjectMapper());
     return new WebSessionRepository(persistentWebSessionClient, webSessionMapper, request);
   }
 

--- a/dist/src/test/java/io/camunda/application/commons/backup/BackupPrioritiesTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/backup/BackupPrioritiesTest.java
@@ -184,7 +184,7 @@ class BackupPrioritiesTest {
             "camunda-authorization-8.8.0_",
             "camunda-group-8.8.0_",
             "camunda-mapping-rule-8.8.0_",
-            "camunda-web-session-8.8.0_",
+            "camunda-web-session-8.8.1_",
             "camunda-role-8.8.0_",
             "camunda-tenant-8.8.0_",
             "camunda-user-8.8.0_");

--- a/schema-manager/src/test/java/io/camunda/search/schema/SchemaManagerIT.java
+++ b/schema-manager/src/test/java/io/camunda/search/schema/SchemaManagerIT.java
@@ -876,7 +876,7 @@ public class SchemaManagerIT {
             newPrefix + "-camunda-role-8.8.0_",
             newPrefix + "-camunda-tenant-8.8.0_",
             newPrefix + "-camunda-user-8.8.0_",
-            newPrefix + "-camunda-web-session-8.8.0_",
+            newPrefix + "-camunda-web-session-8.8.1_",
             newPrefix + "-operate-batch-operation-1.0.0_",
             newPrefix + "-operate-decision-8.3.0_",
             newPrefix + "-operate-decision-instance-8.3.0_",

--- a/search/search-domain/src/main/java/io/camunda/search/entities/PersistentWebSessionEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/PersistentWebSessionEntity.java
@@ -8,7 +8,6 @@
 package io.camunda.search.entities;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import java.util.Map;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record PersistentWebSessionEntity(
@@ -16,4 +15,4 @@ public record PersistentWebSessionEntity(
     Long creationTime,
     Long lastAccessedTime,
     Long maxInactiveIntervalInSeconds,
-    Map<String, byte[]> attributes) {}
+    String attributesAsJson) {}

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/index/PersistentWebSessionIndexDescriptor.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/index/PersistentWebSessionIndexDescriptor.java
@@ -15,7 +15,7 @@ public class PersistentWebSessionIndexDescriptor extends AbstractIndexDescriptor
     implements Prio5Backup {
 
   public static final String INDEX_NAME = "web-session";
-  public static final String INDEX_VERSION = "8.8.0";
+  public static final String INDEX_VERSION = "8.8.1";
 
   public PersistentWebSessionIndexDescriptor(
       final String indexPrefix, final boolean isElasticsearch) {

--- a/webapps-schema/src/main/resources/schema/elasticsearch/create/index/camunda-web-session.json
+++ b/webapps-schema/src/main/resources/schema/elasticsearch/create/index/camunda-web-session.json
@@ -1,7 +1,7 @@
 {
   "aliases": {},
   "mappings": {
-    "dynamic": "true",
+    "dynamic": "strict",
     "properties": {
       "id": {
         "type": "keyword"
@@ -17,6 +17,10 @@
       },
       "attributes": {
         "type": "object"
+      },
+      "attributesAsJson": {
+        "type": "text",
+        "index": false
       }
     }
   }

--- a/webapps-schema/src/main/resources/schema/opensearch/create/index/camunda-web-session.json
+++ b/webapps-schema/src/main/resources/schema/opensearch/create/index/camunda-web-session.json
@@ -1,7 +1,7 @@
 {
   "aliases": {},
   "mappings": {
-    "dynamic": "true",
+    "dynamic": "strict",
     "properties": {
       "id": {
         "type": "keyword"
@@ -17,6 +17,10 @@
       },
       "attributes": {
         "type": "object"
+      },
+      "attributesAsJson": {
+        "type": "text",
+        "index": false
       }
     }
   }


### PR DESCRIPTION
## Description

See [Epic](https://github.com/camunda/product-hub/issues/2990)

This PoC attempts to replace the need for dynamic mapping for our web session index by taking the dynamic content that is generated (the Map of session attributes),  converting it to JSON and storing it as `text` in ES/OS.

**Note:** if there is a ES/OS plugin that rejects index creation when dynamic mapping is enabled, then we **might** need to drop the `attributes` field from the index definition. I have not verified this yet.

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
