### PR TITLE
Remove test dependency to production configuration beans

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/LegacyOperateProperties.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/LegacyOperateProperties.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration.beanoverrides;
+
+import io.camunda.operate.property.OperateProperties;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.DependsOn;
+import org.springframework.context.annotation.PropertySource;
+
+@ConfigurationProperties(OperateProperties.PREFIX)
+@PropertySource("classpath:operate-version.properties")
+@DependsOn("databaseInfo")
+public class LegacyOperateProperties extends OperateProperties {}

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/LegacyTasklistProperties.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/LegacyTasklistProperties.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration.beanoverrides;
+
+import io.camunda.tasklist.property.TasklistProperties;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.PropertySource;
+
+@ConfigurationProperties(TasklistProperties.PREFIX)
+@PropertySource("classpath:tasklist-version.properties")
+public class LegacyTasklistProperties extends TasklistProperties {}

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/OperatePropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/OperatePropertiesOverride.java
@@ -13,23 +13,22 @@ import org.springframework.beans.BeanUtils;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.DependsOn;
 import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.Profile;
 import org.springframework.context.annotation.PropertySource;
 
 @Configuration
-@EnableConfigurationProperties(OperateProperties.class)
+@EnableConfigurationProperties(LegacyOperateProperties.class)
 @PropertySource("classpath:operate-version.properties")
