### PR TITLE
feat: add rdbms exporter for aTU

### DIFF
--- a/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.8.0.xml
+++ b/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.8.0.xml
@@ -593,7 +593,7 @@
     </modifySql>
   </changeSet>
 
-  <changeSet id="create_usage_metric_table" author="camunda">
+  <changeSet id="create_usage_metric_tables" author="camunda">
     <createTable tableName="${prefix}USAGE_METRIC">
       <column name="USAGE_METRIC_KEY" type="BIGINT">
         <constraints primaryKey="true"/>
@@ -608,6 +608,22 @@
     </createTable>
 
     <createIndex tableName="${prefix}USAGE_METRIC" indexName="${prefix}IDX_USAGE_METRIC_EVENT_TIME">
+      <column name="EVENT_TIME"/>
+    </createIndex>
+
+    <createTable tableName="${prefix}USAGE_METRIC_TU">
+      <column name="USAGE_METRIC_KEY" type="BIGINT">
+        <constraints primaryKey="true"/>
+      </column>
+      <column name="TENANT_ID" type="VARCHAR(255)">
+        <constraints primaryKey="true"/>
+      </column>
+      <column name="EVENT_TIME" type="TIMESTAMP WITH TIME ZONE(3)"/>
+      <column name="ASSIGNEE_HASH" type="BIGINT"/>
+      <column name="PARTITION_ID" type="NUMBER"/>
+    </createTable>
+
+    <createIndex tableName="${prefix}USAGE_METRIC_TU" indexName="${prefix}IDX_USAGE_METRIC_TU_EVENT_TIME">
       <column name="EVENT_TIME"/>
     </createIndex>
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/RdbmsService.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/RdbmsService.java
@@ -24,6 +24,7 @@ import io.camunda.db.rdbms.read.service.ProcessInstanceDbReader;
 import io.camunda.db.rdbms.read.service.RoleDbReader;
 import io.camunda.db.rdbms.read.service.SequenceFlowDbReader;
 import io.camunda.db.rdbms.read.service.TenantDbReader;
+import io.camunda.db.rdbms.read.service.UsageMetricTUDbReader;
 import io.camunda.db.rdbms.read.service.UsageMetricsDbReader;
 import io.camunda.db.rdbms.read.service.UserDbReader;
 import io.camunda.db.rdbms.read.service.UserTaskDbReader;
