### PR TITLE
Ensure strict JSON comparison in REST controller tests

### DIFF
--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/ControllerStrictJsonCompareTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/ControllerStrictJsonCompareTest.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest;
+
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.ArchRule;
+import com.tngtech.archunit.lang.syntax.ArchRuleDefinition;
+import org.springframework.test.web.reactive.server.WebTestClient.BodyContentSpec;
+
+@AnalyzeClasses(
+    packages = "io.camunda.zeebe.gateway.rest",
+    importOptions = ImportOption.OnlyIncludeTests.class)
+public class ControllerStrictJsonCompareTest {
+
+  /** This ArchUnit test ensures that any REST API controller tests use JsonCompareMode.STRICT */
+  @ArchTest
+  public static final ArchRule RULE_USE_STRICT_JSON_COMPARISON =
+      ArchRuleDefinition.noClasses()
+          .should()
+          .callMethod(BodyContentSpec.class, "json", String.class);
+}

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AdHocSubProcessActivityControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AdHocSubProcessActivityControllerTest.java
@@ -33,6 +33,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.json.JsonCompareMode;
 
 @WebMvcTest(value = AdHocSubProcessActivityController.class)
 class AdHocSubProcessActivityControllerTest extends RestControllerTest {
@@ -115,12 +116,12 @@ class AdHocSubProcessActivityControllerTest extends RestControllerTest {
                 "type": "about:blank",
                 "title": "INVALID_ARGUMENT",
                 "status": 400,
+                "detail": "%s",
                 "instance": "/v2/element-instances/ad-hoc-activities/%s/activation"
             }
             """
-                  .formatted(AD_HOC_SUBPROCESS_INSTANCE_KEY))
-          .jsonPath(".detail")
-          .isEqualTo(expectedErrorDetail);
+                  .formatted(expectedErrorDetail, AD_HOC_SUBPROCESS_INSTANCE_KEY),
+              JsonCompareMode.STRICT);
 
       verifyNoInteractions(adHocSubProcessActivityServices);
     }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/BatchOperationControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/BatchOperationControllerTest.java
@@ -36,6 +36,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.json.JsonCompareMode;
 
 @WebMvcTest(value = BatchOperationController.class)
 class BatchOperationControllerTest extends RestControllerTest {
@@ -76,8 +77,10 @@ class BatchOperationControllerTest extends RestControllerTest {
               "endDate":"2025-03-18T10:57:45.000+01:00",
               "operationsTotalCount":10,
               "operationsFailedCount":0,
-              "operationsCompletedCount":10
-          }""");
+              "operationsCompletedCount":10,
+              "errors": []
+          }""",
+            JsonCompareMode.STRICT);
   }
 
   @Test
@@ -118,7 +121,8 @@ class BatchOperationControllerTest extends RestControllerTest {
                   "message":"Stack Trace"
                 }
               ]
-          }""");
+          }""",
+            JsonCompareMode.STRICT);
   }
 
   private static Stream<Arguments> provideAdvancedSearchParameters() {
@@ -195,19 +199,26 @@ class BatchOperationControllerTest extends RestControllerTest {
         .expectBody()
         .json(
             """
-          {"items":[
           {
-            "batchOperationKey":"1",
-            "state":"COMPLETED",
-            "batchOperationType":"CANCEL_PROCESS_INSTANCE",
-            "startDate":"2025-03-18T10:57:44.000+01:00",
-            "endDate":"2025-03-18T10:57:45.000+01:00",
-            "operationsTotalCount":10,
-            "operationsFailedCount":0,
-            "operationsCompletedCount":10
-            }],
-            "page":{"totalItems":1}
-           }""");
+            "items":[
+              {
+                "batchOperationKey": "1",
+                "state": "COMPLETED",
+                "batchOperationType": "CANCEL_PROCESS_INSTANCE",
+                "startDate": "2025-03-18T10:57:44.000+01:00",
+                "endDate": "2025-03-18T10:57:45.000+01:00",
+                "operationsTotalCount": 10,
+                "operationsFailedCount": 0,
+                "operationsCompletedCount": 10,
+                "errors": []
+              }
+            ],
+            "page":{
+              "totalItems": 1,
+              "hasMoreTotalItems": false
+             }
+           }""",
+            JsonCompareMode.STRICT);
 
     verify(batchOperationServices).search(new BatchOperationQuery.Builder().filter(filter).build());
   }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/BatchOperationItemControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/BatchOperationItemControllerTest.java
@@ -32,6 +32,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.json.JsonCompareMode;
 
 @WebMvcTest(value = BatchOperationItemsController.class)
 class BatchOperationItemControllerTest extends RestControllerTest {
@@ -131,8 +132,12 @@ class BatchOperationItemControllerTest extends RestControllerTest {
                             "errorMessage": "error"
                         }
                     ],
-                    "page":{"totalItems":1}
-                }""");
+                    "page":{
+                      "totalItems":1,
+                      "hasMoreTotalItems": false
+                    }
+                }""",
+            JsonCompareMode.STRICT);
 
     verify(batchOperationServices)
         .searchItems(new BatchOperationItemQuery.Builder().filter(filter).build());

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionDefinitionQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionDefinitionQueryControllerTest.java
@@ -519,9 +519,10 @@ public class DecisionDefinitionQueryControllerTest extends RestControllerTest {
             ErrorMapper.createForbiddenException(
                 Authorization.of(a -> a.decisionDefinition().read())));
     // when / then
+    final String formattedUrl = url.formatted(decisionDefinitionKey);
     webClient
         .get()
-        .uri(url.formatted(decisionDefinitionKey))
+        .uri(formattedUrl)
         .exchange()
         .expectStatus()
         .isForbidden()
@@ -532,9 +533,12 @@ public class DecisionDefinitionQueryControllerTest extends RestControllerTest {
                       "type": "about:blank",
                       "status": 403,
                       "title": "FORBIDDEN",
-                      "detail": "Unauthorized to perform operation 'READ' on resource 'DECISION_DEFINITION'"
+                      "detail": "Unauthorized to perform operation 'READ' on resource 'DECISION_DEFINITION'",
+                      "instance": "%s"
                     }
-                """);
+                """
+                .formatted(formattedUrl),
+            JsonCompareMode.STRICT);
 
     // Verify that the service was called with the invalid key
     service.apply(verify(decisionDefinitionServices), decisionDefinitionKey);

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionRequirementsQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionRequirementsQueryControllerTest.java
@@ -328,11 +328,10 @@ public class DecisionRequirementsQueryControllerTest extends RestControllerTest 
 
   @Test
   public void shouldReturn404ForInvalidDecisionRequirementsKey() throws Exception {
+    final String uri = "/v2/decision-requirements/" + INVALID_DECISION_REQUIREMENTS_KEY;
     webClient
         .get()
-        .uri(
-            "/v2/decision-requirements/{decisionRequirementsKey}",
-            INVALID_DECISION_REQUIREMENTS_KEY)
+        .uri(uri)
         .accept(MediaType.APPLICATION_JSON)
         .exchange()
         .expectStatus()
@@ -344,9 +343,12 @@ public class DecisionRequirementsQueryControllerTest extends RestControllerTest 
                   "type": "about:blank",
                   "title": "NOT_FOUND",
                   "status": 404,
-                  "detail": "Decision requirements with key 999 not found"
+                  "detail": "Decision requirements with key 999 not found",
+                  "instance": "%s"
                 }
