### PR TITLE
feat: map document hash mismatch errors

### DIFF
--- a/service/src/main/java/io/camunda/service/exception/ErrorMapper.java
+++ b/service/src/main/java/io/camunda/service/exception/ErrorMapper.java
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.core.JsonParseException;
 import io.atomix.cluster.messaging.MessagingException;
 import io.camunda.document.api.DocumentError;
 import io.camunda.document.api.DocumentError.DocumentAlreadyExists;
+import io.camunda.document.api.DocumentError.DocumentHashMismatch;
 import io.camunda.document.api.DocumentError.DocumentNotFound;
 import io.camunda.document.api.DocumentError.InvalidInput;
 import io.camunda.document.api.DocumentError.OperationNotSupported;
@@ -277,6 +278,15 @@ public class ErrorMapper {
               INVALID_ARGUMENT);
       case final OperationNotSupported operationNotSupported ->
           new ServiceError(operationNotSupported.message(), FORBIDDEN);
+      case final DocumentHashMismatch dhm ->
+          dhm.providedHash() == null || dhm.providedHash().isBlank()
+              ? new ServiceError(
+                  "No document hash provided for document %s".formatted(dhm.documentId()),
+                  INVALID_ARGUMENT)
+              : new ServiceError(
+                  "Document hash for document %s doesn't match the provided hash %s"
+                      .formatted(dhm.documentId(), dhm.providedHash()),
+                  INVALID_ARGUMENT);
       default -> new ServiceError("Unexpected error occurred when handling document", INTERNAL);
     };
   }


### PR DESCRIPTION
## Description

Maps the document hash mismatch error from document stores explicitly to INVALID_ARGUMENT exceptions. Verifies correct error mappings in the service and REST layers.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #35464 
