### PR TITLE
feat: add batch operation metrics for failed queries

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/BatchOperationMetricsDoc.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/BatchOperationMetricsDoc.java
@@ -48,7 +48,11 @@ public enum BatchOperationMetricsDoc implements ExtendedMeterDocumentation {
 
   EXECUTED_QUERIES {
     private static final KeyName[] KEY_NAMES =
-        new KeyName[] {PartitionKeyNames.PARTITION, BatchOperationKeyNames.ORGANIZATION_ID};
+        new KeyName[] {
+          PartitionKeyNames.PARTITION,
+          BatchOperationKeyNames.ORGANIZATION_ID,
+          BatchOperationKeyNames.QUERY_STATUS
+        };
 
     @Override
     public String getDescription() {
@@ -231,6 +235,14 @@ public enum BatchOperationMetricsDoc implements ExtendedMeterDocumentation {
       }
     },
 
+    /** The status (completed, failed) of the query. See {@link QueryStatus} for possible values. */
+    QUERY_STATUS {
+      @Override
+      public String asString() {
+        return "queryStatus";
+      }
+    },
+
     /**
      * Metrics that are annotated with this label are vitally important for usage tracking and
      * data-based decision-making as part of Camunda's SaaS offering.
@@ -282,6 +294,21 @@ public enum BatchOperationMetricsDoc implements ExtendedMeterDocumentation {
     private final String label;
 
     BatchOperationLatency(final String label) {
+      this.label = label;
+    }
+
+    public String getLabel() {
+      return label;
+    }
+  }
+
+  public enum QueryStatus {
+    COMPLETED("completed"),
+    FAILED("failed");
+
+    private final String label;
+
+    QueryStatus(final String label) {
       this.label = label;
     }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationItemProvider.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationItemProvider.java
@@ -162,9 +162,15 @@ public class BatchOperationItemProvider {
         return Set.of();
       }
 
-      metrics.recordQueryAgainstSecondaryDatabase();
+      final ItemPage result;
+      try {
+        result = itemPageFetcher.fetchItems(filter, searchAfter, authentication);
+        metrics.recordQueryAgainstSecondaryDatabase();
+      } catch (final Exception e) {
+        metrics.recordFailedQueryAgainstSecondaryDatabase();
+        throw e;
+      }
 
-      final var result = itemPageFetcher.fetchItems(filter, searchAfter, authentication);
       items.addAll(result.items);
       searchAfter = result.searchAfter();
 


### PR DESCRIPTION
## Description

This adds the needed code changes in order to have metrics for failed queries from batch operation engine. 

The changes for the grafana dashboard will be part of a follow up PR. 

relates to #34532
 