-                """);
+                """
+                .formatted(uri),
+            JsonCompareMode.STRICT);
 
     verify(decisionRequirementsServices, times(1)).getByKey(INVALID_DECISION_REQUIREMENTS_KEY);
   }
@@ -364,9 +366,10 @@ public class DecisionRequirementsQueryControllerTest extends RestControllerTest 
             ErrorMapper.createForbiddenException(
                 Authorization.of(a -> a.decisionRequirementsDefinition().read())));
     // when / then
+    final String formattedUrl = url.formatted(decisionRequirementsKey);
     webClient
         .get()
-        .uri(url.formatted(decisionRequirementsKey))
+        .uri(formattedUrl)
         .exchange()
         .expectStatus()
         .isForbidden()
@@ -377,9 +380,12 @@ public class DecisionRequirementsQueryControllerTest extends RestControllerTest 
                       "type": "about:blank",
                       "status": 403,
                       "title": "FORBIDDEN",
-                      "detail": "Unauthorized to perform operation 'READ' on resource 'DECISION_REQUIREMENTS_DEFINITION'"
+                      "detail": "Unauthorized to perform operation 'READ' on resource 'DECISION_REQUIREMENTS_DEFINITION'",
+                      "instance": "%s"
                     }
-                """);
+                """
+                .formatted(formattedUrl),
+            JsonCompareMode.STRICT);
 
     // Verify that the service was called with the invalid key
     service.apply(verify(decisionRequirementsServices), decisionRequirementsKey);
@@ -416,7 +422,8 @@ public class DecisionRequirementsQueryControllerTest extends RestControllerTest 
                   "detail": "Unexpected error occurred during the request processing: Unexpected error",
                   "instance": "/v2/decision-requirements/1"
                 }
-                """);
+                """,
+            JsonCompareMode.STRICT);
 
     verify(decisionRequirementsServices, times(1)).getByKey(VALID_DECISION_REQUIREMENTS_KEY);
   }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DocumentControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DocumentControllerTest.java
@@ -39,6 +39,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.http.client.MultipartBodyBuilder;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.json.JsonCompareMode;
 
 @WebMvcTest(DocumentController.class)
 public class DocumentControllerTest extends RestControllerTest {
@@ -97,14 +98,19 @@ public class DocumentControllerTest extends RestControllerTest {
                     {
                       "documentId": "documentId",
                       "storeId": "default",
+                      "camunda.document.type": "camunda",
+                      "contentHash": "dummy_hash",
                       "metadata": {
                         "contentType": "application/octet-stream",
                         "fileName": "file.txt",
-                        "expiresAt": "%s"
+                        "expiresAt": "%s",
+                        "size": 0,
+                        "customProperties": {}
                       }
                     }
                     """,
-                timestamp));
+                timestamp),
+            JsonCompareMode.STRICT);
 
     verify(documentServices).createDocument(requestCaptor.capture());
 
@@ -172,14 +178,19 @@ public class DocumentControllerTest extends RestControllerTest {
                     {
                       "documentId": "documentId",
                       "storeId": "default",
+                      "camunda.document.type": "camunda",
+                      "contentHash": "dummy_hash",
                       "metadata": {
                         "contentType": "application/octet-stream",
                         "fileName": "file.txt",
-                        "expiresAt": "%s"
+                        "expiresAt": "%s",
+                        "size": 0,
+                        "customProperties": {}
                       }
                     }
                     """,
-                timestamp));
+                timestamp),
+            JsonCompareMode.STRICT);
 
     verify(documentServices).createDocument(requestCaptor.capture());
 
@@ -294,7 +305,8 @@ public class DocumentControllerTest extends RestControllerTest {
                       "failedDocuments": []
                     }
                     """
-                .formatted(timestamp, timestamp));
+                .formatted(timestamp, timestamp),
+            JsonCompareMode.STRICT);
 
     verify(documentServices).createDocumentBatch(requestCaptor.capture());
 
@@ -403,9 +415,12 @@ public class DocumentControllerTest extends RestControllerTest {
                   "type": "about:blank",
                   "title": "INVALID_ARGUMENT",
                   "status": 400,
-                  "detail": "No document hash provided for document foo"
+                  "detail": "No document hash provided for document foo",
+                  "instance": "%s"
                 }
-                """);
+                """
+                .formatted(DOCUMENTS_BASE_URL + "/foo"),
+            JsonCompareMode.STRICT);
   }
 
   @Test
@@ -431,9 +446,12 @@ public class DocumentControllerTest extends RestControllerTest {
                   "type": "about:blank",
                   "title": "INVALID_ARGUMENT",
                   "status": 400,
-                  "detail": "Document hash for document foo doesn't match the provided hash barbaz"
+                  "detail": "Document hash for document foo doesn't match the provided hash barbaz",
+                  "instance": "%s"
                 }
-                """);
+                """
+                .formatted(DOCUMENTS_BASE_URL + "/foo"),
+            JsonCompareMode.STRICT);
   }
 
   // TODO: test error cases

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ElementInstanceQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ElementInstanceQueryControllerTest.java
@@ -363,7 +363,8 @@ public class ElementInstanceQueryControllerTest extends RestControllerTest {
                       "status":404,
                       "instance":"/v2/element-instances/5"
                   }
-                """);
+                """,
+            JsonCompareMode.STRICT);
 
     verify(elementInstanceServices).getByKey(5L);
   }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/IncidentQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/IncidentQueryControllerTest.java
@@ -316,7 +316,8 @@ public class IncidentQueryControllerTest extends RestControllerTest {
                       "status":404,
                       "instance":"/v2/incidents/5"
                   }
-                """);
+                """,
+            JsonCompareMode.STRICT);
 
     verify(incidentServices).getByKey(5L);
   }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerTest.java
@@ -884,7 +884,8 @@ public class JobControllerTest extends RestControllerTest {
               "detail": "Expected to handle request Activate Jobs with tenant identifiers [], but no tenant identifier was provided.",
               "instance": "%s"
             }"""
-                .formatted(JOBS_BASE_URL + "/activation"));
+                .formatted(JOBS_BASE_URL + "/activation"),
+            JsonCompareMode.STRICT);
     verifyNoInteractions(jobServices);
   }
 
@@ -930,7 +931,8 @@ public class JobControllerTest extends RestControllerTest {
                     tenantIds.size() == 1
                         ? "identifier '" + tenantIds.getFirst() + "'"
                         : "identifiers " + tenantIds,
-                    JOBS_BASE_URL + "/activation"));
+                    JOBS_BASE_URL + "/activation"),
+            JsonCompareMode.STRICT);
     verifyNoInteractions(jobServices);
   }
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/MessageControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/MessageControllerTest.java
@@ -112,7 +112,8 @@ public class MessageControllerTest extends RestControllerTest {
                   "messageKey": "123",
                   "tenantId": "<default>",
                   "processInstanceKey": "321"
-                }""");
+                }""",
+            JsonCompareMode.STRICT);
   }
 
   @Test
