### PR TITLE
feat: allow segments manager to handle overlaps

### DIFF
--- a/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentsManager.java
+++ b/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentsManager.java
@@ -268,14 +268,7 @@ final class SegmentsManager implements AutoCloseable {
     if (lastSegment != null) {
       currentSegment = lastSegment;
     } else {
-      final SegmentDescriptor descriptor =
-          SegmentDescriptor.builder()
-              .withId(FIRST_SEGMENT_ID)
-              .withIndex(INITIAL_INDEX)
-              .withMaxSegmentSize(maxSegmentSize)
-              .build();
-
-      currentSegment = createSegment(descriptor, INITIAL_ASQN);
+      currentSegment = createInitialSegment();
 
       segments.put(1L, currentSegment);
       journalMetrics.incSegmentCount();
@@ -286,23 +279,19 @@ final class SegmentsManager implements AutoCloseable {
   void open() {
     final var openDurationTimer = journalMetrics.startJournalOpenDurationTimer();
     // Load existing log segments from disk.
-    for (final Segment segment : loadSegments()) {
-      segments.put(segment.descriptor().index(), segment);
-      journalMetrics.incSegmentCount();
-    }
+    loadSegments()
+        .forEach(
+            segment -> {
+              if (segments.put(segment.descriptor().index(), segment) == null) {
+                journalMetrics.incSegmentCount();
+              }
+            });
 
     // If a segment doesn't already exist, create an initial segment starting at index 1.
     if (!segments.isEmpty()) {
       currentSegment = segments.lastEntry().getValue();
     } else {
-      final SegmentDescriptor descriptor =
-          SegmentDescriptor.builder()
-              .withId(FIRST_SEGMENT_ID)
-              .withIndex(INITIAL_INDEX)
-              .withMaxSegmentSize(maxSegmentSize)
-              .build();
-
-      currentSegment = createSegment(descriptor, INITIAL_ASQN);
+      currentSegment = createInitialSegment();
 
       segments.put(1L, currentSegment);
       journalMetrics.incSegmentCount();
@@ -324,6 +313,17 @@ final class SegmentsManager implements AutoCloseable {
             .withMaxSegmentSize(maxSegmentSize)
             .build();
     nextSegment = CompletableFuture.supplyAsync(() -> createUninitializedSegment(descriptor));
+  }
+
+  private Segment createInitialSegment() {
+    final SegmentDescriptor descriptor =
+        SegmentDescriptor.builder()
+            .withId(FIRST_SEGMENT_ID)
+            .withIndex(INITIAL_INDEX)
+            .withMaxSegmentSize(maxSegmentSize)
+            .build();
+
+    return createSegment(descriptor, INITIAL_ASQN);
   }
 
   SortedMap<Long, Segment> getTailSegments(final long index) {
@@ -390,7 +390,6 @@ final class SegmentsManager implements AutoCloseable {
         if (handleSegmentCorruption(files, segments, i, lastFlushedIndex)) {
           return segments;
         }
-
         throw e;
       }
     }
@@ -399,7 +398,7 @@ final class SegmentsManager implements AutoCloseable {
   }
 
   private void checkForIndexGaps(final Segment prevSegment, final Segment segment) {
-    if (prevSegment.lastIndex() != segment.index() - 1) {
+    if (prevSegment.lastIndex() < segment.index() - 1) {
       throw new CorruptedJournalException(
           String.format(
               "Log segment %s is not aligned with previous segment %s (last index: %d).",
@@ -419,7 +418,7 @@ final class SegmentsManager implements AutoCloseable {
       long lastSegmentIndex = 0;
 
       if (!segments.isEmpty()) {
-        final Segment previousSegment = segments.get(segments.size() - 1);
+        final Segment previousSegment = segments.getLast();
         lastSegmentIndex = previousSegment.lastIndex();
       }
 

--- a/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentsManager.java
+++ b/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentsManager.java
@@ -282,7 +282,12 @@ final class SegmentsManager implements AutoCloseable {
     loadSegments()
         .forEach(
             segment -> {
-              if (segments.put(segment.descriptor().index(), segment) == null) {
+              final Segment replacedSegment = segments.put(segment.descriptor().index(), segment);
+              if (replacedSegment != null) {
+                // The previous segment can be safely deleted to free resources.
+                replacedSegment.close();
+                replacedSegment.delete();
+              } else {
                 journalMetrics.incSegmentCount();
               }
             });

--- a/zeebe/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentsManagerTest.java
+++ b/zeebe/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentsManagerTest.java
@@ -16,27 +16,37 @@ import io.camunda.zeebe.journal.CorruptedJournalException;
 import io.camunda.zeebe.test.util.junit.RegressionTest;
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
 import org.agrona.CloseHelper;
 import org.agrona.collections.ArrayUtil;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mockito;
 
 class SegmentsManagerTest {
   private static final String JOURNAL_NAME = "journal";
-  private final TestJournalFactory journalFactory = new TestJournalFactory();
-
+  private TestJournalFactory journalFactory;
   private @TempDir Path directory;
   private SegmentsManager segments;
+  private final List<AutoCloseable> closeables = new ArrayList<>();
+
+  @BeforeEach
+  void beforeEach() {
+    journalFactory = new TestJournalFactory();
+  }
 
   @AfterEach
   void afterEach() {
     CloseHelper.quietClose(segments);
+    closeables.forEach(CloseHelper::quietClose);
   }
 
   @Test
@@ -293,7 +303,139 @@ class SegmentsManagerTest {
     }
   }
 
+  @Test
+  void shouldReplaceSegmentWithLargerOneOnOpen() throws IOException {
+    // given two journals, to simulate segments with same id but different lastIndex
+    final var journal = openJournal(directory, 3);
+    final var journal2 = openJournal(directory.resolve("secondary"), 3);
+    journal.append(1, journalFactory.entry()).index();
+    journal.getLastSegment().updateDescriptor();
+    journal.close();
+
+    appendJournalEntries(journal2, 1, 2, 3);
+    journal2.getLastSegment().updateDescriptor();
+    journal2.close();
+
+    // move the segment file from the second journal to the first one, replacing the suffix to point
+    // to a segment further in time
+    Files.move(
+        directory.resolve("secondary").resolve("data").resolve("journal-1.log"),
+        directory.resolve("data").resolve("journal-2.log"));
+
+    // when opening the journal
+    final var segmentsManager = journalFactory.segmentsManager(directory);
+    segmentsManager.open();
+
+    // then the segment with the greater lastIndex should be used
+    final var segment = segmentsManager.getCurrentSegment();
+    assertThat(segment.id()).isEqualTo(1);
+    assertThat(segment.file().file().getName()).isEqualTo("journal-2.log");
+    assertThat(segment.lastIndex()).isEqualTo(3);
+    assertThat(segmentsManager.getFirstSegment()).isEqualTo(segmentsManager.getLastSegment());
+  }
+
+  @Test
+  void shouldBuildJournalWithContinuousOverlaps() throws IOException {
+    // given three journals, to simulate segments with same id but different lastIndex
+    final var journal = openJournal(directory, 3);
+    final var journal2 = openJournal(directory.resolve("secondary"), 3);
+    final var journal3 = openJournal(directory.resolve("third"), 5);
+    appendJournalEntries(journal, 1, 2);
+    journal.getLastSegment().updateDescriptor();
+    journal.close();
+
+    appendJournalEntries(journal2, 1, 2, 3);
+    journal2.getLastSegment().updateDescriptor();
+    journal2.close();
+
+    appendJournalEntries(journal3, 1, 2, 3, 4, 5);
+    journal3.getLastSegment().updateDescriptor();
+    journal3.close();
+
+    // move the segment file from the second journal to the first one, replacing the suffix to point
+    // to a segment further in time
+    Files.move(
+        directory.resolve("secondary").resolve("data").resolve("journal-1.log"),
+        directory.resolve("data").resolve("journal-2.log"));
+
+    Files.move(
+        directory.resolve("third").resolve("data").resolve("journal-1.log"),
+        directory.resolve("data").resolve("journal-3.log"));
+
+    // when opening the journal
+    final var segmentsManager = journalFactory.segmentsManager(directory);
+    segmentsManager.open();
+
+    // then the segment with the greater lastIndex should be used
+    final var segment = segmentsManager.getCurrentSegment();
+    assertThat(segment.id()).isEqualTo(1);
+    assertThat(segment.file().file().getName()).isEqualTo("journal-3.log");
+    assertThat(segment.lastIndex()).isEqualTo(5);
+    assertThat(segmentsManager.getFirstSegment()).isEqualTo(segmentsManager.getLastSegment());
+  }
+
+  @Test
+  void shouldBuildJournalWithSegmentedOverlaps() throws IOException {
+    // given three journals, to simulate segments with same id but different lastIndex
+    final var journal = openJournal(directory, 3);
+    final var journal2 = openJournal(directory.resolve("secondary"), 2);
+    final var journal3 = openJournal(directory.resolve("third"), 2);
+    appendJournalEntries(journal, 1, 2);
+    journal.getLastSegment().updateDescriptor();
+
+    appendJournalEntries(journal2, -1, -1, 3, 4);
+    journal2.getLastSegment().updateDescriptor();
+
+    appendJournalEntries(journal3, -1, -1, -1, 4, 5, 6);
+    journal3.getLastSegment().updateDescriptor();
+
+    // move segment with id 2 from the second journal to the first one, replacing the suffix to
+    // point
+    // to a segment further in time
+    Files.move(
+        directory.resolve("secondary").resolve("data").resolve("journal-2.log"),
+        directory.resolve("data").resolve("journal-2.log"));
+
+    // move segment with id 3 from the third journal to the first one, replacing the suffix to point
+    // to a segment further in time
+    Files.move(
+        directory.resolve("third").resolve("data").resolve("journal-3.log"),
+        directory.resolve("data").resolve("journal-3.log"));
+
+    // when opening the journal
+    final var segmentsManager = journalFactory.segmentsManager(directory);
+    segmentsManager.open();
+
+    // then the segment with the greater lastIndex should be used
+    final var segment = segmentsManager.getCurrentSegment();
+    assertThat(segment.id()).isEqualTo(3);
+    assertThat(segment.file().file().getName()).isEqualTo("journal-3.log");
+    assertThat(segment.lastIndex()).isEqualTo(6);
+
+    assertThat(segmentsManager.getNextSegment(1).id()).isEqualTo(journal2.getSegment(3).id());
+    assertThat(segmentsManager.getLastSegment().id()).isEqualTo(journal3.getLastSegment().id());
+    journal.close();
+    journal2.close();
+    journal3.close();
+  }
+
+  private void appendJournalEntries(final SegmentedJournal journal, final int... asqns) {
+    Arrays.stream(asqns).forEach(asqn -> journal.append(asqn, journalFactory.entry()));
+  }
+
   private SegmentedJournal openJournal() {
     return journalFactory.journal(journalFactory.segmentsManager(directory));
+  }
+
+  private SegmentedJournal openJournal(final Path directory, final int entriesPerSegment) {
+    return openJournal("test", directory, entriesPerSegment);
+  }
+
+  private SegmentedJournal openJournal(
+      final String data, final Path directory, final int entriesPerSegment) {
+    journalFactory = new TestJournalFactory(data, entriesPerSegment);
+    final var journal = journalFactory.journal(journalFactory.segmentsManager(directory));
+    closeables.add(journal);
+    return journal;
   }
 }

--- a/zeebe/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentsManagerTest.java
+++ b/zeebe/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentsManagerTest.java
@@ -26,6 +26,7 @@ import java.util.Objects;
 import org.agrona.CloseHelper;
 import org.agrona.collections.ArrayUtil;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -402,6 +403,51 @@ class SegmentsManagerTest {
     assertThat(lastSegment.file().name()).isEqualTo("journal-3.log");
   }
 
+  @Test
+  void shouldBuildJournalWithPartialOverlap() throws IOException {
+    // given two journals, to simulate segments with different first and last index
+    final var journal = openJournal(directory, 5);
+    final var secondaryJournal = openJournal(directory.resolve("secondary"), 5);
+    closeables.addAll(List.of(journal, secondaryJournal));
+
+    appendJournalEntries(journal, 1, 2, 3, 4, 5);
+    journal.getLastSegment().updateDescriptor();
+
+    secondaryJournal.reset(3);
+    appendJournalEntries(secondaryJournal, 3, 4, 5, 6, 7);
+    secondaryJournal.getLastSegment().updateDescriptor();
+
+    // move segment with id 2 from the second journal to the first one, replacing the suffix to
+    // point to a segment further in time
+    Files.move(
+        directory.resolve("secondary").resolve("data").resolve("journal-1.log"),
+        directory.resolve("data").resolve("journal-2.log"));
+
+    // when opening the journal
+    segments = journalFactory.segmentsManager(directory);
+    segments.open();
+
+    // then the segment with the greater lastIndex should be used
+    final var segment = segments.getCurrentSegment();
+    assertThat(segment.file().file().getName()).isEqualTo("journal-2.log");
+    assertThat(segment.lastIndex()).isEqualTo(7);
+    assertThat(segment.lastAsqn()).isEqualTo(7);
+
+    // First segment should be the one from the first journal
+    final var firstSegment = segments.getFirstSegment();
+    Assertions.assertNotNull(firstSegment);
+    assertThat(firstSegment.lastIndex()).isEqualTo(journal.getFirstSegment().lastIndex());
+    assertThat(firstSegment.lastAsqn()).isEqualTo(journal.getFirstSegment().lastAsqn());
+    assertThat(firstSegment.file().name()).isEqualTo("journal-1.log");
+
+    // Last segment should be the one from the third journal
+    final var lastSegment = segments.getLastSegment();
+    Assertions.assertNotNull(lastSegment);
+    assertThat(lastSegment.lastIndex()).isEqualTo(secondaryJournal.getFirstSegment().lastIndex());
+    assertThat(lastSegment.lastAsqn()).isEqualTo(secondaryJournal.getFirstSegment().lastAsqn());
+    assertThat(lastSegment.file().name()).isEqualTo("journal-2.log");
+  }
+
   private void appendJournalEntries(final SegmentedJournal journal, final int... asqns) {
     Arrays.stream(asqns).forEach(asqn -> journal.append(asqn, journalFactory.entry()));
   }
@@ -412,14 +458,6 @@ class SegmentsManagerTest {
 
   private SegmentedJournal openJournal(final Path directory, final int entriesPerSegment) {
     journalFactory = new TestJournalFactory(entriesPerSegment);
-    final var journal = journalFactory.journal(journalFactory.segmentsManager(directory));
-    closeables.add(journal);
-    return journal;
-  }
-
-  private SegmentedJournal openJournal(
-      final String data, final Path directory, final int entriesPerSegment) {
-    journalFactory = new TestJournalFactory(data, entriesPerSegment);
     final var journal = journalFactory.journal(journalFactory.segmentsManager(directory));
     closeables.add(journal);
     return journal;

--- a/zeebe/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentsManagerTest.java
+++ b/zeebe/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentsManagerTest.java
@@ -342,6 +342,8 @@ class SegmentsManagerTest {
     assertThat(segment.lastAsqn()).isEqualTo(thirdJournal.getLastSegment().lastAsqn());
     assertThat(segment.lastIndex()).isEqualTo(5);
     assertThat(segments.getFirstSegment()).isEqualTo(segments.getLastSegment());
+    assertThat(directory.resolve("data").resolve("journal-1.log")).doesNotExist();
+    assertThat(directory.resolve("data").resolve("journal-2.log")).doesNotExist();
   }
 
   @Test
@@ -401,6 +403,9 @@ class SegmentsManagerTest {
     assertThat(lastSegment.lastIndex()).isEqualTo(thirdJournal.getFirstSegment().lastIndex());
     assertThat(lastSegment.lastAsqn()).isEqualTo(thirdJournal.getFirstSegment().lastAsqn());
     assertThat(lastSegment.file().name()).isEqualTo("journal-3.log");
+    assertThat(directory.resolve("data").resolve("journal-1.log")).exists();
+    assertThat(directory.resolve("data").resolve("journal-2.log")).exists();
+    assertThat(directory.resolve("data").resolve("journal-3.log")).exists();
   }
 
   @Test
@@ -446,6 +451,8 @@ class SegmentsManagerTest {
     assertThat(lastSegment.lastIndex()).isEqualTo(secondaryJournal.getFirstSegment().lastIndex());
     assertThat(lastSegment.lastAsqn()).isEqualTo(secondaryJournal.getFirstSegment().lastAsqn());
     assertThat(lastSegment.file().name()).isEqualTo("journal-2.log");
+    assertThat(directory.resolve("data").resolve("journal-1.log")).exists();
+    assertThat(directory.resolve("data").resolve("journal-2.log")).exists();
   }
 
   private void appendJournalEntries(final SegmentedJournal journal, final int... asqns) {

--- a/zeebe/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentsManagerTest.java
+++ b/zeebe/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentsManagerTest.java
@@ -304,53 +304,22 @@ class SegmentsManagerTest {
   }
 
   @Test
-  void shouldReplaceSegmentWithLargerOneOnOpen() throws IOException {
-    // given two journals, to simulate segments with same id but different lastIndex
+  void shouldBuildJournalWithLargestSegment() throws IOException {
+    // given three journals, to simulate segments with different first and last index
     final var journal = openJournal(directory, 3);
-    final var journal2 = openJournal(directory.resolve("secondary"), 3);
-    journal.append(1, journalFactory.entry()).index();
-    journal.getLastSegment().updateDescriptor();
-    journal.close();
+    final var secondaryJournal = openJournal(directory.resolve("secondary"), 3);
+    final var thirdJournal = openJournal(directory.resolve("third"), 5);
+    closeables.addAll(List.of(journal, secondaryJournal, thirdJournal));
 
-    appendJournalEntries(journal2, 1, 2, 3);
-    journal2.getLastSegment().updateDescriptor();
-    journal2.close();
-
-    // move the segment file from the second journal to the first one, replacing the suffix to point
-    // to a segment further in time
-    Files.move(
-        directory.resolve("secondary").resolve("data").resolve("journal-1.log"),
-        directory.resolve("data").resolve("journal-2.log"));
-
-    // when opening the journal
-    final var segmentsManager = journalFactory.segmentsManager(directory);
-    segmentsManager.open();
-
-    // then the segment with the greater lastIndex should be used
-    final var segment = segmentsManager.getCurrentSegment();
-    assertThat(segment.id()).isEqualTo(1);
-    assertThat(segment.file().file().getName()).isEqualTo("journal-2.log");
-    assertThat(segment.lastIndex()).isEqualTo(3);
-    assertThat(segmentsManager.getFirstSegment()).isEqualTo(segmentsManager.getLastSegment());
-  }
-
-  @Test
-  void shouldBuildJournalWithContinuousOverlaps() throws IOException {
-    // given three journals, to simulate segments with same id but different lastIndex
-    final var journal = openJournal(directory, 3);
-    final var journal2 = openJournal(directory.resolve("secondary"), 3);
-    final var journal3 = openJournal(directory.resolve("third"), 5);
     appendJournalEntries(journal, 1, 2);
     journal.getLastSegment().updateDescriptor();
-    journal.close();
 
-    appendJournalEntries(journal2, 1, 2, 3);
-    journal2.getLastSegment().updateDescriptor();
-    journal2.close();
+    appendJournalEntries(secondaryJournal, 1, 2, 3);
+    secondaryJournal.getLastSegment().updateDescriptor();
+    secondaryJournal.close();
 
-    appendJournalEntries(journal3, 1, 2, 3, 4, 5);
-    journal3.getLastSegment().updateDescriptor();
-    journal3.close();
+    appendJournalEntries(thirdJournal, 1, 2, 3, 4, 5);
+    thirdJournal.getLastSegment().updateDescriptor();
 
     // move the segment file from the second journal to the first one, replacing the suffix to point
     // to a segment further in time
@@ -363,60 +332,74 @@ class SegmentsManagerTest {
         directory.resolve("data").resolve("journal-3.log"));
 
     // when opening the journal
-    final var segmentsManager = journalFactory.segmentsManager(directory);
-    segmentsManager.open();
+    segments = journalFactory.segmentsManager(directory);
+    segments.open();
 
     // then the segment with the greater lastIndex should be used
-    final var segment = segmentsManager.getCurrentSegment();
-    assertThat(segment.id()).isEqualTo(1);
+    final var segment = segments.getCurrentSegment();
     assertThat(segment.file().file().getName()).isEqualTo("journal-3.log");
+    assertThat(segment.lastAsqn()).isEqualTo(thirdJournal.getLastSegment().lastAsqn());
     assertThat(segment.lastIndex()).isEqualTo(5);
-    assertThat(segmentsManager.getFirstSegment()).isEqualTo(segmentsManager.getLastSegment());
+    assertThat(segments.getFirstSegment()).isEqualTo(segments.getLastSegment());
   }
 
   @Test
-  void shouldBuildJournalWithSegmentedOverlaps() throws IOException {
-    // given three journals, to simulate segments with same id but different lastIndex
+  void shouldBuildJournalWithContinuousOverlaps() throws IOException {
+    // given three journals, to simulate segments with different first and last index
     final var journal = openJournal(directory, 3);
-    final var journal2 = openJournal(directory.resolve("secondary"), 2);
-    final var journal3 = openJournal(directory.resolve("third"), 2);
+    final var secondaryJournal = openJournal(directory.resolve("secondary"), 2);
+    final var thirdJournal = openJournal(directory.resolve("third"), 2);
+    closeables.addAll(List.of(journal, secondaryJournal, thirdJournal));
+
     appendJournalEntries(journal, 1, 2);
     journal.getLastSegment().updateDescriptor();
 
-    appendJournalEntries(journal2, -1, -1, 3, 4);
-    journal2.getLastSegment().updateDescriptor();
+    secondaryJournal.reset(2);
+    appendJournalEntries(secondaryJournal, 2, 3);
+    secondaryJournal.getLastSegment().updateDescriptor();
 
-    appendJournalEntries(journal3, -1, -1, -1, 4, 5, 6);
-    journal3.getLastSegment().updateDescriptor();
+    thirdJournal.reset(3);
+    appendJournalEntries(thirdJournal, 3, 4);
+    thirdJournal.getLastSegment().updateDescriptor();
 
     // move segment with id 2 from the second journal to the first one, replacing the suffix to
-    // point
-    // to a segment further in time
+    // point to a segment further in time
     Files.move(
-        directory.resolve("secondary").resolve("data").resolve("journal-2.log"),
+        directory.resolve("secondary").resolve("data").resolve("journal-1.log"),
         directory.resolve("data").resolve("journal-2.log"));
 
     // move segment with id 3 from the third journal to the first one, replacing the suffix to point
     // to a segment further in time
     Files.move(
-        directory.resolve("third").resolve("data").resolve("journal-3.log"),
+        directory.resolve("third").resolve("data").resolve("journal-1.log"),
         directory.resolve("data").resolve("journal-3.log"));
 
     // when opening the journal
-    final var segmentsManager = journalFactory.segmentsManager(directory);
-    segmentsManager.open();
+    segments = journalFactory.segmentsManager(directory);
+    segments.open();
 
     // then the segment with the greater lastIndex should be used
-    final var segment = segmentsManager.getCurrentSegment();
-    assertThat(segment.id()).isEqualTo(3);
+    final var segment = segments.getCurrentSegment();
     assertThat(segment.file().file().getName()).isEqualTo("journal-3.log");
-    assertThat(segment.lastIndex()).isEqualTo(6);
+    assertThat(segment.lastIndex()).isEqualTo(4);
 
-    assertThat(segmentsManager.getNextSegment(1).id()).isEqualTo(journal2.getSegment(3).id());
-    assertThat(segmentsManager.getLastSegment().id()).isEqualTo(journal3.getLastSegment().id());
-    journal.close();
-    journal2.close();
-    journal3.close();
+    // First segment should be the one from the first journal
+    final var firstSegment = segments.getFirstSegment();
+    assertThat(firstSegment.lastIndex()).isEqualTo(journal.getFirstSegment().lastIndex());
+    assertThat(firstSegment.lastAsqn()).isEqualTo(journal.getFirstSegment().lastAsqn());
+    assertThat(firstSegment.file().name()).isEqualTo("journal-1.log");
+
+    // Second segment should be the one from the second journal
+    final var secondSegment = segments.getSegment(2);
+    assertThat(secondSegment.lastIndex()).isEqualTo(secondaryJournal.getFirstSegment().lastIndex());
+    assertThat(secondSegment.lastAsqn()).isEqualTo(secondaryJournal.getFirstSegment().lastAsqn());
+    assertThat(secondSegment.file().name()).isEqualTo("journal-2.log");
+
+    // Last segment should be the one from the third journal
+    final var lastSegment = segments.getLastSegment();
+    assertThat(lastSegment.lastIndex()).isEqualTo(thirdJournal.getFirstSegment().lastIndex());
+    assertThat(lastSegment.lastAsqn()).isEqualTo(thirdJournal.getFirstSegment().lastAsqn());
+    assertThat(lastSegment.file().name()).isEqualTo("journal-3.log");
   }
 
   private void appendJournalEntries(final SegmentedJournal journal, final int... asqns) {
@@ -428,7 +411,10 @@ class SegmentsManagerTest {
   }
 
   private SegmentedJournal openJournal(final Path directory, final int entriesPerSegment) {
-    return openJournal("test", directory, entriesPerSegment);
+    journalFactory = new TestJournalFactory(entriesPerSegment);
+    final var journal = journalFactory.journal(journalFactory.segmentsManager(directory));
+    closeables.add(journal);
+    return journal;
   }
 
   private SegmentedJournal openJournal(


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
`SegmentsManager` can handle overlapping segments during restore from multiple backups. The given point, as discussed, is that the segment files from all the backups will be sorted before building the Journal. That means that it's safe to replace segments with a given `index` upon discovering one later in the list of parsed segments, since it will be guaranteed that it would have the same or greater `lastIndex`. 

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #35521
