### PR TITLE
fix: add logic for /me/token to return the access token when available

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/CamundaOidcUserService.java
+++ b/authentication/src/main/java/io/camunda/authentication/CamundaOidcUserService.java
@@ -41,12 +41,14 @@ public class CamundaOidcUserService extends OidcUserService {
     try {
       final var jwt = jwtDecoder.decode(userRequest.getAccessToken().getTokenValue());
       claims = jwt.getClaims();
+      return new CamundaOidcUser(
+          oidcUser, jwt.getTokenValue(), camundaOAuthPrincipalService.loadOAuthContext(claims));
     } catch (final JwtException e) {
       LOGGER.warn(
           "Failed to decode access token: {}, falling back to ID Token claims", e.getMessage());
       claims = oidcUser.getIdToken().getClaims();
+      return new CamundaOidcUser(
+          oidcUser, null, camundaOAuthPrincipalService.loadOAuthContext(claims));
     }
-
-    return new CamundaOidcUser(oidcUser, camundaOAuthPrincipalService.loadOAuthContext(claims));
   }
 }

--- a/authentication/src/main/java/io/camunda/authentication/entity/CamundaOidcUser.java
+++ b/authentication/src/main/java/io/camunda/authentication/entity/CamundaOidcUser.java
@@ -18,18 +18,23 @@ import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 
 public class CamundaOidcUser implements OidcUser, CamundaOAuthPrincipal, Serializable {
   private final OidcUser user;
+  private final String accessToken;
   private final OAuthContext oAuthContext;
 
   public CamundaOidcUser(
       final OidcUser oidcUser,
+      final String accessToken,
       final Set<String> mappingIds,
       final AuthenticationContext authentication) {
     user = oidcUser;
+    this.accessToken = accessToken;
     oAuthContext = new OAuthContext(mappingIds, authentication);
   }
 
-  public CamundaOidcUser(final OidcUser user, final OAuthContext oAuthContext) {
+  public CamundaOidcUser(
+      final OidcUser user, final String accessToken, final OAuthContext oAuthContext) {
     this.user = user;
+    this.accessToken = accessToken;
     this.oAuthContext = oAuthContext;
   }
 
@@ -85,6 +90,10 @@ public class CamundaOidcUser implements OidcUser, CamundaOAuthPrincipal, Seriali
 
   public Set<String> getMappingIds() {
     return oAuthContext.mappingIds();
+  }
+
+  public String getAccessToken() {
+    return accessToken;
   }
 
   @Override

--- a/authentication/src/main/java/io/camunda/authentication/service/OidcCamundaUserService.java
+++ b/authentication/src/main/java/io/camunda/authentication/service/OidcCamundaUserService.java
@@ -67,8 +67,13 @@ public class OidcCamundaUserService implements CamundaUserService {
         .map(
             user -> {
               if (user instanceof final CamundaOidcUser camundaOAuthPrincipal) {
-                return Json.createValue(camundaOAuthPrincipal.getIdToken().getTokenValue())
-                    .toString();
+                // If the user has an access token, return it; otherwise, return the ID token to
+                // match the fallback behavior of CamundaOidcUserService#loadUser.
+                final var token =
+                    camundaOAuthPrincipal.getAccessToken() != null
+                        ? camundaOAuthPrincipal.getAccessToken()
+                        : camundaOAuthPrincipal.getIdToken().getTokenValue();
+                return Json.createValue(token).toString();
               }
 
               throw new UnsupportedOperationException(

--- a/authentication/src/test/java/io/camunda/authentication/DefaultCamundaAuthenticationProviderTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/DefaultCamundaAuthenticationProviderTest.java
@@ -136,6 +136,7 @@ public class DefaultCamundaAuthenticationProviderTest {
                     Instant.now(),
                     Instant.now().plusSeconds(3600),
                     Map.of("sub", username))),
+            null,
             Collections.emptySet(),
             authenticationContext);
 
@@ -167,6 +168,7 @@ public class DefaultCamundaAuthenticationProviderTest {
                     Instant.now(),
                     Instant.now().plusSeconds(3600),
                     Map.of("sub", username))),
+            null,
             Collections.emptySet(),
             authenticationContext);
 
@@ -197,6 +199,7 @@ public class DefaultCamundaAuthenticationProviderTest {
                     Instant.now(),
                     Instant.now().plusSeconds(3600),
                     Map.of("sub", clientId))),
+            null,
             Collections.emptySet(),
             authenticationContext);
 
@@ -284,6 +287,7 @@ public class DefaultCamundaAuthenticationProviderTest {
                         tokenIssuedAt,
                         tokenExpiresAt,
                         Map.of("aud", aud, usernameClaim, usernameValue))),
+                null,
                 Collections.emptySet(),
                 new AuthenticationContextBuilder().withUsername(usernameValue).build()),
             List.of(),

--- a/authentication/src/test/java/io/camunda/authentication/OidcCamundaUserServiceTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/OidcCamundaUserServiceTest.java
@@ -41,7 +41,7 @@ public class OidcCamundaUserServiceTest {
   }
 
   @Test
