### PR TITLE
refactor: enforce that an `Authorization` is provided when calling the search client

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/migration/IdentityMigrationModuleConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/migration/IdentityMigrationModuleConfiguration.java
@@ -25,10 +25,7 @@ import io.camunda.search.clients.MappingRuleSearchClient;
 import io.camunda.search.clients.RoleSearchClient;
 import io.camunda.search.clients.SearchClientsProxy;
 import io.camunda.search.clients.TenantSearchClient;
-import io.camunda.search.clients.reader.AuthorizationReader;
-import io.camunda.search.clients.reader.impl.NoopAuthorizationReader;
 import io.camunda.security.configuration.SecurityConfiguration;
-import io.camunda.security.impl.AuthorizationChecker;
 import io.camunda.service.AuthorizationServices;
 import io.camunda.service.GroupServices;
 import io.camunda.service.MappingRuleServices;
@@ -123,20 +120,8 @@ public class IdentityMigrationModuleConfiguration {
   }
 
   @Bean
-  public SecurityContextProvider securityContextProvider(
-      final SecurityConfiguration securityConfiguration,
-      final AuthorizationChecker authorizationChecker) {
-    return new SecurityContextProvider(securityConfiguration, authorizationChecker);
-  }
-
-  @Bean
-  public AuthorizationReader authorizationReader() {
-    return new NoopAuthorizationReader();
-  }
-
-  @Bean
-  public AuthorizationChecker authorizationChecker(final AuthorizationReader authorizationReader) {
-    return new AuthorizationChecker(authorizationReader);
+  public SecurityContextProvider securityContextProvider() {
+    return new SecurityContextProvider();
   }
 
   @Bean

--- a/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
@@ -217,16 +217,16 @@ public class CamundaServicesConfiguration {
       final SecurityContextProvider securityContextProvider,
       final UserTaskSearchClient userTaskSearchClient,
       final FormServices formServices,
-      final FlowNodeInstanceSearchClient flowNodeInstanceSearchClient,
-      final VariableSearchClient variableSearchClient,
+      final ElementInstanceServices elementInstanceServices,
+      final VariableServices variableServices,
       final ProcessCache processCache) {
     return new UserTaskServices(
         brokerClient,
         securityContextProvider,
         userTaskSearchClient,
         formServices,
-        flowNodeInstanceSearchClient,
-        variableSearchClient,
+        elementInstanceServices,
+        variableServices,
         processCache,
         null);
   }
@@ -323,10 +323,8 @@ public class CamundaServicesConfiguration {
   }
 
   @Bean
-  public SecurityContextProvider securityContextProvider(
-      final SecurityConfiguration securityConfiguration,
-      final AuthorizationChecker authorizationChecker) {
-    return new SecurityContextProvider(securityConfiguration, authorizationChecker);
+  public SecurityContextProvider securityContextProvider() {
+    return new SecurityContextProvider();
   }
 
   @Bean

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/security/permission/PermissionsService.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/security/permission/PermissionsService.java
@@ -171,7 +171,7 @@ public class PermissionsService {
     final var authorization =
         Authorization.of(a -> a.resourceType(resourceType).permissionType(permissionType));
     final SecurityContext securityContext = getSecurityContext(authorization);
-    final List<String> ids = authorizationChecker.retrieveAuthorizedResourceKeys(securityContext);
+    final List<String> ids = authorizationChecker.retrieveAuthorizedResourceIds(securityContext);
 
     if (hasWildcardPermission(ids)) {
       return ResourcesAllowed.all();

--- a/qa/util/src/main/java/io/camunda/qa/util/cluster/TestCamundaApplication.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/cluster/TestCamundaApplication.java
@@ -176,6 +176,7 @@ public final class TestCamundaApplication extends TestSpringApplication<TestCamu
   public TestCamundaApplication withAuthorizationsEnabled() {
     // when using authorizations, api authentication needs to be enforced too
     withAuthenticatedAccess();
+    withProperty("camunda.security.authorizations.enabled", true);
     return withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true));
   }
 

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/auth/DefaultResourceAccessProvider.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/auth/DefaultResourceAccessProvider.java
@@ -30,12 +30,6 @@ public class DefaultResourceAccessProvider implements ResourceAccessProvider {
   @Override
   public <T> ResourceAccess resolveResourceAccess(
       final CamundaAuthentication authentication, final Authorization<T> requiredAuthorization) {
-    // right now, not all Services provide an authorization with #withSecurityContext()
-    // typically, the authorization check happens afterward in the respective Service
-    if (requiredAuthorization == null) {
-      return ResourceAccess.wildcard(null);
-    }
-
     final var resultingAuthorization =
         new Authorization.Builder<>()
             .resourceType(requiredAuthorization.resourceType())
@@ -43,7 +37,7 @@ public class DefaultResourceAccessProvider implements ResourceAccessProvider {
 
     // fetch the authorization entities for the authenticated user
     final var securityContext = createSecurityContext(authentication, requiredAuthorization);
-    final var resourceIds = authorizationChecker.retrieveAuthorizedResourceKeys(securityContext);
+    final var resourceIds = authorizationChecker.retrieveAuthorizedResourceIds(securityContext);
 
     if (resourceIds.contains(WILDCARD)) {
       // no authorization check required, user can access

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/auth/DisabledResourceAccessProvider.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/auth/DisabledResourceAccessProvider.java
@@ -7,6 +7,9 @@
  */
 package io.camunda.search.clients.auth;
 
+import static io.camunda.security.auth.Authorization.WILDCARD;
+import static io.camunda.security.auth.Authorization.withAuthorization;
+
 import io.camunda.security.auth.Authorization;
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.security.reader.ResourceAccess;
@@ -15,9 +18,9 @@ import io.camunda.security.reader.ResourceAccessProvider;
 public class DisabledResourceAccessProvider implements ResourceAccessProvider {
 
   @Override
-  public ResourceAccess resolveResourceAccess(
-      final CamundaAuthentication authentication, final Authorization requiredAuthorization) {
-    return ResourceAccess.wildcard(requiredAuthorization);
+  public <T> ResourceAccess resolveResourceAccess(
+      final CamundaAuthentication authentication, final Authorization<T> requiredAuthorization) {
+    return ResourceAccess.wildcard(withAuthorization(requiredAuthorization, WILDCARD));
   }
 
   @Override
@@ -25,7 +28,7 @@ public class DisabledResourceAccessProvider implements ResourceAccessProvider {
       final CamundaAuthentication authentication,
       final Authorization<T> requiredAuthorization,
       final T resource) {
-    return ResourceAccess.wildcard(requiredAuthorization);
+    return ResourceAccess.wildcard(withAuthorization(requiredAuthorization, WILDCARD));
   }
 
   @Override
@@ -33,6 +36,6 @@ public class DisabledResourceAccessProvider implements ResourceAccessProvider {
       final CamundaAuthentication authentication,
       final Authorization<T> requiredAuthorization,
       final String resourceId) {
-    return ResourceAccess.wildcard(requiredAuthorization);
+    return ResourceAccess.wildcard(withAuthorization(requiredAuthorization, WILDCARD));
   }
 }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/auth/DocumentBasedResourceAccessController.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/auth/DocumentBasedResourceAccessController.java
@@ -59,7 +59,9 @@ public class DocumentBasedResourceAccessController implements ResourceAccessCont
 
   @Override
   public boolean supports(final SecurityContext securityContext) {
-    return Optional.of(securityContext).map(SecurityContext::authentication).isPresent()
+    return Optional.of(securityContext)
+            .filter(c -> c.authentication() != null && c.authorization() != null)
+            .isPresent()
         && !isAnonymousAuthentication(securityContext.authentication());
   }
 

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/auth/DefaultResourceAccessProviderTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/auth/DefaultResourceAccessProviderTest.java
@@ -42,7 +42,7 @@ class DefaultResourceAccessProviderTest {
     final var authentication = CamundaAuthentication.of(a -> a.user("foo"));
     final var authorization = Authorization.of(a -> a.processDefinition().readProcessDefinition());
 
-    when(authorizationChecker.retrieveAuthorizedResourceKeys(any()))
+    when(authorizationChecker.retrieveAuthorizedResourceIds(any()))
         .thenReturn(List.of("bar", "baz"));
 
     // when
@@ -63,7 +63,7 @@ class DefaultResourceAccessProviderTest {
     final var authentication = CamundaAuthentication.of(a -> a.user("foo"));
     final var authorization = Authorization.of(a -> a.processDefinition().readProcessDefinition());
 
-    when(authorizationChecker.retrieveAuthorizedResourceKeys(any())).thenReturn(List.of("*"));
+    when(authorizationChecker.retrieveAuthorizedResourceIds(any())).thenReturn(List.of("*"));
 
     // when
     final var result = resourceAccessProvider.resolveResourceAccess(authentication, authorization);
@@ -83,7 +83,7 @@ class DefaultResourceAccessProviderTest {
     final var authentication = CamundaAuthentication.of(a -> a.user("foo"));
     final var authorization = Authorization.of(a -> a.processDefinition().readProcessDefinition());
 
-    when(authorizationChecker.retrieveAuthorizedResourceKeys(any())).thenReturn(List.of());
+    when(authorizationChecker.retrieveAuthorizedResourceIds(any())).thenReturn(List.of());
 
     // when
     final var result = resourceAccessProvider.resolveResourceAccess(authentication, authorization);

--- a/search/search-domain/src/main/java/io/camunda/search/exception/ErrorMessages.java
+++ b/search/search-domain/src/main/java/io/camunda/search/exception/ErrorMessages.java
@@ -35,4 +35,10 @@ public class ErrorMessages {
       "Resource Access %s does not include an authorization";
   public static final String ERROR_RESOURCE_ACCESS_CONTROLLER_NO_TENANT_ACCESS =
       "Tenant access was denied";
+
+  public static final String ERROR_INDEX_FILTER_TRANSFORMER_AUTH_CHECK_MISSING =
+      "Transformer '%s' requires an authorization check to be applied to the search query.";
+
+  public static final String ERROR_INDEX_FILTER_TRANSFORMER_TENANT_CHECK_MISSING =
+      "Transformer '%s' requires a tenant check to be applied to the search query.";
 }

--- a/security/security-core/src/main/java/io/camunda/security/auth/SecurityContext.java
+++ b/security/security-core/src/main/java/io/camunda/security/auth/SecurityContext.java
@@ -24,16 +24,8 @@ public record SecurityContext(
     @JsonProperty("authentication") CamundaAuthentication authentication,
     @JsonProperty("authorization") Authorization<?> authorization) {
 
-  public boolean requiresAuthorizationChecks() {
-    return authentication != null && authorization != null;
-  }
-
   public static SecurityContext of(final Function<Builder, Builder> builderFunction) {
     return builderFunction.apply(new Builder()).build();
-  }
-
-  public static SecurityContext withoutAuthentication() {
-    return new Builder().build();
   }
 
   public static class Builder {

--- a/security/security-services/src/main/java/io/camunda/security/impl/AuthorizationChecker.java
+++ b/security/security-services/src/main/java/io/camunda/security/impl/AuthorizationChecker.java
@@ -27,8 +27,8 @@ import java.util.stream.Collectors;
 
 /**
  * The AuthorizationChecker class provides methods for checking resource authorization by
- * interacting with the AuthorizationSearchClient. It retrieves authorized resource keys or checks
- * if a specific resource key is authorized, based on the provided SecurityContext.
+ * interacting with the AuthorizationSearchClient. It retrieves authorized resource ids or checks if
+ * a specific resource id is authorized, based on the provided SecurityContext.
  */
 public class AuthorizationChecker {
 
@@ -39,14 +39,14 @@ public class AuthorizationChecker {
   }
 
   /**
-   * Retrieves a list of authorized resource keys for the given SecurityContext. The resource keys
+   * Retrieves a list of authorized resource ids for the given SecurityContext. The resource ids
    * represent resources that the user or one of their groups or roles, as specified in the
    * SecurityContext, has access to based on the defined resource type and permission type.
    *
    * @param securityContext the context containing authorization and authentication information
-   * @return a list of authorized resource keys for the user or group in the SecurityContext
+   * @return a list of authorized resource ids for the user or group in the SecurityContext
    */
-  public List<String> retrieveAuthorizedResourceKeys(final SecurityContext securityContext) {
+  public List<String> retrieveAuthorizedResourceIds(final SecurityContext securityContext) {
     final var ownerIds = collectOwnerTypeToOwnerIds(securityContext.authentication());
     final var resourceType = securityContext.authorization().resourceType();
     final var permissionType = securityContext.authorization().permissionType();
@@ -68,13 +68,13 @@ public class AuthorizationChecker {
   }
 
   /**
-   * Checks if a specific resource key is authorized for the user or one of their groups or roles
+   * Checks if a specific resource id is authorized for the user or one of their groups or roles
    * defined in the provided SecurityContext. The authorization check is based on the resource type
    * and permission type in the SecurityContext.
    *
    * @param resourceId the resource id to check authorization for
    * @param securityContext the context containing authorization and authentication information
-   * @return true if the resource key is authorized, false otherwise
+   * @return true if the resource id is authorized, false otherwise
    */
   public boolean isAuthorized(final String resourceId, final SecurityContext securityContext) {
     final var ownerIds = collectOwnerTypeToOwnerIds(securityContext.authentication());

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -78,10 +78,6 @@
       <groupId>io.camunda</groupId>
       <artifactId>camunda-security-protocol</artifactId>
     </dependency>
-    <dependency>
-      <groupId>io.camunda</groupId>
-      <artifactId>camunda-security-services</artifactId>
-    </dependency>
 
     <dependency>
       <groupId>org.agrona</groupId>

--- a/service/src/main/java/io/camunda/service/MappingRuleServices.java
+++ b/service/src/main/java/io/camunda/service/MappingRuleServices.java
@@ -13,6 +13,7 @@ import static io.camunda.service.authorization.Authorizations.MAPPING_RULE_READ_
 import io.camunda.search.clients.MappingRuleSearchClient;
 import io.camunda.search.entities.MappingRuleEntity;
 import io.camunda.search.query.MappingRuleQuery;
+import io.camunda.search.query.SearchQueryBase.AbstractQueryBuilder;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.security.auth.MappingRuleMatcher;
@@ -93,7 +94,7 @@ public class MappingRuleServices
 
   public Stream<MappingRuleEntity> getMatchingMappingRules(final Map<String, Object> claims) {
     return MappingRuleMatcher.matchingRules(
-        search(MappingRuleQuery.of(q -> q.unlimited())).items().stream(), claims);
+        search(MappingRuleQuery.of(AbstractQueryBuilder::unlimited)).items().stream(), claims);
   }
 
   public record MappingRuleDTO(

--- a/service/src/main/java/io/camunda/service/ProcessDefinitionServices.java
+++ b/service/src/main/java/io/camunda/service/ProcessDefinitionServices.java
@@ -93,7 +93,7 @@ public class ProcessDefinitionServices
         .flatMap(
             p ->
                 formServices
-                    .withAuthentication(authentication)
+                    .withAuthentication(CamundaAuthentication.anonymous())
                     .getLatestVersionByFormIdAndTenantId(p.formId(), p.tenantId()));
   }
 

--- a/service/src/main/java/io/camunda/service/VariableServices.java
+++ b/service/src/main/java/io/camunda/service/VariableServices.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.service;
 
-import static io.camunda.search.query.SearchQueryBuilders.variableSearchQuery;
 import static io.camunda.security.auth.Authorization.withAuthorization;
 import static io.camunda.service.authorization.Authorizations.VARIABLE_READ_AUTHORIZATION;
 
@@ -15,13 +14,10 @@ import io.camunda.search.clients.VariableSearchClient;
 import io.camunda.search.entities.VariableEntity;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.search.query.VariableQuery;
-import io.camunda.search.query.VariableQuery.Builder;
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.search.core.SearchQueryService;
 import io.camunda.service.security.SecurityContextProvider;
-import io.camunda.util.ObjectBuilder;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
-import java.util.function.Function;
 
 public final class VariableServices
     extends SearchQueryService<VariableServices, VariableQuery, VariableEntity> {
@@ -52,11 +48,6 @@ public final class VariableServices
                     securityContextProvider.provideSecurityContext(
                         authentication, VARIABLE_READ_AUTHORIZATION))
                 .searchVariables(query));
-  }
-
-  public SearchQueryResult<VariableEntity> search(
-      final Function<Builder, ObjectBuilder<VariableQuery>> fn) {
-    return search(variableSearchQuery(fn));
   }
 
   public VariableEntity getByKey(final Long key) {

--- a/service/src/main/java/io/camunda/service/security/SecurityContextProvider.java
+++ b/service/src/main/java/io/camunda/service/security/SecurityContextProvider.java
@@ -11,43 +11,18 @@ import io.camunda.security.auth.Authorization;
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.security.auth.SecurityContext;
 import io.camunda.security.auth.SecurityContext.Builder;
-import io.camunda.security.configuration.SecurityConfiguration;
-import io.camunda.security.impl.AuthorizationChecker;
 
 public class SecurityContextProvider {
 
-  private final SecurityConfiguration securityConfiguration;
-  private final AuthorizationChecker authorizationChecker;
-
-  public SecurityContextProvider(
-      final SecurityConfiguration securityConfiguration,
-      final AuthorizationChecker authorizationChecker) {
-    this.securityConfiguration = securityConfiguration;
-    this.authorizationChecker = authorizationChecker;
-  }
-
   public SecurityContext provideSecurityContext(
       final CamundaAuthentication authentication, final Authorization authorization) {
-    final SecurityContext.Builder securityContextbuilder =
-        new Builder().withAuthentication(authentication);
-    if (securityConfiguration.getAuthorizations().isEnabled()) {
-      securityContextbuilder.withAuthorization(authorization);
-    }
-    return securityContextbuilder.build();
+    return new Builder()
+        .withAuthentication(authentication)
+        .withAuthorization(authorization)
+        .build();
   }
 
   public SecurityContext provideSecurityContext(final CamundaAuthentication authentication) {
     return provideSecurityContext(authentication, null);
-  }
-
-  public boolean isAuthorized(
-      final String resourceKey,
-      final CamundaAuthentication authentication,
-      final Authorization authorization) {
-    final var securityContext = provideSecurityContext(authentication, authorization);
-    if (securityContext.requiresAuthorizationChecks()) {
-      return authorizationChecker.isAuthorized(resourceKey, securityContext);
-    }
-    return true;
   }
 }

--- a/service/src/test/java/io/camunda/service/DecisionRequirementsServiceTest.java
+++ b/service/src/test/java/io/camunda/service/DecisionRequirementsServiceTest.java
@@ -20,7 +20,6 @@ import io.camunda.search.exception.ResourceAccessDeniedException;
 import io.camunda.search.query.DecisionRequirementsQuery;
 import io.camunda.search.query.SearchQueryBuilders;
 import io.camunda.search.query.SearchQueryResult;
-import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.authorization.Authorizations;
 import io.camunda.service.exception.ServiceException;
 import io.camunda.service.exception.ServiceException.Status;
@@ -33,17 +32,14 @@ public final class DecisionRequirementsServiceTest {
 
   private DecisionRequirementsServices services;
   private DecisionRequirementSearchClient client;
-  private SecurityContextProvider securityContextProvider;
-  private CamundaAuthentication authentication;
 
   @BeforeEach
   public void before() {
     client = mock(DecisionRequirementSearchClient.class);
     when(client.withSecurityContext(any())).thenReturn(client);
-    securityContextProvider = mock(SecurityContextProvider.class);
     services =
         new DecisionRequirementsServices(
-            mock(BrokerClient.class), securityContextProvider, client, authentication);
+            mock(BrokerClient.class), mock(SecurityContextProvider.class), client, null);
   }
 
   @Test

--- a/service/src/test/java/io/camunda/service/IncidentServiceTest.java
+++ b/service/src/test/java/io/camunda/service/IncidentServiceTest.java
@@ -18,7 +18,6 @@ import io.camunda.search.entities.IncidentEntity;
 import io.camunda.search.exception.ResourceAccessDeniedException;
 import io.camunda.search.query.SearchQueryBuilders;
 import io.camunda.search.query.SearchQueryResult;
-import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.authorization.Authorizations;
 import io.camunda.service.exception.ServiceException;
 import io.camunda.service.exception.ServiceException.Status;
@@ -32,18 +31,14 @@ public final class IncidentServiceTest {
 
   private IncidentServices services;
   private IncidentSearchClient client;
-  private SecurityContextProvider securityContextProvider;
-  private CamundaAuthentication authentication;
 
   @BeforeEach
   public void before() {
     client = mock(IncidentSearchClient.class);
     when(client.withSecurityContext(any())).thenReturn(client);
-    securityContextProvider = mock(SecurityContextProvider.class);
-    authentication = mock(CamundaAuthentication.class);
     services =
         new IncidentServices(
-            mock(BrokerClient.class), securityContextProvider, client, authentication);
+            mock(BrokerClient.class), mock(SecurityContextProvider.class), client, null);
   }
 
   @Test

--- a/service/src/test/java/io/camunda/service/JobServiceTest.java
+++ b/service/src/test/java/io/camunda/service/JobServiceTest.java
@@ -16,7 +16,6 @@ import io.camunda.search.clients.JobSearchClient;
 import io.camunda.search.entities.JobEntity;
 import io.camunda.search.query.SearchQueryBuilders;
 import io.camunda.search.query.SearchQueryResult;
-import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import org.junit.jupiter.api.BeforeEach;
@@ -26,18 +25,14 @@ public class JobServiceTest {
 
   private JobServices<SearchQueryResult<JobEntity>> services;
   private JobSearchClient client;
-  private SecurityContextProvider securityContextProvider;
-  private CamundaAuthentication authentication;
 
   @BeforeEach
   public void before() {
     client = mock(JobSearchClient.class);
     when(client.withSecurityContext(any())).thenReturn(client);
-    securityContextProvider = mock(SecurityContextProvider.class);
-    authentication = mock(CamundaAuthentication.class);
     services =
         new JobServices<>(
-            mock(BrokerClient.class), securityContextProvider, null, client, authentication);
+            mock(BrokerClient.class), mock(SecurityContextProvider.class), null, client, null);
   }
 
   @Test

--- a/service/src/test/java/io/camunda/service/MessageSubscriptionServiceTest.java
+++ b/service/src/test/java/io/camunda/service/MessageSubscriptionServiceTest.java
@@ -30,11 +30,9 @@ public class MessageSubscriptionServiceTest {
   public void before() {
     client = mock(MessageSubscriptionSearchClient.class);
     when(client.withSecurityContext(any())).thenReturn(client);
-    final SecurityContextProvider securityContextProvider = mock(SecurityContextProvider.class);
-    final CamundaAuthentication authentication = mock(CamundaAuthentication.class);
     services =
         new MessageSubscriptionServices(
-            mock(BrokerClient.class), securityContextProvider, client, authentication);
+            mock(BrokerClient.class), mock(SecurityContextProvider.class), client, null);
   }
 
   @Test

--- a/service/src/test/java/io/camunda/service/TenantServiceTest.java
+++ b/service/src/test/java/io/camunda/service/TenantServiceTest.java
@@ -20,7 +20,6 @@ import io.camunda.search.exception.ResourceAccessDeniedException;
 import io.camunda.search.filter.TenantFilter;
 import io.camunda.search.query.SearchQueryBuilders;
 import io.camunda.search.query.SearchQueryResult;
-import io.camunda.security.auth.Authorization;
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.TenantServices.TenantDTO;
 import io.camunda.service.TenantServices.TenantMemberRequest;
@@ -56,13 +55,10 @@ public class TenantServiceTest {
     final CamundaAuthentication authentication =
         CamundaAuthentication.of(builder -> builder.user("foo"));
     client = mock(TenantSearchClient.class);
-    final SecurityContextProvider securityContextProvider = mock(SecurityContextProvider.class);
     when(client.withSecurityContext(any())).thenReturn(client);
-    when(securityContextProvider.isAuthorized(
-            "tenant-id", authentication, Authorization.of(a -> a.tenant().read())))
-        .thenReturn(true);
     services =
-        new TenantServices(stubbedBrokerClient, securityContextProvider, client, authentication);
+        new TenantServices(
+            stubbedBrokerClient, mock(SecurityContextProvider.class), client, authentication);
   }
 
   @Test

--- a/service/src/test/java/io/camunda/service/UsageMetricsServiceTest.java
+++ b/service/src/test/java/io/camunda/service/UsageMetricsServiceTest.java
@@ -17,7 +17,6 @@ import io.camunda.search.entities.UsageMetricStatisticsEntity;
 import io.camunda.search.filter.UsageMetricsFilter;
 import io.camunda.search.query.SearchQueryBuilders;
 import io.camunda.search.query.UsageMetricsQuery;
-import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import java.time.OffsetDateTime;
@@ -28,17 +27,14 @@ public final class UsageMetricsServiceTest {
 
   private UsageMetricsServices services;
   private UsageMetricsSearchClient client;
-  private SecurityContextProvider securityContextProvider;
-  private CamundaAuthentication authentication;
 
   @BeforeEach
   public void before() {
     client = mock(UsageMetricsSearchClient.class);
     when(client.withSecurityContext(any())).thenReturn(client);
-    securityContextProvider = mock(SecurityContextProvider.class);
     services =
         new UsageMetricsServices(
-            mock(BrokerClient.class), securityContextProvider, client, authentication);
+            mock(BrokerClient.class), mock(SecurityContextProvider.class), client, null);
   }
 
   @Test

--- a/service/src/test/java/io/camunda/service/VariableServiceTest.java
+++ b/service/src/test/java/io/camunda/service/VariableServiceTest.java
@@ -20,7 +20,6 @@ import io.camunda.search.filter.VariableFilter;
 import io.camunda.search.filter.VariableFilter.Builder;
 import io.camunda.search.query.SearchQueryBuilders;
 import io.camunda.search.query.SearchQueryResult;
-import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.authorization.Authorizations;
 import io.camunda.service.exception.ServiceException;
 import io.camunda.service.exception.ServiceException.Status;
@@ -35,18 +34,14 @@ public class VariableServiceTest {
 
   private VariableServices services;
   private VariableSearchClient client;
-  private SecurityContextProvider securityContextProvider;
-  private CamundaAuthentication authentication;
 
   @BeforeEach
   public void before() {
     client = mock(VariableSearchClient.class);
     when(client.withSecurityContext(any())).thenReturn(client);
-    securityContextProvider = mock(SecurityContextProvider.class);
-    authentication = mock(CamundaAuthentication.class);
     services =
         new VariableServices(
-            mock(BrokerClient.class), securityContextProvider, client, authentication);
+            mock(BrokerClient.class), mock(SecurityContextProvider.class), client, null);
   }
 
   @Test

--- a/service/src/test/java/io/camunda/service/security/SecurityContextProviderTest.java
+++ b/service/src/test/java/io/camunda/service/security/SecurityContextProviderTest.java
@@ -8,33 +8,20 @@
 package io.camunda.service.security;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 import io.camunda.security.auth.Authorization;
 import io.camunda.security.auth.CamundaAuthentication;
-import io.camunda.security.auth.SecurityContext;
-import io.camunda.security.configuration.SecurityConfiguration;
-import io.camunda.security.impl.AuthorizationChecker;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Answers;
 
 class SecurityContextProviderTest {
 
-  private SecurityConfiguration securityConfiguration;
-  private AuthorizationChecker authorizationChecker;
   private SecurityContextProvider securityContextProvider;
 
   @BeforeEach
   void before() {
-    securityConfiguration = mock(SecurityConfiguration.class, Answers.RETURNS_DEEP_STUBS);
-    authorizationChecker = mock(AuthorizationChecker.class);
-    securityContextProvider =
-        new SecurityContextProvider(securityConfiguration, authorizationChecker);
+    securityContextProvider = new SecurityContextProvider();
   }
 
   @Test
@@ -42,7 +29,6 @@ class SecurityContextProviderTest {
     // given
     final var authentication = mock(CamundaAuthentication.class);
     final var authorization = mock(Authorization.class);
-    when(securityConfiguration.getAuthorizations().isEnabled()).thenReturn(true);
 
     // when
     final var securityContext =
@@ -50,82 +36,6 @@ class SecurityContextProviderTest {
 
     // then
     assertThat(securityContext.authorization()).isEqualTo(authorization);
-    assertThat(securityContext.requiresAuthorizationChecks()).isTrue();
     assertThat(securityContext.authentication()).isEqualTo(authentication);
-  }
-
-  @Test
-  void shouldProvideSecurityContextWithoutAuthorizationWhenDisabled() {
-    // given
-    final var authentication = mock(CamundaAuthentication.class);
-    final var authorization = mock(Authorization.class);
-    when(securityConfiguration.getAuthorizations().isEnabled()).thenReturn(false);
-
-    // when
-    final var securityContext =
-        securityContextProvider.provideSecurityContext(authentication, authorization);
-
-    // then
-    assertThat(securityContext.authorization()).isNull();
-    assertThat(securityContext.requiresAuthorizationChecks()).isFalse();
-    assertThat(securityContext.authentication()).isEqualTo(authentication);
-  }
-
-  @Test
-  void isAuthorizedShouldReturnTrueWhenAuthorizationIsDisabled() {
-    // given
-    final var authentication = mock(CamundaAuthentication.class);
-    final var authorization = mock(Authorization.class);
-    when(securityConfiguration.getAuthorizations().isEnabled()).thenReturn(false);
-
-    // when
-    final var authorized =
-        securityContextProvider.isAuthorized("resourceKey", authentication, authorization);
-
-    // then
-    assertThat(authorized).isTrue();
-    verify(authorizationChecker, never()).isAuthorized(any(), any());
-  }
-
-  @Test
-  void isAuthorizedShouldReturnTrueWhenAuthorizationCheckerReturnsTrue() {
-    // given
-    final var authentication = mock(CamundaAuthentication.class);
-    final var authorization = mock(Authorization.class);
-    when(securityConfiguration.getAuthorizations().isEnabled()).thenReturn(true);
-    when(authorizationChecker.isAuthorized(any(), any())).thenReturn(true);
-
-    // when
-    final var authorized =
-        securityContextProvider.isAuthorized("resourceKey", authentication, authorization);
-
-    // then
-    assertThat(authorized).isTrue();
-    verify(authorizationChecker)
-        .isAuthorized(
-            "resourceKey",
-            SecurityContext.of(
-                s -> s.withAuthentication(authentication).withAuthorization(authorization)));
-  }
-
-  @Test
-  void isAuthorizedShouldReturnFalseWhenAuthorizationCheckerReturnsFalse() {
-    // given
-    final var authentication = mock(CamundaAuthentication.class);
-    final var authorization = mock(Authorization.class);
-    when(securityConfiguration.getAuthorizations().isEnabled()).thenReturn(true);
-    when(authorizationChecker.isAuthorized(any(), any())).thenReturn(false);
-
-    // when
-    final var authorized =
-        securityContextProvider.isAuthorized("resourceKey", authentication, authorization);
-
-    // then
-    assertThat(authorized).isFalse();
-    verify(authorizationChecker)
-        .isAuthorized(
-            "resourceKey",
-            SecurityContext.of(
-                s -> s.withAuthentication(authentication).withAuthorization(authorization)));
   }
 }

--- a/tasklist/webapp/pom.xml
+++ b/tasklist/webapp/pom.xml
@@ -76,11 +76,6 @@
 
     <dependency>
       <groupId>io.camunda</groupId>
-      <artifactId>camunda-security-services</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>io.camunda</groupId>
       <artifactId>camunda-schema-manager</artifactId>
     </dependency>
     <dependency>

--- a/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/es/cache/ProcessStoreOpenSearchTest.java
+++ b/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/es/cache/ProcessStoreOpenSearchTest.java
@@ -21,12 +21,13 @@ import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.authentication.entity.CamundaUser;
+import io.camunda.security.auth.Authorization;
 import io.camunda.security.auth.CamundaAuthenticationProvider;
 import io.camunda.security.configuration.AuthorizationsConfiguration;
 import io.camunda.security.configuration.MultiTenancyConfiguration;
 import io.camunda.security.configuration.SecurityConfiguration;
-import io.camunda.security.impl.AuthorizationChecker;
-import io.camunda.service.security.SecurityContextProvider;
+import io.camunda.security.reader.ResourceAccess;
+import io.camunda.security.reader.ResourceAccessProvider;
 import io.camunda.tasklist.exceptions.NotFoundException;
 import io.camunda.tasklist.exceptions.TasklistRuntimeException;
 import io.camunda.tasklist.property.TasklistProperties;
@@ -75,8 +76,7 @@ class ProcessStoreOpenSearchTest {
   @Mock private SecurityConfiguration securityConfiguration;
   @Mock private TasklistProperties tasklistProperties;
   @Mock private io.camunda.identity.autoconfigure.IdentityProperties identityProperties;
-  @Mock private SecurityContextProvider securityContextProvider;
-  @Mock private AuthorizationChecker authorizationChecker;
+  @Mock private ResourceAccessProvider resourceAccessProvider;
   @Mock private CamundaAuthenticationProvider authenticationProvider;
   @Mock private TasklistPermissionServices permissionServices;
 
@@ -270,13 +270,12 @@ class ProcessStoreOpenSearchTest {
     SecurityContextHolder.getContext().setAuthentication(auth);
     when(securityContext.getAuthentication()).thenReturn(auth);
 
-    when(securityContextProvider.provideSecurityContext(any()))
-        .thenReturn(mock(io.camunda.security.auth.SecurityContext.class));
-
     if (isAuthorizated) {
-      when(authorizationChecker.retrieveAuthorizedResourceKeys(any())).thenReturn(List.of("*"));
+      when(resourceAccessProvider.resolveResourceAccess(any(), any()))
+          .thenReturn(ResourceAccess.wildcard(Authorization.of(b -> b.resourceIds(List.of("*")))));
     } else {
-      when(authorizationChecker.retrieveAuthorizedResourceKeys(any())).thenReturn(List.of());
+      when(resourceAccessProvider.resolveResourceAccess(any(), any()))
+          .thenReturn(ResourceAccess.wildcard(Authorization.of(b -> b.resourceIds(List.of()))));
     }
   }
 

--- a/zeebe/gateway-rest/pom.xml
+++ b/zeebe/gateway-rest/pom.xml
@@ -105,12 +105,6 @@
 
     <dependency>
       <groupId>io.camunda</groupId>
-      <artifactId>camunda-security-services</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>io.camunda</groupId>
       <artifactId>camunda-search-client</artifactId>
       <scope>test</scope>
     </dependency>

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerLongPollingTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerLongPollingTest.java
@@ -14,7 +14,6 @@ import static org.mockito.Mockito.when;
 import com.jayway.jsonpath.JsonPath;
 import io.camunda.security.auth.CamundaAuthenticationProvider;
 import io.camunda.security.configuration.MultiTenancyConfiguration;
-import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.service.JobServices;
 import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
@@ -428,11 +427,7 @@ public class JobControllerLongPollingTest extends RestControllerTest {
         final BrokerClient brokerClient,
         final ActivateJobsHandler<JobActivationResult> activateJobsHandler) {
       return new JobServices<>(
-          brokerClient,
-          new SecurityContextProvider(new SecurityConfiguration(), null),
-          activateJobsHandler,
-          null,
-          null);
+          brokerClient, new SecurityContextProvider(), activateJobsHandler, null, null);
     }
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerRoundRobinTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerRoundRobinTest.java
@@ -14,7 +14,6 @@ import static org.mockito.Mockito.when;
 import com.jayway.jsonpath.JsonPath;
 import io.camunda.security.auth.CamundaAuthenticationProvider;
 import io.camunda.security.configuration.MultiTenancyConfiguration;
-import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.service.JobServices;
 import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
@@ -416,11 +415,7 @@ public class JobControllerRoundRobinTest extends RestControllerTest {
         final BrokerClient brokerClient,
         final ActivateJobsHandler<JobActivationResult> activateJobsHandler) {
       return new JobServices<>(
-          brokerClient,
-          new SecurityContextProvider(new SecurityConfiguration(), null),
-          activateJobsHandler,
-          null,
-          null);
+          brokerClient, new SecurityContextProvider(), activateJobsHandler, null, null);
     }
   }
 }


### PR DESCRIPTION
## Description

This enforces that an `Authorization` is passed to the search client when fetching an entity by ID/key or when executing a search query. In other words, the service layer must provide anonymous authentication (if access is ensured) or dedicated authentication and authorization to be checked.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

related to #35595
