### PR TITLE
deps: update optimize to use elastisearch 8.16.6 Java client

### DIFF
--- a/optimize/backend/src/it/java/io/camunda/optimize/test/it/extension/db/ElasticsearchDatabaseTestService.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/test/it/extension/db/ElasticsearchDatabaseTestService.java
@@ -413,12 +413,7 @@ public class ElasticsearchDatabaseTestService extends DatabaseTestService {
                       u.index(zeebeRecordPrefix + "_" + indexName + "*")
                           .refresh(true)
                           .script(
-                              Script.of(
-                                  s ->
-                                      s.inline(
-                                          i ->
-                                              i.lang(ScriptLanguage.Painless)
-                                                  .source(updateScript))))
+                              Script.of(s -> s.lang(ScriptLanguage.Painless).source(updateScript)))
                           .query(Query.of(q -> q.matchAll(m -> m)))));
     } catch (final IOException e) {
       throw new OptimizeRuntimeException(e);
@@ -440,12 +435,7 @@ public class ElasticsearchDatabaseTestService extends DatabaseTestService {
                       u.index(zeebeRecordPrefix + "_" + indexName + "*")
                           .refresh(true)
                           .script(
-                              Script.of(
-                                  s ->
-                                      s.inline(
-                                          i ->
-                                              i.lang(ScriptLanguage.Painless)
-                                                  .source(updateScript))))
+                              Script.of(s -> s.lang(ScriptLanguage.Painless).source(updateScript)))
                           .query(
                               Query.of(
                                   q ->
@@ -478,12 +468,7 @@ public class ElasticsearchDatabaseTestService extends DatabaseTestService {
                       u.index(zeebeRecordPrefix + "_" + ZEEBE_PROCESS_INSTANCE_INDEX_NAME + "*")
                           .refresh(true)
                           .script(
-                              Script.of(
-                                  s ->
-                                      s.inline(
-                                          i ->
-                                              i.lang(ScriptLanguage.Painless)
-                                                  .source(updateScript))))
+                              Script.of(s -> s.lang(ScriptLanguage.Painless).source(updateScript)))
                           .query(
                               Query.of(
                                   q ->
@@ -521,12 +506,7 @@ public class ElasticsearchDatabaseTestService extends DatabaseTestService {
                               getProcessInstanceIndexAliasName(processDefinitionKey))
                           .id(processInstanceId)
                           .script(
-                              Script.of(
-                                  s ->
-                                      s.inline(
-                                          i ->
-                                              i.lang(ScriptLanguage.Painless)
-                                                  .source(updateScript))))
+                              Script.of(s -> s.lang(ScriptLanguage.Painless).source(updateScript)))
                           .retryOnConflict(NUMBER_OF_RETRIES_ON_CONFLICT)),
               Object.class);
     } catch (final IOException e) {
@@ -854,16 +834,13 @@ public class ElasticsearchDatabaseTestService extends DatabaseTestService {
             .script(
                 Script.of(
                     s ->
-                        s.inline(
-                            i ->
-                                i.lang(ScriptLanguage.Painless)
-                                    .source(scriptData.scriptString())
-                                    .params(
-                                        scriptData.params().entrySet().stream()
-                                            .collect(
-                                                Collectors.toMap(
-                                                    Map.Entry::getKey,
-                                                    e -> JsonData.of(e.getValue())))))))
+                        s.lang(ScriptLanguage.Painless)
+                            .source(scriptData.scriptString())
+                            .params(
+                                scriptData.params().entrySet().stream()
+                                    .collect(
+                                        Collectors.toMap(
+                                            Map.Entry::getKey, e -> JsonData.of(e.getValue()))))))
             .refresh(true);
 
     try {
@@ -894,16 +871,13 @@ public class ElasticsearchDatabaseTestService extends DatabaseTestService {
             .script(
                 Script.of(
                     s ->
-                        s.inline(
-                            i ->
-                                i.lang(ScriptLanguage.Painless)
-                                    .source(script.scriptString())
-                                    .params(
-                                        script.params().entrySet().stream()
-                                            .collect(
-                                                Collectors.toMap(
-                                                    Map.Entry::getKey,
-                                                    e -> JsonData.of(e.getValue())))))))
+                        s.lang(ScriptLanguage.Painless)
+                            .source(script.scriptString())
+                            .params(
+                                script.params().entrySet().stream()
+                                    .collect(
+                                        Collectors.toMap(
+                                            Map.Entry::getKey, e -> JsonData.of(e.getValue()))))))
             .refresh(true);
 
     try {

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/filter/AbstractProcessVariableQueryFilterES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/filter/AbstractProcessVariableQueryFilterES.java
@@ -24,7 +24,6 @@ import co.elastic.clients.elasticsearch._types.FieldValue;
 import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
 import co.elastic.clients.elasticsearch._types.query_dsl.ChildScoreMode;
 import co.elastic.clients.elasticsearch._types.query_dsl.Query;
-import co.elastic.clients.json.JsonData;
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.OperatorMultipleValuesFilterDataDto;
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.variable.BooleanVariableFilterDataDto;
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.variable.DateVariableFilterDataDto;
@@ -152,28 +151,6 @@ public abstract class AbstractProcessVariableQueryFilterES extends AbstractVaria
     return queryBuilder;
   }
 
-  private static Query.Builder getBuilder(final String valueToContain) {
-    final String lowerCaseValue = valueToContain.toLowerCase(Locale.ENGLISH);
-
-    final Query.Builder filter = new Query.Builder();
-    if (lowerCaseValue.length() > MAX_GRAM) {
-      /*
-        using the slow wildcard query for uncommonly large filter strings (> 10 chars)
-      */
-      filter.wildcard(
-          w ->
-              w.field(getValueSearchField(LOWERCASE_FIELD))
-                  .wildcard(buildWildcardQuery(lowerCaseValue)));
-    } else {
-      /*
-        using Elasticsearch ngrams to filter for strings < 10 chars,
-        because it's fast but increasing the number of chars makes the index bigger
-      */
-      filter.term(t -> t.field(getValueSearchField(N_GRAM_FIELD)).value(lowerCaseValue));
-    }
-    return filter;
-  }
-
   @Override
   protected Query.Builder createEqualsOneOrMoreValuesQueryBuilder(
       final OperatorMultipleValuesVariableFilterDataDto dto) {
@@ -197,63 +174,6 @@ public abstract class AbstractProcessVariableQueryFilterES extends AbstractVaria
 
     return createEqualsOneOrMoreValuesFilterQuery(
         dto.getName(), dto.getType(), dto.getData().getValues());
-  }
-
-  private Query.Builder createEqualsOneOrMoreValuesFilterQuery(
-      final String variableName, final VariableType variableType, final List<?> values) {
-    final Query.Builder builder = new Query.Builder();
-    final BoolQuery.Builder variableFilterBuilder = new BoolQuery.Builder().minimumShouldMatch("1");
-    final String nestedVariableNameFieldLabel = getNestedVariableNameField();
-    final String nestedVariableValueFieldLabel = getVariableValueFieldForType(variableType);
-
-    final List<?> nonNullValues = values.stream().filter(Objects::nonNull).toList();
-
-    if (!nonNullValues.isEmpty()) {
-      variableFilterBuilder.should(
-          s ->
-              s.nested(
-                  n ->
-                      n.path(VARIABLES)
-                          .query(
-                              q ->
-                                  q.bool(
-                                      b ->
-                                          b.must(
-                                                  m ->
-                                                      m.term(
-                                                          t ->
-                                                              t.field(nestedVariableNameFieldLabel)
-                                                                  .value(variableName)))
-                                              .must(
-                                                  m ->
-                                                      m.term(
-                                                          t ->
-                                                              t.field(getNestedVariableTypeField())
-                                                                  .value(variableType.getId())))
-                                              .must(
-                                                  m ->
-                                                      m.terms(
-                                                          t ->
-                                                              t.field(nestedVariableValueFieldLabel)
-                                                                  .terms(
-                                                                      tt ->
-                                                                          tt.value(
-                                                                              nonNullValues.stream()
-                                                                                  .map(
-                                                                                      FieldValue
-                                                                                          ::of)
-                                                                                  .toList()))))))));
-    }
-
-    final boolean hasNullValues = nonNullValues.size() < values.size();
-    if (hasNullValues) {
-      variableFilterBuilder.should(
-          s ->
-              s.bool(
-                  createFilterForUndefinedOrNullQueryBuilder(variableName, variableType).build()));
-    }
-    builder.bool(variableFilterBuilder.build());
-    return builder;
   }
 
   @Override
@@ -286,8 +206,10 @@ public abstract class AbstractProcessVariableQueryFilterES extends AbstractVaria
                                         m ->
                                             m.range(
                                                 r ->
-                                                    r.field(nestedVariableValueFieldLabel)
-                                                        .lt(JsonData.of(value))))
+                                                    r.number(
+                                                        nf ->
+                                                            nf.field(nestedVariableValueFieldLabel)
+                                                                .lt(convertToDouble(value)))))
                                     .build())));
         break;
       case GREATER_THAN:
