### PR TITLE
fix: Truncate variables at max bytes by RDBMS vendor, fixes #35097

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -28,8 +28,6 @@
       </option>
       <option name="IMPORT_LAYOUT_TABLE">
         <value>
-          <package name="" withSubpackages="true" static="false" module="true" />
-          <package name="" withSubpackages="true" static="false" />
           <package name="" withSubpackages="true" static="false" />
           <package name="" withSubpackages="true" static="true" />
           <emptyLine />

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -28,6 +28,7 @@
       </option>
       <option name="IMPORT_LAYOUT_TABLE">
         <value>
+          <package name="" withSubpackages="true" static="false" module="true" />
           <package name="" withSubpackages="true" static="false" />
           <package name="" withSubpackages="true" static="true" />
           <emptyLine />

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -30,6 +30,7 @@
         <value>
           <package name="" withSubpackages="true" static="false" module="true" />
           <package name="" withSubpackages="true" static="false" />
+          <package name="" withSubpackages="true" static="false" />
           <package name="" withSubpackages="true" static="true" />
           <emptyLine />
           <package name="" withSubpackages="true" static="false" />

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/config/VendorDatabaseProperties.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/config/VendorDatabaseProperties.java
@@ -11,7 +11,16 @@ import java.util.Properties;
 
 public class VendorDatabaseProperties {
 
+  /**
+   * Required property to specify the size of the variable value preview in characters. This is used
+   * to truncate variable values for preview purposes.
+   */
   private static final String VARIABLE_VALUE_PREVIEW_SIZE = "variableValue.previewSize";
+
+  /**
+   * Optional property to limit the maximum size of variable values in bytes, if required by the
+   * database vendor. If not set, no limit is applied.
+   */
   private static final String VARIABLE_VALUE_MAX_BYTES = "variableValue.maxBytes";
 
   private static final String DISABLE_FK_BEFORE_TRUNCATE = "disableFkBeforeTruncate";

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/config/VendorDatabaseProperties.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/config/VendorDatabaseProperties.java
@@ -12,6 +12,7 @@ import java.util.Properties;
 public class VendorDatabaseProperties {
 
   private static final String VARIABLE_VALUE_PREVIEW_SIZE = "variableValue.previewSize";
+  private static final String VARIABLE_VALUE_MAX_BYTES = "variableValue.maxBytes";
 
   private static final String DISABLE_FK_BEFORE_TRUNCATE = "disableFkBeforeTruncate";
 
@@ -19,6 +20,7 @@ public class VendorDatabaseProperties {
 
   private final int variableValuePreviewSize;
   private final boolean disableFkBeforeTruncate;
+  private final Integer variableValueMaxBytes;
 
   public VendorDatabaseProperties(final Properties properties) {
     this.properties = properties;
@@ -30,6 +32,12 @@ public class VendorDatabaseProperties {
     variableValuePreviewSize =
         Integer.parseInt(properties.getProperty(VARIABLE_VALUE_PREVIEW_SIZE));
 
+    if (!properties.containsKey(VARIABLE_VALUE_MAX_BYTES)) {
+      variableValueMaxBytes = null;
+    } else {
+      variableValueMaxBytes = Integer.parseInt(properties.getProperty(VARIABLE_VALUE_MAX_BYTES));
+    }
+
     if (!properties.containsKey(DISABLE_FK_BEFORE_TRUNCATE)) {
       throw new IllegalArgumentException(
           "Property '" + DISABLE_FK_BEFORE_TRUNCATE + "' is missing");
@@ -40,6 +48,10 @@ public class VendorDatabaseProperties {
 
   public int variableValuePreviewSize() {
     return variableValuePreviewSize;
+  }
+
+  public Integer variableValueMaxBytes() {
+    return variableValueMaxBytes;
   }
 
   public boolean disableFkBeforeTruncate() {

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/VariableDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/VariableDbModel.java
@@ -115,7 +115,7 @@ public record VariableDbModel(
     while (len > 0) {
       try {
         return new String(bytes, 0, len, StandardCharsets.UTF_8);
-      } catch (final Exception e) {
+      } catch (final CharacterCodingException e) {
         len--;
       }
     }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/VariableDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/VariableDbModel.java
@@ -54,6 +54,15 @@ public record VariableDbModel(
         .build();
   }
 
+  /**
+   * Truncates the value of the variable if it exceeds the specified size limit or byte limit.
+   * Truncate is done in two steps: First based on the character size limit, and then based on the
+   * (optional) byte size limit, if the byte size exceeds the specified limit.
+   *
+   * @param sizeLimit the maximum number of characters allowed for the variable value
+   * @param byteLimit the maximum number of bytes allowed for the variable value
+   * @return a new VariableDbModel with the truncated value
+   */
   public VariableDbModel truncateValue(final int sizeLimit, final Integer byteLimit) {
     var truncatedValue = value;
     String fullValue = null;

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/VariableDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/VariableDbModel.java
@@ -110,13 +110,13 @@ public record VariableDbModel(
       return original;
     }
 
-    // Find the last valid position (without broken character)
-    int len = maxBytes;
-    while (len > 0) {
-      try {
-        return new String(bytes, 0, len, StandardCharsets.UTF_8);
-      } catch (final CharacterCodingException e) {
-        len--;
+    var truncatedVariable = original;
+
+    while (truncatedVariable.getBytes().length > maxBytes) {
+      truncatedVariable = truncatedVariable.substring(0, truncatedVariable.length() - 1);
+
+      if (truncatedVariable.getBytes().length <= maxBytes) {
+        return truncatedVariable;
       }
     }
     return "";

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/VariableDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/VariableDbModel.java
@@ -81,7 +81,7 @@ public record VariableDbModel(
     if (byteLimit != null
         && type == ValueTypeEnum.STRING
         && value != null
-        && value.getBytes().length > byteLimit) {
+        && value.getBytes(StandardCharsets.UTF_8).length > byteLimit) {
 
       return new VariableDbModel(
           variableKey,

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/VariableDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/VariableDbModel.java
@@ -17,7 +17,6 @@ import io.camunda.util.ValueTypeUtil;
 import java.nio.charset.StandardCharsets;
 import java.time.OffsetDateTime;
 import java.util.function.Function;
-import org.apache.commons.lang3.StringUtils;
 
 public record VariableDbModel(
     Long variableKey,
@@ -90,7 +89,7 @@ public record VariableDbModel(
           doubleValue,
           longValue,
           truncateBytes(value, byteLimit),
-          !StringUtils.isEmpty(fullValue) ? fullValue : value,
+          fullValue != null && !fullValue.isEmpty() ? fullValue : value,
           true,
           scopeKey,
           processInstanceKey,

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/VariableDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/VariableDbModel.java
@@ -110,7 +110,7 @@ public record VariableDbModel(
       return original;
     }
 
-    // Finde letzte gültige Stelle (ohne kaputtes Zeichen)
+    // Find the last valid position (without broken character)
     int len = maxBytes;
     while (len > 0) {
       try {

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/VariableWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/VariableWriter.java
@@ -34,14 +34,15 @@ public class VariableWriter {
   }
 
   public void create(final VariableDbModel variable) {
-
     executionQueue.executeInQueue(
         new QueueItem(
             ContextType.VARIABLE,
             WriteStatementType.INSERT,
             variable.variableKey(),
             "io.camunda.db.rdbms.sql.VariableMapper.insert",
-            variable.truncateValue(vendorDatabaseProperties.variableValuePreviewSize())));
+            variable
+                .truncateValue(vendorDatabaseProperties.variableValuePreviewSize())
+                .truncateBytes(vendorDatabaseProperties.variableValueMaxBytes())));
   }
 
   public void update(final VariableDbModel variable) {
@@ -51,7 +52,9 @@ public class VariableWriter {
             WriteStatementType.UPDATE,
             variable.variableKey(),
             "io.camunda.db.rdbms.sql.VariableMapper.update",
-            variable.truncateValue(vendorDatabaseProperties.variableValuePreviewSize())));
+            variable
+                .truncateValue(vendorDatabaseProperties.variableValuePreviewSize())
+                .truncateBytes(vendorDatabaseProperties.variableValueMaxBytes())));
   }
 
   public void scheduleForHistoryCleanup(

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/VariableWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/VariableWriter.java
@@ -40,9 +40,9 @@ public class VariableWriter {
             WriteStatementType.INSERT,
             variable.variableKey(),
             "io.camunda.db.rdbms.sql.VariableMapper.insert",
-            variable
-                .truncateValue(vendorDatabaseProperties.variableValuePreviewSize())
-                .truncateBytes(vendorDatabaseProperties.variableValueMaxBytes())));
+            variable.truncateValue(
+                vendorDatabaseProperties.variableValuePreviewSize(),
+                vendorDatabaseProperties.variableValueMaxBytes())));
   }
 
   public void update(final VariableDbModel variable) {
@@ -52,9 +52,9 @@ public class VariableWriter {
             WriteStatementType.UPDATE,
             variable.variableKey(),
             "io.camunda.db.rdbms.sql.VariableMapper.update",
-            variable
-                .truncateValue(vendorDatabaseProperties.variableValuePreviewSize())
-                .truncateBytes(vendorDatabaseProperties.variableValueMaxBytes())));
+            variable.truncateValue(
+                vendorDatabaseProperties.variableValuePreviewSize(),
+                vendorDatabaseProperties.variableValueMaxBytes())));
   }
 
   public void scheduleForHistoryCleanup(

--- a/db/rdbms/src/main/resources/db/vendor-properties/oracle.properties
+++ b/db/rdbms/src/main/resources/db/vendor-properties/oracle.properties
@@ -9,5 +9,6 @@
 paging.after=OFFSET #{page.from} ROWS FETCH NEXT #{page.size} ROWS ONLY
 keysetPaging.limit=FETCH NEXT #{page.size} ROWS ONLY
 variableValue.previewSize=4000
+variableValue.maxBytes=4000
 disableFkBeforeTruncate=false
 escapeChar='\\'

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/write/domain/VariableDbModelTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/write/domain/VariableDbModelTest.java
@@ -202,4 +202,38 @@ public class VariableDbModelTest {
     assertThat(model.processInstanceKey()).isEqualTo(3L);
     assertThat(model.tenantId()).isEqualTo("tenant1");
   }
+
+  @Test
+  public void shouldSetCorrectTypeAndValueForLargeByteValue() {
+    // given
+    final int maxBytesThreshold = 10;
+    final String largeValue = "ä".repeat(maxBytesThreshold);
+    final VariableDbModel.VariableDbModelBuilder builder =
+        new VariableDbModel.VariableDbModelBuilder();
+
+    // when
+    final VariableDbModel model =
+        builder
+            .variableKey(1L)
+            .name("test")
+            .value(largeValue)
+            .scopeKey(2L)
+            .processInstanceKey(3L)
+            .tenantId("tenant1")
+            .build()
+            .truncateBytes(maxBytesThreshold);
+
+    // then
+    assertThat(model.variableKey()).isEqualTo(1L);
+    assertThat(model.name()).isEqualTo("test");
+    assertThat(model.type()).isEqualTo(ValueTypeEnum.STRING);
+    assertThat(model.doubleValue()).isNull();
+    assertThat(model.longValue()).isNull();
+    assertThat(model.value()).isEqualTo("äääää");
+    assertThat(model.fullValue()).isEqualTo(largeValue);
+    assertThat(model.isPreview()).isTrue();
+    assertThat(model.scopeKey()).isEqualTo(2L);
+    assertThat(model.processInstanceKey()).isEqualTo(3L);
+    assertThat(model.tenantId()).isEqualTo("tenant1");
+  }
 }

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/write/domain/VariableDbModelTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/write/domain/VariableDbModelTest.java
@@ -187,7 +187,7 @@ public class VariableDbModelTest {
             .processInstanceKey(3L)
             .tenantId("tenant1")
             .build()
-            .truncateValue(variableSizeThreshold);
+            .truncateValue(variableSizeThreshold, null);
 
     // then
     assertThat(model.variableKey()).isEqualTo(1L);
@@ -206,6 +206,7 @@ public class VariableDbModelTest {
   @Test
   public void shouldSetCorrectTypeAndValueForLargeByteValue() {
     // given
+    final int variableSizeThreshold = 10;
     final int maxBytesThreshold = 10;
     final String largeValue = "ä".repeat(maxBytesThreshold);
     final VariableDbModel.VariableDbModelBuilder builder =
@@ -221,7 +222,7 @@ public class VariableDbModelTest {
             .processInstanceKey(3L)
             .tenantId("tenant1")
             .build()
-            .truncateBytes(maxBytesThreshold);
+            .truncateValue(variableSizeThreshold, maxBytesThreshold);
 
     // then
     assertThat(model.variableKey()).isEqualTo(1L);

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/variables/VariableIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/variables/VariableIT.java
@@ -88,7 +88,26 @@ public class VariableIT {
     assertThat(instance.isPreview()).isTrue();
     assertThat(instance.fullValue()).isEqualTo(bigValue);
     assertThat(instance.value()).hasSizeLessThan(instance.fullValue().length());
-    assertThat(instance.isPreview()).isTrue();
+  }
+
+  @TestTemplate
+  public void shouldSaveAndFindLargeByteVariableByKey(
+      final CamundaRdbmsTestApplication testApplication) {
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+
+    final String bigValue = "ä".repeat(9000);
+    final VariableDbModel randomizedVariable =
+        VariableFixtures.createRandomized(b -> b.value(bigValue));
+    createAndSaveVariable(rdbmsService, randomizedVariable);
+
+    final var instance = rdbmsService.getVariableReader().findOne(randomizedVariable.variableKey());
+
+    assertThat(instance).as("variable is not null").isNotNull();
+    assertThat(instance.isPreview()).as("variable is preview").isTrue();
+    assertThat(instance.fullValue()).as("fullValue is equal to bigValue").isEqualTo(bigValue);
+    assertThat(instance.value())
+        .as("value length is less than fullValueLength")
+        .hasSizeLessThan(instance.fullValue().length());
   }
 
   @TestTemplate


### PR DESCRIPTION
## Description

In the context of the RDBMS module, Oracle's varchar2 supports only 4000 bytes. We now truncate variable values at a max bytes length, configurable per RDBMS vendor.

## Related issues

closes #35672
