### PR TITLE
Groups by role should use correct request and result classes

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/RoleGroupFilter.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/RoleGroupFilter.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.search.filter;
+
+import io.camunda.client.api.search.request.TypedFilterableRequest.SearchRequestFilter;
+
+public interface RoleGroupFilter extends SearchRequestFilter {}

--- a/clients/java/src/main/java/io/camunda/client/api/search/request/GroupsByRoleSearchRequest.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/request/GroupsByRoleSearchRequest.java
@@ -15,10 +15,10 @@
  */
 package io.camunda.client.api.search.request;
 
-import io.camunda.client.api.search.filter.GroupFilter;
-import io.camunda.client.api.search.response.Group;
-import io.camunda.client.api.search.sort.GroupSort;
+import io.camunda.client.api.search.filter.RoleGroupFilter;
+import io.camunda.client.api.search.response.RoleGroup;
+import io.camunda.client.api.search.sort.RoleGroupSort;
 
 public interface GroupsByRoleSearchRequest
-    extends TypedSearchRequest<GroupFilter, GroupSort, GroupsByRoleSearchRequest>,
-        FinalSearchRequestStep<Group> {}
+    extends TypedSearchRequest<RoleGroupFilter, RoleGroupSort, GroupsByRoleSearchRequest>,
+        FinalSearchRequestStep<RoleGroup> {}

--- a/clients/java/src/main/java/io/camunda/client/api/search/request/SearchRequestBuilders.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/request/SearchRequestBuilders.java
@@ -52,6 +52,7 @@ import io.camunda.client.api.search.sort.MappingSort;
 import io.camunda.client.api.search.sort.MessageSubscriptionSort;
 import io.camunda.client.api.search.sort.ProcessDefinitionSort;
 import io.camunda.client.api.search.sort.ProcessInstanceSort;
+import io.camunda.client.api.search.sort.RoleGroupSort;
 import io.camunda.client.api.search.sort.RoleSort;
 import io.camunda.client.api.search.sort.RoleUserSort;
 import io.camunda.client.api.search.sort.TenantSort;
@@ -98,6 +99,7 @@ import io.camunda.client.impl.search.sort.MappingSortImpl;
 import io.camunda.client.impl.search.sort.MessageSubscriptionSortImpl;
 import io.camunda.client.impl.search.sort.ProcessDefinitionSortImpl;
 import io.camunda.client.impl.search.sort.ProcessInstanceSortImpl;
+import io.camunda.client.impl.search.sort.RoleGroupSortImpl;
 import io.camunda.client.impl.search.sort.RoleSortImpl;
 import io.camunda.client.impl.search.sort.RoleUserSortImpl;
 import io.camunda.client.impl.search.sort.TenantSortImpl;
