### PR TITLE
Strict JSON tests for REST API

### DIFF
--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionDefinitionControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionDefinitionControllerTest.java
@@ -29,6 +29,7 @@ import org.mockito.Mockito;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.json.JsonCompareMode;
 import org.springframework.test.web.reactive.server.WebTestClient.ResponseSpec;
 
 @WebMvcTest(DecisionDefinitionController.class)
@@ -96,7 +97,7 @@ public class DecisionDefinitionControllerTest extends RestControllerTest {
             .expectStatus()
             .isOk();
 
-    response.expectBody().json(EXPECTED_EVALUATION_RESPONSE);
+    response.expectBody().json(EXPECTED_EVALUATION_RESPONSE, JsonCompareMode.STRICT);
     Mockito.verify(decisionServices)
         .evaluateDecision("", 123456L, Map.of("key", "value"), "tenantId");
   }
@@ -164,7 +165,7 @@ public class DecisionDefinitionControllerTest extends RestControllerTest {
             .expectStatus()
             .isOk();
 
-    response.expectBody().json(EXPECTED_EVALUATION_RESPONSE);
+    response.expectBody().json(EXPECTED_EVALUATION_RESPONSE, JsonCompareMode.STRICT);
     Mockito.verify(decisionServices)
         .evaluateDecision("decisionId", -1L, Map.of("key", "value"), "tenantId");
   }
@@ -203,7 +204,7 @@ public class DecisionDefinitionControllerTest extends RestControllerTest {
         .expectStatus()
         .isBadRequest()
         .expectBody()
-        .json(expectedBody);
+        .json(expectedBody, JsonCompareMode.STRICT);
   }
 
   @Test
@@ -238,7 +239,7 @@ public class DecisionDefinitionControllerTest extends RestControllerTest {
         .expectStatus()
         .isBadRequest()
         .expectBody()
-        .json(expectedBody);
+        .json(expectedBody, JsonCompareMode.STRICT);
   }
 
   private CompletableFuture<BrokerResponse<DecisionEvaluationRecord>> buildResponse(

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionDefinitionQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionDefinitionQueryControllerTest.java
@@ -38,6 +38,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.json.JsonCompareMode;
 
 @WebMvcTest(value = DecisionDefinitionController.class)
 public class DecisionDefinitionQueryControllerTest extends RestControllerTest {
@@ -59,7 +60,8 @@ public class DecisionDefinitionQueryControllerTest extends RestControllerTest {
               "page": {
                   "totalItems": 1,
                   "startCursor": "f",
-                  "endCursor": "v"
+                  "endCursor": "v",
+                  "hasMoreTotalItems": false
               }
           }""";
 
@@ -102,7 +104,7 @@ public class DecisionDefinitionQueryControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_JSON)
         .expectBody()
-        .json(EXPECTED_SEARCH_RESPONSE);
+        .json(EXPECTED_SEARCH_RESPONSE, JsonCompareMode.STRICT);
 
     verify(decisionDefinitionServices).search(new DecisionDefinitionQuery.Builder().build());
   }
@@ -126,7 +128,7 @@ public class DecisionDefinitionQueryControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_JSON)
         .expectBody()
-        .json(EXPECTED_SEARCH_RESPONSE);
+        .json(EXPECTED_SEARCH_RESPONSE, JsonCompareMode.STRICT);
 
     verify(decisionDefinitionServices).search(new DecisionDefinitionQuery.Builder().build());
   }
@@ -165,7 +167,7 @@ public class DecisionDefinitionQueryControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_JSON)
         .expectBody()
-        .json(EXPECTED_SEARCH_RESPONSE);
+        .json(EXPECTED_SEARCH_RESPONSE, JsonCompareMode.STRICT);
 
     verify(decisionDefinitionServices)
         .search(
@@ -231,7 +233,7 @@ public class DecisionDefinitionQueryControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_JSON)
         .expectBody()
-        .json(EXPECTED_SEARCH_RESPONSE);
+        .json(EXPECTED_SEARCH_RESPONSE, JsonCompareMode.STRICT);
 
     verify(decisionDefinitionServices)
         .search(
@@ -292,7 +294,7 @@ public class DecisionDefinitionQueryControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_PROBLEM_JSON)
         .expectBody()
-        .json(expectedResponse);
+        .json(expectedResponse, JsonCompareMode.STRICT);
 
     verify(decisionDefinitionServices, never()).search(any(DecisionDefinitionQuery.class));
   }
@@ -349,7 +351,7 @@ public class DecisionDefinitionQueryControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_PROBLEM_JSON)
         .expectBody()
-        .json(expectedResponse);
+        .json(expectedResponse, JsonCompareMode.STRICT);
   }
 
   @Test
@@ -379,7 +381,7 @@ public class DecisionDefinitionQueryControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_PROBLEM_JSON)
         .expectBody()
-        .json(expectedResponse);
+        .json(expectedResponse, JsonCompareMode.STRICT);
   }
 
   @Test
@@ -407,7 +409,7 @@ public class DecisionDefinitionQueryControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_PROBLEM_JSON)
         .expectBody()
-        .json(expectedResponse);
+        .json(expectedResponse, JsonCompareMode.STRICT);
   }
 
   @Test
@@ -439,7 +441,7 @@ public class DecisionDefinitionQueryControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_JSON)
         .expectBody()
-        .json(expectedResponse);
+        .json(expectedResponse, JsonCompareMode.STRICT);
   }
 
   @Test
@@ -472,7 +474,7 @@ public class DecisionDefinitionQueryControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_PROBLEM_JSON)
         .expectBody()
-        .json(expectedResponse);
+        .json(expectedResponse, JsonCompareMode.STRICT);
   }
 
   @Test
@@ -501,7 +503,7 @@ public class DecisionDefinitionQueryControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_PROBLEM_JSON)
         .expectBody()
-        .json(expectedResponse);
+        .json(expectedResponse, JsonCompareMode.STRICT);
   }
 
   @ParameterizedTest

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionInstanceQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionInstanceQueryControllerTest.java
@@ -42,6 +42,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.json.JsonCompareMode;
 
 @WebMvcTest(value = DecisionInstanceController.class)
 public class DecisionInstanceQueryControllerTest extends RestControllerTest {
@@ -69,7 +70,8 @@ public class DecisionInstanceQueryControllerTest extends RestControllerTest {
                "page": {
                    "totalItems": 1,
                    "startCursor": "f",
-                   "endCursor": "v"
+                   "endCursor": "v",
+                   "hasMoreTotalItems": false
                }
            }""";
 
@@ -185,7 +187,7 @@ public class DecisionInstanceQueryControllerTest extends RestControllerTest {
         .expectStatus()
         .isOk()
         .expectBody()
-        .json(EXPECTED_SEARCH_RESPONSE);
+        .json(EXPECTED_SEARCH_RESPONSE, JsonCompareMode.STRICT);
   }
 
   @Test
@@ -202,7 +204,7 @@ public class DecisionInstanceQueryControllerTest extends RestControllerTest {
         .expectStatus()
         .isOk()
         .expectBody()
-        .json(EXPECTED_SEARCH_RESPONSE);
+        .json(EXPECTED_SEARCH_RESPONSE, JsonCompareMode.STRICT);
   }
 
   @Test
@@ -424,7 +426,7 @@ public class DecisionInstanceQueryControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_JSON)
         .expectBody()
-        .json(EXPECTED_SEARCH_RESPONSE);
+        .json(EXPECTED_SEARCH_RESPONSE, JsonCompareMode.STRICT);
 
     verify(decisionInstanceServices)
         .search(new DecisionInstanceQuery.Builder().filter(filter).build());
@@ -457,7 +459,7 @@ public class DecisionInstanceQueryControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_PROBLEM_JSON)
         .expectBody()
-        .json(expectedResponse);
+        .json(expectedResponse, JsonCompareMode.STRICT);
 
     verify(decisionInstanceServices, never()).search(any(DecisionInstanceQuery.class));
   }
@@ -489,7 +491,7 @@ public class DecisionInstanceQueryControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_PROBLEM_JSON)
         .expectBody()
-        .json(expectedResponse);
+        .json(expectedResponse, JsonCompareMode.STRICT);
 
     verify(decisionInstanceServices, never()).search(any(DecisionInstanceQuery.class));
   }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionRequirementsQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionRequirementsQueryControllerTest.java
@@ -38,6 +38,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.json.JsonCompareMode;
 
 @WebMvcTest(value = DecisionRequirementsController.class)
 public class DecisionRequirementsQueryControllerTest extends RestControllerTest {
@@ -58,7 +59,8 @@ public class DecisionRequirementsQueryControllerTest extends RestControllerTest 
               "page": {
                   "totalItems": 1,
                   "startCursor": "f",
-                  "endCursor": "v"
+                  "endCursor": "v",
+                  "hasMoreTotalItems": false
               }
           }""";
   static final SearchQueryResult<DecisionRequirementsEntity> SEARCH_QUERY_RESULT =
@@ -125,7 +127,7 @@ public class DecisionRequirementsQueryControllerTest extends RestControllerTest 
         .expectHeader()
         .contentType(MediaType.APPLICATION_JSON)
         .expectBody()
-        .json(EXPECTED_SEARCH_RESPONSE);
+        .json(EXPECTED_SEARCH_RESPONSE, JsonCompareMode.STRICT);
 
     verify(decisionRequirementsServices).search(new DecisionRequirementsQuery.Builder().build());
   }
@@ -149,7 +151,7 @@ public class DecisionRequirementsQueryControllerTest extends RestControllerTest 
         .expectHeader()
         .contentType(MediaType.APPLICATION_JSON)
         .expectBody()
-        .json(EXPECTED_SEARCH_RESPONSE);
+        .json(EXPECTED_SEARCH_RESPONSE, JsonCompareMode.STRICT);
 
     verify(decisionRequirementsServices).search(new DecisionRequirementsQuery.Builder().build());
   }
@@ -185,7 +187,7 @@ public class DecisionRequirementsQueryControllerTest extends RestControllerTest 
         .expectHeader()
         .contentType(MediaType.APPLICATION_JSON)
         .expectBody()
-        .json(EXPECTED_SEARCH_RESPONSE);
+        .json(EXPECTED_SEARCH_RESPONSE, JsonCompareMode.STRICT);
 
     verify(decisionRequirementsServices)
         .search(
@@ -246,7 +248,7 @@ public class DecisionRequirementsQueryControllerTest extends RestControllerTest 
         .expectHeader()
         .contentType(MediaType.APPLICATION_JSON)
         .expectBody()
-        .json(EXPECTED_SEARCH_RESPONSE);
+        .json(EXPECTED_SEARCH_RESPONSE, JsonCompareMode.STRICT);
 
     verify(decisionRequirementsServices)
         .search(
@@ -304,7 +306,7 @@ public class DecisionRequirementsQueryControllerTest extends RestControllerTest 
         .expectHeader()
         .contentType(MediaType.APPLICATION_PROBLEM_JSON)
         .expectBody()
-        .json(expectedResponse);
+        .json(expectedResponse, JsonCompareMode.STRICT);
 
     verify(decisionRequirementsServices, never()).search(any(DecisionRequirementsQuery.class));
   }
@@ -319,7 +321,7 @@ public class DecisionRequirementsQueryControllerTest extends RestControllerTest 
         .expectStatus()
         .isOk()
         .expectBody()
-        .json(DECISION_REQUIREMENTS_ITEM_JSON);
+        .json(DECISION_REQUIREMENTS_ITEM_JSON, JsonCompareMode.STRICT);
 
     verify(decisionRequirementsServices, times(1)).getByKey(VALID_DECISION_REQUIREMENTS_KEY);
   }
@@ -471,7 +473,7 @@ public class DecisionRequirementsQueryControllerTest extends RestControllerTest 
         .expectHeader()
         .contentType(MediaType.APPLICATION_PROBLEM_JSON)
         .expectBody()
-        .json(expectedResponse);
+        .json(expectedResponse, JsonCompareMode.STRICT);
   }
 
   @Test
@@ -501,7 +503,7 @@ public class DecisionRequirementsQueryControllerTest extends RestControllerTest 
         .expectHeader()
         .contentType(MediaType.APPLICATION_PROBLEM_JSON)
         .expectBody()
-        .json(expectedResponse);
+        .json(expectedResponse, JsonCompareMode.STRICT);
   }
 
   @Test
@@ -528,6 +530,6 @@ public class DecisionRequirementsQueryControllerTest extends RestControllerTest 
         .expectHeader()
         .contentType(MediaType.APPLICATION_PROBLEM_JSON)
         .expectBody()
-        .json(expectedResponse);
+        .json(expectedResponse, JsonCompareMode.STRICT);
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ElementInstanceControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ElementInstanceControllerTest.java
@@ -27,6 +27,7 @@ import org.mockito.Mockito;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.json.JsonCompareMode;
 
 @WebMvcTest(ElementInstanceController.class)
 public class ElementInstanceControllerTest extends RestControllerTest {
@@ -112,7 +113,7 @@ public class ElementInstanceControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_PROBLEM_JSON)
         .expectBody()
-        .json(expectedBody);
+        .json(expectedBody, JsonCompareMode.STRICT);
   }
 
   @Test
@@ -147,7 +148,7 @@ public class ElementInstanceControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_PROBLEM_JSON)
         .expectBody()
-        .json(expectedBody);
+        .json(expectedBody, JsonCompareMode.STRICT);
   }
 
   @Test
@@ -185,6 +186,6 @@ public class ElementInstanceControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_PROBLEM_JSON)
         .expectBody()
-        .json(expectedBody);
+        .json(expectedBody, JsonCompareMode.STRICT);
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ElementInstanceQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ElementInstanceQueryControllerTest.java
@@ -40,6 +40,7 @@ import org.mockito.Captor;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.json.JsonCompareMode;
 
 @WebMvcTest(value = ElementInstanceController.class)
 public class ElementInstanceQueryControllerTest extends RestControllerTest {
@@ -66,7 +67,8 @@ public class ElementInstanceQueryControllerTest extends RestControllerTest {
               "page": {
                   "totalItems": 1,
                   "startCursor": "f",
-                  "endCursor": "v"
+                  "endCursor": "v",
+                  "hasMoreTotalItems": false
               }
           }""";
 
@@ -160,7 +162,7 @@ public class ElementInstanceQueryControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_JSON)
         .expectBody()
-        .json(EXPECTED_SEARCH_RESPONSE);
+        .json(EXPECTED_SEARCH_RESPONSE, JsonCompareMode.STRICT);
 
     verify(elementInstanceServices).search(new FlowNodeInstanceQuery.Builder().build());
   }
@@ -184,7 +186,7 @@ public class ElementInstanceQueryControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_JSON)
         .expectBody()
-        .json(EXPECTED_SEARCH_RESPONSE);
+        .json(EXPECTED_SEARCH_RESPONSE, JsonCompareMode.STRICT);
 
     verify(elementInstanceServices).search(new FlowNodeInstanceQuery.Builder().build());
   }
@@ -227,7 +229,7 @@ public class ElementInstanceQueryControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_JSON)
         .expectBody()
-        .json(EXPECTED_SEARCH_RESPONSE);
+        .json(EXPECTED_SEARCH_RESPONSE, JsonCompareMode.STRICT);
 
     verify(elementInstanceServices)
         .search(
@@ -288,7 +290,7 @@ public class ElementInstanceQueryControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_JSON)
         .expectBody()
-        .json(EXPECTED_SEARCH_RESPONSE);
+        .json(EXPECTED_SEARCH_RESPONSE, JsonCompareMode.STRICT);
 
     verify(elementInstanceServices)
         .search(
@@ -332,7 +334,7 @@ public class ElementInstanceQueryControllerTest extends RestControllerTest {
         .expectStatus()
         .isOk()
         .expectBody()
-        .json(EXPECTED_GET_RESPONSE);
+        .json(EXPECTED_GET_RESPONSE, JsonCompareMode.STRICT);
 
     verify(elementInstanceServices).getByKey(23L);
   }
@@ -420,7 +422,7 @@ public class ElementInstanceQueryControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_JSON)
         .expectBody()
-        .json(EXPECTED_SEARCH_RESPONSE);
+        .json(EXPECTED_SEARCH_RESPONSE, JsonCompareMode.STRICT);
 
     verify(elementInstanceServices)
         .search(new FlowNodeInstanceQuery.Builder().filter(filter).build());

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ErrorMapperTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ErrorMapperTest.java
@@ -57,6 +57,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ProblemDetail;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.json.JsonCompareMode;
 import org.springframework.web.servlet.View;
 import reactor.core.publisher.Mono;
 
@@ -244,7 +245,7 @@ public class ErrorMapperTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_PROBLEM_JSON)
         .expectBody()
-        .json(expectedBody);
+        .json(expectedBody, JsonCompareMode.STRICT);
 
     Mockito.verify(userTaskServices).completeUserTask(1L, Map.of(), "");
   }
@@ -285,7 +286,7 @@ public class ErrorMapperTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_PROBLEM_JSON)
         .expectBody()
-        .json(expectedBody);
+        .json(expectedBody, JsonCompareMode.STRICT);
 
     Mockito.verify(userTaskServices).completeUserTask(1L, Map.of(), "");
   }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/IncidentControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/IncidentControllerTest.java
@@ -27,6 +27,7 @@ import org.mockito.Mockito;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.json.JsonCompareMode;
 
 @WebMvcTest(IncidentController.class)
 public class IncidentControllerTest extends RestControllerTest {
@@ -106,7 +107,7 @@ public class IncidentControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_PROBLEM_JSON)
         .expectBody()
-        .json(expectedBody);
+        .json(expectedBody, JsonCompareMode.STRICT);
 
     Mockito.verify(incidentServices).resolveIncident(1L, null);
   }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/IncidentQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/IncidentQueryControllerTest.java
@@ -34,6 +34,7 @@ import org.mockito.ArgumentMatchers;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.json.JsonCompareMode;
 
 @WebMvcTest(value = IncidentController.class)
 public class IncidentQueryControllerTest extends RestControllerTest {
@@ -60,7 +61,8 @@ public class IncidentQueryControllerTest extends RestControllerTest {
               "page": {
                   "totalItems": 1,
                   "startCursor": "f",
-                  "endCursor": "v"
+                  "endCursor": "v",
+                  "hasMoreTotalItems": false
               }
           }""";
 
@@ -147,7 +149,7 @@ public class IncidentQueryControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_JSON)
         .expectBody()
-        .json(EXPECTED_SEARCH_RESPONSE);
+        .json(EXPECTED_SEARCH_RESPONSE, JsonCompareMode.STRICT);
 
     verify(incidentServices).search(new IncidentQuery.Builder().build());
   }
@@ -170,7 +172,7 @@ public class IncidentQueryControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_JSON)
         .expectBody()
-        .json(EXPECTED_SEARCH_RESPONSE);
+        .json(EXPECTED_SEARCH_RESPONSE, JsonCompareMode.STRICT);
 
     verify(incidentServices).search(new IncidentQuery.Builder().build());
   }
@@ -211,7 +213,7 @@ public class IncidentQueryControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_JSON)
         .expectBody()
-        .json(EXPECTED_SEARCH_RESPONSE);
+        .json(EXPECTED_SEARCH_RESPONSE, JsonCompareMode.STRICT);
 
     final var creationTime = OffsetDateTime.of(2024, 5, 23, 23, 5, 0, 0, ZoneOffset.UTC);
 
@@ -263,7 +265,7 @@ public class IncidentQueryControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_JSON)
         .expectBody()
-        .json(EXPECTED_SEARCH_RESPONSE);
+        .json(EXPECTED_SEARCH_RESPONSE, JsonCompareMode.STRICT);
 
     verify(incidentServices)
         .search(
@@ -285,7 +287,7 @@ public class IncidentQueryControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_JSON)
         .expectBody()
-        .json(EXPECTED_GET_RESPONSE);
+        .json(EXPECTED_GET_RESPONSE, JsonCompareMode.STRICT);
 
     verify(incidentServices).getByKey(23L);
   }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerLongPollingTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerLongPollingTest.java
@@ -49,6 +49,7 @@ import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.json.JsonCompareMode;
 import org.springframework.test.web.reactive.server.WebTestClient.ResponseSpec;
 import org.springframework.util.unit.DataSize;
 
@@ -146,7 +147,7 @@ public class JobControllerLongPollingTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_JSON)
         .expectBody()
-        .json(expectedBody);
+        .json(expectedBody, JsonCompareMode.STRICT);
 
     Mockito.verify(responseObserver, Mockito.never()).onNext(any());
     Mockito.verify(responseObserver).onCompleted();
@@ -270,7 +271,7 @@ public class JobControllerLongPollingTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_PROBLEM_JSON)
         .expectBody()
-        .json(expectedBody);
+        .json(expectedBody, JsonCompareMode.STRICT);
 
     assertThat(callCounter).hasValue(1);
   }
@@ -315,7 +316,11 @@ public class JobControllerLongPollingTest extends RestControllerTest {
             .expectStatus()
             .isOk();
 
-    response.expectHeader().contentType(MediaType.APPLICATION_JSON).expectBody().json(expectedBody);
+    response
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_JSON)
+        .expectBody()
+        .json(expectedBody, JsonCompareMode.STRICT);
   }
 
   @Test
@@ -356,7 +361,7 @@ public class JobControllerLongPollingTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_JSON)
         .expectBody()
-        .json(expectedBody);
+        .json(expectedBody, JsonCompareMode.STRICT);
   }
 
   @TestConfiguration

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerRoundRobinTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerRoundRobinTest.java
@@ -48,6 +48,7 @@ import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.json.JsonCompareMode;
 import org.springframework.util.unit.DataSize;
 
 @WebMvcTest(JobController.class)
@@ -109,11 +110,19 @@ public class JobControllerRoundRobinTest extends RestControllerTest {
               "retries": 12,
               "deadline": 123123123,
               "tenantId": "<default>",
-              "variables": {},
-              "customHeaders": {},
               "processDefinitionId": "stubProcess",
               "elementId": "stubActivity",
-              "worker": "bar"
+              "worker": "bar",
+              "customHeaders": {
+                "foo": 12,
+                "bar": "val"
+              },
+              "variables": {
+                "foo": 13,
+                "bar": "world"
+              },
+              "kind": "BPMN_ELEMENT",
+              "listenerEventType": "UNSPECIFIED"
             },
             {
               "jobKey": "%d",
@@ -125,11 +134,19 @@ public class JobControllerRoundRobinTest extends RestControllerTest {
               "retries": 12,
               "deadline": 123123123,
               "tenantId": "<default>",
-              "variables": {},
-              "customHeaders": {},
               "processDefinitionId": "stubProcess",
               "elementId": "stubActivity",
-              "worker": "bar"
+              "worker": "bar",
+              "customHeaders": {
+                "foo": 12,
+                "bar": "val"
+              },
+              "variables": {
+                "foo": 13,
+                "bar": "world"
+              },
+              "kind": "BPMN_ELEMENT",
+              "listenerEventType": "UNSPECIFIED"
             }
           ]
         }"""
@@ -149,7 +166,7 @@ public class JobControllerRoundRobinTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_JSON)
         .expectBody()