-@DependsOn("databaseInfo")
-@Profile("operate | test")
+@Profile("operate")
 public class OperatePropertiesOverride {
 
   private final UnifiedConfiguration unifiedConfiguration;
-  private final OperateProperties legacyOperateProperties;
+  private final LegacyOperateProperties legacyOperateProperties;
 
   public OperatePropertiesOverride(
-      UnifiedConfiguration unifiedConfiguration, OperateProperties legacyOperateProperties) {
+      final UnifiedConfiguration unifiedConfiguration,
+      final LegacyOperateProperties legacyOperateProperties) {
     this.unifiedConfiguration = unifiedConfiguration;
     this.legacyOperateProperties = legacyOperateProperties;
   }

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/TasklistPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/TasklistPropertiesOverride.java
@@ -19,16 +19,17 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.context.annotation.PropertySource;
 
 @Configuration
-@EnableConfigurationProperties(TasklistProperties.class)
+@EnableConfigurationProperties(LegacyTasklistProperties.class)
 @PropertySource("classpath:tasklist-version.properties")
-@Profile("tasklist | test")
+@Profile("tasklist")
 public class TasklistPropertiesOverride {
 
   private final UnifiedConfiguration unifiedConfiguration;
-  private final TasklistProperties legacyTasklistProperties;
+  private final LegacyTasklistProperties legacyTasklistProperties;
 
   public TasklistPropertiesOverride(
-      UnifiedConfiguration unifiedConfiguration, TasklistProperties legacyTasklistProperties) {
+      final UnifiedConfiguration unifiedConfiguration,
+      final LegacyTasklistProperties legacyTasklistProperties) {
     this.unifiedConfiguration = unifiedConfiguration;
     this.legacyTasklistProperties = legacyTasklistProperties;
   }

--- a/operate/common/src/main/java/io/camunda/operate/property/OperateProperties.java
+++ b/operate/common/src/main/java/io/camunda/operate/property/OperateProperties.java
@@ -11,13 +11,9 @@ import io.camunda.operate.conditions.DatabaseInfo;
 import io.camunda.operate.conditions.DatabaseType;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
-import org.springframework.context.annotation.PropertySource;
 
 /** This class contains all project configuration parameters. */
-@ConfigurationProperties(OperateProperties.PREFIX)
-@PropertySource("classpath:operate-version.properties")
 public class OperateProperties {
 
   public static final String PREFIX = "camunda.operate";

--- a/operate/qa/integration-tests/pom.xml
+++ b/operate/qa/integration-tests/pom.xml
@@ -507,13 +507,6 @@
       <version>11.0.9</version>
       <scope>test</scope>
     </dependency>
-
-    <dependency>
-      <groupId>io.camunda</groupId>
-      <artifactId>configuration</artifactId>
-      <version>${project.version}</version>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <build>

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/elasticsearch/ElasticsearchConnectorIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/elasticsearch/ElasticsearchConnectorIT.java
@@ -14,6 +14,7 @@ import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import io.camunda.operate.conditions.DatabaseInfo;
 import io.camunda.operate.connect.ElasticsearchConnector;
 import io.camunda.operate.property.OperateProperties;
+import io.camunda.operate.util.TestOperatePropertiesOverride;
 import io.camunda.operate.util.TestPlugin;
 import io.camunda.search.connect.plugin.PluginConfiguration;
 import io.camunda.webapps.schema.SupportedVersions;
@@ -29,7 +30,6 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
@@ -40,9 +40,12 @@ import org.testcontainers.utility.DockerImageName;
 
 @Testcontainers
 @SpringBootTest(
-    classes = {ElasticsearchConnector.class, DatabaseInfo.class, OperateProperties.class},
+    classes = {
+      ElasticsearchConnector.class,
+      DatabaseInfo.class,
+      TestOperatePropertiesOverride.class
+    },
     properties = OperateProperties.PREFIX + ".database=elasticsearch")
-@EnableConfigurationProperties(OperateProperties.class)
 public class ElasticsearchConnectorIT {
 
   @Container

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/opensearch/OpensearchConnectorIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/opensearch/OpensearchConnectorIT.java
@@ -18,6 +18,7 @@ import io.camunda.operate.connect.OperateDateTimeFormatter;
 import io.camunda.operate.property.OpensearchProperties;
 import io.camunda.operate.property.OperateProperties;
 import io.camunda.operate.util.OperateAbstractIT;
+import io.camunda.operate.util.TestOperatePropertiesOverride;
 import io.camunda.operate.util.TestPlugin;
 import io.camunda.search.connect.plugin.PluginConfiguration;
 import io.camunda.zeebe.util.FileUtil;
@@ -34,7 +35,6 @@ import org.junit.Test;
 import org.opensearch.client.opensearch.cluster.HealthRequest;
 import org.opensearch.testcontainers.OpensearchContainer;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
@@ -47,10 +47,10 @@ import org.testcontainers.junit.jupiter.Testcontainers;
       OpensearchProperties.class,
       JacksonConfig.class,
       OperateDateTimeFormatter.class,
-      DatabaseInfo.class
+      DatabaseInfo.class,
+      TestOperatePropertiesOverride.class
     },
     properties = OperateProperties.PREFIX + ".database=opensearch")
-@EnableConfigurationProperties(OperateProperties.class)
 public class OpensearchConnectorIT extends OperateAbstractIT {
 
   private static final OpensearchContainer<?> OPENSEARCH_CONTAINER =

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/properties/PropertiesIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/properties/PropertiesIT.java
@@ -12,6 +12,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.camunda.application.commons.security.CamundaSecurityConfiguration.CamundaSecurityProperties;
 import io.camunda.operate.conditions.DatabaseInfo;
 import io.camunda.operate.property.OperateProperties;
+import io.camunda.operate.util.TestOperatePropertiesOverride;
 import io.camunda.operate.util.apps.nobeans.TestApplicationWithNoBeans;
 import io.camunda.security.configuration.SecurityConfiguration;
 import org.junit.Test;
@@ -26,7 +27,7 @@ import org.springframework.test.context.junit4.SpringRunner;
     classes = {
       TestApplicationWithNoBeans.class,
       DatabaseInfo.class,
-      OperateProperties.class,
+      TestOperatePropertiesOverride.class,
       CamundaSecurityProperties.class
     },
     webEnvironment = SpringBootTest.WebEnvironment.NONE)

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/rest/ClientConfigRestServiceEnterpriseIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/rest/ClientConfigRestServiceEnterpriseIT.java
@@ -19,6 +19,7 @@ import io.camunda.operate.conditions.DatabaseInfo;
 import io.camunda.operate.connect.OperateDateTimeFormatter;
 import io.camunda.operate.property.OperateProperties;
 import io.camunda.operate.util.OperateAbstractIT;
+import io.camunda.operate.util.TestOperatePropertiesOverride;
 import io.camunda.operate.util.apps.nobeans.TestApplicationWithNoBeans;
 import io.camunda.operate.webapp.rest.ClientConfig;
 import io.camunda.operate.webapp.rest.ClientConfigRestService;
@@ -36,7 +37,7 @@ import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilde
       JacksonConfig.class,
       OperateDateTimeFormatter.class,
       DatabaseInfo.class,
-      OperateProperties.class,
+      TestOperatePropertiesOverride.class,
       CamundaSecurityProperties.class
     },
     properties = {

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/rest/ClientConfigRestServiceIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/rest/ClientConfigRestServiceIT.java
@@ -19,6 +19,7 @@ import io.camunda.operate.conditions.DatabaseInfo;
 import io.camunda.operate.connect.OperateDateTimeFormatter;
 import io.camunda.operate.property.OperateProperties;
 import io.camunda.operate.util.OperateAbstractIT;
+import io.camunda.operate.util.TestOperatePropertiesOverride;
 import io.camunda.operate.util.apps.nobeans.TestApplicationWithNoBeans;
 import io.camunda.operate.webapp.rest.ClientConfig;
 import io.camunda.operate.webapp.rest.ClientConfigRestService;
@@ -38,7 +39,7 @@ import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilde
       JacksonConfig.class,
       OperateDateTimeFormatter.class,
       DatabaseInfo.class,
-      OperateProperties.class,
+      TestOperatePropertiesOverride.class,
       SecurityConfiguration.class
     },
     properties = {

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/rest/ClientConfigRestServiceIdentityIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/rest/ClientConfigRestServiceIdentityIT.java
@@ -18,6 +18,7 @@ import io.camunda.operate.conditions.DatabaseInfo;
 import io.camunda.operate.connect.OperateDateTimeFormatter;
 import io.camunda.operate.property.OperateProperties;
 import io.camunda.operate.util.OperateAbstractIT;
+import io.camunda.operate.util.TestOperatePropertiesOverride;
 import io.camunda.operate.util.apps.nobeans.TestApplicationWithNoBeans;
 import io.camunda.operate.webapp.rest.ClientConfig;
 import io.camunda.operate.webapp.rest.ClientConfigRestService;
@@ -38,7 +39,7 @@ import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilde
       JacksonConfig.class,
       OperateDateTimeFormatter.class,
       DatabaseInfo.class,
-      OperateProperties.class,
+      TestOperatePropertiesOverride.class,
       SecurityConfiguration.class
     },
     properties = {OperateProperties.PREFIX + ".identity.issuerUrl = http://some.issuer.url"})

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/rest/DecisionInstanceRestServiceIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/rest/DecisionInstanceRestServiceIT.java
@@ -13,8 +13,8 @@ import io.camunda.operate.JacksonConfig;
 import io.camunda.operate.OperateProfileService;
 import io.camunda.operate.conditions.DatabaseInfo;
 import io.camunda.operate.connect.OperateDateTimeFormatter;