@@ -167,7 +168,8 @@ public class MessageControllerTest extends RestControllerTest {
                   "messageKey": "123",
                   "tenantId": "tenantId",
                   "processInstanceKey": "321"
-                }""");
+                }""",
+            JsonCompareMode.STRICT);
   }
 
   @Test
@@ -202,7 +204,8 @@ public class MessageControllerTest extends RestControllerTest {
                   "detail": "No messageName provided.",
                   "instance": "%s"
                 }"""
-                .formatted(CORRELATION_ENDPOINT));
+                .formatted(CORRELATION_ENDPOINT),
+            JsonCompareMode.STRICT);
     verifyNoInteractions(messageServices);
   }
 
@@ -239,7 +242,8 @@ public class MessageControllerTest extends RestControllerTest {
                   "detail": "No messageName provided.",
                   "instance": "%s"
                 }"""
-                .formatted(CORRELATION_ENDPOINT));
+                .formatted(CORRELATION_ENDPOINT),
+            JsonCompareMode.STRICT);
     verifyNoInteractions(messageServices);
   }
 
@@ -274,7 +278,8 @@ public class MessageControllerTest extends RestControllerTest {
               "detail": "Expected to handle request Correlate Message with tenant identifiers [], but no tenant identifier was provided.",
               "instance": "%s"
             }"""
-                .formatted(CORRELATION_ENDPOINT));
+                .formatted(CORRELATION_ENDPOINT),
+            JsonCompareMode.STRICT);
     verifyNoInteractions(messageServices);
   }
 
@@ -310,7 +315,8 @@ public class MessageControllerTest extends RestControllerTest {
                   "detail": "Expected to handle request Correlate Message with tenant identifier 'tenant', but multi-tenancy is disabled",
                   "instance": "%s"
                 }"""
-                .formatted(CORRELATION_ENDPOINT));
+                .formatted(CORRELATION_ENDPOINT),
+            JsonCompareMode.STRICT);
     verifyNoInteractions(messageServices);
   }
 
@@ -346,7 +352,8 @@ public class MessageControllerTest extends RestControllerTest {
                   "detail": "Expected to handle request Correlate Message with tenant identifier 'tenanttenanttenanttenanttenanttenanttenanttenanttenant', but tenant identifier is longer than 31 characters.",
                   "instance": "%s"
                 }"""
-                .formatted(CORRELATION_ENDPOINT));
+                .formatted(CORRELATION_ENDPOINT),
+            JsonCompareMode.STRICT);
     verifyNoInteractions(messageServices);
   }
 
@@ -382,7 +389,8 @@ public class MessageControllerTest extends RestControllerTest {
               "detail": "Expected to handle request Correlate Message with tenant identifier '<invalid>', but tenant identifier contains illegal characters.",
               "instance": "%s"
             }"""
-                .formatted(CORRELATION_ENDPOINT));
+                .formatted(CORRELATION_ENDPOINT),
+            JsonCompareMode.STRICT);
     verifyNoInteractions(messageServices);
   }
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessDefinitionQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessDefinitionQueryControllerTest.java
@@ -179,9 +179,11 @@ public class ProcessDefinitionQueryControllerTest extends RestControllerTest {
                       "type": "about:blank",
                       "status": 404,
                       "title": "NOT_FOUND",
-                      "detail": "Process definition with key 17 not found"
+                      "detail": "Process definition with key 17 not found",
+                      "instance": "/v2/process-definitions/17"
                     }
-                """);
+                """,
+            JsonCompareMode.STRICT);
 
     // Verify that the service was called with the invalid key
     verify(processDefinitionServices).getByKey(17L);
@@ -220,9 +222,10 @@ public class ProcessDefinitionQueryControllerTest extends RestControllerTest {
             ErrorMapper.createForbiddenException(
                 Authorization.of(a -> a.processDefinition().read())));
     // when / then
+    final String formattedUrl = url.formatted(processDefinitionKey);
     webClient
         .get()
-        .uri(url.formatted(processDefinitionKey))
+        .uri(formattedUrl)
         .exchange()
         .expectStatus()
         .isForbidden()
@@ -233,9 +236,12 @@ public class ProcessDefinitionQueryControllerTest extends RestControllerTest {
                       "type": "about:blank",
                       "status": 403,
                       "title": "FORBIDDEN",
-                      "detail": "Unauthorized to perform operation 'READ' on resource 'PROCESS_DEFINITION'"
+                      "detail": "Unauthorized to perform operation 'READ' on resource 'PROCESS_DEFINITION'",
+                      "instance": "%s"
                     }
-                """);
+                """
+                .formatted(formattedUrl),
+            JsonCompareMode.STRICT);
 
     // Verify that the service was called with the invalid key
     service.apply(verify(processDefinitionServices), processDefinitionKey);
@@ -433,9 +439,11 @@ public class ProcessDefinitionQueryControllerTest extends RestControllerTest {
               "type": "about:blank",
               "title": "NOT_FOUND",
               "status": 404,
-              "detail": "Process definition with key 999 not found"
+              "detail": "Process definition with key 999 not found",
+              "instance": "/v2/process-definitions/999/form"
             }
-            """);
+            """,
+            JsonCompareMode.STRICT);
   }
 
   @Test
@@ -460,6 +468,7 @@ public class ProcessDefinitionQueryControllerTest extends RestControllerTest {
               "detail": "Unexpected error occurred during the request processing: Unexpected error",
               "instance": "/v2/process-definitions/1/form"
             }
-            """);
+            """,
+            JsonCompareMode.STRICT);
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceControllerTest.java
@@ -1346,7 +1346,8 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
         .json(
             """
           {"batchOperationKey":"123","batchOperationType":"CANCEL_PROCESS_INSTANCE"}
-        """);
+        """,
+            JsonCompareMode.STRICT);
 
     verify(processInstanceServices)
         .cancelProcessInstanceBatchOperationWithResult(any(ProcessInstanceFilter.class));
@@ -1394,7 +1395,8 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
         .json(
             """
           {"batchOperationKey":"123","batchOperationType":"MODIFY_PROCESS_INSTANCE"}
