### PR TITLE
fix: Slack notification formatting fix

### DIFF
--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -759,7 +759,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": ":success: *Release job for ${{ inputs.releaseVersion }}* **succeeded!** (excluding Maven Central publishing - this is done separately)\n"
+                    "text": ":success: *Release job for ${{ inputs.releaseVersion }}* succeeded! (excluding Maven Central publishing - this is done separately)\n"
                   }
                 }
               ]


### PR DESCRIPTION
## Description

fix: Slack notification formatting fix

Currently formatting is broken:

<img width="631" height="81" alt="Screenshot 2025-07-15 at 13 45 24" src="https://github.com/user-attachments/assets/3006b409-1a8d-4f96-a49a-cd84e1031a4e" />

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
