### PR TITLE
fix: Helm install for benchmark to have higher timeout

### DIFF
--- a/.github/workflows/zeebe-benchmark.yml
+++ b/.github/workflows/zeebe-benchmark.yml
@@ -241,7 +241,7 @@ jobs:
           echo "chart-release=$(helm get metadata -o json --namespace ${{ inputs.name }} ${{ inputs.name }} | jq --raw-output .version)" >> "$GITHUB_OUTPUT"
       - name: Helm install
         run: >
-          helm upgrade --install ${{ inputs.name }} zeebe-benchmark/zeebe-benchmark --wait --timeout 10m0s
+          helm upgrade --install ${{ inputs.name }} zeebe-benchmark/zeebe-benchmark --wait --timeout 20m0s
           --namespace ${{ inputs.name }}
           --create-namespace
           --reuse-values


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

fix: Helm install for benchmark to have higher timeout - it eventually succeeds, but needs more time for pods to get ready.

Currently, 10 min is not sufficient: [example](https://github.com/camunda/camunda/actions/runs/16323401447/job/46107025441)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