-        """);
+        """,
+            JsonCompareMode.STRICT);
 
     verify(processInstanceServices)
         .modifyProcessInstancesBatchOperation(
@@ -1470,7 +1472,8 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
         .json(
             """
           {"batchOperationKey":"123","batchOperationType":"RESOLVE_INCIDENT"}
-        """);
+        """,
+            JsonCompareMode.STRICT);
 
     verify(processInstanceServices)
         .resolveIncidentsBatchOperationWithResult(any(ProcessInstanceFilter.class));
@@ -1520,7 +1523,8 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
         .json(
             """
           {"batchOperationKey":"123","batchOperationType":"MIGRATE_PROCESS_INSTANCE"}
-        """);
+        """,
+            JsonCompareMode.STRICT);
 
     verify(processInstanceServices)
         .migrateProcessInstancesBatchOperation(

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceQueryControllerTest.java
@@ -542,9 +542,12 @@ public class ProcessInstanceQueryControllerTest extends RestControllerTest {
                       "type": "about:blank",
                       "status": 404,
                       "title": "NOT_FOUND",
-                      "detail": "Process Instance with key 100 not found"
+                      "detail": "Process Instance with key 100 not found",
+                      "instance": "/v2/process-instances/%s"
                     }
-                """);
+                """
+                .formatted(invalidProcesInstanceKey),
+            JsonCompareMode.STRICT);
 
     // Verify that the service was called with the invalid key
     verify(processInstanceServices).getByKey(invalidProcesInstanceKey);

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ResourceControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ResourceControllerTest.java
@@ -125,7 +125,8 @@ public class ResourceControllerTest extends RestControllerTest {
                     ],
                     "tenantId":"<default>"
                  }
-                """);
+                """,
+            JsonCompareMode.STRICT);
   }
 
   @Test
@@ -188,7 +189,8 @@ public class ResourceControllerTest extends RestControllerTest {
                     ],
                     "tenantId":"<default>"
                  }
-                """);
+                """,
+            JsonCompareMode.STRICT);
   }
 
   @Test
@@ -255,7 +257,8 @@ public class ResourceControllerTest extends RestControllerTest {
                     ],
                     "tenantId":"<default>"
                  }
-                """);
+                """,
+            JsonCompareMode.STRICT);
   }
 
   @Test
@@ -365,7 +368,8 @@ public class ResourceControllerTest extends RestControllerTest {
                     ],
                     "tenantId":"<default>"
                  }
-                """);
+                """,
+            JsonCompareMode.STRICT);
   }
 
   @Test
@@ -530,7 +534,8 @@ public class ResourceControllerTest extends RestControllerTest {
             "tenantId": "tenant-1",
             "resourceKey": "1"
           }
-          """);
+          """,
+            JsonCompareMode.STRICT);
   }
 
   @Test
@@ -564,7 +569,8 @@ public class ResourceControllerTest extends RestControllerTest {
               "instance": "%s"
             }
             """
-                .formatted(url));
+                .formatted(url),
+            JsonCompareMode.STRICT);
   }
 
   @Test
@@ -601,7 +607,8 @@ public class ResourceControllerTest extends RestControllerTest {
               "instance": "%s"
             }
             """
-                .formatted(url));
+                .formatted(url),
+            JsonCompareMode.STRICT);
   }
 
   @Test
@@ -634,7 +641,8 @@ public class ResourceControllerTest extends RestControllerTest {
               "instance": "%s"
             }
             """
-                .formatted(url));
+                .formatted(url),
+            JsonCompareMode.STRICT);
   }
 
   @Test
@@ -695,7 +703,8 @@ public class ResourceControllerTest extends RestControllerTest {
               "instance": "%s"
             }
             """
-                .formatted(url));
+                .formatted(url),
+            JsonCompareMode.STRICT);
   }
 
   @Test
@@ -732,7 +741,8 @@ public class ResourceControllerTest extends RestControllerTest {
               "instance": "%s"
             }
             """
-                .formatted(url));
+                .formatted(url),
+            JsonCompareMode.STRICT);
   }
 
   @Test
@@ -765,6 +775,7 @@ public class ResourceControllerTest extends RestControllerTest {
               "instance": "%s"
             }
             """
-                .formatted(url));
+                .formatted(url),
+            JsonCompareMode.STRICT);
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/VariablesQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/VariablesQueryControllerTest.java
@@ -428,7 +428,8 @@ public class VariablesQueryControllerTest extends RestControllerTest {
                   "status": 404,
                   "detail": "Variable with key 99 not found",
                   "instance": "/v2/variables/99"
-                }""");
+                }""",
+            JsonCompareMode.STRICT);
 
     verify(variableServices).getByKey(INVALID_VARIABLE_KEY);
   }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/setup/SetupControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/setup/SetupControllerTest.java
@@ -93,10 +93,12 @@ class SetupControllerTest extends RestControllerTest {
           {
             "username": "%s",
             "name": "%s",
-            "email": "%s"
+            "email": "%s",
+            "userKey": "-1"
           }
         """
-                .formatted(dto.username(), dto.name(), dto.email()));
+                .formatted(dto.username(), dto.name(), dto.email()),
+            JsonCompareMode.STRICT);
 
     // then
     verify(userServices, times(1)).createInitialAdminUser(dto);
@@ -258,10 +260,12 @@ class SetupControllerTest extends RestControllerTest {
           {
             "username": "%s",
             "name": "",
-            "email": ""
+            "email": "",
+            "userKey": "-1"
           }
         """
-                .formatted(dto.username()));
+                .formatted(dto.username()),
+            JsonCompareMode.STRICT);
 
     // then
     verify(userServices, times(1)).createInitialAdminUser(dto);

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantControllerTest.java
@@ -151,7 +151,8 @@ public class TenantControllerTest {
               "description": "%s"
             }
             """
-                  .formatted(tenantKey, tenantId, tenantName, tenantDescription));
+                  .formatted(tenantKey, tenantId, tenantName, tenantDescription),
+              JsonCompareMode.STRICT);
 
       // then
       verify(tenantServices, times(1))
@@ -183,7 +184,8 @@ public class TenantControllerTest {
               "detail": "No tenantId provided.",
               "instance": "%s"
             }"""
-                  .formatted(TENANT_BASE_URL));
+                  .formatted(TENANT_BASE_URL),
+              JsonCompareMode.STRICT);
 
       // then
       verifyNoInteractions(tenantServices);
@@ -221,7 +223,8 @@ public class TenantControllerTest {
               "detail": "The provided tenantId contains illegal characters. It must match the pattern '%s'.",
               "instance": "%s"
             }"""
-                  .formatted(IdentifierPatterns.ID_PATTERN, TENANT_BASE_URL));
+                  .formatted(IdentifierPatterns.ID_PATTERN, TENANT_BASE_URL),
+              JsonCompareMode.STRICT);
 
       // then
       verifyNoInteractions(tenantServices);
@@ -253,7 +256,8 @@ public class TenantControllerTest {
               "detail": "The provided tenantId exceeds the limit of 256 characters.",
               "instance": "%s"
             }"""
-                  .formatted(TENANT_BASE_URL));
+                  .formatted(TENANT_BASE_URL),
+              JsonCompareMode.STRICT);
 
       // then
       verifyNoInteractions(tenantServices);
@@ -296,7 +300,8 @@ public class TenantControllerTest {
               "description": "%s"
             }
             """
-                  .formatted(tenantKey, tenantId, tenantName, tenantDescription));
+                  .formatted(tenantKey, tenantId, tenantName, tenantDescription),
+              JsonCompareMode.STRICT);
 
       // then
       verify(tenantServices, times(1))
@@ -330,7 +335,8 @@ public class TenantControllerTest {
               "detail": "No description provided.",
               "instance": "%s"
             }"""
