### PR TITLE
fix: increase assertion timeout

### DIFF
--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/DecisionInstanceAssertTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/DecisionInstanceAssertTest.java
@@ -69,7 +69,7 @@ public class DecisionInstanceAssertTest {
   void configureAssertions() {
     CamundaAssert.initialize(camundaDataSource);
     CamundaAssert.setAssertionInterval(Duration.ZERO);
-    CamundaAssert.setAssertionTimeout(Duration.ofSeconds(1));
+    CamundaAssert.setAssertionTimeout(Duration.ofSeconds(3));
   }
 
   @AfterEach


### PR DESCRIPTION
## Description

The DecisionInstanceAssertTests are flaky. Philipp mentioned that it might be related to the very small CamundaAssert timeout that leads to assertion failures with no obvious errors. This PR increases the timeout to see if the flaky tests are fixed.