### PR TITLE
Add CamundaClient builder for ad-hoc sub process job completion results

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/command/CompleteAdHocSubProcessResultStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/CompleteAdHocSubProcessResultStep1.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.command;
+
+import java.io.InputStream;
+import java.util.Map;
+
+public interface CompleteAdHocSubProcessResultStep1 extends CompleteJobResult {
+
+  /**
+   * Adds an element to activate in the ad-hoc sub-process.
+   *
+   * @return this result
+   */
+  CompleteAdHocSubProcessResultStep2 activateElement(String elementId);
+
+  interface CompleteAdHocSubProcessResultStep2
+      extends CompleteAdHocSubProcessResultStep1,
+          CommandWithVariables<CompleteAdHocSubProcessResultStep1> {
+    /**
+     * The variables that will be created on the activated element instance.
+     *
+     * @param variables the variables JSON document as String
+     * @return the builder for this command.
+     */
+    @Override
+    CompleteAdHocSubProcessResultStep1 variables(String variables);
+
+    /**
+     * The variables that will be created on the activated element instance.
+     *
+     * @param variables the variables document as object to be serialized to JSON
+     * @return the builder for this command.
+     */
+    @Override
+    CompleteAdHocSubProcessResultStep1 variables(Object variables);
+
+    /**
+     * The variables that will be created on the activated element instance.
+     *
+     * @param variables the variables JSON document as stream
+     * @return the builder for this command.
+     */
+    @Override
+    CompleteAdHocSubProcessResultStep1 variables(InputStream variables);
+
+    /**
+     * The variables that will be created on the activated element instance.
+     *
+     * @param variables the variables document as map
+     * @return the builder for this command.
+     */
+    @Override
+    CompleteAdHocSubProcessResultStep1 variables(Map<String, Object> variables);
+
+    /**
+     * A single variable that will be created on the activated element instance.
+     *
+     * @param key the key of the variable as string
+     * @param value the value of the variable as object
+     * @return the builder for this command.
+     */
+    @Override
+    CompleteAdHocSubProcessResultStep1 variable(String key, Object value);
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/api/command/CompleteJobCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/CompleteJobCommandStep1.java
@@ -96,15 +96,37 @@ public interface CompleteJobCommandStep1
      *
      * <pre>{@code
      * client.newCompleteJobCommand(jobKey)
-     *     .withResult()
-     *     .correctAssignee("john_doe")                 // dynamically reassigns the task to 'john_doe'
-     *     .correctPriority(84)                         // adjusts the priority of the task
-     *     .correctDueDate("2024-11-22T11:44:55.0000Z") // sets a new due date
-     *     .send();
+     *     .withResult(r -> r.forUserTask()
+     *      .correctAssignee("john_doe")                 // dynamically reassigns the task to 'john_doe'
+     *      .correctPriority(84)                         // adjusts the priority of the task
+     *      .correctDueDate("2024-11-22T11:44:55.0000Z")) // sets a new due date
+     *      .send();
      * }</pre>
      *
      * @return the builder for this command.
      */
     CompleteUserTaskJobResult forUserTask();
+
+    /**
+     * Initialized the job result to allow activation of elements in an ad-hoc sub process.
+     *
+     * <p>This method is used to activate elements as a followup of a job completion. It will
+     * activate elements by id and variables provided will be created in the scope of the created
+     * element.
+     *
+     * <pre>{@code
+     * client.newCompleteJobCommand(jobKey)
+     *  .withResult(r -> r.forAdHocSubProcess()
+     *    .activateElement("elementId")           // Activate the element with id 'elementId'
+     *    .variable("key", "value")               // Create variable in the scope of 'elementId'
+     *    .activateElement("anotherElementId"))   // Activate another element with id 'anotherElementId'
+     *    .variable("key", "value")               // Create a variable in the scope of 'anotherElementId'
+     *    .send();
+     *
+     * }</pre>
+     *
+     * @return the builder for this command.
+     */
+    CompleteAdHocSubProcessResultStep1 forAdHocSubProcess();
   }
 }

