### PR TITLE
OS repo tests: do not delete lifecycle policies after each test.

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryIT.java
@@ -350,7 +350,7 @@ final class OpenSearchArchiverRepositoryIT {
   void shouldSetTheCorrectFinishDateWithRollover() throws IOException {
     Assumptions.assumeTrue(
         System.getProperty(TEST_INTEGRATION_OPENSEARCH_AWS_URL, "").isEmpty(),
-        "Skipping test if AWS is used.");
+        "Skipping test if AWS is used. See https://github.com/camunda/camunda/pull/35591");
     // given a rollover of 3 days:
     config.setRolloverInterval("3d");
     final var dateFormatter =
@@ -435,7 +435,7 @@ final class OpenSearchArchiverRepositoryIT {
   void shouldFetchHistoricalDatesOnStart() throws IOException {
     Assumptions.assumeTrue(
         System.getProperty(TEST_INTEGRATION_OPENSEARCH_AWS_URL, "").isEmpty(),
-        "Skipping test if AWS is used.");
+        "Skipping test if AWS is used. See https://github.com/camunda/camunda/pull/35591");
     final var dateFormatter =
         DateTimeFormatter.ofPattern("yyyy-MM-dd").withZone(ZoneId.systemDefault());
     final var now = Instant.now();
@@ -470,7 +470,7 @@ final class OpenSearchArchiverRepositoryIT {
   void shouldFetchHistoricalDatesOnStartAndExcludeZeebePrefix() throws IOException {
     Assumptions.assumeTrue(
         System.getProperty(TEST_INTEGRATION_OPENSEARCH_AWS_URL, "").isEmpty(),
-        "Skipping test if AWS is used.");
+        "Skipping test if AWS is used. See https://github.com/camunda/camunda/pull/35591");
 
     final var dateFormatter =
         DateTimeFormatter.ofPattern("yyyy-MM-dd").withZone(ZoneId.systemDefault());

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryIT.java
@@ -85,7 +85,7 @@ final class OpenSearchArchiverRepositoryIT {
   void afterEach() throws IOException {
     // wipes all data in OS between tests
     final var response =
-        transport.restClient().performRequest(new org.opensearch.client.Request("DELETE", "_all"));
+        transport.restClient().performRequest(new org.opensearch.client.Request("DELETE", "*"));
     assertThat(response.getStatusLine().getStatusCode()).isEqualTo(200);
   }
 


### PR DESCRIPTION
## Description

[<!-- Describe the goal and purpose of this PR. -->
](https://camunda.slack.com/archives/C08NQKV761G/p1752760231857609) In these AWS tests, the clean-up step seems to fail because the default configs for AWS cannot delete lifecycle policies, which is also not needed to clean for these tests, so we change the clean-up process to only clean user-generated indexes. 

The rollover tests also seem to fail when running in AWS so will disable these just when running in AWS until we find the root cause.

The issue https://github.com/camunda/camunda/issues/35675 was created to investigate the root cause. 
## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
