### PR TITLE
fix: return the users token as a JSON string to be able to be parsed into the UIs and used more efficiently whilst matching the existing format

### DIFF
--- a/authentication/pom.xml
+++ b/authentication/pom.xml
@@ -65,6 +65,14 @@
       <artifactId>jakarta.servlet-api</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.eclipse.parsson</groupId>
+      <artifactId>parsson</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.json</groupId>
+      <artifactId>jakarta.json-api</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-beans</artifactId>
     </dependency>

--- a/authentication/pom.xml
+++ b/authentication/pom.xml
@@ -218,6 +218,7 @@
           <ignoredUnusedDeclaredDependencies>
             <dep>com.nimbusds:oauth2-oidc-sdk</dep>
             <dep>org.springframework:spring-webmvc</dep>
+            <dep>org.eclipse.parsson:parsson</dep>
           </ignoredUnusedDeclaredDependencies>
         </configuration>
       </plugin>

--- a/authentication/src/main/java/io/camunda/authentication/service/OidcCamundaUserService.java
+++ b/authentication/src/main/java/io/camunda/authentication/service/OidcCamundaUserService.java
@@ -15,6 +15,7 @@ import io.camunda.authentication.entity.CamundaUserDTO;
 import io.camunda.search.entities.RoleEntity;
 import io.camunda.security.entity.AuthenticationMethod;
 import io.camunda.security.entity.ClusterMetadata.AppName;
+import jakarta.json.Json;
 import java.util.Map;
 import java.util.Optional;
 import org.springframework.context.annotation.Profile;
@@ -66,11 +67,16 @@ public class OidcCamundaUserService implements CamundaUserService {
         .map(
             user -> {
               if (user instanceof final CamundaOidcUser camundaOAuthPrincipal) {
-                return camundaOAuthPrincipal.getIdToken().getTokenValue();
+                return Json.createValue(camundaOAuthPrincipal.getIdToken().getTokenValue())
+                    .toString();
               }
 
-              return null;
+              throw new UnsupportedOperationException(
+                  "Not supported for token class: " + user.getClass().getName());
             })
-        .orElse(null);
+        .orElseThrow(
+            () ->
+                new UnsupportedOperationException(
+                    "User is not authenticated or does not have a valid token"));
   }
 }

--- a/authentication/src/test/java/io/camunda/authentication/OidcCamundaUserServiceTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/OidcCamundaUserServiceTest.java
@@ -14,11 +14,13 @@ import io.camunda.authentication.entity.CamundaJwtUser;
 import io.camunda.authentication.entity.CamundaOidcUser;
 import io.camunda.authentication.entity.OAuthContext;
 import io.camunda.authentication.service.OidcCamundaUserService;
+import jakarta.json.Json;
 import java.time.Instant;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -55,7 +57,8 @@ public class OidcCamundaUserServiceTest {
     final var auth = new OAuth2AuthenticationToken(principal, List.of(), "oidc");
     SecurityContextHolder.getContext().setAuthentication(auth);
 
-    assertThat(oidcCamundaUserService.getUserToken()).isEqualTo(TOKEN_VALUE);
+    final var expectedToken = Json.createValue(TOKEN_VALUE).toString();
+    assertThat(oidcCamundaUserService.getUserToken()).isEqualTo(expectedToken);
   }
 
   @Test
@@ -83,6 +86,9 @@ public class OidcCamundaUserServiceTest {
             null);
     SecurityContextHolder.getContext().setAuthentication(camundaJwtAuthenticationToken);
 
-    assertThat(oidcCamundaUserService.getUserToken()).isNull();
+    Assertions.assertThatThrownBy(() -> oidcCamundaUserService.getUserToken())
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessageContaining(
+            "Not supported for token class: io.camunda.authentication.entity.CamundaJwtUser");
   }
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

We introduced a replacement for the existing endpoint to get the token of the logged in user (which used in the webapp code) however the format was not as expected. In this PR I update the structure to use the same return type and the old code so that the UIs are better able to migrate over.
