### PR TITLE
fix: keep aggregation results order

### DIFF
--- a/search/search-client-elasticsearch/src/main/java/io/camunda/search/es/transformers/aggregator/SearchAggregationResultTransformer.java
+++ b/search/search-client-elasticsearch/src/main/java/io/camunda/search/es/transformers/aggregator/SearchAggregationResultTransformer.java
@@ -29,6 +29,7 @@ import io.camunda.search.clients.transformers.query.Cursor;
 import io.camunda.search.es.transformers.ElasticsearchTransformers;
 import io.camunda.search.es.transformers.search.SearchQueryHitTransformer;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -98,7 +99,7 @@ public class SearchAggregationResultTransformer<T>
 
   private <B extends MultiBucketBase> AggregationResult transformMultiBucketAggregate(
       final MultiBucketAggregateBase<B> aggregate) {
-    final var map = new HashMap<String, AggregationResult>();
+    final var map = new LinkedHashMap<String, AggregationResult>();
     final var buckets = aggregate.buckets();
     final var searchAfter = extractSearchAfter(aggregate);
     if (buckets.isKeyed()) {

--- a/search/search-client-opensearch/src/main/java/io/camunda/search/os/transformers/aggregator/SearchAggregationResultTransformer.java
+++ b/search/search-client-opensearch/src/main/java/io/camunda/search/os/transformers/aggregator/SearchAggregationResultTransformer.java
@@ -17,6 +17,7 @@ import io.camunda.search.clients.transformers.query.Cursor;
 import io.camunda.search.os.transformers.OpensearchTransformers;
 import io.camunda.search.os.transformers.search.SearchQueryHitTransformer;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -97,7 +98,7 @@ public class SearchAggregationResultTransformer<T>
 
   private <B extends MultiBucketBase> AggregationResult transformMultiBucketAggregate(
       final MultiBucketAggregateBase<B> aggregate) {
-    final var map = new HashMap<String, AggregationResult>();
+    final var map = new LinkedHashMap<String, AggregationResult>();
     final var buckets = aggregate.buckets();
     final var searchAfter = extractSearchAfter(aggregate);
     if (buckets.isKeyed()) {


### PR DESCRIPTION
## Description

- Keep aggregation results order, especially important for composite aggregations.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).


