### PR TITLE
deps: update tomcat version to 10.1.43

### DIFF
--- a/optimize/pom.xml
+++ b/optimize/pom.xml
@@ -54,6 +54,7 @@
     <spring.boot.version>3.3.11</spring.boot.version>
     <spring.version>6.1.21</spring.version>
     <spring.security.version>6.4.7</spring.security.version>
+    <version.tomcat>10.1.43</version.tomcat>
     <httpclient.version>4.5.14</httpclient.version>
     <quartz.version>2.3.2</quartz.version>
     <jakarta.rs-api.version>4.0.0</jakarta.rs-api.version>
@@ -175,6 +176,24 @@
         <artifactId>jetty-util</artifactId>
         <version>${jetty.version}</version>
       </dependency>
+      <!-- override wrong tomcat embed version coming from spring-boot-dependencies BOM -->
+      <dependency>
+        <groupId>org.apache.tomcat.embed</groupId>
+        <artifactId>tomcat-embed-core</artifactId>
+        <version>${version.tomcat}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.tomcat.embed</groupId>
+        <artifactId>tomcat-embed-el</artifactId>
+        <version>${version.tomcat}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.tomcat.embed</groupId>
+        <artifactId>tomcat-embed-websocket</artifactId>
+        <version>${version.tomcat}</version>
+      </dependency>
+
+
       <dependency>
         <groupId>jakarta.ws.rs</groupId>
         <artifactId>jakarta.ws.rs-api</artifactId>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -101,6 +101,7 @@
     <version.spring>6.1.21</version.spring>
     <version.spring-security>6.4.7</version.spring-security>
     <version.spring-boot>3.3.11</version.spring-boot>
+    <version.tomcat>10.1.43</version.tomcat>
     <version.concurrentunit>0.4.6</version.concurrentunit>
     <version.kryo>5.6.0</version.kryo>
     <version.failsafe>2.4.4</version.failsafe>
@@ -1988,6 +1989,22 @@
         <groupId>org.testcontainers</groupId>
         <artifactId>postgresql</artifactId>
         <version>${version.postgres-test-container}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.apache.tomcat.embed</groupId>
+        <artifactId>tomcat-embed-core</artifactId>
+        <version>${version.tomcat}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.tomcat.embed</groupId>
+        <artifactId>tomcat-embed-el</artifactId>
+        <version>${version.tomcat}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.tomcat.embed</groupId>
+        <artifactId>tomcat-embed-websocket</artifactId>
+        <version>${version.tomcat}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Updating org.apache.tomcat.embed dependencies to 10.1.43 to fix [this CVE](https://camunda.slack.com/archives/C096BFS5VDE).

Tomcat is a transitive dependency of spring-boot-starter-web for which there is no new patch yet.

main PR: https://github.com/camunda/camunda/pull/35461

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

relates to https://github.com/camunda/camunda/issues/35459