### PR TITLE
fix: get start form by form id and tenant

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
@@ -122,9 +122,10 @@ public class CamundaServicesConfiguration {
   public ProcessDefinitionServices processDefinitionServices(
       final BrokerClient brokerClient,
       final SecurityContextProvider securityContextProvider,
-      final ProcessDefinitionSearchClient processDefinitionSearchClient) {
+      final ProcessDefinitionSearchClient processDefinitionSearchClient,
+      final FormServices formServices) {
     return new ProcessDefinitionServices(
-        brokerClient, securityContextProvider, processDefinitionSearchClient, null);
+        brokerClient, securityContextProvider, processDefinitionSearchClient, formServices, null);
   }
 
   @Bean

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessDefinitionSearchMultiTenantsTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessDefinitionSearchMultiTenantsTest.java
@@ -46,7 +46,6 @@ public class ProcessDefinitionSearchMultiTenantsTest {
       new TestCamundaApplication().withBasicAuth().withMultiTenancyEnabled();
 
   private static final String TENANT_ID_1 = "tenant1";
-  private static final String TENANT_ID_2 = "tenant2";
   private static final String USERNAME_1 = "user1";
   private static final String PROCESS_DEFINITION_WITH_START_FORM_ID = "Process_11hxie4";
 

--- a/qa/util/src/main/java/io/camunda/qa/util/cluster/TestCamundaApplication.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/cluster/TestCamundaApplication.java
@@ -178,6 +178,7 @@ public final class TestCamundaApplication extends TestSpringApplication<TestCamu
 
   public TestCamundaApplication withMultiTenancyEnabled() {
     withAuthenticatedAccess();
+    withProperty("camunda.security.multiTenancy.enabled", true);
     return withSecurityConfig(cfg -> cfg.getMultiTenancy().setEnabled(true));
   }
 

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/FormFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/FormFilterTransformer.java
@@ -11,13 +11,16 @@ import static io.camunda.search.clients.query.SearchQueryBuilders.and;
 import static io.camunda.search.clients.query.SearchQueryBuilders.longTerms;
 import static io.camunda.search.clients.query.SearchQueryBuilders.matchAll;
 import static io.camunda.search.clients.query.SearchQueryBuilders.stringTerms;
+import static io.camunda.search.clients.query.SearchQueryBuilders.term;
 import static io.camunda.webapps.schema.descriptors.index.FormIndex.BPMN_ID;
 import static io.camunda.webapps.schema.descriptors.index.FormIndex.KEY;
+import static io.camunda.webapps.schema.descriptors.index.FormIndex.TENANT_ID;
 
 import io.camunda.search.clients.query.SearchQuery;
 import io.camunda.search.filter.FormFilter;
 import io.camunda.security.auth.Authorization;
 import io.camunda.webapps.schema.descriptors.IndexDescriptor;
+import java.util.Optional;
 
 public class FormFilterTransformer extends IndexFilterTransformer<FormFilter> {
 
@@ -27,7 +30,10 @@ public class FormFilterTransformer extends IndexFilterTransformer<FormFilter> {
 
   @Override
   public SearchQuery toSearchQuery(final FormFilter filter) {
-    return and(longTerms(KEY, filter.formKeys()), stringTerms(BPMN_ID, filter.formIds()));
+    final var tenantFilter =
+        Optional.ofNullable(filter.tenantId()).map(t -> term(TENANT_ID, t)).orElse(null);
+    return and(
+        longTerms(KEY, filter.formKeys()), stringTerms(BPMN_ID, filter.formIds()), tenantFilter);
   }
 
   @Override

--- a/search/search-domain/src/main/java/io/camunda/search/filter/FormFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/FormFilter.java
@@ -15,12 +15,14 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
-public record FormFilter(List<Long> formKeys, List<String> formIds) implements FilterBase {
+public record FormFilter(List<Long> formKeys, List<String> formIds, String tenantId)
+    implements FilterBase {
 
   public static final class Builder implements ObjectBuilder<FormFilter> {
 
     private List<Long> formKeys;
     private List<String> formIds;
+    private String tenantId;
 
     public Builder formKeys(final Long value, final Long... values) {
       return formKeys(collectValues(value, values));
@@ -40,11 +42,17 @@ public record FormFilter(List<Long> formKeys, List<String> formIds) implements F
       return this;
     }
 
+    public Builder tenantId(final String value) {
+      tenantId = value;
+      return this;
+    }
+
     @Override
     public FormFilter build() {
       return new FormFilter(
           Objects.requireNonNullElse(formKeys, Collections.emptyList()),
-          Objects.requireNonNullElse(formIds, Collections.emptyList()));
+          Objects.requireNonNullElse(formIds, Collections.emptyList()),
+          tenantId);
     }
   }
 }

--- a/service/src/main/java/io/camunda/service/FormServices.java
+++ b/service/src/main/java/io/camunda/service/FormServices.java
@@ -52,21 +52,15 @@ public final class FormServices extends SearchQueryService<FormServices, FormQue
         .getFirst();
   }
 
-  public Optional<FormEntity> getLatestVersionByFormId(final String formId) {
-    final Optional<FormEntity> result =
-        search(
-                SearchQueryBuilders.formSearchQuery()
-                    .filter(f -> f.formIds(formId))
-                    .sort(s -> s.version().desc())
-                    .build())
-            .items()
-            .stream()
-            .findFirst();
-
-    if (result.isPresent()) {
-      return result;
-    } else {
-      return Optional.empty();
-    }
+  public Optional<FormEntity> getLatestVersionByFormIdAndTenantId(
+      final String formId, final String tenantId) {
+    return search(
+            SearchQueryBuilders.formSearchQuery()
+                .filter(f -> f.formIds(formId).tenantId(tenantId))
+                .sort(s -> s.version().desc())
+                .build())
+        .items()
+        .stream()
+        .findFirst();
   }
 }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ProcessDefinitionController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ProcessDefinitionController.java
@@ -9,7 +9,6 @@ package io.camunda.zeebe.gateway.rest.controller;
 
 import static io.camunda.zeebe.gateway.rest.RestErrorMapper.mapErrorToResponse;
 
-import io.camunda.search.entities.ProcessDefinitionEntity;
 import io.camunda.search.filter.ProcessDefinitionStatisticsFilter;
 import io.camunda.search.query.ProcessDefinitionQuery;
 import io.camunda.security.auth.CamundaAuthenticationProvider;
@@ -112,22 +111,12 @@ public class ProcessDefinitionController {
   public ResponseEntity<FormResult> getStartProcessForm(
       @PathVariable("processDefinitionKey") final long processDefinitionKey) {
     try {
-      final ProcessDefinitionEntity processDefinition =
-          processDefinitionServices
-              .withAuthentication(authenticationProvider.getCamundaAuthentication())
-              .getByKey(processDefinitionKey);
-
-      if (processDefinition.formId() != null) {
-        return ResponseEntity.ok()
-            .body(
-                SearchQueryResponseMapper.toFormItem(
-                    formServices
-                        .withAuthentication(authenticationProvider.getCamundaAuthentication())
-                        .getLatestVersionByFormId(processDefinition.formId())
-                        .get()));
-      } else {
-        return ResponseEntity.noContent().build();
-      }
+      return processDefinitionServices
+          .withAuthentication(authenticationProvider.getCamundaAuthentication())
+          .getProcessDefinitionStartForm(processDefinitionKey)
+          .map(SearchQueryResponseMapper::toFormItem)
+          .map(s -> ResponseEntity.ok().body(s))
+          .orElseGet(() -> ResponseEntity.noContent().build());
     } catch (final Exception e) {
       return mapErrorToResponse(e);
     }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessDefinitionQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessDefinitionQueryControllerTest.java
@@ -247,7 +247,9 @@ public class ProcessDefinitionQueryControllerTest extends RestControllerTest {
         Pair.of(PROCESS_DEFINITION_URL + "%d", ProcessDefinitionServices::getByKey),
         Pair.of(
             PROCESS_DEFINITION_URL + "%d/xml", ProcessDefinitionServices::getProcessDefinitionXml),
-        Pair.of(PROCESS_DEFINITION_URL + "%d/form", ProcessDefinitionServices::getByKey));
+        Pair.of(
+            PROCESS_DEFINITION_URL + "%d/form",
+            ProcessDefinitionServices::getProcessDefinitionStartForm));
   }
 
   @Test
@@ -393,11 +395,7 @@ public class ProcessDefinitionQueryControllerTest extends RestControllerTest {
 
   @Test
   public void shouldReturnFormItemForValidFormKey() throws Exception {
-    when(processDefinitionServices.getByKey(1L))
-        .thenReturn(
-            new ProcessDefinitionEntity(
-                1L, "name", "id", "xml", "resource", 1, "tag", "tenant", "formId"));
-    when(formServices.getLatestVersionByFormId("formId"))
+    when(processDefinitionServices.getProcessDefinitionStartForm(1L))
         .thenReturn(Optional.of(new FormEntity(0L, "tenant-1", "formId", "schema", 1L)));
 
     webClient
@@ -410,13 +408,12 @@ public class ProcessDefinitionQueryControllerTest extends RestControllerTest {
         .expectBody()
         .json(FORM_ITEM_JSON, JsonCompareMode.STRICT);
 
-    verify(processDefinitionServices, times(1)).getByKey(1L);
-    verify(formServices, times(1)).getLatestVersionByFormId("formId");
+    verify(processDefinitionServices, times(1)).getProcessDefinitionStartForm(1L);
   }
 
   @Test
   public void shouldReturn404ForFormInvaliProcessKey() throws Exception {
-    when(processDefinitionServices.getByKey(999L))
+    when(processDefinitionServices.getProcessDefinitionStartForm(999L))
         .thenThrow(
             ErrorMapper.mapSearchError(
                 new CamundaSearchException(
@@ -443,7 +440,7 @@ public class ProcessDefinitionQueryControllerTest extends RestControllerTest {
 
   @Test
   public void shouldReturn500OnUnexpectedException() throws Exception {
-    when(processDefinitionServices.getByKey(1L))
+    when(processDefinitionServices.getProcessDefinitionStartForm(1L))
         .thenThrow(new RuntimeException("Unexpected error"));
 
     webClient


### PR DESCRIPTION
## Description

Ensure to fetch the start form by form id and tenant id to avoid return a wrong form (assigned to any other tenant)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #35608 
