### PR TITLE
Increase Timeout for Flaky Tasklist Test 

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/task-details.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/task-details.spec.ts
@@ -299,7 +299,7 @@ test.describe('task details page', () => {
     await taskDetailsPage.completeTaskButton.click();
 
     await expect(taskDetailsPage.taskCompletedBanner).toBeVisible({
-      timeout: 40000,
+      timeout: 60000,
     });
     await taskPanelPage.filterBy('Completed');
     await taskPanelPage.assertCompletedHeadingVisible();


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

On the nightly test run, the `task completion with deployed form` test has become flaky. An increase in the timeout has been added to fix this flaky test behaviour. 

A successful test run can be seen [here](https://github.com/camunda/camunda/actions/runs/16439976452).  Note: tests are failing due to the following bugs:
https://github.com/camunda/camunda/issues/35443
https://github.com/camunda/camunda/issues/34148

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

