### PR TITLE
fix: use UnifiedConfiguration in StandalonePrefixMigration

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/LegacyOperateProperties.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/LegacyOperateProperties.java
@@ -9,10 +9,8 @@ package io.camunda.configuration.beanoverrides;
 
 import io.camunda.operate.property.OperateProperties;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.context.annotation.DependsOn;
 import org.springframework.context.annotation.PropertySource;
 
 @ConfigurationProperties(OperateProperties.PREFIX)
 @PropertySource("classpath:operate-version.properties")
-@DependsOn("databaseInfo")
 public class LegacyOperateProperties extends OperateProperties {}

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/OperatePropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/OperatePropertiesOverride.java
@@ -14,13 +14,11 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
-import org.springframework.context.annotation.Profile;
 import org.springframework.context.annotation.PropertySource;
 
 @Configuration
 @EnableConfigurationProperties(LegacyOperateProperties.class)
 @PropertySource("classpath:operate-version.properties")
-@Profile("operate")
 public class OperatePropertiesOverride {
 
   private final UnifiedConfiguration unifiedConfiguration;

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/TasklistPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/TasklistPropertiesOverride.java
@@ -15,13 +15,11 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
-import org.springframework.context.annotation.Profile;
 import org.springframework.context.annotation.PropertySource;
 
 @Configuration
 @EnableConfigurationProperties(LegacyTasklistProperties.class)
 @PropertySource("classpath:tasklist-version.properties")
-@Profile("tasklist")
 public class TasklistPropertiesOverride {
 
   private final UnifiedConfiguration unifiedConfiguration;

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -746,6 +746,13 @@
       <artifactId>wiremock-standalone</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>com.github.docker-java</groupId>
+      <artifactId>docker-java-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/dist/src/main/java/io/camunda/application/StandalonePrefixMigration.java
+++ b/dist/src/main/java/io/camunda/application/StandalonePrefixMigration.java
@@ -9,6 +9,9 @@ package io.camunda.application;
 
 import io.camunda.application.commons.migration.PrefixMigrationHelper;
 import io.camunda.application.commons.search.SearchEngineDatabaseConfiguration;
+import io.camunda.configuration.UnifiedConfiguration;
+import io.camunda.configuration.beanoverrides.OperatePropertiesOverride;
+import io.camunda.configuration.beanoverrides.TasklistPropertiesOverride;
 import io.camunda.operate.property.OperateProperties;
 import io.camunda.search.connect.configuration.ConnectConfiguration;
 import io.camunda.tasklist.property.TasklistProperties;
@@ -49,8 +52,9 @@ public class StandalonePrefixMigration implements CommandLineRunner {
             .sources(
                 StandalonePrefixMigration.class,
                 SearchEngineDatabaseConfiguration.class,
-                TasklistProperties.class,
-                OperateProperties.class)
+                UnifiedConfiguration.class,
+                TasklistPropertiesOverride.class,
+                OperatePropertiesOverride.class)
             .addCommandLineProperties(true)
             .build(args);
 

--- a/dist/src/main/java/io/camunda/application/commons/backup/BackupPriorityConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/backup/BackupPriorityConfiguration.java
@@ -10,8 +10,6 @@ package io.camunda.application.commons.backup;
 import static io.camunda.application.commons.backup.ConfigValidation.allMatch;
 import static io.camunda.application.commons.backup.ConfigValidation.skipEmptyOptional;
 
-import io.camunda.operate.conditions.DatabaseInfo;
-import io.camunda.operate.conditions.DatabaseType;
 import io.camunda.operate.property.OperateProperties;
 import io.camunda.tasklist.property.TasklistProperties;
 import io.camunda.webapps.profiles.ProfileWebApp;
@@ -184,8 +182,7 @@ public class BackupPriorityConfiguration {
             differentConfigFor("database.type"),
             Map.of(
                 "operate",
-                Optional.ofNullable(operateProperties)
-                    .map(ignored -> DatabaseInfo.isCurrent(DatabaseType.Elasticsearch)),
+                Optional.ofNullable(operateProperties).map(OperateProperties::isElasticsearchDB),
                 "tasklist",
                 Optional.ofNullable(tasklistProperties)
                     .map(prop -> prop.getDatabase().equals(TasklistProperties.ELASTIC_SEARCH))),

--- a/dist/src/test/java/io/camunda/application/CamundaDockerIT.java
+++ b/dist/src/test/java/io/camunda/application/CamundaDockerIT.java
@@ -117,7 +117,8 @@ public class CamundaDockerIT {
             .withCreateContainerCmdModifier(
                 (final CreateContainerCmd cmd) ->
                     cmd.withEntrypoint("/usr/local/camunda/bin/prefix-migration"))
-            .withStartupCheckStrategy(new OneShotStartupCheckStrategy())
+            .withStartupCheckStrategy(
+                new OneShotStartupCheckStrategy().withTimeout(Duration.ofSeconds(180)))
             .withNetwork(Network.SHARED)
             .withNetworkAliases(CAMUNDA_NETWORK_ALIAS)
             .withEnv("CAMUNDA_TASKLIST_ELASTICSEARCH_URL", elasticsearchUrl())

--- a/dist/src/test/java/io/camunda/application/CamundaDockerIT.java
+++ b/dist/src/test/java/io/camunda/application/CamundaDockerIT.java
@@ -12,6 +12,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.dockerjava.api.command.CreateContainerCmd;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
@@ -25,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
+import org.testcontainers.containers.startupcheck.OneShotStartupCheckStrategy;
 import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
 import org.testcontainers.elasticsearch.ElasticsearchContainer;
 
@@ -98,6 +100,33 @@ public class CamundaDockerIT {
 
       assertThat(actualJson).isEqualTo(expectedJson);
     }
+  }
+
+  // Regression for https://github.com/camunda/camunda/issues/35520
+  @Test
+  public void testStartStandalonePrefixMigration() throws Exception {
+    // given
+    // create and start Elasticsearch container
+    final ElasticsearchContainer elasticsearchContainer =
+        createContainer(this::createElasticsearchContainer);
+    elasticsearchContainer.start();
+
+    // create camunda container with only StandalonePrefixMigration app
+    final var prefixMigrationContainer =
+        new GenericContainer<>(CAMUNDA_TEST_DOCKER_IMAGE)
+            .withCreateContainerCmdModifier(
+                (final CreateContainerCmd cmd) ->
+                    cmd.withEntrypoint("/usr/local/camunda/bin/prefix-migration"))
+            .withStartupCheckStrategy(new OneShotStartupCheckStrategy())
+            .withNetwork(Network.SHARED)
+            .withNetworkAliases(CAMUNDA_NETWORK_ALIAS)
+            .withEnv("CAMUNDA_TASKLIST_ELASTICSEARCH_URL", elasticsearchUrl())
+            .withEnv("CAMUNDA_OPERATE_ELASTICSEARCH_URL", elasticsearchUrl())
+            .withEnv("CAMUNDA_DATABASE_INDEXPREFIX", "some-prefix")
+            .withEnv("CAMUNDA_DATABASE_URL", elasticsearchUrl());
+
+    // when - then the container should start without errors
+    startContainer(createContainer(() -> prefixMigrationContainer));
   }
 
   private void startContainer(final GenericContainer container) {

--- a/operate/common/src/main/java/io/camunda/operate/property/OperateProperties.java
+++ b/operate/common/src/main/java/io/camunda/operate/property/OperateProperties.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.operate.property;
 
-import io.camunda.operate.conditions.DatabaseInfo;
 import io.camunda.operate.conditions.DatabaseType;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Value;
@@ -89,6 +88,24 @@ public class OperateProperties {
 
   @NestedConfigurationProperty
   private WebSecurityProperties webSecurity = new WebSecurityProperties();
+
+  private DatabaseType database = DatabaseType.Elasticsearch;
+
+  public DatabaseType getDatabase() {
+    return database;
+  }
+
+  public void setDatabase(final DatabaseType database) {
+    this.database = database;
+  }
+
+  public boolean isElasticsearchDB() {
+    return DatabaseType.Elasticsearch.equals(database);
+  }
+
+  public boolean isOpensearchDB() {
+    return DatabaseType.Opensearch.equals(database);
+  }
 
   public boolean isImporterEnabled() {
     return importerEnabled;
@@ -340,6 +357,6 @@ public class OperateProperties {
   }
 
   public String getIndexPrefix() {
-    return getIndexPrefix(DatabaseInfo.getCurrent());
+    return getIndexPrefix(database);
   }
 }

--- a/schema-manager/src/main/java/io/camunda/search/schema/opensearch/OpensearchPrefixMigrationClient.java
+++ b/schema-manager/src/main/java/io/camunda/search/schema/opensearch/OpensearchPrefixMigrationClient.java
@@ -20,6 +20,7 @@ import org.opensearch.client.opensearch._types.OpType;
 import org.opensearch.client.opensearch.cat.indices.IndicesRecord;
 import org.opensearch.client.opensearch.core.ReindexRequest;
 import org.opensearch.client.opensearch.indices.Alias;
+import org.opensearch.client.opensearch.indices.ExistsRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,8 +42,11 @@ public class OpensearchPrefixMigrationClient implements PrefixMigrationClient {
             .build();
 
     try {
-      LOG.info("Reindexing [{}] into [{}]", src, dest);
-      client.reindex(reindexRequest);
+      final var existRequest = new ExistsRequest.Builder().index(src).build();
+      if (client.indices().exists(existRequest).value()) {
+        LOG.info("Reindexing [{}] into [{}]", src, dest);
+        client.reindex(reindexRequest);
+      }
       return new ReindexResult(true, src, dest, null);
     } catch (final IOException e) {
       LOG.error("Failed to reindex [{}] into [{}]", src, dest, e);


### PR DESCRIPTION
## Description

* Refactor OperateProperties to not depend on `DatabaseInfo`. This was causing issues when injecting beans in prefix migration.
* Added a test to verify that prefix migration app can start.
* Refactored migration client to check for indices before migration. Without this the newly added test was failing because ES/OS has no data. The test has to only verify if the app can start, so there was no need to fill ES with data.

## Related issues

closes #35520 
