### PR TITLE
feat: simplify future handling in document services

### DIFF
--- a/service/src/main/java/io/camunda/service/DocumentServices.java
+++ b/service/src/main/java/io/camunda/service/DocumentServices.java
@@ -133,8 +133,7 @@ public class DocumentServices extends ApiServices<DocumentServices> {
 
   public CompletableFuture<Void> deleteDocument(final String documentId, final String storeId) {
 
-    final DocumentStoreRecord documentStore = getDocumentStore(storeId);
-    return documentStore
+    return getDocumentStore(storeId)
         .instance()
         .deleteDocument(documentId)
         .handleAsync(this::requireRightOrThrow);

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/DocumentController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/DocumentController.java
@@ -93,18 +93,19 @@ public class DocumentController {
   @CamundaGetMapping(
       path = "/{documentId}",
       produces = {}) // produces arbitrary content type
-  public CompletableFuture<ResponseEntity<StreamingResponseBody>> getDocumentContent(
+  public ResponseEntity<StreamingResponseBody> getDocumentContent(
       @PathVariable final String documentId,
       @RequestParam(required = false) final String storeId,
       @RequestParam(required = false) final String contentHash) {
 
     // handle the future explicitly here because a StreamingResponseBody is needed as result instead
-    // of Object
+    // of a future wrapping the stream response
     return documentServices
         .withAuthentication(authenticationProvider.getCamundaAuthentication())
         .getDocumentContent(documentId, storeId, contentHash)
         // Any service exception that can occur is handled by the GlobalControllerExceptionHandler
-        .thenApplyAsync(ResponseMapper::toDocumentContentResponse);
+        .thenApply(ResponseMapper::toDocumentContentResponse)
+        .join();
   }
 
   @CamundaDeleteMapping(path = "/{documentId}")


### PR DESCRIPTION
## Description

Reduces the Java `Future` usage and complexity in the document services. The document store retrieval can be unwrapped and called synchronously. This reduces complexity a lot. The document store methods all receive streamlined error handling, ensuring errors are mapped accordingly.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

related to https://github.com/camunda/camunda/issues/35069