### PR TITLE
test: await start forms to be exported to secondary storage

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessDefinitionSearchMultiTenantsTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessDefinitionSearchMultiTenantsTest.java
@@ -11,6 +11,7 @@ import static io.camunda.it.util.TestHelper.createTenant;
 import static io.camunda.it.util.TestHelper.deployResource;
 import static io.camunda.it.util.TestHelper.deployResourceForTenant;
 import static io.camunda.it.util.TestHelper.waitForProcessesToBeDeployed;
+import static io.camunda.it.util.TestHelper.waitForStartFormsBeingExported;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.client.CamundaClient;
@@ -48,6 +49,7 @@ public class ProcessDefinitionSearchMultiTenantsTest {
   private static final String TENANT_ID_1 = "tenant1";
   private static final String USERNAME_1 = "user1";
   private static final String PROCESS_DEFINITION_WITH_START_FORM_ID = "Process_11hxie4";
+  private static final String FORM_ID = "test";
 
   private static final List<ProcessDefinitionTestContext> PROCESSES_IN_DEFAULT_TENANT =
       List.of(
@@ -105,6 +107,8 @@ public class ProcessDefinitionSearchMultiTenantsTest {
 
     waitForProcessesToBeDeployed(
         adminClient, PROCESSES_IN_DEFAULT_TENANT.size() + PROCESSES_IN_TENANT_1.size());
+    waitForStartFormsBeingExported(
+        camundaClient, PROCESS_DEFINITION_WITH_START_FORM_ID, FORM_ID, 2L);
   }
 
   @Test

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessDefinitionSearchTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessDefinitionSearchTest.java
@@ -9,6 +9,7 @@ package io.camunda.it.client;
 
 import static io.camunda.it.util.TestHelper.deployResource;
 import static io.camunda.it.util.TestHelper.waitForProcessesToBeDeployed;
+import static io.camunda.it.util.TestHelper.waitForStartFormsBeingExported;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 
@@ -35,6 +36,8 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 @MultiDbTest
 public class ProcessDefinitionSearchTest {
+  private static final String PROCESS_ID_WITH_START_FORM = "Process_11hxie4";
+  private static final String FORM_ID = "test";
   private static final List<Process> DEPLOYED_PROCESSES = new ArrayList<>();
   private static final List<ProcessDefinitionTestContext> PROCESSES_IN_DEFAULT_TENANT =
       List.of(
@@ -70,6 +73,7 @@ public class ProcessDefinitionSearchTest {
                 deployResource(camundaClient, process.resourceName()).getProcesses()));
 
     waitForProcessesToBeDeployed(camundaClient, PROCESSES_IN_DEFAULT_TENANT.size());
+    waitForStartFormsBeingExported(camundaClient, PROCESS_ID_WITH_START_FORM, FORM_ID, 2L);
   }
 
   @Test

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/util/TestHelper.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/util/TestHelper.java
@@ -506,6 +506,35 @@ public final class TestHelper {
             });
   }
 
+  public static void waitForStartFormsBeingExported(
+      final CamundaClient camundaClient,
+      final String processDefinitionId,
+      final String expectedFormId,
+      final long expectedFormVersion) {
+    Awaitility.await("should export start forms to secondary storage")
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .ignoreExceptions() // Ignore exceptions and continue retrying
+        .untilAsserted(
+            () -> {
+              final var processDefinitionKey =
+                  camundaClient
+                      .newProcessDefinitionSearchRequest()
+                      .filter(f -> f.processDefinitionId(processDefinitionId))
+                      .send()
+                      .join()
+                      .items()
+                      .getFirst()
+                      .getProcessDefinitionKey();
+              final var form =
+                  camundaClient
+                      .newProcessDefinitionGetFormRequest(processDefinitionKey)
+                      .send()
+                      .join();
+              assertThat(form.getFormId()).isEqualTo(expectedFormId);
+              assertThat(form.getVersion()).isEqualTo(expectedFormVersion);
+            });
+  }
+
   public static void waitForProcessesToBeDeployed(
       final CamundaClient camundaClient,
       final Consumer<ProcessDefinitionFilter> filter,


### PR DESCRIPTION
## Description

Resolves flaky tests that require forms to be present.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
