### PR TITLE
ci: add linting rule to detect situations of unintentional skipping

### DIFF
--- a/.github/conftest-unified-ci-rules.rego
+++ b/.github/conftest-unified-ci-rules.rego
@@ -78,6 +78,16 @@ deny[msg] {
         [concat(", ", jobs_that_should_fail_checkresults - jobs_that_actually_fail_checkresults)])
 }
 
+deny[msg] {
+    # only enforced on Unified CI since it is specific to jobs after check-results job
+    input.name == "CI"
+
+    count(get_jobs_after_checkresults_without_ifalways(input.jobs)) > 0
+
+    msg := sprintf("There are GitHub Actions jobs in Unified CI that depend on check-results but without specifying `if: always()...` which means they will get skipped! Affected job IDs: %s",
+        [concat(", ", get_jobs_after_checkresults_without_ifalways(input.jobs))])
+}
+
 ###########################   RULE HELPERS   ##################################
 
 get_jobs_without_timeoutminutes(jobInput) = jobs_without_timeoutminutes {
@@ -157,5 +167,27 @@ get_jobs_not_needing_detectchanges(jobInput) = jobs_not_needing_detectchanges {
             need == "detect-changes"
         }
         count(job_needs_detectchanges) == 0
+    }
+}
+
+get_jobs_after_checkresults_without_ifalways(jobInput) = jobs_after_checkresults_without_ifalways {
+    jobs_after_checkresults_without_ifalways := { job_id |
+        job := jobInput[job_id]
+
+        # check if job declares dependency on "check-results" job anywhere
+        job_needs_checkresults := { need |
+            need := job.needs[_]
+            need == "check-results"
+        }
+        count(job_needs_checkresults) == 1
+
+        # check that the job declares an `if: ...` condition and it contains `always()`
+        #
+        # this is important because GHA by default skips execution of jobs that itself
+        # depend on jobs (transitively) that were skipped - which happens a lot in Unified CI
+        # and we want to avoid accidentally skipping deploy jobs or similar
+        #
+        job_if := object.get(job, "if", "")  # get with empty default value
+        not contains(job_if, "always() && needs.check-results.result == 'success'")
     }
 }


### PR DESCRIPTION
## Description

Would detect the problem in https://github.com/camunda/camunda/pull/35180 before merge and avoid having a fix like https://github.com/camunda/camunda/pull/35317

See https://github.com/camunda/camunda/pull/35317#discussion_r2207675347 for an explanation on why the problem happened.

See for a [demo](https://github.com/camunda/camunda/actions/runs/16297346204/job/46022623208?pr=35393#step:4:201) of this in action: https://github.com/camunda/camunda/pull/35393 (should be unmergeable because of new lint rule)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

None
