### PR TITLE
Ad-hoc sub-process: add job worker properties 

### DIFF
--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractAdHocSubProcessBuilder.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractAdHocSubProcessBuilder.java
@@ -26,15 +26,17 @@ import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeAdHoc;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeAdHocImplementationType;
 
 public class AbstractAdHocSubProcessBuilder<B extends AbstractAdHocSubProcessBuilder<B>>
-    extends AbstractSubProcessBuilder<B> {
+    extends AbstractSubProcessBuilder<B> implements ZeebeJobWorkerElementBuilder<B> {
 
   protected boolean isDone = false;
+  private final ZeebeJobWorkerPropertiesBuilder<B> jobWorkerPropertiesBuilder;
 
   protected AbstractAdHocSubProcessBuilder(
       final BpmnModelInstance modelInstance,
       final AdHocSubProcess element,
       final Class<?> selfType) {
     super(modelInstance, element, selfType);
+    jobWorkerPropertiesBuilder = new ZeebeJobWorkerPropertiesBuilderImpl<>(myself);
   }
 
   /**
@@ -82,6 +84,31 @@ public class AbstractAdHocSubProcessBuilder<B extends AbstractAdHocSubProcessBui
     final ZeebeAdHoc adHoc = getCreateSingleExtensionElement(ZeebeAdHoc.class);
     adHoc.setImplementationType(implementationType);
     return myself;
+  }
+
+  @Override
+  public B zeebeJobType(final String type) {
+    return jobWorkerPropertiesBuilder.zeebeJobType(type);
+  }
+
+  @Override
+  public B zeebeJobTypeExpression(final String expression) {
+    return jobWorkerPropertiesBuilder.zeebeJobTypeExpression(expression);
+  }
+
+  @Override
+  public B zeebeJobRetries(final String retries) {
+    return jobWorkerPropertiesBuilder.zeebeJobRetries(retries);
+  }
+
+  @Override
+  public B zeebeJobRetriesExpression(final String expression) {
+    return jobWorkerPropertiesBuilder.zeebeJobRetriesExpression(expression);
+  }
+
+  @Override
+  public B zeebeTaskHeader(final String key, final String value) {
+    return jobWorkerPropertiesBuilder.zeebeTaskHeader(key, value);
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableAdHocSubProcess.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableAdHocSubProcess.java
@@ -13,12 +13,14 @@ import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.HashMap;
 import java.util.Map;
 
-public class ExecutableAdHocSubProcess extends ExecutableFlowElementContainer {
+public class ExecutableAdHocSubProcess extends ExecutableFlowElementContainer
+    implements ExecutableJobWorkerElement {
 
   private Expression activeElementsCollection;
   private Expression completionCondition;
   private boolean cancelRemainingInstances;
   private ZeebeAdHocImplementationType implementationType;
+  private JobWorkerProperties jobWorkerProperties;
 
   private final Map<String, ExecutableFlowNode> adHocActivitiesById = new HashMap<>();
 
@@ -65,5 +67,15 @@ public class ExecutableAdHocSubProcess extends ExecutableFlowElementContainer {
 
   public void setImplementationType(final ZeebeAdHocImplementationType implementationType) {
     this.implementationType = implementationType;
+  }
+
+  @Override
+  public JobWorkerProperties getJobWorkerProperties() {
+    return jobWorkerProperties;
+  }
+
+  @Override
+  public void setJobWorkerProperties(final JobWorkerProperties jobWorkerProperties) {
+    this.jobWorkerProperties = jobWorkerProperties;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/AdHocSubProcessTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/AdHocSubProcessTransformer.java
@@ -14,16 +14,24 @@ import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlo
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableProcess;
 import io.camunda.zeebe.engine.processing.deployment.model.transformation.ModelElementTransformer;
 import io.camunda.zeebe.engine.processing.deployment.model.transformation.TransformContext;
+import io.camunda.zeebe.engine.processing.deployment.model.transformer.zeebe.TaskDefinitionTransformer;
+import io.camunda.zeebe.engine.processing.deployment.model.transformer.zeebe.TaskHeadersTransformer;
 import io.camunda.zeebe.model.bpmn.instance.AdHocSubProcess;
 import io.camunda.zeebe.model.bpmn.instance.CompletionCondition;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeAdHoc;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeAdHocImplementationType;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskDefinition;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskHeaders;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.BpmnEventType;
 import java.util.Collection;
 import java.util.Optional;
 
 public final class AdHocSubProcessTransformer implements ModelElementTransformer<AdHocSubProcess> {
+
+  private final TaskDefinitionTransformer taskDefinitionTransformer =
+      new TaskDefinitionTransformer();
+  private final TaskHeadersTransformer taskHeadersTransformer = new TaskHeadersTransformer();
 
   @Override
   public Class<AdHocSubProcess> getType() {
@@ -51,6 +59,12 @@ public final class AdHocSubProcessTransformer implements ModelElementTransformer
         executableAdHocSubProcess.getChildElements();
     setAdHocActivities(executableAdHocSubProcess, childElements);
     setImplementationType(executableAdHocSubProcess, element);
+
+    final var taskDefinition = element.getSingleExtensionElement(ZeebeTaskDefinition.class);
+    taskDefinitionTransformer.transform(executableAdHocSubProcess, context, taskDefinition);
+
+    final var taskHeaders = element.getSingleExtensionElement(ZeebeTaskHeaders.class);
+    taskHeadersTransformer.transform(executableAdHocSubProcess, taskHeaders, element);
   }
 
   private static void setActiveElementsCollection(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/AdHocSubProcessTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/AdHocSubProcessTransformer.java
@@ -59,12 +59,7 @@ public final class AdHocSubProcessTransformer implements ModelElementTransformer
         executableAdHocSubProcess.getChildElements();
     setAdHocActivities(executableAdHocSubProcess, childElements);
     setImplementationType(executableAdHocSubProcess, element);
-
-    final var taskDefinition = element.getSingleExtensionElement(ZeebeTaskDefinition.class);
-    taskDefinitionTransformer.transform(executableAdHocSubProcess, context, taskDefinition);
-
-    final var taskHeaders = element.getSingleExtensionElement(ZeebeTaskHeaders.class);
-    taskHeadersTransformer.transform(executableAdHocSubProcess, taskHeaders, element);
+    setJobWorkerProperties(executableAdHocSubProcess, context, element);
   }
 
   private static void setActiveElementsCollection(
@@ -97,6 +92,17 @@ public final class AdHocSubProcessTransformer implements ModelElementTransformer
             .map(ZeebeAdHoc::getImplementationType)
             .orElse(ZeebeAdHocImplementationType.BPMN);
     executableAdHocSubProcess.setImplementationType(implementationType);
+  }
+
+  private void setJobWorkerProperties(
+      final ExecutableAdHocSubProcess executableAdHocSubProcess,
+      final TransformContext context,
+      final AdHocSubProcess element) {
+    final var taskDefinition = element.getSingleExtensionElement(ZeebeTaskDefinition.class);
+    taskDefinitionTransformer.transform(executableAdHocSubProcess, context, taskDefinition);
+
+    final var taskHeaders = element.getSingleExtensionElement(ZeebeTaskHeaders.class);
+    taskHeadersTransformer.transform(executableAdHocSubProcess, taskHeaders, element);
   }
 
   /**


### PR DESCRIPTION
## Description

Adds `JobWorkerProperties` to the ad-hoc sub-process and validates the existence of `ZeebeTaskDefinition` when the implementation type (implemented in #35599) is configured to `JOB_WORKER`.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes https://github.com/camunda/ad-hoc-sub-process-phase-3/issues/2