@@ -302,8 +224,10 @@ public abstract class AbstractProcessVariableQueryFilterES extends AbstractVaria
                                         m ->
                                             m.range(
                                                 r ->
-                                                    r.field(nestedVariableValueFieldLabel)
-                                                        .gt(JsonData.of(value))))
+                                                    r.number(
+                                                        nf ->
+                                                            nf.field(nestedVariableValueFieldLabel)
+                                                                .gt(convertToDouble(value)))))
                                     .build())));
         break;
       case LESS_THAN_EQUALS:
@@ -318,8 +242,10 @@ public abstract class AbstractProcessVariableQueryFilterES extends AbstractVaria
                                         m ->
                                             m.range(
                                                 r ->
-                                                    r.field(nestedVariableValueFieldLabel)
-                                                        .lte(JsonData.of(value))))
+                                                    r.number(
+                                                        nf ->
+                                                            nf.field(nestedVariableValueFieldLabel)
+                                                                .lte(convertToDouble(value)))))
                                     .build())));
         break;
       case GREATER_THAN_EQUALS:
@@ -334,8 +260,10 @@ public abstract class AbstractProcessVariableQueryFilterES extends AbstractVaria
                                         m ->
                                             m.range(
                                                 r ->
-                                                    r.field(nestedVariableValueFieldLabel)
-                                                        .gte(JsonData.of(value))))
+                                                    r.number(
+                                                        nf ->
+                                                            nf.field(nestedVariableValueFieldLabel)
+                                                                .gte(convertToDouble(value)))))
                                     .build())));
         break;
       default:
@@ -401,6 +329,85 @@ public abstract class AbstractProcessVariableQueryFilterES extends AbstractVaria
     return dateFilterBuilder;
   }
 
+  private static Query.Builder getBuilder(final String valueToContain) {
+    final String lowerCaseValue = valueToContain.toLowerCase(Locale.ENGLISH);
+
+    final Query.Builder filter = new Query.Builder();
+    if (lowerCaseValue.length() > MAX_GRAM) {
+      /*
+        using the slow wildcard query for uncommonly large filter strings (> 10 chars)
+      */
+      filter.wildcard(
+          w ->
+              w.field(getValueSearchField(LOWERCASE_FIELD))
+                  .wildcard(buildWildcardQuery(lowerCaseValue)));
+    } else {
+      /*
+        using Elasticsearch ngrams to filter for strings < 10 chars,
+        because it's fast but increasing the number of chars makes the index bigger
+      */
+      filter.term(t -> t.field(getValueSearchField(N_GRAM_FIELD)).value(lowerCaseValue));
+    }
+    return filter;
+  }
+
+  private Query.Builder createEqualsOneOrMoreValuesFilterQuery(
+      final String variableName, final VariableType variableType, final List<?> values) {
+    final Query.Builder builder = new Query.Builder();
+    final BoolQuery.Builder variableFilterBuilder = new BoolQuery.Builder().minimumShouldMatch("1");
+    final String nestedVariableNameFieldLabel = getNestedVariableNameField();
+    final String nestedVariableValueFieldLabel = getVariableValueFieldForType(variableType);
+
+    final List<?> nonNullValues = values.stream().filter(Objects::nonNull).toList();
+
+    if (!nonNullValues.isEmpty()) {
+      variableFilterBuilder.should(
+          s ->
+              s.nested(
+                  n ->
+                      n.path(VARIABLES)
+                          .query(
+                              q ->
+                                  q.bool(
+                                      b ->
+                                          b.must(
+                                                  m ->
+                                                      m.term(
+                                                          t ->
+                                                              t.field(nestedVariableNameFieldLabel)
+                                                                  .value(variableName)))
+                                              .must(
+                                                  m ->
+                                                      m.term(
+                                                          t ->
+                                                              t.field(getNestedVariableTypeField())
+                                                                  .value(variableType.getId())))
+                                              .must(
+                                                  m ->
+                                                      m.terms(
+                                                          t ->
+                                                              t.field(nestedVariableValueFieldLabel)
+                                                                  .terms(
+                                                                      tt ->
+                                                                          tt.value(
+                                                                              nonNullValues.stream()
+                                                                                  .map(
+                                                                                      FieldValue
+                                                                                          ::of)
+                                                                                  .toList()))))))));
+    }
+
+    final boolean hasNullValues = nonNullValues.size() < values.size();
+    if (hasNullValues) {
+      variableFilterBuilder.should(
+          s ->
+              s.bool(
+                  createFilterForUndefinedOrNullQueryBuilder(variableName, variableType).build()));
+    }
+    builder.bool(variableFilterBuilder.build());
+    return builder;
+  }
+
   private String getVariableValueFieldForType(final VariableType type) {
     return getNestedVariableValueFieldForType(type);
   }
@@ -414,5 +421,9 @@ public abstract class AbstractProcessVariableQueryFilterES extends AbstractVaria
   private BoolQuery.Builder createExcludeUndefinedOrNullQueryBuilder(
       final String variableName, final VariableType variableType) {
     return createExcludeUndefinedOrNullQueryFilterBuilder(variableName, variableType);
+  }
+
+  private static Double convertToDouble(final Object value) {
+    return value == null ? null : ((Number) value).doubleValue();
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/filter/DecisionVariableQueryFilterES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/filter/DecisionVariableQueryFilterES.java
@@ -20,7 +20,6 @@ import co.elastic.clients.elasticsearch._types.FieldValue;
 import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
 import co.elastic.clients.elasticsearch._types.query_dsl.ChildScoreMode;
 import co.elastic.clients.elasticsearch._types.query_dsl.Query;
-import co.elastic.clients.json.JsonData;
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.OperatorMultipleValuesFilterDataDto;
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.variable.BooleanVariableFilterDataDto;
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.variable.DateVariableFilterDataDto;
@@ -208,6 +207,164 @@ public abstract class DecisionVariableQueryFilterES extends AbstractVariableQuer
         getVariableId(dto), dto.getType(), dto.getData().getValues());
   }
 
