### PR TITLE
Adding commands to search groups by tenant

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/CamundaClient.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClient.java
@@ -121,6 +121,7 @@ import io.camunda.client.api.search.request.DecisionInstanceSearchRequest;
 import io.camunda.client.api.search.request.DecisionRequirementsSearchRequest;
 import io.camunda.client.api.search.request.ElementInstanceSearchRequest;
 import io.camunda.client.api.search.request.GroupsByRoleSearchRequest;
+import io.camunda.client.api.search.request.GroupsByTenantSearchRequest;
 import io.camunda.client.api.search.request.GroupsSearchRequest;
 import io.camunda.client.api.search.request.IncidentSearchRequest;
 import io.camunda.client.api.search.request.IncidentsByProcessInstanceSearchRequest;
@@ -2600,6 +2601,22 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    * @return a builder for the groups by role search request
    */
   GroupsByRoleSearchRequest newGroupsByRoleSearchRequest(String roleId);
+
+  /**
+   * Executes a search request to query groups by tenant.
+   *
+   * <pre>
+   * camundaClient
+   *  .newGroupsByTenantSearchRequest("tenantId")
+   *  .sort((s) -> s.name().asc())
+   *  .page((p) -> p.limit(100))
+   *  .send();
+   * </pre>
+   *
+   * @param tenantId the ID of the tenant
+   * @return a builder for the groups by tenant search request
+   */
+  GroupsByTenantSearchRequest newGroupsByTenantSearchRequest(String tenantId);
 
   /**
    * Executes a search request to query jobs.

--- a/clients/java/src/main/java/io/camunda/client/CamundaClient.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClient.java
@@ -2592,7 +2592,7 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    * <pre>
    * camundaClient
    *  .newGroupsByRoleSearchRequest("roleId")
-   *  .sort((s) -> s.name().asc())
+   *  .sort((s) -> s.groupdId().asc())
    *  .page((p) -> p.limit(100))
    *  .send();
    * </pre>
@@ -2608,7 +2608,7 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    * <pre>
    * camundaClient
    *  .newGroupsByTenantSearchRequest("tenantId")
-   *  .sort((s) -> s.name().asc())
+   *  .sort((s) -> s.groupId().desc())
    *  .page((p) -> p.limit(100))
    *  .send();
    * </pre>

--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/TenantGroupFilter.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/TenantGroupFilter.java
@@ -13,12 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.camunda.client.api.search.request;
+package io.camunda.client.api.search.filter;
 
-import io.camunda.client.api.search.filter.TenantGroupFilter;
-import io.camunda.client.api.search.response.TenantGroup;
-import io.camunda.client.api.search.sort.TenantGroupSort;
+import io.camunda.client.api.search.request.TypedFilterableRequest.SearchRequestFilter;
 
-public interface GroupsByTenantSearchRequest
-    extends TypedSearchRequest<TenantGroupFilter, TenantGroupSort, GroupsByTenantSearchRequest>,
-        FinalSearchRequestStep<TenantGroup> {}
+public interface TenantGroupFilter extends SearchRequestFilter {}

--- a/clients/java/src/main/java/io/camunda/client/api/search/request/GroupsByTenantSearchRequest.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/request/GroupsByTenantSearchRequest.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.search.request;
+
+import io.camunda.client.api.search.filter.GroupFilter;
+import io.camunda.client.api.search.response.Group;
+import io.camunda.client.api.search.sort.GroupSort;
+
+public interface GroupsByTenantSearchRequest
+    extends TypedSearchRequest<GroupFilter, GroupSort, GroupsByTenantSearchRequest>,
+        FinalSearchRequestStep<Group> {}

--- a/clients/java/src/main/java/io/camunda/client/api/search/request/SearchRequestBuilders.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/request/SearchRequestBuilders.java
@@ -55,6 +55,7 @@ import io.camunda.client.api.search.sort.ProcessInstanceSort;
 import io.camunda.client.api.search.sort.RoleGroupSort;
 import io.camunda.client.api.search.sort.RoleSort;
 import io.camunda.client.api.search.sort.RoleUserSort;
+import io.camunda.client.api.search.sort.TenantGroupSort;
 import io.camunda.client.api.search.sort.TenantSort;
 import io.camunda.client.api.search.sort.TenantUserSort;
 import io.camunda.client.api.search.sort.UserSort;
@@ -102,6 +103,7 @@ import io.camunda.client.impl.search.sort.ProcessInstanceSortImpl;
 import io.camunda.client.impl.search.sort.RoleGroupSortImpl;
 import io.camunda.client.impl.search.sort.RoleSortImpl;
 import io.camunda.client.impl.search.sort.RoleUserSortImpl;
+import io.camunda.client.impl.search.sort.TenantGroupSortImpl;
 import io.camunda.client.impl.search.sort.TenantSortImpl;
 import io.camunda.client.impl.search.sort.TenantUserSortImpl;
 import io.camunda.client.impl.search.sort.UserSortImpl;
@@ -375,6 +377,12 @@ public final class SearchRequestBuilders {
 
   public static TenantUserSort tenantUserSort(final Consumer<TenantUserSort> fn) {
     final TenantUserSort sort = new TenantUserSortImpl();
+    fn.accept(sort);
+    return sort;
+  }
+
+  public static TenantGroupSort tenantGroupSort(final Consumer<TenantGroupSort> fn) {
+    final TenantGroupSort sort = new TenantGroupSortImpl();
     fn.accept(sort);
     return sort;
   }

--- a/clients/java/src/main/java/io/camunda/client/api/search/response/TenantGroup.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/response/TenantGroup.java
@@ -13,12 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.camunda.client.api.search.request;
+package io.camunda.client.api.search.response;
 
-import io.camunda.client.api.search.filter.TenantGroupFilter;
-import io.camunda.client.api.search.response.TenantGroup;
-import io.camunda.client.api.search.sort.TenantGroupSort;
-
-public interface GroupsByTenantSearchRequest
-    extends TypedSearchRequest<TenantGroupFilter, TenantGroupSort, GroupsByTenantSearchRequest>,
-        FinalSearchRequestStep<TenantGroup> {}
+public interface TenantGroup {
+  String getGroupId();
+}

--- a/clients/java/src/main/java/io/camunda/client/api/search/sort/TenantGroupSort.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/sort/TenantGroupSort.java
@@ -13,12 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.camunda.client.api.search.request;
+package io.camunda.client.api.search.sort;
 
-import io.camunda.client.api.search.filter.TenantGroupFilter;
-import io.camunda.client.api.search.response.TenantGroup;
-import io.camunda.client.api.search.sort.TenantGroupSort;
+import io.camunda.client.api.search.request.TypedSortableRequest.SearchRequestSort;
 
-public interface GroupsByTenantSearchRequest
-    extends TypedSearchRequest<TenantGroupFilter, TenantGroupSort, GroupsByTenantSearchRequest>,
-        FinalSearchRequestStep<TenantGroup> {}
+public interface TenantGroupSort extends SearchRequestSort<TenantGroupSort> {
+  TenantGroupSort groupId();
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
@@ -132,6 +132,7 @@ import io.camunda.client.api.search.request.DecisionInstanceSearchRequest;
 import io.camunda.client.api.search.request.DecisionRequirementsSearchRequest;
 import io.camunda.client.api.search.request.ElementInstanceSearchRequest;
 import io.camunda.client.api.search.request.GroupsByRoleSearchRequest;
+import io.camunda.client.api.search.request.GroupsByTenantSearchRequest;
 import io.camunda.client.api.search.request.GroupsSearchRequest;
 import io.camunda.client.api.search.request.IncidentSearchRequest;
 import io.camunda.client.api.search.request.IncidentsByProcessInstanceSearchRequest;
@@ -263,6 +264,7 @@ import io.camunda.client.impl.search.request.DecisionRequirementsSearchRequestIm
 import io.camunda.client.impl.search.request.ElementInstanceSearchRequestImpl;
 import io.camunda.client.impl.search.request.GroupSearchRequestImpl;
 import io.camunda.client.impl.search.request.GroupsByRoleSearchRequestImpl;
+import io.camunda.client.impl.search.request.GroupsByTenantSearchRequestImpl;
 import io.camunda.client.impl.search.request.IncidentSearchRequestImpl;
 import io.camunda.client.impl.search.request.IncidentsByProcessInstanceSearchRequestImpl;
 import io.camunda.client.impl.search.request.JobSearchRequestImpl;
@@ -1298,6 +1300,11 @@ public final class CamundaClientImpl implements CamundaClient {
   @Override
   public GroupsByRoleSearchRequest newGroupsByRoleSearchRequest(final String roleId) {
     return new GroupsByRoleSearchRequestImpl(httpClient, jsonMapper, roleId);
+  }
+
+  @Override
+  public GroupsByTenantSearchRequest newGroupsByTenantSearchRequest(final String tenantId) {
+    return new GroupsByTenantSearchRequestImpl(httpClient, jsonMapper, tenantId);
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/client/impl/search/request/GroupsByTenantSearchRequestImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/request/GroupsByTenantSearchRequestImpl.java
@@ -80,13 +80,13 @@ public class GroupsByTenantSearchRequestImpl
   @Override
   public GroupsByTenantSearchRequest filter(final TenantGroupFilter value) {
     // this command does not support filtering
-    return this;
+    throw new UnsupportedOperationException("This command does not support filtering");
   }
 
   @Override
   public GroupsByTenantSearchRequest filter(final Consumer<TenantGroupFilter> fn) {
     // this command does not support filtering
-    return this;
+    throw new UnsupportedOperationException("This command does not support filtering");
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/client/impl/search/request/GroupsByTenantSearchRequestImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/request/GroupsByTenantSearchRequestImpl.java
@@ -15,24 +15,24 @@
  */
 package io.camunda.client.impl.search.request;
 
