### PR TITLE
Camunda exporter flush failure type metric

### DIFF
--- a/monitor/grafana/dashboards/data_layer.json
+++ b/monitor/grafana/dashboards/data_layer.json
@@ -1025,7 +1025,7 @@
         "type": "prometheus",
         "uid": "PBFA97CFB590B2093"
       },
-      "description": "How long an export request is open and collecting new records before flushing.",
+      "description": "When bulk request flushes fail, the type of error returned is counted.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1037,11 +1037,10 @@
             "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
-            "axisSoftMax": 5,
             "barAlignment": 0,
             "barWidthFactor": 0.6,
             "drawStyle": "line",
-            "fillOpacity": 10,
+            "fillOpacity": 0,
             "gradientMode": "none",
             "hideFrom": {
               "legend": false,
@@ -1055,7 +1054,7 @@
             "scaleDistribution": {
               "type": "linear"
             },
-            "showPoints": "never",
+            "showPoints": "auto",
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -1065,8 +1064,6 @@
               "mode": "off"
             }
           },
-          "decimals": 0,
-          "links": [],
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
@@ -1079,8 +1076,7 @@
                 "value": 80
               }
             ]
-          },
-          "unit": "dtdurations"
+          }
         },
         "overrides": []
       },
@@ -1090,7 +1086,7 @@
         "x": 0,
         "y": 13
       },
-      "id": 10,
+      "id": 44,
       "options": {
         "legend": {
           "calcs": [],
@@ -1100,26 +1096,21 @@
         },
         "tooltip": {
           "hideZeros": false,
-          "mode": "multi",
+          "mode": "single",
           "sort": "none"
         }
       },
       "pluginVersion": "12.0.2",
       "targets": [
         {
-          "datasource": {
-            "uid": "$DS_PROMETHEUS"
-          },
           "editorMode": "code",
-          "exemplar": true,
-          "expr": "rate(zeebe_camunda_exporter_flush_latency_seconds_sum{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval]) / rate(zeebe_camunda_exporter_flush_latency_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])",
-          "interval": "",
-          "legendFormat": "{{pod}} Exporter {{partition}}",
+          "expr": "increase(zeebe_camunda_exporter_flush_failure_type_total{cluster=~\"$cluster\", namespace=~\"$namespace\",partition=~\"$partition\"}[1m])",
+          "legendFormat": "__auto",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Camunda Exporter (Flush Latency)",
+      "title": "Camunda Exporter (Flush Failure Type)",
       "type": "timeseries"
     },
     {
@@ -1212,7 +1203,7 @@
         "type": "prometheus",
         "uid": "PBFA97CFB590B2093"
       },
-      "description": "Shows the rate of access to the process cache per partition",
+      "description": "How long an export request is open and collecting new records before flushing.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1224,10 +1215,11 @@
             "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
+            "axisSoftMax": 5,
             "barAlignment": 0,
             "barWidthFactor": 0.6,
             "drawStyle": "line",
-            "fillOpacity": 0,
+            "fillOpacity": 10,
             "gradientMode": "none",
             "hideFrom": {
               "legend": false,
@@ -1241,7 +1233,7 @@
             "scaleDistribution": {
               "type": "linear"
             },
-            "showPoints": "auto",
+            "showPoints": "never",
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -1251,6 +1243,8 @@
               "mode": "off"
             }
           },
+          "decimals": 0,
+          "links": [],
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
@@ -1263,7 +1257,8 @@
                 "value": 80
               }
             ]
-          }
+          },
+          "unit": "dtdurations"
         },
         "overrides": []
       },
@@ -1273,52 +1268,36 @@
         "x": 0,
         "y": 21
       },
