### PR TITLE
Feat/35234 filter process instance by batch operation

### DIFF
--- a/db/rdbms/src/main/resources/mapper/ProcessInstanceMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/ProcessInstanceMapper.xml
@@ -246,6 +246,17 @@
         AND i.ERROR_MESSAGE_HASH IN <foreach collection="filter.incidentErrorHashCodes" item="value" open="(" separator=", " close=")">#{value}</foreach>
       )
     </if>
+      <if test="filter.batchOperationIdOperations != null and !filter.batchOperationIdOperations.isEmpty()">
+        AND EXISTS (
+        SELECT 1
+        FROM ${prefix}BATCH_OPERATION_ITEM boi
+        WHERE boi.PROCESS_INSTANCE_KEY = pi.PROCESS_INSTANCE_KEY
+        <foreach collection="filter.batchOperationIdOperations" item="operation">
+          AND boi.BATCH_OPERATION_KEY
+          <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+        </foreach>
+        )
+      </if>
     </trim>
   </sql>
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/BatchOperationSearchTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/BatchOperationSearchTest.java
@@ -24,6 +24,7 @@ import io.camunda.client.api.search.enums.BatchOperationState;
 import io.camunda.client.api.search.enums.BatchOperationType;
 import io.camunda.client.api.search.response.BatchOperation;
 import io.camunda.client.api.search.response.BatchOperationItems.BatchOperationItem;
+import io.camunda.client.api.search.response.ProcessInstance;
 import io.camunda.client.api.search.response.SearchResponse;
 import io.camunda.client.impl.search.filter.ProcessInstanceFilterImpl;
 import io.camunda.qa.util.multidb.MultiDbTest;
@@ -306,6 +307,23 @@ public class BatchOperationSearchTest {
     // then
     assertThat(page).isNotNull();
     assertItems(page, ACTIVE_PROCESS_INSTANCES_2);
+  }
+
+  @Test
+  void shouldSearchProcessInstanceByBatchOperationKey() {
+    // when
+    final var page =
+        camundaClient
+            .newProcessInstanceSearchRequest()
+            .filter(f -> f.batchOperationId(batchOperationKey1))
+            .send()
+            .join();
+
+    // then
+    assertThat(page).isNotNull();
+    assertThat(page.items()).hasSize(ACTIVE_PROCESS_INSTANCES_1.size());
+    assertThat(page.items().stream().map(ProcessInstance::getProcessInstanceKey))
+        .containsExactlyInAnyOrderElementsOf(ACTIVE_PROCESS_INSTANCES_1);
   }
 
   private static void assertCancelBatchOperation(final BatchOperation batch) {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
@@ -74,6 +74,11 @@ import io.camunda.exporter.handlers.batchoperation.ProcessInstanceCancellationOp
 import io.camunda.exporter.handlers.batchoperation.ProcessInstanceMigrationOperationHandler;
 import io.camunda.exporter.handlers.batchoperation.ProcessInstanceModificationOperationHandler;
 import io.camunda.exporter.handlers.batchoperation.ResolveIncidentOperationHandler;
+import io.camunda.exporter.handlers.batchoperation.listview.ListViewFromChunkItemHandler;
+import io.camunda.exporter.handlers.batchoperation.listview.ListViewFromIncidentResolutionOperationHandler;
+import io.camunda.exporter.handlers.batchoperation.listview.ListViewFromProcessInstanceCancellationOperationHandler;
+import io.camunda.exporter.handlers.batchoperation.listview.ListViewFromProcessInstanceMigrationOperationHandler;
+import io.camunda.exporter.handlers.batchoperation.listview.ListViewFromProcessInstanceModificationOperationHandler;
 import io.camunda.exporter.handlers.operation.OperationFromIncidentHandler;
 import io.camunda.exporter.handlers.operation.OperationFromProcessInstanceHandler;
 import io.camunda.exporter.handlers.operation.OperationFromVariableDocumentHandler;
@@ -300,6 +305,18 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
                 batchOperationCache),
             new ResolveIncidentOperationHandler(
                 indexDescriptors.get(OperationTemplate.class).getFullQualifiedName(),
+                batchOperationCache),
+            new ListViewFromProcessInstanceCancellationOperationHandler(
+                indexDescriptors.get(ListViewTemplate.class).getFullQualifiedName(),
+                batchOperationCache),
+            new ListViewFromProcessInstanceMigrationOperationHandler(
+                indexDescriptors.get(ListViewTemplate.class).getFullQualifiedName(),
+                batchOperationCache),
+            new ListViewFromProcessInstanceModificationOperationHandler(
+                indexDescriptors.get(ListViewTemplate.class).getFullQualifiedName(),
+                batchOperationCache),
+            new ListViewFromIncidentResolutionOperationHandler(
+                indexDescriptors.get(ListViewTemplate.class).getFullQualifiedName(),
                 batchOperationCache)));
 
     if (configuration.getBatchOperation().isExportItemsOnCreation()) {
@@ -307,6 +324,9 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
       exportHandlers.add(
           new BatchOperationChunkCreatedItemHandler(
               indexDescriptors.get(OperationTemplate.class).getFullQualifiedName()));
+      exportHandlers.add(
+          new ListViewFromChunkItemHandler(
+              indexDescriptors.get(ListViewTemplate.class).getFullQualifiedName()));
     }
 
     indicesWithCustomErrorHandlers =

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/AbstractOperationHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/AbstractOperationHandler.java
@@ -14,7 +14,6 @@ import io.camunda.zeebe.exporter.common.cache.ExporterEntityCache;
 import io.camunda.zeebe.exporter.common.cache.batchoperation.CachedBatchOperationEntity;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordValue;
