### PR TITLE
refactor: get entities by id and key

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/security/RdbmsResourceAccessController.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/security/RdbmsResourceAccessController.java
@@ -16,6 +16,13 @@ import java.util.function.Function;
 public class RdbmsResourceAccessController implements ResourceAccessController {
 
   @Override
+  public <T> T doGet(
+      final SecurityContext securityContext,
+      final Function<ResourceAccessChecks, T> resourceChecksApplier) {
+    return resourceChecksApplier.apply(ResourceAccessChecks.disabled());
+  }
+
+  @Override
   public <T> T doSearch(
       final SecurityContext securityContext,
       final Function<ResourceAccessChecks, T> resourceChecksApplier) {

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/AuthorizationDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/AuthorizationDbReader.java
@@ -45,6 +45,16 @@ public class AuthorizationDbReader extends AbstractEntityReader<AuthorizationEnt
   }
 
   @Override
+  public AuthorizationEntity getByKey(
+      final long key, final ResourceAccessChecks resourceAccessChecks) {
+    return search(
+            AuthorizationQuery.of(q -> q.filter(f -> f.authorizationKey(key)).singleResult()),
+            resourceAccessChecks)
+        .items()
+        .getFirst();
+  }
+
+  @Override
   public SearchQueryResult<AuthorizationEntity> search(
       final AuthorizationQuery query, final ResourceAccessChecks resourceAccessChecks) {
     final var dbSort =

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/BatchOperationDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/BatchOperationDbReader.java
@@ -42,8 +42,8 @@ public class BatchOperationDbReader extends AbstractEntityReader<BatchOperationE
   }
 
   @Override
-  public BatchOperationEntity getById(final String id,
-      final ResourceAccessChecks resourceAccessChecks) {
+  public BatchOperationEntity getById(
+      final String id, final ResourceAccessChecks resourceAccessChecks) {
     return findOne(id).orElse(null);
   }
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/BatchOperationDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/BatchOperationDbReader.java
@@ -41,14 +41,10 @@ public class BatchOperationDbReader extends AbstractEntityReader<BatchOperationE
     return batchOperationMapper.count(query) == 1;
   }
 
-  public Optional<BatchOperationEntity> findOne(final String batchOperationKey) {
-    final var result =
-        search(BatchOperationQuery.of(b -> b.filter(f -> f.batchOperationKeys(batchOperationKey))));
-    return Optional.ofNullable(result.items()).flatMap(it -> it.stream().findFirst());
-  }
-
-  public SearchQueryResult<BatchOperationEntity> search(final BatchOperationQuery query) {
-    return search(query, ResourceAccessChecks.disabled());
+  @Override
+  public BatchOperationEntity getById(final String id,
+      final ResourceAccessChecks resourceAccessChecks) {
+    return findOne(id).orElse(null);
   }
 
   @Override
@@ -67,5 +63,15 @@ public class BatchOperationDbReader extends AbstractEntityReader<BatchOperationE
             .toList();
     ensureSingleResultIfRequired(hits, query);
     return buildSearchQueryResult(totalHits, hits, dbSort);
+  }
+
+  public Optional<BatchOperationEntity> findOne(final String batchOperationKey) {
+    final var result =
+        search(BatchOperationQuery.of(b -> b.filter(f -> f.batchOperationKeys(batchOperationKey))));
+    return Optional.ofNullable(result.items()).flatMap(it -> it.stream().findFirst());
+  }
+
+  public SearchQueryResult<BatchOperationEntity> search(final BatchOperationQuery query) {
+    return search(query, ResourceAccessChecks.disabled());
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/DecisionDefinitionDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/DecisionDefinitionDbReader.java
@@ -31,16 +31,10 @@ public class DecisionDefinitionDbReader extends AbstractEntityReader<DecisionDef
     this.decisionDefinitionMapper = decisionDefinitionMapper;
   }
 
-  public Optional<DecisionDefinitionEntity> findOne(final long decisionDefinitionKey) {
-    final var result =
-        search(
-            DecisionDefinitionQuery.of(
-                b -> b.filter(f -> f.decisionDefinitionKeys(decisionDefinitionKey))));
-    return Optional.ofNullable(result.items()).flatMap(it -> it.stream().findFirst());
-  }
-
-  public SearchQueryResult<DecisionDefinitionEntity> search(final DecisionDefinitionQuery query) {
-    return search(query, ResourceAccessChecks.disabled());
+  @Override
+  public DecisionDefinitionEntity getByKey(final long key,
+      final ResourceAccessChecks resourceAccessChecks) {
+    return findOne(key).orElse(null);
   }
 
   @Override
@@ -57,5 +51,17 @@ public class DecisionDefinitionDbReader extends AbstractEntityReader<DecisionDef
     final var hits = decisionDefinitionMapper.search(dbQuery);
     ensureSingleResultIfRequired(hits, query);
     return buildSearchQueryResult(totalHits, hits, dbSort);
+  }
+
+  public Optional<DecisionDefinitionEntity> findOne(final long decisionDefinitionKey) {
+    final var result =
+        search(
+            DecisionDefinitionQuery.of(
+                b -> b.filter(f -> f.decisionDefinitionKeys(decisionDefinitionKey))));
+    return Optional.ofNullable(result.items()).flatMap(it -> it.stream().findFirst());
+  }
+
+  public SearchQueryResult<DecisionDefinitionEntity> search(final DecisionDefinitionQuery query) {
+    return search(query, ResourceAccessChecks.disabled());
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/DecisionDefinitionDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/DecisionDefinitionDbReader.java
@@ -32,8 +32,8 @@ public class DecisionDefinitionDbReader extends AbstractEntityReader<DecisionDef
   }
 
   @Override
-  public DecisionDefinitionEntity getByKey(final long key,
-      final ResourceAccessChecks resourceAccessChecks) {
+  public DecisionDefinitionEntity getByKey(
+      final long key, final ResourceAccessChecks resourceAccessChecks) {
     return findOne(key).orElse(null);
   }
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/DecisionInstanceDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/DecisionInstanceDbReader.java
@@ -40,20 +40,10 @@ public class DecisionInstanceDbReader extends AbstractEntityReader<DecisionInsta
     this.decisionInstanceMapper = decisionInstanceMapper;
   }
 
-  public Optional<DecisionInstanceEntity> findOne(final String decisionInstanceId) {
-    LOG.trace("[RDBMS DB] Search for decision instance with key {}", decisionInstanceId);
-    final var result =
-        search(
-            DecisionInstanceQuery.of(
-                b ->
-                    b.filter(f -> f.decisionInstanceIds(decisionInstanceId))
-                        .resultConfig(
-                            r -> r.includeEvaluatedInputs(true).includeEvaluatedOutputs(true))));
-    return Optional.ofNullable(result.items()).flatMap(it -> it.stream().findFirst());
-  }
-
-  public SearchQueryResult<DecisionInstanceEntity> search(final DecisionInstanceQuery query) {
-    return search(query, ResourceAccessChecks.disabled());
+  @Override
+  public DecisionInstanceEntity getById(final String id,
+      final ResourceAccessChecks resourceAccessChecks) {
+    return findOne(id).orElse(null);
   }
 
   @Override
@@ -70,6 +60,22 @@ public class DecisionInstanceDbReader extends AbstractEntityReader<DecisionInsta
 
     ensureSingleResultIfRequired(hits, query);
     return buildSearchQueryResult(totalHits, hits, dbSort);
+  }
+
+  public Optional<DecisionInstanceEntity> findOne(final String decisionInstanceId) {
+    LOG.trace("[RDBMS DB] Search for decision instance with key {}", decisionInstanceId);
+    final var result =
+        search(
+            DecisionInstanceQuery.of(
+                b ->
+                    b.filter(f -> f.decisionInstanceIds(decisionInstanceId))
+                        .resultConfig(
+                            r -> r.includeEvaluatedInputs(true).includeEvaluatedOutputs(true))));
+    return Optional.ofNullable(result.items()).flatMap(it -> it.stream().findFirst());
+  }
+
+  public SearchQueryResult<DecisionInstanceEntity> search(final DecisionInstanceQuery query) {
+    return search(query, ResourceAccessChecks.disabled());
   }
 
   /**

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/DecisionInstanceDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/DecisionInstanceDbReader.java
@@ -41,8 +41,8 @@ public class DecisionInstanceDbReader extends AbstractEntityReader<DecisionInsta
   }
 
   @Override
-  public DecisionInstanceEntity getById(final String id,
-      final ResourceAccessChecks resourceAccessChecks) {
+  public DecisionInstanceEntity getById(
+      final String id, final ResourceAccessChecks resourceAccessChecks) {
     return findOne(id).orElse(null);
   }
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/DecisionRequirementsDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/DecisionRequirementsDbReader.java
@@ -65,4 +65,10 @@ public class DecisionRequirementsDbReader extends AbstractEntityReader<DecisionR
     ensureSingleResultIfRequired(hits, query);
     return buildSearchQueryResult(totalHits, hits, dbSort);
   }
+
+  @Override
+  public DecisionRequirementsEntity getByKey(
+      final long key, final ResourceAccessChecks resourceAccessChecks, final boolean includeXml) {
+    return findOne(key).orElse(null);
+  }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/DecisionRequirementsDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/DecisionRequirementsDbReader.java
@@ -31,19 +31,10 @@ public class DecisionRequirementsDbReader extends AbstractEntityReader<DecisionR
     this.decisionRequirementsMapper = decisionRequirementsMapper;
   }
 
-  public Optional<DecisionRequirementsEntity> findOne(final long decisionRequirementsKey) {
-    final var result =
-        search(
-            DecisionRequirementsQuery.of(
-                b ->
-                    b.filter(f -> f.decisionRequirementsKeys(decisionRequirementsKey))
-                        .resultConfig(c -> c.includeXml(true))));
-    return Optional.ofNullable(result.items()).flatMap(it -> it.stream().findFirst());
-  }
-
-  public SearchQueryResult<DecisionRequirementsEntity> search(
-      final DecisionRequirementsQuery query) {
-    return search(query, ResourceAccessChecks.disabled());
+  @Override
+  public DecisionRequirementsEntity getByKey(
+      final long key, final ResourceAccessChecks resourceAccessChecks) {
+    return getByKey(key, resourceAccessChecks, false);
   }
 
   @Override
@@ -64,6 +55,21 @@ public class DecisionRequirementsDbReader extends AbstractEntityReader<DecisionR
     final var hits = decisionRequirementsMapper.search(dbQuery);
     ensureSingleResultIfRequired(hits, query);
     return buildSearchQueryResult(totalHits, hits, dbSort);
+  }
+
+  public Optional<DecisionRequirementsEntity> findOne(final long decisionRequirementsKey) {
+    final var result =
+        search(
+            DecisionRequirementsQuery.of(
+                b ->
+                    b.filter(f -> f.decisionRequirementsKeys(decisionRequirementsKey))
+                        .resultConfig(c -> c.includeXml(true))));
+    return Optional.ofNullable(result.items()).flatMap(it -> it.stream().findFirst());
+  }
+
+  public SearchQueryResult<DecisionRequirementsEntity> search(
+      final DecisionRequirementsQuery query) {
+    return search(query, ResourceAccessChecks.disabled());
   }
 
   @Override

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/FlowNodeInstanceDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/FlowNodeInstanceDbReader.java
@@ -31,14 +31,10 @@ public class FlowNodeInstanceDbReader extends AbstractEntityReader<FlowNodeInsta
     this.flowNodeInstanceMapper = flowNodeInstanceMapper;
   }
 
-  public Optional<FlowNodeInstanceEntity> findOne(final long key) {
-    final var result =
-        search(FlowNodeInstanceQuery.of(b -> b.filter(f -> f.flowNodeInstanceKeys(key))));
-    return Optional.ofNullable(result.items()).flatMap(it -> it.stream().findFirst());
-  }
-
-  public SearchQueryResult<FlowNodeInstanceEntity> search(final FlowNodeInstanceQuery query) {
-    return search(query, ResourceAccessChecks.disabled());
+  @Override
+  public FlowNodeInstanceEntity getByKey(
+      final long key, final ResourceAccessChecks resourceAccessChecks) {
+    return findOne(key).orElse(null);
   }
 
   @Override
@@ -55,5 +51,15 @@ public class FlowNodeInstanceDbReader extends AbstractEntityReader<FlowNodeInsta
     final var hits = flowNodeInstanceMapper.search(dbQuery);
     ensureSingleResultIfRequired(hits, query);
     return buildSearchQueryResult(totalHits, hits, dbSort);
+  }
+
+  public Optional<FlowNodeInstanceEntity> findOne(final long key) {
+    final var result =
+        search(FlowNodeInstanceQuery.of(b -> b.filter(f -> f.flowNodeInstanceKeys(key))));
+    return Optional.ofNullable(result.items()).flatMap(it -> it.stream().findFirst());
+  }
+
+  public SearchQueryResult<FlowNodeInstanceEntity> search(final FlowNodeInstanceQuery query) {
+    return search(query, ResourceAccessChecks.disabled());
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/FormDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/FormDbReader.java
@@ -30,15 +30,9 @@ public class FormDbReader extends AbstractEntityReader<FormEntity> implements Fo
     this.formMapper = formMapper;
   }
 
-  public Optional<FormEntity> findOne(final Long formKey) {
-    LOG.trace("[RDBMS DB] Search for form with form key {}", formKey);
-    final SearchQueryResult<FormEntity> queryResult =
-        search(FormQuery.of(b -> b.filter(f -> f.formKeys(formKey))));
-    return Optional.ofNullable(queryResult.items()).flatMap(hits -> hits.stream().findFirst());
-  }
-
-  public SearchQueryResult<FormEntity> search(final FormQuery query) {
-    return search(query, ResourceAccessChecks.disabled());
+  @Override
+  public FormEntity getByKey(final long key, final ResourceAccessChecks resourceAccessChecks) {
+    return findOne(key).orElse(null);
   }
 
   @Override
@@ -54,5 +48,16 @@ public class FormDbReader extends AbstractEntityReader<FormEntity> implements Fo
     final var hits = formMapper.search(dbQuery);
     ensureSingleResultIfRequired(hits, query);
     return buildSearchQueryResult(totalHits, hits, dbSort);
+  }
+
+  public Optional<FormEntity> findOne(final Long formKey) {
+    LOG.trace("[RDBMS DB] Search for form with form key {}", formKey);
+    final SearchQueryResult<FormEntity> queryResult =
+        search(FormQuery.of(b -> b.filter(f -> f.formKeys(formKey))));
+    return Optional.ofNullable(queryResult.items()).flatMap(hits -> hits.stream().findFirst());
+  }
+
+  public SearchQueryResult<FormEntity> search(final FormQuery query) {
+    return search(query, ResourceAccessChecks.disabled());
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/GroupDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/GroupDbReader.java
@@ -31,17 +31,9 @@ public class GroupDbReader extends AbstractEntityReader<GroupEntity> implements 
     this.groupMapper = groupMapper;
   }
 
-  public Optional<GroupEntity> findOne(final String groupId) {
-    final var result = search(GroupQuery.of(b -> b.filter(f -> f.groupIds(groupId))));
-    return Optional.ofNullable(result.items()).flatMap(items -> items.stream().findFirst());
-  }
-
-  public SearchQueryResult<GroupEntity> search(final GroupQuery query) {
-    return search(query, ResourceAccessChecks.disabled());
-  }
-
-  private GroupEntity map(final GroupDbModel model) {
-    return new GroupEntity(model.groupKey(), model.groupId(), model.name(), model.description());
+  @Override
+  public GroupEntity getById(final String id, final ResourceAccessChecks resourceAccessChecks) {
+    return findOne(id).orElse(null);
   }
 
   @Override
@@ -57,5 +49,18 @@ public class GroupDbReader extends AbstractEntityReader<GroupEntity> implements 
     final var hits = groupMapper.search(dbQuery).stream().map(this::map).toList();
     ensureSingleResultIfRequired(hits, query);
     return buildSearchQueryResult(totalHits, hits, dbSort);
+  }
+
+  public Optional<GroupEntity> findOne(final String groupId) {
+    final var result = search(GroupQuery.of(b -> b.filter(f -> f.groupIds(groupId))));
+    return Optional.ofNullable(result.items()).flatMap(items -> items.stream().findFirst());
+  }
+
+  public SearchQueryResult<GroupEntity> search(final GroupQuery query) {
+    return search(query, ResourceAccessChecks.disabled());
+  }
+
+  private GroupEntity map(final GroupDbModel model) {
+    return new GroupEntity(model.groupKey(), model.groupId(), model.name(), model.description());
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/IncidentDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/IncidentDbReader.java
@@ -31,13 +31,9 @@ public class IncidentDbReader extends AbstractEntityReader<IncidentEntity>
     this.incidentMapper = incidentMapper;
   }
 
-  public Optional<IncidentEntity> findOne(final long key) {
-    final var result = search(IncidentQuery.of(b -> b.filter(f -> f.incidentKeys(key))));
-    return Optional.ofNullable(result.items()).flatMap(it -> it.stream().findFirst());
-  }
-
-  public SearchQueryResult<IncidentEntity> search(final IncidentQuery query) {
-    return search(query, ResourceAccessChecks.disabled());
+  @Override
+  public IncidentEntity getByKey(final long key, final ResourceAccessChecks resourceAccessChecks) {
+    return findOne(key).orElse(null);
   }
 
   @Override
@@ -53,5 +49,14 @@ public class IncidentDbReader extends AbstractEntityReader<IncidentEntity>
     final var hits = incidentMapper.search(dbQuery);
     ensureSingleResultIfRequired(hits, query);
     return buildSearchQueryResult(totalHits, hits, dbSort);
+  }
+
+  public Optional<IncidentEntity> findOne(final long key) {
+    final var result = search(IncidentQuery.of(b -> b.filter(f -> f.incidentKeys(key))));
+    return Optional.ofNullable(result.items()).flatMap(it -> it.stream().findFirst());
+  }
+
+  public SearchQueryResult<IncidentEntity> search(final IncidentQuery query) {
+    return search(query, ResourceAccessChecks.disabled());
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/JobDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/JobDbReader.java
@@ -31,15 +31,6 @@ public class JobDbReader extends AbstractEntityReader<JobEntity> implements JobR
     this.jobMapper = jobMapper;
   }
 
-  public Optional<JobEntity> findOne(final long jobKey) {
-    final var result = search(JobQuery.of(b -> b.filter(f -> f.jobKeys(jobKey))));
-    return Optional.ofNullable(result.items()).flatMap(it -> it.stream().findFirst());
-  }
-
-  public SearchQueryResult<JobEntity> search(final JobQuery query) {
-    return search(query, ResourceAccessChecks.disabled());
-  }
-
   @Override
   public SearchQueryResult<JobEntity> search(
       final JobQuery query, final ResourceAccessChecks resourceAccessChecks) {
@@ -53,5 +44,14 @@ public class JobDbReader extends AbstractEntityReader<JobEntity> implements JobR
     final var hits = jobMapper.search(dbQuery).stream().map(JobEntityMapper::toEntity).toList();
     ensureSingleResultIfRequired(hits, query);
     return buildSearchQueryResult(totalHits, hits, dbSort);
+  }
+
+  public Optional<JobEntity> findOne(final long jobKey) {
+    final var result = search(JobQuery.of(b -> b.filter(f -> f.jobKeys(jobKey))));
+    return Optional.ofNullable(result.items()).flatMap(it -> it.stream().findFirst());
+  }
+
+  public SearchQueryResult<JobEntity> search(final JobQuery query) {
+    return search(query, ResourceAccessChecks.disabled());
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/MappingRuleDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/MappingRuleDbReader.java
@@ -31,15 +31,10 @@ public class MappingRuleDbReader extends AbstractEntityReader<MappingRuleEntity>
     this.mappingMapper = mappingMapper;
   }
 
-  public Optional<MappingRuleEntity> findOne(final String mappingId) {
-    LOG.trace("[RDBMS DB] Search for mapping with mapping ID {}", mappingId);
-    final SearchQueryResult<MappingRuleEntity> queryResult =
-        search(MappingRuleQuery.of(b -> b.filter(f -> f.mappingRuleId(mappingId))));
-    return Optional.ofNullable(queryResult.items()).flatMap(hits -> hits.stream().findFirst());
-  }
-
-  public SearchQueryResult<MappingRuleEntity> search(final MappingRuleQuery query) {
-    return search(query, ResourceAccessChecks.disabled());
+  @Override
+  public MappingRuleEntity getById(
+      final String id, final ResourceAccessChecks resourceAccessChecks) {
+    return findOne(id).orElse(null);
   }
 
   @Override
@@ -55,5 +50,16 @@ public class MappingRuleDbReader extends AbstractEntityReader<MappingRuleEntity>
     final var hits = mappingMapper.search(dbQuery);
     ensureSingleResultIfRequired(hits, query);
     return buildSearchQueryResult(totalHits, hits, dbSort);
+  }
+
+  public Optional<MappingRuleEntity> findOne(final String mappingId) {
+    LOG.trace("[RDBMS DB] Search for mapping with mapping ID {}", mappingId);
+    final SearchQueryResult<MappingRuleEntity> queryResult =
+        search(MappingRuleQuery.of(b -> b.filter(f -> f.mappingRuleId(mappingId))));
+    return Optional.ofNullable(queryResult.items()).flatMap(hits -> hits.stream().findFirst());
+  }
+
+  public SearchQueryResult<MappingRuleEntity> search(final MappingRuleQuery query) {
+    return search(query, ResourceAccessChecks.disabled());
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/ProcessDefinitionDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/ProcessDefinitionDbReader.java
@@ -12,12 +12,9 @@ import io.camunda.db.rdbms.sql.ProcessDefinitionMapper;
 import io.camunda.db.rdbms.sql.columns.ProcessDefinitionSearchColumn;
 import io.camunda.search.clients.reader.ProcessDefinitionReader;
 import io.camunda.search.entities.ProcessDefinitionEntity;
-import io.camunda.search.entities.ProcessFlowNodeStatisticsEntity;
-import io.camunda.search.filter.ProcessDefinitionStatisticsFilter;
 import io.camunda.search.query.ProcessDefinitionQuery;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.reader.ResourceAccessChecks;
-import java.util.List;
 import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -34,20 +31,10 @@ public class ProcessDefinitionDbReader extends AbstractEntityReader<ProcessDefin
     this.processDefinitionMapper = processDefinitionMapper;
   }
 
-  public Optional<ProcessDefinitionEntity> findOne(final long processDefinitionKey) {
-    final var result =
-        search(
-            ProcessDefinitionQuery.of(
-                b -> b.filter(f -> f.processDefinitionKeys(processDefinitionKey))));
-    if (result.items() == null || result.items().isEmpty()) {
-      return Optional.empty();
-    } else {
-      return Optional.of(result.items().getFirst());
-    }
-  }
-
-  public SearchQueryResult<ProcessDefinitionEntity> search(final ProcessDefinitionQuery query) {
-    return search(query, ResourceAccessChecks.disabled());
+  @Override
+  public ProcessDefinitionEntity getByKey(
+      final long key, final ResourceAccessChecks resourceAccessChecks) {
+    return findOne(key).orElse(null);
   }
 
   @Override
@@ -66,9 +53,19 @@ public class ProcessDefinitionDbReader extends AbstractEntityReader<ProcessDefin
     return buildSearchQueryResult(totalHits, hits, dbSort);
   }
 
-  public List<ProcessFlowNodeStatisticsEntity> flowNodeStatistics(
-      final ProcessDefinitionStatisticsFilter filter) {
-    LOG.trace("[RDBMS DB] Query process definition flow node statistics with filter {}", filter);
-    return processDefinitionMapper.flowNodeStatistics(filter);
+  public Optional<ProcessDefinitionEntity> findOne(final long processDefinitionKey) {
+    final var result =
+        search(
+            ProcessDefinitionQuery.of(
+                b -> b.filter(f -> f.processDefinitionKeys(processDefinitionKey))));
+    if (result.items() == null || result.items().isEmpty()) {
+      return Optional.empty();
+    } else {
+      return Optional.of(result.items().getFirst());
+    }
+  }
+
+  public SearchQueryResult<ProcessDefinitionEntity> search(final ProcessDefinitionQuery query) {
+    return search(query, ResourceAccessChecks.disabled());
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/ProcessInstanceDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/ProcessInstanceDbReader.java
@@ -38,13 +38,10 @@ public class ProcessInstanceDbReader extends AbstractEntityReader<ProcessInstanc
     return Optional.ofNullable(processInstanceMapper.findOne(processInstanceKey));
   }
 
-  public SearchQueryResult<ProcessInstanceEntity> search(final ProcessInstanceQuery query) {
-    return search(query, ResourceAccessChecks.disabled());
-  }
-
-  public List<ProcessFlowNodeStatisticsEntity> flowNodeStatistics(final long processInstanceKey) {
-    LOG.trace("[RDBMS DB] Query process instance flow node statistics with {}", processInstanceKey);
-    return processInstanceMapper.flowNodeStatistics(processInstanceKey);
+  @Override
+  public ProcessInstanceEntity getByKey(
+      final long key, final ResourceAccessChecks resourceAccessChecks) {
+    return findOne(key).orElse(null);
   }
 
   @Override
@@ -60,5 +57,14 @@ public class ProcessInstanceDbReader extends AbstractEntityReader<ProcessInstanc
     final var hits = processInstanceMapper.search(dbQuery);
     ensureSingleResultIfRequired(hits, query);
     return buildSearchQueryResult(totalHits, hits, dbSort);
+  }
+
+  public SearchQueryResult<ProcessInstanceEntity> search(final ProcessInstanceQuery query) {
+    return search(query, ResourceAccessChecks.disabled());
+  }
+
+  public List<ProcessFlowNodeStatisticsEntity> flowNodeStatistics(final long processInstanceKey) {
+    LOG.trace("[RDBMS DB] Query process instance flow node statistics with {}", processInstanceKey);
+    return processInstanceMapper.flowNodeStatistics(processInstanceKey);
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/RoleDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/RoleDbReader.java
@@ -31,17 +31,9 @@ public class RoleDbReader extends AbstractEntityReader<RoleEntity> implements Ro
     this.roleMapper = roleMapper;
   }
 
-  public Optional<RoleEntity> findOne(final String roleId) {
-    final var result = search(RoleQuery.of(b -> b.filter(f -> f.roleId(roleId))));
-    return Optional.ofNullable(result.items()).flatMap(items -> items.stream().findFirst());
-  }
-
-  public SearchQueryResult<RoleEntity> search(final RoleQuery query) {
-    return search(query, ResourceAccessChecks.disabled());
-  }
-
-  private RoleEntity map(final RoleDbModel model) {
-    return new RoleEntity(model.roleKey(), model.roleId(), model.name(), model.description());
+  @Override
+  public RoleEntity getById(final String id, final ResourceAccessChecks resourceAccessChecks) {
+    return findOne(id).orElse(null);
   }
 
   @Override
@@ -57,5 +49,18 @@ public class RoleDbReader extends AbstractEntityReader<RoleEntity> implements Ro
     final var hits = roleMapper.search(dbQuery).stream().map(this::map).toList();
     ensureSingleResultIfRequired(hits, query);
     return buildSearchQueryResult(totalHits, hits, dbSort);
+  }
+
+  public Optional<RoleEntity> findOne(final String roleId) {
+    final var result = search(RoleQuery.of(b -> b.filter(f -> f.roleId(roleId))));
+    return Optional.ofNullable(result.items()).flatMap(items -> items.stream().findFirst());
+  }
+
+  public SearchQueryResult<RoleEntity> search(final RoleQuery query) {
+    return search(query, ResourceAccessChecks.disabled());
+  }
+
+  private RoleEntity map(final RoleDbModel model) {
+    return new RoleEntity(model.roleKey(), model.roleId(), model.name(), model.description());
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/TenantDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/TenantDbReader.java
@@ -31,17 +31,9 @@ public class TenantDbReader extends AbstractEntityReader<TenantEntity> implement
     this.tenantMapper = tenantMapper;
   }
 
-  public Optional<TenantEntity> findOne(final String tenantId) {
-    final var result = search(TenantQuery.of(b -> b.filter(f -> f.tenantId(tenantId))));
-    return Optional.ofNullable(result.items()).flatMap(items -> items.stream().findFirst());
-  }
-
-  public SearchQueryResult<TenantEntity> search(final TenantQuery query) {
-    return search(query, ResourceAccessChecks.disabled());
-  }
-
-  private TenantEntity map(final TenantDbModel model) {
-    return new TenantEntity(model.tenantKey(), model.tenantId(), model.name(), model.description());
+  @Override
+  public TenantEntity getById(final String id, final ResourceAccessChecks resourceAccessChecks) {
+    return findOne(id).orElse(null);
   }
 
   @Override
@@ -57,5 +49,18 @@ public class TenantDbReader extends AbstractEntityReader<TenantEntity> implement
     final var hits = tenantMapper.search(dbQuery).stream().map(this::map).toList();
     ensureSingleResultIfRequired(hits, query);
     return buildSearchQueryResult(totalHits, hits, dbSort);
+  }
+
+  public Optional<TenantEntity> findOne(final String tenantId) {
+    final var result = search(TenantQuery.of(b -> b.filter(f -> f.tenantId(tenantId))));
+    return Optional.ofNullable(result.items()).flatMap(items -> items.stream().findFirst());
+  }
+
+  public SearchQueryResult<TenantEntity> search(final TenantQuery query) {
+    return search(query, ResourceAccessChecks.disabled());
+  }
+
+  private TenantEntity map(final TenantDbModel model) {
+    return new TenantEntity(model.tenantKey(), model.tenantId(), model.name(), model.description());
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/UserDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/UserDbReader.java
@@ -30,13 +30,9 @@ public class UserDbReader extends AbstractEntityReader<UserEntity> implements Us
     this.userMapper = userMapper;
   }
 
-  public Optional<UserEntity> findOne(final long userKey) {
-    final var result = search(UserQuery.of(b -> b.filter(f -> f.key(userKey))));
-    return Optional.ofNullable(result.items()).flatMap(items -> items.stream().findFirst());
-  }
-
-  public SearchQueryResult<UserEntity> search(final UserQuery query) {
-    return search(query, ResourceAccessChecks.disabled());
+  @Override
+  public UserEntity getById(final String id, final ResourceAccessChecks resourceAccessChecks) {
+    return findOneByUsername(id).orElse(null);
   }
 
   @Override
@@ -52,5 +48,19 @@ public class UserDbReader extends AbstractEntityReader<UserEntity> implements Us
     final var hits = userMapper.search(dbQuery);
     ensureSingleResultIfRequired(hits, query);
     return buildSearchQueryResult(totalHits, hits, dbSort);
+  }
+
+  public Optional<UserEntity> findOneByUsername(final String username) {
+    final var result = search(UserQuery.of(b -> b.filter(f -> f.usernames(username))));
+    return Optional.ofNullable(result.items()).flatMap(items -> items.stream().findFirst());
+  }
+
+  public Optional<UserEntity> findOne(final long userKey) {
+    final var result = search(UserQuery.of(b -> b.filter(f -> f.key(userKey))));
+    return Optional.ofNullable(result.items()).flatMap(items -> items.stream().findFirst());
+  }
+
+  public SearchQueryResult<UserEntity> search(final UserQuery query) {
+    return search(query, ResourceAccessChecks.disabled());
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/UserTaskDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/UserTaskDbReader.java
@@ -33,14 +33,9 @@ public class UserTaskDbReader extends AbstractEntityReader<UserTaskEntity>
     this.userTaskMapper = userTaskMapper;
   }
 
-  public Optional<UserTaskEntity> findOne(final long userTaskKey) {
-    final var result =
-        search(UserTaskQuery.of(b -> b.filter(f -> f.userTaskKeys(List.of(userTaskKey)))));
-    return Optional.ofNullable(result.items()).flatMap(items -> items.stream().findFirst());
-  }
-
-  public SearchQueryResult<UserTaskEntity> search(final UserTaskQuery query) {
-    return search(query, ResourceAccessChecks.disabled());
+  @Override
+  public UserTaskEntity getByKey(final long key, final ResourceAccessChecks resourceAccessChecks) {
+    return findOne(key).orElse(null);
   }
 
   @Override
@@ -57,5 +52,15 @@ public class UserTaskDbReader extends AbstractEntityReader<UserTaskEntity>
         userTaskMapper.search(dbQuery).stream().map(UserTaskEntityMapper::toEntity).toList();
     ensureSingleResultIfRequired(hits, query);
     return buildSearchQueryResult(totalHits, hits, dbSort);
+  }
+
+  public Optional<UserTaskEntity> findOne(final long userTaskKey) {
+    final var result =
+        search(UserTaskQuery.of(b -> b.filter(f -> f.userTaskKeys(List.of(userTaskKey)))));
+    return Optional.ofNullable(result.items()).flatMap(items -> items.stream().findFirst());
+  }
+
+  public SearchQueryResult<UserTaskEntity> search(final UserTaskQuery query) {
+    return search(query, ResourceAccessChecks.disabled());
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/VariableDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/VariableDbReader.java
@@ -34,18 +34,9 @@ public class VariableDbReader extends AbstractEntityReader<VariableEntity>
     this.variableMapper = variableMapper;
   }
 
-  public VariableEntity findOne(final Long key) {
-    return search(
-            new VariableQuery(
-                new Builder().variableKeys(key).build(),
-                VariableSort.of(b -> b),
-                SearchQueryPage.of(b -> b.from(0).size(1))))
-        .items()
-        .getFirst();
-  }
-
-  public SearchQueryResult<VariableEntity> search(final VariableQuery query) {
-    return search(query, ResourceAccessChecks.disabled());
+  @Override
+  public VariableEntity getByKey(final long key, final ResourceAccessChecks resourceAccessChecks) {
+    return findOne(key);
   }
 
   @Override
@@ -60,6 +51,22 @@ public class VariableDbReader extends AbstractEntityReader<VariableEntity>
     final var hits = variableMapper.search(dbQuery);
     ensureSingleResultIfRequired(hits, query);
     return buildSearchQueryResult(totalHits, hits, dbSort);
+  }
+
+  public VariableEntity findOne(final Long key) {
+    return search(
+            new VariableQuery(
+                new Builder().variableKeys(key).build(),
+                VariableSort.of(b -> b),
+                SearchQueryPage.of(b -> b.from(0).size(1))))
+        .items()
+        .stream()
+        .findFirst()
+        .orElse(null);
+  }
+
+  public SearchQueryResult<VariableEntity> search(final VariableQuery query) {
+    return search(query, ResourceAccessChecks.disabled());
   }
 
   public record SearchResult(List<VariableEntity> hits, Integer total) {}

--- a/dist/src/main/java/io/camunda/application/commons/search/SearchClientReaderConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/search/SearchClientReaderConfiguration.java
@@ -68,6 +68,28 @@ import io.camunda.search.clients.transformers.ServiceTransformers;
 import io.camunda.search.connect.configuration.ConnectConfiguration;
 import io.camunda.search.connect.configuration.DatabaseConfig;
 import io.camunda.webapps.schema.descriptors.IndexDescriptors;
+import io.camunda.webapps.schema.descriptors.index.AuthorizationIndex;
+import io.camunda.webapps.schema.descriptors.index.DecisionIndex;
+import io.camunda.webapps.schema.descriptors.index.DecisionRequirementsIndex;
+import io.camunda.webapps.schema.descriptors.index.FormIndex;
+import io.camunda.webapps.schema.descriptors.index.GroupIndex;
+import io.camunda.webapps.schema.descriptors.index.MappingRuleIndex;
+import io.camunda.webapps.schema.descriptors.index.MetricIndex;
+import io.camunda.webapps.schema.descriptors.index.ProcessIndex;
+import io.camunda.webapps.schema.descriptors.index.RoleIndex;
+import io.camunda.webapps.schema.descriptors.index.TenantIndex;
+import io.camunda.webapps.schema.descriptors.index.UserIndex;
+import io.camunda.webapps.schema.descriptors.template.BatchOperationTemplate;
+import io.camunda.webapps.schema.descriptors.template.DecisionInstanceTemplate;
+import io.camunda.webapps.schema.descriptors.template.EventTemplate;
+import io.camunda.webapps.schema.descriptors.template.FlowNodeInstanceTemplate;
+import io.camunda.webapps.schema.descriptors.template.IncidentTemplate;
+import io.camunda.webapps.schema.descriptors.template.JobTemplate;
+import io.camunda.webapps.schema.descriptors.template.ListViewTemplate;
+import io.camunda.webapps.schema.descriptors.template.OperationTemplate;
+import io.camunda.webapps.schema.descriptors.template.SequenceFlowTemplate;
+import io.camunda.webapps.schema.descriptors.template.TaskTemplate;
+import io.camunda.webapps.schema.descriptors.template.VariableTemplate;
 import io.camunda.zeebe.gateway.rest.ConditionalOnRestGatewayEnabled;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -78,96 +100,112 @@ import org.springframework.context.annotation.Configuration;
 public class SearchClientReaderConfiguration {
 
   @Bean
+  public IndexDescriptors indexDescriptors(final ConnectConfiguration connectConfiguration) {
+    return new IndexDescriptors(
+        connectConfiguration.getIndexPrefix(),
+        connectConfiguration.getTypeEnum().isElasticSearch());
+  }
+
+  @Bean
   public SearchClientBasedQueryExecutor searchClientBasedQueryExecutor(
-      final DocumentBasedSearchClient searchClient,
-      final ConnectConfiguration connectConfiguration) {
-    final var descriptors =
-        new IndexDescriptors(
-            connectConfiguration.getIndexPrefix(),
-            connectConfiguration.getTypeEnum().isElasticSearch());
+      final DocumentBasedSearchClient searchClient, final IndexDescriptors descriptors) {
     final var transformers = ServiceTransformers.newInstance(descriptors);
     return new SearchClientBasedQueryExecutor(searchClient, transformers);
   }
 
   @Bean
-  public AuthorizationReader authorizationReader(final SearchClientBasedQueryExecutor executor) {
-    return new AuthorizationDocumentReader(executor);
+  public AuthorizationReader authorizationReader(
+      final SearchClientBasedQueryExecutor executor, final IndexDescriptors descriptors) {
+    return new AuthorizationDocumentReader(executor, descriptors.get(AuthorizationIndex.class));
   }
 
   @Bean
-  public BatchOperationReader batchOperationReader(final SearchClientBasedQueryExecutor executor) {
-    return new BatchOperationDocumentReader(executor);
+  public BatchOperationReader batchOperationReader(
+      final SearchClientBasedQueryExecutor executor, final IndexDescriptors descriptors) {
+    return new BatchOperationDocumentReader(
+        executor, descriptors.get(BatchOperationTemplate.class));
   }
 
   @Bean
   public BatchOperationItemReader batchOperationItemReader(
-      final SearchClientBasedQueryExecutor executor) {
-    return new BatchOperationItemDocumentReader(executor);
+      final SearchClientBasedQueryExecutor executor, final IndexDescriptors descriptors) {
+    return new BatchOperationItemDocumentReader(executor, descriptors.get(OperationTemplate.class));
   }
 
   @Bean
   public DecisionDefinitionReader decisionDefinitionReader(
-      final SearchClientBasedQueryExecutor executor) {
-    return new DecisionDefinitionDocumentReader(executor);
+      final SearchClientBasedQueryExecutor executor, final IndexDescriptors descriptors) {
+    return new DecisionDefinitionDocumentReader(executor, descriptors.get(DecisionIndex.class));
   }
 
   @Bean
   public DecisionInstanceReader decisionInstanceReader(
-      final SearchClientBasedQueryExecutor executor) {
-    return new DecisionInstanceDocumentReader(executor);
+      final SearchClientBasedQueryExecutor executor, final IndexDescriptors descriptors) {
+    return new DecisionInstanceDocumentReader(
+        executor, descriptors.get(DecisionInstanceTemplate.class));
   }
 
   @Bean
   public DecisionRequirementsReader decisionRequirementsReader(
-      final SearchClientBasedQueryExecutor executor) {
-    return new DecisionRequirementsDocumentReader(executor);
+      final SearchClientBasedQueryExecutor executor, final IndexDescriptors descriptors) {
+    return new DecisionRequirementsDocumentReader(
+        executor, descriptors.get(DecisionRequirementsIndex.class));
   }
 
   @Bean
   public FlowNodeInstanceReader flowNodeInstanceReader(
-      final SearchClientBasedQueryExecutor executor) {
-    return new FlowNodeInstanceDocumentReader(executor);
+      final SearchClientBasedQueryExecutor executor, final IndexDescriptors descriptors) {
+    return new FlowNodeInstanceDocumentReader(
+        executor, descriptors.get(FlowNodeInstanceTemplate.class));
   }
 
   @Bean
-  public FormReader formReader(final SearchClientBasedQueryExecutor executor) {
-    return new FormDocumentReader(executor);
+  public FormReader formReader(
+      final SearchClientBasedQueryExecutor executor, final IndexDescriptors descriptors) {
+    return new FormDocumentReader(executor, descriptors.get(FormIndex.class));
   }
 
   @Bean
   public GroupReader groupReader(
       final SearchClientBasedQueryExecutor executor,
+      final IndexDescriptors descriptors,
       final TenantMemberReader tenantMemberReader,
       final RoleMemberReader roleMemberReader) {
     return new GroupDocumentReader(
         executor,
+        descriptors.get(GroupIndex.class),
         (TenantMemberDocumentReader) tenantMemberReader,
         (RoleMemberDocumentReader) roleMemberReader);
   }
 
   @Bean
-  public GroupMemberReader groupMemberReader(final SearchClientBasedQueryExecutor executor) {
-    return new GroupMemberDocumentReader(executor);
+  public GroupMemberReader groupMemberReader(
+      final SearchClientBasedQueryExecutor executor, final IndexDescriptors descriptors) {
+    return new GroupMemberDocumentReader(executor, descriptors.get(GroupIndex.class));
   }
 
   @Bean
-  public IncidentReader incidentReader(final SearchClientBasedQueryExecutor executor) {
-    return new IncidentDocumentReader(executor);
+  public IncidentReader incidentReader(
+      final SearchClientBasedQueryExecutor executor, final IndexDescriptors descriptors) {
+    return new IncidentDocumentReader(executor, descriptors.get(IncidentTemplate.class));
   }
 
   @Bean
-  public JobReader jobReader(final SearchClientBasedQueryExecutor executor) {
-    return new JobDocumentReader(executor);
+  public JobReader jobReader(
+      final SearchClientBasedQueryExecutor executor, final IndexDescriptors descriptors) {
+    return new JobDocumentReader(executor, descriptors.get(JobTemplate.class));
   }
 
   @Bean
   public MappingRuleReader mappingRuleReader(
       final SearchClientBasedQueryExecutor executor,
+      final IndexDescriptors descriptors,
       final RoleMemberReader roleMemberReader,
       final TenantMemberReader tenantMemberReader,
       final GroupMemberReader groupMemberReader) {
     return new MappingRuleDocumentReader(
         executor,
+        descriptors.get(MappingRuleIndex.class),
         (RoleMemberDocumentReader) roleMemberReader,
         (TenantMemberDocumentReader) tenantMemberReader,
         (GroupMemberDocumentReader) groupMemberReader);
@@ -175,87 +213,106 @@ public class SearchClientReaderConfiguration {
 
   @Bean
   public MessageSubscriptionReader messageSubscriptionReader(
-      final SearchClientBasedQueryExecutor executor) {
-    return new MessageSubscriptionDocumentReader(executor);
+      final SearchClientBasedQueryExecutor executor, final IndexDescriptors descriptors) {
+    return new MessageSubscriptionDocumentReader(executor, descriptors.get(EventTemplate.class));
   }
 
   @Bean
   public ProcessDefinitionReader processDefinitionReader(
-      final SearchClientBasedQueryExecutor executor) {
-    return new ProcessDefinitionDocumentReader(executor);
+      final SearchClientBasedQueryExecutor executor, final IndexDescriptors descriptors) {
+    return new ProcessDefinitionDocumentReader(executor, descriptors.get(ProcessIndex.class));
   }
 
   @Bean
   public ProcessDefinitionStatisticsReader processDefinitionStatisticsReader(
-      final SearchClientBasedQueryExecutor executor, final IncidentReader incidentReader) {
+      final SearchClientBasedQueryExecutor executor,
+      final IndexDescriptors descriptors,
+      final IncidentReader incidentReader) {
     return new ProcessDefinitionStatisticsDocumentReader(
-        executor, (IncidentDocumentReader) incidentReader);
+        executor, descriptors.get(ListViewTemplate.class), (IncidentDocumentReader) incidentReader);
   }
 
   @Bean
   public ProcessInstanceReader processInstanceReader(
-      final SearchClientBasedQueryExecutor executor, final IncidentReader incidentReader) {
-    return new ProcessInstanceDocumentReader(executor, (IncidentDocumentReader) incidentReader);
+      final SearchClientBasedQueryExecutor executor,
+      final IndexDescriptors descriptors,
+      final IncidentReader incidentReader) {
+    return new ProcessInstanceDocumentReader(
+        executor, descriptors.get(ListViewTemplate.class), (IncidentDocumentReader) incidentReader);
   }
 
   @Bean
   public ProcessInstanceStatisticsReader processInstanceStatisticsReader(
-      final SearchClientBasedQueryExecutor executor) {
-    return new ProcessInstanceStatisticsDocumentReader(executor);
+      final SearchClientBasedQueryExecutor executor, final IndexDescriptors descriptors) {
+    return new ProcessInstanceStatisticsDocumentReader(
+        executor, descriptors.get(ListViewTemplate.class));
   }
 
   @Bean
   public RoleReader roleReader(
-      final SearchClientBasedQueryExecutor executor, final TenantMemberReader tenantMemberReader) {
-    return new RoleDocumentReader(executor, (TenantMemberDocumentReader) tenantMemberReader);
+      final SearchClientBasedQueryExecutor executor,
+      final IndexDescriptors descriptors,
+      final TenantMemberReader tenantMemberReader) {
+    return new RoleDocumentReader(
+        executor,
+        descriptors.get(RoleIndex.class),
+        (TenantMemberDocumentReader) tenantMemberReader);
   }
 
   @Bean
-  public RoleMemberReader roleMemberReader(final SearchClientBasedQueryExecutor executor) {
-    return new RoleMemberDocumentReader(executor);
+  public RoleMemberReader roleMemberReader(
+      final SearchClientBasedQueryExecutor executor, final IndexDescriptors descriptors) {
+    return new RoleMemberDocumentReader(executor, descriptors.get(RoleIndex.class));
   }
 
   @Bean
-  public SequenceFlowReader sequenceFlowReader(final SearchClientBasedQueryExecutor executor) {
-    return new SequenceFlowDocumentReader(executor);
+  public SequenceFlowReader sequenceFlowReader(
+      final SearchClientBasedQueryExecutor executor, final IndexDescriptors descriptors) {
+    return new SequenceFlowDocumentReader(executor, descriptors.get(SequenceFlowTemplate.class));
   }
 
   @Bean
-  public TenantReader tenantReader(final SearchClientBasedQueryExecutor executor) {
-    return new TenantDocumentReader(executor);
+  public TenantReader tenantReader(
+      final SearchClientBasedQueryExecutor executor, final IndexDescriptors descriptors) {
+    return new TenantDocumentReader(executor, descriptors.get(TenantIndex.class));
   }
 
   @Bean
   public TenantMemberReader tenantMemberReaderReader(
-      final SearchClientBasedQueryExecutor executor) {
-    return new TenantMemberDocumentReader(executor);
+      final SearchClientBasedQueryExecutor executor, final IndexDescriptors descriptors) {
+    return new TenantMemberDocumentReader(executor, descriptors.get(TenantIndex.class));
   }
 
   @Bean
-  public UsageMetricsReader usageMetricsReader(final SearchClientBasedQueryExecutor executor) {
-    return new UsageMetricsDocumentReader(executor);
+  public UsageMetricsReader usageMetricsReader(
+      final SearchClientBasedQueryExecutor executor, final IndexDescriptors descriptors) {
+    return new UsageMetricsDocumentReader(executor, descriptors.get(MetricIndex.class));
   }
 
   @Bean
   public UserReader userReader(
       final SearchClientBasedQueryExecutor executor,
+      final IndexDescriptors descriptors,
       final RoleMemberReader roleMemberReader,
       final TenantMemberReader tenantMemberReader,
       final GroupMemberReader groupMemberReader) {
     return new UserDocumentReader(
         executor,
+        descriptors.get(UserIndex.class),
         (RoleMemberDocumentReader) roleMemberReader,
         (TenantMemberDocumentReader) tenantMemberReader,
         (GroupMemberDocumentReader) groupMemberReader);
   }
 
   @Bean
-  public UserTaskReader userTaskReader(final SearchClientBasedQueryExecutor executor) {
-    return new UserTaskDocumentReader(executor);
+  public UserTaskReader userTaskReader(
+      final SearchClientBasedQueryExecutor executor, final IndexDescriptors descriptors) {
+    return new UserTaskDocumentReader(executor, descriptors.get(TaskTemplate.class));
   }
 
   @Bean
-  public VariableReader variableReader(final SearchClientBasedQueryExecutor executor) {
-    return new VariableDocumentReader(executor);
+  public VariableReader variableReader(
+      final SearchClientBasedQueryExecutor executor, final IndexDescriptors descriptors) {
+    return new VariableDocumentReader(executor, descriptors.get(VariableTemplate.class));
   }
 }

--- a/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
@@ -134,13 +134,13 @@ public class CamundaServicesConfiguration {
       final SecurityContextProvider securityContextProvider,
       final ProcessInstanceSearchClient processInstanceSearchClient,
       final SequenceFlowSearchClient sequenceFlowSearchClient,
-      final IncidentSearchClient incidentSearchClient) {
+      final IncidentServices incidentServices) {
     return new ProcessInstanceServices(
         brokerClient,
         securityContextProvider,
         processInstanceSearchClient,
         sequenceFlowSearchClient,
-        incidentSearchClient,
+        incidentServices,
         null);
   }
 

--- a/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
@@ -216,7 +216,7 @@ public class CamundaServicesConfiguration {
       final BrokerClient brokerClient,
       final SecurityContextProvider securityContextProvider,
       final UserTaskSearchClient userTaskSearchClient,
-      final FormSearchClient formSearchClient,
+      final FormServices formServices,
       final FlowNodeInstanceSearchClient flowNodeInstanceSearchClient,
       final VariableSearchClient variableSearchClient,
       final ProcessCache processCache) {
@@ -224,7 +224,7 @@ public class CamundaServicesConfiguration {
         brokerClient,
         securityContextProvider,
         userTaskSearchClient,
-        formSearchClient,
+        formServices,
         flowNodeInstanceSearchClient,
         variableSearchClient,
         processCache,

--- a/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
@@ -100,12 +100,12 @@ public class CamundaServicesConfiguration {
       final BrokerClient brokerClient,
       final SecurityContextProvider securityContextProvider,
       final DecisionDefinitionSearchClient decisionDefinitionSearchClient,
-      final DecisionRequirementSearchClient decisionRequirementSearchClient) {
+      final DecisionRequirementsServices decisionRequirementsServices) {
     return new DecisionDefinitionServices(
         brokerClient,
         securityContextProvider,
         decisionDefinitionSearchClient,
-        decisionRequirementSearchClient,
+        decisionRequirementsServices,
         null);
   }
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/BatchOperationAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/BatchOperationAuthorizationIT.java
@@ -324,7 +324,7 @@ class BatchOperationAuthorizationIT {
   }
 
   @Test
-  void shouldReturnNotFoundForUnauthorizedReadOfBatchOperation(
+  void shouldReturnForbiddenForUnauthorizedReadOfBatchOperation(
       @Authenticated(ADMIN) final CamundaClient camundaAdminClient,
       @Authenticated(RESTRICTED_READ) final CamundaClient camundaRestictedClient) {
     // given some processes with a scopeId in variables
@@ -351,7 +351,7 @@ class BatchOperationAuthorizationIT {
               } catch (final ProblemException e) {
                 code = e.code();
               }
-              assertThat(code).isEqualTo(404);
+              assertThat(code).isEqualTo(403);
             });
   }
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/InheritedBasicAuthAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/InheritedBasicAuthAuthorizationIT.java
@@ -198,7 +198,7 @@ public class InheritedBasicAuthAuthorizationIT {
                       .send()
                       .join())
           .isInstanceOf(ProblemException.class)
-          .hasMessageContaining("404: 'Not Found'");
+          .hasMessageContaining("403: 'Forbidden'");
     }
   }
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/InheritedOIDCAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/InheritedOIDCAuthorizationIT.java
@@ -208,7 +208,7 @@ public class InheritedOIDCAuthorizationIT {
                       .send()
                       .join())
           .isInstanceOf(ProblemException.class)
-          .hasMessageContaining("404: 'Not Found'");
+          .hasMessageContaining("403: 'Forbidden'");
     }
   }
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/ProcessInstanceAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/ProcessInstanceAuthorizationIT.java
@@ -85,11 +85,27 @@ class ProcessInstanceAuthorizationIT {
   @Test
   public void searchShouldReturnAuthorizedProcessInstances(
       @Authenticated(USER1) final CamundaClient camundaClient) {
+
     // when
     final var result = camundaClient.newProcessInstanceSearchRequest().send().join();
+
     // then
     assertThat(result.items()).hasSize(1);
     assertThat(result.items().getFirst().getProcessDefinitionId()).isEqualTo(PROCESS_ID_1);
+  }
+
+  @Test
+  public void searchShouldNotReturnNotauthorizedProcessInstances(
+      @Authenticated(USER1) final CamundaClient camundaClient) {
+    // when
+    final var result =
+        camundaClient
+            .newProcessInstanceSearchRequest()
+            .filter(f -> f.processDefinitionId(PROCESS_ID_2))
+            .send()
+            .join();
+    // then
+    assertThat(result.items()).hasSize(0);
   }
 
   @Test

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/RoleAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/RoleAuthorizationIT.java
@@ -204,7 +204,7 @@ class RoleAuthorizationIT {
       @Authenticated(RESTRICTED) final CamundaClient camundaClient) {
     assertThatThrownBy(() -> camundaClient.newRoleGetRequest(ROLE_ID_1).send().join())
         .isInstanceOf(ProblemException.class)
-        .hasMessageContaining("404: 'Not Found'");
+        .hasMessageContaining("403: 'Forbidden'");
   }
 
   @Test

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/UserAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/UserAuthorizationIT.java
@@ -76,7 +76,7 @@ class UserAuthorizationIT {
 
   private static CamundaClient camundaClient;
 
-  private List<String> createdUsers = new ArrayList<>();
+  private final List<String> createdUsers = new ArrayList<>();
 
   @AfterEach
   void awaitExpectedUsers() {
@@ -197,7 +197,7 @@ class UserAuthorizationIT {
       @Authenticated(RESTRICTED) final CamundaClient camundaClient) {
     assertThatThrownBy(() -> camundaClient.newUserGetRequest(USER_1.username()).send().join())
         .isInstanceOf(ProblemException.class)
-        .hasMessageContaining("404: 'Not Found'");
+        .hasMessageContaining("403: 'Forbidden'");
   }
 
   @Test

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/AuthorizationIntegrationTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/AuthorizationIntegrationTest.java
@@ -80,7 +80,8 @@ public class AuthorizationIntegrationTest {
                 camundaClient.newAuthorizationGetRequest(nonExistingAuthorizationKey).send().join())
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 404: 'Not Found'")
-        .hasMessageContaining("A single result was expected, but none was found matching");
+        .hasMessageContaining(
+            "Authorization with key '%s' not found".formatted(nonExistingAuthorizationKey));
   }
 
   @Test

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/DecisionInstanceSearchTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/DecisionInstanceSearchTest.java
@@ -404,7 +404,7 @@ class DecisionInstanceSearchTest {
     // then
     assertThat(problemException.code()).isEqualTo(404);
     assertThat(problemException.details().getDetail())
-        .contains("A single result was expected, but none was found matching");
+        .contains("Decision Instance with id '%s' not found".formatted(decisionInstanceId));
   }
 
   private static EvaluateDecisionResponse evaluateDecision(

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/DecisionSearchTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/DecisionSearchTest.java
@@ -179,7 +179,7 @@ class DecisionSearchTest {
     // then
     assertThat(problemException.code()).isEqualTo(404);
     assertThat(problemException.details().getDetail())
-        .contains("A single result was expected, but none was found matching");
+        .contains("Decision Definition with key '%d' not found".formatted(decisionKey));
   }
 
   @Test
@@ -203,7 +203,7 @@ class DecisionSearchTest {
     // then
     assertThat(problemException.code()).isEqualTo(404);
     assertThat(problemException.details().getDetail())
-        .contains("A single result was expected, but none was found matching");
+        .contains("Decision Definition with key '%d' not found".formatted(decisionKey));
   }
 
   @Test

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/DecisionSearchTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/DecisionSearchTest.java
@@ -580,7 +580,8 @@ class DecisionSearchTest {
     // then
     assertThat(problemException.code()).isEqualTo(404);
     assertThat(problemException.details().getDetail())
-        .contains("A single result was expected, but none was found matching");
+        .contains(
+            "Decision Requirements with key '%d' not found".formatted(decisionRequirementsKey));
   }
 
   @Test

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/IncidentSearchTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/IncidentSearchTest.java
@@ -116,7 +116,7 @@ class IncidentSearchTest {
     assertThat(exception.details().getTitle()).isEqualTo("NOT_FOUND");
     assertThat(exception.details().getStatus()).isEqualTo(404);
     assertThat(exception.details().getDetail())
-        .contains("A single result was expected, but none was found matching");
+        .contains("Incident with key '%s' not found".formatted(invalidIncidentKey));
   }
 
   @Test

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessDefinitionSearchTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessDefinitionSearchTest.java
@@ -231,7 +231,8 @@ public class ProcessDefinitionSearchTest {
     assertThat(exception.details().getTitle()).isEqualTo("NOT_FOUND");
     assertThat(exception.details().getStatus()).isEqualTo(404);
     assertThat(exception.details().getDetail())
-        .contains("A single result was expected, but none was found matching");
+        .contains(
+            "Process Definition with key '%d' not found".formatted(invalidProcessDefinitionKey));
   }
 
   @Test

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceIncidentSearchTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceIncidentSearchTest.java
@@ -108,7 +108,7 @@ class ProcessInstanceIncidentSearchTest {
     assertThat(exception.details().getTitle()).isEqualTo("NOT_FOUND");
     assertThat(exception.details().getStatus()).isEqualTo(404);
     assertThat(exception.details().getDetail())
-        .contains("A single result was expected, but none was found matching");
+        .contains("Process Instance with key '%s' not found".formatted(processInstanceKey));
   }
 
   @ParameterizedTest

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceSearchTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceSearchTest.java
@@ -162,7 +162,7 @@ public class ProcessInstanceSearchTest {
     assertThat(exception.details().getTitle()).isEqualTo("NOT_FOUND");
     assertThat(exception.details().getStatus()).isEqualTo(404);
     assertThat(exception.details().getDetail())
-        .contains("A single result was expected, but none was found matching");
+        .contains("Process Instance with key '%s' not found".formatted(invalidProcessInstanceKey));
   }
 
   @Test

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/RoleIntegrationTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/RoleIntegrationTest.java
@@ -116,7 +116,7 @@ public class RoleIntegrationTest {
     assertThatThrownBy(() -> camundaClient.newRoleGetRequest("someRoleId").send().join())
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 404: 'Not Found'")
-        .hasMessageContaining("A single result was expected, but none was found matching");
+        .hasMessageContaining("Role with id 'someRoleId' not found");
   }
 
   @Test

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/UserTaskSearchTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/UserTaskSearchTest.java
@@ -619,7 +619,7 @@ class UserTaskSearchTest {
     // then
     assertThat(problemException.code()).isEqualTo(404);
     assertThat(problemException.details().getDetail())
-        .contains("A single result was expected, but none was found matching");
+        .contains("User Task with key '%d' not found".formatted(userTaskKey));
   }
 
   @Test

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/UsersSearchIntegrationTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/UsersSearchIntegrationTest.java
@@ -69,7 +69,7 @@ public class UsersSearchIntegrationTest {
     assertThatThrownBy(() -> camundaClient.newUserGetRequest("testUsername").send().join())
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 404: 'Not Found'")
-        .hasMessageContaining("A single result was expected, but none was found matching");
+        .hasMessageContaining("User with id 'testUsername' not found");
   }
 
   @Test

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/VariableSearchTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/VariableSearchTest.java
@@ -315,7 +315,7 @@ class VariableSearchTest {
     // then
     assertThat(problemException.code()).isEqualTo(404);
     assertThat(problemException.details().getDetail())
-        .contains("A single result was expected, but none was found matching");
+        .contains("Variable with key '%d' not found".formatted(variableKey));
   }
 
   @Test

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/DecisionDefinitionTenancyIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/DecisionDefinitionTenancyIT.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.tenancy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.command.ProblemException;
+import io.camunda.client.api.response.Decision;
+import io.camunda.qa.util.auth.Authenticated;
+import io.camunda.qa.util.auth.TestUser;
+import io.camunda.qa.util.auth.UserDefinition;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.qa.util.multidb.MultiDbTestApplication;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import java.time.Duration;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+
+@MultiDbTest
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms")
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
+public class DecisionDefinitionTenancyIT {
+
+  @MultiDbTestApplication
+  static final TestStandaloneBroker BROKER =
+      new TestStandaloneBroker()
+          .withBasicAuth()
+          .withMultiTenancyEnabled()
+          .withAuthenticatedAccess();
+
+  private static final String ADMIN = "admin";
+  private static final String USER1 = "user1";
+  private static final String USER2 = "user2";
+  private static final String TENANT_A = "tenantA";
+  private static final String TENANT_B = "tenantB";
+
+  @UserDefinition
+  private static final TestUser ADMIN_USER = new TestUser(ADMIN, "password", List.of());
+
+  @UserDefinition
+  private static final TestUser USER1_USER = new TestUser(USER1, "password", List.of());
+
+  @UserDefinition
+  private static final TestUser USER2_USER = new TestUser(USER2, "password", List.of());
+
+  @BeforeAll
+  static void setUp(@Authenticated(ADMIN) final CamundaClient adminClient) {
+    createTenant(adminClient, TENANT_A);
+    createTenant(adminClient, TENANT_B);
+    assignUserToTenant(adminClient, ADMIN, TENANT_A);
+    assignUserToTenant(adminClient, ADMIN, TENANT_B);
+    assignUserToTenant(adminClient, USER1, TENANT_A);
+
+    deployResource(adminClient, "decisions/decision_model.dmn", TENANT_A);
+    deployResource(adminClient, "decisions/decision_model_1.dmn", TENANT_B);
+
+    waitForDecisionDefinitionsToBeDeployed(adminClient, 2);
+  }
+
+  @Test
+  public void shouldReturnAllDecisionDefinitionsWithTenantAccess(
+      @Authenticated(ADMIN) final CamundaClient camundaClient) {
+    // when
+    final var result = camundaClient.newDecisionDefinitionSearchRequest().send().join();
+    // then
+    assertThat(result.items()).hasSize(2);
+    assertThat(result.items().stream().map(Decision::getTenantId).collect(Collectors.toSet()))
+        .containsExactlyInAnyOrder(TENANT_A, TENANT_B);
+  }
+
+  @Test
+  public void shouldReturnOnlyTenantADecisionDefinition(
+      @Authenticated(USER1) final CamundaClient camundaClient) {
+    // when
+    final var result = camundaClient.newDecisionDefinitionSearchRequest().send().join();
+    // then
+    assertThat(result.items()).hasSize(1);
+    assertThat(result.items().stream().map(Decision::getTenantId).collect(Collectors.toSet()))
+        .containsExactlyInAnyOrder(TENANT_A);
+  }
+
+  @Test
+  public void shouldNotReturnAnyDecisionDefinition(
+      @Authenticated(USER2) final CamundaClient camundaClient) {
+    // when
+    final var result = camundaClient.newDecisionDefinitionSearchRequest().send().join();
+    // then
+    assertThat(result.items()).hasSize(0);
+  }
+
+  @Test
+  void getByKeyShouldReturnTenantOwnedDecisionDefinition(
+      @Authenticated(ADMIN) final CamundaClient adminClient,
+      @Authenticated(USER1) final CamundaClient camundaClient) {
+    // given
+    final var decisionDefinition =
+        adminClient
+            .newDecisionDefinitionSearchRequest()
+            .filter(f -> f.tenantId(TENANT_A))
+            .page(p -> p.limit(1))
+            .send()
+            .join()
+            .items()
+            .getFirst();
+
+    // when
+    final var result =
+        camundaClient
+            .newDecisionDefinitionGetRequest(decisionDefinition.getDecisionKey())
+            .send()
+            .join();
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.getDecisionKey()).isEqualTo(decisionDefinition.getDecisionKey());
+    assertThat(result.getTenantId()).isEqualTo(TENANT_A);
+  }
+
+  @Test
+  void getByKeyShouldThrowNotFoundException(
+      @Authenticated(ADMIN) final CamundaClient adminClient,
+      @Authenticated(USER2) final CamundaClient camundaClient) {
+    // given
+    final var decisionDefinition =
+        adminClient
+            .newDecisionDefinitionSearchRequest()
+            .filter(f -> f.tenantId(TENANT_A))
+            .page(p -> p.limit(1))
+            .send()
+            .join()
+            .items()
+            .getFirst();
+
+    // when
+    final var exception =
+        assertThrowsExactly(
+            ProblemException.class,
+            () ->
+                camundaClient
+                    .newDecisionDefinitionGetRequest(decisionDefinition.getDecisionKey())
+                    .send()
+                    .join());
+
+    // then
+    assertThat(exception.getMessage()).startsWith("Failed with code 404");
+    assertThat(exception.details()).isNotNull();
+    assertThat(exception.details().getTitle()).isEqualTo("NOT_FOUND");
+    assertThat(exception.details().getStatus()).isEqualTo(404);
+    assertThat(exception.details().getDetail())
+        .contains(
+            "Decision Definition with key '%s' not found"
+                .formatted(decisionDefinition.getDecisionKey()));
+  }
+
+  private static void createTenant(final CamundaClient camundaClient, final String tenant) {
+    camundaClient.newCreateTenantCommand().tenantId(tenant).name(tenant).send().join();
+  }
+
+  private static void assignUserToTenant(
+      final CamundaClient camundaClient, final String username, final String tenant) {
+    camundaClient.newAssignUserToTenantCommand().username(username).tenantId(tenant).send().join();
+  }
+
+  private static void deployResource(
+      final CamundaClient camundaClient, final String resourceName, final String tenant) {
+    camundaClient
+        .newDeployResourceCommand()
+        .addResourceFromClasspath(resourceName)
+        .tenantId(tenant)
+        .send()
+        .join();
+  }
+
+  private static void waitForDecisionDefinitionsToBeDeployed(
+      final CamundaClient camundaClient, final int expectedCount) {
+    Awaitility.await("should deploy decision definitions")
+        .atMost(Duration.ofSeconds(15))
+        .ignoreExceptions() // Ignore exceptions and continue retrying
+        .untilAsserted(
+            () -> {
+              final var result = camundaClient.newDecisionDefinitionSearchRequest().send().join();
+              assertThat(result.items().size()).isEqualTo(expectedCount);
+            });
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/DecisionInstanceTenancyIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/DecisionInstanceTenancyIT.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.tenancy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.command.ProblemException;
+import io.camunda.client.api.response.EvaluateDecisionResponse;
+import io.camunda.client.api.search.response.DecisionInstance;
+import io.camunda.qa.util.auth.Authenticated;
+import io.camunda.qa.util.auth.TestUser;
+import io.camunda.qa.util.auth.UserDefinition;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.qa.util.multidb.MultiDbTestApplication;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import java.time.Duration;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+
+@MultiDbTest
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms")
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
+public class DecisionInstanceTenancyIT {
+
+  @MultiDbTestApplication
+  static final TestStandaloneBroker BROKER =
+      new TestStandaloneBroker()
+          .withBasicAuth()
+          .withMultiTenancyEnabled()
+          .withAuthenticatedAccess();
+
+  private static final String ADMIN = "admin";
+  private static final String USER1 = "user1";
+  private static final String USER2 = "user2";
+  private static final String TENANT_A = "tenantA";
+  private static final String TENANT_B = "tenantB";
+
+  @UserDefinition
+  private static final TestUser ADMIN_USER = new TestUser(ADMIN, "password", List.of());
+
+  @UserDefinition
+  private static final TestUser USER1_USER = new TestUser(USER1, "password", List.of());
+
+  @UserDefinition
+  private static final TestUser USER2_USER = new TestUser(USER2, "password", List.of());
+
+  @BeforeAll
+  static void setUp(@Authenticated(ADMIN) final CamundaClient adminClient) {
+    createTenant(adminClient, TENANT_A);
+    createTenant(adminClient, TENANT_B);
+    assignUserToTenant(adminClient, ADMIN, TENANT_A);
+    assignUserToTenant(adminClient, ADMIN, TENANT_B);
+    assignUserToTenant(adminClient, USER1, TENANT_A);
+
+    deployResource(adminClient, "decisions/decision_model.dmn", TENANT_A);
+    deployResource(adminClient, "decisions/decision_model_1.dmn", TENANT_B);
+
+    evaluateDecision(adminClient, "decision_1", TENANT_A);
+    evaluateDecision(adminClient, "test_qa", TENANT_B);
+
+    waitForDecisionsToBeEvaluated(adminClient, 2);
+  }
+
+  @Test
+  public void shouldReturnAllDecisionInstancesWithTenantAccess(
+      @Authenticated(ADMIN) final CamundaClient camundaClient) {
+    // when
+    final var result = camundaClient.newDecisionInstanceSearchRequest().send().join();
+    // then
+    assertThat(result.items()).hasSize(2);
+    // at the moment no tenant ids are returned with the response
+    assertThat(
+            result.items().stream().map(DecisionInstance::getTenantId).collect(Collectors.toSet()))
+        .containsExactlyInAnyOrder(TENANT_A, TENANT_B);
+  }
+
+  @Test
+  public void shouldReturnOnlyTenantADecisionInstance(
+      @Authenticated(USER1) final CamundaClient camundaClient) {
+    // when
+    final var result = camundaClient.newDecisionInstanceSearchRequest().send().join();
+    // then
+    assertThat(result.items()).hasSize(1);
+    assertThat(
+            result.items().stream().map(DecisionInstance::getTenantId).collect(Collectors.toSet()))
+        .containsExactlyInAnyOrder(TENANT_A);
+  }
+
+  @Test
+  public void shouldNotReturnAnyDecisionInstance(
+      @Authenticated(USER2) final CamundaClient camundaClient) {
+    // when
+    final var result = camundaClient.newDecisionInstanceSearchRequest().send().join();
+    // then
+    assertThat(result.items()).hasSize(0);
+  }
+
+  @Test
+  void getByKeyShouldReturnTenantOwnedDecisionInstance(
+      @Authenticated(ADMIN) final CamundaClient adminClient,
+      @Authenticated(USER1) final CamundaClient camundaClient) {
+    // given
+    final var decisionInstance =
+        adminClient
+            .newDecisionInstanceSearchRequest()
+            .filter(f -> f.tenantId(TENANT_A))
+            .page(p -> p.limit(1))
+            .send()
+            .join()
+            .items()
+            .getFirst();
+
+    // when
+    final var result =
+        camundaClient
+            .newDecisionInstanceGetRequest(decisionInstance.getDecisionInstanceId())
+            .send()
+            .join();
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.getDecisionInstanceId()).isEqualTo(decisionInstance.getDecisionInstanceId());
+    assertThat(result.getTenantId()).isEqualTo(TENANT_A);
+  }
+
+  @Test
+  void getByKeyShouldThrowNotFoundException(
+      @Authenticated(ADMIN) final CamundaClient adminClient,
+      @Authenticated(USER2) final CamundaClient camundaClient) {
+    // given
+    final var decisionInstance =
+        adminClient
+            .newDecisionInstanceSearchRequest()
+            .filter(f -> f.tenantId(TENANT_A))
+            .page(p -> p.limit(1))
+            .send()
+            .join()
+            .items()
+            .getFirst();
+
+    // when
+    final var exception =
+        assertThrowsExactly(
+            ProblemException.class,
+            () ->
+                camundaClient
+                    .newDecisionInstanceGetRequest(decisionInstance.getDecisionInstanceId())
+                    .send()
+                    .join());
+
+    // then
+    assertThat(exception.getMessage()).startsWith("Failed with code 404");
+    assertThat(exception.details()).isNotNull();
+    assertThat(exception.details().getTitle()).isEqualTo("NOT_FOUND");
+    assertThat(exception.details().getStatus()).isEqualTo(404);
+    assertThat(exception.details().getDetail())
+        .contains(
+            "Decision Instance with id '%s' not found"
+                .formatted(decisionInstance.getDecisionInstanceId()));
+  }
+
+  private static void createTenant(final CamundaClient camundaClient, final String tenant) {
+    camundaClient.newCreateTenantCommand().tenantId(tenant).name(tenant).send().join();
+  }
+
+  private static void assignUserToTenant(
+      final CamundaClient camundaClient, final String username, final String tenant) {
+    camundaClient.newAssignUserToTenantCommand().username(username).tenantId(tenant).send().join();
+  }
+
+  private static void deployResource(
+      final CamundaClient camundaClient, final String resourceName, final String tenant) {
+    camundaClient
+        .newDeployResourceCommand()
+        .addResourceFromClasspath(resourceName)
+        .tenantId(tenant)
+        .send()
+        .join();
+  }
+
+  private static EvaluateDecisionResponse evaluateDecision(
+      final CamundaClient camundaClient, final String decisionId, final String tenantId) {
+    return camundaClient
+        .newEvaluateDecisionCommand()
+        .decisionId(decisionId)
+        .tenantId(tenantId)
+        .variables("{\"input1\": \"A\"}")
+        .send()
+        .join();
+  }
+
+  private static void waitForDecisionsToBeEvaluated(
+      final CamundaClient camundaClient, final int expectedCount) {
+    Awaitility.await("should evaluate decision definitions")
+        .atMost(Duration.ofSeconds(15))
+        .ignoreExceptions() // Ignore exceptions and continue retrying
+        .untilAsserted(
+            () -> {
+              final var result = camundaClient.newDecisionInstanceSearchRequest().send().join();
+              assertThat(result.items().size()).isEqualTo(expectedCount);
+            });
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/DecisionRequirementsTenancyIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/DecisionRequirementsTenancyIT.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.tenancy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.command.ProblemException;
+import io.camunda.client.api.response.DecisionRequirements;
+import io.camunda.qa.util.auth.Authenticated;
+import io.camunda.qa.util.auth.TestUser;
+import io.camunda.qa.util.auth.UserDefinition;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.qa.util.multidb.MultiDbTestApplication;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import java.time.Duration;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+
+@MultiDbTest
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms")
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
+public class DecisionRequirementsTenancyIT {
+
+  @MultiDbTestApplication
+  static final TestStandaloneBroker BROKER =
+      new TestStandaloneBroker()
+          .withBasicAuth()
+          .withMultiTenancyEnabled()
+          .withAuthenticatedAccess();
+
+  private static final String ADMIN = "admin";
+  private static final String USER1 = "user1";
+  private static final String USER2 = "user2";
+  private static final String TENANT_A = "tenantA";
+  private static final String TENANT_B = "tenantB";
+
+  @UserDefinition
+  private static final TestUser ADMIN_USER = new TestUser(ADMIN, "password", List.of());
+
+  @UserDefinition
+  private static final TestUser USER1_USER = new TestUser(USER1, "password", List.of());
+
+  @UserDefinition
+  private static final TestUser USER2_USER = new TestUser(USER2, "password", List.of());
+
+  @BeforeAll
+  static void setUp(@Authenticated(ADMIN) final CamundaClient adminClient) {
+    createTenant(adminClient, TENANT_A);
+    createTenant(adminClient, TENANT_B);
+    assignUserToTenant(adminClient, ADMIN, TENANT_A);
+    assignUserToTenant(adminClient, ADMIN, TENANT_B);
+    assignUserToTenant(adminClient, USER1, TENANT_A);
+
+    deployResource(adminClient, "decisions/decision_model.dmn", TENANT_A);
+    deployResource(adminClient, "decisions/decision_model_1.dmn", TENANT_B);
+
+    waitForDecisionRequirementsToBeDeployed(adminClient, 2);
+  }
+
+  @Test
+  public void shouldReturnAllDecisionRequirementsWithTenantAccess(
+      @Authenticated(ADMIN) final CamundaClient camundaClient) {
+    // when
+    final var result = camundaClient.newDecisionRequirementsSearchRequest().send().join();
+    // then
+    assertThat(result.items()).hasSize(2);
+    assertThat(
+            result.items().stream()
+                .map(DecisionRequirements::getTenantId)
+                .collect(Collectors.toSet()))
+        .containsExactlyInAnyOrder(TENANT_A, TENANT_B);
+  }
+
+  @Test
+  public void shouldReturnOnlyTenantADecisionRequirements(
+      @Authenticated(USER1) final CamundaClient camundaClient) {
+    // when
+    final var result = camundaClient.newDecisionRequirementsSearchRequest().send().join();
+    // then
+    assertThat(result.items()).hasSize(1);
+    assertThat(
+            result.items().stream()
+                .map(DecisionRequirements::getTenantId)
+                .collect(Collectors.toSet()))
+        .containsExactlyInAnyOrder(TENANT_A);
+  }
+
+  @Test
+  public void shouldNotReturnAnyDecisionRequirements(
+      @Authenticated(USER2) final CamundaClient camundaClient) {
+    // when
+    final var result = camundaClient.newDecisionRequirementsSearchRequest().send().join();
+    // then
+    assertThat(result.items()).hasSize(0);
+  }
+
+  @Test
+  void getByKeyShouldReturnTenantOwnedDecisionRequirements(
+      @Authenticated(ADMIN) final CamundaClient adminClient,
+      @Authenticated(USER1) final CamundaClient camundaClient) {
+    // given
+    final var decisionRequirements =
+        adminClient
+            .newDecisionRequirementsSearchRequest()
+            .filter(f -> f.tenantId(TENANT_A))
+            .page(p -> p.limit(1))
+            .send()
+            .join()
+            .items()
+            .getFirst();
+
+    // when
+    final var result =
+        camundaClient
+            .newDecisionRequirementsGetRequest(decisionRequirements.getDecisionRequirementsKey())
+            .send()
+            .join();
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.getDecisionRequirementsKey())
+        .isEqualTo(decisionRequirements.getDecisionRequirementsKey());
+    assertThat(result.getTenantId()).isEqualTo(TENANT_A);
+  }
+
+  @Test
+  void getByKeyShouldThrowNotFoundException(
+      @Authenticated(ADMIN) final CamundaClient adminClient,
+      @Authenticated(USER2) final CamundaClient camundaClient) {
+    // given
+    final var decisionRequirements =
+        adminClient
+            .newDecisionRequirementsSearchRequest()
+            .filter(f -> f.tenantId(TENANT_A))
+            .page(p -> p.limit(1))
+            .send()
+            .join()
+            .items()
+            .getFirst();
+
+    // when
+    final var exception =
+        assertThrowsExactly(
+            ProblemException.class,
+            () ->
+                camundaClient
+                    .newDecisionRequirementsGetRequest(
+                        decisionRequirements.getDecisionRequirementsKey())
+                    .send()
+                    .join());
+
+    // then
+    assertThat(exception.getMessage()).startsWith("Failed with code 404");
+    assertThat(exception.details()).isNotNull();
+    assertThat(exception.details().getTitle()).isEqualTo("NOT_FOUND");
+    assertThat(exception.details().getStatus()).isEqualTo(404);
+    assertThat(exception.details().getDetail())
+        .contains(
+            "Decision Requirements with key '%s' not found"
+                .formatted(decisionRequirements.getDecisionRequirementsKey()));
+  }
+
+  private static void createTenant(final CamundaClient camundaClient, final String tenant) {
+    camundaClient.newCreateTenantCommand().tenantId(tenant).name(tenant).send().join();
+  }
+
+  private static void assignUserToTenant(
+      final CamundaClient camundaClient, final String username, final String tenant) {
+    camundaClient.newAssignUserToTenantCommand().username(username).tenantId(tenant).send().join();
+  }
+
+  private static void deployResource(
+      final CamundaClient camundaClient, final String resourceName, final String tenant) {
+    camundaClient
+        .newDeployResourceCommand()
+        .addResourceFromClasspath(resourceName)
+        .tenantId(tenant)
+        .send()
+        .join();
+  }
+
+  private static void waitForDecisionRequirementsToBeDeployed(
+      final CamundaClient camundaClient, final int expectedCount) {
+    Awaitility.await("should deploy decision definitions")
+        .atMost(Duration.ofSeconds(15))
+        .ignoreExceptions() // Ignore exceptions and continue retrying
+        .untilAsserted(
+            () -> {
+              final var result = camundaClient.newDecisionRequirementsSearchRequest().send().join();
+              assertThat(result.items().size()).isEqualTo(expectedCount);
+            });
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/ElementInstanceTenancyIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/ElementInstanceTenancyIT.java
@@ -1,0 +1,205 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.tenancy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.command.ProblemException;
+import io.camunda.client.api.search.enums.ElementInstanceState;
+import io.camunda.client.api.search.response.ElementInstance;
+import io.camunda.qa.util.auth.Authenticated;
+import io.camunda.qa.util.auth.TestUser;
+import io.camunda.qa.util.auth.UserDefinition;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.qa.util.multidb.MultiDbTestApplication;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import java.time.Duration;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+
+@MultiDbTest
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms")
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
+public class ElementInstanceTenancyIT {
+
+  @MultiDbTestApplication
+  static final TestStandaloneBroker BROKER =
+      new TestStandaloneBroker()
+          .withBasicAuth()
+          .withMultiTenancyEnabled()
+          .withAuthenticatedAccess();
+
+  private static final String ADMIN = "admin";
+  private static final String USER1 = "user1";
+  private static final String USER2 = "user2";
+  private static final String TENANT_A = "tenantA";
+  private static final String TENANT_B = "tenantB";
+  private static final String PROCESS_ID = "service_tasks_v1";
+
+  @UserDefinition
+  private static final TestUser ADMIN_USER = new TestUser(ADMIN, "password", List.of());
+
+  @UserDefinition
+  private static final TestUser USER1_USER = new TestUser(USER1, "password", List.of());
+
+  @UserDefinition
+  private static final TestUser USER2_USER = new TestUser(USER2, "password", List.of());
+
+  @BeforeAll
+  static void setUp(@Authenticated(ADMIN) final CamundaClient adminClient) {
+    createTenant(adminClient, TENANT_A);
+    createTenant(adminClient, TENANT_B);
+    assignUserToTenant(adminClient, ADMIN, TENANT_A);
+    assignUserToTenant(adminClient, ADMIN, TENANT_B);
+    assignUserToTenant(adminClient, USER1, TENANT_A);
+
+    deployResource(adminClient, "process/service_tasks_v1.bpmn", TENANT_A);
+    startProcessInstance(adminClient, PROCESS_ID, TENANT_A);
+
+    deployResource(adminClient, "process/service_tasks_v1.bpmn", TENANT_B);
+    startProcessInstance(adminClient, PROCESS_ID, TENANT_B);
+    waitForElementInstancesBeingExported(adminClient);
+  }
+
+  @Test
+  public void shouldReturnAllElementInstancesWithTenantAccess(
+      @Authenticated(ADMIN) final CamundaClient camundaClient) {
+    // when
+    final var result = camundaClient.newElementInstanceSearchRequest().send().join();
+    // then
+    assertThat(result.items()).hasSize(4);
+    assertThat(
+            result.items().stream().map(ElementInstance::getTenantId).collect(Collectors.toSet()))
+        .containsExactlyInAnyOrder(TENANT_A, TENANT_B);
+  }
+
+  @Test
+  public void shouldReturnOnlyTenantAElementInstances(
+      @Authenticated(USER1) final CamundaClient camundaClient) {
+    // when
+    final var result = camundaClient.newElementInstanceSearchRequest().send().join();
+    // then
+    assertThat(result.items()).hasSize(2);
+    assertThat(
+            result.items().stream().map(ElementInstance::getTenantId).collect(Collectors.toSet()))
+        .containsExactlyInAnyOrder(TENANT_A);
+  }
+
+  @Test
+  public void shouldNotReturnAnyElementInstances(
+      @Authenticated(USER2) final CamundaClient camundaClient) {
+    // when
+    final var result = camundaClient.newElementInstanceSearchRequest().send().join();
+    // then
+    assertThat(result.items()).hasSize(0);
+  }
+
+  @Test
+  void getByKeyShouldReturnTenantOwnedElementInstance(
+      @Authenticated(ADMIN) final CamundaClient adminClient,
+      @Authenticated(USER1) final CamundaClient camundaClient) {
+    // given
+    final var elementInstanceKey = getElementInstanceKey(adminClient, PROCESS_ID, TENANT_A);
+    // when
+    final var result = camundaClient.newElementInstanceGetRequest(elementInstanceKey).send().join();
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.getElementInstanceKey()).isEqualTo(elementInstanceKey);
+    assertThat(result.getTenantId()).isEqualTo(TENANT_A);
+  }
+
+  @Test
+  void getByKeyShouldThrowNotFoundException(
+      @Authenticated(ADMIN) final CamundaClient adminClient,
+      @Authenticated(USER2) final CamundaClient camundaClient) {
+    // given
+    final var elementInstanceKey = getElementInstanceKey(adminClient, PROCESS_ID, TENANT_A);
+
+    // when
+    final var exception =
+        assertThrowsExactly(
+            ProblemException.class,
+            () -> camundaClient.newElementInstanceGetRequest(elementInstanceKey).send().join());
+    // then
+    assertThat(exception.getMessage()).startsWith("Failed with code 404");
+    assertThat(exception.details()).isNotNull();
+    assertThat(exception.details().getTitle()).isEqualTo("NOT_FOUND");
+    assertThat(exception.details().getStatus()).isEqualTo(404);
+    assertThat(exception.details().getDetail())
+        .contains("Element Instance with key '%s' not found".formatted(elementInstanceKey));
+  }
+
+  private static void createTenant(final CamundaClient camundaClient, final String tenant) {
+    camundaClient.newCreateTenantCommand().tenantId(tenant).name(tenant).send().join();
+  }
+
+  private static void assignUserToTenant(
+      final CamundaClient camundaClient, final String username, final String tenant) {
+    camundaClient.newAssignUserToTenantCommand().username(username).tenantId(tenant).send().join();
+  }
+
+  private static void deployResource(
+      final CamundaClient camundaClient, final String resourceName, final String tenant) {
+    camundaClient
+        .newDeployResourceCommand()
+        .addResourceFromClasspath(resourceName)
+        .tenantId(tenant)
+        .send()
+        .join();
+  }
+
+  private static void startProcessInstance(
+      final CamundaClient camundaClient, final String processId, final String tenant) {
+    camundaClient
+        .newCreateInstanceCommand()
+        .bpmnProcessId(processId)
+        .latestVersion()
+        .tenantId(tenant)
+        .send()
+        .join();
+  }
+
+  private static void waitForElementInstancesBeingExported(final CamundaClient camundaClient) {
+    Awaitility.await("should receive data from secondary storage")
+        .atMost(Duration.ofMinutes(1))
+        .ignoreExceptions() // Ignore exceptions and continue retrying
+        .untilAsserted(
+            () -> {
+              assertThat(
+                      camundaClient
+                          .newElementInstanceSearchRequest()
+                          .filter(filter -> filter.processDefinitionId(PROCESS_ID))
+                          .send()
+                          .join()
+                          .items())
+                  .hasSize(4);
+            });
+  }
+
+  private long getElementInstanceKey(
+      final CamundaClient camundaClient, final String processId, final String tenantId) {
+    return camundaClient
+        .newElementInstanceSearchRequest()
+        .filter(
+            f ->
+                f.processDefinitionId(processId)
+                    .tenantId(tenantId)
+                    .state(ElementInstanceState.ACTIVE))
+        .send()
+        .join()
+        .items()
+        .getFirst()
+        .getElementInstanceKey();
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/IncidentTenancyIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/IncidentTenancyIT.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.tenancy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.command.ProblemException;
+import io.camunda.client.api.search.response.Incident;
+import io.camunda.qa.util.auth.Authenticated;
+import io.camunda.qa.util.auth.TestUser;
+import io.camunda.qa.util.auth.UserDefinition;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.qa.util.multidb.MultiDbTestApplication;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import java.time.Duration;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+
+@MultiDbTest
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms")
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
+public class IncidentTenancyIT {
+
+  @MultiDbTestApplication
+  static final TestStandaloneBroker BROKER =
+      new TestStandaloneBroker()
+          .withBasicAuth()
+          .withMultiTenancyEnabled()
+          .withAuthenticatedAccess();
+
+  private static final String ADMIN = "admin";
+  private static final String USER1 = "user1";
+  private static final String USER2 = "user2";
+  private static final String TENANT_A = "tenantA";
+  private static final String TENANT_B = "tenantB";
+  private static final String PROCESS_ID = "incident_process_v1";
+
+  @UserDefinition
+  private static final TestUser ADMIN_USER = new TestUser(ADMIN, "password", List.of());
+
+  @UserDefinition
+  private static final TestUser USER1_USER = new TestUser(USER1, "password", List.of());
+
+  @UserDefinition
+  private static final TestUser USER2_USER = new TestUser(USER2, "password", List.of());
+
+  @BeforeAll
+  static void setUp(@Authenticated(ADMIN) final CamundaClient adminClient) {
+    createTenant(adminClient, TENANT_A);
+    createTenant(adminClient, TENANT_B);
+    assignUserToTenant(adminClient, ADMIN, TENANT_A);
+    assignUserToTenant(adminClient, ADMIN, TENANT_B);
+    assignUserToTenant(adminClient, USER1, TENANT_A);
+
+    deployResource(adminClient, "process/incident_process_v1.bpmn", TENANT_A);
+    startProcessInstance(adminClient, PROCESS_ID, TENANT_A);
+
+    deployResource(adminClient, "process/incident_process_v1.bpmn", TENANT_B);
+    startProcessInstance(adminClient, PROCESS_ID, TENANT_B);
+    waitForIncidentsBeingExported(adminClient);
+  }
+
+  @Test
+  public void shouldReturnAllIncidentsWithTenantAccess(
+      @Authenticated(ADMIN) final CamundaClient camundaClient) {
+    // when
+    final var result = camundaClient.newIncidentSearchRequest().send().join();
+    // then
+    assertThat(result.items()).hasSize(2);
+    assertThat(result.items().stream().map(Incident::getTenantId).collect(Collectors.toSet()))
+        .containsExactlyInAnyOrder(TENANT_A, TENANT_B);
+  }
+
+  @Test
+  public void shouldReturnOnlyTenantAIncidents(
+      @Authenticated(USER1) final CamundaClient camundaClient) {
+    // when
+    final var result = camundaClient.newIncidentSearchRequest().send().join();
+    // then
+    assertThat(result.items()).hasSize(1);
+    assertThat(result.items().stream().map(Incident::getTenantId).collect(Collectors.toSet()))
+        .containsExactlyInAnyOrder(TENANT_A);
+  }
+
+  @Test
+  public void shouldNotReturnAnyIncidents(@Authenticated(USER2) final CamundaClient camundaClient) {
+    // when
+    final var result = camundaClient.newIncidentSearchRequest().send().join();
+    // then
+    assertThat(result.items()).hasSize(0);
+  }
+
+  @Test
+  void getByKeyShouldReturnTenantOwnedIncident(
+      @Authenticated(ADMIN) final CamundaClient adminClient,
+      @Authenticated(USER1) final CamundaClient camundaClient) {
+    // given
+    final var incidentKey = getIncidentKey(adminClient, PROCESS_ID, TENANT_A);
+    // when
+    final var result = camundaClient.newIncidentGetRequest(incidentKey).send().join();
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.getIncidentKey()).isEqualTo(incidentKey);
+    assertThat(result.getTenantId()).isEqualTo(TENANT_A);
+  }
+
+  @Test
+  void getByKeyShouldThrowNotFoundException(
+      @Authenticated(ADMIN) final CamundaClient adminClient,
+      @Authenticated(USER2) final CamundaClient camundaClient) {
+    // given
+    final var incidentKey = getIncidentKey(adminClient, PROCESS_ID, TENANT_A);
+
+    // when
+    final var exception =
+        assertThrowsExactly(
+            ProblemException.class,
+            () -> camundaClient.newIncidentGetRequest(incidentKey).send().join());
+    // then
+    assertThat(exception.getMessage()).startsWith("Failed with code 404");
+    assertThat(exception.details()).isNotNull();
+    assertThat(exception.details().getTitle()).isEqualTo("NOT_FOUND");
+    assertThat(exception.details().getStatus()).isEqualTo(404);
+    assertThat(exception.details().getDetail())
+        .contains("Incident with key '%s' not found".formatted(incidentKey));
+  }
+
+  private static void createTenant(final CamundaClient camundaClient, final String tenant) {
+    camundaClient.newCreateTenantCommand().tenantId(tenant).name(tenant).send().join();
+  }
+
+  private static void assignUserToTenant(
+      final CamundaClient camundaClient, final String username, final String tenant) {
+    camundaClient.newAssignUserToTenantCommand().username(username).tenantId(tenant).send().join();
+  }
+
+  private static void deployResource(
+      final CamundaClient camundaClient, final String resourceName, final String tenant) {
+    camundaClient
+        .newDeployResourceCommand()
+        .addResourceFromClasspath(resourceName)
+        .tenantId(tenant)
+        .send()
+        .join();
+  }
+
+  private static void startProcessInstance(
+      final CamundaClient camundaClient, final String processId, final String tenant) {
+    camundaClient
+        .newCreateInstanceCommand()
+        .bpmnProcessId(processId)
+        .latestVersion()
+        .tenantId(tenant)
+        .send()
+        .join();
+  }
+
+  private static void waitForIncidentsBeingExported(final CamundaClient camundaClient) {
+    Awaitility.await("should receive data from secondary storage")
+        .atMost(Duration.ofMinutes(1))
+        .ignoreExceptions() // Ignore exceptions and continue retrying
+        .untilAsserted(
+            () -> {
+              assertThat(
+                      camundaClient
+                          .newIncidentSearchRequest()
+                          .filter(filter -> filter.processDefinitionId(PROCESS_ID))
+                          .send()
+                          .join()
+                          .items())
+                  .hasSize(2);
+            });
+  }
+
+  private long getIncidentKey(
+      final CamundaClient camundaClient, final String processId, final String tenantId) {
+    return camundaClient
+        .newIncidentSearchRequest()
+        .filter(f -> f.processDefinitionId(processId).tenantId(tenantId))
+        .send()
+        .join()
+        .items()
+        .getFirst()
+        .getIncidentKey();
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/JobTenancyIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/JobTenancyIT.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.tenancy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.search.response.Job;
+import io.camunda.qa.util.auth.Authenticated;
+import io.camunda.qa.util.auth.TestUser;
+import io.camunda.qa.util.auth.UserDefinition;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.qa.util.multidb.MultiDbTestApplication;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import java.time.Duration;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+
+@MultiDbTest
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms")
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
+public class JobTenancyIT {
+
+  @MultiDbTestApplication
+  static final TestStandaloneBroker BROKER =
+      new TestStandaloneBroker()
+          .withBasicAuth()
+          .withMultiTenancyEnabled()
+          .withAuthenticatedAccess();
+
+  private static final String ADMIN = "admin";
+  private static final String USER1 = "user1";
+  private static final String USER2 = "user2";
+  private static final String TENANT_A = "tenantA";
+  private static final String TENANT_B = "tenantB";
+  private static final String PROCESS_ID = "service_tasks_v1";
+
+  @UserDefinition
+  private static final TestUser ADMIN_USER = new TestUser(ADMIN, "password", List.of());
+
+  @UserDefinition
+  private static final TestUser USER1_USER = new TestUser(USER1, "password", List.of());
+
+  @UserDefinition
+  private static final TestUser USER2_USER = new TestUser(USER2, "password", List.of());
+
+  @BeforeAll
+  static void setUp(@Authenticated(ADMIN) final CamundaClient adminClient) {
+    createTenant(adminClient, TENANT_A);
+    createTenant(adminClient, TENANT_B);
+    assignUserToTenant(adminClient, ADMIN, TENANT_A);
+    assignUserToTenant(adminClient, ADMIN, TENANT_B);
+    assignUserToTenant(adminClient, USER1, TENANT_A);
+
+    deployResource(adminClient, "process/service_tasks_v1.bpmn", TENANT_A);
+    startProcessInstance(adminClient, PROCESS_ID, TENANT_A);
+
+    deployResource(adminClient, "process/service_tasks_v1.bpmn", TENANT_B);
+    startProcessInstance(adminClient, PROCESS_ID, TENANT_B);
+    waitForJobsBeingExported(adminClient);
+  }
+
+  @Test
+  public void shouldReturnAllJobsWithTenantAccess(
+      @Authenticated(ADMIN) final CamundaClient camundaClient) {
+    // when
+    final var result = camundaClient.newJobSearchRequest().send().join();
+    // then
+    assertThat(result.items()).hasSize(2);
+    assertThat(result.items().stream().map(Job::getTenantId).collect(Collectors.toSet()))
+        .containsExactlyInAnyOrder(TENANT_A, TENANT_B);
+  }
+
+  @Test
+  public void shouldReturnOnlyTenantAJobs(@Authenticated(USER1) final CamundaClient camundaClient) {
+    // when
+    final var result = camundaClient.newJobSearchRequest().send().join();
+    // then
+    assertThat(result.items()).hasSize(1);
+    assertThat(result.items().stream().map(Job::getTenantId).collect(Collectors.toSet()))
+        .containsExactlyInAnyOrder(TENANT_A);
+  }
+
+  @Test
+  public void shouldNotReturnAnyJobs(@Authenticated(USER2) final CamundaClient camundaClient) {
+    // when
+    final var result = camundaClient.newJobSearchRequest().send().join();
+    // then
+    assertThat(result.items()).hasSize(0);
+  }
+
+  private static void createTenant(final CamundaClient camundaClient, final String tenant) {
+    camundaClient.newCreateTenantCommand().tenantId(tenant).name(tenant).send().join();
+  }
+
+  private static void assignUserToTenant(
+      final CamundaClient camundaClient, final String username, final String tenant) {
+    camundaClient.newAssignUserToTenantCommand().username(username).tenantId(tenant).send().join();
+  }
+
+  private static void deployResource(
+      final CamundaClient camundaClient, final String resourceName, final String tenant) {
+    camundaClient
+        .newDeployResourceCommand()
+        .addResourceFromClasspath(resourceName)
+        .tenantId(tenant)
+        .send()
+        .join();
+  }
+
+  private static void startProcessInstance(
+      final CamundaClient camundaClient, final String processId, final String tenant) {
+    camundaClient
+        .newCreateInstanceCommand()
+        .bpmnProcessId(processId)
+        .latestVersion()
+        .tenantId(tenant)
+        .send()
+        .join();
+  }
+
+  private static void waitForJobsBeingExported(final CamundaClient camundaClient) {
+    Awaitility.await("should receive data from secondary storage")
+        .atMost(Duration.ofMinutes(1))
+        .ignoreExceptions() // Ignore exceptions and continue retrying
+        .untilAsserted(
+            () -> {
+              assertThat(
+                      camundaClient
+                          .newJobSearchRequest()
+                          .filter(filter -> filter.processDefinitionId(fn -> fn.in(PROCESS_ID)))
+                          .send()
+                          .join()
+                          .items())
+                  .hasSize(2);
+            });
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/MessageSubscriptionTenancyIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/MessageSubscriptionTenancyIT.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.tenancy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.search.response.MessageSubscription;
+import io.camunda.qa.util.auth.Authenticated;
+import io.camunda.qa.util.auth.TestUser;
+import io.camunda.qa.util.auth.UserDefinition;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.qa.util.multidb.MultiDbTestApplication;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import java.time.Duration;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+
+@MultiDbTest
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms")
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
+public class MessageSubscriptionTenancyIT {
+
+  @MultiDbTestApplication
+  static final TestStandaloneBroker BROKER =
+      new TestStandaloneBroker()
+          .withBasicAuth()
+          .withMultiTenancyEnabled()
+          .withAuthenticatedAccess();
+
+  private static final String ADMIN = "admin";
+  private static final String USER1 = "user1";
+  private static final String USER2 = "user2";
+  private static final String TENANT_A = "tenantA";
+  private static final String TENANT_B = "tenantB";
+  private static final String PROCESS_ID = "process_with_parallel_receive_tasks";
+
+  @UserDefinition
+  private static final TestUser ADMIN_USER = new TestUser(ADMIN, "password", List.of());
+
+  @UserDefinition
+  private static final TestUser USER1_USER = new TestUser(USER1, "password", List.of());
+
+  @UserDefinition
+  private static final TestUser USER2_USER = new TestUser(USER2, "password", List.of());
+
+  @BeforeAll
+  static void setUp(@Authenticated(ADMIN) final CamundaClient adminClient) {
+    createTenant(adminClient, TENANT_A);
+    createTenant(adminClient, TENANT_B);
+    assignUserToTenant(adminClient, ADMIN, TENANT_A);
+    assignUserToTenant(adminClient, ADMIN, TENANT_B);
+    assignUserToTenant(adminClient, USER1, TENANT_A);
+
+    deployResource(adminClient, "process/process_with_parallel_receive_tasks.bpmn", TENANT_A);
+    startProcessInstance(adminClient, PROCESS_ID, TENANT_A);
+
+    deployResource(adminClient, "process/process_with_parallel_receive_tasks.bpmn", TENANT_B);
+    startProcessInstance(adminClient, PROCESS_ID, TENANT_B);
+    waitForMessageSubscriptionsExported(adminClient);
+  }
+
+  @Test
+  public void shouldReturnAllMessageSubscriptionsWithTenantAccess(
+      @Authenticated(ADMIN) final CamundaClient camundaClient) {
+    // when
+    final var result = camundaClient.newMessageSubscriptionSearchRequest().send().join();
+    // then
+    assertThat(result.items()).hasSize(6);
+    assertThat(
+            result.items().stream()
+                .map(MessageSubscription::getTenantId)
+                .collect(Collectors.toSet()))
+        .containsExactlyInAnyOrder(TENANT_A, TENANT_B);
+  }
+
+  @Test
+  public void shouldReturnOnlyTenantAMessageSubscriptions(
+      @Authenticated(USER1) final CamundaClient camundaClient) {
+    // when
+    final var result = camundaClient.newMessageSubscriptionSearchRequest().send().join();
+    // then
+    assertThat(result.items()).hasSize(3);
+    assertThat(
+            result.items().stream()
+                .map(MessageSubscription::getTenantId)
+                .collect(Collectors.toSet()))
+        .containsExactlyInAnyOrder(TENANT_A);
+  }
+
+  @Test
+  public void shouldNotReturnAnyMessageSubscriptions(
+      @Authenticated(USER2) final CamundaClient camundaClient) {
+    // when
+    final var result = camundaClient.newMessageSubscriptionSearchRequest().send().join();
+    // then
+    assertThat(result.items()).hasSize(0);
+  }
+
+  private static void createTenant(final CamundaClient camundaClient, final String tenant) {
+    camundaClient.newCreateTenantCommand().tenantId(tenant).name(tenant).send().join();
+  }
+
+  private static void assignUserToTenant(
+      final CamundaClient camundaClient, final String username, final String tenant) {
+    camundaClient.newAssignUserToTenantCommand().username(username).tenantId(tenant).send().join();
+  }
+
+  private static void deployResource(
+      final CamundaClient camundaClient, final String resourceName, final String tenant) {
+    camundaClient
+        .newDeployResourceCommand()
+        .addResourceFromClasspath(resourceName)
+        .tenantId(tenant)
+        .send()
+        .join();
+  }
+
+  private static void startProcessInstance(
+      final CamundaClient camundaClient, final String processId, final String tenant) {
+    camundaClient
+        .newCreateInstanceCommand()
+        .bpmnProcessId(processId)
+        .latestVersion()
+        .tenantId(tenant)
+        .send()
+        .join();
+  }
+
+  private static void waitForMessageSubscriptionsExported(final CamundaClient camundaClient) {
+    Awaitility.await("should receive data from secondary storage")
+        .atMost(Duration.ofMinutes(1))
+        .ignoreExceptions() // Ignore exceptions and continue retrying
+        .untilAsserted(
+            () -> {
+              assertThat(
+                      camundaClient
+                          .newMessageSubscriptionSearchRequest()
+                          .filter(filter -> filter.processDefinitionId(fn -> fn.in(PROCESS_ID)))
+                          .send()
+                          .join()
+                          .items())
+                  .hasSize(6);
+            });
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/ProcessDefinitionTenancyIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/ProcessDefinitionTenancyIT.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.tenancy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.command.ProblemException;
+import io.camunda.client.api.search.response.ProcessDefinition;
+import io.camunda.qa.util.auth.Authenticated;
+import io.camunda.qa.util.auth.TestUser;
+import io.camunda.qa.util.auth.UserDefinition;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.qa.util.multidb.MultiDbTestApplication;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import java.time.Duration;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+
+@MultiDbTest
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms")
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
+public class ProcessDefinitionTenancyIT {
+
+  @MultiDbTestApplication
+  static final TestStandaloneBroker BROKER =
+      new TestStandaloneBroker()
+          .withBasicAuth()
+          .withMultiTenancyEnabled()
+          .withAuthenticatedAccess();
+
+  private static final String ADMIN = "admin";
+  private static final String USER1 = "user1";
+  private static final String USER2 = "user2";
+  private static final String TENANT_A = "tenantA";
+  private static final String TENANT_B = "tenantB";
+  private static final String PROCESS_ID = "service_tasks_v1";
+
+  @UserDefinition
+  private static final TestUser ADMIN_USER = new TestUser(ADMIN, "password", List.of());
+
+  @UserDefinition
+  private static final TestUser USER1_USER = new TestUser(USER1, "password", List.of());
+
+  @UserDefinition
+  private static final TestUser USER2_USER = new TestUser(USER2, "password", List.of());
+
+  @BeforeAll
+  static void setUp(@Authenticated(ADMIN) final CamundaClient adminClient) {
+    createTenant(adminClient, TENANT_A);
+    createTenant(adminClient, TENANT_B);
+    assignUserToTenant(adminClient, ADMIN, TENANT_A);
+    assignUserToTenant(adminClient, ADMIN, TENANT_B);
+    assignUserToTenant(adminClient, USER1, TENANT_A);
+
+    deployResource(adminClient, "process/service_tasks_v1.bpmn", TENANT_A);
+    deployResource(adminClient, "process/service_tasks_v1.bpmn", TENANT_B);
+    waitForProcessBeingExported(adminClient);
+  }
+
+  @Test
+  public void shouldReturnAllProcessDefinitionsWithTenantAccess(
+      @Authenticated(ADMIN) final CamundaClient camundaClient) {
+    // when
+    final var result = camundaClient.newProcessDefinitionSearchRequest().send().join();
+    // then
+    assertThat(result.items()).hasSize(2);
+    assertThat(
+            result.items().stream().map(ProcessDefinition::getTenantId).collect(Collectors.toSet()))
+        .containsExactlyInAnyOrder(TENANT_A, TENANT_B);
+  }
+
+  @Test
+  public void shouldReturnOnlyTenantAProcessDefinitions(
+      @Authenticated(USER1) final CamundaClient camundaClient) {
+    // when
+    final var result = camundaClient.newProcessDefinitionSearchRequest().send().join();
+    // then
+    assertThat(result.items()).hasSize(1);
+    assertThat(
+            result.items().stream().map(ProcessDefinition::getTenantId).collect(Collectors.toSet()))
+        .containsExactlyInAnyOrder(TENANT_A);
+  }
+
+  @Test
+  public void shouldNotReturnAnyProcessDefinitions(
+      @Authenticated(USER2) final CamundaClient camundaClient) {
+    // when
+    final var result = camundaClient.newProcessDefinitionSearchRequest().send().join();
+    // then
+    assertThat(result.items()).hasSize(0);
+  }
+
+  @Test
+  void getByKeyShouldReturnTenantOwnedProcessInstance(
+      @Authenticated(ADMIN) final CamundaClient adminClient,
+      @Authenticated(USER1) final CamundaClient camundaClient) {
+    // given
+    final var processDefinitionKey = getProcessDefinitionKey(adminClient, PROCESS_ID, TENANT_A);
+    // when
+    final var result =
+        camundaClient.newProcessDefinitionGetRequest(processDefinitionKey).send().join();
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.getProcessDefinitionKey()).isEqualTo(processDefinitionKey);
+    assertThat(result.getTenantId()).isEqualTo(TENANT_A);
+  }
+
+  @Test
+  void getByKeyShouldThrowNotFoundException(
+      @Authenticated(ADMIN) final CamundaClient adminClient,
+      @Authenticated(USER2) final CamundaClient camundaClient) {
+    // given
+    final var processDefinitionKey = getProcessDefinitionKey(adminClient, PROCESS_ID, TENANT_A);
+
+    // when
+    final var exception =
+        assertThrowsExactly(
+            ProblemException.class,
+            () -> camundaClient.newProcessDefinitionGetRequest(processDefinitionKey).send().join());
+    // then
+    assertThat(exception.getMessage()).startsWith("Failed with code 404");
+    assertThat(exception.details()).isNotNull();
+    assertThat(exception.details().getTitle()).isEqualTo("NOT_FOUND");
+    assertThat(exception.details().getStatus()).isEqualTo(404);
+    assertThat(exception.details().getDetail())
+        .contains("Process Definition with key '%s' not found".formatted(processDefinitionKey));
+  }
+
+  private static void createTenant(final CamundaClient camundaClient, final String tenant) {
+    camundaClient.newCreateTenantCommand().tenantId(tenant).name(tenant).send().join();
+  }
+
+  private static void assignUserToTenant(
+      final CamundaClient camundaClient, final String username, final String tenant) {
+    camundaClient.newAssignUserToTenantCommand().username(username).tenantId(tenant).send().join();
+  }
+
+  private static void deployResource(
+      final CamundaClient camundaClient, final String resourceName, final String tenant) {
+    camundaClient
+        .newDeployResourceCommand()
+        .addResourceFromClasspath(resourceName)
+        .tenantId(tenant)
+        .send()
+        .join();
+  }
+
+  private static void startProcessInstance(
+      final CamundaClient camundaClient, final String processId, final String tenant) {
+    camundaClient
+        .newCreateInstanceCommand()
+        .bpmnProcessId(processId)
+        .latestVersion()
+        .tenantId(tenant)
+        .send()
+        .join();
+  }
+
+  private static void waitForProcessBeingExported(final CamundaClient camundaClient) {
+    Awaitility.await("should receive data from secondary storage")
+        .atMost(Duration.ofMinutes(1))
+        .ignoreExceptions() // Ignore exceptions and continue retrying
+        .untilAsserted(
+            () -> {
+              assertThat(
+                      camundaClient
+                          .newProcessDefinitionSearchRequest()
+                          .filter(filter -> filter.processDefinitionId(PROCESS_ID))
+                          .send()
+                          .join()
+                          .items())
+                  .hasSize(2);
+            });
+  }
+
+  private long getProcessDefinitionKey(
+      final CamundaClient camundaClient, final String processId, final String tenantId) {
+    return camundaClient
+        .newProcessDefinitionSearchRequest()
+        .filter(f -> f.processDefinitionId(processId).tenantId(tenantId))
+        .send()
+        .join()
+        .items()
+        .getFirst()
+        .getProcessDefinitionKey();
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/VariableTenancyIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/VariableTenancyIT.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.tenancy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.command.ProblemException;
+import io.camunda.client.api.search.response.Variable;
+import io.camunda.qa.util.auth.Authenticated;
+import io.camunda.qa.util.auth.TestUser;
+import io.camunda.qa.util.auth.UserDefinition;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.qa.util.multidb.MultiDbTestApplication;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import java.time.Duration;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+
+@MultiDbTest
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms")
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
+public class VariableTenancyIT {
+
+  @MultiDbTestApplication
+  static final TestStandaloneBroker BROKER =
+      new TestStandaloneBroker()
+          .withBasicAuth()
+          .withMultiTenancyEnabled()
+          .withAuthenticatedAccess();
+
+  private static final String ADMIN = "admin";
+  private static final String USER1 = "user1";
+  private static final String USER2 = "user2";
+  private static final String TENANT_A = "tenantA";
+  private static final String TENANT_B = "tenantB";
+  private static final String PROCESS_ID = "bpmProcessVariable";
+
+  @UserDefinition
+  private static final TestUser ADMIN_USER = new TestUser(ADMIN, "password", List.of());
+
+  @UserDefinition
+  private static final TestUser USER1_USER = new TestUser(USER1, "password", List.of());
+
+  @UserDefinition
+  private static final TestUser USER2_USER = new TestUser(USER2, "password", List.of());
+
+  @BeforeAll
+  static void setUp(@Authenticated(ADMIN) final CamundaClient adminClient) {
+    createTenant(adminClient, TENANT_A);
+    createTenant(adminClient, TENANT_B);
+    assignUserToTenant(adminClient, ADMIN, TENANT_A);
+    assignUserToTenant(adminClient, ADMIN, TENANT_B);
+    assignUserToTenant(adminClient, USER1, TENANT_A);
+
+    deployResource(adminClient, "process/bpm_variable_test.bpmn", TENANT_A);
+    startProcessInstance(adminClient, PROCESS_ID, TENANT_A);
+
+    deployResource(adminClient, "process/bpm_variable_test.bpmn", TENANT_B);
+    startProcessInstance(adminClient, PROCESS_ID, TENANT_B);
+    waitForVariablesBeingExported(adminClient);
+  }
+
+  @Test
+  public void shouldReturnAllVariablesWithTenantAccess(
+      @Authenticated(ADMIN) final CamundaClient camundaClient) {
+    // when
+    final var result = camundaClient.newVariableSearchRequest().send().join();
+    // then
+    assertThat(result.items()).hasSize(10);
+    assertThat(result.items().stream().map(Variable::getTenantId).collect(Collectors.toSet()))
+        .containsExactlyInAnyOrder(TENANT_A, TENANT_B);
+  }
+
+  @Test
+  public void shouldReturnOnlyTenantAVariables(
+      @Authenticated(USER1) final CamundaClient camundaClient) {
+    // when
+    final var result = camundaClient.newVariableSearchRequest().send().join();
+    // then
+    assertThat(result.items()).hasSize(5);
+    assertThat(result.items().stream().map(Variable::getTenantId).collect(Collectors.toSet()))
+        .containsExactlyInAnyOrder(TENANT_A);
+  }
+
+  @Test
+  public void shouldNotReturnAnyVariables(@Authenticated(USER2) final CamundaClient camundaClient) {
+    // when
+    final var result = camundaClient.newVariableSearchRequest().send().join();
+    // then
+    assertThat(result.items()).hasSize(0);
+  }
+
+  @Test
+  void getByKeyShouldReturnTenantOwnedVariable(
+      @Authenticated(ADMIN) final CamundaClient adminClient,
+      @Authenticated(USER1) final CamundaClient camundaClient) {
+    // given
+    final var variableKey = getVariableInstanceKey(adminClient, TENANT_A);
+    // when
+    final var result = camundaClient.newVariableGetRequest(variableKey).send().join();
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.getVariableKey()).isEqualTo(variableKey);
+    assertThat(result.getTenantId()).isEqualTo(TENANT_A);
+  }
+
+  @Test
+  void getByKeyShouldThrowNotFoundException(
+      @Authenticated(ADMIN) final CamundaClient adminClient,
+      @Authenticated(USER2) final CamundaClient camundaClient) {
+    // given
+    final var variableKey = getVariableInstanceKey(adminClient, TENANT_A);
+
+    // when
+    final var exception =
+        assertThrowsExactly(
+            ProblemException.class,
+            () -> camundaClient.newVariableGetRequest(variableKey).send().join());
+
+    // then
+    assertThat(exception.getMessage()).startsWith("Failed with code 404");
+    assertThat(exception.details()).isNotNull();
+    assertThat(exception.details().getTitle()).isEqualTo("NOT_FOUND");
+    assertThat(exception.details().getStatus()).isEqualTo(404);
+    assertThat(exception.details().getDetail())
+        .contains("Variable with key '%s' not found".formatted(variableKey));
+  }
+
+  private static void createTenant(final CamundaClient camundaClient, final String tenant) {
+    camundaClient.newCreateTenantCommand().tenantId(tenant).name(tenant).send().join();
+  }
+
+  private static void assignUserToTenant(
+      final CamundaClient camundaClient, final String username, final String tenant) {
+    camundaClient.newAssignUserToTenantCommand().username(username).tenantId(tenant).send().join();
+  }
+
+  private static void deployResource(
+      final CamundaClient camundaClient, final String resourceName, final String tenant) {
+    camundaClient
+        .newDeployResourceCommand()
+        .addResourceFromClasspath(resourceName)
+        .tenantId(tenant)
+        .send()
+        .join();
+  }
+
+  private static void startProcessInstance(
+      final CamundaClient camundaClient, final String processId, final String tenant) {
+    camundaClient
+        .newCreateInstanceCommand()
+        .bpmnProcessId(processId)
+        .latestVersion()
+        .tenantId(tenant)
+        .send()
+        .join();
+  }
+
+  private static void waitForVariablesBeingExported(final CamundaClient camundaClient) {
+    Awaitility.await("should receive data from secondary storage")
+        .atMost(Duration.ofMinutes(1))
+        .ignoreExceptions() // Ignore exceptions and continue retrying
+        .untilAsserted(
+            () -> {
+              assertThat(camundaClient.newVariableSearchRequest().send().join().items())
+                  .hasSize(10);
+            });
+  }
+
+  private long getVariableInstanceKey(final CamundaClient camundaClient, final String tenantId) {
+    return camundaClient
+        .newVariableSearchRequest()
+        .filter(f -> f.tenantId(tenantId))
+        .send()
+        .join()
+        .items()
+        .getFirst()
+        .getVariableKey();
+  }
+}

--- a/qa/util/src/main/java/io/camunda/qa/util/cluster/TestCamundaApplication.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/cluster/TestCamundaApplication.java
@@ -129,6 +129,9 @@ public final class TestCamundaApplication extends TestSpringApplication<TestCamu
         .withProperty(
             AuthenticationProperties.API_UNPROTECTED,
             securityConfig.getAuthentication().getUnprotectedApi())
+        .withProperty(
+            "camunda.security.authorizations.enabled",
+            securityConfig.getAuthorizations().isEnabled())
         .withAdditionalProfile(Profile.BROKER)
         .withAdditionalProfile(Profile.OPERATE)
         .withAdditionalProfile(Profile.TASKLIST)

--- a/search/search-client-elasticsearch/src/main/java/io/camunda/search/es/transformers/search/SearchGetRequestTransformer.java
+++ b/search/search-client-elasticsearch/src/main/java/io/camunda/search/es/transformers/search/SearchGetRequestTransformer.java
@@ -21,9 +21,16 @@ public final class SearchGetRequestTransformer
 
   @Override
   public GetRequest apply(final SearchGetRequest value) {
-    final var id = value.id();
-    final var index = value.index();
-    final var routing = value.routing();
-    return GetRequest.of(b -> b.id(id).index(index).routing(routing));
+    final var builder = new GetRequest.Builder();
+
+    builder.id(value.id());
+    builder.index(value.index());
+    builder.routing(value.routing());
+
+    final var excludes = value.sourceExcludes();
+    if (excludes != null && !excludes.isEmpty()) {
+      builder.sourceExcludes(excludes);
+    }
+    return builder.build();
   }
 }

--- a/search/search-client-opensearch/src/main/java/io/camunda/search/os/transformers/search/SearchGetRequestTransformer.java
+++ b/search/search-client-opensearch/src/main/java/io/camunda/search/os/transformers/search/SearchGetRequestTransformer.java
@@ -21,9 +21,16 @@ public final class SearchGetRequestTransformer
 
   @Override
   public GetRequest apply(final SearchGetRequest value) {
-    final var id = value.id();
-    final var index = value.index();
-    final var routing = value.routing();
-    return GetRequest.of(b -> b.id(id).index(index).routing(routing));
+    final var builder = new GetRequest.Builder();
+
+    builder.id(value.id());
+    builder.index(value.index());
+    builder.routing(value.routing());
+
+    final var excludes = value.sourceExcludes();
+    if (excludes != null && !excludes.isEmpty()) {
+      builder.sourceExcludes(excludes);
+    }
+    return builder.build();
   }
 }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/SearchClientBasedQueryExecutor.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/SearchClientBasedQueryExecutor.java
@@ -8,21 +8,31 @@
 package io.camunda.search.clients;
 
 import io.camunda.search.aggregation.result.AggregationResultBase;
+import io.camunda.search.clients.core.SearchGetRequest;
+import io.camunda.search.clients.core.SearchGetResponse;
 import io.camunda.search.clients.core.SearchQueryRequest;
 import io.camunda.search.clients.core.SearchQueryResponse;
+import io.camunda.search.clients.source.SearchSourceConfig;
+import io.camunda.search.clients.source.SearchSourceFilter;
 import io.camunda.search.clients.transformers.ServiceTransformer;
 import io.camunda.search.clients.transformers.ServiceTransformers;
 import io.camunda.search.clients.transformers.query.SearchQueryResultTransformer;
 import io.camunda.search.clients.transformers.query.TypedSearchQueryTransformer;
+import io.camunda.search.clients.transformers.result.ResultConfigTransformer;
+import io.camunda.search.exception.CamundaSearchException;
+import io.camunda.search.exception.ErrorMessages;
 import io.camunda.search.filter.FilterBase;
 import io.camunda.search.page.SearchQueryPage.SearchQueryResultType;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.search.query.TypedSearchQuery;
+import io.camunda.search.result.QueryResultConfig;
 import io.camunda.search.sort.SortOption;
 import io.camunda.security.reader.ResourceAccessChecks;
 import io.camunda.zeebe.util.CloseableSilently;
 import io.camunda.zeebe.util.VisibleForTesting;
+import java.util.Optional;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 public final class SearchClientBasedQueryExecutor implements CloseableSilently {
 
@@ -70,6 +80,56 @@ public final class SearchClientBasedQueryExecutor implements CloseableSilently {
         .apply(searchQueryResponse.aggregations());
   }
 
+  /** Returns a single document by id * */
+  public <T, R> R getById(final String id, final Class<T> documentClass, final String index) {
+    return getById(id, documentClass, index, null);
+  }
+
+  /** Returns a single document by id * */
+  public <T, R> R getById(
+      final String id,
+      final Class<T> documentClass,
+      final String index,
+      final QueryResultConfig config) {
+    final var builder = new SearchGetRequest.Builder().id(id).index(index);
+
+    Optional.ofNullable(config)
+        .map(c -> getResultConfigTransformer(config.getClass()))
+        .map(t -> t.apply(config))
+        .map(SearchSourceConfig::sourceFilter)
+        .map(SearchSourceFilter::excludes)
+        .ifPresent(builder::sourceExcludes);
+
+    final var getRequest = builder.build();
+    final SearchGetResponse<T> getResponse = searchClient.get(getRequest, documentClass);
+    final ServiceTransformer<T, R> transformer =
+        (ServiceTransformer<T, R>) getDocumentTransformer(documentClass);
+    return Optional.ofNullable(getResponse)
+        .filter(SearchGetResponse::found)
+        .map(SearchGetResponse::source)
+        .map(transformer::apply)
+        .orElse(null);
+  }
+
+  /**
+   * Gets a single document (or null) by query. Throws an exception if the query returns more than
+   * one document.
+   */
+  public <F extends FilterBase, S extends SortOption, T, R> R getByQuery(
+      final TypedSearchQuery<F, S> query, final Class<T> documentClass) {
+    return getSingleDocumentOrThrowIfNotUnique(
+        () -> search(query, documentClass, ResourceAccessChecks.disabled()));
+  }
+
+  private <R> R getSingleDocumentOrThrowIfNotUnique(
+      final Supplier<SearchQueryResult<R>> resultSupplier) {
+    final var searchResult = resultSupplier.get();
+    if (searchResult.items().size() > 1) {
+      throw new CamundaSearchException(ErrorMessages.ERROR_GET_BY_QUERY_NOT_UNIQUE);
+    }
+    return searchResult.items().stream().findFirst().orElse(null);
+  }
+
   <F extends FilterBase, S extends SortOption, T> SearchQueryResponse<T> executePaginatedSearch(
       final TypedSearchQuery<F, S> query,
       final Class<T> documentClass,
@@ -107,6 +167,13 @@ public final class SearchClientBasedQueryExecutor implements CloseableSilently {
 
   private <T, R> ServiceTransformer<T, R> getDocumentTransformer(final Class<R> documentClass) {
     return transformers.getTransformer(documentClass);
+  }
+
+  private <T extends QueryResultConfig>
+      ResultConfigTransformer<QueryResultConfig> getResultConfigTransformer(final Class<T> clazz) {
+    final ServiceTransformer<QueryResultConfig, SearchSourceConfig> transformer =
+        transformers.getTransformer(clazz);
+    return (ResultConfigTransformer) transformer;
   }
 
   @Override

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/auth/AnonymousResourceAccessController.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/auth/AnonymousResourceAccessController.java
@@ -15,6 +15,13 @@ import java.util.function.Function;
 public class AnonymousResourceAccessController implements ResourceAccessController {
 
   @Override
+  public <T> T doGet(
+      final SecurityContext securityContext,
+      final Function<ResourceAccessChecks, T> resourceChecksApplier) {
+    return doReadAnonymously(resourceChecksApplier);
+  }
+
+  @Override
   public <T> T doSearch(
       final SecurityContext securityContext,
       final Function<ResourceAccessChecks, T> resourceChecksApplier) {

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/auth/DefaultResourceAccessProvider.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/auth/DefaultResourceAccessProvider.java
@@ -9,18 +9,16 @@ package io.camunda.search.clients.auth;
 
 import static io.camunda.security.auth.Authorization.WILDCARD;
 
+import io.camunda.search.exception.CamundaSearchException;
 import io.camunda.security.auth.Authorization;
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.security.auth.SecurityContext;
 import io.camunda.security.impl.AuthorizationChecker;
 import io.camunda.security.reader.ResourceAccess;
 import io.camunda.security.reader.ResourceAccessProvider;
+import java.util.List;
+import java.util.Optional;
 
-/**
- * Document based datastore (ES/OS) strategy implementation of {@link ResourceAccessProvider}. It
- * applies authorization to a search query by fetching the authorized resources for the
- * authenticated user and creating a new search query with the authorization applied.
- */
 public class DefaultResourceAccessProvider implements ResourceAccessProvider {
 
   private final AuthorizationChecker authorizationChecker;
@@ -30,8 +28,8 @@ public class DefaultResourceAccessProvider implements ResourceAccessProvider {
   }
 
   @Override
-  public ResourceAccess resolveResourceAccess(
-      final CamundaAuthentication authentication, final Authorization requiredAuthorization) {
+  public <T> ResourceAccess resolveResourceAccess(
+      final CamundaAuthentication authentication, final Authorization<T> requiredAuthorization) {
     // right now, not all Services provide an authorization with #withSecurityContext()
     // typically, the authorization check happens afterward in the respective Service
     if (requiredAuthorization == null) {
@@ -39,7 +37,7 @@ public class DefaultResourceAccessProvider implements ResourceAccessProvider {
     }
 
     final var resultingAuthorization =
-        new Authorization.Builder()
+        new Authorization.Builder<>()
             .resourceType(requiredAuthorization.resourceType())
             .permissionType(requiredAuthorization.permissionType());
 
@@ -62,8 +60,50 @@ public class DefaultResourceAccessProvider implements ResourceAccessProvider {
     return ResourceAccess.allowed(authorizationWithResolvedResourceIds);
   }
 
+  @Override
+  public <T> ResourceAccess hasResourceAccess(
+      final CamundaAuthentication authentication,
+      final Authorization<T> requiredAuthorization,
+      final T resource) {
+    final var resourceIdSupplier = requiredAuthorization.resourceIdSupplier();
+    final var resourceIds = requiredAuthorization.resourceIds();
+    final var resourceId =
+        Optional.ofNullable(resourceIdSupplier)
+            .map(supplier -> supplier.apply(resource))
+            .orElseGet(
+                () ->
+                    Optional.ofNullable(resourceIds)
+                        .filter(l -> l.size() == 1)
+                        .map(List::getFirst)
+                        .orElseThrow(
+                            () ->
+                                new CamundaSearchException(
+                                    "Expected one resource id to check resource access, but received no or more than one")));
+
+    return hasResourceAccessByResourceId(authentication, requiredAuthorization, resourceId);
+  }
+
+  @Override
+  public <T> ResourceAccess hasResourceAccessByResourceId(
+      final CamundaAuthentication authentication,
+      final Authorization<T> requiredAuthorization,
+      final String resourceId) {
+    final var securityContext = createSecurityContext(authentication, requiredAuthorization);
+    final var isAuthorized = authorizationChecker.isAuthorized(resourceId, securityContext);
+    final var checkedAuthorization =
+        Authorization.of(
+            a ->
+                a.resourceType(requiredAuthorization.resourceType())
+                    .permissionType(requiredAuthorization.permissionType())
+                    .resourceIds(List.of(resourceId)));
+
+    return isAuthorized
+        ? ResourceAccess.allowed(checkedAuthorization)
+        : ResourceAccess.denied(checkedAuthorization);
+  }
+
   private SecurityContext createSecurityContext(
-      final CamundaAuthentication authentication, final Authorization authorization) {
+      final CamundaAuthentication authentication, final Authorization<?> authorization) {
     return SecurityContext.of(
         s -> s.withAuthentication(authentication).withAuthorization(authorization));
   }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/auth/DefaultResourceAccessProvider.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/auth/DefaultResourceAccessProvider.java
@@ -78,7 +78,7 @@ public class DefaultResourceAccessProvider implements ResourceAccessProvider {
                         .orElseThrow(
                             () ->
                                 new CamundaSearchException(
-                                    "Expected one resource id to check resource access, but received no or more than one")));
+                                    "Expected one resource id to check resource access, but received none or more than one")));
 
     return hasResourceAccessByResourceId(authentication, requiredAuthorization, resourceId);
   }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/auth/DisabledResourceAccessProvider.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/auth/DisabledResourceAccessProvider.java
@@ -19,4 +19,20 @@ public class DisabledResourceAccessProvider implements ResourceAccessProvider {
       final CamundaAuthentication authentication, final Authorization requiredAuthorization) {
     return ResourceAccess.wildcard(requiredAuthorization);
   }
+
+  @Override
+  public <T> ResourceAccess hasResourceAccess(
+      final CamundaAuthentication authentication,
+      final Authorization<T> requiredAuthorization,
+      final T resource) {
+    return ResourceAccess.wildcard(requiredAuthorization);
+  }
+
+  @Override
+  public <T> ResourceAccess hasResourceAccessByResourceId(
+      final CamundaAuthentication authentication,
+      final Authorization<T> requiredAuthorization,
+      final String resourceId) {
+    return ResourceAccess.wildcard(requiredAuthorization);
+  }
 }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/auth/DisabledTenantAccessProvider.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/auth/DisabledTenantAccessProvider.java
@@ -17,4 +17,16 @@ public class DisabledTenantAccessProvider implements TenantAccessProvider {
   public TenantAccess resolveTenantAccess(final CamundaAuthentication authentication) {
     return TenantAccess.wildcard(null);
   }
+
+  @Override
+  public <T> TenantAccess hasTenantAccess(
+      final CamundaAuthentication authentication, final T resource) {
+    return TenantAccess.wildcard(null);
+  }
+
+  @Override
+  public TenantAccess hasTenantAccessByTenantId(
+      final CamundaAuthentication authentication, final String tenantId) {
+    return TenantAccess.wildcard(null);
+  }
 }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/auth/ResourceAccessDelegatingController.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/auth/ResourceAccessDelegatingController.java
@@ -30,6 +30,13 @@ public class ResourceAccessDelegatingController implements ResourceAccessControl
   }
 
   @Override
+  public <T> T doGet(
+      final SecurityContext securityContext,
+      final Function<ResourceAccessChecks, T> resourceChecksApplier) {
+    return getMatchingController(securityContext).doGet(securityContext, resourceChecksApplier);
+  }
+
+  @Override
   public <T> T doSearch(
       final SecurityContext securityContext,
       final Function<ResourceAccessChecks, T> resourceChecksApplier) {

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/core/SearchGetRequest.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/core/SearchGetRequest.java
@@ -8,12 +8,15 @@
 package io.camunda.search.clients.core;
 
 import static io.camunda.search.clients.core.RequestBuilders.getRequest;
+import static io.camunda.util.CollectionUtil.addValuesToList;
 
 import io.camunda.util.ObjectBuilder;
+import java.util.List;
 import java.util.Objects;
 import java.util.function.Function;
 
-public record SearchGetRequest(String id, String index, String routing) {
+public record SearchGetRequest(
+    String id, String index, String routing, List<String> sourceExcludes) {
 
   public static SearchGetRequest of(
       final Function<SearchGetRequest.Builder, ObjectBuilder<SearchGetRequest>> fn) {
@@ -25,6 +28,7 @@ public record SearchGetRequest(String id, String index, String routing) {
     private String id;
     private String index;
     private String routing;
+    private List<String> sourceExcludes;
 
     public SearchGetRequest.Builder id(final String value) {
       id = value;
@@ -41,6 +45,11 @@ public record SearchGetRequest(String id, String index, String routing) {
       return this;
     }
 
+    public SearchGetRequest.Builder sourceExcludes(final List<String> values) {
+      sourceExcludes = addValuesToList(sourceExcludes, values);
+      return this;
+    }
+
     @Override
     public SearchGetRequest build() {
       return new SearchGetRequest(
@@ -48,7 +57,8 @@ public record SearchGetRequest(String id, String index, String routing) {
               id, "Expected to retrieve a document by id, but given id was null."),
           Objects.requireNonNull(
               index, "Expected to create request for index, but given index was null."),
-          routing);
+          routing,
+          sourceExcludes);
     }
   }
 }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/AuthorizationDocumentReader.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/AuthorizationDocumentReader.java
@@ -12,12 +12,24 @@ import io.camunda.search.entities.AuthorizationEntity;
 import io.camunda.search.query.AuthorizationQuery;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.reader.ResourceAccessChecks;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 
 public class AuthorizationDocumentReader extends DocumentBasedReader
     implements AuthorizationReader {
 
-  public AuthorizationDocumentReader(final SearchClientBasedQueryExecutor executor) {
-    super(executor);
+  public AuthorizationDocumentReader(
+      final SearchClientBasedQueryExecutor executor, final IndexDescriptor indexDescriptor) {
+    super(executor, indexDescriptor);
+  }
+
+  @Override
+  public AuthorizationEntity getByKey(
+      final long key, final ResourceAccessChecks resourceAccessChecks) {
+    return getSearchExecutor()
+        .getById(
+            String.valueOf(key),
+            io.camunda.webapps.schema.entities.usermanagement.AuthorizationEntity.class,
+            indexDescriptor.getFullQualifiedName());
   }
 
   @Override

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/BatchOperationDocumentReader.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/BatchOperationDocumentReader.java
@@ -23,12 +23,11 @@ public class BatchOperationDocumentReader extends DocumentBasedReader
   }
 
   @Override
-  public BatchOperationEntity getByKey(
-      final long key, final ResourceAccessChecks resourceAccessChecks) {
+  public BatchOperationEntity getById(
+      final String id, final ResourceAccessChecks resourceAccessChecks) {
     return getSearchExecutor()
         .getByQuery(
-            BatchOperationQuery.of(
-                b -> b.filter(f -> f.batchOperationKeys(String.valueOf(key))).singleResult()),
+            BatchOperationQuery.of(b -> b.filter(f -> f.batchOperationKeys(id)).singleResult()),
             io.camunda.webapps.schema.entities.operation.BatchOperationEntity.class);
   }
 

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/BatchOperationDocumentReader.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/BatchOperationDocumentReader.java
@@ -12,12 +12,24 @@ import io.camunda.search.entities.BatchOperationEntity;
 import io.camunda.search.query.BatchOperationQuery;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.reader.ResourceAccessChecks;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 
 public class BatchOperationDocumentReader extends DocumentBasedReader
     implements BatchOperationReader {
 
-  public BatchOperationDocumentReader(final SearchClientBasedQueryExecutor executor) {
-    super(executor);
+  public BatchOperationDocumentReader(
+      final SearchClientBasedQueryExecutor executor, final IndexDescriptor indexDescriptor) {
+    super(executor, indexDescriptor);
+  }
+
+  @Override
+  public BatchOperationEntity getByKey(
+      final long key, final ResourceAccessChecks resourceAccessChecks) {
+    return getSearchExecutor()
+        .getByQuery(
+            BatchOperationQuery.of(
+                b -> b.filter(f -> f.batchOperationKeys(String.valueOf(key))).singleResult()),
+            io.camunda.webapps.schema.entities.operation.BatchOperationEntity.class);
   }
 
   @Override

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/BatchOperationItemDocumentReader.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/BatchOperationItemDocumentReader.java
@@ -12,12 +12,14 @@ import io.camunda.search.entities.BatchOperationEntity.BatchOperationItemEntity;
 import io.camunda.search.query.BatchOperationItemQuery;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.reader.ResourceAccessChecks;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 
 public class BatchOperationItemDocumentReader extends DocumentBasedReader
     implements BatchOperationItemReader {
 
-  public BatchOperationItemDocumentReader(final SearchClientBasedQueryExecutor executor) {
-    super(executor);
+  public BatchOperationItemDocumentReader(
+      final SearchClientBasedQueryExecutor executor, final IndexDescriptor indexDescriptor) {
+    super(executor, indexDescriptor);
   }
 
   @Override

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/DecisionDefinitionDocumentReader.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/DecisionDefinitionDocumentReader.java
@@ -12,12 +12,24 @@ import io.camunda.search.entities.DecisionDefinitionEntity;
 import io.camunda.search.query.DecisionDefinitionQuery;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.reader.ResourceAccessChecks;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 
 public class DecisionDefinitionDocumentReader extends DocumentBasedReader
     implements DecisionDefinitionReader {
 
-  public DecisionDefinitionDocumentReader(final SearchClientBasedQueryExecutor executor) {
-    super(executor);
+  public DecisionDefinitionDocumentReader(
+      final SearchClientBasedQueryExecutor executor, final IndexDescriptor indexDescriptor) {
+    super(executor, indexDescriptor);
+  }
+
+  @Override
+  public DecisionDefinitionEntity getByKey(
+      final long key, final ResourceAccessChecks resourceAccessChecks) {
+    return getSearchExecutor()
+        .getById(
+            String.valueOf(key),
+            io.camunda.webapps.schema.entities.dmn.definition.DecisionDefinitionEntity.class,
+            indexDescriptor.getFullQualifiedName());
   }
 
   @Override

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/DecisionInstanceDocumentReader.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/DecisionInstanceDocumentReader.java
@@ -12,12 +12,23 @@ import io.camunda.search.entities.DecisionInstanceEntity;
 import io.camunda.search.query.DecisionInstanceQuery;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.reader.ResourceAccessChecks;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 
 public class DecisionInstanceDocumentReader extends DocumentBasedReader
     implements DecisionInstanceReader {
 
-  public DecisionInstanceDocumentReader(final SearchClientBasedQueryExecutor executor) {
-    super(executor);
+  public DecisionInstanceDocumentReader(
+      final SearchClientBasedQueryExecutor executor, final IndexDescriptor indexDescriptor) {
+    super(executor, indexDescriptor);
+  }
+
+  @Override
+  public DecisionInstanceEntity getById(
+      final String id, final ResourceAccessChecks resourceAccessChecks) {
+    return getSearchExecutor()
+        .getByQuery(
+            DecisionInstanceQuery.of(b -> b.filter(f -> f.decisionInstanceIds(id)).singleResult()),
+            io.camunda.webapps.schema.entities.dmn.DecisionInstanceEntity.class);
   }
 
   @Override

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/DecisionRequirementsDocumentReader.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/DecisionRequirementsDocumentReader.java
@@ -11,13 +11,33 @@ import io.camunda.search.clients.SearchClientBasedQueryExecutor;
 import io.camunda.search.entities.DecisionRequirementsEntity;
 import io.camunda.search.query.DecisionRequirementsQuery;
 import io.camunda.search.query.SearchQueryResult;
+import io.camunda.search.result.DecisionRequirementsQueryResultConfig;
 import io.camunda.security.reader.ResourceAccessChecks;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 
 public class DecisionRequirementsDocumentReader extends DocumentBasedReader
     implements DecisionRequirementsReader {
 
-  public DecisionRequirementsDocumentReader(final SearchClientBasedQueryExecutor executor) {
-    super(executor);
+  public DecisionRequirementsDocumentReader(
+      final SearchClientBasedQueryExecutor executor, final IndexDescriptor indexDescriptor) {
+    super(executor, indexDescriptor);
+  }
+
+  @Override
+  public DecisionRequirementsEntity getByKey(
+      final long key, final ResourceAccessChecks resourceAccessChecks, final boolean includeXml) {
+    return getSearchExecutor()
+        .getById(
+            String.valueOf(key),
+            io.camunda.webapps.schema.entities.dmn.definition.DecisionRequirementsEntity.class,
+            indexDescriptor.getFullQualifiedName(),
+            DecisionRequirementsQueryResultConfig.of(b -> b.includeXml(includeXml)));
+  }
+
+  @Override
+  public DecisionRequirementsEntity getByKey(
+      final long key, final ResourceAccessChecks resourceAccessChecks) {
+    return getByKey(key, resourceAccessChecks, false);
   }
 
   @Override

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/DocumentBasedReader.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/DocumentBasedReader.java
@@ -8,13 +8,17 @@
 package io.camunda.search.clients.reader;
 
 import io.camunda.search.clients.SearchClientBasedQueryExecutor;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 
 public abstract class DocumentBasedReader {
 
   protected final SearchClientBasedQueryExecutor executor;
+  protected final IndexDescriptor indexDescriptor;
 
-  public DocumentBasedReader(final SearchClientBasedQueryExecutor executor) {
+  public DocumentBasedReader(
+      final SearchClientBasedQueryExecutor executor, final IndexDescriptor indexDescriptor) {
     this.executor = executor;
+    this.indexDescriptor = indexDescriptor;
   }
 
   protected SearchClientBasedQueryExecutor getSearchExecutor() {

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/FlowNodeInstanceDocumentReader.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/FlowNodeInstanceDocumentReader.java
@@ -12,12 +12,24 @@ import io.camunda.search.entities.FlowNodeInstanceEntity;
 import io.camunda.search.query.FlowNodeInstanceQuery;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.reader.ResourceAccessChecks;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 
 public class FlowNodeInstanceDocumentReader extends DocumentBasedReader
     implements FlowNodeInstanceReader {
 
-  public FlowNodeInstanceDocumentReader(final SearchClientBasedQueryExecutor executor) {
-    super(executor);
+  public FlowNodeInstanceDocumentReader(
+      final SearchClientBasedQueryExecutor executor, final IndexDescriptor indexDescriptor) {
+    super(executor, indexDescriptor);
+  }
+
+  @Override
+  public FlowNodeInstanceEntity getByKey(
+      final long key, final ResourceAccessChecks resourceAccessChecks) {
+    return getSearchExecutor()
+        .getByQuery(
+            FlowNodeInstanceQuery.of(
+                b -> b.filter(f -> f.flowNodeInstanceKeys(key)).singleResult()),
+            io.camunda.webapps.schema.entities.flownode.FlowNodeInstanceEntity.class);
   }
 
   @Override

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/FormDocumentReader.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/FormDocumentReader.java
@@ -12,11 +12,22 @@ import io.camunda.search.entities.FormEntity;
 import io.camunda.search.query.FormQuery;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.reader.ResourceAccessChecks;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 
 public class FormDocumentReader extends DocumentBasedReader implements FormReader {
 
-  public FormDocumentReader(final SearchClientBasedQueryExecutor executor) {
-    super(executor);
+  public FormDocumentReader(
+      final SearchClientBasedQueryExecutor executor, final IndexDescriptor indexDescriptor) {
+    super(executor, indexDescriptor);
+  }
+
+  @Override
+  public FormEntity getByKey(final long key, final ResourceAccessChecks resourceAccessChecks) {
+    return getSearchExecutor()
+        .getById(
+            String.valueOf(key),
+            io.camunda.webapps.schema.entities.form.FormEntity.class,
+            indexDescriptor.getFullQualifiedName());
   }
 
   @Override

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/GroupDocumentReader.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/GroupDocumentReader.java
@@ -14,6 +14,7 @@ import io.camunda.search.entities.GroupEntity;
 import io.camunda.search.query.GroupQuery;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.reader.ResourceAccessChecks;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 
 public class GroupDocumentReader extends DocumentBasedReader implements GroupReader {
 
@@ -22,11 +23,20 @@ public class GroupDocumentReader extends DocumentBasedReader implements GroupRea
 
   public GroupDocumentReader(
       final SearchClientBasedQueryExecutor executor,
+      final IndexDescriptor indexDescriptor,
       final TenantMemberDocumentReader tenantMemberReader,
       final RoleMemberDocumentReader roleMemberReader) {
-    super(executor);
+    super(executor, indexDescriptor);
     this.tenantMemberReader = tenantMemberReader;
     this.roleMemberReader = roleMemberReader;
+  }
+
+  @Override
+  public GroupEntity getById(final String id, final ResourceAccessChecks resourceAccessChecks) {
+    return getSearchExecutor()
+        .getByQuery(
+            GroupQuery.of(b -> b.filter(f -> f.groupIds(id)).singleResult()),
+            io.camunda.webapps.schema.entities.usermanagement.GroupEntity.class);
   }
 
   @Override

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/GroupMemberDocumentReader.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/GroupMemberDocumentReader.java
@@ -12,14 +12,16 @@ import io.camunda.search.entities.GroupMemberEntity;
 import io.camunda.search.query.GroupQuery;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.reader.ResourceAccessChecks;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.zeebe.protocol.record.value.EntityType;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 public class GroupMemberDocumentReader extends DocumentBasedReader implements GroupMemberReader {
 
-  public GroupMemberDocumentReader(final SearchClientBasedQueryExecutor executor) {
-    super(executor);
+  public GroupMemberDocumentReader(
+      final SearchClientBasedQueryExecutor executor, final IndexDescriptor indexDescriptor) {
+    super(executor, indexDescriptor);
   }
 
   @Override

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/IncidentDocumentReader.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/IncidentDocumentReader.java
@@ -14,12 +14,22 @@ import io.camunda.search.filter.Operation;
 import io.camunda.search.query.IncidentQuery;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.reader.ResourceAccessChecks;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import java.util.List;
 
 public class IncidentDocumentReader extends DocumentBasedReader implements IncidentReader {
 
-  public IncidentDocumentReader(final SearchClientBasedQueryExecutor executor) {
-    super(executor);
+  public IncidentDocumentReader(
+      final SearchClientBasedQueryExecutor executor, final IndexDescriptor indexDescriptor) {
+    super(executor, indexDescriptor);
+  }
+
+  @Override
+  public IncidentEntity getByKey(final long key, final ResourceAccessChecks resourceAccessChecks) {
+    return getSearchExecutor()
+        .getByQuery(
+            IncidentQuery.of(b -> b.filter(f -> f.incidentKeys(key)).singleResult()),
+            io.camunda.webapps.schema.entities.incident.IncidentEntity.class);
   }
 
   @Override

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/JobDocumentReader.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/JobDocumentReader.java
@@ -12,11 +12,21 @@ import io.camunda.search.entities.JobEntity;
 import io.camunda.search.query.JobQuery;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.reader.ResourceAccessChecks;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 
 public class JobDocumentReader extends DocumentBasedReader implements JobReader {
 
-  public JobDocumentReader(final SearchClientBasedQueryExecutor executor) {
-    super(executor);
+  public JobDocumentReader(
+      final SearchClientBasedQueryExecutor executor, final IndexDescriptor indexDescriptor) {
+    super(executor, indexDescriptor);
+  }
+
+  @Override
+  public JobEntity getByKey(final long key, final ResourceAccessChecks resourceAccessChecks) {
+    return getSearchExecutor()
+        .getByQuery(
+            JobQuery.of(b -> b.filter(f -> f.jobKeys(key)).singleResult()),
+            io.camunda.webapps.schema.entities.JobEntity.class);
   }
 
   @Override

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/JobDocumentReader.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/JobDocumentReader.java
@@ -22,14 +22,6 @@ public class JobDocumentReader extends DocumentBasedReader implements JobReader 
   }
 
   @Override
-  public JobEntity getByKey(final long key, final ResourceAccessChecks resourceAccessChecks) {
-    return getSearchExecutor()
-        .getByQuery(
-            JobQuery.of(b -> b.filter(f -> f.jobKeys(key)).singleResult()),
-            io.camunda.webapps.schema.entities.JobEntity.class);
-  }
-
-  @Override
   public SearchQueryResult<JobEntity> search(
       final JobQuery query, final ResourceAccessChecks resourceAccessChecks) {
     return getSearchExecutor()

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/MappingRuleDocumentReader.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/MappingRuleDocumentReader.java
@@ -14,6 +14,7 @@ import io.camunda.search.entities.MappingRuleEntity;
 import io.camunda.search.query.MappingRuleQuery;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.reader.ResourceAccessChecks;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 
 public class MappingRuleDocumentReader extends DocumentBasedReader implements MappingRuleReader {
 
@@ -23,13 +24,24 @@ public class MappingRuleDocumentReader extends DocumentBasedReader implements Ma
 
   public MappingRuleDocumentReader(
       final SearchClientBasedQueryExecutor executor,
+      final IndexDescriptor indexDescriptor,
       final RoleMemberDocumentReader roleMemberReader,
       final TenantMemberDocumentReader tenantMemberReader,
       final GroupMemberDocumentReader groupMemberReader) {
-    super(executor);
+    super(executor, indexDescriptor);
     this.roleMemberReader = roleMemberReader;
     this.tenantMemberReader = tenantMemberReader;
     this.groupMemberReader = groupMemberReader;
+  }
+
+  @Override
+  public MappingRuleEntity getById(
+      final String id, final ResourceAccessChecks resourceAccessChecks) {
+    return getSearchExecutor()
+        .getById(
+            id,
+            io.camunda.webapps.schema.entities.usermanagement.MappingRuleEntity.class,
+            indexDescriptor.getFullQualifiedName());
   }
 
   @Override

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/MessageSubscriptionDocumentReader.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/MessageSubscriptionDocumentReader.java
@@ -12,13 +12,15 @@ import io.camunda.search.entities.MessageSubscriptionEntity;
 import io.camunda.search.query.MessageSubscriptionQuery;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.reader.ResourceAccessChecks;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.entities.event.EventEntity;
 
 public class MessageSubscriptionDocumentReader extends DocumentBasedReader
     implements MessageSubscriptionReader {
 
-  public MessageSubscriptionDocumentReader(final SearchClientBasedQueryExecutor executor) {
-    super(executor);
+  public MessageSubscriptionDocumentReader(
+      final SearchClientBasedQueryExecutor executor, final IndexDescriptor indexDescriptor) {
+    super(executor, indexDescriptor);
   }
 
   @Override

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/ProcessDefinitionDocumentReader.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/ProcessDefinitionDocumentReader.java
@@ -13,13 +13,25 @@ import io.camunda.search.entities.ProcessDefinitionEntity;
 import io.camunda.search.query.ProcessDefinitionQuery;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.reader.ResourceAccessChecks;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.entities.ProcessEntity;
 
 public class ProcessDefinitionDocumentReader extends DocumentBasedReader
     implements ProcessDefinitionReader {
 
-  public ProcessDefinitionDocumentReader(final SearchClientBasedQueryExecutor executor) {
-    super(executor);
+  public ProcessDefinitionDocumentReader(
+      final SearchClientBasedQueryExecutor executor, final IndexDescriptor indexDescriptor) {
+    super(executor, indexDescriptor);
+  }
+
+  @Override
+  public ProcessDefinitionEntity getByKey(
+      final long key, final ResourceAccessChecks resourceAccessChecks) {
+    return getSearchExecutor()
+        .getByQuery(
+            ProcessDefinitionQuery.of(
+                b -> b.filter(f -> f.processDefinitionKeys(key)).singleResult()),
+            ProcessEntity.class);
   }
 
   @Override

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/ProcessDefinitionStatisticsDocumentReader.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/ProcessDefinitionStatisticsDocumentReader.java
@@ -14,6 +14,7 @@ import io.camunda.search.filter.Operation;
 import io.camunda.search.filter.ProcessDefinitionStatisticsFilter;
 import io.camunda.search.query.ProcessDefinitionFlowNodeStatisticsQuery;
 import io.camunda.security.reader.ResourceAccessChecks;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -23,8 +24,10 @@ public class ProcessDefinitionStatisticsDocumentReader extends DocumentBasedRead
   private final IncidentDocumentReader incidentReader;
 
   public ProcessDefinitionStatisticsDocumentReader(
-      final SearchClientBasedQueryExecutor executor, final IncidentDocumentReader incidentReader) {
-    super(executor);
+      final SearchClientBasedQueryExecutor executor,
+      final IndexDescriptor indexDescriptor,
+      final IncidentDocumentReader incidentReader) {
+    super(executor, indexDescriptor);
     this.incidentReader = incidentReader;
   }
 

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/ProcessInstanceDocumentReader.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/ProcessInstanceDocumentReader.java
@@ -14,6 +14,7 @@ import io.camunda.search.filter.ProcessInstanceFilter;
 import io.camunda.search.query.ProcessInstanceQuery;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.reader.ResourceAccessChecks;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.entities.listview.ProcessInstanceForListViewEntity;
 import java.util.ArrayList;
 import java.util.List;
@@ -24,9 +25,20 @@ public class ProcessInstanceDocumentReader extends DocumentBasedReader
   private final IncidentDocumentReader incidentReader;
 
   public ProcessInstanceDocumentReader(
-      final SearchClientBasedQueryExecutor executor, final IncidentDocumentReader incidentReader) {
-    super(executor);
+      final SearchClientBasedQueryExecutor executor,
+      final IndexDescriptor indexDescriptor,
+      final IncidentDocumentReader incidentReader) {
+    super(executor, indexDescriptor);
     this.incidentReader = incidentReader;
+  }
+
+  @Override
+  public ProcessInstanceEntity getByKey(
+      final long key, final ResourceAccessChecks resourceAccessChecks) {
+    return getSearchExecutor()
+        .getByQuery(
+            ProcessInstanceQuery.of(b -> b.filter(f -> f.processInstanceKeys(key)).singleResult()),
+            ProcessInstanceForListViewEntity.class);
   }
 
   @Override

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/ProcessInstanceStatisticsDocumentReader.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/ProcessInstanceStatisticsDocumentReader.java
@@ -12,13 +12,15 @@ import io.camunda.search.clients.SearchClientBasedQueryExecutor;
 import io.camunda.search.entities.ProcessFlowNodeStatisticsEntity;
 import io.camunda.search.query.ProcessInstanceFlowNodeStatisticsQuery;
 import io.camunda.security.reader.ResourceAccessChecks;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import java.util.List;
 
 public class ProcessInstanceStatisticsDocumentReader extends DocumentBasedReader
     implements ProcessInstanceStatisticsReader {
 
-  public ProcessInstanceStatisticsDocumentReader(final SearchClientBasedQueryExecutor executor) {
-    super(executor);
+  public ProcessInstanceStatisticsDocumentReader(
+      final SearchClientBasedQueryExecutor executor, final IndexDescriptor indexDescriptor) {
+    super(executor, indexDescriptor);
   }
 
   @Override

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/RoleDocumentReader.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/RoleDocumentReader.java
@@ -14,6 +14,7 @@ import io.camunda.search.entities.RoleEntity;
 import io.camunda.search.query.RoleQuery;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.reader.ResourceAccessChecks;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 
 public class RoleDocumentReader extends DocumentBasedReader implements RoleReader {
 
@@ -21,9 +22,18 @@ public class RoleDocumentReader extends DocumentBasedReader implements RoleReade
 
   public RoleDocumentReader(
       final SearchClientBasedQueryExecutor executor,
+      final IndexDescriptor indexDescriptor,
       final TenantMemberDocumentReader tenantMemberReader) {
-    super(executor);
+    super(executor, indexDescriptor);
     this.tenantMemberReader = tenantMemberReader;
+  }
+
+  @Override
+  public RoleEntity getById(final String id, final ResourceAccessChecks resourceAccessChecks) {
+    return getSearchExecutor()
+        .getByQuery(
+            RoleQuery.of(b -> b.filter(f -> f.roleId(id)).singleResult()),
+            io.camunda.webapps.schema.entities.usermanagement.RoleEntity.class);
   }
 
   @Override

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/RoleMemberDocumentReader.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/RoleMemberDocumentReader.java
@@ -12,14 +12,16 @@ import io.camunda.search.entities.RoleMemberEntity;
 import io.camunda.search.query.RoleQuery;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.reader.ResourceAccessChecks;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.zeebe.protocol.record.value.EntityType;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 public class RoleMemberDocumentReader extends DocumentBasedReader implements RoleMemberReader {
 
-  public RoleMemberDocumentReader(final SearchClientBasedQueryExecutor executor) {
-    super(executor);
+  public RoleMemberDocumentReader(
+      final SearchClientBasedQueryExecutor executor, final IndexDescriptor indexDescriptor) {
+    super(executor, indexDescriptor);
   }
 
   @Override

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/SequenceFlowDocumentReader.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/SequenceFlowDocumentReader.java
@@ -12,11 +12,13 @@ import io.camunda.search.entities.SequenceFlowEntity;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.search.query.SequenceFlowQuery;
 import io.camunda.security.reader.ResourceAccessChecks;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 
 public class SequenceFlowDocumentReader extends DocumentBasedReader implements SequenceFlowReader {
 
-  public SequenceFlowDocumentReader(final SearchClientBasedQueryExecutor executor) {
-    super(executor);
+  public SequenceFlowDocumentReader(
+      final SearchClientBasedQueryExecutor executor, final IndexDescriptor indexDescriptor) {
+    super(executor, indexDescriptor);
   }
 
   @Override

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/TenantDocumentReader.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/TenantDocumentReader.java
@@ -12,11 +12,21 @@ import io.camunda.search.entities.TenantEntity;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.search.query.TenantQuery;
 import io.camunda.security.reader.ResourceAccessChecks;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 
 public class TenantDocumentReader extends DocumentBasedReader implements TenantReader {
 
-  public TenantDocumentReader(final SearchClientBasedQueryExecutor executor) {
-    super(executor);
+  public TenantDocumentReader(
+      final SearchClientBasedQueryExecutor executor, final IndexDescriptor indexDescriptor) {
+    super(executor, indexDescriptor);
+  }
+
+  @Override
+  public TenantEntity getById(final String id, final ResourceAccessChecks resourceAccessChecks) {
+    return getSearchExecutor()
+        .getByQuery(
+            TenantQuery.of(b -> b.filter(f -> f.tenantId(id)).singleResult()),
+            io.camunda.webapps.schema.entities.usermanagement.TenantEntity.class);
   }
 
   @Override

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/TenantMemberDocumentReader.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/TenantMemberDocumentReader.java
@@ -12,14 +12,16 @@ import io.camunda.search.entities.TenantMemberEntity;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.search.query.TenantQuery;
 import io.camunda.security.reader.ResourceAccessChecks;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.zeebe.protocol.record.value.EntityType;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 public class TenantMemberDocumentReader extends DocumentBasedReader implements TenantMemberReader {
 
-  public TenantMemberDocumentReader(final SearchClientBasedQueryExecutor executor) {
-    super(executor);
+  public TenantMemberDocumentReader(
+      final SearchClientBasedQueryExecutor executor, final IndexDescriptor indexDescriptor) {
+    super(executor, indexDescriptor);
   }
 
   @Override

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/UsageMetricsDocumentReader.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/UsageMetricsDocumentReader.java
@@ -13,11 +13,13 @@ import io.camunda.search.entities.UsageMetricsEntity;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.search.query.UsageMetricsQuery;
 import io.camunda.security.reader.ResourceAccessChecks;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 
 public class UsageMetricsDocumentReader extends DocumentBasedReader implements UsageMetricsReader {
 
-  public UsageMetricsDocumentReader(final SearchClientBasedQueryExecutor executor) {
-    super(executor);
+  public UsageMetricsDocumentReader(
+      final SearchClientBasedQueryExecutor executor, final IndexDescriptor indexDescriptor) {
+    super(executor, indexDescriptor);
   }
 
   @Override

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/UserDocumentReader.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/UserDocumentReader.java
@@ -14,6 +14,7 @@ import io.camunda.search.entities.UserEntity;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.search.query.UserQuery;
 import io.camunda.security.reader.ResourceAccessChecks;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 
 public class UserDocumentReader extends DocumentBasedReader implements UserReader {
 
@@ -23,13 +24,23 @@ public class UserDocumentReader extends DocumentBasedReader implements UserReade
 
   public UserDocumentReader(
       final SearchClientBasedQueryExecutor executor,
+      final IndexDescriptor indexDescriptor,
       final RoleMemberDocumentReader roleMemberReader,
       final TenantMemberDocumentReader tenantMemberReader,
       final GroupMemberDocumentReader groupMemberReader) {
-    super(executor);
+    super(executor, indexDescriptor);
     this.roleMemberReader = roleMemberReader;
     this.tenantMemberReader = tenantMemberReader;
     this.groupMemberReader = groupMemberReader;
+  }
+
+  @Override
+  public UserEntity getById(final String id, final ResourceAccessChecks resourceAccessChecks) {
+    return getSearchExecutor()
+        .getById(
+            id,
+            io.camunda.webapps.schema.entities.usermanagement.UserEntity.class,
+            indexDescriptor.getFullQualifiedName());
   }
 
   @Override

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/UserTaskDocumentReader.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/UserTaskDocumentReader.java
@@ -12,12 +12,22 @@ import io.camunda.search.entities.UserTaskEntity;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.search.query.UserTaskQuery;
 import io.camunda.security.reader.ResourceAccessChecks;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.entities.usertask.TaskEntity;
 
 public class UserTaskDocumentReader extends DocumentBasedReader implements UserTaskReader {
 
-  public UserTaskDocumentReader(final SearchClientBasedQueryExecutor executor) {
-    super(executor);
+  public UserTaskDocumentReader(
+      final SearchClientBasedQueryExecutor executor, final IndexDescriptor indexDescriptor) {
+    super(executor, indexDescriptor);
+  }
+
+  @Override
+  public UserTaskEntity getByKey(final long key, final ResourceAccessChecks resourceAccessChecks) {
+    return getSearchExecutor()
+        .getByQuery(
+            UserTaskQuery.of(b -> b.filter(f -> f.userTaskKeys(key)).singleResult()),
+            TaskEntity.class);
   }
 
   @Override

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/VariableDocumentReader.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/VariableDocumentReader.java
@@ -12,11 +12,21 @@ import io.camunda.search.entities.VariableEntity;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.search.query.VariableQuery;
 import io.camunda.security.reader.ResourceAccessChecks;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 
 public class VariableDocumentReader extends DocumentBasedReader implements VariableReader {
 
-  public VariableDocumentReader(final SearchClientBasedQueryExecutor executor) {
-    super(executor);
+  public VariableDocumentReader(
+      final SearchClientBasedQueryExecutor executor, final IndexDescriptor indexDescriptor) {
+    super(executor, indexDescriptor);
+  }
+
+  @Override
+  public VariableEntity getByKey(final long key, final ResourceAccessChecks resourceAccessChecks) {
+    return getSearchExecutor()
+        .getByQuery(
+            VariableQuery.of(b -> b.filter(f -> f.variableKeys(key)).singleResult()),
+            io.camunda.webapps.schema.entities.VariableEntity.class);
   }
 
   @Override

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/AuthorizationFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/AuthorizationFilterTransformer.java
@@ -44,7 +44,7 @@ public final class AuthorizationFilterTransformer
   }
 
   @Override
-  protected SearchQuery toAuthorizationCheckSearchQuery(final Authorization authorization) {
+  protected SearchQuery toAuthorizationCheckSearchQuery(final Authorization<?> authorization) {
     return longTerms(ID, authorization.resourceIds().stream().map(Long::valueOf).toList());
   }
 

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/BatchOperationFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/BatchOperationFilterTransformer.java
@@ -24,7 +24,7 @@ public final class BatchOperationFilterTransformer
   }
 
   @Override
-  protected SearchQuery toAuthorizationCheckSearchQuery(final Authorization authorization) {
+  protected SearchQuery toAuthorizationCheckSearchQuery(final Authorization<?> authorization) {
     return matchAll();
   }
 

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/BatchOperationItemFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/BatchOperationItemFilterTransformer.java
@@ -34,7 +34,7 @@ public final class BatchOperationItemFilterTransformer
   }
 
   @Override
-  protected SearchQuery toAuthorizationCheckSearchQuery(final Authorization authorization) {
+  protected SearchQuery toAuthorizationCheckSearchQuery(final Authorization<?> authorization) {
     return matchAll();
   }
 

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/DecisionDefinitionFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/DecisionDefinitionFilterTransformer.java
@@ -32,7 +32,7 @@ public final class DecisionDefinitionFilterTransformer
   }
 
   @Override
-  protected SearchQuery toAuthorizationCheckSearchQuery(final Authorization authorization) {
+  protected SearchQuery toAuthorizationCheckSearchQuery(final Authorization<?> authorization) {
     return stringTerms(DECISION_ID, authorization.resourceIds());
   }
 

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/DecisionInstanceFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/DecisionInstanceFilterTransformer.java
@@ -75,7 +75,7 @@ public final class DecisionInstanceFilterTransformer
   }
 
   @Override
-  protected SearchQuery toAuthorizationCheckSearchQuery(final Authorization authorization) {
+  protected SearchQuery toAuthorizationCheckSearchQuery(final Authorization<?> authorization) {
     return stringTerms(DECISION_ID, authorization.resourceIds());
   }
 

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/DecisionRequirementsFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/DecisionRequirementsFilterTransformer.java
@@ -42,7 +42,7 @@ public final class DecisionRequirementsFilterTransformer
   }
 
   @Override
-  protected SearchQuery toAuthorizationCheckSearchQuery(final Authorization authorization) {
+  protected SearchQuery toAuthorizationCheckSearchQuery(final Authorization<?> authorization) {
     return stringTerms(DECISION_REQUIREMENTS_ID, authorization.resourceIds());
   }
 }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/FlownodeInstanceFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/FlownodeInstanceFilterTransformer.java
@@ -59,7 +59,7 @@ public class FlownodeInstanceFilterTransformer
   }
 
   @Override
-  protected SearchQuery toAuthorizationCheckSearchQuery(final Authorization authorization) {
+  protected SearchQuery toAuthorizationCheckSearchQuery(final Authorization<?> authorization) {
     return stringTerms(BPMN_PROCESS_ID, authorization.resourceIds());
   }
 }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/FormFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/FormFilterTransformer.java
@@ -37,7 +37,7 @@ public class FormFilterTransformer extends IndexFilterTransformer<FormFilter> {
   }
 
   @Override
-  protected SearchQuery toAuthorizationCheckSearchQuery(final Authorization authorization) {
+  protected SearchQuery toAuthorizationCheckSearchQuery(final Authorization<?> authorization) {
     return matchAll();
   }
 }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/GroupFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/GroupFilterTransformer.java
@@ -92,7 +92,7 @@ public class GroupFilterTransformer extends IndexFilterTransformer<GroupFilter> 
   }
 
   @Override
-  protected SearchQuery toAuthorizationCheckSearchQuery(final Authorization authorization) {
+  protected SearchQuery toAuthorizationCheckSearchQuery(final Authorization<?> authorization) {
     return stringTerms(GROUP_ID, authorization.resourceIds());
   }
 }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/IncidentFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/IncidentFilterTransformer.java
@@ -59,7 +59,7 @@ public class IncidentFilterTransformer extends IndexFilterTransformer<IncidentFi
   }
 
   @Override
-  protected SearchQuery toAuthorizationCheckSearchQuery(final Authorization authorization) {
+  protected SearchQuery toAuthorizationCheckSearchQuery(final Authorization<?> authorization) {
     return stringTerms(BPMN_PROCESS_ID, authorization.resourceIds());
   }
 }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/IndexFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/IndexFilterTransformer.java
@@ -107,7 +107,7 @@ public abstract class IndexFilterTransformer<T extends FilterBase> implements Fi
     return and(filteredQueries);
   }
 
-  protected abstract SearchQuery toAuthorizationCheckSearchQuery(Authorization authorization);
+  protected abstract SearchQuery toAuthorizationCheckSearchQuery(Authorization<?> authorization);
 
   @Override
   public IndexDescriptor getIndex() {

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/JobFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/JobFilterTransformer.java
@@ -84,7 +84,7 @@ public class JobFilterTransformer extends IndexFilterTransformer<JobFilter> {
   }
 
   @Override
-  protected SearchQuery toAuthorizationCheckSearchQuery(final Authorization authorization) {
+  protected SearchQuery toAuthorizationCheckSearchQuery(final Authorization<?> authorization) {
     return stringTerms(BPMN_PROCESS_ID, authorization.resourceIds());
   }
 }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/MappingRuleFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/MappingRuleFilterTransformer.java
@@ -52,7 +52,7 @@ public class MappingRuleFilterTransformer extends IndexFilterTransformer<Mapping
   }
 
   @Override
-  protected SearchQuery toAuthorizationCheckSearchQuery(final Authorization authorization) {
+  protected SearchQuery toAuthorizationCheckSearchQuery(final Authorization<?> authorization) {
     return stringTerms(MAPPING_RULE_ID, authorization.resourceIds());
   }
 }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/MessageSubscriptionFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/MessageSubscriptionFilterTransformer.java
@@ -55,7 +55,7 @@ public class MessageSubscriptionFilterTransformer
   }
 
   @Override
-  protected SearchQuery toAuthorizationCheckSearchQuery(final Authorization authorization) {
+  protected SearchQuery toAuthorizationCheckSearchQuery(final Authorization<?> authorization) {
     return stringTerms(BPMN_PROCESS_ID, authorization.resourceIds());
   }
 }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/ProcessDefinitionFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/ProcessDefinitionFilterTransformer.java
@@ -61,7 +61,7 @@ public class ProcessDefinitionFilterTransformer
   }
 
   @Override
-  protected SearchQuery toAuthorizationCheckSearchQuery(final Authorization authorization) {
+  protected SearchQuery toAuthorizationCheckSearchQuery(final Authorization<?> authorization) {
     return stringTerms(BPMN_PROCESS_ID, authorization.resourceIds());
   }
 }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/ProcessDefinitionStatisticsFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/ProcessDefinitionStatisticsFilterTransformer.java
@@ -139,7 +139,7 @@ public class ProcessDefinitionStatisticsFilterTransformer
   }
 
   @Override
-  protected SearchQuery toAuthorizationCheckSearchQuery(final Authorization authorization) {
+  protected SearchQuery toAuthorizationCheckSearchQuery(final Authorization<?> authorization) {
     return stringTerms(BPMN_PROCESS_ID, authorization.resourceIds());
   }
 

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/ProcessInstanceFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/ProcessInstanceFilterTransformer.java
@@ -117,7 +117,7 @@ public final class ProcessInstanceFilterTransformer
   }
 
   @Override
-  protected SearchQuery toAuthorizationCheckSearchQuery(final Authorization authorization) {
+  protected SearchQuery toAuthorizationCheckSearchQuery(final Authorization<?> authorization) {
     return stringTerms(BPMN_PROCESS_ID, authorization.resourceIds());
   }
 

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/ProcessInstanceStatisticsFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/ProcessInstanceStatisticsFilterTransformer.java
@@ -35,7 +35,7 @@ public class ProcessInstanceStatisticsFilterTransformer
   }
 
   @Override
-  protected SearchQuery toAuthorizationCheckSearchQuery(final Authorization authorization) {
+  protected SearchQuery toAuthorizationCheckSearchQuery(final Authorization<?> authorization) {
     return stringTerms(BPMN_PROCESS_ID, authorization.resourceIds());
   }
 }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/RoleFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/RoleFilterTransformer.java
@@ -65,7 +65,7 @@ public class RoleFilterTransformer extends IndexFilterTransformer<RoleFilter> {
   }
 
   @Override
-  protected SearchQuery toAuthorizationCheckSearchQuery(final Authorization authorization) {
+  protected SearchQuery toAuthorizationCheckSearchQuery(final Authorization<?> authorization) {
     return stringTerms(RoleIndex.ROLE_ID, authorization.resourceIds());
   }
 

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/SequenceFlowFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/SequenceFlowFilterTransformer.java
@@ -30,7 +30,7 @@ public final class SequenceFlowFilterTransformer
   }
 
   @Override
-  protected SearchQuery toAuthorizationCheckSearchQuery(final Authorization authorization) {
+  protected SearchQuery toAuthorizationCheckSearchQuery(final Authorization<?> authorization) {
     return stringTerms(BPMN_PROCESS_ID, authorization.resourceIds());
   }
 }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/TenantFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/TenantFilterTransformer.java
@@ -57,7 +57,7 @@ public class TenantFilterTransformer extends IndexFilterTransformer<TenantFilter
   }
 
   @Override
-  protected SearchQuery toAuthorizationCheckSearchQuery(final Authorization authorization) {
+  protected SearchQuery toAuthorizationCheckSearchQuery(final Authorization<?> authorization) {
     return stringTerms(TENANT_ID, authorization.resourceIds());
   }
 

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/UsageMetricsFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/UsageMetricsFilterTransformer.java
@@ -48,7 +48,7 @@ public class UsageMetricsFilterTransformer extends IndexFilterTransformer<UsageM
   }
 
   @Override
-  protected SearchQuery toAuthorizationCheckSearchQuery(final Authorization authorization) {
+  protected SearchQuery toAuthorizationCheckSearchQuery(final Authorization<?> authorization) {
     return matchAll();
   }
 

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/UserFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/UserFilterTransformer.java
@@ -41,7 +41,7 @@ public class UserFilterTransformer extends IndexFilterTransformer<UserFilter> {
   }
 
   @Override
-  protected SearchQuery toAuthorizationCheckSearchQuery(final Authorization authorization) {
+  protected SearchQuery toAuthorizationCheckSearchQuery(final Authorization<?> authorization) {
     return stringTerms(USERNAME, authorization.resourceIds());
   }
 }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/UserTaskFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/UserTaskFilterTransformer.java
@@ -81,7 +81,7 @@ public class UserTaskFilterTransformer extends IndexFilterTransformer<UserTaskFi
   }
 
   @Override
-  protected SearchQuery toAuthorizationCheckSearchQuery(final Authorization authorization) {
+  protected SearchQuery toAuthorizationCheckSearchQuery(final Authorization<?> authorization) {
     return stringTerms(BPMN_PROCESS_ID, authorization.resourceIds());
   }
 

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/VariableFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/VariableFilterTransformer.java
@@ -52,7 +52,7 @@ public class VariableFilterTransformer extends IndexFilterTransformer<VariableFi
   }
 
   @Override
-  protected SearchQuery toAuthorizationCheckSearchQuery(final Authorization authorization) {
+  protected SearchQuery toAuthorizationCheckSearchQuery(final Authorization<?> authorization) {
     return stringTerms(BPMN_PROCESS_ID, authorization.resourceIds());
   }
 

--- a/search/search-client-reader/src/main/java/io/camunda/search/clients/reader/DecisionRequirementsReader.java
+++ b/search/search-client-reader/src/main/java/io/camunda/search/clients/reader/DecisionRequirementsReader.java
@@ -9,6 +9,11 @@ package io.camunda.search.clients.reader;
 
 import io.camunda.search.entities.DecisionRequirementsEntity;
 import io.camunda.search.query.DecisionRequirementsQuery;
+import io.camunda.security.reader.ResourceAccessChecks;
 
 public interface DecisionRequirementsReader
-    extends SearchEntityReader<DecisionRequirementsEntity, DecisionRequirementsQuery> {}
+    extends SearchEntityReader<DecisionRequirementsEntity, DecisionRequirementsQuery> {
+
+  DecisionRequirementsEntity getByKey(
+      final long key, final ResourceAccessChecks resourceAccessChecks, final boolean includeXml);
+}

--- a/search/search-client-reader/src/main/java/io/camunda/search/clients/reader/SearchEntityReader.java
+++ b/search/search-client-reader/src/main/java/io/camunda/search/clients/reader/SearchEntityReader.java
@@ -14,5 +14,30 @@ import io.camunda.security.reader.ResourceAccessChecks;
 public interface SearchEntityReader<T, Q extends TypedSearchQuery<?, ?>>
     extends SearchClientReader {
 
+  /**
+   * Returns an entity by id. This method must be implemented if the id of the given entity is
+   * either specified by a user (for example, a user specifies a group id for a group).
+   *
+   * @param resourceAccessChecks to be applied when retrieving the entity, if applicable
+   */
+  default T getById(final String id, final ResourceAccessChecks resourceAccessChecks) {
+    throw new UnsupportedOperationException("SearchClientReader#getById() not supported");
+  }
+
+  /**
+   * Returns an entity by key. This method must be implemented if the key is a {@link Long} and
+   * provided by the C8 Orchestration Cluster itself.
+   *
+   * @param resourceAccessChecks to be applied when retrieving the entity, if applicable.
+   */
+  default T getByKey(final long key, final ResourceAccessChecks resourceAccessChecks) {
+    throw new UnsupportedOperationException("SearchClientReader#getByKey() not supported");
+  }
+
+  /**
+   * Execute the given query and applies the resourceAccessChecks.
+   *
+   * @param resourceAccessChecks to be applied
+   */
   SearchQueryResult<T> search(final Q query, final ResourceAccessChecks resourceAccessChecks);
 }

--- a/search/search-client/pom.xml
+++ b/search/search-client/pom.xml
@@ -33,10 +33,6 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
-    <dependency>
-      <groupId>io.camunda</groupId>
-      <artifactId>camunda-security-protocol</artifactId>
-    </dependency>
 
   </dependencies>
 

--- a/search/search-client/src/main/java/io/camunda/search/clients/AuthorizationSearchClient.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/AuthorizationSearchClient.java
@@ -14,6 +14,8 @@ import io.camunda.security.auth.SecurityContext;
 
 public interface AuthorizationSearchClient {
 
+  AuthorizationEntity getAuthorization(final long key);
+
   SearchQueryResult<AuthorizationEntity> searchAuthorizations(AuthorizationQuery filter);
 
   AuthorizationSearchClient withSecurityContext(SecurityContext securityContext);

--- a/search/search-client/src/main/java/io/camunda/search/clients/BatchOperationSearchClient.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/BatchOperationSearchClient.java
@@ -16,6 +16,8 @@ import io.camunda.security.auth.SecurityContext;
 
 public interface BatchOperationSearchClient {
 
+  BatchOperationEntity getBatchOperation(final String id);
+
   SearchQueryResult<BatchOperationEntity> searchBatchOperations(BatchOperationQuery query);
 
   SearchQueryResult<BatchOperationItemEntity> searchBatchOperationItems(

--- a/search/search-client/src/main/java/io/camunda/search/clients/CamundaSearchClients.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/CamundaSearchClients.java
@@ -272,6 +272,12 @@ public class CamundaSearchClients implements SearchClientsProxy {
   }
 
   @Override
+  public TenantEntity getTenant(final String id) {
+    return doGetWithReader(readers.tenantReader(), id)
+        .orElseThrow(() -> entityByIdNotFoundException("Tenant", id));
+  }
+
+  @Override
   public SearchQueryResult<TenantEntity> searchTenants(final TenantQuery query) {
     return doSearchWithReader(readers.tenantReader(), query);
   }

--- a/search/search-client/src/main/java/io/camunda/search/clients/CamundaSearchClients.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/CamundaSearchClients.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.search.clients;
 
+import static io.camunda.search.exception.ErrorMessages.ERROR_ENTITY_BY_ID_NOT_FOUND;
 import static io.camunda.search.exception.ErrorMessages.ERROR_ENTITY_BY_KEY_NOT_FOUND;
 
 import io.camunda.search.clients.reader.SearchClientReaders;
@@ -129,13 +130,13 @@ public class CamundaSearchClients implements SearchClientsProxy {
   @Override
   public MappingRuleEntity getMappingRule(final String id) {
     return doGetWithReader(readers.mappingRuleReader(), id)
-        .orElseThrow(() -> entityByIdNotFoundException("Mapping", id));
+        .orElseThrow(() -> entityByIdNotFoundException("Mapping Rule", id));
   }
 
   @Override
   public SearchQueryResult<MappingRuleEntity> searchMappingRules(
-      final MappingRuleQuery mappingQuery) {
-    return doSearchWithReader(readers.mappingRuleReader(), mappingQuery);
+      final MappingRuleQuery mappingRuleQuery) {
+    return doSearchWithReader(readers.mappingRuleReader(), mappingRuleQuery);
   }
 
   @Override
@@ -185,6 +186,12 @@ public class CamundaSearchClients implements SearchClientsProxy {
   public SearchQueryResult<FlowNodeInstanceEntity> searchFlowNodeInstances(
       final FlowNodeInstanceQuery query) {
     return doSearchWithReader(readers.flowNodeInstanceReader(), query);
+  }
+
+  @Override
+  public FormEntity getForm(final long key) {
+    return doGetWithReader(readers.formReader(), key)
+        .orElseThrow(() -> entityByKeyNotFoundException("Form", key));
   }
 
   @Override
@@ -446,6 +453,6 @@ public class CamundaSearchClients implements SearchClientsProxy {
   protected CamundaSearchException entityByIdNotFoundException(
       final String entityType, final String id) {
     return new CamundaSearchException(
-        ErrorMessages.ERROR_ENTITY_BY_ID_NOT_FOUND.formatted(entityType, id), Reason.NOT_FOUND);
+        ERROR_ENTITY_BY_ID_NOT_FOUND.formatted(entityType, id), Reason.NOT_FOUND);
   }
 }

--- a/search/search-client/src/main/java/io/camunda/search/clients/CamundaSearchClients.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/CamundaSearchClients.java
@@ -101,7 +101,7 @@ public class CamundaSearchClients implements SearchClientsProxy {
   @Override
   public AuthorizationEntity getAuthorization(final long key) {
     return doGetWithReader(readers.authorizationReader(), key)
-        .orElseThrow(() -> entityNotFoundException("Authorization", key));
+        .orElseThrow(() -> entityByKeyNotFoundException("Authorization", key));
   }
 
   @Override
@@ -185,7 +185,7 @@ public class CamundaSearchClients implements SearchClientsProxy {
   @Override
   public ProcessInstanceEntity getProcessInstance(final long processInstanceKey) {
     return doGetWithReader(readers.processInstanceReader(), processInstanceKey)
-        .orElseThrow(() -> entityNotFoundException("Process Instance", processInstanceKey));
+        .orElseThrow(() -> entityByKeyNotFoundException("Process Instance", processInstanceKey));
   }
 
   @Override
@@ -283,6 +283,12 @@ public class CamundaSearchClients implements SearchClientsProxy {
   }
 
   @Override
+  public BatchOperationEntity getBatchOperation(final String id) {
+    return doGetWithReader(readers.batchOperationReader(), id)
+        .orElseThrow(() -> entityByIdNotFoundException("Batch Operation", id));
+  }
+
+  @Override
   public SearchQueryResult<BatchOperationEntity> searchBatchOperations(
       final BatchOperationQuery query) {
     return doSearchWithReader(readers.batchOperationReader(), query);
@@ -297,6 +303,11 @@ public class CamundaSearchClients implements SearchClientsProxy {
   protected <T, Q extends TypedSearchQuery<?, ?>> Optional<T> doGetWithReader(
       final SearchEntityReader<T, Q> reader, final long key) {
     return doGet(a -> reader.getByKey(key, a));
+  }
+
+  protected <T, Q extends TypedSearchQuery<?, ?>> Optional<T> doGetWithReader(
+      final SearchEntityReader<T, Q> reader, final String id) {
+    return doGet(a -> reader.getById(id, a));
   }
 
   protected <T, Q extends TypedSearchQuery<?, ?>> SearchQueryResult<T> doSearchWithReader(
@@ -347,9 +358,15 @@ public class CamundaSearchClients implements SearchClientsProxy {
     return resourceAccessController.doGet(securityContext, applier);
   }
 
-  protected CamundaSearchException entityNotFoundException(
+  protected CamundaSearchException entityByKeyNotFoundException(
       final String entityType, final long key) {
     return new CamundaSearchException(
         ERROR_ENTITY_BY_KEY_NOT_FOUND.formatted(entityType, key), Reason.NOT_FOUND);
+  }
+
+  protected CamundaSearchException entityByIdNotFoundException(
+      final String entityType, final String id) {
+    return new CamundaSearchException(
+        ErrorMessages.ERROR_ENTITY_BY_ID_NOT_FOUND.formatted(entityType, id), Reason.NOT_FOUND);
   }
 }

--- a/search/search-client/src/main/java/io/camunda/search/clients/CamundaSearchClients.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/CamundaSearchClients.java
@@ -315,6 +315,12 @@ public class CamundaSearchClients implements SearchClientsProxy {
   }
 
   @Override
+  public UserTaskEntity getUserTask(final long key) {
+    return doGetWithReader(readers.userTaskReader(), key)
+        .orElseThrow(() -> entityByKeyNotFoundException("User Task", key));
+  }
+
+  @Override
   public SearchQueryResult<UserTaskEntity> searchUserTasks(final UserTaskQuery query) {
     return doSearchWithReader(readers.userTaskReader(), query);
   }

--- a/search/search-client/src/main/java/io/camunda/search/clients/CamundaSearchClients.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/CamundaSearchClients.java
@@ -133,6 +133,12 @@ public class CamundaSearchClients implements SearchClientsProxy {
   }
 
   @Override
+  public DecisionDefinitionEntity getDecisionDefinition(final long key) {
+    return doGetWithReader(readers.decisionDefinitionReader(), key)
+        .orElseThrow(() -> entityByKeyNotFoundException("Decision Definition", key));
+  }
+
+  @Override
   public SearchQueryResult<DecisionDefinitionEntity> searchDecisionDefinitions(
       final DecisionDefinitionQuery query) {
     return doSearchWithReader(readers.decisionDefinitionReader(), query);

--- a/search/search-client/src/main/java/io/camunda/search/clients/CamundaSearchClients.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/CamundaSearchClients.java
@@ -304,6 +304,12 @@ public class CamundaSearchClients implements SearchClientsProxy {
   }
 
   @Override
+  public UserEntity getUser(final String id) {
+    return doGetWithReader(readers.userReader(), id)
+        .orElseThrow(() -> entityByIdNotFoundException("User", id));
+  }
+
+  @Override
   public SearchQueryResult<UserEntity> searchUsers(final UserQuery query) {
     return doSearchWithReader(readers.userReader(), query);
   }

--- a/search/search-client/src/main/java/io/camunda/search/clients/CamundaSearchClients.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/CamundaSearchClients.java
@@ -157,6 +157,13 @@ public class CamundaSearchClients implements SearchClientsProxy {
   }
 
   @Override
+  public DecisionRequirementsEntity getDecisionRequirements(
+      final long key, final boolean includeXml) {
+    return doGet(a -> readers.decisionRequirementsReader().getByKey(key, a, includeXml))
+        .orElseThrow(() -> entityByKeyNotFoundException("Decision Requirements", key));
+  }
+
+  @Override
   public SearchQueryResult<DecisionRequirementsEntity> searchDecisionRequirements(
       final DecisionRequirementsQuery query) {
     return doSearchWithReader(readers.decisionRequirementsReader(), query);

--- a/search/search-client/src/main/java/io/camunda/search/clients/CamundaSearchClients.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/CamundaSearchClients.java
@@ -127,6 +127,12 @@ public class CamundaSearchClients implements SearchClientsProxy {
   }
 
   @Override
+  public MappingRuleEntity getMappingRule(final String id) {
+    return doGetWithReader(readers.mappingRuleReader(), id)
+        .orElseThrow(() -> entityByIdNotFoundException("Mapping", id));
+  }
+
+  @Override
   public SearchQueryResult<MappingRuleEntity> searchMappingRules(
       final MappingRuleQuery mappingQuery) {
     return doSearchWithReader(readers.mappingRuleReader(), mappingQuery);

--- a/search/search-client/src/main/java/io/camunda/search/clients/CamundaSearchClients.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/CamundaSearchClients.java
@@ -326,6 +326,12 @@ public class CamundaSearchClients implements SearchClientsProxy {
   }
 
   @Override
+  public VariableEntity getVariable(final long key) {
+    return doGetWithReader(readers.variableReader(), key)
+        .orElseThrow(() -> entityByKeyNotFoundException("Variable", key));
+  }
+
+  @Override
   public SearchQueryResult<VariableEntity> searchVariables(final VariableQuery query) {
     return doSearchWithReader(readers.variableReader(), query);
   }

--- a/search/search-client/src/main/java/io/camunda/search/clients/CamundaSearchClients.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/CamundaSearchClients.java
@@ -187,6 +187,12 @@ public class CamundaSearchClients implements SearchClientsProxy {
   }
 
   @Override
+  public IncidentEntity getIncident(final long key) {
+    return doGetWithReader(readers.incidentReader(), key)
+        .orElseThrow(() -> entityByKeyNotFoundException("Incident", key));
+  }
+
+  @Override
   public SearchQueryResult<IncidentEntity> searchIncidents(final IncidentQuery query) {
     return doSearchWithReader(readers.incidentReader(), query);
   }

--- a/search/search-client/src/main/java/io/camunda/search/clients/CamundaSearchClients.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/CamundaSearchClients.java
@@ -99,6 +99,12 @@ public class CamundaSearchClients implements SearchClientsProxy {
   }
 
   @Override
+  public AuthorizationEntity getAuthorization(final long key) {
+    return doGetWithReader(readers.authorizationReader(), key)
+        .orElseThrow(() -> entityNotFoundException("Authorization", key));
+  }
+
+  @Override
   public SearchQueryResult<AuthorizationEntity> searchAuthorizations(
       final AuthorizationQuery query) {
     return doSearchWithReader(readers.authorizationReader(), query);

--- a/search/search-client/src/main/java/io/camunda/search/clients/CamundaSearchClients.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/CamundaSearchClients.java
@@ -170,6 +170,12 @@ public class CamundaSearchClients implements SearchClientsProxy {
   }
 
   @Override
+  public FlowNodeInstanceEntity getFlowNodeInstance(final long key) {
+    return doGetWithReader(readers.flowNodeInstanceReader(), key)
+        .orElseThrow(() -> entityByKeyNotFoundException("Element Instance", key));
+  }
+
+  @Override
   public SearchQueryResult<FlowNodeInstanceEntity> searchFlowNodeInstances(
       final FlowNodeInstanceQuery query) {
     return doSearchWithReader(readers.flowNodeInstanceReader(), query);

--- a/search/search-client/src/main/java/io/camunda/search/clients/CamundaSearchClients.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/CamundaSearchClients.java
@@ -204,6 +204,12 @@ public class CamundaSearchClients implements SearchClientsProxy {
   }
 
   @Override
+  public ProcessDefinitionEntity getProcessDefinition(final long key) {
+    return doGetWithReader(readers.processDefinitionReader(), key)
+        .orElseThrow(() -> entityByKeyNotFoundException("Process Definition", key));
+  }
+
+  @Override
   public SearchQueryResult<ProcessDefinitionEntity> searchProcessDefinitions(
       final ProcessDefinitionQuery query) {
     return doSearchWithReader(readers.processDefinitionReader(), query);

--- a/search/search-client/src/main/java/io/camunda/search/clients/CamundaSearchClients.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/CamundaSearchClients.java
@@ -145,6 +145,12 @@ public class CamundaSearchClients implements SearchClientsProxy {
   }
 
   @Override
+  public DecisionInstanceEntity getDecisionInstance(final String id) {
+    return doGetWithReader(readers.decisionInstanceReader(), id)
+        .orElseThrow(() -> entityByIdNotFoundException("Decision Instance", id));
+  }
+
+  @Override
   public SearchQueryResult<DecisionInstanceEntity> searchDecisionInstances(
       final DecisionInstanceQuery query) {
     return doSearchWithReader(readers.decisionInstanceReader(), query);

--- a/search/search-client/src/main/java/io/camunda/search/clients/CamundaSearchClients.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/CamundaSearchClients.java
@@ -258,6 +258,12 @@ public class CamundaSearchClients implements SearchClientsProxy {
   }
 
   @Override
+  public GroupEntity getGroup(final String id) {
+    return doGetWithReader(readers.groupReader(), id)
+        .orElseThrow(() -> entityByIdNotFoundException("Group", id));
+  }
+
+  @Override
   public SearchQueryResult<GroupEntity> searchGroups(final GroupQuery query) {
     return doSearchWithReader(readers.groupReader(), query);
   }

--- a/search/search-client/src/main/java/io/camunda/search/clients/CamundaSearchClients.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/CamundaSearchClients.java
@@ -256,6 +256,12 @@ public class CamundaSearchClients implements SearchClientsProxy {
   }
 
   @Override
+  public RoleEntity getRole(final String id) {
+    return doGetWithReader(readers.roleReader(), id)
+        .orElseThrow(() -> entityByIdNotFoundException("Role", id));
+  }
+
+  @Override
   public SearchQueryResult<RoleEntity> searchRoles(final RoleQuery query) {
     return doSearchWithReader(readers.roleReader(), query);
   }

--- a/search/search-client/src/main/java/io/camunda/search/clients/DecisionDefinitionSearchClient.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/DecisionDefinitionSearchClient.java
@@ -14,6 +14,8 @@ import io.camunda.security.auth.SecurityContext;
 
 public interface DecisionDefinitionSearchClient {
 
+  DecisionDefinitionEntity getDecisionDefinition(final long key);
+
   SearchQueryResult<DecisionDefinitionEntity> searchDecisionDefinitions(
       DecisionDefinitionQuery filter);
 

--- a/search/search-client/src/main/java/io/camunda/search/clients/DecisionInstanceSearchClient.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/DecisionInstanceSearchClient.java
@@ -14,6 +14,8 @@ import io.camunda.security.auth.SecurityContext;
 
 public interface DecisionInstanceSearchClient {
 
+  DecisionInstanceEntity getDecisionInstance(final String id);
+
   SearchQueryResult<DecisionInstanceEntity> searchDecisionInstances(DecisionInstanceQuery filter);
 
   DecisionInstanceSearchClient withSecurityContext(SecurityContext securityContext);

--- a/search/search-client/src/main/java/io/camunda/search/clients/DecisionRequirementSearchClient.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/DecisionRequirementSearchClient.java
@@ -14,6 +14,8 @@ import io.camunda.security.auth.SecurityContext;
 
 public interface DecisionRequirementSearchClient {
 
+  DecisionRequirementsEntity getDecisionRequirements(final long key, final boolean includeXml);
+
   SearchQueryResult<DecisionRequirementsEntity> searchDecisionRequirements(
       DecisionRequirementsQuery filter);
 

--- a/search/search-client/src/main/java/io/camunda/search/clients/FlowNodeInstanceSearchClient.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/FlowNodeInstanceSearchClient.java
@@ -14,6 +14,8 @@ import io.camunda.security.auth.SecurityContext;
 
 public interface FlowNodeInstanceSearchClient {
 
+  FlowNodeInstanceEntity getFlowNodeInstance(final long key);
+
   SearchQueryResult<FlowNodeInstanceEntity> searchFlowNodeInstances(FlowNodeInstanceQuery filter);
 
   FlowNodeInstanceSearchClient withSecurityContext(SecurityContext securityContext);

--- a/search/search-client/src/main/java/io/camunda/search/clients/FormSearchClient.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/FormSearchClient.java
@@ -14,6 +14,8 @@ import io.camunda.security.auth.SecurityContext;
 
 public interface FormSearchClient {
 
+  FormEntity getForm(final long key);
+
   SearchQueryResult<FormEntity> searchForms(FormQuery filter);
 
   FormSearchClient withSecurityContext(SecurityContext securityContext);

--- a/search/search-client/src/main/java/io/camunda/search/clients/GroupSearchClient.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/GroupSearchClient.java
@@ -15,6 +15,8 @@ import io.camunda.security.auth.SecurityContext;
 
 public interface GroupSearchClient {
 
+  GroupEntity getGroup(final String id);
+
   SearchQueryResult<GroupEntity> searchGroups(final GroupQuery query);
 
   SearchQueryResult<GroupMemberEntity> searchGroupMembers(GroupQuery query);

--- a/search/search-client/src/main/java/io/camunda/search/clients/IncidentSearchClient.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/IncidentSearchClient.java
@@ -14,6 +14,8 @@ import io.camunda.security.auth.SecurityContext;
 
 public interface IncidentSearchClient {
 
+  IncidentEntity getIncident(final long key);
+
   SearchQueryResult<IncidentEntity> searchIncidents(IncidentQuery filter);
 
   IncidentSearchClient withSecurityContext(SecurityContext securityContext);

--- a/search/search-client/src/main/java/io/camunda/search/clients/MappingRuleSearchClient.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/MappingRuleSearchClient.java
@@ -14,7 +14,9 @@ import io.camunda.security.auth.SecurityContext;
 
 public interface MappingRuleSearchClient {
 
-  SearchQueryResult<MappingRuleEntity> searchMappingRules(MappingRuleQuery filter);
+  MappingRuleEntity getMappingRule(final String id);
+
+  SearchQueryResult<MappingRuleEntity> searchMappingRules(MappingRuleQuery mappingRuleQuery);
 
   MappingRuleSearchClient withSecurityContext(SecurityContext securityContext);
 }

--- a/search/search-client/src/main/java/io/camunda/search/clients/ProcessDefinitionSearchClient.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/ProcessDefinitionSearchClient.java
@@ -17,6 +17,8 @@ import java.util.List;
 
 public interface ProcessDefinitionSearchClient {
 
+  ProcessDefinitionEntity getProcessDefinition(final long key);
+
   SearchQueryResult<ProcessDefinitionEntity> searchProcessDefinitions(
       ProcessDefinitionQuery filter);
 

--- a/search/search-client/src/main/java/io/camunda/search/clients/ProcessInstanceSearchClient.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/ProcessInstanceSearchClient.java
@@ -16,6 +16,8 @@ import java.util.List;
 
 public interface ProcessInstanceSearchClient {
 
+  ProcessInstanceEntity getProcessInstance(final long processInstanceKey);
+
   SearchQueryResult<ProcessInstanceEntity> searchProcessInstances(ProcessInstanceQuery query);
 
   List<ProcessFlowNodeStatisticsEntity> processInstanceFlowNodeStatistics(

--- a/search/search-client/src/main/java/io/camunda/search/clients/RoleSearchClient.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/RoleSearchClient.java
@@ -15,6 +15,8 @@ import io.camunda.security.auth.SecurityContext;
 
 public interface RoleSearchClient {
 
+  RoleEntity getRole(final String id);
+
   SearchQueryResult<RoleEntity> searchRoles(RoleQuery filter);
 
   SearchQueryResult<RoleMemberEntity> searchRoleMembers(RoleQuery filter);

--- a/search/search-client/src/main/java/io/camunda/search/clients/TenantSearchClient.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/TenantSearchClient.java
@@ -14,6 +14,9 @@ import io.camunda.search.query.TenantQuery;
 import io.camunda.security.auth.SecurityContext;
 
 public interface TenantSearchClient {
+
+  TenantEntity getTenant(final String id);
+
   SearchQueryResult<TenantEntity> searchTenants(TenantQuery filter);
 
   SearchQueryResult<TenantMemberEntity> searchTenantMembers(TenantQuery filter);

--- a/search/search-client/src/main/java/io/camunda/search/clients/UserSearchClient.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/UserSearchClient.java
@@ -14,6 +14,8 @@ import io.camunda.security.auth.SecurityContext;
 
 public interface UserSearchClient {
 
+  UserEntity getUser(final String id);
+
   SearchQueryResult<UserEntity> searchUsers(UserQuery userQuery);
 
   UserSearchClient withSecurityContext(SecurityContext securityContext);

--- a/search/search-client/src/main/java/io/camunda/search/clients/UserTaskSearchClient.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/UserTaskSearchClient.java
@@ -14,6 +14,8 @@ import io.camunda.security.auth.SecurityContext;
 
 public interface UserTaskSearchClient {
 
+  UserTaskEntity getUserTask(final long key);
+
   SearchQueryResult<UserTaskEntity> searchUserTasks(UserTaskQuery filter);
 
   UserTaskSearchClient withSecurityContext(SecurityContext securityContext);

--- a/search/search-client/src/main/java/io/camunda/search/clients/VariableSearchClient.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/VariableSearchClient.java
@@ -14,6 +14,8 @@ import io.camunda.security.auth.SecurityContext;
 
 public interface VariableSearchClient {
 
+  VariableEntity getVariable(final long key);
+
   SearchQueryResult<VariableEntity> searchVariables(VariableQuery filter);
 
   VariableSearchClient withSecurityContext(SecurityContext securityContext);

--- a/search/search-client/src/main/java/io/camunda/search/clients/impl/NoDBSearchClientsProxy.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/impl/NoDBSearchClientsProxy.java
@@ -138,6 +138,11 @@ public class NoDBSearchClientsProxy implements SearchClientsProxy {
   }
 
   @Override
+  public FormEntity getForm(final long key) {
+    throw new NoSecondaryStorageException();
+  }
+
+  @Override
   public SearchQueryResult<FormEntity> searchForms(final FormQuery filter) {
     throw new NoSecondaryStorageException();
   }

--- a/search/search-client/src/main/java/io/camunda/search/clients/impl/NoDBSearchClientsProxy.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/impl/NoDBSearchClientsProxy.java
@@ -168,7 +168,13 @@ public class NoDBSearchClientsProxy implements SearchClientsProxy {
   }
 
   @Override
-  public SearchQueryResult<MappingRuleEntity> searchMappingRules(final MappingRuleQuery filter) {
+  public MappingRuleEntity getMappingRule(final String id) {
+    throw new NoSecondaryStorageException();
+  }
+
+  @Override
+  public SearchQueryResult<MappingRuleEntity> searchMappingRules(
+      final MappingRuleQuery mappingRuleQuery) {
     throw new NoSecondaryStorageException();
   }
 

--- a/search/search-client/src/main/java/io/camunda/search/clients/impl/NoDBSearchClientsProxy.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/impl/NoDBSearchClientsProxy.java
@@ -228,6 +228,11 @@ public class NoDBSearchClientsProxy implements SearchClientsProxy {
   }
 
   @Override
+  public TenantEntity getTenant(final String id) {
+    throw new NoSecondaryStorageException();
+  }
+
+  @Override
   public SearchQueryResult<TenantEntity> searchTenants(final TenantQuery filter) {
     throw new NoSecondaryStorageException();
   }

--- a/search/search-client/src/main/java/io/camunda/search/clients/impl/NoDBSearchClientsProxy.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/impl/NoDBSearchClientsProxy.java
@@ -263,6 +263,11 @@ public class NoDBSearchClientsProxy implements SearchClientsProxy {
   }
 
   @Override
+  public VariableEntity getVariable(final long key) {
+    throw new NoSecondaryStorageException();
+  }
+
+  @Override
   public SearchQueryResult<VariableEntity> searchVariables(final VariableQuery filter) {
     throw new NoSecondaryStorageException();
   }

--- a/search/search-client/src/main/java/io/camunda/search/clients/impl/NoDBSearchClientsProxy.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/impl/NoDBSearchClientsProxy.java
@@ -179,6 +179,11 @@ public class NoDBSearchClientsProxy implements SearchClientsProxy {
   }
 
   @Override
+  public ProcessDefinitionEntity getProcessDefinition(final long key) {
+    throw new NoSecondaryStorageException();
+  }
+
+  @Override
   public SearchQueryResult<ProcessDefinitionEntity> searchProcessDefinitions(
       final ProcessDefinitionQuery filter) {
     throw new NoSecondaryStorageException();

--- a/search/search-client/src/main/java/io/camunda/search/clients/impl/NoDBSearchClientsProxy.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/impl/NoDBSearchClientsProxy.java
@@ -158,6 +158,11 @@ public class NoDBSearchClientsProxy implements SearchClientsProxy {
   }
 
   @Override
+  public IncidentEntity getIncident(final long key) {
+    throw new NoSecondaryStorageException();
+  }
+
+  @Override
   public SearchQueryResult<IncidentEntity> searchIncidents(final IncidentQuery filter) {
     throw new NoSecondaryStorageException();
   }

--- a/search/search-client/src/main/java/io/camunda/search/clients/impl/NoDBSearchClientsProxy.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/impl/NoDBSearchClientsProxy.java
@@ -213,6 +213,11 @@ public class NoDBSearchClientsProxy implements SearchClientsProxy {
   }
 
   @Override
+  public RoleEntity getRole(final String id) {
+    throw new NoSecondaryStorageException();
+  }
+
+  @Override
   public SearchQueryResult<RoleEntity> searchRoles(final RoleQuery filter) {
     throw new NoSecondaryStorageException();
   }

--- a/search/search-client/src/main/java/io/camunda/search/clients/impl/NoDBSearchClientsProxy.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/impl/NoDBSearchClientsProxy.java
@@ -144,6 +144,11 @@ public class NoDBSearchClientsProxy implements SearchClientsProxy {
   }
 
   @Override
+  public ProcessInstanceEntity getProcessInstance(final long processInstanceKey) {
+    throw new NoSecondaryStorageException();
+  }
+
+  @Override
   public SearchQueryResult<ProcessInstanceEntity> searchProcessInstances(
       final ProcessInstanceQuery query) {
     throw new NoSecondaryStorageException();

--- a/search/search-client/src/main/java/io/camunda/search/clients/impl/NoDBSearchClientsProxy.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/impl/NoDBSearchClientsProxy.java
@@ -253,6 +253,11 @@ public class NoDBSearchClientsProxy implements SearchClientsProxy {
   }
 
   @Override
+  public UserTaskEntity getUserTask(final long key) {
+    throw new NoSecondaryStorageException();
+  }
+
+  @Override
   public SearchQueryResult<UserTaskEntity> searchUserTasks(final UserTaskQuery filter) {
     throw new NoSecondaryStorageException();
   }

--- a/search/search-client/src/main/java/io/camunda/search/clients/impl/NoDBSearchClientsProxy.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/impl/NoDBSearchClientsProxy.java
@@ -115,6 +115,12 @@ public class NoDBSearchClientsProxy implements SearchClientsProxy {
   }
 
   @Override
+  public DecisionRequirementsEntity getDecisionRequirements(
+      final long key, final boolean includeXml) {
+    throw new NoSecondaryStorageException();
+  }
+
+  @Override
   public SearchQueryResult<DecisionRequirementsEntity> searchDecisionRequirements(
       final DecisionRequirementsQuery filter) {
     throw new NoSecondaryStorageException();

--- a/search/search-client/src/main/java/io/camunda/search/clients/impl/NoDBSearchClientsProxy.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/impl/NoDBSearchClientsProxy.java
@@ -243,6 +243,11 @@ public class NoDBSearchClientsProxy implements SearchClientsProxy {
   }
 
   @Override
+  public UserEntity getUser(final String id) {
+    throw new NoSecondaryStorageException();
+  }
+
+  @Override
   public SearchQueryResult<UserEntity> searchUsers(final UserQuery userQuery) {
     throw new NoSecondaryStorageException();
   }

--- a/search/search-client/src/main/java/io/camunda/search/clients/impl/NoDBSearchClientsProxy.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/impl/NoDBSearchClientsProxy.java
@@ -127,6 +127,11 @@ public class NoDBSearchClientsProxy implements SearchClientsProxy {
   }
 
   @Override
+  public FlowNodeInstanceEntity getFlowNodeInstance(final long key) {
+    throw new NoSecondaryStorageException();
+  }
+
+  @Override
   public SearchQueryResult<FlowNodeInstanceEntity> searchFlowNodeInstances(
       final FlowNodeInstanceQuery filter) {
     throw new NoSecondaryStorageException();

--- a/search/search-client/src/main/java/io/camunda/search/clients/impl/NoDBSearchClientsProxy.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/impl/NoDBSearchClientsProxy.java
@@ -65,8 +65,18 @@ import java.util.List;
 public class NoDBSearchClientsProxy implements SearchClientsProxy {
 
   @Override
+  public AuthorizationEntity getAuthorization(final long key) {
+    throw new NoSecondaryStorageException();
+  }
+
+  @Override
   public SearchQueryResult<AuthorizationEntity> searchAuthorizations(
       final AuthorizationQuery filter) {
+    throw new NoSecondaryStorageException();
+  }
+
+  @Override
+  public BatchOperationEntity getBatchOperation(final String id) {
     throw new NoSecondaryStorageException();
   }
 

--- a/search/search-client/src/main/java/io/camunda/search/clients/impl/NoDBSearchClientsProxy.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/impl/NoDBSearchClientsProxy.java
@@ -143,6 +143,11 @@ public class NoDBSearchClientsProxy implements SearchClientsProxy {
   }
 
   @Override
+  public GroupEntity getGroup(final String id) {
+    throw new NoSecondaryStorageException();
+  }
+
+  @Override
   public SearchQueryResult<GroupEntity> searchGroups(final GroupQuery query) {
     throw new NoSecondaryStorageException();
   }

--- a/search/search-client/src/main/java/io/camunda/search/clients/impl/NoDBSearchClientsProxy.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/impl/NoDBSearchClientsProxy.java
@@ -104,6 +104,11 @@ public class NoDBSearchClientsProxy implements SearchClientsProxy {
   }
 
   @Override
+  public DecisionInstanceEntity getDecisionInstance(final String id) {
+    throw new NoSecondaryStorageException();
+  }
+
+  @Override
   public SearchQueryResult<DecisionInstanceEntity> searchDecisionInstances(
       final DecisionInstanceQuery filter) {
     throw new NoSecondaryStorageException();

--- a/search/search-client/src/main/java/io/camunda/search/clients/impl/NoDBSearchClientsProxy.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/impl/NoDBSearchClientsProxy.java
@@ -93,6 +93,11 @@ public class NoDBSearchClientsProxy implements SearchClientsProxy {
   }
 
   @Override
+  public DecisionDefinitionEntity getDecisionDefinition(final long key) {
+    throw new NoSecondaryStorageException();
+  }
+
+  @Override
   public SearchQueryResult<DecisionDefinitionEntity> searchDecisionDefinitions(
       final DecisionDefinitionQuery filter) {
     throw new NoSecondaryStorageException();

--- a/search/search-client/src/main/java/io/camunda/search/clients/impl/NoopSearchClientsProxy.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/impl/NoopSearchClientsProxy.java
@@ -245,6 +245,11 @@ public class NoopSearchClientsProxy implements SearchClientsProxy {
   }
 
   @Override
+  public UserEntity getUser(final String id) {
+    return null;
+  }
+
+  @Override
   public SearchQueryResult<UserEntity> searchUsers(final UserQuery userQuery) {
     return SearchQueryResult.empty();
   }

--- a/search/search-client/src/main/java/io/camunda/search/clients/impl/NoopSearchClientsProxy.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/impl/NoopSearchClientsProxy.java
@@ -106,6 +106,11 @@ public class NoopSearchClientsProxy implements SearchClientsProxy {
   }
 
   @Override
+  public DecisionInstanceEntity getDecisionInstance(final String id) {
+    return null;
+  }
+
+  @Override
   public SearchQueryResult<DecisionInstanceEntity> searchDecisionInstances(
       final DecisionInstanceQuery filter) {
     return SearchQueryResult.empty();

--- a/search/search-client/src/main/java/io/camunda/search/clients/impl/NoopSearchClientsProxy.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/impl/NoopSearchClientsProxy.java
@@ -140,6 +140,11 @@ public class NoopSearchClientsProxy implements SearchClientsProxy {
   }
 
   @Override
+  public FormEntity getForm(final long key) {
+    return null;
+  }
+
+  @Override
   public SearchQueryResult<FormEntity> searchForms(final FormQuery filter) {
     return SearchQueryResult.empty();
   }

--- a/search/search-client/src/main/java/io/camunda/search/clients/impl/NoopSearchClientsProxy.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/impl/NoopSearchClientsProxy.java
@@ -170,7 +170,13 @@ public class NoopSearchClientsProxy implements SearchClientsProxy {
   }
 
   @Override
-  public SearchQueryResult<MappingRuleEntity> searchMappingRules(final MappingRuleQuery filter) {
+  public MappingRuleEntity getMappingRule(final String id) {
+    return null;
+  }
+
+  @Override
+  public SearchQueryResult<MappingRuleEntity> searchMappingRules(
+      final MappingRuleQuery mappingRuleQuery) {
     return SearchQueryResult.empty();
   }
 

--- a/search/search-client/src/main/java/io/camunda/search/clients/impl/NoopSearchClientsProxy.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/impl/NoopSearchClientsProxy.java
@@ -160,6 +160,11 @@ public class NoopSearchClientsProxy implements SearchClientsProxy {
   }
 
   @Override
+  public IncidentEntity getIncident(final long key) {
+    return null;
+  }
+
+  @Override
   public SearchQueryResult<IncidentEntity> searchIncidents(final IncidentQuery filter) {
     return SearchQueryResult.empty();
   }

--- a/search/search-client/src/main/java/io/camunda/search/clients/impl/NoopSearchClientsProxy.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/impl/NoopSearchClientsProxy.java
@@ -265,6 +265,11 @@ public class NoopSearchClientsProxy implements SearchClientsProxy {
   }
 
   @Override
+  public VariableEntity getVariable(final long key) {
+    return null;
+  }
+
+  @Override
   public SearchQueryResult<VariableEntity> searchVariables(final VariableQuery filter) {
     return SearchQueryResult.empty();
   }

--- a/search/search-client/src/main/java/io/camunda/search/clients/impl/NoopSearchClientsProxy.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/impl/NoopSearchClientsProxy.java
@@ -145,6 +145,11 @@ public class NoopSearchClientsProxy implements SearchClientsProxy {
   }
 
   @Override
+  public GroupEntity getGroup(final String id) {
+    return null;
+  }
+
+  @Override
   public SearchQueryResult<GroupEntity> searchGroups(final GroupQuery query) {
     return SearchQueryResult.empty();
   }

--- a/search/search-client/src/main/java/io/camunda/search/clients/impl/NoopSearchClientsProxy.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/impl/NoopSearchClientsProxy.java
@@ -215,6 +215,11 @@ public class NoopSearchClientsProxy implements SearchClientsProxy {
   }
 
   @Override
+  public RoleEntity getRole(final String id) {
+    return null;
+  }
+
+  @Override
   public SearchQueryResult<RoleEntity> searchRoles(final RoleQuery filter) {
     return SearchQueryResult.empty();
   }

--- a/search/search-client/src/main/java/io/camunda/search/clients/impl/NoopSearchClientsProxy.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/impl/NoopSearchClientsProxy.java
@@ -230,6 +230,11 @@ public class NoopSearchClientsProxy implements SearchClientsProxy {
   }
 
   @Override
+  public TenantEntity getTenant(final String id) {
+    return null;
+  }
+
+  @Override
   public SearchQueryResult<TenantEntity> searchTenants(final TenantQuery filter) {
     return SearchQueryResult.empty();
   }

--- a/search/search-client/src/main/java/io/camunda/search/clients/impl/NoopSearchClientsProxy.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/impl/NoopSearchClientsProxy.java
@@ -129,6 +129,11 @@ public class NoopSearchClientsProxy implements SearchClientsProxy {
   }
 
   @Override
+  public FlowNodeInstanceEntity getFlowNodeInstance(final long key) {
+    return null;
+  }
+
+  @Override
   public SearchQueryResult<FlowNodeInstanceEntity> searchFlowNodeInstances(
       final FlowNodeInstanceQuery filter) {
     return SearchQueryResult.empty();

--- a/search/search-client/src/main/java/io/camunda/search/clients/impl/NoopSearchClientsProxy.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/impl/NoopSearchClientsProxy.java
@@ -181,6 +181,11 @@ public class NoopSearchClientsProxy implements SearchClientsProxy {
   }
 
   @Override
+  public ProcessDefinitionEntity getProcessDefinition(final long key) {
+    return null;
+  }
+
+  @Override
   public SearchQueryResult<ProcessDefinitionEntity> searchProcessDefinitions(
       final ProcessDefinitionQuery filter) {
     return SearchQueryResult.empty();

--- a/search/search-client/src/main/java/io/camunda/search/clients/impl/NoopSearchClientsProxy.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/impl/NoopSearchClientsProxy.java
@@ -95,6 +95,11 @@ public class NoopSearchClientsProxy implements SearchClientsProxy {
   }
 
   @Override
+  public DecisionDefinitionEntity getDecisionDefinition(final long key) {
+    return null;
+  }
+
+  @Override
   public SearchQueryResult<DecisionDefinitionEntity> searchDecisionDefinitions(
       final DecisionDefinitionQuery filter) {
     return SearchQueryResult.empty();

--- a/search/search-client/src/main/java/io/camunda/search/clients/impl/NoopSearchClientsProxy.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/impl/NoopSearchClientsProxy.java
@@ -117,6 +117,12 @@ public class NoopSearchClientsProxy implements SearchClientsProxy {
   }
 
   @Override
+  public DecisionRequirementsEntity getDecisionRequirements(
+      final long key, final boolean includeXml) {
+    return null;
+  }
+
+  @Override
   public SearchQueryResult<DecisionRequirementsEntity> searchDecisionRequirements(
       final DecisionRequirementsQuery filter) {
     return SearchQueryResult.empty();

--- a/search/search-client/src/main/java/io/camunda/search/clients/impl/NoopSearchClientsProxy.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/impl/NoopSearchClientsProxy.java
@@ -78,6 +78,11 @@ public class NoopSearchClientsProxy implements SearchClientsProxy {
   }
 
   @Override
+  public BatchOperationEntity getBatchOperation(final String id) {
+    return null;
+  }
+
+  @Override
   public SearchQueryResult<BatchOperationEntity> searchBatchOperations(
       final BatchOperationQuery query) {
     return SearchQueryResult.empty();

--- a/search/search-client/src/main/java/io/camunda/search/clients/impl/NoopSearchClientsProxy.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/impl/NoopSearchClientsProxy.java
@@ -255,6 +255,11 @@ public class NoopSearchClientsProxy implements SearchClientsProxy {
   }
 
   @Override
+  public UserTaskEntity getUserTask(final long key) {
+    return null;
+  }
+
+  @Override
   public SearchQueryResult<UserTaskEntity> searchUserTasks(final UserTaskQuery filter) {
     return SearchQueryResult.empty();
   }

--- a/search/search-client/src/main/java/io/camunda/search/clients/impl/NoopSearchClientsProxy.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/impl/NoopSearchClientsProxy.java
@@ -67,6 +67,11 @@ import java.util.Map;
 public class NoopSearchClientsProxy implements SearchClientsProxy {
 
   @Override
+  public AuthorizationEntity getAuthorization(final long key) {
+    return null;
+  }
+
+  @Override
   public SearchQueryResult<AuthorizationEntity> searchAuthorizations(
       final AuthorizationQuery filter) {
     return SearchQueryResult.empty();

--- a/search/search-client/src/main/java/io/camunda/search/clients/impl/NoopSearchClientsProxy.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/impl/NoopSearchClientsProxy.java
@@ -146,6 +146,11 @@ public class NoopSearchClientsProxy implements SearchClientsProxy {
   }
 
   @Override
+  public ProcessInstanceEntity getProcessInstance(final long processInstanceKey) {
+    return null;
+  }
+
+  @Override
   public SearchQueryResult<ProcessInstanceEntity> searchProcessInstances(
       final ProcessInstanceQuery query) {
     return SearchQueryResult.empty();

--- a/search/search-domain/src/main/java/io/camunda/search/entities/DecisionDefinitionEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/DecisionDefinitionEntity.java
@@ -17,4 +17,5 @@ public record DecisionDefinitionEntity(
     Integer version,
     String decisionRequirementsId,
     Long decisionRequirementsKey,
-    String tenantId) {}
+    String tenantId)
+    implements TenantOwnedEntity {}

--- a/search/search-domain/src/main/java/io/camunda/search/entities/DecisionInstanceEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/DecisionInstanceEntity.java
@@ -29,7 +29,8 @@ public record DecisionInstanceEntity(
     DecisionDefinitionType decisionDefinitionType,
     String result,
     List<DecisionInstanceInputEntity> evaluatedInputs,
-    List<DecisionInstanceOutputEntity> evaluatedOutputs) {
+    List<DecisionInstanceOutputEntity> evaluatedOutputs)
+    implements TenantOwnedEntity {
 
   public Builder toBuilder() {
     return new Builder()

--- a/search/search-domain/src/main/java/io/camunda/search/entities/DecisionRequirementsEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/DecisionRequirementsEntity.java
@@ -17,4 +17,5 @@ public record DecisionRequirementsEntity(
     Integer version,
     String resourceName,
     String xml,
-    String tenantId) {}
+    String tenantId)
+    implements TenantOwnedEntity {}

--- a/search/search-domain/src/main/java/io/camunda/search/entities/FlowNodeInstanceEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/FlowNodeInstanceEntity.java
@@ -25,7 +25,8 @@ public record FlowNodeInstanceEntity(
     Boolean hasIncident,
     Long incidentKey,
     String processDefinitionId,
-    String tenantId) {
+    String tenantId)
+    implements TenantOwnedEntity {
 
   public FlowNodeInstanceEntity withFlowNodeName(final String name) {
     return new FlowNodeInstanceEntity(

--- a/search/search-domain/src/main/java/io/camunda/search/entities/FormEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/FormEntity.java
@@ -10,5 +10,5 @@ package io.camunda.search.entities;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-public record FormEntity(
-    Long formKey, String tenantId, String formId, String schema, Long version) {}
+public record FormEntity(Long formKey, String tenantId, String formId, String schema, Long version)
+    implements TenantOwnedEntity {}

--- a/search/search-domain/src/main/java/io/camunda/search/entities/IncidentEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/IncidentEntity.java
@@ -23,7 +23,8 @@ public record IncidentEntity(
     OffsetDateTime creationTime,
     IncidentState state,
     Long jobKey,
-    String tenantId) {
+    String tenantId)
+    implements TenantOwnedEntity {
 
   public enum IncidentState {
     ACTIVE,

--- a/search/search-domain/src/main/java/io/camunda/search/entities/JobEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/JobEntity.java
@@ -36,7 +36,8 @@ public record JobEntity(
     Long processInstanceKey,
     String elementId,
     Long elementInstanceKey,
-    String tenantId) {
+    String tenantId)
+    implements TenantOwnedEntity {
 
   public static class Builder implements ObjectBuilder<JobEntity> {
     private Long jobKey;

--- a/search/search-domain/src/main/java/io/camunda/search/entities/MessageSubscriptionEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/MessageSubscriptionEntity.java
@@ -22,7 +22,8 @@ public record MessageSubscriptionEntity(
     OffsetDateTime dateTime,
     String messageName,
     String correlationKey,
-    String tenantId) {
+    String tenantId)
+    implements TenantOwnedEntity {
   public static Builder builder() {
     return new Builder();
   }

--- a/search/search-domain/src/main/java/io/camunda/search/entities/ProcessDefinitionEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/ProcessDefinitionEntity.java
@@ -16,4 +16,5 @@ public record ProcessDefinitionEntity(
     Integer version,
     String versionTag,
     String tenantId,
-    String formId) {}
+    String formId)
+    implements TenantOwnedEntity {}

--- a/search/search-domain/src/main/java/io/camunda/search/entities/ProcessInstanceEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/ProcessInstanceEntity.java
@@ -25,7 +25,8 @@ public record ProcessInstanceEntity(
     ProcessInstanceState state,
     Boolean hasIncident,
     String tenantId,
-    String treePath) {
+    String treePath)
+    implements TenantOwnedEntity {
 
   public enum ProcessInstanceState {
     ACTIVE,

--- a/search/search-domain/src/main/java/io/camunda/search/entities/SequenceFlowEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/SequenceFlowEntity.java
@@ -19,7 +19,8 @@ public record SequenceFlowEntity(
     Long processInstanceKey,
     Long processDefinitionKey,
     String processDefinitionId,
-    String tenantId) {
+    String tenantId)
+    implements TenantOwnedEntity {
 
   public static class Builder implements ObjectBuilder<SequenceFlowEntity> {
 

--- a/search/search-domain/src/main/java/io/camunda/search/entities/TenantOwnedEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/TenantOwnedEntity.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.entities;
+
+public interface TenantOwnedEntity {
+
+  String tenantId();
+}

--- a/search/search-domain/src/main/java/io/camunda/search/entities/UserTaskEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/UserTaskEntity.java
@@ -34,7 +34,8 @@ public record UserTaskEntity(
     String externalFormReference,
     Integer processDefinitionVersion,
     Map<String, String> customHeaders,
-    Integer priority) {
+    Integer priority)
+    implements TenantOwnedEntity {
 
   public UserTaskEntity withName(final String newName) {
     return new UserTaskEntity(

--- a/search/search-domain/src/main/java/io/camunda/search/entities/VariableEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/VariableEntity.java
@@ -10,7 +10,7 @@ package io.camunda.search.entities;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-public final record VariableEntity(
+public record VariableEntity(
     Long variableKey,
     String name,
     String value,
@@ -19,4 +19,5 @@ public final record VariableEntity(
     Long scopeKey,
     Long processInstanceKey,
     String processDefinitionId,
-    String tenantId) {}
+    String tenantId)
+    implements TenantOwnedEntity {}

--- a/search/search-domain/src/main/java/io/camunda/search/exception/ErrorMessages.java
+++ b/search/search-domain/src/main/java/io/camunda/search/exception/ErrorMessages.java
@@ -30,4 +30,6 @@ public class ErrorMessages {
       "Failed to find a matching ResourceAccessController, make sure to set a security context using #withSecurityContext()";
   public static final String ERROR_RESOURCE_ACCESS_DOES_NOT_CONTAIN_AUTHORIZATION =
       "Resource Access %s does not include an authorization";
+  public static final String ERROR_RESOURCE_ACCESS_CONTROLLER_NO_TENANT_ACCESS =
+      "Tenant access was denied";
 }

--- a/search/search-domain/src/main/java/io/camunda/search/exception/ErrorMessages.java
+++ b/search/search-domain/src/main/java/io/camunda/search/exception/ErrorMessages.java
@@ -26,4 +26,6 @@ public class ErrorMessages {
 
   public static final String ERROR_RESOURCE_ACCESS_CONTROLLER_NO_MATCHING_FOUND =
       "Failed to find a matching ResourceAccessController, make sure to set a security context using #withSecurityContext()";
+  public static final String ERROR_RESOURCE_ACCESS_DOES_NOT_CONTAIN_AUTHORIZATION =
+      "Resource Access %s does not include an authorization";
 }

--- a/search/search-domain/src/main/java/io/camunda/search/exception/ErrorMessages.java
+++ b/search/search-domain/src/main/java/io/camunda/search/exception/ErrorMessages.java
@@ -9,6 +9,8 @@ package io.camunda.search.exception;
 
 public class ErrorMessages {
 
+  public static final String ERROR_ENTITY_BY_KEY_NOT_FOUND = "%s with key '%d' not found";
+
   public static final String ERROR_FAILED_DELETE_REQUEST = "Failed to execute delete request";
   public static final String ERROR_FAILED_FIND_ALL_QUERY = "Failed to execute findAll query";
   public static final String ERROR_FAILED_GET_ALIAS_REQUEST = "Failed to execute getAlias request";

--- a/search/search-domain/src/main/java/io/camunda/search/exception/ErrorMessages.java
+++ b/search/search-domain/src/main/java/io/camunda/search/exception/ErrorMessages.java
@@ -10,6 +10,7 @@ package io.camunda.search.exception;
 public class ErrorMessages {
 
   public static final String ERROR_ENTITY_BY_KEY_NOT_FOUND = "%s with key '%d' not found";
+  public static final String ERROR_ENTITY_BY_ID_NOT_FOUND = "%s with id '%s' not found";
 
   public static final String ERROR_FAILED_DELETE_REQUEST = "Failed to execute delete request";
   public static final String ERROR_FAILED_FIND_ALL_QUERY = "Failed to execute findAll query";

--- a/search/search-domain/src/main/java/io/camunda/search/exception/ErrorMessages.java
+++ b/search/search-domain/src/main/java/io/camunda/search/exception/ErrorMessages.java
@@ -23,6 +23,8 @@ public class ErrorMessages {
       "A single result was expected, but multiple results were found matching %s";
   public static final String ERROR_SINGLE_RESULT_NOT_FOUND =
       "A single result was expected, but none was found matching %s";
+  public static final String ERROR_GET_BY_QUERY_NOT_UNIQUE =
+      "Failed to get entity by a search request, the search query returned more than one result";
 
   public static final String ERROR_RESOURCE_ACCESS_CONTROLLER_NO_MATCHING_FOUND =
       "Failed to find a matching ResourceAccessController, make sure to set a security context using #withSecurityContext()";

--- a/search/search-domain/src/main/java/io/camunda/search/exception/TenantAccessDeniedException.java
+++ b/search/search-domain/src/main/java/io/camunda/search/exception/TenantAccessDeniedException.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.exception;
+
+public class TenantAccessDeniedException extends CamundaSearchException {
+
+  public TenantAccessDeniedException(final String message) {
+    super(message);
+  }
+}

--- a/security/security-core/src/main/java/io/camunda/security/auth/SecurityContext.java
+++ b/security/security-core/src/main/java/io/camunda/security/auth/SecurityContext.java
@@ -22,7 +22,7 @@ import java.util.function.Function;
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
 public record SecurityContext(
     @JsonProperty("authentication") CamundaAuthentication authentication,
-    @JsonProperty("authorization") Authorization authorization) {
+    @JsonProperty("authorization") Authorization<?> authorization) {
 
   public boolean requiresAuthorizationChecks() {
     return authentication != null && authorization != null;
@@ -38,7 +38,7 @@ public record SecurityContext(
 
   public static class Builder {
     private CamundaAuthentication authentication;
-    private Authorization authorization;
+    private Authorization<?> authorization;
 
     public Builder withAuthentication(final CamundaAuthentication authentication) {
       this.authentication = authentication;
@@ -56,8 +56,8 @@ public record SecurityContext(
       return this;
     }
 
-    public Builder withAuthorization(
-        final Function<Authorization.Builder, Authorization.Builder> builderFunction) {
+    public <T> Builder withAuthorization(
+        final Function<Authorization.Builder<T>, Authorization.Builder<T>> builderFunction) {
       return withAuthorization(Authorization.of(builderFunction));
     }
 

--- a/security/security-core/src/main/java/io/camunda/security/reader/AuthorizationCheck.java
+++ b/security/security-core/src/main/java/io/camunda/security/reader/AuthorizationCheck.java
@@ -9,9 +9,13 @@ package io.camunda.security.reader;
 
 import io.camunda.security.auth.Authorization;
 
-public record AuthorizationCheck(boolean enabled, Authorization authorization) {
+/**
+ * Enables or disables a {@link AuthorizationCheck}. If enabled, then the authorization to be
+ * checked must be provided.
+ */
+public record AuthorizationCheck(boolean enabled, Authorization<?> authorization) {
 
-  public static AuthorizationCheck enabled(final Authorization authorization) {
+  public static AuthorizationCheck enabled(final Authorization<?> authorization) {
     return new AuthorizationCheck(true, authorization);
   }
 

--- a/security/security-core/src/main/java/io/camunda/security/reader/ResourceAccess.java
+++ b/security/security-core/src/main/java/io/camunda/security/reader/ResourceAccess.java
@@ -11,18 +11,31 @@ import io.camunda.security.auth.Authorization;
 
 public record ResourceAccess(boolean allowed, boolean wildcard, Authorization authorization) {
 
+  /** Returns true if access to the resource is denied. */
   public boolean denied() {
     return !allowed;
   }
 
+  /**
+   * Creates a {@link ResourceAccess} that allows access to a specific resource. The resource and
+   * the granted permissions are specified by the passed {@link Authorization authorization}.
+   */
   public static ResourceAccess allowed(final Authorization authorization) {
     return new ResourceAccess(true, false, authorization);
   }
 
+  /**
+   * Creates a {@link ResourceAccess} that denies access to a specific resource. The denied access
+   * is specified by the passed {@link Authorization authorization}.
+   */
   public static ResourceAccess denied(final Authorization authorization) {
     return new ResourceAccess(false, false, authorization);
   }
 
+  /**
+   * Creates a {@link ResourceAccess} that allows wildcard access to any specific resource. The
+   * passed {@link Authorization authorization} specifies the permissions that are allowed.
+   */
   public static ResourceAccess wildcard(final Authorization authorization) {
     return new ResourceAccess(true, true, authorization);
   }

--- a/security/security-core/src/main/java/io/camunda/security/reader/ResourceAccess.java
+++ b/security/security-core/src/main/java/io/camunda/security/reader/ResourceAccess.java
@@ -9,7 +9,7 @@ package io.camunda.security.reader;
 
 import io.camunda.security.auth.Authorization;
 
-public record ResourceAccess(boolean allowed, boolean wildcard, Authorization authorization) {
+public record ResourceAccess(boolean allowed, boolean wildcard, Authorization<?> authorization) {
 
   /** Returns true if access to the resource is denied. */
   public boolean denied() {
@@ -20,7 +20,7 @@ public record ResourceAccess(boolean allowed, boolean wildcard, Authorization au
    * Creates a {@link ResourceAccess} that allows access to a specific resource. The resource and
    * the granted permissions are specified by the passed {@link Authorization authorization}.
    */
-  public static ResourceAccess allowed(final Authorization authorization) {
+  public static ResourceAccess allowed(final Authorization<?> authorization) {
     return new ResourceAccess(true, false, authorization);
   }
 
@@ -28,7 +28,7 @@ public record ResourceAccess(boolean allowed, boolean wildcard, Authorization au
    * Creates a {@link ResourceAccess} that denies access to a specific resource. The denied access
    * is specified by the passed {@link Authorization authorization}.
    */
-  public static ResourceAccess denied(final Authorization authorization) {
+  public static ResourceAccess denied(final Authorization<?> authorization) {
     return new ResourceAccess(false, false, authorization);
   }
 
@@ -36,7 +36,7 @@ public record ResourceAccess(boolean allowed, boolean wildcard, Authorization au
    * Creates a {@link ResourceAccess} that allows wildcard access to any specific resource. The
    * passed {@link Authorization authorization} specifies the permissions that are allowed.
    */
-  public static ResourceAccess wildcard(final Authorization authorization) {
+  public static ResourceAccess wildcard(final Authorization<?> authorization) {
     return new ResourceAccess(true, true, authorization);
   }
 }

--- a/security/security-core/src/main/java/io/camunda/security/reader/ResourceAccessController.java
+++ b/security/security-core/src/main/java/io/camunda/security/reader/ResourceAccessController.java
@@ -13,13 +13,46 @@ import io.camunda.zeebe.auth.Authorization;
 import java.util.Optional;
 import java.util.function.Function;
 
+/**
+ * A {@link ResourceAccessController} enhances any get and search with additional {@link
+ * ResourceAccessChecks} to be applied executing them. However, any implementation of the {@link
+ * ResourceAccessController} may decide to deny access immediately, and by that, to not execute the
+ * read (i.e., get or search) at all and throw an exception instead.
+ */
 public interface ResourceAccessController {
 
+  /**
+   * Called before doing a get to retrieve a single resource.
+   *
+   * @param securityContext contains the {@link CamundaAuthentication} and the required {@link
+   *     io.camunda.security.auth.Authorization authorization} to be checked.
+   * @param resourceChecksApplier will be used to pass required @{@link ResourceAccessChecks} to the
+   *     actual reader
+   */
+  <T> T doGet(
+      SecurityContext securityContext, Function<ResourceAccessChecks, T> resourceChecksApplier);
+
+  /**
+   * Called before doing a search by query.
+   *
+   * @param securityContext contains the {@link CamundaAuthentication} and the required {@link
+   *     io.camunda.security.auth.Authorization authorization} to be checked.
+   * @param resourceChecksApplier will be used to pass required @{@link ResourceAccessChecks} to the
+   *     actual reader
+   */
   <T> T doSearch(
       SecurityContext securityContext, Function<ResourceAccessChecks, T> resourceChecksApplier);
 
+  /**
+   * Returns true if the given {@link io.camunda.security.auth.SecurityContext securityContext} is
+   * supported by this {@link io.camunda.security.reader.ResourceAccessController} *
+   */
   boolean supports(SecurityContext securityContext);
 
+  /**
+   * Returns true if the given {@link io.camunda.security.auth.CamundaAuthentication authentication}
+   * is anonymously. *
+   */
   default boolean isAnonymousAuthentication(final CamundaAuthentication authentication) {
     final var claims =
         Optional.ofNullable(authentication).map(CamundaAuthentication::claims).orElse(null);

--- a/security/security-core/src/main/java/io/camunda/security/reader/ResourceAccessController.java
+++ b/security/security-core/src/main/java/io/camunda/security/reader/ResourceAccessController.java
@@ -51,7 +51,7 @@ public interface ResourceAccessController {
 
   /**
    * Returns true if the given {@link io.camunda.security.auth.CamundaAuthentication authentication}
-   * is anonymously. *
+   * is anonymous. *
    */
   default boolean isAnonymousAuthentication(final CamundaAuthentication authentication) {
     final var claims =

--- a/security/security-core/src/main/java/io/camunda/security/reader/ResourceAccessProvider.java
+++ b/security/security-core/src/main/java/io/camunda/security/reader/ResourceAccessProvider.java
@@ -10,16 +10,26 @@ package io.camunda.security.reader;
 import io.camunda.security.auth.Authorization;
 import io.camunda.security.auth.CamundaAuthentication;
 
-/** Strategy to apply authorization to a search query. */
 public interface ResourceAccessProvider {
 
-  ResourceAccessProvider NONE = (authentication, authorization) -> ResourceAccess.wildcard(null);
-
   /**
-   * Apply authorization to a search query.
-   *
-   * @return the search query request with authorization applied
+   * Resolves the given {@link CamundaAuthentication authentication} and {@link Authorization
+   * requiredAuthorization} into a {@link ResourceAccess}. The resulting {@link
+   * ResourceAccess#authorization()} shall contain the resource ids the principal is granted to
+   * access if access is not denied.
    */
-  ResourceAccess resolveResourceAccess(
-      final CamundaAuthentication authentication, final Authorization requiredAuthorization);
+  <T> ResourceAccess resolveResourceAccess(
+      final CamundaAuthentication authentication, final Authorization<T> requiredAuthorization);
+
+  /** Returns a {@link ResourceAccess} allowing or denying access to the given resource. */
+  <T> ResourceAccess hasResourceAccess(
+      final CamundaAuthentication authentication,
+      Authorization<T> requiredAuthorization,
+      final T resource);
+
+  /** Returns a {@link ResourceAccess} allowing or denying access to the given resource id. */
+  <T> ResourceAccess hasResourceAccessByResourceId(
+      final CamundaAuthentication authentication,
+      final Authorization<T> requiredAuthorization,
+      final String resourceId);
 }

--- a/security/security-core/src/main/java/io/camunda/security/reader/TenantAccess.java
+++ b/security/security-core/src/main/java/io/camunda/security/reader/TenantAccess.java
@@ -11,18 +11,28 @@ import java.util.List;
 
 public record TenantAccess(boolean allowed, boolean wildcard, List<String> tenantIds) {
 
+  /** Returns true if the access to all provided tenantIds is denied. */
   public boolean denied() {
     return !allowed;
   }
 
+  /**
+   * Creates a {@link TenantAccess} allowing access the tenants passed with {@link List<String>
+   * tenantIds}.
+   */
   public static TenantAccess allowed(final List<String> tenantIds) {
     return new TenantAccess(true, false, tenantIds);
   }
 
+  /**
+   * Creates a {@link TenantAccess} denying access to any tenant passed with {@link List<String>
+   * tenantIds}.
+   */
   public static TenantAccess denied(final List<String> tenantIds) {
     return new TenantAccess(false, false, tenantIds);
   }
 
+  /** Creates a {@link TenantAccess} allowing wildcard access to any tenant. */
   public static TenantAccess wildcard(final List<String> tenantIds) {
     return new TenantAccess(true, true, tenantIds);
   }

--- a/security/security-core/src/main/java/io/camunda/security/reader/TenantAccessProvider.java
+++ b/security/security-core/src/main/java/io/camunda/security/reader/TenantAccessProvider.java
@@ -8,11 +8,22 @@
 package io.camunda.security.reader;
 
 import io.camunda.security.auth.CamundaAuthentication;
-import java.util.List;
 
 public interface TenantAccessProvider {
 
-  TenantAccessProvider NONE = (authentication) -> TenantAccess.allowed(List.of());
-
+  /**
+   * Resolves the given {@link CamundaAuthentication authentication} into a {@link TenantAccess}.
+   * The resulting {@link TenantAccess#tenantIds()} contains the tenant ids the principal is granted
+   * to access if access is not denied.
+   */
   TenantAccess resolveTenantAccess(final CamundaAuthentication authentication);
+
+  /**
+   * Returns a {@link TenantAccess} allowing or denying access to the given resource based on the
+   * tenant.
+   */
+  <T> TenantAccess hasTenantAccess(CamundaAuthentication authentication, T resource);
+
+  /** Returns a {@link TenantAccess} allowing or denying access to the given tenant id. */
+  TenantAccess hasTenantAccessByTenantId(CamundaAuthentication authentication, String tenantId);
 }

--- a/security/security-core/src/main/java/io/camunda/security/reader/TenantCheck.java
+++ b/security/security-core/src/main/java/io/camunda/security/reader/TenantCheck.java
@@ -9,6 +9,9 @@ package io.camunda.security.reader;
 
 import java.util.List;
 
+/**
+ * Enables or disables a {@link TenantCheck}. If enabled, then a list of tenantIds must be provided.
+ */
 public record TenantCheck(boolean enabled, List<String> tenantIds) {
 
   public static TenantCheck enabled(final List<String> tenantIds) {

--- a/service/src/main/java/io/camunda/service/AuthorizationServices.java
+++ b/service/src/main/java/io/camunda/service/AuthorizationServices.java
@@ -7,12 +7,14 @@
  */
 package io.camunda.service;
 
+import static io.camunda.security.auth.Authorization.withAuthorization;
+import static io.camunda.service.authorization.Authorizations.AUTHORIZATION_READ_AUTHORIZATION;
+
 import io.camunda.search.clients.AuthorizationSearchClient;
 import io.camunda.search.entities.AuthorizationEntity;
 import io.camunda.search.query.AuthorizationQuery;
 import io.camunda.search.query.SearchQueryBuilders;
 import io.camunda.search.query.SearchQueryResult;
-import io.camunda.security.auth.Authorization;
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.service.search.core.SearchQueryService;
@@ -66,7 +68,7 @@ public class AuthorizationServices
             authorizationSearchClient
                 .withSecurityContext(
                     securityContextProvider.provideSecurityContext(
-                        authentication, Authorization.of(a -> a.authorization().read())))
+                        authentication, AUTHORIZATION_READ_AUTHORIZATION))
                 .searchAuthorizations(query));
   }
 
@@ -112,13 +114,15 @@ public class AuthorizationServices
   }
 
   public AuthorizationEntity getAuthorization(final long authorizationKey) {
-    return search(
-            SearchQueryBuilders.authorizationSearchQuery()
-                .filter(f -> f.authorizationKey(authorizationKey))
-                .singleResult()
-                .build())
-        .items()
-        .getFirst();
+    return executeSearchRequest(
+        () ->
+            authorizationSearchClient
+                .withSecurityContext(
+                    securityContextProvider.provideSecurityContext(
+                        authentication,
+                        withAuthorization(
+                            AUTHORIZATION_READ_AUTHORIZATION, String.valueOf(authorizationKey))))
+                .getAuthorization(authorizationKey));
   }
 
   public CompletableFuture<AuthorizationRecord> deleteAuthorization(final long authorizationKey) {

--- a/service/src/main/java/io/camunda/service/AuthorizationServices.java
+++ b/service/src/main/java/io/camunda/service/AuthorizationServices.java
@@ -95,10 +95,7 @@ public class AuthorizationServices
                         .page(p -> p.size(1))))
         .items()
         .stream()
-        .map(
-            authorizationEntity -> {
-              return authorizationEntity.resourceId();
-            })
+        .map(AuthorizationEntity::resourceId)
         .collect(Collectors.toList());
   }
 

--- a/service/src/main/java/io/camunda/service/DecisionDefinitionServices.java
+++ b/service/src/main/java/io/camunda/service/DecisionDefinitionServices.java
@@ -8,16 +8,16 @@
 package io.camunda.service;
 
 import static io.camunda.search.query.SearchQueryBuilders.decisionDefinitionSearchQuery;
-import static io.camunda.search.query.SearchQueryBuilders.decisionRequirementsSearchQuery;
 import static io.camunda.security.auth.Authorization.withAuthorization;
 import static io.camunda.service.authorization.Authorizations.DECISION_DEFINITION_READ_AUTHORIZATION;
 
 import io.camunda.search.clients.DecisionDefinitionSearchClient;
-import io.camunda.search.clients.DecisionRequirementSearchClient;
 import io.camunda.search.entities.DecisionDefinitionEntity;
 import io.camunda.search.query.DecisionDefinitionQuery;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.auth.CamundaAuthentication;
+import io.camunda.service.exception.ServiceException;
+import io.camunda.service.exception.ServiceException.Status;
 import io.camunda.service.search.core.SearchQueryService;
 import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.util.ObjectBuilder;
@@ -26,6 +26,7 @@ import io.camunda.zeebe.broker.client.api.dto.BrokerResponse;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerEvaluateDecisionRequest;
 import io.camunda.zeebe.protocol.impl.record.value.decision.DecisionEvaluationRecord;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 
@@ -34,17 +35,17 @@ public final class DecisionDefinitionServices
         DecisionDefinitionServices, DecisionDefinitionQuery, DecisionDefinitionEntity> {
 
   private final DecisionDefinitionSearchClient decisionDefinitionSearchClient;
-  private final DecisionRequirementSearchClient decisionRequirementSearchClient;
+  private final DecisionRequirementsServices decisionRequirementServices;
 
   public DecisionDefinitionServices(
       final BrokerClient brokerClient,
       final SecurityContextProvider securityContextProvider,
       final DecisionDefinitionSearchClient decisionDefinitionSearchClient,
-      final DecisionRequirementSearchClient decisionRequirementSearchClient,
+      final DecisionRequirementsServices decisionRequirementServices,
       final CamundaAuthentication authentication) {
     super(brokerClient, securityContextProvider, authentication);
     this.decisionDefinitionSearchClient = decisionDefinitionSearchClient;
-    this.decisionRequirementSearchClient = decisionRequirementSearchClient;
+    this.decisionRequirementServices = decisionRequirementServices;
   }
 
   @Override
@@ -53,7 +54,7 @@ public final class DecisionDefinitionServices
         brokerClient,
         securityContextProvider,
         decisionDefinitionSearchClient,
-        decisionRequirementSearchClient,
+        decisionRequirementServices,
         authentication);
   }
 
@@ -74,24 +75,18 @@ public final class DecisionDefinitionServices
   }
 
   public String getDecisionDefinitionXml(final long decisionKey) {
-    final var decisionDefinition = getByKey(decisionKey);
-
-    final Long decisionRequirementsKey = decisionDefinition.decisionRequirementsKey();
-    final var decisionRequirementsQuery =
-        decisionRequirementsSearchQuery(
-            q ->
-                q.filter(f -> f.decisionRequirementsKeys(decisionRequirementsKey))
-                    .resultConfig(r -> r.includeXml(true))
-                    .singleResult());
-    return executeSearchRequest(
+    return Optional.ofNullable(getByKey(decisionKey))
+        .map(DecisionDefinitionEntity::decisionRequirementsKey)
+        .map(
+            k ->
+                decisionRequirementServices
+                    .withAuthentication(CamundaAuthentication.anonymous())
+                    .getDecisionRequirementsXml(k))
+        .orElseThrow(
             () ->
-                decisionRequirementSearchClient
-                    .withSecurityContext(
-                        securityContextProvider.provideSecurityContext(authentication))
-                    .searchDecisionRequirements(decisionRequirementsQuery))
-        .items()
-        .getFirst()
-        .xml();
+                new ServiceException(
+                    "Decision Definition Xml by key %d not found".formatted(decisionKey),
+                    Status.NOT_FOUND));
   }
 
   public DecisionDefinitionEntity getByKey(final long decisionKey) {

--- a/service/src/main/java/io/camunda/service/FormServices.java
+++ b/service/src/main/java/io/camunda/service/FormServices.java
@@ -47,9 +47,11 @@ public final class FormServices extends SearchQueryService<FormServices, FormQue
   }
 
   public FormEntity getByKey(final Long key) {
-    return search(FormQuery.of(b -> b.filter(f -> f.formKeys(key)).singleResult()))
-        .items()
-        .getFirst();
+    return executeSearchRequest(
+        () ->
+            formSearchClient
+                .withSecurityContext(securityContextProvider.provideSecurityContext(authentication))
+                .getForm(key));
   }
 
   public Optional<FormEntity> getLatestVersionByFormIdAndTenantId(

--- a/service/src/main/java/io/camunda/service/GroupServices.java
+++ b/service/src/main/java/io/camunda/service/GroupServices.java
@@ -7,12 +7,14 @@
  */
 package io.camunda.service;
 
+import static io.camunda.security.auth.Authorization.withAuthorization;
+import static io.camunda.service.authorization.Authorizations.GROUP_READ_AUTHORIZATION;
+
 import io.camunda.search.clients.GroupSearchClient;
 import io.camunda.search.entities.GroupEntity;
 import io.camunda.search.entities.GroupMemberEntity;
 import io.camunda.search.query.GroupQuery;
 import io.camunda.search.query.SearchQueryResult;
-import io.camunda.security.auth.Authorization;
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.search.core.SearchQueryService;
 import io.camunda.service.security.SecurityContextProvider;
@@ -59,7 +61,7 @@ public class GroupServices extends SearchQueryService<GroupServices, GroupQuery,
             groupSearchClient
                 .withSecurityContext(
                     securityContextProvider.provideSecurityContext(
-                        authentication, Authorization.of(a -> a.group().read())))
+                        authentication, GROUP_READ_AUTHORIZATION))
                 .searchGroups(query));
   }
 
@@ -78,9 +80,13 @@ public class GroupServices extends SearchQueryService<GroupServices, GroupQuery,
   }
 
   public GroupEntity getGroup(final String groupId) {
-    return search(GroupQuery.of(b -> b.filter(f -> f.groupIds(groupId)).singleResult()))
-        .items()
-        .getFirst();
+    return executeSearchRequest(
+        () ->
+            groupSearchClient
+                .withSecurityContext(
+                    securityContextProvider.provideSecurityContext(
+                        authentication, withAuthorization(GROUP_READ_AUTHORIZATION, groupId)))
+                .getGroup(groupId));
   }
 
   public GroupEntity getGroupByName(final String name) {
@@ -134,7 +140,7 @@ public class GroupServices extends SearchQueryService<GroupServices, GroupQuery,
             groupSearchClient
                 .withSecurityContext(
                     securityContextProvider.provideSecurityContext(
-                        authentication, Authorization.of(a -> a.group().read())))
+                        authentication, GROUP_READ_AUTHORIZATION))
                 .searchGroupMembers(query));
   }
 

--- a/service/src/main/java/io/camunda/service/JobServices.java
+++ b/service/src/main/java/io/camunda/service/JobServices.java
@@ -7,11 +7,12 @@
  */
 package io.camunda.service;
 
+import static io.camunda.service.authorization.Authorizations.JOB_READ_AUTHORIZATION;
+
 import io.camunda.search.clients.JobSearchClient;
 import io.camunda.search.entities.JobEntity;
 import io.camunda.search.query.JobQuery;
 import io.camunda.search.query.SearchQueryResult;
-import io.camunda.security.auth.Authorization;
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.search.core.SearchQueryService;
 import io.camunda.service.security.SecurityContextProvider;
@@ -120,8 +121,7 @@ public final class JobServices<T> extends SearchQueryService<JobServices<T>, Job
             jobSearchClient
                 .withSecurityContext(
                     securityContextProvider.provideSecurityContext(
-                        authentication,
-                        Authorization.of(a -> a.processDefinition().readProcessInstance())))
+                        authentication, JOB_READ_AUTHORIZATION))
                 .searchJobs(query));
   }
 

--- a/service/src/main/java/io/camunda/service/MessageSubscriptionServices.java
+++ b/service/src/main/java/io/camunda/service/MessageSubscriptionServices.java
@@ -7,11 +7,12 @@
  */
 package io.camunda.service;
 
+import static io.camunda.service.authorization.Authorizations.MESSAGE_SUBSCRIPTION_READ_AUTHORIZATION;
+
 import io.camunda.search.clients.MessageSubscriptionSearchClient;
 import io.camunda.search.entities.MessageSubscriptionEntity;
 import io.camunda.search.query.MessageSubscriptionQuery;
 import io.camunda.search.query.SearchQueryResult;
-import io.camunda.security.auth.Authorization;
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.search.core.SearchQueryService;
 import io.camunda.service.security.SecurityContextProvider;
@@ -39,8 +40,7 @@ public class MessageSubscriptionServices
             searchClient
                 .withSecurityContext(
                     securityContextProvider.provideSecurityContext(
-                        authentication,
-                        Authorization.of(a -> a.processDefinition().readProcessInstance())))
+                        authentication, MESSAGE_SUBSCRIPTION_READ_AUTHORIZATION))
                 .searchMessageSubscriptions(query));
   }
 

--- a/service/src/main/java/io/camunda/service/authorization/Authorizations.java
+++ b/service/src/main/java/io/camunda/service/authorization/Authorizations.java
@@ -8,6 +8,7 @@
 package io.camunda.service.authorization;
 
 import io.camunda.search.entities.AuthorizationEntity;
+import io.camunda.search.entities.BatchOperationEntity;
 import io.camunda.search.entities.ProcessInstanceEntity;
 import io.camunda.security.auth.Authorization;
 
@@ -15,6 +16,9 @@ public abstract class Authorizations {
 
   public static final Authorization<AuthorizationEntity> AUTHORIZATION_READ_AUTHORIZATION =
       Authorization.of(a -> a.authorization().read());
+
+  public static final Authorization<BatchOperationEntity> BATCH_OPERATION_READ_AUTHORIZATION =
+      Authorization.of(a -> a.batchOperation().read());
 
   public static final Authorization<ProcessInstanceEntity> PROCESS_INSTANCE_READ_AUTHORIZATION =
       Authorization.of(a -> a.processDefinition().readProcessInstance());

--- a/service/src/main/java/io/camunda/service/authorization/Authorizations.java
+++ b/service/src/main/java/io/camunda/service/authorization/Authorizations.java
@@ -14,6 +14,7 @@ import io.camunda.search.entities.DecisionInstanceEntity;
 import io.camunda.search.entities.DecisionRequirementsEntity;
 import io.camunda.search.entities.FlowNodeInstanceEntity;
 import io.camunda.search.entities.GroupEntity;
+import io.camunda.search.entities.IncidentEntity;
 import io.camunda.search.entities.ProcessInstanceEntity;
 import io.camunda.security.auth.Authorization;
 
@@ -41,6 +42,9 @@ public abstract class Authorizations {
 
   public static final Authorization<GroupEntity> GROUP_READ_AUTHORIZATION =
       Authorization.of(a -> a.group().read());
+
+  public static final Authorization<IncidentEntity> INCIDENT_READ_AUTHORIZATION =
+      Authorization.of(a -> a.processDefinition().readProcessInstance());
 
   public static final Authorization<ProcessInstanceEntity> PROCESS_INSTANCE_READ_AUTHORIZATION =
       Authorization.of(a -> a.processDefinition().readProcessInstance());

--- a/service/src/main/java/io/camunda/service/authorization/Authorizations.java
+++ b/service/src/main/java/io/camunda/service/authorization/Authorizations.java
@@ -16,6 +16,7 @@ import io.camunda.search.entities.FlowNodeInstanceEntity;
 import io.camunda.search.entities.GroupEntity;
 import io.camunda.search.entities.IncidentEntity;
 import io.camunda.search.entities.JobEntity;
+import io.camunda.search.entities.MappingRuleEntity;
 import io.camunda.search.entities.ProcessInstanceEntity;
 import io.camunda.security.auth.Authorization;
 
@@ -49,6 +50,9 @@ public abstract class Authorizations {
 
   public static final Authorization<JobEntity> JOB_READ_AUTHORIZATION =
       Authorization.of(a -> a.processDefinition().readProcessInstance());
+
+  public static final Authorization<MappingRuleEntity> MAPPING_RULE_READ_AUTHORIZATION =
+      Authorization.of(a -> a.mappingRule().read());
 
   public static final Authorization<ProcessInstanceEntity> PROCESS_INSTANCE_READ_AUTHORIZATION =
       Authorization.of(a -> a.processDefinition().readProcessInstance());

--- a/service/src/main/java/io/camunda/service/authorization/Authorizations.java
+++ b/service/src/main/java/io/camunda/service/authorization/Authorizations.java
@@ -18,6 +18,7 @@ import io.camunda.search.entities.IncidentEntity;
 import io.camunda.search.entities.JobEntity;
 import io.camunda.search.entities.MappingRuleEntity;
 import io.camunda.search.entities.MessageSubscriptionEntity;
+import io.camunda.search.entities.ProcessDefinitionEntity;
 import io.camunda.search.entities.ProcessInstanceEntity;
 import io.camunda.security.auth.Authorization;
 
@@ -58,6 +59,9 @@ public abstract class Authorizations {
   public static final Authorization<MessageSubscriptionEntity>
       MESSAGE_SUBSCRIPTION_READ_AUTHORIZATION =
           Authorization.of(a -> a.processDefinition().readProcessInstance());
+
+  public static final Authorization<ProcessDefinitionEntity> PROCESS_DEFINITION_READ_AUTHORIZATION =
+      Authorization.of(a -> a.processDefinition().readProcessDefinition());
 
   public static final Authorization<ProcessInstanceEntity> PROCESS_INSTANCE_READ_AUTHORIZATION =
       Authorization.of(a -> a.processDefinition().readProcessInstance());

--- a/service/src/main/java/io/camunda/service/authorization/Authorizations.java
+++ b/service/src/main/java/io/camunda/service/authorization/Authorizations.java
@@ -11,6 +11,7 @@ import io.camunda.search.entities.AuthorizationEntity;
 import io.camunda.search.entities.BatchOperationEntity;
 import io.camunda.search.entities.DecisionDefinitionEntity;
 import io.camunda.search.entities.DecisionInstanceEntity;
+import io.camunda.search.entities.DecisionRequirementsEntity;
 import io.camunda.search.entities.ProcessInstanceEntity;
 import io.camunda.security.auth.Authorization;
 
@@ -28,6 +29,10 @@ public abstract class Authorizations {
 
   public static final Authorization<DecisionInstanceEntity> DECISION_INSTANCE_READ_AUTHORIZATION =
       Authorization.of(a -> a.decisionDefinition().readDecisionInstance());
+
+  public static final Authorization<DecisionRequirementsEntity>
+      DECISION_REQUIREMENTS_READ_AUTHORIZATION =
+          Authorization.of(a -> a.decisionRequirementsDefinition().read());
 
   public static final Authorization<ProcessInstanceEntity> PROCESS_INSTANCE_READ_AUTHORIZATION =
       Authorization.of(a -> a.processDefinition().readProcessInstance());

--- a/service/src/main/java/io/camunda/service/authorization/Authorizations.java
+++ b/service/src/main/java/io/camunda/service/authorization/Authorizations.java
@@ -13,6 +13,7 @@ import io.camunda.search.entities.DecisionDefinitionEntity;
 import io.camunda.search.entities.DecisionInstanceEntity;
 import io.camunda.search.entities.DecisionRequirementsEntity;
 import io.camunda.search.entities.FlowNodeInstanceEntity;
+import io.camunda.search.entities.GroupEntity;
 import io.camunda.search.entities.ProcessInstanceEntity;
 import io.camunda.security.auth.Authorization;
 
@@ -37,6 +38,9 @@ public abstract class Authorizations {
 
   public static final Authorization<FlowNodeInstanceEntity> ELEMENT_INSTANCE_READ_AUTHORIZATION =
       Authorization.of(a -> a.processDefinition().readProcessInstance());
+
+  public static final Authorization<GroupEntity> GROUP_READ_AUTHORIZATION =
+      Authorization.of(a -> a.group().read());
 
   public static final Authorization<ProcessInstanceEntity> PROCESS_INSTANCE_READ_AUTHORIZATION =
       Authorization.of(a -> a.processDefinition().readProcessInstance());

--- a/service/src/main/java/io/camunda/service/authorization/Authorizations.java
+++ b/service/src/main/java/io/camunda/service/authorization/Authorizations.java
@@ -12,6 +12,7 @@ import io.camunda.search.entities.BatchOperationEntity;
 import io.camunda.search.entities.DecisionDefinitionEntity;
 import io.camunda.search.entities.DecisionInstanceEntity;
 import io.camunda.search.entities.DecisionRequirementsEntity;
+import io.camunda.search.entities.FlowNodeInstanceEntity;
 import io.camunda.search.entities.ProcessInstanceEntity;
 import io.camunda.security.auth.Authorization;
 
@@ -33,6 +34,9 @@ public abstract class Authorizations {
   public static final Authorization<DecisionRequirementsEntity>
       DECISION_REQUIREMENTS_READ_AUTHORIZATION =
           Authorization.of(a -> a.decisionRequirementsDefinition().read());
+
+  public static final Authorization<FlowNodeInstanceEntity> ELEMENT_INSTANCE_READ_AUTHORIZATION =
+      Authorization.of(a -> a.processDefinition().readProcessInstance());
 
   public static final Authorization<ProcessInstanceEntity> PROCESS_INSTANCE_READ_AUTHORIZATION =
       Authorization.of(a -> a.processDefinition().readProcessInstance());

--- a/service/src/main/java/io/camunda/service/authorization/Authorizations.java
+++ b/service/src/main/java/io/camunda/service/authorization/Authorizations.java
@@ -7,10 +7,14 @@
  */
 package io.camunda.service.authorization;
 
+import io.camunda.search.entities.AuthorizationEntity;
 import io.camunda.search.entities.ProcessInstanceEntity;
 import io.camunda.security.auth.Authorization;
 
 public abstract class Authorizations {
+
+  public static final Authorization<AuthorizationEntity> AUTHORIZATION_READ_AUTHORIZATION =
+      Authorization.of(a -> a.authorization().read());
 
   public static final Authorization<ProcessInstanceEntity> PROCESS_INSTANCE_READ_AUTHORIZATION =
       Authorization.of(a -> a.processDefinition().readProcessInstance());

--- a/service/src/main/java/io/camunda/service/authorization/Authorizations.java
+++ b/service/src/main/java/io/camunda/service/authorization/Authorizations.java
@@ -20,6 +20,7 @@ import io.camunda.search.entities.MappingRuleEntity;
 import io.camunda.search.entities.MessageSubscriptionEntity;
 import io.camunda.search.entities.ProcessDefinitionEntity;
 import io.camunda.search.entities.ProcessInstanceEntity;
+import io.camunda.search.entities.RoleEntity;
 import io.camunda.security.auth.Authorization;
 
 public abstract class Authorizations {
@@ -65,4 +66,7 @@ public abstract class Authorizations {
 
   public static final Authorization<ProcessInstanceEntity> PROCESS_INSTANCE_READ_AUTHORIZATION =
       Authorization.of(a -> a.processDefinition().readProcessInstance());
+
+  public static final Authorization<RoleEntity> ROLE_READ_AUTHORIZATION =
+      Authorization.of(a -> a.role().read());
 }

--- a/service/src/main/java/io/camunda/service/authorization/Authorizations.java
+++ b/service/src/main/java/io/camunda/service/authorization/Authorizations.java
@@ -9,6 +9,7 @@ package io.camunda.service.authorization;
 
 import io.camunda.search.entities.AuthorizationEntity;
 import io.camunda.search.entities.BatchOperationEntity;
+import io.camunda.search.entities.DecisionDefinitionEntity;
 import io.camunda.search.entities.ProcessInstanceEntity;
 import io.camunda.security.auth.Authorization;
 
@@ -19,6 +20,10 @@ public abstract class Authorizations {
 
   public static final Authorization<BatchOperationEntity> BATCH_OPERATION_READ_AUTHORIZATION =
       Authorization.of(a -> a.batchOperation().read());
+
+  public static final Authorization<DecisionDefinitionEntity>
+      DECISION_DEFINITION_READ_AUTHORIZATION =
+          Authorization.of(a -> a.decisionDefinition().readDecisionDefinition());
 
   public static final Authorization<ProcessInstanceEntity> PROCESS_INSTANCE_READ_AUTHORIZATION =
       Authorization.of(a -> a.processDefinition().readProcessInstance());

--- a/service/src/main/java/io/camunda/service/authorization/Authorizations.java
+++ b/service/src/main/java/io/camunda/service/authorization/Authorizations.java
@@ -15,6 +15,7 @@ import io.camunda.search.entities.DecisionRequirementsEntity;
 import io.camunda.search.entities.FlowNodeInstanceEntity;
 import io.camunda.search.entities.GroupEntity;
 import io.camunda.search.entities.IncidentEntity;
+import io.camunda.search.entities.JobEntity;
 import io.camunda.search.entities.ProcessInstanceEntity;
 import io.camunda.security.auth.Authorization;
 
@@ -44,6 +45,9 @@ public abstract class Authorizations {
       Authorization.of(a -> a.group().read());
 
   public static final Authorization<IncidentEntity> INCIDENT_READ_AUTHORIZATION =
+      Authorization.of(a -> a.processDefinition().readProcessInstance());
+
+  public static final Authorization<JobEntity> JOB_READ_AUTHORIZATION =
       Authorization.of(a -> a.processDefinition().readProcessInstance());
 
   public static final Authorization<ProcessInstanceEntity> PROCESS_INSTANCE_READ_AUTHORIZATION =

--- a/service/src/main/java/io/camunda/service/authorization/Authorizations.java
+++ b/service/src/main/java/io/camunda/service/authorization/Authorizations.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service.authorization;
+
+import io.camunda.search.entities.ProcessInstanceEntity;
+import io.camunda.security.auth.Authorization;
+
+public abstract class Authorizations {
+
+  public static final Authorization<ProcessInstanceEntity> PROCESS_INSTANCE_READ_AUTHORIZATION =
+      Authorization.of(a -> a.processDefinition().readProcessInstance());
+}

--- a/service/src/main/java/io/camunda/service/authorization/Authorizations.java
+++ b/service/src/main/java/io/camunda/service/authorization/Authorizations.java
@@ -17,6 +17,7 @@ import io.camunda.search.entities.GroupEntity;
 import io.camunda.search.entities.IncidentEntity;
 import io.camunda.search.entities.JobEntity;
 import io.camunda.search.entities.MappingRuleEntity;
+import io.camunda.search.entities.MessageSubscriptionEntity;
 import io.camunda.search.entities.ProcessInstanceEntity;
 import io.camunda.security.auth.Authorization;
 
@@ -53,6 +54,10 @@ public abstract class Authorizations {
 
   public static final Authorization<MappingRuleEntity> MAPPING_RULE_READ_AUTHORIZATION =
       Authorization.of(a -> a.mappingRule().read());
+
+  public static final Authorization<MessageSubscriptionEntity>
+      MESSAGE_SUBSCRIPTION_READ_AUTHORIZATION =
+          Authorization.of(a -> a.processDefinition().readProcessInstance());
 
   public static final Authorization<ProcessInstanceEntity> PROCESS_INSTANCE_READ_AUTHORIZATION =
       Authorization.of(a -> a.processDefinition().readProcessInstance());

--- a/service/src/main/java/io/camunda/service/authorization/Authorizations.java
+++ b/service/src/main/java/io/camunda/service/authorization/Authorizations.java
@@ -21,6 +21,7 @@ import io.camunda.search.entities.MessageSubscriptionEntity;
 import io.camunda.search.entities.ProcessDefinitionEntity;
 import io.camunda.search.entities.ProcessInstanceEntity;
 import io.camunda.search.entities.RoleEntity;
+import io.camunda.search.entities.TenantEntity;
 import io.camunda.security.auth.Authorization;
 
 public abstract class Authorizations {
@@ -69,4 +70,7 @@ public abstract class Authorizations {
 
   public static final Authorization<RoleEntity> ROLE_READ_AUTHORIZATION =
       Authorization.of(a -> a.role().read());
+
+  public static final Authorization<TenantEntity> TENANT_READER_AUTHORIZATION =
+      Authorization.of(a -> a.tenant().read());
 }

--- a/service/src/main/java/io/camunda/service/authorization/Authorizations.java
+++ b/service/src/main/java/io/camunda/service/authorization/Authorizations.java
@@ -24,6 +24,7 @@ import io.camunda.search.entities.RoleEntity;
 import io.camunda.search.entities.TenantEntity;
 import io.camunda.search.entities.UserEntity;
 import io.camunda.search.entities.UserTaskEntity;
+import io.camunda.search.entities.VariableEntity;
 import io.camunda.security.auth.Authorization;
 
 public abstract class Authorizations {
@@ -81,4 +82,7 @@ public abstract class Authorizations {
 
   public static final Authorization<UserTaskEntity> USER_TASK_READ_AUTHORIZATION =
       Authorization.of(a -> a.processDefinition().readUserTask());
+
+  public static final Authorization<VariableEntity> VARIABLE_READ_AUTHORIZATION =
+      Authorization.of(a -> a.processDefinition().readProcessInstance());
 }

--- a/service/src/main/java/io/camunda/service/authorization/Authorizations.java
+++ b/service/src/main/java/io/camunda/service/authorization/Authorizations.java
@@ -23,6 +23,7 @@ import io.camunda.search.entities.ProcessInstanceEntity;
 import io.camunda.search.entities.RoleEntity;
 import io.camunda.search.entities.TenantEntity;
 import io.camunda.search.entities.UserEntity;
+import io.camunda.search.entities.UserTaskEntity;
 import io.camunda.security.auth.Authorization;
 
 public abstract class Authorizations {
@@ -77,4 +78,7 @@ public abstract class Authorizations {
 
   public static final Authorization<UserEntity> USER_READ_AUTHORIZATION =
       Authorization.of(a -> a.user().read());
+
+  public static final Authorization<UserTaskEntity> USER_TASK_READ_AUTHORIZATION =
+      Authorization.of(a -> a.processDefinition().readUserTask());
 }

--- a/service/src/main/java/io/camunda/service/authorization/Authorizations.java
+++ b/service/src/main/java/io/camunda/service/authorization/Authorizations.java
@@ -10,6 +10,7 @@ package io.camunda.service.authorization;
 import io.camunda.search.entities.AuthorizationEntity;
 import io.camunda.search.entities.BatchOperationEntity;
 import io.camunda.search.entities.DecisionDefinitionEntity;
+import io.camunda.search.entities.DecisionInstanceEntity;
 import io.camunda.search.entities.ProcessInstanceEntity;
 import io.camunda.security.auth.Authorization;
 
@@ -24,6 +25,9 @@ public abstract class Authorizations {
   public static final Authorization<DecisionDefinitionEntity>
       DECISION_DEFINITION_READ_AUTHORIZATION =
           Authorization.of(a -> a.decisionDefinition().readDecisionDefinition());
+
+  public static final Authorization<DecisionInstanceEntity> DECISION_INSTANCE_READ_AUTHORIZATION =
+      Authorization.of(a -> a.decisionDefinition().readDecisionInstance());
 
   public static final Authorization<ProcessInstanceEntity> PROCESS_INSTANCE_READ_AUTHORIZATION =
       Authorization.of(a -> a.processDefinition().readProcessInstance());

--- a/service/src/main/java/io/camunda/service/authorization/Authorizations.java
+++ b/service/src/main/java/io/camunda/service/authorization/Authorizations.java
@@ -22,6 +22,7 @@ import io.camunda.search.entities.ProcessDefinitionEntity;
 import io.camunda.search.entities.ProcessInstanceEntity;
 import io.camunda.search.entities.RoleEntity;
 import io.camunda.search.entities.TenantEntity;
+import io.camunda.search.entities.UserEntity;
 import io.camunda.security.auth.Authorization;
 
 public abstract class Authorizations {
@@ -73,4 +74,7 @@ public abstract class Authorizations {
 
   public static final Authorization<TenantEntity> TENANT_READER_AUTHORIZATION =
       Authorization.of(a -> a.tenant().read());
+
+  public static final Authorization<UserEntity> USER_READ_AUTHORIZATION =
+      Authorization.of(a -> a.user().read());
 }

--- a/service/src/main/java/io/camunda/service/cache/ProcessElementProvider.java
+++ b/service/src/main/java/io/camunda/service/cache/ProcessElementProvider.java
@@ -9,6 +9,7 @@ package io.camunda.service.cache;
 
 import io.camunda.search.entities.ProcessDefinitionEntity;
 import io.camunda.search.query.ProcessDefinitionQuery;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.ProcessDefinitionServices;
 import io.camunda.zeebe.util.modelreader.ProcessModelReader;
 import java.nio.charset.StandardCharsets;
@@ -31,7 +32,10 @@ public class ProcessElementProvider {
       final Long processDefinitionKey,
       final BiConsumer<Long, ProcessElement> processDefinitionKeyElementConsumer) {
     try {
-      final var processDefinition = processDefinitionServices.getByKey(processDefinitionKey);
+      final var processDefinition =
+          processDefinitionServices
+              .withAuthentication(CamundaAuthentication.anonymous())
+              .getByKey(processDefinitionKey);
       extractElementNames(processDefinition, processDefinitionKeyElementConsumer);
     } catch (final Exception e) {
       LOG.warn(
@@ -48,11 +52,13 @@ public class ProcessElementProvider {
 
     try {
       final var result =
-          processDefinitionServices.search(
-              ProcessDefinitionQuery.of(
-                  q ->
-                      q.filter(f -> f.processDefinitionKeys(keysList))
-                          .page(p -> p.size(keysList.size()))));
+          processDefinitionServices
+              .withAuthentication(CamundaAuthentication.anonymous())
+              .search(
+                  ProcessDefinitionQuery.of(
+                      q ->
+                          q.filter(f -> f.processDefinitionKeys(keysList))
+                              .page(p -> p.size(keysList.size()))));
 
       if (result.total() < processDefinitionKeys.size()) {
         LOG.warn("Could not load all required process definitions into the cache");

--- a/service/src/main/java/io/camunda/service/exception/ErrorMapper.java
+++ b/service/src/main/java/io/camunda/service/exception/ErrorMapper.java
@@ -66,6 +66,7 @@ public class ErrorMapper {
     return switch (cse.getReason()) {
       case NOT_FOUND -> new ServiceException(errorMessage, NOT_FOUND);
       case NOT_UNIQUE -> new ServiceException(errorMessage, ALREADY_EXISTS);
+      case FORBIDDEN -> new ServiceException(errorMessage, FORBIDDEN);
       case CONNECTION_FAILED -> {
         final String detail = "The search client could not connect to the search server";
         LOGGER.debug(detail, cse);

--- a/service/src/test/java/io/camunda/service/AuthorizationServiceTest.java
+++ b/service/src/test/java/io/camunda/service/AuthorizationServiceTest.java
@@ -20,7 +20,6 @@ import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
-import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -113,8 +112,7 @@ public class AuthorizationServiceTest {
   public void shouldReturnSingleAuthorizationForGet() {
     // given
     final var entity = mock(AuthorizationEntity.class);
-    final var result = new SearchQueryResult<>(1, false, List.of(entity), null, null);
-    when(client.searchAuthorizations(any())).thenReturn(result);
+    when(client.getAuthorization(any(Long.class))).thenReturn(entity);
 
     // when
     final var searchQueryResult = services.getAuthorization(entity.authorizationKey());

--- a/service/src/test/java/io/camunda/service/GroupServiceTest.java
+++ b/service/src/test/java/io/camunda/service/GroupServiceTest.java
@@ -106,9 +106,7 @@ public class GroupServiceTest {
   public void shouldReturnSingleGroupForGet() {
     // given
     final var entity = mock(GroupEntity.class);
-    final var result =
-        new SearchQueryResult.Builder<GroupEntity>().total(1).items(List.of(entity)).build();
-    when(client.searchGroups(any())).thenReturn(result);
+    when(client.getGroup(any())).thenReturn(entity);
 
     // when
     final var searchQueryResult = services.getGroup("groupId");

--- a/service/src/test/java/io/camunda/service/MappingRuleServicesTest.java
+++ b/service/src/test/java/io/camunda/service/MappingRuleServicesTest.java
@@ -110,11 +110,10 @@ public class MappingRuleServicesTest {
   }
 
   @Test
-  public void shouldReturnSingleVariableForFind() {
+  public void shouldReturnSingleMappingForFind() {
     // given
     final var entity = mock(MappingRuleEntity.class);
-    final var result = new SearchQueryResult<>(1, false, List.of(entity), null, null);
-    when(client.searchMappingRules(any())).thenReturn(result);
+    when(client.getMappingRule(any(String.class))).thenReturn(entity);
 
     // when
     final var searchQueryResult = services.getMappingRule("mappingRuleId");

--- a/service/src/test/java/io/camunda/service/ProcessInstanceServiceTest.java
+++ b/service/src/test/java/io/camunda/service/ProcessInstanceServiceTest.java
@@ -10,6 +10,7 @@ package io.camunda.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -22,6 +23,7 @@ import io.camunda.search.entities.IncidentEntity;
 import io.camunda.search.entities.ProcessInstanceEntity;
 import io.camunda.search.entities.ProcessInstanceEntity.ProcessInstanceState;
 import io.camunda.search.entities.SequenceFlowEntity;
+import io.camunda.search.exception.ResourceAccessDeniedException;
 import io.camunda.search.filter.FilterBuilders;
 import io.camunda.search.filter.Operation;
 import io.camunda.search.filter.ProcessInstanceFilter;
@@ -34,6 +36,7 @@ import io.camunda.security.auth.Authorization;
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.ProcessInstanceServices.ProcessInstanceMigrateBatchOperationRequest;
 import io.camunda.service.ProcessInstanceServices.ProcessInstanceModifyBatchOperationRequest;
+import io.camunda.service.authorization.Authorizations;
 import io.camunda.service.exception.ServiceException;
 import io.camunda.service.exception.ServiceException.Status;
 import io.camunda.service.security.SecurityContextProvider;
@@ -130,9 +133,7 @@ public final class ProcessInstanceServiceTest {
     final var entity = mock(ProcessInstanceEntity.class);
     when(entity.processInstanceKey()).thenReturn(key);
     when(entity.processDefinitionId()).thenReturn("processId");
-    when(processInstanceSearchClient.searchProcessInstances(any()))
-        .thenReturn(new SearchQueryResult(1, false, List.of(entity), null, null));
-    authorizeProcessReadInstance(true, "processId");
+    when(processInstanceSearchClient.getProcessInstance(eq(123L))).thenReturn(entity);
 
     // when
     final var searchQueryResult = services.getByKey(key);
@@ -146,9 +147,9 @@ public final class ProcessInstanceServiceTest {
     // given
     final var entity = mock(ProcessInstanceEntity.class);
     when(entity.processDefinitionId()).thenReturn("processId");
-    when(processInstanceSearchClient.searchProcessInstances(any()))
-        .thenReturn(new SearchQueryResult<>(1, false, List.of(entity), null, null));
-    authorizeProcessReadInstance(false, "processId");
+    when(processInstanceSearchClient.getProcessInstance(any(Long.class)))
+        .thenThrow(
+            new ResourceAccessDeniedException(Authorizations.PROCESS_INSTANCE_READ_AUTHORIZATION));
     // when
     final Executable executeGetByKey = () -> services.getByKey(1L);
     // then
@@ -198,13 +199,12 @@ public final class ProcessInstanceServiceTest {
     when(childProcess.processInstanceKey()).thenReturn(789L);
     when(childProcess.treePath()).thenReturn("PI_123/FN_A/FNI_456/PI_789/FN_B/FNI_654");
     when(childProcess.processDefinitionId()).thenReturn("child_process_id");
-    authorizeProcessReadInstance(true, "child_process_id");
 
     final var parentProcess = mock(ProcessInstanceEntity.class);
     when(parentProcess.processInstanceKey()).thenReturn(123L);
     when(parentProcess.processDefinitionId()).thenReturn("parent_process_id");
-    authorizeProcessReadInstance(true, "parent_process_id");
 
+    when(processInstanceSearchClient.getProcessInstance(eq(789L))).thenReturn(childProcess);
     when(processInstanceSearchClient.searchProcessInstances(any()))
         .thenReturn(
             new SearchQueryResult<>(1, false, List.of(childProcess, parentProcess), null, null));
@@ -224,11 +224,9 @@ public final class ProcessInstanceServiceTest {
     final var rootInstance = mock(ProcessInstanceEntity.class);
     when(rootInstance.processInstanceKey()).thenReturn(123L);
     when(rootInstance.processDefinitionId()).thenReturn("root_process_id");
-    authorizeProcessReadInstance(true, "root_process_id");
     when(rootInstance.treePath()).thenReturn(null); // No treePath
 
-    when(processInstanceSearchClient.searchProcessInstances(any()))
-        .thenReturn(new SearchQueryResult<>(1, false, List.of(rootInstance), null, null));
+    when(processInstanceSearchClient.getProcessInstance(eq(123L))).thenReturn(rootInstance);
 
     // when
     final var result = services.callHierarchy(123L);
@@ -243,11 +241,9 @@ public final class ProcessInstanceServiceTest {
     final var rootInstance = mock(ProcessInstanceEntity.class);
     when(rootInstance.processInstanceKey()).thenReturn(123L);
     when(rootInstance.processDefinitionId()).thenReturn("root_process_id");
-    authorizeProcessReadInstance(true, "root_process_id");
     when(rootInstance.treePath()).thenReturn("PI_123"); // Root treePath
 
-    when(processInstanceSearchClient.searchProcessInstances(any()))
-        .thenReturn(new SearchQueryResult<>(1, false, List.of(rootInstance), null, null));
+    when(processInstanceSearchClient.getProcessInstance(eq(123L))).thenReturn(rootInstance);
 
     // when
     final var result = services.callHierarchy(123L);
@@ -388,14 +384,6 @@ public final class ProcessInstanceServiceTest {
         .isEqualTo("target1");
   }
 
-  private void authorizeProcessReadInstance(final boolean authorize, final String processId) {
-    when(securityContextProvider.isAuthorized(
-            processId,
-            authentication,
-            Authorization.of(a -> a.processDefinition().readProcessInstance())))
-        .thenReturn(authorize);
-  }
-
   @Test
   void shouldReturnIncidentsForProcessInstanceKey() {
     // given
@@ -407,9 +395,8 @@ public final class ProcessInstanceServiceTest {
     when(processInstance.treePath()).thenReturn("PI_123/FN_A/FNI_456/PI_789/FN_B/FNI_654");
     when(processInstance.processInstanceKey()).thenReturn(processInstanceKey);
     when(processInstance.processDefinitionId()).thenReturn("processId");
-    when(processInstanceSearchClient.searchProcessInstances(any()))
-        .thenReturn(new SearchQueryResult<>(1, false, List.of(processInstance), null, null));
-    authorizeProcessReadInstance(true, processInstance.processDefinitionId());
+    when(processInstanceSearchClient.getProcessInstance(eq(processInstanceKey)))
+        .thenReturn(processInstance);
 
     when(incidentSearchClient.searchIncidents(any())).thenReturn(queryResult);
 
@@ -440,9 +427,10 @@ public final class ProcessInstanceServiceTest {
 
     final var processInstance = mock(ProcessInstanceEntity.class);
     when(processInstance.processDefinitionId()).thenReturn("processId");
-    when(processInstanceSearchClient.searchProcessInstances(any()))
-        .thenReturn(new SearchQueryResult<>(1, false, List.of(processInstance), null, null));
-    authorizeProcessReadInstance(false, processInstance.processDefinitionId());
+    when(processInstanceSearchClient.getProcessInstance(eq(processInstanceKey)))
+        .thenThrow(
+            new ResourceAccessDeniedException(
+                Authorization.of(a -> a.processDefinition().readProcessInstance())));
 
     final var query = new IncidentQuery.Builder().build();
 

--- a/service/src/test/java/io/camunda/service/RoleServicesTest.java
+++ b/service/src/test/java/io/camunda/service/RoleServicesTest.java
@@ -9,6 +9,7 @@ package io.camunda.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -104,8 +105,8 @@ public class RoleServicesTest {
   public void shouldReturnSingleVariableForGet() {
     // given
     final var entity = mock(RoleEntity.class);
-    final var result = new SearchQueryResult<>(1, false, List.of(entity), null, null);
-    when(client.searchRoles(any())).thenReturn(result);
+    when(entity.roleId()).thenReturn("roleId");
+    when(client.getRole(eq("roleId"))).thenReturn(entity);
 
     // when
     final var searchQueryResult = services.getRole(entity.roleId());

--- a/service/src/test/java/io/camunda/service/UserServiceTest.java
+++ b/service/src/test/java/io/camunda/service/UserServiceTest.java
@@ -9,6 +9,7 @@ package io.camunda.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -24,7 +25,6 @@ import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.broker.client.api.dto.BrokerResponse;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerUserDeleteRequest;
 import io.camunda.zeebe.protocol.impl.record.value.user.UserRecord;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import org.junit.jupiter.api.BeforeEach;
@@ -95,8 +95,8 @@ public class UserServiceTest {
   public void shouldReturnUserForGet() {
     // given
     final var entity = mock(UserEntity.class);
-    final var result = new SearchQueryResult<>(1, false, List.of(entity), null, null);
-    when(client.searchUsers(any())).thenReturn(result);
+    when(entity.username()).thenReturn("test");
+    when(client.getUser(eq("test"))).thenReturn(entity);
 
     // when
     final var searchQueryResult = services.getUser(entity.username());

--- a/service/src/test/java/io/camunda/service/UserTaskServiceTest.java
+++ b/service/src/test/java/io/camunda/service/UserTaskServiceTest.java
@@ -27,16 +27,20 @@ import io.camunda.search.entities.FlowNodeInstanceEntity;
 import io.camunda.search.entities.FormEntity;
 import io.camunda.search.entities.UserTaskEntity;
 import io.camunda.search.entities.VariableEntity;
+import io.camunda.search.exception.ResourceAccessDeniedException;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.search.query.UserTaskQuery;
 import io.camunda.security.auth.Authorization;
 import io.camunda.security.auth.CamundaAuthentication;
+import io.camunda.service.authorization.Authorizations;
 import io.camunda.service.cache.ProcessCache;
+import io.camunda.service.cache.ProcessCacheItem;
 import io.camunda.service.cache.ProcessCacheResult;
 import io.camunda.service.exception.ServiceException;
 import io.camunda.service.exception.ServiceException.Status;
 import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
+import java.util.Map;
 import java.util.Set;
 import org.instancio.Instancio;
 import org.junit.jupiter.api.BeforeEach;
@@ -96,15 +100,10 @@ public class UserTaskServiceTest {
     public void searchVariablesShouldThrowExceptionWhenNotAuthorized() {
       // given
       final var entity = Instancio.create(UserTaskEntity.class);
-      final var flowNodeInstanceEntity =
-          Instancio.of(FlowNodeInstanceEntity.class)
-              .set(field(FlowNodeInstanceEntity::flowNodeInstanceKey), entity.elementInstanceKey())
-              .set(field(FlowNodeInstanceEntity::treePath), "1/2/3")
-              .create();
-      final var variable = Instancio.create(VariableEntity.class);
 
-      when(client.searchUserTasks(any())).thenReturn(SearchQueryResult.of(entity));
-      authorizeReadUserTasksForProcess(false, entity.processDefinitionId());
+      when(client.getUserTask(any(Long.class)))
+          .thenThrow(
+              new ResourceAccessDeniedException(Authorizations.USER_TASK_READ_AUTHORIZATION));
 
       // when
       final Executable executable =
@@ -113,12 +112,7 @@ public class UserTaskServiceTest {
       // then
       assertThat(assertThrows(ServiceException.class, executable).getStatus())
           .isEqualTo(Status.FORBIDDEN);
-      verify(client).searchUserTasks(any());
-      verify(securityContextProvider)
-          .isAuthorized(
-              entity.processDefinitionId(),
-              authentication,
-              Authorization.of(a -> a.processDefinition().readUserTask()));
+      verify(client).getUserTask(any(Long.class));
       verify(flowNodeInstanceSearchClient, never()).searchFlowNodeInstances(any());
       verify(variableSearchClient, never()).searchVariables(any());
     }
@@ -134,7 +128,7 @@ public class UserTaskServiceTest {
               .create();
       final var variable = Instancio.create(VariableEntity.class);
 
-      when(client.searchUserTasks(any())).thenReturn(SearchQueryResult.of(entity));
+      when(client.getUserTask(any(Long.class))).thenReturn(entity);
       when(flowNodeInstanceSearchClient.searchFlowNodeInstances(
               flownodeInstanceSearchQuery(
                   q ->
@@ -170,8 +164,7 @@ public class UserTaskServiceTest {
       when(formSearchClient.searchForms(
               formSearchQuery(q -> q.filter(f -> f.formKeys(entity.formKey())).singleResult())))
           .thenReturn(SearchQueryResult.of(form));
-      when(client.searchUserTasks(any())).thenReturn(SearchQueryResult.of(entity));
-      authorizeReadUserTasksForProcess(true, entity.processDefinitionId());
+      when(client.getUserTask(any(Long.class))).thenReturn(entity);
 
       // when
       final var result = services.getUserTaskForm(entity.userTaskKey());
@@ -187,8 +180,7 @@ public class UserTaskServiceTest {
       final var entity =
           Instancio.of(UserTaskEntity.class).set(field(UserTaskEntity::formKey), null).create();
 
-      when(client.searchUserTasks(any())).thenReturn(SearchQueryResult.of(entity));
-      authorizeReadUserTasksForProcess(true, entity.processDefinitionId());
+      when(client.getUserTask(any(Long.class))).thenReturn(entity);
 
       // when
       final var result = services.getUserTaskForm(1L);
@@ -205,8 +197,7 @@ public class UserTaskServiceTest {
     void shouldReturnUserTask() {
       final var entity = Instancio.create(UserTaskEntity.class);
 
-      when(client.searchUserTasks(any())).thenReturn(SearchQueryResult.of(entity));
-      authorizeReadUserTasksForProcess(true, entity.processDefinitionId());
+      when(client.getUserTask(any(Long.class))).thenReturn(entity);
 
       final var searchQueryResult = services.getByKey(entity.userTaskKey());
 
@@ -218,12 +209,9 @@ public class UserTaskServiceTest {
       final var entity =
           Instancio.of(UserTaskEntity.class).set(field(UserTaskEntity::name), null).create();
 
-      when(client.searchUserTasks(any())).thenReturn(SearchQueryResult.of(entity));
-      authorizeReadUserTasksForProcess(true, entity.processDefinitionId());
-      when(processCache.getCacheItems(Set.of(entity.processDefinitionKey())))
-          .thenReturn(
-              ProcessCacheResult.of(
-                  entity.processDefinitionKey(), entity.elementId(), "cached name"));
+      when(client.getUserTask(any(Long.class))).thenReturn(entity);
+      when(processCache.getCacheItem(entity.processDefinitionKey()))
+          .thenReturn(new ProcessCacheItem(Map.of(entity.elementId(), "cached name")));
 
       final var foundEntity = services.getByKey(entity.userTaskKey());
 
@@ -235,8 +223,9 @@ public class UserTaskServiceTest {
       final var entity =
           Instancio.of(UserTaskEntity.class).set(field(UserTaskEntity::name), null).create();
 
-      when(client.searchUserTasks(any())).thenReturn(SearchQueryResult.of(entity));
-      authorizeReadUserTasksForProcess(true, entity.processDefinitionId());
+      when(client.getUserTask(any(Long.class))).thenReturn(entity);
+      when(processCache.getCacheItem(entity.processDefinitionKey()))
+          .thenReturn(new ProcessCacheItem(Map.of("unknown-id", "cached name")));
 
       final var foundEntity = services.getByKey(entity.userTaskKey());
 
@@ -247,19 +236,15 @@ public class UserTaskServiceTest {
     void shouldThrowExceptionWhenNotAuthorized() {
       final var entity = Instancio.create(UserTaskEntity.class);
 
-      when(client.searchUserTasks(any())).thenReturn(SearchQueryResult.of(entity));
-      authorizeReadUserTasksForProcess(false, entity.processDefinitionId());
+      when(client.getUserTask(any(Long.class)))
+          .thenThrow(
+              new ResourceAccessDeniedException(Authorizations.USER_TASK_READ_AUTHORIZATION));
 
       final Executable executable = () -> services.getByKey(entity.userTaskKey());
 
       assertThat(assertThrows(ServiceException.class, executable).getStatus())
           .isEqualTo(Status.FORBIDDEN);
-      verify(client).searchUserTasks(any());
-      verify(securityContextProvider)
-          .isAuthorized(
-              entity.processDefinitionId(),
-              authentication,
-              Authorization.of(a -> a.processDefinition().readUserTask()));
+      verify(client).getUserTask(any(Long.class));
     }
   }
 

--- a/service/src/test/java/io/camunda/service/cache/ProcessCacheTest.java
+++ b/service/src/test/java/io/camunda/service/cache/ProcessCacheTest.java
@@ -18,6 +18,7 @@ import static org.mockito.Mockito.when;
 import com.github.benmanes.caffeine.cache.LoadingCache;
 import io.camunda.search.entities.ProcessDefinitionEntity;
 import io.camunda.search.query.SearchQueryResult;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.ProcessDefinitionServices;
 import io.camunda.service.cache.ProcessCache.Configuration;
 import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
@@ -61,6 +62,8 @@ class ProcessCacheTest {
         new ProcessCache(
             configuration, processDefinitionServices, brokerTopologyManager, meterRegistry);
 
+    when(processDefinitionServices.withAuthentication(any(CamundaAuthentication.class)))
+        .thenReturn(processDefinitionServices);
     when(processDefinitionServices.getByKey(entity.processDefinitionKey())).thenReturn(entity);
   }
 

--- a/service/src/test/java/io/camunda/service/cache/ProcessFlowNodeProviderTest.java
+++ b/service/src/test/java/io/camunda/service/cache/ProcessFlowNodeProviderTest.java
@@ -19,6 +19,7 @@ import io.camunda.search.entities.ProcessDefinitionEntity;
 import io.camunda.search.page.SearchQueryPage;
 import io.camunda.search.query.ProcessDefinitionQuery;
 import io.camunda.search.query.SearchQueryResult;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.ProcessDefinitionServices;
 import io.camunda.service.cache.ProcessElementProvider.ProcessElement;
 import java.io.IOException;
@@ -75,6 +76,8 @@ class ProcessElementProviderTest {
     when(processDefinition.processDefinitionKey()).thenReturn(PROC_DEF_KEY);
     when(processDefinition.processDefinitionId()).thenReturn(PROC_DEF_ID1);
     when(processDefinitionServices.getByKey(eq(PROC_DEF_KEY))).thenReturn(processDefinition);
+    when(processDefinitionServices.withAuthentication(any(CamundaAuthentication.class)))
+        .thenReturn(processDefinitionServices);
   }
 
   private void verifyElementsBpmn1() {

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/UserTaskController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/UserTaskController.java
@@ -9,7 +9,6 @@ package io.camunda.zeebe.gateway.rest.controller;
 
 import static io.camunda.zeebe.gateway.rest.RestErrorMapper.mapErrorToResponse;
 
-import io.camunda.search.entities.FormEntity;
 import io.camunda.search.query.UserTaskQuery;
 import io.camunda.search.query.VariableQuery;
 import io.camunda.security.auth.CamundaAuthenticationProvider;
@@ -35,7 +34,6 @@ import io.camunda.zeebe.gateway.rest.annotation.CamundaGetMapping;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaPatchMapping;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaPostMapping;
 import io.camunda.zeebe.gateway.rest.annotation.RequiresSecondaryStorage;
-import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -119,11 +117,10 @@ public class UserTaskController {
   public ResponseEntity<FormResult> getFormByUserTaskKey(
       @PathVariable("userTaskKey") final long userTaskKey) {
     try {
-      final Optional<FormEntity> form =
-          userTaskServices
-              .withAuthentication(authenticationProvider.getCamundaAuthentication())
-              .getUserTaskForm(userTaskKey);
-      return form.map(SearchQueryResponseMapper::toFormItem)
+      return userTaskServices
+          .withAuthentication(authenticationProvider.getCamundaAuthentication())
+          .getUserTaskForm(userTaskKey)
+          .map(SearchQueryResponseMapper::toFormItem)
           .map(ResponseEntity::ok)
           .orElseGet(() -> ResponseEntity.noContent().build());
     } catch (final Exception e) {

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/it/util/SearchClientsUtil.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/it/util/SearchClientsUtil.java
@@ -23,6 +23,11 @@ import io.camunda.search.connect.os.OpensearchConnector;
 import io.camunda.search.es.clients.ElasticsearchSearchClient;
 import io.camunda.search.os.clients.OpensearchSearchClient;
 import io.camunda.webapps.schema.descriptors.IndexDescriptors;
+import io.camunda.webapps.schema.descriptors.index.AuthorizationIndex;
+import io.camunda.webapps.schema.descriptors.index.GroupIndex;
+import io.camunda.webapps.schema.descriptors.index.RoleIndex;
+import io.camunda.webapps.schema.descriptors.index.TenantIndex;
+import io.camunda.webapps.schema.descriptors.index.UserIndex;
 
 public class SearchClientsUtil {
 
@@ -39,11 +44,18 @@ public class SearchClientsUtil {
     final var executor =
         new SearchClientBasedQueryExecutor(
             client, ServiceTransformers.newInstance(indexDescriptors));
-    final var roleMemberReader = new RoleMemberDocumentReader(executor);
-    final var tenantMemberReader = new TenantMemberDocumentReader(executor);
-    final var groupMemberReader = new GroupMemberDocumentReader(executor);
+    final var roleMemberReader =
+        new RoleMemberDocumentReader(executor, indexDescriptors.get(RoleIndex.class));
+    final var tenantMemberReader =
+        new TenantMemberDocumentReader(executor, indexDescriptors.get(TenantIndex.class));
+    final var groupMemberReader =
+        new GroupMemberDocumentReader(executor, indexDescriptors.get(GroupIndex.class));
     return new UserDocumentReader(
-        executor, roleMemberReader, tenantMemberReader, groupMemberReader);
+        executor,
+        indexDescriptors.get(UserIndex.class),
+        roleMemberReader,
+        tenantMemberReader,
+        groupMemberReader);
   }
 
   public static AuthorizationReader createAuthorizationReader(
@@ -51,7 +63,8 @@ public class SearchClientsUtil {
     final var indexDescriptors = new IndexDescriptors("", true);
     return new AuthorizationDocumentReader(
         new SearchClientBasedQueryExecutor(
-            client, ServiceTransformers.newInstance(indexDescriptors)));
+            client, ServiceTransformers.newInstance(indexDescriptors)),
+        indexDescriptors.get(AuthorizationIndex.class));
   }
 
   public static OpensearchSearchClient createLowLevelOpensearchSearchClient(

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneBroker.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneBroker.java
@@ -103,6 +103,8 @@ public final class TestStandaloneBroker extends TestSpringApplication<TestStanda
     withProperty(
         AuthenticationProperties.API_UNPROTECTED,
         securityConfig.getAuthentication().getUnprotectedApi());
+    withProperty(
+        "camunda.security.authorizations.enabled", securityConfig.getAuthorizations().isEnabled());
     // by default, we don't want to create the schema as ES/OS containers may not be used in the
     // current test
     withCreateSchema(false);
@@ -138,6 +140,7 @@ public final class TestStandaloneBroker extends TestSpringApplication<TestStanda
   public TestStandaloneBroker withAuthorizationsEnabled() {
     // when using authorizations, api authentication needs to be enforced too
     withAuthenticatedAccess();
+    withProperty("camunda.security.authorizations.enabled", true);
     return withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true));
   }
 


### PR DESCRIPTION
## Description

* Refactoring:
  * Implements dedicated "gets" (by id or key) to fetch a single resource
  * Applies an authorization and tenant check when the resource is returned.
* Returns 403 if the user is not authorized to access the resource
* Returns 404 if the user does nothave  access to the tenant (the resource is assigned to)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

related to #35595
