### PR TITLE
fix: skip clients w/o permissions in keycloak migration

### DIFF
--- a/migration/identity-migration/pom.xml
+++ b/migration/identity-migration/pom.xml
@@ -37,6 +37,10 @@
       <artifactId>spring-web</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-autoconfigure</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
@@ -95,6 +99,10 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
     </dependency>
     <dependency>
       <groupId>jakarta.validation</groupId>

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/ManagementIdentityConnectorConfig.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/ManagementIdentityConnectorConfig.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.migration.identity.config;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import io.camunda.identity.sdk.Identity;
 import io.camunda.identity.sdk.IdentityConfiguration;
 import io.camunda.identity.sdk.IdentityConfiguration.Type;
@@ -14,6 +15,7 @@ import io.camunda.migration.identity.client.ManagementIdentityClient;
 import java.io.IOException;
 import java.util.Optional;
 import org.apache.commons.lang3.NotImplementedException;
+import org.springframework.boot.autoconfigure.jackson.Jackson2ObjectMapperBuilderCustomizer;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
@@ -53,6 +55,13 @@ public class ManagementIdentityConnectorConfig {
       case KEYCLOAK -> Type.KEYCLOAK.name();
       default -> Type.AUTH0.name();
     };
+  }
+
+  @Bean
+  public Jackson2ObjectMapperBuilderCustomizer jsonCustomizer() {
+    return builder ->
+        builder.featuresToEnable(
+            DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE);
   }
 
   @Bean

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/dto/ClientType.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/dto/ClientType.java
@@ -7,8 +7,12 @@
  */
 package io.camunda.migration.identity.dto;
 
-public record Client(String id, String clientId, ClientType type) {
-  public Client(final String id, final String clientId) {
-    this(id, clientId, ClientType.M2M);
-  }
+import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
+
+public enum ClientType {
+  CONFIDENTIAL,
+  M2M,
+  PUBLIC,
+  @JsonEnumDefaultValue
+  UNKNOWN
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/migration/KeycloakIdentityMigrationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/migration/KeycloakIdentityMigrationIT.java
@@ -149,6 +149,11 @@ public class KeycloakIdentityMigrationIT {
           .withEnv("IDENTITY_TENANTS_1_MEMBERS_1_USERNAME", "user1")
           .withEnv("IDENTITY_TENANTS_1_MEMBERS_2_TYPE", "APPLICATION")
           .withEnv("IDENTITY_TENANTS_1_MEMBERS_2_APPLICATION-ID", IDENTITY_CLIENT)
+          // public client to be ignored
+          .withEnv("KEYCLOAK_CLIENTS_1_NAME", "console")
+          .withEnv("KEYCLOAK_CLIENTS_1_ID", "console")
+          .withEnv("KEYCLOAK_CLIENTS_1_ROOT_URL", "http://console.camunda.com")
+          .withEnv("KEYCLOAK_CLIENTS_1_TYPE", "public")
           .waitingFor(
               new HttpWaitStrategy()
                   .forPort(8082)


### PR DESCRIPTION
## Description

The migration app was failing when encountering "PUBLIC" clients returned from management identity.

This instructs it to only handle supported clients of type m2m and confidential and skip everything else, issuing a debug log in this expected but handled case. See the equivalent logic in management identity [here](https://github.com/camunda-cloud/identity/blob/d76e23bc85c76c1c31ace0fd1d21e148706a9885/management-api/src/main/java/io/camunda/identity/impl/keycloak/initializer/service/ClientInitializationService.java#L216).
## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #35431 
