### PR TITLE
fix: Fix SaaS app switcher on Operate and Tasklist

### DIFF
--- a/operate/client/src/App/Layout/AppHeader/tests/appSwitcher.test.tsx
+++ b/operate/client/src/App/Layout/AppHeader/tests/appSwitcher.test.tsx
@@ -22,73 +22,11 @@ const Wrapper: React.FC<{children?: React.ReactNode}> = ({children}) => {
 };
 
 describe('App switcher', () => {
-  afterEach(() => {
-    window.clientConfig = undefined;
-  });
-
-  it('should render with correct links', async () => {
-    window.clientConfig = {
-      isEnterprise: false,
-      organizationId: 'some-organization-id',
-    };
-
-    mockMe().withSuccess(
-      createUser({
-        c8Links: {
-          operate: 'https://link-to-operate',
-          tasklist: 'https://link-to-tasklist',
-          modeler: 'https://link-to-modeler',
-          console: 'https://link-to-console',
-          optimize: 'https://link-to-optimize',
-        },
-      }),
-    );
-
-    await authenticationStore.authenticate();
-    const {user} = render(<AppHeader />, {
-      wrapper: Wrapper,
-    });
-
-    await user.click(
-      await screen.findByRole('button', {
-        name: /camunda components/i,
-      }),
-    );
-
-    const withinAppPanel = within(
-      screen.getByRole('navigation', {
-        name: /app panel/i,
-      }),
-    );
-
-    const consoleLink = await withinAppPanel.findByRole('link', {
-      name: 'Console',
-    });
-    expect(consoleLink).toHaveAttribute('href', 'https://link-to-console');
-    expect(consoleLink).not.toHaveAttribute('target');
-
-    const modelerLink = withinAppPanel.getByRole('link', {name: 'Modeler'});
-    expect(modelerLink).toHaveAttribute('href', 'https://link-to-modeler');
-    expect(modelerLink).not.toHaveAttribute('target');
-
-    const tasklistLink = withinAppPanel.getByRole('link', {name: 'Tasklist'});
-    expect(tasklistLink).toHaveAttribute('href', 'https://link-to-tasklist');
-    expect(tasklistLink).not.toHaveAttribute('target');
-
-    const operateLink = withinAppPanel.getByRole('link', {name: 'Operate'});
-    expect(operateLink).toHaveAttribute('href', '/');
-    expect(operateLink).not.toHaveAttribute('target');
-
-    const optimizeLink = withinAppPanel.getByRole('link', {name: 'Optimize'});
-    expect(optimizeLink).toHaveAttribute('href', 'https://link-to-optimize');
-    expect(optimizeLink).not.toHaveAttribute('target');
-  });
-
   it('should not render links for CCSM', async () => {
-    window.clientConfig = {
+    vi.stubGlobal('clientConfig', {
       isEnterprise: false,
       organizationId: null,
-    };
+    });
 
     mockMe().withSuccess(
       createUser({

--- a/operate/client/src/App/Layout/AppHeader/tests/licenseNote.test.tsx
+++ b/operate/client/src/App/Layout/AppHeader/tests/licenseNote.test.tsx
@@ -102,13 +102,7 @@ describe('license note', () => {
       expect(licenseTagStore.state.status).toEqual('fetched'),
     );
 
-    expect(
-      await screen.findByText(/^production license$/i),
-    ).toBeInTheDocument();
-
-    expect(
-      screen.queryByText(/^Non-production license$/i),
-    ).not.toBeInTheDocument();
+    // e/;
   });
 
   it('should not show license note on fetch error', async () => {

--- a/operate/client/src/App/Layout/AppHeader/tests/licenseNote.test.tsx
+++ b/operate/client/src/App/Layout/AppHeader/tests/licenseNote.test.tsx
@@ -102,7 +102,13 @@ describe('license note', () => {
       expect(licenseTagStore.state.status).toEqual('fetched'),
     );
 
-    // e/;
+    expect(
+      await screen.findByText(/^production license$/i),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.queryByText(/^Non-production license$/i),
+    ).not.toBeInTheDocument();
   });
 
   it('should not show license note on fetch error', async () => {

--- a/operate/client/src/App/Layout/AppHeader/tests/userInfo.test.tsx
+++ b/operate/client/src/App/Layout/AppHeader/tests/userInfo.test.tsx
@@ -54,6 +54,10 @@ describe('User info', () => {
   });
 
   it('should handle a SSO user', async () => {
+    vi.stubGlobal('clientConfig', {
+      ...window.clientConfig,
+      canLogout: false,
+    });
     mockMe().withSuccess(mockSsoUser);
 
     const {user} = render(<AppHeader />, {

--- a/operate/client/src/App/Layout/C3Provider.tsx
+++ b/operate/client/src/App/Layout/C3Provider.tsx
@@ -61,7 +61,7 @@ const C3Provider: React.FC<Props> = ({children}) => {
       userToken={token}
       getNewUserToken={fetchToken}
       currentClusterUuid={clusterId}
-      currentApp="tasklist"
+      currentApp="operate"
       stage={STAGE === 'unknown' ? 'dev' : STAGE}
       handleTheme
     >

--- a/operate/client/src/App/Layout/C3Provider.tsx
+++ b/operate/client/src/App/Layout/C3Provider.tsx
@@ -1,0 +1,74 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {C3UserConfigurationProvider} from '@camunda/camunda-composite-components';
+import {C3ThemePersister} from './C3ThemePersister';
+import {useEffect, useState} from 'react';
+import {logger} from 'modules/logger';
+import {getStage} from 'modules/tracking/getStage';
+import {getSaasUserToken} from 'modules/api/v2/authentication/token';
+
+const STAGE = getStage(window.location.host);
+
+async function fetchToken() {
+  const {isSuccess, data} = await getSaasUserToken();
+
+  if (isSuccess) {
+    return data;
+  }
+
+  logger.error('Failed to fetch user token');
+  return '';
+}
+
+type Props = {
+  children: React.ReactNode;
+};
+
+const C3Provider: React.FC<Props> = ({children}) => {
+  const [token, setToken] = useState<string | null>(null);
+  const organizationId = window.clientConfig?.organizationId;
+  const clusterId = window.clientConfig?.clusterId;
+
+  useEffect(() => {
+    async function init() {
+      const organizationId = window.clientConfig?.organizationId;
+
+      if (typeof organizationId === 'string') {
+        setToken(await fetchToken());
+      }
+    }
+
+    init();
+  }, []);
+
+  if (
+    token === null ||
+    typeof organizationId !== 'string' ||
+    typeof clusterId !== 'string'
+  ) {
+    return children;
+  }
+
+  return (
+    <C3UserConfigurationProvider
+      activeOrganizationId={organizationId}
+      userToken={token}
+      getNewUserToken={fetchToken}
+      currentClusterUuid={clusterId}
+      currentApp="tasklist"
+      stage={STAGE === 'unknown' ? 'dev' : STAGE}
+      handleTheme
+    >
+      <C3ThemePersister />
+      {children}
+    </C3UserConfigurationProvider>
+  );
+};
+
+export {C3Provider};

--- a/operate/client/src/App/Layout/C3ThemePersister.tsx
+++ b/operate/client/src/App/Layout/C3ThemePersister.tsx
@@ -1,0 +1,23 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {useC3Profile} from '@camunda/camunda-composite-components';
+import {currentTheme} from 'modules/stores/currentTheme';
+import {useEffect} from 'react';
+
+const C3ThemePersister: React.FC = () => {
+  const {theme} = useC3Profile();
+
+  useEffect(() => {
+    currentTheme.changeTheme(theme);
+  }, [theme]);
+
+  return null;
+};
+
+export {C3ThemePersister};

--- a/operate/client/src/App/Layout/index.tsx
+++ b/operate/client/src/App/Layout/index.tsx
@@ -10,15 +10,16 @@ import {Outlet} from 'react-router-dom';
 import {AppHeader} from './AppHeader';
 import {PageContent} from './styled';
 import {observer} from 'mobx-react';
+import {C3Provider} from './C3Provider';
 
 const Layout: React.FC = observer(() => {
   return (
-    <>
+    <C3Provider>
       <AppHeader />
       <PageContent id="main-content">
         <Outlet />
       </PageContent>
-    </>
+    </C3Provider>
   );
 });
 

--- a/operate/client/src/modules/api/v2/authentication/token.ts
+++ b/operate/client/src/modules/api/v2/authentication/token.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {requestAndParse} from 'modules/request';
+
+const getSaasUserToken = async (
+  options?: Parameters<typeof requestAndParse>[1],
+) => {
+  return requestAndParse<string>({url: '/v2/authentication/me/token'}, options);
+};
+
+export {getSaasUserToken};

--- a/operate/client/src/modules/tracking/index.ts
+++ b/operate/client/src/modules/tracking/index.ts
@@ -229,7 +229,7 @@ type Events =
     }
   | {
       eventName: 'info-bar';
-      link: 'documentation' | 'academy' | 'feedback' | 'slack';
+      link: 'documentation' | 'academy' | 'feedback' | 'forum';
     }
   | {
       eventName: 'dashboard-link-clicked';

--- a/tasklist/client/src/common/components/Layout/C3Provider.tsx
+++ b/tasklist/client/src/common/components/Layout/C3Provider.tsx
@@ -8,7 +8,7 @@
 
 import {C3UserConfigurationProvider} from '@camunda/camunda-composite-components';
 import {C3ThemePersister} from 'common/theme/C3ThemePersister';
-import {api} from 'v1/api';
+import {api} from 'v2/api';
 import {getClientConfig} from 'common/config/getClientConfig';
 import {getStage} from 'common/config/getStage';
 import {useEffect, useState} from 'react';
@@ -45,7 +45,6 @@ const C3Provider: React.FC<Props> = ({children}) => {
     async function init() {
       const {organizationId} = getClientConfig();
 
-      // We'll temporarily use the V1 endpoint even on V2. This should be fixed on #32255
       if (organizationId !== null) {
         setToken(await fetchToken());
       }

--- a/tasklist/client/src/v1/api/index.ts
+++ b/tasklist/client/src/v1/api/index.ts
@@ -257,15 +257,6 @@ const api = {
       },
     );
   },
-  getSaasUserToken: () => {
-    return new Request(getFullURL('/v1/internal/users/token'), {
-      ...BASE_REQUEST_OPTIONS,
-      method: 'GET',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-    });
-  },
 } as const;
 
 export {api};

--- a/tasklist/client/src/v2/api/index.ts
+++ b/tasklist/client/src/v2/api/index.ts
@@ -144,6 +144,15 @@ const api = {
       },
     });
   },
+  getSaasUserToken: () => {
+    return new Request(getFullURL('/v2/authentication/me/token'), {
+      ...BASE_REQUEST_OPTIONS,
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
+  },
 } as const;
 
 export {api};


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

On this PR on Tasklist:
- We change the token endpoint so it works with the new Identity auth and the app switcher works again

On this PR on Operate
- We migrate the app header so it's enhanced with Console data on SaaS mode


Right now the solution in Operate is mostly copied from Tasklist. I'll extract these common parts in the future when we have the frontend monorepo

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #32255
