### PR TITLE
feat: Dedicated no-op search client for no-db case with a sensible error

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/search/SearchClientDatabaseConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/search/SearchClientDatabaseConfiguration.java
@@ -11,7 +11,7 @@ import io.camunda.application.commons.condition.ConditionalOnDatabaseNone;
 import io.camunda.db.rdbms.RdbmsService;
 import io.camunda.search.clients.DocumentBasedSearchClient;
 import io.camunda.search.clients.DocumentBasedSearchClients;
-import io.camunda.search.clients.impl.NoopSearchClientsProxy;
+import io.camunda.search.clients.impl.NoDBSearchClientsProxy;
 import io.camunda.search.connect.configuration.ConnectConfiguration;
 import io.camunda.search.connect.configuration.DatabaseConfig;
 import io.camunda.search.connect.es.ElasticsearchConnector;
@@ -77,7 +77,7 @@ public class SearchClientDatabaseConfiguration {
 
   @Bean
   @ConditionalOnDatabaseNone
-  public NoopSearchClientsProxy noopSearchClientsProxy() {
-    return new NoopSearchClientsProxy();
+  public NoDBSearchClientsProxy noDBSearchClientsProxy() {
+    return new NoDBSearchClientsProxy();
   }
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/nodb/NoSecondaryStorageTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/nodb/NoSecondaryStorageTest.java
@@ -9,8 +9,10 @@ package io.camunda.it.nodb;
 
 import static io.camunda.application.commons.utils.DatabaseTypeUtils.PROPERTY_CAMUNDA_DATABASE_TYPE;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.client.CamundaClient;
+import io.camunda.client.api.command.ProblemException;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
@@ -147,6 +149,15 @@ public class NoSecondaryStorageTest {
     assertThat(instance1.getProcessInstanceKey()).isNotEqualTo(instance2.getProcessInstanceKey());
     assertThat(instance1.getBpmnProcessId()).isEqualTo(processId);
     assertThat(instance2.getBpmnProcessId()).isEqualTo(processId);
+  }
+
+  @Test
+  public void shouldReturnForbiddenWhenQueryingWithNoSecondaryStorage() {
+    assertThatThrownBy(() -> camundaClient.newUsersSearchRequest().send().join())
+        .isInstanceOf(ProblemException.class)
+        .hasMessageContaining("The search client requires a secondary storage, but none is set")
+        .hasMessageContaining("FORBIDDEN")
+        .hasMessageContaining("status: 403");
   }
 
   private BpmnModelInstance createSimpleProcess(final String processId) {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/nodb/NoSecondaryStorageTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/nodb/NoSecondaryStorageTest.java
@@ -156,6 +156,10 @@ public class NoSecondaryStorageTest {
     assertThatThrownBy(() -> camundaClient.newUsersSearchRequest().send().join())
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("The search client requires a secondary storage, but none is set")
+        .hasMessageContaining(
+            String.format(
+                "Secondary storage can be configured using the '%s' property",
+                PROPERTY_CAMUNDA_DATABASE_TYPE))
         .hasMessageContaining("FORBIDDEN")
         .hasMessageContaining("status: 403");
   }

--- a/search/search-client/src/main/java/io/camunda/search/clients/impl/NoDBSearchClientsProxy.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/impl/NoDBSearchClientsProxy.java
@@ -66,138 +66,138 @@ public class NoDBSearchClientsProxy implements SearchClientsProxy {
   @Override
   public SearchQueryResult<AuthorizationEntity> searchAuthorizations(
       final AuthorizationQuery filter) {
-    return throwNoSecondaryStorage();
+    throw new NoSecondaryStorageException();
   }
 
   @Override
   public SearchQueryResult<BatchOperationEntity> searchBatchOperations(
       final BatchOperationQuery query) {
-    return throwNoSecondaryStorage();
+    throw new NoSecondaryStorageException();
   }
 
   @Override
   public SearchQueryResult<BatchOperationItemEntity> searchBatchOperationItems(
       final BatchOperationItemQuery query) {
-    return throwNoSecondaryStorage();
+    throw new NoSecondaryStorageException();
   }
 
   @Override
   public SearchQueryResult<DecisionDefinitionEntity> searchDecisionDefinitions(
       final DecisionDefinitionQuery filter) {
-    return throwNoSecondaryStorage();
+    throw new NoSecondaryStorageException();
   }
 
   @Override
   public SearchQueryResult<DecisionInstanceEntity> searchDecisionInstances(
       final DecisionInstanceQuery filter) {
-    return throwNoSecondaryStorage();
+    throw new NoSecondaryStorageException();
   }
 
   @Override
   public SearchQueryResult<DecisionRequirementsEntity> searchDecisionRequirements(
       final DecisionRequirementsQuery filter) {
-    return throwNoSecondaryStorage();
+    throw new NoSecondaryStorageException();
   }
 
   @Override
   public SearchQueryResult<FlowNodeInstanceEntity> searchFlowNodeInstances(
       final FlowNodeInstanceQuery filter) {
-    return throwNoSecondaryStorage();
+    throw new NoSecondaryStorageException();
   }
 
   @Override
   public SearchQueryResult<FormEntity> searchForms(final FormQuery filter) {
-    return throwNoSecondaryStorage();
+    throw new NoSecondaryStorageException();
   }
 
   @Override
   public SearchQueryResult<GroupEntity> searchGroups(final GroupQuery query) {
-    return throwNoSecondaryStorage();
+    throw new NoSecondaryStorageException();
   }
 
   @Override
   public SearchQueryResult<GroupMemberEntity> searchGroupMembers(final GroupQuery query) {
-    return throwNoSecondaryStorage();
+    throw new NoSecondaryStorageException();
   }
 
   @Override
   public SearchQueryResult<IncidentEntity> searchIncidents(final IncidentQuery filter) {
-    return throwNoSecondaryStorage();
+    throw new NoSecondaryStorageException();
   }
 
   @Override
   public SearchQueryResult<MappingEntity> searchMappings(final MappingQuery filter) {
-    return throwNoSecondaryStorage();
+    throw new NoSecondaryStorageException();
   }
 
   @Override
   public SearchQueryResult<ProcessDefinitionEntity> searchProcessDefinitions(
       final ProcessDefinitionQuery filter) {
-    return throwNoSecondaryStorage();
+    throw new NoSecondaryStorageException();
   }
 
   @Override
   public List<ProcessFlowNodeStatisticsEntity> processDefinitionFlowNodeStatistics(
       final ProcessDefinitionStatisticsFilter filter) {
-    return throwNoSecondaryStorage();
+    throw new NoSecondaryStorageException();
   }
 
   @Override
   public SearchQueryResult<ProcessInstanceEntity> searchProcessInstances(
       final ProcessInstanceQuery query) {
-    return throwNoSecondaryStorage();
+    throw new NoSecondaryStorageException();
   }
 
   @Override
   public List<ProcessFlowNodeStatisticsEntity> processInstanceFlowNodeStatistics(
       final long processInstanceKey) {
-    return throwNoSecondaryStorage();
+    throw new NoSecondaryStorageException();
   }
 
   @Override
   public SearchQueryResult<RoleEntity> searchRoles(final RoleQuery filter) {
-    return throwNoSecondaryStorage();
+    throw new NoSecondaryStorageException();
   }
 
   @Override
   public SearchQueryResult<RoleMemberEntity> searchRoleMembers(final RoleQuery filter) {
-    return throwNoSecondaryStorage();
+    throw new NoSecondaryStorageException();
   }
 
   @Override
   public SearchQueryResult<TenantEntity> searchTenants(final TenantQuery filter) {
-    return throwNoSecondaryStorage();
+    throw new NoSecondaryStorageException();
   }
 
   @Override
   public SearchQueryResult<TenantMemberEntity> searchTenantMembers(final TenantQuery filter) {
-    return throwNoSecondaryStorage();
+    throw new NoSecondaryStorageException();
   }
 
   @Override
   public SearchQueryResult<UserEntity> searchUsers(final UserQuery userQuery) {
-    return throwNoSecondaryStorage();
+    throw new NoSecondaryStorageException();
   }
 
   @Override
   public SearchQueryResult<UserTaskEntity> searchUserTasks(final UserTaskQuery filter) {
-    return throwNoSecondaryStorage();
+    throw new NoSecondaryStorageException();
   }
 
   @Override
   public SearchQueryResult<VariableEntity> searchVariables(final VariableQuery filter) {
-    return throwNoSecondaryStorage();
+    throw new NoSecondaryStorageException();
   }
 
   @Override
   public SearchQueryResult<SequenceFlowEntity> searchSequenceFlows(final SequenceFlowQuery filter) {
-    return throwNoSecondaryStorage();
+    throw new NoSecondaryStorageException();
   }
 
   @Override
   public SearchQueryResult<MessageSubscriptionEntity> searchMessageSubscriptions(
       final MessageSubscriptionQuery filter) {
-    return throwNoSecondaryStorage();
+    throw new NoSecondaryStorageException();
   }
 
   @Override
@@ -207,25 +207,21 @@ public class NoDBSearchClientsProxy implements SearchClientsProxy {
 
   @Override
   public Long countAssignees(final UsageMetricsQuery query) {
-    return throwNoSecondaryStorage();
+    throw new NoSecondaryStorageException();
   }
 
   @Override
   public Long countProcessInstances(final UsageMetricsQuery query) {
-    return throwNoSecondaryStorage();
+    throw new NoSecondaryStorageException();
   }
 
   @Override
   public Long countDecisionInstances(final UsageMetricsQuery query) {
-    return throwNoSecondaryStorage();
+    throw new NoSecondaryStorageException();
   }
 
   @Override
   public SearchQueryResult<JobEntity> searchJobs(final JobQuery query) {
-    return throwNoSecondaryStorage();
-  }
-
-  private <T> T throwNoSecondaryStorage() {
     throw new NoSecondaryStorageException();
   }
 }

--- a/search/search-client/src/main/java/io/camunda/search/clients/impl/NoDBSearchClientsProxy.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/impl/NoDBSearchClientsProxy.java
@@ -1,0 +1,231 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.impl;
+
+import io.camunda.search.clients.SearchClientsProxy;
+import io.camunda.search.entities.AuthorizationEntity;
+import io.camunda.search.entities.BatchOperationEntity;
+import io.camunda.search.entities.BatchOperationEntity.BatchOperationItemEntity;
+import io.camunda.search.entities.DecisionDefinitionEntity;
+import io.camunda.search.entities.DecisionInstanceEntity;
+import io.camunda.search.entities.DecisionRequirementsEntity;
+import io.camunda.search.entities.FlowNodeInstanceEntity;
+import io.camunda.search.entities.FormEntity;
+import io.camunda.search.entities.GroupEntity;
+import io.camunda.search.entities.GroupMemberEntity;
+import io.camunda.search.entities.IncidentEntity;
+import io.camunda.search.entities.JobEntity;
+import io.camunda.search.entities.MappingEntity;
+import io.camunda.search.entities.MessageSubscriptionEntity;
+import io.camunda.search.entities.ProcessDefinitionEntity;
+import io.camunda.search.entities.ProcessFlowNodeStatisticsEntity;
+import io.camunda.search.entities.ProcessInstanceEntity;
+import io.camunda.search.entities.RoleEntity;
+import io.camunda.search.entities.RoleMemberEntity;
+import io.camunda.search.entities.SequenceFlowEntity;
+import io.camunda.search.entities.TenantEntity;
+import io.camunda.search.entities.TenantMemberEntity;
+import io.camunda.search.entities.UserEntity;
+import io.camunda.search.entities.UserTaskEntity;
+import io.camunda.search.entities.VariableEntity;
+import io.camunda.search.exception.NoSecondaryStorageException;
+import io.camunda.search.filter.ProcessDefinitionStatisticsFilter;
+import io.camunda.search.query.AuthorizationQuery;
+import io.camunda.search.query.BatchOperationItemQuery;
+import io.camunda.search.query.BatchOperationQuery;
+import io.camunda.search.query.DecisionDefinitionQuery;
+import io.camunda.search.query.DecisionInstanceQuery;
+import io.camunda.search.query.DecisionRequirementsQuery;
+import io.camunda.search.query.FlowNodeInstanceQuery;
+import io.camunda.search.query.FormQuery;
+import io.camunda.search.query.GroupQuery;
+import io.camunda.search.query.IncidentQuery;
+import io.camunda.search.query.JobQuery;
+import io.camunda.search.query.MappingQuery;
+import io.camunda.search.query.MessageSubscriptionQuery;
+import io.camunda.search.query.ProcessDefinitionQuery;
+import io.camunda.search.query.ProcessInstanceQuery;
+import io.camunda.search.query.RoleQuery;
+import io.camunda.search.query.SearchQueryResult;
+import io.camunda.search.query.SequenceFlowQuery;
+import io.camunda.search.query.TenantQuery;
+import io.camunda.search.query.UsageMetricsQuery;
+import io.camunda.search.query.UserQuery;
+import io.camunda.search.query.UserTaskQuery;
+import io.camunda.search.query.VariableQuery;
+import io.camunda.security.auth.SecurityContext;
+import java.util.List;
+
+public class NoDBSearchClientsProxy implements SearchClientsProxy {
+
+  @Override
+  public SearchQueryResult<AuthorizationEntity> searchAuthorizations(
+      final AuthorizationQuery filter) {
+    return throwNoSecondaryStorage();
+  }
+
+  @Override
+  public SearchQueryResult<BatchOperationEntity> searchBatchOperations(
+      final BatchOperationQuery query) {
+    return throwNoSecondaryStorage();
+  }
+
+  @Override
+  public SearchQueryResult<BatchOperationItemEntity> searchBatchOperationItems(
+      final BatchOperationItemQuery query) {
+    return throwNoSecondaryStorage();
+  }
+
+  @Override
+  public SearchQueryResult<DecisionDefinitionEntity> searchDecisionDefinitions(
+      final DecisionDefinitionQuery filter) {
+    return throwNoSecondaryStorage();
+  }
+
+  @Override
+  public SearchQueryResult<DecisionInstanceEntity> searchDecisionInstances(
+      final DecisionInstanceQuery filter) {
+    return throwNoSecondaryStorage();
+  }
+
+  @Override
+  public SearchQueryResult<DecisionRequirementsEntity> searchDecisionRequirements(
+      final DecisionRequirementsQuery filter) {
+    return throwNoSecondaryStorage();
+  }
+
+  @Override
+  public SearchQueryResult<FlowNodeInstanceEntity> searchFlowNodeInstances(
+      final FlowNodeInstanceQuery filter) {
+    return throwNoSecondaryStorage();
+  }
+
+  @Override
+  public SearchQueryResult<FormEntity> searchForms(final FormQuery filter) {
+    return throwNoSecondaryStorage();
+  }
+
+  @Override
+  public SearchQueryResult<GroupEntity> searchGroups(final GroupQuery query) {
+    return throwNoSecondaryStorage();
+  }
+
+  @Override
+  public SearchQueryResult<GroupMemberEntity> searchGroupMembers(final GroupQuery query) {
+    return throwNoSecondaryStorage();
+  }
+
+  @Override
+  public SearchQueryResult<IncidentEntity> searchIncidents(final IncidentQuery filter) {
+    return throwNoSecondaryStorage();
+  }
+
+  @Override
+  public SearchQueryResult<MappingEntity> searchMappings(final MappingQuery filter) {
+    return throwNoSecondaryStorage();
+  }
+
+  @Override
+  public SearchQueryResult<ProcessDefinitionEntity> searchProcessDefinitions(
+      final ProcessDefinitionQuery filter) {
+    return throwNoSecondaryStorage();
+  }
+
+  @Override
+  public List<ProcessFlowNodeStatisticsEntity> processDefinitionFlowNodeStatistics(
+      final ProcessDefinitionStatisticsFilter filter) {
+    return throwNoSecondaryStorage();
+  }
+
+  @Override
+  public SearchQueryResult<ProcessInstanceEntity> searchProcessInstances(
+      final ProcessInstanceQuery query) {
+    return throwNoSecondaryStorage();
+  }
+
+  @Override
+  public List<ProcessFlowNodeStatisticsEntity> processInstanceFlowNodeStatistics(
+      final long processInstanceKey) {
+    return throwNoSecondaryStorage();
+  }
+
+  @Override
+  public SearchQueryResult<RoleEntity> searchRoles(final RoleQuery filter) {
+    return throwNoSecondaryStorage();
+  }
+
+  @Override
+  public SearchQueryResult<RoleMemberEntity> searchRoleMembers(final RoleQuery filter) {
+    return throwNoSecondaryStorage();
+  }
+
+  @Override
+  public SearchQueryResult<TenantEntity> searchTenants(final TenantQuery filter) {
+    return throwNoSecondaryStorage();
+  }
+
+  @Override
+  public SearchQueryResult<TenantMemberEntity> searchTenantMembers(final TenantQuery filter) {
+    return throwNoSecondaryStorage();
+  }
+
+  @Override
+  public SearchQueryResult<UserEntity> searchUsers(final UserQuery userQuery) {
+    return throwNoSecondaryStorage();
+  }
+
+  @Override
+  public SearchQueryResult<UserTaskEntity> searchUserTasks(final UserTaskQuery filter) {
+    return throwNoSecondaryStorage();
+  }
+
+  @Override
+  public SearchQueryResult<VariableEntity> searchVariables(final VariableQuery filter) {
+    return throwNoSecondaryStorage();
+  }
+
+  @Override
+  public SearchQueryResult<SequenceFlowEntity> searchSequenceFlows(final SequenceFlowQuery filter) {
+    return throwNoSecondaryStorage();
+  }
+
+  @Override
+  public SearchQueryResult<MessageSubscriptionEntity> searchMessageSubscriptions(
+      final MessageSubscriptionQuery filter) {
+    return throwNoSecondaryStorage();
+  }
+
+  @Override
+  public SearchClientsProxy withSecurityContext(final SecurityContext securityContext) {
+    return this;
+  }
+
+  @Override
+  public Long countAssignees(final UsageMetricsQuery query) {
+    return throwNoSecondaryStorage();
+  }
+
+  @Override
+  public Long countProcessInstances(final UsageMetricsQuery query) {
+    return throwNoSecondaryStorage();
+  }
+
+  @Override
+  public Long countDecisionInstances(final UsageMetricsQuery query) {
+    return throwNoSecondaryStorage();
+  }
+
+  @Override
+  public SearchQueryResult<JobEntity> searchJobs(final JobQuery query) {
+    return throwNoSecondaryStorage();
+  }
+
+  private <T> T throwNoSecondaryStorage() {
+    throw new NoSecondaryStorageException();
+  }
+}

--- a/search/search-domain/pom.xml
+++ b/search/search-domain/pom.xml
@@ -67,6 +67,10 @@
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-web</artifactId>
+    </dependency>
   </dependencies>
 
 </project>

--- a/search/search-domain/pom.xml
+++ b/search/search-domain/pom.xml
@@ -67,10 +67,6 @@
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.springframework</groupId>
-      <artifactId>spring-web</artifactId>
-    </dependency>
   </dependencies>
 
 </project>

--- a/search/search-domain/src/main/java/io/camunda/search/exception/CamundaSearchException.java
+++ b/search/search-domain/src/main/java/io/camunda/search/exception/CamundaSearchException.java
@@ -50,6 +50,7 @@ public class CamundaSearchException extends RuntimeException {
     NOT_FOUND,
     NOT_UNIQUE,
     CONNECTION_FAILED,
+    SECONDARY_STORAGE_NOT_SET,
     SEARCH_CLIENT_FAILED,
     SEARCH_SERVER_FAILED,
     UNKNOWN

--- a/search/search-domain/src/main/java/io/camunda/search/exception/NoSecondaryStorageException.java
+++ b/search/search-domain/src/main/java/io/camunda/search/exception/NoSecondaryStorageException.java
@@ -7,16 +7,14 @@
  */
 package io.camunda.search.exception;
 
-import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.ResponseStatus;
-
-@ResponseStatus(HttpStatus.FORBIDDEN)
-public class NoSecondaryStorageException extends RuntimeException {
+public class NoSecondaryStorageException extends CamundaSearchException {
 
   private static final long serialVersionUID = 1L;
 
   public NoSecondaryStorageException() {
-    super("This endpoint requires a secondary storage and none is set.");
+    super(
+        "The search client requires a secondary storage, but none is set",
+        Reason.SECONDARY_STORAGE_NOT_SET);
   }
 
   public NoSecondaryStorageException(final String message) {

--- a/search/search-domain/src/main/java/io/camunda/search/exception/NoSecondaryStorageException.java
+++ b/search/search-domain/src/main/java/io/camunda/search/exception/NoSecondaryStorageException.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.FORBIDDEN)
+public class NoSecondaryStorageException extends RuntimeException {
+
+  private static final long serialVersionUID = 1L;
+
+  public NoSecondaryStorageException() {
+    super("This endpoint requires a secondary storage and none is set.");
+  }
+
+  public NoSecondaryStorageException(final String message) {
+    super(message);
+  }
+}

--- a/service/src/main/java/io/camunda/service/exception/ErrorMapper.java
+++ b/service/src/main/java/io/camunda/service/exception/ErrorMapper.java
@@ -71,7 +71,8 @@ public class ErrorMapper {
         yield new ServiceException(detail, UNAVAILABLE);
       }
       case SECONDARY_STORAGE_NOT_SET -> {
-        final String detail = "The search client requires a secondary storage, but none is set";
+        final String detail =
+            "The search client requires a secondary storage, but none is set. Secondary storage can be configured using the 'camunda.database.type' property";
         LOGGER.debug(detail, cse);
         yield new ServiceException(detail, FORBIDDEN);
       }

--- a/service/src/main/java/io/camunda/service/exception/ErrorMapper.java
+++ b/service/src/main/java/io/camunda/service/exception/ErrorMapper.java
@@ -70,6 +70,11 @@ public class ErrorMapper {
         LOGGER.debug(detail, cse);
         yield new ServiceException(detail, UNAVAILABLE);
       }
+      case SECONDARY_STORAGE_NOT_SET -> {
+        final String detail = "The search client requires a secondary storage, but none is set";
+        LOGGER.debug(detail, cse);
+        yield new ServiceException(detail, FORBIDDEN);
+      }
       case SEARCH_SERVER_FAILED -> {
         final String detail = "The search server was unable to process the request";
         LOGGER.debug(detail, cse);


### PR DESCRIPTION
## Description

This PR introduces a dedicated no-op search client that is activated when secondary storage is disabled (`camunda.database.type: none`). I'm also returning a 403 error when trying to call an unsupported endpoint (see [thread](https://camunda.slack.com/archives/C06UYJMMETZ/p1750903603001499))

<img width="1068" height="535" alt="Screenshot 2568-07-15 at 11 13 59" src="https://github.com/user-attachments/assets/4fe660f4-825d-4b13-8acc-1be84d1b6e04" />

This change is only affecting the search client and is meant as a fallback in case an engineer adds a new endpoint but doesn't specify an annotation for no-db (not yet implemented, see #34385)

## Related issues

closes #35348
