### PR TITLE
deps: update orch cluster to use elastisearch 8.16.6 Java client

### DIFF
--- a/operate/qa/integration-tests/src/test/resources/config/application-test.yml
+++ b/operate/qa/integration-tests/src/test/resources/config/application-test.yml
@@ -1,5 +1,5 @@
 testcontainers:
-  elasticsearch: "docker.elastic.co/elasticsearch/elasticsearch:8.16.4"
+  elasticsearch: "docker.elastic.co/elasticsearch/elasticsearch:8.16.6"
   opensearch: "opensearchproject/opensearch:2.5.0"
 
 camunda.operate:

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -53,7 +53,7 @@
     <version.commons-text>1.13.1</version.commons-text>
     <version.cron-utils>9.2.1</version.cron-utils>
     <version.docker-java-api>3.5.2</version.docker-java-api>
-    <version.elasticsearch>8.16.4</version.elasticsearch>
+    <version.elasticsearch>8.16.6</version.elasticsearch>
     <version.error-prone>2.40.0</version.error-prone>
     <version.grpc>1.73.0</version.grpc>
     <version.gson>2.13.1</version.gson>

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/SupportedVersions.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/SupportedVersions.java
@@ -14,7 +14,7 @@ public final class SupportedVersions {
    *
    * <p>To be used for client and server dependencies (e.g. in test container tests).
    */
-  public static final String SUPPORTED_ELASTICSEARCH_VERSION = "8.16.4";
+  public static final String SUPPORTED_ELASTICSEARCH_VERSION = "8.16.6";
 
   private SupportedVersions() {}
 }

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/testcontainers/TestSearchContainers.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/testcontainers/TestSearchContainers.java
@@ -21,7 +21,7 @@ public final class TestSearchContainers {
           .withTag(
               Objects.requireNonNullElse(
                   org.elasticsearch.client.RestClient.class.getPackage().getImplementationVersion(),
-                  "8.16.4"));
+                  "8.16.6"));
 
   private static final DockerImageName OPENSEARCH_IMAGE =
       DockerImageName.parse("opensearchproject/opensearch")


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Updates the ES client used by the Orchestration cluster to 8.16.6

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #35744