-        .json(expectedBody);
+        .json(expectedBody, JsonCompareMode.STRICT);
 
     // two responses where received (base partition determination and tested activation)
     Mockito.verify(responseObserver, Mockito.times(2)).onNext(any());
@@ -191,7 +208,7 @@ public class JobControllerRoundRobinTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_JSON)
         .expectBody()
-        .json(expectedBody);
+        .json(expectedBody, JsonCompareMode.STRICT);
 
     Mockito.verify(responseObserver, Mockito.never()).onNext(any());
     Mockito.verify(responseObserver).onCompleted();
@@ -292,7 +309,7 @@ public class JobControllerRoundRobinTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_PROBLEM_JSON)
         .expectBody()
-        .json(expectedBody);
+        .json(expectedBody, JsonCompareMode.STRICT);
 
     assertThat(callCounter).hasValue(1);
   }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerTest.java
@@ -41,6 +41,7 @@ import org.mockito.Mockito;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.json.JsonCompareMode;
 
 @WebMvcTest(JobController.class)
 public class JobControllerTest extends RestControllerTest {
@@ -188,7 +189,7 @@ public class JobControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_PROBLEM_JSON)
         .expectBody()
-        .json(expectedBody);
+        .json(expectedBody, JsonCompareMode.STRICT);
   }
 
   @Test
@@ -227,7 +228,7 @@ public class JobControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_PROBLEM_JSON)
         .expectBody()
-        .json(expectedBody);
+        .json(expectedBody, JsonCompareMode.STRICT);
   }
 
   @Test
@@ -267,7 +268,7 @@ public class JobControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_PROBLEM_JSON)
         .expectBody()
-        .json(expectedBody);
+        .json(expectedBody, JsonCompareMode.STRICT);
   }
 
   @Test
@@ -307,7 +308,7 @@ public class JobControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_PROBLEM_JSON)
         .expectBody()
-        .json(expectedBody);
+        .json(expectedBody, JsonCompareMode.STRICT);
   }
 
   @Test
@@ -815,7 +816,7 @@ public class JobControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_PROBLEM_JSON)
         .expectBody()
-        .json(expectedBody);
+        .json(expectedBody, JsonCompareMode.STRICT);
   }
 
   @Test
@@ -844,7 +845,7 @@ public class JobControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_PROBLEM_JSON)
         .expectBody()
-        .json(expectedBody);
+        .json(expectedBody, JsonCompareMode.STRICT);
   }
 
   @Test

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobQueryControllerTest.java
@@ -33,6 +33,7 @@ import org.mockito.ArgumentMatchers;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.json.JsonCompareMode;
 
 @WebMvcTest(value = JobController.class)
 public class JobQueryControllerTest extends RestControllerTest {
@@ -72,7 +73,8 @@ public class JobQueryControllerTest extends RestControllerTest {
             "page": {
                 "totalItems": 1,
                 "startCursor": "123base64",
-                "endCursor": "456base64"
+                "endCursor": "456base64",
+                "hasMoreTotalItems": false
             }
         }
         """;
@@ -135,7 +137,7 @@ public class JobQueryControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_JSON)
         .expectBody()
-        .json(EXPECTED_SEARCH_RESPONSE);
+        .json(EXPECTED_SEARCH_RESPONSE, JsonCompareMode.STRICT);
 
     verify(jobServices).search(new JobQuery.Builder().build());
   }
@@ -186,7 +188,7 @@ public class JobQueryControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_JSON)
         .expectBody()
-        .json(EXPECTED_SEARCH_RESPONSE);
+        .json(EXPECTED_SEARCH_RESPONSE, JsonCompareMode.STRICT);
 
     verify(jobServices)
         .search(
@@ -263,7 +265,7 @@ public class JobQueryControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_JSON)
         .expectBody()
-        .json(EXPECTED_SEARCH_RESPONSE);
+        .json(EXPECTED_SEARCH_RESPONSE, JsonCompareMode.STRICT);
 
     verify(jobServices)
         .search(

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/LicenseControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/LicenseControllerTest.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.test.json.JsonCompareMode;
 
 @WebMvcTest(value = LicenseController.class)
 public class LicenseControllerTest extends RestControllerTest {
@@ -63,7 +64,7 @@ public class LicenseControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_JSON)
         .expectBody()
-        .json(EXPECTED_LICENSE_RESPONSE);
+        .json(EXPECTED_LICENSE_RESPONSE, JsonCompareMode.STRICT);
 
     verify(managementServices).isCamundaLicenseValid();
     verify(managementServices).getCamundaLicenseType();
@@ -90,7 +91,7 @@ public class LicenseControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_JSON)
         .expectBody()
-        .json(EXPECTED_LICENSE_RESPONSE_NO_EXPIRATION);
+        .json(EXPECTED_LICENSE_RESPONSE_NO_EXPIRATION, JsonCompareMode.STRICT);
 
     verify(managementServices).isCamundaLicenseValid();
     verify(managementServices).getCamundaLicenseType();

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/MessageControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/MessageControllerTest.java
@@ -33,6 +33,7 @@ import org.mockito.Mockito;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.json.JsonCompareMode;
 import org.springframework.test.web.reactive.server.WebTestClient.ResponseSpec;
 
 @WebMvcTest(MessageController.class)
@@ -414,7 +415,7 @@ public class MessageControllerTest extends RestControllerTest {
         .expectStatus()
         .isOk()
         .expectBody()
-        .json(EXPECTED_PUBLICATION_RESPONSE);
+        .json(EXPECTED_PUBLICATION_RESPONSE, JsonCompareMode.STRICT);
 
     Mockito.verify(messageServices).publishMessage(publicationRequestCaptor.capture());
     final var capturedRequest = publicationRequestCaptor.getValue();
@@ -454,7 +455,7 @@ public class MessageControllerTest extends RestControllerTest {
         .expectStatus()
         .isOk()
         .expectBody()
-        .json(EXPECTED_PUBLICATION_RESPONSE);
+        .json(EXPECTED_PUBLICATION_RESPONSE, JsonCompareMode.STRICT);
 
     Mockito.verify(messageServices).publishMessage(publicationRequestCaptor.capture());
     final var capturedRequest = publicationRequestCaptor.getValue();
@@ -493,7 +494,7 @@ public class MessageControllerTest extends RestControllerTest {
         .expectStatus()
         .isOk()
         .expectBody()
-        .json(EXPECTED_PUBLICATION_RESPONSE);
+        .json(EXPECTED_PUBLICATION_RESPONSE, JsonCompareMode.STRICT);
 
     Mockito.verify(messageServices).publishMessage(publicationRequestCaptor.capture());
     final var capturedRequest = publicationRequestCaptor.getValue();
@@ -542,7 +543,7 @@ public class MessageControllerTest extends RestControllerTest {
         .expectStatus()
         .isBadRequest()
         .expectBody()
-        .json(expectedBody);
+        .json(expectedBody, JsonCompareMode.STRICT);
   }
 
   private CompletableFuture<BrokerResponse<MessageRecord>> buildPublishResponse() {

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/MessageSubscriptionQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/MessageSubscriptionQueryControllerTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.json.JsonCompareMode;
 
 @WebMvcTest(value = MessageSubscriptionController.class)
 public class MessageSubscriptionQueryControllerTest extends RestControllerTest {
@@ -50,7 +51,8 @@ public class MessageSubscriptionQueryControllerTest extends RestControllerTest {
             "page": {
                 "totalItems": 1,
                 "startCursor": "WzIyNTE3OTk4MTM2ODU4Mjld",
-                "endCursor": "WzIyNTE3OTk4MTM2ODU4NjZd"
+                "endCursor": "WzIyNTE3OTk4MTM2ODU4NjZd",
+                "hasMoreTotalItems": false
             }
         }
       """;
@@ -102,7 +104,7 @@ public class MessageSubscriptionQueryControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_JSON)
         .expectBody()
