### PR TITLE
Handle `ClassCircularityError` when wrapped by gRPC

### DIFF
--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/error/VirtualMachineErrorHandler.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/error/VirtualMachineErrorHandler.java
@@ -43,7 +43,7 @@ public final class VirtualMachineErrorHandler
    */
   @Override
   public void handleError(final Throwable e) {
-    if (e instanceof VirtualMachineError) {
+    if (e instanceof VirtualMachineError || e instanceof ClassCircularityError) {
       tryLoggingThenExit(e);
     }
 

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/error/VirtualMachineErrorHandler.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/error/VirtualMachineErrorHandler.java
@@ -35,14 +35,29 @@ public final class VirtualMachineErrorHandler
    * there is no action we can take to resolve them, and it is safer to terminate and let a
    * hypervisor restart Zeebe.
    *
+   * <p>ClassCircularityError might occur while gateway loading virtual threads due to a known bug
+   * https://github.com/corretto/corretto-21/issues/65. gRPC wraps such errors in an
+   * IllegalStateException, so we should detect such a case and let a hypervisor restart Zeebe.
+   *
    * @param e the throwable
    */
   @Override
   public void handleError(final Throwable e) {
-    if (e instanceof VirtualMachineError || e instanceof ClassCircularityError) {
-      tryLogging(e);
-      System.exit(EXIT_CODE);
+    if (e instanceof VirtualMachineError) {
+      tryLoggingThenExit(e);
     }
+
+    if (e instanceof IllegalStateException) {
+      final Throwable cause = e.getCause();
+      if (cause instanceof ClassCircularityError) {
+        tryLoggingThenExit(cause);
+      }
+    }
+  }
+
+  private void tryLoggingThenExit(final Throwable cause) {
+    tryLogging(cause);
+    System.exit(EXIT_CODE);
   }
 
   private void tryLogging(final Throwable e) {


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Our existing fix #32756  added `ClassCircularityError` to the list of fatal errors in `VirtualMachineErrorHandler`, but it didn’t cover the case where gRPC’s `SerializingExecutor` wraps that error inside an `IllegalStateException`. As a result, the gateway continued running when the circularity first occurred during request handling on virtual threads.

This PR updates the handler to unwrap a `ClassCircularityError` from within an `IllegalStateException` and treat it as fatal, restoring the intended shutdown behavior.

#### Original symptom
We saw `ClassCircularityError` in JDK internals (e.g. `jdk.internal.misc.VirtualThreads or jdk.internal.event.VirtualThreadPinnedEvent`) causing subtle failures in our gRPC gateway after weeks of uptime.

#### First fix
We extended `VirtualMachineErrorHandler.handleError()` to catch `ClassCircularityError` and exit.

```java
if (e instanceof VirtualMachineError || e instanceof ClassCircularityError) {
  tryLogging(e);
  System.exit(EXIT_CODE);
}
```

#### Why it failed

gRPC’s SerializingExecutor catches all throwables in request threads and re‑throws them as:
`IllegalStateException: ClassCircularityError: …` Because the raw `ClassCircularityError` never escapes on its own, our handler never saw it, and the gateway didn’t shut down. Stack trace:

```
java.lang.IllegalStateException: java.lang.ClassCircularityError: jdk/internal/misc/VirtualThreads
	at io.grpc.internal.ServerImpl$ServerTransportListenerImpl$1HandleServerCall.runInternal(ServerImpl.java:617) ~[grpc-core-1.68.1.jar:1.68.1]
	at io.grpc.internal.ServerImpl$ServerTransportListenerImpl$1HandleServerCall.runInContext(ServerImpl.java:603) ~[grpc-core-1.68.1.jar:1.68.1]
	at io.grpc.internal.ContextRunnable.run(ContextRunnable.java:37) ~[grpc-core-1.68.1.jar:1.68.1]
	at io.grpc.internal.SerializingExecutor.run(SerializingExecutor.java:133) ~[grpc-core-1.68.1.jar:1.68.1]
	at java.base/java.util.concurrent.ThreadPerTaskExecutor$TaskRunner.run(Unknown Source) ~[?:?]
	at java.base/java.lang.VirtualThread.run(Unknown Source) ~[?:?]
Caused by: java.lang.ClassCircularityError: jdk/internal/misc/VirtualThreads
	at java.base/java.util.concurrent.locks.LockSupport.park(Unknown Source) ~[?:?]
```


#### Change

Unwrap a `ClassCircularityError` hidden inside an `IllegalStateException` and treat it as fatal alongside `VirtualMachineError`.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
