### PR TITLE
ci: align zeebe ci and integration tests with unified ci naming

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -368,7 +368,7 @@ jobs:
 
   zeebe-unit-tests:
     if: needs.detect-changes.outputs.java-code-changes == 'true'
-    name: "[UT] Zeebe - ${{matrix.component}} - ${{matrix.suiteName}}"
+    name: "Zeebe / [UT] ${{matrix.component}} / ${{matrix.suiteName}}"
     needs: [ detect-changes, setup-unit-tests ]
     timeout-minutes: 10
     permissions: { }  # GITHUB_TOKEN unused in this job
@@ -1078,6 +1078,7 @@ jobs:
 
   zeebe-ci:
     if: needs.detect-changes.outputs.zeebe-changes == 'true'
+    name: "Zeebe"
     needs: [ detect-changes ]
     uses: ./.github/workflows/zeebe-ci.yml
     secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,7 +245,7 @@ jobs:
   # Runs unit tests for all modules that are not Operate, Optimize, Tasklist, or Zeebe. This test will run any new modules that are added and are not included in setup-unit-tests
   general-unit-tests:
     if: needs.detect-changes.outputs.java-code-changes == 'true'
-    name: "[UT] General Unit Tests"
+    name: "General / [UT] Run Unit Tests"
     needs: [ detect-changes, setup-unit-tests ]
     timeout-minutes: 10
     permissions: { }  # GITHUB_TOKEN unused in this job
@@ -292,7 +292,7 @@ jobs:
         uses: ./.github/actions/collect-test-artifacts
         if: ${{ failure() || cancelled() || steps.analyze-test-run.outputs.flakyTests != '' }}
         with:
-          name: "[UT] General Unit Tests"
+          name: "General / [UT]"
       - name: Observe build status
         if: always()
         continue-on-error: true
@@ -768,7 +768,7 @@ jobs:
 
   integration-tests:
     if: needs.detect-changes.outputs.java-code-changes == 'true'
-    name: "[IT] ${{ matrix.name }} ${{ matrix.suite }}"
+    name: "${{ matrix.module }} / [IT] ${{ matrix.name }} / ${{ matrix.owner }}"
     needs: [ detect-changes ]
     timeout-minutes: 25
     permissions: { }  # GITHUB_TOKEN unused in this job
@@ -785,7 +785,8 @@ jobs:
             runs-on: gcp-perf-core-8-default
             docker-repository: localhost:5000/camunda/zeebe
             docker-file: Dockerfile
-            suite: ""
+            owner: "QA"
+            module: "QA"
           - group: modules
             name: "Zeebe Module"
             maven-modules: "'!qa/integration-tests,!qa/update-tests' -f zeebe"
@@ -794,7 +795,8 @@ jobs:
             runs-on: gcp-perf-core-16-longrunning
             docker-repository: localhost:5000/camunda/zeebe
             docker-file: Dockerfile
-            suite: "Core Features"
+            owner: "Core Features"
+            module: "Zeebe"
           - group: schema-manager
             name: "Schema Manager"
             maven-modules: "schema-manager"
@@ -803,7 +805,8 @@ jobs:
             runs-on: gcp-perf-core-8-default
             docker-repository: localhost:5000/camunda/camunda
             docker-file: camunda.Dockerfile
-            suite: "Data Layer"
+            owner: "Data Layer"
+            module: "Schema Manager"
           - group: qa-integration
             name: "Zeebe QA"
             maven-modules: "zeebe/qa/integration-tests"
@@ -812,7 +815,8 @@ jobs:
             runs-on: gcp-perf-core-16-default
             docker-repository: localhost:5000/camunda/zeebe
             docker-file: Dockerfile
-            suite: ""
+            owner: "Core Features"
+            module: "Zeebe"
           - group: qa-migration-integration
             name: "Migration QA"
             maven-modules: "migration/process-migration"
