### PR TITLE
[Backport stable/8.7] fix: Helm install for benchmark to have higher timeout

### DIFF
--- a/.github/workflows/zeebe-benchmark.yml
+++ b/.github/workflows/zeebe-benchmark.yml
@@ -290,7 +290,7 @@ jobs:
           echo "chart-release=$(helm get metadata -o json --namespace ${{ inputs.name }} ${{ inputs.name }} | jq --raw-output .version)" >> $GITHUB_OUTPUT
       - name: Helm install
         run: >
-          helm upgrade --install ${{ inputs.name }} zeebe-benchmark/zeebe-benchmark --wait --timeout 10m0s
+          helm upgrade --install ${{ inputs.name }} zeebe-benchmark/zeebe-benchmark --wait --timeout 20m0s
           --namespace ${{ inputs.name }}
           --create-namespace
           --reuse-values


### PR DESCRIPTION
# Description
Backport of #35480 to `stable/8.7`.

relates to 