### PR TITLE
fix: use access token when loading auth

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/CamundaOidcUserService.java
+++ b/authentication/src/main/java/io/camunda/authentication/CamundaOidcUserService.java
@@ -10,26 +10,43 @@ package io.camunda.authentication;
 import io.camunda.authentication.entity.CamundaOidcUser;
 import io.camunda.security.entity.AuthenticationMethod;
 import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserRequest;
 import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserService;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtException;
 import org.springframework.stereotype.Service;
 
 @Service
 @ConditionalOnAuthenticationMethod(AuthenticationMethod.OIDC)
 public class CamundaOidcUserService extends OidcUserService {
-
+  private static final Logger LOGGER = LoggerFactory.getLogger(CamundaOidcUserService.class);
   private final CamundaOAuthPrincipalService camundaOAuthPrincipalService;
+  private final JwtDecoder jwtDecoder;
 
-  public CamundaOidcUserService(final CamundaOAuthPrincipalService camundaOAuthPrincipalService) {
+  public CamundaOidcUserService(
+      final CamundaOAuthPrincipalService camundaOAuthPrincipalService,
+      final JwtDecoder jwtDecoder) {
     this.camundaOAuthPrincipalService = camundaOAuthPrincipalService;
+    this.jwtDecoder = jwtDecoder;
   }
 
   @Override
   public OidcUser loadUser(final OidcUserRequest userRequest) throws OAuth2AuthenticationException {
     final OidcUser oidcUser = super.loadUser(userRequest);
-    final Map<String, Object> claims = userRequest.getIdToken().getClaims();
+    Map<String, Object> claims;
+    try {
+      final var jwt = jwtDecoder.decode(userRequest.getAccessToken().getTokenValue());
+      claims = jwt.getClaims();
+    } catch (final JwtException e) {
+      LOGGER.warn(
+          "Failed to decode access token: {}, falling back to ID Token claims", e.getMessage());
+      claims = oidcUser.getIdToken().getClaims();
+    }
+
     return new CamundaOidcUser(oidcUser, camundaOAuthPrincipalService.loadOAuthContext(claims));
   }
 }

--- a/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
@@ -689,7 +689,8 @@ public class WebSecurityConfig {
                 .getOidc()
                 .getAdditionalAuthenticationParameters();
 
-        if (!additionalAuthenticationParameters.isEmpty()) {
+        if (additionalAuthenticationParameters != null
+            && !additionalAuthenticationParameters.isEmpty()) {
           customizer.additionalParameters(additionalAuthenticationParameters);
         }
       };

--- a/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
@@ -683,15 +683,15 @@ public class WebSecurityConfig {
     private Consumer<Builder> authorizationRequestCustomizer(
         final SecurityConfiguration securityConfiguration) {
       return customizer -> {
-        final var additionalAuthenticationParameters =
+        final var additionalParameters =
             securityConfiguration
                 .getAuthentication()
                 .getOidc()
-                .getAdditionalAuthenticationParameters();
+                .getAuthorizeRequest()
+                .getAdditionalParameters();
 
-        if (additionalAuthenticationParameters != null
-            && !additionalAuthenticationParameters.isEmpty()) {
-          customizer.additionalParameters(additionalAuthenticationParameters);
+        if (additionalParameters != null && !additionalParameters.isEmpty()) {
+          customizer.additionalParameters(additionalParameters);
         }
       };
     }

--- a/security/security-core/src/main/java/io/camunda/security/configuration/AuthorizeRequestConfiguration.java
+++ b/security/security-core/src/main/java/io/camunda/security/configuration/AuthorizeRequestConfiguration.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.security.configuration;
+
+import java.util.Map;
+
+public class AuthorizeRequestConfiguration {
+  private Map<String, Object> additionalParameters;
+
+  public Map<String, Object> getAdditionalParameters() {
+    return additionalParameters;
+  }
+
+  public void setAdditionalParameters(final Map<String, Object> additionalParameters) {
+    this.additionalParameters = additionalParameters;
+  }
+}

--- a/security/security-core/src/main/java/io/camunda/security/configuration/OidcAuthenticationConfiguration.java
+++ b/security/security-core/src/main/java/io/camunda/security/configuration/OidcAuthenticationConfiguration.java
@@ -10,7 +10,6 @@ package io.camunda.security.configuration;
 import io.camunda.security.auth.OidcGroupsLoader;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 public class OidcAuthenticationConfiguration {
@@ -26,7 +25,7 @@ public class OidcAuthenticationConfiguration {
   private String jwkSetUri;
   private String authorizationUri;
   private String tokenUri;
-  private Map<String, Object> additionalAuthenticationParams;
+  private AuthorizeRequestConfiguration authorizeRequestConfiguration;
   private Set<String> audiences;
   private String usernameClaim = "sub";
   private String clientIdClaim;
@@ -105,13 +104,13 @@ public class OidcAuthenticationConfiguration {
     this.tokenUri = tokenUri;
   }
 
-  public Map<String, Object> getAdditionalAuthenticationParameters() {
-    return additionalAuthenticationParams;
+  public AuthorizeRequestConfiguration getAuthorizeRequest() {
+    return authorizeRequestConfiguration;
   }
 
-  public void setAdditionalAuthenticationParameters(
-      final Map<String, Object> additionalAuthenticationParams) {
-    this.additionalAuthenticationParams = additionalAuthenticationParams;
+  public void setAuthorizeRequest(
+      final AuthorizeRequestConfiguration authorizeRequestConfiguration) {
+    this.authorizeRequestConfiguration = authorizeRequestConfiguration;
   }
 
   public Set<String> getAudiences() {

--- a/security/security-core/src/main/java/io/camunda/security/configuration/OidcAuthenticationConfiguration.java
+++ b/security/security-core/src/main/java/io/camunda/security/configuration/OidcAuthenticationConfiguration.java
@@ -10,6 +10,7 @@ package io.camunda.security.configuration;
 import io.camunda.security.auth.OidcGroupsLoader;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 public class OidcAuthenticationConfiguration {
@@ -25,6 +26,7 @@ public class OidcAuthenticationConfiguration {
   private String jwkSetUri;
   private String authorizationUri;
   private String tokenUri;
+  private Map<String, Object> additionalAuthenticationParams;
   private Set<String> audiences;
   private String usernameClaim = "sub";
   private String clientIdClaim;
@@ -101,6 +103,15 @@ public class OidcAuthenticationConfiguration {
 
   public void setTokenUri(final String tokenUri) {
     this.tokenUri = tokenUri;
+  }
+
+  public Map<String, Object> getAdditionalAuthenticationParameters() {
+    return additionalAuthenticationParams;
+  }
+
+  public void setAdditionalAuthenticationParameters(
+      final Map<String, Object> additionalAuthenticationParams) {
+    this.additionalAuthenticationParams = additionalAuthenticationParams;
   }
 
   public Set<String> getAudiences() {


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR achieves two things:
1. Support the ability to pass additional parameters into the authorize request - this allows us to pass the audience into the request for the SaaS deployments which returns the access token as a JWT when an `audience` parameter is provided.
2. Switches to prefer the access token instead of the ID token to derive the claims from - to remain defensive here I've added a fallback so if the access token cannot be parsed, then we will still use the ID token but log an error for the user to fix it longer term (or accept the usage of the ID token).

## Related issues

closes #34420
