### PR TITLE
ci: help debugging intermittent checksum errors by showing installer output

### DIFF
--- a/.github/actions/paths-filter/action.yml
+++ b/.github/actions/paths-filter/action.yml
@@ -163,6 +163,7 @@ outputs:
       ${{
         github.event_name == 'push' ||
         github.event_name == 'schedule' ||
+        steps.filter-common.outputs.github-actions-change == 'true' ||
         steps.filter-common.outputs.openapi-change == 'true'
       }}
   stable-branch-changes:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1206,7 +1206,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install Vacuum
-        run: curl -fsSL https://quobix.com/scripts/install_vacuum.sh | sh > /dev/null
+        run: curl -fsSL https://quobix.com/scripts/install_vacuum.sh | sh
         shell: bash
       - name: Run OpenAPI Linter
         run: >


### PR DESCRIPTION
## Description

We observe intermittent checksum validation errors from the vacuum installer, example:

* https://github.com/camunda/camunda/actions/runs/16299097265/attempts/1
* https://github.com/camunda/camunda/actions/runs/16298978848/attempts/1
* https://github.com/camunda/camunda/actions/runs/16298044042/attempts/1

As shown in https://github.com/daveshanley/vacuum/issues/657 the installer output can provide insights to what happened, allowing better root causing. This PR removes sending the installer output to `/dev/null`, see https://github.com/camunda/camunda/actions/runs/16317862981/job/46088031230?pr=35444#step:3:9

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

https://github.com/camunda/camunda/issues/35448
