### PR TITLE
build: use 8.6-SNAPSHOT in the OC

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/config/docker-compose.yml
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/config/docker-compose.yml
@@ -39,7 +39,7 @@ services:
 
   zeebe: &zeebe
     container_name: zeebe-${DATABASE}
-    image: camunda/zeebe:8.6.21
+    image: camunda/zeebe:8.6-SNAPSHOT
     environment:
       - 'JAVA_TOOL_OPTIONS=-Xms512m -Xmx512m'
       #- "JAVA_OPTS=-agentlib:jdwp=transport=dt_socket,address=8000,server=y,suspend=n"
@@ -57,7 +57,7 @@ services:
 
   tasklist: &tasklist
     container_name: tasklist-${DATABASE}
-    image: camunda/tasklist:8.6.21
+    image: camunda/tasklist:8.6-SNAPSHOT
     ports:
       - 8080:8080
     environment:
@@ -75,7 +75,7 @@ services:
 
   operate: &operate
     container_name: operate-${DATABASE}
-    image: camunda/operate:8.6.21
+    image: camunda/operate:8.6-SNAPSHOT
     ports:
       - 8081:8080
     environment:


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Following [this ticket](https://github.com/camunda/camunda/issues/30477), `8.6-SNAPSHOT` images have been published, so we’re now able to run our tests against them.

🧪 Test Run [here](https://github.com/camunda/camunda/actions/runs/16290738312)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
