### PR TITLE
Extend the job result for the ad-hoc sub-process

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/impl/command/CompleteJobCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/CompleteJobCommandImpl.java
@@ -57,7 +57,7 @@ public final class CompleteJobCommandImpl extends CommandWithVariables<CompleteJ
   private final long jobKey;
   private final JsonMapper jsonMapper;
   private JobResult.Builder resultGrpc;
-  private io.camunda.client.protocol.rest.JobResult resultRest;
+  private io.camunda.client.protocol.rest.JobCompletionRequestResult resultRest;
   private io.camunda.zeebe.gateway.protocol.GatewayOuterClass.JobResultCorrections.Builder
       correctionsGrpc;
   private io.camunda.client.protocol.rest.JobResultCorrections correctionsRest;
@@ -128,7 +128,7 @@ public final class CompleteJobCommandImpl extends CommandWithVariables<CompleteJ
   }
 
   private void initJobResult() {
-    resultRest = new io.camunda.client.protocol.rest.JobResult();
+    resultRest = new io.camunda.client.protocol.rest.JobCompletionRequestResult();
     correctionsRest = new io.camunda.client.protocol.rest.JobResultCorrections();
     resultRest.setCorrections(correctionsRest);
     httpRequestObject.setResult(resultRest);

--- a/clients/java/src/main/java/io/camunda/client/impl/command/CompleteJobCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/CompleteJobCommandImpl.java
@@ -29,6 +29,7 @@ import io.camunda.client.impl.http.HttpCamundaFuture;
 import io.camunda.client.impl.http.HttpClient;
 import io.camunda.client.impl.response.CompleteJobResponseImpl;
 import io.camunda.client.protocol.rest.JobCompletionRequest;
+import io.camunda.client.protocol.rest.JobResult.TypeEnum;
 import io.camunda.zeebe.gateway.protocol.GatewayGrpc.GatewayStub;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.CompleteJobRequest;
@@ -57,7 +58,7 @@ public final class CompleteJobCommandImpl extends CommandWithVariables<CompleteJ
   private final long jobKey;
   private final JsonMapper jsonMapper;
   private JobResult.Builder resultGrpc;
-  private io.camunda.client.protocol.rest.JobCompletionRequestResult resultRest;
+  private io.camunda.client.protocol.rest.JobResultUserTask resultRest;
   private io.camunda.zeebe.gateway.protocol.GatewayOuterClass.JobResultCorrections.Builder
       correctionsGrpc;
   private io.camunda.client.protocol.rest.JobResultCorrections correctionsRest;
@@ -128,7 +129,9 @@ public final class CompleteJobCommandImpl extends CommandWithVariables<CompleteJ
   }
 
   private void initJobResult() {
-    resultRest = new io.camunda.client.protocol.rest.JobCompletionRequestResult();
+    resultRest = new io.camunda.client.protocol.rest.JobResultUserTask();
+    resultRest.setType(
+        TypeEnum.USER_TASK); // TODO replace later when ad hoc subprocess is supported
     correctionsRest = new io.camunda.client.protocol.rest.JobResultCorrections();
     resultRest.setCorrections(correctionsRest);
     httpRequestObject.setResult(resultRest);

--- a/clients/java/src/test/java/io/camunda/client/job/rest/CompleteJobRestTest.java
+++ b/clients/java/src/test/java/io/camunda/client/job/rest/CompleteJobRestTest.java
@@ -21,7 +21,9 @@ import io.camunda.client.api.command.CompleteJobResult;
 import io.camunda.client.api.response.ActivatedJob;
 import io.camunda.client.job.CompleteJobTest;
 import io.camunda.client.protocol.rest.JobCompletionRequest;
-import io.camunda.client.protocol.rest.JobCompletionRequestResult;
+import io.camunda.client.protocol.rest.JobResult;
+import io.camunda.client.protocol.rest.JobResult.TypeEnum;
+import io.camunda.client.protocol.rest.JobResultUserTask;
 import io.camunda.client.util.ClientRestTest;
 import io.camunda.client.util.JsonUtil;
 import io.camunda.client.util.StringUtil;
@@ -38,6 +40,8 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mockito;
 
 class CompleteJobRestTest extends ClientRestTest {
+
+  public static final JobResult.TypeEnum USER_TASK_DISCRIMINATOR = TypeEnum.USER_TASK;
 
   @Test
   void shouldCompleteJobByKey() {
@@ -174,8 +178,10 @@ class CompleteJobRestTest extends ClientRestTest {
     // then
     final JobCompletionRequest request = gatewayService.getLastRequest(JobCompletionRequest.class);
     assertThat(request.getResult()).isNotNull();
-    assertThat(request.getResult().getDenied()).isEqualTo(denied);
-    assertThat(request.getResult().getDeniedReason()).isEqualTo(deniedReason);
+    assertThat(request.getResult().getType()).isEqualTo(USER_TASK_DISCRIMINATOR);
+    final JobResultUserTask result = (JobResultUserTask) request.getResult();
+    assertThat(result.getDenied()).isEqualTo(denied);
+    assertThat(result.getDeniedReason()).isEqualTo(deniedReason);
   }
 
   @ParameterizedTest
@@ -190,8 +196,10 @@ class CompleteJobRestTest extends ClientRestTest {
     // then
     final JobCompletionRequest request = gatewayService.getLastRequest(JobCompletionRequest.class);
     assertThat(request.getResult()).isNotNull();
-    assertThat(request.getResult().getDenied()).isEqualTo(denied);
-    assertThat(request.getResult().getDeniedReason()).isEqualTo(deniedReason);
+    assertThat(request.getResult().getType()).isEqualTo(USER_TASK_DISCRIMINATOR);
+    final JobResultUserTask result = (JobResultUserTask) request.getResult();
+    assertThat(result.getDenied()).isEqualTo(denied);
+    assertThat(result.getDeniedReason()).isEqualTo(deniedReason);
   }
 
   @ParameterizedTest
@@ -210,8 +218,10 @@ class CompleteJobRestTest extends ClientRestTest {
     // then
     final JobCompletionRequest request = gatewayService.getLastRequest(JobCompletionRequest.class);
     assertThat(request.getResult()).isNotNull();
-    assertThat(request.getResult().getDenied()).isEqualTo(denied);
-    assertThat(request.getResult().getDeniedReason()).isEqualTo(deniedReason);
+    assertThat(request.getResult().getType()).isEqualTo(USER_TASK_DISCRIMINATOR);
+    final JobResultUserTask result = (JobResultUserTask) request.getResult();
+    assertThat(result.getDenied()).isEqualTo(denied);
+    assertThat(result.getDeniedReason()).isEqualTo(deniedReason);
   }
 
   @Test
@@ -232,7 +242,9 @@ class CompleteJobRestTest extends ClientRestTest {
     // then
     final JobCompletionRequest request = gatewayService.getLastRequest(JobCompletionRequest.class);
     assertThat(request.getResult()).isNotNull();
-    assertThat(request.getResult().getDenied()).isEqualTo(false);
+    assertThat(request.getResult().getType()).isEqualTo(USER_TASK_DISCRIMINATOR);
+    final JobResultUserTask result = (JobResultUserTask) request.getResult();
+    assertThat(result.getDenied()).isEqualTo(false);
 
     final Map<String, String> expectedVariables = new HashMap<>();
     expectedVariables.put("we_can", "still_set_vars");
@@ -250,8 +262,10 @@ class CompleteJobRestTest extends ClientRestTest {
     // then
     final JobCompletionRequest request = gatewayService.getLastRequest(JobCompletionRequest.class);
     assertThat(request.getResult()).isNotNull();
-    assertThat(request.getResult().getDenied()).isNull();
-    assertThat(request.getResult().getDeniedReason()).isNull();
+    assertThat(request.getResult().getType()).isEqualTo(USER_TASK_DISCRIMINATOR);
+    final JobResultUserTask result = (JobResultUserTask) request.getResult();
+    assertThat(result.getDenied()).isNull();
+    assertThat(result.getDeniedReason()).isNull();
   }
 
   @Test
@@ -278,7 +292,8 @@ class CompleteJobRestTest extends ClientRestTest {
     final JobCompletionRequest expectedRequest =
         new JobCompletionRequest()
             .result(
-                new JobCompletionRequestResult()
+                new JobResultUserTask()
+                    .type(USER_TASK_DISCRIMINATOR)
                     .corrections(
                         new io.camunda.client.protocol.rest.JobResultCorrections()
                             .assignee("Test")
@@ -314,7 +329,8 @@ class CompleteJobRestTest extends ClientRestTest {
     final JobCompletionRequest expectedRequest =
         new JobCompletionRequest()
             .result(
-                new JobCompletionRequestResult()
+                new JobResultUserTask()
+                    .type(USER_TASK_DISCRIMINATOR)
                     .corrections(
                         new io.camunda.client.protocol.rest.JobResultCorrections()
                             .assignee("Test")
@@ -351,7 +367,8 @@ class CompleteJobRestTest extends ClientRestTest {
     final JobCompletionRequest expectedRequest =
         new JobCompletionRequest()
             .result(
-                new JobCompletionRequestResult()
+                new JobResultUserTask()
+                    .type(USER_TASK_DISCRIMINATOR)
                     .corrections(
                         new io.camunda.client.protocol.rest.JobResultCorrections()
                             .assignee(null)
@@ -389,7 +406,8 @@ class CompleteJobRestTest extends ClientRestTest {
     final JobCompletionRequest expectedRequest =
         new JobCompletionRequest()
             .result(
-                new JobCompletionRequestResult()
+                new JobResultUserTask()
+                    .type(USER_TASK_DISCRIMINATOR)
                     .denied(false)
                     .corrections(
                         new io.camunda.client.protocol.rest.JobResultCorrections()
@@ -429,7 +447,8 @@ class CompleteJobRestTest extends ClientRestTest {
     final JobCompletionRequest expectedRequest =
         new JobCompletionRequest()
             .result(
-                new JobCompletionRequestResult()
+                new JobResultUserTask()
+                    .type(USER_TASK_DISCRIMINATOR)
                     .denied(false)
                     .corrections(
                         new io.camunda.client.protocol.rest.JobResultCorrections()
@@ -457,7 +476,8 @@ class CompleteJobRestTest extends ClientRestTest {
     final JobCompletionRequest expectedRequest =
         new JobCompletionRequest()
             .result(
-                new JobCompletionRequestResult()
+                new JobResultUserTask()
+                    .type(USER_TASK_DISCRIMINATOR)
                     .corrections(
                         new io.camunda.client.protocol.rest.JobResultCorrections()
                             .assignee(null)

--- a/clients/java/src/test/java/io/camunda/client/job/rest/CompleteJobRestTest.java
+++ b/clients/java/src/test/java/io/camunda/client/job/rest/CompleteJobRestTest.java
@@ -21,7 +21,7 @@ import io.camunda.client.api.command.CompleteJobResult;
 import io.camunda.client.api.response.ActivatedJob;
 import io.camunda.client.job.CompleteJobTest;
 import io.camunda.client.protocol.rest.JobCompletionRequest;
-import io.camunda.client.protocol.rest.JobResult;
+import io.camunda.client.protocol.rest.JobCompletionRequestResult;
 import io.camunda.client.util.ClientRestTest;
 import io.camunda.client.util.JsonUtil;
 import io.camunda.client.util.StringUtil;
@@ -278,7 +278,7 @@ class CompleteJobRestTest extends ClientRestTest {
     final JobCompletionRequest expectedRequest =
         new JobCompletionRequest()
             .result(
-                new JobResult()
+                new JobCompletionRequestResult()
                     .corrections(
                         new io.camunda.client.protocol.rest.JobResultCorrections()
                             .assignee("Test")
@@ -314,7 +314,7 @@ class CompleteJobRestTest extends ClientRestTest {
     final JobCompletionRequest expectedRequest =
         new JobCompletionRequest()
             .result(
-                new JobResult()
+                new JobCompletionRequestResult()
                     .corrections(
                         new io.camunda.client.protocol.rest.JobResultCorrections()
                             .assignee("Test")
@@ -351,7 +351,7 @@ class CompleteJobRestTest extends ClientRestTest {
     final JobCompletionRequest expectedRequest =
         new JobCompletionRequest()
             .result(
-                new JobResult()
+                new JobCompletionRequestResult()
                     .corrections(
                         new io.camunda.client.protocol.rest.JobResultCorrections()
                             .assignee(null)
@@ -389,7 +389,7 @@ class CompleteJobRestTest extends ClientRestTest {
     final JobCompletionRequest expectedRequest =
         new JobCompletionRequest()
             .result(
-                new JobResult()
+                new JobCompletionRequestResult()
                     .denied(false)
                     .corrections(
                         new io.camunda.client.protocol.rest.JobResultCorrections()
@@ -429,7 +429,7 @@ class CompleteJobRestTest extends ClientRestTest {
     final JobCompletionRequest expectedRequest =
         new JobCompletionRequest()
             .result(
-                new JobResult()
+                new JobCompletionRequestResult()
                     .denied(false)
                     .corrections(
                         new io.camunda.client.protocol.rest.JobResultCorrections()
@@ -457,7 +457,7 @@ class CompleteJobRestTest extends ClientRestTest {
     final JobCompletionRequest expectedRequest =
         new JobCompletionRequest()
             .result(
-                new JobResult()
+                new JobCompletionRequestResult()
                     .corrections(
                         new io.camunda.client.protocol.rest.JobResultCorrections()
                             .assignee(null)

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-job-batch-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-job-batch-template.json
@@ -103,6 +103,9 @@
                 },
                 "result": {
                   "properties": {
+                    "type": {
+                      "type": "text"
+                    },
                     "denied": {
                       "type": "boolean"
                     },
@@ -131,6 +134,16 @@
                         },
                         "priority": {
                           "type": "integer"
+                        }
+                      }
+                    },
+                    "activateElements": {
+                      "properties": {
+                        "elementId": {
+                          "type": "text"
+                        },
+                        "variables": {
+                          "enabled": false
                         }
                       }
                     }

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-job-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-job-template.json
@@ -84,6 +84,9 @@
             },
             "result": {
               "properties": {
+                "type": {
+                  "type": "text"
+                },
                 "denied": {
                   "type": "boolean"
                 },
@@ -112,6 +115,16 @@
                     },
                     "priority": {
                       "type": "integer"
+                    }
+                  }
+                },
+                "activateElements": {
+                  "properties": {
+                    "elementId": {
+                      "type": "text"
+                    },
+                    "variables": {
+                      "enabled": false
                     }
                   }
                 }

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-job-batch-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-job-batch-template.json
@@ -103,6 +103,9 @@
                 },
                 "result": {
                   "properties": {
+                    "type": {
+                      "type": "text"
+                    },
                     "denied": {
                       "type": "boolean"
                     },
@@ -131,6 +134,16 @@
                         },
                         "priority": {
                           "type": "integer"
+                        }
+                      }
+                    },
+                    "activateElements": {
+                      "properties": {
+                        "elementId": {
+                          "type": "text"
+                        },
+                        "variables": {
+                          "enabled": false
                         }
                       }
                     }

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-job-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-job-template.json
@@ -84,6 +84,9 @@
             },
             "result": {
               "properties": {
+                "type": {
+                  "type": "text"
+                },
                 "denied": {
                   "type": "boolean"
                 },
@@ -112,6 +115,16 @@
                     },
                     "priority": {
                       "type": "integer"
+                    }
+                  }
+                },
+                "activateElements": {
+                  "properties": {
+                    "elementId": {
+                      "type": "text"
+                    },
+                    "variables": {
+                      "enabled": false
                     }
                   }
                 }

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/RequestMapper.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/RequestMapper.java
@@ -57,6 +57,7 @@ import io.camunda.zeebe.protocol.impl.record.value.job.JobResultCorrections;
 import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
 import io.camunda.zeebe.protocol.impl.stream.job.JobActivationProperties;
 import io.camunda.zeebe.protocol.impl.stream.job.JobActivationPropertiesImpl;
+import io.camunda.zeebe.protocol.record.value.JobResultType;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import java.util.ArrayList;
 import java.util.List;
@@ -171,6 +172,7 @@ public final class RequestMapper extends RequestUtil {
 
     if (!request.getResult().hasCorrections()) {
       return new JobResult()
+          .setType(JobResultType.from(request.getResult().getType()))
           .setDenied(request.getResult().getDenied())
           .setDeniedReason(request.getResult().getDeniedReason());
     }
@@ -207,6 +209,7 @@ public final class RequestMapper extends RequestUtil {
     }
 
     return new JobResult()
+        .setType(JobResultType.from(request.getResult().getType()))
         .setDenied(request.getResult().getDenied())
         .setDeniedReason(request.getResult().getDeniedReason())
         .setCorrections(corrections)

--- a/zeebe/gateway-protocol/src/main/proto/gateway.proto
+++ b/zeebe/gateway-protocol/src/main/proto/gateway.proto
@@ -182,6 +182,10 @@ message JobResult{
   optional JobResultCorrections corrections = 2;
   // The reason provided by the user task listener for denying the work.
   optional string deniedReason = 3;
+  // Used to distinguish between different types of job results. Must be one of ["userTask", "adHocSubprocess"]. If not set, defaults to "userTask".
+  optional string type = 4;
+  // The list of elements that should be activated after the job is completed. Only relevant for ad-hoc subprocesses.
+  repeated JobResultActivateElement activateElements = 5;
 }
 
 message JobResultCorrections {
@@ -197,6 +201,17 @@ message JobResultCorrections {
   optional StringList candidateGroups = 5;
   // The priority of the task.
   optional int32 priority = 6;
+}
+
+message JobResultActivateElement {
+  // The id of the element to activate
+  string elementId = 1;
+  // JSON document of variables that will be created on the scope of the activated element.
+  // It must be a JSON object, as variables will be mapped in a key-value fashion.
+  // e.g. { "a": 1, "b": 2 } will create two variables, named "a" and
+  // "b" respectively, with their associated values. [{ "a": 1, "b": 2 }] would not be a
+  // valid argument, as the root of the JSON document is an array and not an object.
+  string variables = 2;
 }
 
 message StringList {

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -8732,27 +8732,43 @@ components:
         result:
           $ref: "#/components/schemas/JobResult"
     JobResult:
-      type: object
-      nullable: true
       description: >
         The result of the completed job as determined by the worker.
-        This functionality is currently supported only by user task listeners.
+      discriminator:
+        propertyName: type
+        mapping:
+          userTask: "#/components/schemas/JobResultUserTask"
+          adHocSubProcess: "#/components/schemas/JobResultAdHocSubProcess"
+      required:
+        - type
       properties:
-        denied:
-          type: boolean
-          description: >
-            Indicates whether the worker denies the work, i.e. explicitly doesn't approve it.
-            For example, a user task listener can deny the completion of a task by setting this flag to true.
-            In this example, the completion of a task is represented by a job that the worker can complete as denied.
-            As a result, the completion request is rejected and the task remains active.
-            Defaults to false.
-          nullable: true
-        deniedReason:
+        type:
           type: string
-          description: The reason provided by the user task listener for denying the work.
-          nullable: true
-        corrections:
-          $ref: "#/components/schemas/JobResultCorrections"
+          description: Used to distinguish between different types of job results.
+          enum: [ "userTask", "adHocSubProcess" ]
+          default: "userTask"
+    JobResultUserTask:
+      type: object
+      nullable: true
+      allOf:
+        - $ref: "#/components/schemas/JobResult"
+        - type: object
+          properties:
+            denied:
+              type: boolean
+              description: >
+                Indicates whether the worker denies the work, i.e. explicitly doesn't approve it.
+                For example, a user task listener can deny the completion of a task by setting this flag to true.
+                In this example, the completion of a task is represented by a job that the worker can complete as denied.
+                As a result, the completion request is rejected and the task remains active.
+                Defaults to false.
+              nullable: true
+            deniedReason:
+              type: string
+              description: The reason provided by the user task listener for denying the work.
+              nullable: true
+            corrections:
+              $ref: "#/components/schemas/JobResultCorrections"
     JobResultCorrections:
       type: object
       description: |
@@ -8803,6 +8819,31 @@ components:
           description: The priority of the task.
           minimum: 0
           maximum: 100
+          nullable: true
+    JobResultAdHocSubProcess:
+      type: object
+      nullable: true
+      allOf:
+        - $ref: "#/components/schemas/JobResult"
+        - type: object
+          properties:
+            activateElements:
+              type: array
+              description: Indicates which elements need to be activated in the ad-hoc subprocess.
+              items:
+                $ref: "#/components/schemas/JobResultActivateElement"
+    JobResultActivateElement:
+      type: object
+      properties:
+        elementId:
+          description: The ID of the element to activate.
+          type: string
+        variables:
+          description: |
+            JSON document that will create the variables on the scope of the activated element.
+            It must be a JSON object, as variables will be mapped in a key-value fashion.
+          additionalProperties: true
+          type: object
           nullable: true
     JobUpdateRequest:
       type: object

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RequestMapper.java
@@ -130,6 +130,7 @@ import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.EntityType;
+import io.camunda.zeebe.protocol.record.value.JobResultType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.util.Either;
 import jakarta.servlet.http.Part;

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RequestMapper.java
@@ -967,6 +967,7 @@ public class RequestMapper {
 
     final JobResult jobResult = new JobResult();
     final var jobResultUserTask = (JobResultUserTask) request.getResult();
+    jobResult.setType(JobResultType.from(jobResultUserTask.getType().getValue()));
     jobResult.setDenied(
         getBooleanOrDefault(request, r -> ((JobResultUserTask) r.getResult()).getDenied(), false));
     jobResult.setDeniedReason(

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RequestMapper.java
@@ -87,6 +87,7 @@ import io.camunda.zeebe.gateway.protocol.rest.JobActivationRequest;
 import io.camunda.zeebe.gateway.protocol.rest.JobCompletionRequest;
 import io.camunda.zeebe.gateway.protocol.rest.JobErrorRequest;
 import io.camunda.zeebe.gateway.protocol.rest.JobFailRequest;
+import io.camunda.zeebe.gateway.protocol.rest.JobResultUserTask;
 import io.camunda.zeebe.gateway.protocol.rest.JobUpdateRequest;
 import io.camunda.zeebe.gateway.protocol.rest.MappingRuleCreateRequest;
 import io.camunda.zeebe.gateway.protocol.rest.MappingRuleUpdateRequest;
@@ -965,10 +966,13 @@ public class RequestMapper {
     }
 
     final JobResult jobResult = new JobResult();
-    jobResult.setDenied(getBooleanOrDefault(request, r -> r.getResult().getDenied(), false));
-    jobResult.setDeniedReason(getStringOrEmpty(request, r -> r.getResult().getDeniedReason()));
+    final var jobResultUserTask = (JobResultUserTask) request.getResult();
+    jobResult.setDenied(
+        getBooleanOrDefault(request, r -> ((JobResultUserTask) r.getResult()).getDenied(), false));
+    jobResult.setDeniedReason(
+        getStringOrEmpty(request, r -> ((JobResultUserTask) r.getResult()).getDeniedReason()));
 
-    final var jobResultCorrections = request.getResult().getCorrections();
+    final var jobResultCorrections = jobResultUserTask.getCorrections();
     if (jobResultCorrections == null) {
       return jobResult;
     }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerTest.java
@@ -338,6 +338,7 @@ public class JobControllerTest extends RestControllerTest {
         """
           {
             "result": {
+              "type": "userTask",
               "denied": true,
               "corrections": {}
             }
@@ -372,6 +373,7 @@ public class JobControllerTest extends RestControllerTest {
         """
           {
             "result": {
+              "type": "userTask",
               "denied": true,
               "deniedReason": "Reason to deny lifecycle transition",
               "corrections": {}
@@ -409,6 +411,7 @@ public class JobControllerTest extends RestControllerTest {
         """
           {
             "result": {
+              "type": "userTask",
               "denied": false,
               "corrections": {
                 "assignee": "Test",
@@ -468,6 +471,7 @@ public class JobControllerTest extends RestControllerTest {
         """
           {
             "result": {
+              "type": "userTask",
               "denied": false,
               "corrections": {
                 "assignee": "Test",
@@ -521,6 +525,7 @@ public class JobControllerTest extends RestControllerTest {
         """
           {
             "result": {
+              "type": "userTask",
               "denied": false,
               "corrections": {
                 "assignee": null,
@@ -573,6 +578,7 @@ public class JobControllerTest extends RestControllerTest {
         """
           {
             "result": {
+              "type": "userTask",
               "denied": false,
               "corrections": {}
             }
@@ -608,6 +614,7 @@ public class JobControllerTest extends RestControllerTest {
         """
           {
             "result": {
+              "type": "userTask",
               "unknownField": true,
               "corrections": {}
             }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobResultActivateElement.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobResultActivateElement.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.protocol.impl.record.value.job;
+
+import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.camunda.zeebe.msgpack.UnpackedObject;
+import io.camunda.zeebe.msgpack.property.DocumentProperty;
+import io.camunda.zeebe.msgpack.property.StringProperty;
+import io.camunda.zeebe.msgpack.value.StringValue;
+import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
+import io.camunda.zeebe.protocol.record.value.JobRecordValue.JobResultActivateElementValue;
+import java.util.Map;
+import org.agrona.DirectBuffer;
+
+@JsonIgnoreProperties({
+  /* These fields are inherited from ObjectValue; there have no purpose in exported JSON records*/
+  "empty",
+  "encodedLength",
+  "length"
+})
+public final class JobResultActivateElement extends UnpackedObject
+    implements JobResultActivateElementValue {
+
+  private static final StringValue ELEMENT_ID_KEY = new StringValue("elementId");
+  private static final StringValue VARIABLES_KEY = new StringValue("variables");
+
+  private final StringProperty elementIdProp = new StringProperty(ELEMENT_ID_KEY);
+  private final DocumentProperty variablesProp = new DocumentProperty(VARIABLES_KEY);
+
+  public JobResultActivateElement() {
+    super(2);
+    declareProperty(elementIdProp).declareProperty(variablesProp);
+  }
+
+  @Override
+  public String getElementId() {
+    return bufferAsString(elementIdProp.getValue());
+  }
+
+  public JobResultActivateElement setElementId(final String elementId) {
+    elementIdProp.setValue(elementId);
+    return this;
+  }
+
+  @Override
+  public Map<String, Object> getVariables() {
+    return MsgPackConverter.convertToMap(variablesProp.getValue());
+  }
+
+  public JobResultActivateElement setVariables(final DirectBuffer variables) {
+    variablesProp.setValue(variables);
+    return this;
+  }
+}

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -47,6 +47,7 @@ import io.camunda.zeebe.protocol.impl.record.value.incident.IncidentRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobBatchRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobResult;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobResultActivateElement;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobResultCorrections;
 import io.camunda.zeebe.protocol.impl.record.value.management.CheckpointRecord;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageBatchRecord;
@@ -88,6 +89,7 @@ import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.BpmnEventType;
 import io.camunda.zeebe.protocol.record.value.EntityType;
 import io.camunda.zeebe.protocol.record.value.ErrorType;
+import io.camunda.zeebe.protocol.record.value.JobResultType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.protocol.record.value.UsageMetricRecordValue.EventType;
@@ -702,6 +704,7 @@ final class JsonSerializableToJsonTest {
               final Set<String> changedAttributes = Set.of("bar", "foo");
               final JobResult result =
                   new JobResult()
+                      .setType(JobResultType.USER_TASK)
                       .setDenied(true)
                       .setDeniedReason("Reason to deny lifecycle transition")
                       .setCorrections(
@@ -719,7 +722,15 @@ final class JsonSerializableToJsonTest {
                               "followUpDate",
                               "candidateGroupsList",
                               "candidateUsersList",
-                              "priority"));
+                              "priority"))
+                      .setActivateElements(
+                          List.of(
+                              new JobResultActivateElement()
+                                  .setElementId("gandalf")
+                                  .setVariables(VARIABLES_MSGPACK),
+                              new JobResultActivateElement()
+                                  .setElementId("sauron")
+                                  .setVariables(VARIABLES_MSGPACK)));
 
               jobRecord
                   .setWorker(wrapString(worker))
@@ -777,6 +788,7 @@ final class JsonSerializableToJsonTest {
               "tenantId": "<default>",
               "changedAttributes": ["bar", "foo"],
               "result": {
+                "type": "USER_TASK",
                 "denied": true,
                 "deniedReason": "Reason to deny lifecycle transition",
                 "correctedAttributes": [
@@ -794,7 +806,21 @@ final class JsonSerializableToJsonTest {
                   "candidateGroupsList": ["fellowship", "eagles"],
                   "candidateUsersList": ["frodo", "sam", "gollum"],
                   "priority": 1
-                }
+                },
+               "activateElements": [
+                  {
+                    "elementId": "gandalf",
+                    "variables": {
+                      "foo": "bar"
+                    }
+                  },
+                  {
+                    "elementId": "sauron",
+                    "variables": {
+                      "foo": "bar"
+                    }
+                  }
+                ]
               }
             }
           ],
@@ -848,6 +874,7 @@ final class JsonSerializableToJsonTest {
               final Set<String> changedAttributes = Set.of("bar", "foo");
               final JobResult result =
                   new JobResult()
+                      .setType(JobResultType.AD_HOC_SUB_PROCESS)
                       .setDenied(true)
                       .setDeniedReason("Reason to deny lifecycle transition")
                       .setCorrections(
@@ -865,7 +892,15 @@ final class JsonSerializableToJsonTest {
                               "followUpDate",
                               "candidateGroupsList",
                               "candidateUsersList",
-                              "priority"));
+                              "priority"))
+                      .setActivateElements(
+                          List.of(
+                              new JobResultActivateElement()
+                                  .setElementId("gandalf")
+                                  .setVariables(VARIABLES_MSGPACK),
+                              new JobResultActivateElement()
+                                  .setElementId("sauron")
+                                  .setVariables(VARIABLES_MSGPACK)));
 
               final Map<String, String> customHeaders =
                   Collections.singletonMap("workerVersion", "42");
@@ -922,6 +957,7 @@ final class JsonSerializableToJsonTest {
           "tenantId": "<default>",
           "changedAttributes": ["bar", "foo"],
           "result": {
+            "type": "AD_HOC_SUB_PROCESS",
             "denied": true,
             "deniedReason": "Reason to deny lifecycle transition",
             "correctedAttributes": [
@@ -939,7 +975,21 @@ final class JsonSerializableToJsonTest {
               "candidateGroupsList": ["fellowship", "eagles"],
               "candidateUsersList": ["frodo", "sam", "gollum"],
               "priority": 1
-            }
+            },
+            "activateElements": [
+              {
+                "elementId": "gandalf",
+                "variables": {
+                  "foo": "bar"
+                }
+              },
+              {
+                "elementId": "sauron",
+                "variables": {
+                  "foo": "bar"
+                }
+              }
+            ]
           }
         }
         """
@@ -975,6 +1025,7 @@ final class JsonSerializableToJsonTest {
           "tenantId": "<default>",
           "changedAttributes": [],
           "result": {
+            "type": "USER_TASK",
             "denied": false,
             "deniedReason": "",
             "correctedAttributes": [],
@@ -985,7 +1036,8 @@ final class JsonSerializableToJsonTest {
               "candidateGroupsList": [],
               "candidateUsersList": [],
               "priority": -1
-            }
+            },
+            "activateElements": []
           }
         }
         """
@@ -1026,6 +1078,7 @@ final class JsonSerializableToJsonTest {
           "tenantId": "<default>",
           "changedAttributes": [],
           "result": {
+            "type": "USER_TASK",
             "denied": false,
             "deniedReason": "",
             "correctedAttributes": [],
@@ -1036,7 +1089,8 @@ final class JsonSerializableToJsonTest {
               "candidateGroupsList": [],
               "candidateUsersList": [],
               "priority": -1
-            }
+            },
+            "activateElements": []
           }
         }
         """

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/JobRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/JobRecordValue.java
@@ -136,6 +136,12 @@ public interface JobRecordValue
   interface JobResultValue {
 
     /**
+     * @return the type of the job result, e.g. "userTask" for user task jobs or "adHocSubprocess"
+     *     for ad-hoc subprocess jobs. Depending on the type different properties are set.
+     */
+    JobResultType getType();
+
+    /**
      * @return true if the operation was rejected by Task Listener
      */
     boolean isDenied();
@@ -162,6 +168,12 @@ public interface JobRecordValue
      *     JobResultValue#getCorrectedAttributes()} to determine which fields are set
      */
     JobResultCorrectionsValue getCorrections();
+
+    /**
+     * @return a list of elements that need to be activated as a result of completing the job, as
+     *     well as variables that need to be set on the scope of each of these elements.
+     */
+    List<JobResultActivateElementValue> getActivateElements();
   }
 
   /**
@@ -203,5 +215,21 @@ public interface JobRecordValue
      * @return the corrected priority
      */
     int getPriority();
+  }
+
+  /** Represents the activate elements that can be opart of a {@link JobResultValue} */
+  @Value.Immutable
+  @ImmutableProtocol(builder = ImmutableJobResultActivateElementValue.Builder.class)
+  interface JobResultActivateElementValue {
+
+    /**
+     * @return the id of the element that needs to be activated
+     */
+    String getElementId();
+
+    /**
+     * @return the variables that need to be set on the element when it is activated
+     */
+    Map<String, Object> getVariables();
   }
 }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/JobResultType.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/JobResultType.java
@@ -33,6 +33,11 @@ public enum JobResultType {
   }
 
   public static JobResultType from(final String resultType) {
+    // If resultType is null or empty we will default to USER_TASK for backward compatibility.
+    if (resultType == null || resultType.isEmpty()) {
+      return USER_TASK;
+    }
+
     for (final JobResultType type : values()) {
       if (type.type.equals(resultType)) {
         return type;

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/JobResultType.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/JobResultType.java
@@ -31,4 +31,13 @@ public enum JobResultType {
   JobResultType(final String type) {
     this.type = type;
   }
+
+  public static JobResultType from(final String resultType) {
+    for (final JobResultType type : values()) {
+      if (type.type.equals(resultType)) {
+        return type;
+      }
+    }
+    throw new IllegalArgumentException("Unknown job result type: " + resultType);
+  }
 }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/JobResultType.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/JobResultType.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.protocol.record.value;
+
+/**
+ * Enumerates the different supported types of job results. Depending on this type different
+ * properties of the {@link io.camunda.zeebe.protocol.record.value.JobRecordValue.JobResultValue}
+ * will be set.
+ */
+public enum JobResultType {
+  /** Represents a user task job result type. */
+  USER_TASK("userTask"),
+  /** Represents an ad-hoc subprocess job result type. */
+  AD_HOC_SUB_PROCESS("adHocSubprocess");
+
+  final String type;
+
+  JobResultType(final String type) {
+    this.type = type;
+  }
+}


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Extends the Job completion results api to allow specifying a type (`userTask` or `adHocSubProcess`). Depending on the type a different set of properties will be set on the response. These properties will detail which followup action needs to be taken upon job completion.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

Related to #34493 
Related to https://github.com/camunda/ad-hoc-sub-process-phase-3/issues/5 (needs to be closed manually due to different repo)
