### PR TITLE
30477 fix generate snapshot and concurrency group

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1281,6 +1281,7 @@ jobs:
     secrets: inherit
     permissions:
       contents: read
+    if: always() && needs.check-results.result == 'success'
     with:
       job_to_run: 'concurrency-group'
       base_group_name: deploy-maven-snapshot
@@ -1337,6 +1338,7 @@ jobs:
     secrets: inherit
     permissions:
       contents: read
+    if: always() && needs.check-results.result == 'success'
     with:
       base_group_name: deploy-camunda-docker-snapshot
 

--- a/.github/workflows/generate-snapshot-docker-tag-and-concurrency-group.yml
+++ b/.github/workflows/generate-snapshot-docker-tag-and-concurrency-group.yml
@@ -36,8 +36,8 @@ jobs:
     timeout-minutes: 3
     permissions: {}
     if: >-
-      always() &&
-      github.repository == 'camunda/camunda' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/stable/')) &&
+      github.repository == 'camunda/camunda' &&
+      (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/stable/')) &&
       (inputs.job_to_run == 'all' || inputs.job_to_run == 'snapshot-tag')
     outputs:
       tag: ${{ steps.set_docker_snapshot_version_tag.outputs.tag }}
@@ -61,9 +61,10 @@ jobs:
     timeout-minutes: 3
     permissions: { }
     if: >-
-      always() &&
-      github.repository == 'camunda/camunda' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/stable/')) &&
-      (inputs.job_to_run == 'all' || inputs.job_to_run == 'concurrency-group') && inputs.base_group_name != ''
+      github.repository == 'camunda/camunda' &&
+      (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/stable/')) &&
+      (inputs.job_to_run == 'all' || inputs.job_to_run == 'concurrency-group') &&
+      inputs.base_group_name != ''
     outputs:
       result: ${{ steps.split_branch.outputs.result }}
     steps:

--- a/.github/workflows/generate-snapshot-docker-tag-and-concurrency-group.yml
+++ b/.github/workflows/generate-snapshot-docker-tag-and-concurrency-group.yml
@@ -35,8 +35,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 3
     permissions: {}
-    if: (github.repository == 'camunda/camunda' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/stable/'))) &&
-            (inputs.job_to_run == 'all' || inputs.job_to_run == 'snapshot-tag')
+    if: >-
+      (github.repository == 'camunda/camunda' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/stable/')) &&
+      (inputs.job_to_run == 'all' || inputs.job_to_run == 'snapshot-tag'))
     outputs:
       tag: ${{ steps.set_docker_snapshot_version_tag.outputs.tag }}
     steps:
@@ -58,8 +59,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 3
     permissions: { }
-    if: (github.repository == 'camunda/camunda' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/stable/'))) &&
-            (inputs.job_to_run == 'all' || inputs.job_to_run == 'concurrency-group') && inputs.base_group_name != ''
+    if: >-
+      (github.repository == 'camunda/camunda' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/stable/')) &&
+      (inputs.job_to_run == 'all' || inputs.job_to_run == 'concurrency-group') && inputs.base_group_name != '')
     outputs:
       result: ${{ steps.split_branch.outputs.result }}
     steps:

--- a/.github/workflows/generate-snapshot-docker-tag-and-concurrency-group.yml
+++ b/.github/workflows/generate-snapshot-docker-tag-and-concurrency-group.yml
@@ -36,8 +36,9 @@ jobs:
     timeout-minutes: 3
     permissions: {}
     if: >-
-      (github.repository == 'camunda/camunda' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/stable/')) &&
-      (inputs.job_to_run == 'all' || inputs.job_to_run == 'snapshot-tag'))
+      always() &&
+      github.repository == 'camunda/camunda' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/stable/')) &&
+      (inputs.job_to_run == 'all' || inputs.job_to_run == 'snapshot-tag')
     outputs:
       tag: ${{ steps.set_docker_snapshot_version_tag.outputs.tag }}
     steps:
@@ -60,8 +61,9 @@ jobs:
     timeout-minutes: 3
     permissions: { }
     if: >-
-      (github.repository == 'camunda/camunda' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/stable/')) &&
-      (inputs.job_to_run == 'all' || inputs.job_to_run == 'concurrency-group') && inputs.base_group_name != '')
+      always() &&
+      github.repository == 'camunda/camunda' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/stable/')) &&
+      (inputs.job_to_run == 'all' || inputs.job_to_run == 'concurrency-group') && inputs.base_group_name != ''
     outputs:
       result: ${{ steps.split_branch.outputs.result }}
     steps:


### PR DESCRIPTION
## Description

Since the merge of https://github.com/camunda/camunda/pull/35180 we have only failed branch [builds](https://github.com/camunda/camunda/actions/runs/16226945070):
Error when evaluating 'concurrency' for job 'deploy-snapshots'. .github/workflows/ci.yml (Line: 1296, Col: 14): Unexpected value ''
Error when evaluating 'concurrency' for job 'deploy-camunda-docker-snapshot'. .github/workflows/ci.yml (Line: 1351, Col: 14): Unexpected value ''

This PR goal is to fix those and backport them.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
