### PR TITLE
fix: check if members exist with anonymous authentication

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/filters/AdminUserCheckFilter.java
+++ b/authentication/src/main/java/io/camunda/authentication/filters/AdminUserCheckFilter.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.authentication.filters;
 
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.service.RoleServices;
 import io.camunda.zeebe.protocol.record.value.DefaultRole;
@@ -67,7 +68,9 @@ public class AdminUserCheckFilter extends OncePerRequestFilter {
     }
 
     try {
-      if (!roleServices.hasMembersOfType(ADMIN_ROLE_ID, EntityType.USER)) {
+      if (!roleServices
+          .withAuthentication(CamundaAuthentication.anonymous())
+          .hasMembersOfType(ADMIN_ROLE_ID, EntityType.USER)) {
         LOG.debug("No user with admin role exists. Redirecting to identity setup page.");
         final var redirectUrl = String.format("%s%s", request.getContextPath(), REDIRECT_PATH);
         response.sendRedirect(redirectUrl);

--- a/authentication/src/test/java/io/camunda/authentication/filters/AdminUserCheckFilterTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/filters/AdminUserCheckFilterTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.service.RoleServices;
 import jakarta.servlet.FilterChain;
@@ -42,6 +43,8 @@ class AdminUserCheckFilterTest {
     // given
     final var securityConfig = new SecurityConfiguration();
     securityConfig.getAuthentication().setUnprotectedApi(false);
+    when(roleServices.withAuthentication(any(CamundaAuthentication.class)))
+        .thenReturn(roleServices);
     when(roleServices.hasMembersOfType(any(), any())).thenReturn(false);
     when(request.getContextPath()).thenReturn("localhost:8080");
     final AdminUserCheckFilter adminUserCheckFilter =
@@ -78,6 +81,8 @@ class AdminUserCheckFilterTest {
     // given
     final var securityConfig = new SecurityConfiguration();
     securityConfig.getAuthentication().setUnprotectedApi(false);
+    when(roleServices.withAuthentication(any(CamundaAuthentication.class)))
+        .thenReturn(roleServices);
     when(roleServices.hasMembersOfType(any(), any())).thenReturn(true);
     final AdminUserCheckFilter adminUserCheckFilter =
         new AdminUserCheckFilter(securityConfig, roleServices);


### PR DESCRIPTION
## Description

Ensure to pass an anonymous authentication when checking if a member exists.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
