### PR TITLE
[Backport stable/8.7] fix: Zeebe Benchmark deploy step only done after corresponding images are built

### DIFF
--- a/.github/workflows/zeebe-benchmark.yml
+++ b/.github/workflows/zeebe-benchmark.yml
@@ -264,10 +264,8 @@ jobs:
       - calculate-image-tag
       - build-zeebe-image
       - build-benchmark-images
-    # Deploy will be run:
-    # - after build jobs if they are not skipped
-    # - after calculate-image-tag if build jobs are skipped
-    # this is to have the possibility to re-deploy the benchmarks without rebuilding the images
+    # To have the possibility to re-deploy the benchmarks without rebuilding the images,
+    # the deploy will be run, when build is skipped or successful.
     if: |
       always() &&
       (needs.build-zeebe-image.result == 'success' || needs.build-zeebe-image.result == 'skipped') &&

--- a/.github/workflows/zeebe-benchmark.yml
+++ b/.github/workflows/zeebe-benchmark.yml
@@ -262,6 +262,8 @@ jobs:
     name: Deploy
     needs:
       - calculate-image-tag
+      - build-benchmark-images
+      - build-zeebe-image
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:

--- a/.github/workflows/zeebe-benchmark.yml
+++ b/.github/workflows/zeebe-benchmark.yml
@@ -262,8 +262,16 @@ jobs:
     name: Deploy
     needs:
       - calculate-image-tag
-      - build-benchmark-images
       - build-zeebe-image
+      - build-benchmark-images
+    # Deploy will be run:
+    # - after build jobs if they are not skipped
+    # - after calculate-image-tag if build jobs are skipped
+    # this is to have the possibility to re-deploy the benchmarks without rebuilding the images
+    if: |
+      always() &&
+      (needs.build-zeebe-image.result == 'success' || needs.build-zeebe-image.result == 'skipped') &&
+      (needs.build-benchmark-images.result == 'success' || needs.build-benchmark-images.result == 'skipped')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:


### PR DESCRIPTION
# Description
Backport of #34578 to `stable/8.7`.

relates to 