+  @Override
+  protected Query.Builder createNumericQueryBuilder(
+      final OperatorMultipleValuesVariableFilterDataDto dto) {
+    OperatorMultipleValuesVariableFilterDataDtoUtil.validateMultipleValuesFilterDataDto(dto);
+
+    final String nestedVariableValueFieldLabel = getVariableValueFieldForType(dto.getType());
+    final OperatorMultipleValuesFilterDataDto data = dto.getData();
+
+    final Query.Builder builder = new Query.Builder();
+    final Supplier<BoolQuery.Builder> supplier =
+        () ->
+            new BoolQuery.Builder()
+                .must(m -> m.term(t -> t.field(getVariableIdField()).value(getVariableId(dto))));
+    if (data.getValues().isEmpty()) {
+      logger.warn(
+          "Could not filter for variables! No values provided for operator [{}] and type [{}]. Ignoring filter.",
+          data.getOperator(),
+          dto.getType());
+      builder.bool(supplier.get().build());
+      return builder;
+    }
+
+    final Object value = OperatorMultipleValuesVariableFilterDataDtoUtil.retrieveValue(dto);
+    switch (data.getOperator()) {
+      case IN:
+      case NOT_IN:
+        return createEqualsOneOrMoreValuesQueryBuilder(dto);
+      case LESS_THAN:
+        builder.nested(
+            n ->
+                n.path(getVariablePath())
+                    .scoreMode(ChildScoreMode.None)
+                    .query(
+                        q ->
+                            q.bool(
+                                supplier
+                                    .get()
+                                    .must(
+                                        m ->
+                                            m.range(
+                                                r ->
+                                                    r.number(
+                                                        nf ->
+                                                            nf.field(nestedVariableValueFieldLabel)
+                                                                .lt(convertToDouble(value)))))
+                                    .build())));
+        break;
+      case GREATER_THAN:
+        builder.nested(
+            n ->
+                n.path(getVariablePath())
+                    .scoreMode(ChildScoreMode.None)
+                    .query(
+                        q ->
+                            q.bool(
+                                supplier
+                                    .get()
+                                    .must(
+                                        m ->
+                                            m.range(
+                                                r ->
+                                                    r.number(
+                                                        nf ->
+                                                            nf.field(nestedVariableValueFieldLabel)
+                                                                .gt(convertToDouble(value)))))
+                                    .build())));
+        break;
+      case LESS_THAN_EQUALS:
+        builder.nested(
+            n ->
+                n.path(getVariablePath())
+                    .scoreMode(ChildScoreMode.None)
+                    .query(
+                        q ->
+                            q.bool(
+                                supplier
+                                    .get()
+                                    .must(
+                                        m ->
+                                            m.range(
+                                                r ->
+                                                    r.number(
+                                                        nf ->
+                                                            nf.field(nestedVariableValueFieldLabel)
+                                                                .lte(convertToDouble(value)))))
+                                    .build())));
+        break;
+      case GREATER_THAN_EQUALS:
+        builder.nested(
+            n ->
+                n.path(getVariablePath())
+                    .scoreMode(ChildScoreMode.None)
+                    .query(
+                        q ->
+                            q.bool(
+                                supplier
+                                    .get()
+                                    .must(
+                                        m ->
+                                            m.range(
+                                                r ->
+                                                    r.number(
+                                                        nf ->
+                                                            nf.field(nestedVariableValueFieldLabel)
+                                                                .gte(convertToDouble(value)))))
+                                    .build())));
+        break;
+      default:
+        builder.nested(
+            n ->
+                n.path(getVariablePath())
+                    .scoreMode(ChildScoreMode.None)
+                    .query(q -> q.bool(supplier.get().build())));
+        logger.warn(
+            "Could not filter for variables! Operator [{}] is not supported for type [{}]. Ignoring filter.",
+            data.getOperator(),
+            dto.getType());
+    }
+    return builder;
+  }
+
+  @Override
+  protected Query.Builder createDateQueryBuilder(
+      final DateVariableFilterDataDto dto, final ZoneId timezone) {
+    final Query.Builder builder = new Query.Builder();
+    builder.bool(
+        b -> {
+          b.minimumShouldMatch("1");
+          if (dto.getData().isIncludeUndefined()) {
+            b.should(createFilterForUndefinedOrNullQueryBuilder(getVariableId(dto)).build());
+          } else if (dto.getData().isExcludeUndefined()) {
+            b.should(createExcludeUndefinedOrNullQueryBuilder(getVariableId(dto)).build());
+          }
+
+          final BoolQuery.Builder dateValueFilterQuery =
+              new BoolQuery.Builder()
+                  .must(m -> m.term(t -> t.field(getVariableIdField()).value(getVariableId(dto))));
+          DateFilterQueryUtilES.addFilters(
+              dateValueFilterQuery,
+              Collections.singletonList(dto.getData()),
+              getVariableValueFieldForType(dto.getType()),
+              timezone);
+          final BoolQuery build = dateValueFilterQuery.build();
+          if (!build.filter().isEmpty()) {
+            b.should(
+                s ->
+                    s.nested(
+                        n ->
+                            n.path(getVariablePath())
+                                .query(q -> q.bool(build))
+                                .scoreMode(ChildScoreMode.None)));
+          }
+          return b;
+        });
+
+    return builder;
+  }
+
   private Query.Builder createMultiValueVariableFilterQuery(
       final String variableId, final VariableType variableType, final List<?> values) {
     final Query.Builder builder = new Query.Builder();
@@ -255,156 +412,6 @@ public abstract class DecisionVariableQueryFilterES extends AbstractVariableQuer
 
           if (nonNullValues.size() < values.size()) {
             b.should(createFilterForUndefinedOrNullQueryBuilder(variableId).build());
-          }
-          return b;
-        });
-
-    return builder;
-  }
-
-  @Override
-  protected Query.Builder createNumericQueryBuilder(
-      final OperatorMultipleValuesVariableFilterDataDto dto) {
-    OperatorMultipleValuesVariableFilterDataDtoUtil.validateMultipleValuesFilterDataDto(dto);
-
-    final String nestedVariableValueFieldLabel = getVariableValueFieldForType(dto.getType());
-    final OperatorMultipleValuesFilterDataDto data = dto.getData();
-
-    final Query.Builder builder = new Query.Builder();
-    final Supplier<BoolQuery.Builder> supplier =
-        () ->
-            new BoolQuery.Builder()
-                .must(m -> m.term(t -> t.field(getVariableIdField()).value(getVariableId(dto))));
-    if (data.getValues().isEmpty()) {
-      logger.warn(
-          "Could not filter for variables! No values provided for operator [{}] and type [{}]. Ignoring filter.",
-          data.getOperator(),
-          dto.getType());
-      builder.bool(supplier.get().build());
-      return builder;
-    }
-
-    final Object value = OperatorMultipleValuesVariableFilterDataDtoUtil.retrieveValue(dto);
-    switch (data.getOperator()) {
-      case IN:
-      case NOT_IN:
-        return createEqualsOneOrMoreValuesQueryBuilder(dto);
-      case LESS_THAN:
-        builder.nested(
-            n ->
-                n.path(getVariablePath())
-                    .scoreMode(ChildScoreMode.None)
-                    .query(
-                        q ->
-                            q.bool(
-                                supplier
-                                    .get()
-                                    .must(
-                                        m ->
-                                            m.range(
-                                                r ->
-                                                    r.field(nestedVariableValueFieldLabel)
-                                                        .lt(JsonData.of(value))))
-                                    .build())));
-        break;
-      case GREATER_THAN:
-        builder.nested(
-            n ->
-                n.path(getVariablePath())
-                    .scoreMode(ChildScoreMode.None)
-                    .query(
-                        q ->
-                            q.bool(
-                                supplier
-                                    .get()
-                                    .must(
-                                        m ->
-                                            m.range(
-                                                r ->
-                                                    r.field(nestedVariableValueFieldLabel)
-                                                        .gt(JsonData.of(value))))
-                                    .build())));
-        break;
-      case LESS_THAN_EQUALS:
-        builder.nested(
-            n ->
-                n.path(getVariablePath())
-                    .scoreMode(ChildScoreMode.None)
-                    .query(
-                        q ->
-                            q.bool(
-                                supplier
-                                    .get()
-                                    .must(
-                                        m ->
-                                            m.range(
-                                                r ->
-                                                    r.field(nestedVariableValueFieldLabel)
-                                                        .lte(JsonData.of(value))))
-                                    .build())));
-        break;
-      case GREATER_THAN_EQUALS:
-        builder.nested(
-            n ->
-                n.path(getVariablePath())
-                    .scoreMode(ChildScoreMode.None)
-                    .query(
-                        q ->
-                            q.bool(
-                                supplier
-                                    .get()
-                                    .must(
-                                        m ->
-                                            m.range(
-                                                r ->
-                                                    r.field(nestedVariableValueFieldLabel)
-                                                        .gte(JsonData.of(value))))
-                                    .build())));
-        break;
-      default:
-        builder.nested(
-            n ->
-                n.path(getVariablePath())
-                    .scoreMode(ChildScoreMode.None)
-                    .query(q -> q.bool(supplier.get().build())));
-        logger.warn(
-            "Could not filter for variables! Operator [{}] is not supported for type [{}]. Ignoring filter.",
-            data.getOperator(),
-            dto.getType());
-    }
-    return builder;
-  }
-
-  @Override
-  protected Query.Builder createDateQueryBuilder(
-      final DateVariableFilterDataDto dto, final ZoneId timezone) {
-    final Query.Builder builder = new Query.Builder();
-    builder.bool(
-        b -> {
-          b.minimumShouldMatch("1");
-          if (dto.getData().isIncludeUndefined()) {
-            b.should(createFilterForUndefinedOrNullQueryBuilder(getVariableId(dto)).build());
-          } else if (dto.getData().isExcludeUndefined()) {
-            b.should(createExcludeUndefinedOrNullQueryBuilder(getVariableId(dto)).build());
-          }
-
-          final BoolQuery.Builder dateValueFilterQuery =
-              new BoolQuery.Builder()
-                  .must(m -> m.term(t -> t.field(getVariableIdField()).value(getVariableId(dto))));
-          DateFilterQueryUtilES.addFilters(
-              dateValueFilterQuery,
-              Collections.singletonList(dto.getData()),
-              getVariableValueFieldForType(dto.getType()),
-              timezone);
-          final BoolQuery build = dateValueFilterQuery.build();
-          if (!build.filter().isEmpty()) {
-            b.should(
-                s ->
-                    s.nested(
-                        n ->
-                            n.path(getVariablePath())
-                                .query(q -> q.bool(build))
-                                .scoreMode(ChildScoreMode.None)));
           }
           return b;
         });
@@ -509,5 +516,9 @@ public abstract class DecisionVariableQueryFilterES extends AbstractVariableQuer
 
   private String getVariableIdField() {
     return DecisionVariableHelper.getVariableClauseIdField(getVariablePath());
+  }
+
+  private static Double convertToDouble(final Object value) {
+    return value == null ? null : ((Number) value).doubleValue();
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/filter/util/DateHistogramFilterUtilES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/filter/util/DateHistogramFilterUtilES.java
@@ -15,7 +15,6 @@ import co.elastic.clients.elasticsearch._types.aggregations.DateHistogramAggrega
 import co.elastic.clients.elasticsearch._types.aggregations.ExtendedBounds;
 import co.elastic.clients.elasticsearch._types.aggregations.FieldDateMath;
 import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
-import co.elastic.clients.json.JsonData;
 import io.camunda.optimize.dto.optimize.query.report.single.decision.filter.EvaluationDateFilterDto;
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.date.DateFilterDataDto;
 import io.camunda.optimize.dto.optimize.query.report.single.process.filter.InstanceEndDateFilterDto;
@@ -42,10 +41,12 @@ public final class DateHistogramFilterUtilES {
         f ->
             f.range(
                 r ->
-                    r.field(context.getDateField())
-                        .gte(JsonData.of(dateTimeFormatter.format(context.getEarliestDate())))
-                        .lte(JsonData.of(dateTimeFormatter.format(context.getLatestDate())))
-                        .format(OPTIMIZE_DATE_FORMAT)));
+                    r.date(
+                        d ->
+                            d.field(context.getDateField())
+                                .gte(dateTimeFormatter.format(context.getEarliestDate()))
+                                .lte(dateTimeFormatter.format(context.getLatestDate()))
+                                .format(OPTIMIZE_DATE_FORMAT))));
     return queryDate;
   }
 

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/reader/DurationOutliersReaderES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/reader/DurationOutliersReaderES.java
@@ -40,7 +40,6 @@ import co.elastic.clients.elasticsearch._types.query_dsl.ChildScoreMode;
 import co.elastic.clients.elasticsearch._types.query_dsl.TermQuery;
 import co.elastic.clients.elasticsearch.core.SearchRequest;
 import co.elastic.clients.elasticsearch.core.SearchResponse;
