### PR TITLE
Access task headers on execution listener

### DIFF
--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractJobWorkerTaskBuilder.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractJobWorkerTaskBuilder.java
@@ -25,7 +25,8 @@ import io.camunda.zeebe.model.bpmn.instance.Task;
  */
 public abstract class AbstractJobWorkerTaskBuilder<
         B extends AbstractJobWorkerTaskBuilder<B, T>, T extends Task>
-    extends AbstractTaskBuilder<B, T> implements ZeebeJobWorkerElementBuilder<B> {
+    extends AbstractTaskBuilder<B, T>
+    implements ZeebeJobWorkerElementBuilder<B>, BuilderWithTaskHeaders<B> {
 
   private final ZeebeJobWorkerPropertiesBuilder<B> jobWorkerPropertiesBuilder;
 

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractThrowEventBuilder.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractThrowEventBuilder.java
@@ -31,7 +31,8 @@ import java.util.function.Consumer;
  */
 public abstract class AbstractThrowEventBuilder<
         B extends AbstractThrowEventBuilder<B, E>, E extends ThrowEvent>
-    extends AbstractEventBuilder<B, E> implements ZeebeJobWorkerElementBuilder<B> {
+    extends AbstractEventBuilder<B, E>
+    implements ZeebeJobWorkerElementBuilder<B>, BuilderWithTaskHeaders<B> {
 
   private final ZeebeJobWorkerPropertiesBuilder<B> jobWorkerPropertiesBuilder;
   private final ZeebeVariablesMappingBuilder<B> variablesMappingBuilder;

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractUserTaskBuilder.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractUserTaskBuilder.java
@@ -38,7 +38,8 @@ import java.util.function.Consumer;
  * @author Sebastian Menski
  */
 public abstract class AbstractUserTaskBuilder<B extends AbstractUserTaskBuilder<B>>
-    extends AbstractTaskBuilder<B, UserTask> implements ZeebeUserTaskPropertiesBuilder<B> {
+    extends AbstractTaskBuilder<B, UserTask>
+    implements ZeebeUserTaskPropertiesBuilder<B>, BuilderWithTaskHeaders<B> {
 
   protected AbstractUserTaskBuilder(
       final BpmnModelInstance modelInstance, final UserTask element, final Class<?> selfType) {
@@ -210,6 +211,7 @@ public abstract class AbstractUserTaskBuilder<B extends AbstractUserTaskBuilder<
     return zeebeTaskPriority(asZeebeExpression(expression));
   }
 
+  @Override
   public B zeebeTaskHeader(final String key, final String value) {
     final ZeebeTaskHeaders taskHeaders = getCreateSingleExtensionElement(ZeebeTaskHeaders.class);
     final ZeebeHeader header = createChild(taskHeaders, ZeebeHeader.class);

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/BuilderWithTaskHeaders.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/BuilderWithTaskHeaders.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.model.bpmn.builder;
+
+public interface BuilderWithTaskHeaders<B extends BuilderWithTaskHeaders<B>> {
+
+  B zeebeTaskHeader(String key, String value);
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobBehavior.java
@@ -296,7 +296,7 @@ public final class BpmnJobBehavior {
         jobProperties,
         JobKind.EXECUTION_LISTENER,
         jobListenerEventType,
-        Collections.emptyMap());
+        executionListener.getJobWorkerProperties().getTaskHeaders());
   }
 
   public void createNewTaskListenerJob(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableFlowNode.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableFlowNode.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.el.Expression;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeExecutionListenerEventType;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 public class ExecutableFlowNode extends AbstractFlowElement {
@@ -62,13 +63,15 @@ public class ExecutableFlowNode extends AbstractFlowElement {
   public void addListener(
       final ZeebeExecutionListenerEventType eventType,
       final Expression type,
-      final Expression retries) {
+      final Expression retries,
+      final Map<String, String> taskHeaders) {
     final ExecutionListener listener = new ExecutionListener();
     listener.setEventType(eventType);
 
     final JobWorkerProperties jobWorkerProperties = new JobWorkerProperties();
     jobWorkerProperties.setType(type);
     jobWorkerProperties.setRetries(retries);
+    jobWorkerProperties.setTaskHeaders(taskHeaders);
     listener.setJobWorkerProperties(jobWorkerProperties);
     executionListeners.add(listener);
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableFlowNode.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableFlowNode.java
@@ -71,9 +71,7 @@ public class ExecutableFlowNode extends AbstractFlowElement {
     final JobWorkerProperties jobWorkerProperties = new JobWorkerProperties();
     jobWorkerProperties.setType(type);
     jobWorkerProperties.setRetries(retries);
-    if (taskHeaders != null) {
-      jobWorkerProperties.setTaskHeaders(taskHeaders);
-    }
+    jobWorkerProperties.setTaskHeaders(taskHeaders);
     listener.setJobWorkerProperties(jobWorkerProperties);
     executionListeners.add(listener);
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableFlowNode.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableFlowNode.java
@@ -71,7 +71,9 @@ public class ExecutableFlowNode extends AbstractFlowElement {
     final JobWorkerProperties jobWorkerProperties = new JobWorkerProperties();
     jobWorkerProperties.setType(type);
     jobWorkerProperties.setRetries(retries);
-    jobWorkerProperties.setTaskHeaders(taskHeaders);
+    if (taskHeaders != null) {
+      jobWorkerProperties.setTaskHeaders(taskHeaders);
+    }
     listener.setJobWorkerProperties(jobWorkerProperties);
     executionListeners.add(listener);
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/FlowNodeTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/FlowNodeTransformer.java
@@ -97,6 +97,6 @@ public final class FlowNodeTransformer implements ModelElementTransformer<FlowNo
         .ifPresent(
             listeners ->
                 executionListenerTransformer.transform(
-                    flowNode, listeners.getExecutionListeners(), expressionLanguage));
+                    element, flowNode, listeners.getExecutionListeners(), expressionLanguage));
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/ProcessTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/ProcessTransformer.java
@@ -50,6 +50,6 @@ public final class ProcessTransformer implements ModelElementTransformer<Process
         .ifPresent(
             listeners ->
                 executionListenerTransformer.transform(
-                    flowNode, listeners.getExecutionListeners(), expressionLanguage));
+                    element, flowNode, listeners.getExecutionListeners(), expressionLanguage));
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/zeebe/ExecutionListenerTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/zeebe/ExecutionListenerTransformer.java
@@ -9,11 +9,16 @@ package io.camunda.zeebe.engine.processing.deployment.model.transformer.zeebe;
 
 import io.camunda.zeebe.el.ExpressionLanguage;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlowNode;
+import io.camunda.zeebe.model.bpmn.instance.BaseElement;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeExecutionListener;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeHeader;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskHeaders;
 import io.camunda.zeebe.util.Either;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.Collection;
+import java.util.Map;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -22,14 +27,22 @@ public final class ExecutionListenerTransformer {
   private static final Logger LOGGER = LoggerFactory.getLogger(ExecutionListenerTransformer.class);
 
   public void transform(
+      final BaseElement element,
       final ExecutableFlowNode executableFlowNode,
       final Collection<ZeebeExecutionListener> executionListeners,
       final ExpressionLanguage expressionLanguage) {
 
+    if (executionListeners.isEmpty()) {
+      // No execution listeners defined, nothing to do
+      return;
+    }
+
+    final var taskHeaders = transformTaskHeaders(element);
+
     executionListeners.forEach(
         listener -> {
           try {
-            addListenerToFlowNode(listener, executableFlowNode, expressionLanguage);
+            addListenerToFlowNode(listener, executableFlowNode, expressionLanguage, taskHeaders);
           } catch (final Exception e) {
             // This is an additional safety, as our transformers currently require additional
             // safeguards to avoid breaking the partition on replay
@@ -44,10 +57,21 @@ public final class ExecutionListenerTransformer {
         });
   }
 
+  private Map<String, String> transformTaskHeaders(final BaseElement element) {
+    final var zeebeTaskHeaders = element.getSingleExtensionElement(ZeebeTaskHeaders.class);
+    if (zeebeTaskHeaders == null) {
+      return null;
+    }
+    return zeebeTaskHeaders.getHeaders().stream()
+        .filter(this::isValidHeader)
+        .collect(Collectors.toMap(ZeebeHeader::getKey, ZeebeHeader::getValue));
+  }
+
   private void addListenerToFlowNode(
       final ZeebeExecutionListener listener,
       final ExecutableFlowNode flowNode,
-      final ExpressionLanguage expressionLanguage) {
+      final ExpressionLanguage expressionLanguage,
+      final Map<String, String> taskHeaders) {
     Either.<Error, ZeebeExecutionListener>right(listener)
         .flatMap(l -> requireNotNull(l, () -> l, "listener"))
         .flatMap(l -> requireNotNull(l, l::getEventType, "eventType"))
@@ -58,7 +82,8 @@ public final class ExecutionListenerTransformer {
                 flowNode.addListener(
                     listener.getEventType(),
                     expressionLanguage.parseExpression(listener.getType()),
-                    expressionLanguage.parseExpression(listener.getRetries())),
+                    expressionLanguage.parseExpression(listener.getRetries()),
+                    taskHeaders),
             error ->
                 LOGGER.debug(
                     """
@@ -75,6 +100,14 @@ public final class ExecutionListenerTransformer {
       return Either.left(new Error("'%s' is null".formatted(attributeName)));
     }
     return Either.right(listener);
+  }
+
+  public boolean isValidHeader(final ZeebeHeader header) {
+    return header != null
+        && header.getValue() != null
+        && !header.getValue().isEmpty()
+        && header.getKey() != null
+        && !header.getKey().isEmpty();
   }
 
   private record Error(String reason) {}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/zeebe/ExecutionListenerTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/zeebe/ExecutionListenerTransformer.java
@@ -60,7 +60,7 @@ public final class ExecutionListenerTransformer {
   private Map<String, String> transformTaskHeaders(final BaseElement element) {
     final var zeebeTaskHeaders = element.getSingleExtensionElement(ZeebeTaskHeaders.class);
     if (zeebeTaskHeaders == null) {
-      return null;
+      return Map.of();
     }
     return zeebeTaskHeaders.getHeaders().stream()
         .filter(this::isValidHeader)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/execution/ExecutionListenerTaskElementsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/execution/ExecutionListenerTaskElementsTest.java
@@ -30,6 +30,7 @@ import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.model.bpmn.builder.AbstractFlowNodeBuilder;
 import io.camunda.zeebe.model.bpmn.builder.AbstractTaskBuilder;
+import io.camunda.zeebe.model.bpmn.builder.BuilderWithTaskHeaders;
 import io.camunda.zeebe.model.bpmn.builder.StartEventBuilder;
 import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.Record;
@@ -48,6 +49,7 @@ import io.camunda.zeebe.protocol.record.value.JobRecordValue;
 import io.camunda.zeebe.protocol.record.value.VariableRecordValue;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import io.camunda.zeebe.util.collection.Tuple;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collection;
@@ -55,6 +57,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import org.assertj.core.api.Assumptions;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -1129,6 +1132,56 @@ public class ExecutionListenerTaskElementsTest {
                   .getFirst())
           .extracting(Record::getKey)
           .isEqualTo(incident.getKey());
+    }
+
+    @Test
+    public void shouldCreateListenerJobsWithCustomHeadersContainingTaskHeaders() {
+      Assumptions.assumeThat(
+              scenario.taskConfigurer.apply(Bpmn.createExecutableProcess(PROCESS_ID).startEvent()))
+          .describedAs(
+              "This test case is only applicable to task builders that support task headers")
+          .isInstanceOf(BuilderWithTaskHeaders.class);
+
+      final var taskHeaderA = Tuple.of("someTaskHeader", "foo");
+      final var taskHeaderB = Tuple.of("anotherTaskHeader", "bar");
+
+      // given
+      deployProcess(
+          createProcessWithTask(
+              b ->
+                  ((BuilderWithTaskHeaders<?>)
+                          b.zeebeStartExecutionListener(START_EL_TYPE)
+                              .zeebeEndExecutionListener(END_EL_TYPE))
+                      .zeebeTaskHeader(taskHeaderA.getLeft(), taskHeaderA.getRight())
+                      .zeebeTaskHeader(taskHeaderB.getLeft(), taskHeaderB.getRight())));
+
+      // when both start and end execution listeners are created and completed
+      final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+      ENGINE.job().ofInstance(processInstanceKey).withType(START_EL_TYPE).complete();
+      scenario.taskProcessor.accept(processInstanceKey);
+      ENGINE.job().ofInstance(processInstanceKey).withType(END_EL_TYPE).complete();
+
+      // then
+      assertThat(
+              jobRecords()
+                  .withProcessInstanceKey(processInstanceKey)
+                  .withJobKind(JobKind.EXECUTION_LISTENER)
+                  .withIntent(JobIntent.CREATED)
+                  .limit(2))
+          .hasSize(2)
+          .extracting(r -> r.getValue().getCustomHeaders())
+          .describedAs("Expect that the created jobs have the task headers")
+          .containsOnly(Map.ofEntries(taskHeaderA.toEntry(), taskHeaderB.toEntry()));
+      assertThat(
+              jobRecords()
+                  .withProcessInstanceKey(processInstanceKey)
+                  .withJobKind(JobKind.EXECUTION_LISTENER)
+                  .withIntent(JobIntent.COMPLETED)
+                  .limit(2))
+          .hasSize(2)
+          .extracting(r -> r.getValue().getCustomHeaders())
+          .describedAs("Expect that the completed jobs also have the task headers")
+          .containsOnly(Map.ofEntries(taskHeaderA.toEntry(), taskHeaderB.toEntry()));
     }
 
     private void assertExecutionListenerJobsCompleted(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/execution/ExecutionListenerTaskElementsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/execution/ExecutionListenerTaskElementsTest.java
@@ -1169,9 +1169,11 @@ public class ExecutionListenerTaskElementsTest {
                   .withIntent(JobIntent.CREATED)
                   .limit(2))
           .hasSize(2)
-          .extracting(r -> r.getValue().getCustomHeaders())
-          .describedAs("Expect that the created jobs have the task headers")
-          .containsOnly(Map.ofEntries(taskHeaderA.toEntry(), taskHeaderB.toEntry()));
+          .allSatisfy(
+              r ->
+                  assertThat(r.getValue().getCustomHeaders())
+                      .describedAs("Expect that the created job have the task headers")
+                      .containsOnly(taskHeaderA.toEntry(), taskHeaderB.toEntry()));
       assertThat(
               jobRecords()
                   .withProcessInstanceKey(processInstanceKey)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/execution/ExecutionListenerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/execution/ExecutionListenerTest.java
@@ -587,6 +587,7 @@ public class ExecutionListenerTest {
                 <bpmn:extensionElements>
                   <zeebe:executionListeners>
                     <zeebe:executionListener eventType="start" type="start" />
+                    <zeebe:executionListener eventType="end" type="end" />
                   </zeebe:executionListeners>
                   <zeebe:taskHeaders>
                     <zeebe:header key="foo" value="bar" />
@@ -623,6 +624,7 @@ public class ExecutionListenerTest {
     final long processInstanceKey =
         ENGINE.processInstance().ofBpmnProcessId("Process_1x1wunc").create();
     ENGINE.job().ofInstance(processInstanceKey).withType("start").complete();
+    ENGINE.job().ofInstance(processInstanceKey).withType("end").complete();
 
     // then
     assertThat(
@@ -630,21 +632,25 @@ public class ExecutionListenerTest {
                 .withProcessInstanceKey(processInstanceKey)
                 .withJobKind(JobKind.EXECUTION_LISTENER)
                 .withIntent(JobIntent.CREATED)
-                .limit(1))
-        .hasSize(1)
-        .extracting(r -> r.getValue().getCustomHeaders())
-        .describedAs("Expect that the created jobs have the task headers")
-        .containsOnly(Map.of("foo", "bar"));
+                .limit(2))
+        .hasSize(2)
+        .allSatisfy(
+            r ->
+                assertThat(r.getValue().getCustomHeaders())
+                    .describedAs("Expect that the created jobs have the task headers")
+                    .isEqualTo(Map.of("foo", "bar")));
     assertThat(
             jobRecords()
                 .withProcessInstanceKey(processInstanceKey)
                 .withJobKind(JobKind.EXECUTION_LISTENER)
                 .withIntent(JobIntent.COMPLETED)
-                .limit(1))
-        .hasSize(1)
-        .extracting(r -> r.getValue().getCustomHeaders())
-        .describedAs("Expect that the completed jobs also have the task headers")
-        .containsOnly(Map.of("foo", "bar"));
+                .limit(2))
+        .hasSize(2)
+        .allSatisfy(
+            r ->
+                assertThat(r.getValue().getCustomHeaders())
+                    .describedAs("Expect that the completed jobs also have the task headers")
+                    .isEqualTo(Map.of("foo", "bar")));
   }
 
   // test util methods

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/execution/ExecutionListenerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/execution/ExecutionListenerTest.java
@@ -30,7 +30,6 @@ import io.camunda.zeebe.protocol.record.value.JobKind;
 import io.camunda.zeebe.protocol.record.value.JobRecordValue;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
-import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
@@ -575,49 +574,12 @@ public class ExecutionListenerTest {
   }
 
   @Test
-  public void shouldCreateListenerJobsWithCustomHeadersContainingTaskHeadersOnProcessStart() {
+  public void shouldCreateExecutionListenerJobsWithCustomHeadersContainingTaskHeaders() {
     // given
     ENGINE
         .deployment()
-        .withXmlResource(
-            """
-            <?xml version="1.0" encoding="UTF-8"?>
-            <bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1wnykb0" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.37.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.7.0">
-              <bpmn:process id="Process_1x1wunc" isExecutable="true">
-                <bpmn:extensionElements>
-                  <zeebe:executionListeners>
-                    <zeebe:executionListener eventType="start" type="start" />
-                    <zeebe:executionListener eventType="end" type="end" />
-                  </zeebe:executionListeners>
-                  <zeebe:taskHeaders>
-                    <zeebe:header key="foo" value="bar" />
-                  </zeebe:taskHeaders>
-                </bpmn:extensionElements>
-                <bpmn:startEvent id="StartEvent_1">
-                  <bpmn:outgoing>Flow_0g4i5lz</bpmn:outgoing>
-                </bpmn:startEvent>
-                <bpmn:endEvent id="Event_0ykkkx4">
-                  <bpmn:incoming>Flow_0g4i5lz</bpmn:incoming>
-                </bpmn:endEvent>
-                <bpmn:sequenceFlow id="Flow_0g4i5lz" sourceRef="StartEvent_1" targetRef="Event_0ykkkx4" />
-              </bpmn:process>
-              <bpmndi:BPMNDiagram id="BPMNDiagram_1">
-                <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1x1wunc">
-                  <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
-                    <dc:Bounds x="182" y="82" width="36" height="36" />
-                  </bpmndi:BPMNShape>
-                  <bpmndi:BPMNShape id="Event_0ykkkx4_di" bpmnElement="Event_0ykkkx4">
-                    <dc:Bounds x="272" y="82" width="36" height="36" />
-                  </bpmndi:BPMNShape>
-                  <bpmndi:BPMNEdge id="Flow_0g4i5lz_di" bpmnElement="Flow_0g4i5lz">
-                    <di:waypoint x="218" y="100" />
-                    <di:waypoint x="272" y="100" />
-                  </bpmndi:BPMNEdge>
-                </bpmndi:BPMNPlane>
-              </bpmndi:BPMNDiagram>
-            </bpmn:definitions>
-            """
-                .getBytes(StandardCharsets.UTF_8))
+        .withXmlClasspathResource(
+            "/processes/process_with_execution_listeners_and_task_headers.bpmn")
         .deploy();
 
     // when both start and end execution listeners are created and completed

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/execution/ExecutionListenerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/execution/ExecutionListenerTest.java
@@ -30,6 +30,7 @@ import io.camunda.zeebe.protocol.record.value.JobKind;
 import io.camunda.zeebe.protocol.record.value.JobRecordValue;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
@@ -571,6 +572,79 @@ public class ExecutionListenerTest {
                 .getFirst())
         .extracting(r -> r.getValue().getType())
         .isEqualTo(START_EL_TYPE + "_sub");
+  }
+
+  @Test
+  public void shouldCreateListenerJobsWithCustomHeadersContainingTaskHeadersOnProcessStart() {
+    // given
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1wnykb0" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.37.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.7.0">
+              <bpmn:process id="Process_1x1wunc" isExecutable="true">
+                <bpmn:extensionElements>
+                  <zeebe:executionListeners>
+                    <zeebe:executionListener eventType="start" type="start" />
+                  </zeebe:executionListeners>
+                  <zeebe:taskHeaders>
+                    <zeebe:header key="foo" value="bar" />
+                  </zeebe:taskHeaders>
+                </bpmn:extensionElements>
+                <bpmn:startEvent id="StartEvent_1">
+                  <bpmn:outgoing>Flow_0g4i5lz</bpmn:outgoing>
+                </bpmn:startEvent>
+                <bpmn:endEvent id="Event_0ykkkx4">
+                  <bpmn:incoming>Flow_0g4i5lz</bpmn:incoming>
+                </bpmn:endEvent>
+                <bpmn:sequenceFlow id="Flow_0g4i5lz" sourceRef="StartEvent_1" targetRef="Event_0ykkkx4" />
+              </bpmn:process>
+              <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+                <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1x1wunc">
+                  <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
+                    <dc:Bounds x="182" y="82" width="36" height="36" />
+                  </bpmndi:BPMNShape>
+                  <bpmndi:BPMNShape id="Event_0ykkkx4_di" bpmnElement="Event_0ykkkx4">
+                    <dc:Bounds x="272" y="82" width="36" height="36" />
+                  </bpmndi:BPMNShape>
+                  <bpmndi:BPMNEdge id="Flow_0g4i5lz_di" bpmnElement="Flow_0g4i5lz">
+                    <di:waypoint x="218" y="100" />
+                    <di:waypoint x="272" y="100" />
+                  </bpmndi:BPMNEdge>
+                </bpmndi:BPMNPlane>
+              </bpmndi:BPMNDiagram>
+            </bpmn:definitions>
+            """
+                .getBytes(StandardCharsets.UTF_8))
+        .deploy();
+
+    // when both start and end execution listeners are created and completed
+    final long processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId("Process_1x1wunc").create();
+    ENGINE.job().ofInstance(processInstanceKey).withType("start").complete();
+
+    // then
+    assertThat(
+            jobRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .withJobKind(JobKind.EXECUTION_LISTENER)
+                .withIntent(JobIntent.CREATED)
+                .limit(1))
+        .hasSize(1)
+        .extracting(r -> r.getValue().getCustomHeaders())
+        .describedAs("Expect that the created jobs have the task headers")
+        .containsOnly(Map.of("foo", "bar"));
+    assertThat(
+            jobRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .withJobKind(JobKind.EXECUTION_LISTENER)
+                .withIntent(JobIntent.COMPLETED)
+                .limit(1))
+        .hasSize(1)
+        .extracting(r -> r.getValue().getCustomHeaders())
+        .describedAs("Expect that the completed jobs also have the task headers")
+        .containsOnly(Map.of("foo", "bar"));
   }
 
   // test util methods

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/zeebe/ExecutionListenerTransformerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/zeebe/ExecutionListenerTransformerTest.java
@@ -9,6 +9,8 @@ package io.camunda.zeebe.engine.processing.deployment.model.transformer.zeebe;
 
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableProcess;
 import io.camunda.zeebe.engine.util.FakeExpressionLanguage;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.instance.BaseElement;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeExecutionListener;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -19,6 +21,8 @@ import org.junit.jupiter.api.Test;
 
 class ExecutionListenerTransformerTest {
 
+  private final BaseElement element = Bpmn.createProcess().getElement();
+
   @Test
   void shouldNotAddListenersIfNoneProvided() {
     // given
@@ -26,7 +30,8 @@ class ExecutionListenerTransformerTest {
 
     // when
     final Collection<ZeebeExecutionListener> listeners = List.of();
-    new ExecutionListenerTransformer().transform(process, listeners, new FakeExpressionLanguage());
+    new ExecutionListenerTransformer()
+        .transform(element, process, listeners, new FakeExpressionLanguage());
 
     // then
     Assertions.assertThat(process.hasExecutionListeners()).isFalse();
@@ -40,7 +45,7 @@ class ExecutionListenerTransformerTest {
     // when
     final var listener = new FakeZeebeExecutionListener("start", "type", "3");
     new ExecutionListenerTransformer()
-        .transform(process, List.of(listener), new FakeExpressionLanguage());
+        .transform(element, process, List.of(listener), new FakeExpressionLanguage());
 
     // then
     Assertions.assertThat(process.hasExecutionListeners()).isTrue();
@@ -58,7 +63,7 @@ class ExecutionListenerTransformerTest {
       final var listeners = new ArrayList<ZeebeExecutionListener>();
       listeners.add(null);
       new ExecutionListenerTransformer()
-          .transform(process, listeners, new FakeExpressionLanguage());
+          .transform(element, process, listeners, new FakeExpressionLanguage());
 
       // then
       Assertions.assertThat(process.hasExecutionListeners()).isFalse();
@@ -73,7 +78,7 @@ class ExecutionListenerTransformerTest {
       final var listeners = new ArrayList<ZeebeExecutionListener>();
       listeners.add(new FakeZeebeExecutionListener(null, "type", "3"));
       new ExecutionListenerTransformer()
-          .transform(process, listeners, new FakeExpressionLanguage());
+          .transform(element, process, listeners, new FakeExpressionLanguage());
 
       // then
       Assertions.assertThat(process.hasExecutionListeners()).isFalse();
@@ -88,7 +93,7 @@ class ExecutionListenerTransformerTest {
       final var listeners = new ArrayList<ZeebeExecutionListener>();
       listeners.add(new FakeZeebeExecutionListener("start", null, "3"));
       new ExecutionListenerTransformer()
-          .transform(process, listeners, new FakeExpressionLanguage());
+          .transform(element, process, listeners, new FakeExpressionLanguage());
 
       // then
       Assertions.assertThat(process.hasExecutionListeners()).isFalse();
@@ -103,7 +108,7 @@ class ExecutionListenerTransformerTest {
       final var listeners = new ArrayList<ZeebeExecutionListener>();
       listeners.add(new FakeZeebeExecutionListener("start", "type", null));
       new ExecutionListenerTransformer()
-          .transform(process, listeners, new FakeExpressionLanguage());
+          .transform(element, process, listeners, new FakeExpressionLanguage());
 
       // then
       Assertions.assertThat(process.hasExecutionListeners()).isFalse();

--- a/zeebe/engine/src/test/resources/processes/process_with_execution_listeners_and_task_headers.bpmn
+++ b/zeebe/engine/src/test/resources/processes/process_with_execution_listeners_and_task_headers.bpmn
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1wnykb0" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.37.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.7.0">
+  <bpmn:process id="Process_1x1wunc" isExecutable="true">
+    <bpmn:extensionElements>
+      <zeebe:executionListeners>
+        <zeebe:executionListener eventType="start" type="start" />
+        <zeebe:executionListener eventType="end" type="end" />
+      </zeebe:executionListeners>
+      <zeebe:taskHeaders>
+        <zeebe:header key="foo" value="bar" />
+      </zeebe:taskHeaders>
+    </bpmn:extensionElements>
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_0g4i5lz</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:endEvent id="Event_0ykkkx4">
+      <bpmn:incoming>Flow_0g4i5lz</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0g4i5lz" sourceRef="StartEvent_1" targetRef="Event_0ykkkx4" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1x1wunc">
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="182" y="82" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0ykkkx4_di" bpmnElement="Event_0ykkkx4">
+        <dc:Bounds x="272" y="82" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0g4i5lz_di" bpmnElement="Flow_0g4i5lz">
+        <di:waypoint x="218" y="100" />
+        <di:waypoint x="272" y="100" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/collection/Tuple.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/collection/Tuple.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.util.collection;
 
+import java.util.Map;
+
 public final class Tuple<L, R> {
 
   private L left;
@@ -35,6 +37,11 @@ public final class Tuple<L, R> {
 
   public void setLeft(final L left) {
     this.left = left;
+  }
+
+  /** Convenience method to use Tuple in Map.ofEntry. */
+  public Map.Entry<L, R> toEntry() {
+    return Map.entry(left, right);
   }
 
   @Override


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This enables accessing configured static task headers through the custom headers of the execution listener job.

While it works for task headers specified on any flow node or process element, it does not (yet) allow specifying task headers on all elements via the bpmn-model-api. So, in specific cases, the task headers must be added by modifying the XML directly.

Here's an example of a task header on the process element. You can add the `taskHeaders` extension element to any flow node or process element with one or more execution listener defined:

> ```xml
> <bpmn:process id="Process_1x1wunc" isExecutable="true">
>   <bpmn:extensionElements>
>     <zeebe:executionListeners>
>       <zeebe:executionListener eventType="start" type="start" />
>     </zeebe:executionListeners>
>     <zeebe:taskHeaders>
>       <zeebe:header key="foo" value="bar" />
>     </zeebe:taskHeaders>
>   </bpmn:extensionElements>
>   <bpmn:startEvent id="StartEvent_1">
>     <bpmn:outgoing>Flow_0g4i5lz</bpmn:outgoing>
>   </bpmn:startEvent>
>   <!--...-->
> </bpmn:process>
> ```

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #29460 