-                  .formatted(uri));
+                  .formatted(uri),
+              JsonCompareMode.STRICT);
 
       verifyNoInteractions(tenantServices);
     }
@@ -362,7 +368,8 @@ public class TenantControllerTest {
               "detail": "No name provided.",
               "instance": "%s"
             }"""
-                  .formatted(uri));
+                  .formatted(uri),
+              JsonCompareMode.STRICT);
 
       verifyNoInteractions(tenantServices);
     }
@@ -477,7 +484,8 @@ public class TenantControllerTest {
               "detail": "The provided tenantId contains illegal characters. It must match the pattern '%s'.",
               "instance": "%s"
             }"""
-                  .formatted(IdentifierPatterns.ID_PATTERN, uri));
+                  .formatted(IdentifierPatterns.ID_PATTERN, uri),
+              JsonCompareMode.STRICT);
 
       // then
       verifyNoInteractions(tenantServices);
@@ -513,7 +521,8 @@ public class TenantControllerTest {
               "detail": "The provided %s contains illegal characters. It must match the pattern '%s'.",
               "instance": "%s"
             }"""
-                  .formatted(entityIdName, IdentifierPatterns.ID_PATTERN, uri));
+                  .formatted(entityIdName, IdentifierPatterns.ID_PATTERN, uri),
+              JsonCompareMode.STRICT);
 
       // then
       verifyNoInteractions(tenantServices);
@@ -574,7 +583,8 @@ public class TenantControllerTest {
               "detail": "The provided tenantId contains illegal characters. It must match the pattern '%s'.",
               "instance": "%s"
             }"""
-                  .formatted(IdentifierPatterns.ID_PATTERN, uri));
+                  .formatted(IdentifierPatterns.ID_PATTERN, uri),
+              JsonCompareMode.STRICT);
 
       // then
       verifyNoInteractions(tenantServices);
@@ -611,7 +621,8 @@ public class TenantControllerTest {
               "detail": "The provided %s contains illegal characters. It must match the pattern '%s'.",
               "instance": "%s"
             }"""
-                  .formatted(entityIdName, IdentifierPatterns.ID_PATTERN, uri));
+                  .formatted(entityIdName, IdentifierPatterns.ID_PATTERN, uri),
+              JsonCompareMode.STRICT);
 
       // then
       verifyNoInteractions(tenantServices);

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantQueryControllerTest.java
@@ -271,7 +271,8 @@ public class TenantQueryControllerTest extends RestControllerTest {
               "tenantId": "%s"
             }
             """
-                .formatted(tenant.key(), tenantName, tenantDescription, tenantId));
+                .formatted(tenant.key(), tenantName, tenantDescription, tenantId),
+            JsonCompareMode.STRICT);
 
     // then
     verify(tenantServices, times(1)).getById(tenant.tenantId());
@@ -306,7 +307,8 @@ public class TenantQueryControllerTest extends RestControllerTest {
               "detail": "tenant not found",
               "instance": "%s"
             }"""
-                .formatted(path));
+                .formatted(path),
+            JsonCompareMode.STRICT);
 
     // then
     verify(tenantServices, times(1)).getById(tenantId);
@@ -562,8 +564,19 @@ public class TenantQueryControllerTest extends RestControllerTest {
         .json(
             // language=json
             """
-                {"items":[{"clientId":"client1"},{"clientId":"client2"},{"clientId":"client3"}],"page":{"totalItems":3}}
-            """);
+                {
+                  "items": [
+                    { "clientId":"client1" },
+                    { "clientId":"client2" },
+                    { "clientId":"client3" }
+                  ],
+                  "page": {
+                    "totalItems":3,
+                    "hasMoreTotalItems": false
+                  }
+                }
+            """,
+            JsonCompareMode.STRICT);
   }
 
   @Test
@@ -595,8 +608,19 @@ public class TenantQueryControllerTest extends RestControllerTest {
         .json(
             // language=json
             """
-                {"items":[{"username":"user1"},{"username":"user2"},{"username":"user3"}],"page":{"totalItems":3}}
-            """);
+                {
+                  "items": [
+                    { "username":"user1" },
+                    { "username":"user2" },
+                    { "username":"user3" }
+                  ],
+                  "page": {
+                    "totalItems": 3,
+                    "hasMoreTotalItems": false
+                  }
+                }
+            """,
+            JsonCompareMode.STRICT);
   }
 
   @Test
@@ -628,8 +652,19 @@ public class TenantQueryControllerTest extends RestControllerTest {
         .json(
             // language=json
             """
-                {"items":[{"groupId":"group1"},{"groupId":"group2"},{"groupId":"group3"}],"page":{"totalItems":3}}
-            """);
+                {
+                  "items": [
+                    { "groupId":"group1" },
+                    { "groupId":"group2" },
+                    { "groupId":"group3" }
+                  ],
+                  "page": {
+                    "totalItems":3,
+                    "hasMoreTotalItems": false
+                  }
+                }
+            """,
+            JsonCompareMode.STRICT);
   }
 
   public static Stream<Arguments> invalidTenantSearchQueries() {

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/AuthorizationControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/AuthorizationControllerTest.java
@@ -44,6 +44,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ProblemDetail;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.json.JsonCompareMode;
 
 @WebMvcTest(AuthorizationController.class)
 public class AuthorizationControllerTest extends RestControllerTest {
@@ -100,7 +101,8 @@ public class AuthorizationControllerTest extends RestControllerTest {
             {
               "authorizationKey": "%s"
             }"""
-                .formatted(authorizationKey));
+                .formatted(authorizationKey),
+            JsonCompareMode.STRICT);
 
     final var captor = ArgumentCaptor.forClass(CreateAuthorizationRequest.class);
     verify(authorizationServices, times(1)).createAuthorization(captor.capture());

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/AuthorizationQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/AuthorizationQueryControllerTest.java
@@ -125,7 +125,8 @@ public class AuthorizationQueryControllerTest extends RestControllerTest {
                   "resourceId": "resourceId",
                   "resourceType": "PROCESS_DEFINITION",
                   "permissionTypes": ["CREATE"]
-                }""");
+                }""",
+            JsonCompareMode.STRICT);
 
     // then
     verify(authorizationServices, times(1)).getAuthorization(authorizationKey);
@@ -160,7 +161,8 @@ public class AuthorizationQueryControllerTest extends RestControllerTest {
               "detail": "authorization not found",
               "instance": "%s"
             }"""
-                .formatted(path));
+                .formatted(path),
+            JsonCompareMode.STRICT);
 
     // then
     verify(authorizationServices, times(1)).getAuthorization(authorizationKey);

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupControllerTest.java
@@ -276,7 +276,8 @@ public class GroupControllerTest {
               "detail": "No name provided.",
               "instance": "%s"
             }"""
-                  .formatted(GROUP_BASE_URL));
+                  .formatted(GROUP_BASE_URL),
+              JsonCompareMode.STRICT);
 
       // then
       verifyNoInteractions(groupServices);
@@ -304,7 +305,8 @@ public class GroupControllerTest {
               "detail": "No groupId provided.",
               "instance": "%s"
             }"""