-import io.camunda.operate.property.OperateProperties;
 import io.camunda.operate.util.OperateAbstractIT;
+import io.camunda.operate.util.TestOperatePropertiesOverride;
 import io.camunda.operate.util.apps.nobeans.TestApplicationWithNoBeans;
 import io.camunda.operate.webapp.reader.DecisionInstanceReader;
 import io.camunda.operate.webapp.rest.DecisionInstanceRestService;
@@ -30,12 +30,11 @@ import org.springframework.test.web.servlet.MvcResult;
     classes = {
       TestApplicationWithNoBeans.class,
       DecisionInstanceRestService.class,
-      OperateProperties.class,
       OperateProfileService.class,
       JacksonConfig.class,
       OperateDateTimeFormatter.class,
       DatabaseInfo.class,
-      OperateProperties.class
+      TestOperatePropertiesOverride.class
     })
 public class DecisionInstanceRestServiceIT extends OperateAbstractIT {
 

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/rest/DecisionRestServiceIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/rest/DecisionRestServiceIT.java
@@ -17,8 +17,8 @@ import io.camunda.operate.JacksonConfig;
 import io.camunda.operate.OperateProfileService;
 import io.camunda.operate.conditions.DatabaseInfo;
 import io.camunda.operate.connect.OperateDateTimeFormatter;
-import io.camunda.operate.property.OperateProperties;
 import io.camunda.operate.util.OperateAbstractIT;
+import io.camunda.operate.util.TestOperatePropertiesOverride;
 import io.camunda.operate.util.apps.nobeans.TestApplicationWithNoBeans;
 import io.camunda.operate.webapp.reader.DecisionReader;
 import io.camunda.operate.webapp.rest.DecisionRestService;
@@ -39,12 +39,11 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
     classes = {
       TestApplicationWithNoBeans.class,
       DecisionRestService.class,
-      OperateProperties.class,
       OperateProfileService.class,
       JacksonConfig.class,
       OperateDateTimeFormatter.class,
       DatabaseInfo.class,
-      OperateProperties.class
+      TestOperatePropertiesOverride.class
     })
 public class DecisionRestServiceIT extends OperateAbstractIT {
 

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/rest/FlowNodeInstanceRestServiceIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/rest/FlowNodeInstanceRestServiceIT.java
@@ -16,8 +16,8 @@ import io.camunda.operate.JacksonConfig;
 import io.camunda.operate.OperateProfileService;
 import io.camunda.operate.conditions.DatabaseInfo;
 import io.camunda.operate.connect.OperateDateTimeFormatter;
-import io.camunda.operate.property.OperateProperties;
 import io.camunda.operate.util.OperateAbstractIT;
+import io.camunda.operate.util.TestOperatePropertiesOverride;
 import io.camunda.operate.util.apps.nobeans.TestApplicationWithNoBeans;
 import io.camunda.operate.webapp.elasticsearch.reader.ProcessInstanceReader;
 import io.camunda.operate.webapp.reader.FlowNodeInstanceReader;
@@ -40,12 +40,11 @@ import org.springframework.test.web.servlet.MvcResult;
     classes = {
       TestApplicationWithNoBeans.class,
       FlowNodeInstanceRestService.class,
-      OperateProperties.class,
+      TestOperatePropertiesOverride.class,
       OperateProfileService.class,
       JacksonConfig.class,
       OperateDateTimeFormatter.class,
-      DatabaseInfo.class,
-      OperateProperties.class
+      DatabaseInfo.class
     })
 public class FlowNodeInstanceRestServiceIT extends OperateAbstractIT {
 

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/rest/ProcessRestServiceIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/rest/ProcessRestServiceIT.java
@@ -17,8 +17,8 @@ import io.camunda.operate.JacksonConfig;
 import io.camunda.operate.OperateProfileService;
 import io.camunda.operate.conditions.DatabaseInfo;
 import io.camunda.operate.connect.OperateDateTimeFormatter;
-import io.camunda.operate.property.OperateProperties;
 import io.camunda.operate.util.OperateAbstractIT;
+import io.camunda.operate.util.TestOperatePropertiesOverride;
 import io.camunda.operate.util.apps.nobeans.TestApplicationWithNoBeans;
 import io.camunda.operate.webapp.elasticsearch.reader.ProcessInstanceReader;
 import io.camunda.operate.webapp.reader.ProcessReader;
@@ -40,12 +40,11 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
     classes = {
       TestApplicationWithNoBeans.class,
       ProcessRestService.class,
-      OperateProperties.class,
       OperateProfileService.class,
       JacksonConfig.class,
       OperateDateTimeFormatter.class,
       DatabaseInfo.class,
-      OperateProperties.class
+      TestOperatePropertiesOverride.class
     })
 public class ProcessRestServiceIT extends OperateAbstractIT {
 

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/TestApplication.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/TestApplication.java
@@ -7,8 +7,6 @@
  */
 package io.camunda.operate.util;
 
-import io.camunda.configuration.UnifiedConfiguration;
-import io.camunda.configuration.beanoverrides.OperatePropertiesOverride;
 import io.camunda.operate.OperateModuleConfiguration;
 import io.camunda.webapps.WebappsModuleConfiguration;
 import org.springframework.boot.SpringApplication;
@@ -30,12 +28,7 @@ import org.springframework.context.annotation.Import;
           value = OperateModuleConfiguration.class),
     },
     nameGenerator = FullyQualifiedAnnotationBeanNameGenerator.class)
