### PR TITLE
[Backport stable/optimize-8.6] deps: upgrade spring version to fix CVE-2025-41234

### DIFF
--- a/identity/client/pom.xml
+++ b/identity/client/pom.xml
@@ -87,4 +87,14 @@
     </profile>
   </profiles>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-web</artifactId>
+        <version>6.1.21</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
 </project>

--- a/identity/migration/pom.xml
+++ b/identity/migration/pom.xml
@@ -47,6 +47,11 @@
         <artifactId>commons-lang3</artifactId>
         <version>3.18.0</version>
       </dependency>
+      <dependency>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-web</artifactId>
+        <version>6.1.21</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 

--- a/optimize/pom.xml
+++ b/optimize/pom.xml
@@ -51,7 +51,7 @@
     <apache.http5-client.version>5.4</apache.http5-client.version>
     <apache.http5-core.version>5.3.1</apache.http5-core.version>
     <guava.version>33.3.1-jre</guava.version>
-    <spring.boot.version>3.3.11</spring.boot.version>
+    <spring.boot.version>3.3.13</spring.boot.version>
     <spring.version>6.1.21</spring.version>
     <spring.security.version>6.4.7</spring.security.version>
     <version.tomcat>10.1.43</version.tomcat>


### PR DESCRIPTION
# Description
Backport of #35132 to `stable/optimize-8.6`.

relates to 
original author: @matthewBearCamunda