### PR TITLE
fix: add missing BATCH authorizations to SaaS migration

### DIFF
--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/saas/StaticEntities.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/saas/StaticEntities.java
@@ -69,6 +69,12 @@ public class StaticEntities {
               AuthorizationResourceType.DECISION_REQUIREMENTS_DEFINITION,
               AuthorizationResourceType.DECISION_REQUIREMENTS_DEFINITION
                   .getSupportedPermissionTypes()),
+          new CreateAuthorizationRequest(
+              DEVELOPER_ROLE_ID,
+              AuthorizationOwnerType.ROLE,
+              "*",
+              AuthorizationResourceType.BATCH_OPERATION,
+              Set.of(PermissionType.CREATE, PermissionType.READ, PermissionType.UPDATE)),
           // OPERATIONS ENGINEER
           new CreateAuthorizationRequest(
               OPERATIONS_ENGINEER_ROLE_ID,
@@ -100,6 +106,12 @@ public class StaticEntities {
               AuthorizationResourceType.DECISION_REQUIREMENTS_DEFINITION,
               AuthorizationResourceType.DECISION_REQUIREMENTS_DEFINITION
                   .getSupportedPermissionTypes()),
+          new CreateAuthorizationRequest(
+              OPERATIONS_ENGINEER_ROLE_ID,
+              AuthorizationOwnerType.ROLE,
+              "*",
+              AuthorizationResourceType.BATCH_OPERATION,
+              Set.of(PermissionType.CREATE, PermissionType.READ, PermissionType.UPDATE)),
           // TASK USER
           new CreateAuthorizationRequest(
               TASK_USER_ROLE_ID,
@@ -151,6 +163,12 @@ public class StaticEntities {
               AuthorizationOwnerType.ROLE,
               "*",
               AuthorizationResourceType.DECISION_REQUIREMENTS_DEFINITION,
+              Set.of(PermissionType.READ)),
+          new CreateAuthorizationRequest(
+              VISITOR_ROLE_ID,
+              AuthorizationOwnerType.ROLE,
+              "*",
+              AuthorizationResourceType.BATCH_OPERATION,
               Set.of(PermissionType.READ)));
 
   public static List<CreateAuthorizationRequest> getZeebeClientPermissions(final String clientId) {

--- a/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/saas/StaticConsoleRoleAuthorizationMigrationHandlerTest.java
+++ b/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/saas/StaticConsoleRoleAuthorizationMigrationHandlerTest.java
@@ -45,7 +45,7 @@ public class StaticConsoleRoleAuthorizationMigrationHandlerTest {
     migrationHandler.migrate();
 
     final var results = ArgumentCaptor.forClass(CreateAuthorizationRequest.class);
-    Mockito.verify(authorizationServices, Mockito.times(16)).createAuthorization(results.capture());
+    Mockito.verify(authorizationServices, Mockito.times(19)).createAuthorization(results.capture());
     final var requests = results.getAllValues();
     assertThat(requests).containsExactlyElementsOf(ROLE_PERMISSIONS);
   }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/migration/SaaSIdentityMigrationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/migration/SaaSIdentityMigrationIT.java
@@ -333,6 +333,12 @@ public class SaaSIdentityMigrationIT {
                 ResourceType.DECISION_REQUIREMENTS_DEFINITION,
                 Set.of(PermissionType.READ, PermissionType.UPDATE, PermissionType.DELETE)),
             tuple(
+                DEVELOPER_ROLE_ID,
+                OwnerType.ROLE,
+                "*",
+                ResourceType.BATCH_OPERATION,
+                Set.of(PermissionType.CREATE, PermissionType.READ, PermissionType.UPDATE)),
+            tuple(
                 OPERATIONS_ENGINEER_ROLE_ID,
                 OwnerType.ROLE,
                 "operate",
@@ -365,6 +371,12 @@ public class SaaSIdentityMigrationIT {
                 "*",
                 ResourceType.DECISION_REQUIREMENTS_DEFINITION,
                 Set.of(PermissionType.READ, PermissionType.UPDATE, PermissionType.DELETE)),
+            tuple(
+                OPERATIONS_ENGINEER_ROLE_ID,
+                OwnerType.ROLE,
+                "*",
+                ResourceType.BATCH_OPERATION,
+                Set.of(PermissionType.CREATE, PermissionType.READ, PermissionType.UPDATE)),
             tuple(
                 TASK_USER_ROLE_ID,
                 OwnerType.ROLE,
@@ -415,6 +427,12 @@ public class SaaSIdentityMigrationIT {
                 OwnerType.ROLE,
                 "*",
                 ResourceType.DECISION_REQUIREMENTS_DEFINITION,
+                Set.of(PermissionType.READ)),
+            tuple(
+                VISITOR_ROLE_ID,
+                OwnerType.ROLE,
+                "*",
+                ResourceType.BATCH_OPERATION,
                 Set.of(PermissionType.READ)));
   }
 


### PR DESCRIPTION
## Description

BATCH authorizations for roles with operate permissions were missed to get created.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #35749 
