### PR TITLE
Add implementation type attribute to ad-hoc sub processes

### DIFF
--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractAdHocSubProcessBuilder.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractAdHocSubProcessBuilder.java
@@ -23,6 +23,7 @@ import io.camunda.zeebe.model.bpmn.instance.FlowNode;
 import io.camunda.zeebe.model.bpmn.instance.bpmndi.BpmnShape;
 import io.camunda.zeebe.model.bpmn.instance.dc.Bounds;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeAdHoc;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeAdHocImplementationType;
 
 public class AbstractAdHocSubProcessBuilder<B extends AbstractAdHocSubProcessBuilder<B>>
     extends AbstractSubProcessBuilder<B> {
@@ -68,6 +69,18 @@ public class AbstractAdHocSubProcessBuilder<B extends AbstractAdHocSubProcessBui
    */
   public B cancelRemainingInstances(final boolean cancelRemainingInstances) {
     ((AdHocSubProcess) element).setCancelRemainingInstances(cancelRemainingInstances);
+    return myself;
+  }
+
+  /**
+   * Sets the implementation type of the ad-hoc sub-process.
+   *
+   * @param implementationType the type of implementation
+   * @return the builder object
+   */
+  public B zeebeImplementation(final ZeebeAdHocImplementationType implementationType) {
+    final ZeebeAdHoc adHoc = getCreateSingleExtensionElement(ZeebeAdHoc.class);
+    adHoc.setImplementationType(implementationType);
     return myself;
   }
 

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/impl/instance/zeebe/ZeebeAdHocImpl.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/impl/instance/zeebe/ZeebeAdHocImpl.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.model.bpmn.impl.BpmnModelConstants;
 import io.camunda.zeebe.model.bpmn.impl.ZeebeConstants;
 import io.camunda.zeebe.model.bpmn.impl.instance.BpmnModelElementInstanceImpl;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeAdHoc;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeAdHocImplementationType;
 import org.camunda.bpm.model.xml.ModelBuilder;
 import org.camunda.bpm.model.xml.impl.instance.ModelTypeInstanceContext;
 import org.camunda.bpm.model.xml.type.ModelElementTypeBuilder;
@@ -27,6 +28,7 @@ import org.camunda.bpm.model.xml.type.attribute.Attribute;
 public class ZeebeAdHocImpl extends BpmnModelElementInstanceImpl implements ZeebeAdHoc {
 
   private static Attribute<String> activeElementsCollectionAttribute;
+  private static Attribute<ZeebeAdHocImplementationType> implementationTypeAttribute;
 
   public ZeebeAdHocImpl(final ModelTypeInstanceContext instanceContext) {
     super(instanceContext);
@@ -45,6 +47,15 @@ public class ZeebeAdHocImpl extends BpmnModelElementInstanceImpl implements Zeeb
             .namespace(BpmnModelConstants.ZEEBE_NS)
             .build();
 
+    implementationTypeAttribute =
+        typeBuilder
+            .enumAttribute(
+                BpmnModelConstants.BPMN_ATTRIBUTE_IMPLEMENTATION,
+                ZeebeAdHocImplementationType.class)
+            .namespace(BpmnModelConstants.ZEEBE_NS)
+            .defaultValue(ZeebeAdHocImplementationType.BPMN)
+            .build();
+
     typeBuilder.build();
   }
 
@@ -56,5 +67,15 @@ public class ZeebeAdHocImpl extends BpmnModelElementInstanceImpl implements Zeeb
   @Override
   public void setActiveElementsCollection(final String activeElementsCollection) {
     activeElementsCollectionAttribute.setValue(this, activeElementsCollection);
+  }
+
+  @Override
+  public ZeebeAdHocImplementationType getImplementationType() {
+    return implementationTypeAttribute.getValue(this);
+  }
+
+  @Override
+  public void setImplementationType(final ZeebeAdHocImplementationType implementationType) {
+    implementationTypeAttribute.setValue(this, implementationType);
   }
 }

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeAdHoc.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeAdHoc.java
@@ -32,4 +32,16 @@ public interface ZeebeAdHoc extends BpmnModelElementInstance {
    * @param activateElements the collection of element to be activated
    */
   void setActiveElementsCollection(final String activateElements);
+
+  /**
+   * @return the implementation type of the ad-hoc sub-process
+   */
+  ZeebeAdHocImplementationType getImplementationType();
+
+  /**
+   * Sets the implementation type of the ad-hoc sub-process.
+   *
+   * @param implementationType the implementation type
+   */
+  void setImplementationType(ZeebeAdHocImplementationType implementationType);
 }

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeAdHocImplementationType.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeAdHocImplementationType.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.model.bpmn.instance.zeebe;
+
+/** The implementation type of ad-hoc sub-process. */
+public enum ZeebeAdHocImplementationType {
+  /** The BPMN properties controls the ad-hoc sub-process. */
+  BPMN,
+
+  /** A job worker controls the ad-hoc sub-process. */
+  JOB_WORKER
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableAdHocSubProcess.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableAdHocSubProcess.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.engine.processing.deployment.model.element;
 
 import io.camunda.zeebe.el.Expression;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeAdHocImplementationType;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.HashMap;
 import java.util.Map;
@@ -17,6 +18,7 @@ public class ExecutableAdHocSubProcess extends ExecutableFlowElementContainer {
   private Expression activeElementsCollection;
   private Expression completionCondition;
   private boolean cancelRemainingInstances;
+  private ZeebeAdHocImplementationType implementationType;
 
   private final Map<String, ExecutableFlowNode> adHocActivitiesById = new HashMap<>();
 
@@ -55,5 +57,13 @@ public class ExecutableAdHocSubProcess extends ExecutableFlowElementContainer {
   public void addAdHocActivity(final ExecutableFlowNode adHocActivity) {
     final String elementId = BufferUtil.bufferAsString(adHocActivity.getId());
     adHocActivitiesById.put(elementId, adHocActivity);
+  }
+
+  public ZeebeAdHocImplementationType getImplementationType() {
+    return implementationType;
+  }
+
+  public void setImplementationType(final ZeebeAdHocImplementationType implementationType) {
+    this.implementationType = implementationType;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/AdHocSubProcessTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/AdHocSubProcessTransformer.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.engine.processing.deployment.model.transformation.Transf
 import io.camunda.zeebe.model.bpmn.instance.AdHocSubProcess;
 import io.camunda.zeebe.model.bpmn.instance.CompletionCondition;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeAdHoc;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeAdHocImplementationType;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.BpmnEventType;
 import java.util.Collection;
@@ -49,6 +50,7 @@ public final class AdHocSubProcessTransformer implements ModelElementTransformer
     final Collection<AbstractFlowElement> childElements =
         executableAdHocSubProcess.getChildElements();
     setAdHocActivities(executableAdHocSubProcess, childElements);
+    setImplementationType(executableAdHocSubProcess, element);
   }
 
   private static void setActiveElementsCollection(
@@ -72,6 +74,15 @@ public final class AdHocSubProcessTransformer implements ModelElementTransformer
         .filter(e -> isAdHocActivity(e.getElementType(), e.getEventType()))
         .filter(flowElement -> flowElement.getIncoming().isEmpty())
         .forEach(executableAdHocSubProcess::addAdHocActivity);
+  }
+
+  private static void setImplementationType(
+      final ExecutableAdHocSubProcess executableAdHocSubProcess, final AdHocSubProcess element) {
+    final var implementationType =
+        Optional.ofNullable(element.getSingleExtensionElement(ZeebeAdHoc.class))
+            .map(ZeebeAdHoc::getImplementationType)
+            .orElse(ZeebeAdHocImplementationType.BPMN);
+    executableAdHocSubProcess.setImplementationType(implementationType);
   }
 
   /**


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR makes it possible to deploy an ad-hoc sub process with an implementation type. The implementation type will default to `BPMN` for backwards compatibility.
Currently this new attribute is still unused. In later PRs we will change the ad-hoc subprocess behavior depending on the implementation type.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes https://github.com/camunda/ad-hoc-sub-process-phase-3/issues/1 (needs to be closed manually due to different repo)
