### PR TITLE
[Backport stable/8.7] fix: increase tomcat max part count to 50

### DIFF
--- a/dist/src/main/resources/application.properties
+++ b/dist/src/main/resources/application.properties
@@ -69,6 +69,7 @@ spring.jpa.hibernate.ddl-auto=validate
 # Multipart file uploads
 spring.servlet.multipart.max-file-size=4MB
 spring.servlet.multipart.max-request-size=4MB
+server.tomcat.max-part-count=50
 
 # Disable specific autoconfiguration classes which are triggered automatically (e.g. creating an
 # Elastic client which spawns 16 threads)


### PR DESCRIPTION
# Description
Backport of #35068 to `stable/8.7`.

relates to #34322