-import static io.camunda.client.api.search.request.SearchRequestBuilders.groupSort;
 import static io.camunda.client.api.search.request.SearchRequestBuilders.searchRequestPage;
+import static io.camunda.client.api.search.request.SearchRequestBuilders.tenantGroupSort;
 
 import io.camunda.client.api.CamundaFuture;
 import io.camunda.client.api.JsonMapper;
-import io.camunda.client.api.search.filter.GroupFilter;
+import io.camunda.client.api.search.filter.TenantGroupFilter;
 import io.camunda.client.api.search.request.FinalSearchRequestStep;
 import io.camunda.client.api.search.request.GroupsByTenantSearchRequest;
 import io.camunda.client.api.search.request.SearchRequestPage;
-import io.camunda.client.api.search.response.Group;
 import io.camunda.client.api.search.response.SearchResponse;
-import io.camunda.client.api.search.sort.GroupSort;
+import io.camunda.client.api.search.response.TenantGroup;
+import io.camunda.client.api.search.sort.TenantGroupSort;
 import io.camunda.client.impl.command.ArgumentUtil;
 import io.camunda.client.impl.http.HttpCamundaFuture;
 import io.camunda.client.impl.http.HttpClient;
 import io.camunda.client.impl.search.response.SearchResponseMapper;
