### PR TITLE
ci: more reliable download of vacuum without installer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1203,14 +1203,19 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 2
     permissions: {}  # GITHUB_TOKEN unused in this job
+    env:
+      # renovate: datasource=github-releases depName=daveshanley/vacuum
+      VACUUM_VERSION: 'v0.17.5'
     steps:
       - uses: actions/checkout@v4
-      - name: Install Vacuum
-        run: curl -fsSL https://quobix.com/scripts/install_vacuum.sh | sh
+      - name: Install vacuum
+        run: |
+          STRIPPED_VACUUM_VERSION="${VACUUM_VERSION#v}"
+          curl -s -L "https://github.com/daveshanley/vacuum/releases/download/${VACUUM_VERSION}/vacuum_${STRIPPED_VACUUM_VERSION}_Linux_x86_64.tar.gz" | tar xvz vacuum
         shell: bash
       - name: Run OpenAPI Linter
         run: >
-          vacuum lint zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+          ./vacuum lint zeebe/gateway-protocol/src/main/proto/rest-api.yaml
           --ruleset zeebe/gateway-protocol/vacuum-ruleset.yaml
           --ignore-file zeebe/gateway-protocol/vacuum-ignores.yaml
           --functions zeebe/gateway-protocol/vacuum-rules


### PR DESCRIPTION
## Description

### Hypothesis

Based on the insights of https://github.com/daveshanley/vacuum/issues/657 and the [error messages we got](https://github.com/camunda/camunda/actions/runs/16339177427/job/46157394299), I'm **assuming** that the installer is indeed running into rate-limiting problems with unauthenticated GH REST API requests to internally retrieve the latest version. Artifact downloads seem to work fine and don't have rate-limiting problems.

### Implementation

Given that the installer doesn't offer any more detailed error messages or error handling, and in general is opaque (see [Maxim's remark](https://camunda.slack.com/archives/C071KP5BTHB/p1752667037457879?thread_ts=1752665639.513049&cid=C071KP5BTHB)), I was looking for a different [way of installation](https://github.com/daveshanley/vacuum):

The project uses GH releases so the least overhead comes from using `curl` but without the opaque installer, instead integrating a templated download URL with Renovate like we also do for `actionlint` and `conftest` ([source](https://github.com/camunda/camunda/blob/cfae621c3bebadbb45231b7ae61ee79993382a5d/.github/workflows/ci.yml#L90-L91)). This is what I implemented here in this PR.

This PR also adds tracking `vacuum` version by Renovate so we don't accidentally run into breaking changes: CI will fail on Renovate PR of the `vacuum` version upgrade. Previously, a breaking change would have directly broken `main` and all branches because they implicitly rely on "latest" `vacuum` version.

### Demo

See successful run in https://github.com/camunda/camunda/actions/runs/16341496073/job/46165119685?pr=35523

### Rollout Plan

I propose to merge this PR as it works functionally and I will observe via CI Health metrics whether it fixes the reliability problem, if not we revert.


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)). - feature only on `main`

## Related issues

Related to #35448
