### PR TITLE
fix: do not configure grpc but our messaging service instead

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/configuration/GatewayBasedConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/configuration/GatewayBasedConfiguration.java
@@ -144,12 +144,15 @@ public final class GatewayBasedConfiguration {
 
   private MessagingConfig messagingConfig(final GatewayCfg config) {
     final var cluster = config.getCluster();
+    final var network = config.getNetwork();
 
     final var messaging =
         new MessagingConfig()
             .setCompressionAlgorithm(cluster.getMessageCompression())
             .setInterfaces(Collections.singletonList(cluster.getHost()))
-            .setPort(cluster.getPort());
+            .setPort(cluster.getPort())
+            .setSocketSendBuffer((int) network.getSocketSendBuffer().toBytes())
+            .setSocketReceiveBuffer((int) network.getSocketReceiveBuffer().toBytes());
 
     final var security = cluster.getSecurity();
     if (security.isEnabled()) {

--- a/dist/src/main/java/io/camunda/application/commons/configuration/GatewayBasedConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/configuration/GatewayBasedConfiguration.java
@@ -144,15 +144,14 @@ public final class GatewayBasedConfiguration {
 
   private MessagingConfig messagingConfig(final GatewayCfg config) {
     final var cluster = config.getCluster();
-    final var network = config.getNetwork();
 
     final var messaging =
         new MessagingConfig()
             .setCompressionAlgorithm(cluster.getMessageCompression())
             .setInterfaces(Collections.singletonList(cluster.getHost()))
             .setPort(cluster.getPort())
-            .setSocketSendBuffer((int) network.getSocketSendBuffer().toBytes())
-            .setSocketReceiveBuffer((int) network.getSocketReceiveBuffer().toBytes());
+            .setSocketSendBuffer((int) cluster.getSocketSendBuffer().toBytes())
+            .setSocketReceiveBuffer((int) cluster.getSocketReceiveBuffer().toBytes());
 
     final var security = cluster.getSecurity();
     if (security.isEnabled()) {

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/Gateway.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/Gateway.java
@@ -55,7 +55,6 @@ import io.grpc.netty.NettyServerBuilder;
 import io.grpc.protobuf.StatusProto;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.binder.grpc.MetricCollectingServerInterceptor;
-import io.netty.channel.ChannelOption;
 import io.netty.handler.ssl.SslContextBuilder;
 import java.io.IOException;
 import java.io.UncheckedIOException;

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/Gateway.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/Gateway.java
@@ -277,9 +277,7 @@ public final class Gateway implements CloseableSilently {
     return NettyServerBuilder.forAddress(new InetSocketAddress(cfg.getHost(), cfg.getPort()))
         .maxInboundMessageSize(maxMessageSize)
         .permitKeepAliveTime(minKeepAliveInterval.toMillis(), TimeUnit.MILLISECONDS)
-        .permitKeepAliveWithoutCalls(false)
-        .withOption(ChannelOption.SO_RCVBUF, (int) cfg.getSocketReceiveBuffer().toBytes())
-        .withChildOption(ChannelOption.SO_SNDBUF, (int) cfg.getSocketSendBuffer().toBytes());
+        .permitKeepAliveWithoutCalls(false);
   }
 
   private void setSecurityConfig(

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/configuration/ClusterCfg.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/configuration/ClusterCfg.java
@@ -14,6 +14,8 @@ import static io.camunda.zeebe.gateway.impl.configuration.ConfigurationDefaults.
 import static io.camunda.zeebe.gateway.impl.configuration.ConfigurationDefaults.DEFAULT_CLUSTER_PORT;
 import static io.camunda.zeebe.gateway.impl.configuration.ConfigurationDefaults.DEFAULT_CONTACT_POINT_HOST;
 import static io.camunda.zeebe.gateway.impl.configuration.ConfigurationDefaults.DEFAULT_CONTACT_POINT_PORT;
+import static io.camunda.zeebe.gateway.impl.configuration.ConfigurationDefaults.DEFAULT_GATEWAY_SOCKET_RECEIVE_BUFFER;
+import static io.camunda.zeebe.gateway.impl.configuration.ConfigurationDefaults.DEFAULT_GATEWAY_SOCKET_SEND_BUFFER;
 import static io.camunda.zeebe.gateway.impl.configuration.ConfigurationDefaults.DEFAULT_REQUEST_TIMEOUT;
 import static io.camunda.zeebe.util.StringUtil.LIST_SANITIZER;
 
@@ -24,6 +26,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import org.springframework.util.unit.DataSize;
 
 public final class ClusterCfg {
 
@@ -43,6 +46,8 @@ public final class ClusterCfg {
   private SecurityCfg security = new SecurityCfg();
   private CompressionAlgorithm messageCompression = CompressionAlgorithm.NONE;
   private ConfigManagerCfg configManager = ConfigManagerCfg.defaultConfig();
+  private DataSize socketSendBuffer = DEFAULT_GATEWAY_SOCKET_SEND_BUFFER;
+  private DataSize socketReceiveBuffer = DEFAULT_GATEWAY_SOCKET_RECEIVE_BUFFER;
 
   public String getMemberId() {
     return memberId;
@@ -166,6 +171,24 @@ public final class ClusterCfg {
     return this;
   }
 
+  public DataSize getSocketSendBuffer() {
+    return socketSendBuffer;
+  }
+
+  public ClusterCfg setSocketSendBuffer(final DataSize socketSendBuffer) {
+    this.socketSendBuffer = socketSendBuffer;
+    return this;
+  }
+
+  public DataSize getSocketReceiveBuffer() {
+    return socketReceiveBuffer;
+  }
+
+  public ClusterCfg setSocketReceiveBuffer(final DataSize socketReceiveBuffer) {
+    this.socketReceiveBuffer = socketReceiveBuffer;
+    return this;
+  }
+
   @Override
   public int hashCode() {
     return Objects.hash(
@@ -178,7 +201,9 @@ public final class ClusterCfg {
         membership,
         security,
         messageCompression,
-        configManager);
+        configManager,
+        socketSendBuffer,
+        socketReceiveBuffer);
   }
 
   @Override
@@ -199,7 +224,9 @@ public final class ClusterCfg {
         && Objects.equals(membership, that.membership)
         && Objects.equals(security, that.security)
         && Objects.equals(messageCompression, that.messageCompression)
-        && Objects.equals(configManager, that.configManager);
+        && Objects.equals(configManager, that.configManager)
+        && Objects.equals(socketSendBuffer, that.socketSendBuffer)
+        && Objects.equals(socketReceiveBuffer, that.socketReceiveBuffer);
   }
 
   @Override
@@ -228,6 +255,10 @@ public final class ClusterCfg {
         + messageCompression
         + ", configManagerCfg="
         + configManager
+        + ", socketSendBuffer="
+        + socketSendBuffer
+        + ", socketReceiveBuffer="
+        + socketReceiveBuffer
         + '}';
   }
 }

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/configuration/NetworkCfg.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/configuration/NetworkCfg.java
@@ -7,8 +7,6 @@
  */
 package io.camunda.zeebe.gateway.impl.configuration;
 
-import static io.camunda.zeebe.gateway.impl.configuration.ConfigurationDefaults.DEFAULT_GATEWAY_SOCKET_RECEIVE_BUFFER;
-import static io.camunda.zeebe.gateway.impl.configuration.ConfigurationDefaults.DEFAULT_GATEWAY_SOCKET_SEND_BUFFER;
 import static io.camunda.zeebe.gateway.impl.configuration.ConfigurationDefaults.DEFAULT_PORT;
 
 import java.net.InetSocketAddress;
@@ -22,8 +20,6 @@ public final class NetworkCfg {
   private int port = DEFAULT_PORT;
   private Duration minKeepAliveInterval = Duration.ofSeconds(30);
   private DataSize maxMessageSize = DataSize.ofMegabytes(4);
-  private DataSize socketSendBuffer = DEFAULT_GATEWAY_SOCKET_SEND_BUFFER;
-  private DataSize socketReceiveBuffer = DEFAULT_GATEWAY_SOCKET_RECEIVE_BUFFER;
 
   public void init(final String defaultHost) {
     if (host == null) {
@@ -67,31 +63,13 @@ public final class NetworkCfg {
     return this;
   }
 
-  public DataSize getSocketSendBuffer() {
-    return socketSendBuffer;
-  }
-
-  public NetworkCfg setSocketSendBuffer(final DataSize socketSendBuffer) {
-    this.socketSendBuffer = socketSendBuffer;
-    return this;
-  }
-
-  public DataSize getSocketReceiveBuffer() {
-    return socketReceiveBuffer;
-  }
-
-  public NetworkCfg setSocketReceiveBuffer(final DataSize socketReceiveBuffer) {
-    this.socketReceiveBuffer = socketReceiveBuffer;
-    return this;
-  }
-
   public InetSocketAddress toSocketAddress() {
     return new InetSocketAddress(host, port);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(host, port, socketSendBuffer, socketReceiveBuffer);
+    return Objects.hash(host, port);
   }
 
   @Override
@@ -103,10 +81,7 @@ public final class NetworkCfg {
       return false;
     }
     final NetworkCfg that = (NetworkCfg) o;
-    return port == that.port
-        && Objects.equals(host, that.host)
-        && Objects.equals(socketReceiveBuffer, that.socketReceiveBuffer)
-        && Objects.equals(socketSendBuffer, that.socketSendBuffer);
+    return port == that.port && Objects.equals(host, that.host);
   }
 
   @Override
@@ -119,10 +94,6 @@ public final class NetworkCfg {
         + port
         + ", minKeepAliveInterval="
         + minKeepAliveInterval
-        + ", socketReceiveBuffer="
-        + socketReceiveBuffer
-        + ", socketSendBuffer="
-        + socketSendBuffer
         + '}';
   }
 }

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/configuration/NetworkCfg.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/configuration/NetworkCfg.java
@@ -69,7 +69,7 @@ public final class NetworkCfg {
 
   @Override
   public int hashCode() {
-    return Objects.hash(host, port);
+    return Objects.hash(host, port, minKeepAliveInterval, maxMessageSize);
   }
 
   @Override

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/configuration/NetworkCfg.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/configuration/NetworkCfg.java
@@ -81,7 +81,10 @@ public final class NetworkCfg {
       return false;
     }
     final NetworkCfg that = (NetworkCfg) o;
-    return port == that.port && Objects.equals(host, that.host);
+    return port == that.port
+        && Objects.equals(host, that.host)
+        && Objects.equals(minKeepAliveInterval, that.minKeepAliveInterval)
+        && Objects.equals(maxMessageSize, that.maxMessageSize);
   }
 
   @Override

--- a/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/impl/configuration/GatewayCfgTest.java
+++ b/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/impl/configuration/GatewayCfgTest.java
@@ -182,9 +182,7 @@ public final class GatewayCfgTest {
         .getNetwork()
         .setHost("zeebe")
         .setPort(5432)
-        .setMinKeepAliveInterval(Duration.ofSeconds(30))
-        .setSocketReceiveBuffer(DataSize.ofMegabytes(3))
-        .setSocketSendBuffer(DataSize.ofMegabytes(3));
+        .setMinKeepAliveInterval(Duration.ofSeconds(30));
     expected
         .getCluster()
         .setInitialContactPoints(List.of("broker:432", "anotherBroker:789"))
@@ -195,6 +193,8 @@ public final class GatewayCfgTest {
         .setPort(12345);
     expected
         .getCluster()
+        .setSocketReceiveBuffer(DataSize.ofMegabytes(3))
+        .setSocketSendBuffer(DataSize.ofMegabytes(3))
         .setConfigManager(
             new ConfigManagerCfg(
                 new ClusterConfigurationGossiperConfig(


### PR DESCRIPTION
## Description

This PR configures the Netty messaging service for the gateway and _not_ the gRPC channels. This is for two reasons:

1. We never tested changing the Netty buffer sizes for gRPC, and it only adds confusion to allow doing that with similar parameters as with Netty.
2. This was in the wrong configuration option. You can change the buffer sizes in the brokers, but not in the standalone gateway. We should allow setting them also on the gateways, and for the cluster messaging.

## Related issues

closes #26396 
