### PR TITLE
deps: update tomcat version to 10.1.43

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -105,6 +105,7 @@
     <version.spring>6.2.8</version.spring>
     <version.spring-security>6.5.1</version.spring-security>
     <version.spring-boot>3.4.7</version.spring-boot>
+    <version.tomcat>10.1.43</version.tomcat>
     <version.concurrentunit>0.4.6</version.concurrentunit>
     <version.kryo>5.6.2</version.kryo>
     <version.failsafe>2.4.4</version.failsafe>
@@ -2042,6 +2043,22 @@
         <groupId>org.testcontainers</groupId>
         <artifactId>postgresql</artifactId>
         <version>${version.postgres-test-container}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.apache.tomcat.embed</groupId>
+        <artifactId>tomcat-embed-core</artifactId>
+        <version>${version.tomcat}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.tomcat.embed</groupId>
+        <artifactId>tomcat-embed-el</artifactId>
+        <version>${version.tomcat}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.tomcat.embed</groupId>
+        <artifactId>tomcat-embed-websocket</artifactId>
+        <version>${version.tomcat}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Updating `org.apache.tomcat.embed` dependencies to `10.1.43` to fix [this CVE](https://camunda.slack.com/archives/C096BFS5VDE).

Tomcat is a transitive dependency of `spring-boot-starter-web` for which there is no new patch yet.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

relates to https://github.com/camunda/camunda/issues/35459
