### PR TITLE
Extend advanced search to support incidentErrorHashCode in OR filter

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/ProcessInstanceFilter.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/ProcessInstanceFilter.java
@@ -182,6 +182,10 @@ public interface ProcessInstanceFilter extends ProcessInstanceFilterBase {
   @Override
   ProcessInstanceFilter incidentErrorHashCode(final Integer incidentErrorHashCode);
 
+  /** Filter by incidentErrorHashCode using {@link IntegerProperty} consumer */
+  @Override
+  ProcessInstanceFilter incidentErrorHashCode(final Consumer<IntegerProperty> fn);
+
   /** Filter by or conjunction using {@link ProcessInstanceFilterBase} consumer */
   ProcessInstanceFilterBase orFilters(List<Consumer<ProcessInstanceFilterBase>> filters);
 }

--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/ProcessInstanceFilterBase.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/ProcessInstanceFilterBase.java
@@ -145,4 +145,7 @@ public interface ProcessInstanceFilterBase extends SearchRequestFilter {
 
   /** Filter by incidentErrorHashCode */
   ProcessInstanceFilterBase incidentErrorHashCode(final Integer incidentErrorHashCode);
+
+  /** Filter by incidentErrorHashCode using {@link IntegerProperty} */
+  ProcessInstanceFilterBase incidentErrorHashCode(final Consumer<IntegerProperty> fn);
 }

--- a/clients/java/src/main/java/io/camunda/client/api/statistics/filter/ProcessDefinitionStatisticsFilter.java
+++ b/clients/java/src/main/java/io/camunda/client/api/statistics/filter/ProcessDefinitionStatisticsFilter.java
@@ -22,6 +22,7 @@ import io.camunda.client.api.search.filter.VariableValueFilter;
 import io.camunda.client.api.search.filter.builder.BasicLongProperty;
 import io.camunda.client.api.search.filter.builder.DateTimeProperty;
 import io.camunda.client.api.search.filter.builder.ElementInstanceStateProperty;
+import io.camunda.client.api.search.filter.builder.IntegerProperty;
 import io.camunda.client.api.search.filter.builder.ProcessInstanceStateProperty;
 import io.camunda.client.api.search.filter.builder.StringProperty;
 import java.time.OffsetDateTime;
@@ -145,6 +146,10 @@ public interface ProcessDefinitionStatisticsFilter extends ProcessDefinitionStat
   /** Filter by incidentErrorHashCode */
   @Override
   ProcessDefinitionStatisticsFilter incidentErrorHashCode(final Integer incidentErrorHashCode);
