### PR TITLE
refactor: use virtual threads to orchestrate broker restore from backup

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/restore/RestoreApp.java
+++ b/dist/src/main/java/io/camunda/zeebe/restore/RestoreApp.java
@@ -14,6 +14,8 @@ import io.camunda.application.commons.configuration.WorkingDirectoryConfiguratio
 import io.camunda.zeebe.backup.api.BackupStore;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.micrometer.core.instrument.MeterRegistry;
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -67,11 +69,11 @@ public class RestoreApp implements ApplicationRunner {
   }
 
   @Override
-  public void run(final ApplicationArguments args) {
+  public void run(final ApplicationArguments args)
+      throws IOException, ExecutionException, InterruptedException {
     LOG.info("Starting to restore from backup {}", backupId);
     new RestoreManager(configuration, backupStore, meterRegistry)
-        .restore(backupId, restoreConfiguration.validateConfig())
-        .join();
+        .restore(backupId, restoreConfiguration.validateConfig());
     LOG.info("Successfully restored broker from backup {}", backupId);
   }
 }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/RestoreAcceptance.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/RestoreAcceptance.java
@@ -23,7 +23,6 @@ import io.camunda.zeebe.restore.BackupNotFoundException;
 import io.camunda.zeebe.snapshots.impl.FileBasedSnapshotId;
 import java.time.Duration;
 import java.util.Optional;
