### PR TITLE
fix: initialize AuthorizeRequestConfiguration to continue the other config patterns and prevent NPEs

### DIFF
--- a/security/security-core/src/main/java/io/camunda/security/configuration/OidcAuthenticationConfiguration.java
+++ b/security/security-core/src/main/java/io/camunda/security/configuration/OidcAuthenticationConfiguration.java
@@ -25,7 +25,8 @@ public class OidcAuthenticationConfiguration {
   private String jwkSetUri;
   private String authorizationUri;
   private String tokenUri;
-  private AuthorizeRequestConfiguration authorizeRequestConfiguration;
+  private AuthorizeRequestConfiguration authorizeRequestConfiguration =
+      new AuthorizeRequestConfiguration();
   private Set<String> audiences;
   private String usernameClaim = "sub";
   private String clientIdClaim;


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

With https://github.com/camunda/camunda/pull/35561 we added in an option to support the addition of parameters in the authorize call, leaving the configuration out incorrectly throws a NPE (in the instance of no configuration we should just pass through).

In this PR I extend the existing pattern in the configuration classes to instantiate the parent config class with an empty configuration for the authorization request. 

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes https://github.com/camunda/camunda/issues/35643