-import co.elastic.clients.json.JsonData;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.optimize.dto.optimize.query.analysis.DurationChartEntryDto;
 import io.camunda.optimize.dto.optimize.query.analysis.FindingsDto;
@@ -499,16 +498,20 @@ public class DurationOutliersReaderES implements DurationOutliersReader {
           s ->
               s.range(
                   r ->
-                      r.gt(JsonData.of(outlierParams.getHigherOutlierBound()))
-                          .field(FLOW_NODE_INSTANCES + "." + FLOW_NODE_TOTAL_DURATION)));
+                      r.number(
+                          nf ->
+                              nf.gt(outlierParams.getHigherOutlierBound().doubleValue())
+                                  .field(FLOW_NODE_INSTANCES + "." + FLOW_NODE_TOTAL_DURATION))));
     }
     if (outlierParams.getLowerOutlierBound() != null) {
       flowNodeFilterQuery.should(
           s ->
               s.range(
                   r ->
-                      r.lt(JsonData.of(outlierParams.getLowerOutlierBound()))
-                          .field(FLOW_NODE_INSTANCES + "." + FLOW_NODE_TOTAL_DURATION)));
+                      r.number(
+                          nf ->
+                              nf.lt(outlierParams.getLowerOutlierBound().doubleValue())
+                                  .field(FLOW_NODE_INSTANCES + "." + FLOW_NODE_TOTAL_DURATION))));
     }
     return flowNodeFilterQuery;
   }
@@ -627,16 +630,20 @@ public class DurationOutliersReaderES implements DurationOutliersReader {
           s ->
               s.range(
                   r ->
-                      r.field(FLOW_NODE_INSTANCES + "." + FLOW_NODE_TOTAL_DURATION)
-                          .lte(JsonData.of(outlierParams.getHigherOutlierBound()))));
+                      r.number(
+                          nf ->
+                              nf.field(FLOW_NODE_INSTANCES + "." + FLOW_NODE_TOTAL_DURATION)
+                                  .lte(outlierParams.getHigherOutlierBound().doubleValue()))));
     }
     if (outlierParams.getLowerOutlierBound() != null) {
       flowNodeFilterQuery.should(
           s ->
               s.range(
                   r ->
-                      r.field(FLOW_NODE_INSTANCES + "." + FLOW_NODE_TOTAL_DURATION)
-                          .gte(JsonData.of(outlierParams.getLowerOutlierBound()))));
+                      r.number(
+                          nf ->
+                              nf.field(FLOW_NODE_INSTANCES + "." + FLOW_NODE_TOTAL_DURATION)
+                                  .gte(outlierParams.getLowerOutlierBound().doubleValue()))));
     }
     final Aggregation nestedVariableAggregation =
         Aggregation.of(
@@ -780,13 +787,13 @@ public class DurationOutliersReaderES implements DurationOutliersReader {
                                       f ->
                                           f.range(
                                               r ->
-                                                  r.field(
-                                                          FLOW_NODE_INSTANCES
-                                                              + "."
-                                                              + FLOW_NODE_TOTAL_DURATION)
-                                                      .lte(
-                                                          JsonData.of(
-                                                              finalStdDeviationBoundLower)))));
+                                                  r.number(
+                                                      nf ->
+                                                          nf.field(
+                                                                  FLOW_NODE_INSTANCES
+                                                                      + "."
+                                                                      + FLOW_NODE_TOTAL_DURATION)
+                                                              .lte(finalStdDeviationBoundLower)))));
 
                       final double finalStdDeviationBoundHigher = stdDeviationBoundHigher;
                       final Aggregation higherOutlierEventFilter =
@@ -796,13 +803,14 @@ public class DurationOutliersReaderES implements DurationOutliersReader {
                                       f ->
                                           f.range(
                                               r ->
-                                                  r.field(
-                                                          FLOW_NODE_INSTANCES
-                                                              + "."
-                                                              + FLOW_NODE_TOTAL_DURATION)
-                                                      .gte(
-                                                          JsonData.of(
-                                                              finalStdDeviationBoundHigher)))));
+                                                  r.number(
+                                                      nf ->
+                                                          nf.field(
+                                                                  FLOW_NODE_INSTANCES
+                                                                      + "."
+                                                                      + FLOW_NODE_TOTAL_DURATION)
+                                                              .gte(
+                                                                  finalStdDeviationBoundHigher)))));
 
                       final TermQuery terms =
                           TermQuery.of(

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/report/interpreter/util/ProcessPartQueryUtilES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/report/interpreter/util/ProcessPartQueryUtilES.java
@@ -109,11 +109,9 @@ public final class ProcessPartQueryUtilES extends AbstractProcessPartQueryUtil {
     // @formatter:off
     return Script.of(
         s ->
-            s.inline(
-                i ->
-                    i.source(
-                        ("state.procInstIdToStartDates = new HashMap();"
-                            + "state.procInstIdToEndDates = new HashMap();"))));
+            s.source(
+                ("state.procInstIdToStartDates = new HashMap();"
+                    + "state.procInstIdToEndDates = new HashMap();")));
     // @formatter:on
   }
 
