### PR TITLE
Port component template overwriting fix from 8.6 to 8.7

### DIFF
--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchClient.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchClient.java
@@ -235,7 +235,13 @@ class ElasticsearchClient implements AutoCloseable {
 
   private boolean putComponentTemplate(final Template template) {
     try {
-      final var request = new Request("PUT", "/_component_template/" + configuration.index.prefix);
+      final var request =
+          new Request(
+              "PUT",
+              "/_component_template/"
+                  + configuration.index.prefix
+                  + "-"
+                  + VersionUtil.getVersionLowerCase());
       request.setJsonEntity(MAPPER.writeValueAsString(template));
 
       final var response = sendRequest(request, PutIndexTemplateResponse.class);

--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/TemplateReader.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/TemplateReader.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.exporter;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.zeebe.exporter.dto.Template;
 import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.util.VersionUtil;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Collections;
@@ -45,8 +46,7 @@ final class TemplateReader {
     final Template template = readTemplate(findResourceForTemplate(valueType));
 
     // update prefix in template in case it was changed in configuration
-    template.composedOf().set(0, config.index.prefix);
-
+    template.composedOf().set(0, config.index.prefix + "-" + VersionUtil.getVersionLowerCase());
     template.patterns().set(0, searchPattern);
     template.template().aliases().clear();
     template.template().aliases().put(aliasName, Collections.emptyMap());

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchClientIT.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchClientIT.java
@@ -148,7 +148,7 @@ final class ElasticsearchClientIT {
         .isPresent()
         .get()
         .extracting(ComponentTemplateWrapper::name)
-        .isEqualTo(config.index.prefix);
+        .isEqualTo(config.index.prefix + "-" + VersionUtil.getVersionLowerCase());
 
     final var template = templateWrapper.get().template();
     assertIndexTemplate(template, expectedTemplate);

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterIT.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterIT.java
@@ -225,7 +225,7 @@ final class ElasticsearchExporterIT {
         .isPresent()
         .get()
         .extracting(ComponentTemplateWrapper::name)
-        .isEqualTo(config.index.prefix);
+        .isEqualTo(config.index.prefix + "-" + VersionUtil.getVersionLowerCase());
   }
 
   private boolean export(final Record<?> record) {

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/SchemaManagerIT.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/SchemaManagerIT.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.exporter;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import io.camunda.zeebe.util.VersionUtil;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import org.elasticsearch.client.Request;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.testcontainers.elasticsearch.ElasticsearchContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+public class SchemaManagerIT {
+  @Container
+  private static final ElasticsearchContainer CONTAINER =
+      TestSupport.createDefaultContainer().withEnv("action.destructive_requires_name", "false");
+
+  private static final ElasticsearchExporterConfiguration CONFIG =
+      new ElasticsearchExporterConfiguration();
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  @BeforeAll
+  static void setup() {
+    CONFIG.url = "http://" + CONTAINER.getHttpHostAddress();
+  }
+
+  @Test
+  public void shouldUseVersionedComponentTemplateForIndexTemplates() throws IOException {
+    // given
+    final var restClient = RestClientFactory.of(CONFIG);
+    final var esClient = new ElasticsearchClient(CONFIG, new SimpleMeterRegistry());
+
+    // when
+    // we create an 8.5 component template
+    final var schemaManager = new SchemaManager(esClient, CONFIG);
+    schemaManager.createSchema("8.5.0");
+
+    // create the 8.6 component template
+    final var upgradedVersion = "8.6.0";
+    try (final MockedStatic<VersionUtil> mockedVersionUtil = mockStatic(VersionUtil.class)) {
+      mockedVersionUtil.when(VersionUtil::getVersion).thenReturn(upgradedVersion);
+      mockedVersionUtil.when(VersionUtil::getVersionLowerCase).thenReturn(upgradedVersion);
+
+      final var schemaManager2 = new SchemaManager(esClient, CONFIG);
+      schemaManager2.createSchema("8.6.0");
+    }
+
+    // Use a new schema manager to mock 8.5 broker restart which then triggers schema manager.
+    // 8.5 schema manager runs again and attempts to create old component template
+    final var schemaManager3 = new SchemaManager(esClient, CONFIG);
+    schemaManager3.createSchema("8.5.0");
+
+    // then
+    // 8.6.0 component template exists
+    final var request = new Request("GET", "/_component_template/" + CONFIG.index.prefix + "*");
+    final var response = restClient.performRequest(request);
+    final var componentTemplateInElasticsearch =
+        MAPPER.readValue(response.getEntity().getContent().readAllBytes(), JsonNode.class);
+
+    assertThat(componentTemplateInElasticsearch.at("/component_templates"))
+        .anySatisfy(
+            node ->
+                assertThat(node.at("/name").asText()).isEqualTo("zeebe-record-" + upgradedVersion));
+
+    // all 8.6.0 index templates are composed of the new index template
+    final var templateReq = new Request("GET", "/_index_template/*" + upgradedVersion + "*");
+    final var templateRes = restClient.performRequest(templateReq);
+    final var indexTemplates =
+        MAPPER.readValue(templateRes.getEntity().getContent().readAllBytes(), JsonNode.class);
+
+    assertThat(indexTemplates.at("/index_templates").size()).isGreaterThan(0);
+    assertThat(indexTemplates.at("/index_templates"))
+        .allSatisfy(
+            node -> {
+              final JsonNode composedOfNode = node.at("/index_template/composed_of");
+              assertThat(composedOfNode.isArray()).isTrue();
+
+              // Convert ArrayNode to List<String> for easier assertion
+              final List<String> stringList = new ArrayList<>();
+              final ArrayNode arrayNode = (ArrayNode) composedOfNode;
+              for (final JsonNode element : arrayNode) {
+                if (element.isTextual()) {
+                  stringList.add(element.asText());
+                }
+              }
+              assertThat(stringList).contains("zeebe-record-" + upgradedVersion);
+            });
+  }
+}

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/TemplateReaderTest.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/TemplateReaderTest.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.exporter;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.util.VersionUtil;
 import java.util.Collections;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -116,7 +117,7 @@ final class TemplateReaderTest {
     // then
     assertThat(template.composedOf())
         .as("index template is composed of the component template")
-        .containsExactly(config.index.prefix);
+        .containsExactly(config.index.prefix + "-" + VersionUtil.getVersionLowerCase());
     assertThat(template.patterns()).containsExactly("searchPattern");
     assertThat(template.template().aliases())
         .containsExactlyEntriesOf(Map.of("alias", Collections.emptyMap()));
@@ -138,7 +139,9 @@ final class TemplateReaderTest {
 
     // then
     assertThat(template.composedOf())
-        .allMatch(composedOf -> composedOf.equals(config.index.prefix));
+        .allMatch(
+            composedOf ->
+                composedOf.equals(config.index.prefix + "-" + VersionUtil.getVersionLowerCase()));
   }
 
   @Test

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/TestClient.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/TestClient.java
@@ -99,7 +99,13 @@ final class TestClient implements CloseableSilently {
 
   Optional<ComponentTemplateWrapper> getComponentTemplate() {
     try {
-      final var request = new Request("GET", "/_component_template/" + config.index.prefix);
+      final var request =
+          new Request(
+              "GET",
+              "/_component_template/"
+                  + config.index.prefix
+                  + "-"
+                  + VersionUtil.getVersionLowerCase());
       final var response = restClient.performRequest(request);
       final var templates =
           MAPPER.readValue(response.getEntity().getContent(), ComponentTemplatesDto.class);

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchClient.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchClient.java
@@ -224,7 +224,13 @@ public class OpensearchClient implements AutoCloseable {
 
   private boolean putComponentTemplate(final Template template) {
     try {
-      final var request = new Request("PUT", "/_component_template/" + configuration.index.prefix);
+      final var request =
+          new Request(
+              "PUT",
+              "/_component_template/"
+                  + configuration.index.prefix
+                  + "-"
+                  + VersionUtil.getVersionLowerCase());
       request.setJsonEntity(MAPPER.writeValueAsString(template));
 
       final var response = sendRequest(request, PutIndexTemplateResponse.class);

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/TemplateReader.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/TemplateReader.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.zeebe.exporter.opensearch.OpensearchExporterConfiguration.IndexConfiguration;
 import io.camunda.zeebe.exporter.opensearch.dto.Template;
 import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.util.VersionUtil;
 import java.io.InputStream;
 import java.util.Collections;
 import java.util.Map;
@@ -45,7 +46,7 @@ final class TemplateReader {
     final Template template = readTemplate(findResourceForTemplate(valueType));
 
     // update prefix in template in case it was changed in configuration
-    template.composedOf().set(0, config.prefix);
+    template.composedOf().set(0, config.prefix + "-" + VersionUtil.getVersionLowerCase());
 
     template.patterns().set(0, searchPattern);
     template.template().aliases().clear();

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchClientIT.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchClientIT.java
@@ -137,7 +137,7 @@ final class OpensearchClientIT {
         .isPresent()
         .get()
         .extracting(ComponentTemplateWrapper::name)
-        .isEqualTo(config.index.prefix);
+        .isEqualTo(config.index.prefix + "-" + VersionUtil.getVersionLowerCase());
 
     final var template = templateWrapper.get().template();
     assertIndexTemplate(template, expectedTemplate);

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterIT.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterIT.java
@@ -225,7 +225,7 @@ final class OpensearchExporterIT {
         .isPresent()
         .get()
         .extracting(ComponentTemplateWrapper::name)
-        .isEqualTo(config.index.prefix);
+        .isEqualTo(config.index.prefix + "-" + VersionUtil.getVersionLowerCase());
   }
 
   @Test

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/SchemaManagerIT.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/SchemaManagerIT.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.exporter.opensearch;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.util.VersionUtil;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.opensearch.client.Request;
+import org.opensearch.testcontainers.OpensearchContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+/**
+ * The OS exporter does not have a schema manager abstraction, all actions are done using the
+ * Opensearch client in the camunda exporter, this is why the test does not have a schema manager
+ * class.
+ */
+@Testcontainers
+public class SchemaManagerIT {
+  @Container
+  private static final OpensearchContainer<?> CONTAINER =
+      TestSupport.createDefaultContainer().withEnv("action.destructive_requires_name", "false");
+
+  private static final OpensearchExporterConfiguration CONFIG =
+      new OpensearchExporterConfiguration();
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  @BeforeAll
+  static void setup() {
+    CONFIG.url = CONTAINER.getHttpHostAddress();
+  }
+
+  @Test
+  public void shouldUseVersionedComponentTemplateForIndexTemplates() throws IOException {
+    // given
+    final var restClient = RestClientFactory.of(CONFIG);
+    final var osClient = new OpensearchClient(CONFIG, new SimpleMeterRegistry());
+
+    // when
+    // we create an 8.5 component template
+    osClient.putComponentTemplate();
+    osClient.putIndexTemplate(ValueType.PROCESS_INSTANCE);
+
+    // create the 8.6 component template
+    final var upgradedVersion = "8.6.0";
+    try (final MockedStatic<VersionUtil> mockedVersionUtil = mockStatic(VersionUtil.class)) {
+      mockedVersionUtil.when(VersionUtil::getVersion).thenReturn(upgradedVersion);
+      mockedVersionUtil.when(VersionUtil::getVersionLowerCase).thenReturn(upgradedVersion);
+
+      osClient.putComponentTemplate();
+      osClient.putIndexTemplate(ValueType.PROCESS_INSTANCE);
+    }
+
+    // Use a new schema manager to mock 8.5 broker restart which then triggers schema manager.
+    // 8.5 schema manager runs again and attempts to create old component template
+    osClient.putComponentTemplate();
+    osClient.putIndexTemplate(ValueType.PROCESS_INSTANCE);
+
+    // then
+    // 8.6.0 component template exists
+    final var request = new Request("GET", "/_component_template/" + CONFIG.index.prefix + "*");
+    final var response = restClient.performRequest(request);
+    final var componentTemplateInElasticsearch =
+        MAPPER.readValue(response.getEntity().getContent().readAllBytes(), JsonNode.class);
+
+    assertThat(componentTemplateInElasticsearch.at("/component_templates"))
+        .anySatisfy(
+            node ->
+                assertThat(node.at("/name").asText()).isEqualTo("zeebe-record-" + upgradedVersion));
+
+    // all 8.6.0 index templates are composed of the new index template
+    final var templateReq = new Request("GET", "/_index_template/*" + upgradedVersion + "*");
+    final var templateRes = restClient.performRequest(templateReq);
+    final var indexTemplates =
+        MAPPER.readValue(templateRes.getEntity().getContent().readAllBytes(), JsonNode.class);
+
+    assertThat(indexTemplates.at("/index_templates").size()).isGreaterThan(0);
+    assertThat(indexTemplates.at("/index_templates"))
+        .allSatisfy(
+            node -> {
+              final JsonNode composedOfNode = node.at("/index_template/composed_of");
+              assertThat(composedOfNode.isArray()).isTrue();
+
+              // Convert ArrayNode to List<String> for easier assertion
+              final List<String> stringList = new ArrayList<>();
+              final ArrayNode arrayNode = (ArrayNode) composedOfNode;
+              for (final JsonNode element : arrayNode) {
+                if (element.isTextual()) {
+                  stringList.add(element.asText());
+                }
+              }
+              assertThat(stringList).contains("zeebe-record-" + upgradedVersion);
+            });
+  }
+}

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/TemplateReaderTest.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/TemplateReaderTest.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.exporter.opensearch.OpensearchExporterConfiguration.IndexConfiguration;
 import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.util.VersionUtil;
 import java.util.Collections;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -116,7 +117,7 @@ final class TemplateReaderTest {
     // then
     assertThat(template.composedOf())
         .as("index template is composed of the component template")
-        .containsExactly(config.prefix);
+        .containsExactly(config.prefix + "-" + VersionUtil.getVersionLowerCase());
     assertThat(template.patterns()).containsExactly("searchPattern");
     assertThat(template.template().aliases())
         .containsExactlyEntriesOf(Map.of("alias", Collections.emptyMap()));
@@ -137,6 +138,9 @@ final class TemplateReaderTest {
     final var template = templateReader.readIndexTemplate(valueType, "searchPattern", "alias");
 
     // then
-    assertThat(template.composedOf()).allMatch(composedOf -> composedOf.equals(config.prefix));
+    assertThat(template.composedOf())
+        .allMatch(
+            composedOf ->
+                composedOf.equals(config.prefix + "-" + VersionUtil.getVersionLowerCase()));
   }
 }

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/TestClient.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/TestClient.java
@@ -113,7 +113,13 @@ final class TestClient implements CloseableSilently {
 
   Optional<ComponentTemplateWrapper> getComponentTemplate() {
     try {
-      final var request = new Request("GET", "/_component_template/" + config.index.prefix);
+      final var request =
+          new Request(
+              "GET",
+              "/_component_template/"
+                  + config.index.prefix
+                  + "-"
+                  + VersionUtil.getVersionLowerCase());
       final var response = restClient.performRequest(request);
       final var templates =
           MAPPER.readValue(response.getEntity().getContent(), ComponentTemplatesDto.class);


### PR DESCRIPTION
## Description

There is a bug that can occur during upgrades involving an overwriting of the component template detailed and fix for 8.6 in  https://github.com/camunda/camunda/pull/34938, this PR ports the fix to 8.7, 8.8 is not needed as it already fixed there.

## Related issues

relates to #33881 