@@ -821,7 +825,8 @@ jobs:
             runs-on: gcp-perf-core-8-default
             docker-repository: localhost:5000/camunda/zeebe
             docker-file: Dockerfile
-            suite: "Data Layer"
+            owner: "Data Layer"
+            module: "Migration"
           - group: qa-update
             name: "Zeebe QA - Update"
             maven-modules: "zeebe/qa/update-tests"
@@ -830,7 +835,8 @@ jobs:
             runs-on: gcp-perf-core-8-default
             docker-repository: localhost:5000/camunda/zeebe
             docker-file: Dockerfile
-            suite: ""
+            owner: "Core Features"
+            module: "Zeebe"
           - group: qa-camunda-process-test
             name: "Camunda Process"
             maven-modules: "testing/camunda-process-test-java,testing/camunda-process-test-spring,testing/camunda-process-test-example"
@@ -839,7 +845,8 @@ jobs:
             runs-on: gcp-perf-core-8-default
             docker-repository: localhost:5000/camunda/camunda
             docker-file: camunda.Dockerfile
-            suite: ""
+            owner: ""
+            module: "Testing"
     env:
       ZEEBE_TEST_DOCKER_IMAGE: localhost:5000/camunda/zeebe:current-test
       OPERATE_TEST_DOCKER_IMAGE: localhost:5000/camunda/operate:current-test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -845,7 +845,7 @@ jobs:
             runs-on: gcp-perf-core-8-default
             docker-repository: localhost:5000/camunda/camunda
             docker-file: camunda.Dockerfile
-            owner: ""
+            owner: "Core Features"
             module: "Testing"
     env:
       ZEEBE_TEST_DOCKER_IMAGE: localhost:5000/camunda/zeebe:current-test

--- a/.github/workflows/zeebe-ci.yml
+++ b/.github/workflows/zeebe-ci.yml
@@ -31,7 +31,7 @@ env:
 
 jobs:
   smoke-tests:
-    name: "[Smoke] ${{ matrix.os }} with ${{ matrix.arch }}"
+    name: "[Smoke] ${{ matrix.os }} with ${{ matrix.arch }} / Core Features"
     timeout-minutes: 20
     permissions: {}  # GITHUB_TOKEN unused in this job
     runs-on: ${{ matrix.runner }}
@@ -112,7 +112,7 @@ jobs:
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
 
   property-tests:
-    name: Property Tests
+    name: "[Property] Tests / Core Features"
     runs-on: gcp-perf-core-8-default
     timeout-minutes: 20
     permissions: {}  # GITHUB_TOKEN unused in this job
@@ -164,7 +164,7 @@ jobs:
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
 
   performance-tests:
-    name: Performance Tests
+    name: "[Performance] Tests / Core Features"
     runs-on: gcp-perf-core-16-default
     timeout-minutes: 20
     permissions: {}  # GITHUB_TOKEN unused in this job
@@ -230,7 +230,7 @@ jobs:
 
   strace-tests:
     # Zeebe tests requiring strace
-    name: Strace Tests
+    name: "[UT] Strace Tests / Core Features"
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions: {}  # GITHUB_TOKEN unused in this job
@@ -286,7 +286,7 @@ jobs:
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
 
   docker-checks:
-    name: Docker checks
+    name: "[Build] Docker Build Checks / Core Features"
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Align CI names with the naming convention laid out in this PR https://github.com/camunda/camunda/pull/35856
```
CI / <componentName> / [<testType>] <testName> / <ownerName> / ...
```

CI Job names should have a clear component, test type, and owner ([ref](https://github.com/camunda/camunda/wiki/CI-&-Automation#naming-conventions)). This PR makes changes to the Zeebe CI and Integration job names

Similar PR exist for the other components
- Operate https://github.com/camunda/camunda/pull/35708
- Tasklist https://github.com/camunda/camunda/pull/35703
- Optimize https://github.com/camunda/camunda/pull/35631

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

related to https://github.com/camunda/product-hub/issues/2819
related to https://github.com/camunda/camunda/pull/35611
