### PR TITLE
New GitHub Workflow to profile running load test

### DIFF
--- a/.github/workflows/profile-load-test.yml
+++ b/.github/workflows/profile-load-test.yml
@@ -40,7 +40,7 @@ jobs:
         with:
           # Name of the artifact to upload.
           # Optional. Default is 'artifact'
-          name: flamegraph.html
+          name: flamegraph-${{ inputs.name }}-${{ inputs.pod }}
           # A file, directory or wildcard pattern that describes what to upload
           # Required.
           path: ${{ inputs.name }}-${{ inputs.pod }}*

--- a/.github/workflows/profile-load-test.yml
+++ b/.github/workflows/profile-load-test.yml
@@ -1,0 +1,53 @@
+# description: This workflow allows to profile more easily running load tests
+# type: CI
+# owner: @camunda/zeebe-distributed-platform
+name: Profile running load test
+on:
+  workflow_dispatch:
+    inputs:
+      name:
+        description: 'Specifies the name of the load test to profile'
+        required: true
+      pod:
+        description: 'Specifies the pod name of the load test to profile. Please only specify the suffix like zeebe-0, or zeebe-1, etc.'
+        default: 'zeebe-0'
+        required: false
+jobs:
+  profile-load-test:
+    name: Async profiling running load test
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: 'projects/628707732411/locations/global/workloadIdentityPools/zeebe-gh-actions/providers/gha-provider'
+          service_account: 'zeebe-gh-actions@zeebe-io.iam.gserviceaccount.com'
+      - uses: google-github-actions/get-gke-credentials@v2.3.3
+        with:
+          cluster_name: 'zeebe-cluster'
+          location: europe-west1-b
+      - name: Set right namespace
+        run: |
+          kubectl config set-context --current --namespace=${{ inputs.name }}
+      - name: Execute profiling
+        run: >
+          ./zeebe/benchmarks/docs/scripts/executeProfiling.sh ${{ inputs.name }}-${{ inputs.pod }}
+      - uses: actions/upload-artifact@v4
+        with:
+          # Name of the artifact to upload.
+          # Optional. Default is 'artifact'
+          name: flamegraph.html
+          # A file, directory or wildcard pattern that describes what to upload
+          # Required.
+          path: ${{ inputs.name }}-${{ inputs.pod }}*
+      - name: Summarize profiling
+        if: success()
+        run: |
+          cat >> "$GITHUB_STEP_SUMMARY" <<EOF
+            ## Profiling \`${{ inputs.name }}\`
+            Async profiling has been executed on ${{ inputs.name }}-${{ inputs.pod }}. Please make sure to download the artifact.
+          EOF


### PR DESCRIPTION
## Description

  * Create a new github workflow to profile existing load test
  * Workflow uploads resulting flamegraph as artifact so it can be downloaded later
  * Showing flamegraph was not yet possible (need to investigate further here)
  

### Details

Test runs can be found [here](https://github.com/camunda/camunda/actions/workflows/zeebe-benchmark.yml)

 * Example 1 https://github.com/camunda/camunda/actions/runs/16372836592
 * Example 2 https://github.com/camunda/camunda/actions/runs/16372831979

How to start the github workflow
<img width="510" height="497" alt="2025-07-18_16-11" src="https://github.com/user-attachments/assets/2744ef82-9148-4892-89b8-c2c9c68e0c8b" />

Allows to specify the load test (or benchmark) name and Camunda pod name by suffix.


<img width="1320" height="217" alt="2025-07-18_16-12" src="https://github.com/user-attachments/assets/d2755e2a-17ba-4b6a-8f04-bb2fe94ed677" />

We can run multiple actions to profile different pods.

<img width="1986" height="489" alt="2025-07-18_16-20" src="https://github.com/user-attachments/assets/bc573e45-6de1-49d7-8bcb-f701915e8975" />

When profiling is successful artifact can be downloaded and unpacked locally.

<img width="2553" height="989" alt="2025-07-18_16-21" src="https://github.com/user-attachments/assets/cbc7440c-660f-4c12-9eb2-baa9d960e52a" />

Resulting flamegraph can be viewed in a browser.
