### PR TITLE
refactor: remove ldap profile from Operate profile class

### DIFF
--- a/operate/common/src/main/java/io/camunda/operate/OperateProfileService.java
+++ b/operate/common/src/main/java/io/camunda/operate/OperateProfileService.java
@@ -23,7 +23,6 @@ public class OperateProfileService {
   public static final String IDENTITY_AUTH_PROFILE = "identity-auth";
   public static final String AUTH_PROFILE = "auth";
   public static final String CONSOLIDATED_AUTH = "consolidated-auth";
-  public static final String LDAP_AUTH_PROFILE = "ldap-auth";
 
   private static final Set<String> CANT_LOGOUT_AUTH_PROFILES = Set.of(SSO_AUTH_PROFILE);
 

--- a/operate/schema/src/main/java/io/camunda/operate/store/elasticsearch/ElasticsearchUserStore.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/elasticsearch/ElasticsearchUserStore.java
@@ -38,8 +38,6 @@ import org.springframework.stereotype.Component;
 @Component
 @Profile(
     "!"
-        + OperateProfileService.LDAP_AUTH_PROFILE
-        + " & !"
         + OperateProfileService.SSO_AUTH_PROFILE
         + " & !"
         + OperateProfileService.IDENTITY_AUTH_PROFILE)

--- a/operate/schema/src/main/java/io/camunda/operate/store/opensearch/OpensearchUserStore.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/opensearch/OpensearchUserStore.java
@@ -31,8 +31,6 @@ import org.springframework.stereotype.Component;
 @Component
 @Profile(
     "!"
-        + OperateProfileService.LDAP_AUTH_PROFILE
-        + " & !"
         + OperateProfileService.SSO_AUTH_PROFILE
         + " & !"
         + OperateProfileService.IDENTITY_AUTH_PROFILE)

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/security/auth/OperateUserDetailsService.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/security/auth/OperateUserDetailsService.java
@@ -32,8 +32,6 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 @Configuration
 @Profile({
   "!"
-      + OperateProfileService.LDAP_AUTH_PROFILE
-      + " & !"
       + OperateProfileService.SSO_AUTH_PROFILE
       + " & !"
       + OperateProfileService.IDENTITY_AUTH_PROFILE


### PR DESCRIPTION
## Description
<!-- Describe the goal and purpose of this PR. -->
This PR removes the final pieces of the `ldap-auth` profile from the Operate security package

## Related issues

closes https://github.com/camunda/camunda/issues/35283
