### PR TITLE
Camunda Exporter record to export backlog

### DIFF
--- a/monitor/grafana/dashboards/data_layer.json
+++ b/monitor/grafana/dashboards/data_layer.json
@@ -19,7 +19,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 7,
+  "id": 11,
   "links": [],
   "panels": [
     {
@@ -1211,7 +1211,7 @@
         "type": "prometheus",
         "uid": "PBFA97CFB590B2093"
       },
-      "description": "How long an export request is open and collecting new records before flushing.",
+      "description": "For each exporter how far behind is it from exporting the records which have been committed.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1223,11 +1223,10 @@
             "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
-            "axisSoftMax": 5,
             "barAlignment": 0,
             "barWidthFactor": 0.6,
             "drawStyle": "line",
-            "fillOpacity": 10,
+            "fillOpacity": 0,
             "gradientMode": "none",
             "hideFrom": {
               "legend": false,
@@ -1241,7 +1240,7 @@
             "scaleDistribution": {
               "type": "linear"
             },
-            "showPoints": "never",
+            "showPoints": "auto",
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -1251,8 +1250,6 @@
               "mode": "off"
             }
           },
-          "decimals": 0,
-          "links": [],
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
@@ -1265,8 +1262,7 @@
                 "value": 80
               }
             ]
-          },
-          "unit": "dtdurations"
+          }
         },
         "overrides": []
       },
@@ -1276,7 +1272,7 @@
         "x": 0,
         "y": 21
       },
-      "id": 10,
+      "id": 46,
       "options": {
         "legend": {
           "calcs": [],
@@ -1286,26 +1282,21 @@
         },
         "tooltip": {
           "hideZeros": false,
-          "mode": "multi",
+          "mode": "single",
           "sort": "none"
         }
       },
       "pluginVersion": "12.0.2",
       "targets": [
         {
-          "datasource": {
-            "uid": "$DS_PROMETHEUS"
-          },
           "editorMode": "code",
-          "exemplar": true,
-          "expr": "rate(zeebe_camunda_exporter_flush_latency_seconds_sum{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval]) / rate(zeebe_camunda_exporter_flush_latency_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])",
-          "interval": "",
-          "legendFormat": "{{pod}} Exporter {{partition}}",
+          "expr": "max (zeebe_log_appender_last_committed_position{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\"}) by (partition) - max (zeebe_exporter_last_exported_position{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\", exporter=\"camundaexporter\"}) by (partition)",
+          "legendFormat": "partition {{partition}}",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Camunda Exporter (Flush Latency)",
+      "title": "Camunda Exporter (Records to export backlog)",
       "type": "timeseries"
     },
     {
@@ -1398,7 +1389,7 @@
         "type": "prometheus",
         "uid": "PBFA97CFB590B2093"
       },
-      "description": "Shows the rate of access to the process cache per partition",
+      "description": "How long an export request is open and collecting new records before flushing.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1410,10 +1401,11 @@
             "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
+            "axisSoftMax": 5,
             "barAlignment": 0,
             "barWidthFactor": 0.6,
             "drawStyle": "line",
-            "fillOpacity": 0,
+            "fillOpacity": 10,
             "gradientMode": "none",
             "hideFrom": {
               "legend": false,
@@ -1427,7 +1419,7 @@
             "scaleDistribution": {
               "type": "linear"
             },
-            "showPoints": "auto",
+            "showPoints": "never",
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -1437,6 +1429,8 @@
               "mode": "off"
             }
           },
+          "decimals": 0,
+          "links": [],
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
@@ -1449,7 +1443,8 @@
                 "value": 80
               }
             ]
-          }
+          },
+          "unit": "dtdurations"
         },
         "overrides": []
       },
@@ -1459,52 +1454,36 @@
         "x": 0,
         "y": 29
       },
