### PR TITLE
Only allow the restore profile in the restore app.

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/restore/RestoreApp.java
+++ b/dist/src/main/java/io/camunda/zeebe/restore/RestoreApp.java
@@ -67,7 +67,10 @@ public class RestoreApp implements ApplicationRunner {
             .build();
 
     final String activeProfiles = System.getProperty("spring.profiles.active");
-    if (!Objects.equals(activeProfiles, Profile.RESTORE.getId())) {
+    final String springProfilesActive = System.getenv("SPRING_PROFILES_ACTIVE");
+    if (!Objects.equals(activeProfiles, Profile.RESTORE.getId())
+        || (springProfilesActive != null
+            && !springProfilesActive.equals(Profile.RESTORE.getId()))) {
       LOG.warn(
           "Additional profiles besides restore are set, which is not supported: {}. "
               + "The application will run only with the restore profile.",

--- a/dist/src/main/java/io/camunda/zeebe/restore/RestoreApp.java
+++ b/dist/src/main/java/io/camunda/zeebe/restore/RestoreApp.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.backup.api.BackupStore;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.io.IOException;
+import java.util.Objects;
 import java.util.concurrent.ExecutionException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -64,6 +65,15 @@ public class RestoreApp implements ApplicationRunner {
             .sources(RestoreApp.class)
             .profiles(Profile.RESTORE.getId())
             .build();
+
+    final String activeProfiles = System.getProperty("spring.profiles.active");
+    if (!Objects.equals(activeProfiles, Profile.RESTORE.getId())) {
+      LOG.warn(
+          "Additional profiles besides restore are set, which is not supported: {}. "
+              + "The application will run only with the restore profile.",
+          activeProfiles);
+      System.setProperty("spring.profiles.active", Profile.RESTORE.getId());
+    }
 
     application.run(args);
   }


### PR DESCRIPTION
## Description

This PR fixes the issue of several profiles being set while running the restore app. 

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes https://github.com/camunda/camunda/issues/35022
