### PR TITLE
feat: do not remove exporters that are removed from application config

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/BlockingExporter.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/BlockingExporter.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker.exporter.stream;
+
+import io.camunda.zeebe.exporter.api.Exporter;
+import io.camunda.zeebe.exporter.api.context.Context;
+import io.camunda.zeebe.exporter.api.context.Controller;
+import io.camunda.zeebe.protocol.record.Record;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This is a special Exporter which is configured in place of previously enabled exporters whose
+ * configuration is not found. The exporting to this exporter will be paused until the configuration
+ * is fixed and the broker is restarted. Or the exporter is permanently deleted via explicit call to
+ * the management api.
+ */
+public class BlockingExporter implements Exporter {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(BlockingExporter.class);
+  private String exporterId;
+
+  @Override
+  public void configure(final Context context) throws Exception {
+    exporterId = context.getConfiguration().getId();
+    LOGGER.warn(
+        "Exporter '{}' is enabled, but the configuration is not found. Exporting to this exporter will be paused."
+            + " Please add the exporter configuration or delete them permanently via management api.",
+        exporterId);
+  }
+
+  @Override
+  public void open(final Controller controller) {
+    // No op
+  }
+
+  @Override
+  public void close() {
+    Exporter.super.close();
+  }
+
+  @Override
+  public void export(final Record<?> record) {
+    // no-op
+    // This exporter never updates Controller#updateLastExportedRecordPosition. Thus, the partition
+    // will
+    // never compact the logs.
+  }
+}

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/ExporterDirectorPartitionTransitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/ExporterDirectorPartitionTransitionStep.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.broker.system.partitions.impl.steps;
 
 import io.atomix.raft.RaftServer.Role;
 import io.camunda.zeebe.broker.exporter.repo.ExporterDescriptor;
+import io.camunda.zeebe.broker.exporter.stream.BlockingExporter;
 import io.camunda.zeebe.broker.exporter.stream.ExporterDirector;
 import io.camunda.zeebe.broker.exporter.stream.ExporterDirector.ExporterInitializationInfo;
 import io.camunda.zeebe.broker.exporter.stream.ExporterDirectorContext;
@@ -25,10 +26,10 @@ import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.stream.impl.SkipPositionsFilter;
 import io.camunda.zeebe.util.VisibleForTesting;
