### PR TITLE
feat(engine): add SEQUENCE_FLOW_DELETED intent and its applier

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -244,6 +244,9 @@ public final class EventAppliers implements EventApplier {
         ProcessInstanceIntent.SEQUENCE_FLOW_TAKEN,
         new ProcessInstanceSequenceFlowTakenApplier(elementInstanceState, processState));
     register(
+        ProcessInstanceIntent.SEQUENCE_FLOW_DELETED,
+        new ProcessInstanceSequenceFlowDeletedApplier(elementInstanceState, processState));
+    register(
         ProcessInstanceIntent.ELEMENT_MIGRATED,
         1,
         new ProcessInstanceElementMigratedV1Applier(elementInstanceState, processState));

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceSequenceFlowDeletedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceSequenceFlowDeletedApplier.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableSequenceFlow;
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableElementInstanceState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessState;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+
+/**
+ * Reverse of ProcessInstanceSequenceFlowTakenApplier. Currently only used to migrate taken sequence
+ * flows. We apply this intent and right after create a new sequence flow on the target process
+ * definition.
+ */
+final class ProcessInstanceSequenceFlowDeletedApplier
+    implements TypedEventApplier<ProcessInstanceIntent, ProcessInstanceRecord> {
+
+  private final MutableElementInstanceState elementInstanceState;
+  private final MutableProcessState processState;
+
+  public ProcessInstanceSequenceFlowDeletedApplier(
+      final MutableElementInstanceState elementInstanceState,
+      final MutableProcessState processState) {
+    this.elementInstanceState = elementInstanceState;
+    this.processState = processState;
+  }
+
+  @Override
+  public void applyState(final long key, final ProcessInstanceRecord value) {
+    final var sequenceFlow =
+        processState.getFlowElement(
+            value.getProcessDefinitionKey(),
+            value.getTenantId(),
+            value.getElementIdBuffer(),
+            ExecutableSequenceFlow.class);
+
+    final var flowScopeInstance = elementInstanceState.getInstance(value.getFlowScopeKey());
+    flowScopeInstance.decrementActiveSequenceFlows();
+    flowScopeInstance.removeActiveSequenceFlowId(sequenceFlow.getId());
+    elementInstanceState.updateInstance(flowScopeInstance);
+
+    final var target = sequenceFlow.getTarget();
+    if (target.getElementType() == BpmnElementType.PARALLEL_GATEWAY
+        || target.getElementType() == BpmnElementType.INCLUSIVE_GATEWAY) {
+      elementInstanceState.decrementNumberOfTakenSequenceFlows(
+          value.getFlowScopeKey(), target.getId(), sequenceFlow.getId());
+    }
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceSequenceFlowDeletedApplierTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceSequenceFlowDeletedApplierTest.java
@@ -1,0 +1,224 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import static io.camunda.zeebe.util.buffer.BufferUtil.wrapString;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.state.instance.ElementInstance;
+import io.camunda.zeebe.engine.state.mutable.MutableElementInstanceState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.util.ProcessingStateExtension;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.ProcessRecord;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
+import io.camunda.zeebe.stream.api.state.KeyGenerator;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(ProcessingStateExtension.class)
+public class ProcessInstanceSequenceFlowDeletedApplierTest {
+
+  /** Injected by {@link ProcessingStateExtension} */
+  private MutableProcessingState processingState;
+
+  private MutableElementInstanceState elementInstanceState;
+  private MutableProcessState processState;
+  private ProcessInstanceSequenceFlowDeletedApplier sequenceFlowDeletedApplier;
+
+  /** For setting up the state before testing the applier. */
+  private AppliersTestSetupHelper testSetup;
+
+  @BeforeEach
+  public void setup() {
+    elementInstanceState = processingState.getElementInstanceState();
+    processState = processingState.getProcessState();
+    sequenceFlowDeletedApplier =
+        new ProcessInstanceSequenceFlowDeletedApplier(elementInstanceState, processState);
+    testSetup = new AppliersTestSetupHelper(processingState);
+  }
+
+  @Test
+  void shouldDecrementSequenceFlowFromFlowScope() {
+    // given
+    final String processId = "process";
+    final String serviceTaskElementId = "task";
+    final String sequenceFlowElementId = "flow1";
+    final BpmnModelInstance modelInstance =
+        Bpmn.createExecutableProcess(processId)
+            .startEvent("startEvent")
+            .serviceTask(serviceTaskElementId, task -> task.zeebeJobType("type"))
+            .sequenceFlowId(sequenceFlowElementId)
+            .endEvent("endEvent")
+            .done();
+    final ProcessRecord processRecord = new ProcessRecord();
+    final String resourceName = "process.bpmn";
+    final var resource = wrapString(Bpmn.convertToString(modelInstance));
+    final var checksum = wrapString("checksum");
+
+    final KeyGenerator keyGenerator = processingState.getKeyGenerator();
+    final long processDefinitionKey = keyGenerator.nextKey();
+
+    processRecord
+        .setResourceName(wrapString(resourceName))
+        .setResource(resource)
+        .setBpmnProcessId(BufferUtil.wrapString(processId))
+        .setVersion(1)
+        .setKey(processDefinitionKey)
+        .setResourceName(resourceName)
+        .setChecksum(checksum)
+        .setTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER)
+        .setDeploymentKey(keyGenerator.nextKey());
+
+    testSetup.applyEventToState(processDefinitionKey, ProcessIntent.CREATED, processRecord);
+
+    final long serviceTaskKey = keyGenerator.nextKey();
+    final long processInstanceKey = keyGenerator.nextKey();
+    final var serviceTask =
+        new ProcessInstanceRecord()
+            .setProcessDefinitionKey(processDefinitionKey)
+            .setBpmnProcessId(processId)
+            .setVersion(1)
+            .setElementId(serviceTaskElementId)
+            .setBpmnElementType(BpmnElementType.SERVICE_TASK)
+            .setProcessInstanceKey(processInstanceKey);
+    elementInstanceState.createInstance(
+        new ElementInstance(serviceTaskKey, ProcessInstanceIntent.ELEMENT_ACTIVATED, serviceTask));
+
+    final var sequenceFlowRecord =
+        new ProcessInstanceRecord()
+            .setElementId(sequenceFlowElementId)
+            .setBpmnElementType(BpmnElementType.SEQUENCE_FLOW)
+            .setBpmnProcessId(processId)
+            .setVersion(1)
+            .setProcessDefinitionKey(processDefinitionKey)
+            .setProcessInstanceKey(processInstanceKey)
+            .setFlowScopeKey(serviceTaskKey);
+
+    testSetup.applyEventToState(
+        keyGenerator.nextKey(), ProcessInstanceIntent.SEQUENCE_FLOW_TAKEN, sequenceFlowRecord);
+
+    // when
+    sequenceFlowDeletedApplier.applyState(keyGenerator.nextKey(), sequenceFlowRecord);
+
+    // then
+    final ElementInstance serviceTaskInstance = elementInstanceState.getInstance(serviceTaskKey);
+    assertThat(serviceTaskInstance.getActiveSequenceFlows())
+        .describedAs("Expect that the sequence flow is removed from the service task")
+        .isEqualTo(0);
+    assertThat(serviceTaskInstance.getActiveSequenceFlowIds())
+        .describedAs("Expect that the sequence flow is removed from the service task")
+        .isEmpty();
+  }
+
+  @Test
+  void shouldDecrementSequenceFlowFromJoiningGateway() {
+    // given
+    final String processId = "process";
+    final String gatewayElementId = "join1";
+    final String serviceTaskElementId = "task1";
+    final String sequenceFlowElementId = "flow1";
+    final BpmnModelInstance modelInstance =
+        Bpmn.createExecutableProcess(processId)
+            .startEvent()
+            .parallelGateway("fork")
+            .serviceTask(serviceTaskElementId, b -> b.zeebeJobType("type1"))
+            .sequenceFlowId(sequenceFlowElementId)
+            .parallelGateway(gatewayElementId)
+            .endEvent()
+            .moveToNode("fork")
+            .serviceTask("task2", b -> b.zeebeJobType("type2"))
+            .connectTo(gatewayElementId)
+            .done();
+    final ProcessRecord processRecord = new ProcessRecord();
+    final String resourceName = "process.bpmn";
+    final var resource = wrapString(Bpmn.convertToString(modelInstance));
+    final var checksum = wrapString("checksum");
+
+    final KeyGenerator keyGenerator = processingState.getKeyGenerator();
+    final long key = keyGenerator.nextKey();
+
+    processRecord
+        .setResourceName(wrapString(resourceName))
+        .setResource(resource)
+        .setBpmnProcessId(BufferUtil.wrapString(processId))
+        .setVersion(1)
+        .setKey(key)
+        .setResourceName(resourceName)
+        .setChecksum(checksum)
+        .setTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER)
+        .setDeploymentKey(keyGenerator.nextKey());
+
+    testSetup.applyEventToState(key, ProcessIntent.CREATED, processRecord);
+
+    final long serviceTaskKey = keyGenerator.nextKey();
+    final long processInstanceKey = keyGenerator.nextKey();
+    final var serviceTask =
+        new ProcessInstanceRecord()
+            .setProcessDefinitionKey(key)
+            .setBpmnProcessId(processId)
+            .setVersion(1)
+            .setElementId(serviceTaskElementId)
+            .setBpmnElementType(BpmnElementType.SERVICE_TASK)
+            .setProcessInstanceKey(processInstanceKey);
+    elementInstanceState.createInstance(
+        new ElementInstance(serviceTaskKey, ProcessInstanceIntent.ELEMENT_ACTIVATED, serviceTask));
+
+    final long gatewayKey = keyGenerator.nextKey();
+    final var gateway =
+        new ProcessInstanceRecord()
+            .setProcessDefinitionKey(key)
+            .setBpmnProcessId(processId)
+            .setVersion(1)
+            .setElementId(gatewayElementId)
+            .setBpmnElementType(BpmnElementType.PARALLEL_GATEWAY)
+            .setProcessInstanceKey(processInstanceKey);
+    elementInstanceState.createInstance(
+        new ElementInstance(gatewayKey, ProcessInstanceIntent.ELEMENT_ACTIVATED, gateway));
+
+    final var sequenceFlowRecord =
+        new ProcessInstanceRecord()
+            .setElementId(sequenceFlowElementId)
+            .setBpmnElementType(BpmnElementType.SEQUENCE_FLOW)
+            .setBpmnProcessId(processId)
+            .setVersion(1)
+            .setProcessDefinitionKey(key)
+            .setProcessInstanceKey(processInstanceKey)
+            .setFlowScopeKey(serviceTaskKey);
+
+    testSetup.applyEventToState(
+        keyGenerator.nextKey(), ProcessInstanceIntent.SEQUENCE_FLOW_TAKEN, sequenceFlowRecord);
+
+    // when
+    sequenceFlowDeletedApplier.applyState(keyGenerator.nextKey(), sequenceFlowRecord);
+
+    // then
+    final ElementInstance serviceTaskInstance = elementInstanceState.getInstance(serviceTaskKey);
+    assertThat(serviceTaskInstance.getActiveSequenceFlows())
+        .describedAs("Expect that the sequence flow is removed from the service task")
+        .isEqualTo(0);
+    assertThat(serviceTaskInstance.getActiveSequenceFlowIds())
+        .describedAs("Expect that the sequence flow is removed from the service task")
+        .isEmpty();
+
+    final int numberOfTakenSequenceFlows =
+        elementInstanceState.getNumberOfTakenSequenceFlows(
+            processInstanceKey, wrapString(gatewayElementId));
+    assertThat(numberOfTakenSequenceFlows)
+        .describedAs("Expect that the sequence flow is removed from the gateway")
+        .isEqualTo(0);
+  }
+}

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ProcessInstanceIntent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ProcessInstanceIntent.java
@@ -58,7 +58,9 @@ public enum ProcessInstanceIntent implements ProcessInstanceRelatedIntent {
    * `canceling` task listener was triggered - to resume and finalize the termination of the user
    * task element.
    */
-  CONTINUE_TERMINATING_ELEMENT((short) 14);
+  CONTINUE_TERMINATING_ELEMENT((short) 14),
+
+  SEQUENCE_FLOW_DELETED((short) 15);
 
   private static final Set<ProcessInstanceIntent> PROCESS_INSTANCE_COMMANDS = EnumSet.of(CANCEL);
   private static final Set<ProcessInstanceIntent> BPMN_ELEMENT_COMMANDS =
@@ -142,6 +144,7 @@ public enum ProcessInstanceIntent implements ProcessInstanceRelatedIntent {
       case ELEMENT_MIGRATED:
       case ANCESTOR_MIGRATED:
       case ELEMENT_SUSPENDED:
+      case SEQUENCE_FLOW_DELETED:
         return true;
       default:
         return false;

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ProcessInstanceIntent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ProcessInstanceIntent.java
@@ -30,6 +30,7 @@ public enum ProcessInstanceIntent implements ProcessInstanceRelatedIntent {
   ELEMENT_TERMINATING((short) 6),
   ELEMENT_TERMINATED((short) 7),
   ELEMENT_SUSPENDED((short) 15),
+  SEQUENCE_FLOW_DELETED((short) 16),
 
   ACTIVATE_ELEMENT((short) 8),
   COMPLETE_ELEMENT((short) 9),
@@ -58,9 +59,7 @@ public enum ProcessInstanceIntent implements ProcessInstanceRelatedIntent {
    * `canceling` task listener was triggered - to resume and finalize the termination of the user
    * task element.
    */
-  CONTINUE_TERMINATING_ELEMENT((short) 14),
-
-  SEQUENCE_FLOW_DELETED((short) 15);
+  CONTINUE_TERMINATING_ELEMENT((short) 14);
 
   private static final Set<ProcessInstanceIntent> PROCESS_INSTANCE_COMMANDS = EnumSet.of(CANCEL);
   private static final Set<ProcessInstanceIntent> BPMN_ELEMENT_COMMANDS =
@@ -121,6 +120,8 @@ public enum ProcessInstanceIntent implements ProcessInstanceRelatedIntent {
         return CONTINUE_TERMINATING_ELEMENT;
       case 15:
         return ELEMENT_SUSPENDED;
+      case 16:
+        return SEQUENCE_FLOW_DELETED;
       default:
         return Intent.UNKNOWN;
     }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Introduce a new intent ProcessInstanceIntent.SEQUENCE_FLOW_DELETED to support cleanup of previously taken sequence flows during migration. Implement ProcessInstanceSequenceFlowDeletedApplier, which reverses the effects of the SEQUENCE_FLOW_TAKEN applier by:

Retrieving the ExecutableSequenceFlow from the process definition. Decrementing and removing the active sequence flow count on the parent element instance.

Handling gateway-specific counters for parallel and inclusive gateways via decrementNumberOfTakenSequenceFlows. This deletion intent will be immediately followed by a standard SEQUENCE_FLOW_TAKEN intent to recreate the flow in the target process definition. Opting for a deletion approach avoids introducing a separate “migrated” intent, since sequence flows are not stored by their keys (see PoC discussion in #35231).

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #35329 