--- a/clients/java/src/main/java/io/camunda/client/api/command/CompleteJobCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/CompleteJobCommandStep1.java
@@ -105,7 +105,7 @@ public interface CompleteJobCommandStep1
      *
      * @return the builder for this command.
      */
-    CompleteUserTaskJobResult forUserTask();
+    CompleteUserTaskJobResultStep1 forUserTask();
 
     /**
      * Initialized the job result to allow activation of elements in an ad-hoc sub process.

--- a/clients/java/src/main/java/io/camunda/client/api/command/CompleteUserTaskJobResultStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/CompleteUserTaskJobResultStep1.java
@@ -15,20 +15,10 @@
  */
 package io.camunda.client.api.command;
 
-import io.camunda.client.protocol.rest.JobResult.TypeEnum;
 import java.util.List;
 import java.util.function.UnaryOperator;
 
-public class CompleteUserTaskJobResult implements CompleteJobResult {
-
-  private boolean isDenied;
-  private String deniedReason;
-  private JobResultCorrections corrections;
-
-  public CompleteUserTaskJobResult() {
-    corrections = new JobResultCorrections();
-  }
-
+public interface CompleteUserTaskJobResultStep1 extends CompleteJobResult {
   /**
    * Indicates whether the worker denies the work, i.e. explicitly doesn't approve it. For example,
    * a user task listener can deny the completion of a task by setting this flag to true. In this
@@ -39,10 +29,7 @@ public class CompleteUserTaskJobResult implements CompleteJobResult {
    * @param isDenied indicates if the worker has denied the reason for the job
    * @return this job result
    */
-  public CompleteUserTaskJobResult deny(final boolean isDenied) {
-    this.isDenied = isDenied;
-    return this;
-  }
+  CompleteUserTaskJobResultStep1 deny(final boolean isDenied);
 
   /**
    * Indicates whether the worker denies the work, i.e. explicitly doesn't approve it. For example,
@@ -56,11 +43,7 @@ public class CompleteUserTaskJobResult implements CompleteJobResult {
    * @param deniedReason indicates the reason why the worker denied the job
    * @return this job result
    */
-  public CompleteUserTaskJobResult deny(final boolean isDenied, final String deniedReason) {
-    deny(isDenied);
-    deniedReason(deniedReason);
-    return this;
-  }
+  CompleteUserTaskJobResultStep1 deny(final boolean isDenied, final String deniedReason);
 
   /**
    * Indicates the reason why the worker denied the job. For example, a user task listener can deny
@@ -70,10 +53,7 @@ public class CompleteUserTaskJobResult implements CompleteJobResult {
    * @param deniedReason indicates the reason why the worker denied the job
    * @return this job result
    */
-  public CompleteUserTaskJobResult deniedReason(final String deniedReason) {
-    this.deniedReason = deniedReason;
-    return this;
-  }
+  CompleteUserTaskJobResultStep1 deniedReason(final String deniedReason);
 
   /**
    * Applies corrections to the user task attributes.
@@ -84,14 +64,7 @@ public class CompleteUserTaskJobResult implements CompleteJobResult {
    * @param corrections the corrections to apply to the user task.
    * @return this job result
    */
-  public CompleteUserTaskJobResult correct(final JobResultCorrections corrections) {
-    if (corrections == null) {
-      this.corrections = new JobResultCorrections();
-    } else {
-      this.corrections = corrections;
-    }
-    return this;
-  }
+  CompleteUserTaskJobResultStep1 correct(final JobResultCorrections corrections);
 
   /**
    * Dynamically applies corrections to the user task attributes using a lambda expression.
@@ -105,9 +78,7 @@ public class CompleteUserTaskJobResult implements CompleteJobResult {
    * @param corrections a lambda expression to modify the {@link JobResultCorrections}.
    * @return this job result
    */
-  public CompleteUserTaskJobResult correct(final UnaryOperator<JobResultCorrections> corrections) {
-    return correct(corrections.apply(this.corrections));
-  }
+  CompleteUserTaskJobResultStep1 correct(final UnaryOperator<JobResultCorrections> corrections);
 
   /**
    * Correct the assignee of the task.
@@ -115,10 +86,7 @@ public class CompleteUserTaskJobResult implements CompleteJobResult {
    * @param assignee assignee of the task
    * @return this job result
    */
-  public CompleteUserTaskJobResult correctAssignee(final String assignee) {
-    corrections.assignee(assignee);
-    return this;
-  }
+  CompleteUserTaskJobResultStep1 correctAssignee(final String assignee);
 
   /**
    * Correct the due date of the task.
@@ -126,10 +94,7 @@ public class CompleteUserTaskJobResult implements CompleteJobResult {
    * @param dueDate due date of the task
    * @return this job result
    */
-  public CompleteUserTaskJobResult correctDueDate(final String dueDate) {
-    corrections.dueDate(dueDate);
-    return this;
-  }
+  CompleteUserTaskJobResultStep1 correctDueDate(final String dueDate);
 
   /**
    * Correct the follow up date of the task.
@@ -137,10 +102,7 @@ public class CompleteUserTaskJobResult implements CompleteJobResult {
    * @param followUpDate follow up date of the task
    * @return this job result
    */
-  public CompleteUserTaskJobResult correctFollowUpDate(final String followUpDate) {
-    corrections.followUpDate(followUpDate);
-    return this;
-  }
+  CompleteUserTaskJobResultStep1 correctFollowUpDate(final String followUpDate);
 
   /**
    * Correct the candidate groups of the task.
@@ -148,10 +110,7 @@ public class CompleteUserTaskJobResult implements CompleteJobResult {
    * @param candidateGroups candidate groups of the task
    * @return this job result
    */
-  public CompleteUserTaskJobResult correctCandidateGroups(final List<String> candidateGroups) {
-    corrections.candidateGroups(candidateGroups);
-    return this;
-  }
+  CompleteUserTaskJobResultStep1 correctCandidateGroups(final List<String> candidateGroups);
 
   /**
    * Correct the candidate users of the task.
@@ -159,10 +118,7 @@ public class CompleteUserTaskJobResult implements CompleteJobResult {
    * @param candidateUsers candidate users of the task
    * @return this job result
    */
-  public CompleteUserTaskJobResult correctCandidateUsers(final List<String> candidateUsers) {
-    corrections.candidateUsers(candidateUsers);
-    return this;
-  }
+  CompleteUserTaskJobResultStep1 correctCandidateUsers(final List<String> candidateUsers);
 
   /**
    * Correct the priority of the task.
@@ -170,25 +126,5 @@ public class CompleteUserTaskJobResult implements CompleteJobResult {
    * @param priority priority of the task
    * @return this job result
    */
-  public CompleteUserTaskJobResult correctPriority(final Integer priority) {
-    corrections.priority(priority);
-    return this;
-  }
-
-  public boolean isDenied() {
-    return isDenied;
-  }
-
-  public String getDeniedReason() {
-    return deniedReason;
-  }
-
-  public JobResultCorrections getCorrections() {
-    return corrections;
-  }
-
-  @Override
-  public TypeEnum getType() {
-    return TypeEnum.USER_TASK;
-  }
+  CompleteUserTaskJobResultStep1 correctPriority(final Integer priority);
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/command/CompleteAdHocSubProcessJobResultImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/CompleteAdHocSubProcessJobResultImpl.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.command;
+
+import io.camunda.client.api.JsonMapper;
+import io.camunda.client.api.command.CompleteAdHocSubProcessResultStep1;
+import io.camunda.client.api.command.CompleteAdHocSubProcessResultStep1.CompleteAdHocSubProcessResultStep2;
+import io.camunda.client.protocol.rest.JobResult.TypeEnum;
+import java.util.ArrayList;
+import java.util.List;
+
+public class CompleteAdHocSubProcessJobResultImpl
+    extends CommandWithVariables<CompleteAdHocSubProcessResultStep2>
+    implements CompleteAdHocSubProcessResultStep1, CompleteAdHocSubProcessResultStep2 {
+
+  private final List<ActivateElement> activateElements = new ArrayList<>();
+  private ActivateElement latestActivateElement;
+
+  public CompleteAdHocSubProcessJobResultImpl(final JsonMapper jsonMapper) {
+    super(jsonMapper);
+  }
+
+  public List<ActivateElement> getActivateElements() {
+    return activateElements;
+  }
+
+  @Override
+  public TypeEnum getType() {
+    return TypeEnum.AD_HOC_SUB_PROCESS;
+  }
+
+  @Override
+  public CompleteAdHocSubProcessResultStep2 activateElement(final String elementId) {
+    ArgumentUtil.ensureNotNull("elementId", elementId);
+    latestActivateElement = new ActivateElement().setElementId(elementId);
+    activateElements.add(latestActivateElement);
+    return this;
+  }
+
+  @Override
+  protected CompleteAdHocSubProcessResultStep2 setVariablesInternal(final String variables) {
+    latestActivateElement.setVariables(variables);
+    return this;
+  }
+
+  public static class ActivateElement {
+    private String elementId;
+    private String variables;
+
+    public String getElementId() {
+      return elementId;
+    }
+
+    public ActivateElement setElementId(final String elementId) {
+      this.elementId = elementId;
+      return this;
+    }
+
+    public String getVariables() {
+      return variables;
+    }
+
+    public ActivateElement setVariables(final String variables) {
+      this.variables = variables;
+      return this;
+    }
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/command/CompleteJobCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/CompleteJobCommandImpl.java
@@ -22,7 +22,6 @@ import io.camunda.client.api.command.CompleteAdHocSubProcessResultStep1;
 import io.camunda.client.api.command.CompleteJobCommandStep1;
 import io.camunda.client.api.command.CompleteJobCommandStep1.CompleteJobCommandJobResultStep;
 import io.camunda.client.api.command.CompleteJobResult;
-import io.camunda.client.api.command.CompleteUserTaskJobResult;
 import io.camunda.client.api.command.FinalCommandStep;
 import io.camunda.client.api.response.CompleteJobResponse;
 import io.camunda.client.impl.RetriableClientFutureImpl;
@@ -105,8 +104,8 @@ public final class CompleteJobCommandImpl extends CommandWithVariables<CompleteJ
   public CompleteJobCommandStep1 withResult(
       final Function<CompleteJobCommandJobResultStep, CompleteJobResult> function) {
     final CompleteJobResult result = function.apply(this);
-    if (result instanceof CompleteUserTaskJobResult) {
-      setJobResult((CompleteUserTaskJobResult) result);
+    if (result instanceof CompleteUserTaskJobResultImpl) {
+      setJobResult((CompleteUserTaskJobResultImpl) result);
     } else if (result instanceof CompleteAdHocSubProcessResultStep1) {
       setJobResult(((CompleteAdHocSubProcessJobResultImpl) result));
     } else {
@@ -117,8 +116,8 @@ public final class CompleteJobCommandImpl extends CommandWithVariables<CompleteJ
   }
 
   @Override
-  public CompleteUserTaskJobResult forUserTask() {
-    return new CompleteUserTaskJobResult();
+  public CompleteUserTaskJobResultImpl forUserTask() {
+    return new CompleteUserTaskJobResultImpl();
   }
 
   @Override
@@ -126,7 +125,7 @@ public final class CompleteJobCommandImpl extends CommandWithVariables<CompleteJ
     return new CompleteAdHocSubProcessJobResultImpl(objectMapper);
   }
 
-  private void setJobResult(final CompleteUserTaskJobResult jobResult) {
+  private void setJobResult(final CompleteUserTaskJobResultImpl jobResult) {
     if (useRest) {
       setRestJobResult(jobResult);
     } else {
@@ -134,7 +133,7 @@ public final class CompleteJobCommandImpl extends CommandWithVariables<CompleteJ
     }
   }
 
-  private void setRestJobResult(final CompleteUserTaskJobResult jobResult) {
+  private void setRestJobResult(final CompleteUserTaskJobResultImpl jobResult) {
     final JobResultUserTask resultRest = new JobResultUserTask();
     final JobResultCorrections correctionsRest = new JobResultCorrections();
     correctionsRest
@@ -152,7 +151,7 @@ public final class CompleteJobCommandImpl extends CommandWithVariables<CompleteJ
     httpRequestObject.setResult(resultRest);
   }
 
-  private void setGrpcJobResult(final CompleteUserTaskJobResult jobResult) {
+  private void setGrpcJobResult(final CompleteUserTaskJobResultImpl jobResult) {
     final JobResult.Builder resultGrpc = JobResult.newBuilder();
     final GatewayOuterClass.JobResultCorrections.Builder correctionsGrpc =
         GatewayOuterClass.JobResultCorrections.newBuilder();

--- a/clients/java/src/main/java/io/camunda/client/impl/command/CompleteUserTaskJobResultImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/CompleteUserTaskJobResultImpl.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.command;
+
+import io.camunda.client.api.command.CompleteUserTaskJobResultStep1;
+import io.camunda.client.api.command.JobResultCorrections;
+import io.camunda.client.protocol.rest.JobResult.TypeEnum;
+import java.util.List;
+import java.util.function.UnaryOperator;
+
+public class CompleteUserTaskJobResultImpl implements CompleteUserTaskJobResultStep1 {
+
+  private boolean isDenied;
+  private String deniedReason;
+  private JobResultCorrections corrections;
+
+  public CompleteUserTaskJobResultImpl() {
+    corrections = new JobResultCorrections();
+  }
+
+  @Override
+  public CompleteUserTaskJobResultImpl deny(final boolean isDenied) {
+    this.isDenied = isDenied;
+    return this;
+  }
+
+  @Override
+  public CompleteUserTaskJobResultImpl deny(final boolean isDenied, final String deniedReason) {
+    deny(isDenied);
+    deniedReason(deniedReason);
+    return this;
+  }
+
+  @Override
+  public CompleteUserTaskJobResultImpl deniedReason(final String deniedReason) {
+    this.deniedReason = deniedReason;
+    return this;
+  }
+
+  @Override
+  public CompleteUserTaskJobResultImpl correct(final JobResultCorrections corrections) {
+    if (corrections == null) {
+      this.corrections = new JobResultCorrections();
+    } else {
+      this.corrections = corrections;
+    }
+    return this;
+  }
+
+  @Override
+  public CompleteUserTaskJobResultImpl correct(
+      final UnaryOperator<JobResultCorrections> corrections) {
+    return correct(corrections.apply(this.corrections));
+  }
+
+  @Override
+  public CompleteUserTaskJobResultImpl correctAssignee(final String assignee) {
+    corrections.assignee(assignee);
+    return this;
+  }
+
+  @Override
+  public CompleteUserTaskJobResultImpl correctDueDate(final String dueDate) {
+    corrections.dueDate(dueDate);
+    return this;
+  }
+
+  @Override
+  public CompleteUserTaskJobResultImpl correctFollowUpDate(final String followUpDate) {
+    corrections.followUpDate(followUpDate);
+    return this;
+  }
+
+  @Override
+  public CompleteUserTaskJobResultImpl correctCandidateGroups(final List<String> candidateGroups) {
+    corrections.candidateGroups(candidateGroups);
+    return this;
+  }
+
+  @Override
+  public CompleteUserTaskJobResultImpl correctCandidateUsers(final List<String> candidateUsers) {
+    corrections.candidateUsers(candidateUsers);
+    return this;
+  }
+
+  @Override
+  public CompleteUserTaskJobResultImpl correctPriority(final Integer priority) {
+    corrections.priority(priority);
+    return this;
+  }
+
+  public boolean isDenied() {
+    return isDenied;
+  }
+
+  public String getDeniedReason() {
+    return deniedReason;
+  }
+
+  public JobResultCorrections getCorrections() {
+    return corrections;
+  }
+
+  @Override
+  public TypeEnum getType() {
+    return TypeEnum.USER_TASK;
+  }
+}

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/RequestMapper.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/RequestMapper.java
@@ -234,7 +234,7 @@ public final class RequestMapper extends RequestUtil {
             element -> {
               final var activateElement =
                   new JobResultActivateElement().setElementId(element.getElementId());
-              if (element.getVariables() != null && !element.getVariables().isEmpty()) {
+              if (!element.getVariables().isEmpty()) {
                 activateElement.setVariables(
                     new UnsafeBuffer(MsgPackConverter.convertToMsgPack(element.getVariables())));
               }

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/RequestMapper.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/RequestMapper.java
@@ -231,12 +231,15 @@ public final class RequestMapper extends RequestUtil {
     jobResult.setType(JobResultType.from(result.getType()));
     result.getActivateElementsList().stream()
         .map(
-            element ->
-                new JobResultActivateElement()
-                    .setElementId(element.getElementId())
-                    .setVariables(
-                        new UnsafeBuffer(
-                            MsgPackConverter.convertToMsgPack(element.getVariables()))))
+            element -> {
+              final var activateElement =
+                  new JobResultActivateElement().setElementId(element.getElementId());
+              if (element.getVariables() != null && !element.getVariables().isEmpty()) {
+                activateElement.setVariables(
+                    new UnsafeBuffer(MsgPackConverter.convertToMsgPack(element.getVariables())));
+              }
+              return activateElement;
+            })
         .forEach(jobResult::addActivateElement);
     return jobResult;
   }

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/RequestMapper.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/RequestMapper.java
@@ -52,7 +52,9 @@ import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ThrowErrorRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.UpdateJobRetriesRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.UpdateJobTimeoutRequest;
 import io.camunda.zeebe.msgpack.value.StringValue;
+import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobResult;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobResultActivateElement;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobResultCorrections;
 import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
 import io.camunda.zeebe.protocol.impl.stream.job.JobActivationProperties;
@@ -63,6 +65,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Pattern;
 import org.agrona.DirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
 import org.apache.commons.lang3.StringUtils;
 
 public final class RequestMapper extends RequestUtil {
@@ -170,18 +173,25 @@ public final class RequestMapper extends RequestUtil {
       return null;
     }
 
-    if (!request.getResult().hasCorrections()) {
+    return switch (request.getResult().getType()) {
+      case "userTask" -> getUserTaskJobResult(request.getResult());
+      case "adHocSubProcess" -> getAdHocSubProcessJobResult(request.getResult());
+      default -> getUserTaskJobResult(request.getResult());
+    };
+  }
+
+  private static JobResult getUserTaskJobResult(final GatewayOuterClass.JobResult result) {
+    if (!result.hasCorrections()) {
       return new JobResult()
-          .setType(JobResultType.from(request.getResult().getType()))
-          .setDenied(request.getResult().getDenied())
-          .setDeniedReason(request.getResult().getDeniedReason());
+          .setType(JobResultType.from(result.getType()))
+          .setDenied(result.getDenied())
+          .setDeniedReason(result.getDeniedReason());
     }
 
     final JobResultCorrections corrections = new JobResultCorrections();
     final List<String> correctedAttributes = new ArrayList<>();
 
-    final GatewayOuterClass.JobResultCorrections requestCorrections =
-        request.getResult().getCorrections();
+    final GatewayOuterClass.JobResultCorrections requestCorrections = result.getCorrections();
 
     if (requestCorrections.hasAssignee()) {
       corrections.setAssignee(requestCorrections.getAssignee());
@@ -209,11 +219,26 @@ public final class RequestMapper extends RequestUtil {
     }
 
     return new JobResult()
-        .setType(JobResultType.from(request.getResult().getType()))
-        .setDenied(request.getResult().getDenied())
-        .setDeniedReason(request.getResult().getDeniedReason())
+        .setType(JobResultType.from(result.getType()))
+        .setDenied(result.getDenied())
+        .setDeniedReason(result.getDeniedReason())
         .setCorrections(corrections)
         .setCorrectedAttributes(correctedAttributes);
+  }
+
+  private static JobResult getAdHocSubProcessJobResult(final GatewayOuterClass.JobResult result) {
+    final JobResult jobResult = new JobResult();
+    jobResult.setType(JobResultType.from(result.getType()));
+    result.getActivateElementsList().stream()
+        .map(
+            element ->
+                new JobResultActivateElement()
+                    .setElementId(element.getElementId())
+                    .setVariables(
+                        new UnsafeBuffer(
+                            MsgPackConverter.convertToMsgPack(element.getVariables()))))
+        .forEach(jobResult::addActivateElement);
+    return jobResult;
   }
 
   public static BrokerCreateProcessInstanceRequest toCreateProcessInstanceRequest(

--- a/zeebe/gateway-protocol/src/main/proto/gateway.proto
+++ b/zeebe/gateway-protocol/src/main/proto/gateway.proto
@@ -182,7 +182,7 @@ message JobResult{
   optional JobResultCorrections corrections = 2;
   // The reason provided by the user task listener for denying the work.
   optional string deniedReason = 3;
-  // Used to distinguish between different types of job results. Must be one of ["userTask", "adHocSubprocess"]. If not set, defaults to "userTask".
+  // Used to distinguish between different types of job results. Must be one of ["userTask", "adHocSubProcess"]. If not set, defaults to "userTask".
   optional string type = 4;
   // The list of elements that should be activated after the job is completed. Only relevant for ad-hoc subprocesses.
   repeated JobResultActivateElement activateElements = 5;

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RequestMapper.java
@@ -81,6 +81,7 @@ import io.camunda.zeebe.gateway.protocol.rest.JobActivationRequest;
 import io.camunda.zeebe.gateway.protocol.rest.JobCompletionRequest;
 import io.camunda.zeebe.gateway.protocol.rest.JobErrorRequest;
 import io.camunda.zeebe.gateway.protocol.rest.JobFailRequest;
+import io.camunda.zeebe.gateway.protocol.rest.JobResultAdHocSubProcess;
 import io.camunda.zeebe.gateway.protocol.rest.JobResultUserTask;
 import io.camunda.zeebe.gateway.protocol.rest.JobUpdateRequest;
 import io.camunda.zeebe.gateway.protocol.rest.MappingRuleCreateRequest;
@@ -113,6 +114,7 @@ import io.camunda.zeebe.gateway.rest.validator.TenantRequestValidator;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationProcessInstanceModificationMoveInstruction;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobResult;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobResultActivateElement;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobResultCorrections;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceCreationRuntimeInstruction;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceMigrationMappingInstruction;
@@ -936,16 +938,20 @@ public class RequestMapper {
     if (request == null || request.getResult() == null) {
       return new JobResult();
     }
+    return switch (request.getResult().getType()) {
+      case USER_TASK -> getJobResult((JobResultUserTask) request.getResult());
+      case AD_HOC_SUB_PROCESS -> getJobResult((JobResultAdHocSubProcess) request.getResult());
+    };
+  }
 
+  private static JobResult getJobResult(final JobResultUserTask result) {
     final JobResult jobResult = new JobResult();
-    final var jobResultUserTask = (JobResultUserTask) request.getResult();
-    jobResult.setType(JobResultType.from(jobResultUserTask.getType().getValue()));
-    jobResult.setDenied(
-        getBooleanOrDefault(request, r -> ((JobResultUserTask) r.getResult()).getDenied(), false));
-    jobResult.setDeniedReason(
-        getStringOrEmpty(request, r -> ((JobResultUserTask) r.getResult()).getDeniedReason()));
+    jobResult.setType(JobResultType.from(result.getType().getValue()));
+    jobResult.setDenied(result.getDenied() != null ? result.getDenied() : false);
+    jobResult.setDenied(getBooleanOrDefault(result, JobResultUserTask::getDenied, false));
+    jobResult.setDeniedReason(getStringOrEmpty(result, JobResultUserTask::getDeniedReason));
 
-    final var jobResultCorrections = jobResultUserTask.getCorrections();
+    final var jobResultCorrections = result.getCorrections();
     if (jobResultCorrections == null) {
       return jobResult;
     }
@@ -980,6 +986,24 @@ public class RequestMapper {
 
     jobResult.setCorrections(corrections);
     jobResult.setCorrectedAttributes(correctedAttributes);
+    return jobResult;
+  }
+
+  private static JobResult getJobResult(final JobResultAdHocSubProcess result) {
+    final JobResult jobResult = new JobResult();
+    jobResult.setType(JobResultType.from(result.getType().getValue()));
+    result.getActivateElements().stream()
+        .map(
+            element -> {
+              final var activateElement =
+                  new JobResultActivateElement().setElementId(element.getElementId());
+              if (element.getVariables() != null) {
+                activateElement.setVariables(
+                    new UnsafeBuffer(MsgPackConverter.convertToMsgPack(element.getVariables())));
+              }
+              return activateElement;
+            })
+        .forEach(jobResult::addActivateElement);
     return jobResult;
   }
 

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobResult.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobResult.java
@@ -151,4 +151,9 @@ public class JobResult extends UnpackedObject implements JobResultValue {
         element -> activateElementsProp.add().copyFrom((JobResultActivateElement) element));
     return this;
   }
+
+  public JobResult addActivateElement(final JobResultActivateElement activateElement) {
+    activateElementsProp.add().copyFrom(activateElement);
+    return this;
+  }
 }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/JobResultType.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/JobResultType.java
@@ -24,7 +24,7 @@ public enum JobResultType {
   /** Represents a user task job result type. */
   USER_TASK("userTask"),
   /** Represents an ad-hoc subprocess job result type. */
-  AD_HOC_SUB_PROCESS("adHocSubprocess");
+  AD_HOC_SUB_PROCESS("adHocSubProcess");
 
   final String type;
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Relies on https://github.com/camunda/camunda/pull/35466 being merged first

This PR adds the builder for the ad-hoc sub process job results. The builder lets users define a collection of activate elements, as well as variables for these elements. The API is used like so:

```java
    client
        .newCompleteCommand(jobKey)
        .withResult(
            r ->
                r.forAdHocSubProcess()
                    .activateElement(elementId1)
                    .variable("key", "value")
                    .activateElement(elementId2)
                    .variable("anotherKey", "anotherValue")
                    .activateElement(elementId3))
        .send()
        .join();
```

Variable calls are added to the element id that was added called before. Adding variables is optional.

I have added a slight refactoring on the user task job result as well. We had an implementation class in the API. I've added an interface in between. There's no need for users create this implementation class themselves.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes https://github.com/camunda/ad-hoc-sub-process-phase-3/issues/5 (must be manually closed due to different repo)
