### PR TITLE
Camunda exporter flush duration metric

### DIFF
--- a/monitor/grafana/dashboards/data_layer.json
+++ b/monitor/grafana/dashboards/data_layer.json
@@ -19,7 +19,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 20,
+  "id": 28,
   "links": [],
   "panels": [
     {
@@ -939,7 +939,7 @@
             "uid": "$DS_PROMETHEUS"
           },
           "editorMode": "code",
-          "expr": "sum(increase(zeebe_camunda_exporter_flush_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\"}[$__rate_interval])) by (le)",
+          "expr": "sum(increase(zeebe_camunda_exporter_flush_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\", exporterId=~\"$exporterId\"}[$__rate_interval])) by (le)",
           "format": "heatmap",
           "interval": "30s",
           "intervalFactor": 1,
@@ -3023,5 +3023,5 @@
   "timezone": "browser",
   "title": "Data Layer",
   "uid": "728720fd-6b20-430a-b931-bbfdc71531dd",
-  "version": 4
+  "version": 6
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
@@ -284,7 +284,7 @@ public class CamundaExporter implements Exporter {
 
     if (writer.getBatchSize() == configuration.getBulk().getSize()) {
       LOG.info(
-"""
+          """
 Cached maximum batch size [{}] number of records, exporting will block at the current position of [{}] while waiting for the importers to finish
 processing records from previous version
 """,

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterIT.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -716,7 +717,7 @@ final class CamundaExporterIT {
 
       // then
       assertThat(controller.getPosition()).isEqualTo(record.getPosition());
-      verify(controller, times(1))
+      verify(controller, atLeastOnce())
           .updateLastExportedRecordPosition(eq(record.getPosition()), any());
 
       final var authHandler =


### PR DESCRIPTION
## Description

Correctly measure flush duration for the camunda exporter on all non-empty flushes (before it would not measure flushes which resulted from periodic scheduling, only measure flushes when the bulk request reached it's limit).

Here is a snapshot of the dashboard (which is unchanged) https://snapshots.raintank.io/dashboard/snapshot/7rurdxBvv245vsdgD9wFu0t02N3EWz1R

<img width="1423" height="815" alt="image" src="https://github.com/user-attachments/assets/7b8aff0e-27b5-4761-bd9d-2cb971a00658" />

## Related issues

closes #34747 
