### PR TITLE
fix: avoid multiple metadata fetches

### DIFF
--- a/operate/client/src/App/ProcessInstance/TopPanel/index.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/index.tsx
@@ -123,7 +123,7 @@ const TopPanel: React.FC = observer(() => {
     if (flowNodeInstancesStatistics?.items) {
       init(processInstanceId, flowNodeInstancesStatistics.items);
     }
-  });
+  }, [flowNodeInstancesStatistics?.items, processInstanceId]);
 
   useEffect(() => {
     sequenceFlowsStore.init();

--- a/operate/client/src/App/ProcessInstance/TopPanel/v2/index.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/v2/index.tsx
@@ -134,7 +134,7 @@ const TopPanel: React.FC = observer(() => {
         flowNodeInstancesStatistics.items,
       );
     }
-  });
+  }, [flowNodeInstancesStatistics?.items, processInstance]);
 
   useEffect(() => {
     return () => {


### PR DESCRIPTION
## Description

Metadata was fetched multiple time when clicking on diagram elements. This PR adds dependencies to the related effect, which avoids fetches on every render.

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