-import io.camunda.zeebe.util.VisibleForTesting;
 
 public abstract class AbstractOperationHandler<T extends ExporterEntity<T>, R extends RecordValue>
     implements ExportHandler<T, R> {
@@ -22,7 +21,7 @@ public abstract class AbstractOperationHandler<T extends ExporterEntity<T>, R ex
   protected static final String ID_PATTERN = "%s_%s";
   protected final String indexName;
   protected final ExporterEntityCache<String, CachedBatchOperationEntity> batchOperationCache;
-  @VisibleForTesting final OperationType relevantOperationType;
+  private final OperationType relevantOperationType;
 
   public AbstractOperationHandler(
       final String indexName,
@@ -31,6 +30,10 @@ public abstract class AbstractOperationHandler<T extends ExporterEntity<T>, R ex
     this.indexName = indexName;
     this.batchOperationCache = batchOperationCache;
     this.relevantOperationType = relevantOperationType;
+  }
+
+  public OperationType getRelevantOperationType() {
+    return relevantOperationType;
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/AbstractOperationHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/AbstractOperationHandler.java
@@ -7,25 +7,33 @@
  */
 package io.camunda.exporter.handlers.batchoperation;
 
-import io.camunda.webapps.schema.entities.operation.OperationEntity;
+import io.camunda.exporter.handlers.ExportHandler;
+import io.camunda.webapps.schema.entities.ExporterEntity;
+import io.camunda.webapps.schema.entities.operation.OperationType;
+import io.camunda.zeebe.exporter.common.cache.ExporterEntityCache;
+import io.camunda.zeebe.exporter.common.cache.batchoperation.CachedBatchOperationEntity;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordValue;
+import io.camunda.zeebe.util.VisibleForTesting;
 
-public class AbstractOperationHandler {
+public abstract class AbstractOperationHandler<T extends ExporterEntity<T>, R extends RecordValue>
+    implements ExportHandler<T, R> {
 
   protected static final String ID_PATTERN = "%s_%s";
   protected final String indexName;
+  protected final ExporterEntityCache<String, CachedBatchOperationEntity> batchOperationCache;
+  @VisibleForTesting final OperationType relevantOperationType;
 
-  public AbstractOperationHandler(final String indexName) {
+  public AbstractOperationHandler(
+      final String indexName,
+      final ExporterEntityCache<String, CachedBatchOperationEntity> batchOperationCache,
+      final OperationType relevantOperationType) {
     this.indexName = indexName;
+    this.batchOperationCache = batchOperationCache;
+    this.relevantOperationType = relevantOperationType;
   }
 
-  public Class<OperationEntity> getEntityType() {
-    return OperationEntity.class;
-  }
-
-  public OperationEntity createNewEntity(final String id) {
-    return new OperationEntity().setId(id);
-  }
-
+  @Override
   public String getIndexName() {
     return indexName;
   }
@@ -40,5 +48,30 @@ public class AbstractOperationHandler {
    */
   protected String generateId(final long batchOperationKey, final long itemKey) {
     return String.format(ID_PATTERN, batchOperationKey, itemKey);
+  }
+
+  /**
+   * Checks if the record is relevant for the batch operation type handled by this handler. The
+   * record is relevant, when the operationType of the overall batch operation is the same as the
+   * monitored batch operation type of this record.<br>
+   * <br>
+   * This needs to be checked, because the <code>Record.getBatchOperationReference()</code> is
+   * present for all follow-up records of the actual operation command and not just the direct
+   * response record. E.g. an incident present on a canceled process instance is also resolved
+   * during the cancellation and the appended <code>Incident.RESOLVED</code> also has a valid
+   * batchOperationReference.
+   *
+   * @param record the record to check for relevance
+   * @return true if the record is relevant, otherwise false
+   */
+  protected boolean isRelevantForBatchOperation(final Record<R> record) {
+    final var cachedEntity =
+        batchOperationCache.get(String.valueOf(record.getBatchOperationReference()));
+
+    return cachedEntity
+        .filter(
+            cachedBatchOperationEntity ->
+                cachedBatchOperationEntity.type() == relevantOperationType)
+        .isPresent();
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/listview/AbstractProcessInstanceFromOperationItemHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/listview/AbstractProcessInstanceFromOperationItemHandler.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.handlers.batchoperation.listview;
+
+import static io.camunda.zeebe.protocol.record.RecordMetadataDecoder.batchOperationReferenceNullValue;
+
+import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.handlers.batchoperation.AbstractOperationHandler;
+import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.entities.listview.ProcessInstanceForListViewEntity;
+import io.camunda.webapps.schema.entities.operation.OperationType;
+import io.camunda.zeebe.exporter.common.cache.ExporterEntityCache;
+import io.camunda.zeebe.exporter.common.cache.batchoperation.CachedBatchOperationEntity;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordValue;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceRelated;
+import java.util.List;
+import java.util.Map;
+
+public abstract class AbstractProcessInstanceFromOperationItemHandler<
+        R extends RecordValue & ProcessInstanceRelated>
+    extends AbstractOperationHandler<ProcessInstanceForListViewEntity, R> {
+
+  protected AbstractProcessInstanceFromOperationItemHandler(
+      final String indexName,
+      final ExporterEntityCache<String, CachedBatchOperationEntity> batchOperationCache,
+      final OperationType relevantOperationType) {
+    super(indexName, batchOperationCache, relevantOperationType);
+  }
+
+  @Override
+  public Class<ProcessInstanceForListViewEntity> getEntityType() {
+    return ProcessInstanceForListViewEntity.class;
+  }
+
+  @Override
+  public boolean handlesRecord(final Record<R> record) {
+    return record.getBatchOperationReference() != batchOperationReferenceNullValue()
+        && (isCompleted(record) || isFailed(record))
+        && isRelevantForBatchOperation(record);
+  }
+
+  @Override
+  public List<String> generateIds(final Record<R> record) {
+    return List.of(String.valueOf(record.getValue().getProcessInstanceKey()));
+  }
+
+  @Override
+  public ProcessInstanceForListViewEntity createNewEntity(final String id) {
+    return new ProcessInstanceForListViewEntity().setId(id);
+  }
+
+  @Override
+  public void updateEntity(final Record<R> record, final ProcessInstanceForListViewEntity entity) {
+    entity.setBatchOperationIds(List.of(String.valueOf(record.getBatchOperationReference())));
+  }
+
+  @Override
+  public void flush(final ProcessInstanceForListViewEntity entity, final BatchRequest batchRequest)
+      throws PersistenceException {
+    final String script =
+        "if (ctx._source.batchOperationIds == null){"
+            + "ctx._source.batchOperationIds = new String[]{params.batchOperationId};"
+            + "} else if (!ctx._source.batchOperationIds.contains(params.batchOperationId)) {"
+            + "ctx._source.batchOperationIds.add(params.batchOperationId);"
+            + "}";
+    batchRequest.updateWithScript(
+        indexName,
+        entity.getId(),
+        script,
+        Map.of("batchOperationId", entity.getBatchOperationIds().getFirst()));
+  }
+
+  protected abstract boolean isFailed(final Record<R> record);
+
+  protected abstract boolean isCompleted(final Record<R> record);
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/listview/ListViewFromChunkItemHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/listview/ListViewFromChunkItemHandler.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.handlers.batchoperation.listview;
+
+import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.handlers.ExportHandler;
+import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.entities.listview.ProcessInstanceForListViewEntity;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.BatchOperationChunkIntent;
+import io.camunda.zeebe.protocol.record.value.BatchOperationChunkRecordValue;
+import java.util.List;
+import java.util.Map;
+
+public class ListViewFromChunkItemHandler
+    implements ExportHandler<ProcessInstanceForListViewEntity, BatchOperationChunkRecordValue> {
+  private final String indexName;
+
+  public ListViewFromChunkItemHandler(final String indexName) {
+    this.indexName = indexName;
+  }
+
+  @Override
+  public ValueType getHandledValueType() {
+    return ValueType.BATCH_OPERATION_CHUNK;
+  }
+
+  @Override
+  public Class<ProcessInstanceForListViewEntity> getEntityType() {
+    return ProcessInstanceForListViewEntity.class;
+  }
+
+  @Override
+  public boolean handlesRecord(final Record<BatchOperationChunkRecordValue> record) {
+    return record.getIntent().equals(BatchOperationChunkIntent.CREATED);
+  }
+
+  @Override
+  public List<String> generateIds(final Record<BatchOperationChunkRecordValue> record) {
+    return record.getValue().getItems().stream()
+        .map(item -> String.valueOf(item.getProcessInstanceKey()))
+        .toList();
+  }
+
+  @Override
+  public ProcessInstanceForListViewEntity createNewEntity(final String id) {
+    return new ProcessInstanceForListViewEntity().setId(id);
+  }
+
+  @Override
+  public void updateEntity(
+      final Record<BatchOperationChunkRecordValue> record,
+      final ProcessInstanceForListViewEntity entity) {
+    entity.setBatchOperationIds(List.of(String.valueOf(record.getBatchOperationReference())));
+  }
+
+  @Override
+  public void flush(final ProcessInstanceForListViewEntity entity, final BatchRequest batchRequest)
+      throws PersistenceException {
+    final String script =
+        "if (ctx._source.batchOperationIds == null){"
+            + "ctx._source.batchOperationIds = new String[]{params.batchOperationId};"
+            + "} else {"
+            + "ctx._source.batchOperationIds.add(params.batchOperationId);"
+            + "}";
+    batchRequest.updateWithScript(
+        indexName,
+        entity.getId(),
+        script,
+        Map.of("batchOperationId", entity.getBatchOperationIds().getFirst()));
+  }
+
+  @Override
+  public String getIndexName() {
+    return indexName;
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/listview/ListViewFromIncidentResolutionOperationHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/listview/ListViewFromIncidentResolutionOperationHandler.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.handlers.batchoperation.listview;
+
+import io.camunda.webapps.schema.entities.operation.OperationType;
+import io.camunda.zeebe.exporter.common.cache.ExporterEntityCache;
+import io.camunda.zeebe.exporter.common.cache.batchoperation.CachedBatchOperationEntity;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
+import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
+
+public class ListViewFromIncidentResolutionOperationHandler
+    extends AbstractProcessInstanceFromOperationItemHandler<IncidentRecordValue> {
+
+  public ListViewFromIncidentResolutionOperationHandler(
+      final String indexName,
+      final ExporterEntityCache<String, CachedBatchOperationEntity> batchOperationCache) {
+    super(indexName, batchOperationCache, OperationType.RESOLVE_INCIDENT);
+  }
+
+  @Override
+  public ValueType getHandledValueType() {
+    return ValueType.INCIDENT;
+  }
+
+  @Override
+  protected boolean isFailed(final Record<IncidentRecordValue> record) {
+    return record.getIntent().equals(IncidentIntent.RESOLVE)
+        && record.getRejectionType() != RejectionType.NULL_VAL;
+  }
+
+  @Override
+  protected boolean isCompleted(final Record<IncidentRecordValue> record) {
+    return record.getIntent() == IncidentIntent.RESOLVED;
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/listview/ListViewFromProcessInstanceCancellationOperationHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/listview/ListViewFromProcessInstanceCancellationOperationHandler.java
@@ -35,14 +35,21 @@ public class ListViewFromProcessInstanceCancellationOperationHandler
     return record.getValue().getBpmnElementType() == BpmnElementType.PROCESS;
   }
 
+  private boolean isRootProcessInstance(final Record<ProcessInstanceRecordValue> record) {
+    return record.getValue().getParentProcessInstanceKey() == -1;
+  }
+
   @Override
   protected boolean isFailed(final Record<ProcessInstanceRecordValue> record) {
-    return record.getIntent().equals(ProcessInstanceIntent.CANCEL)
+    return isRootProcessInstance(record)
+        && record.getIntent().equals(ProcessInstanceIntent.CANCEL)
         && record.getRejectionType() != RejectionType.NULL_VAL;
   }
 
   @Override
   protected boolean isCompleted(final Record<ProcessInstanceRecordValue> record) {
-    return isProcess(record) && record.getIntent() == ProcessInstanceIntent.ELEMENT_TERMINATED;
+    return isProcess(record)
+        && isRootProcessInstance(record)
+        && record.getIntent() == ProcessInstanceIntent.ELEMENT_TERMINATED;
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/listview/ListViewFromProcessInstanceCancellationOperationHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/listview/ListViewFromProcessInstanceCancellationOperationHandler.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.handlers.batchoperation.listview;
+
+import io.camunda.webapps.schema.entities.operation.OperationType;
+import io.camunda.zeebe.exporter.common.cache.ExporterEntityCache;
+import io.camunda.zeebe.exporter.common.cache.batchoperation.CachedBatchOperationEntity;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
+
+public class ListViewFromProcessInstanceCancellationOperationHandler
+    extends AbstractProcessInstanceFromOperationItemHandler<ProcessInstanceRecordValue> {
+
+  public ListViewFromProcessInstanceCancellationOperationHandler(
+      final String indexName,
+      final ExporterEntityCache<String, CachedBatchOperationEntity> batchOperationCache) {
+    super(indexName, batchOperationCache, OperationType.CANCEL_PROCESS_INSTANCE);
+  }
+
+  @Override
+  public ValueType getHandledValueType() {
+    return ValueType.PROCESS_INSTANCE;
+  }
+
+  private boolean isProcess(final Record<ProcessInstanceRecordValue> record) {
+    return record.getValue().getBpmnElementType() == BpmnElementType.PROCESS;
+  }
+
+  @Override
+  protected boolean isFailed(final Record<ProcessInstanceRecordValue> record) {
+    return record.getIntent().equals(ProcessInstanceIntent.CANCEL)
+        && record.getRejectionType() != RejectionType.NULL_VAL;
+  }
+
+  @Override
+  protected boolean isCompleted(final Record<ProcessInstanceRecordValue> record) {
+    return isProcess(record) && record.getIntent() == ProcessInstanceIntent.ELEMENT_TERMINATED;
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/listview/ListViewFromProcessInstanceMigrationOperationHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/listview/ListViewFromProcessInstanceMigrationOperationHandler.java
@@ -14,10 +14,10 @@ import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceMigrationIntent;
-import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceMigrationRecordValue;
 
 public class ListViewFromProcessInstanceMigrationOperationHandler
-    extends AbstractProcessInstanceFromOperationItemHandler<ProcessInstanceRecordValue> {
+    extends AbstractProcessInstanceFromOperationItemHandler<ProcessInstanceMigrationRecordValue> {
 
   public ListViewFromProcessInstanceMigrationOperationHandler(
       final String indexName,
@@ -31,13 +31,13 @@ public class ListViewFromProcessInstanceMigrationOperationHandler
   }
 
   @Override
-  protected boolean isFailed(final Record<ProcessInstanceRecordValue> record) {
+  protected boolean isFailed(final Record<ProcessInstanceMigrationRecordValue> record) {
     return record.getIntent().equals(ProcessInstanceMigrationIntent.MIGRATE)
         && record.getRejectionType() != RejectionType.NULL_VAL;
   }
 
   @Override
-  protected boolean isCompleted(final Record<ProcessInstanceRecordValue> record) {
+  protected boolean isCompleted(final Record<ProcessInstanceMigrationRecordValue> record) {
     return record.getIntent().equals(ProcessInstanceMigrationIntent.MIGRATED);
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/listview/ListViewFromProcessInstanceMigrationOperationHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/listview/ListViewFromProcessInstanceMigrationOperationHandler.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.handlers.batchoperation.listview;
+
+import io.camunda.webapps.schema.entities.operation.OperationType;
+import io.camunda.zeebe.exporter.common.cache.ExporterEntityCache;
+import io.camunda.zeebe.exporter.common.cache.batchoperation.CachedBatchOperationEntity;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceMigrationIntent;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
+
+public class ListViewFromProcessInstanceMigrationOperationHandler
+    extends AbstractProcessInstanceFromOperationItemHandler<ProcessInstanceRecordValue> {
+
+  public ListViewFromProcessInstanceMigrationOperationHandler(
+      final String indexName,
+      final ExporterEntityCache<String, CachedBatchOperationEntity> batchOperationCache) {
+    super(indexName, batchOperationCache, OperationType.MIGRATE_PROCESS_INSTANCE);
+  }
+
+  @Override
+  public ValueType getHandledValueType() {
+    return ValueType.PROCESS_INSTANCE_MIGRATION;
+  }
+
+  @Override
+  protected boolean isFailed(final Record<ProcessInstanceRecordValue> record) {
+    return record.getIntent().equals(ProcessInstanceMigrationIntent.MIGRATE)
+        && record.getRejectionType() != RejectionType.NULL_VAL;
+  }
+
+  @Override
+  protected boolean isCompleted(final Record<ProcessInstanceRecordValue> record) {
+    return record.getIntent().equals(ProcessInstanceMigrationIntent.MIGRATED);
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/listview/ListViewFromProcessInstanceModificationOperationHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/listview/ListViewFromProcessInstanceModificationOperationHandler.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.handlers.batchoperation.listview;
+
+import io.camunda.webapps.schema.entities.operation.OperationType;
+import io.camunda.zeebe.exporter.common.cache.ExporterEntityCache;
+import io.camunda.zeebe.exporter.common.cache.batchoperation.CachedBatchOperationEntity;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceModificationIntent;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
+
+public class ListViewFromProcessInstanceModificationOperationHandler
+    extends AbstractProcessInstanceFromOperationItemHandler<ProcessInstanceRecordValue> {
+
+  public ListViewFromProcessInstanceModificationOperationHandler(
+      final String indexName,
+      final ExporterEntityCache<String, CachedBatchOperationEntity> batchOperationCache) {
+    super(indexName, batchOperationCache, OperationType.MODIFY_PROCESS_INSTANCE);
+  }
+
+  @Override
+  public ValueType getHandledValueType() {
+    return ValueType.PROCESS_INSTANCE_MODIFICATION;
+  }
+
+  @Override
+  protected boolean isFailed(final Record<ProcessInstanceRecordValue> record) {
+    return record.getIntent().equals(ProcessInstanceModificationIntent.MODIFY)
+        && record.getRejectionType() != RejectionType.NULL_VAL;
+  }
+
+  @Override
+  protected boolean isCompleted(final Record<ProcessInstanceRecordValue> record) {
+    return record.getIntent() == ProcessInstanceModificationIntent.MODIFIED;
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/listview/ListViewFromProcessInstanceModificationOperationHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/listview/ListViewFromProcessInstanceModificationOperationHandler.java
@@ -14,10 +14,11 @@ import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceModificationIntent;
-import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceModificationRecordValue;
 
 public class ListViewFromProcessInstanceModificationOperationHandler
-    extends AbstractProcessInstanceFromOperationItemHandler<ProcessInstanceRecordValue> {
+    extends AbstractProcessInstanceFromOperationItemHandler<
+        ProcessInstanceModificationRecordValue> {
 
   public ListViewFromProcessInstanceModificationOperationHandler(
       final String indexName,
@@ -31,13 +32,13 @@ public class ListViewFromProcessInstanceModificationOperationHandler
   }
 
   @Override
-  protected boolean isFailed(final Record<ProcessInstanceRecordValue> record) {
+  protected boolean isFailed(final Record<ProcessInstanceModificationRecordValue> record) {
     return record.getIntent().equals(ProcessInstanceModificationIntent.MODIFY)
         && record.getRejectionType() != RejectionType.NULL_VAL;
   }
 
   @Override
-  protected boolean isCompleted(final Record<ProcessInstanceRecordValue> record) {
+  protected boolean isCompleted(final Record<ProcessInstanceModificationRecordValue> record) {
     return record.getIntent() == ProcessInstanceModificationIntent.MODIFIED;
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/BatchOperationChunkCreatedItemHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/BatchOperationChunkCreatedItemHandlerTest.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.handlers.batchoperation;
+
+import static io.camunda.exporter.handlers.batchoperation.BatchOperationChunkCreatedItemHandler.ID_PATTERN;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.template.OperationTemplate;
+import io.camunda.webapps.schema.entities.operation.OperationEntity;
+import io.camunda.webapps.schema.entities.operation.OperationState;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.BatchOperationChunkIntent;
+import io.camunda.zeebe.protocol.record.value.BatchOperationChunkRecordValue;
+import io.camunda.zeebe.protocol.record.value.BatchOperationChunkRecordValue.BatchOperationItemValue;
+import io.camunda.zeebe.protocol.record.value.ImmutableBatchOperationChunkRecordValue;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class BatchOperationChunkCreatedItemHandlerTest {
+  private final String indexName = "test-" + OperationTemplate.INDEX_NAME;
+
+  private final ProtocolFactory factory = new ProtocolFactory();
+  private final BatchOperationChunkCreatedItemHandler underTest =
+      new BatchOperationChunkCreatedItemHandler(indexName);
+
+  @Test
+  void testGetHandledValueType() {
+    assertThat(underTest.getHandledValueType()).isEqualTo(ValueType.BATCH_OPERATION_CHUNK);
+  }
+
+  @Test
+  void testGetEntityType() {
+    assertThat(underTest.getEntityType()).isEqualTo(OperationEntity.class);
+  }
+
+  @Test
+  void shouldHandleChunkCreatedRecord() {
+    // given
+    final Record<BatchOperationChunkRecordValue> record =
+        factory.generateRecordWithIntent(
+            ValueType.BATCH_OPERATION_CHUNK, BatchOperationChunkIntent.CREATED);
+
+    // when - then
+    assertThat(underTest.handlesRecord(record)).isTrue();
+  }
+
+  @Test
+  void shouldGenerateIds() {
+    // given
+    final int numItems = 3;
+    final Record<BatchOperationChunkRecordValue> record = aChunkRecordWithMultipleItems(numItems);
+
+    // when
+    final var idList = underTest.generateIds(record);
+
+    // then
+    assertThat(idList).hasSize(numItems);
+    final long batchOperationKey = record.getValue().getBatchOperationKey();
+    record
+        .getValue()
+        .getItems()
+        .forEach(
+            item -> {
+              final String expectedId =
+                  String.format(ID_PATTERN, batchOperationKey, item.getItemKey());
+              assertThat(idList).contains(expectedId);
+            });
+  }
+
+  @Test
+  void shouldCreateNewEntity() {
+    // when
+    final var result = underTest.createNewEntity("id");
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.getId()).isEqualTo("id");
+  }
+
+  @Test
+  void shouldUpdateEntityFromRecord() {
+    // given
+    final int numItems = 3;
+    final Record<BatchOperationChunkRecordValue> record = aChunkRecordWithMultipleItems(numItems);
+    final var item = record.getValue().getItems().getFirst();
+    final String expectedId =
+        String.format(ID_PATTERN, record.getValue().getBatchOperationKey(), item.getItemKey());
+
+    // when
+    final var entity = underTest.createNewEntity(expectedId);
+    underTest.updateEntity(record, entity);
+
+    // then
+    assertThat(entity.getId()).isEqualTo(expectedId);
+    assertThat(entity.getBatchOperationId())
+        .isEqualTo(String.valueOf(record.getValue().getBatchOperationKey()));
+    assertThat(entity.getState()).isEqualTo(OperationState.SCHEDULED);
+    assertThat(entity.getProcessInstanceKey()).isEqualTo(item.getProcessInstanceKey());
+  }
+
+  @Test
+  void shouldFlushEntity() {
+    // given
+    final var mockRequest = mock(BatchRequest.class);
+    final Record<BatchOperationChunkRecordValue> record =
+        factory.generateRecordWithIntent(
+            ValueType.BATCH_OPERATION_CHUNK, BatchOperationChunkIntent.CREATED);
+    final var item = record.getValue().getItems().getFirst();
+    final String expectedId =
+        String.format(ID_PATTERN, record.getValue().getBatchOperationKey(), item.getItemKey());
+    final var entity = underTest.createNewEntity(expectedId);
+    underTest.updateEntity(record, entity);
+
+    // when
+    underTest.flush(entity, mockRequest); // Assuming null is acceptable for this test
+
+    // then
+    final var entityCaptor = ArgumentCaptor.forClass(OperationEntity.class);
+    verify(mockRequest).add(eq(indexName), entityCaptor.capture());
+    final var capturedEntity = entityCaptor.getValue();
+    assertThat(capturedEntity).isEqualTo(entity);
+  }
+
+  private Record<BatchOperationChunkRecordValue> aChunkRecordWithMultipleItems(final int numItems) {
+    final List<BatchOperationItemValue> items = new ArrayList<>();
+    for (int i = 0; i < numItems; i++) {
+      final BatchOperationItemValue item = factory.generateObject(BatchOperationItemValue.class);
+      items.add(item);
+    }
+    final var value =
+        ImmutableBatchOperationChunkRecordValue.builder()
+            .from(factory.generateObject(BatchOperationChunkRecordValue.class))
+            .withItems(items)
+            .build();
+    return factory.generateRecord(
+        ValueType.BATCH_OPERATION_CHUNK,
+        r -> r.withValue(value),
+        BatchOperationChunkIntent.CREATED);
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/BatchOperationStatusHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/BatchOperationStatusHandlerTest.java
@@ -63,7 +63,7 @@ class BatchOperationStatusHandlerTest {
           .thenReturn(
               Optional.of(
                   new CachedBatchOperationEntity(
-                      String.valueOf(batchOperationKey), handler.relevantOperationType)));
+                      String.valueOf(batchOperationKey), handler.getRelevantOperationType())));
     }
 
     @Test
@@ -89,7 +89,7 @@ class BatchOperationStatusHandlerTest {
       Mockito.reset(batchOperationCache);
       final var otherOperationType =
           Arrays.stream(OperationType.values())
-              .filter(t -> !t.equals(handler.relevantOperationType))
+              .filter(t -> !t.equals(handler.getRelevantOperationType()))
               .findAny()
               .get();
 
@@ -131,7 +131,7 @@ class BatchOperationStatusHandlerTest {
       Mockito.reset(batchOperationCache);
       final var otherOperationType =
           Arrays.stream(OperationType.values())
-              .filter(t -> !t.equals(handler.relevantOperationType))
+              .filter(t -> !t.equals(handler.getRelevantOperationType()))
               .findAny()
               .get();
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/listview/AbstractProcessInstanceFromOperationItemHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/listview/AbstractProcessInstanceFromOperationItemHandlerTest.java
@@ -31,7 +31,7 @@ import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
-public abstract class ProcessInstanceFromOperationItemHandlerTest<
+public abstract class AbstractProcessInstanceFromOperationItemHandlerTest<
     R extends RecordValue & ProcessInstanceRelated> {
   protected static final ExporterEntityCache<String, CachedBatchOperationEntity> CACHE =
       mock(ExporterEntityCache.class);
@@ -39,7 +39,7 @@ public abstract class ProcessInstanceFromOperationItemHandlerTest<
   protected final ProtocolFactory factory = new ProtocolFactory();
   final AbstractProcessInstanceFromOperationItemHandler<R> underTest;
 
-  ProcessInstanceFromOperationItemHandlerTest(
+  AbstractProcessInstanceFromOperationItemHandlerTest(
       final AbstractProcessInstanceFromOperationItemHandler<R> underTest) {
     this.underTest = underTest;
   }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/listview/ListViewFromChunkItemHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/listview/ListViewFromChunkItemHandlerTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.handlers.batchoperation.listview;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+
+import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.template.ListViewTemplate;
+import io.camunda.webapps.schema.entities.listview.ProcessInstanceForListViewEntity;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.BatchOperationChunkIntent;
+import io.camunda.zeebe.protocol.record.value.BatchOperationChunkRecordValue;
+import io.camunda.zeebe.protocol.record.value.BatchOperationChunkRecordValue.BatchOperationItemValue;
+import io.camunda.zeebe.protocol.record.value.ImmutableBatchOperationChunkRecordValue;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class ListViewFromChunkItemHandlerTest {
+  private final String indexName = "test-" + ListViewTemplate.INDEX_NAME;
+  private final ProtocolFactory factory = new ProtocolFactory();
+
+  private final ListViewFromChunkItemHandler underTest =
+      new ListViewFromChunkItemHandler(indexName);
+
+  @Test
+  void testGetHandledValueType() {
+    assertThat(underTest.getHandledValueType()).isEqualTo(ValueType.BATCH_OPERATION_CHUNK);
+  }
+
+  @Test
+  void testGetEntityType() {
+    assertThat(underTest.getEntityType()).isEqualTo(ProcessInstanceForListViewEntity.class);
+  }
+
+  @Test
+  void shouldHandleChunkCreatedRecord() {
+    // given
+    final Record<BatchOperationChunkRecordValue> record =
+        factory.generateRecordWithIntent(
+            ValueType.BATCH_OPERATION_CHUNK, BatchOperationChunkIntent.CREATED);
+
+    // when - then
+    assertThat(underTest.handlesRecord(record)).isTrue();
+  }
+
+  @Test
+  void shouldGenerateIdsFromRecord() {
+    // given
+    final int numItems = 3;
+    final Record<BatchOperationChunkRecordValue> record = aChunkRecordWithMultipleItems(numItems);
+    factory.generateRecordWithIntent(
+        ValueType.BATCH_OPERATION_CHUNK, BatchOperationChunkIntent.CREATED);
+    final var itemPIKeys =
+        record.getValue().getItems().stream()
+            .map(BatchOperationItemValue::getProcessInstanceKey)
+            .map(String::valueOf)
+            .toList();
+    // when
+    final var ids = underTest.generateIds(record);
+
+    // then
+    assertThat(ids).hasSize(numItems);
+    assertThat(ids).containsExactlyInAnyOrderElementsOf(itemPIKeys);
+  }
+
+  @Test
+  void shouldCreateNewEntity() {
+    // when
+    final var result = underTest.createNewEntity("id");
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.getId()).isEqualTo("id");
+  }
+
+  @Test
+  void shouldUpdateEntityFromRecord() {
+    // given
+    final Record<BatchOperationChunkRecordValue> record =
+        factory.generateRecordWithIntent(
+            ValueType.BATCH_OPERATION_CHUNK, BatchOperationChunkIntent.CREATED);
+    final var entity = underTest.createNewEntity("id");
+
+    // when
+    underTest.updateEntity(record, entity);
+
+    // then
+    assertThat(entity.getBatchOperationIds())
+        .containsExactly(String.valueOf(record.getBatchOperationReference()));
+  }
+
+  @Test
+  void shouldFlushEntity() {
+    // given
+    final Record<BatchOperationChunkRecordValue> record =
+        factory.generateRecordWithIntent(
+            ValueType.BATCH_OPERATION_CHUNK, BatchOperationChunkIntent.CREATED);
+    final var entity = underTest.createNewEntity("id");
+    final String batchOpKey = String.valueOf(record.getBatchOperationReference());
+    entity.setBatchOperationIds(List.of(batchOpKey));
+
+    // when
+    final var batchRequest = mock(BatchRequest.class);
+    underTest.flush(entity, batchRequest);
+
+    // then
+    Mockito.verify(batchRequest)
+        .updateWithScript(
+            eq(underTest.getIndexName()),
+            eq(entity.getId()),
+            anyString(),
+            eq(Map.of("batchOperationId", batchOpKey)));
+  }
+
+  private Record<BatchOperationChunkRecordValue> aChunkRecordWithMultipleItems(final int numItems) {
+    final List<BatchOperationItemValue> items = new ArrayList<>();
+    for (int i = 0; i < numItems; i++) {
+      final BatchOperationItemValue item = factory.generateObject(BatchOperationItemValue.class);
+      items.add(item);
+    }
+    final var value =
+        ImmutableBatchOperationChunkRecordValue.builder()
+            .from(factory.generateObject(BatchOperationChunkRecordValue.class))
+            .withItems(items)
+            .build();
+    return factory.generateRecord(
+        ValueType.BATCH_OPERATION_CHUNK,
+        r -> r.withValue(value),
+        BatchOperationChunkIntent.CREATED);
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/listview/ListViewFromIncidentResolutionOperationHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/listview/ListViewFromIncidentResolutionOperationHandlerTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.handlers.batchoperation.listview;
+
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
+import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
+
+class ListViewFromIncidentResolutionOperationHandlerTest
+    extends ProcessInstanceFromOperationItemHandlerTest<IncidentRecordValue> {
+
+  ListViewFromIncidentResolutionOperationHandlerTest() {
+    super(new ListViewFromIncidentResolutionOperationHandler(INDEX_NAME, CACHE));
+  }
+
+  @Override
+  protected io.camunda.zeebe.protocol.record.Record<IncidentRecordValue> createCompletedRecord() {
+    return factory.generateRecord(ValueType.INCIDENT, b -> b.withIntent(IncidentIntent.RESOLVED));
+  }
+
+  @Override
+  protected Record<IncidentRecordValue> createRejectedRecord() {
+    return factory.generateRecord(
+        ValueType.INCIDENT,
+        b -> b.withRejectionType(RejectionType.NOT_FOUND).withIntent(IncidentIntent.RESOLVE));
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/listview/ListViewFromIncidentResolutionOperationHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/listview/ListViewFromIncidentResolutionOperationHandlerTest.java
@@ -14,7 +14,7 @@ import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
 
 class ListViewFromIncidentResolutionOperationHandlerTest
-    extends ProcessInstanceFromOperationItemHandlerTest<IncidentRecordValue> {
+    extends AbstractProcessInstanceFromOperationItemHandlerTest<IncidentRecordValue> {
 
   ListViewFromIncidentResolutionOperationHandlerTest() {
     super(new ListViewFromIncidentResolutionOperationHandler(INDEX_NAME, CACHE));

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/listview/ListViewFromProcessInstanceCancellationOperationHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/listview/ListViewFromProcessInstanceCancellationOperationHandlerTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.handlers.batchoperation.listview;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.ImmutableProcessInstanceRecordValue;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
+import org.junit.jupiter.api.Test;
+
+class ListViewFromProcessInstanceCancellationOperationHandlerTest
+    extends ProcessInstanceFromOperationItemHandlerTest<ProcessInstanceRecordValue> {
+
+  ListViewFromProcessInstanceCancellationOperationHandlerTest() {
+    super(new ListViewFromProcessInstanceCancellationOperationHandler(INDEX_NAME, CACHE));
+  }
+
+  @Test
+  void shouldOnlyHandleRootProcessInstances() {
+    final var value =
+        ImmutableProcessInstanceRecordValue.builder()
+            .from(factory.generateObject(ProcessInstanceRecordValue.class))
+            .withBpmnElementType(BpmnElementType.PROCESS)
+            .withParentProcessInstanceKey(12345) // This is a subprocess
+            .build();
+    final Record<ProcessInstanceRecordValue> record =
+        factory.generateRecord(
+            ValueType.PROCESS_INSTANCE,
+            b -> b.withIntent(ProcessInstanceIntent.ELEMENT_TERMINATED).withValue(value));
+
+    assertThat(underTest.handlesRecord(record)).isFalse();
+  }
+
+  @Override
+  protected Record<ProcessInstanceRecordValue> createCompletedRecord() {
+    final var value =
+        ImmutableProcessInstanceRecordValue.builder()
+            .from(factory.generateObject(ProcessInstanceRecordValue.class))
+            .withBpmnElementType(BpmnElementType.PROCESS)
+            .withParentProcessInstanceKey(-1)
+            .build();
+    return factory.generateRecord(
+        ValueType.PROCESS_INSTANCE,
+        b -> b.withIntent(ProcessInstanceIntent.ELEMENT_TERMINATED).withValue(value));
+  }
+
+  @Override
+  protected Record<ProcessInstanceRecordValue> createRejectedRecord() {
+    final var value =
+        ImmutableProcessInstanceRecordValue.builder()
+            .from(factory.generateObject(ProcessInstanceRecordValue.class))
+            .withBpmnElementType(BpmnElementType.PROCESS)
+            .withParentProcessInstanceKey(-1)
+            .build();
+    return factory.generateRecord(
+        ValueType.PROCESS_INSTANCE,
+        b ->
+            b.withRejectionType(RejectionType.NOT_FOUND)
+                .withIntent(ProcessInstanceIntent.CANCEL)
+                .withValue(value));
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/listview/ListViewFromProcessInstanceCancellationOperationHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/listview/ListViewFromProcessInstanceCancellationOperationHandlerTest.java
@@ -19,7 +19,7 @@ import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
 import org.junit.jupiter.api.Test;
 
 class ListViewFromProcessInstanceCancellationOperationHandlerTest
-    extends ProcessInstanceFromOperationItemHandlerTest<ProcessInstanceRecordValue> {
+    extends AbstractProcessInstanceFromOperationItemHandlerTest<ProcessInstanceRecordValue> {
 
   ListViewFromProcessInstanceCancellationOperationHandlerTest() {
     super(new ListViewFromProcessInstanceCancellationOperationHandler(INDEX_NAME, CACHE));

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/listview/ListViewFromProcessInstanceMigrationOperationHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/listview/ListViewFromProcessInstanceMigrationOperationHandlerTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.handlers.batchoperation.listview;
+
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceMigrationIntent;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceMigrationRecordValue;
+
+class ListViewFromProcessInstanceMigrationOperationHandlerTest
+    extends ProcessInstanceFromOperationItemHandlerTest<ProcessInstanceMigrationRecordValue> {
+
+  ListViewFromProcessInstanceMigrationOperationHandlerTest() {
+    super(new ListViewFromProcessInstanceMigrationOperationHandler(INDEX_NAME, CACHE));
+  }
+
+  @Override
+  protected Record<ProcessInstanceMigrationRecordValue> createCompletedRecord() {
+    return factory.generateRecord(
+        ValueType.PROCESS_INSTANCE_MIGRATION,
+        b -> b.withIntent(ProcessInstanceMigrationIntent.MIGRATED));
+  }
+
+  @Override
+  protected Record<ProcessInstanceMigrationRecordValue> createRejectedRecord() {
+    return factory.generateRecord(
+        ValueType.PROCESS_INSTANCE_MIGRATION,
+        b ->
+            b.withRejectionType(RejectionType.NOT_FOUND)
+                .withIntent(ProcessInstanceMigrationIntent.MIGRATE));
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/listview/ListViewFromProcessInstanceMigrationOperationHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/listview/ListViewFromProcessInstanceMigrationOperationHandlerTest.java
@@ -14,7 +14,8 @@ import io.camunda.zeebe.protocol.record.intent.ProcessInstanceMigrationIntent;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceMigrationRecordValue;
 
 class ListViewFromProcessInstanceMigrationOperationHandlerTest
-    extends ProcessInstanceFromOperationItemHandlerTest<ProcessInstanceMigrationRecordValue> {
+    extends AbstractProcessInstanceFromOperationItemHandlerTest<
+        ProcessInstanceMigrationRecordValue> {
 
   ListViewFromProcessInstanceMigrationOperationHandlerTest() {
     super(new ListViewFromProcessInstanceMigrationOperationHandler(INDEX_NAME, CACHE));

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/listview/ListViewFromProcessInstanceModificationOperationHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/listview/ListViewFromProcessInstanceModificationOperationHandlerTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.handlers.batchoperation.listview;
+
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceModificationIntent;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceModificationRecordValue;
+
+class ListViewFromProcessInstanceModificationOperationHandlerTest
+    extends ProcessInstanceFromOperationItemHandlerTest<ProcessInstanceModificationRecordValue> {
+
+  ListViewFromProcessInstanceModificationOperationHandlerTest() {
+    super(new ListViewFromProcessInstanceModificationOperationHandler(INDEX_NAME, CACHE));
+  }
+
+  @Override
+  protected Record<ProcessInstanceModificationRecordValue> createCompletedRecord() {
+    return factory.generateRecord(
+        ValueType.PROCESS_INSTANCE_MODIFICATION,
+        b -> b.withIntent(ProcessInstanceModificationIntent.MODIFIED));
+  }
+
+  @Override
+  protected Record<ProcessInstanceModificationRecordValue> createRejectedRecord() {
+    return factory.generateRecord(
+        ValueType.PROCESS_INSTANCE_MODIFICATION,
+        b ->
+            b.withRejectionType(RejectionType.NOT_FOUND)
+                .withIntent(ProcessInstanceModificationIntent.MODIFY));
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/listview/ListViewFromProcessInstanceModificationOperationHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/listview/ListViewFromProcessInstanceModificationOperationHandlerTest.java
@@ -14,7 +14,8 @@ import io.camunda.zeebe.protocol.record.intent.ProcessInstanceModificationIntent
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceModificationRecordValue;
 
 class ListViewFromProcessInstanceModificationOperationHandlerTest
-    extends ProcessInstanceFromOperationItemHandlerTest<ProcessInstanceModificationRecordValue> {
+    extends AbstractProcessInstanceFromOperationItemHandlerTest<
+        ProcessInstanceModificationRecordValue> {
 
   ListViewFromProcessInstanceModificationOperationHandlerTest() {
     super(new ListViewFromProcessInstanceModificationOperationHandler(INDEX_NAME, CACHE));

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/listview/ProcessInstanceFromOperationItemHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/listview/ProcessInstanceFromOperationItemHandlerTest.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.handlers.batchoperation.listview;
+
+import static io.camunda.zeebe.protocol.record.RecordMetadataDecoder.batchOperationReferenceNullValue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.template.ListViewTemplate;
+import io.camunda.webapps.schema.entities.operation.OperationType;
+import io.camunda.zeebe.exporter.common.cache.ExporterEntityCache;
+import io.camunda.zeebe.exporter.common.cache.batchoperation.CachedBatchOperationEntity;
+import io.camunda.zeebe.protocol.record.ImmutableRecord;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordValue;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceRelated;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+public abstract class ProcessInstanceFromOperationItemHandlerTest<
+    R extends RecordValue & ProcessInstanceRelated> {
+  protected static final ExporterEntityCache<String, CachedBatchOperationEntity> CACHE =
+      mock(ExporterEntityCache.class);
+  protected static final String INDEX_NAME = "test-" + ListViewTemplate.INDEX_NAME;
+  protected final ProtocolFactory factory = new ProtocolFactory();
+  final AbstractProcessInstanceFromOperationItemHandler<R> underTest;
+
+  ProcessInstanceFromOperationItemHandlerTest(
+      final AbstractProcessInstanceFromOperationItemHandler<R> underTest) {
+    this.underTest = underTest;
+  }
+
+  @Test
+  void shouldHandleCompletedRecord() {
+    // Given
+    final var record = createCompletedRecord();
+    when(CACHE.get(Mockito.anyString()))
+        .thenReturn(
+            Optional.of(
+                new CachedBatchOperationEntity(
+                    String.valueOf(record.getBatchOperationReference()),
+                    underTest.getRelevantOperationType())));
+
+    assertThat(underTest.handlesRecord(record)).isTrue();
+  }
+
+  @Test
+  void shouldHandleRejectedRecord() {
+    // Given
+    final var record = createRejectedRecord();
+    when(CACHE.get(Mockito.anyString()))
+        .thenReturn(
+            Optional.of(
+                new CachedBatchOperationEntity(
+                    String.valueOf(record.getBatchOperationReference()),
+                    underTest.getRelevantOperationType())));
+
+    assertThat(underTest.handlesRecord(record)).isTrue();
+  }
+
+  @Test
+  void shouldNotHandleRecordsWithNoOperationReference() {
+    // Given
+    final var record =
+        ImmutableRecord.<R>builder()
+            .from(createCompletedRecord())
+            .withBatchOperationReference(batchOperationReferenceNullValue())
+            .build();
+    when(CACHE.get(Mockito.anyString()))
+        .thenReturn(
+            Optional.of(
+                new CachedBatchOperationEntity(
+                    String.valueOf(record.getBatchOperationReference()),
+                    underTest.getRelevantOperationType())));
+    // When
+    final boolean result = underTest.handlesRecord(record);
+
+    // Then
+    assertThat(result).isFalse();
+  }
+
+  @Test
+  void shouldNotHandleIrrelevantRecord() {
+    // Given
+    final var record = createCompletedRecord();
+    final var irrelevantOperationType =
+        Arrays.stream(OperationType.values())
+            .filter(t -> t != underTest.getRelevantOperationType())
+            .findFirst()
+            .get();
+
+    when(CACHE.get(Mockito.anyString()))
+        .thenReturn(
+            Optional.of(
+                new CachedBatchOperationEntity(
+                    String.valueOf(record.getBatchOperationReference()), irrelevantOperationType)));
+
+    // When
+    final boolean result = underTest.handlesRecord(record);
+
+    // Then
+    assertThat(result).isFalse();
+  }
+
+  @Test
+  void shouldGenerateId() {
+    // Given
+    final var record = createCompletedRecord();
+
+    // When
+    final var idList = underTest.generateIds(record);
+
+    // Then
+    assertThat(idList).containsExactly(String.valueOf(record.getValue().getProcessInstanceKey()));
+  }
+
+  @Test
+  void shouldUpdateEntityFromRecord() {
+    // Given
+    final var record = createCompletedRecord();
+    final var entity = underTest.createNewEntity("test-id");
+
+    // When
+    underTest.updateEntity(record, entity);
+
+    // Then
+    assertThat(entity.getBatchOperationIds())
+        .containsExactly(String.valueOf(record.getBatchOperationReference()));
+  }
+
+  @Test
+  void shouldFlushEntity() {
+    // Given
+    final var entity = underTest.createNewEntity("test-id");
+    entity.setBatchOperationIds(List.of("batch-op-1"));
+    final var batchRequest = mock(BatchRequest.class);
+
+    // When
+    underTest.flush(entity, batchRequest);
+
+    // Then
+    Mockito.verify(batchRequest)
+        .updateWithScript(
+            eq(underTest.getIndexName()),
+            eq(entity.getId()),
+            anyString(),
+            eq(Map.of("batchOperationId", "batch-op-1")));
+  }
+
+  protected abstract Record<R> createCompletedRecord();
+
+  protected abstract Record<R> createRejectedRecord();
+}


### PR DESCRIPTION
## Description

Adds feature to search process instances by the existing batchOperationIds filter via V2 REST API:
- added JOIN filter to ProcessInstanceMapper.xml (didn't exist at all)
- added update scripts to update the listview index with a batchOperationId when a Zeebe batch operation is processed

Notes:
- For CamundaExporter this had major performance issues:
  - When `exportItemsOnCreation` is `true`, the handler now executes two updates for each batch operation item: The insert into the `_operation` index and the update script for the `_list-view index`
  - Independently of the `exportItemsOnCreation` setting, the OperationStatusUpdate handlers will now always execute two updates: The upsert into the `_operation` index and the update script for the `_list-view index`. The last updateWithScript only changes the document if the batchOperation is not already in the document.

## Related issues

closes #35234