-                  .formatted(GROUP_BASE_URL));
+                  .formatted(GROUP_BASE_URL),
+              JsonCompareMode.STRICT);
 
       // then
       verifyNoInteractions(groupServices);
@@ -332,7 +334,8 @@ public class GroupControllerTest {
               "detail": "No groupId provided.",
               "instance": "%s"
             }"""
-                  .formatted(GROUP_BASE_URL));
+                  .formatted(GROUP_BASE_URL),
+              JsonCompareMode.STRICT);
 
       // then
       verifyNoInteractions(groupServices);
@@ -363,7 +366,8 @@ public class GroupControllerTest {
               "detail": "The provided groupId exceeds the limit of 256 characters.",
               "instance": "%s"
             }"""
-                  .formatted(GROUP_BASE_URL));
+                  .formatted(GROUP_BASE_URL),
+              JsonCompareMode.STRICT);
 
       // then
       verifyNoInteractions(groupServices);
@@ -397,7 +401,8 @@ public class GroupControllerTest {
                 "detail": "The provided groupId contains illegal characters. It must match the pattern '%s'.",
                 "instance": "%s"
               }"""
-                  .formatted(IdentifierPatterns.ID_PATTERN, GROUP_BASE_URL));
+                  .formatted(IdentifierPatterns.ID_PATTERN, GROUP_BASE_URL),
+              JsonCompareMode.STRICT);
       verifyNoInteractions(groupServices);
     }
 
@@ -436,7 +441,8 @@ public class GroupControllerTest {
               "description": "%s"
             }
             """
-                  .formatted(groupId, groupName, description));
+                  .formatted(groupId, groupName, description),
+              JsonCompareMode.STRICT);
 
       // then
       verify(groupServices, times(1)).updateGroup(groupId, groupName, description);
@@ -469,7 +475,8 @@ public class GroupControllerTest {
               "detail": "No name provided.",
               "instance": "%s"
             }"""
-                  .formatted(uri));
+                  .formatted(uri),
+              JsonCompareMode.STRICT);
 
       verifyNoInteractions(groupServices);
     }
@@ -501,7 +508,8 @@ public class GroupControllerTest {
               "detail": "No description provided.",
               "instance": "%s"
             }"""
-                  .formatted(uri));
+                  .formatted(uri),
+              JsonCompareMode.STRICT);
 
       verifyNoInteractions(groupServices);
     }
@@ -562,7 +570,8 @@ public class GroupControllerTest {
                 "detail": "The provided groupId contains illegal characters. It must match the pattern '%s'.",
                 "instance": "%s"
               }"""
-                  .formatted(IdentifierPatterns.ID_PATTERN, path));
+                  .formatted(IdentifierPatterns.ID_PATTERN, path),
+              JsonCompareMode.STRICT);
       verifyNoInteractions(groupServices);
     }
 
@@ -775,7 +784,8 @@ public class GroupControllerTest {
                 "detail": "The provided mappingRuleId contains illegal characters. It must match the pattern '%s'.",
                 "instance": "%s"
               }"""
-                  .formatted(IdentifierPatterns.ID_PATTERN, path));
+                  .formatted(IdentifierPatterns.ID_PATTERN, path),
+              JsonCompareMode.STRICT);
       verifyNoInteractions(groupServices);
     }
 
@@ -805,7 +815,8 @@ public class GroupControllerTest {
                 "detail": "The provided groupId contains illegal characters. It must match the pattern '%s'.",
                 "instance": "%s"
               }"""
-                  .formatted(IdentifierPatterns.ID_PATTERN, path));
+                  .formatted(IdentifierPatterns.ID_PATTERN, path),
+              JsonCompareMode.STRICT);
       verifyNoInteractions(groupServices);
     }
 
@@ -994,7 +1005,8 @@ public class GroupControllerTest {
                   "detail": "The provided mappingRuleId contains illegal characters. It must match the pattern '%s'.",
                   "instance": "%s"
                 }"""
-                  .formatted(IdentifierPatterns.ID_PATTERN, path));
+                  .formatted(IdentifierPatterns.ID_PATTERN, path),
+              JsonCompareMode.STRICT);
       verifyNoInteractions(groupServices);
     }
 
@@ -1023,7 +1035,8 @@ public class GroupControllerTest {
                   "detail": "The provided groupId contains illegal characters. It must match the pattern '%s'.",
                   "instance": "%s"
                 }"""
-                  .formatted(IdentifierPatterns.ID_PATTERN, path));
+                  .formatted(IdentifierPatterns.ID_PATTERN, path),
+              JsonCompareMode.STRICT);
       verifyNoInteractions(groupServices);
     }
   }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupQueryControllerTest.java
@@ -271,7 +271,8 @@ public class GroupQueryControllerTest extends RestControllerTest {
               "name": "%s",
               "description": "%s"
             }"""
-                .formatted(groupId, groupName, groupDescription));
+                .formatted(groupId, groupName, groupDescription),
+            JsonCompareMode.STRICT);
 
     // then
     verify(groupServices, times(1)).getGroup(group.groupId());
@@ -306,7 +307,8 @@ public class GroupQueryControllerTest extends RestControllerTest {
               "detail": "group not found",
               "instance": "%s"
             }"""
-                .formatted(path));
+                .formatted(path),
+            JsonCompareMode.STRICT);
 
     // then
     verify(groupServices, times(1)).getGroup(groupId);
@@ -376,7 +378,8 @@ public class GroupQueryControllerTest extends RestControllerTest {
              "page": {
                "totalItems": 3,
                "startCursor": "f",
-               "endCursor": "v"
+               "endCursor": "v",
+               "hasMoreTotalItems": false
              }
            }"""
                 .formatted(
@@ -388,7 +391,8 @@ public class GroupQueryControllerTest extends RestControllerTest {
                     description2,
                     groupId3,
                     groupName3,
-                    description3));
+                    description3),
+            JsonCompareMode.STRICT);
 
     verify(groupServices).search(new GroupQuery.Builder().build());
   }
@@ -462,7 +466,8 @@ public class GroupQueryControllerTest extends RestControllerTest {
              "page": {
                "totalItems": 3,
                "startCursor": "f",
-               "endCursor": "v"
+               "endCursor": "v",
+               "hasMoreTotalItems": false
              }
            }"""
                 .formatted(
@@ -474,7 +479,8 @@ public class GroupQueryControllerTest extends RestControllerTest {
                     description2,
                     groupId3,
                     groupName3,
-                    description3));
+                    description3),
+            JsonCompareMode.STRICT);
 
     verify(groupServices)
         .search(new GroupQuery.Builder().filter(fn -> fn.groupIds(groupId1, groupId2)).build());

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/MappingRuleQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/MappingRuleQueryControllerTest.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.json.JsonCompareMode;
 
 @WebMvcTest(value = MappingRuleController.class)
 public class MappingRuleQueryControllerTest extends RestControllerTest {
@@ -66,8 +67,10 @@ public class MappingRuleQueryControllerTest extends RestControllerTest {
                           {
                             "claimName": "Claim Name",
                             "claimValue": "Claim Value",
-                            "name": "Map Name"
-                          }""");
+                            "name": "Map Name",
+                            "mappingRuleId": "id"
+                          }""",
+            JsonCompareMode.STRICT);
 
     // then
     verify(mappingRuleServices, times(1)).getMappingRule(mappingRule.mappingRuleId());
@@ -102,7 +105,8 @@ public class MappingRuleQueryControllerTest extends RestControllerTest {
               "detail": "mapping rule not found",
               "instance": "%s"
             }"""
