### PR TITLE
feat: add an optional checksum to snapshot ids

### DIFF
--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
@@ -99,7 +99,7 @@ public class PassiveRole extends InactiveRole {
 
     // as a safeguard, we clean up any orphaned pending snapshots
     try {
-      raft.getPersistedSnapshotStore().purgePendingSnapshots().join();
+      raft.getPersistedSnapshotStore().abortPendingSnapshots().join();
     } catch (final Exception e) {
       log.warn(
           "Failed to purge pending snapshots, which may result in unnecessary disk usage and should be monitored",

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/cluster/NoopSnapshotStore.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/cluster/NoopSnapshotStore.java
@@ -50,7 +50,7 @@ public class NoopSnapshotStore implements ReceivableSnapshotStore {
   }
 
   @Override
-  public ActorFuture<Void> purgePendingSnapshots() {
+  public ActorFuture<Void> abortPendingSnapshots() {
     return null;
   }
 

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/roles/LeaderRoleTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/roles/LeaderRoleTest.java
@@ -102,7 +102,7 @@ public class LeaderRoleTest {
     when(context.getLog()).thenReturn(log);
 
     final ReceivableSnapshotStore persistedSnapshotStore = mock(ReceivableSnapshotStore.class);
-    when(persistedSnapshotStore.purgePendingSnapshots())
+    when(persistedSnapshotStore.abortPendingSnapshots())
         .thenReturn(CompletableActorFuture.completed(null));
     when(context.getPersistedSnapshotStore()).thenReturn(persistedSnapshotStore);
     when(context.getEntryValidator()).thenReturn((a, b) -> ValidationResult.ok());

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/snapshot/TestSnapshotStore.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/snapshot/TestSnapshotStore.java
@@ -76,7 +76,7 @@ public class TestSnapshotStore implements ReceivableSnapshotStore {
   }
 
   @Override
-  public ActorFuture<Void> purgePendingSnapshots() {
+  public ActorFuture<Void> abortPendingSnapshots() {
     receivedSnapshots.clear();
     return CompletableActorFuture.completed(null);
   }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/management/BrokerAdminServiceImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/management/BrokerAdminServiceImpl.java
@@ -170,8 +170,7 @@ public final class BrokerAdminServiceImpl extends Actor implements BrokerAdminSe
     final var snapshotId = getSnapshotId(partition);
     final var processedPositionInSnapshot =
         snapshotId
-            .flatMap(FileBasedSnapshotId::ofFileName)
-            .map(FileBasedSnapshotId::getProcessedPosition)
+            .map(id -> FileBasedSnapshotId.ofFileName(id).getOrThrow().getProcessedPosition())
             .orElse(null);
     final var clockFuture = streamProcessor.getClock();
 

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/BrokerSnapshotTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/BrokerSnapshotTest.java
@@ -116,6 +116,6 @@ public class BrokerSnapshotTest {
                             .processedPositionInSnapshot())
                     .isNotNull());
     final PartitionStatus partitionStatus = brokerAdminService.getPartitionStatus().get(1);
-    return FileBasedSnapshotId.ofFileName(partitionStatus.snapshotId()).get();
+    return FileBasedSnapshotId.ofFileName(partitionStatus.snapshotId()).getOrThrow();
   }
 }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/StateControllerImplTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/StateControllerImplTest.java
@@ -197,8 +197,8 @@ public final class StateControllerImplTest {
         .extracting(PersistedSnapshot::getCompactionBound)
         .isEqualTo(firstSnapshot.getCompactionBound());
     assertThat(snapshot.getId()).isNotEqualTo(firstSnapshot.getId());
-    final var newSnapshotId = FileBasedSnapshotId.ofFileName(snapshot.getId()).orElseThrow();
-    final var firstSnapshotId = FileBasedSnapshotId.ofFileName(firstSnapshot.getId()).orElseThrow();
+    final var newSnapshotId = FileBasedSnapshotId.ofFileName(snapshot.getId()).getOrThrow();
+    final var firstSnapshotId = FileBasedSnapshotId.ofFileName(firstSnapshot.getId()).getOrThrow();
     assertThat(firstSnapshotId).isLessThan(newSnapshotId);
   }
 
@@ -221,8 +221,8 @@ public final class StateControllerImplTest {
         .extracting(PersistedSnapshot::getCompactionBound)
         .isEqualTo(firstSnapshot.getCompactionBound());
     assertThat(snapshot.getId()).isNotEqualTo(firstSnapshot.getId());
-    final var newSnapshotId = FileBasedSnapshotId.ofFileName(snapshot.getId()).orElseThrow();
-    final var firstSnapshotId = FileBasedSnapshotId.ofFileName(firstSnapshot.getId()).orElseThrow();
+    final var newSnapshotId = FileBasedSnapshotId.ofFileName(snapshot.getId()).getOrThrow();
+    final var firstSnapshotId = FileBasedSnapshotId.ofFileName(firstSnapshot.getId()).getOrThrow();
     assertThat(newSnapshotId.getExportedPosition())
         .isEqualTo(firstSnapshotId.getExportedPosition());
     assertThat(newSnapshotId.getProcessedPosition())
@@ -248,8 +248,8 @@ public final class StateControllerImplTest {
         .extracting(PersistedSnapshot::getCompactionBound)
         .isEqualTo(firstSnapshot.getCompactionBound());
     assertThat(snapshot.getId()).isNotEqualTo(firstSnapshot.getId());
-    final var newSnapshotId = FileBasedSnapshotId.ofFileName(snapshot.getId()).orElseThrow();
-    final var firstSnapshotId = FileBasedSnapshotId.ofFileName(firstSnapshot.getId()).orElseThrow();
+    final var newSnapshotId = FileBasedSnapshotId.ofFileName(snapshot.getId()).getOrThrow();
+    final var firstSnapshotId = FileBasedSnapshotId.ofFileName(firstSnapshot.getId()).getOrThrow();
     assertThat(firstSnapshotId).isLessThan(newSnapshotId);
   }
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/ContinuousBackupIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/ContinuousBackupIT.java
@@ -116,7 +116,7 @@ final class ContinuousBackupIT {
 
   private long getSnapshotIndex() {
     return FileBasedSnapshotId.ofFileName(partitionsActuator.query().get(1).snapshotId())
-        .orElseThrow()
+        .getOrThrow()
         .getIndex();
   }
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/RestoreAcceptance.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/RestoreAcceptance.java
@@ -20,9 +20,8 @@ import io.camunda.zeebe.qa.util.actuator.PartitionsActuator;
 import io.camunda.zeebe.qa.util.cluster.TestRestoreApp;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import io.camunda.zeebe.restore.BackupNotFoundException;
-import io.camunda.zeebe.snapshots.impl.FileBasedSnapshotId;
 import java.time.Duration;
-import java.util.Optional;
+import java.util.Objects;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 
@@ -63,11 +62,7 @@ public interface RestoreAcceptance {
 
       Awaitility.await("Snapshot is taken")
           .atMost(Duration.ofSeconds(60))
-          .until(
-              () ->
-                  Optional.ofNullable(partitions.query().get(1).snapshotId())
-                      .flatMap(FileBasedSnapshotId::ofFileName),
-              Optional::isPresent);
+          .until(() -> partitions.query().get(1).snapshotId(), Objects::nonNull);
 
       assertThat(actuator.take(backupId)).isInstanceOf(TakeBackupRuntimeResponse.class);
       Awaitility.await("until a backup exists with the given ID")

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ClusteringRule.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ClusteringRule.java
@@ -947,7 +947,7 @@ public class ClusteringRule extends ExternalResource {
 
     return Optional.ofNullable(partitionStatus)
         .map(PartitionStatus::snapshotId)
-        .flatMap(FileBasedSnapshotId::ofFileName);
+        .map(id -> FileBasedSnapshotId.ofFileName(id).getOrThrow());
   }
 
   public Optional<SnapshotId> getSnapshot(final Broker broker) {

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/SnapshotWithExportersTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/SnapshotWithExportersTest.java
@@ -65,7 +65,7 @@ final class SnapshotWithExportersTest {
               .until(
                   () ->
                       Optional.ofNullable(partitions.query().get(1).snapshotId())
-                          .flatMap(FileBasedSnapshotId::ofFileName),
+                          .map(id -> FileBasedSnapshotId.ofFileName(id).getOrThrow()),
                   Optional::isPresent)
               .orElseThrow();
       // pause processing to avoid new processing to cause a new snapshot after restart
@@ -83,7 +83,7 @@ final class SnapshotWithExportersTest {
               .until(
                   () ->
                       Optional.ofNullable(partitions.query().get(1).snapshotId())
-                          .flatMap(FileBasedSnapshotId::ofFileName),
+                          .map(id -> FileBasedSnapshotId.ofFileName(id).getOrThrow()),
                   hasStableValue())
               .orElseThrow();
 
@@ -122,7 +122,7 @@ final class SnapshotWithExportersTest {
               .until(
                   () ->
                       Optional.ofNullable(partitions.query().get(1).snapshotId())
-                          .flatMap(FileBasedSnapshotId::ofFileName),
+                          .map(id -> FileBasedSnapshotId.ofFileName(id).getOrThrow()),
                   Optional::isPresent)
               .orElseThrow();
 
@@ -165,7 +165,7 @@ final class SnapshotWithExportersTest {
                 .until(
                     () ->
                         Optional.ofNullable(partitions.query().get(1).snapshotId())
-                            .flatMap(FileBasedSnapshotId::ofFileName),
+                            .map(id -> FileBasedSnapshotId.ofFileName(id).getOrThrow()),
                     hasStableValue())
                 .orElseThrow();
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/SnapshotAfterScalingTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/SnapshotAfterScalingTest.java
@@ -138,7 +138,9 @@ final class SnapshotAfterScalingTest {
             statuses.stream()
                 .map(
                     status ->
-                        FileBasedSnapshotId.ofFileName(status.get(1).snapshotId()).get().getIndex())
+                        FileBasedSnapshotId.ofFileName(status.get(1).snapshotId())
+                            .getOrThrow()
+                            .getIndex())
                 .distinct()
                 .count())
         .describedAs(

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/processing/FormLinkingIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/processing/FormLinkingIT.java
@@ -17,11 +17,10 @@ import io.camunda.zeebe.qa.util.actuator.PartitionsActuator;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
-import io.camunda.zeebe.snapshots.impl.FileBasedSnapshotId;
 import io.camunda.zeebe.test.util.junit.RegressionTest;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import java.time.Duration;
-import java.util.Optional;
+import java.util.Objects;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.BeforeEach;
@@ -74,12 +73,7 @@ final class FormLinkingIT {
     partitions.takeSnapshot();
     Awaitility.await("Snapshot is taken")
         .atMost(Duration.ofSeconds(60))
-        .until(
-            () ->
-                Optional.ofNullable(partitions.query().get(1).snapshotId())
-                    .flatMap(FileBasedSnapshotId::ofFileName),
-            Optional::isPresent)
-        .orElseThrow();
+        .until(() -> partitions.query().get(1).snapshotId(), Objects::nonNull);
     zeebe.stop();
 
     // when

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/system/BrokerAdminServiceTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/system/BrokerAdminServiceTest.java
@@ -21,7 +21,6 @@ import io.camunda.zeebe.qa.util.actuator.PartitionsActuator;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
-import io.camunda.zeebe.snapshots.impl.FileBasedSnapshotId;
 import io.camunda.zeebe.stream.impl.StreamProcessor.Phase;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.util.buffer.BufferWriter;
@@ -31,7 +30,7 @@ import io.grpc.StatusRuntimeException;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
-import java.util.Optional;
+import java.util.Objects;
 import java.util.concurrent.Future;
 import org.agrona.DirectBuffer;
 import org.assertj.core.api.InstanceOfAssertFactories;
@@ -299,12 +298,7 @@ public class BrokerAdminServiceTest {
   private void waitForSnapshotAtBroker() {
     Awaitility.await("snapshot is taken")
         .atMost(Duration.ofSeconds(60))
-        .until(
-            () ->
-                Optional.ofNullable(partitions.query().get(1).snapshotId())
-                    .flatMap(FileBasedSnapshotId::ofFileName),
-            Optional::isPresent)
-        .orElseThrow();
+        .until(() -> partitions.query().get(1).snapshotId(), Objects::nonNull);
   }
 
   private static final class TestClockRequest extends BrokerExecuteCommand<ClockRecord> {

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/PersistedSnapshotStore.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/PersistedSnapshotStore.java
@@ -49,7 +49,7 @@ public interface PersistedSnapshotStore extends CloseableSilently, BootstrapSnap
    *
    * @return future which will be completed when all pending snapshots are deleted
    */
-  ActorFuture<Void> purgePendingSnapshots();
+  ActorFuture<Void> abortPendingSnapshots();
 
   /**
    * Adds an {@link PersistedSnapshotListener} to the store, which is notified when a new {@link

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStore.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStore.java
@@ -166,7 +166,7 @@ public final class FileBasedSnapshotStore extends Actor
   }
 
   public SnapshotMetrics getSnapshotMetrics() {
-    return snapshotStore.getSnapshotMetrics();
+    return snapshotStore.getMetrics();
   }
 
   @Override

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStore.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStore.java
@@ -94,9 +94,9 @@ public final class FileBasedSnapshotStore extends Actor
   }
 
   @Override
-  public ActorFuture<Void> purgePendingSnapshots() {
+  public ActorFuture<Void> abortPendingSnapshots() {
     final CompletableActorFuture<Void> abortFuture = new CompletableActorFuture<>();
-    return snapshotStore.purgePendingSnapshots();
+    return snapshotStore.abortPendingSnapshots();
   }
 
   @Override

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedTransientSnapshot.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedTransientSnapshot.java
@@ -73,7 +73,7 @@ public final class FileBasedTransientSnapshot implements TransientSnapshot {
   }
 
   private void takeInternal(final Consumer<Path> takeSnapshot) {
-    final var snapshotMetrics = snapshotStore.getSnapshotMetrics();
+    final var snapshotMetrics = snapshotStore.getMetrics();
 
     try (final var ignored = snapshotMetrics.startTimer(isBootstrap)) {
       try {

--- a/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/PersistedSnapshotStoreTest.java
+++ b/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/PersistedSnapshotStoreTest.java
@@ -83,7 +83,8 @@ public class PersistedSnapshotStoreTest {
     final var index = 1L;
 
     // when
-    final var transientSnapshot = persistedSnapshotStore.newReceivedSnapshot("1-0-123-121").join();
+    final var transientSnapshot =
+        persistedSnapshotStore.newReceivedSnapshot("1-0-123-121-1").join();
 
     // then
     assertThat(transientSnapshot.index()).isEqualTo(index);

--- a/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/ReceivedSnapshotTest.java
+++ b/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/ReceivedSnapshotTest.java
@@ -65,7 +65,7 @@ public class ReceivedSnapshotTest {
     // given
 
     // when
-    final var receivedSnapshot = receiverSnapshotStore.newReceivedSnapshot("1-0-123-121").join();
+    final var receivedSnapshot = receiverSnapshotStore.newReceivedSnapshot("1-0-123-121-1").join();
 
     // then
     assertThat(receivedSnapshot.index()).isEqualTo(1L);

--- a/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/ReceivedSnapshotTest.java
+++ b/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/ReceivedSnapshotTest.java
@@ -57,7 +57,7 @@ public class ReceivedSnapshotTest {
 
     // when
     assertThatThrownBy(() -> receiverSnapshotStore.newReceivedSnapshot("invalid").join())
-        .isInstanceOf(IllegalArgumentException.class);
+        .isInstanceOf(IllegalStateException.class);
   }
 
   @Test

--- a/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/ReceivedSnapshotTest.java
+++ b/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/ReceivedSnapshotTest.java
@@ -128,7 +128,7 @@ public class ReceivedSnapshotTest {
     final var receivedSnapshot = receiveSnapshot(persistedSnapshot).persist().join();
 
     // when
-    receiverSnapshotStore.purgePendingSnapshots().join();
+    receiverSnapshotStore.abortPendingSnapshots().join();
 
     // then
     assertThat(receivedSnapshot.getPath()).as("the received snapshot still exists").exists();

--- a/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/TransientSnapshotTest.java
+++ b/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/TransientSnapshotTest.java
@@ -311,7 +311,7 @@ public class TransientSnapshotTest {
     transientSnapshot.take(this::writeSnapshot).join();
 
     // when
-    snapshotStore.purgePendingSnapshots().join();
+    snapshotStore.abortPendingSnapshots().join();
     final var persisted = transientSnapshot.persist();
 
     // then

--- a/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedReceivedSnapshotTest.java
+++ b/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedReceivedSnapshotTest.java
@@ -70,7 +70,7 @@ public class FileBasedReceivedSnapshotTest {
 
     // when
     final ReceivedSnapshot receivedSnapshot =
-        receiverSnapshotStore.newReceivedSnapshot("1-0-123-121").join();
+        receiverSnapshotStore.newReceivedSnapshot("1-0-123-121-1").join();
 
     // then
     assertThat(receivedSnapshot.getPath())

--- a/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotIdTest.java
+++ b/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotIdTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.snapshots.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+final class FileBasedSnapshotIdTest {
+  @Test
+  void canParseIdWithoutChecksum() {
+    // given
+    final var id = "1-2-3-4-5";
+
+    // when
+    final var snapshotId = FileBasedSnapshotId.ofFileName(id).getOrThrow();
+
+    // then
+    assertThat(snapshotId.getIndex()).isEqualTo(1);
+    assertThat(snapshotId.getTerm()).isEqualTo(2);
+    assertThat(snapshotId.getProcessedPosition()).isEqualTo(3);
+    assertThat(snapshotId.getExportedPosition()).isEqualTo(4);
+  }
+
+  @Test
+  void canRoundTripWithoutChecksum() {
+    // given
+    final var originalId = "1-2-3-4-5";
+
+    // when
+    final var parsedId = FileBasedSnapshotId.ofFileName(originalId).getOrThrow();
+
+    // then
+    assertThat(parsedId.getSnapshotIdAsString()).isEqualTo(originalId);
+  }
+
+  @Test
+  void canParseIdWithChecksum() {
+    // given
+    final var id = "1-2-3-4-5-somechecksum";
+
+    // when
+    final var snapshotId = FileBasedSnapshotId.ofFileName(id).getOrThrow();
+    // then
+    assertThat(snapshotId.getIndex()).isEqualTo(1);
+    assertThat(snapshotId.getTerm()).isEqualTo(2);
+    assertThat(snapshotId.getProcessedPosition()).isEqualTo(3);
+    assertThat(snapshotId.getExportedPosition()).isEqualTo(4);
+  }
+
+  @Test
+  void canRoundTripWithChecksum() {
+    // given
+    final var originalId = "1-2-3-4-5-somechecksum";
+
+    // when
+    final var parsedId = FileBasedSnapshotId.ofFileName(originalId).getOrThrow();
+
+    // then
+    assertThat(parsedId.getSnapshotIdAsString()).isEqualTo(originalId);
+  }
+}

--- a/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedTransientSnapshotTest.java
+++ b/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedTransientSnapshotTest.java
@@ -64,7 +64,7 @@ public class FileBasedTransientSnapshotTest {
     final var transientSnapshot = snapshotStore.newTransientSnapshot(1L, 2L, 3L, 4L).get();
 
     // when
-    final var pathId = FileBasedSnapshotId.ofPath(transientSnapshot.getPath()).orElseThrow();
+    final var pathId = FileBasedSnapshotId.ofPath(transientSnapshot.getPath()).getOrThrow();
 
     // then
     assertThat(pathId).isEqualTo(transientSnapshot.snapshotId());

--- a/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedTransientSnapshotTest.java
+++ b/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedTransientSnapshotTest.java
@@ -30,7 +30,6 @@ import org.junit.rules.TemporaryFolder;
 
 public class FileBasedTransientSnapshotTest {
   private static final String SNAPSHOT_DIRECTORY = "snapshots";
-  private static final String PENDING_DIRECTORY = "pending";
   private static final Map<String, String> SNAPSHOT_FILE_CONTENTS =
       Map.of(
           "file1", "file1 contents",
@@ -41,12 +40,10 @@ public class FileBasedTransientSnapshotTest {
 
   private FileBasedSnapshotStore snapshotStore;
   private Path snapshotsDir;
-  private Path pendingDir;
 
   @Before
   public void beforeEach() throws IOException {
     final var root = temporaryFolder.getRoot().toPath();
-    pendingDir = root.resolve(PENDING_DIRECTORY);
     snapshotsDir = root.resolve(SNAPSHOT_DIRECTORY);
     snapshotStore = createStore(root);
   }
@@ -57,9 +54,6 @@ public class FileBasedTransientSnapshotTest {
     snapshotStore.newTransientSnapshot(1L, 0L, 1L, 0L);
 
     // then
-    assertThat(pendingDir)
-        .as("the pending directory is empty as nothing was written")
-        .isEmptyDirectory();
     assertThat(snapshotsDir)
         .as("the snapshots directory is empty as nothing was written")
         .isEmptyDirectory();
@@ -118,7 +112,6 @@ public class FileBasedTransientSnapshotTest {
     assertThat(transientSnapshot.getPath())
         .as("the transient directory should not exist after abort")
         .doesNotExist();
-    assertThat(pendingDir).as("the pending directory is empty after abort").isEmptyDirectory();
   }
 
   @Test
@@ -129,7 +122,7 @@ public class FileBasedTransientSnapshotTest {
     final var persistedSnapshot = transientSnapshot.persist().join();
 
     // when
-    snapshotStore.purgePendingSnapshots().join();
+    snapshotStore.abortPendingSnapshots().join();
 
     // then
     assertThat(persistedSnapshot.getPath())
@@ -186,41 +179,6 @@ public class FileBasedTransientSnapshotTest {
   }
 
   @Test
-  public void shouldRemoveTransientSnapshotOnPersist() {
-    // given
-    final var transientSnapshot = snapshotStore.newTransientSnapshot(1L, 0L, 1L, 0L).get();
-    transientSnapshot.take(this::writeSnapshot);
-
-    // when
-    final var newSnapshot = snapshotStore.newTransientSnapshot(2L, 0L, 1L, 0L).get();
-    newSnapshot.take(this::writeSnapshot);
-    newSnapshot.persist().join();
-
-    // then
-    assertThat(pendingDir)
-        .as("there are no more transient snapshots after persisting a snapshot with higher index")
-        .isEmptyDirectory();
-  }
-
-  @Test
-  public void shouldRemoveTransientWhenCurrentSnapshotIsNewer() {
-    // given
-    final var transientSnapshot = snapshotStore.newTransientSnapshot(10L, 10L, 10L, 10L).get();
-    transientSnapshot.take(this::writeSnapshot);
-    transientSnapshot.persist().join();
-
-    // when
-    final var oldSnapshot = snapshotStore.newTransientSnapshot(1L, 1L, 1L, 1L).get();
-    oldSnapshot.take(this::writeSnapshot);
-    oldSnapshot.persist().join();
-
-    // then
-    assertThat(pendingDir)
-        .as("transient and outdated snapshot has been deleted")
-        .isEmptyDirectory();
-  }
-
-  @Test
   public void shouldNotRemoveTransientSnapshotWithGreaterIdOnPersist() {
     // given
     final var newerTransientSnapshot = snapshotStore.newTransientSnapshot(2L, 0L, 1L, 0L).get();
@@ -252,7 +210,6 @@ public class FileBasedTransientSnapshotTest {
 
     // then
     assertThatThrownBy(didTakeSnapshot::join).hasCauseInstanceOf(RuntimeException.class);
-    assertThat(pendingDir).as("there is no leftover transient directory").isEmptyDirectory();
     assertThat(snapshotsDir).as("there is no committed snapshot").isEmptyDirectory();
   }
 

--- a/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/testing/TestFileBasedSnapshotStore.java
+++ b/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/testing/TestFileBasedSnapshotStore.java
@@ -77,8 +77,8 @@ public class TestFileBasedSnapshotStore implements ReceivableSnapshotStore {
   }
 
   @Override
-  public ActorFuture<Void> purgePendingSnapshots() {
-    return snapshotStore.purgePendingSnapshots();
+  public ActorFuture<Void> abortPendingSnapshots() {
+    return snapshotStore.abortPendingSnapshots();
   }
 
   @Override


### PR DESCRIPTION
This contains a lot of refactorings and (part of) the actual feature, adding an optional checksum component to the snapshot id.
The previous backwards compatibility for snapshot ids without the broker id was removed, we can assume that all versions we upgrade from use snapshot ids with broker ids.

The new checksum component is not used yet, this will come in a later PR.

Relates to #31102