-        .json(EXPECTED_SEARCH_RESPONSE);
+        .json(EXPECTED_SEARCH_RESPONSE, JsonCompareMode.STRICT);
 
     verify(services).search(new MessageSubscriptionQuery.Builder().build());
   }
@@ -124,7 +126,7 @@ public class MessageSubscriptionQueryControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_JSON)
         .expectBody()
-        .json(EXPECTED_SEARCH_RESPONSE);
+        .json(EXPECTED_SEARCH_RESPONSE, JsonCompareMode.STRICT);
 
     verify(services).search(new MessageSubscriptionQuery.Builder().build());
   }
@@ -163,7 +165,7 @@ public class MessageSubscriptionQueryControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_JSON)
         .expectBody()
-        .json(EXPECTED_SEARCH_RESPONSE);
+        .json(EXPECTED_SEARCH_RESPONSE, JsonCompareMode.STRICT);
 
     verify(services)
         .search(
@@ -252,7 +254,7 @@ public class MessageSubscriptionQueryControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_JSON)
         .expectBody()
-        .json(EXPECTED_SEARCH_RESPONSE);
+        .json(EXPECTED_SEARCH_RESPONSE, JsonCompareMode.STRICT);
 
     verify(services)
         .search(

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessDefinitionQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessDefinitionQueryControllerTest.java
@@ -40,6 +40,7 @@ import org.mockito.ArgumentMatchers;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.json.JsonCompareMode;
 
 @WebMvcTest(value = ProcessDefinitionController.class)
 public class ProcessDefinitionQueryControllerTest extends RestControllerTest {
@@ -85,7 +86,8 @@ public class ProcessDefinitionQueryControllerTest extends RestControllerTest {
           "page": {
               "totalItems": 1,
               "startCursor": "f",
-              "endCursor": "v"
+              "endCursor": "v",
+              "hasMoreTotalItems": false
           }
       }""";
   static final SearchQueryResult<ProcessDefinitionEntity> SEARCH_QUERY_RESULT =
@@ -148,7 +150,7 @@ public class ProcessDefinitionQueryControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_JSON)
         .expectBody()
-        .json(EXPECTED_SEARCH_RESPONSE);
+        .json(EXPECTED_SEARCH_RESPONSE, JsonCompareMode.STRICT);
 
     verify(processDefinitionServices).search(new ProcessDefinitionQuery.Builder().build());
   }
@@ -199,7 +201,7 @@ public class ProcessDefinitionQueryControllerTest extends RestControllerTest {
         .expectStatus()
         .isOk()
         .expectBody()
-        .json(PROCESS_DEFINITION_ENTITY_JSON);
+        .json(PROCESS_DEFINITION_ENTITY_JSON, JsonCompareMode.STRICT);
 
     // Verify that the service was called with the valid key
     verify(processDefinitionServices).getByKey(23L);
@@ -286,7 +288,7 @@ public class ProcessDefinitionQueryControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_JSON)
         .expectBody()
-        .json(response);
+        .json(response, JsonCompareMode.STRICT);
 
     verify(processDefinitionServices)
         .elementStatistics(
@@ -337,7 +339,7 @@ public class ProcessDefinitionQueryControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_JSON)
         .expectBody()
-        .json(response);
+        .json(response, JsonCompareMode.STRICT);
 
     verify(processDefinitionServices)
         .elementStatistics(
@@ -406,7 +408,7 @@ public class ProcessDefinitionQueryControllerTest extends RestControllerTest {
         .expectStatus()
         .isOk()
         .expectBody()
-        .json(FORM_ITEM_JSON);
+        .json(FORM_ITEM_JSON, JsonCompareMode.STRICT);
 
     verify(processDefinitionServices, times(1)).getByKey(1L);
     verify(formServices, times(1)).getLatestVersionByFormId("formId");

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceControllerTest.java
@@ -49,6 +49,7 @@ import org.mockito.Mockito;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.json.JsonCompareMode;
 import org.springframework.test.web.reactive.server.WebTestClient.ResponseSpec;
 
 @WebMvcTest(value = ProcessInstanceController.class)
@@ -61,7 +62,8 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
              "processDefinitionId":"bpmnProcessId",
              "processDefinitionVersion":-1,
              "processInstanceKey":"123",
-             "tenantId":"tenantId"
+             "tenantId":"tenantId",
+             "variables":{}
           }""";
   static final String PROCESS_INSTANCES_START_URL = "/v2/process-instances";
   static final String CANCEL_PROCESS_URL = PROCESS_INSTANCES_START_URL + "/%s/cancellation";
@@ -123,7 +125,7 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_JSON)
         .expectBody()
-        .json(EXPECTED_START_RESPONSE);
+        .json(EXPECTED_START_RESPONSE, JsonCompareMode.STRICT);
 
     verify(processInstanceServices).createProcessInstance(createRequestCaptor.capture());
     final var capturedRequest = createRequestCaptor.getValue();
@@ -156,7 +158,8 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
               "processDefinitionId":"bpmnProcessId",
               "processDefinitionVersion":-1,
               "processInstanceKey":"123",
-              "tenantId":"<default>"
+              "tenantId":"<default>",
+              "variables":{}
             }""";
 
     // when / then
@@ -172,7 +175,7 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_JSON)
         .expectBody()
-        .json(expectedResponse);
+        .json(expectedResponse, JsonCompareMode.STRICT);
 
     verify(processInstanceServices).createProcessInstance(createRequestCaptor.capture());
     final var capturedRequest = createRequestCaptor.getValue();
@@ -220,7 +223,7 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_JSON)
         .expectBody()
-        .json(EXPECTED_START_RESPONSE);
+        .json(EXPECTED_START_RESPONSE, JsonCompareMode.STRICT);
 
     verify(processInstanceServices).createProcessInstance(createRequestCaptor.capture());
     final var capturedRequest = createRequestCaptor.getValue();
@@ -267,7 +270,7 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_JSON)
         .expectBody()
-        .json(EXPECTED_START_RESPONSE);
+        .json(EXPECTED_START_RESPONSE, JsonCompareMode.STRICT);
 
     verify(processInstanceServices).createProcessInstance(createRequestCaptor.capture());
     final var capturedRequest = createRequestCaptor.getValue();
@@ -316,7 +319,7 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_JSON)
         .expectBody()
-        .json(EXPECTED_START_RESPONSE);
+        .json(EXPECTED_START_RESPONSE, JsonCompareMode.STRICT);
 
     verify(processInstanceServices).createProcessInstanceWithResult(createRequestCaptor.capture());
     final var capturedRequest = createRequestCaptor.getValue();
@@ -366,7 +369,7 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_JSON)
         .expectBody()
-        .json(EXPECTED_START_RESPONSE);
+        .json(EXPECTED_START_RESPONSE, JsonCompareMode.STRICT);
 
     verify(processInstanceServices).createProcessInstanceWithResult(createRequestCaptor.capture());
     final var capturedRequest = createRequestCaptor.getValue();
@@ -415,7 +418,7 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_JSON)
         .expectBody()
-        .json(EXPECTED_START_RESPONSE);
+        .json(EXPECTED_START_RESPONSE, JsonCompareMode.STRICT);
 
     verify(processInstanceServices).createProcessInstanceWithResult(createRequestCaptor.capture());
     final var capturedRequest = createRequestCaptor.getValue();
@@ -456,7 +459,7 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_PROBLEM_JSON)
         .expectBody()
-        .json(expectedBody);
+        .json(expectedBody, JsonCompareMode.STRICT);
   }
 
   @Test
@@ -493,7 +496,7 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_PROBLEM_JSON)
         .expectBody()
-        .json(expectedBody);
+        .json(expectedBody, JsonCompareMode.STRICT);
   }
 
   @Test
@@ -529,7 +532,7 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_PROBLEM_JSON)
         .expectBody()
-        .json(expectedBody);
+        .json(expectedBody, JsonCompareMode.STRICT);
   }
 
   @Test
@@ -642,7 +645,7 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_PROBLEM_JSON)
         .expectBody()
-        .json(expectedBody);
+        .json(expectedBody, JsonCompareMode.STRICT);
   }
 
   @Test
@@ -730,7 +733,7 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_PROBLEM_JSON)
         .expectBody()
-        .json(expectedBody);
+        .json(expectedBody, JsonCompareMode.STRICT);
   }
 
   @Test
@@ -766,7 +769,7 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_PROBLEM_JSON)
         .expectBody()
-        .json(expectedBody);
+        .json(expectedBody, JsonCompareMode.STRICT);
   }
 
   @Test
@@ -803,7 +806,7 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_PROBLEM_JSON)
         .expectBody()
-        .json(expectedBody);
+        .json(expectedBody, JsonCompareMode.STRICT);
   }
 
   @Test
@@ -848,7 +851,7 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_PROBLEM_JSON)
         .expectBody()
-        .json(expectedBody);
+        .json(expectedBody, JsonCompareMode.STRICT);
   }
 
   @Test
@@ -894,7 +897,7 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_PROBLEM_JSON)
         .expectBody()
-        .json(expectedBody);
+        .json(expectedBody, JsonCompareMode.STRICT);
   }
 
   @Test
@@ -1138,7 +1141,7 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_PROBLEM_JSON)
         .expectBody()
-        .json(expectedBody);
+        .json(expectedBody, JsonCompareMode.STRICT);
   }
 
   @Test
@@ -1196,7 +1199,7 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_PROBLEM_JSON)
         .expectBody()
-        .json(expectedBody);
+        .json(expectedBody, JsonCompareMode.STRICT);
   }
 
   @Test
@@ -1247,7 +1250,7 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_PROBLEM_JSON)
         .expectBody()
-        .json(expectedBody);
+        .json(expectedBody, JsonCompareMode.STRICT);
   }
 
   @Test
@@ -1307,7 +1310,7 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_PROBLEM_JSON)
         .expectBody()
-        .json(expectedBody);
+        .json(expectedBody, JsonCompareMode.STRICT);
   }
 
   @Test
@@ -1429,7 +1432,7 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_JSON)
         .expectBody()
-        .json(response);
+        .json(response, JsonCompareMode.STRICT);
 
     verify(processInstanceServices).elementStatistics(processInstanceKey);
   }
@@ -1554,7 +1557,7 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_JSON)
         .expectBody()
-        .json(response);
+        .json(response, JsonCompareMode.STRICT);
 
     verify(processInstanceServices).sequenceFlows(processInstanceKey);
   }
@@ -1609,7 +1612,8 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
         "page": {
             "totalItems": 1,
             "startCursor": "<cursor before>",
-            "endCursor": "<cursor after>"
+            "endCursor": "<cursor after>",
+            "hasMoreTotalItems": false
         }
     }""";
 
