### PR TITLE
fix: wait for initial usage metrics EXPORTED event in flaky tests

### DIFF
--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/randomized/ProcessExecutionRandomizedPropertyTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/randomized/ProcessExecutionRandomizedPropertyTest.java
@@ -13,8 +13,6 @@ import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.engine.util.ProcessExecutor;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
-import io.camunda.zeebe.protocol.record.value.UsageMetricRecordValue.EventType;
-import io.camunda.zeebe.protocol.record.value.UsageMetricRecordValue.IntervalType;
 import io.camunda.zeebe.test.util.bpmn.random.ExecutionPath;
 import io.camunda.zeebe.test.util.bpmn.random.ScheduledExecutionStep;
 import io.camunda.zeebe.test.util.bpmn.random.TestDataGenerator;
@@ -67,13 +65,6 @@ public class ProcessExecutionRandomizedPropertyTest {
    */
   @Test
   public void shouldExecuteProcessToEnd() {
-    engineRule
-        .usageMetrics()
-        .withEventType(EventType.NONE)
-        .withIntervalType(IntervalType.ACTIVE)
-        .withResetTime(engineRule.getClock().getCurrentTimeInMillis())
-        .export();
-
     final var deployment = engineRule.deployment();
     record.getBpmnModels().forEach(deployment::withXmlResource);
     deployment.deploy();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/randomized/ReplayStateRandomizedPropertyTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/randomized/ReplayStateRandomizedPropertyTest.java
@@ -14,8 +14,6 @@ import io.camunda.zeebe.engine.util.ProcessExecutor;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
-import io.camunda.zeebe.protocol.record.value.UsageMetricRecordValue.EventType;
-import io.camunda.zeebe.protocol.record.value.UsageMetricRecordValue.IntervalType;
 import io.camunda.zeebe.stream.impl.StreamProcessorMode;
 import io.camunda.zeebe.test.util.bpmn.random.ExecutionPath;
 import io.camunda.zeebe.test.util.bpmn.random.ScheduledExecutionStep;
@@ -68,13 +66,6 @@ public class ReplayStateRandomizedPropertyTest {
    */
   @Test
   public void shouldRestoreStateAtEachStepInExecution() {
-    engineRule
-        .usageMetrics()
-        .withEventType(EventType.NONE)
-        .withIntervalType(IntervalType.ACTIVE)
-        .withResetTime(engineRule.getClock().getCurrentTimeInMillis())
-        .export();
-
     final var deployment = engineRule.deployment();
     record.getBpmnModels().forEach(deployment::withXmlResource);
     deployment.deploy();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/ReplayStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/ReplayStateTest.java
@@ -22,8 +22,6 @@ import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.JobBatchRecordValue;
 import io.camunda.zeebe.protocol.record.value.JobRecordValue;
-import io.camunda.zeebe.protocol.record.value.UsageMetricRecordValue.EventType;
-import io.camunda.zeebe.protocol.record.value.UsageMetricRecordValue.IntervalType;
 import io.camunda.zeebe.protocol.record.value.UserTaskRecordValue;
 import io.camunda.zeebe.stream.impl.StreamProcessorMode;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
@@ -395,12 +393,6 @@ public final class ReplayStateTest {
   @Test
   public void shouldRestoreState() {
     // given
-    engine
-        .usageMetrics()
-        .withEventType(EventType.NONE)
-        .withIntervalType(IntervalType.ACTIVE)
-        .withResetTime(engine.getClock().getCurrentTimeInMillis())
-        .export();
     testCase.processes.forEach(process -> engine.deployment().withXmlResource(process).deploy());
     testCase.forms.forEach(form -> engine.deployment().withJsonClasspathResource(form).deploy());
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
@@ -61,9 +61,11 @@ import io.camunda.zeebe.protocol.record.intent.CommandDistributionIntent;
 import io.camunda.zeebe.protocol.record.intent.IdentitySetupIntent;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.intent.UsageMetricIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.JobRecordValue;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
+import io.camunda.zeebe.protocol.record.value.UsageMetricRecordValue.EventType;
 import io.camunda.zeebe.scheduler.ActorScheduler;
 import io.camunda.zeebe.scheduler.clock.ControlledActorClock;
 import io.camunda.zeebe.stream.api.CommandResponseWriter;
@@ -161,6 +163,8 @@ public final class EngineRule extends ExternalResource {
     if (awaitIdentitySetup) {
       awaitIdentitySetup();
     }
+    awaitUsageMetricsExported();
+    RecordingExporter.reset();
   }
 
   public void start() {
@@ -579,8 +583,12 @@ public final class EngineRule extends ExternalResource {
           .skip(totalAmountOfAuthorizationsCreated - 1)
           .await();
     }
+  }
 
-    RecordingExporter.reset();
+  private void awaitUsageMetricsExported() {
+    RecordingExporter.usageMetricsRecords(UsageMetricIntent.EXPORTED)
+        .withEventType(EventType.NONE)
+        .await();
   }
 
   public void awaitProcessingOf(final Record<?> record) {

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/smoke/StandaloneBrokerIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/smoke/StandaloneBrokerIT.java
@@ -15,15 +15,20 @@ import io.camunda.client.CamundaClient;
 import io.camunda.client.api.response.ProcessInstanceResult;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.protocol.record.intent.UsageMetricIntent;
+import io.camunda.zeebe.protocol.record.value.UsageMetricRecordValue.EventType;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import io.camunda.zeebe.qa.util.cluster.TestZeebePort;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
 import io.camunda.zeebe.test.util.Strings;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.restassured.builder.RequestSpecBuilder;
 import io.restassured.http.ContentType;
 import io.restassured.specification.RequestSpecification;
+import java.time.Duration;
 import java.util.Objects;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.BeforeEach;
 
@@ -32,13 +37,21 @@ final class StandaloneBrokerIT {
 
   @TestZeebe
   private final TestStandaloneBroker broker =
-      new TestStandaloneBroker().withUnauthenticatedAccess();
+      new TestStandaloneBroker().withUnauthenticatedAccess().withRecordingExporter(true);
 
   @AutoClose private CamundaClient client;
 
   @BeforeEach
   void beforeEach() {
     client = broker.newClientBuilder().build();
+
+    Awaitility.await()
+        .timeout(Duration.ofSeconds(10))
+        .until(
+            () ->
+                RecordingExporter.usageMetricsRecords(UsageMetricIntent.EXPORTED)
+                    .withEventType(EventType.NONE)
+                    .exists());
   }
 
   /** A simple smoke test to ensure the broker starts and can perform basic functionality. */

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/junit/ZeebeIntegrationExtension.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/junit/ZeebeIntegrationExtension.java
@@ -84,6 +84,8 @@ final class ZeebeIntegrationExtension
    */
   @Override
   public void beforeEach(final ExtensionContext extensionContext) {
+    RecordingExporter.reset();
+
     final var testInstance = extensionContext.getRequiredTestInstance();
     final var clusters =
         lookupClusters(extensionContext, testInstance, ModifierSupport::isNotStatic);
@@ -91,8 +93,6 @@ final class ZeebeIntegrationExtension
         lookupApplications(extensionContext, testInstance, ModifierSupport::isNotStatic);
     manageClusters(extensionContext, clusters);
     manageApplications(extensionContext, nodes);
-
-    RecordingExporter.reset();
   }
 
   @Override


### PR DESCRIPTION
## Description

Await `EXPORTED` usage metrics event in flaky tests.

## Related issues

closes https://github.com/camunda/camunda/issues/35642
