### PR TITLE
feat: do not mark dead when replay fails

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/EventApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/EventApplier.java
@@ -45,7 +45,8 @@ public interface EventApplier {
       public NoApplierForIntent(final Intent intent) {
         super(
             String.format(
-                "Expected to find an event applier for intent '%s', but none was found.", intent));
+                "Expected to find an event applier for intent '%s', but none was found. This may happen during a rolling update.",
+                intent));
       }
     }
 
@@ -54,7 +55,7 @@ public interface EventApplier {
           final Intent intent, final int recordVersion, final int latestVersion) {
         super(
             String.format(
-                "Expected to find an event applier for intent '%s' and version '%d', but '%s' is the latest supported version.",
+                "Expected to find an event applier for intent '%s' and version '%d', but '%s' is the latest supported version. This may happen during a rolling update.",
                 intent, recordVersion, latestVersion));
       }
     }

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessor.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessor.java
@@ -28,6 +28,7 @@ import io.camunda.zeebe.stream.impl.metrics.StreamProcessorMetrics;
 import io.camunda.zeebe.stream.impl.records.RecordValues;
 import io.camunda.zeebe.stream.impl.state.DbKeyGenerator;
 import io.camunda.zeebe.stream.impl.state.StreamProcessorDbState;
+import io.camunda.zeebe.util.exception.UnrecoverableException;
 import io.camunda.zeebe.util.health.FailureListener;
 import io.camunda.zeebe.util.health.HealthMonitorable;
 import io.camunda.zeebe.util.health.HealthReport;
@@ -397,9 +398,24 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
                 openFuture.completeExceptionally(throwable);
               }
 
-              final var report =
-                  HealthReport.dead(this).withIssue(throwable, ActorClock.current().instant());
-              failureListeners.forEach(l -> l.onUnrecoverableFailure(report));
+              if (streamProcessorContext.getProcessorMode().equals(StreamProcessorMode.REPLAY)
+                  && !(throwable instanceof UnrecoverableException)) {
+                // If the stream processor is in replay mode, we do not want to report it as dead
+                // because it is not critical. The leaders are still active and able to process
+                // requests.
+                final var report =
+                    HealthReport.unhealthy(this)
+                        .withIssue(throwable, ActorClock.current().instant());
+                failureListeners.forEach(l -> l.onFailure(report));
+              } else {
+
+                // If it is a leader, we always want to report it as dead so that all related
+                // services
+                // are shutdown. (https://github.com/camunda/camunda/issues/16180)
+                final var report =
+                    HealthReport.dead(this).withIssue(throwable, ActorClock.current().instant());
+                failureListeners.forEach(l -> l.onUnrecoverableFailure(report));
+              }
             });
   }
 


### PR DESCRIPTION
## Description

During rolling update, sometimes the leader of partition is in newer version and writes records for new version. When followers try to replay them they fail because no event applier is found. This resulted in a dead partition. Since the replay stopping is not a stop-the-world issue, we now treat it as a normal failure

In this PR, when a replay is failed (for whatever reason):
* `StreamProcessor` is marked as unhealthy
* `StreamProcessor` is stopped and would not restart until the broker is restarted. 
* The raft partition remains active and continues to replicate records, thus not impacting availability of the whole cluster. 
* The health report of the partition will be shown as unhealthy.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #30727 