@@ -1624,7 +1628,7 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_JSON)
         .expectBody()
-        .json(expectedResponse);
+        .json(expectedResponse, JsonCompareMode.STRICT);
 
     verify(processInstanceServices).searchIncidents(processInstanceKey, query);
   }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceQueryControllerTest.java
@@ -44,6 +44,7 @@ import org.mockito.Captor;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.json.JsonCompareMode;
 
 @WebMvcTest(value = ProcessInstanceController.class)
 public class ProcessInstanceQueryControllerTest extends RestControllerTest {
@@ -112,7 +113,8 @@ public class ProcessInstanceQueryControllerTest extends RestControllerTest {
               "page": {
                   "totalItems": 1,
                   "startCursor": "f",
-                  "endCursor": "v"
+                  "endCursor": "v",
+                  "hasMoreTotalItems": false
               }
           }
           """;
@@ -164,7 +166,7 @@ public class ProcessInstanceQueryControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_JSON)
         .expectBody()
-        .json(EXPECTED_SEARCH_RESPONSE);
+        .json(EXPECTED_SEARCH_RESPONSE, JsonCompareMode.STRICT);
 
     verify(processInstanceServices).search(new ProcessInstanceQuery.Builder().build());
   }
@@ -188,7 +190,7 @@ public class ProcessInstanceQueryControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_JSON)
         .expectBody()
-        .json(EXPECTED_SEARCH_RESPONSE);
+        .json(EXPECTED_SEARCH_RESPONSE, JsonCompareMode.STRICT);
 
     verify(processInstanceServices).search(new ProcessInstanceQuery.Builder().build());
   }
@@ -232,7 +234,7 @@ public class ProcessInstanceQueryControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_PROBLEM_JSON)
         .expectBody()
-        .json(expectedResponse);
+        .json(expectedResponse, JsonCompareMode.STRICT);
 
     verify(processInstanceServices, never()).search(any(ProcessInstanceQuery.class));
   }
@@ -275,7 +277,7 @@ public class ProcessInstanceQueryControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_PROBLEM_JSON)
         .expectBody()
-        .json(expectedResponse);
+        .json(expectedResponse, JsonCompareMode.STRICT);
 
     verify(processInstanceServices, never()).search(any(ProcessInstanceQuery.class));
   }
@@ -312,7 +314,7 @@ public class ProcessInstanceQueryControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_JSON)
         .expectBody()
-        .json(EXPECTED_SEARCH_RESPONSE);
+        .json(EXPECTED_SEARCH_RESPONSE, JsonCompareMode.STRICT);
 
     verify(processInstanceServices)
         .search(
@@ -364,7 +366,7 @@ public class ProcessInstanceQueryControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_PROBLEM_JSON)
         .expectBody()
-        .json(expectedResponse);
+        .json(expectedResponse, JsonCompareMode.STRICT);
 
     verify(processInstanceServices, never()).search(any(ProcessInstanceQuery.class));
   }
@@ -406,7 +408,7 @@ public class ProcessInstanceQueryControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_PROBLEM_JSON)
         .expectBody()
-        .json(expectedResponse);
+        .json(expectedResponse, JsonCompareMode.STRICT);
 
     verify(processInstanceServices, never()).search(any(ProcessInstanceQuery.class));
   }
@@ -447,7 +449,7 @@ public class ProcessInstanceQueryControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_PROBLEM_JSON)
         .expectBody()
-        .json(expectedResponse);
+        .json(expectedResponse, JsonCompareMode.STRICT);
 
     verify(processInstanceServices, never()).search(any(ProcessInstanceQuery.class));
   }
@@ -487,7 +489,7 @@ public class ProcessInstanceQueryControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_PROBLEM_JSON)
         .expectBody()
-        .json(expectedResponse);
+        .json(expectedResponse, JsonCompareMode.STRICT);
 
     verify(processInstanceServices, never()).search(any(ProcessInstanceQuery.class));
   }
@@ -508,7 +510,7 @@ public class ProcessInstanceQueryControllerTest extends RestControllerTest {
         .expectStatus()
         .isOk()
         .expectBody()
-        .json(PROCESS_INSTANCE_ENTITY_JSON);
+        .json(PROCESS_INSTANCE_ENTITY_JSON, JsonCompareMode.STRICT);
 
     // Verify that the service was called with the valid key
     verify(processInstanceServices).getByKey(validProcesInstanceKey);
@@ -644,7 +646,7 @@ public class ProcessInstanceQueryControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_JSON)
         .expectBody()
-        .json(EXPECTED_SEARCH_RESPONSE);
+        .json(EXPECTED_SEARCH_RESPONSE, JsonCompareMode.STRICT);
 
     verify(processInstanceServices)
         .search(new ProcessInstanceQuery.Builder().filter(filter).build());
@@ -680,7 +682,7 @@ public class ProcessInstanceQueryControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_JSON)
         .expectBody()
-        .json(EXPECTED_SEARCH_RESPONSE);
+        .json(EXPECTED_SEARCH_RESPONSE, JsonCompareMode.STRICT);
 
     // then
     verify(processInstanceServices)
@@ -732,7 +734,7 @@ public class ProcessInstanceQueryControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_JSON)
         .expectBody()
-        .json(EXPECTED_SEARCH_RESPONSE);
+        .json(EXPECTED_SEARCH_RESPONSE, JsonCompareMode.STRICT);
 
     verify(processInstanceServices)
         .search(new ProcessInstanceQuery.Builder().filter(expectedFilter.build()).build());
@@ -755,7 +757,7 @@ public class ProcessInstanceQueryControllerTest extends RestControllerTest {
         .expectStatus()
         .isOk()
         .expectBody()
-        .json(EXPECTED_CALL_HIERARCHY);
+        .json(EXPECTED_CALL_HIERARCHY, JsonCompareMode.STRICT);
 
     // Verify that the service was called with the valid key
     verify(processInstanceServices).callHierarchy(processInstanceKey);

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ResourceControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ResourceControllerTest.java
@@ -41,6 +41,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.client.MultipartBodyBuilder;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.json.JsonCompareMode;
 
 @WebMvcTest(ResourceController.class)
 public class ResourceControllerTest extends RestControllerTest {
@@ -494,7 +495,7 @@ public class ResourceControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_PROBLEM_JSON)
         .expectBody()
-        .json(expectedBody);
+        .json(expectedBody, JsonCompareMode.STRICT);
   }
 
   @Test
@@ -660,7 +661,7 @@ public class ResourceControllerTest extends RestControllerTest {
         .expectStatus()
         .isOk()
         .expectBody()
-        .json(content);
+        .json(content, JsonCompareMode.STRICT);
   }
 
   @Test

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/SignalControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/SignalControllerTest.java
@@ -28,6 +28,7 @@ import org.mockito.Mockito;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.json.JsonCompareMode;
 import org.springframework.test.web.reactive.server.WebTestClient.ResponseSpec;
 
 @WebMvcTest(SignalController.class)
@@ -85,7 +86,7 @@ public class SignalControllerTest extends RestControllerTest {
             .expectStatus()
             .isOk();
 
-    response.expectBody().json(EXPECTED_PUBLICATION_RESPONSE);
+    response.expectBody().json(EXPECTED_PUBLICATION_RESPONSE, JsonCompareMode.STRICT);
     Mockito.verify(signalServices)
         .broadcastSignal("signalName", Map.of("key", "value"), "tenantId");
   }
@@ -154,7 +155,7 @@ public class SignalControllerTest extends RestControllerTest {
             .expectStatus()
             .isOk();
 
-    response.expectBody().json(EXPECTED_PUBLICATION_RESPONSE);
+    response.expectBody().json(EXPECTED_PUBLICATION_RESPONSE, JsonCompareMode.STRICT);
     Mockito.verify(signalServices).broadcastSignal("", Map.of("key", "value"), "tenantId");
   }
 
@@ -190,7 +191,7 @@ public class SignalControllerTest extends RestControllerTest {
         .expectStatus()
         .isBadRequest()
         .expectBody()
-        .json(expectedBody);
+        .json(expectedBody, JsonCompareMode.STRICT);
   }
 
   private CompletableFuture<BrokerResponse<SignalRecord>> buildSignalResponse(

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/TopologyControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/TopologyControllerTest.java
@@ -23,6 +23,7 @@ import org.mockito.Mockito;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.json.JsonCompareMode;
 
 @WebMvcTest(TopologyController.class)
 public class TopologyControllerTest extends RestControllerTest {
@@ -106,7 +107,7 @@ public class TopologyControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_JSON)
         .expectBody()
-        .json(expectedResponse);
+        .json(expectedResponse, JsonCompareMode.STRICT);
   }
 
   @ParameterizedTest
@@ -134,7 +135,7 @@ public class TopologyControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_JSON)
         .expectBody()
-        .json(expectedResponse);
+        .json(expectedResponse, JsonCompareMode.STRICT);
   }
 
   /**

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/UsageMetricsControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/UsageMetricsControllerTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.json.JsonCompareMode;
 
 @WebMvcTest(UsageMetricsController.class)
 public class UsageMetricsControllerTest extends RestControllerTest {
@@ -71,7 +72,7 @@ public class UsageMetricsControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_JSON)
         .expectBody()
-        .json(EXPECTED_SEARCH_RESPONSE);
+        .json(EXPECTED_SEARCH_RESPONSE, JsonCompareMode.STRICT);
 
     final var startTime = OffsetDateTime.of(1970, 11, 14, 10, 50, 26, 0, ZoneOffset.UTC);
     final var endTime = OffsetDateTime.of(2024, 12, 31, 10, 50, 26, 0, ZoneOffset.UTC);
@@ -110,7 +111,7 @@ public class UsageMetricsControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_PROBLEM_JSON_VALUE)
         .expectBody()
-        .json(expectedResponse);
+        .json(expectedResponse, JsonCompareMode.STRICT);
   }
 
   @Test
@@ -137,7 +138,7 @@ public class UsageMetricsControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_PROBLEM_JSON_VALUE)
         .expectBody()
-        .json(expectedResponse);
+        .json(expectedResponse, JsonCompareMode.STRICT);
   }
 
   @Test
@@ -164,7 +165,7 @@ public class UsageMetricsControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_PROBLEM_JSON_VALUE)
         .expectBody()
-        .json(expectedResponse);
+        .json(expectedResponse, JsonCompareMode.STRICT);
   }
 
   @Test
@@ -191,6 +192,6 @@ public class UsageMetricsControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_PROBLEM_JSON_VALUE)
         .expectBody()
-        .json(expectedResponse);
+        .json(expectedResponse, JsonCompareMode.STRICT);
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/UserTaskControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/UserTaskControllerTest.java
@@ -40,6 +40,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.json.JsonCompareMode;
 
 @WebMvcTest(UserTaskController.class)
 public class UserTaskControllerTest extends RestControllerTest {
@@ -478,7 +479,7 @@ public class UserTaskControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_PROBLEM_JSON)
         .expectBody()
-        .json(expectedBody);
+        .json(expectedBody, JsonCompareMode.STRICT);
 
     Mockito.verifyNoInteractions(userTaskServices);
   }
@@ -519,7 +520,7 @@ public class UserTaskControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_PROBLEM_JSON)
         .expectBody()
-        .json(expectedBody);
+        .json(expectedBody, JsonCompareMode.STRICT);
 
     Mockito.verifyNoInteractions(userTaskServices);
   }
@@ -560,7 +561,7 @@ public class UserTaskControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_PROBLEM_JSON)
         .expectBody()
-        .json(expectedBody);
+        .json(expectedBody, JsonCompareMode.STRICT);
 
     Mockito.verifyNoInteractions(userTaskServices);
   }
@@ -605,7 +606,7 @@ public class UserTaskControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_PROBLEM_JSON)
         .expectBody()
-        .json(expectedBody);
+        .json(expectedBody, JsonCompareMode.STRICT);
 
     Mockito.verifyNoInteractions(userTaskServices);
   }
@@ -649,7 +650,7 @@ public class UserTaskControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_PROBLEM_JSON)
         .expectBody()
-        .json(expectedBody);
+        .json(expectedBody, JsonCompareMode.STRICT);
 
     Mockito.verifyNoInteractions(userTaskServices);
   }
@@ -688,7 +689,7 @@ public class UserTaskControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_PROBLEM_JSON)
         .expectBody()
-        .json(expectedBody);
+        .json(expectedBody, JsonCompareMode.STRICT);
 
     Mockito.verifyNoInteractions(userTaskServices);
   }
@@ -729,7 +730,7 @@ public class UserTaskControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_PROBLEM_JSON)
         .expectBody()
-        .json(expectedBody);
+        .json(expectedBody, JsonCompareMode.STRICT);
 
     Mockito.verifyNoInteractions(userTaskServices);
   }
@@ -778,7 +779,7 @@ public class UserTaskControllerTest extends RestControllerTest {
         .expectStatus()
         .isBadRequest()
         .expectBody()
-        .json(expectedBody);
+        .json(expectedBody, JsonCompareMode.STRICT);
 
     Mockito.verifyNoInteractions(userTaskServices);
   }
@@ -817,7 +818,7 @@ public class UserTaskControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_PROBLEM_JSON)
         .expectBody()
-        .json(expectedBody);
+        .json(expectedBody, JsonCompareMode.STRICT);
 
     Mockito.verify(userTaskServices).completeUserTask(1L, Map.of(), "");
   }
@@ -859,7 +860,7 @@ public class UserTaskControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_PROBLEM_JSON)
         .expectBody()
-        .json(expectedBody);
+        .json(expectedBody, JsonCompareMode.STRICT);
 
     Mockito.verify(userTaskServices).completeUserTask(1L, Map.of(), "");
   }
@@ -902,7 +903,7 @@ public class UserTaskControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_PROBLEM_JSON)
         .expectBody()
-        .json(expectedBody);
+        .json(expectedBody, JsonCompareMode.STRICT);
 
     Mockito.verify(userTaskServices).completeUserTask(1L, Map.of(), "");
   }
@@ -945,7 +946,7 @@ public class UserTaskControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_PROBLEM_JSON)
         .expectBody()
-        .json(expectedBody);
+        .json(expectedBody, JsonCompareMode.STRICT);
 
     Mockito.verify(userTaskServices).completeUserTask(1L, Map.of(), "");
   }
@@ -1161,7 +1162,7 @@ public class UserTaskControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_PROBLEM_JSON)
         .expectBody()
-        .json(expectedBody);
+        .json(expectedBody, JsonCompareMode.STRICT);
 
     Mockito.verifyNoInteractions(userTaskServices);
   }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/UserTaskQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/UserTaskQueryControllerTest.java
@@ -46,6 +46,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.json.JsonCompareMode;
 
 @WebMvcTest(value = UserTaskController.class)
 public class UserTaskQueryControllerTest extends RestControllerTest {
@@ -84,7 +85,8 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
               "page": {
                   "totalItems": 1,
                   "startCursor": "f",
-                  "endCursor": "v"
+                  "endCursor": "v",
+                  "hasMoreTotalItems": false
               }
           }""";
 
@@ -114,7 +116,8 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
         "page": {
           "totalItems": 2,
           "startCursor": "0",
-          "endCursor": "1"
+          "endCursor": "1",
+          "hasMoreTotalItems": false
         }
       }
       """;
@@ -261,7 +264,7 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(APPLICATION_JSON)
         .expectBody()
-        .json(EXPECTED_SEARCH_RESPONSE);
+        .json(EXPECTED_SEARCH_RESPONSE, JsonCompareMode.STRICT);
 
     verify(userTaskServices).search(new UserTaskQuery.Builder().build());
   }
@@ -284,7 +287,7 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(APPLICATION_JSON)
         .expectBody()
-        .json(EXPECTED_SEARCH_RESPONSE);
+        .json(EXPECTED_SEARCH_RESPONSE, JsonCompareMode.STRICT);
 
     verify(userTaskServices).search(new UserTaskQuery.Builder().build());
   }
@@ -320,7 +323,7 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(APPLICATION_JSON)
         .expectBody()
-        .json(EXPECTED_SEARCH_RESPONSE);
+        .json(EXPECTED_SEARCH_RESPONSE, JsonCompareMode.STRICT);
 
     verify(userTaskServices)
         .search(
@@ -369,7 +372,7 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_PROBLEM_JSON)
         .expectBody()
-        .json(expectedResponse);
+        .json(expectedResponse, JsonCompareMode.STRICT);
 
     verify(userTaskServices, never()).search(any(UserTaskQuery.class));
   }
@@ -412,7 +415,7 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_PROBLEM_JSON)
         .expectBody()
-        .json(expectedResponse);
+        .json(expectedResponse, JsonCompareMode.STRICT);
 
     verify(userTaskServices, never()).search(any(UserTaskQuery.class));
   }
@@ -456,7 +459,7 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_PROBLEM_JSON)
         .expectBody()
-        .json(expectedResponse);
+        .json(expectedResponse, JsonCompareMode.STRICT);
 
     verify(userTaskServices, never()).search(any(UserTaskQuery.class));
   }
@@ -499,7 +502,7 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_PROBLEM_JSON)
         .expectBody()
-        .json(expectedResponse);
+        .json(expectedResponse, JsonCompareMode.STRICT);
 
     verify(userTaskServices, never()).search(any(UserTaskQuery.class));
   }
@@ -541,7 +544,7 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_PROBLEM_JSON)
         .expectBody()
-        .json(expectedResponse);
+        .json(expectedResponse, JsonCompareMode.STRICT);
 
     verify(userTaskServices, never()).search(any(UserTaskQuery.class));
   }
@@ -583,7 +586,7 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_PROBLEM_JSON)
         .expectBody()
-        .json(expectedResponse);
+        .json(expectedResponse, JsonCompareMode.STRICT);
 
     verify(userTaskServices, never()).search(any(UserTaskQuery.class));
   }
@@ -624,7 +627,7 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_PROBLEM_JSON)
         .expectBody()
-        .json(expectedResponse);
+        .json(expectedResponse, JsonCompareMode.STRICT);
 
     verify(userTaskServices, never()).search(any(UserTaskQuery.class));
   }
@@ -664,7 +667,7 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_PROBLEM_JSON)
         .expectBody()
-        .json(expectedResponse);
+        .json(expectedResponse, JsonCompareMode.STRICT);
 
     verify(userTaskServices, never()).search(any(UserTaskQuery.class));
   }
@@ -680,7 +683,7 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
         .expectStatus()
         .isOk()
         .expectBody()
-        .json(USER_TASK_ITEM_JSON);
+        .json(USER_TASK_ITEM_JSON, JsonCompareMode.STRICT);
 
     // Verify that the service was called with the invalid userTaskKey
     verify(userTaskServices).getByKey(VALID_USER_TASK_KEY);
@@ -724,7 +727,7 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
         .expectStatus()
         .isOk()
         .expectBody()
-        .json(FORM_ITEM_JSON);
+        .json(FORM_ITEM_JSON, JsonCompareMode.STRICT);
 
     verify(userTaskServices).getUserTaskForm(VALID_FORM_KEY);
   }
@@ -807,7 +810,7 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
         .expectStatus()
         .isOk()
         .expectBody()
-        .json(EXPECTED_VARIABLE_RESULT_JSON);
+        .json(EXPECTED_VARIABLE_RESULT_JSON, JsonCompareMode.STRICT);
 
     verify(userTaskServices)
         .searchUserTaskVariables(
@@ -864,7 +867,7 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_JSON)
         .expectBody()
-        .json(EXPECTED_SEARCH_RESPONSE);
+        .json(EXPECTED_SEARCH_RESPONSE, JsonCompareMode.STRICT);
 
     verify(userTaskServices).search(new UserTaskQuery.Builder().filter(filter).build());
   }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/VariablesQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/VariablesQueryControllerTest.java
@@ -37,6 +37,7 @@ import org.mockito.Captor;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.json.JsonCompareMode;
 
 @WebMvcTest(value = VariableController.class)
 public class VariablesQueryControllerTest extends RestControllerTest {
@@ -91,7 +92,8 @@ public class VariablesQueryControllerTest extends RestControllerTest {
               "page": {
                   "totalItems": 2,
                   "startCursor": "0",
-                  "endCursor": "1"
+                  "endCursor": "1",
+                  "hasMoreTotalItems": false
               }
           }""";
 
