### PR TITLE
[Backport stable/8.7] feat: log insecure transport warning only once in client

### DIFF
--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeCallCredentials.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeCallCredentials.java
@@ -29,6 +29,7 @@ public final class ZeebeCallCredentials extends io.grpc.CallCredentials {
   private static final Logger LOG = LoggerFactory.getLogger(ZeebeCallCredentials.class);
 
   private final CredentialsProvider credentialsProvider;
+  private boolean securityWarningIssued;
 
   ZeebeCallCredentials(final CredentialsProvider credentialsProvider) {
     this.credentialsProvider = credentialsProvider;
@@ -37,9 +38,12 @@ public final class ZeebeCallCredentials extends io.grpc.CallCredentials {
   @Override
   public void applyRequestMetadata(
       final RequestInfo requestInfo, final Executor appExecutor, final MetadataApplier applier) {
-    if (requestInfo.getSecurityLevel().ordinal() < SecurityLevel.PRIVACY_AND_INTEGRITY.ordinal()) {
+    if (!securityWarningIssued
+        && requestInfo.getSecurityLevel().ordinal()
+            < SecurityLevel.PRIVACY_AND_INTEGRITY.ordinal()) {
       LOG.warn(
           "The request's security level does not guarantee that the credentials will be confidential.");
+      securityWarningIssued = true;
     }
 
     appExecutor.execute(


### PR DESCRIPTION
# Description
Backport of #35620 to `stable/8.7`.

relates to #35619