### PR TITLE
[Backport stable/8.6] fix: add metadata backupId to equals and hashcode

### DIFF
--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/backup/Metadata.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/backup/Metadata.java
@@ -132,7 +132,7 @@ public class Metadata {
 
   @Override
   public int hashCode() {
-    return Objects.hash(version, partNo, partCount);
+    return Objects.hash(backupId, version, partNo, partCount);
   }
 
   @Override
@@ -144,7 +144,8 @@ public class Metadata {
       return false;
     }
     final Metadata that = (Metadata) o;
-    return Objects.equals(version, that.version)
+    return Objects.equals(backupId, that.backupId)
+        && Objects.equals(version, that.version)
         && Objects.equals(partNo, that.partNo)
         && Objects.equals(partCount, that.partCount);
   }

--- a/operate/webapp/src/test/java/io/camunda/operate/webapp/backup/MetadataTest.java
+++ b/operate/webapp/src/test/java/io/camunda/operate/webapp/backup/MetadataTest.java
@@ -43,9 +43,6 @@ public class MetadataTest {
                 metadata.getVersion()),
             "");
     assertThat(extracted).isEqualTo(metadata);
-    assertThat(extracted.getBackupId())
-        .isEqualTo(
-            metadata.getBackupId()); // why backupId is not part of the Metadata.equals() method??
   }
 
   @Test


### PR DESCRIPTION
# Description
Backport of #35282 to `stable/8.6`.

relates to #33929