### PR TITLE
build: update license check configuration format

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -198,20 +198,24 @@
           <artifactId>license-maven-plugin</artifactId>
           <version>${plugin.version.license}</version>
           <configuration>
-            <header>${license.header}</header>
             <properties>
               <owner>camunda services GmbH</owner>
               <email>info@camunda.com</email>
             </properties>
-            <includes>
-              <include>**/*.java</include>
-              <include>**/*.scala</include>
-            </includes>
-            <excludes>
-              <exclude>zeebe/benchmarks/project/**/*</exclude>
-              <exclude>operate/**/*</exclude>
-              <exclude>tasklist/**/*</exclude>
-            </excludes>
+            <licenseSets>
+              <licenseSet>
+                <header>${license.header}</header>
+                <includes>
+                  <include>**/*.java</include>
+                  <include>**/*.scala</include>
+                </includes>
+                <excludes>
+                  <exclude>zeebe/benchmarks/project/**/*</exclude>
+                  <exclude>operate/**/*</exclude>
+                  <exclude>tasklist/**/*</exclude>
+                </excludes>
+              </licenseSet>
+            </licenseSets>
             <mapping>
               <java>SLASHSTAR_STYLE</java>
             </mapping>


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

I noticed a bunch of deprecation warnings logged in the license check plugin. This changes to use the new version 5+ format with license sets

<img width="980" height="65" alt="Screenshot 2025-07-22 at 14 58 00" src="https://github.com/user-attachments/assets/16b700c8-e7d2-4ecb-ab3e-4e76b44284d4" />