@@ -144,7 +146,7 @@ public class VariablesQueryControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(APPLICATION_JSON)
         .expectBody()
-        .json(EXPECTED_SEARCH_RESPONSE);
+        .json(EXPECTED_SEARCH_RESPONSE, JsonCompareMode.STRICT);
 
     verify(variableServices).search(new VariableQuery.Builder().build());
   }
@@ -164,7 +166,7 @@ public class VariablesQueryControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(APPLICATION_JSON)
         .expectBody()
-        .json(EXPECTED_SEARCH_RESPONSE);
+        .json(EXPECTED_SEARCH_RESPONSE, JsonCompareMode.STRICT);
 
     verify(variableServices).search(new VariableQuery.Builder().build());
   }
@@ -200,7 +202,7 @@ public class VariablesQueryControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(APPLICATION_JSON)
         .expectBody()
-        .json(EXPECTED_SEARCH_RESPONSE);
+        .json(EXPECTED_SEARCH_RESPONSE, JsonCompareMode.STRICT);
 
     verify(variableServices)
         .search(
@@ -246,7 +248,7 @@ public class VariablesQueryControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_PROBLEM_JSON)
         .expectBody()
-        .json(expectedResponse);
+        .json(expectedResponse, JsonCompareMode.STRICT);
 
     verify(variableServices, never()).search(any(VariableQuery.class));
   }
