### PR TITLE
[Backport stable/8.7] Handle `ClassCircularityError` when wrapped by gRPC

### DIFF
--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/error/VirtualMachineErrorHandler.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/error/VirtualMachineErrorHandler.java
@@ -43,7 +43,7 @@ public final class VirtualMachineErrorHandler
    */
   @Override
   public void handleError(final Throwable e) {
-    if (e instanceof VirtualMachineError) {
+    if (e instanceof VirtualMachineError || e instanceof ClassCircularityError) {
       tryLoggingThenExit(e);
     }
 

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/error/VirtualMachineErrorHandler.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/error/VirtualMachineErrorHandler.java
@@ -35,14 +35,29 @@ public final class VirtualMachineErrorHandler
    * there is no action we can take to resolve them, and it is safer to terminate and let a
    * hypervisor restart Zeebe.
    *
+   * <p>ClassCircularityError might occur while gateway loading virtual threads due to a known bug
+   * https://github.com/corretto/corretto-21/issues/65. gRPC wraps such errors in an
+   * IllegalStateException, so we should detect such a case and let a hypervisor restart Zeebe.
+   *
    * @param e the throwable
    */
   @Override
   public void handleError(final Throwable e) {
-    if (e instanceof VirtualMachineError || e instanceof ClassCircularityError) {
-      tryLogging(e);
-      System.exit(EXIT_CODE);
+    if (e instanceof VirtualMachineError) {
+      tryLoggingThenExit(e);
     }
+
+    if (e instanceof IllegalStateException) {
+      final Throwable cause = e.getCause();
+      if (cause instanceof ClassCircularityError) {
+        tryLoggingThenExit(cause);
+      }
+    }
+  }
+
+  private void tryLoggingThenExit(final Throwable cause) {
+    tryLogging(cause);
+    System.exit(EXIT_CODE);
   }
 
   private void tryLogging(final Throwable e) {


### PR DESCRIPTION
# Description
Backport of #35454 to `stable/8.7`.

relates to #32756