@@ -132,24 +130,22 @@ public final class ProcessPartQueryUtilES extends AbstractProcessPartQueryUtil {
     // @formatter:off
     return Script.of(
         s ->
-            s.inline(
-                i ->
-                    i.source(
-                        substitutor.replace(
-                            "def processInstanceId = doc['${flowNodeProcessInstanceIdField}'].value;"
-                                + "if(doc['${flowNodeIdField}'].value == params.startFlowNodeId && "
-                                + "doc['${flowNodeStartDateField}'].size() != 0 && doc['${flowNodeStartDateField}'].value != null && "
-                                + "doc['${flowNodeStartDateField}'].value.toInstant().toEpochMilli() != 0) {"
-                                + "long startDateInMillis = doc['${flowNodeStartDateField}'].value.toInstant().toEpochMilli();"
-                                + "state.procInstIdToStartDates.putIfAbsent(processInstanceId, new ArrayList());"
-                                + "state.procInstIdToStartDates.get(processInstanceId).add(startDateInMillis);"
-                                + "} else if(doc['${flowNodeIdField}'].value == params.endFlowNodeId && "
-                                + "doc['${flowNodeEndDateField}'].size() != 0 && doc['${flowNodeEndDateField}'].value != null && "
-                                + "doc['${flowNodeEndDateField}'].value.toInstant().toEpochMilli() != 0) {"
-                                + "long endDateInMillis = doc['${flowNodeEndDateField}'].value.toInstant().toEpochMilli();"
-                                + "state.procInstIdToEndDates.putIfAbsent(processInstanceId, new ArrayList());"
-                                + "state.procInstIdToEndDates.get(processInstanceId).add(endDateInMillis);"
-                                + "}"))));
+            s.source(
+                substitutor.replace(
+                    "def processInstanceId = doc['${flowNodeProcessInstanceIdField}'].value;"
+                        + "if(doc['${flowNodeIdField}'].value == params.startFlowNodeId && "
+                        + "doc['${flowNodeStartDateField}'].size() != 0 && doc['${flowNodeStartDateField}'].value != null && "
+                        + "doc['${flowNodeStartDateField}'].value.toInstant().toEpochMilli() != 0) {"
+                        + "long startDateInMillis = doc['${flowNodeStartDateField}'].value.toInstant().toEpochMilli();"
+                        + "state.procInstIdToStartDates.putIfAbsent(processInstanceId, new ArrayList());"
+                        + "state.procInstIdToStartDates.get(processInstanceId).add(startDateInMillis);"
+                        + "} else if(doc['${flowNodeIdField}'].value == params.endFlowNodeId && "
+                        + "doc['${flowNodeEndDateField}'].size() != 0 && doc['${flowNodeEndDateField}'].value != null && "
+                        + "doc['${flowNodeEndDateField}'].value.toInstant().toEpochMilli() != 0) {"
+                        + "long endDateInMillis = doc['${flowNodeEndDateField}'].value.toInstant().toEpochMilli();"
+                        + "state.procInstIdToEndDates.putIfAbsent(processInstanceId, new ArrayList());"
+                        + "state.procInstIdToEndDates.get(processInstanceId).add(endDateInMillis);"
+                        + "}")));
     // @formatter:on
   }
 
@@ -157,37 +153,35 @@ public final class ProcessPartQueryUtilES extends AbstractProcessPartQueryUtil {
     // @formatter:off
     return Script.of(
         s ->
-            s.inline(
-                i ->
-                    i.source(
-                        "double sum = 0.0;"
-                            + "long count = 0;"
-                            + "double min = Double.MAX_VALUE;"
-                            + "double max = Double.MIN_VALUE;"
-                            + "for (procInstIdToStartDatesEntry in state.procInstIdToStartDates.entrySet()) {  "
-                            + "def endDates = state.procInstIdToEndDates.getOrDefault(procInstIdToStartDatesEntry.getKey(), new ArrayList());"
-                            + "def startDates = procInstIdToStartDatesEntry.getValue();"
-                            + "if (!startDates.isEmpty() && !endDates.isEmpty()) {"
-                            + "long minStartDate = startDates.stream().min(Long::compareTo).get(); "
-                            + "List endDatesLargerMinStartDate = endDates.stream().filter(e -> e >= minStartDate).collect(Collectors.toList());"
-                            + "if (!endDatesLargerMinStartDate.isEmpty()) {"
-                            + "long closestEndDate = endDatesLargerMinStartDate.stream()"
-                            + ".min(Comparator.comparingDouble(v -> Math.abs(v - minStartDate))).get();"
-                            + "double duration = closestEndDate - minStartDate;"
-                            + "min = duration < min? duration : min;"
-                            + "max = duration > max? duration : max;"
-                            + "sum += duration;"
-                            + "count += 1;"
-                            + "}"
-                            + "}"
-                            + "}"
-                            + "Map result = new HashMap();"
-                            + "result.put('aggregationType', params.aggregationType);"
-                            + "result.put('sum', sum);"
-                            + "result.put('count', count);"
-                            + "result.put('min', min);"
-                            + "result.put('max', max);"
-                            + "return result;")));
+            s.source(
+                "double sum = 0.0;"
+                    + "long count = 0;"
+                    + "double min = Double.MAX_VALUE;"
+                    + "double max = Double.MIN_VALUE;"
+                    + "for (procInstIdToStartDatesEntry in state.procInstIdToStartDates.entrySet()) {  "
+                    + "def endDates = state.procInstIdToEndDates.getOrDefault(procInstIdToStartDatesEntry.getKey(), new ArrayList());"
+                    + "def startDates = procInstIdToStartDatesEntry.getValue();"
+                    + "if (!startDates.isEmpty() && !endDates.isEmpty()) {"
+                    + "long minStartDate = startDates.stream().min(Long::compareTo).get(); "
+                    + "List endDatesLargerMinStartDate = endDates.stream().filter(e -> e >= minStartDate).collect(Collectors.toList());"
+                    + "if (!endDatesLargerMinStartDate.isEmpty()) {"
+                    + "long closestEndDate = endDatesLargerMinStartDate.stream()"
+                    + ".min(Comparator.comparingDouble(v -> Math.abs(v - minStartDate))).get();"
+                    + "double duration = closestEndDate - minStartDate;"
+                    + "min = duration < min? duration : min;"
+                    + "max = duration > max? duration : max;"
+                    + "sum += duration;"
+                    + "count += 1;"
+                    + "}"
+                    + "}"
+                    + "}"
+                    + "Map result = new HashMap();"
+                    + "result.put('aggregationType', params.aggregationType);"
+                    + "result.put('sum', sum);"
+                    + "result.put('count', count);"
+                    + "result.put('min', min);"
+                    + "result.put('max', max);"
+                    + "return result;"));
     // @formatter:on
   }
 
@@ -195,41 +189,39 @@ public final class ProcessPartQueryUtilES extends AbstractProcessPartQueryUtil {
     // @formatter:off
     return Script.of(
         s ->
-            s.inline(
-                i ->
-                    i.source(
-                        "if (states == null || states.isEmpty()) {"
-                            + "return null;"
-                            + "}"
-                            + "double sum = 0; "
-                            + "long count = 0; "
-                            + "double min = Double.MAX_VALUE;"
-                            + "double max = Double.MIN_VALUE;"
-                            + "def aggregationType = 'avg';"
-                            + "for (a in states) { "
-                            + "if (a != null) {"
-                            + "sum += a.get('sum');"
-                            + "count += a.get('count');"
-                            + "min = a.get('min') < min? a.get('min') : min;"
-                            + "max = a.get('max') > max? a.get('max') : max;"
-                            + "}"
-                            + "}"
-                            + "if (count == 0) {"
-                            + "return null;"
-                            + "}"
-                            +
-                            // return correct result depending on the aggregation type
-                            "if (params.aggregationType == 'avg') {"
-                            + "return sum / count;"
-                            + "} else if (params.aggregationType == 'min') {"
-                            + "return min;"
-                            + "} else if (params.aggregationType == 'max') {"
-                            + "return max;"
-                            + "} else if (params.aggregationType == 'sum') {"
-                            + "return sum;"
-                            + "} else {"
-                            + "Debug.explain('Aggregation type ' + params.aggregationType + ' is not supported!');"
-                            + "}")));
+            s.source(
+                "if (states == null || states.isEmpty()) {"
+                    + "return null;"
+                    + "}"
+                    + "double sum = 0; "
+                    + "long count = 0; "
+                    + "double min = Double.MAX_VALUE;"
+                    + "double max = Double.MIN_VALUE;"
+                    + "def aggregationType = 'avg';"
+                    + "for (a in states) { "
+                    + "if (a != null) {"
+                    + "sum += a.get('sum');"
+                    + "count += a.get('count');"
+                    + "min = a.get('min') < min? a.get('min') : min;"
+                    + "max = a.get('max') > max? a.get('max') : max;"
+                    + "}"
+                    + "}"
+                    + "if (count == 0) {"
+                    + "return null;"
+                    + "}"
+                    +
+                    // return correct result depending on the aggregation type
+                    "if (params.aggregationType == 'avg') {"
+                    + "return sum / count;"
+                    + "} else if (params.aggregationType == 'min') {"
+                    + "return min;"
+                    + "} else if (params.aggregationType == 'max') {"
+                    + "return max;"
+                    + "} else if (params.aggregationType == 'sum') {"
+                    + "return sum;"
+                    + "} else {"
+                    + "Debug.explain('Aggregation type ' + params.aggregationType + ' is not supported!');"
+                    + "}"));
     // @formatter:on
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/report/service/DateAggregationServiceES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/report/service/DateAggregationServiceES.java
@@ -32,7 +32,6 @@ import co.elastic.clients.elasticsearch._types.aggregations.MultiBucketBase;
 import co.elastic.clients.elasticsearch._types.aggregations.RangeBucket;
 import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
 import co.elastic.clients.elasticsearch._types.query_dsl.Query;