+
+  /** Filter by incidentErrorHashCode using {@link IntegerProperty} */
+  @Override
+  ProcessDefinitionStatisticsFilter incidentErrorHashCode(final Consumer<IntegerProperty> fn);
 
   /** Filter by or conjunction using {@link ProcessInstanceFilterBase} consumer */
   ProcessDefinitionStatisticsFilter orFilters(

--- a/clients/java/src/main/java/io/camunda/client/api/statistics/filter/ProcessDefinitionStatisticsFilterBase.java
+++ b/clients/java/src/main/java/io/camunda/client/api/statistics/filter/ProcessDefinitionStatisticsFilterBase.java
@@ -21,6 +21,7 @@ import io.camunda.client.api.search.filter.VariableValueFilter;
 import io.camunda.client.api.search.filter.builder.BasicLongProperty;
 import io.camunda.client.api.search.filter.builder.DateTimeProperty;
 import io.camunda.client.api.search.filter.builder.ElementInstanceStateProperty;
+import io.camunda.client.api.search.filter.builder.IntegerProperty;
 import io.camunda.client.api.search.filter.builder.ProcessInstanceStateProperty;
 import io.camunda.client.api.search.filter.builder.StringProperty;
 import io.camunda.client.api.statistics.request.StatisticsRequest.StatisticsRequestFilter;
@@ -121,4 +122,7 @@ public interface ProcessDefinitionStatisticsFilterBase extends StatisticsRequest
 
   /** Filter by incidentErrorHashCode */
   ProcessDefinitionStatisticsFilterBase incidentErrorHashCode(final Integer incidentErrorHashCode);
+
+  /** Filter by incidentErrorHashCode using {@link IntegerProperty} */
+  ProcessDefinitionStatisticsFilterBase incidentErrorHashCode(final Consumer<IntegerProperty> fn);
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/ProcessInstanceFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/ProcessInstanceFilterImpl.java
@@ -313,7 +313,15 @@ public class ProcessInstanceFilterImpl
 
   @Override
   public ProcessInstanceFilter incidentErrorHashCode(final Integer incidentErrorHashCode) {
-    filter.setIncidentErrorHashCode(incidentErrorHashCode);
+    incidentErrorHashCode(b -> b.eq(incidentErrorHashCode));
+    return this;
+  }
+
+  @Override
+  public ProcessInstanceFilter incidentErrorHashCode(final Consumer<IntegerProperty> fn) {
+    final IntegerProperty property = new IntegerPropertyImpl();
+    fn.accept(property);
+    filter.setIncidentErrorHashCode(provideSearchRequestProperty(property));
     return this;
   }
 

--- a/clients/java/src/main/java/io/camunda/client/impl/statistics/filter/ProcessDefinitionStatisticsFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/statistics/filter/ProcessDefinitionStatisticsFilterImpl.java
@@ -21,6 +21,7 @@ import io.camunda.client.api.search.filter.VariableValueFilter;
 import io.camunda.client.api.search.filter.builder.BasicLongProperty;
 import io.camunda.client.api.search.filter.builder.DateTimeProperty;
 import io.camunda.client.api.search.filter.builder.ElementInstanceStateProperty;
+import io.camunda.client.api.search.filter.builder.IntegerProperty;
 import io.camunda.client.api.search.filter.builder.ProcessInstanceStateProperty;
 import io.camunda.client.api.search.filter.builder.StringProperty;
 import io.camunda.client.api.statistics.filter.ProcessDefinitionStatisticsFilter;
@@ -29,6 +30,7 @@ import io.camunda.client.impl.search.filter.VariableFilterMapper;
 import io.camunda.client.impl.search.filter.builder.BasicLongPropertyImpl;
 import io.camunda.client.impl.search.filter.builder.DateTimePropertyImpl;
 import io.camunda.client.impl.search.filter.builder.ElementInstanceStatePropertyImpl;
+import io.camunda.client.impl.search.filter.builder.IntegerPropertyImpl;
 import io.camunda.client.impl.search.filter.builder.ProcessInstanceStatePropertyImpl;
 import io.camunda.client.impl.search.filter.builder.StringPropertyImpl;
 import io.camunda.client.impl.search.request.TypedSearchRequestPropertyProvider;
@@ -248,7 +250,16 @@ public class ProcessDefinitionStatisticsFilterImpl
   @Override
   public ProcessDefinitionStatisticsFilter incidentErrorHashCode(
       final Integer incidentErrorHashCode) {
-    filter.setIncidentErrorHashCode(incidentErrorHashCode);
+    incidentErrorHashCode(b -> b.eq(incidentErrorHashCode));
+    return this;
+  }
+
+  @Override
+  public ProcessDefinitionStatisticsFilter incidentErrorHashCode(
+      final Consumer<IntegerProperty> fn) {
+    final IntegerProperty property = new IntegerPropertyImpl();
+    fn.accept(property);
+    filter.setIncidentErrorHashCode(provideSearchRequestProperty(property));
     return this;
   }
 

--- a/clients/java/src/test/java/io/camunda/client/process/ProcessDefinitionStatisticsTest.java
+++ b/clients/java/src/test/java/io/camunda/client/process/ProcessDefinitionStatisticsTest.java
@@ -118,7 +118,7 @@ public class ProcessDefinitionStatisticsTest extends ClientRestTest {
     assertThat(filter.getElementInstanceState().get$Eq())
         .isEqualTo(ElementInstanceStateEnum.ACTIVE);
     assertThat(filter.getHasElementInstanceIncident()).isEqualTo(true);
-    assertThat(filter.getIncidentErrorHashCode()).isEqualTo(123456789);
+    assertThat(filter.getIncidentErrorHashCode().get$Eq()).isEqualTo(123456789);
   }
 
   @Test

--- a/clients/java/src/test/java/io/camunda/client/process/QueryProcessInstanceTest.java
+++ b/clients/java/src/test/java/io/camunda/client/process/QueryProcessInstanceTest.java
@@ -129,7 +129,7 @@ public class QueryProcessInstanceTest extends ClientRestTest {
     assertThat(filter.getElementInstanceState().get$Eq())
         .isEqualTo(ElementInstanceStateEnum.ACTIVE);
     assertThat(filter.getHasElementInstanceIncident()).isEqualTo(true);
-    assertThat(filter.getIncidentErrorHashCode()).isEqualTo(123456789);
+    assertThat(filter.getIncidentErrorHashCode().get$Eq()).isEqualTo(123456789);
   }
 
   @Test

--- a/db/rdbms/src/main/resources/mapper/ProcessDefinitionMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/ProcessDefinitionMapper.xml
@@ -275,13 +275,15 @@
           )
         </foreach>
       </if>
-      <if test="filter.incidentErrorHashCodes != null and !filter.incidentErrorHashCodes.isEmpty()">
+      <if test="filter.incidentErrorHashCodeOperations != null and !filter.incidentErrorHashCodeOperations.isEmpty()">
+        <foreach collection="filter.incidentErrorHashCodeOperations" item="operation">
           AND EXISTS (
           SELECT 1
           FROM INCIDENT i
           WHERE i.PROCESS_INSTANCE_KEY = pi.PROCESS_INSTANCE_KEY
-          AND i.ERROR_MESSAGE_HASH IN <foreach collection="filter.incidentErrorHashCodes" item="value" open="(" separator=", " close=")">#{value}</foreach>
+          AND i.ERROR_MESSAGE_HASH <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition" />
         )
+        </foreach>
       </if>
     </trim>
   </sql>

--- a/db/rdbms/src/main/resources/mapper/ProcessInstanceMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/ProcessInstanceMapper.xml
@@ -238,13 +238,15 @@
         )
       </foreach>
     </if>
