### PR TITLE
ci: make Operate+Tasklist snapshot+release artifacts public

### DIFF
--- a/operate/pom.xml
+++ b/operate/pom.xml
@@ -27,11 +27,6 @@
   </modules>
 
   <properties>
-
-    <!-- release parent settings -->
-    <nexus.snapshot.repository>https://artifacts.camunda.com/artifactory/camunda-operate-snapshots/</nexus.snapshot.repository>
-    <nexus.release.repository>https://artifacts.camunda.com/artifactory/camunda-operate/</nexus.release.repository>
-
     <maven.compiler.target>21</maven.compiler.target>
     <maven.compiler.source>21</maven.compiler.source>
 

--- a/tasklist/pom.xml
+++ b/tasklist/pom.xml
@@ -30,10 +30,6 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-    <!-- release parent settings -->
-    <nexus.snapshot.repository>https://artifacts.camunda.com/artifactory/camunda-zeebe-tasklist-snapshots/</nexus.snapshot.repository>
-    <nexus.release.repository>https://artifacts.camunda.com/artifactory/camunda-zeebe-tasklist/</nexus.release.repository>
-
     <maven.compiler.target>21</maven.compiler.target>
     <maven.compiler.source>21</maven.compiler.source>
 


### PR DESCRIPTION
## Description

This PR has a quite minimal code change with potentially big implications, as described below:

Removing settings from [operate/pom.xml](https://github.com/camunda/camunda/blob/main/operate/pom.xml) and [tasklist/pom.xml](https://github.com/camunda/camunda/blob/main/tasklist/pom.xml) means the settings in [bom/pom.xml](https://github.com/camunda/camunda/blob/main/bom/pom.xml) take effect for every module in the monorepo:

* all modules' SNAPSHOTs will be uploaded to https://artifacts.camunda.com/artifactory/zeebe-io-snapshots/ (public)
* all modules' releases will be uploaded to https://artifacts.camunda.com/artifactory/zeebe-io/ (public)

### Impact

The previous upload URLs pointed to Artifactory repos only accessible to Camundi, the new ones are publicly accessible → new module versions e.g. for new 8.6, 8.7 and 8.8 SNAPSHOTs and future releases will be public starting after this change is merged. Earlier versions stay private.

No known usages of the previous upload URLs: ✔️

* https://github.com/search?q=org%3Acamunda%20https%3A%2F%2Fartifacts.camunda.com%2Fartifactory%2Fcamunda-operate&type=code
* https://github.com/search?q=org%3Acamunda%20https%3A%2F%2Fartifacts.camunda.com%2Fartifactory%2Fcamunda-zeebe-tasklist&type=code

Since SNAPSHOTS for Operate/Tasklist will exist in both the old private repos and the new https://artifacts.camunda.com/artifactory/zeebe-io-snapshots/ we need to ensure that the [resolution order](https://jfrog.com/help/r/jfrog-artifactory-documentation/virtual-resolution-order) puts the new ones first:

* manually checked that `zeebe-io` and `zeebe-io-snapshot` are listed before the old private repos, all users should transparently get to use the more recent artifacts from the new public repos ✔️ 

Release artifacts are unique and there is no evidence of any direct usage (can only be inside Camunda due to private nature) of the Artifactory repositories. Usages of virtual repositories will continue to work since the change is transparent to them. ✔️

The machine account used by CI has (the same) necessary permissions to old and new Artifactory repo alike. ✔️


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)). - enabled for monorepo branches that contain Operate+Tasklist

## Related issues

Related to https://github.com/camunda/camunda/issues/19035
