### PR TITLE
ci: trigger component jobs on base level and zeebe change

### DIFF
--- a/.github/actions/paths-filter/action.yml
+++ b/.github/actions/paths-filter/action.yml
@@ -183,6 +183,18 @@ outputs:
         steps.filter-common.outputs.maven-change == 'true' ||
         steps.filter-common.outputs.rdbms-change == 'true'
       }}
+  zeebe-base-module-changes:
+    description: Output whether backend tests should be run if base level modules or Zeebe have changed
+    value: >-
+      ${{
+        github.event_name == 'push' ||
+        github.event_name == 'schedule' ||
+        steps.filter-common.outputs.github-actions-change == 'true' ||
+        steps.filter-common.outputs.webapps-change == 'true' ||
+        steps.filter-common.outputs.maven-change == 'true' ||
+        steps.filter-common.outputs.base-module-change == 'true' ||
+        steps.filter-zeebe.outputs.zeebe-change == 'true'
+      }}
 
 runs:
   using: composite
@@ -249,6 +261,15 @@ runs:
         - 'qa/acceptance-tests/**'
         - 'search/search-domain/**'
         - 'zeebe/exporters/rdbms-exporter/**'
+
+        base-module-change:
+        - 'authentication/**'
+        - 'clients/**'
+        - 'document/**'
+        - 'schema-manager/**'
+        - 'search/**'
+        - 'security/**'
+        - 'service/**'
 
   - uses: dorny/paths-filter@v3
     id: filter-identity

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,7 @@ jobs:
       camunda-docker-tests: ${{ steps.filter.outputs.camunda-docker-tests}}
       identity-frontend-tests: ${{ steps.filter.outputs.identity-frontend-tests }}
       frontend-changes: ${{ steps.filter.outputs.frontend-changes }}
+      zeebe-base-module-changes: ${{ steps.filter.outputs.zeebe-base-module-changes }}
       zeebe-changes: ${{ steps.filter.outputs.zeebe-changes }}
       operate-backend-changes: ${{ steps.filter.outputs.operate-backend-changes }}
       operate-frontend-changes: ${{ steps.filter.outputs.operate-frontend-changes }}
@@ -306,7 +307,7 @@ jobs:
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
 
   operate-backend-unit-tests:
-    if: needs.detect-changes.outputs.java-code-changes == 'true'
+    if: needs.detect-changes.outputs.operate-backend-changes == 'true' || needs.detect-changes.outputs.zeebe-base-module-changes == 'true'
     name: "[UT] Operate - ${{matrix.suiteName}}"
     needs: [ detect-changes ]
     uses: ./.github/workflows/ci-webapp-run-ut-reuseable.yml
@@ -326,7 +327,7 @@ jobs:
       suite: ${{ matrix.suite }}
 
   optimize-backend-unit-tests:
-    if: needs.detect-changes.outputs.optimize-backend-changes == 'true'
+    if: needs.detect-changes.outputs.optimize-backend-changes == 'true' || needs.detect-changes.outputs.zeebe-base-module-changes == 'true'
     name: "[UT] Optimize - ${{matrix.suiteName}}"
     needs: [ detect-changes ]
     uses: ./.github/workflows/ci-webapp-run-ut-reuseable.yml
@@ -346,7 +347,7 @@ jobs:
       suite: ${{ matrix.suite }}
 
   tasklist-backend-unit-tests:
-    if: needs.detect-changes.outputs.java-code-changes == 'true'
+    if: needs.detect-changes.outputs.tasklist-backend-changes == 'true' || needs.detect-changes.outputs.zeebe-base-module-changes == 'true'
     name: "[UT] Tasklist - ${{matrix.suiteName}}"
     needs: [ detect-changes ]
     uses: ./.github/workflows/ci-webapp-run-ut-reuseable.yml
@@ -366,7 +367,7 @@ jobs:
       suite: ${{ matrix.suite }}
 
   zeebe-unit-tests:
-    if: needs.detect-changes.outputs.java-code-changes == 'true'
+    if: needs.detect-changes.outputs.zeebe-changes == 'true' || needs.detect-changes.outputs.zeebe-base-module-changes == 'true'
     name: "[UT] Zeebe - ${{matrix.component}} - ${{matrix.suiteName}}"
     needs: [ detect-changes, setup-unit-tests ]
     timeout-minutes: 10


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Trigger tests based on where a change is detected. 

Run Operate/Optimize/Taskilst tests if there is a change in one of those applications. Also run their tests if there is a lower level change in a module it is dependent on, such as Zeebe, `service`, or `search`

Run Zeebe tests if there is a change in any of the Zeebe modules, or if there is a change in a lower level module.

The lower level modules are grouped together in `.github/actions/paths-filter/action.yml` under `zeebe-base-module-changes`

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

related to https://github.com/camunda/camunda/pull/34458
related to https://github.com/camunda/product-hub/issues/2818
