### PR TITLE
test: don't fail when backup isn't available immediately

### DIFF
--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/ContinuousBackupIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/ContinuousBackupIT.java
@@ -102,6 +102,7 @@ final class ContinuousBackupIT {
     backupActuator.take(backupId);
 
     await("backup is completed")
+        .ignoreExceptions()
         .untilAsserted(
             () ->
                 assertThat(backupActuator.status(backupId).getState())


### PR DESCRIPTION
`ContinuousBackupIT#successfulBackupEnablesSnapshotProgress` was very flaky, [apparently](https://github.com/camunda/camunda/actions/runs/16277684528/attempts/1#summary-45960447864) because we would check a backup status before it was created. The resulting 404 would let the test fail. Instead, we now just ignore any exceptions, only failing when the default timeout of 10 seconds has passed.