-import co.elastic.clients.json.JsonData;
 import co.elastic.clients.util.NamedValue;
 import co.elastic.clients.util.Pair;
 import io.camunda.optimize.dto.optimize.query.report.single.group.AggregateByDateUnit;
@@ -263,8 +262,10 @@ public class DateAggregationServiceES extends DateAggregationService {
                                   m ->
                                       m.range(
                                           r ->
-                                              r.field(context.getDateField())
-                                                  .lt(JsonData.of(endAsString))))
+                                              r.date(
+                                                  d ->
+                                                      d.field(context.getDateField())
+                                                          .lt(endAsString))))
                               .must(
                                   m ->
                                       m.bool(
@@ -273,12 +274,12 @@ public class DateAggregationServiceES extends DateAggregationService {
                                                       s ->
                                                           s.range(
                                                               r ->
-                                                                  r.field(
-                                                                          context
-                                                                              .getRunningDateReportEndDateField())
-                                                                      .gte(
-                                                                          JsonData.of(
-                                                                              startAsString))))
+                                                                  r.date(
+                                                                      d ->
+                                                                          d.field(
+                                                                                  context
+                                                                                      .getRunningDateReportEndDateField())
+                                                                              .gte(startAsString))))
                                                   .should(
                                                       s ->
                                                           s.bool(

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/report/service/VariableAggregationServiceES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/report/service/VariableAggregationServiceES.java
@@ -19,7 +19,6 @@ import co.elastic.clients.elasticsearch._types.aggregations.MultiBucketAggregate
 import co.elastic.clients.elasticsearch._types.aggregations.MultiBucketBase;
 import co.elastic.clients.elasticsearch._types.aggregations.ReverseNestedAggregate;
 import co.elastic.clients.elasticsearch._types.query_dsl.Query;
-import co.elastic.clients.json.JsonData;
 import io.camunda.optimize.dto.optimize.query.variable.VariableType;
 import io.camunda.optimize.service.db.es.report.context.DateAggregationContextES;
 import io.camunda.optimize.service.db.es.report.context.VariableAggregationContextES;
@@ -100,9 +99,11 @@ public class VariableAggregationServiceES {
                       q ->
                           q.range(
                               r ->
-                                  r.field(context.getNestedVariableValueFieldLabel())
-                                      .lte(JsonData.of(context.getMaxVariableValue()))
-                                      .gte(JsonData.of(baseLineValue)))));
+                                  r.number(
+                                      nf ->
+                                          nf.field(context.getNestedVariableValueFieldLabel())
+                                              .lte(context.getMaxVariableValue())
+                                              .gte(baseLineValue)))));
     } else {
       return Optional.empty();
     }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/writer/CollectionWriterES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/writer/CollectionWriterES.java
