### PR TITLE
feat: allow taking snapshots when positions didn't change

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/StateController.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/StateController.java
@@ -20,7 +20,8 @@ public interface StateController extends AutoCloseable {
    * @param lowerBoundSnapshotPosition the lower bound snapshot position
    * @return a future
    */
-  ActorFuture<TransientSnapshot> takeTransientSnapshot(long lowerBoundSnapshotPosition);
+  ActorFuture<TransientSnapshot> takeTransientSnapshot(
+      long lowerBoundSnapshotPosition, final boolean forceSnapshot);
 
   /**
    * Recovers the state from the snapshot and opens the database

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/AsyncSnapshotDirector.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/AsyncSnapshotDirector.java
@@ -161,8 +161,8 @@ public final class AsyncSnapshotDirector extends Actor
   }
 
   private void scheduleSnapshotOnRate() {
-    actor.runAtFixedRate(snapshotRate, this::trySnapshot);
-    trySnapshot();
+    actor.runAtFixedRate(snapshotRate, () -> trySnapshot(false));
+    trySnapshot(false);
   }
 
   /**
@@ -173,7 +173,7 @@ public final class AsyncSnapshotDirector extends Actor
    */
   public ActorFuture<PersistedSnapshot> forceSnapshot() {
     final var newSnapshotFuture = new CompletableActorFuture<PersistedSnapshot>();
-    actor.call(() -> trySnapshot().onComplete(newSnapshotFuture));
+    actor.call(() -> trySnapshot(true).onComplete(newSnapshotFuture));
     return newSnapshotFuture;
   }
 
@@ -201,7 +201,7 @@ public final class AsyncSnapshotDirector extends Actor
   // there is nothing to snapshot. Future is completed with null if the snapshot is skipped.
   // Otherwise, future is completed with the committed snapshot, or completed exceptionally if
   // snapshotting fails.
-  private ActorFuture<PersistedSnapshot> trySnapshot() {
+  private ActorFuture<PersistedSnapshot> trySnapshot(final boolean forceSnapshot) {
     if (ongoingSnapshotFuture != null) {
       LOG.debug("Already taking snapshot, skipping this request for a new snapshot");
       return CompletableActorFuture.completed(null);
@@ -221,7 +221,7 @@ public final class AsyncSnapshotDirector extends Actor
               } else {
                 inProgressSnapshot.lowerBoundSnapshotPosition =
                     position == StreamProcessor.UNSET_POSITION ? 0L : position;
-                snapshot(inProgressSnapshot).onComplete(snapshotFuture);
+                snapshot(inProgressSnapshot, forceSnapshot).onComplete(snapshotFuture);
               }
             });
 
@@ -237,8 +237,9 @@ public final class AsyncSnapshotDirector extends Actor
     return snapshotFuture;
   }
 
-  private ActorFuture<PersistedSnapshot> snapshot(final InProgressSnapshot inProgressSnapshot) {
-    return takeTransientSnapshot(inProgressSnapshot)
+  private ActorFuture<PersistedSnapshot> snapshot(
+      final InProgressSnapshot inProgressSnapshot, final boolean forceSnapshot) {
+    return takeTransientSnapshot(inProgressSnapshot, forceSnapshot)
         .andThen(() -> getLastWrittenPosition(inProgressSnapshot), actor)
         .andThen(() -> waitUntilLastWrittenPositionIsCommitted(inProgressSnapshot), actor)
         .andThen(this::flushJournal, actor)
@@ -322,9 +323,10 @@ public final class AsyncSnapshotDirector extends Actor
     }
   }
 