@@ -287,7 +289,7 @@ public class VariablesQueryControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_PROBLEM_JSON)
         .expectBody()
-        .json(expectedResponse);
+        .json(expectedResponse, JsonCompareMode.STRICT);
 
     verify(variableServices, never()).search(any(VariableQuery.class));
   }
@@ -327,7 +329,7 @@ public class VariablesQueryControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_PROBLEM_JSON)
         .expectBody()
-        .json(expectedResponse);
+        .json(expectedResponse, JsonCompareMode.STRICT);
 
     verify(variableServices, never()).search(any(VariableQuery.class));
   }
@@ -367,7 +369,7 @@ public class VariablesQueryControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_PROBLEM_JSON)
         .expectBody()
-        .json(expectedResponse);
+        .json(expectedResponse, JsonCompareMode.STRICT);
 
     verify(variableServices, never()).search(any(VariableQuery.class));
   }
@@ -384,7 +386,7 @@ public class VariablesQueryControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(APPLICATION_JSON)
         .expectBody()
-        .json(EXPECT_SINGLE_VARIABLE_RESPONSE);
+        .json(EXPECT_SINGLE_VARIABLE_RESPONSE, JsonCompareMode.STRICT);
 
     verify(variableServices).getByKey(VALID_VARIABLE_KEY);
   }
@@ -401,7 +403,7 @@ public class VariablesQueryControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(APPLICATION_JSON)
         .expectBody()
-        .json(EXPECT_SINGLE_TRUNCATED_VARIABLE_RESPONSE);
+        .json(EXPECT_SINGLE_TRUNCATED_VARIABLE_RESPONSE, JsonCompareMode.STRICT);
 
     verify(variableServices).getByKey(VALID_TRUNCATED_VARIABLE_KEY);
   }
@@ -477,7 +479,7 @@ public class VariablesQueryControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_JSON)
         .expectBody()
-        .json(EXPECTED_SEARCH_RESPONSE);
+        .json(EXPECTED_SEARCH_RESPONSE, JsonCompareMode.STRICT);
 
     verify(variableServices).search(new VariableQuery.Builder().filter(filter).build());
   }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/setup/SetupControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/setup/SetupControllerTest.java
@@ -39,6 +39,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ProblemDetail;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.json.JsonCompareMode;
 
 @WebMvcTest(SetupController.class)
 class SetupControllerTest extends RestControllerTest {
@@ -368,6 +369,6 @@ class SetupControllerTest extends RestControllerTest {
         .expectStatus()
         .isBadRequest()
         .expectBody()
-        .json(expectedError);
+        .json(expectedError, JsonCompareMode.STRICT);
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantControllerTest.java
@@ -49,6 +49,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.json.JsonCompareMode;
 import org.springframework.test.web.reactive.server.WebTestClient;
 import org.springframework.test.web.reactive.server.WebTestClient.ResponseSpec;
 
@@ -667,7 +668,7 @@ public class TenantControllerTest {
           .expectStatus()
           .isForbidden()
           .expectBody()
-          .json(FORBIDDEN_MESSAGE.formatted(uri, uri));
+          .json(FORBIDDEN_MESSAGE.formatted(uri, uri), JsonCompareMode.STRICT);
     }
 
     private static Stream<Arguments> tenantControllerRequests() {

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantQueryControllerTest.java
@@ -44,6 +44,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.json.JsonCompareMode;
 
 @WebMvcTest(value = TenantController.class)
 public class TenantQueryControllerTest extends RestControllerTest {
@@ -97,7 +98,8 @@ public class TenantQueryControllerTest extends RestControllerTest {
          "page": {
            "totalItems": %s,
            "startCursor": "f",
-           "endCursor": "v"
+           "endCursor": "v",
+           "hasMoreTotalItems": false
          }
        }
       """;
@@ -137,7 +139,8 @@ public class TenantQueryControllerTest extends RestControllerTest {
          "page": {
            "totalItems": %s,
            "startCursor": "f",
-           "endCursor": "v"
+           "endCursor": "v",
+           "hasMoreTotalItems": false
          }
        }
       """;
@@ -168,7 +171,8 @@ public class TenantQueryControllerTest extends RestControllerTest {
          "page": {
            "totalItems": %s,
            "startCursor": "f",
-           "endCursor": "v"
+           "endCursor": "v",
+           "hasMoreTotalItems": false
          }
        }
       """;
@@ -201,7 +205,8 @@ public class TenantQueryControllerTest extends RestControllerTest {
          "page": {
            "totalItems": %s,
            "startCursor": "f",
-           "endCursor": "v"
+           "endCursor": "v",
+           "hasMoreTotalItems": false
          }
        }
       """;
@@ -332,7 +337,7 @@ public class TenantQueryControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_JSON)
         .expectBody()
-        .json(EXPECTED_RESPONSE);
+        .json(EXPECTED_RESPONSE, JsonCompareMode.STRICT);
 
     verify(tenantServices).search(new TenantQuery.Builder().build());
   }
@@ -367,7 +372,7 @@ public class TenantQueryControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_JSON)
         .expectBody()
-        .json(EXPECTED_RESPONSE);
+        .json(EXPECTED_RESPONSE, JsonCompareMode.STRICT);
 
     verify(tenantServices)
         .search(
@@ -406,7 +411,7 @@ public class TenantQueryControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_JSON)
         .expectBody()
-        .json(EXPECTED_MAPPING_RESPONSE);
+        .json(EXPECTED_MAPPING_RESPONSE, JsonCompareMode.STRICT);
   }
 
   @Test
@@ -438,7 +443,7 @@ public class TenantQueryControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_JSON)
         .expectBody()
-        .json(EXPECTED_MAPPING_RESPONSE);
+        .json(EXPECTED_MAPPING_RESPONSE, JsonCompareMode.STRICT);
   }
 
   @Test
@@ -471,7 +476,7 @@ public class TenantQueryControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_JSON)
         .expectBody()
-        .json(EXPECTED_ROLE_RESPONSE);
+        .json(EXPECTED_ROLE_RESPONSE, JsonCompareMode.STRICT);
   }
 
   @Test
@@ -503,7 +508,7 @@ public class TenantQueryControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_JSON)
         .expectBody()
-        .json(EXPECTED_ROLE_RESPONSE);
+        .json(EXPECTED_ROLE_RESPONSE, JsonCompareMode.STRICT);
   }
 
   @ParameterizedTest
@@ -523,7 +528,7 @@ public class TenantQueryControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_PROBLEM_JSON)
         .expectBody()
-        .json(expectedResponse);
+        .json(expectedResponse, JsonCompareMode.STRICT);
 
     verify(tenantServices, never()).search(any(TenantQuery.class));
   }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/AuthorizationQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/AuthorizationQueryControllerTest.java