-      "id": 12,
+      "id": 10,
       "options": {
         "legend": {
-          "calcs": [
-            "mean"
-          ],
-          "displayMode": "table",
-          "placement": "right",
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
           "showLegend": true
         },
         "tooltip": {
           "hideZeros": false,
           "mode": "multi",
-          "sort": "desc"
+          "sort": "none"
         }
       },
       "pluginVersion": "12.0.2",
       "targets": [
         {
           "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "editorMode": "code",
-          "expr": "sum(rate(zeebe_camunda_exporter_cache_process_result_total{namespace=~\"$namespace\",partition=~\"$partition\"}[$__rate_interval])) by (partition)",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "Cache access {{partition}}",
+          "exemplar": true,
+          "expr": "rate(zeebe_camunda_exporter_flush_latency_seconds_sum{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval]) / rate(zeebe_camunda_exporter_flush_latency_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])",
+          "interval": "",
+          "legendFormat": "{{pod}} Exporter {{partition}}",
           "range": true,
           "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "expr": "sum(rate(zeebe_camunda_exporter_cache_process_result_total{namespace=~\"$namespace\",partition=~\"$partition\"}[$__rate_interval])) by (partition, type)",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "P{{partition}} - {{type}}",
-          "range": true,
-          "refId": "B"
         }
       ],
-      "title": "Process cache access",
+      "title": "Camunda Exporter (Flush Latency)",
       "type": "timeseries"
     },
     {
@@ -1424,7 +1403,7 @@
         "type": "prometheus",
         "uid": "PBFA97CFB590B2093"
       },
-      "description": "The rate of the loading data into the cache",
+      "description": "Shows the rate of access to the process cache per partition",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1485,33 +1464,34 @@
         "x": 0,
         "y": 29
       },
-      "id": 15,
+      "id": 12,
       "options": {
         "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
+          "calcs": [
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "right",
           "showLegend": true
         },
         "tooltip": {
           "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
+          "mode": "multi",
+          "sort": "desc"
         }
       },
       "pluginVersion": "12.0.2",
       "targets": [
         {
           "datasource": {
-            "uid": "$DS_PROMETHEUS"
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(zeebe_camunda_exporter_cache_process_load_duration_success_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\"}[$__rate_interval])) by (partition)",
-          "format": "heatmap",
+          "expr": "sum(rate(zeebe_camunda_exporter_cache_process_result_total{namespace=~\"$namespace\",partition=~\"$partition\"}[$__rate_interval])) by (partition)",
           "hide": false,
-          "interval": "30s",
-          "intervalFactor": 1,
-          "legendFormat": "Success p{{partition}}",
+          "instant": false,
+          "legendFormat": "Cache access {{partition}}",
           "range": true,
           "refId": "A"
         },
@@ -1521,15 +1501,15 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(zeebe_camunda_exporter_cache_process_load_duration_failure_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\"}[$__rate_interval])) by (partition)",
+          "expr": "sum(rate(zeebe_camunda_exporter_cache_process_result_total{namespace=~\"$namespace\",partition=~\"$partition\"}[$__rate_interval])) by (partition, type)",
           "hide": false,
           "instant": false,
-          "legendFormat": "Failure p{{partition}}",
+          "legendFormat": "P{{partition}} - {{type}}",
           "range": true,
           "refId": "B"
         }
       ],
-      "title": "Cache load rate",
+      "title": "Process cache access",
       "type": "timeseries"
     },
     {
@@ -1641,7 +1621,7 @@
         "type": "prometheus",
         "uid": "PBFA97CFB590B2093"
       },
-      "description": "Shows the rate of archiving (in-progress) and archived process instance and batch operations. Batch operations or process instances need to be completed before being able to be archived. The rate is aggregated by partition.",
+      "description": "The rate of the loading data into the cache",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1702,35 +1682,33 @@
         "x": 0,
         "y": 37
       },
-      "id": 16,
+      "id": 15,
       "options": {
         "legend": {
-          "calcs": [
-            "lastNotNull",
-            "max",
-            "min"
-          ],
-          "displayMode": "table",
+          "calcs": [],
+          "displayMode": "list",
           "placement": "bottom",
           "showLegend": true
         },
         "tooltip": {
           "hideZeros": false,
-          "mode": "multi",
-          "sort": "desc"
+          "mode": "single",
+          "sort": "none"
         }
       },
       "pluginVersion": "12.0.2",
       "targets": [
         {
           "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "editorMode": "code",
-          "expr": "sum(rate(zeebe_camunda_exporter_archiver_process_instances_total{namespace=~\"$namespace\",partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval])) by (partition, state)",
-          "instant": false,
-          "legendFormat": "{{state}} process instances [p{{partition}}]",
+          "expr": "sum(rate(zeebe_camunda_exporter_cache_process_load_duration_success_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\"}[$__rate_interval])) by (partition)",
+          "format": "heatmap",
+          "hide": false,
+          "interval": "30s",
+          "intervalFactor": 1,
+          "legendFormat": "Success p{{partition}}",
           "range": true,
           "refId": "A"
         },
@@ -1740,15 +1718,15 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(zeebe_camunda_exporter_archiver_batch_operations_total{namespace=~\"$namespace\",partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval])) by (partition, state)",
+          "expr": "sum(rate(zeebe_camunda_exporter_cache_process_load_duration_failure_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\"}[$__rate_interval])) by (partition)",
           "hide": false,
           "instant": false,
-          "legendFormat": "{{state}} batch operations [p{{partition}}]",
+          "legendFormat": "Failure p{{partition}}",
           "range": true,
           "refId": "B"
         }
       ],
-      "title": "Archiving",
+      "title": "Cache load rate",
       "type": "timeseries"
     },
     {
@@ -2101,12 +2079,127 @@
       "type": "heatmap"
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "description": "Shows the rate of archiving (in-progress) and archived process instance and batch operations. Batch operations or process instances need to be completed before being able to be archived. The rate is aggregated by partition.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 53
+      },
+      "id": 16,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max",
+            "min"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(zeebe_camunda_exporter_archiver_process_instances_total{namespace=~\"$namespace\",partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval])) by (partition, state)",
+          "instant": false,
+          "legendFormat": "{{state}} process instances [p{{partition}}]",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(zeebe_camunda_exporter_archiver_batch_operations_total{namespace=~\"$namespace\",partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval])) by (partition, state)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "{{state}} batch operations [p{{partition}}]",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Archiving",
+      "type": "timeseries"
+    },
+    {
       "collapsed": true,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 53
+        "y": 61
       },
       "id": 1,
       "panels": [
@@ -2483,7 +2576,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 54
+        "y": 62
       },
       "id": 21,
       "panels": [],
@@ -2514,7 +2607,7 @@
         "h": 8,
         "w": 10,
         "x": 0,
-        "y": 55
+        "y": 63
       },
       "id": 22,
       "options": {
@@ -2600,7 +2693,7 @@
         "h": 8,
         "w": 11,
         "x": 10,
-        "y": 55
+        "y": 63
       },
       "id": 23,
       "options": {
@@ -2701,7 +2794,7 @@
         "h": 8,
         "w": 3,
         "x": 21,
-        "y": 55
+        "y": 63
       },
       "id": 24,
       "options": {
@@ -2761,7 +2854,7 @@
         "h": 10,
         "w": 11,
         "x": 0,
-        "y": 63
+        "y": 71
       },
       "id": 25,
       "options": {
@@ -2888,7 +2981,7 @@
         "h": 10,
         "w": 8,
         "x": 11,
-        "y": 63
+        "y": 71
       },
       "id": 26,
       "options": {
@@ -2965,7 +3058,7 @@
         "h": 10,
         "w": 5,
         "x": 19,
-        "y": 63
+        "y": 71
       },
       "id": 27,
       "options": {
@@ -3023,5 +3116,5 @@
   "timezone": "browser",
   "title": "Data Layer",
   "uid": "728720fd-6b20-430a-b931-bbfdc71531dd",
-  "version": 6
+  "version": 10
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
@@ -388,7 +388,7 @@ processing records from previous version
 
     try (final var ignored = metrics.measureFlushDuration()) {
       metrics.recordBulkSize(writer.getBatchSize());
-      final BatchRequest batchRequest = clientAdapter.createBatchRequest();
+      final BatchRequest batchRequest = clientAdapter.createBatchRequest().withMetrics(metrics);
       writer.flush(batchRequest);
       metrics.stopFlushLatencyMeasurement();
     } catch (final PersistenceException ex) {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/metrics/CamundaExporterMetrics.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/metrics/CamundaExporterMetrics.java
@@ -181,6 +181,10 @@ public class CamundaExporterMetrics {
     batchOperationsArchiving.increment(count);
   }
 
+  public void recordFlushFailureType(final String failureType) {
+    meterRegistry.counter(meterName("flush.failure.type"), "failure_type", failureType).increment();
+  }
+
   /**
    * For each record write timestamp, observes the export latency by subtracting the timestamp from
    * the current stream clock.

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/BatchRequest.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/BatchRequest.java
@@ -9,6 +9,7 @@ package io.camunda.exporter.store;
 
 import io.camunda.exporter.errorhandling.Error;
 import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.metrics.CamundaExporterMetrics;
 import io.camunda.webapps.schema.entities.ExporterEntity;
 import java.util.Map;
 import java.util.function.BiConsumer;
@@ -16,6 +17,8 @@ import java.util.function.BiConsumer;
 /** A {@link BatchRequest} contains updates to one or more {@link ExporterEntity} */
 @SuppressWarnings("rawtypes")
 public interface BatchRequest {
+
+  BatchRequest withMetrics(final CamundaExporterMetrics metrics);
 
   BatchRequest add(String index, ExporterEntity entity);
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/ElasticsearchBatchRequest.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/ElasticsearchBatchRequest.java
@@ -307,7 +307,9 @@ public class ElasticsearchBatchRequest implements BatchRequest {
                   "%s failed on index [%s] and id [%s]: %s",
                   item.operationType(), item.index(), item.id(), item.error().reason());
 
-          metrics.recordFlushFailureType(item.error().type());
+          if (metrics != null) {
+            metrics.recordFlushFailureType(item.error().type());
+          }
           if (customErrorHandlers != null) {
             final Error error = new Error(message, item.error().type(), item.status());
             customErrorHandlers.accept(item.index(), error);

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/OpensearchBatchRequest.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/OpensearchBatchRequest.java
@@ -305,7 +305,9 @@ public class OpensearchBatchRequest implements BatchRequest {
                   "%s failed for type [%s] and id [%s]: %s",
                   item.operationType(), item.index(), item.id(), item.error().reason());
 
-          metrics.recordFlushFailureType(item.error().type());
+          if (metrics != null) {
+            metrics.recordFlushFailureType(item.error().type());
+          }
           if (errorHandlers != null) {
             final Error error = new Error(message, item.error().type(), item.status());
             errorHandlers.accept(item.index(), error);


### PR DESCRIPTION
## Description

When a bulk request is flushed it can partially or completely fail, when it does it sends back error objects per item in the bulk request, we now track all error types that are returned, this enables the narrowing down of errors.

Here is a snapshot to see the title, description, query https://snapshots.raintank.io/dashboard/snapshot/j85fGg1DBPDMYhp02KzniFBL3sYn58xg

Here is an image of what it looks like 
<img width="1124" height="408" alt="image" src="https://github.com/user-attachments/assets/e56c2b02-4c36-448a-8538-0483507d5cea" />


## Related issues

closes #34737 