@@ -59,6 +60,7 @@ public class RdbmsService {
   private final BatchOperationItemDbReader batchOperationItemReader;
   private final JobDbReader jobReader;
   private final UsageMetricsDbReader usageMetricReader;
+  private final UsageMetricTUDbReader usageMetricTUDbReader;
 
   public RdbmsService(
       final RdbmsWriterFactory rdbmsWriterFactory,
@@ -82,7 +84,8 @@ public class RdbmsService {
       final SequenceFlowDbReader sequenceFlowReader,
       final BatchOperationItemDbReader batchOperationItemReader,
       final JobDbReader jobReader,
-      final UsageMetricsDbReader usageMetricReader) {
+      final UsageMetricsDbReader usageMetricReader,
+      final UsageMetricTUDbReader usageMetricTUDbReader) {
     this.rdbmsWriterFactory = rdbmsWriterFactory;
     this.authorizationReader = authorizationReader;
     this.decisionRequirementsReader = decisionRequirementsReader;
@@ -105,6 +108,7 @@ public class RdbmsService {
     this.batchOperationItemReader = batchOperationItemReader;
     this.jobReader = jobReader;
     this.usageMetricReader = usageMetricReader;
+    this.usageMetricTUDbReader = usageMetricTUDbReader;
   }
 
   public AuthorizationDbReader getAuthorizationReader() {
@@ -181,6 +185,10 @@ public class RdbmsService {
 
   public UsageMetricsDbReader getUsageMetricReader() {
     return usageMetricReader;
+  }
+
+  public UsageMetricTUDbReader getUsageMetricTUReader() {
+    return usageMetricTUDbReader;
   }
 
   public BatchOperationItemDbReader getBatchOperationItemReader() {

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/UsageMetricTUEntityMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/UsageMetricTUEntityMapper.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.read.mapper;
+
+import io.camunda.db.rdbms.write.domain.UsageMetricTUDbModel.UsageMetricTUTenantStatisticsDbModel;
+import io.camunda.search.entities.UsageMetricTUStatisticsEntity;
+import io.camunda.search.entities.UsageMetricTUStatisticsEntity.UsageMetricTUStatisticsEntityTenant;
+import io.camunda.search.entities.UsageMetricTUStatisticsEntity.UsageMetricTUStatisticsEntityTenant.Builder;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Optional;
+
+public class UsageMetricTUEntityMapper {
+
+  public static UsageMetricTUStatisticsEntity toEntity(
+      final List<UsageMetricTUTenantStatisticsDbModel> dbModels) {
+
+    long totalAtu = 0;
+
+    final var tenants = new HashMap<String, UsageMetricTUStatisticsEntityTenant>(dbModels.size());
+
+    for (final UsageMetricTUTenantStatisticsDbModel dbModel : dbModels) {
+      final long tenantAtu = Optional.ofNullable(dbModel.tu()).orElse(0L);
+      totalAtu += tenantAtu;
+      tenants.put(dbModel.tenantId(), new Builder().atu(tenantAtu).build());
+    }
+
+    return new UsageMetricTUStatisticsEntity(totalAtu, tenants);
+  }
+}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/UsageMetricTUDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/UsageMetricTUDbReader.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.read.service;
+
+import static java.util.Optional.ofNullable;
+
+import io.camunda.db.rdbms.read.mapper.UsageMetricTUEntityMapper;
+import io.camunda.db.rdbms.sql.UsageMetricTUMapper;
+import io.camunda.search.entities.UsageMetricTUStatisticsEntity;
+import io.camunda.search.filter.UsageMetricsFilter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class UsageMetricTUDbReader {
+
+  private static final Logger LOG = LoggerFactory.getLogger(UsageMetricTUDbReader.class);
+  private final UsageMetricTUMapper usageMetricTUMapper;
+
+  public UsageMetricTUDbReader(final UsageMetricTUMapper usageMetricTUMapper) {
+    this.usageMetricTUMapper = usageMetricTUMapper;
+  }
+
+  public UsageMetricTUStatisticsEntity usageMetricTUStatistics(final UsageMetricsFilter filter) {
+    LOG.trace("[RDBMS DB] Usage metrics assignees with {}", filter);
+
+    if (filter.withTenants()) {
+      final var result = usageMetricTUMapper.usageMetricTUTenantsStatistics(filter);
+      return UsageMetricTUEntityMapper.toEntity(result);
+    } else {
+      final var result = usageMetricTUMapper.usageMetricTUStatistics(filter);
+      return new UsageMetricTUStatisticsEntity(ofNullable(result.tu()).orElse(0L), null);
+    }
+  }
+}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/UsageMetricTUMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/UsageMetricTUMapper.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.sql;
+
+import io.camunda.db.rdbms.sql.HistoryCleanupMapper.CleanupHistoryDto;
+import io.camunda.db.rdbms.write.domain.UsageMetricTUDbModel.UsageMetricTUStatisticsDbModel;
+import io.camunda.db.rdbms.write.domain.UsageMetricTUDbModel.UsageMetricTUTenantStatisticsDbModel;
+import io.camunda.search.filter.UsageMetricsFilter;
+import java.util.List;
+
+public interface UsageMetricTUMapper {
+
+  List<UsageMetricTUTenantStatisticsDbModel> usageMetricTUTenantsStatistics(
+      final UsageMetricsFilter filter);
+
+  UsageMetricTUStatisticsDbModel usageMetricTUStatistics(final UsageMetricsFilter filter);
+
+  int cleanupMetrics(CleanupHistoryDto dto);
+}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriter.java
@@ -17,6 +17,7 @@ import io.camunda.db.rdbms.sql.ProcessInstanceMapper;
 import io.camunda.db.rdbms.sql.PurgeMapper;
 import io.camunda.db.rdbms.sql.SequenceFlowMapper;
 import io.camunda.db.rdbms.sql.UsageMetricMapper;
+import io.camunda.db.rdbms.sql.UsageMetricTUMapper;
 import io.camunda.db.rdbms.sql.UserTaskMapper;
 import io.camunda.db.rdbms.sql.VariableMapper;
 import io.camunda.db.rdbms.write.queue.ExecutionQueue;
@@ -39,6 +40,7 @@ import io.camunda.db.rdbms.write.service.RdbmsPurger;
 import io.camunda.db.rdbms.write.service.RoleWriter;
 import io.camunda.db.rdbms.write.service.SequenceFlowWriter;
 import io.camunda.db.rdbms.write.service.TenantWriter;
+import io.camunda.db.rdbms.write.service.UsageMetricTUWriter;
 import io.camunda.db.rdbms.write.service.UsageMetricWriter;
 import io.camunda.db.rdbms.write.service.UserTaskWriter;
 import io.camunda.db.rdbms.write.service.UserWriter;
@@ -69,6 +71,7 @@ public class RdbmsWriter {
   private final JobWriter jobWriter;
   private final SequenceFlowWriter sequenceFlowWriter;
   private final UsageMetricWriter usageMetricWriter;
+  private final UsageMetricTUWriter usageMetricTUWriter;
 
   private final HistoryCleanupService historyCleanupService;
 
@@ -88,7 +91,8 @@ public class RdbmsWriter {
       final BatchOperationDbReader batchOperationReader,
       final JobMapper jobMapper,
       final SequenceFlowMapper sequenceFlowMapper,
-      final UsageMetricMapper usageMetricMapper) {
+      final UsageMetricMapper usageMetricMapper,
+      final UsageMetricTUMapper usageMetricTUMapper) {
     this.executionQueue = executionQueue;
     this.exporterPositionService = exporterPositionService;
     rdbmsPurger = new RdbmsPurger(purgeMapper, vendorDatabaseProperties);
@@ -112,6 +116,7 @@ public class RdbmsWriter {
     jobWriter = new JobWriter(executionQueue, jobMapper);
     sequenceFlowWriter = new SequenceFlowWriter(executionQueue, sequenceFlowMapper);
     usageMetricWriter = new UsageMetricWriter(executionQueue, usageMetricMapper);
+    usageMetricTUWriter = new UsageMetricTUWriter(executionQueue, usageMetricTUMapper);
 
     historyCleanupService =
         new HistoryCleanupService(
@@ -205,6 +210,10 @@ public class RdbmsWriter {
 
   public UsageMetricWriter getUsageMetricWriter() {
     return usageMetricWriter;
+  }
+
+  public UsageMetricTUWriter getUsageMetricTUWriter() {
+    return usageMetricTUWriter;
   }
 
   public ExporterPositionService getExporterPositionService() {

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriterFactory.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriterFactory.java
@@ -18,6 +18,7 @@ import io.camunda.db.rdbms.sql.ProcessInstanceMapper;
 import io.camunda.db.rdbms.sql.PurgeMapper;
 import io.camunda.db.rdbms.sql.SequenceFlowMapper;
 import io.camunda.db.rdbms.sql.UsageMetricMapper;
+import io.camunda.db.rdbms.sql.UsageMetricTUMapper;
 import io.camunda.db.rdbms.sql.UserTaskMapper;
 import io.camunda.db.rdbms.sql.VariableMapper;
 import io.camunda.db.rdbms.write.queue.DefaultExecutionQueue;
@@ -41,6 +42,7 @@ public class RdbmsWriterFactory {
   private final JobMapper jobMapper;
   private final SequenceFlowMapper sequenceFlowMapper;
   private final UsageMetricMapper usageMetricMapper;
+  private final UsageMetricTUMapper usageMetricTUMapper;
 
   public RdbmsWriterFactory(
       final SqlSessionFactory sqlSessionFactory,
@@ -57,7 +59,8 @@ public class RdbmsWriterFactory {
       final BatchOperationDbReader batchOperationReader,
       final JobMapper jobMapper,
       final SequenceFlowMapper sequenceFlowMapper,
-      final UsageMetricMapper usageMetricMapper) {
+      final UsageMetricMapper usageMetricMapper,
+      final UsageMetricTUMapper usageMetricTUMapper) {
     this.sqlSessionFactory = sqlSessionFactory;
     this.exporterPositionMapper = exporterPositionMapper;
     this.vendorDatabaseProperties = vendorDatabaseProperties;
@@ -73,6 +76,7 @@ public class RdbmsWriterFactory {
     this.batchOperationReader = batchOperationReader;
     this.sequenceFlowMapper = sequenceFlowMapper;
     this.usageMetricMapper = usageMetricMapper;
+    this.usageMetricTUMapper = usageMetricTUMapper;
   }
 
   public RdbmsWriter createWriter(final RdbmsWriterConfig config) {
@@ -95,6 +99,7 @@ public class RdbmsWriterFactory {
         batchOperationReader,
         jobMapper,
         sequenceFlowMapper,
-        usageMetricMapper);
+        usageMetricMapper,
+        usageMetricTUMapper);
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/UsageMetricDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/UsageMetricDbModel.java
@@ -73,7 +73,8 @@ public record UsageMetricDbModel(
 
   public enum EventTypeDbModel {
     RPI(0),
-    EDI(1);
+    EDI(1),
+    TU(2);
 
     private final int code;
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/UsageMetricTUDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/UsageMetricTUDbModel.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.write.domain;
+
+import io.camunda.util.ObjectBuilder;
+import java.time.OffsetDateTime;
+
+public record UsageMetricTUDbModel(
+    long key, OffsetDateTime eventTime, String tenantId, long assigneeHash, int partitionId) {
+
+  public String getId() {
+    return key + "_" + tenantId;
+  }
+
+  public record UsageMetricTUStatisticsDbModel(Long tu) {}
+
+  public record UsageMetricTUTenantStatisticsDbModel(String tenantId, Long tu) {}
+
+  public static class Builder implements ObjectBuilder<UsageMetricTUDbModel> {
+
+    private long key;
+    private OffsetDateTime eventTime;
+    private String tenantId;
+    private long assigneeHash;
+    private int partitionId;
+
+    public Builder key(final long key) {
+      this.key = key;
+      return this;
+    }
+
+    public Builder eventTime(final OffsetDateTime eventTime) {
+      this.eventTime = eventTime;
+      return this;
+    }
+
+    public Builder tenantId(final String tenantId) {
+      this.tenantId = tenantId;
+      return this;
+    }
+
+    public Builder assigneeHash(final long assigneeHash) {
+      this.assigneeHash = assigneeHash;
+      return this;
+    }
+
+    public Builder partitionId(final int partitionId) {
+      this.partitionId = partitionId;
+      return this;
+    }
+
+    @Override
+    public UsageMetricTUDbModel build() {
+      return new UsageMetricTUDbModel(key, eventTime, tenantId, assigneeHash, partitionId);
+    }
+  }
+}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/queue/ContextType.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/queue/ContextType.java
@@ -27,7 +27,8 @@ public enum ContextType {
   BATCH_OPERATION(false),
   JOB(false),
   SEQUENCE_FLOW(false),
-  USAGE_METRIC(false);
+  USAGE_METRIC(false),
+  USAGE_METRIC_TU(false);
 
   private final boolean preserveOrder;
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/RdbmsPurger.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/RdbmsPurger.java
@@ -44,7 +44,8 @@ public class RdbmsPurger {
           "BATCH_OPERATION",
           "JOB",
           "SEQUENCE_FLOW",
-          "USAGE_METRIC");
+          "USAGE_METRIC",
+          "USAGE_METRIC_TU");
 
   private final PurgeMapper purgeMapper;
   private final VendorDatabaseProperties vendorDatabaseProperties;

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/UsageMetricTUWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/UsageMetricTUWriter.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.write.service;
+
+import io.camunda.db.rdbms.sql.HistoryCleanupMapper.CleanupHistoryDto;
+import io.camunda.db.rdbms.sql.UsageMetricTUMapper;
+import io.camunda.db.rdbms.write.domain.UsageMetricTUDbModel;
+import io.camunda.db.rdbms.write.queue.ContextType;
+import io.camunda.db.rdbms.write.queue.ExecutionQueue;
+import io.camunda.db.rdbms.write.queue.QueueItem;
+import io.camunda.db.rdbms.write.queue.WriteStatementType;
+import java.time.OffsetDateTime;
+
+public class UsageMetricTUWriter {
+
+  private final ExecutionQueue executionQueue;
+  private final UsageMetricTUMapper mapper;
+
+  public UsageMetricTUWriter(
+      final ExecutionQueue executionQueue, final UsageMetricTUMapper usageMetricTUMapper) {
+    this.executionQueue = executionQueue;
+    mapper = usageMetricTUMapper;
+  }
+
+  public void create(final UsageMetricTUDbModel dbModel) {
+    executionQueue.executeInQueue(
+        new QueueItem(
+            ContextType.USAGE_METRIC_TU,
+            WriteStatementType.INSERT,
+            dbModel.getId(),
+            "io.camunda.db.rdbms.sql.UsageMetricTUMapper.insert",
+            dbModel));
+  }
+
+  public int cleanupMetrics(
+      final int partitionId, final OffsetDateTime cleanupDate, final int rowsToRemove) {
+    return mapper.cleanupMetrics(
+        new CleanupHistoryDto.Builder()
+            .partitionId(partitionId)
+            .cleanupDate(cleanupDate)
+            .limit(rowsToRemove)
+            .build());
+  }
+}

--- a/db/rdbms/src/main/resources/mapper/UsageMetricTUMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/UsageMetricTUMapper.xml
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+  ~ Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+  ~ one or more contributor license agreements. See the NOTICE file distributed
+  ~ with this work for additional information regarding copyright ownership.
+  ~ Licensed under the Camunda License 1.0. You may not use this file
+  ~ except in compliance with the Camunda License 1.0.
+  -->
+<!DOCTYPE mapper
+  PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+  "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="io.camunda.db.rdbms.sql.UsageMetricTUMapper">
+
+  <resultMap id="UsageMetricTUStatisticsResultMap"
+    type="io.camunda.db.rdbms.write.domain.UsageMetricTUDbModel$UsageMetricTUStatisticsDbModel">
+    <constructor>
+      <arg column="TU" javaType="java.lang.Long"/>
+    </constructor>
+  </resultMap>
+
+  <resultMap id="UsageMetricTUStatisticsResultMap2"
+    type="io.camunda.db.rdbms.write.domain.UsageMetricTUDbModel$UsageMetricTUTenantStatisticsDbModel">
+    <constructor>
+      <arg column="TENANT_ID" javaType="java.lang.String"/>
+      <arg column="TU" javaType="java.lang.Long"/>
+    </constructor>
+  </resultMap>
+
+  <select id="usageMetricTUStatistics"
+    parameterType="io.camunda.search.filter.UsageMetricsFilter"
+    resultMap="UsageMetricTUStatisticsResultMap"
+    statementType="PREPARED">
+    SELECT COUNT(DISTINCT ASSIGNEE_HASH) AS TU
+        FROM ${prefix}USAGE_METRIC_TU
+    <bind name="filter" value="_parameter"/>
+    <include refid="io.camunda.db.rdbms.sql.UsageMetricTUMapper.usageMetricStatisticsFilter"/>
+  </select>
+
+  <select id="usageMetricTUTenantsStatistics"
+    parameterType="io.camunda.search.filter.UsageMetricsFilter"
+    resultMap="UsageMetricTUStatisticsResultMap2"
+    statementType="PREPARED">
+    SELECT TENANT_ID,
+           COUNT(DISTINCT ASSIGNEE_HASH) AS TU
+    FROM ${prefix}USAGE_METRIC_TU
+    <bind name="filter" value="_parameter"/>
+    <include refid="io.camunda.db.rdbms.sql.UsageMetricTUMapper.usageMetricStatisticsFilter"/>
+    GROUP BY TENANT_ID
+  </select>
+
+  <sql id="usageMetricStatisticsFilter">
+    <where>
+      <if test="filter.startTime != null">
+        AND EVENT_TIME &gt;= #{filter.startTime}
+      </if>
+      <if test="filter.endTime != null">
+        AND EVENT_TIME &lt; #{filter.endTime}
+      </if>
+    </where>
+  </sql>
+
+  <insert id="insert" parameterType="io.camunda.db.rdbms.write.domain.UsageMetricTUDbModel">
+    INSERT INTO ${prefix}USAGE_METRIC_TU (USAGE_METRIC_KEY,
+                                          EVENT_TIME,
+                                          TENANT_ID,
+                                          ASSIGNEE_HASH,
+                                          PARTITION_ID)
+    VALUES (#{key},
+            #{eventTime, jdbcType=TIMESTAMP},
+            #{tenantId},
+            #{assigneeHash},
+            #{partitionId})
+  </insert>
+
+  <delete flushCache="true"
+    id="cleanupMetrics"
+    statementType="PREPARED">
+    DELETE
+    FROM ${prefix}USAGE_METRIC_TU
+    WHERE PARTITION_ID = #{partitionId}
+      AND EVENT_TIME &lt; #{cleanupDate} LIMIT #{limit}
+  </delete>
+
+  <delete flushCache="true"
+    id="cleanupMetrics"
+    statementType="PREPARED"
+    databaseId="oracle">
+    DELETE
+    FROM ${prefix}USAGE_METRIC_TU
+    WHERE rowid IN (SELECT rowid
+                    FROM ${prefix}USAGE_METRIC_TU
+                    WHERE PARTITION_ID = #{partitionId}
+                      AND EVENT_TIME &lt; #{cleanupDate}
+                      AND ROWNUM &lt;= #{limit})
+  </delete>
+
+  <delete flushCache="true"
+    id="cleanupMetrics"
+    statementType="PREPARED"
+    databaseId="postgresql">
+    DELETE
+    FROM ${prefix}USAGE_METRIC_TU
+    WHERE ctid IN (SELECT ctid
+                   FROM ${prefix}USAGE_METRIC_TU
+                   WHERE PARTITION_ID = #{partitionId}
+                     AND EVENT_TIME &lt; #{cleanupDate}
+      LIMIT #{limit})
+  </delete>
+
+</mapper>

--- a/dist/src/main/java/io/camunda/application/commons/rdbms/MyBatisConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/rdbms/MyBatisConfiguration.java
@@ -27,6 +27,7 @@ import io.camunda.db.rdbms.sql.RoleMapper;
 import io.camunda.db.rdbms.sql.SequenceFlowMapper;
 import io.camunda.db.rdbms.sql.TenantMapper;
 import io.camunda.db.rdbms.sql.UsageMetricMapper;
+import io.camunda.db.rdbms.sql.UsageMetricTUMapper;
 import io.camunda.db.rdbms.sql.UserMapper;
 import io.camunda.db.rdbms.sql.UserTaskMapper;
 import io.camunda.db.rdbms.sql.VariableMapper;
@@ -256,6 +257,12 @@ public class MyBatisConfiguration {
   public MapperFactoryBean<UsageMetricMapper> usageMetricMapper(
       final SqlSessionFactory sqlSessionFactory) {
     return createMapperFactoryBean(sqlSessionFactory, UsageMetricMapper.class);
+  }
+
+  @Bean
+  public MapperFactoryBean<UsageMetricTUMapper> usageMetricTUMapper(
+      final SqlSessionFactory sqlSessionFactory) {
+    return createMapperFactoryBean(sqlSessionFactory, UsageMetricTUMapper.class);
   }
 
   private <T> MapperFactoryBean<T> createMapperFactoryBean(

--- a/dist/src/main/java/io/camunda/application/commons/rdbms/RdbmsConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/rdbms/RdbmsConfiguration.java
@@ -33,6 +33,7 @@ import io.camunda.db.rdbms.read.service.RoleMemberDbReader;
 import io.camunda.db.rdbms.read.service.SequenceFlowDbReader;
 import io.camunda.db.rdbms.read.service.TenantDbReader;
 import io.camunda.db.rdbms.read.service.TenantMemberDbReader;
+import io.camunda.db.rdbms.read.service.UsageMetricTUDbReader;
 import io.camunda.db.rdbms.read.service.UsageMetricsDbReader;
 import io.camunda.db.rdbms.read.service.UserDbReader;
 import io.camunda.db.rdbms.read.service.UserTaskDbReader;
@@ -56,6 +57,7 @@ import io.camunda.db.rdbms.sql.RoleMapper;
 import io.camunda.db.rdbms.sql.SequenceFlowMapper;
 import io.camunda.db.rdbms.sql.TenantMapper;
 import io.camunda.db.rdbms.sql.UsageMetricMapper;
+import io.camunda.db.rdbms.sql.UsageMetricTUMapper;
 import io.camunda.db.rdbms.sql.UserMapper;
 import io.camunda.db.rdbms.sql.UserTaskMapper;
 import io.camunda.db.rdbms.sql.VariableMapper;
@@ -219,6 +221,11 @@ public class RdbmsConfiguration {
   }
 
   @Bean
+  public UsageMetricTUDbReader usageMetricTUReader(final UsageMetricTUMapper usageMetricTUMapper) {
+    return new UsageMetricTUDbReader(usageMetricTUMapper);
+  }
+
+  @Bean
   public RdbmsWriterMetrics rdbmsExporterMetrics(final MeterRegistry meterRegistry) {
     return new RdbmsWriterMetrics(meterRegistry);
   }
@@ -239,7 +246,8 @@ public class RdbmsConfiguration {
       final BatchOperationDbReader batchOperationReader,
       final JobMapper jobMapper,
       final SequenceFlowMapper sequenceFlowMapper,
-      final UsageMetricMapper usageMetricMapper) {
+      final UsageMetricMapper usageMetricMapper,
+      final UsageMetricTUMapper usageMetricTUMapper) {
     return new RdbmsWriterFactory(
         sqlSessionFactory,
         exporterPositionMapper,
@@ -255,7 +263,8 @@ public class RdbmsConfiguration {
         batchOperationReader,
         jobMapper,
         sequenceFlowMapper,
-        usageMetricMapper);
+        usageMetricMapper,
+        usageMetricTUMapper);
   }
 
   @Bean
@@ -281,7 +290,8 @@ public class RdbmsConfiguration {
       final SequenceFlowDbReader sequenceFlowReader,
       final BatchOperationItemDbReader batchOperationItemReader,
       final JobDbReader jobReader,
-      final UsageMetricsDbReader usageMetricReader) {
+      final UsageMetricsDbReader usageMetricReader,
+      final UsageMetricTUDbReader usageMetricTUDbReader) {
     return new RdbmsService(
         rdbmsWriterFactory,
         authorizationReader,
@@ -304,6 +314,7 @@ public class RdbmsConfiguration {
         sequenceFlowReader,
         batchOperationItemReader,
         jobReader,
-        usageMetricReader);
+        usageMetricReader,
+        usageMetricTUDbReader);
   }
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/usagemetrics/UsageMetricsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/usagemetrics/UsageMetricsIT.java
@@ -7,21 +7,30 @@
  */
 package io.camunda.it.rdbms.db.usagemetrics;
 
-import static io.camunda.db.rdbms.write.domain.UsageMetricDbModel.EventTypeDbModel.*;
-import static org.assertj.core.api.Assertions.*;
+import static io.camunda.db.rdbms.write.domain.UsageMetricDbModel.EventTypeDbModel.EDI;
+import static io.camunda.db.rdbms.write.domain.UsageMetricDbModel.EventTypeDbModel.RPI;
+import static io.camunda.db.rdbms.write.domain.UsageMetricDbModel.EventTypeDbModel.TU;
+import static io.camunda.zeebe.util.HashUtil.getStringHashValue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.db.rdbms.RdbmsService;
+import io.camunda.db.rdbms.read.service.UsageMetricTUDbReader;
 import io.camunda.db.rdbms.read.service.UsageMetricsDbReader;
 import io.camunda.db.rdbms.write.RdbmsWriter;
 import io.camunda.db.rdbms.write.domain.UsageMetricDbModel;
 import io.camunda.db.rdbms.write.domain.UsageMetricDbModel.EventTypeDbModel;
+import io.camunda.db.rdbms.write.domain.UsageMetricTUDbModel;
+import io.camunda.db.rdbms.write.service.UsageMetricTUWriter;
 import io.camunda.db.rdbms.write.service.UsageMetricWriter;
 import io.camunda.it.rdbms.db.fixtures.CommonFixtures;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
 import io.camunda.search.entities.UsageMetricStatisticsEntity;
 import io.camunda.search.entities.UsageMetricStatisticsEntity.UsageMetricStatisticsEntityTenant;
+import io.camunda.search.entities.UsageMetricTUStatisticsEntity;
+import io.camunda.search.entities.UsageMetricTUStatisticsEntity.UsageMetricTUStatisticsEntityTenant;
 import io.camunda.search.filter.UsageMetricsFilter;
+import io.camunda.search.filter.UsageMetricsFilter.Builder;
 import java.time.OffsetDateTime;
 import java.util.Map;
 import org.junit.jupiter.api.AfterEach;
@@ -34,15 +43,22 @@ import org.junit.jupiter.api.extension.ExtendWith;
 @ExtendWith(CamundaRdbmsInvocationContextProviderExtension.class)
 public class UsageMetricsIT {
 
-  public static final Long PARTITION_ID = 0L;
-  public static final OffsetDateTime NOW = OffsetDateTime.now();
-  public static final String TENANT1 = "tenant1";
-  public static final String TENANT2 = "tenant2";
+  private static final long ASSIGNEE_HASH_1 = getStringHashValue("assignee1");
+  private static final long ASSIGNEE_HASH_2 = getStringHashValue("assignee2");
+  private static final long ASSIGNEE_HASH_3 = getStringHashValue("assignee3");
+  private static final Long PARTITION_ID = 0L;
+  private static final OffsetDateTime NOW = OffsetDateTime.now();
+  private static final OffsetDateTime NOW_MINUS_5M = NOW.minusMinutes(5);
+  private static final OffsetDateTime NOW_MINUS_10M = NOW.minusMinutes(10);
+  private static final String TENANT1 = "tenant1";
+  private static final String TENANT2 = "tenant2";
 
   private CamundaRdbmsTestApplication testApplication;
   private RdbmsWriter rdbmsWriter;
   private UsageMetricsDbReader usageMetricReader;
+  private UsageMetricTUDbReader usageMetricTUDbReader;
   private UsageMetricWriter usageMetricWriter;
+  private UsageMetricTUWriter usageMetricTUWriter;
 
   private void writeMetric(
       final UsageMetricWriter usageMetricWriter,
@@ -61,110 +77,222 @@ public class UsageMetricsIT {
             .build());
   }
 
+  private void writeTUMetric(
+      final UsageMetricTUWriter usageMetricTUWriter,
+      final OffsetDateTime time,
+      final String tenantId,
+      final long value) {
+    usageMetricTUWriter.create(
+        new UsageMetricTUDbModel.Builder()
+            .key(CommonFixtures.nextKey())
+            .eventTime(time)
+            .tenantId(tenantId)
+            .assigneeHash(value)
+            .partitionId(PARTITION_ID.intValue())
+            .build());
+  }
+
   @BeforeEach
   void setUp() {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     rdbmsWriter = rdbmsService.createWriter(PARTITION_ID);
     usageMetricReader = rdbmsService.getUsageMetricReader();
+    usageMetricTUDbReader = rdbmsService.getUsageMetricTUReader();
     usageMetricWriter = rdbmsWriter.getUsageMetricWriter();
+    usageMetricTUWriter = rdbmsWriter.getUsageMetricTUWriter();
   }
 
   @AfterEach
   void tearDown() {
-    usageMetricWriter.cleanupMetrics(
-        PARTITION_ID.intValue(), OffsetDateTime.now().plusDays(1), Integer.MAX_VALUE);
+    usageMetricWriter.cleanupMetrics(PARTITION_ID.intValue(), NOW.plusDays(1), Integer.MAX_VALUE);
+    usageMetricTUWriter.cleanupMetrics(PARTITION_ID.intValue(), NOW.plusDays(1), Integer.MAX_VALUE);
   }
 
   @TestTemplate
   public void shouldAggregateMetricsWithTenant() {
     // given
-    final var now = OffsetDateTime.now();
-    writeMetric(usageMetricWriter, RPI, now, TENANT1, 11L);
-    writeMetric(usageMetricWriter, EDI, now, TENANT1, 11L);
-    writeMetric(usageMetricWriter, RPI, now.minusMinutes(5), TENANT1, 2L);
-    writeMetric(usageMetricWriter, RPI, now.minusMinutes(5), TENANT2, 3L);
-    writeMetric(usageMetricWriter, EDI, now.minusMinutes(5), TENANT2, 3L);
+    writeMetric(usageMetricWriter, RPI, NOW, TENANT1, 11L);
+    writeMetric(usageMetricWriter, EDI, NOW, TENANT1, 11L);
+    writeMetric(usageMetricWriter, TU, NOW, TENANT1, 1L);
+    writeMetric(usageMetricWriter, RPI, NOW_MINUS_5M, TENANT1, 2L);
+    writeMetric(usageMetricWriter, RPI, NOW_MINUS_5M, TENANT2, 3L);
+    writeMetric(usageMetricWriter, EDI, NOW_MINUS_5M, TENANT2, 3L);
+    writeMetric(usageMetricWriter, TU, NOW_MINUS_5M, TENANT2, 2L);
+    writeMetric(usageMetricWriter, RPI, NOW_MINUS_10M, TENANT2, 3L);
+    writeMetric(usageMetricWriter, EDI, NOW_MINUS_10M, TENANT2, 3L);
+    writeMetric(usageMetricWriter, TU, NOW_MINUS_10M, TENANT2, 1L);
+    writeMetric(usageMetricWriter, TU, NOW_MINUS_10M, TENANT1, 1L);
     rdbmsWriter.flush();
 
     // when
     final var actual =
-        usageMetricReader.usageMetricStatistics(
-            new UsageMetricsFilter.Builder().withTenants(true).build());
+        usageMetricReader.usageMetricStatistics(new Builder().withTenants(true).build());
 
     // then
     assertThat(actual)
         .isEqualTo(
             new UsageMetricStatisticsEntity(
-                16,
-                14,
+                19,
+                17,
                 2,
                 Map.of(
-                    "tenant1",
+                    TENANT1,
                     new UsageMetricStatisticsEntityTenant(13L, 11L),
-                    "tenant2",
-                    new UsageMetricStatisticsEntityTenant(3L, 3L))));
+                    TENANT2,
+                    new UsageMetricStatisticsEntityTenant(6L, 6L))));
+  }
+
+  @TestTemplate
+  public void shouldAggregateTUMetricsWithTenant() {
+    // given
+    writeTUMetric(usageMetricTUWriter, NOW, TENANT1, ASSIGNEE_HASH_1);
+    writeTUMetric(usageMetricTUWriter, NOW_MINUS_5M, TENANT2, ASSIGNEE_HASH_1);
+    writeTUMetric(usageMetricTUWriter, NOW_MINUS_5M, TENANT2, ASSIGNEE_HASH_2);
+    writeTUMetric(usageMetricTUWriter, NOW_MINUS_10M, TENANT2, ASSIGNEE_HASH_3);
+    writeTUMetric(usageMetricTUWriter, NOW_MINUS_10M, TENANT1, ASSIGNEE_HASH_3);
+    rdbmsWriter.flush();
+
+    // when
+    final var actualTU =
+        usageMetricTUDbReader.usageMetricTUStatistics(new Builder().withTenants(true).build());
+
+    // then
+    assertThat(actualTU)
+        .isEqualTo(
+            new UsageMetricTUStatisticsEntity(
+                5,
+                Map.of(
+                    TENANT1,
+                    new UsageMetricTUStatisticsEntityTenant(2L),
+                    TENANT2,
+                    new UsageMetricTUStatisticsEntityTenant(3L))));
   }
 
   @TestTemplate
   public void shouldAggregateMetricsWithoutTenant() {
     // given
-    final var now = OffsetDateTime.now();
-    writeMetric(usageMetricWriter, RPI, now, TENANT1, 11L);
-    writeMetric(usageMetricWriter, EDI, now, TENANT1, 11L);
-    writeMetric(usageMetricWriter, RPI, now.minusMinutes(5), TENANT1, 2L);
-    writeMetric(usageMetricWriter, RPI, now.minusMinutes(5), TENANT2, 3L);
-    writeMetric(usageMetricWriter, EDI, now.minusMinutes(5), TENANT2, 3L);
+    writeMetric(usageMetricWriter, RPI, NOW, TENANT1, 11L);
+    writeMetric(usageMetricWriter, EDI, NOW, TENANT1, 11L);
+    writeMetric(usageMetricWriter, TU, NOW, TENANT1, 2L);
+    writeMetric(usageMetricWriter, RPI, NOW_MINUS_5M, TENANT1, 2L);
+    writeMetric(usageMetricWriter, RPI, NOW_MINUS_5M, TENANT2, 3L);
+    writeMetric(usageMetricWriter, EDI, NOW_MINUS_5M, TENANT2, 3L);
+    writeMetric(usageMetricWriter, TU, NOW_MINUS_5M, TENANT2, 3L);
     rdbmsWriter.flush();
 
     // when
-    final var actual =
-        usageMetricReader.usageMetricStatistics(new UsageMetricsFilter.Builder().build());
+    final var actual = usageMetricReader.usageMetricStatistics(new Builder().build());
 
     // then
     assertThat(actual).isEqualTo(new UsageMetricStatisticsEntity(16, 14, 2, null));
   }
 
   @TestTemplate
-  public void shouldFilterMetricsByDate() {
+  public void shouldAggregateTUMetricsWithoutTenant() {
     // given
-    final var now = OffsetDateTime.now();
-    writeMetric(usageMetricWriter, RPI, now, TENANT1, 1L);
-    writeMetric(usageMetricWriter, EDI, now.minusMinutes(5), TENANT2, 1L);
+    writeTUMetric(usageMetricTUWriter, NOW, TENANT1, ASSIGNEE_HASH_1);
+    writeTUMetric(usageMetricTUWriter, NOW, TENANT1, ASSIGNEE_HASH_2);
+    writeTUMetric(usageMetricTUWriter, NOW_MINUS_5M, TENANT2, ASSIGNEE_HASH_1);
+    writeTUMetric(usageMetricTUWriter, NOW_MINUS_5M, TENANT2, ASSIGNEE_HASH_2);
+    writeTUMetric(usageMetricTUWriter, NOW_MINUS_5M, TENANT2, ASSIGNEE_HASH_3);
     rdbmsWriter.flush();
 
     // when
-    final var actual =
-        usageMetricReader.usageMetricStatistics(
-            new UsageMetricsFilter.Builder()
-                .startTime(now.minusMinutes(1))
-                .endTime(now.plusMinutes(1))
-                .build());
+    final var actualTU = usageMetricTUDbReader.usageMetricTUStatistics(new Builder().build());
 
     // then
-    assertThat(actual).isEqualTo(new UsageMetricStatisticsEntity(1, 0, 1, null));
+    assertThat(actualTU).isEqualTo(new UsageMetricTUStatisticsEntity(3, null));
+  }
+
+  @TestTemplate
+  public void shouldFilterMetricsByDate() {
+    // given
+    writeMetric(usageMetricWriter, RPI, NOW, TENANT1, 1L);
+    writeMetric(usageMetricWriter, EDI, NOW_MINUS_5M, TENANT1, 1L);
+    writeMetric(usageMetricWriter, TU, NOW_MINUS_5M, TENANT1, 2L);
+    writeMetric(usageMetricWriter, EDI, NOW_MINUS_10M, TENANT2, 1L);
+    writeMetric(usageMetricWriter, TU, NOW_MINUS_10M, TENANT2, 1L);
+    rdbmsWriter.flush();
+
+    // when
+    final UsageMetricsFilter umFilter =
+        new Builder().startTime(NOW.minusMinutes(6)).endTime(NOW.plusMinutes(6)).build();
+    final var actual = usageMetricReader.usageMetricStatistics(umFilter);
+
+    // then
+    assertThat(actual).isEqualTo(new UsageMetricStatisticsEntity(1, 1, 1, null));
+  }
+
+  @TestTemplate
+  public void shouldFilterTUMetricsByDate() {
+    // given
+    writeTUMetric(usageMetricTUWriter, NOW_MINUS_5M, TENANT1, ASSIGNEE_HASH_1);
+    writeTUMetric(usageMetricTUWriter, NOW_MINUS_5M, TENANT1, ASSIGNEE_HASH_2);
+    writeTUMetric(usageMetricTUWriter, NOW_MINUS_10M, TENANT1, ASSIGNEE_HASH_1);
+    writeTUMetric(usageMetricTUWriter, NOW_MINUS_10M, TENANT1, ASSIGNEE_HASH_2);
+    rdbmsWriter.flush();
+
+    // when
+    final UsageMetricsFilter umFilter =
+        new Builder().startTime(NOW.minusMinutes(6)).endTime(NOW.plusMinutes(6)).build();
+    final var actualTU = usageMetricTUDbReader.usageMetricTUStatistics(umFilter);
+
+    // then
+    assertThat(actualTU).isEqualTo(new UsageMetricTUStatisticsEntity(2, null));
   }
 
   @TestTemplate
   public void shouldFilterMetricsWithTenantByDate() {
     // given
-    final var now = OffsetDateTime.now();
-    writeMetric(usageMetricWriter, RPI, now, TENANT1, 1L);
-    writeMetric(usageMetricWriter, EDI, now.minusMinutes(5), TENANT2, 1L);
+    writeMetric(usageMetricWriter, RPI, NOW, TENANT1, 1L);
+    writeMetric(usageMetricWriter, RPI, NOW, TENANT2, 1L);
+    writeMetric(usageMetricWriter, EDI, NOW_MINUS_5M, TENANT2, 1L);
+    writeMetric(usageMetricWriter, TU, NOW_MINUS_5M, TENANT2, 1L);
+    writeMetric(usageMetricWriter, EDI, NOW_MINUS_10M, TENANT2, 1L);
+    writeMetric(usageMetricWriter, TU, NOW_MINUS_10M, TENANT2, 1L);
     rdbmsWriter.flush();
 
     // when
-    final var actual =
-        usageMetricReader.usageMetricStatistics(
-            new UsageMetricsFilter.Builder()
-                .startTime(now.minusMinutes(1))
-                .endTime(now.plusMinutes(1))
-                .withTenants(true)
-                .build());
+    final UsageMetricsFilter filter =
+        new Builder()
+            .startTime(NOW.minusMinutes(6))
+            .endTime(NOW.plusMinutes(6))
+            .withTenants(true)
+            .build();
+    final var actual = usageMetricReader.usageMetricStatistics(filter);
 
     // then
     assertThat(actual)
         .isEqualTo(
             new UsageMetricStatisticsEntity(
-                1, 0, 1, Map.of(TENANT1, new UsageMetricStatisticsEntityTenant(1L, 0L))));
+                2,
+                1,
+                2,
+                Map.of(
+                    TENANT1, new UsageMetricStatisticsEntityTenant(1L, 0L),
+                    TENANT2, new UsageMetricStatisticsEntityTenant(1L, 1L))));
+  }
+
+  @TestTemplate
+  public void shouldFilterTUMetricsWithTenantByDate() {
+    // given
+    writeTUMetric(usageMetricTUWriter, NOW_MINUS_5M, TENANT2, ASSIGNEE_HASH_1);
+    writeTUMetric(usageMetricTUWriter, NOW_MINUS_10M, TENANT1, ASSIGNEE_HASH_2);
+    rdbmsWriter.flush();
+
+    // when
+    final UsageMetricsFilter filter =
+        new Builder()
+            .startTime(NOW.minusMinutes(6))
+            .endTime(NOW.plusMinutes(6))
+            .withTenants(true)
+            .build();
+    final var actualTU = usageMetricTUDbReader.usageMetricTUStatistics(filter);
+
+    // then
+    assertThat(actualTU)
+        .isEqualTo(
+            new UsageMetricTUStatisticsEntity(
+                1, Map.of(TENANT2, new UsageMetricTUStatisticsEntityTenant(1L))));
   }
 }

--- a/search/search-domain/src/main/java/io/camunda/search/entities/UsageMetricTUStatisticsEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/UsageMetricTUStatisticsEntity.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.entities;
+
+import io.camunda.util.ObjectBuilder;
+import java.util.Map;
+
+public record UsageMetricTUStatisticsEntity(
+    long totalAtu, Map<String, UsageMetricTUStatisticsEntityTenant> tenants) {
+
+  public record UsageMetricTUStatisticsEntityTenant(long atu) {
+
+    public static class Builder implements ObjectBuilder<UsageMetricTUStatisticsEntityTenant> {
+
+      private long atu = 0;
+
+      public UsageMetricTUStatisticsEntityTenant.Builder atu(final long atu) {
+        this.atu = atu;
+        return this;
+      }
+
+      @Override
+      public UsageMetricTUStatisticsEntityTenant build() {
+        return new UsageMetricTUStatisticsEntityTenant(atu);
+      }
+    }
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/metrics/DbUsageMetricState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/metrics/DbUsageMetricState.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.engine.state.metrics;
 
+import static io.camunda.zeebe.util.HashUtil.getStringHashValue;
+
 import io.camunda.zeebe.db.ColumnFamily;
 import io.camunda.zeebe.db.TransactionContext;
 import io.camunda.zeebe.db.ZeebeDb;
@@ -81,7 +83,8 @@ public class DbUsageMetricState implements MutableUsageMetricState {
 
   @Override
   public void recordTUMetric(final String tenantId, final String assignee) {
-    updateActiveBucket(getOrCreateActiveBucket().recordTU(tenantId, assignee));
+    final long assigneeHashed = getStringHashValue(assignee);
+    updateActiveBucket(getOrCreateActiveBucket().recordTU(tenantId, assigneeHashed));
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/metrics/PersistedUsageMetrics.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/metrics/PersistedUsageMetrics.java
@@ -85,11 +85,11 @@ public class PersistedUsageMetrics extends UnpackedObject implements DbValue {
     return tenantTUMapProp.getValue();
   }
 
-  public Map<String, Set<String>> getTenantTUMap() {
-    return MsgPackConverter.convertToSetStringMap(tenantTUMapProp.getValue());
+  public Map<String, Set<Long>> getTenantTUMap() {
+    return MsgPackConverter.convertToSetLongMap(tenantTUMapProp.getValue());
   }
 
-  public PersistedUsageMetrics setTenantTUMap(final Map<String, Set<String>> tenantTUMap) {
+  public PersistedUsageMetrics setTenantTUMap(final Map<String, Set<Long>> tenantTUMap) {
     tenantTUMapProp.setValue(BufferUtil.wrapArray(MsgPackConverter.convertToMsgPack(tenantTUMap)));
     return this;
   }
@@ -108,7 +108,7 @@ public class PersistedUsageMetrics extends UnpackedObject implements DbValue {
     return this;
   }
 
-  public PersistedUsageMetrics recordTU(final String tenantId, final String assignee) {
+  public PersistedUsageMetrics recordTU(final String tenantId, final Long assignee) {
     final var tenantTUMap = getTenantTUMap();
     final boolean added = tenantTUMap.computeIfAbsent(tenantId, k -> new HashSet<>()).add(assignee);
     if (added) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/metrics/UsageMetricsExportProcessorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/metrics/UsageMetricsExportProcessorTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.metrics;
 
+import static io.camunda.zeebe.util.HashUtil.getStringHashValue;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 import static org.mockito.Mockito.mock;
@@ -32,7 +33,8 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 class UsageMetricsExportProcessorTest {
-
+  private static final long ASSIGNEE_HASH_1 = getStringHashValue("assignee1");
+  private static final String TENANT_1 = "tenant1";
   private MutableUsageMetricState state;
   private StateWriter stateWriter;
   private UsageMetricsExportProcessor processor;
@@ -90,7 +92,7 @@ class UsageMetricsExportProcessorTest {
             new PersistedUsageMetrics()
                 .setFromTime(1)
                 .setToTime(10)
-                .setTenantRPIMap(Map.of("tenant1", 10L)));
+                .setTenantRPIMap(Map.of(TENANT_1, 10L)));
 
     // when
     processor.processRecord(record);
@@ -106,7 +108,7 @@ class UsageMetricsExportProcessorTest {
     assertThat(actual.getResetTime()).isEqualTo(2);
     assertThat(actual.getStartTime()).isEqualTo(1);
     assertThat(actual.getEndTime()).isEqualTo(10);
-    assertThat(actual.getCounterValues()).isEqualTo(Map.of("tenant1", 10L));
+    assertThat(actual.getCounterValues()).isEqualTo(Map.of(TENANT_1, 10L));
     assertThat(actual.getSetValues()).isEqualTo(Map.of());
   }
 
@@ -118,7 +120,7 @@ class UsageMetricsExportProcessorTest {
             new PersistedUsageMetrics()
                 .setFromTime(1)
                 .setToTime(10)
-                .setTenantEDIMap(Map.of("tenant1", 10L)));
+                .setTenantEDIMap(Map.of(TENANT_1, 10L)));
     // when
     processor.processRecord(record);
 
@@ -133,7 +135,7 @@ class UsageMetricsExportProcessorTest {
     assertThat(actual.getResetTime()).isEqualTo(2);
     assertThat(actual.getStartTime()).isEqualTo(1);
     assertThat(actual.getEndTime()).isEqualTo(10);
-    assertThat(actual.getCounterValues()).isEqualTo(Map.of("tenant1", 10L));
+    assertThat(actual.getCounterValues()).isEqualTo(Map.of(TENANT_1, 10L));
     assertThat(actual.getSetValues()).isEqualTo(Map.of());
   }
 
@@ -145,7 +147,7 @@ class UsageMetricsExportProcessorTest {
             new PersistedUsageMetrics()
                 .setFromTime(1)
                 .setToTime(10)
-                .setTenantTUMap(Map.of("tenant1", Set.of("assignee1"))));
+                .setTenantTUMap(Map.of(TENANT_1, Set.of(ASSIGNEE_HASH_1))));
     // when
     processor.processRecord(record);
 
@@ -161,7 +163,7 @@ class UsageMetricsExportProcessorTest {
     assertThat(actual.getStartTime()).isEqualTo(1);
     assertThat(actual.getEndTime()).isEqualTo(10);
     assertThat(actual.getCounterValues()).isEqualTo(Map.of());
-    assertThat(actual.getSetValues()).isEqualTo(Map.of("tenant1", Set.of("assignee1")));
+    assertThat(actual.getSetValues()).isEqualTo(Map.of(TENANT_1, Set.of(ASSIGNEE_HASH_1)));
   }
 
   @Test
@@ -172,9 +174,9 @@ class UsageMetricsExportProcessorTest {
             new PersistedUsageMetrics()
                 .setFromTime(1)
                 .setToTime(10)
-                .setTenantRPIMap(Map.of("tenant1", 10L))
-                .setTenantEDIMap(Map.of("tenant1", 10L))
-                .setTenantTUMap(Map.of("tenant1", Set.of("assignee1"))));
+                .setTenantRPIMap(Map.of(TENANT_1, 10L))
+                .setTenantEDIMap(Map.of(TENANT_1, 10L))
+                .setTenantTUMap(Map.of(TENANT_1, Set.of(ASSIGNEE_HASH_1))));
     // when
     processor.processRecord(record);
 
@@ -196,9 +198,9 @@ class UsageMetricsExportProcessorTest {
         .contains(EventType.RPI, EventType.EDI, EventType.TU);
     assertThat(actual)
         .extracting(UsageMetricRecord::getCounterValues)
-        .contains(Map.of("tenant1", 10L), Map.of());
+        .contains(Map.of(TENANT_1, 10L), Map.of());
     assertThat(actual)
         .extracting(UsageMetricRecord::getSetValues)
-        .contains(Map.of(), Map.of("tenant1", Set.of("assignee1")));
+        .contains(Map.of(), Map.of(TENANT_1, Set.of(ASSIGNEE_HASH_1)));
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/UsageMetricsExportedApplierTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/UsageMetricsExportedApplierTest.java
@@ -7,8 +7,12 @@
  */
 package io.camunda.zeebe.engine.state.appliers;
 
-import static org.assertj.core.api.Assertions.*;
-import static org.mockito.Mockito.*;
+import static io.camunda.zeebe.util.HashUtil.getStringHashValue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import io.camunda.zeebe.engine.state.metrics.PersistedUsageMetrics;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
@@ -23,7 +27,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(ProcessingStateExtension.class)
 class UsageMetricsExportedApplierTest {
-
+  private static final long ASSIGNEE_HASH_1 = getStringHashValue("assignee1");
   private MutableProcessingState processingState;
   private MutableUsageMetricState usageMetricState;
   private UsageMetricsExportedApplier usageMetricsExportedApplier;
@@ -100,7 +104,7 @@ class UsageMetricsExportedApplierTest {
     final var bucket = usageMetricState.getActiveBucket();
     assertThat(bucket).isNotNull();
     assertThat(bucket.getTenantTUMap())
-        .containsExactlyInAnyOrderEntriesOf(Map.of("tenant1", Set.of("assignee1")));
+        .containsExactlyInAnyOrderEntriesOf(Map.of("tenant1", Set.of(ASSIGNEE_HASH_1)));
 
     // when
     usageMetricsExportedApplier.applyState(1L, new UsageMetricRecord().setResetTime(2L));

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/metrics/DbUsageMetricStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/metrics/DbUsageMetricStateTest.java
@@ -7,8 +7,10 @@
  */
 package io.camunda.zeebe.engine.state.metrics;
 
-import static org.assertj.core.api.Assertions.*;
-import static org.mockito.Mockito.*;
+import static io.camunda.zeebe.util.HashUtil.getStringHashValue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import io.camunda.zeebe.db.TransactionContext;
 import io.camunda.zeebe.db.ZeebeDb;
@@ -27,6 +29,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 @ExtendWith(ProcessingStateExtension.class)
 public class DbUsageMetricStateTest {
 
+  private static final long ASSIGNEE_HASH_1 = getStringHashValue("assignee1");
+  private static final long ASSIGNEE_HASH_2 = getStringHashValue("assignee2");
+  private static final long ASSIGNEE_HASH_3 = getStringHashValue("assignee3");
   private ZeebeDb<ZbColumnFamilies> zeebeDb;
   private TransactionContext transactionContext;
   private InstantSource mockClock;
@@ -129,10 +134,10 @@ public class DbUsageMetricStateTest {
         .containsExactlyInAnyOrderEntriesOf(
             Map.of(
                 TenantOwned.DEFAULT_TENANT_IDENTIFIER,
-                Set.of("assignee1", "assignee2"),
+                Set.of(ASSIGNEE_HASH_1, ASSIGNEE_HASH_2),
                 "tenant1",
-                Set.of("assignee1", "assignee2", "assignee3"),
+                Set.of(ASSIGNEE_HASH_1, ASSIGNEE_HASH_2, ASSIGNEE_HASH_3),
                 "tenant2",
-                Set.of("assignee1")));
+                Set.of(ASSIGNEE_HASH_1)));
   }
 }

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporterWrapper.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporterWrapper.java
@@ -288,7 +288,9 @@ public class RdbmsExporterWrapper implements Exporter {
         ValueType.PROCESS_INSTANCE,
         new SequenceFlowExportHandler(rdbmsWriter.getSequenceFlowWriter()));
     builder.withHandler(
-        ValueType.USAGE_METRIC, new UsageMetricExportHandler(rdbmsWriter.getUsageMetricWriter()));
+        ValueType.USAGE_METRIC,
+        new UsageMetricExportHandler(
+            rdbmsWriter.getUsageMetricWriter(), rdbmsWriter.getUsageMetricTUWriter()));
   }
 
   private void createBatchOperationHandlers(

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/MsgPackConverter.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/MsgPackConverter.java
@@ -55,7 +55,7 @@ public final class MsgPackConverter {
       new TypeReference<>() {};
   private static final TypeReference<HashMap<String, Long>> LONG_MAP_TYPE_REFERENCE =
       new TypeReference<>() {};
-  private static final TypeReference<HashMap<String, Set<String>>> SET_STRING_MAP_TYPE_REFERENCE =
+  private static final TypeReference<HashMap<String, Set<Long>>> SET_LONG_MAP_TYPE_REFERENCE =
       new TypeReference<>() {};
   private static final TypeReference<HashMap<PermissionType, Set<String>>>
       PERMISSION_MAP_TYPE_REFERENCE = new TypeReference<>() {};
@@ -186,8 +186,8 @@ public final class MsgPackConverter {
     return convertToMap(LONG_MAP_TYPE_REFERENCE, buffer);
   }
 
-  public static Map<String, Set<String>> convertToSetStringMap(final DirectBuffer buffer) {
-    return convertToMap(SET_STRING_MAP_TYPE_REFERENCE, buffer);
+  public static Map<String, Set<Long>> convertToSetLongMap(final DirectBuffer buffer) {
+    return convertToMap(SET_LONG_MAP_TYPE_REFERENCE, buffer);
   }
 
   public static Map<PermissionType, Set<String>> convertToPermissionMap(final DirectBuffer buffer) {

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/metrics/UsageMetricRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/metrics/UsageMetricRecord.java
@@ -121,8 +121,8 @@ public class UsageMetricRecord extends UnifiedRecordValue implements UsageMetric
   }
 
   @Override
-  public Map<String, Set<String>> getSetValues() {
-    return MsgPackConverter.convertToSetStringMap(setValuesProp.getValue());
+  public Map<String, Set<Long>> getSetValues() {
+    return MsgPackConverter.convertToSetLongMap(setValuesProp.getValue());
   }
 
   public UsageMetricRecord setSetValues(final DirectBuffer value) {

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/UsageMetricRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/UsageMetricRecordValue.java
@@ -37,7 +37,7 @@ public interface UsageMetricRecordValue extends RecordValue {
 
   Map<String, Long> getCounterValues();
 
-  Map<String, Set<String>> getSetValues();
+  Map<String, Set<Long>> getSetValues();
 
   enum EventType {
     NONE,

--- a/zeebe/util/pom.xml
+++ b/zeebe/util/pom.xml
@@ -109,6 +109,11 @@
     </dependency>
 
     <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>provided</scope>

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/HashUtil.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/HashUtil.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.util;
+
+import com.google.common.hash.Hashing;
+import java.nio.charset.StandardCharsets;
+
+/** Utility class for generating hash values. */
+public final class HashUtil {
+
+  private HashUtil() {}
+
+  /**
+   * Computes a 64-bit hash value from the given string using Murmur3 128-bit hashing.
+   *
+   * <p>Murmur3 is chosen for its excellent performance and well-distributed hash values, making it
+   * ideal for use cases such as hash tables, IDs, and partitioning tasks where cryptographic
+   * security is not a concern. The probability of collision for the 64-bit hash output is extremely
+   * low for typical applications—collisions only become likely (about 50% chance) after
+   * approximately 8 billion unique inputs, due to the birthday paradox. Note that Murmur3 is not
+   * suitable for cryptographic purposes or adversarial environments.
+   *
+   * <p><b>Dependency Note:</b> If there is a need to remove external dependency, Murmur3 can be
+   * replaced with Java's built-in SHA-256 hash function. SHA-256 provides very low collision
+   * probability and is suitable for security-sensitive applications, though it is slower than
+   * Murmur3. See the alternative implementation below:
+   *
+   * <pre>{@code
+   * public static long getStringHashValueSHA256(final String stringValue) {
+   *     try {
+   *         MessageDigest digest = MessageDigest.getInstance("SHA-256");
+   *         byte[] hash = digest.digest(stringValue.getBytes(StandardCharsets.UTF_8));
+   *         return ByteBuffer.wrap(hash).getLong(); // Uses first 8 bytes as a long
+   *     } catch (NoSuchAlgorithmException e) {
+   *         throw new RuntimeException(e);
+   *     }
+   * }
+   * }</pre>
+   *
+   * @param stringValue the input string to hash
+   * @return the 64-bit hash value of the input string
+   */
+  public static long getStringHashValue(final String stringValue) {
+    return Hashing.murmur3_128().hashString(stringValue, StandardCharsets.UTF_8).asLong();
+  }
+}


### PR DESCRIPTION
## Description

Handle aTU introducing new table USAGE_METRICS_TU
Add aTU relative Reader and Writer

### High level overview
#### Writer
- rPI: counter values on USAGE_METRIC table
- eDI: counter values on USAGE_METRIC table
- aTU: 
  - counter values on USAGE_METRIC table (**this value will be miss-leading**: If assignee_hash already exists for specified tenant_id, it should not be inserted to USAGE_METRICS_TU )
  - actual unique values on USAGE_METRIC_TU table

#### Reader 
- rPI/eDI/at (active tenants): from USAGE_METRIC table
- aTU: from USAGE_METRIC_TU table

### ❓ Discussion:

1. Should be hashed with that way? HashUtils need refactor package/name?
2. Is data structure valid so that we can continue to Camunda Exporter
3. Why does key has to be composite? -- relative PR https://github.com/camunda/camunda/pull/35401
4. Should I also have different unique constraints in USAGE_METRICS_TU?

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes https://github.com/camunda/camunda/issues/31133
