### PR TITLE
fix: increment totalOperationsCount correctly #35455

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/BatchOperationChunkCreatedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/BatchOperationChunkCreatedHandler.java
@@ -72,7 +72,8 @@ public class BatchOperationChunkCreatedHandler
   public void updateEntity(
       final Record<BatchOperationChunkRecordValue> record, final BatchOperationEntity entity) {
     // set to just the size of the current chunk. delta update is performed in the update script
-    entity.setOperationsTotalCount(record.getValue().getItems().size());
+    entity.setOperationsTotalCount(
+        entity.getOperationsTotalCount() + record.getValue().getItems().size());
   }
 
   @Override


### PR DESCRIPTION
## Description

Fixes a bug where the totalOperationsCount was not updated correctly when the item chunks are very small and the entity was updated multiple times before flushing.

## Related issues

closes #35455 
