### PR TITLE
feat: segment manager can handle overlapping segments

### DIFF
--- a/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/Segment.java
+++ b/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/Segment.java
@@ -264,7 +264,11 @@ final class Segment implements AutoCloseable, FlushableSegment {
 
   @Override
   public String toString() {
-    return toStringHelper(this).add("id", id()).add("index", index()).toString();
+    return toStringHelper(this)
+        .add("id", id())
+        .add("index", index())
+        .add("lastIndex", lastIndex())
+        .toString();
   }
 
   private void markForDeletion() {


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Allow `SegmentsManager` to load overlapping segments. 

One change compared to the backup's PoC is that the exclusion of segments now happens when loading the files based on the following assumption: 

> Since the segment files are ordered, an overlap can only happen between the previously read segment and the current one. 

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

part of #34314
closes #35521 