-      "id": 12,
+      "id": 10,
       "options": {
         "legend": {
-          "calcs": [
-            "mean"
-          ],
-          "displayMode": "table",
-          "placement": "right",
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
           "showLegend": true
         },
         "tooltip": {
           "hideZeros": false,
           "mode": "multi",
-          "sort": "desc"
+          "sort": "none"
         }
       },
       "pluginVersion": "12.0.2",
       "targets": [
         {
           "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "editorMode": "code",
-          "expr": "sum(rate(zeebe_camunda_exporter_cache_process_result_total{namespace=~\"$namespace\",partition=~\"$partition\"}[$__rate_interval])) by (partition)",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "Cache access {{partition}}",
+          "exemplar": true,
+          "expr": "rate(zeebe_camunda_exporter_flush_latency_seconds_sum{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval]) / rate(zeebe_camunda_exporter_flush_latency_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])",
+          "interval": "",
+          "legendFormat": "{{pod}} Exporter {{partition}}",
           "range": true,
           "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "expr": "sum(rate(zeebe_camunda_exporter_cache_process_result_total{namespace=~\"$namespace\",partition=~\"$partition\"}[$__rate_interval])) by (partition, type)",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "P{{partition}} - {{type}}",
-          "range": true,
-          "refId": "B"
         }
       ],
-      "title": "Process cache access",
+      "title": "Camunda Exporter (Flush Latency)",
       "type": "timeseries"
     },
     {
@@ -1610,7 +1589,7 @@
         "type": "prometheus",
         "uid": "PBFA97CFB590B2093"
       },
-      "description": "The rate of the loading data into the cache",
+      "description": "Shows the rate of access to the process cache per partition",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1671,33 +1650,34 @@
         "x": 0,
         "y": 37
       },
-      "id": 15,
+      "id": 12,
       "options": {
         "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
+          "calcs": [
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "right",
           "showLegend": true
         },
         "tooltip": {
           "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
+          "mode": "multi",
+          "sort": "desc"
         }
       },
       "pluginVersion": "12.0.2",
       "targets": [
         {
           "datasource": {
-            "uid": "$DS_PROMETHEUS"
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(zeebe_camunda_exporter_cache_process_load_duration_success_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\"}[$__rate_interval])) by (partition)",
-          "format": "heatmap",
+          "expr": "sum(rate(zeebe_camunda_exporter_cache_process_result_total{namespace=~\"$namespace\",partition=~\"$partition\"}[$__rate_interval])) by (partition)",
           "hide": false,
-          "interval": "30s",
-          "intervalFactor": 1,
-          "legendFormat": "Success p{{partition}}",
+          "instant": false,
+          "legendFormat": "Cache access {{partition}}",
           "range": true,
           "refId": "A"
         },
@@ -1707,15 +1687,15 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(zeebe_camunda_exporter_cache_process_load_duration_failure_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\"}[$__rate_interval])) by (partition)",
+          "expr": "sum(rate(zeebe_camunda_exporter_cache_process_result_total{namespace=~\"$namespace\",partition=~\"$partition\"}[$__rate_interval])) by (partition, type)",
           "hide": false,
           "instant": false,
-          "legendFormat": "Failure p{{partition}}",
+          "legendFormat": "P{{partition}} - {{type}}",
           "range": true,
           "refId": "B"
         }
       ],
-      "title": "Cache load rate",
+      "title": "Process cache access",
       "type": "timeseries"
     },
     {
@@ -2092,18 +2072,57 @@
         "type": "prometheus",
         "uid": "PBFA97CFB590B2093"
       },
-      "description": "Histogram to show the distribution of the overall archiving duration, which includes searching, reindexing, and deletion.",
+      "description": "The rate of the loading data into the cache",
       "fieldConfig": {
         "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
           "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
             "hideFrom": {
               "legend": false,
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
             "scaleDistribution": {
               "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
             }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
           }
         },
         "overrides": []
@@ -2114,62 +2133,52 @@
         "x": 0,
         "y": 53
       },
-      "id": 17,
+      "id": 15,
       "options": {
-        "calculate": false,
-        "cellGap": 1,
-        "color": {
-          "exponent": 0.5,
-          "fill": "dark-orange",
-          "mode": "scheme",
-          "reverse": false,
-          "scale": "exponential",
-          "scheme": "Spectral",
-          "steps": 64
-        },
-        "exemplars": {
-          "color": "rgba(255,0,255,0.7)"
-        },
-        "filterValues": {
-          "le": 1e-9
-        },
         "legend": {
-          "show": false
-        },
-        "rowsFrame": {
-          "layout": "auto"
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "single",
-          "showColorScale": false,
-          "yHistogram": false
-        },
-        "yAxis": {
-          "axisPlacement": "left",
-          "reverse": false,
-          "unit": "dtdurations"
+          "sort": "none"
         }
       },
       "pluginVersion": "12.0.2",
       "targets": [
         {
           "datasource": {
+            "uid": "$DS_PROMETHEUS"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(zeebe_camunda_exporter_cache_process_load_duration_success_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\"}[$__rate_interval])) by (partition)",
+          "format": "heatmap",
+          "hide": false,
+          "interval": "30s",
+          "intervalFactor": 1,
+          "legendFormat": "Success p{{partition}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(zeebe_camunda_exporter_archiver_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\"}[$__rate_interval])) by (le)",
-          "format": "heatmap",
+          "expr": "sum(rate(zeebe_camunda_exporter_cache_process_load_duration_failure_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\"}[$__rate_interval])) by (partition)",
           "hide": false,
           "instant": false,
-          "interval": "30",
-          "legendFormat": "{{le}}",
+          "legendFormat": "Failure p{{partition}}",
           "range": true,
           "refId": "B"
         }
       ],
-      "title": "Archiving duration",
-      "type": "heatmap"
+      "title": "Cache load rate",
+      "type": "timeseries"
     },
     {
       "datasource": {
@@ -2287,12 +2296,96 @@
       "type": "timeseries"
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "description": "Histogram to show the distribution of the overall archiving duration, which includes searching, reindexing, and deletion.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "scaleDistribution": {
+              "type": "linear"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 61
+      },
+      "id": 17,
+      "options": {
+        "calculate": false,
+        "cellGap": 1,
+        "color": {
+          "exponent": 0.5,
+          "fill": "dark-orange",
+          "mode": "scheme",
+          "reverse": false,
+          "scale": "exponential",
+          "scheme": "Spectral",
+          "steps": 64
+        },
+        "exemplars": {
+          "color": "rgba(255,0,255,0.7)"
+        },
+        "filterValues": {
+          "le": 1e-9
+        },
+        "legend": {
+          "show": false
+        },
+        "rowsFrame": {
+          "layout": "auto"
+        },
+        "tooltip": {
+          "mode": "single",
+          "showColorScale": false,
+          "yHistogram": false
+        },
+        "yAxis": {
+          "axisPlacement": "left",
+          "reverse": false,
+          "unit": "dtdurations"
+        }
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(zeebe_camunda_exporter_archiver_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\"}[$__rate_interval])) by (le)",
+          "format": "heatmap",
+          "hide": false,
+          "instant": false,
+          "interval": "30",
+          "legendFormat": "{{le}}",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Archiving duration",
+      "type": "heatmap"
+    },
+    {
       "collapsed": true,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 61
+        "y": 69
       },
       "id": 1,
       "panels": [
@@ -2669,7 +2762,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 62
+        "y": 70
       },
       "id": 21,
       "panels": [],
@@ -2700,7 +2793,7 @@
         "h": 8,
         "w": 10,
         "x": 0,
-        "y": 63
+        "y": 71
       },
       "id": 22,
       "options": {
@@ -2786,7 +2879,7 @@
         "h": 8,
         "w": 11,
         "x": 10,
-        "y": 63
+        "y": 71
       },
       "id": 23,
       "options": {
@@ -2887,7 +2980,7 @@
         "h": 8,
         "w": 3,
         "x": 21,
-        "y": 63
+        "y": 71
       },
       "id": 24,
       "options": {
@@ -2947,7 +3040,7 @@
         "h": 10,
         "w": 11,
         "x": 0,
-        "y": 71
+        "y": 79
       },
       "id": 25,
       "options": {
@@ -3074,7 +3167,7 @@
         "h": 10,
         "w": 8,
         "x": 11,
-        "y": 71
+        "y": 79
       },
       "id": 26,
       "options": {
@@ -3151,7 +3244,7 @@
         "h": 10,
         "w": 5,
         "x": 19,
-        "y": 71
+        "y": 79
       },
       "id": 27,
       "options": {
@@ -3279,12 +3372,12 @@
     ]
   },
   "time": {
-    "from": "now-6h",
+    "from": "now-5m",
     "to": "now"
   },
   "timepicker": {},
   "timezone": "browser",
-  "title": "Data Layer",
-  "uid": "728720fd-6b20-430a-b931-bbfdc71531dd",
-  "version": 3
+  "title": "Data Layer with backlog panel",
+  "uid": "71add83b-578c-4493-8ea7-30580b17caf5",
+  "version": 1
 }

--- a/monitor/grafana/dashboards/data_layer.json
+++ b/monitor/grafana/dashboards/data_layer.json
@@ -3377,7 +3377,7 @@
   },
   "timepicker": {},
   "timezone": "browser",
-  "title": "Data Layer with backlog panel",
+  "title": "Data Layer",
   "uid": "71add83b-578c-4493-8ea7-30580b17caf5",
   "version": 1
 }

--- a/monitor/grafana/dashboards/data_layer.json
+++ b/monitor/grafana/dashboards/data_layer.json
@@ -1211,7 +1211,7 @@
         "type": "prometheus",
         "uid": "PBFA97CFB590B2093"
       },
-      "description": "For each exporter how far behind is it from exporting the records which have been committed.",
+      "description": "How far behind each exporter is from exporting the records which have been committed.",
       "fieldConfig": {
         "defaults": {
           "color": {


### PR DESCRIPTION
## Description

Given the metrics already exist, this just adds the panel for the records left to export backlog for the camunda exporter, a spike or sustained increase in this value can suggest high load and or an issue with flushing.

Snapshot showing panel: name, description and query
https://snapshots.raintank.io/dashboard/snapshot/inBt0goV1k8lE6CGSGQsqp2uwghqdFC9

<img width="1429" height="816" alt="image" src="https://github.com/user-attachments/assets/04eba662-b954-4c3c-93dd-d6219d5cd050" />
panel shows simulated high load with zeebe benchmark starter and worker.

## Related issues

closes #34734 
