### PR TITLE
fix: retry on sneaky thrown exceptions in schema manager

### DIFF
--- a/schema-manager/pom.xml
+++ b/schema-manager/pom.xml
@@ -91,6 +91,11 @@
     </dependency>
 
     <dependency>
+      <groupId>io.github.resilience4j</groupId>
+      <artifactId>resilience4j-core</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
       <scope>test</scope>

--- a/schema-manager/src/main/java/io/camunda/search/schema/SchemaManager.java
+++ b/schema-manager/src/main/java/io/camunda/search/schema/SchemaManager.java
@@ -103,7 +103,10 @@ public class SchemaManager {
         ofNullable(schemaManagerMetrics)
             .map(SchemaManagerMetrics::startSchemaInitTimer)
             .orElse(() -> {});
-    retryDecorator.decorate("init schema", this::initializeSchema);
+    // even that initializeSchema does not declare throwing any exception, it may still do sneaky
+    // throws (see #joinOnFutures) which are retried only by
+    // io.github.resilience4j.retry.Retry.decorateCheckedRunnable
+    retryDecorator.decorateCheckedRunnable("init schema", this::initializeSchema);
     // record the time taken to initialize schema only if it was successful
     timer.close();
   }

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/retry/RetryDecorator.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/retry/RetryDecorator.java
@@ -66,6 +66,10 @@ public class RetryDecorator {
     return Retry.decorateCallable(retry, callable).call();
   }
 
+  /**
+   * Caution: This method will retry only on unchecked exceptions (extending RuntimeException).
+   * Sneaky throws of checked exceptions will not be retried.
+   */
   public void decorate(final String operationName, final Runnable runnable) {
     final Retry retry = buildRetry(operationName, null);
     Retry.decorateRunnable(retry, runnable).run();

--- a/zeebe/util/src/test/java/io/camunda/zeebe/util/retry/RetryDecoratorTest.java
+++ b/zeebe/util/src/test/java/io/camunda/zeebe/util/retry/RetryDecoratorTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.util.retry;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import org.agrona.LangUtil;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class RetryDecoratorTest {
+
+  private RetryDecorator retryDecorator;
+
+  @BeforeEach
+  void setUp() {
+    final var retryConfiguration = new RetryConfiguration();
+    retryConfiguration.setMaxRetries(2); // retry twice
+    retryDecorator = new RetryDecorator(retryConfiguration);
+  }
+
+  @Test
+  void shouldDecorateCheckedRunnableRetryOnSneakyThrows() {
+    // given
+    final Runnable runnable = mock(Runnable.class);
+    doAnswer(
+            a -> {
+              LangUtil.rethrowUnchecked(new Exception("Sneaky throws"));
+              return null;
+            })
+        .doAnswer(a -> null)
+        .when(runnable)
+        .run();
+    // when
+    retryDecorator.decorateCheckedRunnable("operation", () -> runnable.run());
+    // then
+    verify(runnable, times(2)).run();
+  }
+
+  @Test
+  void shouldDecorateRunnableNotRetryOnSneakyThrows() {
+    // given
+    final Runnable runnable = mock(Runnable.class);
+    doAnswer(
+            a -> {
+              LangUtil.rethrowUnchecked(new Exception("Sneaky throws"));
+              return null;
+            })
+        .doAnswer(a -> null)
+        .when(runnable)
+        .run();
+
+    // when
+    final var exception =
+        assertThrows(Exception.class, () -> retryDecorator.decorate("operation", runnable));
+
+    // then
+    verify(runnable, times(1)).run();
+    assertThat(exception.getMessage()).isEqualTo("Sneaky throws");
+  }
+}


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
I have noticed that when there is an exception thrown on index creation or index template creation (timeout or connectivity exceptions), the schema manager does not trigger retries
This is due to sneaky throws of checked exceptions in https://github.com/camunda/camunda/blob/c8579167b2172c0cc1fcb0787f6a015d9275ae7b/schema-manager/src/main/java/io/camunda/search/schema/SchemaManager.java#L276

Resilience4j's `Retry.decorateRunnable(Runnable)` retries only for exceptions extending `RuntimeException` which is not the case here even if the exception is not declared by the method. See discussion [here](https://camunda.slack.com/archives/C01H4NG9XDY/p1752766609854409)
We need to use `Retry.decorateCheckedRunnable(CheckedRunnable)` that handles all exceptions extending Exception.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

