### PR TITLE
feat: add batch operations config validation

### DIFF
--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/SystemContextTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/SystemContextTest.java
@@ -445,4 +445,91 @@ final class SystemContextTest {
         .hasMessageContaining(
             String.format("gossipFanout must be greater than 1: configured value = %d", 1));
   }
+
+  @Test
+  void shouldNotThrowExceptionForDefaultBatchOperationConfig() {
+    // given
+    final BrokerCfg brokerCfg = new BrokerCfg();
+
+    // when
+    final var systemContext = initSystemContext(brokerCfg);
+
+    // then
+    assertThat(
+            systemContext
+                .getBrokerConfiguration()
+                .getExperimental()
+                .getEngine()
+                .getBatchOperations())
+        .isNotNull();
+  }
+
+  @Test
+  void shouldThrowExceptionIfBatchOperationSchedulerIntervalIsNegative() {
+    // given
+    final BrokerCfg brokerCfg = new BrokerCfg();
+    brokerCfg
+        .getExperimental()
+        .getEngine()
+        .getBatchOperations()
+        .setSchedulerInterval(Duration.ofSeconds(-1));
+
+    // when - then
+    assertThatCode(() -> initSystemContext(brokerCfg))
+        .isInstanceOf(InvalidConfigurationException.class)
+        .hasMessageContaining(
+            "experimental.engine.batchOperation.schedulerInterval must be positive");
+  }
+
+  @Test
+  void shouldThrowExceptionIfBatchOperationChunkSizeIsInvalid() {
+    // given
+    final BrokerCfg brokerCfg = new BrokerCfg();
+    brokerCfg.getExperimental().getEngine().getBatchOperations().setChunkSize(0);
+
+    // when - then
+    assertThatCode(() -> initSystemContext(brokerCfg))
+        .isInstanceOf(InvalidConfigurationException.class)
+        .hasMessageContaining(
+            "experimental.engine.batchOperation.chunkSize must be greater than 0");
+  }
+
+  @Test
+  void shouldThrowExceptionIfBatchOperationDbChunkSizeIsInvalid() {
+    // given
+    final BrokerCfg brokerCfg = new BrokerCfg();
+    brokerCfg.getExperimental().getEngine().getBatchOperations().setDbChunkSize(0);
+
+    // when - then
+    assertThatCode(() -> initSystemContext(brokerCfg))
+        .isInstanceOf(InvalidConfigurationException.class)
+        .hasMessageContaining(
+            "experimental.engine.batchOperation.dbChunkSize must be greater than 0");
+  }
+
+  @Test
+  void shouldThrowExceptionIfBatchOperationQueryPageSizeIsInvalid() {
+    // given
+    final BrokerCfg brokerCfg = new BrokerCfg();
+    brokerCfg.getExperimental().getEngine().getBatchOperations().setQueryPageSize(0);
+
+    // when - then
+    assertThatCode(() -> initSystemContext(brokerCfg))
+        .isInstanceOf(InvalidConfigurationException.class)
+        .hasMessageContaining(
+            "experimental.engine.batchOperation.queryPageSize must be greater than 0");
+  }
+
+  @Test
+  void shouldThrowExceptionIfBatchOperationQueryInClauseSizeIsInvalid() {
+    // given
+    final BrokerCfg brokerCfg = new BrokerCfg();
+    brokerCfg.getExperimental().getEngine().getBatchOperations().setQueryInClauseSize(0);
+
+    // when - then
+    assertThatCode(() -> initSystemContext(brokerCfg))
+        .isInstanceOf(InvalidConfigurationException.class)
+        .hasMessageContaining(
+            "experimental.engine.batchOperation.queryInClauseSize must be greater than 0");
+  }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/config/ConfigValidator.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/config/ConfigValidator.java
@@ -116,6 +116,14 @@ public final class ConfigValidator {
               + processCacheMaxCacheSize);
     }
 
+    final int batchOperationCacheMaxCacheSize =
+        configuration.getBatchOperationCache().getMaxCacheSize();
+    if (batchOperationCacheMaxCacheSize < 1) {
+      throw new ExporterException(
+          "CamundaExporter batchOperationCache.maxCacheSize must be >= 1. Current value: "
+              + batchOperationCacheMaxCacheSize);
+    }
+
     final int formCacheMaxCacheSize = configuration.getFormCache().getMaxCacheSize();
     if (formCacheMaxCacheSize < 1) {
       throw new ExporterException(

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/config/ConfigValidatorTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/config/ConfigValidatorTest.java
@@ -163,4 +163,16 @@ public class ConfigValidatorTest {
         .isInstanceOf(ExporterException.class)
         .hasMessageContaining("CamundaExporter processCache.maxCacheSize must be >= 1.");
   }
+
+  @ParameterizedTest(name = "{0}")
+  @ValueSource(ints = {-1, 0})
+  void shouldForbidNonPositiveMaxBatchOperationCacheSize(final int maxCacheSize) {
+    // given
+    config.getBatchOperationCache().setMaxCacheSize(maxCacheSize);
+
+    // when - then
+    assertThatCode(() -> ConfigValidator.validate(config))
+        .isInstanceOf(ExporterException.class)
+        .hasMessageContaining("CamundaExporter batchOperationCache.maxCacheSize must be >= 1.");
+  }
 }


### PR DESCRIPTION
## Description

Adds config validation for batch operation related configs in CamundaExporter and Zeebe Engine

Note: The RdbmsExporter so far has no Config validation at all. This will be implemented in #35304 as part of the Rdbms-project

## Related issues

closes #35060
