### PR TITLE
[Backport stable/8.6] ci: make Operate+Tasklist snapshot+release artifacts public

### DIFF
--- a/operate/pom.xml
+++ b/operate/pom.xml
@@ -29,11 +29,6 @@
   </modules>
 
   <properties>
-
-    <!-- release parent settings -->
-    <nexus.snapshot.repository>https://artifacts.camunda.com/artifactory/camunda-operate-snapshots/</nexus.snapshot.repository>
-    <nexus.release.repository>https://artifacts.camunda.com/artifactory/camunda-operate/</nexus.release.repository>
-
     <maven.compiler.target>21</maven.compiler.target>
     <maven.compiler.source>21</maven.compiler.source>
 

--- a/tasklist/pom.xml
+++ b/tasklist/pom.xml
@@ -32,10 +32,6 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-    <!-- release parent settings -->
-    <nexus.snapshot.repository>https://artifacts.camunda.com/artifactory/camunda-zeebe-tasklist-snapshots/</nexus.snapshot.repository>
-    <nexus.release.repository>https://artifacts.camunda.com/artifactory/camunda-zeebe-tasklist/</nexus.release.repository>
-
     <maven.compiler.target>21</maven.compiler.target>
     <maven.compiler.source>21</maven.compiler.source>
 


### PR DESCRIPTION
# Description
Backport of #35376 to `stable/8.6`.

relates to camunda/camunda#19035