-import io.camunda.client.protocol.rest.GroupSearchQueryResult;
 import io.camunda.client.protocol.rest.TenantGroupSearchQueryRequest;
+import io.camunda.client.protocol.rest.TenantGroupSearchResult;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
@@ -58,33 +58,33 @@ public class GroupsByTenantSearchRequestImpl
   }
 
   @Override
-  public FinalSearchRequestStep<Group> requestTimeout(final Duration requestTimeout) {
+  public FinalSearchRequestStep<TenantGroup> requestTimeout(final Duration requestTimeout) {
     httpRequestConfig.setResponseTimeout(requestTimeout.toMillis(), TimeUnit.MILLISECONDS);
     return this;
   }
 
   @Override
-  public CamundaFuture<SearchResponse<Group>> send() {
+  public CamundaFuture<SearchResponse<TenantGroup>> send() {
     ArgumentUtil.ensureNotNullNorEmpty("tenantId", tenantId);
-    final HttpCamundaFuture<SearchResponse<Group>> result = new HttpCamundaFuture<>();
+    final HttpCamundaFuture<SearchResponse<TenantGroup>> result = new HttpCamundaFuture<>();
     httpClient.post(
         String.format("/tenants/%s/groups/search", tenantId),
         jsonMapper.toJson(request),
         httpRequestConfig.build(),
-        GroupSearchQueryResult.class,
-        SearchResponseMapper::toGroupsResponse,
+        TenantGroupSearchResult.class,
+        SearchResponseMapper::toTenantGroupsResponse,
         result);
     return result;
   }
 
   @Override
-  public GroupsByTenantSearchRequest filter(final GroupFilter value) {
+  public GroupsByTenantSearchRequest filter(final TenantGroupFilter value) {
     // this command does not support filtering
     return this;
   }
 
   @Override
-  public GroupsByTenantSearchRequest filter(final Consumer<GroupFilter> fn) {
+  public GroupsByTenantSearchRequest filter(final Consumer<TenantGroupFilter> fn) {
     // this command does not support filtering
     return this;
   }
@@ -101,7 +101,7 @@ public class GroupsByTenantSearchRequestImpl
   }
 
   @Override
-  public GroupsByTenantSearchRequest sort(final GroupSort value) {
+  public GroupsByTenantSearchRequest sort(final TenantGroupSort value) {
     request.setSort(
         SearchRequestSortMapper.toTenantGroupSearchQuerySortRequest(
             provideSearchRequestProperty(value)));
@@ -109,8 +109,8 @@ public class GroupsByTenantSearchRequestImpl
   }
 
   @Override
-  public GroupsByTenantSearchRequest sort(final Consumer<GroupSort> fn) {
-    return sort(groupSort(fn));
+  public GroupsByTenantSearchRequest sort(final Consumer<TenantGroupSort> fn) {
+    return sort(tenantGroupSort(fn));
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/client/impl/search/request/GroupsByTenantSearchRequestImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/request/GroupsByTenantSearchRequestImpl.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.search.request;
+
+import static io.camunda.client.api.search.request.SearchRequestBuilders.groupSort;
+import static io.camunda.client.api.search.request.SearchRequestBuilders.searchRequestPage;
+
+import io.camunda.client.api.CamundaFuture;
+import io.camunda.client.api.JsonMapper;
+import io.camunda.client.api.search.filter.GroupFilter;
+import io.camunda.client.api.search.request.FinalSearchRequestStep;
+import io.camunda.client.api.search.request.GroupsByTenantSearchRequest;
+import io.camunda.client.api.search.request.SearchRequestPage;
+import io.camunda.client.api.search.response.Group;
+import io.camunda.client.api.search.response.SearchResponse;
+import io.camunda.client.api.search.sort.GroupSort;
+import io.camunda.client.impl.command.ArgumentUtil;
+import io.camunda.client.impl.http.HttpCamundaFuture;
+import io.camunda.client.impl.http.HttpClient;
+import io.camunda.client.impl.search.response.SearchResponseMapper;
+import io.camunda.client.protocol.rest.GroupSearchQueryResult;
+import io.camunda.client.protocol.rest.TenantGroupSearchQueryRequest;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import org.apache.hc.client5.http.config.RequestConfig;
+
+public class GroupsByTenantSearchRequestImpl
+    extends TypedSearchRequestPropertyProvider<TenantGroupSearchQueryRequest>
+    implements GroupsByTenantSearchRequest {
+
+  private final TenantGroupSearchQueryRequest request;
+  private final String tenantId;
+  private final HttpClient httpClient;
+  private final JsonMapper jsonMapper;
+  private final RequestConfig.Builder httpRequestConfig;
+
+  public GroupsByTenantSearchRequestImpl(
+      final HttpClient httpClient, final JsonMapper jsonMapper, final String tenantId) {
+    this.httpClient = httpClient;
+    this.jsonMapper = jsonMapper;
+    this.tenantId = tenantId;
+    httpRequestConfig = httpClient.newRequestConfig();
+    request = new TenantGroupSearchQueryRequest();
+  }
+
+  @Override
+  public FinalSearchRequestStep<Group> requestTimeout(final Duration requestTimeout) {
+    httpRequestConfig.setResponseTimeout(requestTimeout.toMillis(), TimeUnit.MILLISECONDS);
+    return this;
+  }
+
+  @Override
+  public CamundaFuture<SearchResponse<Group>> send() {
+    ArgumentUtil.ensureNotNullNorEmpty("tenantId", tenantId);
+    final HttpCamundaFuture<SearchResponse<Group>> result = new HttpCamundaFuture<>();
+    httpClient.post(
+        String.format("/tenants/%s/groups/search", tenantId),
+        jsonMapper.toJson(request),
+        httpRequestConfig.build(),
+        GroupSearchQueryResult.class,
+        SearchResponseMapper::toGroupsResponse,
+        result);
+    return result;
+  }
+
+  @Override
+  public GroupsByTenantSearchRequest filter(final GroupFilter value) {
+    // this command does not support filtering
+    return this;
+  }
+
+  @Override
+  public GroupsByTenantSearchRequest filter(final Consumer<GroupFilter> fn) {
+    // this command does not support filtering
+    return this;
+  }
+
+  @Override
+  public GroupsByTenantSearchRequest page(final SearchRequestPage value) {
+    request.setPage(provideSearchRequestProperty(value));
+    return this;
+  }
+
+  @Override
+  public GroupsByTenantSearchRequest page(final Consumer<SearchRequestPage> fn) {
+    return page(searchRequestPage(fn));
+  }
+
+  @Override
+  public GroupsByTenantSearchRequest sort(final GroupSort value) {
+    request.setSort(
+        SearchRequestSortMapper.toTenantGroupSearchQuerySortRequest(
+            provideSearchRequestProperty(value)));
+    return this;
+  }
+
+  @Override
+  public GroupsByTenantSearchRequest sort(final Consumer<GroupSort> fn) {
+    return sort(groupSort(fn));
+  }
+
+  @Override
+  protected TenantGroupSearchQueryRequest getSearchRequestProperty() {
+    return request;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/search/request/SearchRequestSortMapper.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/request/SearchRequestSortMapper.java
@@ -203,6 +203,20 @@ public class SearchRequestSortMapper {
         .collect(Collectors.toList());
   }
 
+  public static List<TenantGroupSearchQuerySortRequest> toTenantGroupSearchQuerySortRequest(
+      final List<SearchRequestSort> requests) {
+    return requests.stream()
+        .map(
+            r -> {
+              final TenantGroupSearchQuerySortRequest request =
+                  new TenantGroupSearchQuerySortRequest();
+              request.setField(TenantGroupSearchQuerySortRequest.FieldEnum.fromValue(r.getField()));
+              request.setOrder(r.getOrder());
+              return request;
+            })
+        .collect(Collectors.toList());
+  }
+
   public static List<RoleClientSearchQuerySortRequest> toRoleClientSearchQuerySortRequest(
       final List<SearchRequestSort> requests) {
     return requests.stream()

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/SearchResponseMapper.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/SearchResponseMapper.java
@@ -44,6 +44,7 @@ import io.camunda.client.api.search.response.RoleUser;
 import io.camunda.client.api.search.response.SearchResponse;
 import io.camunda.client.api.search.response.SearchResponsePage;
 import io.camunda.client.api.search.response.Tenant;
+import io.camunda.client.api.search.response.TenantGroup;
 import io.camunda.client.api.search.response.TenantUser;
 import io.camunda.client.api.search.response.User;
 import io.camunda.client.api.search.response.UserTask;
@@ -313,6 +314,18 @@ public final class SearchResponseMapper {
 
   private static TenantUser toTenantUser(final TenantUserResult response) {
     return new TenantUserImpl(response.getUsername());
+  }
+
+  public static SearchResponse<TenantGroup> toTenantGroupsResponse(
+      final TenantGroupSearchResult response) {
+    final SearchResponsePage page = toSearchResponsePage(response.getPage());
+    final List<TenantGroup> instances =
+        toSearchResponseInstances(response.getItems(), SearchResponseMapper::toTenantGroup);
+    return new SearchResponseImpl<>(instances, page);
+  }
+
+  private static TenantGroup toTenantGroup(final TenantGroupResult response) {
+    return new TenantGroupImpl(response.getGroupId());
   }
 
   public static MappingRule toMappingResponse(final MappingRuleResult response) {

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/TenantGroupImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/TenantGroupImpl.java
@@ -13,12 +13,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.camunda.client.api.search.request;
+package io.camunda.client.impl.search.response;
 
-import io.camunda.client.api.search.filter.TenantGroupFilter;
 import io.camunda.client.api.search.response.TenantGroup;
-import io.camunda.client.api.search.sort.TenantGroupSort;
 
-public interface GroupsByTenantSearchRequest
-    extends TypedSearchRequest<TenantGroupFilter, TenantGroupSort, GroupsByTenantSearchRequest>,
-        FinalSearchRequestStep<TenantGroup> {}
+public class TenantGroupImpl implements TenantGroup {
+
+  private final String groupId;
+
+  public TenantGroupImpl(final String groupId) {
+    this.groupId = groupId;
+  }
+
+  @Override
+  public String getGroupId() {
+    return groupId;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/search/sort/TenantGroupSortImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/sort/TenantGroupSortImpl.java
@@ -13,12 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.camunda.client.api.search.request;
+package io.camunda.client.impl.search.sort;
 
-import io.camunda.client.api.search.filter.TenantGroupFilter;
-import io.camunda.client.api.search.response.TenantGroup;
 import io.camunda.client.api.search.sort.TenantGroupSort;
+import io.camunda.client.impl.search.request.SearchRequestSortBase;
 
-public interface GroupsByTenantSearchRequest
-    extends TypedSearchRequest<TenantGroupFilter, TenantGroupSort, GroupsByTenantSearchRequest>,
-        FinalSearchRequestStep<TenantGroup> {}
+public class TenantGroupSortImpl extends SearchRequestSortBase<TenantGroupSort>
+    implements TenantGroupSort {
+
+  @Override
+  public TenantGroupSort groupId() {
+    return field("groupId");
+  }
+
+  @Override
+  protected TenantGroupSort self() {
+    return this;
+  }
+}

--- a/clients/java/src/test/java/io/camunda/client/tenant/SearchGroupsByTenantTest.java
+++ b/clients/java/src/test/java/io/camunda/client/tenant/SearchGroupsByTenantTest.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.github.tomakehurst.wiremock.http.RequestMethod;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+import io.camunda.client.api.search.filter.TenantGroupFilter;
 import io.camunda.client.util.ClientRestTest;
 import io.camunda.client.util.RestGatewayService;
 import org.junit.jupiter.api.Test;
@@ -70,5 +71,26 @@ public class SearchGroupsByTenantTest extends ClientRestTest {
     assertThatThrownBy(() -> client.newGroupsByTenantSearchRequest("").send().join())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("tenantId must not be empty");
+  }
+
+  @Test
+  void shouldRaiseExceptionOnNullTenantId1() {
+    assertThatThrownBy(
+            () -> client.newGroupsByTenantSearchRequest(TENANT_ID).filter(fn -> {}).send().join())
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessageContaining("This command does not support filtering");
+  }
+
+  @Test
+  void shouldRaiseExceptionOnNullTenantId2() {
+    assertThatThrownBy(
+            () ->
+                client
+                    .newGroupsByTenantSearchRequest(TENANT_ID)
+                    .filter(new TenantGroupFilter() {})
+                    .send()
+                    .join())
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessageContaining("This command does not support filtering");
   }
 }

--- a/clients/java/src/test/java/io/camunda/client/tenant/SearchGroupsByTenantTest.java
+++ b/clients/java/src/test/java/io/camunda/client/tenant/SearchGroupsByTenantTest.java
@@ -19,6 +19,7 @@ import static io.camunda.client.impl.http.HttpClientFactory.REST_API_PATH;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.github.tomakehurst.wiremock.http.RequestMethod;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
 import io.camunda.client.util.ClientRestTest;
 import io.camunda.client.util.RestGatewayService;
@@ -36,18 +37,25 @@ public class SearchGroupsByTenantTest extends ClientRestTest {
     // then
     final String requestPath = RestGatewayService.getLastRequest().getUrl();
     assertThat(requestPath).isEqualTo(REST_API_PATH + "/tenants/" + TENANT_ID + "/groups/search");
+    assertThat(RestGatewayService.getLastRequest().getMethod()).isEqualTo(RequestMethod.POST);
   }
 
   @Test
-  void shouldIncludedSortInSearchRequestBody() {
+  void shouldIncludedSortAndPaginationInSearchRequestBody() {
     // when
-    client.newGroupsByTenantSearchRequest(TENANT_ID).sort(s -> s.groupId().desc()).send().join();
+    client
+        .newGroupsByTenantSearchRequest(TENANT_ID)
+        .sort(s -> s.groupId().desc())
+        .page(p -> p.limit(2))
+        .send()
+        .join();
 
     // then
     final LoggedRequest lastRequest = RestGatewayService.getLastRequest();
     final String requestBody = lastRequest.getBodyAsString();
 
     assertThat(requestBody).contains("\"sort\":[{\"field\":\"groupId\",\"order\":\"DESC\"}]");
+    assertThat(requestBody).contains("\"page\":{\"limit\":2}");
   }
 
   @Test

--- a/clients/java/src/test/java/io/camunda/client/tenant/SearchGroupsByTenantTest.java
+++ b/clients/java/src/test/java/io/camunda/client/tenant/SearchGroupsByTenantTest.java
@@ -74,7 +74,7 @@ public class SearchGroupsByTenantTest extends ClientRestTest {
   }
 
   @Test
-  void shouldRaiseExceptionOnNullTenantId1() {
+  void shouldRaiseExceptionWhenFilteringIsPresentAsFunction() {
     assertThatThrownBy(
             () -> client.newGroupsByTenantSearchRequest(TENANT_ID).filter(fn -> {}).send().join())
         .isInstanceOf(UnsupportedOperationException.class)
@@ -82,7 +82,7 @@ public class SearchGroupsByTenantTest extends ClientRestTest {
   }
 
   @Test
-  void shouldRaiseExceptionOnNullTenantId2() {
+  void shouldRaiseExceptionWhenFilteringIsPresent() {
     assertThatThrownBy(
             () ->
                 client

--- a/clients/java/src/test/java/io/camunda/client/tenant/SearchGroupsByTenantTest.java
+++ b/clients/java/src/test/java/io/camunda/client/tenant/SearchGroupsByTenantTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.tenant;
+
+import static io.camunda.client.impl.http.HttpClientFactory.REST_API_PATH;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+import io.camunda.client.util.ClientRestTest;
+import io.camunda.client.util.RestGatewayService;
+import org.junit.jupiter.api.Test;
+
+public class SearchGroupsByTenantTest extends ClientRestTest {
+
+  private static final String TENANT_ID = "tenant-123";
+
+  @Test
+  void shouldSendSearchRequestForGroupsByTenant() {
+    // when
+    client.newGroupsByTenantSearchRequest(TENANT_ID).send().join();
+
+    // then
+    final String requestPath = RestGatewayService.getLastRequest().getUrl();
+    assertThat(requestPath).isEqualTo(REST_API_PATH + "/tenants/" + TENANT_ID + "/groups/search");
+  }
+
+  @Test
+  void shouldIncludedSortInSearchRequestBody() {
+    // when
+    client.newGroupsByTenantSearchRequest(TENANT_ID).sort(s -> s.groupId().desc()).send().join();
+
+    // then
+    final LoggedRequest lastRequest = RestGatewayService.getLastRequest();
+    final String requestBody = lastRequest.getBodyAsString();
+
+    assertThat(requestBody).contains("\"sort\":[{\"field\":\"groupId\",\"order\":\"DESC\"}]");
+  }
+
+  @Test
+  void shouldRaiseExceptionOnNullTenantId() {
+    assertThatThrownBy(() -> client.newGroupsByTenantSearchRequest(null).send().join())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("tenantId must not be null");
+  }
+
+  @Test
+  void shouldRaiseExceptionOnEmptyTenantId() {
+    assertThatThrownBy(() -> client.newGroupsByTenantSearchRequest("").send().join())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("tenantId must not be empty");
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/TenantAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/TenantAuthorizationIT.java
@@ -24,6 +24,7 @@ import io.camunda.client.api.search.response.Client;
 import io.camunda.client.api.search.response.Group;
 import io.camunda.client.api.search.response.SearchResponse;
 import io.camunda.client.api.search.response.Tenant;
+import io.camunda.client.api.search.response.TenantGroup;
 import io.camunda.client.api.search.response.TenantUser;
 import io.camunda.qa.util.auth.Authenticated;
 import io.camunda.qa.util.auth.Permissions;
@@ -213,9 +214,9 @@ class TenantAuthorizationIT {
         .ignoreExceptionsInstanceOf(ProblemException.class)
         .untilAsserted(
             () -> {
-              final SearchResponse<Group> response =
+              final SearchResponse<TenantGroup> response =
                   adminClient.newGroupsByTenantSearchRequest("tenant1").send().join();
-              Assertions.assertThat(response.items().stream().map(Group::getGroupId).toList())
+              Assertions.assertThat(response.items().stream().map(TenantGroup::getGroupId).toList())
                   .contains(groupId);
             });
   }
@@ -223,7 +224,7 @@ class TenantAuthorizationIT {
   @Test
   void searchGroupsByTenantShouldReturnEmptyListIfUnauthorized(
       @Authenticated(UNAUTHORIZED) final CamundaClient camundaClient) {
-    final SearchResponse<Group> response =
+    final SearchResponse<TenantGroup> response =
         camundaClient.newGroupsByTenantSearchRequest("tenant1").send().join();
     Assertions.assertThat(response.items()).isEmpty();
   }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/TenantAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/TenantAuthorizationIT.java
@@ -21,7 +21,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ProblemException;
 import io.camunda.client.api.search.response.Client;
-import io.camunda.client.api.search.response.Group;
 import io.camunda.client.api.search.response.SearchResponse;
 import io.camunda.client.api.search.response.Tenant;
 import io.camunda.client.api.search.response.TenantGroup;
@@ -109,8 +108,7 @@ class TenantAuthorizationIT {
         .untilAsserted(
             () -> {
               final var tenantsSearchResponse = adminClient.newTenantsSearchRequest().send().join();
-              Assertions.assertThat(
-                      tenantsSearchResponse.items().stream().map(Tenant::getTenantId))
+              Assertions.assertThat(tenantsSearchResponse.items().stream().map(Tenant::getTenantId))
                   .containsAll(Arrays.asList(TENANT_ID_1, TENANT_ID_2));
             });
   }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/TenantAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/TenantAuthorizationIT.java
@@ -110,7 +110,7 @@ class TenantAuthorizationIT {
             () -> {
               final var tenantsSearchResponse = adminClient.newTenantsSearchRequest().send().join();
               Assertions.assertThat(
-                      tenantsSearchResponse.items().stream().map(Tenant::getTenantId).toList())
+                      tenantsSearchResponse.items().stream().map(Tenant::getTenantId))
                   .containsAll(Arrays.asList(TENANT_ID_1, TENANT_ID_2));
             });
   }
@@ -196,7 +196,7 @@ class TenantAuthorizationIT {
             () -> {
               final SearchResponse<TenantUser> response =
                   adminClient.newUsersByTenantSearchRequest(TENANT_ID_1).send().join();
-              Assertions.assertThat(response.items().stream().map(TenantUser::getUsername).toList())
+              Assertions.assertThat(response.items().stream().map(TenantUser::getUsername))
                   .contains(userName);
             });
   }
@@ -216,7 +216,7 @@ class TenantAuthorizationIT {
             () -> {
               final SearchResponse<TenantGroup> response =
                   adminClient.newGroupsByTenantSearchRequest("tenant1").send().join();
-              Assertions.assertThat(response.items().stream().map(TenantGroup::getGroupId).toList())
+              Assertions.assertThat(response.items().stream().map(TenantGroup::getGroupId))
                   .contains(groupId);
             });
   }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/GroupsByTenantIntegrationTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/GroupsByTenantIntegrationTest.java
@@ -12,7 +12,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
 import io.camunda.client.CamundaClient;
-import io.camunda.client.api.search.response.Group;
+import io.camunda.client.api.search.response.TenantGroup;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.zeebe.test.util.Strings;
 import java.util.List;
@@ -61,23 +61,25 @@ public class GroupsByTenantIntegrationTest {
         .atMost(TIMEOUT_DATA_AVAILABILITY)
         .untilAsserted(
             () -> {
-              final List<Group> groups =
+              final List<TenantGroup> groups =
                   camundaClient.newGroupsByTenantSearchRequest(TENANT_ID).send().join().items();
-              assertThat(groups).extracting(Group::getGroupId).contains(A_GROUP_ID, B_GROUP_ID);
+              assertThat(groups)
+                  .extracting(TenantGroup::getGroupId)
+                  .contains(A_GROUP_ID, B_GROUP_ID);
             });
   }
 
   @Test
   void shouldReturnGroupsByTenant() {
-    final List<Group> groups =
+    final List<TenantGroup> groups =
         camundaClient.newGroupsByTenantSearchRequest(TENANT_ID).send().join().items();
     assertThat(groups).hasSize(2);
-    assertThat(groups).extracting(Group::getGroupId).containsExactly(A_GROUP_ID, B_GROUP_ID);
+    assertThat(groups).extracting(TenantGroup::getGroupId).containsExactly(A_GROUP_ID, B_GROUP_ID);
   }
 
   @Test
   void shouldReturnGroupsByTenantSortedByTenantIdDesc() {
-    final List<Group> groups =
+    final List<TenantGroup> groups =
         camundaClient
             .newGroupsByTenantSearchRequest(TENANT_ID)
             .sort(s -> s.groupId().desc())
@@ -85,7 +87,7 @@ public class GroupsByTenantIntegrationTest {
             .join()
             .items();
     assertThat(groups).hasSize(2);
-    assertThat(groups).extracting(Group::getGroupId).containsExactly(B_GROUP_ID, A_GROUP_ID);
+    assertThat(groups).extracting(TenantGroup::getGroupId).containsExactly(B_GROUP_ID, A_GROUP_ID);
   }
 
   @Test

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/GroupsByTenantIntegrationTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/GroupsByTenantIntegrationTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.client;
+
+import static io.camunda.qa.util.multidb.CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.search.response.Group;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.zeebe.test.util.Strings;
+import java.util.List;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+
+@MultiDbTest
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms")
+public class GroupsByTenantIntegrationTest {
+  private static CamundaClient camundaClient;
+
+  private static final String TENANT_ID = Strings.newRandomValidIdentityId();
+  private static final String A_GROUP_ID = "aGroupId";
+  private static final String B_GROUP_ID = "bGroupId";
+  private static final String UNASSIGNED_GROUP_ID = Strings.newRandomValidIdentityId();
+
+  @BeforeAll
+  static void setup() {
+    camundaClient.newCreateTenantCommand().tenantId(TENANT_ID).name("tenantName").send().join();
+
+    camundaClient.newCreateGroupCommand().groupId(A_GROUP_ID).name("firstGroupName").send().join();
+    camundaClient.newCreateGroupCommand().groupId(B_GROUP_ID).name("secondGroupName").send().join();
+    camundaClient
+        .newCreateGroupCommand()
+        .groupId(UNASSIGNED_GROUP_ID)
+        .name("groupName")
+        .send()
+        .join();
+
+    camundaClient
+        .newAssignGroupToTenantCommand()
+        .groupId(A_GROUP_ID)
+        .tenantId(TENANT_ID)
+        .send()
+        .join();
+    camundaClient
+        .newAssignGroupToTenantCommand()
+        .groupId(B_GROUP_ID)
+        .tenantId(TENANT_ID)
+        .send()
+        .join();
+
+    Awaitility.await("Groups should appear in tenant group search")
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .untilAsserted(
+            () -> {
+              final List<Group> groups =
+                  camundaClient.newGroupsByTenantSearchRequest(TENANT_ID).send().join().items();
+              assertThat(groups).extracting(Group::getGroupId).contains(A_GROUP_ID, B_GROUP_ID);
+            });
+  }
+
+  @Test
+  void shouldReturnGroupsByTenant() {
+    final List<Group> groups =
+        camundaClient.newGroupsByTenantSearchRequest(TENANT_ID).send().join().items();
+    assertThat(groups).hasSize(2);
+    assertThat(groups).extracting(Group::getGroupId).containsExactly(A_GROUP_ID, B_GROUP_ID);
+  }
+
+  @Test
+  void shouldReturnGroupsByTenantSortedByTenantIdDesc() {
+    final List<Group> groups =
+        camundaClient
+            .newGroupsByTenantSearchRequest(TENANT_ID)
+            .sort(s -> s.groupId().desc())
+            .send()
+            .join()
+            .items();
+    assertThat(groups).hasSize(2);
+    assertThat(groups).extracting(Group::getGroupId).containsExactly(B_GROUP_ID, A_GROUP_ID);
+  }
+
+  @Test
+  void shouldRejectGroupsByTenantSearchIfMissingTenantId() {
+    // when / then
+    assertThatThrownBy(() -> camundaClient.newGroupsByTenantSearchRequest(null).send().join())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("tenantId must not be null");
+  }
+
+  @Test
+  void shouldRejectGroupsByTenantSearchIfEmptyTenantId() {
+    // when / then
+    assertThatThrownBy(() -> camundaClient.newGroupsByTenantSearchRequest("").send().join())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("tenantId must not be empty");
+  }
+
+  @Test
+  void searchGroupsShouldReturnEmptyListWhenSearchingForNonExistingTenantId() {
+    final var clientsSearchResponse =
+        camundaClient.newGroupsByTenantSearchRequest("someTenantId").send().join();
+    assertThat(clientsSearchResponse.items()).isEmpty();
+  }
+}


### PR DESCRIPTION
## Description

Adding command to search Groups in Tenant to Java Client.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #35216