-  public void givenCamundaOidcUserWhenGetUserTokenThenTokenIsReturned() {
+  public void givenCamundaOidcUserWithAccessTokenWhenGetUserTokenThenAccessTokenIsReturned() {
     final var principal =
         new CamundaOidcUser(
             new DefaultOidcUser(
@@ -51,6 +51,29 @@ public class OidcCamundaUserServiceTest {
                     Instant.now(),
                     Instant.now().plusSeconds(3600),
                     Map.of("sub", "not-tested"))),
+            "test-access-token",
+            Collections.emptySet(),
+            null);
+
+    final var auth = new OAuth2AuthenticationToken(principal, List.of(), "oidc");
+    SecurityContextHolder.getContext().setAuthentication(auth);
+
+    final var expectedToken = Json.createValue("test-access-token").toString();
+    assertThat(oidcCamundaUserService.getUserToken()).isEqualTo(expectedToken);
+  }
+
+  @Test
+  public void givenCamundaOidcUserWithIdTokenWhenGetUserTokenThenIdTokenIsReturned() {
+    final var principal =
+        new CamundaOidcUser(
+            new DefaultOidcUser(
+                Collections.emptyList(),
+                new OidcIdToken(
+                    TOKEN_VALUE,
+                    Instant.now(),
+                    Instant.now().plusSeconds(3600),
+                    Map.of("sub", "not-tested"))),
+            null,
             Collections.emptySet(),
             null);
 

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/authentication/AuthenticationController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/authentication/AuthenticationController.java
@@ -5,11 +5,12 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.zeebe.gateway.rest.controller;
+package io.camunda.zeebe.gateway.rest.controller.authentication;
 
 import io.camunda.authentication.entity.CamundaUserDTO;
 import io.camunda.authentication.service.CamundaUserService;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaGetMapping;
+import io.camunda.zeebe.gateway.rest.controller.CamundaRestController;
 import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/authentication/SaaSTokenController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/authentication/SaaSTokenController.java
@@ -5,11 +5,12 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.zeebe.gateway.rest.controller;
+package io.camunda.zeebe.gateway.rest.controller.authentication;
 
 import io.camunda.authentication.service.CamundaUserService;
 import io.camunda.security.ConditionalOnSaaSConfigured;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaGetMapping;
+import io.camunda.zeebe.gateway.rest.controller.CamundaRestController;
 import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -28,10 +29,10 @@ public class SaaSTokenController {
 
   @CamundaGetMapping(path = "/me/token")
   public ResponseEntity<String> getCurrentToken() {
-    final var idToken = camundaUserService.getUserToken();
+    final var token = camundaUserService.getUserToken();
 
-    return idToken == null
+    return token == null
         ? ResponseEntity.status(HttpStatus.UNAUTHORIZED).build()
-        : ResponseEntity.ok(idToken);
+        : ResponseEntity.ok(token);
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/authentication/SaasTokenControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/authentication/SaasTokenControllerTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.controller.authentication;
+
+import static org.mockito.Mockito.when;
+
+import io.camunda.authentication.service.CamundaUserService;
+import io.camunda.zeebe.gateway.rest.RestControllerTest;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+class SaasTokenControllerTest {
+  private static final String BASE_PATH = "/v2/authentication/me";
+  private static final String TOKEN_PATH = BASE_PATH + "/token";
+
+  @Nested
+  @WebMvcTest(SaaSTokenController.class)
+  @TestPropertySource(properties = "spring.profiles.active=consolidated-auth")
+  public class SaasNotConfiguredTest extends RestControllerTest {
+
+    @MockitoBean private CamundaUserService camundaUserService;
+
+    @Test
+    void shouldReturn404WhenSaaSNotConfigured() {
+      // when
+      when(camundaUserService.getUserToken()).thenReturn("{b: 'blah'}");
+      webClient
+          .get()
+          .uri(TOKEN_PATH)
+          .accept(MediaType.APPLICATION_JSON)
+          .exchange()
+          .expectStatus()
+          .isNotFound();
+    }
+  }
+
+  @Nested
+  @WebMvcTest(SaaSTokenController.class)
+  @TestPropertySource(
+      properties = {
+        "spring.profiles.active=consolidated-auth",
+        "camunda.security.saas.organizationId=test-org-id",
+        "camunda.security.saas.clusterId=test-cluster-id"
+      })
+  public class SaasConfiguredTest extends RestControllerTest {
+
+    @MockitoBean private CamundaUserService camundaUserService;
+
+    @Test
+    void shouldReturn200WhenSaaSConfigured() {
+      // when
+      when(camundaUserService.getUserToken()).thenReturn("{b: 'blah'}");
+      webClient
+          .get()
+          .uri(TOKEN_PATH)
+          .accept(MediaType.APPLICATION_JSON)
+          .exchange()
+          .expectStatus()
+          .isOk()
+          .expectBody()
+          .json("{b: 'blah'}");
+    }
+
+    @Test
+    void shouldReturn401WhenSaaSConfiguredAndTokenNotFound() {
+      // when
+      when(camundaUserService.getUserToken()).thenReturn(null);
+      webClient
+          .get()
+          .uri(TOKEN_PATH)
+          .accept(MediaType.APPLICATION_JSON)
+          .exchange()
+          .expectStatus()
+          .isUnauthorized();
+    }
+  }
+}


### PR DESCRIPTION
## Description
<!-- Describe the goal and purpose of this PR. -->

In https://github.com/camunda/camunda/issues/34420 we updated the way in which we request the token in the authorize request for SaaS to provide the audience. This achieved two things:
1. We retrieve the access token in a JWT format
2. We receive the access token with a specified audience (`cloud.<domain>`)

Unfortunately I missed the new token endpoint change where we were (prior to this PR) returning the ID token still. This will still cause the dependent code in the app switcher/notification tab to fail because the audience on the ID token is the client ID configured.

To resolve this I have used a similar pattern to the loadUser method in that we first use the access token but if this cannot be found, fall back to the id token.