+import io.camunda.zeebe.util.collection.Tuple;
 import java.util.Collection;
 import java.util.Map;
 import java.util.function.BiFunction;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
 public final class ExporterDirectorPartitionTransitionStep implements PartitionTransitionStep {
@@ -181,31 +182,40 @@ public final class ExporterDirectorPartitionTransitionStep implements PartitionT
       final PartitionTransitionContext context) {
     final Collection<ExporterDescriptor> exporterDescriptors = context.getExportedDescriptors();
     final var exporterConfig = context.getDynamicPartitionConfig().exporting().exporters();
+
+    return exporterConfig.entrySet().stream()
+        .filter(
+            entry ->
+                entry.getValue().state() == State.ENABLED
+                    // Exporters whose configuration is not found are considered as enabled, but
+                    // since configuration is not found, we cannot export any records to them.
+                    || entry.getValue().state() == State.CONFIG_NOT_FOUND)
+        .map(entry -> getExporterDescriptor(entry.getKey(), entry.getValue(), exporterDescriptors))
+        .collect(Collectors.toMap(Tuple::getLeft, Tuple::getRight));
+  }
+
+  private static Tuple<ExporterDescriptor, ExporterInitializationInfo> getExporterDescriptor(
+      final String id,
+      final ExporterState config,
+      final Collection<ExporterDescriptor> exporterDescriptors) {
+
     return exporterDescriptors.stream()
-        .filter(exporterDescriptor -> isEnabled(exporterConfig, exporterDescriptor))
-        .collect(
-            Collectors.toMap(
-                Function.identity(),
-                descriptor -> getInitializationInfo(descriptor, exporterConfig)));
-  }
-
-  private static ExporterInitializationInfo getInitializationInfo(
-      final ExporterDescriptor descriptor, final Map<String, ExporterState> exportersConfig) {
-    if (exportersConfig.containsKey(descriptor.getId())) {
-      final ExporterState config = exportersConfig.get(descriptor.getId());
-      return new ExporterInitializationInfo(
-          config.metadataVersion(), config.initializedFrom().orElse(null));
-    }
-
-    // TODO: This case won't happen after https://github.com/camunda/camunda/issues/18296 and we
-    // handle the default behaviour for newly added exporters.
-    return new ExporterInitializationInfo(0, null);
-  }
-
-  private static boolean isEnabled(
-      final Map<String, ExporterState> exporterConfig,
-      final ExporterDescriptor exporterDescriptor) {
-    return exporterConfig.containsKey(exporterDescriptor.getId())
-        && exporterConfig.get(exporterDescriptor.getId()).state() == State.ENABLED;
+        .filter(exporterDescriptor -> exporterDescriptor.getId().equals(id))
+        .findAny()
+        // If a configured exporter is found, return the descriptor and its initialization info.
+        .map(
+            exporterDescriptor -> {
+              final ExporterInitializationInfo initializationInfo =
+                  new ExporterInitializationInfo(
+                      config.metadataVersion(), config.initializedFrom().orElse(null));
+              return Tuple.of(exporterDescriptor, initializationInfo);
+            })
+        // if the exporter's config is not found, return a blocking exporter descriptor as a
+        // placeholder. Exporting to this exporter will be blocked.
+        .orElse(
+            Tuple.of(
+                new ExporterDescriptor(id, BlockingExporter.class, Map.of()),
+                new ExporterInitializationInfo(
+                    config.metadataVersion(), config.initializedFrom().orElse(null))));
   }
 }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/steps/ExporterDirectorPartitionTransitionStepTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/steps/ExporterDirectorPartitionTransitionStepTest.java
@@ -158,6 +158,33 @@ class ExporterDirectorPartitionTransitionStepTest {
   }
 
   @Test
+  void shouldCreateDescriptorsForConfigNotFoundExporters() {
+    // given
+    final String enabledExporterId = "expA";
+    final String configNotFoundExporterId = "expB";
+    final var exporterConfig =
+        getExporterConfig(
+            enabledExporterId, State.ENABLED, configNotFoundExporterId, State.CONFIG_NOT_FOUND);
+
+    final Map<String, ExporterDescriptor> exporters =
+        Map.of(enabledExporterId, new ExporterDescriptor(enabledExporterId));
+    when(exporterRepository.getExporters()).thenReturn(exporters);
+    transitionContext.setDynamicPartitionConfig(exporterConfig);
+
+    final AtomicReference<ExporterDirectorContext> capturedContext = new AtomicReference<>();
+    final var exporterDirectorStep = getExporterDirectorPartitionTransitionStep(capturedContext);
+
+    // when
+    exporterDirectorStep.prepareTransition(transitionContext, 1, Role.LEADER).join();
+    exporterDirectorStep.transitionTo(transitionContext, 1, Role.LEADER).join();
+
+    // then
+    assertThat(
+            capturedContext.get().getDescriptors().keySet().stream().map(ExporterDescriptor::getId))
+        .containsExactlyInAnyOrder(enabledExporterId, configNotFoundExporterId);
+  }
+
+  @Test
   void shouldDisableExporterIfConfigChangedConcurrently() {
     // given
     final String enabledExporterId = "expA";


### PR DESCRIPTION
## Description

When the exporter is removed from the application properties, we do not want to disable or permanently remove them. Instead, we move it to a "paused" state by starting a `BlockingExporter`. The `BlockingExporter` serves as an explicit placeholder to pause exporting to that exporter. This is necessary to prevent record compaction for the unexported data to this exporter, which can result in data gaps upon re-enabling the exporter, as previously unexported records might no longer be available.

To recover from this
- the user has to restart the brokers after adding the exporter back to the configuration which will re-enable the exporter and continue exporting without any data loss
- Or permanently delete the exporter via management api (which will be added in #35321)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #35319 