-import java.util.concurrent.CompletionException;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 
@@ -44,7 +43,6 @@ public interface RestoreAcceptance {
   default void shouldFailForNonExistingBackup() {
     // then -- restore application exits with an error code
     assertThatCode(() -> restoreBackup(1234))
-        .isInstanceOf(CompletionException.class)
         .hasRootCauseExactlyInstanceOf(BackupNotFoundException.class);
   }
 

--- a/zeebe/restore/src/main/java/io/camunda/zeebe/restore/PartitionRestoreService.java
+++ b/zeebe/restore/src/main/java/io/camunda/zeebe/restore/PartitionRestoreService.java
@@ -84,7 +84,7 @@ public class PartitionRestoreService {
       return CompletableFuture.failedFuture(e);
     }
 
-    final var tempTargetDirectory = rootDirectory.resolve("restoring-" + backupId);
+    final var tempTargetDirectory = rootDirectory.resolve("restoring-" + partitionId);
     try {
       FileUtil.ensureDirectoryExists(tempTargetDirectory);
     } catch (final IOException e) {

--- a/zeebe/restore/src/main/java/io/camunda/zeebe/restore/RestoreManager.java
+++ b/zeebe/restore/src/main/java/io/camunda/zeebe/restore/RestoreManager.java
@@ -124,9 +124,8 @@ public class RestoreManager {
   }
 
   private void restorePartition(
-      final InstrumentedRaftPartition partition,
-      final long backupId,
-      final boolean validateConfig) {
+      final InstrumentedRaftPartition partition, final long backupId, final boolean validateConfig)
+      throws IOException {
     final BackupValidator validator;
     final RaftPartition raftPartition = partition.partition();
 
@@ -146,7 +145,7 @@ public class RestoreManager {
             new ChecksumProviderRocksDBImpl(),
             partition.registry());
     try {
-      final var backup = restoreService.restore(backupId, validator).join();
+      final var backup = restoreService.restore(backupId, validator);
       LOG.info(
           "Successfully restored partition {} from backup {}. Backup description: {}",
           raftPartition.id().id(),

--- a/zeebe/restore/src/main/java/io/camunda/zeebe/restore/RestoreManager.java
+++ b/zeebe/restore/src/main/java/io/camunda/zeebe/restore/RestoreManager.java
@@ -70,13 +70,13 @@ public class RestoreManager {
       throw new DirectoryNotEmptyException(dataDirectory.toString());
     }
 
-    final var partitionToRestore = collectPartitions();
+    final var partitionsToRestore = collectPartitions();
 
     try (final var executor =
         Executors.newThreadPerTaskExecutor(
             Thread.ofVirtual().name("zeebe-restore-", 0).factory())) {
-      final var tasks = new ArrayList<Callable<Void>>(partitionToRestore.size());
-      for (final var partition : partitionToRestore) {
+      final var tasks = new ArrayList<Callable<Void>>(partitionsToRestore.size());
+      for (final var partition : partitionsToRestore) {
         tasks.add(
             () -> {
               restorePartition(partition, backupId, validateConfig);

--- a/zeebe/restore/src/main/java/io/camunda/zeebe/restore/RestoreManager.java
+++ b/zeebe/restore/src/main/java/io/camunda/zeebe/restore/RestoreManager.java
@@ -10,7 +10,6 @@ package io.camunda.zeebe.restore;
 import io.atomix.cluster.MemberId;
 import io.atomix.primitive.partition.PartitionMetadata;
 import io.atomix.raft.partition.RaftPartition;
-import io.camunda.zeebe.backup.api.BackupDescriptor;
 import io.camunda.zeebe.backup.api.BackupStatus;
 import io.camunda.zeebe.backup.api.BackupStore;
 import io.camunda.zeebe.broker.partitioning.startup.RaftPartitionFactory;
@@ -35,10 +34,13 @@ import java.io.IOException;
 import java.nio.file.DirectoryNotEmptyException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -58,41 +60,44 @@ public class RestoreManager {
     this.meterRegistry = meterRegistry;
   }
 
-  public CompletableFuture<Void> restore(final long backupId, final boolean validateConfig) {
-    final Path dataDirectory = Path.of(configuration.getData().getDirectory());
-    try {
-      if (!dataFolderIsEmpty(dataDirectory)) {
-        LOG.error(
-            "Brokers's data directory {} is not empty. Aborting restore to avoid overwriting data. Please restart with a clean directory.",
-            dataDirectory);
-        return CompletableFuture.failedFuture(
-            new DirectoryNotEmptyException(dataDirectory.toString()));
-      }
-    } catch (final IOException e) {
-      return CompletableFuture.failedFuture(e);
+  public void restore(final long backupId, final boolean validateConfig)
+      throws IOException, ExecutionException, InterruptedException {
+    final var dataDirectory = Path.of(configuration.getData().getDirectory());
+    if (!dataFolderIsEmpty(dataDirectory)) {
+      LOG.error(
+          "Brokers's data directory {} is not empty. Aborting restore to avoid overwriting data. Please restart with a clean directory.",
+          dataDirectory);
+      throw new DirectoryNotEmptyException(dataDirectory.toString());
     }
 
     final var partitionToRestore = collectPartitions();
 
-    final var partitionIds = partitionToRestore.stream().map(p -> p.partition().id().id()).toList();
-    LOG.info("Restoring partitions {}", partitionIds);
-
-    return CompletableFuture.allOf(
-            partitionToRestore.stream()
-                .map(partition -> restorePartition(partition, backupId, validateConfig))
-                .toArray(CompletableFuture[]::new))
-        .<Void>thenApply(
-            ignored -> {
-              // restore Topology file
-              if (configuration.getCluster().getNodeId() == 0) {
-                restoreTopologyFile();
-              }
+    try (final var executor =
+        Executors.newThreadPerTaskExecutor(
+            Thread.ofVirtual().name("zeebe-restore-", 0).factory())) {
+      final var tasks = new ArrayList<Callable<Void>>(partitionToRestore.size());
+      for (final var partition : partitionToRestore) {
+        tasks.add(
+            () -> {
+              restorePartition(partition, backupId, validateConfig);
               return null;
-            })
-        .exceptionallyComposeAsync(error -> logFailureAndDeleteDataDirectory(dataDirectory, error));
+            });
+      }
+      for (final var result : executor.invokeAll(tasks)) {
+        result.get(); // throw exception if any of the tasks failed
+      }
+
+      if (configuration.getCluster().getNodeId() == 0) {
+        restoreTopologyFile();
+      }
+    } catch (final ExecutionException | InterruptedException e) {
+      LOG.error("Failed to restore broker. Deleting data directory {}", dataDirectory, e);
+      FileUtil.deleteFolderContents(dataDirectory);
+      throw e;
+    }
   }
 
-  private void restoreTopologyFile() {
+  private void restoreTopologyFile() throws ExecutionException, InterruptedException, IOException {
     final var coordinatorId = MemberId.from("0");
     LOG.info("Restoring topology file");
     final var file =
@@ -101,49 +106,24 @@ public class RestoreManager {
     final var staticConfiguration =
         StaticConfigurationGenerator.getStaticConfiguration(configuration, coordinatorId);
     final var initializer = new StaticInitializer(staticConfiguration);
-    try {
-      // it's ok to block, it's not really async
-      final var base = initializer.initialize().get();
-      final var configuration =
-          new ClusterConfiguration(
-              base.version(),
-              base.members(),
-              base.lastChange(),
-              Optional.of(
-                  ClusterChangePlan.init(
-                      1L, List.of(new UpdateRoutingState(coordinatorId, Optional.empty())))),
-              base.routingState());
-      final var persistedConfiguration =
-          PersistedClusterConfiguration.ofFile(file, new ProtoBufSerializer());
-      persistedConfiguration.update(configuration);
-      LOG.info("Successfully restored topology file {}", base);
-    } catch (final Exception e) {
-      throw new RuntimeException(e);
-    }
+    // it's ok to block, it's not really async
+    final var base = initializer.initialize().get();
+    final var configuration =
+        new ClusterConfiguration(
+            base.version(),
+            base.members(),
+            base.lastChange(),
+            Optional.of(
+                ClusterChangePlan.init(
+                    1L, List.of(new UpdateRoutingState(coordinatorId, Optional.empty())))),
+            base.routingState());
+    final var persistedConfiguration =
+        PersistedClusterConfiguration.ofFile(file, new ProtoBufSerializer());
+    persistedConfiguration.update(configuration);
+    LOG.info("Successfully restored topology file {}", base);
   }
 
-  private CompletableFuture<Void> logFailureAndDeleteDataDirectory(
-      final Path dataDirectory, final Throwable error) {
-    LOG.error("Failed to restore broker. Deleting data directory {}", dataDirectory, error);
-    try {
-      FileUtil.deleteFolderContents(dataDirectory);
-    } catch (final IOException e) {
-      return CompletableFuture.failedFuture(e);
-    }
-    // Must fail because restore failed
-    return CompletableFuture.failedFuture(error);
-  }
-
-  private void logSuccessfulRestore(
-      final BackupDescriptor backup, final int partitionId, final long backupId) {
-    LOG.info(
-        "Successfully restored partition {} from backup {}. Backup description: {}",
-        partitionId,
-        backupId,
-        backup);
-  }
-
-  private CompletableFuture<Void> restorePartition(
+  private void restorePartition(
       final InstrumentedRaftPartition partition,
       final long backupId,
       final boolean validateConfig) {
@@ -158,15 +138,23 @@ public class RestoreManager {
     }
 
     final var registry = partition.registry();
-    return new PartitionRestoreService(
+    final var restoreService =
+        new PartitionRestoreService(
             backupStore,
             partition.partition(),
             configuration.getCluster().getNodeId(),
             new ChecksumProviderRocksDBImpl(),
-            partition.registry())
-        .restore(backupId, validator)
-        .thenAccept(backup -> logSuccessfulRestore(backup, raftPartition.id().id(), backupId))
-        .whenComplete((ok, error) -> MicrometerUtil.close(registry));
+            partition.registry());
+    try {
+      final var backup = restoreService.restore(backupId, validator).join();
+      LOG.info(
+          "Successfully restored partition {} from backup {}. Backup description: {}",
+          raftPartition.id().id(),
+          backupId,
+          backup);
+    } finally {
+      MicrometerUtil.close(registry);
+    }
   }
 
   private Set<InstrumentedRaftPartition> collectPartitions() {

--- a/zeebe/restore/src/test/java/io/camunda/zeebe/restore/RestoreManagerTest.java
+++ b/zeebe/restore/src/test/java/io/camunda/zeebe/restore/RestoreManagerTest.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.zeebe.restore;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
@@ -15,7 +15,6 @@ import java.io.IOException;
 import java.nio.file.DirectoryNotEmptyException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.time.Duration;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -34,11 +33,8 @@ final class RestoreManagerTest {
     Files.createDirectory(dir.resolve("other-data"));
 
     // then
-    assertThat(restoreManager.restore(1L, false))
-        .failsWithin(Duration.ofSeconds(5))
-        .withThrowableThat()
-        .withRootCauseInstanceOf(DirectoryNotEmptyException.class)
-        .isNotNull();
+    assertThatThrownBy(() -> restoreManager.restore(1L, false))
+        .isInstanceOf(DirectoryNotEmptyException.class);
   }
 
   @Test
@@ -54,10 +50,7 @@ final class RestoreManagerTest {
     Files.createDirectory(dir.resolve("lost+found"));
 
     // then
-    assertThat(restoreManager.restore(1L, false))
-        .failsWithin(Duration.ofSeconds(5))
-        .withThrowableThat()
-        .withRootCauseInstanceOf(BackupNotFoundException.class)
-        .isNotNull();
+    assertThatThrownBy(() -> restoreManager.restore(1L, false))
+        .hasRootCauseInstanceOf(BackupNotFoundException.class);
   }
 }


### PR DESCRIPTION
This contains a couple of refactorings on how we orchestrate the restore of a single broker from a backup. These will make it easier to implement #34316
