### PR TITLE
fix: skip archiving batch operations if no IDs given

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/BatchOperationArchiverJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/BatchOperationArchiverJob.java
@@ -58,7 +58,7 @@ public class BatchOperationArchiverJob implements ArchiverJob {
 
   private CompletableFuture<Integer> archiveBatch(final ArchiveBatch archiveBatch) {
 
-    if (archiveBatch != null) {
+    if (archiveBatch != null && !(archiveBatch.ids() == null || archiveBatch.ids().isEmpty())) {
       logger.trace("Following batch operations are found for archiving: {}", archiveBatch);
       metrics.recordBatchOperationsArchiving(archiveBatch.ids().size());
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/BatchOperationArchiverJobTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/BatchOperationArchiverJobTest.java
@@ -39,6 +39,7 @@ final class BatchOperationArchiverJobTest {
 
     // then
     assertThat(result).succeedsWithin(Duration.ZERO).isEqualTo(0);
+    assertThat(repository.moves).isEmpty();
   }
 
   @Test
@@ -51,6 +52,7 @@ final class BatchOperationArchiverJobTest {
 
     // then
     assertThat(result).succeedsWithin(Duration.ZERO).isEqualTo(0);
+    assertThat(repository.moves).isEmpty();
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ProcessInstancesArchiverJobTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ProcessInstancesArchiverJobTest.java
@@ -51,6 +51,7 @@ final class ProcessInstancesArchiverJobTest {
 
     // then
     assertThat(result).succeedsWithin(Duration.ZERO).isEqualTo(0);
+    assertThat(repository.moves).isEmpty();
   }
 
   @Test
@@ -63,6 +64,7 @@ final class ProcessInstancesArchiverJobTest {
 
     // then
     assertThat(result).succeedsWithin(Duration.ZERO).isEqualTo(0);
+    assertThat(repository.moves).isEmpty();
   }
 
   @Test


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
I noticed when debugging that we do continuously call ES reindex to archive batch operations, even-though no ids were provided in the batch

The main reason is that, in [ElasticsearchArchiverRepository](https://github.com/camunda/camunda/blob/9394901b6d4879375134265244c82f77a8c30900/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepository.java#L233-L235) when there is no hits for batch operation to archive, we return a default `new ArchiverBatch(null, List.of())` , which is not handled in `BatchOperationArchiverJob`

I made the same check as in [ProcessInstancesArchiverJob](https://github.com/camunda/camunda/blob/9394901b6d4879375134265244c82f77a8c30900/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ProcessInstancesArchiverJob.java#L64)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