-                .formatted(path));
+                .formatted(path),
+            JsonCompareMode.STRICT);
 
     // then
     verify(mappingRuleServices, times(1)).getMappingRule(mappingRuleId);
@@ -147,25 +151,30 @@ public class MappingRuleQueryControllerTest extends RestControllerTest {
                {
                  "claimName": "Claim Name1",
                  "claimValue": "Claim Value1",
-                 "name": "Map Name1"
+                 "name": "Map Name1",
+                 "mappingRuleId": "id1"
                },
                {
                  "claimName": "Claim Name2",
                  "claimValue": "Claim Value2",
-                 "name": "Map Name2"
+                 "name": "Map Name2",
+                 "mappingRuleId": "id2"
                },
                {
                  "claimName": "Claim Name3",
                  "claimValue": "Claim Value3",
-                 "name": "Map Name3"
+                 "name": "Map Name3",
+                 "mappingRuleId": "id3"
                }
              ],
              "page": {
                "totalItems": 3,
                "startCursor": "f",
-               "endCursor": "v"
+               "endCursor": "v",
+               "hasMoreTotalItems": false
              }
-           }""");
+           }""",
+            JsonCompareMode.STRICT);
 
     verify(mappingRuleServices).search(new MappingRuleQuery.Builder().build());
   }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleControllerTest.java
@@ -41,6 +41,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.json.JsonCompareMode;
 
 @WebMvcTest(RoleController.class)
 public class RoleControllerTest extends RestControllerTest {
@@ -120,7 +121,8 @@ public class RoleControllerTest extends RestControllerTest {
               "detail": "No roleId provided.",
               "instance": "%s"
             }"""
-                .formatted(ROLE_BASE_URL));
+                .formatted(ROLE_BASE_URL),
+            JsonCompareMode.STRICT);
 
     // then
     verifyNoInteractions(roleServices);
@@ -152,7 +154,8 @@ public class RoleControllerTest extends RestControllerTest {
               "detail": "No roleId provided.",
               "instance": "%s"
             }"""
-                .formatted(ROLE_BASE_URL));
+                .formatted(ROLE_BASE_URL),
+            JsonCompareMode.STRICT);
 
     // then
     verifyNoInteractions(roleServices);
@@ -184,7 +187,8 @@ public class RoleControllerTest extends RestControllerTest {
               "detail": "No name provided.",
               "instance": "%s"
             }"""
-                .formatted(ROLE_BASE_URL));
+                .formatted(ROLE_BASE_URL),
+            JsonCompareMode.STRICT);
 
     // then
     verifyNoInteractions(roleServices);
@@ -215,7 +219,8 @@ public class RoleControllerTest extends RestControllerTest {
               "detail": "The provided roleId exceeds the limit of 256 characters.",
               "instance": "%s"
             }"""
-                .formatted(ROLE_BASE_URL));
+                .formatted(ROLE_BASE_URL),
+            JsonCompareMode.STRICT);
 
     // then
     verifyNoInteractions(roleServices);
@@ -249,7 +254,8 @@ public class RoleControllerTest extends RestControllerTest {
                 "detail": "The provided roleId contains illegal characters. It must match the pattern '%s'.",
                 "instance": "%s"
               }"""
-                .formatted(IdentifierPatterns.ID_PATTERN, ROLE_BASE_URL));
+                .formatted(IdentifierPatterns.ID_PATTERN, ROLE_BASE_URL),
+            JsonCompareMode.STRICT);
     verifyNoInteractions(roleServices);
   }
 
@@ -289,7 +295,8 @@ public class RoleControllerTest extends RestControllerTest {
               "description": "%s"
             }
             """
-                .formatted(roleId, roleName, description));
+                .formatted(roleId, roleName, description),
+            JsonCompareMode.STRICT);
 
     // then
     verify(roleServices, times(1)).updateRole(request);
@@ -323,7 +330,8 @@ public class RoleControllerTest extends RestControllerTest {
               "detail": "No name provided.",
               "instance": "%s"
             }"""
-                .formatted(uri));
+                .formatted(uri),
+            JsonCompareMode.STRICT);
 
     verifyNoInteractions(roleServices);
   }
@@ -385,7 +393,8 @@ public class RoleControllerTest extends RestControllerTest {
               "detail": "No description provided.",
               "instance": "%s"
             }"""
-                .formatted(uri));
+                .formatted(uri),
+            JsonCompareMode.STRICT);
 
     verifyNoInteractions(roleServices);
   }
@@ -538,7 +547,8 @@ public class RoleControllerTest extends RestControllerTest {
                 "detail": "The provided mappingRuleId contains illegal characters. It must match the pattern '%s'.",
                 "instance": "%s"
               }"""
-                .formatted(IdentifierPatterns.ID_PATTERN, path));
+                .formatted(IdentifierPatterns.ID_PATTERN, path),
+            JsonCompareMode.STRICT);
     verifyNoInteractions(roleServices);
   }
 
@@ -568,7 +578,8 @@ public class RoleControllerTest extends RestControllerTest {
                 "detail": "The provided roleId contains illegal characters. It must match the pattern '%s'.",
                 "instance": "%s"
               }"""
-                .formatted(IdentifierPatterns.ID_PATTERN, path));
+                .formatted(IdentifierPatterns.ID_PATTERN, path),
+            JsonCompareMode.STRICT);
     verifyNoInteractions(roleServices);
   }
 
@@ -731,7 +742,8 @@ public class RoleControllerTest extends RestControllerTest {
                 "detail": "The provided username contains illegal characters. It must match the pattern '%s'.",
                 "instance": "%s"
               }"""
-                .formatted(IdentifierPatterns.ID_PATTERN, path));
+                .formatted(IdentifierPatterns.ID_PATTERN, path),
+            JsonCompareMode.STRICT);
     verifyNoInteractions(roleServices);
   }
 
@@ -761,7 +773,8 @@ public class RoleControllerTest extends RestControllerTest {
                 "detail": "The provided roleId contains illegal characters. It must match the pattern '%s'.",
                 "instance": "%s"
               }"""
-                .formatted(IdentifierPatterns.ID_PATTERN, path));
+                .formatted(IdentifierPatterns.ID_PATTERN, path),
+            JsonCompareMode.STRICT);
     verifyNoInteractions(roleServices);
   }
 
