### PR TITLE
feat: log insecure transport warning only once in client

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaCallCredentials.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaCallCredentials.java
@@ -29,6 +29,7 @@ public final class CamundaCallCredentials extends io.grpc.CallCredentials {
   private static final Logger LOG = LoggerFactory.getLogger(CamundaCallCredentials.class);
 
   private final CredentialsProvider credentialsProvider;
+  private boolean securityWarningIssued;
 
   CamundaCallCredentials(final CredentialsProvider credentialsProvider) {
     this.credentialsProvider = credentialsProvider;
@@ -37,9 +38,12 @@ public final class CamundaCallCredentials extends io.grpc.CallCredentials {
   @Override
   public void applyRequestMetadata(
       final RequestInfo requestInfo, final Executor appExecutor, final MetadataApplier applier) {
-    if (requestInfo.getSecurityLevel().ordinal() < SecurityLevel.PRIVACY_AND_INTEGRITY.ordinal()) {
+    if (!securityWarningIssued
+        && requestInfo.getSecurityLevel().ordinal()
+            < SecurityLevel.PRIVACY_AND_INTEGRITY.ordinal()) {
       LOG.warn(
           "The request's security level does not guarantee that the credentials will be confidential.");
+      securityWarningIssued = true;
     }
 
     appExecutor.execute(

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeCallCredentials.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeCallCredentials.java
@@ -29,6 +29,7 @@ public final class ZeebeCallCredentials extends io.grpc.CallCredentials {
   private static final Logger LOG = LoggerFactory.getLogger(ZeebeCallCredentials.class);
 
   private final CredentialsProvider credentialsProvider;
+  private boolean securityWarningIssued;
 
   ZeebeCallCredentials(final CredentialsProvider credentialsProvider) {
     this.credentialsProvider = credentialsProvider;
@@ -37,9 +38,12 @@ public final class ZeebeCallCredentials extends io.grpc.CallCredentials {
   @Override
   public void applyRequestMetadata(
       final RequestInfo requestInfo, final Executor appExecutor, final MetadataApplier applier) {
-    if (requestInfo.getSecurityLevel().ordinal() < SecurityLevel.PRIVACY_AND_INTEGRITY.ordinal()) {
+    if (!securityWarningIssued
+        && requestInfo.getSecurityLevel().ordinal()
+            < SecurityLevel.PRIVACY_AND_INTEGRITY.ordinal()) {
       LOG.warn(
           "The request's security level does not guarantee that the credentials will be confidential.");
+      securityWarningIssued = true;
     }
 
     appExecutor.execute(


### PR DESCRIPTION
## Description

Previously the warning was issued on every request. It was way too verbose and logging it once for each instance is suffice to nudge the user to check their setup.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #35619 
