### PR TITLE
feat: add validation for mandatory fields in create new mapping rule …

### DIFF
--- a/identity/client/src/pages/mapping-rules/modals/AddModal.tsx
+++ b/identity/client/src/pages/mapping-rules/modals/AddModal.tsx
@@ -75,7 +75,7 @@ const AddMappingRuleModal: FC<UseModalProps> = ({
         onChange={setMappingRuleId}
         value={mappingRuleId}
         helperText={t("uniqueIdForMappingRule")}
-        validate={(value) => value.length > 0}
+        validate={(value) => value.trim().length > 0}
         errorMessage={t("mappingRuleIdRequired")}
         autoFocus
       />
@@ -85,7 +85,7 @@ const AddMappingRuleModal: FC<UseModalProps> = ({
         onChange={setMappingRuleName}
         value={mappingRuleName}
         helperText={t("uniqueNameForMappingRule")}
-        validate={(value) => value.length > 0}
+        validate={(value) => value.trim().length > 0}
         errorMessage={t("mappingRuleNameRequired")}
       />
       <MappingRuleContainer>

--- a/identity/client/src/pages/mapping-rules/modals/AddModal.tsx
+++ b/identity/client/src/pages/mapping-rules/modals/AddModal.tsx
@@ -75,6 +75,8 @@ const AddMappingRuleModal: FC<UseModalProps> = ({
         onChange={setMappingRuleId}
         value={mappingRuleId}
         helperText={t("uniqueIdForMappingRule")}
+        validate={(value) => value.length > 0}
+        errorMessage={t("mappingRuleIdRequired")}
         autoFocus
       />
       <TextField
@@ -83,6 +85,8 @@ const AddMappingRuleModal: FC<UseModalProps> = ({
         onChange={setMappingRuleName}
         value={mappingRuleName}
         helperText={t("uniqueNameForMappingRule")}
+        validate={(value) => value.length > 0}
+        errorMessage={t("mappingRuleNameRequired")}
       />
       <MappingRuleContainer>
         <Stack gap={spacing05}>

--- a/identity/client/src/utility/localization/en/mappingRules.json
+++ b/identity/client/src/utility/localization/en/mappingRules.json
@@ -28,5 +28,7 @@
   "updatingMappingRule": "Updating mapping rule",
   "updateMappingRule": "Update Mapping rule",
   "enterClaimValue": "Enter claim value",
-  "valueForClaim": "Enter the value for the claim"
+  "valueForClaim": "Enter the value for the claim",
+  "mappingRuleIdRequired": "Mapping rule ID is required",
+  "mappingRuleNameRequired": "Mapping rule name is required"
 }


### PR DESCRIPTION
…modal

## Description

<!-- Describe the goal and purpose of this PR. -->
See description of the linked issue.


### Note for the reviewer

- I found two approaches in the code for validating form fields
  - [Using the `onBlur` callback in the custom `TextField` component](https://github.com/camunda/camunda/blob/82b7887ec6a177b3d1edb67ead1547ae6727c1fb/identity/client/src/pages/tenants/modals/AddModal.tsx#L80)
  - [Using the `onBlur` callback in the Carbon component directly](https://github.com/camunda/camunda/blob/82b7887ec6a177b3d1edb67ead1547ae6727c1fb/identity/client/src/pages/setup/SetupPage.tsx#L104)
- I didn't use both approaches, but created a new approach by modifying the custom `TextField` component slightly
  - The new approach has a better UX because the validation is done both when the field is changed and on blur. Without this, when a user corrects the field, they see the error until they move away from the field, leading to confusion.
  - The validation state is handled in the shared component reducing the boilerplate needed to add validation for other usages of this component

If my approach is acceptable, I can open a follow-up PR applying the same pattern to all other places where similar validation is performed.

### Additional thoughts

- I'm missing unit/integration tests and there is no confidence when making changes that I'm not breaking existing functionality, especially when modifying shared components like the `TextField` component.


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #33461 
