### PR TITLE
feat(config): add and apply cluster change operation for delete exporter

### DIFF
--- a/dist/src/test/java/io/camunda/zeebe/shared/management/ClusterApiUtilsTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/shared/management/ClusterApiUtilsTest.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.MemberLeaveOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.MemberRemoveOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionBootstrapOperation;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionDeleteExporterOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionDisableExporterOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionEnableExporterOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionForceReconfigureOperation;
@@ -290,6 +291,7 @@ final class ClusterApiUtilsTest {
         new PartitionReconfigurePriorityOperation(memberId1, 1, 2),
         new PartitionForceReconfigureOperation(memberId1, 1, memberCollection),
         new PartitionDisableExporterOperation(memberId1, 1, "test-exporter"),
+        new PartitionDeleteExporterOperation(memberId1, 1, "test-exporter"),
         new PartitionEnableExporterOperation(memberId1, 1, "test-exporter", emptyExporterId),
         new PartitionBootstrapOperation(memberId1, 1, 1, emptyConfig, false),
         new PartitionBootstrapOperation(memberId1, 2, 1, true) // Alternative constructor

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImpl.java
@@ -490,6 +490,11 @@ public final class PartitionManagerImpl
   }
 
   @Override
+  public ActorFuture<Void> deleteExporter(final int partitionId, final String exporterId) {
+    throw new UnsupportedOperationException("deleteExporter not yet implemented");
+  }
+
+  @Override
   public ActorFuture<Void> enableExporter(
       final int partitionId,
       final String exporterId,

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementApi.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementApi.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.BrokerScaleRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ClusterPatchRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ClusterScaleRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ExporterDeleteRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ExporterDisableRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ExporterEnableRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ForceRemoveBrokersRequest;
@@ -68,6 +69,9 @@ public interface ClusterConfigurationManagementApi {
 
   ActorFuture<ClusterConfigurationChangeResponse> disableExporter(
       ExporterDisableRequest exporterDisableRequest);
+
+  ActorFuture<ClusterConfigurationChangeResponse> deleteExporter(
+      ExporterDeleteRequest exporterDisableRequest);
 
   ActorFuture<ClusterConfigurationChangeResponse> enableExporter(
       ExporterEnableRequest enableRequest);

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequest.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequest.java
@@ -70,6 +70,9 @@ public sealed interface ClusterConfigurationManagementRequest {
   record ExporterDisableRequest(String exporterId, boolean dryRun)
       implements ClusterConfigurationManagementRequest {}
 
+  record ExporterDeleteRequest(String exporterId, boolean dryRun)
+      implements ClusterConfigurationManagementRequest {}
+
   record ExporterEnableRequest(String exporterId, Optional<String> initializeFrom, boolean dryRun)
       implements ClusterConfigurationManagementRequest {}
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestSender.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestSender.java
@@ -12,6 +12,7 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.BrokerScaleRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ClusterPatchRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ClusterScaleRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ExporterDeleteRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ExporterDisableRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ExporterEnableRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ForceRemoveBrokersRequest;
@@ -172,6 +173,17 @@ public final class ClusterConfigurationManagementRequestSender {
         ClusterConfigurationRequestTopics.DISABLE_EXPORTER.topic(),
         exporterDisableRequest,
         serializer::encodeExporterDisableRequest,
+        serializer::decodeTopologyChangeResponse,
+        coordinatorSupplier.getDefaultCoordinator(),
+        TIMEOUT);
+  }
+
+  public CompletableFuture<Either<ErrorResponse, ClusterConfigurationChangeResponse>>
+      deleteExporter(final ExporterDeleteRequest exporterDeleteRequest) {
+    return communicationService.send(
+        ClusterConfigurationRequestTopics.DELETE_EXPORTER.topic(),
+        exporterDeleteRequest,
+        serializer::encodeExporterDeleteRequest,
         serializer::decodeTopologyChangeResponse,
         coordinatorSupplier.getDefaultCoordinator(),
         TIMEOUT);

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestsHandler.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestsHandler.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.CancelChangeRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ClusterPatchRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ClusterScaleRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ExporterDeleteRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ExporterDisableRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ExporterEnableRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ForceRemoveBrokersRequest;
@@ -207,6 +208,14 @@ public final class ClusterConfigurationManagementRequestsHandler
     return handleRequest(
         exporterDisableRequest.dryRun(),
         new ExporterDisableRequestTransformer(exporterDisableRequest.exporterId()));
+  }
+
+  @Override
+  public ActorFuture<ClusterConfigurationChangeResponse> deleteExporter(
+      final ExporterDeleteRequest exporterDeleteRequest) {
+    return handleRequest(
+        exporterDeleteRequest.dryRun(),
+        new ExporterDeleteRequestTransformer(exporterDeleteRequest.exporterId()));
   }
 
   @Override

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationRequestServer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationRequestServer.java
@@ -46,6 +46,7 @@ public final class ClusterConfigurationRequestServer implements AutoCloseable {
     registerForceScaleDownHandler();
     registerDisableExporterHandler();
     registerEnableExporterHandler();
+    registerDeleteExporterHandler();
     registerClusterScaleRequestHandler();
     registerClusterPatchRequestHandler();
     registerUpdateRoutingStateHandler();
@@ -155,6 +156,14 @@ public final class ClusterConfigurationRequestServer implements AutoCloseable {
         ClusterConfigurationRequestTopics.DISABLE_EXPORTER.topic(),
         serializer::decodeExporterDisableRequest,
         request -> mapResponse(clusterConfigurationManagementApi.disableExporter(request)),
+        this::encodeResponse);
+  }
+
+  private void registerDeleteExporterHandler() {
+    communicationService.replyTo(
+        ClusterConfigurationRequestTopics.DELETE_EXPORTER.topic(),
+        serializer::decodeExporterDeleteRequest,
+        request -> mapResponse(clusterConfigurationManagementApi.deleteExporter(request)),
         this::encodeResponse);
   }
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationRequestTopics.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationRequestTopics.java
@@ -19,6 +19,7 @@ public enum ClusterConfigurationRequestTopics {
   FORCE_SCALE_DOWN("topology-force-scale-down"),
   DISABLE_EXPORTER("topology-exporter-disable"),
   ENABLE_EXPORTER("topology-exporter-enable"),
+  DELETE_EXPORTER("topology-exporter-delete"),
 
   SCALE_CLUSTER("topology-cluster-scale"),
   PATCH_CLUSTER("topology-cluster-patch"),

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ExporterDeleteRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ExporterDeleteRequestTransformer.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.api;
+
+import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeCoordinator.ConfigurationChangeRequest;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionDeleteExporterOperation;
+import io.camunda.zeebe.util.Either;
+import java.util.ArrayList;
+import java.util.List;
+
+public final class ExporterDeleteRequestTransformer implements ConfigurationChangeRequest {
+
+  private final String exporterId;
+
+  public ExporterDeleteRequestTransformer(final String exporterId) {
+
+    this.exporterId = exporterId;
+  }
+
+  @Override
+  public Either<Exception, List<ClusterConfigurationChangeOperation>> operations(
+      final ClusterConfiguration clusterConfiguration) {
+    final List<ClusterConfigurationChangeOperation> operations = new ArrayList<>();
+    for (final var member : clusterConfiguration.members().entrySet()) {
+      final var memberId = member.getKey();
+      for (final var partitions : member.getValue().partitions().entrySet()) {
+        final var partitionId = partitions.getKey();
+        operations.add(new PartitionDeleteExporterOperation(memberId, partitionId, exporterId));
+      }
+    }
+    return Either.right(operations);
+  }
+}

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/ConfigurationChangeAppliersImpl.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/ConfigurationChangeAppliersImpl.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.MemberLeaveOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.MemberRemoveOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionBootstrapOperation;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionDeleteExporterOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionDisableExporterOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionEnableExporterOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionForceReconfigureOperation;
@@ -89,6 +90,12 @@ public class ConfigurationChangeAppliersImpl implements ConfigurationChangeAppli
               enableExporterOperation.memberId(),
               enableExporterOperation.exporterId(),
               enableExporterOperation.initializeFrom(),
+              partitionChangeExecutor);
+      case final PartitionDeleteExporterOperation deleteExporterOperation ->
+          new PartitionDeleteExporterApplier(
+              deleteExporterOperation.partitionId(),
+              deleteExporterOperation.memberId(),
+              deleteExporterOperation.exporterId(),
               partitionChangeExecutor);
       case final PartitionBootstrapOperation bootstrapOperation ->
           new PartitionBootstrapApplier(bootstrapOperation, partitionChangeExecutor);

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/NoopPartitionChangeExecutor.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/NoopPartitionChangeExecutor.java
@@ -55,6 +55,11 @@ public final class NoopPartitionChangeExecutor implements PartitionChangeExecuto
   }
 
   @Override
+  public ActorFuture<Void> deleteExporter(final int partitionId, final String exporterId) {
+    return CompletableActorFuture.completed(null);
+  }
+
+  @Override
   public ActorFuture<Void> enableExporter(
       final int partitionId,
       final String exporterId,

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/PartitionChangeExecutor.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/PartitionChangeExecutor.java
@@ -90,6 +90,15 @@ public interface PartitionChangeExecutor {
   ActorFuture<Void> disableExporter(final int partitionId, final String exporterId);
 
   /**
+   * Delete the exporter for the given partition.
+   *
+   * @param partitionId id of the partition
+   * @param exporterId id of the exporter to delete
+   * @return a future that completes when the exporter is deleted
+   */
+  ActorFuture<Void> deleteExporter(final int partitionId, final String exporterId);
+
+  /**
    * Enables the exporter for the given partition.
    *
    * @param partitionId id of the partition

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/PartitionDeleteExporterApplier.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/PartitionDeleteExporterApplier.java
@@ -66,11 +66,10 @@ final class PartitionDeleteExporterApplier implements MemberOperationApplier {
                   memberId, partitionId)));
     }
 
-    final Map<String, ExporterState> exporters = member.getPartition(partitionId).config()
-        .exporting().exporters();
+    final Map<String, ExporterState> exporters =
+        member.getPartition(partitionId).config().exporting().exporters();
 
-    final var partitionHasExporter =
-        exporters.containsKey(exporterId);
+    final var partitionHasExporter = exporters.containsKey(exporterId);
 
     if (!partitionHasExporter) {
       return Either.left(

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/PartitionDeleteExporterApplier.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/PartitionDeleteExporterApplier.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.changes;
+
+import static io.camunda.zeebe.dynamic.config.state.ExporterState.State.CONFIG_NOT_FOUND;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeAppliers.MemberOperationApplier;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
+import io.camunda.zeebe.dynamic.config.state.ExporterState;
+import io.camunda.zeebe.dynamic.config.state.MemberState;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.util.Either;
+import java.util.Map;
+import java.util.function.UnaryOperator;
+
+final class PartitionDeleteExporterApplier implements MemberOperationApplier {
+
+  private final int partitionId;
+  private final MemberId memberId;
+  private final String exporterId;
+  private final PartitionChangeExecutor partitionChangeExecutor;
+
+  public PartitionDeleteExporterApplier(
+      final int partitionId,
+      final MemberId memberId,
+      final String exporterId,
+      final PartitionChangeExecutor partitionChangeExecutor) {
+    this.partitionId = partitionId;
+    this.memberId = memberId;
+    this.exporterId = exporterId;
+    this.partitionChangeExecutor = partitionChangeExecutor;
+  }
+
+  @Override
+  public MemberId memberId() {
+    return memberId;
+  }
+
+  @Override
+  public Either<Exception, UnaryOperator<MemberState>> initMemberState(
+      final ClusterConfiguration currentClusterConfiguration) {
+
+    if (!currentClusterConfiguration.hasMember(memberId)) {
+      return Either.left(
+          new IllegalStateException(
+              String.format(
+                  "Expected to delete exporter, but the member '%s' does not exist in the cluster",
+                  memberId)));
+    }
+
+    final MemberState member = currentClusterConfiguration.getMember(memberId);
+    final var partitionExistsInLocalMember = member.hasPartition(partitionId);
+
+    if (!partitionExistsInLocalMember) {
+      return Either.left(
+          new IllegalStateException(
+              String.format(
+                  "Expected to delete exporter, but the member '%s' does not have the partition '%s'",
+                  memberId, partitionId)));
+    }
+
+    final Map<String, ExporterState> exporters = member.getPartition(partitionId).config()
+        .exporting().exporters();
+
+    final var partitionHasExporter =
+        exporters.containsKey(exporterId);
+
+    if (!partitionHasExporter) {
+      return Either.left(
+          new IllegalStateException(
+              String.format(
+                  "Expected to delete exporter, but the partition '%s' does not have the exporter '%s'",
+                  partitionId, exporterId)));
+    }
+
+    final var exporterState = exporters.get(exporterId).state();
+    final boolean isConfigNotFound = exporterState.equals(CONFIG_NOT_FOUND);
+
+    if (!isConfigNotFound) {
+      return Either.left(
+          new IllegalStateException(
+              String.format(
+                  "Expected to delete exporter, but partition '%s' with exporter '%s' is in state '%s' instead of '%s'.",
+                  partitionId, exporterId, exporterState, CONFIG_NOT_FOUND)));
+    }
+
+    // No need to change the state
+    return Either.right(memberstate -> memberstate);
+  }
+
+  @Override
+  public ActorFuture<UnaryOperator<MemberState>> applyOperation() {
+    return partitionChangeExecutor
+        .deleteExporter(partitionId, exporterId)
+        .thenApply(
+            (nothing) -> {
+              return memberState ->
+                  memberState.updatePartition(
+                      partitionId,
+                      partition ->
+                          partition.updateConfig(config -> deleteExporter(config, exporterId)));
+            });
+  }
+
+  private DynamicPartitionConfig deleteExporter(
+      final DynamicPartitionConfig config, final String exporterId) {
+    return config.updateExporting(exporting -> exporting.deleteExporter(exporterId));
+  }
+}

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ClusterConfigurationRequestsSerializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ClusterConfigurationRequestsSerializer.java
@@ -40,6 +40,9 @@ public interface ClusterConfigurationRequestsSerializer {
   byte[] encodeExporterDisableRequest(
       ClusterConfigurationManagementRequest.ExporterDisableRequest exporterDisableRequest);
 
+  byte[] encodeExporterDeleteRequest(
+      ClusterConfigurationManagementRequest.ExporterDeleteRequest exporterDeleteRequest);
+
   byte[] encodeExporterEnableRequest(
       ClusterConfigurationManagementRequest.ExporterEnableRequest exporterEnableRequest);
 
@@ -75,6 +78,9 @@ public interface ClusterConfigurationRequestsSerializer {
       byte[] encodedState);
 
   ClusterConfigurationManagementRequest.ExporterDisableRequest decodeExporterDisableRequest(
+      byte[] encodedRequest);
+
+  ClusterConfigurationManagementRequest.ExporterDeleteRequest decodeExporterDeleteRequest(
       byte[] encodedRequest);
 
   ClusterConfigurationManagementRequest.ExporterEnableRequest decodeExporterEnableRequest(

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.CancelChangeRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ClusterPatchRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ClusterScaleRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ExporterDeleteRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ExporterDisableRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ExporterEnableRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ForceRemoveBrokersRequest;
@@ -45,6 +46,7 @@ import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.MemberRemoveOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionBootstrapOperation;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionDeleteExporterOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionDisableExporterOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionEnableExporterOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionForceReconfigureOperation;
@@ -428,6 +430,12 @@ public class ProtoBufSerializer
                   .setPartitionId(disableExporterOperation.partitionId())
                   .setExporterId(disableExporterOperation.exporterId())
                   .build());
+      case final PartitionDeleteExporterOperation deleteExporterOperation ->
+          builder.setPartitionDeleteExporter(
+              Topology.PartitionDeleteExporterOperation.newBuilder()
+                  .setPartitionId(deleteExporterOperation.partitionId())
+                  .setExporterId(deleteExporterOperation.exporterId())
+                  .build());
       case final PartitionEnableExporterOperation enableExporterOperation ->
           builder.setPartitionEnableExporter(
               encodeEnabledExporterOperation(enableExporterOperation));
@@ -646,6 +654,11 @@ public class ProtoBufSerializer
           memberId,
           topologyChangeOperation.getPartitionDisableExporter().getPartitionId(),
           topologyChangeOperation.getPartitionDisableExporter().getExporterId());
+    } else if (topologyChangeOperation.hasPartitionDeleteExporter()) {
+      return new PartitionDeleteExporterOperation(
+          memberId,
+          topologyChangeOperation.getPartitionDeleteExporter().getPartitionId(),
+          topologyChangeOperation.getPartitionDeleteExporter().getExporterId());
     } else if (topologyChangeOperation.hasPartitionEnableExporter()) {
       final var enableExporterOperation = topologyChangeOperation.getPartitionEnableExporter();
       final Optional<String> initializeFrom =
@@ -788,6 +801,15 @@ public class ProtoBufSerializer
     return Requests.ExporterDisableRequest.newBuilder()
         .setExporterId(exporterDisableRequest.exporterId())
         .setDryRun(exporterDisableRequest.dryRun())
+        .build()
+        .toByteArray();
+  }
+
+  @Override
+  public byte[] encodeExporterDeleteRequest(final ExporterDeleteRequest exporterDeleteRequest) {
+    return Requests.ExporterDeleteRequest.newBuilder()
+        .setExporterId(exporterDeleteRequest.exporterId())
+        .setDryRun(exporterDeleteRequest.dryRun())
         .build()
         .toByteArray();
   }
@@ -959,6 +981,17 @@ public class ProtoBufSerializer
       final var exporterDisableRequest = Requests.ExporterDisableRequest.parseFrom(encodedRequest);
       return new ExporterDisableRequest(
           exporterDisableRequest.getExporterId(), exporterDisableRequest.getDryRun());
+    } catch (final InvalidProtocolBufferException e) {
+      throw new DecodingFailed(e);
+    }
+  }
+
+  @Override
+  public ExporterDeleteRequest decodeExporterDeleteRequest(final byte[] encodedRequest) {
+    try {
+      final var exporterDeleteRequest = Requests.ExporterDeleteRequest.parseFrom(encodedRequest);
+      return new ExporterDeleteRequest(
+          exporterDeleteRequest.getExporterId(), exporterDeleteRequest.getDryRun());
     } catch (final InvalidProtocolBufferException e) {
       throw new DecodingFailed(e);
     }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ClusterConfigurationChangeOperation.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ClusterConfigurationChangeOperation.java
@@ -147,6 +147,16 @@ public sealed interface ClusterConfigurationChangeOperation {
         implements PartitionChangeOperation {}
 
     /**
+     * Operation to delete an exporter on a partition in the given member.
+     *
+     * @param memberId the member id of the member that will apply this operation
+     * @param partitionId id of the partition which delete the exporter
+     * @param exporterId id of the exporter to delete
+     */
+    record PartitionDeleteExporterOperation(MemberId memberId, int partitionId, String exporterId)
+        implements PartitionChangeOperation {}
+
+    /**
      * Operation to enable an exporter on a partition in the given member.
      *
      * @param memberId the member id of the member that will apply this operation

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ExportersConfig.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ExportersConfig.java
@@ -43,6 +43,14 @@ public record ExportersConfig(Map<String, ExporterState> exporters) {
             Optional.empty()));
   }
 
+  public ExportersConfig deleteExporter(final String exporterName) {
+    final var newExporters =
+        exporters.entrySet().stream()
+            .filter(entry -> !entry.getKey().equals(exporterName))
+            .collect(ImmutableMap.toImmutableMap(Map.Entry::getKey, Map.Entry::getValue));
+    return new ExportersConfig(newExporters);
+  }
+
   public ExportersConfig disableExporters(final Collection<String> exporterNames) {
     final var builder = ImmutableMap.<String, ExporterState>builder().putAll(exporters);
 

--- a/zeebe/dynamic-config/src/main/resources/proto/requests.proto
+++ b/zeebe/dynamic-config/src/main/resources/proto/requests.proto
@@ -74,6 +74,11 @@ message ExporterDisableRequest {
   bool dryRun = 2;
 }
 
+message ExporterDeleteRequest {
+  string exporterId = 1;
+  bool dryRun = 2;
+}
+
 message ExporterEnableRequest {
   string exporterId = 1;
   optional string initializeFrom = 2;

--- a/zeebe/dynamic-config/src/main/resources/proto/topology.proto
+++ b/zeebe/dynamic-config/src/main/resources/proto/topology.proto
@@ -98,6 +98,7 @@ message TopologyChangeOperation {
     AwaitRedistributionCompletion awaitRedistributionCompletion = 14;
     AwaitRelocationCompletion awaitRelocationCompletion = 15;
     UpdateRoutingState updateRoutingState = 16;
+    PartitionDeleteExporterOperation partitionDeleteExporter = 17;
   }
 }
 
@@ -127,6 +128,11 @@ message PartitionForceReconfigureOperation {
 }
 
 message PartitionDisableExporterOperation {
+  int32 partitionId = 1;
+  string exporterId = 2;
+}
+
+message PartitionDeleteExporterOperation {
   int32 partitionId = 1;
   string exporterId = 2;
 }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ExporterDeleteRequestTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ExporterDeleteRequestTransformerTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionDeleteExporterOperation;
+import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
+import io.camunda.zeebe.dynamic.config.state.ExporterState;
+import io.camunda.zeebe.dynamic.config.state.ExporterState.State;
+import io.camunda.zeebe.dynamic.config.state.ExportersConfig;
+import io.camunda.zeebe.dynamic.config.state.MemberState;
+import io.camunda.zeebe.dynamic.config.state.PartitionState;
+import io.camunda.zeebe.test.util.asserts.EitherAssert;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+final class ExporterDeleteRequestTransformerTest {
+
+  final String exporterId = "exporterA";
+  private final MemberId id0 = MemberId.from("0");
+  private final MemberId id1 = MemberId.from("1");
+  private final DynamicPartitionConfig config =
+      new DynamicPartitionConfig(
+          new ExportersConfig(
+              Map.of(exporterId, new ExporterState(1, State.ENABLED, Optional.empty()))));
+
+  @Test
+  void shouldGenerateOperationForAllPartitionsAndMembers() {
+    // given
+    final var transformer = new ExporterDeleteRequestTransformer(exporterId);
+
+    final var clusterConfiguration =
+        ClusterConfiguration.init()
+            .addMember(id0, MemberState.initializeAsActive(Map.of()))
+            .addMember(id1, MemberState.initializeAsActive(Map.of()))
+            .updateMember(id0, m -> m.addPartition(1, PartitionState.active(1, config)))
+            .updateMember(id0, m -> m.addPartition(2, PartitionState.active(2, config)))
+            .updateMember(id1, m -> m.addPartition(2, PartitionState.active(1, config)))
+            .updateMember(id1, m -> m.addPartition(1, PartitionState.active(2, config)));
+
+    // when
+    final var result = transformer.operations(clusterConfiguration);
+
+    // then
+    EitherAssert.assertThat(result).isRight();
+    assertThat(result.get())
+        .containsExactlyInAnyOrder(
+            new PartitionDeleteExporterOperation(id0, 1, exporterId),
+            new PartitionDeleteExporterOperation(id0, 2, exporterId),
+            new PartitionDeleteExporterOperation(id1, 2, exporterId),
+            new PartitionDeleteExporterOperation(id1, 1, exporterId));
+  }
+}

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/ConfigurationChangeAppliersImplTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/ConfigurationChangeAppliersImplTest.java
@@ -14,6 +14,7 @@ import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.DeleteHistoryOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.MemberJoinOperation;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionDeleteExporterOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionDisableExporterOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionEnableExporterOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionForceReconfigureOperation;
@@ -60,6 +61,9 @@ final class ConfigurationChangeAppliersImplTest {
         Arguments.of(
             new PartitionDisableExporterOperation(localMemberId, 1, "expId"),
             PartitionDisableExporterApplier.class),
+        Arguments.of(
+            new PartitionDeleteExporterOperation(localMemberId, 1, "expId"),
+            PartitionDeleteExporterApplier.class),
         Arguments.of(
             new PartitionEnableExporterOperation(localMemberId, 1, "expId", Optional.empty()),
             PartitionEnableExporterApplier.class),

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/PartitionDeleteExporterApplierTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/PartitionDeleteExporterApplierTest.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.changes;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
+import io.camunda.zeebe.dynamic.config.state.ExporterState;
+import io.camunda.zeebe.dynamic.config.state.ExporterState.State;
+import io.camunda.zeebe.dynamic.config.state.ExportersConfig;
+import io.camunda.zeebe.dynamic.config.state.MemberState;
+import io.camunda.zeebe.dynamic.config.state.PartitionState;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import io.camunda.zeebe.test.util.asserts.EitherAssert;
+import java.time.Duration;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+import org.junit.jupiter.api.Test;
+
+final class PartitionDeleteExporterApplierTest {
+
+  private final PartitionChangeExecutor partitionChangeExecutor =
+      mock(PartitionChangeExecutor.class);
+
+  private final String exporterId = "exporterA";
+  private final int partitionId = 2;
+  private final MemberId localMemberId = MemberId.from("3");
+
+  private final PartitionDeleteExporterApplier applier =
+      new PartitionDeleteExporterApplier(
+          partitionId, localMemberId, exporterId, partitionChangeExecutor);
+
+  @Test
+  void shouldFailInitIfMemberDoesNotExist() {
+    // given
+    final var clusterConfiguration = ClusterConfiguration.init();
+
+    // when
+    final var result = applier.initMemberState(clusterConfiguration);
+
+    // then
+    EitherAssert.assertThat(result).isLeft();
+    assertThat(result.getLeft())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("member '3' does not exist in the cluster");
+  }
+
+  @Test
+  void shouldFailInitIfPartitionDoesNotExist() {
+    // given
+    final var clusterConfiguration =
+        ClusterConfiguration.init()
+            .addMember(localMemberId, MemberState.initializeAsActive(Map.of()));
+
+    // when
+    final var result = applier.initMemberState(clusterConfiguration);
+
+    // then
+    EitherAssert.assertThat(result).isLeft();
+    assertThat(result.getLeft())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("does not have the partition '2'");
+  }
+
+  @Test
+  void shouldFailInitIfExporterDoesNotExist() {
+    // given
+    final var clusterConfiguration =
+        ClusterConfiguration.init()
+            .addMember(
+                localMemberId,
+                MemberState.initializeAsActive(
+                    Map.of(partitionId, PartitionState.active(1, DynamicPartitionConfig.init()))));
+
+    // when
+    final var result = applier.initMemberState(clusterConfiguration);
+
+    // then
+    EitherAssert.assertThat(result).isLeft();
+    assertThat(result.getLeft())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("does not have the exporter 'exporterA'");
+  }
+
+  @Test
+  void shouldFailInitIfStateIsNotInConfigNotFound() {
+    // given
+    final var configWithExporter =
+        new DynamicPartitionConfig(
+            new ExportersConfig(
+                Map.of(exporterId, new ExporterState(1, State.ENABLED, Optional.empty()))));
+    final var clusterConfiguration =
+        ClusterConfiguration.init()
+            .addMember(
+                localMemberId,
+                MemberState.initializeAsActive(
+                    Map.of(partitionId, PartitionState.active(1, configWithExporter))));
+
+    // when
+    final var result = applier.initMemberState(clusterConfiguration);
+
+    // then
+    EitherAssert.assertThat(result).isLeft();
+    assertThat(result.getLeft())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("Expected to delete exporter, but partition '2' with exporter 'exporterA' is in state 'ENABLED' instead of 'CONFIG_NOT_FOUND'.");
+  }
+
+  @Test
+  void shouldNotChangeStateInInit() {
+    // given
+    final var configWithExporter =
+        new DynamicPartitionConfig(
+            new ExportersConfig(
+                Map.of(exporterId, new ExporterState(1, State.CONFIG_NOT_FOUND, Optional.empty()))));
+    final var clusterConfiguration =
+        ClusterConfiguration.init()
+            .addMember(
+                localMemberId,
+                MemberState.initializeAsActive(
+                    Map.of(partitionId, PartitionState.active(1, configWithExporter))));
+
+    // when
+    final var result = applier.initMemberState(clusterConfiguration);
+
+    // then
+    EitherAssert.assertThat(result).isRight();
+    final MemberState memberState = clusterConfiguration.getMember(localMemberId);
+    assertThat(result.get().apply(memberState)).isEqualTo(memberState);
+  }
+
+  @Test
+  void shouldFailFutureIfApplyFails() {
+    // given
+    when(partitionChangeExecutor.deleteExporter(partitionId, exporterId))
+        .thenReturn(
+            CompletableActorFuture.completedExceptionally(new RuntimeException("force fail")));
+
+    // when
+    final var result = applier.applyOperation();
+
+    // then
+    assertThat(result)
+        .failsWithin(Duration.ofMillis(100))
+        .withThrowableOfType(ExecutionException.class)
+        .withMessageContaining("force fail");
+  }
+
+  @Test
+  void shouldCompleteFutureAndUpdateStateIfApplySucceeds() {
+    // given
+    final var exporterState = new ExporterState(1, State.CONFIG_NOT_FOUND, Optional.empty());
+    final var exporterConfig = new ExportersConfig(Map.of(exporterId, exporterState));
+    final var partitionConfig = new DynamicPartitionConfig(exporterConfig);
+    final var memberState = MemberState.initializeAsActive(
+            Map.of(partitionId, PartitionState.active(1, partitionConfig)));
+
+    when(partitionChangeExecutor.deleteExporter(partitionId, exporterId))
+        .thenReturn(CompletableActorFuture.completed(null));
+
+    // when
+    final var result = applier.applyOperation();
+
+    // then
+    assertThat(result).succeedsWithin(Duration.ofMillis(100));
+
+    final var updatedExporter = result.join().apply(memberState);
+    assertThat(updatedExporter
+                .getPartition(partitionId)
+                .config()
+                .exporting()
+                .exporters()).isEmpty();
+  }
+}

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/PartitionDeleteExporterApplierTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/PartitionDeleteExporterApplierTest.java
@@ -113,7 +113,8 @@ final class PartitionDeleteExporterApplierTest {
     EitherAssert.assertThat(result).isLeft();
     assertThat(result.getLeft())
         .isInstanceOf(IllegalStateException.class)
-        .hasMessageContaining("Expected to delete exporter, but partition '2' with exporter 'exporterA' is in state 'ENABLED' instead of 'CONFIG_NOT_FOUND'.");
+        .hasMessageContaining(
+            "Expected to delete exporter, but partition '2' with exporter 'exporterA' is in state 'ENABLED' instead of 'CONFIG_NOT_FOUND'.");
   }
 
   @Test
@@ -122,7 +123,8 @@ final class PartitionDeleteExporterApplierTest {
     final var configWithExporter =
         new DynamicPartitionConfig(
             new ExportersConfig(
-                Map.of(exporterId, new ExporterState(1, State.CONFIG_NOT_FOUND, Optional.empty()))));
+                Map.of(
+                    exporterId, new ExporterState(1, State.CONFIG_NOT_FOUND, Optional.empty()))));
     final var clusterConfiguration =
         ClusterConfiguration.init()
             .addMember(
@@ -162,7 +164,8 @@ final class PartitionDeleteExporterApplierTest {
     final var exporterState = new ExporterState(1, State.CONFIG_NOT_FOUND, Optional.empty());
     final var exporterConfig = new ExportersConfig(Map.of(exporterId, exporterState));
     final var partitionConfig = new DynamicPartitionConfig(exporterConfig);
-    final var memberState = MemberState.initializeAsActive(
+    final var memberState =
+        MemberState.initializeAsActive(
             Map.of(partitionId, PartitionState.active(1, partitionConfig)));
 
     when(partitionChangeExecutor.deleteExporter(partitionId, exporterId))
@@ -175,10 +178,7 @@ final class PartitionDeleteExporterApplierTest {
     assertThat(result).succeedsWithin(Duration.ofMillis(100));
 
     final var updatedExporter = result.join().apply(memberState);
-    assertThat(updatedExporter
-                .getPartition(partitionId)
-                .config()
-                .exporting()
-                .exporters()).isEmpty();
+    assertThat(updatedExporter.getPartition(partitionId).config().exporting().exporters())
+        .isEmpty();
   }
 }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializerTest.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationChangeResponse;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.AddMembersRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ClusterPatchRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ClusterScaleRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ExporterDeleteRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ExporterDisableRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ExporterEnableRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ForceRemoveBrokersRequest;
@@ -117,6 +118,20 @@ final class ProtoBufSerializerTest {
     // then
     final var decodedRequest = protoBufSerializer.decodeExporterDisableRequest(encodedRequest);
     assertThat(decodedRequest).isEqualTo(exporterDisableRequest);
+  }
+
+  @Test
+  void shouldEncodeAndDecodeExporterDeleteRequest() {
+    // given
+    final var exporterDeleteRequest = new ExporterDeleteRequest("expId", false);
+
+    // when
+    final var encodedRequest =
+        protoBufSerializer.encodeExporterDeleteRequest(exporterDeleteRequest);
+
+    // then
+    final var decodedRequest = protoBufSerializer.decodeExporterDeleteRequest(encodedRequest);
+    assertThat(decodedRequest).isEqualTo(exporterDeleteRequest);
   }
 
   @Test


### PR DESCRIPTION
## Description

Implements:

- #35322: Add PartitionDeleteExporterOperation to represent a request to delete an exporter from a partition
- #35323: Add ClusterChangeOperationApplier to apply delete-exporter operations to partition configurations

Details:

- Introduce a new `PartitionDeleteExporterOperation` in the cluster configuration model
- Implement `ExporterDeleteRequestTransformer` to generate delete operations for all relevant partitions
- Update `ClusterChangePlanExecutor` and `PartitionChangeExecutor` to support the new operation type
- Apply config mutation in `PartitionDeleteExporterOperationApplier`
- Add tests to validate transformer behavior and applier logic

## Checklist

## Related issues

closes #35322 #35323