-    <if test="filter.incidentErrorHashCodes != null and !filter.incidentErrorHashCodes.isEmpty()">
+    <if test="filter.incidentErrorHashCodeOperations != null and !filter.incidentErrorHashCodeOperations.isEmpty()">
+      <foreach collection="filter.incidentErrorHashCodeOperations" item="operation">
         AND EXISTS (
         SELECT 1
         FROM INCIDENT i
         WHERE i.PROCESS_INSTANCE_KEY = pi.PROCESS_INSTANCE_KEY
-        AND i.ERROR_MESSAGE_HASH IN <foreach collection="filter.incidentErrorHashCodes" item="value" open="(" separator=", " close=")">#{value}</foreach>
-      )
+        AND i.ERROR_MESSAGE_HASH <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+        )
+      </foreach>
     </if>
       <if test="filter.batchOperationIdOperations != null and !filter.batchOperationIdOperations.isEmpty()">
         AND EXISTS (

--- a/search/search-client-elasticsearch/src/main/java/io/camunda/search/es/transformers/ElasticsearchTransformers.java
+++ b/search/search-client-elasticsearch/src/main/java/io/camunda/search/es/transformers/ElasticsearchTransformers.java
@@ -31,6 +31,7 @@ import io.camunda.search.clients.query.SearchHasParentQuery;
 import io.camunda.search.clients.query.SearchIdsQuery;
 import io.camunda.search.clients.query.SearchMatchAllQuery;
 import io.camunda.search.clients.query.SearchMatchNoneQuery;
+import io.camunda.search.clients.query.SearchMatchPhraseQuery;
 import io.camunda.search.clients.query.SearchMatchQuery;
 import io.camunda.search.clients.query.SearchPrefixQuery;
 import io.camunda.search.clients.query.SearchQuery;
@@ -57,6 +58,7 @@ import io.camunda.search.es.transformers.query.HasParentQueryTransformer;
 import io.camunda.search.es.transformers.query.IdsQueryTransformer;
 import io.camunda.search.es.transformers.query.MatchAllQueryTransformer;
 import io.camunda.search.es.transformers.query.MatchNoneQueryTransformer;
+import io.camunda.search.es.transformers.query.MatchPhraseQueryTransformer;
 import io.camunda.search.es.transformers.query.MatchQueryTransformer;
 import io.camunda.search.es.transformers.query.PrefixQueryTransformer;
 import io.camunda.search.es.transformers.query.QueryTransformer;
@@ -135,6 +137,7 @@ public final class ElasticsearchTransformers {
     mappers.put(SearchTermsQuery.class, new TermsQueryTransformer(mappers));
     mappers.put(SearchWildcardQuery.class, new WildcardQueryTransformer(mappers));
     mappers.put(SearchHasParentQuery.class, new HasParentQueryTransformer(mappers));
+    mappers.put(SearchMatchPhraseQuery.class, new MatchPhraseQueryTransformer(mappers));
 
     // aggregations
     mappers.put(SearchFilterAggregator.class, new SearchFilterAggregatorTransformer(mappers));

--- a/search/search-client-elasticsearch/src/main/java/io/camunda/search/es/transformers/query/MatchPhraseQueryTransformer.java
+++ b/search/search-client-elasticsearch/src/main/java/io/camunda/search/es/transformers/query/MatchPhraseQueryTransformer.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.es.transformers.query;
+
+import co.elastic.clients.elasticsearch._types.query_dsl.MatchPhraseQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.QueryBuilders;
+import io.camunda.search.clients.query.SearchMatchPhraseQuery;
+import io.camunda.search.es.transformers.ElasticsearchTransformers;
+
+public class MatchPhraseQueryTransformer
+    extends QueryOptionTransformer<SearchMatchPhraseQuery, MatchPhraseQuery> {
+
+  public MatchPhraseQueryTransformer(final ElasticsearchTransformers transformers) {
+    super(transformers);
+  }
+
+  @Override
+  public MatchPhraseQuery apply(final SearchMatchPhraseQuery value) {
+    return QueryBuilders.matchPhrase().query(value.query()).field(value.field()).build();
+  }
+}

--- a/search/search-client-elasticsearch/src/test/java/io/camunda/search/es/transformers/query/MatchPhraseQueryTransformerTest.java
+++ b/search/search-client-elasticsearch/src/test/java/io/camunda/search/es/transformers/query/MatchPhraseQueryTransformerTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.es.transformers.query;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import co.elastic.clients.elasticsearch._types.query_dsl.MatchPhraseQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import io.camunda.search.clients.query.SearchQuery;
+import io.camunda.search.clients.query.SearchQueryBuilders;
+import io.camunda.search.clients.transformers.SearchTransfomer;
+import io.camunda.search.es.transformers.ElasticsearchTransformers;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class MatchPhraseQueryTransformerTest {
+
+  private SearchTransfomer<SearchQuery, Query> transformer;
+
+  @BeforeEach
+  public void setUp() {
+    transformer = new ElasticsearchTransformers().getTransformer(SearchQuery.class);
+  }
+
+  @Test
+  public void shouldTransformMatchPhraseQuery() {
+    // given
+    final SearchQuery query = SearchQueryBuilders.matchPhrase("foo", "bar");
+
+    // when
+    final Query result = transformer.apply(query);
+
+    // then
+    final MatchPhraseQuery matchPhrase = (MatchPhraseQuery) result._get();
+    assertThat(matchPhrase.field()).isEqualTo("foo");
+    assertThat(matchPhrase.query()).isEqualTo("bar");
+  }
+
+  @Test
+  public void shouldThrowWhenFieldOrQueryIsNull() {
+    // expect
+
+    assertThatThrownBy(() -> SearchQueryBuilders.matchPhrase().query("bar").build())
+        .hasMessageContaining("Expected a non-null field for the match phrase query.")
+        .isInstanceOf(NullPointerException.class);
+
+    assertThatThrownBy(() -> SearchQueryBuilders.matchPhrase().field("foo").build())
+        .hasMessageContaining(
+            "Expected a non-null query parameter for the match phrase query, with field: 'foo'")
+        .isInstanceOf(NullPointerException.class);
+  }
+}

--- a/search/search-client-opensearch/src/main/java/io/camunda/search/os/transformers/OpensearchTransformers.java
+++ b/search/search-client-opensearch/src/main/java/io/camunda/search/os/transformers/OpensearchTransformers.java
@@ -30,6 +30,7 @@ import io.camunda.search.clients.query.SearchHasParentQuery;
 import io.camunda.search.clients.query.SearchIdsQuery;
 import io.camunda.search.clients.query.SearchMatchAllQuery;
 import io.camunda.search.clients.query.SearchMatchNoneQuery;
+import io.camunda.search.clients.query.SearchMatchPhraseQuery;
 import io.camunda.search.clients.query.SearchMatchQuery;
 import io.camunda.search.clients.query.SearchPrefixQuery;
 import io.camunda.search.clients.query.SearchQuery;
@@ -56,6 +57,7 @@ import io.camunda.search.os.transformers.query.HasParentQueryTransformer;
 import io.camunda.search.os.transformers.query.IdsQueryTransformer;
 import io.camunda.search.os.transformers.query.MatchAllQueryTransformer;
 import io.camunda.search.os.transformers.query.MatchNoneQueryTransformer;
+import io.camunda.search.os.transformers.query.MatchPhraseQueryTransformer;
 import io.camunda.search.os.transformers.query.MatchQueryTransformer;
 import io.camunda.search.os.transformers.query.PrefixQueryTransformer;
 import io.camunda.search.os.transformers.query.QueryTransformer;
@@ -135,6 +137,7 @@ public final class OpensearchTransformers {
     mappers.put(SearchTermsQuery.class, new TermsQueryTransformer(mappers));
     mappers.put(SearchWildcardQuery.class, new WildcardQueryTransformer(mappers));
     mappers.put(SearchHasParentQuery.class, new HasParentQueryTransformer(mappers));
+    mappers.put(SearchMatchPhraseQuery.class, new MatchPhraseQueryTransformer(mappers));
 
     // aggregations
     mappers.put(SearchFilterAggregator.class, new SearchFilterAggregatorTransformer(mappers));

--- a/search/search-client-opensearch/src/main/java/io/camunda/search/os/transformers/query/MatchPhraseQueryTransformer.java
+++ b/search/search-client-opensearch/src/main/java/io/camunda/search/os/transformers/query/MatchPhraseQueryTransformer.java
@@ -5,17 +5,17 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.search.es.transformers.query;
+package io.camunda.search.os.transformers.query;
 
-import co.elastic.clients.elasticsearch._types.query_dsl.MatchPhraseQuery;
-import co.elastic.clients.elasticsearch._types.query_dsl.QueryBuilders;
 import io.camunda.search.clients.query.SearchMatchPhraseQuery;
-import io.camunda.search.es.transformers.ElasticsearchTransformers;
+import io.camunda.search.os.transformers.OpensearchTransformers;
+import org.opensearch.client.opensearch._types.query_dsl.MatchPhraseQuery;
+import org.opensearch.client.opensearch._types.query_dsl.QueryBuilders;
 
 public final class MatchPhraseQueryTransformer
     extends QueryOptionTransformer<SearchMatchPhraseQuery, MatchPhraseQuery> {
 
-  public MatchPhraseQueryTransformer(final ElasticsearchTransformers transformers) {
+  public MatchPhraseQueryTransformer(final OpensearchTransformers transformers) {
     super(transformers);
   }
 

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/query/SearchMatchPhraseQuery.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/query/SearchMatchPhraseQuery.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.query;
+
+import io.camunda.util.ObjectBuilder;
+import java.util.Objects;
+
+public record SearchMatchPhraseQuery(String field, String query) implements SearchQueryOption {
+
+  public static final class Builder implements ObjectBuilder<SearchMatchPhraseQuery> {
+
+    private String field;
+    private String query;
+
+    public Builder field(final String value) {
+      field = value;
+      return this;
+    }
+
+    public Builder query(final String value) {
+      query = value;
+      return this;
+    }
+
+    @Override
+    public SearchMatchPhraseQuery build() {
+      return new SearchMatchPhraseQuery(
+          Objects.requireNonNull(field, "Expected a non-null field for the match phrase query."),
+          Objects.requireNonNull(
+              query,
+              () ->
+                  String.format(
+                      "Expected a non-null query parameter for the match phrase query, with field: '%s'.",
+                      field)));
+    }
+  }
+}

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/ProcessDefinitionStatisticsDocumentReader.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/ProcessDefinitionStatisticsDocumentReader.java
@@ -11,8 +11,10 @@ import io.camunda.search.aggregation.result.ProcessDefinitionFlowNodeStatisticsA
 import io.camunda.search.clients.SearchClientBasedQueryExecutor;
 import io.camunda.search.entities.ProcessFlowNodeStatisticsEntity;
 import io.camunda.search.filter.Operation;
+import io.camunda.search.filter.ProcessDefinitionStatisticsFilter;
 import io.camunda.search.query.ProcessDefinitionFlowNodeStatisticsQuery;
 import io.camunda.security.reader.ResourceAccessChecks;
+import java.util.ArrayList;
 import java.util.List;
 
 public class ProcessDefinitionStatisticsDocumentReader extends DocumentBasedReader
@@ -31,26 +33,29 @@ public class ProcessDefinitionStatisticsDocumentReader extends DocumentBasedRead
       final ProcessDefinitionFlowNodeStatisticsQuery query,
       final ResourceAccessChecks resourceAccessChecks) {
 
-    final var filter = query.filter();
-    if (!filter.incidentErrorHashCodes().isEmpty()) {
-      return incidentReader.mapIncidentErrorHashCodesToProcessInstanceKeys(
-          filter.incidentErrorHashCodes(),
-          filter.processInstanceKeyOperations(),
-          List::of,
-          processInstanceKeys -> {
-            // Create a new filter that narrows the results to only process instances with
-            // matching incident error hashes and existing key filters
-            final var updatedFilter =
-                filter.toBuilder()
-                    .replaceProcessInstanceKeyOperations(
-                        List.of(Operation.in(List.copyOf(processInstanceKeys))))
-                    .hasIncident(true)
-                    .build();
-            return executeAggregate(
-                new ProcessDefinitionFlowNodeStatisticsQuery(updatedFilter), resourceAccessChecks);
-          });
+    var filter = query.filter();
+    if (filter.incidentErrorHashCodeOperations() != null
+        && !filter.incidentErrorHashCodeOperations().isEmpty()) {
+      filter = normalizePDTopLevelIncidentHashCodes(filter, resourceAccessChecks);
+      if (filter.incidentErrorHashCodeOperations() == null
+          || filter.errorMessageOperations().isEmpty()) {
+        // If the incidentErrorHashCodes were resolved to null, we can return an empty result
+        return List.of();
+      }
     }
-    return executeAggregate(query, resourceAccessChecks);
+
+    if (filter.orFilters() != null && !filter.orFilters().isEmpty()) {
+      final var normalizedOr =
+          normalizePDOrFilterErrorHashCodes(filter.orFilters(), resourceAccessChecks);
+      if (normalizedOr.isEmpty()) {
+        // If all OR filters was not resolved, we can return an empty result
+        return List.of();
+      }
+      filter = filter.toBuilder().orFilters(normalizedOr).build();
+    }
+
+    return executeAggregate(
+        new ProcessDefinitionFlowNodeStatisticsQuery(filter), resourceAccessChecks);
   }
 
   private List<ProcessFlowNodeStatisticsEntity> executeAggregate(
@@ -60,5 +65,71 @@ public class ProcessDefinitionStatisticsDocumentReader extends DocumentBasedRead
         .aggregate(
             query, ProcessDefinitionFlowNodeStatisticsAggregationResult.class, resourceAccessChecks)
         .items();
+  }
+
+  private ProcessDefinitionStatisticsFilter normalizePDTopLevelIncidentHashCodes(
+      final ProcessDefinitionStatisticsFilter filter,
+      final ResourceAccessChecks resourceAccessChecks) {
+    if (filter.incidentErrorHashCodeOperations() == null
+        || filter.incidentErrorHashCodeOperations().isEmpty()) {
+      return filter;
+    }
+
+    final var resolvedErrorMessage =
+        incidentReader.findErrorMessageByErrorHashCodes(
+            filter.incidentErrorHashCodeOperations(), resourceAccessChecks);
+
+    if (resolvedErrorMessage == null || resolvedErrorMessage.isEmpty()) {
+      return filter.toBuilder().incidentErrorHashCodeOperations(List.of()).build();
+    }
+    final var existingOps =
+        filter.errorMessageOperations() != null
+            ? new ArrayList<>(filter.errorMessageOperations())
+            : new ArrayList<Operation<String>>();
+
+    existingOps.add(Operation.eq(resolvedErrorMessage));
+
+    return filter.toBuilder()
+        .incidentErrorHashCodeOperations(null)
+        .replaceErrorMessageOperations(existingOps)
+        .build();
+  }
+
+  private List<ProcessDefinitionStatisticsFilter> normalizePDOrFilterErrorHashCodes(
+      final List<ProcessDefinitionStatisticsFilter> orFilters,
+      final ResourceAccessChecks resourceAccessChecks) {
+
+    final List<ProcessDefinitionStatisticsFilter> normalized = new ArrayList<>();
+    for (final var subFilter : orFilters) {
+      if (subFilter.incidentErrorHashCodeOperations() == null
+          || subFilter.incidentErrorHashCodeOperations().isEmpty()) {
+        normalized.add(subFilter);
+        continue;
+      }
+
+      final var resolvedErrorMessage =
+          incidentReader.findErrorMessageByErrorHashCodes(
+              subFilter.incidentErrorHashCodeOperations(), resourceAccessChecks);
+
+      if (resolvedErrorMessage == null || resolvedErrorMessage.isBlank()) {
+        continue;
+      }
+
+      final var existingOps =
+          subFilter.errorMessageOperations() != null
+              ? new ArrayList<>(subFilter.errorMessageOperations())
+              : new ArrayList<Operation<String>>();
+
+      existingOps.add(Operation.eq(resolvedErrorMessage));
+
+      final var updatedSubFilter =
+          subFilter.toBuilder()
+              .incidentErrorHashCodeOperations(null)
+              .replaceErrorMessageOperations(existingOps)
+              .build();
+
+      normalized.add(updatedSubFilter);
+    }
+    return normalized;
   }
 }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/ProcessInstanceDocumentReader.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/ProcessInstanceDocumentReader.java
@@ -10,10 +10,12 @@ package io.camunda.search.clients.reader;
 import io.camunda.search.clients.SearchClientBasedQueryExecutor;
 import io.camunda.search.entities.ProcessInstanceEntity;
 import io.camunda.search.filter.Operation;
+import io.camunda.search.filter.ProcessInstanceFilter;
 import io.camunda.search.query.ProcessInstanceQuery;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.reader.ResourceAccessChecks;
 import io.camunda.webapps.schema.entities.listview.ProcessInstanceForListViewEntity;
+import java.util.ArrayList;
 import java.util.List;
 
 public class ProcessInstanceDocumentReader extends DocumentBasedReader
@@ -31,38 +33,121 @@ public class ProcessInstanceDocumentReader extends DocumentBasedReader
   public SearchQueryResult<ProcessInstanceEntity> search(
       final ProcessInstanceQuery query, final ResourceAccessChecks resourceAccessChecks) {
 
-    if (!query.filter().incidentErrorHashCodes().isEmpty()) {
-      return incidentReader.mapIncidentErrorHashCodesToProcessInstanceKeys(
-          query.filter().incidentErrorHashCodes(),
-          query.filter().processInstanceKeyOperations(),
-          SearchQueryResult::empty,
-          processInstanceKeys -> {
-            // Create a new filter that narrows the results to only process instances with
-            // matching incident error hashes and existing key filters
-            final var updatedFilter =
-                query.filter().toBuilder()
-                    .replaceProcessInstanceKeyOperations(
-                        List.of(Operation.in(List.copyOf(processInstanceKeys))))
-                    .hasIncident(true)
-                    .build();
+    var filter = query.filter();
 
-            final var updatedQuery =
-                ProcessInstanceQuery.of(
-                    q ->
-                        q.filter(updatedFilter)
-                            .sort(query.sort())
-                            .page(query.page())
-                            .resultConfig(query.resultConfig()));
-
-            return executeSearchProcessInstances(updatedQuery, resourceAccessChecks);
-          });
+    if (filter.incidentErrorHashCodeOperations() != null
+        && !filter.incidentErrorHashCodeOperations().isEmpty()) {
+      filter = normalizePITopLevelIncidentHashCodes(filter, resourceAccessChecks);
+      if (filter.incidentErrorHashCodeOperations().isEmpty()
+          || filter.errorMessageOperations().isEmpty()) {
+        // If the incidentErrorHashCode was resolved to empty, we can return an empty result
+        return SearchQueryResult.empty();
+      }
     }
-    return executeSearchProcessInstances(query, resourceAccessChecks);
+
+    if (filter.orFilters() != null && !filter.orFilters().isEmpty()) {
+      final var normalizedOr =
+          normalizePIOrFilterErrorHashCodes(filter.orFilters(), resourceAccessChecks);
+      if (normalizedOr.isEmpty()) {
+        // If all OR filters was not resolved, we can return an empty result
+        return SearchQueryResult.empty();
+      }
+      filter = filter.toBuilder().orFilters(normalizedOr).build();
+    }
+
+    final ProcessInstanceFilter finalFilter = filter;
+    final var updatedQuery =
+        ProcessInstanceQuery.of(
+            q ->
+                q.filter(finalFilter)
+                    .sort(query.sort())
+                    .page(query.page())
+                    .resultConfig(query.resultConfig()));
+
+    return executeSearchProcessInstances(updatedQuery, resourceAccessChecks);
   }
 
   public SearchQueryResult<ProcessInstanceEntity> executeSearchProcessInstances(
       final ProcessInstanceQuery query, final ResourceAccessChecks resourceAccessChecks) {
     return getSearchExecutor()
         .search(query, ProcessInstanceForListViewEntity.class, resourceAccessChecks);
+  }
+
+  /**
+   * Normalizes a top-level incidentErrorHashCode by resolving it to a full errorMessage, and always
+   * adds it as an additional errorMessageOperation (AND), regardless of existing ones. This
+   * reflects the fact that a process instance can have multiple incidents, and all error messages
+   * can be valid under AND semantics.
+   */
+  private ProcessInstanceFilter normalizePITopLevelIncidentHashCodes(
+      final ProcessInstanceFilter filter, final ResourceAccessChecks resourceAccessChecks) {
+    if (filter.incidentErrorHashCodeOperations() == null
+        || filter.incidentErrorHashCodeOperations().isEmpty()) {
+      return filter;
+    }
+
+    final var resolvedErrorMessage =
+        incidentReader.findErrorMessageByErrorHashCodes(
+            filter.incidentErrorHashCodeOperations(), resourceAccessChecks);
+
+    if (resolvedErrorMessage == null || resolvedErrorMessage.isBlank()) {
+      return filter.toBuilder().incidentErrorHashCode(null).build();
+    }
+
+    final var existingOps =
+        filter.errorMessageOperations() != null
+            ? new ArrayList<>(filter.errorMessageOperations())
+            : new ArrayList<Operation<String>>();
+
+    existingOps.add(Operation.eq(resolvedErrorMessage));
+
+    return filter.toBuilder()
+        .incidentErrorHashCode(null)
+        .replaceErrorMessageOperations(existingOps)
+        .build();
+  }
+
+  /**
+   * Given a list of OR filters, normalize any sub-filter that uses incidentErrorHashCode by
+   * resolving it to a full errorMessage equals operation, and adding it to any existing
+   * errorMessage filters, using AND semantics within the subfilter. If the hash code cannot be
+   * resolved, skip that clause.
+   */
+  private List<ProcessInstanceFilter> normalizePIOrFilterErrorHashCodes(
+      final List<ProcessInstanceFilter> orFilters,
+      final ResourceAccessChecks resourceAccessChecks) {
+
+    final List<ProcessInstanceFilter> normalized = new ArrayList<>();
+    for (final var subFilter : orFilters) {
+      if (subFilter.incidentErrorHashCodeOperations() == null
+          || subFilter.incidentErrorHashCodeOperations().isEmpty()) {
+        normalized.add(subFilter);
+        continue;
+      }
+
+      final var resolvedErrorMessage =
+          incidentReader.findErrorMessageByErrorHashCodes(
+              subFilter.incidentErrorHashCodeOperations(), resourceAccessChecks);
+
+      if (resolvedErrorMessage == null || resolvedErrorMessage.isBlank()) {
+        continue;
+      }
+
+      final var existingOps =
+          subFilter.errorMessageOperations() != null
+              ? new ArrayList<>(subFilter.errorMessageOperations())
+              : new ArrayList<Operation<String>>();
+
+      existingOps.add(Operation.eq(resolvedErrorMessage));
+
+      final var updatedSubFilter =
+          subFilter.toBuilder()
+              .incidentErrorHashCode(null)
+              .replaceErrorMessageOperations(existingOps)
+              .build();
+
+      normalized.add(updatedSubFilter);
+    }
+    return normalized;
   }
 }

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/ProcessInstanceQueryTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/ProcessInstanceQueryTransformerTest.java
@@ -12,6 +12,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.camunda.search.clients.query.SearchBoolQuery;
 import io.camunda.search.clients.query.SearchHasChildQuery;
 import io.camunda.search.clients.query.SearchMatchNoneQuery;
+import io.camunda.search.clients.query.SearchMatchPhraseQuery;
 import io.camunda.search.clients.query.SearchMatchQuery;
 import io.camunda.search.clients.query.SearchQueryOption;
 import io.camunda.search.clients.query.SearchRangeQuery;
@@ -410,7 +411,7 @@ public final class ProcessInstanceQueryTransformerTest extends AbstractTransform
               // expected value.
               assertThat(hasChildQuery.query().queryOption())
                   .isInstanceOfSatisfying(
-                      SearchMatchQuery.class,
+                      SearchMatchPhraseQuery.class,
                       (searchMatchQuery) -> {
                         assertThat(searchMatchQuery.field()).isEqualTo("errorMessage");
                         assertThat(searchMatchQuery.query()).isEqualTo(expectedError);

--- a/search/search-domain/src/main/java/io/camunda/search/filter/ProcessDefinitionStatisticsFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/ProcessDefinitionStatisticsFilter.java
@@ -34,7 +34,7 @@ public record ProcessDefinitionStatisticsFilter(
     List<Operation<String>> flowNodeIdOperations,
     Boolean hasFlowNodeInstanceIncident,
     List<Operation<String>> flowNodeInstanceStateOperations,
-    List<Integer> incidentErrorHashCodes,
+    List<Operation<Integer>> incidentErrorHashCodeOperations,
     List<ProcessDefinitionStatisticsFilter> orFilters)
     implements FilterBase {
 
@@ -70,7 +70,7 @@ public record ProcessDefinitionStatisticsFilter(
     private List<Operation<String>> flowNodeIdOperations;
     private Boolean hasFlowNodeInstanceIncident;
     private List<Operation<String>> flowNodeInstanceStateOperations;
-    private List<Integer> incidentErrorHashCodes;
+    private List<Operation<Integer>> incidentErrorHashCodeOperations;
     private List<ProcessDefinitionStatisticsFilter> orFilters;
 
     public Builder(final long processDefinitionKey) {
@@ -86,8 +86,8 @@ public record ProcessDefinitionStatisticsFilter(
       return processInstanceKeyOperations(FilterUtil.mapDefaultToOperation(value, values));
     }
 
-    public Builder replaceProcessInstanceKeyOperations(final List<Operation<Long>> operations) {
-      processInstanceKeyOperations = operations;
+    public Builder replaceErrorMessageOperations(final List<Operation<String>> operations) {
+      errorMessageOperations = new ArrayList<>(operations);
       return this;
     }
 
@@ -262,13 +262,20 @@ public record ProcessDefinitionStatisticsFilter(
       return flowNodeInstanceStateOperations(collectValues(operation, operations));
     }
 
-    public Builder incidentErrorHashCodes(final Integer value, final Integer... values) {
-      return incidentErrorHashCodes(collectValues(value, values));
+    public Builder incidentErrorHashCodeOperations(final Integer value, final Integer... values) {
+      return incidentErrorHashCodeOperations(FilterUtil.mapDefaultToOperation(value, values));
     }
 
-    public Builder incidentErrorHashCodes(final List<Integer> values) {
-      incidentErrorHashCodes = addValuesToList(incidentErrorHashCodes, values);
+    public Builder incidentErrorHashCodeOperations(final List<Operation<Integer>> operations) {
+      incidentErrorHashCodeOperations =
+          addValuesToList(incidentErrorHashCodeOperations, operations);
       return this;
+    }
+
+    @SafeVarargs
+    public final Builder incidentErrorHashCodeOperations(
+        final Operation<Integer> operation, final Operation<Integer>... operations) {
+      return incidentErrorHashCodeOperations(collectValues(operation, operations));
     }
 
     public Builder addOrOperation(final ProcessDefinitionStatisticsFilter orOperation) {
@@ -276,6 +283,11 @@ public record ProcessDefinitionStatisticsFilter(
         orFilters = new ArrayList<>();
       }
       orFilters.add(orOperation);
+      return this;
+    }
+
+    public Builder orFilters(final List<ProcessDefinitionStatisticsFilter> orFilters) {
+      this.orFilters = orFilters;
       return this;
     }
 
@@ -298,7 +310,7 @@ public record ProcessDefinitionStatisticsFilter(
           Objects.requireNonNullElse(flowNodeIdOperations, Collections.emptyList()),
           hasFlowNodeInstanceIncident,
           Objects.requireNonNullElse(flowNodeInstanceStateOperations, Collections.emptyList()),
-          Objects.requireNonNullElse(incidentErrorHashCodes, Collections.emptyList()),
+          Objects.requireNonNullElse(incidentErrorHashCodeOperations, Collections.emptyList()),
           orFilters);
     }
   }

--- a/search/search-domain/src/main/java/io/camunda/search/filter/ProcessInstanceFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/ProcessInstanceFilter.java
@@ -39,7 +39,7 @@ public record ProcessInstanceFilter(
     List<Operation<String>> flowNodeIdOperations,
     Boolean hasFlowNodeInstanceIncident,
     List<Operation<String>> flowNodeInstanceStateOperations,
-    List<Integer> incidentErrorHashCodes,
+    List<Operation<Integer>> incidentErrorHashCodeOperations,
     Integer partitionId,
     List<ProcessInstanceFilter> orFilters)
     implements FilterBase {
@@ -61,7 +61,10 @@ public record ProcessInstanceFilter(
         .tenantIdOperations(tenantIdOperations)
         .variables(variableFilters)
         .batchOperationIdOperations(batchOperationIdOperations)
-        .partitionId(partitionId);
+        .errorMessageOperations(errorMessageOperations)
+        .incidentErrorHashCodeOperations(incidentErrorHashCodeOperations)
+        .partitionId(partitionId)
+        .orFilters(orFilters);
   }
 
   public static final class Builder implements ObjectBuilder<ProcessInstanceFilter> {
@@ -86,7 +89,7 @@ public record ProcessInstanceFilter(
     private List<Operation<String>> flowNodeIdOperations;
     private Boolean hasFlowNodeInstanceIncident;
     private List<Operation<String>> flowNodeInstanceStateOperations;
-    private List<Integer> incidentErrorHashCodes;
+    private List<Operation<Integer>> incidentErrorHashCodeOperations;
     private Integer partitionId;
     private List<ProcessInstanceFilter> orFilters;
 
@@ -99,8 +102,8 @@ public record ProcessInstanceFilter(
       return processInstanceKeyOperations(FilterUtil.mapDefaultToOperation(value, values));
     }
 
-    public Builder replaceProcessInstanceKeyOperations(final List<Operation<Long>> operations) {
-      processInstanceKeyOperations = new ArrayList<>(operations);
+    public Builder replaceErrorMessageOperations(final List<Operation<String>> operations) {
+      errorMessageOperations = new ArrayList<>(operations);
       return this;
     }
 
@@ -354,13 +357,20 @@ public record ProcessInstanceFilter(
       return flowNodeInstanceStateOperations(collectValues(operation, operations));
     }
 
-    public Builder incidentErrorHashCodes(final Integer value, final Integer... values) {
-      return incidentErrorHashCodes(collectValues(value, values));
+    public Builder incidentErrorHashCodeOperations(final List<Operation<Integer>> operations) {
+      incidentErrorHashCodeOperations =
+          addValuesToList(incidentErrorHashCodeOperations, operations);
+      return this;
     }
 
-    public Builder incidentErrorHashCodes(final List<Integer> values) {
-      incidentErrorHashCodes = addValuesToList(incidentErrorHashCodes, values);
-      return this;
+    public Builder incidentErrorHashCode(final Integer value, final Integer... values) {
+      return incidentErrorHashCodeOperations(FilterUtil.mapDefaultToOperation(value, values));
+    }
+
+    @SafeVarargs
+    public final Builder incidentErrorHashCodeOperations(
+        final Operation<Integer> operation, final Operation<Integer>... operations) {
+      return incidentErrorHashCodeOperations(collectValues(operation, operations));
     }
 
     public Builder partitionId(final Integer value) {
@@ -373,6 +383,11 @@ public record ProcessInstanceFilter(
         orFilters = new ArrayList<>();
       }
       orFilters.add(orOperation);
+      return this;
+    }
+
+    public Builder orFilters(final List<ProcessInstanceFilter> orFilters) {
+      this.orFilters = orFilters;
       return this;
     }
 
@@ -400,7 +415,7 @@ public record ProcessInstanceFilter(
           Objects.requireNonNullElse(flowNodeIdOperations, Collections.emptyList()),
           hasFlowNodeInstanceIncident,
           Objects.requireNonNullElse(flowNodeInstanceStateOperations, Collections.emptyList()),
-          Objects.requireNonNullElse(incidentErrorHashCodes, Collections.emptyList()),
+          Objects.requireNonNullElse(incidentErrorHashCodeOperations, Collections.emptyList()),
           partitionId,
           orFilters);
     }

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -6356,8 +6356,8 @@ components:
           type: boolean
         incidentErrorHashCode:
           description: The incident error hash code, associated with this process.
-          type: integer
-          format: int32
+          allOf:
+            - $ref: "#/components/schemas/IntegerFilterProperty"
     ProcessDefinitionStatisticsFilter:
       description: Process definition statistics search filter.
       allOf:

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
@@ -242,7 +242,9 @@ public final class SearchQueryRequestMapper {
       ofNullable(filter.getElementInstanceState())
           .map(mapToOperations(String.class))
           .ifPresent(builder::flowNodeInstanceStateOperations);
-      ofNullable(filter.getIncidentErrorHashCode()).ifPresent(builder::incidentErrorHashCodes);
+      ofNullable(filter.getIncidentErrorHashCode())
+          .map(mapToOperations(Integer.class))
+          .ifPresent(builder::incidentErrorHashCodeOperations);
       if (!CollectionUtils.isEmpty(filter.getVariables())) {
         final Either<List<String>, List<VariableValueFilter>> either =
             toVariableValueFilters(filter.getVariables());
@@ -1017,7 +1019,9 @@ public final class SearchQueryRequestMapper {
       ofNullable(filter.getElementInstanceState())
           .map(mapToOperations(String.class))
           .ifPresent(builder::flowNodeInstanceStateOperations);
-      ofNullable(filter.getIncidentErrorHashCode()).ifPresent(builder::incidentErrorHashCodes);
+      ofNullable(filter.getIncidentErrorHashCode())
+          .map(mapToOperations(Integer.class))
+          .ifPresent(builder::incidentErrorHashCodeOperations);
       if (!CollectionUtils.isEmpty(filter.getVariables())) {
         final Either<List<String>, List<VariableValueFilter>> either =
             toVariableValueFilters(filter.getVariables());


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
This PR adds support for using incidentErrorHashCode with the advanced OR filter in the Process Instance and Process Definition Statistics search endpoints.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #31180