@@ -361,6 +363,12 @@ public final class SearchRequestBuilders {
 
   public static RoleUserSort roleUserSort(final Consumer<RoleUserSort> fn) {
     final RoleUserSort sort = new RoleUserSortImpl();
+    fn.accept(sort);
+    return sort;
+  }
+
+  public static RoleGroupSort roleGroupSort(final Consumer<RoleGroupSort> fn) {
+    final RoleGroupSort sort = new RoleGroupSortImpl();
     fn.accept(sort);
     return sort;
   }

--- a/clients/java/src/main/java/io/camunda/client/api/search/response/RoleGroup.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/response/RoleGroup.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.search.response;
+
+public interface RoleGroup {
+  String getGroupId();
+}

--- a/clients/java/src/main/java/io/camunda/client/api/search/sort/RoleGroupSort.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/sort/RoleGroupSort.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.search.sort;
+
+import io.camunda.client.api.search.request.TypedSortableRequest.SearchRequestSort;
+
+public interface RoleGroupSort extends SearchRequestSort<RoleGroupSort> {
+  RoleGroupSort groupId();
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/search/request/GroupsByRoleSearchRequestImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/request/GroupsByRoleSearchRequestImpl.java
@@ -15,25 +15,24 @@
  */
 package io.camunda.client.impl.search.request;
 
-import static io.camunda.client.api.search.request.SearchRequestBuilders.groupFilter;
-import static io.camunda.client.api.search.request.SearchRequestBuilders.groupSort;
+import static io.camunda.client.api.search.request.SearchRequestBuilders.roleGroupSort;
 import static io.camunda.client.api.search.request.SearchRequestBuilders.searchRequestPage;
 
 import io.camunda.client.api.CamundaFuture;
 import io.camunda.client.api.JsonMapper;
-import io.camunda.client.api.search.filter.GroupFilter;
+import io.camunda.client.api.search.filter.RoleGroupFilter;
 import io.camunda.client.api.search.request.FinalSearchRequestStep;
 import io.camunda.client.api.search.request.GroupsByRoleSearchRequest;
 import io.camunda.client.api.search.request.SearchRequestPage;
-import io.camunda.client.api.search.response.Group;
+import io.camunda.client.api.search.response.RoleGroup;
 import io.camunda.client.api.search.response.SearchResponse;
-import io.camunda.client.api.search.sort.GroupSort;
+import io.camunda.client.api.search.sort.RoleGroupSort;
 import io.camunda.client.impl.command.ArgumentUtil;
 import io.camunda.client.impl.http.HttpCamundaFuture;
 import io.camunda.client.impl.http.HttpClient;
 import io.camunda.client.impl.search.response.SearchResponseMapper;
-import io.camunda.client.protocol.rest.GroupSearchQueryResult;
 import io.camunda.client.protocol.rest.RoleGroupSearchQueryRequest;
+import io.camunda.client.protocol.rest.RoleGroupSearchResult;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
@@ -59,37 +58,37 @@ public class GroupsByRoleSearchRequestImpl
   }
 
   @Override
-  public FinalSearchRequestStep<Group> requestTimeout(final Duration requestTimeout) {
+  public FinalSearchRequestStep<RoleGroup> requestTimeout(final Duration requestTimeout) {
     httpRequestConfig.setResponseTimeout(requestTimeout.toMillis(), TimeUnit.MILLISECONDS);
     return this;
   }
 
   @Override
-  public CamundaFuture<SearchResponse<Group>> send() {
+  public CamundaFuture<SearchResponse<RoleGroup>> send() {
     ArgumentUtil.ensureNotNullNorEmpty("roleId", roleId);
-    final HttpCamundaFuture<SearchResponse<Group>> result = new HttpCamundaFuture<>();
+    final HttpCamundaFuture<SearchResponse<RoleGroup>> result = new HttpCamundaFuture<>();
     httpClient.post(
         String.format("/roles/%s/groups/search", roleId),
         jsonMapper.toJson(request),
         httpRequestConfig.build(),
-        GroupSearchQueryResult.class,
-        SearchResponseMapper::toGroupsResponse,
+        RoleGroupSearchResult.class,
+        SearchResponseMapper::toRoleGroupsResponse,
         result);
     return result;
   }
 
   @Override
-  public GroupsByRoleSearchRequest filter(final GroupFilter value) {
+  public GroupsByRoleSearchRequest filter(final RoleGroupFilter value) {
     return this;
   }
 
   @Override
-  public GroupsByRoleSearchRequest filter(final Consumer<GroupFilter> fn) {
-    return filter(groupFilter(fn));
+  public GroupsByRoleSearchRequest filter(final Consumer<RoleGroupFilter> fn) {
+    return this;
   }
 
   @Override
-  public GroupsByRoleSearchRequest sort(final GroupSort value) {
+  public GroupsByRoleSearchRequest sort(final RoleGroupSort value) {
     request.setSort(
         SearchRequestSortMapper.toRoleGroupSearchQuerySortRequest(
             provideSearchRequestProperty(value)));
@@ -97,8 +96,8 @@ public class GroupsByRoleSearchRequestImpl
   }
 
   @Override
-  public GroupsByRoleSearchRequest sort(final Consumer<GroupSort> fn) {
-    return sort(groupSort(fn));
+  public GroupsByRoleSearchRequest sort(final Consumer<RoleGroupSort> fn) {
+    return sort(roleGroupSort(fn));
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/RoleGroupImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/RoleGroupImpl.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.search.response;
+
+import io.camunda.client.api.search.response.RoleGroup;
+
+public class RoleGroupImpl implements RoleGroup {
+
+  private final String groupId;
+
+  public RoleGroupImpl(final String groupId) {
+    this.groupId = groupId;
+  }
+
+  @Override
+  public String getGroupId() {
+    return groupId;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/SearchResponseMapper.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/SearchResponseMapper.java
@@ -39,6 +39,7 @@ import io.camunda.client.api.search.response.ProcessInstance;
 import io.camunda.client.api.search.response.ProcessInstanceCallHierarchyEntryResponse;
 import io.camunda.client.api.search.response.ProcessInstanceSequenceFlow;
 import io.camunda.client.api.search.response.Role;
+import io.camunda.client.api.search.response.RoleGroup;
 import io.camunda.client.api.search.response.RoleUser;
 import io.camunda.client.api.search.response.SearchResponse;
 import io.camunda.client.api.search.response.SearchResponsePage;
@@ -302,6 +303,18 @@ public final class SearchResponseMapper {
     final List<Group> instances =
         toSearchResponseInstances(response.getItems(), SearchResponseMapper::toGroupResponse);
     return new SearchResponseImpl<>(instances, page);
+  }
+
+  public static SearchResponse<RoleGroup> toRoleGroupsResponse(
+      final RoleGroupSearchResult response) {
+    final SearchResponsePage page = toSearchResponsePage(response.getPage());
+    final List<RoleGroup> instances =
+        toSearchResponseInstances(response.getItems(), SearchResponseMapper::toRoleGroupResponse);
+    return new SearchResponseImpl<>(instances, page);
+  }
+
+  public static RoleGroup toRoleGroupResponse(final RoleGroupResult response) {
+    return new RoleGroupImpl(response.getGroupId());
   }
 
   public static SearchResponse<User> toUsersResponse(final UserSearchResult response) {

--- a/clients/java/src/main/java/io/camunda/client/impl/search/sort/RoleGroupSortImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/sort/RoleGroupSortImpl.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.search.sort;
+
+import io.camunda.client.api.search.sort.RoleGroupSort;
+import io.camunda.client.impl.search.request.SearchRequestSortBase;
+
+public class RoleGroupSortImpl extends SearchRequestSortBase<RoleGroupSort>
+    implements RoleGroupSort {
+
+  @Override
+  public RoleGroupSort groupId() {
+    return field("groupId");
+  }
+
+  @Override
+  protected RoleGroupSort self() {
+    return this;
+  }
+}

--- a/clients/java/src/test/java/io/camunda/client/role/GroupsByRoleSearchRequestTest.java
+++ b/clients/java/src/test/java/io/camunda/client/role/GroupsByRoleSearchRequestTest.java
@@ -38,6 +38,18 @@ public class GroupsByRoleSearchRequestTest extends ClientRestTest {
   }
 
   @Test
+  void shouldIncludedSortInSearchRequestBody() {
+    // when
+    client.newGroupsByRoleSearchRequest(ROLE_ID).sort(s -> s.groupId().desc()).send().join();
+
+    // then
+    final LoggedRequest lastRequest = gatewayService.getLastRequest();
+    final String requestBody = lastRequest.getBodyAsString();
+
+    assertThat(requestBody).contains("\"sort\":[{\"field\":\"groupId\",\"order\":\"DESC\"}]");
+  }
+
+  @Test
   void shouldFailOnEmptyRoleId() {
     assertThatThrownBy(() -> client.newGroupsByRoleSearchRequest("").send().join())
         .isInstanceOf(IllegalArgumentException.class)

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/RoleAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/RoleAuthorizationIT.java
@@ -18,8 +18,8 @@ import io.camunda.client.api.search.enums.OwnerType;
 import io.camunda.client.api.search.enums.PermissionType;
 import io.camunda.client.api.search.enums.ResourceType;
 import io.camunda.client.api.search.response.Client;
-import io.camunda.client.api.search.response.Group;
 import io.camunda.client.api.search.response.Role;
+import io.camunda.client.api.search.response.RoleGroup;
 import io.camunda.client.api.search.response.SearchResponse;
 import io.camunda.qa.util.auth.Authenticated;
 import io.camunda.qa.util.auth.Permissions;
@@ -684,7 +684,7 @@ class RoleAuthorizationIT {
   @Test
   void searchGroupsByRoleShouldReturnEmptyListIfUnauthorized(
       @Authenticated(RESTRICTED) final CamundaClient camundaClient) {
-    final SearchResponse<Group> response =
+    final SearchResponse<RoleGroup> response =
         camundaClient.newGroupsByRoleSearchRequest(ROLE_ID_1).send().join();
     assertThat(response.items()).isEmpty();
   }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/GroupsByRoleIntegrationTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/GroupsByRoleIntegrationTest.java
@@ -9,9 +9,10 @@ package io.camunda.it.client;
 
 import static io.camunda.qa.util.multidb.CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
 import io.camunda.client.CamundaClient;
-import io.camunda.client.api.search.response.Group;
+import io.camunda.client.api.search.response.RoleGroup;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.zeebe.test.util.Strings;
 import java.util.List;
@@ -42,9 +43,9 @@ public class GroupsByRoleIntegrationTest {
         .atMost(TIMEOUT_DATA_AVAILABILITY)
         .untilAsserted(
             () -> {
-              final List<Group> groups =
+              final List<RoleGroup> groups =
                   camundaClient.newGroupsByRoleSearchRequest(roleId).send().join().items();
-              assertThat(groups).extracting(Group::getGroupId).contains(groupId1, groupId2);
+              assertThat(groups).extracting(RoleGroup::getGroupId).contains(groupId1, groupId2);
             });
   }
 
@@ -72,7 +73,9 @@ public class GroupsByRoleIntegrationTest {
                       .send()
                       .join()
                       .items();
-              assertThat(groups).extracting(Group::getGroupId).containsExactly(groupId2, groupId1);
+              assertThat(groups)
+                  .extracting(RoleGroup::getGroupId)
+                  .containsExactly(groupId2, groupId1);
             });
   }
 
@@ -100,8 +103,32 @@ public class GroupsByRoleIntegrationTest {
                       .send()
                       .join()
                       .items();
-              assertThat(groups).extracting(Group::getGroupId).containsExactly(groupId2, groupId1);
+              assertThat(groups)
+                  .extracting(RoleGroup::getGroupId)
+                  .containsExactly(groupId2, groupId1);
             });
+  }
+
+  @Test
+  void shouldRejectGroupsByRoleSearchIfEmptyRoleId() {
+    // when / then
+    assertThatThrownBy(() -> camundaClient.newGroupsByRoleSearchRequest("").send().join())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("roleId must not be empty");
+  }
+
+  @Test
+  void shouldRejectGroupsByRoleSearchIfNullRoleId() {
+    // when / then
+    assertThatThrownBy(() -> camundaClient.newGroupsByRoleSearchRequest(null).send().join())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("roleId must not be null");
+  }
+
+  @Test
+  void searchGroupsShouldReturnEmptyListWhenSearchingForNonExistingRoleId() {
+    final var response = camundaClient.newGroupsByRoleSearchRequest("someRoleId").send().join();
+    assertThat(response.items()).isEmpty();
   }
 
   private static void createRole(final String roleId, final String name, final String desc) {

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -8023,7 +8023,7 @@ components:
         - $ref: "#/components/schemas/SearchQueryResponse"
       properties:
         items:
-          description: The matching users.
+          description: The matching groups.
           type: array
           items:
             $ref: "#/components/schemas/RoleGroupResult"


### PR DESCRIPTION
## Description

`RoleGroupSearchResult` -> `RoleGroupResult` should be used as a result in groups by role search. Currently, the wrong result classes are used.
Also, `RoleGroupSearchQueryRequest` do not have a setter for filter.

But in the code we have:
```
  @Override
  public GroupsByRoleSearchRequest filter(final GroupFilter value) {
    return this;
  }

  @Override
  public GroupsByRoleSearchRequest filter(final Consumer<GroupFilter> fn) {
    return filter(groupFilter(fn));
  }
```
`filter(final GroupFilter value) `will do nothing. But `filter(final Consumer<GroupFilter> fn) `will also do nothing.

There was a change in request and response signature to only return `groupId` and also remove other filtering and sorting options. We should remove filter implementation.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #35659