@@ -191,11 +191,9 @@ public class CollectionWriterES implements CollectionWriter {
     final Script removeScopeEntryFromCollectionsScript =
         Script.of(
             s ->
-                s.inline(
-                    i ->
-                        i.lang(ScriptLanguage.Painless)
-                            .params(Map.of("scopeEntryIdToRemove", JsonData.of(scopeEntryId)))
-                            .source(REMOVE_SCOPE_ENTRY_FROM_COLLECTION_SCRIPT_CODE)));
+                s.lang(ScriptLanguage.Painless)
+                    .params(Map.of("scopeEntryIdToRemove", JsonData.of(scopeEntryId)))
+                    .source(REMOVE_SCOPE_ENTRY_FROM_COLLECTION_SCRIPT_CODE));
 
     final Query query =
         Query.of(

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/writer/DashboardWriterES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/writer/DashboardWriterES.java
@@ -186,12 +186,10 @@ public class DashboardWriterES implements DashboardWriter {
     final Script removeReportFromDashboardScript =
         Script.of(
             s ->
-                s.inline(
-                    i ->
-                        i.lang(ScriptLanguage.Painless)
-                            .params("idToRemove", JsonData.of(reportId))
-                            .source(
-                                "ctx._source.tiles.removeIf(report -> report.id.equals(params.idToRemove))")));
+                s.lang(ScriptLanguage.Painless)
+                    .params("idToRemove", JsonData.of(reportId))
+                    .source(
+                        "ctx._source.tiles.removeIf(report -> report.id.equals(params.idToRemove))"));
 
     final Query query =
         Query.of(

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/writer/DecisionDefinitionWriterES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/writer/DecisionDefinitionWriterES.java
@@ -46,8 +46,7 @@ public class DecisionDefinitionWriterES implements DecisionDefinitionWriter {
   private static final Logger LOG =
       org.slf4j.LoggerFactory.getLogger(DecisionDefinitionWriterES.class);
   private static final Script MARK_AS_DELETED_SCRIPT =
-      Script.of(
-          s -> s.inline(i -> i.lang(ScriptLanguage.Painless).source("ctx._source.deleted = true")));
+      Script.of(s -> s.lang(ScriptLanguage.Painless).source("ctx._source.deleted = true"));
   private final ObjectMapper objectMapper;
   private final OptimizeElasticsearchClient esClient;
   private final ConfigurationService configurationService;

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/writer/ElasticsearchWriterUtil.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/writer/ElasticsearchWriterUtil.java
@@ -38,45 +38,35 @@ public final class ElasticsearchWriterUtil {
       final String inlineUpdateScript, final Map<String, T> params) {
     return Script.of(
         b ->
-            b.inline(
-                i ->
-                    i.lang(ScriptLanguage.Painless)
-                        .source(inlineUpdateScript)
-                        .params(
-                            params.entrySet().stream()
-                                .collect(
-                                    Collectors.toMap(
-                                        Map.Entry::getKey, e -> JsonData.of(e.getValue()))))));
+            b.lang(ScriptLanguage.Painless)
+                .source(inlineUpdateScript)
+                .params(
+                    params.entrySet().stream()
+                        .collect(
+                            Collectors.toMap(Map.Entry::getKey, e -> JsonData.of(e.getValue())))));
   }
 
   public static Script createDefaultScriptWithJsonParams(
       final String inlineUpdateScript, final Map<String, JsonData> params) {
     return Script.of(
-        b ->
-            b.inline(
-                i -> i.lang(ScriptLanguage.Painless).source(inlineUpdateScript).params(params)));
+        b -> b.lang(ScriptLanguage.Painless).source(inlineUpdateScript).params(params));
   }
 
   public static Script createDefaultScriptWithSpecificDtoParams(
       final String inlineUpdateScript, final Map<String, Object> params) {
     return Script.of(
-        b ->
-            b.inline(
-                i -> {
-                  i.lang(ScriptLanguage.Painless).source(inlineUpdateScript);
-                  if (params != null) {
-                    i.params(
-                        params.entrySet().stream()
-                            .collect(
-                                Collectors.toMap(
-                                    Map.Entry::getKey, e -> JsonData.of(e.getValue()))));
-                  }
-                  return i;
-                }));
+        b -> {
+          b.lang(ScriptLanguage.Painless).source(inlineUpdateScript);
+          if (params != null) {
+            b.params(
+                params.entrySet().stream()
+                    .collect(Collectors.toMap(Map.Entry::getKey, e -> JsonData.of(e.getValue()))));
+          }
+          return b;
+        });
   }
 
   public static Script createDefaultScript(final String inlineUpdateScript) {
-    return Script.of(
-        b -> b.inline(i -> i.lang(ScriptLanguage.Painless).source(inlineUpdateScript)));
+    return Script.of(b -> b.lang(ScriptLanguage.Painless).source(inlineUpdateScript));
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/writer/ProcessDefinitionWriterES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/writer/ProcessDefinitionWriterES.java
@@ -44,14 +44,10 @@ public class ProcessDefinitionWriterES extends AbstractProcessDefinitionWriterES
     implements ProcessDefinitionWriter {
 
   private static final Script MARK_AS_DELETED_SCRIPT =
-      Script.of(
-          s -> s.inline(i -> i.lang(ScriptLanguage.Painless).source("ctx._source.deleted = true")));
+      Script.of(s -> s.lang(ScriptLanguage.Painless).source("ctx._source.deleted = true"));
 
   private static final Script MARK_AS_ONBOARDED_SCRIPT =
-      Script.of(
-          s ->
-              s.inline(
-                  i -> i.lang(ScriptLanguage.Painless).source("ctx._source.onboarded = true")));
+      Script.of(s -> s.lang(ScriptLanguage.Painless).source("ctx._source.onboarded = true"));
   private static final Logger LOG =
       org.slf4j.LoggerFactory.getLogger(ProcessDefinitionWriterES.class);
 

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/writer/ReportWriterES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/writer/ReportWriterES.java
@@ -275,14 +275,11 @@ public class ReportWriterES implements ReportWriter {
     final Script updateDefinitionXmlScript =
         Script.of(
             s ->
-                s.inline(
-                    i ->
-                        i.lang(ScriptLanguage.Painless)
-                            // this script is deliberately not updating the modified date as this is
-                            // no user operation
-                            .source("ctx._source.data.configuration.xml = params.newXml;")
-                            .params(
-                                Collections.singletonMap("newXml", JsonData.of(definitionXml)))));
+                s.lang(ScriptLanguage.Painless)
+                    // this script is deliberately not updating the modified date as this is
+                    // no user operation
+                    .source("ctx._source.data.configuration.xml = params.newXml;")
+                    .params(Collections.singletonMap("newXml", JsonData.of(definitionXml))));
 
     taskRepositoryES.tryUpdateByQueryRequest(
         updateItem,
@@ -318,15 +315,13 @@ public class ReportWriterES implements ReportWriter {
     final Script removeReportIdFromCombinedReportsScript =
         Script.of(
             s ->
-                s.inline(
-                    i ->
-                        i.lang(ScriptLanguage.Painless)
-                            .source(
-                                "def reports = ctx._source.data.reports;"
-                                    + "if(reports != null) {"
-                                    + "  reports.removeIf(r -> r.id.equals(params.idToRemove));"
-                                    + "}")
-                            .params(Map.of("idToRemove", JsonData.of(reportId)))));
+                s.lang(ScriptLanguage.Painless)
+                    .source(
+                        "def reports = ctx._source.data.reports;"
+                            + "if(reports != null) {"
+                            + "  reports.removeIf(r -> r.id.equals(params.idToRemove));"
+                            + "}")
+                    .params(Map.of("idToRemove", JsonData.of(reportId))));
 
     taskRepositoryES.tryUpdateByQueryRequest(
         updateItemName,

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/es/DecisionInstanceRepositoryES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/es/DecisionInstanceRepositoryES.java
@@ -12,7 +12,6 @@ import static io.camunda.optimize.service.util.InstanceIndexUtil.getDecisionInst
 import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 import co.elastic.clients.elasticsearch.core.BulkRequest;
 import co.elastic.clients.elasticsearch.core.bulk.BulkOperation;
-import co.elastic.clients.json.JsonData;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.optimize.dto.optimize.importing.DecisionInstanceDto;
 import io.camunda.optimize.service.db.es.OptimizeElasticsearchClient;
@@ -75,10 +74,12 @@ public class DecisionInstanceRepositoryES implements DecisionInstanceRepository 
                             f ->
                                 f.range(
                                     r ->
-                                        r.field(DecisionInstanceIndex.EVALUATION_DATE_TIME)
-                                            .lt(
-                                                JsonData.of(
-                                                    dateTimeFormatter.format(evaluationDate)))))));
+                                        r.date(
+                                            df ->
+                                                df.field(DecisionInstanceIndex.EVALUATION_DATE_TIME)
+                                                    .lt(
+                                                        dateTimeFormatter.format(
+                                                            evaluationDate)))))));
 
     taskRepositoryES.tryDeleteByQueryRequest(
         query,

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/es/ProcessInstanceRepositoryES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/es/ProcessInstanceRepositoryES.java
@@ -27,7 +27,6 @@ import co.elastic.clients.elasticsearch.core.BulkRequest;
 import co.elastic.clients.elasticsearch.core.SearchRequest;
 import co.elastic.clients.elasticsearch.core.SearchResponse;
 import co.elastic.clients.elasticsearch.core.bulk.BulkOperation;
-import co.elastic.clients.json.JsonData;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import io.camunda.optimize.dto.optimize.ImportRequestDto;
@@ -182,8 +181,10 @@ class ProcessInstanceRepositoryES implements ProcessInstanceRepository {
                         q ->
                             q.range(
                                 r ->
-                                    r.field(END_DATE)
-                                        .lt(JsonData.of(dateTimeFormatter.format(endDate)))))
+                                    r.date(
+                                        df ->
+                                            df.field(END_DATE)
+                                                .lt(dateTimeFormatter.format(endDate)))))
                     .filter(
                         f ->
                             f.nested(
@@ -209,8 +210,10 @@ class ProcessInstanceRepositoryES implements ProcessInstanceRepository {
                     q ->
                         q.range(
                             r ->
-                                r.field(END_DATE)
-                                    .lt(JsonData.of(dateTimeFormatter.format(endDate)))))),
+                                r.date(
+                                    df ->
+                                        df.field(END_DATE)
+                                            .lt(dateTimeFormatter.format(endDate)))))),
         limit);
   }
 

--- a/optimize/pom.xml
+++ b/optimize/pom.xml
@@ -64,7 +64,7 @@
     <!-- DATABASE -->
     <!-- Elasticsearch-->
     <elasticsearch.client.version>8.13.4</elasticsearch.client.version>
