### PR TITLE
refactor: rely on command `partitionId` rather than passing the id around

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationSetupProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationSetupProcessors.java
@@ -81,7 +81,6 @@ public final class BatchOperationSetupProcessors {
                 writers,
                 commandDistributionBehavior,
                 keyGenerator,
-                partitionId,
                 batchOperationMetrics,
                 processingState))
         .onCommand(
@@ -96,7 +95,6 @@ public final class BatchOperationSetupProcessors {
                 processingState,
                 commandDistributionBehavior,
                 keyGenerator,
-                partitionId,
                 batchExecutionHandlers,
                 batchOperationMetrics))
         .onCommand(


### PR DESCRIPTION
## Description

During processing, the processed commands contain the partition id they are processed on. 

This refactoring negates the need to pass the same value around in command processors.
