### PR TITLE
refactor: schema initialization should not block broker startup when gateway is deactivated

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/search/SearchEngineDatabaseConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/search/SearchEngineDatabaseConfiguration.java
@@ -20,6 +20,7 @@ import io.camunda.search.schema.config.RetentionConfiguration;
 import io.camunda.search.schema.config.SchemaManagerConfiguration;
 import io.camunda.search.schema.config.SearchEngineConfiguration;
 import io.camunda.zeebe.broker.Broker;
+import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.util.VisibleForTesting;
 import io.micrometer.core.instrument.MeterRegistry;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -43,9 +44,11 @@ public class SearchEngineDatabaseConfiguration {
       final SearchEngineConfiguration searchEngineConfiguration,
       final MeterRegistry meterRegistry,
       @Autowired(required = false)
-          final Broker broker // if present, then it will ensure that the broker is started first
-      ) {
-    return new SearchEngineSchemaInitializer(searchEngineConfiguration, meterRegistry);
+          final Broker broker, // if present, then it will ensure that the broker is started first
+      @Autowired(required = false) final BrokerCfg brokerCfg) {
+    final boolean isGatewayEnabled = brokerCfg == null || brokerCfg.getGateway().isEnable();
+    return new SearchEngineSchemaInitializer(
+        searchEngineConfiguration, meterRegistry, isGatewayEnabled);
   }
 
   @Bean


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
As discussed in [Slack](https://camunda.slack.com/archives/C08E60XVBRR/p1752659968019229):
"pure" brokers, without an embedded gateway, does not need to wait for Schema creation to start and be marked as Ready. 
In this pull request, we make the schema initialization step non-blocking for bootstrapping, when gateway is not enabled. When Elasticsearch is down during startup, the broker app will start and be marked as ready. Only background tasks that require ES (like the exporter, archiver, and batch operation processor) will wait for Elasticsearch.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

relates to [#26890](https://github.com/camunda/camunda/issues/26890)