-    <version.elasticsearch>8.13.4</version.elasticsearch>
+    <version.elasticsearch>8.16.6</version.elasticsearch>
     <elasticsearch.client.test.version>7.17.25</elasticsearch.client.test.version>
 
     <!--The least supported opensearch version we should test against-->

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/es/OptimizeElasticsearchClient.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/es/OptimizeElasticsearchClient.java
@@ -554,16 +554,13 @@ public class OptimizeElasticsearchClient extends DatabaseClient {
                       .id(entityId)
                       .script(
                           sb ->
-                              sb.inline(
-                                  ib ->
-                                      ib.params(
-                                              script.params().entrySet().stream()
-                                                  .collect(
-                                                      Collectors.toMap(
-                                                          Entry::getKey,
-                                                          e -> JsonData.of(e.getValue()))))
-                                          .source(script.scriptString())
-                                          .lang(ScriptLanguage.Painless)))
+                              sb.params(
+                                      script.params().entrySet().stream()
+                                          .collect(
+                                              Collectors.toMap(
+                                                  Entry::getKey, e -> JsonData.of(e.getValue()))))
+                                  .source(script.scriptString())
+                                  .lang(ScriptLanguage.Painless))
                       .retryOnConflict(NUMBER_OF_RETRIES_ON_CONFLICT)),
           Object.class);
     } catch (final IOException e) {
@@ -837,15 +834,11 @@ public class OptimizeElasticsearchClient extends DatabaseClient {
       final String inlineUpdateScript, final Map<String, T> params) {
     return Script.of(
         b ->
-            b.inline(
-                i ->
-                    i.lang(ScriptLanguage.Painless)
-                        .source(inlineUpdateScript)
-                        .params(
-                            params.entrySet().stream()
-                                .collect(
-                                    Collectors.toMap(
-                                        Entry::getKey, e -> JsonData.of(e.getValue()))))));
+            b.lang(ScriptLanguage.Painless)
+                .source(inlineUpdateScript)
+                .params(
+                    params.entrySet().stream()
+                        .collect(Collectors.toMap(Entry::getKey, e -> JsonData.of(e.getValue())))));
   }
 
   public void doBulkRequest(

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/es/schema/ElasticSearchIndexSettingsBuilder.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/es/schema/ElasticSearchIndexSettingsBuilder.java
@@ -50,7 +50,8 @@ public class ElasticSearchIndexSettingsBuilder {
                                 n.limit(
                                     configurationService
                                         .getElasticSearchConfiguration()
-                                        .getNestedDocumentsLimit()))));
+                                        .getNestedDocumentsLimit()
+                                        .longValue()))));
   }
 
   public static IndexSettings buildAllSettings(
@@ -78,7 +79,8 @@ public class ElasticSearchIndexSettingsBuilder {
                               n.limit(
                                   configurationService
                                       .getElasticSearchConfiguration()
-                                      .getNestedDocumentsLimit())));
+                                      .getNestedDocumentsLimit()
+                                      .longValue())));
           try {
             indexMappingCreator.getStaticSettings(i, configurationService);
           } catch (final IOException e) {

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/es/schema/ElasticSearchMetadataService.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/es/schema/ElasticSearchMetadataService.java
@@ -89,16 +89,14 @@ public class ElasticSearchMetadataService
                       .id(MetadataIndex.ID)
                       .script(
                           sb ->
-                              sb.inline(
-                                  ib ->
-                                      ib.lang(ScriptLanguage.Painless)
-                                          .source(scriptData.scriptString())
-                                          .params(
-                                              scriptData.params().entrySet().stream()
-                                                  .collect(
-                                                      Collectors.toMap(
-                                                          Map.Entry::getKey,
-                                                          e -> JsonData.of(e.getValue()))))))
+                              sb.lang(ScriptLanguage.Painless)
+                                  .source(scriptData.scriptString())
+                                  .params(
+                                      scriptData.params().entrySet().stream()
+                                          .collect(
+                                              Collectors.toMap(
+                                                  Map.Entry::getKey,
+                                                  e -> JsonData.of(e.getValue())))))
                       .upsert(newMetadataIfAbsent)
                       .refresh(Refresh.True)
                       .retryOnConflict(NUMBER_OF_RETRIES_ON_CONFLICT));

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/es/schema/ElasticSearchSchemaManager.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/es/schema/ElasticSearchSchemaManager.java
@@ -9,7 +9,6 @@ package io.camunda.optimize.service.db.es.schema;
 
 import static io.camunda.optimize.service.db.DatabaseClient.convertToPrefixedAliasNames;
 import static io.camunda.optimize.service.db.DatabaseConstants.INDEX_ALREADY_EXISTS_EXCEPTION_TYPE;
-import static io.camunda.optimize.service.util.mapper.ObjectMapperFactory.OPTIMIZE_MAPPER;
 import static java.util.stream.Collectors.toSet;
 
 import co.elastic.clients.elasticsearch._types.ElasticsearchException;
@@ -22,11 +21,7 @@ import co.elastic.clients.elasticsearch.indices.IndexSettings;
 import co.elastic.clients.elasticsearch.indices.PutIndicesSettingsRequest;
 import co.elastic.clients.elasticsearch.indices.PutMappingRequest;
 import co.elastic.clients.elasticsearch.indices.PutTemplateRequest;
-import co.elastic.clients.json.JsonData;
-import co.elastic.clients.json.jackson.JacksonJsonpGenerator;
-import co.elastic.clients.json.jackson.JacksonJsonpMapper;
 import co.elastic.clients.util.Pair;
-import com.fasterxml.jackson.core.JsonFactory;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
 import io.camunda.optimize.service.db.es.MappingMetadataUtilES;
@@ -60,16 +55,12 @@ import io.camunda.optimize.service.exceptions.OptimizeRuntimeException;
 import io.camunda.optimize.service.util.configuration.ConfigurationService;
 import io.camunda.optimize.service.util.configuration.condition.ElasticSearchCondition;
 import java.io.IOException;
-import java.io.StringReader;
-import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -187,7 +178,6 @@ public class ElasticSearchSchemaManager
         indexNameService.getOptimizeIndexAliasForIndex(mapping.getIndexName());
     final String suffixedIndexName = indexNameService.getOptimizeIndexNameWithVersion(mapping);
     final IndexSettings indexSettings = createIndexSettings(mapping);
-    final Map<String, JsonData> indexSettingsMap = convertToMap(indexSettings);
 
     try {
       if (mapping.isCreateFromTemplate()) {
@@ -195,7 +185,7 @@ public class ElasticSearchSchemaManager
         // template to
         // ensure correct alias handling on rollover
         createOrUpdateTemplateWithAliases(
-            esClient, mapping, defaultAliasName, prefixedReadOnlyAliases, indexSettingsMap);
+            esClient, mapping, defaultAliasName, prefixedReadOnlyAliases, indexSettings);
         createOptimizeIndexWithWriteAliasFromTemplate(
             esClient, suffixedIndexName, defaultAliasName);
       } else {
@@ -244,7 +234,6 @@ public class ElasticSearchSchemaManager
     final String templateName =
         indexNameService.getOptimizeIndexTemplateNameWithVersion(mappingCreator);
     final IndexSettings indexSettings = createIndexSettings(mappingCreator);
-    final Map<String, JsonData> indexSettingsMap = convertToMap(indexSettings);
     LOG.debug("Creating or updating template with name {}.", templateName);
     try {
       esClient.createTemplate(
@@ -253,7 +242,7 @@ public class ElasticSearchSchemaManager
                   b.name(templateName)
                       .version((long) mappingCreator.getVersion())
                       .mappings(mappingCreator.getSource())
-                      .settings(indexSettingsMap)
+                      .settings(indexSettings)
                       .indexPatterns(
                           Collections.singletonList(
                               indexNameService.getOptimizeIndexNameWithVersionWithWildcardSuffix(
@@ -356,7 +345,7 @@ public class ElasticSearchSchemaManager
       final IndexMappingCreator<IndexSettings.Builder> mappingCreator,
       final String defaultAliasName,
       final Set<String> additionalAliases,
-      final Map<String, JsonData> indexSettings) {
+      final IndexSettings indexSettings) {
     final String templateName =
         indexNameService.getOptimizeIndexNameWithVersionWithoutSuffix(mappingCreator);
     LOG.info("Creating or updating template with name {}", templateName);
@@ -441,9 +430,8 @@ public class ElasticSearchSchemaManager
     final String defaultAliasName =
         indexNameService.getOptimizeIndexAliasForIndex(mappingCreator.getIndexName());
     final IndexSettings indexSettings = createIndexSettings(mappingCreator);
-    final Map<String, JsonData> indexSettingsMap = convertToMap(indexSettings);
     createOrUpdateTemplateWithAliases(
-        esClient, mappingCreator, defaultAliasName, Sets.newHashSet(), indexSettingsMap);
+        esClient, mappingCreator, defaultAliasName, Sets.newHashSet(), indexSettings);
   }
 
   private void updateIndexDynamicSettingsAndMappings(
@@ -492,24 +480,6 @@ public class ElasticSearchSchemaManager
     try {
       return ElasticSearchIndexSettingsBuilder.buildAllSettings(
           configurationService, indexMappingCreator);
-    } catch (final IOException e) {
-      LOG.error("Could not create settings!", e);
-      throw new OptimizeRuntimeException("Could not create index settings");
-    }
-  }
-
-  private Map<String, JsonData> convertToMap(final IndexSettings indexSettings) {
-    try {
-      final JacksonJsonpMapper jsonpMapper = new JacksonJsonpMapper(OPTIMIZE_MAPPER);
-      final StringWriter writer = new StringWriter();
-      final JacksonJsonpGenerator generator =
-          new JacksonJsonpGenerator(new JsonFactory().createGenerator(writer));
-      indexSettings.serialize(generator, jsonpMapper);
-      generator.flush();
-      return ((Map<String, Object>)
-              JsonData.from(new StringReader(writer.toString())).to(Map.class))
-          .entrySet().stream()
-              .collect(Collectors.toMap(Map.Entry::getKey, entry -> JsonData.of(entry.getValue())));
     } catch (final IOException e) {
       LOG.error("Could not create settings!", e);
       throw new OptimizeRuntimeException("Could not create index settings");


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Updates Optimize to use ES Java client 8.16.6. Will not be backported, and is part of epic to increase our minimum supported DB version

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #35606 