-@Import({
-  WebappsModuleConfiguration.class,
-  // Unified Configuration classes
-  UnifiedConfiguration.class,
-  OperatePropertiesOverride.class
-})
+@Import({WebappsModuleConfiguration.class, TestOperatePropertiesOverride.class})
 public class TestApplication {
 
   public static void main(final String[] args) throws Exception {

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/TestOperatePropertiesOverride.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/TestOperatePropertiesOverride.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.operate.util;
+
+import io.camunda.operate.property.OperateProperties;
+import io.camunda.operate.util.TestOperatePropertiesOverride.TestOperateProperties;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
+
+@Configuration
+@EnableConfigurationProperties(TestOperateProperties.class)
+@PropertySource("classpath:operate-version.properties")
+public class TestOperatePropertiesOverride {
+
+  @ConfigurationProperties(OperateProperties.PREFIX)
+  public static class TestOperateProperties extends OperateProperties {}
+}

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/apps/modules/ModulesTestApplication.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/apps/modules/ModulesTestApplication.java
@@ -7,10 +7,9 @@
  */
 package io.camunda.operate.util.apps.modules;
 
-import io.camunda.configuration.UnifiedConfiguration;
-import io.camunda.configuration.beanoverrides.OperatePropertiesOverride;
 import io.camunda.operate.OperateModuleConfiguration;
 import io.camunda.operate.util.TestApplication;
+import io.camunda.operate.util.TestOperatePropertiesOverride;
 import io.camunda.webapps.WebappsModuleConfiguration;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -44,9 +43,7 @@ import org.springframework.context.annotation.Import;
     nameGenerator = FullyQualifiedAnnotationBeanNameGenerator.class)
 @Import({
   WebappsModuleConfiguration.class,
-  // Unified Configuration classes
-  UnifiedConfiguration.class,
-  OperatePropertiesOverride.class
+  TestOperatePropertiesOverride.class,
 })
 public class ModulesTestApplication {
 

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/security/identity/SSOIdentityCreatedIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/security/identity/SSOIdentityCreatedIT.java
@@ -13,6 +13,7 @@ import io.camunda.application.commons.security.CamundaSecurityConfiguration.Camu
 import io.camunda.identity.sdk.Identity;
 import io.camunda.operate.conditions.DatabaseInfo;
 import io.camunda.operate.property.OperateProperties;
+import io.camunda.operate.util.TestOperatePropertiesOverride;
 import io.camunda.operate.webapp.security.SecurityContextWrapper;
 import io.camunda.operate.webapp.security.permission.PermissionsService;
 import io.camunda.operate.webapp.security.tenant.TenantService;
@@ -32,7 +33,7 @@ import org.springframework.test.context.junit4.SpringRunner;
     classes = {
       IdentityConfigurer.class,
       DatabaseInfo.class,
-      OperateProperties.class,
+      TestOperatePropertiesOverride.class,
       CamundaSecurityProperties.class,
       TenantService.class,
       PermissionsService.class,

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/security/identity/SSOIdentityNotCreatedIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/security/identity/SSOIdentityNotCreatedIT.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.operate.conditions.DatabaseInfo;
 import io.camunda.operate.property.OperateProperties;
+import io.camunda.operate.util.TestOperatePropertiesOverride;
 import io.camunda.operate.webapp.security.SecurityContextWrapper;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -27,7 +28,7 @@ import org.springframework.test.context.junit4.SpringRunner;
     classes = {
       IdentityConfigurer.class,
       DatabaseInfo.class,
-      OperateProperties.class,
+      TestOperatePropertiesOverride.class,
       SecurityContextWrapper.class
     },
     properties = {

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/security/oauth2/CCaaSJwtAuthenticationTokenValidatorIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/security/oauth2/CCaaSJwtAuthenticationTokenValidatorIT.java
@@ -12,6 +12,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.operate.conditions.DatabaseInfo;
 import io.camunda.operate.property.OperateProperties;
+import io.camunda.operate.util.TestOperatePropertiesOverride;
 import io.camunda.operate.util.apps.nobeans.TestApplicationWithNoBeans;
 import java.util.List;
 import java.util.Map;
@@ -29,7 +30,7 @@ import org.springframework.test.context.junit4.SpringRunner;
       TestApplicationWithNoBeans.class,
       CCSaaSJwtAuthenticationTokenValidator.class,
       DatabaseInfo.class,
-      OperateProperties.class,
+      TestOperatePropertiesOverride.class,
     },
     properties = {
       OperateProperties.PREFIX + ".client.audience = test.operate.camunda.com",

--- a/tasklist/common/src/main/java/io/camunda/tasklist/property/TasklistProperties.java
+++ b/tasklist/common/src/main/java/io/camunda/tasklist/property/TasklistProperties.java
@@ -9,13 +9,9 @@ package io.camunda.tasklist.property;
 
 import java.util.List;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
-import org.springframework.context.annotation.PropertySource;
 
 /** This class contains all project configuration parameters. */
-@ConfigurationProperties(TasklistProperties.PREFIX)
-@PropertySource("classpath:tasklist-version.properties")
 public class TasklistProperties {
 
   public static final String PREFIX = "camunda.tasklist";

--- a/tasklist/qa/backup-restore-tests/pom.xml
+++ b/tasklist/qa/backup-restore-tests/pom.xml
@@ -192,12 +192,6 @@
       <artifactId>opensearch-java</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>io.camunda</groupId>
-      <artifactId>configuration</artifactId>
-      <version>8.8.0-SNAPSHOT</version>
-      <scope>test</scope>
-    </dependency>
 
   </dependencies>
 

--- a/tasklist/qa/backup-restore-tests/src/test/java/io/camunda/tasklist/qa/backup/BackupRestoreTest.java
+++ b/tasklist/qa/backup-restore-tests/src/test/java/io/camunda/tasklist/qa/backup/BackupRestoreTest.java
@@ -10,8 +10,6 @@ package io.camunda.tasklist.qa.backup;
 import static io.camunda.tasklist.qa.util.ContainerVersionsUtil.ZEEBE_CURRENTVERSION_DOCKER_PROPERTY_NAME;
 import static io.camunda.tasklist.util.CollectionUtil.asMap;
 
-import io.camunda.configuration.UnifiedConfiguration;
-import io.camunda.configuration.beanoverrides.TasklistPropertiesOverride;
 import io.camunda.tasklist.CommonUtils;
 import io.camunda.tasklist.exceptions.TasklistRuntimeException;
 import io.camunda.tasklist.qa.backup.generator.BackupRestoreDataGenerator;
@@ -50,8 +48,7 @@ import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
 
 @ExtendWith(SpringExtension.class)
-@ContextConfiguration(
-    classes = {TestConfig.class, UnifiedConfiguration.class, TasklistPropertiesOverride.class})
+@ContextConfiguration(classes = {TestConfig.class})
 public class BackupRestoreTest {
 
   public static final String INDEX_PREFIX = "backup-restore-test";

--- a/tasklist/qa/integration-tests/pom.xml
+++ b/tasklist/qa/integration-tests/pom.xml
@@ -107,13 +107,6 @@
     <!-- TEST -->
 
     <dependency>
-      <groupId>io.camunda</groupId>
-      <artifactId>configuration</artifactId>
-      <version>${project.version}</version>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/es/ElasticsearchConnectorIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/es/ElasticsearchConnectorIT.java
@@ -19,6 +19,7 @@ import io.camunda.tasklist.connect.ElasticsearchConnector;
 import io.camunda.tasklist.property.TasklistProperties;
 import io.camunda.tasklist.qa.util.TestUtil;
 import io.camunda.tasklist.util.TestPlugin;
+import io.camunda.tasklist.util.TestTasklistPropertiesOverride;
 import io.camunda.zeebe.util.FileUtil;
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -31,7 +32,6 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
@@ -42,9 +42,8 @@ import org.testcontainers.utility.DockerImageName;
 
 @Testcontainers
 @SpringBootTest(
-    classes = {ElasticsearchConnector.class, TasklistProperties.class},
+    classes = {ElasticsearchConnector.class, TestTasklistPropertiesOverride.class},
     properties = TasklistProperties.PREFIX + ".database=elasticsearch")
-@EnableConfigurationProperties(TasklistProperties.class)
 public class ElasticsearchConnectorIT {
 
   @Container

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/es/ElasticsearchConnectorSSLAuthIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/es/ElasticsearchConnectorSSLAuthIT.java
@@ -12,9 +12,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import io.camunda.tasklist.connect.ElasticsearchConnector;
-import io.camunda.tasklist.property.TasklistProperties;
 import io.camunda.tasklist.qa.util.TestUtil;
 import io.camunda.tasklist.util.TasklistIntegrationTest;
+import io.camunda.tasklist.util.TestTasklistPropertiesOverride;
 import io.camunda.tasklist.util.apps.nobeans.TestApplicationWithNoBeans;
 import java.io.File;
 import java.util.Map;
@@ -38,7 +38,7 @@ import org.testcontainers.utility.MountableFile;
 @SpringBootTest(
     classes = {
       TestApplicationWithNoBeans.class,
-      TasklistProperties.class,
+      TestTasklistPropertiesOverride.class,
       ElasticsearchConnector.class
     })
 @ContextConfiguration(initializers = {ElasticsearchConnectorSSLAuthIT.ElasticsearchStarter.class})

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/it/ZeebeConnectorSecureIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/it/ZeebeConnectorSecureIT.java
@@ -16,6 +16,7 @@ import io.camunda.tasklist.property.TasklistProperties;
 import io.camunda.tasklist.property.ZeebeProperties;
 import io.camunda.tasklist.qa.util.ContainerVersionsUtil;
 import io.camunda.tasklist.util.CertificateUtil;
+import io.camunda.tasklist.util.TestTasklistPropertiesOverride;
 import io.camunda.tasklist.zeebe.ZeebeConnector;
 import io.zeebe.containers.ZeebeContainer;
 import java.io.File;
@@ -34,7 +35,7 @@ import org.testcontainers.utility.DockerImageName;
 import org.testcontainers.utility.MountableFile;
 
 @SpringBootTest(
-    classes = {ZeebeConnector.class, TasklistProperties.class},
+    classes = {ZeebeConnector.class, TestTasklistPropertiesOverride.class},
     properties = {
       TasklistProperties.PREFIX + ".importer.startLoadingDataOnStartup = false",
       TasklistProperties.PREFIX + ".archiver.rolloverEnabled = false",

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/management/HealthCheckAuthenticationIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/management/HealthCheckAuthenticationIT.java
@@ -15,8 +15,8 @@ import static org.mockito.BDDMockito.given;
 
 import io.camunda.tasklist.JacksonConfig;
 import io.camunda.tasklist.connect.ElasticsearchConnector;
-import io.camunda.tasklist.property.TasklistProperties;
 import io.camunda.tasklist.qa.util.TestUtil;
+import io.camunda.tasklist.util.TestTasklistPropertiesOverride;
 import io.camunda.tasklist.util.apps.nobeans.TestApplicationWithNoBeans;
 import io.camunda.tasklist.webapp.security.TasklistProfileServiceImpl;
 import io.camunda.tasklist.webapp.security.WebSecurityConfig;
@@ -40,12 +40,11 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 @ExtendWith(SpringExtension.class)
 @SpringBootTest(
     classes = {
-      TasklistProperties.class,
       TestApplicationWithNoBeans.class,
       SearchEngineHealthIndicator.class,
       WebSecurityConfig.class,
       TasklistProfileServiceImpl.class,
-      TasklistProperties.class,
+      TestTasklistPropertiesOverride.class,
       ElasticsearchConnector.class,
       JacksonConfig.class
     },

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/management/HealthCheckIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/management/HealthCheckIT.java
@@ -16,7 +16,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 
 import io.camunda.tasklist.JacksonConfig;
 import io.camunda.tasklist.connect.ElasticsearchConnector;
-import io.camunda.tasklist.property.TasklistProperties;
+import io.camunda.tasklist.util.TestTasklistPropertiesOverride;
 import io.camunda.tasklist.util.apps.nobeans.TestApplicationWithNoBeans;
 import io.camunda.tasklist.webapp.security.WebSecurityConfig;
 import java.util.Map;
@@ -37,11 +37,10 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 @ExtendWith(SpringExtension.class)
 @SpringBootTest(
     classes = {
-      TasklistProperties.class,
       TestApplicationWithNoBeans.class,
       SearchEngineHealthIndicator.class,
       WebSecurityConfig.class,
-      TasklistProperties.class,
+      TestTasklistPropertiesOverride.class,
       ElasticsearchConnector.class,
       JacksonConfig.class
     },

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/os/OpenSearchConnectorSSLAuthIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/os/OpenSearchConnectorSSLAuthIT.java
@@ -9,8 +9,8 @@ package io.camunda.tasklist.os;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.camunda.tasklist.property.TasklistProperties;
 import io.camunda.tasklist.util.TasklistIntegrationTest;
+import io.camunda.tasklist.util.TestTasklistPropertiesOverride;
 import io.camunda.tasklist.util.apps.nobeans.TestApplicationWithNoBeans;
 import java.io.File;
 import java.util.Map;
@@ -35,7 +35,7 @@ import org.testcontainers.utility.MountableFile;
 @SpringBootTest(
     classes = {
       TestApplicationWithNoBeans.class,
-      TasklistProperties.class,
+      TestTasklistPropertiesOverride.class,
       OpenSearchConnector.class
     })
 @ContextConfiguration(initializers = {OpenSearchConnectorSSLAuthIT.ElasticsearchStarter.class})
@@ -79,7 +79,7 @@ public class OpenSearchConnectorSSLAuthIT extends TasklistIntegrationTest {
       implements ApplicationContextInitializer<ConfigurableApplicationContext> {
 
     @Override
-    public void initialize(ConfigurableApplicationContext applicationContext) {
+    public void initialize(final ConfigurableApplicationContext applicationContext) {
       opensearch.start();
 
       final String elsUrl =

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/os/OpensearchConnectorIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/os/OpensearchConnectorIT.java
@@ -18,6 +18,7 @@ import io.camunda.tasklist.JacksonConfig;
 import io.camunda.tasklist.property.TasklistProperties;
 import io.camunda.tasklist.qa.util.TestUtil;
 import io.camunda.tasklist.util.TestPlugin;
+import io.camunda.tasklist.util.TestTasklistPropertiesOverride;
 import io.camunda.zeebe.util.FileUtil;
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -31,7 +32,6 @@ import org.junit.jupiter.api.Test;
 import org.opensearch.client.opensearch.cluster.HealthRequest;
 import org.opensearch.testcontainers.OpensearchContainer;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
@@ -39,9 +39,12 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 
 @Testcontainers
 @SpringBootTest(
-    classes = {OpenSearchConnector.class, TasklistProperties.class, JacksonConfig.class},
+    classes = {
+      OpenSearchConnector.class,
+      TestTasklistPropertiesOverride.class,
+      JacksonConfig.class
+    },
     properties = TasklistProperties.PREFIX + ".database=opensearch")
-@EnableConfigurationProperties(TasklistProperties.class)
 public class OpensearchConnectorIT {
 
   private static final OpensearchContainer<?> OPENSEARCH_CONTAINER =

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/properties/PropertiesTest.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/properties/PropertiesTest.java
@@ -10,6 +10,7 @@ package io.camunda.tasklist.properties;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.tasklist.property.TasklistProperties;
+import io.camunda.tasklist.util.TestTasklistPropertiesOverride;
 import io.camunda.tasklist.util.apps.nobeans.TestApplicationWithNoBeans;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -20,7 +21,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 @ExtendWith(SpringExtension.class)
 @SpringBootTest(
-    classes = {TestApplicationWithNoBeans.class, TasklistProperties.class},
+    classes = {TestApplicationWithNoBeans.class, TestTasklistPropertiesOverride.class},
     webEnvironment = SpringBootTest.WebEnvironment.NONE)
 @ActiveProfiles("test-properties")
 public class PropertiesTest {

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TestApplication.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TestApplication.java
@@ -8,8 +8,6 @@
 package io.camunda.tasklist.util;
 
 import io.camunda.application.commons.CommonsModuleConfiguration;
-import io.camunda.configuration.UnifiedConfiguration;
-import io.camunda.configuration.beanoverrides.TasklistPropertiesOverride;
 import io.camunda.tasklist.TasklistModuleConfiguration;
 import io.camunda.tasklist.data.DataGenerator;
 import io.camunda.tasklist.data.es.DevDataGeneratorElasticSearch;
@@ -38,10 +36,9 @@ import org.springframework.context.annotation.Profile;
     },
     nameGenerator = FullyQualifiedAnnotationBeanNameGenerator.class)
 @Import({
-  UnifiedConfiguration.class,
-  TasklistPropertiesOverride.class,
   WebappsModuleConfiguration.class,
-  CommonsModuleConfiguration.class
+  CommonsModuleConfiguration.class,
+  TestTasklistPropertiesOverride.class
 })
 public class TestApplication {
 

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TestTasklistPropertiesOverride.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TestTasklistPropertiesOverride.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.tasklist.util;
+
+import io.camunda.tasklist.property.TasklistProperties;
+import io.camunda.tasklist.util.TestTasklistPropertiesOverride.TestTasklistProperties;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
+
+@Configuration
+@EnableConfigurationProperties(TestTasklistProperties.class)
+@PropertySource("classpath:tasklist-version.properties")
+public class TestTasklistPropertiesOverride {
+
+  @ConfigurationProperties(TasklistProperties.PREFIX)
+  public static class TestTasklistProperties extends TasklistProperties {}
+}

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/apps/modules/ModulesTestApplication.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/apps/modules/ModulesTestApplication.java
@@ -7,14 +7,13 @@
  */
 package io.camunda.tasklist.util.apps.modules;
 
-import io.camunda.configuration.UnifiedConfiguration;
-import io.camunda.configuration.beanoverrides.TasklistPropertiesOverride;
 import io.camunda.tasklist.TasklistModuleConfiguration;
 import io.camunda.tasklist.data.DataGenerator;
 import io.camunda.tasklist.data.es.DevDataGeneratorElasticSearch;
 import io.camunda.tasklist.data.os.DevDataGeneratorOpenSearch;
 import io.camunda.tasklist.util.TasklistZeebeIntegrationTest;
 import io.camunda.tasklist.util.TestApplication;
+import io.camunda.tasklist.util.TestTasklistPropertiesOverride;
 import io.camunda.tasklist.webapp.management.WebappManagementModuleConfiguration;
 import io.camunda.tasklist.webapp.security.WebappSecurityModuleConfiguration;
 import io.camunda.tasklist.zeebeimport.security.ImporterSecurityModuleConfiguration;
@@ -56,8 +55,7 @@ import org.springframework.context.annotation.Profile;
     },
     nameGenerator = FullyQualifiedAnnotationBeanNameGenerator.class)
 @Import({
-  UnifiedConfiguration.class,
-  TasklistPropertiesOverride.class,
+  TestTasklistPropertiesOverride.class,
   WebappsModuleConfiguration.class,
   WebappSecurityModuleConfiguration.class,
   ImporterSecurityModuleConfiguration.class,

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/identity/IdentityAuthenticationIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/identity/IdentityAuthenticationIT.java
@@ -24,8 +24,8 @@ import io.camunda.identity.sdk.tenants.Tenants;
 import io.camunda.identity.sdk.tenants.dto.Tenant;
 import io.camunda.security.configuration.MultiTenancyConfiguration;
 import io.camunda.security.configuration.SecurityConfiguration;
-import io.camunda.tasklist.property.TasklistProperties;
 import io.camunda.tasklist.util.SpringContextHolder;
+import io.camunda.tasklist.util.TestTasklistPropertiesOverride;
 import io.camunda.tasklist.util.apps.nobeans.TestApplicationWithNoBeans;
 import io.camunda.tasklist.webapp.security.identity.IdentityAuthentication;
 import io.camunda.tasklist.webapp.security.identity.IdentityAuthorization;
@@ -51,7 +51,7 @@ import org.springframework.test.util.ReflectionTestUtils;
     classes = {
       TestApplicationWithNoBeans.class,
       IdentityAuthentication.class,
-      TasklistProperties.class
+      TestTasklistPropertiesOverride.class
     },
     properties = {
       "camunda.tasklist.identity.issuerUrl=http://localhost:18080/auth/realms/camunda-platform",

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/rest/ClientConfigRestServiceIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/rest/ClientConfigRestServiceIT.java
@@ -14,6 +14,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.tasklist.property.TasklistProperties;
+import io.camunda.tasklist.util.TestTasklistPropertiesOverride;
 import io.camunda.tasklist.util.apps.nobeans.TestApplicationWithNoBeans;
 import io.camunda.tasklist.webapp.security.TasklistProfileServiceImpl;
 import org.junit.jupiter.api.*;
@@ -36,7 +37,7 @@ import org.springframework.web.context.WebApplicationContext;
       TasklistProfileServiceImpl.class,
       ClientConfig.class,
       ClientConfigRestService.class,
-      TasklistProperties.class,
+      TestTasklistPropertiesOverride.class,
       SecurityConfiguration.class
     },
     properties = {

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/security/oauth/IdentityJwt2AuthenticationTokenConverterIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/security/oauth/IdentityJwt2AuthenticationTokenConverterIT.java
@@ -26,7 +26,6 @@ import io.camunda.identity.sdk.tenants.dto.Tenant;
 import io.camunda.security.configuration.MultiTenancyConfiguration;
 import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.tasklist.CommonUtils;
-import io.camunda.tasklist.property.TasklistProperties;
 import io.camunda.tasklist.util.SpringContextHolder;
 import io.camunda.tasklist.util.apps.nobeans.TestApplicationWithNoBeans;
 import io.camunda.tasklist.webapp.tenant.TenantAwareAuthentication;
@@ -50,15 +49,8 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 @ExtendWith(SpringExtension.class)
 @SpringBootTest(
-    classes = {
-      TestApplicationWithNoBeans.class,
-      IdentityJwt2AuthenticationTokenConverter.class,
-      TasklistProperties.class
-    },
-    properties = {
-      TasklistProperties.PREFIX + ".identity.issuerUrl = http://some.issuer.url",
-      "management.endpoint.health.group.readiness.include=readinessState"
-    })
+    classes = {TestApplicationWithNoBeans.class, IdentityJwt2AuthenticationTokenConverter.class},
+    properties = {"management.endpoint.health.group.readiness.include=readinessState"})
 @ActiveProfiles({IDENTITY_AUTH_PROFILE, "test"})
 public class IdentityJwt2AuthenticationTokenConverterIT {
 
@@ -70,8 +62,6 @@ public class IdentityJwt2AuthenticationTokenConverterIT {
   @MockBean private Tenants tenants;
 
   @SpyBean private SecurityConfiguration securityConfiguration;
-
-  @SpyBean private TasklistProperties tasklistProperties;
 
   @Autowired private ApplicationContext applicationContext;
 


### PR DESCRIPTION
## Description

Tasklist and Operate IT tests are relying on autowired configuration properties. This resulted in having a dependency to the production bean in unified configuration which needed to be added to profile `test`. To remove those dependencies, we now add a test bean that is available to all IT tests in the corresponding modules.

This PR also removes the `@Configuration` annotations from OperateProperties and TasklistProperties. This ensures that these properties are only build by the unified configuration module, thus ensuring that values from new unified configuration is used everywhere. 

PS: Similar changes are not required for Gateway and Broker related tests because they don't depend on the production bean, but only the properties wrapper class defined in the `configuration` module. 

## Related issues

closes #35310 
