### PR TITLE
fix: add missing body for get mapping endpoint

### DIFF
--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -4103,6 +4103,10 @@ paths:
       responses:
         "200":
           description: The mapping rule was returned successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MappingRuleResult"
         "401":
           $ref: "#/components/responses/Unauthorized"
         "404":


### PR DESCRIPTION
## Description

The response body is missing in the rest-api for`/v2/mapping-rules/:mappingRuleId` and accordingly in documentation:
[Get a mapping rule](https://docs.camunda.io/docs/next/apis-tools/orchestration-cluster-api-rest/specifications/get-mapping-rule/)

