### PR TITLE
feat: Support advanced filtering on user task state property

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/UserTaskFilter.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/UserTaskFilter.java
@@ -19,6 +19,7 @@ import io.camunda.client.api.search.enums.UserTaskState;
 import io.camunda.client.api.search.filter.builder.DateTimeProperty;
 import io.camunda.client.api.search.filter.builder.IntegerProperty;
 import io.camunda.client.api.search.filter.builder.StringProperty;
+import io.camunda.client.api.search.filter.builder.UserTaskStateProperty;
 import io.camunda.client.api.search.request.TypedFilterableRequest.SearchRequestFilter;
 import java.time.OffsetDateTime;
 import java.util.List;
@@ -43,6 +44,14 @@ public interface UserTaskFilter extends SearchRequestFilter {
    * @return the updated filter
    */
   UserTaskFilter state(final UserTaskState state);
+
+  /**
+   * Filters user tasks by the specified state using {@link UserTaskStateProperty} consumer.
+   *
+   * @param fn the {@link UserTaskStateProperty} consumer of the user task
+   * @return the updated filter
+   */
+  UserTaskFilter state(final Consumer<UserTaskStateProperty> fn);
 
   /**
    * Filters user tasks by the specified assignee.

--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/builder/UserTaskStateProperty.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/builder/UserTaskStateProperty.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.search.filter.builder;
+
+import io.camunda.client.api.search.enums.UserTaskState;
+
+public interface UserTaskStateProperty
+    extends LikeProperty<UserTaskState, String, UserTaskStateProperty> {}

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/UserTaskFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/UserTaskFilterImpl.java
@@ -21,13 +21,13 @@ import io.camunda.client.api.search.filter.VariableValueFilter;
 import io.camunda.client.api.search.filter.builder.DateTimeProperty;
 import io.camunda.client.api.search.filter.builder.IntegerProperty;
 import io.camunda.client.api.search.filter.builder.StringProperty;
+import io.camunda.client.api.search.filter.builder.UserTaskStateProperty;
 import io.camunda.client.impl.search.filter.builder.DateTimePropertyImpl;
 import io.camunda.client.impl.search.filter.builder.IntegerPropertyImpl;
 import io.camunda.client.impl.search.filter.builder.StringPropertyImpl;
+import io.camunda.client.impl.search.filter.builder.UserTaskStatePropertyImpl;
 import io.camunda.client.impl.search.request.TypedSearchRequestPropertyProvider;
-import io.camunda.client.impl.util.EnumUtil;
 import io.camunda.client.impl.util.ParseUtil;
-import io.camunda.client.protocol.rest.UserTaskStateEnum;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Map;
@@ -51,7 +51,14 @@ public class UserTaskFilterImpl
 
   @Override
   public UserTaskFilter state(final UserTaskState state) {
-    filter.setState(EnumUtil.convert(state, UserTaskStateEnum.class));
+    return state(b -> b.eq(state));
+  }
+
+  @Override
+  public UserTaskFilter state(final Consumer<UserTaskStateProperty> fn) {
+    final UserTaskStateProperty property = new UserTaskStatePropertyImpl();
+    fn.accept(property);
+    filter.setState(provideSearchRequestProperty(property));
     return this;
   }
 

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/UserTaskFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/UserTaskFilterImpl.java
@@ -27,6 +27,7 @@ import io.camunda.client.impl.search.filter.builder.StringPropertyImpl;
 import io.camunda.client.impl.search.request.TypedSearchRequestPropertyProvider;
 import io.camunda.client.impl.util.EnumUtil;
 import io.camunda.client.impl.util.ParseUtil;
+import io.camunda.client.protocol.rest.UserTaskStateEnum;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Map;
@@ -50,8 +51,7 @@ public class UserTaskFilterImpl
 
   @Override
   public UserTaskFilter state(final UserTaskState state) {
-    filter.setState(
-        EnumUtil.convert(state, io.camunda.client.protocol.rest.UserTaskFilter.StateEnum.class));
+    filter.setState(EnumUtil.convert(state, UserTaskStateEnum.class));
     return this;
   }
 

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/builder/UserTaskStatePropertyImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/builder/UserTaskStatePropertyImpl.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.search.filter.builder;
+
+import io.camunda.client.api.search.enums.UserTaskState;
+import io.camunda.client.api.search.filter.builder.UserTaskStateProperty;
+import io.camunda.client.impl.search.request.TypedSearchRequestPropertyProvider;
+import io.camunda.client.impl.util.CollectionUtil;
+import io.camunda.client.impl.util.EnumUtil;
+import io.camunda.client.protocol.rest.UserTaskStateEnum;
+import io.camunda.client.protocol.rest.UserTaskStateFilterProperty;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class UserTaskStatePropertyImpl
+    extends TypedSearchRequestPropertyProvider<UserTaskStateFilterProperty>
+    implements UserTaskStateProperty {
+
+  private final UserTaskStateFilterProperty filterProperty = new UserTaskStateFilterProperty();
+
+  @Override
+  public UserTaskStateProperty eq(final UserTaskState value) {
+    filterProperty.set$Eq(EnumUtil.convert(value, UserTaskStateEnum.class));
+    return this;
+  }
+
+  @Override
+  public UserTaskStateProperty neq(final UserTaskState value) {
+    filterProperty.set$Neq(EnumUtil.convert(value, UserTaskStateEnum.class));
+    return this;
+  }
+
+  @Override
+  public UserTaskStateProperty exists(final boolean value) {
+    filterProperty.set$Exists(value);
+    return this;
+  }
+
+  @Override
+  public UserTaskStateProperty in(final UserTaskState... values) {
+    return in(CollectionUtil.toList(values));
+  }
+
+  @Override
+  public UserTaskStateProperty in(final List<UserTaskState> values) {
+    filterProperty.set$In(
+        values.stream()
+            .map(source -> (EnumUtil.convert(source, UserTaskStateEnum.class)))
+            .collect(Collectors.toList()));
+    return this;
+  }
+
+  @Override
+  protected UserTaskStateFilterProperty getSearchRequestProperty() {
+    return filterProperty;
+  }
+
+  @Override
+  public UserTaskStateProperty like(final String value) {
+    filterProperty.set$Like(value);
+    return this;
+  }
+}

--- a/clients/java/src/test/java/io/camunda/client/impl/util/EnumUtilTest.java
+++ b/clients/java/src/test/java/io/camunda/client/impl/util/EnumUtilTest.java
@@ -17,10 +17,22 @@ package io.camunda.client.impl.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.camunda.client.api.search.enums.*;
+import io.camunda.client.api.search.enums.BatchOperationItemState;
+import io.camunda.client.api.search.enums.BatchOperationState;
+import io.camunda.client.api.search.enums.BatchOperationType;
+import io.camunda.client.api.search.enums.ElementInstanceState;
+import io.camunda.client.api.search.enums.ElementInstanceType;
+import io.camunda.client.api.search.enums.IncidentErrorType;
+import io.camunda.client.api.search.enums.IncidentState;
+import io.camunda.client.api.search.enums.OwnerType;
+import io.camunda.client.api.search.enums.PermissionType;
+import io.camunda.client.api.search.enums.ProcessInstanceState;
+import io.camunda.client.api.search.enums.ResourceType;
+import io.camunda.client.api.search.enums.UserTaskState;
 import io.camunda.client.protocol.rest.BatchOperationItemResponse;
 import io.camunda.client.protocol.rest.BatchOperationResponse;
 import io.camunda.client.protocol.rest.BatchOperationTypeEnum;
+import io.camunda.client.protocol.rest.UserTaskStateEnum;
 import org.junit.jupiter.api.Test;
 
 public class EnumUtilTest {
@@ -358,24 +370,19 @@ public class EnumUtilTest {
   public void shouldConvertUserTaskResultState() {
 
     for (final UserTaskState value : UserTaskState.values()) {
-      final io.camunda.client.protocol.rest.UserTaskResult.StateEnum protocolValue =
-          EnumUtil.convert(value, io.camunda.client.protocol.rest.UserTaskResult.StateEnum.class);
+      final UserTaskStateEnum protocolValue = EnumUtil.convert(value, UserTaskStateEnum.class);
       assertThat(protocolValue).isNotNull();
       if (value == UserTaskState.UNKNOWN_ENUM_VALUE) {
-        assertThat(protocolValue)
-            .isEqualTo(
-                io.camunda.client.protocol.rest.UserTaskResult.StateEnum.UNKNOWN_DEFAULT_OPEN_API);
+        assertThat(protocolValue).isEqualTo(UserTaskStateEnum.UNKNOWN_DEFAULT_OPEN_API);
       } else {
         assertThat(protocolValue.name()).isEqualTo(value.name());
       }
     }
 
-    for (final io.camunda.client.protocol.rest.UserTaskResult.StateEnum protocolValue :
-        io.camunda.client.protocol.rest.UserTaskResult.StateEnum.values()) {
+    for (final UserTaskStateEnum protocolValue : UserTaskStateEnum.values()) {
       final UserTaskState value = EnumUtil.convert(protocolValue, UserTaskState.class);
       assertThat(value).isNotNull();
-      if (protocolValue
-          == io.camunda.client.protocol.rest.UserTaskResult.StateEnum.UNKNOWN_DEFAULT_OPEN_API) {
+      if (protocolValue == UserTaskStateEnum.UNKNOWN_DEFAULT_OPEN_API) {
         assertThat(value).isEqualTo(UserTaskState.UNKNOWN_ENUM_VALUE);
       } else {
         assertThat(value.name()).isEqualTo(protocolValue.name());
@@ -387,24 +394,19 @@ public class EnumUtilTest {
   public void shouldConvertUserTaskFilterState() {
 
     for (final UserTaskState value : UserTaskState.values()) {
-      final io.camunda.client.protocol.rest.UserTaskFilter.StateEnum protocolValue =
-          EnumUtil.convert(value, io.camunda.client.protocol.rest.UserTaskFilter.StateEnum.class);
+      final UserTaskStateEnum protocolValue = EnumUtil.convert(value, UserTaskStateEnum.class);
       assertThat(protocolValue).isNotNull();
       if (value == UserTaskState.UNKNOWN_ENUM_VALUE) {
-        assertThat(protocolValue)
-            .isEqualTo(
-                io.camunda.client.protocol.rest.UserTaskFilter.StateEnum.UNKNOWN_DEFAULT_OPEN_API);
+        assertThat(protocolValue).isEqualTo(UserTaskStateEnum.UNKNOWN_DEFAULT_OPEN_API);
       } else {
         assertThat(protocolValue.name()).isEqualTo(value.name());
       }
     }
 
-    for (final io.camunda.client.protocol.rest.UserTaskFilter.StateEnum protocolValue :
-        io.camunda.client.protocol.rest.UserTaskFilter.StateEnum.values()) {
+    for (final UserTaskStateEnum protocolValue : UserTaskStateEnum.values()) {
       final UserTaskState value = EnumUtil.convert(protocolValue, UserTaskState.class);
       assertThat(value).isNotNull();
-      if (protocolValue
-          == io.camunda.client.protocol.rest.UserTaskFilter.StateEnum.UNKNOWN_DEFAULT_OPEN_API) {
+      if (protocolValue == UserTaskStateEnum.UNKNOWN_DEFAULT_OPEN_API) {
         assertThat(value).isEqualTo(UserTaskState.UNKNOWN_ENUM_VALUE);
       } else {
         assertThat(value.name()).isEqualTo(protocolValue.name());

--- a/clients/java/src/test/java/io/camunda/client/usertask/SearchUserTaskTest.java
+++ b/clients/java/src/test/java/io/camunda/client/usertask/SearchUserTaskTest.java
@@ -20,17 +20,26 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.github.tomakehurst.wiremock.http.RequestMethod;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
 import io.camunda.client.api.search.enums.UserTaskState;
+import io.camunda.client.api.search.filter.builder.UserTaskStateProperty;
 import io.camunda.client.protocol.rest.IntegerFilterProperty;
 import io.camunda.client.protocol.rest.StringFilterProperty;
 import io.camunda.client.protocol.rest.UserTaskFilter;
 import io.camunda.client.protocol.rest.UserTaskSearchQuery;
 import io.camunda.client.protocol.rest.UserTaskStateEnum;
+import io.camunda.client.protocol.rest.UserTaskStateFilterProperty;
 import io.camunda.client.protocol.rest.VariableValueFilterProperty;
 import io.camunda.client.util.ClientRestTest;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Named;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 public final class SearchUserTaskTest extends ClientRestTest {
 
@@ -74,27 +83,54 @@ public final class SearchUserTaskTest extends ClientRestTest {
     assertThat(request.getFilter().getState().get$Eq()).isEqualTo(UserTaskStateEnum.COMPLETED);
   }
 
-  @Test
-  void shouldSearchUserTaskByStatesIn() {
-    // when
-    client
-        .newUserTaskSearchRequest()
-        .filter(
+  static Stream<Arguments> provideStateFilters() {
+    return Stream.of(
+        stateFilterCase(
+            "eq:CANCELING",
+            f -> f.eq(UserTaskState.CANCELING),
+            f -> assertThat(f.get$Eq()).isEqualTo(UserTaskStateEnum.CANCELING)),
+        stateFilterCase(
+            "neq:COMPLETED",
+            f -> f.neq(UserTaskState.COMPLETED),
+            f -> assertThat(f.get$Neq()).isEqualTo(UserTaskStateEnum.COMPLETED)),
+        stateFilterCase(
+            "exists:true", f -> f.exists(true), f -> assertThat(f.get$Exists()).isTrue()),
+        stateFilterCase(
+            "exists:false", f -> f.exists(false), f -> assertThat(f.get$Exists()).isFalse()),
+        stateFilterCase(
+            "in:[ASSIGNING,UPDATING]",
+            f -> f.in(UserTaskState.ASSIGNING, UserTaskState.UPDATING),
             f ->
-                f.state(
-                    fn ->
-                        fn.in(
-                            UserTaskState.CREATING,
-                            UserTaskState.ASSIGNING,
-                            UserTaskState.UPDATING)))
-        .send()
-        .join();
+                assertThat(f.get$In())
+                    .containsExactly(UserTaskStateEnum.ASSIGNING, UserTaskStateEnum.UPDATING)),
+        stateFilterCase(
+            "like:CREAT*",
+            f -> f.like("CREAT*"),
+            f -> assertThat(f.get$Like()).isEqualTo("CREAT*")));
+  }
+
+  private static Arguments stateFilterCase(
+      final String filterLabel,
+      final Consumer<UserTaskStateProperty> filter,
+      final Consumer<UserTaskStateFilterProperty> assertion) {
+    return Arguments.of(
+        Named.of("state(" + filterLabel + ")", filter),
+        Named.of("assert " + filterLabel, assertion));
+  }
+
+  @ParameterizedTest(name = "[{index}] should apply {0}")
+  @MethodSource("provideStateFilters")
+  @DisplayName("Should search user tasks by state using advanced filters")
+  void shouldSearchUserTasksByStateUsingAdvancedFilter(
+      final Consumer<UserTaskStateProperty> filter,
+      final Consumer<UserTaskStateFilterProperty> assertion) {
+
+    // when
+    client.newUserTaskSearchRequest().filter(f -> f.state(filter)).send().join();
 
     // then
     final UserTaskSearchQuery request = gatewayService.getLastRequest(UserTaskSearchQuery.class);
-    assertThat(request.getFilter().getState().get$In())
-        .containsExactly(
-            UserTaskStateEnum.CREATING, UserTaskStateEnum.ASSIGNING, UserTaskStateEnum.UPDATING);
+    assertThat(request.getFilter().getState()).isNotNull().satisfies(assertion);
   }
 
   @Test

--- a/clients/java/src/test/java/io/camunda/client/usertask/SearchUserTaskTest.java
+++ b/clients/java/src/test/java/io/camunda/client/usertask/SearchUserTaskTest.java
@@ -71,7 +71,30 @@ public final class SearchUserTaskTest extends ClientRestTest {
 
     // then
     final UserTaskSearchQuery request = gatewayService.getLastRequest(UserTaskSearchQuery.class);
-    assertThat(request.getFilter().getState()).isEqualTo(UserTaskStateEnum.COMPLETED);
+    assertThat(request.getFilter().getState().get$Eq()).isEqualTo(UserTaskStateEnum.COMPLETED);
+  }
+
+  @Test
+  void shouldSearchUserTaskByStatesIn() {
+    // when
+    client
+        .newUserTaskSearchRequest()
+        .filter(
+            f ->
+                f.state(
+                    fn ->
+                        fn.in(
+                            UserTaskState.CREATING,
+                            UserTaskState.ASSIGNING,
+                            UserTaskState.UPDATING)))
+        .send()
+        .join();
+
+    // then
+    final UserTaskSearchQuery request = gatewayService.getLastRequest(UserTaskSearchQuery.class);
+    assertThat(request.getFilter().getState().get$In())
+        .containsExactly(
+            UserTaskStateEnum.CREATING, UserTaskStateEnum.ASSIGNING, UserTaskStateEnum.UPDATING);
   }
 
   @Test

--- a/clients/java/src/test/java/io/camunda/client/usertask/SearchUserTaskTest.java
+++ b/clients/java/src/test/java/io/camunda/client/usertask/SearchUserTaskTest.java
@@ -24,6 +24,7 @@ import io.camunda.client.protocol.rest.IntegerFilterProperty;
 import io.camunda.client.protocol.rest.StringFilterProperty;
 import io.camunda.client.protocol.rest.UserTaskFilter;
 import io.camunda.client.protocol.rest.UserTaskSearchQuery;
+import io.camunda.client.protocol.rest.UserTaskStateEnum;
 import io.camunda.client.protocol.rest.VariableValueFilterProperty;
 import io.camunda.client.util.ClientRestTest;
 import java.time.OffsetDateTime;
@@ -70,7 +71,7 @@ public final class SearchUserTaskTest extends ClientRestTest {
 
     // then
     final UserTaskSearchQuery request = gatewayService.getLastRequest(UserTaskSearchQuery.class);
-    assertThat(request.getFilter().getState()).isEqualTo(UserTaskFilter.StateEnum.COMPLETED);
+    assertThat(request.getFilter().getState()).isEqualTo(UserTaskStateEnum.COMPLETED);
   }
 
   @Test

--- a/db/rdbms/src/main/resources/mapper/UserTaskMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/UserTaskMapper.xml
@@ -175,10 +175,10 @@
         <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
       </foreach>
     </if>
-    <if test="filter.states != null and !filter.states.isEmpty()">
-      AND ut.STATE IN
-      <foreach close=")" collection="filter.states" item="value" open="("
-        separator=", ">#{value}
+    <if test="filter.stateOperations != null and !filter.stateOperations.isEmpty()">
+      <foreach collection="filter.stateOperations" item="operation">
+        AND ut.STATE
+        <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
       </foreach>
     </if>
     <if test="filter.processInstanceKeys != null and !filter.processInstanceKeys.isEmpty()">

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/UserTaskFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/UserTaskFilterTransformer.java
@@ -57,7 +57,7 @@ public class UserTaskFilterTransformer extends IndexFilterTransformer<UserTaskFi
     queries.addAll(getCandidateGroupsQuery(filter.candidateGroupOperations()));
     queries.addAll(getAssigneesQuery(filter.assigneeOperations()));
     queries.addAll(getPrioritiesQuery(filter.priorityOperations()));
-    ofNullable(getStateQuery(filter.states())).ifPresent(queries::add);
+    queries.addAll(getStatesQuery(filter.stateOperations()));
     ofNullable(getTenantQuery(filter.tenantIds())).ifPresent(queries::add);
     ofNullable(getElementInstanceKeyQuery(filter.elementInstanceKeys())).ifPresent(queries::add);
     queries.addAll(getCreationTimeQuery(filter.creationDateOperations()));
@@ -132,8 +132,8 @@ public class UserTaskFilterTransformer extends IndexFilterTransformer<UserTaskFi
     return dateTimeOperations(DUE_DATE, dueTime);
   }
 
-  private SearchQuery getStateQuery(final List<String> state) {
-    return stringTerms(STATE, state);
+  private List<SearchQuery> getStatesQuery(final List<Operation<String>> states) {
+    return stringOperations(STATE, states);
   }
 
   private SearchQuery getTenantQuery(final List<String> tenant) {

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/UserTaskQueryTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/UserTaskQueryTransformerTest.java
@@ -63,27 +63,15 @@ public class UserTaskQueryTransformerTest extends AbstractTransformerTest {
             (boolQuery) -> {
               assertThat(boolQuery.must())
                   .anySatisfy(
-                      query ->
-                          assertThat(query.queryOption())
-                              .isInstanceOfSatisfying(
-                                  SearchExistsQuery.class,
-                                  (existsQuery) -> {
-                                    assertThat(existsQuery.field())
-                                        .isEqualTo("flowNodeInstanceId"); // Validate the field
-                                  }));
+                      query -> assertExistsQuery(query.queryOption(), "flowNodeInstanceId"));
             });
 
     assertThat(queryVariant)
         .isInstanceOfSatisfying(
             SearchBoolQuery.class,
             (t) -> {
-              assertThat(t.must().get(1).queryOption())
-                  .isInstanceOfSatisfying(
-                      SearchTermQuery.class,
-                      (term) -> {
-                        assertThat(term.field()).isEqualTo("implementation");
-                        assertThat(term.value().stringValue()).isEqualTo("ZEEBE_USER_TASK");
-                      });
+              assertSearchTermQuery(
+                  t.must().get(1).queryOption(), "implementation", "ZEEBE_USER_TASK");
             });
   }
 
@@ -102,13 +90,7 @@ public class UserTaskQueryTransformerTest extends AbstractTransformerTest {
         .isInstanceOfSatisfying(
             SearchBoolQuery.class,
             (t) -> {
-              assertThat(t.must().get(0).queryOption())
-                  .isInstanceOfSatisfying(
-                      SearchTermQuery.class,
-                      (term) -> {
-                        assertThat(term.field()).isEqualTo("key");
-                        assertThat(term.value().longValue()).isEqualTo(4503599627370497L);
-                      });
+              assertSearchTermQuery(t.must().get(0).queryOption(), "key", 4503599627370497L);
             });
   }
 
@@ -126,13 +108,7 @@ public class UserTaskQueryTransformerTest extends AbstractTransformerTest {
         .isInstanceOfSatisfying(
             SearchBoolQuery.class,
             (t) -> {
-              assertThat(t.must().get(0).queryOption())
-                  .isInstanceOfSatisfying(
-                      SearchTermQuery.class,
-                      (term) -> {
-                        assertThat(term.field()).isEqualTo("state");
-                        assertThat(term.value().stringValue()).isEqualTo("CREATED");
-                      });
+              assertSearchTermQuery(t.must().get(0).queryOption(), "state", "CREATED");
             });
   }
 
@@ -232,13 +208,7 @@ public class UserTaskQueryTransformerTest extends AbstractTransformerTest {
         .isInstanceOfSatisfying(
             SearchBoolQuery.class,
             (t) -> {
-              assertThat(t.must().get(0).queryOption())
-                  .isInstanceOfSatisfying(
-                      SearchTermQuery.class,
-                      (term) -> {
-                        assertThat(term.field()).isEqualTo("assignee");
-                        assertThat(term.value().stringValue()).isEqualTo("assignee1");
-                      });
+              assertSearchTermQuery(t.must().get(0).queryOption(), "assignee", "assignee1");
             });
   }
 
@@ -258,13 +228,7 @@ public class UserTaskQueryTransformerTest extends AbstractTransformerTest {
         .isInstanceOfSatisfying(
             SearchBoolQuery.class,
             (t) -> {
-              assertThat(t.must().get(0).queryOption())
-                  .isInstanceOfSatisfying(
-                      SearchTermQuery.class,
-                      (term) -> {
-                        assertThat(term.field()).isEqualTo("tenantId");
-                        assertThat(term.value().stringValue()).isEqualTo("tenant1");
-                      });
+              assertSearchTermQuery(t.must().get(0).queryOption(), "tenantId", "tenant1");
             });
   }
 
@@ -283,13 +247,7 @@ public class UserTaskQueryTransformerTest extends AbstractTransformerTest {
         .isInstanceOfSatisfying(
             SearchBoolQuery.class,
             (t) -> {
-              assertThat(t.must().get(0).queryOption())
-                  .isInstanceOfSatisfying(
-                      SearchTermQuery.class,
-                      (term) -> {
-                        assertThat(term.field()).isEqualTo("processInstanceId");
-                        assertThat(term.value().longValue()).isEqualTo(12345L);
-                      });
+              assertSearchTermQuery(t.must().get(0).queryOption(), "processInstanceId", 12345L);
             });
   }
 
@@ -308,13 +266,7 @@ public class UserTaskQueryTransformerTest extends AbstractTransformerTest {
         .isInstanceOfSatisfying(
             SearchBoolQuery.class,
             (t) -> {
-              assertThat(t.must().get(0).queryOption())
-                  .isInstanceOfSatisfying(
-                      SearchTermQuery.class,
-                      (term) -> {
-                        assertThat(term.field()).isEqualTo("processDefinitionId");
-                        assertThat(term.value().longValue()).isEqualTo(123L);
-                      });
+              assertSearchTermQuery(t.must().get(0).queryOption(), "processDefinitionId", 123L);
             });
   }
 
@@ -333,13 +285,7 @@ public class UserTaskQueryTransformerTest extends AbstractTransformerTest {
         .isInstanceOfSatisfying(
             SearchBoolQuery.class,
             (t) -> {
-              assertThat(t.must().get(0).queryOption())
-                  .isInstanceOfSatisfying(
-                      SearchTermQuery.class,
-                      (term) -> {
-                        assertThat(term.field()).isEqualTo("bpmnProcessId");
-                        assertThat(term.value().stringValue()).isEqualTo("bpmnProcess1");
-                      });
+              assertSearchTermQuery(t.must().get(0).queryOption(), "bpmnProcessId", "bpmnProcess1");
             });
   }
 
@@ -358,13 +304,8 @@ public class UserTaskQueryTransformerTest extends AbstractTransformerTest {
         .isInstanceOfSatisfying(
             SearchBoolQuery.class,
             (t) -> {
-              assertThat(t.must().get(0).queryOption())
-                  .isInstanceOfSatisfying(
-                      SearchTermQuery.class,
-                      (term) -> {
-                        assertThat(term.field()).isEqualTo("candidateUsers");
-                        assertThat(term.value().stringValue()).isEqualTo("candidateUser1");
-                      });
+              assertSearchTermQuery(
+                  t.must().get(0).queryOption(), "candidateUsers", "candidateUser1");
             });
   }
 
@@ -383,13 +324,7 @@ public class UserTaskQueryTransformerTest extends AbstractTransformerTest {
         .isInstanceOfSatisfying(
             SearchBoolQuery.class,
             (t) -> {
-              assertThat(t.must().get(0).queryOption())
-                  .isInstanceOfSatisfying(
-                      SearchTermQuery.class,
-                      (term) -> {
-                        assertThat(term.field()).isEqualTo("flowNodeInstanceId");
-                        assertThat(term.value().longValue()).isEqualTo(12345L);
-                      });
+              assertSearchTermQuery(t.must().get(0).queryOption(), "flowNodeInstanceId", 12345L);
             });
   }
 
@@ -408,13 +343,8 @@ public class UserTaskQueryTransformerTest extends AbstractTransformerTest {
         .isInstanceOfSatisfying(
             SearchBoolQuery.class,
             (t) -> {
-              assertThat(t.must().get(0).queryOption())
-                  .isInstanceOfSatisfying(
-                      SearchTermQuery.class,
-                      (term) -> {
-                        assertThat(term.field()).isEqualTo("candidateGroups");
-                        assertThat(term.value().stringValue()).isEqualTo("candidateGroup1");
-                      });
+              assertSearchTermQuery(
+                  t.must().get(0).queryOption(), "candidateGroups", "candidateGroup1");
             });
   }
 
@@ -463,21 +393,8 @@ public class UserTaskQueryTransformerTest extends AbstractTransformerTest {
                   (SearchBoolQuery) childQuery.query().queryOption();
               assertThat(innerBoolQuery.must()).hasSize(2);
 
-              assertThat(innerBoolQuery.must().get(0).queryOption())
-                  .isInstanceOfSatisfying(
-                      SearchTermQuery.class,
-                      termQuery -> {
-                        assertThat(termQuery.field()).isEqualTo("name");
-                        assertThat(termQuery.value().value()).isEqualTo("test");
-                      });
-
-              assertThat(innerBoolQuery.must().get(1).queryOption())
-                  .isInstanceOfSatisfying(
-                      SearchTermQuery.class,
-                      termQuery -> {
-                        assertThat(termQuery.field()).isEqualTo("value");
-                        assertThat(termQuery.value().value()).isEqualTo("test");
-                      });
+              assertSearchTermQuery(innerBoolQuery.must().get(0).queryOption(), "name", "test");
+              assertSearchTermQuery(innerBoolQuery.must().get(1).queryOption(), "value", "test");
             });
   }
 
@@ -502,18 +419,8 @@ public class UserTaskQueryTransformerTest extends AbstractTransformerTest {
               assertThat(boolQuery.must())
                   .anySatisfy(
                       query ->
-                          assertThat(query.queryOption())
-                              .isInstanceOfSatisfying(
-                                  SearchTermsQuery.class,
-                                  (termsQuery) -> {
-                                    assertThat(termsQuery.field())
-                                        .isEqualTo(TaskTemplate.BPMN_PROCESS_ID);
-                                    assertThat(
-                                            termsQuery.values().stream()
-                                                .map(TypedValue::stringValue)
-                                                .toList())
-                                        .containsExactlyInAnyOrder("1", "2");
-                                  }));
+                          assertSearchTermsQuery(
+                              query.queryOption(), TaskTemplate.BPMN_PROCESS_ID, "1", "2"));
             });
   }
 
@@ -552,27 +459,15 @@ public class UserTaskQueryTransformerTest extends AbstractTransformerTest {
             (boolQuery) -> {
               assertThat(boolQuery.must())
                   .anySatisfy(
-                      query ->
-                          assertThat(query.queryOption())
-                              .isInstanceOfSatisfying(
-                                  SearchExistsQuery.class,
-                                  (existsQuery) -> {
-                                    assertThat(existsQuery.field())
-                                        .isEqualTo("flowNodeInstanceId"); // Validate the field
-                                  }));
+                      query -> assertExistsQuery(query.queryOption(), "flowNodeInstanceId"));
             });
 
     assertThat(queryVariant)
         .isInstanceOfSatisfying(
             SearchBoolQuery.class,
             (t) -> {
-              assertThat(t.must().get(1).queryOption())
-                  .isInstanceOfSatisfying(
-                      SearchTermQuery.class,
-                      (term) -> {
-                        assertThat(term.field()).isEqualTo("implementation");
-                        assertThat(term.value().stringValue()).isEqualTo("ZEEBE_USER_TASK");
-                      });
+              assertSearchTermQuery(
+                  t.must().get(1).queryOption(), "implementation", "ZEEBE_USER_TASK");
             });
   }
 
@@ -595,18 +490,8 @@ public class UserTaskQueryTransformerTest extends AbstractTransformerTest {
               assertThat(boolQuery.must())
                   .anySatisfy(
                       query ->
-                          assertThat(query.queryOption())
-                              .isInstanceOfSatisfying(
-                                  SearchTermsQuery.class,
-                                  (termsQuery) -> {
-                                    assertThat(termsQuery.field())
-                                        .isEqualTo(TaskTemplate.TENANT_ID);
-                                    assertThat(
-                                            termsQuery.values().stream()
-                                                .map(TypedValue::stringValue)
-                                                .toList())
-                                        .containsExactlyInAnyOrder("a", "b");
-                                  }));
+                          assertSearchTermsQuery(
+                              query.queryOption(), TaskTemplate.TENANT_ID, "a", "b"));
             });
   }
 
@@ -628,27 +513,15 @@ public class UserTaskQueryTransformerTest extends AbstractTransformerTest {
             (boolQuery) -> {
               assertThat(boolQuery.must())
                   .anySatisfy(
-                      query ->
-                          assertThat(query.queryOption())
-                              .isInstanceOfSatisfying(
-                                  SearchExistsQuery.class,
-                                  (existsQuery) -> {
-                                    assertThat(existsQuery.field())
-                                        .isEqualTo("flowNodeInstanceId"); // Validate the field
-                                  }));
+                      query -> assertExistsQuery(query.queryOption(), "flowNodeInstanceId"));
             });
 
     assertThat(queryVariant)
         .isInstanceOfSatisfying(
             SearchBoolQuery.class,
             (t) -> {
-              assertThat(t.must().get(1).queryOption())
-                  .isInstanceOfSatisfying(
-                      SearchTermQuery.class,
-                      (term) -> {
-                        assertThat(term.field()).isEqualTo("implementation");
-                        assertThat(term.value().stringValue()).isEqualTo("ZEEBE_USER_TASK");
-                      });
+              assertSearchTermQuery(
+                  t.must().get(1).queryOption(), "implementation", "ZEEBE_USER_TASK");
             });
   }
 
@@ -673,13 +546,13 @@ public class UserTaskQueryTransformerTest extends AbstractTransformerTest {
   }
 
   private static void assertSearchTermQuery(
-      final SearchQueryOption query, final String field, final String expectedValue) {
+      final SearchQueryOption query, final String field, final Object expectedValue) {
     assertThat(query)
         .isInstanceOfSatisfying(
             SearchTermQuery.class,
             term -> {
               assertThat(term.field()).isEqualTo(field);
-              assertThat(term.value().stringValue()).isEqualTo(expectedValue);
+              assertThat(term.value().value()).isEqualTo(expectedValue);
             });
   }
 

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/UserTaskQueryTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/UserTaskQueryTransformerTest.java
@@ -38,7 +38,6 @@ import java.util.List;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Named;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -115,11 +114,8 @@ public class UserTaskQueryTransformerTest extends AbstractTransformerTest {
   static Stream<Arguments> provideStateOperations() {
     return Stream.of(
         stateOperationCase(
-            "eq:CREATED",
-            Operation.eq("CREATED"),
-            query -> assertSearchTermQuery(query, "state", "CREATED")),
+            Operation.eq("CREATED"), query -> assertSearchTermQuery(query, "state", "CREATED")),
         stateOperationCase(
-            "neq:COMPLETED",
             Operation.neq("COMPLETED"),
             query ->
                 assertThat(query)
@@ -133,10 +129,8 @@ public class UserTaskQueryTransformerTest extends AbstractTransformerTest {
                                     mustNotQuery ->
                                         assertSearchTermQuery(
                                             mustNotQuery, "state", "COMPLETED")))),
+        stateOperationCase(Operation.exists(true), query -> assertExistsQuery(query, "state")),
         stateOperationCase(
-            "exists:true", Operation.exists(true), query -> assertExistsQuery(query, "state")),
-        stateOperationCase(
-            "exists:false",
             Operation.exists(false),
             query ->
                 assertThat(query)
@@ -149,11 +143,9 @@ public class UserTaskQueryTransformerTest extends AbstractTransformerTest {
                                 .satisfies(
                                     mustNotQuery -> assertExistsQuery(mustNotQuery, "state")))),
         stateOperationCase(
-            "in:[CREATING,UPDATING]",
             Operation.in("CREATING", "UPDATING"),
             query -> assertSearchTermsQuery(query, "state", "CREATING", "UPDATING")),
         stateOperationCase(
-            "like:CREAT*",
             Operation.like("CREAT*"),
             query ->
                 assertThat(query)
@@ -166,13 +158,8 @@ public class UserTaskQueryTransformerTest extends AbstractTransformerTest {
   }
 
   private static Arguments stateOperationCase(
-      final String description,
-      final Operation<String> operation,
-      final Consumer<SearchQueryOption> queryAssertion) {
-
-    return Arguments.of(
-        Named.of("state(" + description + ")", operation),
-        Named.of("assert " + description, queryAssertion));
+      final Operation<String> operation, final Consumer<SearchQueryOption> queryAssertion) {
+    return Arguments.of(operation, queryAssertion);
   }
 
   @ParameterizedTest(name = "[{index}] should map {0}")

--- a/search/search-domain/src/main/java/io/camunda/search/filter/UserTaskFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/UserTaskFilter.java
@@ -25,7 +25,7 @@ public record UserTaskFilter(
     List<String> bpmnProcessIds,
     List<Operation<String>> assigneeOperations,
     List<Operation<Integer>> priorityOperations,
-    List<String> states,
+    List<Operation<String>> stateOperations,
     List<Long> processInstanceKeys,
     List<Long> processDefinitionKeys,
     List<Operation<String>> candidateUserOperations,
@@ -49,7 +49,7 @@ public record UserTaskFilter(
     private List<String> bpmnProcessIds;
     private List<Operation<String>> assigneeOperations;
     private List<Operation<Integer>> priorityOperations;
-    private List<String> states;
+    private List<Operation<String>> stateOperations;
     private List<Long> processInstanceKeys;
     private List<Long> processDefinitionKeys;
     private List<Operation<String>> candidateUserOperations;
@@ -130,13 +130,23 @@ public record UserTaskFilter(
       return priorityOperations(collectValues(operation, operations));
     }
 
-    public Builder states(final String... values) {
-      return states(collectValuesAsList(values));
+    public Builder stateOperations(final List<Operation<String>> operations) {
+      stateOperations = addValuesToList(stateOperations, operations);
+      return this;
+    }
+
+    @SafeVarargs
+    public final Builder stateOperations(
+        final Operation<String> operation, final Operation<String>... operations) {
+      return stateOperations(collectValues(operation, operations));
+    }
+
+    public Builder states(final String value, final String... values) {
+      return states(collectValues(value, values));
     }
 
     public Builder states(final List<String> values) {
-      states = addValuesToList(states, values);
-      return this;
+      return stateOperations(FilterUtil.mapDefaultToOperation(values));
     }
 
     public Builder processInstanceKeys(final Long... values) {
@@ -273,7 +283,7 @@ public record UserTaskFilter(
           Objects.requireNonNullElse(bpmnProcessIds, Collections.emptyList()),
           Objects.requireNonNullElse(assigneeOperations, Collections.emptyList()),
           Objects.requireNonNullElse(priorityOperations, Collections.emptyList()),
-          Objects.requireNonNullElse(states, Collections.emptyList()),
+          Objects.requireNonNullElse(stateOperations, Collections.emptyList()),
           Objects.requireNonNullElse(processInstanceKeys, Collections.emptyList()),
           Objects.requireNonNullElse(processDefinitionKeys, Collections.emptyList()),
           Objects.requireNonNullElse(candidateUserOperations, Collections.emptyList()),

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/UserTaskAssertTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/UserTaskAssertTest.java
@@ -22,7 +22,7 @@ import static org.mockito.Mockito.when;
 import io.camunda.client.api.search.response.UserTask;
 import io.camunda.client.impl.search.response.UserTaskImpl;
 import io.camunda.client.protocol.rest.UserTaskResult;
-import io.camunda.client.protocol.rest.UserTaskResult.StateEnum;
+import io.camunda.client.protocol.rest.UserTaskStateEnum;
 import io.camunda.process.test.api.assertions.UserTaskSelectors;
 import io.camunda.process.test.impl.assertions.CamundaDataSource;
 import java.time.Duration;
@@ -66,7 +66,7 @@ public class UserTaskAssertTest {
                         .name("a")
                         .elementInstanceKey("1")
                         .elementId("test_element")
-                        .state(StateEnum.CREATED)
+                        .state(UserTaskStateEnum.CREATED)
                         .assignee("tester")
                         .priority(60))));
 
@@ -90,7 +90,7 @@ public class UserTaskAssertTest {
                       new UserTaskResult()
                           .name("a")
                           .elementInstanceKey("1")
-                          .state(StateEnum.CREATED))));
+                          .state(UserTaskStateEnum.CREATED))));
 
       // then
       assertThat(UserTaskSelectors.byTaskName("a")).isCreated();
@@ -106,7 +106,7 @@ public class UserTaskAssertTest {
                       new UserTaskResult()
                           .name("a")
                           .elementInstanceKey("1")
-                          .state(StateEnum.COMPLETED))));
+                          .state(UserTaskStateEnum.COMPLETED))));
 
       // then
       assertThat(UserTaskSelectors.byTaskName("a")).isCompleted();
@@ -122,7 +122,7 @@ public class UserTaskAssertTest {
                       new UserTaskResult()
                           .name("a")
                           .elementInstanceKey("1")
-                          .state(StateEnum.CANCELED))));
+                          .state(UserTaskStateEnum.CANCELED))));
 
       // then
       assertThat(UserTaskSelectors.byTaskName("a")).isCanceled();
@@ -138,7 +138,7 @@ public class UserTaskAssertTest {
                       new UserTaskResult()
                           .name("a")
                           .elementInstanceKey("1")
-                          .state(StateEnum.FAILED))));
+                          .state(UserTaskStateEnum.FAILED))));
 
       // then
       assertThat(UserTaskSelectors.byTaskName("a")).isFailed();
@@ -154,12 +154,12 @@ public class UserTaskAssertTest {
                       new UserTaskResult()
                           .name("a")
                           .elementInstanceKey("1")
-                          .state(StateEnum.FAILED)),
+                          .state(UserTaskStateEnum.FAILED)),
                   new UserTaskImpl(
                       new UserTaskResult()
                           .name("mult")
                           .elementInstanceKey("2")
-                          .state(StateEnum.CREATED))));
+                          .state(UserTaskStateEnum.CREATED))));
 
       // then
       assertThat(UserTaskSelectors.byTaskName("mult")).isCreated();
@@ -170,7 +170,10 @@ public class UserTaskAssertTest {
       // when
       final UserTask activeTask =
           new UserTaskImpl(
-              new UserTaskResult().name("a").elementInstanceKey("1").state(StateEnum.CREATED));
+              new UserTaskResult()
+                  .name("a")
+                  .elementInstanceKey("1")
+                  .state(UserTaskStateEnum.CREATED));
 
       when(camundaDataSource.findUserTasks(any()))
           .thenReturn(Collections.emptyList())
@@ -196,7 +199,10 @@ public class UserTaskAssertTest {
       // when
       final UserTask completedTask =
           new UserTaskImpl(
-              new UserTaskResult().name("a").elementInstanceKey("1").state(StateEnum.COMPLETED));
+              new UserTaskResult()
+                  .name("a")
+                  .elementInstanceKey("1")
+                  .state(UserTaskStateEnum.COMPLETED));
 
       when(camundaDataSource.findUserTasks(any()))
           .thenReturn(Collections.singletonList(completedTask));
@@ -221,7 +227,7 @@ public class UserTaskAssertTest {
                       new UserTaskResult()
                           .name("a")
                           .elementInstanceKey("1")
-                          .state(StateEnum.CREATED)
+                          .state(UserTaskStateEnum.CREATED)
                           .priority(PRIORITY))));
 
       // then
@@ -238,18 +244,18 @@ public class UserTaskAssertTest {
                       new UserTaskResult()
                           .name("b")
                           .elementInstanceKey("1")
-                          .state(StateEnum.CREATED)),
+                          .state(UserTaskStateEnum.CREATED)),
                   new UserTaskImpl(
                       new UserTaskResult()
                           .name("c")
                           .elementInstanceKey("1")
-                          .state(StateEnum.CREATED)
+                          .state(UserTaskStateEnum.CREATED)
                           .priority(40)),
                   new UserTaskImpl(
                       new UserTaskResult()
                           .name("a")
                           .elementInstanceKey("1")
-                          .state(StateEnum.CREATED)
+                          .state(UserTaskStateEnum.CREATED)
                           .priority(PRIORITY))));
 
       // then
@@ -266,7 +272,7 @@ public class UserTaskAssertTest {
                       new UserTaskResult()
                           .name("a")
                           .elementInstanceKey("1")
-                          .state(StateEnum.CREATED)
+                          .state(UserTaskStateEnum.CREATED)
                           .priority(40))));
 
       // then
@@ -290,7 +296,7 @@ public class UserTaskAssertTest {
                       new UserTaskResult()
                           .name("a")
                           .elementInstanceKey("1")
-                          .state(StateEnum.CREATED)
+                          .state(UserTaskStateEnum.CREATED)
                           .elementId(ELEMENT_ID))));
 
       // then
@@ -307,18 +313,18 @@ public class UserTaskAssertTest {
                       new UserTaskResult()
                           .name("b")
                           .elementInstanceKey("1")
-                          .state(StateEnum.CREATED)),
+                          .state(UserTaskStateEnum.CREATED)),
                   new UserTaskImpl(
                       new UserTaskResult()
                           .name("c")
                           .elementInstanceKey("1")
-                          .state(StateEnum.CREATED)
+                          .state(UserTaskStateEnum.CREATED)
                           .elementId("other")),
                   new UserTaskImpl(
                       new UserTaskResult()
                           .name("a")
                           .elementInstanceKey("1")
-                          .state(StateEnum.CREATED)
+                          .state(UserTaskStateEnum.CREATED)
                           .elementId(ELEMENT_ID))));
 
       // then
@@ -335,7 +341,7 @@ public class UserTaskAssertTest {
                       new UserTaskResult()
                           .name("a")
                           .elementInstanceKey("1")
-                          .state(StateEnum.CREATED)
+                          .state(UserTaskStateEnum.CREATED)
                           .elementId("other_element_id"))));
 
       // then
@@ -358,7 +364,7 @@ public class UserTaskAssertTest {
                   new UserTaskImpl(
                       new UserTaskResult()
                           .elementInstanceKey("1")
-                          .state(StateEnum.CREATED)
+                          .state(UserTaskStateEnum.CREATED)
                           .name(NAME))));
 
       // then
@@ -375,17 +381,17 @@ public class UserTaskAssertTest {
                       new UserTaskResult()
                           .name("b")
                           .elementInstanceKey("1")
-                          .state(StateEnum.CREATED)),
+                          .state(UserTaskStateEnum.CREATED)),
                   new UserTaskImpl(
                       new UserTaskResult()
                           .name("c")
                           .elementInstanceKey("1")
-                          .state(StateEnum.CREATED)
+                          .state(UserTaskStateEnum.CREATED)
                           .name("other")),
                   new UserTaskImpl(
                       new UserTaskResult()
                           .elementInstanceKey("1")
-                          .state(StateEnum.CREATED)
+                          .state(UserTaskStateEnum.CREATED)
                           .name(NAME))));
 
       // then
@@ -402,7 +408,7 @@ public class UserTaskAssertTest {
                       new UserTaskResult()
                           .name(NAME)
                           .elementInstanceKey("1")
-                          .state(StateEnum.CREATED))));
+                          .state(UserTaskStateEnum.CREATED))));
 
       // then
       Assertions.assertThatThrownBy(
@@ -425,7 +431,7 @@ public class UserTaskAssertTest {
                       new UserTaskResult()
                           .name("a")
                           .elementInstanceKey("1")
-                          .state(StateEnum.CREATED)
+                          .state(UserTaskStateEnum.CREATED)
                           .assignee(ASSIGNEE))));
 
       // then
@@ -442,18 +448,18 @@ public class UserTaskAssertTest {
                       new UserTaskResult()
                           .name("b")
                           .elementInstanceKey("1")
-                          .state(StateEnum.CREATED)),
+                          .state(UserTaskStateEnum.CREATED)),
                   new UserTaskImpl(
                       new UserTaskResult()
                           .name("c")
                           .elementInstanceKey("1")
-                          .state(StateEnum.CREATED)
+                          .state(UserTaskStateEnum.CREATED)
                           .assignee("other")),
                   new UserTaskImpl(
                       new UserTaskResult()
                           .name("a")
                           .elementInstanceKey("1")
-                          .state(StateEnum.CREATED)
+                          .state(UserTaskStateEnum.CREATED)
                           .assignee(ASSIGNEE))));
 
       // then
@@ -470,7 +476,7 @@ public class UserTaskAssertTest {
                       new UserTaskResult()
                           .name("a")
                           .elementInstanceKey("1")
-                          .state(StateEnum.CREATED)
+                          .state(UserTaskStateEnum.CREATED)
                           .assignee("other"))));
 
       // then
@@ -494,7 +500,7 @@ public class UserTaskAssertTest {
                       new UserTaskResult()
                           .name("a")
                           .elementInstanceKey("1")
-                          .state(StateEnum.CREATED)
+                          .state(UserTaskStateEnum.CREATED)
                           .dueDate(DUE_DATE))));
 
       // then
@@ -511,18 +517,18 @@ public class UserTaskAssertTest {
                       new UserTaskResult()
                           .name("b")
                           .elementInstanceKey("1")
-                          .state(StateEnum.CREATED)),
+                          .state(UserTaskStateEnum.CREATED)),
                   new UserTaskImpl(
                       new UserTaskResult()
                           .name("c")
                           .elementInstanceKey("1")
-                          .state(StateEnum.CREATED)
+                          .state(UserTaskStateEnum.CREATED)
                           .dueDate("2025-04-30T10:00:00.000Z")),
                   new UserTaskImpl(
                       new UserTaskResult()
                           .name("a")
                           .elementInstanceKey("1")
-                          .state(StateEnum.CREATED)
+                          .state(UserTaskStateEnum.CREATED)
                           .dueDate(DUE_DATE))));
 
       // then
@@ -539,7 +545,7 @@ public class UserTaskAssertTest {
                       new UserTaskResult()
                           .name("a")
                           .elementInstanceKey("1")
-                          .state(StateEnum.CREATED)
+                          .state(UserTaskStateEnum.CREATED)
                           .dueDate("2025-04-30T10:00:00.000Z"))));
 
       // then
@@ -564,7 +570,7 @@ public class UserTaskAssertTest {
                       new UserTaskResult()
                           .name("a")
                           .elementInstanceKey("1")
-                          .state(StateEnum.CREATED)
+                          .state(UserTaskStateEnum.CREATED)
                           .completionDate(COMPLETION_DATE))));
 
       // then
@@ -581,18 +587,18 @@ public class UserTaskAssertTest {
                       new UserTaskResult()
                           .name("b")
                           .elementInstanceKey("1")
-                          .state(StateEnum.CREATED)),
+                          .state(UserTaskStateEnum.CREATED)),
                   new UserTaskImpl(
                       new UserTaskResult()
                           .name("c")
                           .elementInstanceKey("1")
-                          .state(StateEnum.CREATED)
+                          .state(UserTaskStateEnum.CREATED)
                           .completionDate("2025-04-30T10:00:00.000Z")),
                   new UserTaskImpl(
                       new UserTaskResult()
                           .name("a")
                           .elementInstanceKey("1")
-                          .state(StateEnum.CREATED)
+                          .state(UserTaskStateEnum.CREATED)
                           .completionDate(COMPLETION_DATE))));
 
       // then
@@ -609,7 +615,7 @@ public class UserTaskAssertTest {
                       new UserTaskResult()
                           .name("a")
                           .elementInstanceKey("1")
-                          .state(StateEnum.CREATED)
+                          .state(UserTaskStateEnum.CREATED)
                           .completionDate("2025-04-30T10:00:00.000Z"))));
 
       // then
@@ -635,7 +641,7 @@ public class UserTaskAssertTest {
                       new UserTaskResult()
                           .name("a")
                           .elementInstanceKey("1")
-                          .state(StateEnum.CREATED)
+                          .state(UserTaskStateEnum.CREATED)
                           .followUpDate(FOLLOW_UP_DATE))));
 
       // then
@@ -652,18 +658,18 @@ public class UserTaskAssertTest {
                       new UserTaskResult()
                           .name("b")
                           .elementInstanceKey("1")
-                          .state(StateEnum.CREATED)),
+                          .state(UserTaskStateEnum.CREATED)),
                   new UserTaskImpl(
                       new UserTaskResult()
                           .name("c")
                           .elementInstanceKey("1")
-                          .state(StateEnum.CREATED)
+                          .state(UserTaskStateEnum.CREATED)
                           .followUpDate("2025-04-30T10:00:00.000Z")),
                   new UserTaskImpl(
                       new UserTaskResult()
                           .name("a")
                           .elementInstanceKey("1")
-                          .state(StateEnum.CREATED)
+                          .state(UserTaskStateEnum.CREATED)
                           .followUpDate(FOLLOW_UP_DATE))));
 
       // then
@@ -680,7 +686,7 @@ public class UserTaskAssertTest {
                       new UserTaskResult()
                           .name("a")
                           .elementInstanceKey("1")
-                          .state(StateEnum.CREATED)
+                          .state(UserTaskStateEnum.CREATED)
                           .followUpDate("2025-04-30T10:00:00.000Z"))));
 
       // then
@@ -705,7 +711,7 @@ public class UserTaskAssertTest {
                       new UserTaskResult()
                           .name("a")
                           .elementInstanceKey("1")
-                          .state(StateEnum.CREATED)
+                          .state(UserTaskStateEnum.CREATED)
                           .creationDate(CREATION_DATE))));
 
       // then
@@ -722,18 +728,18 @@ public class UserTaskAssertTest {
                       new UserTaskResult()
                           .name("b")
                           .elementInstanceKey("1")
-                          .state(StateEnum.CREATED)),
+                          .state(UserTaskStateEnum.CREATED)),
                   new UserTaskImpl(
                       new UserTaskResult()
                           .name("c")
                           .elementInstanceKey("1")
-                          .state(StateEnum.CREATED)
+                          .state(UserTaskStateEnum.CREATED)
                           .creationDate("2025-04-30T10:00:00.000Z")),
                   new UserTaskImpl(
                       new UserTaskResult()
                           .name("a")
                           .elementInstanceKey("1")
-                          .state(StateEnum.CREATED)
+                          .state(UserTaskStateEnum.CREATED)
                           .creationDate(CREATION_DATE))));
 
       // then
@@ -750,7 +756,7 @@ public class UserTaskAssertTest {
                       new UserTaskResult()
                           .name("a")
                           .elementInstanceKey("1")
-                          .state(StateEnum.CREATED)
+                          .state(UserTaskStateEnum.CREATED)
                           .creationDate("2025-04-30T10:00:00.000Z"))));
 
       // then
@@ -776,7 +782,7 @@ public class UserTaskAssertTest {
                       new UserTaskResult()
                           .name("a")
                           .elementInstanceKey("1")
-                          .state(StateEnum.CREATED)
+                          .state(UserTaskStateEnum.CREATED)
                           .candidateGroups(candidateGroups))));
 
       // then
@@ -793,7 +799,7 @@ public class UserTaskAssertTest {
                       new UserTaskResult()
                           .name("a")
                           .elementInstanceKey("1")
-                          .state(StateEnum.CREATED)
+                          .state(UserTaskStateEnum.CREATED)
                           .candidateGroups(candidateGroups))));
 
       // then
@@ -810,7 +816,7 @@ public class UserTaskAssertTest {
                       new UserTaskResult()
                           .name("a")
                           .elementInstanceKey("1")
-                          .state(StateEnum.CREATED)
+                          .state(UserTaskStateEnum.CREATED)
                           .candidateGroups(
                               Arrays.asList("hr", "engineering", "management", "legal")))));
 
@@ -828,18 +834,18 @@ public class UserTaskAssertTest {
                       new UserTaskResult()
                           .name("b")
                           .elementInstanceKey("1")
-                          .state(StateEnum.CREATED)),
+                          .state(UserTaskStateEnum.CREATED)),
                   new UserTaskImpl(
                       new UserTaskResult()
                           .name("c")
                           .elementInstanceKey("1")
-                          .state(StateEnum.CREATED)
+                          .state(UserTaskStateEnum.CREATED)
                           .candidateGroups(Collections.singletonList("marketing"))),
                   new UserTaskImpl(
                       new UserTaskResult()
                           .name("a")
                           .elementInstanceKey("1")
-                          .state(StateEnum.CREATED)
+                          .state(UserTaskStateEnum.CREATED)
                           .candidateGroups(candidateGroups))));
 
       // then
@@ -856,7 +862,7 @@ public class UserTaskAssertTest {
                       new UserTaskResult()
                           .name("a")
                           .elementInstanceKey("1")
-                          .state(StateEnum.CREATED)
+                          .state(UserTaskStateEnum.CREATED)
                           .candidateGroups(candidateGroups))));
 
       // then
@@ -876,7 +882,7 @@ public class UserTaskAssertTest {
                       new UserTaskResult()
                           .name("a")
                           .elementInstanceKey("1")
-                          .state(StateEnum.CREATED)
+                          .state(UserTaskStateEnum.CREATED)
                           .candidateGroups(Collections.singletonList("marketing")))));
 
       // then

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -5594,18 +5594,7 @@ components:
       type: object
       properties:
         state:
-          type: string
-          description: The state of the user task.
-          enum:
-            - CREATING
-            - CREATED
-            - ASSIGNING
-            - UPDATING
-            - COMPLETING
-            - COMPLETED
-            - CANCELING
-            - CANCELED
-            - FAILED
+          $ref: "#/components/schemas/UserTaskStateEnum"
         assignee:
           description: The assignee of the user task.
           allOf:
@@ -5702,18 +5691,7 @@ components:
           type: string
           description: The name for this user task.
         state:
-          type: string
-          description: The state of the user task.
-          enum:
-            - CREATING
-            - CREATED
-            - ASSIGNING
-            - UPDATING
-            - COMPLETING
-            - COMPLETED
-            - CANCELING
-            - CANCELED
-            - FAILED
+          $ref: "#/components/schemas/UserTaskStateEnum"
         assignee:
           description: The assignee of the user task.
           type: string
@@ -5785,6 +5763,19 @@ components:
         formKey:
           type: string
           description: The key of the form.
+    UserTaskStateEnum:
+      description: The state of the user task.
+      type: string
+      enum:
+        - CREATING
+        - CREATED
+        - ASSIGNING
+        - UPDATING
+        - COMPLETING
+        - COMPLETED
+        - CANCELING
+        - CANCELED
+        - FAILED
     VariableSearchQuerySortRequest:
       type: object
       properties:

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -5594,7 +5594,9 @@ components:
       type: object
       properties:
         state:
-          $ref: "#/components/schemas/UserTaskStateEnum"
+          description: The user task state.
+          allOf:
+            - $ref: "#/components/schemas/UserTaskStateFilterProperty"
         assignee:
           description: The assignee of the user task.
           allOf:
@@ -5663,6 +5665,39 @@ components:
         elementInstanceKey:
           type: string
           description: The key of the element instance.
+    UserTaskStateFilterProperty:
+      description: UserTaskStateEnum property with full advanced search capabilities.
+      type: object
+      oneOf:
+        - type: string
+          title: Exact match
+          description: Matches the value exactly.
+          allOf:
+            - $ref: "#/components/schemas/UserTaskStateEnum"
+        - $ref: "#/components/schemas/AdvancedUserTaskStateFilter"
+    AdvancedUserTaskStateFilter:
+      title: Advanced filter
+      description: Advanced UserTaskStateEnum filter.
+      type: object
+      properties:
+        $eq:
+          description: Checks for equality with the provided value.
+          allOf:
+            - $ref: "#/components/schemas/UserTaskStateEnum"
+        $neq:
+          description: Checks for inequality with the provided value.
+          allOf:
+            - $ref: "#/components/schemas/UserTaskStateEnum"
+        $exists:
+          description: Checks if the current property exists.
+          type: boolean
+        $in:
+          description: Checks if the property matches any of the provided values.
+          type: array
+          items:
+            $ref: "#/components/schemas/UserTaskStateEnum"
+        $like:
+          $ref: "#/components/schemas/LikeFilterProperty"
     VariableValueFilterProperty:
       type: object
       properties:

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
@@ -17,7 +17,6 @@ import static java.util.Optional.ofNullable;
 import io.camunda.search.entities.DecisionInstanceEntity.DecisionDefinitionType;
 import io.camunda.search.entities.DecisionInstanceEntity.DecisionInstanceState;
 import io.camunda.search.entities.FlowNodeInstanceEntity.FlowNodeType;
-import io.camunda.search.entities.UserTaskEntity.UserTaskState;
 import io.camunda.search.filter.AuthorizationFilter;
 import io.camunda.search.filter.BatchOperationFilter;
 import io.camunda.search.filter.DecisionDefinitionFilter;
@@ -1167,8 +1166,8 @@ public final class SearchQueryRequestMapper {
           .map(KeyUtil::keyToLong)
           .ifPresent(builder::userTaskKeys);
       Optional.ofNullable(filter.getState())
-          .map(s -> String.valueOf(UserTaskState.valueOf(s.getValue())))
-          .ifPresent(builder::states);
+          .map(mapToOperations(String.class))
+          .ifPresent(builder::stateOperations);
       Optional.ofNullable(filter.getProcessDefinitionId()).ifPresent(builder::bpmnProcessIds);
       Optional.ofNullable(filter.getElementId()).ifPresent(builder::elementIds);
       Optional.ofNullable(filter.getName()).ifPresent(builder::names);

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
@@ -121,6 +121,7 @@ import io.camunda.zeebe.gateway.protocol.rest.UserResult;
 import io.camunda.zeebe.gateway.protocol.rest.UserSearchResult;
 import io.camunda.zeebe.gateway.protocol.rest.UserTaskResult;
 import io.camunda.zeebe.gateway.protocol.rest.UserTaskSearchQueryResult;
+import io.camunda.zeebe.gateway.protocol.rest.UserTaskStateEnum;
 import io.camunda.zeebe.gateway.protocol.rest.VariableResult;
 import io.camunda.zeebe.gateway.protocol.rest.VariableSearchQueryResult;
 import io.camunda.zeebe.gateway.protocol.rest.VariableSearchResult;
@@ -820,7 +821,7 @@ public final class SearchQueryResponseMapper {
         .processDefinitionKey(KeyUtil.keyToString(t.processDefinitionKey()))
         .elementInstanceKey(KeyUtil.keyToString(t.elementInstanceKey()))
         .processDefinitionId(t.processDefinitionId())
-        .state(UserTaskResult.StateEnum.fromValue(t.state().name()))
+        .state(UserTaskStateEnum.fromValue(t.state().name()))
         .assignee(t.assignee())
         .candidateUsers(t.candidateUsers())
         .candidateGroups(t.candidateGroups())

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/JacksonConfig.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/JacksonConfig.java
@@ -22,6 +22,7 @@ import io.camunda.zeebe.gateway.protocol.rest.JobStateFilterProperty;
 import io.camunda.zeebe.gateway.protocol.rest.MessageSubscriptionTypeFilterProperty;
 import io.camunda.zeebe.gateway.protocol.rest.ProcessInstanceStateFilterProperty;
 import io.camunda.zeebe.gateway.protocol.rest.StringFilterProperty;
+import io.camunda.zeebe.gateway.protocol.rest.UserTaskStateFilterProperty;
 import io.camunda.zeebe.gateway.rest.deserializer.BasicStringFilterPropertyDeserializer;
 import io.camunda.zeebe.gateway.rest.deserializer.BatchOperatioItemStateFilterPropertyDeserializer;
 import io.camunda.zeebe.gateway.rest.deserializer.BatchOperationStateFilterPropertyDeserializer;
@@ -35,6 +36,7 @@ import io.camunda.zeebe.gateway.rest.deserializer.JobStateFilterPropertyDeserial
 import io.camunda.zeebe.gateway.rest.deserializer.MessageSubscriptionTypePropertyDeserializer;
 import io.camunda.zeebe.gateway.rest.deserializer.ProcessInstanceStateFilterPropertyDeserializer;
 import io.camunda.zeebe.gateway.rest.deserializer.StringFilterPropertyDeserializer;
+import io.camunda.zeebe.gateway.rest.deserializer.UserTaskStateFilterPropertyDeserializer;
 import java.util.function.Consumer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -73,6 +75,8 @@ public class JacksonConfig {
     module.addDeserializer(
         MessageSubscriptionTypeFilterProperty.class,
         new MessageSubscriptionTypePropertyDeserializer());
+    module.addDeserializer(
+        UserTaskStateFilterProperty.class, new UserTaskStateFilterPropertyDeserializer());
     return builder -> builder.modulesToInstall(modules -> modules.add(module));
   }
 

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/deserializer/UserTaskStateFilterPropertyDeserializer.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/deserializer/UserTaskStateFilterPropertyDeserializer.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.deserializer;
+
+import io.camunda.zeebe.gateway.protocol.rest.AdvancedUserTaskStateFilter;
+import io.camunda.zeebe.gateway.protocol.rest.UserTaskStateEnum;
+import io.camunda.zeebe.gateway.protocol.rest.UserTaskStateFilterProperty;
+
+public class UserTaskStateFilterPropertyDeserializer
+    extends FilterDeserializer<UserTaskStateFilterProperty, UserTaskStateEnum> {
+
+  @Override
+  protected Class<? extends UserTaskStateFilterProperty> getFinalType() {
+    return AdvancedUserTaskStateFilter.class;
+  }
+
+  @Override
+  protected Class<UserTaskStateEnum> getImplicitValueType() {
+    return UserTaskStateEnum.class;
+  }
+
+  @Override
+  protected UserTaskStateFilterProperty createFromImplicitValue(final UserTaskStateEnum value) {
+    final var filter = new AdvancedUserTaskStateFilter();
+    filter.set$Eq(value);
+    return filter;
+  }
+}


### PR DESCRIPTION
## Description

This pull request introduces support for advanced filtering capabilities on the `user task state` property. The enhancement allows for more granular and precise querying of user tasks.

### Key Changes
- Added support for advanced filtering on the `user task state` property.
- Updated relevant APIs and data models to accommodate the new filtering functionality.
- Added/adjusted tests to verify advanced filtering on the `user task state` property

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #32717 
