### PR TITLE
[Backport stable/8.5] fix: Helm install for benchmark to have higher timeout

### DIFF
--- a/.github/workflows/zeebe-benchmark.yml
+++ b/.github/workflows/zeebe-benchmark.yml
@@ -179,7 +179,7 @@ jobs:
           echo "chart-release=$(helm get metadata -o json --namespace ${{ inputs.name }} ${{ inputs.name }} | jq --raw-output .version)" >> $GITHUB_OUTPUT
       - name: Helm install
         run: >
-          helm upgrade --install ${{ inputs.name }} zeebe-benchmark/zeebe-benchmark --wait --timeout 10m0s
+          helm upgrade --install ${{ inputs.name }} zeebe-benchmark/zeebe-benchmark --wait --timeout 20m0s
           --version 0.3.7
           --namespace ${{ inputs.name }}
           --create-namespace


### PR DESCRIPTION
# Description
Backport of #35480 to `stable/8.5`.

relates to 