### PR TITLE
Update migration processor to migrate taken sequence flows

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
@@ -608,8 +608,6 @@ public class ProcessInstanceMigrationMigrateProcessor
                       .getProcess()
                       .getElementById(targetGatewayId, ExecutableFlowNode.class);
               requireValidTargetIncomingFlowCount(sourceGateway, targetGateway, processInstanceKey);
-              requireSequenceFlowExistsInTarget(
-                  activeFlow.getId(), sourceGateway, targetGateway, processInstanceKey);
 
               return activeFlow;
             })

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationPreconditions.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationPreconditions.java
@@ -185,13 +185,6 @@ public final class ProcessInstanceMigrationPreconditions {
       Joining gateways with at least one incoming sequence flow taken must be mapped \
       to a gateway of the same type in the target process definition.""";
 
-  private static final String ERROR_SEQUENCE_FLOW_NOT_CONNECTED_TO_TARGET_GATEWAY =
-      """
-      Expected to migrate process instance '%s' \
-      but gateway with id '%s' has a taken incoming sequence flow mismatch. \
-      Taken sequence flow with id '%s' must connect to the mapped target gateway \
-      with id '%s' in the target process definition.""";
-
   private static final String ERROR_TARGET_GATEWAY_HAS_LESS_INCOMING_SEQUENCE_FLOWS =
       """
       Expected to migrate process instance '%s' \
@@ -1024,29 +1017,6 @@ public final class ProcessInstanceMigrationPreconditions {
               sourceGateway.getElementType(),
               targetGatewayId,
               targetGateway.getElementType());
-      throw new ProcessInstanceMigrationPreconditionFailedException(
-          reason, RejectionType.INVALID_ARGUMENT);
-    }
-  }
-
-  public static void requireSequenceFlowExistsInTarget(
-      final DirectBuffer activeSequenceFlowId,
-      final ExecutableFlowNode sourceGateway,
-      final ExecutableFlowNode targetGateway,
-      final long processInstanceKey) {
-    final boolean sequenceFLowExistsInTarget =
-        targetGateway.getIncoming().stream()
-            .map(ExecutableSequenceFlow::getId)
-            .anyMatch(activeSequenceFlowId::equals);
-
-    if (!sequenceFLowExistsInTarget) {
-      final var reason =
-          String.format(
-              ERROR_SEQUENCE_FLOW_NOT_CONNECTED_TO_TARGET_GATEWAY,
-              processInstanceKey,
-              BufferUtil.bufferAsString(sourceGateway.getId()),
-              BufferUtil.bufferAsString(activeSequenceFlowId),
-              BufferUtil.bufferAsString(targetGateway.getId()));
       throw new ProcessInstanceMigrationPreconditionFailedException(
           reason, RejectionType.INVALID_ARGUMENT);
     }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
This PR enhances the process instance migration logic to properly handle mapping of taken sequence‐flow IDs when migrating joining gateways (parallel or inclusive). Previously, taken flows were simply re‐emitted using the original IDs, leading to inconsistencies if the target process changed those IDs.

The main change is in `ProcessInstanceMigrationMigrateProcessor`:
* Deletion + Recreation of taken flows
  * Replaced the one‐shot ELEMENT_MIGRATED events for sequence flows with two explicit steps:
    * deleteTakenSequenceFlow(...) – emits a SEQUENCE_FLOW_DELETED event for the old flow ID
    * takeNewSequenceFlow(...) – emits a SEQUENCE_FLOW_TAKEN event for the new, mapped flow ID

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #35330 