-  private ActorFuture<Void> takeTransientSnapshot(final InProgressSnapshot inProgressSnapshot) {
+  private ActorFuture<Void> takeTransientSnapshot(
+      final InProgressSnapshot inProgressSnapshot, final boolean forceSnapshot) {
     return stateController
-        .takeTransientSnapshot(inProgressSnapshot.lowerBoundSnapshotPosition)
+        .takeTransientSnapshot(inProgressSnapshot.lowerBoundSnapshotPosition, forceSnapshot)
         .andThen(
             (snapshot, error) -> {
               if (error != null) {
@@ -388,7 +390,7 @@ public final class AsyncSnapshotDirector extends Actor
     final var inProgressSnapshot = new InProgressSnapshot();
     inProgressSnapshot.lowerBoundSnapshotPosition = lastProcessedPosition;
     final var result = actor.<PersistedSnapshot>createFuture();
-    actor.run(() -> snapshot(inProgressSnapshot).onComplete(result));
+    actor.run(() -> snapshot(inProgressSnapshot, true).onComplete(result));
     return result;
   }
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/AsyncSnapshotDirector.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/AsyncSnapshotDirector.java
@@ -218,12 +218,9 @@ public final class AsyncSnapshotDirector extends Actor
               if (error != null) {
                 LOG.error(ERROR_MSG_ON_RESOLVE_PROCESSED_POS, error);
                 snapshotFuture.completeExceptionally(error);
-              } else if (position == StreamProcessor.UNSET_POSITION) {
-                LOG.debug(
-                    "We will skip taking this snapshot, because we haven't processed anything yet.");
-                snapshotFuture.complete(null);
               } else {
-                inProgressSnapshot.lowerBoundSnapshotPosition = position;
+                inProgressSnapshot.lowerBoundSnapshotPosition =
+                    position == StreamProcessor.UNSET_POSITION ? 0L : position;
                 snapshot(inProgressSnapshot).onComplete(snapshotFuture);
               }
             });

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/StateControllerImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/StateControllerImpl.java
@@ -70,9 +70,10 @@ public class StateControllerImpl implements StateController {
 
   @Override
   public ActorFuture<TransientSnapshot> takeTransientSnapshot(
-      final long lowerBoundSnapshotPosition) {
+      final long lowerBoundSnapshotPosition, final boolean forceSnapshot) {
     final ActorFuture<TransientSnapshot> future = concurrencyControl.createFuture();
-    concurrencyControl.run(() -> takeTransientSnapshotInternal(lowerBoundSnapshotPosition, future));
+    concurrencyControl.run(
+        () -> takeTransientSnapshotInternal(lowerBoundSnapshotPosition, forceSnapshot, future));
     return future;
   }
 
@@ -151,7 +152,9 @@ public class StateControllerImpl implements StateController {
   }
 
   private void takeTransientSnapshotInternal(
-      final long lowerBoundSnapshotPosition, final ActorFuture<TransientSnapshot> future) {
+      final long lowerBoundSnapshotPosition,
+      final boolean forceSnapshot,
+      final ActorFuture<TransientSnapshot> future) {
     if (!isDbOpened()) {
       final String error =
           String.format(
@@ -174,7 +177,8 @@ public class StateControllerImpl implements StateController {
             nextSnapshotId.index,
             nextSnapshotId.term,
             nextSnapshotId.processedPosition,
-            nextSnapshotId.exportedPosition);
+            nextSnapshotId.exportedPosition,
+            forceSnapshot);
 
     if (transientSnapshot.isLeft()) {
       future.completeExceptionally(transientSnapshot.getLeft());

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/MigrationTransitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/MigrationTransitionStep.java
@@ -59,7 +59,7 @@ public class MigrationTransitionStep implements PartitionTransitionStep {
     try {
       final var migrationsPerformed = dbMigrator.runMigrations();
       zeebeDbContext.getCurrentTransaction().commit();
-      if (migrationsPerformed.migrations() > 0) {
+      if (migrationsPerformed.versionChanged()) {
         context.markMigrationsDone();
       }
     } catch (final Exception e) {

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/backup/ConcurrentBackupCompactionTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/backup/ConcurrentBackupCompactionTest.java
@@ -198,7 +198,7 @@ public class ConcurrentBackupCompactionTest extends DynamicAutoCloseable {
   }
 
   private PersistedSnapshot takeSnapshot(final long index, final long lastWrittenPosition) {
-    final var transientSnapshot = snapshotStore.newTransientSnapshot(index, 1, 1, 1).get();
+    final var transientSnapshot = snapshotStore.newTransientSnapshot(index, 1, 1, 1, false).get();
     transientSnapshot.take(
         path -> {
           try {

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/RandomizedPartitionTransitionTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/RandomizedPartitionTransitionTest.java
@@ -446,7 +446,7 @@ public class RandomizedPartitionTransitionTest {
 
     @Override
     public ActorFuture<TransientSnapshot> takeTransientSnapshot(
-        final long lowerBoundSnapshotPosition) {
+        final long lowerBoundSnapshotPosition, final boolean forceSnapshot) {
       throw new IllegalStateException("Not implemented");
     }
 

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/StateControllerImplTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/StateControllerImplTest.java
@@ -92,7 +92,7 @@ public final class StateControllerImplTest {
 
     // then
     assertThat(snapshotController.isDbOpened()).isFalse();
-    assertThatThrownBy(() -> snapshotController.takeTransientSnapshot(1).join())
+    assertThatThrownBy(() -> snapshotController.takeTransientSnapshot(1, false).join())
         .hasCauseInstanceOf(StateClosedException.class);
   }
 
@@ -103,7 +103,7 @@ public final class StateControllerImplTest {
     snapshotController.recover().join();
 
     // then
-    assertThatThrownBy(() -> snapshotController.takeTransientSnapshot(1).join())
+    assertThatThrownBy(() -> snapshotController.takeTransientSnapshot(1, false).join())
         .hasCauseInstanceOf(NoEntryAtSnapshotPosition.class);
   }
 
@@ -115,7 +115,8 @@ public final class StateControllerImplTest {
     snapshotController.recover().join();
 
     // when
-    final var tmpSnapshot = snapshotController.takeTransientSnapshot(snapshotPosition).join();
+    final var tmpSnapshot =
+        snapshotController.takeTransientSnapshot(snapshotPosition, false).join();
     final var snapshot = tmpSnapshot.persist().join();
 
     // then
@@ -136,7 +137,8 @@ public final class StateControllerImplTest {
     // when
     wrapper.wrap(snapshotController.recover().join());
     wrapper.putInt(key, value);
-    final var tmpSnapshot = snapshotController.takeTransientSnapshot(snapshotPosition).join();
+    final var tmpSnapshot =
+        snapshotController.takeTransientSnapshot(snapshotPosition, false).join();
     tmpSnapshot.persist().join();
     snapshotController.close();
     wrapper.wrap(snapshotController.recover().join());
@@ -186,10 +188,11 @@ public final class StateControllerImplTest {
     exporterPosition.set(snapshotPosition - 1);
     snapshotController.recover().join();
     final var firstSnapshot =
-        snapshotController.takeTransientSnapshot(snapshotPosition).join().persist().join();
+        snapshotController.takeTransientSnapshot(snapshotPosition, false).join().persist().join();
 
     // when
-    final var tmpSnapshot = snapshotController.takeTransientSnapshot(snapshotPosition + 1).join();
+    final var tmpSnapshot =
+        snapshotController.takeTransientSnapshot(snapshotPosition + 1, false).join();
     final var snapshot = tmpSnapshot.persist().join();
 
     // then
@@ -209,12 +212,16 @@ public final class StateControllerImplTest {
     exporterPosition.set(snapshotPosition - 1);
     snapshotController.recover().join();
     final var firstSnapshot =
-        snapshotController.takeTransientSnapshot(snapshotPosition).join().persist().join();
+        snapshotController.takeTransientSnapshot(snapshotPosition, false).join().persist().join();
     atomixRecordEntrySupplier.set(emptyEntrySupplier);
 
     // when
     final var snapshot =
-        snapshotController.takeTransientSnapshot(snapshotPosition + 1).join().persist().join();
+        snapshotController
+            .takeTransientSnapshot(snapshotPosition + 1, false)
+            .join()
+            .persist()
+            .join();
 
     // then
     assertThat(snapshot)
@@ -236,11 +243,12 @@ public final class StateControllerImplTest {
     exporterPosition.set(snapshotPosition);
     snapshotController.recover().join();
     final var firstSnapshot =
-        snapshotController.takeTransientSnapshot(snapshotPosition).join().persist().join();
+        snapshotController.takeTransientSnapshot(snapshotPosition, false).join().persist().join();
 
     // when
     exporterPosition.set(snapshotPosition + 1);
-    final var tmpSnapshot = snapshotController.takeTransientSnapshot(snapshotPosition).join();
+    final var tmpSnapshot =
+        snapshotController.takeTransientSnapshot(snapshotPosition, false).join();
     final var snapshot = tmpSnapshot.persist().join();
 
     // then
@@ -324,7 +332,7 @@ public final class StateControllerImplTest {
 
     // when
     final var closed = snapshotController.closeDb();
-    final var snapshotTaken = snapshotController.takeTransientSnapshot(1);
+    final var snapshotTaken = snapshotController.takeTransientSnapshot(1, false);
     closed.join();
 
     // then
@@ -337,7 +345,7 @@ public final class StateControllerImplTest {
     snapshotController.recover().join();
 
     // when
-    final var snapshotTaken = snapshotController.takeTransientSnapshot(1);
+    final var snapshotTaken = snapshotController.takeTransientSnapshot(1, false);
     final var closed = snapshotController.closeDb();
     closed.join();
 
@@ -354,7 +362,8 @@ public final class StateControllerImplTest {
     final long snapshotPosition = 5;
 
     // when
-    final var transientSnapshot = snapshotController.takeTransientSnapshot(snapshotPosition).join();
+    final var transientSnapshot =
+        snapshotController.takeTransientSnapshot(snapshotPosition, false).join();
 
     // then
     final var snapshot = transientSnapshot.snapshotId();
@@ -378,7 +387,8 @@ public final class StateControllerImplTest {
     exporterPosition.set(-1L);
 
     // when
-    final var transientSnapshot = snapshotController.takeTransientSnapshot(snapshotPosition).join();
+    final var transientSnapshot =
+        snapshotController.takeTransientSnapshot(snapshotPosition, true).join();
 
     // then
     final var snapshot = transientSnapshot.snapshotId();
@@ -400,7 +410,7 @@ public final class StateControllerImplTest {
 
     // when
     final var snapshot =
-        snapshotController.takeTransientSnapshot(processedPosition).join().persist().join();
+        snapshotController.takeTransientSnapshot(processedPosition, false).join().persist().join();
 
     // then
     assertThat(snapshot)
@@ -420,7 +430,7 @@ public final class StateControllerImplTest {
 
     // when
     final var snapshot =
-        snapshotController.takeTransientSnapshot(processedPosition).join().persist().join();
+        snapshotController.takeTransientSnapshot(processedPosition, false).join().persist().join();
 
     // then
     assertThat(snapshot)
@@ -439,7 +449,7 @@ public final class StateControllerImplTest {
 
     // when
     final var snapshot =
-        snapshotController.takeTransientSnapshot(processedPosition).join().persist().join();
+        snapshotController.takeTransientSnapshot(processedPosition, false).join().persist().join();
 
     // then - should use exporter position since backup is disabled
     assertThat(snapshot)
@@ -457,7 +467,7 @@ public final class StateControllerImplTest {
 
     // when
     final var transientSnapshot =
-        snapshotController.takeTransientSnapshot(processedPosition).join();
+        snapshotController.takeTransientSnapshot(processedPosition, false).join();
 
     // then
     final var snapshot = transientSnapshot.snapshotId();
@@ -479,7 +489,7 @@ public final class StateControllerImplTest {
 
     // when
     final var snapshot =
-        snapshotController.takeTransientSnapshot(processedPosition).join().persist().join();
+        snapshotController.takeTransientSnapshot(processedPosition, false).join().persist().join();
 
     // then
     assertThat(snapshot)
@@ -488,7 +498,7 @@ public final class StateControllerImplTest {
   }
 
   private File takeSnapshot(final long position) {
-    final var snapshot = snapshotController.takeTransientSnapshot(position).join();
+    final var snapshot = snapshotController.takeTransientSnapshot(position, false).join();
     return snapshot.persist().join().getPath().toFile();
   }
 

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/perf/TestState.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/perf/TestState.java
@@ -58,7 +58,7 @@ final class TestState {
 
   private void generateSnapshot(
       final ConstructableSnapshotStore snapshotStore, final long sizeInBytes) {
-    final var snapshot = snapshotStore.newTransientSnapshot(1, 1, 1, 1).get();
+    final var snapshot = snapshotStore.newTransientSnapshot(1, 1, 1, 1, false).get();
     snapshot.take(path -> generateSnapshot(path, sizeInBytes)).join();
     snapshot.persist().join();
   }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/snapshotapi/SnapshotTransferUtil.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/snapshotapi/SnapshotTransferUtil.java
@@ -35,7 +35,7 @@ public final class SnapshotTransferUtil {
       final long lastProcessedPosition,
       final ConcurrencyControl control) {
     final var transientSnapshot =
-        senderSnapshotStore.newTransientSnapshot(1L, 0L, lastProcessedPosition, 0).get();
+        senderSnapshotStore.newTransientSnapshot(1L, 0L, lastProcessedPosition, 0, false).get();
     return transientSnapshot
         .take(p -> writeSnapshot(p, snapshotFileContents))
         .andThen(ignored -> transientSnapshot.persist(), control);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigrator.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigrator.java
@@ -16,9 +16,9 @@ public interface DbMigrator {
    */
   MigrationsPerformed runMigrations();
 
-  record MigrationsPerformed(int initializations, int migrations) {
-    public static MigrationsPerformed zero() {
-      return new MigrationsPerformed(0, 0);
+  record MigrationsPerformed(int initializations, int migrations, boolean versionChanged) {
+    public static MigrationsPerformed none() {
+      return new MigrationsPerformed(0, 0, false);
     }
 
     public static MigrationsPerformed fromList(final List<MigrationTask> executedMigrations) {
@@ -31,7 +31,7 @@ public interface DbMigrator {
           migrations++;
         }
       }
-      return new MigrationsPerformed(initializations, migrations);
+      return new MigrationsPerformed(initializations, migrations, true);
     }
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigratorImpl.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigratorImpl.java
@@ -106,7 +106,7 @@ public class DbMigratorImpl implements DbMigrator {
         break;
       case final Compatible.SameVersion compatible:
         LOGGER.debug("No migrations to run, snapshot is the same as current version");
-        return MigrationsPerformed.zero();
+        return MigrationsPerformed.none();
       default:
         break;
     }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/FailOverReplicationTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/FailOverReplicationTest.java
@@ -133,7 +133,11 @@ public class FailOverReplicationTest {
         .atMost(Duration.ofSeconds(30))
         .untilAsserted(
             () ->
-                assertThat(clusteringRule.getSnapshot(previousLeader)).hasValue(snapshotMetadata));
+                assertThat(clusteringRule.getSnapshot(previousLeader))
+                    .hasValueSatisfying(
+                        id ->
+                            assertThat(id.getIndex())
+                                .isGreaterThanOrEqualTo(snapshotMetadata.getIndex())));
   }
 
   // regression test for https://github.com/zeebe-io/zeebe/issues/4810

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/BrokerAdminServiceEndpointTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/BrokerAdminServiceEndpointTest.java
@@ -37,125 +37,144 @@ public class BrokerAdminServiceEndpointTest {
   private static final String EXPECTED_PARTITIONS_JSON =
       // language=JSON
       """
-      {
-        "1": {
-          "role": "LEADER",
-          "processedPosition": 2,
-          "snapshotId": null,
-          "processedPositionInSnapshot": null,
-          "streamProcessorPhase": "PROCESSING",
-          "exporterPhase": "EXPORTING",
-          "exportedPosition": -1,
-          "clock": {
-            "instant": "2024-10-29T07:10:02.688Z",
-            "modificationType": "None",
-            "modification": {}
-          },
-          "health": {
-            "id": "Partition-1",
-            "name": "Partition-1",
-            "status": "HEALTHY",
-            "componentsState": "HEALTHY",
-            "children": [
-                {
-                 "id": "SnapshotDirector-1",
-                 "name": "SnapshotDirector-1",
-                 "status": "HEALTHY",
-                 "children": []
-               },
-               {
-                 "id": "ZeebePartitionHealth-1",
-                 "name": "ZeebePartitionHealth-1",
-                 "status": "HEALTHY",
-                 "children": []
-               },
-               {
-                 "id": "StreamProcessor-1",
-                 "name": "StreamProcessor-1",
-                 "status": "HEALTHY",
-                 "children": []
-               },
-               {
-                 "id": "Exporter-1",
-                 "name": "Exporter-1",
-                 "status": "HEALTHY",
-                 "children": []
-               },
-               {
-                 "id": "RaftPartition-1",
-                 "name": "RaftPartition-1",
-                 "status": "HEALTHY",
-                 "children": []
+          {
+            "1": {
+              "role": "LEADER",
+              "processedPosition": 2,
+              "snapshotId": "2-1-2-9223372036854775807-0-a06ff57d",
+              "processedPositionInSnapshot": 2,
+              "streamProcessorPhase": "PROCESSING",
+              "exporterPhase": "EXPORTING",
+              "exportedPosition": -1,
+              "clock": {
+                "instant": "2024-10-29T07:10:02.688Z",
+                "modificationType": "None",
+                "modification": {}
+              },
+              "health": {
+                "id": "Partition-1",
+                "name": "Partition-1",
+                "status": "HEALTHY",
+                "componentsState": "HEALTHY",
+                "children": [
+                    {
+                     "id": "SnapshotDirector-1",
+                     "name": "SnapshotDirector-1",
+                     "status": "HEALTHY",
+                     "children": []
+                   },
+                   {
+                     "id": "ZeebePartitionHealth-1",
+                     "name": "ZeebePartitionHealth-1",
+                     "status": "HEALTHY",
+                     "children": []
+                   },
+                   {
+                     "id": "StreamProcessor-1",
+                     "name": "StreamProcessor-1",
+                     "status": "HEALTHY",
+                     "children": []
+                   },
+                   {
+                     "id": "Exporter-1",
+                     "name": "Exporter-1",
+                     "status": "HEALTHY",
+                     "children": []
+                   },
+                   {
+                     "id":"MigrationSnapshotDirector",
+                     "name":"MigrationSnapshotDirector",
+                     "status":"HEALTHY",
+                     "children":[]
+                   },
+                   {
+                     "id": "RaftPartition-1",
+                     "name": "RaftPartition-1",
+                     "status": "HEALTHY",
+                     "children": []
+                   }
+                 ]
                }
-             ]
-           }
-        }
-      }
-      """;
+            }
+          }
+          """;
   private static final String EXPECTED_PARTITION_JSON =
       // language=JSON
       """
-      {
-        "role": "LEADER",
-        "processedPosition": 2,
-        "snapshotId": null,
-        "processedPositionInSnapshot": null,
-        "streamProcessorPhase": "PROCESSING",
-        "exporterPhase": "EXPORTING",
-        "exportedPosition": -1,
-        "clock": {
-          "instant": "2024-10-29T07:24:41.576Z",
-          "modificationType": "None",
-          "modification": {}
-        },
-        "health": {
-             "id": "Partition-1",
-             "name": "Partition-1",
-             "status": "HEALTHY",
-             "componentsState": "HEALTHY",
-             "children": [
-               {
-                 "id": "SnapshotDirector-1",
-                 "name": "SnapshotDirector-1",
+          {
+            "role": "LEADER",
+            "processedPosition": 2,
+            "snapshotId": "2-1-2-9223372036854775807-0-a06ff57d",
+            "processedPositionInSnapshot": 2,
+            "streamProcessorPhase": "PROCESSING",
+            "exporterPhase": "EXPORTING",
+            "exportedPosition": -1,
+            "clock": {
+              "instant": "2024-10-29T07:24:41.576Z",
+              "modificationType": "None",
+              "modification": {}
+            },
+            "health": {
+                 "id": "Partition-1",
+                 "name": "Partition-1",
                  "status": "HEALTHY",
-                 "children": []
-               },
-               {
-                 "id": "ZeebePartitionHealth-1",
-                 "name": "ZeebePartitionHealth-1",
-                 "status": "HEALTHY",
-                 "children": []
-               },
-               {
-                 "id": "StreamProcessor-1",
-                 "name": "StreamProcessor-1",
-                 "status": "HEALTHY",
-                 "children": []
-               },
-               {
-                 "id": "Exporter-1",
-                 "name": "Exporter-1",
-                 "status": "HEALTHY",
-                 "children": []
-               },
-               {
-                 "id": "RaftPartition-1",
-                 "name": "RaftPartition-1",
-                 "status": "HEALTHY",
-                 "children": []
+                 "componentsState": "HEALTHY",
+                 "children": [
+                   {
+                     "id": "SnapshotDirector-1",
+                     "name": "SnapshotDirector-1",
+                     "status": "HEALTHY",
+                     "children": []
+                   },
+                   {
+                     "id": "ZeebePartitionHealth-1",
+                     "name": "ZeebePartitionHealth-1",
+                     "status": "HEALTHY",
+                     "children": []
+                   },
+                   {
+                     "id": "StreamProcessor-1",
+                     "name": "StreamProcessor-1",
+                     "status": "HEALTHY",
+                     "children": []
+                   },
+                   {
+                     "id": "Exporter-1",
+                     "name": "Exporter-1",
+                     "status": "HEALTHY",
+                     "children": []
+                   },
+                   {
+                     "id":"MigrationSnapshotDirector",
+                     "name":"MigrationSnapshotDirector",
+                     "status":"HEALTHY",
+                     "children":[]
+                   },
+                   {
+                     "id": "RaftPartition-1",
+                     "name": "RaftPartition-1",
+                     "status": "HEALTHY",
+                     "children": []
+                   }
+                 ]
                }
-             ]
-           }
-      }
-      """;
+          }
+          """;
 
   private static String sanitizeJson(final String json) {
     final var timestampPattern =
         Pattern.compile("\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{3}Z");
     final var timestampReplacement = "2024-10-29T07:10:02.688Z";
+
+    // snapshot checksum is not deterministic, so we replace it with a constant value
+    final var snapshotChecksumPattern = Pattern.compile("\\d+-\\d+-\\d+-\\d+-\\d+-\\w+");
+    final var snapshotChecksumReplacement = "2-1-2-9223372036854775807-0-a06ff57d";
+
     return json
         // map timestamp into the same value
         .replaceAll(timestampPattern.pattern(), timestampReplacement)
+        // map snapshot checksum into a constant value
+        .replaceAll(snapshotChecksumPattern.pattern(), snapshotChecksumReplacement)
         // remove all whitespaces from the pretty printing
         .replaceAll("\\s", "");
   }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/system/BrokerAdminServiceClusterTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/system/BrokerAdminServiceClusterTest.java
@@ -73,16 +73,11 @@ public class BrokerAdminServiceClusterTest {
     followerStatus.forEach(
         partitionStatus -> {
           assertThat(partitionStatus.role()).isEqualTo(Role.FOLLOWER);
-          assertThat(partitionStatus.processedPosition()).isPositive();
-          assertThat(partitionStatus.snapshotId()).isNull();
-          assertThat(partitionStatus.processedPositionInSnapshot()).isNull();
           assertThat(partitionStatus.streamProcessorPhase()).isEqualTo(Phase.REPLAY);
         });
 
     assertThat(leaderStatus.role()).isEqualTo(Role.LEADER);
     assertThat(leaderStatus.processedPosition()).isPositive();
-    assertThat(leaderStatus.snapshotId()).isNull();
-    assertThat(leaderStatus.processedPositionInSnapshot()).isNull();
     assertThat(leaderStatus.streamProcessorPhase()).isEqualTo(Phase.PROCESSING);
   }
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/system/BrokerAdminServiceWithOutExporterTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/system/BrokerAdminServiceWithOutExporterTest.java
@@ -36,8 +36,8 @@ public class BrokerAdminServiceWithOutExporterTest {
     final var partitionStatus = leaderAdminService.getPartitionStatus().get(1);
     assertThat(partitionStatus.role()).isEqualTo(Role.LEADER);
     assertThat(partitionStatus.processedPosition()).isPositive();
-    assertThat(partitionStatus.snapshotId()).isNull();
-    assertThat(partitionStatus.processedPositionInSnapshot()).isNull();
+    assertThat(partitionStatus.snapshotId()).isNotNull();
+    assertThat(partitionStatus.processedPositionInSnapshot()).isPositive();
     assertThat(partitionStatus.streamProcessorPhase()).isEqualTo(Phase.PROCESSING);
     assertThat(partitionStatus.exporterPhase()).isEqualTo(ExporterPhase.EXPORTING);
     assertThat(partitionStatus.exportedPosition()).isEqualTo(-1);

--- a/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/NoSnapshotTest.java
+++ b/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/NoSnapshotTest.java
@@ -46,11 +46,11 @@ final class NoSnapshotTest {
     state.withNetwork(network).withOldBroker().start(true);
     final long processInstanceKey = testCase.setUp(state.client());
     final long key = testCase.runBefore(state);
+    assertThat(state).hasNoSnapshotAvailable(1);
 
     // when
     state.close();
     state.withNewBroker().start(true);
-    assertThat(state).hasNoSnapshotAvailable(1);
 
     // then
     testCase.runAfter(state, processInstanceKey, key);

--- a/zeebe/restore/src/test/java/io/camunda/zeebe/restore/PartitionRestoreServiceTest.java
+++ b/zeebe/restore/src/test/java/io/camunda/zeebe/restore/PartitionRestoreServiceTest.java
@@ -257,7 +257,7 @@ class PartitionRestoreServiceTest {
   }
 
   private PersistedSnapshot takeSnapshot(final long index, final long lastWrittenPosition) {
-    final var transientSnapshot = snapshotStore.newTransientSnapshot(index, 1, 1, 1).get();
+    final var transientSnapshot = snapshotStore.newTransientSnapshot(index, 1, 1, 1, false).get();
     transientSnapshot.take(
         path -> {
           try {

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/ConstructableSnapshotStore.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/ConstructableSnapshotStore.java
@@ -22,5 +22,9 @@ public interface ConstructableSnapshotStore extends PersistedSnapshotStore {
    * @return either an exception or transientSnapshot, if it was taken successfully.
    */
   Either<SnapshotException, TransientSnapshot> newTransientSnapshot(
-      long index, long term, long processedPosition, long exportedPosition);
+      long index,
+      long term,
+      long processedPosition,
+      long exportedPosition,
+      final boolean forceSnapshot);
 }

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/ImmutableChecksumsSFV.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/ImmutableChecksumsSFV.java
@@ -36,4 +36,10 @@ public interface ImmutableChecksumsSFV {
    * @return boolean denoting match
    */
   boolean sameChecksums(ImmutableChecksumsSFV o);
+
+  /**
+   * Returns some combined checksum over all the file checksums. If any of the individual checksums
+   * or file names change, the combined checksum will change as well.
+   */
+  long getCombinedChecksum();
 }

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotId.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotId.java
@@ -13,11 +13,8 @@ import io.camunda.zeebe.snapshots.impl.FileBasedSnapshotId.SnapshotParseResult.P
 import java.nio.file.Path;
 import java.util.Objects;
 import java.util.Optional;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public final class FileBasedSnapshotId implements SnapshotId {
-  private static final Logger LOGGER = LoggerFactory.getLogger(FileBasedSnapshotId.class);
   private static final int SNAPSHOT_ID_PARTS = 6;
   private static final int PREV_SNAPSHOT_ID_PARTS = 5;
 
@@ -144,6 +141,10 @@ public final class FileBasedSnapshotId implements SnapshotId {
           "%d-%d-%d-%d-%d",
           getIndex(), getTerm(), getProcessedPosition(), getExportedPosition(), brokerId);
     }
+  }
+
+  public int getBrokerId() {
+    return brokerId;
   }
 
   @Override

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStore.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStore.java
@@ -134,8 +134,10 @@ public final class FileBasedSnapshotStore extends Actor
       final long index,
       final long term,
       final long processedPosition,
-      final long exportedPosition) {
-    return snapshotStore.newTransientSnapshot(index, term, processedPosition, exportedPosition);
+      final long exportedPosition,
+      final boolean forceSnapshot) {
+    return snapshotStore.newTransientSnapshot(
+        index, term, processedPosition, exportedPosition, forceSnapshot);
   }
 
   @Override

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStoreImpl.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStoreImpl.java
@@ -353,13 +353,16 @@ public final class FileBasedSnapshotStoreImpl {
       final long index,
       final long term,
       final long processedPosition,
-      final long exportedPosition) {
+      final long exportedPosition,
+      final boolean forceSnapshot) {
 
     final var newSnapshotId =
         new FileBasedSnapshotId(index, term, processedPosition, exportedPosition, brokerId);
 
     final FileBasedSnapshot currentSnapshot = this.currentSnapshot.get();
-    if (currentSnapshot != null && currentSnapshot.getSnapshotId().equals(newSnapshotId)) {
+    if (!forceSnapshot
+        && currentSnapshot != null
+        && currentSnapshot.getSnapshotId().compareTo(newSnapshotId) >= 0) {
       final String error =
           String.format(
               "Previous snapshot was taken for the same processed position %d and exported position %d.",

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStoreImpl.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStoreImpl.java
@@ -358,7 +358,7 @@ public final class FileBasedSnapshotStoreImpl {
         new FileBasedSnapshotId(index, term, processedPosition, exportedPosition, brokerId);
 
     final FileBasedSnapshot currentSnapshot = this.currentSnapshot.get();
-    if (currentSnapshot != null && currentSnapshot.getSnapshotId().compareTo(newSnapshotId) == 0) {
+    if (currentSnapshot != null && currentSnapshot.getSnapshotId().equals(newSnapshotId)) {
       final String error =
           String.format(
               "Previous snapshot was taken for the same processed position %d and exported position %d.",

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStoreImpl.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStoreImpl.java
@@ -418,7 +418,7 @@ public final class FileBasedSnapshotStoreImpl {
   private boolean isCurrentSnapshotNewer(final FileBasedSnapshotId snapshotId) {
     final var persistedSnapshot = currentSnapshot.get();
     return (persistedSnapshot != null
-        && persistedSnapshot.getSnapshotId().compareTo(snapshotId) >= 0);
+        && persistedSnapshot.getSnapshotId().compareTo(snapshotId) > 0);
   }
 
   FileBasedSnapshot persistNewSnapshot(

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedTransientSnapshot.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedTransientSnapshot.java
@@ -257,7 +257,7 @@ public final class FileBasedTransientSnapshot implements TransientSnapshot {
         + ", snapshotId="
         + snapshotId
         + ", checksum="
-        + checksum.getCombinedChecksum()
+        + (checksum == null ? "none" : checksum.getCombinedChecksum())
         + '}';
   }
 }

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedTransientSnapshot.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedTransientSnapshot.java
@@ -78,7 +78,7 @@ public final class FileBasedTransientSnapshot implements TransientSnapshot {
     try (final var ignored = snapshotMetrics.startTimer(isBootstrap)) {
       try {
         takeSnapshot.accept(getPath());
-        if (!directory.toFile().exists() || directory.toFile().listFiles().length == 0) {
+        if (FileUtil.isEmpty(directory)) {
           // If no snapshot files are created, snapshot is not valid
           abortInternal();
           takenFuture.completeExceptionally(

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedTransientSnapshot.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedTransientSnapshot.java
@@ -257,7 +257,7 @@ public final class FileBasedTransientSnapshot implements TransientSnapshot {
         + ", snapshotId="
         + snapshotId
         + ", checksum="
-        + checksum
+        + checksum.getCombinedChecksum()
         + '}';
   }
 }

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/SfvChecksumImpl.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/SfvChecksumImpl.java
@@ -14,6 +14,7 @@ import java.io.OutputStream;
 import java.io.PrintWriter;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.Map.Entry;
@@ -80,6 +81,19 @@ public final class SfvChecksumImpl implements MutableChecksumsSFV {
       return false;
     }
     return Objects.equals(checksums, o.getChecksums());
+  }
+
+  @Override
+  public long getCombinedChecksum() {
+    final var combinedChecksum = new CRC32C();
+    for (final var entry : checksums.entrySet()) {
+      combinedChecksum.update(entry.getKey().getBytes(StandardCharsets.UTF_8));
+      final int upper = (int) (entry.getValue() >> 32);
+      final int lower = (int) entry.getValue().longValue();
+      combinedChecksum.update(upper);
+      combinedChecksum.update(lower);
+    }
+    return combinedChecksum.getValue();
   }
 
   @Override

--- a/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/PersistedSnapshotStoreTest.java
+++ b/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/PersistedSnapshotStoreTest.java
@@ -93,7 +93,8 @@ public class PersistedSnapshotStoreTest {
   @Test
   public void shouldListAllFiles() {
     // given
-    final var transientSnapshot = persistedSnapshotStore.newTransientSnapshot(1, 0, 123, 121).get();
+    final var transientSnapshot =
+        persistedSnapshotStore.newTransientSnapshot(1, 0, 123, 121, false).get();
     final var snapshotFileNames =
         List.of("zeebe.metadata", "table-0.sst", "table-1.sst", "table-2.sst");
     transientSnapshot

--- a/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/ReceivedSnapshotTest.java
+++ b/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/ReceivedSnapshotTest.java
@@ -179,8 +179,8 @@ public class ReceivedSnapshotTest {
         .failsWithin(Duration.ofMillis(100))
         .withThrowableOfType(ExecutionException.class)
         .withCauseInstanceOf(SnapshotAlreadyExistsException.class)
-        .withMessageContaining(
-            "Expected to receive snapshot with id 1-0-1-0-0, but was already persisted");
+        .withMessageMatching(
+            "Expected to receive snapshot with id 1-0-1-0-0-\\S+, but was already persisted. This shouldn't happen.");
   }
 
   @Test

--- a/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/ReceivedSnapshotTest.java
+++ b/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/ReceivedSnapshotTest.java
@@ -396,7 +396,8 @@ public class ReceivedSnapshotTest {
   }
 
   private PersistedSnapshot takePersistedSnapshot() {
-    final var transientSnapshot = senderSnapshotStore.newTransientSnapshot(1L, 0L, 1, 0).get();
+    final var transientSnapshot =
+        senderSnapshotStore.newTransientSnapshot(1L, 0L, 1, 0, false).get();
     transientSnapshot
         .take(
             p -> SnapshotTransferUtil.writeSnapshot(p, SnapshotTransferUtil.SNAPSHOT_FILE_CONTENTS))

--- a/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/SnapshotTransferUtil.java
+++ b/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/SnapshotTransferUtil.java
@@ -31,7 +31,8 @@ public final class SnapshotTransferUtil {
       final ConstructableSnapshotStore senderSnapshotStore,
       final Map<String, String> snapshotFileContents,
       final ConcurrencyControl control) {
-    final var transientSnapshot = senderSnapshotStore.newTransientSnapshot(1L, 0L, 1, 0).get();
+    final var transientSnapshot =
+        senderSnapshotStore.newTransientSnapshot(1L, 0L, 1, 0, false).get();
     return transientSnapshot
         .take(p -> writeSnapshot(p, snapshotFileContents))
         .andThen(ignored -> transientSnapshot.persist(), control);

--- a/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/TransientSnapshotTest.java
+++ b/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/TransientSnapshotTest.java
@@ -291,7 +291,7 @@ public class TransientSnapshotTest {
   }
 
   @Test
-  public void shouldNotTakeSnapshotIfIdAlreadyExists() {
+  public void shouldTakeSnapshotIfIdAlreadyExists() {
     // given
     final var transientSnapshot = snapshotStore.newTransientSnapshot(1L, 0L, 2L, 3L).get();
     transientSnapshot.take(this::writeSnapshot).join();
@@ -301,9 +301,7 @@ public class TransientSnapshotTest {
     final var secondTransientSnapshot = snapshotStore.newTransientSnapshot(1L, 0L, 2L, 3L);
 
     // then
-    assertThat(secondTransientSnapshot.getLeft())
-        .as("should have no value since there already exists a transient snapshot with the same ID")
-        .isInstanceOf(SnapshotAlreadyExistsException.class);
+    EitherAssert.assertThat(secondTransientSnapshot).isRight();
   }
 
   @Test

--- a/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/TransientSnapshotTest.java
+++ b/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/TransientSnapshotTest.java
@@ -14,9 +14,9 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.testing.ActorSchedulerRule;
-import io.camunda.zeebe.snapshots.SnapshotException.SnapshotAlreadyExistsException;
 import io.camunda.zeebe.snapshots.SnapshotException.SnapshotNotFoundException;
 import io.camunda.zeebe.snapshots.impl.FileBasedSnapshotStore;
+import io.camunda.zeebe.test.util.asserts.EitherAssert;
 import io.camunda.zeebe.util.FileUtil;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.io.File;
@@ -158,8 +158,9 @@ public class TransientSnapshotTest {
 
     // then
     assertThat(persistedSnapshot.getId())
-        .as("the persisted snapshot as the same ID as the transient snapshot")
-        .isEqualTo(transientSnapshot.snapshotId().getSnapshotIdAsString());
+        .as(
+            "the persisted snapshot as the same ID as the transient snapshot, except for the checksum at the end")
+        .startsWith(transientSnapshot.snapshotId().getSnapshotIdAsString());
   }
 
   @Test

--- a/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedReceivedSnapshotTest.java
+++ b/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedReceivedSnapshotTest.java
@@ -233,9 +233,7 @@ public class FileBasedReceivedSnapshotTest {
       assertThatCode(() -> receivedSnapshot.apply(corruptedChunk).join())
           .hasCauseInstanceOf(SnapshotWriteException.class)
           .hasMessageContaining(
-              "Expected to have checksum "
-                  + 0xCAFEL
-                  + " for snapshot chunk file1 (1-0-1-0-0), but calculated 3806033162");
+              "Expected to have checksum " + 0xCAFEL + " for snapshot chunk file1");
     }
   }
 

--- a/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedReceivedSnapshotTest.java
+++ b/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedReceivedSnapshotTest.java
@@ -361,7 +361,8 @@ public class FileBasedReceivedSnapshotTest {
   }
 
   private PersistedSnapshot takePersistedSnapshot(final long index) {
-    final var transientSnapshot = senderSnapshotStore.newTransientSnapshot(index, 0L, 1, 0).get();
+    final var transientSnapshot =
+        senderSnapshotStore.newTransientSnapshot(index, 0L, 1, 0, false).get();
     transientSnapshot.take(this::writeSnapshot).join();
     return transientSnapshot.withLastFollowupEventPosition(100L).persist().join();
   }

--- a/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStoreTest.java
+++ b/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStoreTest.java
@@ -540,7 +540,8 @@ public class FileBasedSnapshotStoreTest {
   }
 
   private TransientSnapshot takeTransientSnapshotWithFiles(final long index) {
-    final var transientSnapshot = snapshotStore.newTransientSnapshot(index, 1, 123L, 0).get();
+    final var transientSnapshot =
+        snapshotStore.newTransientSnapshot(index, 1, 123L, 0, false).get();
 
     final var snapshotFileNames =
         List.of("zeebe.metadata", "table-0.sst", "table-1.sst", "table-2.sst");
@@ -568,7 +569,7 @@ public class FileBasedSnapshotStoreTest {
 
   private TransientSnapshot takeTransientSnapshot(
       final long index, final FileBasedSnapshotStore store) {
-    final var transientSnapshot = store.newTransientSnapshot(index, 1, 1, 0).get();
+    final var transientSnapshot = store.newTransientSnapshot(index, 1, 1, 0, false).get();
     transientSnapshot.take(this::createSnapshotDir);
     return transientSnapshot;
   }

--- a/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStoreTest.java
+++ b/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStoreTest.java
@@ -434,8 +434,8 @@ public class FileBasedSnapshotStoreTest {
     assertThat(copiedSnapshot)
         .satisfies(
             s -> {
-              assertThat(s.getId()).isEqualTo("1-1-0-0-0");
-              assertThat(s.getPath().getFileName().toString()).isEqualTo("1-1-0-0-0");
+              assertThat(s.getId()).startsWith("1-1-0-0-0-");
+              assertThat(s.getPath().getFileName().toString()).startsWith("1-1-0-0-0-");
               assertThat(s.getMetadata())
                   .isEqualTo(
                       FileBasedSnapshotMetadata.forBootstrap(FileBasedSnapshotStoreImpl.VERSION));
@@ -471,7 +471,7 @@ public class FileBasedSnapshotStoreTest {
         .satisfies(s -> assertThat(s.get().getId()).isEqualTo(copiedSnapshot.getId()));
 
     assertThat(rootDirectory.resolve("snapshots"))
-        .isDirectoryContaining(p -> p.getFileName().startsWith("1-1-0-0-0"));
+        .isDirectoryContaining(p -> p.getFileName().toString().startsWith("1-1-0-0-0"));
   }
 
   @Test

--- a/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedTransientSnapshotTest.java
+++ b/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedTransientSnapshotTest.java
@@ -60,17 +60,6 @@ public class FileBasedTransientSnapshotTest {
   }
 
   @Test
-  public void shouldEncodeSnapshotIdInPath() {
-    final var transientSnapshot = snapshotStore.newTransientSnapshot(1L, 2L, 3L, 4L).get();
-
-    // when
-    final var pathId = FileBasedSnapshotId.ofPath(transientSnapshot.getPath()).getOrThrow();
-
-    // then
-    assertThat(pathId).isEqualTo(transientSnapshot.snapshotId());
-  }
-
-  @Test
   public void shouldNotCommitUntilPersisted() {
     // given
     final var transientSnapshot = snapshotStore.newTransientSnapshot(1L, 2L, 3L, 4L).get();

--- a/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedTransientSnapshotTest.java
+++ b/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedTransientSnapshotTest.java
@@ -51,7 +51,7 @@ public class FileBasedTransientSnapshotTest {
   @Test
   public void shouldNotCreateTransientDirectoryIfNothingWritten() {
     // when
-    snapshotStore.newTransientSnapshot(1L, 0L, 1L, 0L);
+    snapshotStore.newTransientSnapshot(1L, 0L, 1L, 0L, false);
 
     // then
     assertThat(snapshotsDir)
@@ -62,7 +62,7 @@ public class FileBasedTransientSnapshotTest {
   @Test
   public void shouldNotCommitUntilPersisted() {
     // given
-    final var transientSnapshot = snapshotStore.newTransientSnapshot(1L, 2L, 3L, 4L).get();
+    final var transientSnapshot = snapshotStore.newTransientSnapshot(1L, 2L, 3L, 4L, false).get();
 
     // when
     transientSnapshot.take(this::writeSnapshot).join();
@@ -76,7 +76,7 @@ public class FileBasedTransientSnapshotTest {
   @Test
   public void shouldTakeTransientSnapshot() {
     // given
-    final var transientSnapshot = snapshotStore.newTransientSnapshot(1L, 2L, 3L, 4L).get();
+    final var transientSnapshot = snapshotStore.newTransientSnapshot(1L, 2L, 3L, 4L, false).get();
 
     // when
     transientSnapshot.take(this::writeSnapshot).join();
@@ -91,7 +91,7 @@ public class FileBasedTransientSnapshotTest {
   @Test
   public void shouldDeleteTransientDirectoryOnAbort() {
     // given
-    final var transientSnapshot = snapshotStore.newTransientSnapshot(1L, 0L, 1L, 0L).get();
+    final var transientSnapshot = snapshotStore.newTransientSnapshot(1L, 0L, 1L, 0L, false).get();
     transientSnapshot.take(this::writeSnapshot).join();
 
     // when
@@ -106,7 +106,7 @@ public class FileBasedTransientSnapshotTest {
   @Test
   public void shouldNotDeletePersistedSnapshotOnPurge() {
     // given
-    final var transientSnapshot = snapshotStore.newTransientSnapshot(1L, 0L, 1L, 0L).get();
+    final var transientSnapshot = snapshotStore.newTransientSnapshot(1L, 0L, 1L, 0L, false).get();
     transientSnapshot.take(this::writeSnapshot).join();
     final var persistedSnapshot = transientSnapshot.persist().join();
 
@@ -126,7 +126,7 @@ public class FileBasedTransientSnapshotTest {
   @Test
   public void shouldPersistSnapshot() {
     // given
-    final var transientSnapshot = snapshotStore.newTransientSnapshot(1L, 0L, 1L, 0L).get();
+    final var transientSnapshot = snapshotStore.newTransientSnapshot(1L, 0L, 1L, 0L, false).get();
     transientSnapshot.take(this::writeSnapshot);
 
     // when
@@ -150,12 +150,12 @@ public class FileBasedTransientSnapshotTest {
   @Test
   public void shouldReplacePreviousSnapshotOnPersist() {
     // given
-    final var oldSnapshot = snapshotStore.newTransientSnapshot(1L, 0L, 1L, 0L).get();
+    final var oldSnapshot = snapshotStore.newTransientSnapshot(1L, 0L, 1L, 0L, false).get();
     oldSnapshot.take(this::writeSnapshot);
     oldSnapshot.persist().join();
 
     // when
-    final var newSnapshot = snapshotStore.newTransientSnapshot(2L, 0L, 1L, 0L).get();
+    final var newSnapshot = snapshotStore.newTransientSnapshot(2L, 0L, 1L, 0L, false).get();
     newSnapshot.take(this::writeSnapshot);
     final var persistedSnapshot = (FileBasedSnapshot) newSnapshot.persist().join();
 
@@ -170,11 +170,12 @@ public class FileBasedTransientSnapshotTest {
   @Test
   public void shouldNotRemoveTransientSnapshotWithGreaterIdOnPersist() {
     // given
-    final var newerTransientSnapshot = snapshotStore.newTransientSnapshot(2L, 0L, 1L, 0L).get();
+    final var newerTransientSnapshot =
+        snapshotStore.newTransientSnapshot(2L, 0L, 1L, 0L, false).get();
     newerTransientSnapshot.take(this::writeSnapshot);
 
     // when
-    final var newSnapshot = snapshotStore.newTransientSnapshot(1L, 0L, 1L, 0L).get();
+    final var newSnapshot = snapshotStore.newTransientSnapshot(1L, 0L, 1L, 0L, false).get();
     newSnapshot.take(this::writeSnapshot);
     newSnapshot.persist().join();
 
@@ -188,7 +189,7 @@ public class FileBasedTransientSnapshotTest {
   @Test
   public void shouldRemoveTransientDirectoryOnTakeException() {
     // given
-    final var snapshot = snapshotStore.newTransientSnapshot(1L, 0L, 1L, 0L).get();
+    final var snapshot = snapshotStore.newTransientSnapshot(1L, 0L, 1L, 0L, false).get();
 
     // when
     final var didTakeSnapshot =
@@ -204,7 +205,7 @@ public class FileBasedTransientSnapshotTest {
 
   @Test
   public void shouldNotPersistNonExistentTransientSnapshot() {
-    final var transientSnapshot = snapshotStore.newTransientSnapshot(1L, 0L, 2L, 3L).get();
+    final var transientSnapshot = snapshotStore.newTransientSnapshot(1L, 0L, 2L, 3L, false).get();
     transientSnapshot.take(p -> {});
 
     // when
@@ -218,7 +219,7 @@ public class FileBasedTransientSnapshotTest {
 
   @Test
   public void shouldNotPersistEmptyTransientSnapshot() {
-    final var transientSnapshot = snapshotStore.newTransientSnapshot(1L, 0L, 2L, 3L).get();
+    final var transientSnapshot = snapshotStore.newTransientSnapshot(1L, 0L, 2L, 3L, false).get();
     transientSnapshot.take(p -> p.toFile().mkdir());
 
     // when
@@ -233,7 +234,7 @@ public class FileBasedTransientSnapshotTest {
   @Test
   public void shouldPersistIdempotently() {
     // given
-    final var transientSnapshot = snapshotStore.newTransientSnapshot(1L, 2L, 3, 4).get();
+    final var transientSnapshot = snapshotStore.newTransientSnapshot(1L, 2L, 3, 4, false).get();
     transientSnapshot.take(this::writeSnapshot).join();
     final var firstSnapshot = (FileBasedSnapshot) transientSnapshot.persist().join();
 
@@ -254,7 +255,7 @@ public class FileBasedTransientSnapshotTest {
   @Test
   public void shouldAddMetadataToPersistedSnapshot() {
     // given
-    final var transientSnapshot = snapshotStore.newTransientSnapshot(1L, 2L, 3, 4).get();
+    final var transientSnapshot = snapshotStore.newTransientSnapshot(1L, 2L, 3, 4, false).get();
     transientSnapshot.take(this::writeSnapshot).join();
     // when
     final var persistedSnapshot =
@@ -274,7 +275,7 @@ public class FileBasedTransientSnapshotTest {
   @Test
   public void shouldPersistMetadata() {
     // given
-    final var transientSnapshot = snapshotStore.newTransientSnapshot(1L, 2L, 3, 4).get();
+    final var transientSnapshot = snapshotStore.newTransientSnapshot(1L, 2L, 3, 4, false).get();
     transientSnapshot.take(this::writeSnapshot).join();
 
     // when

--- a/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/testing/TestFileBasedSnapshotStore.java
+++ b/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/testing/TestFileBasedSnapshotStore.java
@@ -123,7 +123,7 @@ public class TestFileBasedSnapshotStore implements ReceivableSnapshotStore {
             .map(i -> "chunk-" + i)
             .collect(Collectors.toMap(k -> k, v -> String.valueOf(random.nextLong())));
     final var transientSnapshot =
-        snapshotStore.newTransientSnapshot(index, term, index, index).get();
+        snapshotStore.newTransientSnapshot(index, term, index, index, false).get();
     transientSnapshot.take(p -> writeSnapshot(p, chunks)).join();
     transientSnapshot.persist().join();
   }

--- a/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/transfer/SnapshotTransferTest.java
+++ b/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/transfer/SnapshotTransferTest.java
@@ -110,7 +110,7 @@ public class SnapshotTransferTest {
         .succeedsWithin(Duration.ofSeconds(30))
         .satisfies(
             snapshot -> {
-              assertThat(snapshot.getId()).isEqualTo("1-1-0-0-0");
+              assertThat(snapshot.getId()).startsWith("1-1-0-0-0-");
               assertThat(snapshot.getMetadata())
                   .isEqualTo(FileBasedSnapshotMetadata.forBootstrap(1));
               assertThat(snapshot.isBootstrap()).isTrue();


### PR DESCRIPTION
To allow us taking new snapshots when positions didn't change yet, for example after running data migrations, we change the snapshot procedure:

A transient snapshot is taken with a snapshot id without the checksum id and in a temporary folder. Once the snapshot is complete and we have calculated the checksums, we derive a new combined checksum and update the snapshot id. We then move the snapshot atomically to the correct snapshot directory.

Any orphaned transient snapshots will be deleted on startup because they do not fit the expected directory names.

closes #31102