@@ -866,7 +879,8 @@ public class RoleControllerTest extends RestControllerTest {
                   "detail": "The provided username contains illegal characters. It must match the pattern '%s'.",
                   "instance": "%s"
                 }"""
-                .formatted(IdentifierPatterns.ID_PATTERN, path));
+                .formatted(IdentifierPatterns.ID_PATTERN, path),
+            JsonCompareMode.STRICT);
     verifyNoInteractions(roleServices);
   }
 
@@ -895,7 +909,8 @@ public class RoleControllerTest extends RestControllerTest {
                   "detail": "The provided roleId contains illegal characters. It must match the pattern '%s'.",
                   "instance": "%s"
                 }"""
-                .formatted(IdentifierPatterns.ID_PATTERN, path));
+                .formatted(IdentifierPatterns.ID_PATTERN, path),
+            JsonCompareMode.STRICT);
     verifyNoInteractions(roleServices);
   }
 
@@ -1001,7 +1016,8 @@ public class RoleControllerTest extends RestControllerTest {
                 "detail": "The provided groupId contains illegal characters. It must match the pattern '%s'.",
                 "instance": "%s"
               }"""
-                .formatted(IdentifierPatterns.ID_PATTERN, path));
+                .formatted(IdentifierPatterns.ID_PATTERN, path),
+            JsonCompareMode.STRICT);
     verifyNoInteractions(roleServices);
   }
 
@@ -1031,7 +1047,8 @@ public class RoleControllerTest extends RestControllerTest {
                 "detail": "The provided roleId contains illegal characters. It must match the pattern '%s'.",
                 "instance": "%s"
               }"""
-                .formatted(IdentifierPatterns.ID_PATTERN, path));
+                .formatted(IdentifierPatterns.ID_PATTERN, path),
+            JsonCompareMode.STRICT);
     verifyNoInteractions(roleServices);
   }
 
@@ -1139,7 +1156,8 @@ public class RoleControllerTest extends RestControllerTest {
                   "detail": "The provided groupId contains illegal characters. It must match the pattern '%s'.",
                   "instance": "%s"
                 }"""
-                .formatted(IdentifierPatterns.ID_PATTERN, path));
+                .formatted(IdentifierPatterns.ID_PATTERN, path),
+            JsonCompareMode.STRICT);
     verifyNoInteractions(roleServices);
   }
 
@@ -1168,7 +1186,8 @@ public class RoleControllerTest extends RestControllerTest {
                   "detail": "The provided roleId contains illegal characters. It must match the pattern '%s'.",
                   "instance": "%s"
                 }"""
-                .formatted(IdentifierPatterns.ID_PATTERN, path));
+                .formatted(IdentifierPatterns.ID_PATTERN, path),
+            JsonCompareMode.STRICT);
     verifyNoInteractions(roleServices);
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleQueryControllerTest.java
@@ -37,6 +37,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.json.JsonCompareMode;
 
 @WebMvcTest(value = RoleController.class)
 public class RoleQueryControllerTest extends RestControllerTest {
@@ -83,7 +84,8 @@ public class RoleQueryControllerTest extends RestControllerTest {
               "name": "Role Name",
               "roleId": "roleId",
               "description": "description"
-            }""");
+            }""",
+            JsonCompareMode.STRICT);
 
     // then
     verify(roleServices, times(1)).getRole(role.roleId());
@@ -118,7 +120,8 @@ public class RoleQueryControllerTest extends RestControllerTest {
               "detail": "role not found",
               "instance": "%s"
             }"""
-                .formatted(path));
+                .formatted(path),
+            JsonCompareMode.STRICT);
 
     // then
     verify(roleServices, times(1)).getRole(roleId);
@@ -176,9 +179,11 @@ public class RoleQueryControllerTest extends RestControllerTest {
              "page": {
                "totalItems": 3,
                "startCursor": "f",
-               "endCursor": "v"
+               "endCursor": "v",
+               "hasMoreTotalItems": false
              }
-           }""");
+           }""",
+            JsonCompareMode.STRICT);
 
     verify(roleServices).search(new RoleQuery.Builder().build());
   }
@@ -265,9 +270,11 @@ public class RoleQueryControllerTest extends RestControllerTest {
                }
              ],
              "page": {
-               "totalItems": 3
+               "totalItems": 3,
+               "hasMoreTotalItems": false
              }
-           }""");
+           }""",
+            JsonCompareMode.STRICT);
 
     verify(roleServices)
         .searchMembers(
@@ -328,9 +335,11 @@ public class RoleQueryControllerTest extends RestControllerTest {
                 }
              ],
              "page": {
-               "totalItems": 3
+               "totalItems": 3,
+               "hasMoreTotalItems": false
              }
-           }""");
+           }""",
+            JsonCompareMode.STRICT);
 
     verify(mappingRuleServices)
         .search(
@@ -382,9 +391,11 @@ public class RoleQueryControllerTest extends RestControllerTest {
                }
              ],
              "page": {
-               "totalItems": 3
+               "totalItems": 3,
+               "hasMoreTotalItems": false
              }
-           }""");
+           }""",
+            JsonCompareMode.STRICT);
 
     verify(roleServices)
         .searchMembers(
@@ -431,9 +442,11 @@ public class RoleQueryControllerTest extends RestControllerTest {
                 }
               ],
               "page": {
-                "totalItems": 2
+                "totalItems": 2,
+                "hasMoreTotalItems": false
               }
-            }""");
+            }""",
+            JsonCompareMode.STRICT);
 
     verify(roleServices)
         .searchMembers(

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/UserControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/UserControllerTest.java
@@ -90,7 +90,8 @@ public class UserControllerTest extends RestControllerTest {
             "email": "bar@baz.com"
           }
         """
-                .formatted(username));
+                .formatted(username),
+            JsonCompareMode.STRICT);
 
     // then
     verify(userServices, times(1)).createUser(dto);
@@ -234,7 +235,8 @@ public class UserControllerTest extends RestControllerTest {
             "email": ""
           }
         """
-                .formatted(dto.username()));
+                .formatted(dto.username()),
+            JsonCompareMode.STRICT);
 
     // then
     verify(userServices, times(1)).createUser(dto);

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/UserQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/UserQueryControllerTest.java
@@ -102,8 +102,10 @@ public class UserQueryControllerTest extends RestControllerTest {
             {
               "username": "username",
               "name": "User Name",
-              "email": "email@email.com"
-            }""");
+              "email": "email@email.com",
+              "userKey": "100"
+            }""",
+            JsonCompareMode.STRICT);
 
     // then
     verify(userServices, times(1)).getUser(user.username());
@@ -138,7 +140,8 @@ public class UserQueryControllerTest extends RestControllerTest {
               "detail": "user not found",
               "instance": "%s"
             }"""
-                .formatted(path));
+                .formatted(path),
+            JsonCompareMode.STRICT);
 
     // then
     verify(userServices, times(1)).getUser(username);


### PR DESCRIPTION
## Description

Follow-up of https://github.com/camunda/camunda/pull/35510.
Introducing an ArchUnit test to avoid using LENIENT comparison by default.
Adjusting more tests to actually test the whole response.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

n/a