@@ -38,6 +38,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.json.JsonCompareMode;
 
 @WebMvcTest(value = AuthorizationController.class)
 public class AuthorizationQueryControllerTest extends RestControllerTest {
@@ -58,7 +59,8 @@ public class AuthorizationQueryControllerTest extends RestControllerTest {
              "page": {
                "totalItems": 1,
                "startCursor": "f",
-               "endCursor": "v"
+               "endCursor": "v",
+               "hasMoreTotalItems": false
              }
            }""";
   private static final String AUTHORIZATION_SEARCH_URL = "/v2/authorizations/search";
@@ -180,7 +182,7 @@ public class AuthorizationQueryControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_JSON)
         .expectBody()
-        .json(EXPECTED_SEARCH_RESPONSE);
+        .json(EXPECTED_SEARCH_RESPONSE, JsonCompareMode.STRICT);
 
     verify(authorizationServices).search(new AuthorizationQuery.Builder().build());
   }
@@ -204,7 +206,7 @@ public class AuthorizationQueryControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_JSON)
         .expectBody()
-        .json(EXPECTED_SEARCH_RESPONSE);
+        .json(EXPECTED_SEARCH_RESPONSE, JsonCompareMode.STRICT);
 
     verify(authorizationServices).search(new AuthorizationQuery.Builder().build());
   }
@@ -237,7 +239,7 @@ public class AuthorizationQueryControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_JSON)
         .expectBody()
-        .json(EXPECTED_SEARCH_RESPONSE);
+        .json(EXPECTED_SEARCH_RESPONSE, JsonCompareMode.STRICT);
 
     verify(authorizationServices)
         .search(
@@ -263,7 +265,7 @@ public class AuthorizationQueryControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_PROBLEM_JSON)
         .expectBody()
-        .json(expectedResponse);
+        .json(expectedResponse, JsonCompareMode.STRICT);
 
     verify(authorizationServices, never()).search(any(AuthorizationQuery.class));
   }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupControllerTest.java
@@ -45,6 +45,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.json.JsonCompareMode;
 
 public class GroupControllerTest {
 
@@ -85,7 +86,8 @@ public class GroupControllerTest {
           .expectStatus()
           .isForbidden()
           .expectBody()
-          .json(FORBIDDEN_MESSAGE.formatted(GROUP_BASE_URL, GROUP_BASE_URL));
+          .json(
+              FORBIDDEN_MESSAGE.formatted(GROUP_BASE_URL, GROUP_BASE_URL), JsonCompareMode.STRICT);
     }
 
     @Test
@@ -107,7 +109,7 @@ public class GroupControllerTest {
           .expectStatus()
           .isForbidden()
           .expectBody()
-          .json(FORBIDDEN_MESSAGE.formatted(uri, uri));
+          .json(FORBIDDEN_MESSAGE.formatted(uri, uri), JsonCompareMode.STRICT);
     }
 
     @Test
@@ -124,7 +126,7 @@ public class GroupControllerTest {
           .expectStatus()
           .isForbidden()
           .expectBody()
-          .json(FORBIDDEN_MESSAGE.formatted(uri, uri));
+          .json(FORBIDDEN_MESSAGE.formatted(uri, uri), JsonCompareMode.STRICT);
     }
 
     @Test
@@ -143,7 +145,7 @@ public class GroupControllerTest {
           .expectStatus()
           .isForbidden()
           .expectBody()
-          .json(FORBIDDEN_MESSAGE.formatted(uri, uri));
+          .json(FORBIDDEN_MESSAGE.formatted(uri, uri), JsonCompareMode.STRICT);
     }
 
     @Test
@@ -161,7 +163,7 @@ public class GroupControllerTest {
           .expectStatus()
           .isForbidden()
           .expectBody()
-          .json(FORBIDDEN_MESSAGE.formatted(uri, uri));
+          .json(FORBIDDEN_MESSAGE.formatted(uri, uri), JsonCompareMode.STRICT);
     }
 
     @Test
@@ -179,7 +181,7 @@ public class GroupControllerTest {
           .expectStatus()
           .isForbidden()
           .expectBody()
-          .json(FORBIDDEN_MESSAGE.formatted(uri, uri));
+          .json(FORBIDDEN_MESSAGE.formatted(uri, uri), JsonCompareMode.STRICT);
     }
 
     @Test
@@ -199,7 +201,7 @@ public class GroupControllerTest {
           .expectStatus()
           .isForbidden()
           .expectBody()
-          .json(FORBIDDEN_MESSAGE.formatted(uri, uri));
+          .json(FORBIDDEN_MESSAGE.formatted(uri, uri), JsonCompareMode.STRICT);
     }
   }
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupQueryControllerTest.java
@@ -44,6 +44,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.json.JsonCompareMode;
 
 @WebMvcTest(value = GroupController.class)
 public class GroupQueryControllerTest extends RestControllerTest {
@@ -71,7 +72,8 @@ public class GroupQueryControllerTest extends RestControllerTest {
         "page":{
           "totalItems":3,
           "startCursor":"f",
-          "endCursor":"v"
+          "endCursor":"v",
+          "hasMoreTotalItems": false
         }
       }
       """;
@@ -101,7 +103,8 @@ public class GroupQueryControllerTest extends RestControllerTest {
         "page":{
           "totalItems":3,
           "startCursor":"f",
-          "endCursor":"v"
+          "endCursor":"v",
+          "hasMoreTotalItems": false
         }
       }
       """;
@@ -129,7 +132,8 @@ public class GroupQueryControllerTest extends RestControllerTest {
         "page":{
           "totalItems":3,
           "startCursor":"f",
-          "endCursor":"v"
+          "endCursor":"v",
+          "hasMoreTotalItems": false
         }
       }
       """;
@@ -163,7 +167,8 @@ public class GroupQueryControllerTest extends RestControllerTest {
         "page":{
           "totalItems":3,
           "startCursor":"f",
-          "endCursor":"v"
+          "endCursor":"v",
+          "hasMoreTotalItems": false
         }
       }
       """;
@@ -213,7 +218,8 @@ public class GroupQueryControllerTest extends RestControllerTest {
         "page":{
           "totalItems":2,
           "startCursor":"f",
-          "endCursor":"v"
+          "endCursor":"v",
+          "hasMoreTotalItems": false
         }
       }
       """;
@@ -519,7 +525,9 @@ public class GroupQueryControllerTest extends RestControllerTest {
         .expectStatus()
         .isOk()
         .expectBody()
-        .json(EXPECTED_SEARCH_RESPONSE.formatted(groupId1, groupId2, groupId3));
+        .json(
+            EXPECTED_SEARCH_RESPONSE.formatted(groupId1, groupId2, groupId3),
+            JsonCompareMode.STRICT);
 
     verify(groupServices)
         .search(
@@ -559,7 +567,7 @@ public class GroupQueryControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_JSON)
         .expectBody()
-        .json(EXPECTED_USER_RESPONSE);
+        .json(EXPECTED_USER_RESPONSE, JsonCompareMode.STRICT);
   }
 
   @Test
@@ -591,7 +599,7 @@ public class GroupQueryControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_JSON)
         .expectBody()
-        .json(EXPECTED_USER_RESPONSE);
+        .json(EXPECTED_USER_RESPONSE, JsonCompareMode.STRICT);
   }
 
   @Test
@@ -624,7 +632,7 @@ public class GroupQueryControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_JSON)
         .expectBody()
-        .json(EXPECTED_MAPPING_RESPONSE);
+        .json(EXPECTED_MAPPING_RESPONSE, JsonCompareMode.STRICT);
   }
 
   @Test
@@ -656,7 +664,7 @@ public class GroupQueryControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_JSON)
         .expectBody()
-        .json(EXPECTED_MAPPING_RESPONSE);
+        .json(EXPECTED_MAPPING_RESPONSE, JsonCompareMode.STRICT);
   }
 
   @Test
@@ -689,7 +697,7 @@ public class GroupQueryControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_JSON)
         .expectBody()
-        .json(EXPECTED_ROLE_RESPONSE);
+        .json(EXPECTED_ROLE_RESPONSE, JsonCompareMode.STRICT);
   }
 
   @Test
@@ -721,7 +729,7 @@ public class GroupQueryControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_JSON)
         .expectBody()
-        .json(EXPECTED_ROLE_RESPONSE);
+        .json(EXPECTED_ROLE_RESPONSE, JsonCompareMode.STRICT);
   }
 
   @Test
@@ -754,7 +762,7 @@ public class GroupQueryControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_JSON)
         .expectBody()
-        .json(EXPECTED_CLIENT_RESPONSE);
+        .json(EXPECTED_CLIENT_RESPONSE, JsonCompareMode.STRICT);
   }
 
   @Test
@@ -786,7 +794,7 @@ public class GroupQueryControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_JSON)
         .expectBody()
-        .json(EXPECTED_CLIENT_RESPONSE);
+        .json(EXPECTED_CLIENT_RESPONSE, JsonCompareMode.STRICT);
   }
 
   @ParameterizedTest
@@ -806,7 +814,7 @@ public class GroupQueryControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_PROBLEM_JSON)
         .expectBody()
-        .json(expectedResponse);
+        .json(expectedResponse, JsonCompareMode.STRICT);
 
     verify(groupServices, never()).search(any(GroupQuery.class));
   }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/MappingControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/MappingControllerTest.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.json.JsonCompareMode;
 
 @WebMvcTest(MappingRuleController.class)
 public class MappingControllerTest extends RestControllerTest {
@@ -482,7 +483,7 @@ public class MappingControllerTest extends RestControllerTest {
         .expectStatus()
         .isBadRequest()
         .expectBody()
-        .json(expectedError);
+        .json(expectedError, JsonCompareMode.STRICT);
   }
 
   private void assertRequestRejectedExceptionally(
@@ -497,6 +498,6 @@ public class MappingControllerTest extends RestControllerTest {
         .expectStatus()
         .isBadRequest()
         .expectBody()
-        .json(expectedError);
+        .json(expectedError, JsonCompareMode.STRICT);
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/UserControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/UserControllerTest.java
@@ -37,6 +37,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ProblemDetail;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.json.JsonCompareMode;
 
 @WebMvcTest(UserController.class)
 public class UserControllerTest extends RestControllerTest {
@@ -382,6 +383,6 @@ public class UserControllerTest extends RestControllerTest {
         .expectStatus()
         .isBadRequest()
         .expectBody()
-        .json(expectedError);
+        .json(expectedError, JsonCompareMode.STRICT);
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/UserQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/UserQueryControllerTest.java
@@ -37,6 +37,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.json.JsonCompareMode;
 
 @WebMvcTest(value = UserController.class)
 public class UserQueryControllerTest extends RestControllerTest {
@@ -54,7 +55,8 @@ public class UserQueryControllerTest extends RestControllerTest {
               "page": {
                   "totalItems": 1,
                   "startCursor": "f",
-                  "endCursor": "v"
+                  "endCursor": "v",
+                  "hasMoreTotalItems": false
               }
           }""";
   private static final String USERS_SEARCH_URL = "/v2/users/search";
@@ -156,7 +158,7 @@ public class UserQueryControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_JSON)
         .expectBody()
-        .json(EXPECTED_SEARCH_RESPONSE);
+        .json(EXPECTED_SEARCH_RESPONSE, JsonCompareMode.STRICT);
 
     verify(userServices).search(new UserQuery.Builder().build());
   }
@@ -179,7 +181,7 @@ public class UserQueryControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_JSON)
         .expectBody()
-        .json(EXPECTED_SEARCH_RESPONSE);
+        .json(EXPECTED_SEARCH_RESPONSE, JsonCompareMode.STRICT);
 
     verify(userServices).search(new UserQuery.Builder().build());
   }
@@ -211,7 +213,7 @@ public class UserQueryControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_JSON)
         .expectBody()
-        .json(EXPECTED_SEARCH_RESPONSE);
+        .json(EXPECTED_SEARCH_RESPONSE, JsonCompareMode.STRICT);
 
     verify(userServices)
         .search(new UserQuery.Builder().sort(new UserSort.Builder().name().desc().build()).build());
@@ -234,7 +236,7 @@ public class UserQueryControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_PROBLEM_JSON)
         .expectBody()
-        .json(expectedResponse);
+        .json(expectedResponse, JsonCompareMode.STRICT);
 
     verify(userServices, never()).search(any(UserQuery.class));
   }


### PR DESCRIPTION
## Description

Adjusts REST API controller tests to do strict JSON tests. This ensures we are aware of all attributes that endpoints return. Adjusts controller tests to verify all attributes.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

n/a
