### PR TITLE
[Backport stable/8.6] deps: update tomcat version to 10.1.43

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -100,6 +100,7 @@
     <version.spring>6.2.8</version.spring>
     <version.spring-security>6.5.1</version.spring-security>
     <version.spring-boot>3.4.7</version.spring-boot>
+    <version.tomcat>10.1.43</version.tomcat>
     <version.concurrentunit>0.4.6</version.concurrentunit>
     <version.kryo>5.6.2</version.kryo>
     <version.failsafe>2.4.4</version.failsafe>
@@ -1930,6 +1931,22 @@
         <groupId>org.testcontainers</groupId>
         <artifactId>postgresql</artifactId>
         <version>${version.postgres-test-container}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.apache.tomcat.embed</groupId>
+        <artifactId>tomcat-embed-core</artifactId>
+        <version>${version.tomcat}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.tomcat.embed</groupId>
+        <artifactId>tomcat-embed-el</artifactId>
+        <version>${version.tomcat}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.tomcat.embed</groupId>
+        <artifactId>tomcat-embed-websocket</artifactId>
+        <version>${version.tomcat}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
# Description
Backport of #35461 to `stable/8.6`.

relates to camunda/camunda#35459