### PR TITLE
fix: allow tomcat to run on standalone migration

### DIFF
--- a/dist/src/main/java/io/camunda/application/StandaloneProcessMigration.java
+++ b/dist/src/main/java/io/camunda/application/StandaloneProcessMigration.java
@@ -8,7 +8,7 @@
 package io.camunda.application;
 
 import io.camunda.application.commons.migration.AsyncMigrationsRunner;
-import io.camunda.application.commons.migration.AsyncMigrationsRunner.MigrationFinishedEvent;
+import io.camunda.application.commons.migration.MigrationFinishedEvent;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.WebApplicationType;
@@ -50,8 +50,7 @@ public class StandaloneProcessMigration implements ApplicationListener<Migration
   @Override
   public void onApplicationEvent(final MigrationFinishedEvent event) throws RuntimeException {
     final int exitCode =
-        SpringApplication.exit(
-            applicationContext, () -> event.getMigrationsException() == null ? 0 : 1);
+        SpringApplication.exit(applicationContext, () -> event.isSuccess() ? 0 : 1);
     System.exit(exitCode);
   }
 }

--- a/dist/src/main/java/io/camunda/application/commons/migration/AsyncMigrationsRunner.java
+++ b/dist/src/main/java/io/camunda/application/commons/migration/AsyncMigrationsRunner.java
@@ -89,11 +89,6 @@ public class AsyncMigrationsRunner implements ApplicationRunner {
       this.migrationsException = migrationsException;
     }
 
-    @Override
-    public String toString() {
-      return "Migration task completed";
-    }
-
     public Throwable getMigrationsException() {
       return migrationsException;
     }

--- a/dist/src/main/java/io/camunda/application/commons/migration/MigrationFinishedEvent.java
+++ b/dist/src/main/java/io/camunda/application/commons/migration/MigrationFinishedEvent.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.application.commons.migration;
+
+import org.springframework.context.ApplicationEvent;
+
+public abstract class MigrationFinishedEvent extends ApplicationEvent {
+
+  public MigrationFinishedEvent(final Object source) {
+    super(source);
+  }
+
+  public abstract boolean isSuccess();
+}


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Use event to signal the termination of process migration, this way the http server does not get terminated prematurely to allow scrapping of the prometheus metrics.

The event published is only consumed by the `StandaloneProcessMigration` to handle termination thus not interfering when the migration is run in embedded mode. 

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

related to https://github.com/camunda/camunda-operator/pull/4311
closes #[35373](https://github.com/camunda/camunda/issues/35373)
