### PR TITLE
Flakiness Reporting via GitHub Checks

### DIFF
--- a/.github/actions/analyze-test-runs/action.yml
+++ b/.github/actions/analyze-test-runs/action.yml
@@ -64,7 +64,7 @@ runs:
         echo "::warning::Found flaky tests!\n ${flakyTests}"
       fi
   - name: Comment flaky tests on PR
-    if: steps.find-flakes.outputs.FLAKY_TESTS != ''
+    if:  github.event_name == 'pull_request' && steps.find-flakes.outputs.FLAKY_TESTS != ''
     uses: actions/github-script@v7
     with:
       github-token: ${{ github.token }}

--- a/.github/actions/analyze-test-runs/action.yml
+++ b/.github/actions/analyze-test-runs/action.yml
@@ -63,7 +63,16 @@ runs:
 
         echo "::warning::Found flaky tests!\n ${flakyTests}"
       fi
-
+  - name: Comment flaky tests on PR
+    if: steps.find-flakes.outputs.FLAKY_TESTS != ''
+    uses: actions/github-script@v7
+    with:
+      github-token: ${{ github.token }}
+      script: |
+        const { main } = require('./.github/actions/analyze-test-runs/src/flaky-test-analyzer');
+        const flakyTests = `${{ steps.find-flakes.outputs.FLAKY_TESTS }}`;
+        console.log('🚀 Starting flaky test analysis with modular script...');
+        await main(context, github, flakyTests);
   - name: Unfinished tests
     if: failure() || cancelled()
     shell: bash

--- a/.github/actions/analyze-test-runs/action.yml
+++ b/.github/actions/analyze-test-runs/action.yml
@@ -71,7 +71,6 @@ runs:
       script: |
         const { main } = require('./.github/actions/analyze-test-runs/src/flaky-test-analyzer');
         const flakyTests = `${{ steps.find-flakes.outputs.FLAKY_TESTS }}`;
-        console.log('🚀 Starting flaky test analysis with modular script...');
         await main(context, github, flakyTests);
   - name: Unfinished tests
     if: failure() || cancelled()

--- a/.github/actions/analyze-test-runs/src/flaky-test-analyzer.js
+++ b/.github/actions/analyze-test-runs/src/flaky-test-analyzer.js
@@ -23,12 +23,9 @@ const githubApi = require('./github-api');
  * @returns {object} - Analysis results containing touched files, authors, and inline targets
  */
 async function searchFlakyTestsInModifiedFiles(flakyTests, prData, github, owner, repo) {
-  console.log('\n🔍 Step 2: Searching for flaky tests in modified files...');
 
   const flakyTestLines = flakyTests.trim().split('\n').filter(line => line.trim());
   const changedFiles = prData.files.map(file => file.filename);
-
-  console.log(`🧪 Processing ${flakyTestLines.length} flaky test lines...`);
 
   // Centralized data structure to avoid duplication
   const analysisResults = {
@@ -40,29 +37,28 @@ async function searchFlakyTestsInModifiedFiles(flakyTests, prData, github, owner
 
   for (let i = 0; i < flakyTestLines.length; i++) {
     const testLine = flakyTestLines[i];
-    console.log(`\n🔬 Processing test ${i + 1}/${flakyTestLines.length}: ${testLine}`);
+    console.log(`\n Processing test ${i + 1}/${flakyTestLines.length}: ${testLine}`);
 
     const testClass = helpers.extractTestClass(testLine);
     if (!testClass) {
-      console.log(`⏭️ Skipping - no test class found`);
+      console.log(`Skipping - no test class found`);
       continue;
     }
 
     // Skip if we've already processed this test class
     if (analysisResults.processedTestClasses.has(testClass)) {
-      console.log(`⏭️ Skipping - already processed test class: ${testClass}`);
+      console.log(`Skipping - already processed test class: ${testClass}`);
       continue;
     }
     analysisResults.processedTestClasses.add(testClass);
 
     const matchingFile = helpers.findMatchingFile(testClass, changedFiles);
     if (!matchingFile) {
-      console.log(`⏭️ Skipping - no matching file found for test class: ${testClass}`);
+      console.log(`Skipping - no matching file found for test class: ${testClass}`);
       continue;
     }
 
     // Find the author using the commits data we already fetched
-    console.log(`🔎 Finding author for file: ${matchingFile} (reusing fetched commit data)`);
     const { author: fileAuthor, commit: fileCommit } = await githubApi.findLastAuthor(
       github, owner, repo, prData.commits, matchingFile
     );
@@ -81,16 +77,16 @@ async function searchFlakyTestsInModifiedFiles(flakyTests, prData, github, owner
       // Store for inline comments (Map prevents duplicates by filename)
       if (!analysisResults.inlineTargets.has(matchingFile)) {
         analysisResults.inlineTargets.set(matchingFile, fileInfo);
-        console.log(`📌 Added to inline targets: ${matchingFile} → @${fileAuthor}`);
+        console.log(`Added to inline targets: ${matchingFile} → @${fileAuthor}`);
       } else {
-        console.log(`⏭️ File already in inline targets: ${matchingFile}`);
+        console.log(`File already in inline targets: ${matchingFile}`);
       }
     } else {
-      console.log(`❌ Could not find author for file: ${matchingFile}`);
+      console.log(`Could not find author for file: ${matchingFile}`);
     }
   }
 
-  console.log(`\n📊 Analysis Results Summary:`);
+  console.log(`\n Analysis Results Summary:`);
   console.log(`   📁 ${analysisResults.touchedFiles.length} files with flaky tests`);
   console.log(`   👥 ${analysisResults.mentionedAuthors.size} unique authors mentioned`);
   console.log(`   💬 ${analysisResults.inlineTargets.size} inline comments to create`);
@@ -111,8 +107,6 @@ async function main(context, github, flakyTests) {
   const repo = context.repo.repo;
 
   console.log('🚀 Starting flaky test analysis...');
-  console.log(`📋 PR Number: ${prNumber}`);
-  console.log(`📦 Repository: ${owner}/${repo}`);
   console.log(`🧪 Flaky tests found:\n${flakyTests}`);
 
   try {

--- a/.github/actions/analyze-test-runs/src/flaky-test-analyzer.js
+++ b/.github/actions/analyze-test-runs/src/flaky-test-analyzer.js
@@ -1,0 +1,150 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+/**
+ * Main flaky test analyzer that orchestrates the entire process
+ */
+
+const helpers = require('./helpers');
+const githubApi = require('./github-api');
+
+/**
+ * Searches for flaky tests that match files modified in the current PR
+ * @param {string} flakyTests - The flaky tests string
+ * @param {object} prData - PR data containing files and commits
+ * @param {object} github - GitHub API client
+ * @param {string} owner - Repository owner
+ * @param {string} repo - Repository name
+ * @returns {object} - Analysis results containing touched files, authors, and inline targets
+ */
+async function searchFlakyTestsInModifiedFiles(flakyTests, prData, github, owner, repo) {
+  console.log('\n🔍 Step 2: Searching for flaky tests in modified files...');
+
+  const flakyTestLines = flakyTests.trim().split('\n').filter(line => line.trim());
+  const changedFiles = prData.files.map(file => file.filename);
+
+  console.log(`🧪 Processing ${flakyTestLines.length} flaky test lines...`);
+
+  // Centralized data structure to avoid duplication
+  const analysisResults = {
+    touchedFiles: [],
+    mentionedAuthors: new Set(),
+    inlineTargets: new Map(), // Use Map to prevent duplicates by filename
+    processedTestClasses: new Set()
+  };
+
+  for (let i = 0; i < flakyTestLines.length; i++) {
+    const testLine = flakyTestLines[i];
+    console.log(`\n🔬 Processing test ${i + 1}/${flakyTestLines.length}: ${testLine}`);
+
+    const testClass = helpers.extractTestClass(testLine);
+    if (!testClass) {
+      console.log(`⏭️ Skipping - no test class found`);
+      continue;
+    }
+
+    // Skip if we've already processed this test class
+    if (analysisResults.processedTestClasses.has(testClass)) {
+      console.log(`⏭️ Skipping - already processed test class: ${testClass}`);
+      continue;
+    }
+    analysisResults.processedTestClasses.add(testClass);
+
+    const matchingFile = helpers.findMatchingFile(testClass, changedFiles);
+    if (!matchingFile) {
+      console.log(`⏭️ Skipping - no matching file found for test class: ${testClass}`);
+      continue;
+    }
+
+    // Find the author using the commits data we already fetched
+    console.log(`🔎 Finding author for file: ${matchingFile} (reusing fetched commit data)`);
+    const { author: fileAuthor, commit: fileCommit } = await githubApi.findLastAuthor(
+      github, owner, repo, prData.commits, matchingFile
+    );
+
+    if (fileAuthor && fileCommit) {
+      const fileInfo = {
+        file: matchingFile,
+        testClass,
+        author: fileAuthor,
+        commit: fileCommit
+      };
+
+      analysisResults.touchedFiles.push(fileInfo);
+      analysisResults.mentionedAuthors.add(fileAuthor);
+
+      // Store for inline comments (Map prevents duplicates by filename)
+      if (!analysisResults.inlineTargets.has(matchingFile)) {
+        analysisResults.inlineTargets.set(matchingFile, fileInfo);
+        console.log(`📌 Added to inline targets: ${matchingFile} → @${fileAuthor}`);
+      } else {
+        console.log(`⏭️ File already in inline targets: ${matchingFile}`);
+      }
+    } else {
+      console.log(`❌ Could not find author for file: ${matchingFile}`);
+    }
+  }
+
+  console.log(`\n📊 Analysis Results Summary:`);
+  console.log(`   📁 ${analysisResults.touchedFiles.length} files with flaky tests`);
+  console.log(`   👥 ${analysisResults.mentionedAuthors.size} unique authors mentioned`);
+  console.log(`   💬 ${analysisResults.inlineTargets.size} inline comments to create`);
+  console.log(`   🧪 ${analysisResults.processedTestClasses.size} unique test classes processed`);
+
+  return analysisResults;
+}
+
+/**
+ * Main entry point for flaky test analysis
+ * @param {object} context - GitHub Actions context
+ * @param {object} github - GitHub API client
+ * @param {string} flakyTests - The flaky tests string
+ */
+async function main(context, github, flakyTests) {
+  const prNumber = context.issue.number;
+  const owner = context.repo.owner;
+  const repo = context.repo.repo;
+
+  console.log('🚀 Starting flaky test analysis...');
+  console.log(`📋 PR Number: ${prNumber}`);
+  console.log(`📦 Repository: ${owner}/${repo}`);
+  console.log(`🧪 Flaky tests found:\n${flakyTests}`);
+
+  try {
+    // Step 1: Fetch all required data upfront to minimize API calls
+    console.log('\n📡 Step 1: Fetching all PR data...');
+    const prData = await githubApi.fetchPRData(github, owner, repo, prNumber);
+
+    // Step 2: Process flaky tests and map to files/authors
+    console.log('\n 🔍 Step 2: Analyzing flaky tests in modified files...');
+    const analysisResults = await searchFlakyTestsInModifiedFiles(flakyTests, prData, github, owner, repo);
+
+    // Step 3: Execute all GitHub API interactions
+    console.log('\n🚀 Step 3: Creating GitHub interactions...');
+
+    // 3a. Create inline review comments
+    await githubApi.createInlineComments(
+      github, owner, repo, prNumber, prData.pullRequest.head.sha,
+      analysisResults.inlineTargets, helpers.createInlineCommentBody, flakyTests
+    );
+
+    // 3b. Build and post/update the main PR comment
+    await githubApi.createOrUpdateMainComment(
+      github, owner, repo, prNumber, flakyTests, helpers.createMainCommentBody
+    );
+
+    console.log('\n🎉 Flaky test analysis completed successfully!');
+
+  } catch (error) {
+    console.log(`❌ Failed to complete flaky test analysis: ${error.message}`);
+    console.log('🛑 Aborting flaky test analysis');
+    throw error;
+  }
+}
+
+module.exports = { main, searchFlakyTestsInModifiedFiles };

--- a/.github/actions/analyze-test-runs/src/flaky-test-analyzer.js
+++ b/.github/actions/analyze-test-runs/src/flaky-test-analyzer.js
@@ -105,7 +105,13 @@ async function searchFlakyTestsInModifiedFiles(flakyTests, prData, githubConfig)
 async function main(context, github, flakyTests) {
   const owner = context.repo.owner;
   const repo = context.repo.repo;
-  const githubConfig = { github, owner, repo, prNumber: Number(context.issue.number) };
+  const prNumber = Number(context.payload.pull_request?.number || context.issue?.number);
+  const githubConfig = { github, owner, repo, prNumber };
+
+  if (!githubConfig.prNumber || isNaN(githubConfig.prNumber)) {
+    console.log("No PR context detected, skipping PR-based flaky test analysis.");
+    return;
+  }
 
   console.log('🚀 Starting flaky test analysis...');
   console.log(`🧪 Flaky tests found:\n${flakyTests}`);

--- a/.github/actions/analyze-test-runs/src/github-api.js
+++ b/.github/actions/analyze-test-runs/src/github-api.js
@@ -1,0 +1,188 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+/**
+ * GitHub API interactions for flaky test analysis
+ */
+
+/**
+ * Fetches all PR data in parallel to minimize API calls
+ * @param {object} github - GitHub API client
+ * @param {string} owner - Repository owner
+ * @param {string} repo - Repository name
+ * @param {number} prNumber - Pull request number
+ * @returns {object} - Object containing files, commits, and PR data
+ */
+async function fetchPRData(github, owner, repo, prNumber) {
+  console.log('🔄 Making parallel API calls for PR files, commits, and details...');
+
+  const [prFilesResponse, commitsResponse, pullRequestResponse] = await Promise.all([
+    github.rest.pulls.listFiles({ owner, repo, pull_number: prNumber }),
+    github.rest.pulls.listCommits({ owner, repo, pull_number: prNumber }),
+    github.rest.pulls.get({ owner, repo, pull_number: prNumber })
+  ]);
+
+  const prData = {
+    files: prFilesResponse.data,
+    commits: commitsResponse.data,
+    pullRequest: pullRequestResponse.data
+  };
+
+  console.log(`✅ Successfully fetched:`);
+  console.log(`   📄 ${prData.files.length} changed files`);
+  console.log(`   📝 ${prData.commits.length} commits`);
+  console.log(`   🔗 PR head SHA: ${prData.pullRequest.head.sha.substring(0, 7)}`);
+
+  const changedFiles = prData.files.map(file => file.filename);
+  console.log(`📋 Changed files in this PR:`, changedFiles);
+
+  return prData;
+}
+
+/**
+ * Finds the last author who modified a specific file
+ * @param {object} github - GitHub API client
+ * @param {string} owner - Repository owner
+ * @param {string} repo - Repository name
+ * @param {array} commits - Array of commit objects
+ * @param {string} filename - Name of the file to check
+ * @returns {object} - Object containing author and commit info
+ */
+async function findLastAuthor(github, owner, repo, commits, filename) {
+  console.log(`🔎 Finding last author for file: ${filename}`);
+
+  for (const commit of [...commits].reverse()) {
+    try {
+      console.log(`📝 Checking commit ${commit.sha.substring(0, 7)} by ${commit.author?.login || 'unknown'}`);
+
+      const { data: commitFiles } = await github.rest.repos.getCommit({
+        owner,
+        repo,
+        ref: commit.sha,
+      });
+
+      const modifiedFile = commitFiles.files?.find(file => file.filename === filename);
+      if (modifiedFile) {
+        const author = commit.author?.login;
+        console.log(`✅ Found last author for ${filename}: @${author} in commit ${commit.sha.substring(0, 7)}`);
+        return { author, commit };
+      }
+    } catch (error) {
+      console.log(`⚠️ Could not fetch commit ${commit.sha.substring(0, 7)}: ${error.message}`);
+      continue;
+    }
+  }
+
+  console.log(`❌ No author found for file: ${filename}`);
+  return { author: null, commit: null };
+}
+
+/**
+ * Creates inline review comments for flaky tests
+ * @param {object} github - GitHub API client
+ * @param {string} owner - Repository owner
+ * @param {string} repo - Repository name
+ * @param {number} prNumber - Pull request number
+ * @param {string} headSha - Head commit SHA
+ * @param {Map} inlineTargets - Map of filename to target info
+ * @param {function} createInlineCommentBody - Function to create comment body
+ * @param {string} flakyTests - Flaky tests string
+ * @returns {object} - Summary of success/failure counts
+ */
+async function createInlineComments(github, owner, repo, prNumber, headSha, inlineTargets, createInlineCommentBody, flakyTests) {
+  if (inlineTargets.size === 0) {
+    console.log(`⏭️ No inline comments to create`);
+    return { successCount: 0, failCount: 0 };
+  }
+
+  console.log(`\n📝 Creating ${inlineTargets.size} inline review comments...`);
+
+  let successCount = 0;
+  let failCount = 0;
+
+  for (const [filename, target] of inlineTargets.entries()) {
+    console.log(`📝 Creating inline comment ${successCount + failCount + 1}/${inlineTargets.size} for: ${filename}`);
+
+    const inlineBody = createInlineCommentBody(target.author, flakyTests);
+
+    try {
+      await github.rest.pulls.createReviewComment({
+        owner,
+        repo,
+        pull_number: prNumber,
+        commit_id: headSha,
+        path: target.file,
+        line: 1,
+        body: inlineBody
+      });
+      successCount++;
+      console.log(`✅ Successfully created inline comment for ${filename}`);
+    } catch (reviewError) {
+      failCount++;
+      console.log(`❌ Failed to create inline comment for ${filename}: ${reviewError.message}`);
+    }
+  }
+
+  console.log(`📊 Inline comments summary: ${successCount} successful, ${failCount} failed`);
+  return { successCount, failCount };
+}
+
+/**
+ * Creates or updates the main PR comment about flaky tests
+ * @param {object} github - GitHub API client
+ * @param {string} owner - Repository owner
+ * @param {string} repo - Repository name
+ * @param {number} prNumber - Pull request number
+ * @param {string} flakyTests - Flaky tests string
+ * @param {function} createMainCommentBody - Function to create comment body
+ */
+async function createOrUpdateMainComment(github, owner, repo, prNumber, flakyTests, createMainCommentBody) {
+  console.log(`\n💬 Creating main PR comment...`);
+
+  const body = createMainCommentBody(flakyTests);
+
+  const comments = await github.rest.issues.listComments({
+    owner,
+    repo,
+    issue_number: prNumber,
+  });
+
+  console.log(`📋 Found ${comments.data.length} existing comments`);
+
+  const marker = `${flakyTests}`;
+  const botComment = comments.data.find(comment =>
+    comment.user.type === "Bot" && comment.body.includes(marker)
+  );
+
+  if (botComment) {
+    console.log(`🔄 Updating existing bot comment (ID: ${botComment.id})`);
+    await github.rest.issues.updateComment({
+      owner,
+      repo,
+      comment_id: botComment.id,
+      body: body
+    });
+    console.log("✅ Successfully updated existing flaky test comment");
+  } else {
+    console.log(`📝 Creating new bot comment`);
+    await github.rest.issues.createComment({
+      owner,
+      repo,
+      issue_number: prNumber,
+      body: body
+    });
+    console.log("✅ Successfully created new flaky test comment");
+  }
+}
+
+module.exports = {
+  fetchPRData,
+  findLastAuthor,
+  createInlineComments,
+  createOrUpdateMainComment
+};

--- a/.github/actions/analyze-test-runs/src/github-api.js
+++ b/.github/actions/analyze-test-runs/src/github-api.js
@@ -33,13 +33,13 @@ async function fetchPRData(github, owner, repo, prNumber) {
     pullRequest: pullRequestResponse.data
   };
 
-  console.log(`✅ Successfully fetched:`);
+  console.log(`Successfully fetched:`);
   console.log(`   📄 ${prData.files.length} changed files`);
   console.log(`   📝 ${prData.commits.length} commits`);
   console.log(`   🔗 PR head SHA: ${prData.pullRequest.head.sha.substring(0, 7)}`);
 
   const changedFiles = prData.files.map(file => file.filename);
-  console.log(`📋 Changed files in this PR:`, changedFiles);
+  console.log(`Changed files in this PR:`, changedFiles);
 
   return prData;
 }
@@ -54,12 +54,10 @@ async function fetchPRData(github, owner, repo, prNumber) {
  * @returns {object} - Object containing author and commit info
  */
 async function findLastAuthor(github, owner, repo, commits, filename) {
-  console.log(`🔎 Finding last author for file: ${filename}`);
+  console.log(`Finding last author for file: ${filename}`);
 
   for (const commit of [...commits].reverse()) {
     try {
-      console.log(`📝 Checking commit ${commit.sha.substring(0, 7)} by ${commit.author?.login || 'unknown'}`);
-
       const { data: commitFiles } = await github.rest.repos.getCommit({
         owner,
         repo,
@@ -69,16 +67,16 @@ async function findLastAuthor(github, owner, repo, commits, filename) {
       const modifiedFile = commitFiles.files?.find(file => file.filename === filename);
       if (modifiedFile) {
         const author = commit.author?.login;
-        console.log(`✅ Found last author for ${filename}: @${author} in commit ${commit.sha.substring(0, 7)}`);
+        console.log(`Found last author for ${filename}: @${author} in commit ${commit.sha.substring(0, 7)}`);
         return { author, commit };
       }
     } catch (error) {
-      console.log(`⚠️ Could not fetch commit ${commit.sha.substring(0, 7)}: ${error.message}`);
+      console.log(`Could not fetch commit ${commit.sha.substring(0, 7)}: ${error.message}`);
       continue;
     }
   }
 
-  console.log(`❌ No author found for file: ${filename}`);
+  console.log(`No author found for file: ${filename}`);
   return { author: null, commit: null };
 }
 
@@ -96,17 +94,15 @@ async function findLastAuthor(github, owner, repo, commits, filename) {
  */
 async function createInlineComments(github, owner, repo, prNumber, headSha, inlineTargets, createInlineCommentBody, flakyTests) {
   if (inlineTargets.size === 0) {
-    console.log(`⏭️ No inline comments to create`);
+    console.log(`No inline comments to create`);
     return { successCount: 0, failCount: 0 };
   }
-
-  console.log(`\n📝 Creating ${inlineTargets.size} inline review comments...`);
 
   let successCount = 0;
   let failCount = 0;
 
   for (const [filename, target] of inlineTargets.entries()) {
-    console.log(`📝 Creating inline comment ${successCount + failCount + 1}/${inlineTargets.size} for: ${filename}`);
+    console.log(`Creating inline comment ${successCount + failCount + 1}/${inlineTargets.size} for: ${filename}`);
 
     const inlineBody = createInlineCommentBody(target.author, flakyTests);
 
@@ -121,14 +117,14 @@ async function createInlineComments(github, owner, repo, prNumber, headSha, inli
         body: inlineBody
       });
       successCount++;
-      console.log(`✅ Successfully created inline comment for ${filename}`);
+      console.log(`Successfully created inline comment for ${filename}`);
     } catch (reviewError) {
       failCount++;
-      console.log(`❌ Failed to create inline comment for ${filename}: ${reviewError.message}`);
+      console.log(`Failed to create inline comment for ${filename}: ${reviewError.message}`);
     }
   }
 
-  console.log(`📊 Inline comments summary: ${successCount} successful, ${failCount} failed`);
+  console.log(`Inline comments summary: ${successCount} successful, ${failCount} failed`);
   return { successCount, failCount };
 }
 
@@ -142,7 +138,7 @@ async function createInlineComments(github, owner, repo, prNumber, headSha, inli
  * @param {function} createMainCommentBody - Function to create comment body
  */
 async function createOrUpdateMainComment(github, owner, repo, prNumber, flakyTests, createMainCommentBody) {
-  console.log(`\n💬 Creating main PR comment...`);
+  console.log(`\n Creating main PR comment...`);
 
   const body = createMainCommentBody(flakyTests);
 
@@ -152,7 +148,7 @@ async function createOrUpdateMainComment(github, owner, repo, prNumber, flakyTes
     issue_number: prNumber,
   });
 
-  console.log(`📋 Found ${comments.data.length} existing comments`);
+  console.log(`Found ${comments.data.length} existing comments`);
 
   const marker = `${flakyTests}`;
   const botComment = comments.data.find(comment =>
@@ -160,23 +156,21 @@ async function createOrUpdateMainComment(github, owner, repo, prNumber, flakyTes
   );
 
   if (botComment) {
-    console.log(`🔄 Updating existing bot comment (ID: ${botComment.id})`);
+    console.log(`Updating existing bot comment (ID: ${botComment.id})`);
     await github.rest.issues.updateComment({
       owner,
       repo,
       comment_id: botComment.id,
       body: body
     });
-    console.log("✅ Successfully updated existing flaky test comment");
   } else {
-    console.log(`📝 Creating new bot comment`);
+    console.log(`Creating new bot comment`);
     await github.rest.issues.createComment({
       owner,
       repo,
       issue_number: prNumber,
       body: body
     });
-    console.log("✅ Successfully created new flaky test comment");
   }
 }
 

--- a/.github/actions/analyze-test-runs/src/helpers.js
+++ b/.github/actions/analyze-test-runs/src/helpers.js
@@ -6,6 +6,8 @@
  * except in compliance with the Camunda License 1.0.
  */
 
+const path = require('path');
+
 /**
  * Helper functions for flaky test analysis
  */
@@ -16,7 +18,10 @@
  * @returns {string|null} - The extracted test class name or null if not found
  */
 function extractTestClass(testLine) {
-  const match = testLine.match(/([a-zA-Z][a-zA-Z0-9]*\.)+[a-zA-Z][a-zA-Z0-9]*\.[A-Z][a-zA-Z0-9]*(?:Test|IT)/);
+  // Matches the test class path
+  const TEST_CLASS_PATH_REGEX = /([a-zA-Z][a-zA-Z0-9]*\.)+[a-zA-Z][a-zA-Z0-9]*\.[A-Z][a-zA-Z0-9]*(?:Test|IT)/;
+
+  const match = testLine.match(TEST_CLASS_PATH_REGEX);
   const result = match ? match[0] : null;
   console.log(`Extracting test class from: "${testLine}" → ${result || 'NO MATCH'}`);
   return result;
@@ -50,7 +55,7 @@ function findMatchingFile(testClass, changedFiles) {
 
   for (const possiblePath of possiblePaths) {
     const matchingFile = changedFiles.find(file =>
-      file.endsWith(possiblePath) || file.includes(className)
+      file.endsWith(possiblePath) || path.basename(file) === `${className}.java`
     );
     if (matchingFile) {
       console.log(`Found matching file: ${matchingFile} for test class ${testClass}`);

--- a/.github/actions/analyze-test-runs/src/helpers.js
+++ b/.github/actions/analyze-test-runs/src/helpers.js
@@ -111,7 +111,7 @@ Fixable now? Maybe not.
 
 Please consider investigating if you have time. These tests might return, and
 
-![I'll be back](https://media.tenor.com/p2Ie017Zwu8AAAAM/exterminador-do.gif)`;
+I’ll be back. 🤖`;
 }
 
 module.exports = {

--- a/.github/actions/analyze-test-runs/src/helpers.js
+++ b/.github/actions/analyze-test-runs/src/helpers.js
@@ -18,7 +18,7 @@
 function extractTestClass(testLine) {
   const match = testLine.match(/([a-zA-Z][a-zA-Z0-9]*\.)+[a-zA-Z][a-zA-Z0-9]*\.[A-Z][a-zA-Z0-9]*(?:Test|IT)/);
   const result = match ? match[0] : null;
-  console.log(`🔍 Extracting test class from: "${testLine}" → ${result || 'NO MATCH'}`);
+  console.log(`Extracting test class from: "${testLine}" → ${result || 'NO MATCH'}`);
   return result;
 }
 
@@ -34,7 +34,7 @@ function generatePossiblePaths(testClass) {
     `src/test/java/${classPath}.java`,
     `src/main/java/${classPath}.java`
   ];
-  console.log(`📁 Generated possible paths for ${testClass}:`, paths);
+  console.log(`Generated possible paths for ${testClass}:`, paths);
   return paths;
 }
 
@@ -53,11 +53,11 @@ function findMatchingFile(testClass, changedFiles) {
       file.endsWith(possiblePath) || file.includes(className)
     );
     if (matchingFile) {
-      console.log(`✅ Found matching file: ${matchingFile} for test class ${testClass}`);
+      console.log(`Found matching file: ${matchingFile} for test class ${testClass}`);
       return matchingFile;
     }
   }
-  console.log(`❌ No matching file found for test class ${testClass}`);
+  console.log(`No matching file found for test class ${testClass}`);
   return null;
 }
 

--- a/.github/actions/analyze-test-runs/src/helpers.js
+++ b/.github/actions/analyze-test-runs/src/helpers.js
@@ -1,0 +1,118 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+/**
+ * Helper functions for flaky test analysis
+ */
+
+/**
+ * Extracts the test class name from a test line
+ * @param {string} testLine - The test line to parse
+ * @returns {string|null} - The extracted test class name or null if not found
+ */
+function extractTestClass(testLine) {
+  const match = testLine.match(/([a-zA-Z][a-zA-Z0-9]*\.)+[a-zA-Z][a-zA-Z0-9]*\.[A-Z][a-zA-Z0-9]*(?:Test|IT)/);
+  const result = match ? match[0] : null;
+  console.log(`🔍 Extracting test class from: "${testLine}" → ${result || 'NO MATCH'}`);
+  return result;
+}
+
+/**
+ * Generates possible file paths for a given test class
+ * @param {string} testClass - The test class name
+ * @returns {string[]} - Array of possible file paths
+ */
+function generatePossiblePaths(testClass) {
+  const classPath = testClass.replace(/\./g, '/');
+  const paths = [
+    `${classPath}.java`,
+    `src/test/java/${classPath}.java`,
+    `src/main/java/${classPath}.java`
+  ];
+  console.log(`📁 Generated possible paths for ${testClass}:`, paths);
+  return paths;
+}
+
+/**
+ * Finds a matching file for a test class among changed files
+ * @param {string} testClass - The test class name
+ * @param {string[]} changedFiles - Array of changed file paths
+ * @returns {string|null} - The matching file path or null if not found
+ */
+function findMatchingFile(testClass, changedFiles) {
+  const possiblePaths = generatePossiblePaths(testClass);
+  const className = testClass.split('.').pop();
+
+  for (const possiblePath of possiblePaths) {
+    const matchingFile = changedFiles.find(file =>
+      file.endsWith(possiblePath) || file.includes(className)
+    );
+    if (matchingFile) {
+      console.log(`✅ Found matching file: ${matchingFile} for test class ${testClass}`);
+      return matchingFile;
+    }
+  }
+  console.log(`❌ No matching file found for test class ${testClass}`);
+  return null;
+}
+
+/**
+ * Creates the inline comment body for a flaky test
+ * @param {string} author - The author to mention
+ * @param {string} flakyTests - The flaky tests string
+ * @returns {string} - The formatted comment body
+ */
+function createInlineCommentBody(author, flakyTests) {
+  return `### Oh! We've got ourselves flaky ones!
+
+Hey @${author}! 👋
+
+This file contains the flaky test:
+\`\`\`
+${flakyTests}
+\`\`\`
+
+Since you recently modified this file, would you mind taking a quick look?
+You might have insights into what could be causing the test instability.
+
+**What to check:**
+- Recent changes that might affect test timing
+- New dependencies or configurations
+- Race conditions or timing-sensitive code
+
+No pressure if you're busy, just thought you'd be the best person to investigate! 🕵️‍♂️`;
+}
+
+/**
+ * Creates the main PR comment body
+ * @param {string} flakyTests - The flaky tests string
+ * @returns {string} - The formatted comment body
+ */
+function createMainCommentBody(flakyTests) {
+  return `### Oh! We've got ourselves flaky ones!
+
+\`\`\`
+${flakyTests}
+\`\`\`
+
+Related to your code? Maybe.
+
+Fixable now? Maybe not.
+
+Please consider investigating if you have time. These tests might return, and
+
+![I'll be back](https://media.tenor.com/p2Ie017Zwu8AAAAM/exterminador-do.gif)`;
+}
+
+module.exports = {
+  extractTestClass,
+  generatePossiblePaths,
+  findMatchingFile,
+  createInlineCommentBody,
+  createMainCommentBody
+};

--- a/.github/actions/analyze-test-runs/src/helpers.js
+++ b/.github/actions/analyze-test-runs/src/helpers.js
@@ -105,13 +105,13 @@ function createMainCommentBody(flakyTests) {
 ${flakyTests}
 \`\`\`
 
-Related to your code? Maybe.
+Might be related, might be a ghost.
 
-Fixable now? Maybe not.
+If the changes affect this area, **please check and fix before merging**.
 
-Please consider investigating if you have time. These tests might return, and
+If not, **leave a quick comment** explaining why it’s likely unrelated.
 
-I’ll be back. 🤖`;
+Just doing some light ghostbusting. 👻`;
 }
 
 module.exports = {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -248,7 +248,8 @@ jobs:
     name: "[UT] General Unit Tests"
     needs: [ detect-changes, setup-unit-tests ]
     timeout-minutes: 10
-    permissions: { }  # GITHUB_TOKEN unused in this job
+    permissions:
+      pull-requests: write
     runs-on: gcp-perf-core-16-default
     steps:
       - uses: actions/checkout@v4
@@ -457,7 +458,8 @@ jobs:
     needs: [ detect-changes ]
     name: "[IT] Elasticsearch"
     timeout-minutes: 15
-    permissions: { }  # GITHUB_TOKEN unused in this job
+    permissions:
+      pull-requests: write
     runs-on: gcp-perf-core-16-default
     env:
       ZEEBE_TEST_DOCKER_IMAGE: localhost:5000/camunda/zeebe:current-test
@@ -549,7 +551,8 @@ jobs:
     needs: [ detect-changes ]
     name: "[IT] OpenSearch"
     timeout-minutes: 15
-    permissions: { }  # GITHUB_TOKEN unused in this job
+    permissions:
+      pull-requests: write
     runs-on: gcp-perf-core-16-default
     env:
       ZEEBE_TEST_DOCKER_IMAGE: localhost:5000/camunda/zeebe:current-test
@@ -648,7 +651,8 @@ jobs:
     needs: [ detect-changes ]
     name: "[IT] RDBMS - H2"
     timeout-minutes: 15
-    permissions: { }  # GITHUB_TOKEN unused in this job
+    permissions:
+      pull-requests: write
     runs-on: gcp-perf-core-8-default
     env:
       ZEEBE_TEST_DOCKER_IMAGE: localhost:5000/camunda/zeebe:current-test
@@ -715,7 +719,8 @@ jobs:
     name: "[IT] RDBMS"
     timeout-minutes: 7
     runs-on: gcp-perf-core-8-default
-    permissions: { }  # no GITHUB_TOKEN is needed
+    permissions:
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-build
@@ -771,7 +776,8 @@ jobs:
     name: "[IT] ${{ matrix.name }} ${{ matrix.suite }}"
     needs: [ detect-changes ]
     timeout-minutes: 25
-    permissions: { }  # GITHUB_TOKEN unused in this job
+    permissions:
+      pull-requests: write
     runs-on: ${{ matrix.runs-on }}
     strategy:
       fail-fast: false
@@ -937,6 +943,7 @@ jobs:
     timeout-minutes: 20
     permissions:
       security-events: write
+      pull-requests: write
     services:
       # local registry is used as this job needs to push as it builds multi-platform images
       registry:


### PR DESCRIPTION
## Description

This PR introduces the final, cleaned-up implementation of flakiness reporting in CI via GitHub Checks. its goal is to enhance CI visibility by automatically identifying and surfacing flaky tests in pull requests, as described here https://github.com/camunda/camunda/issues/28981

**What’s Included**
- New step on Flaky Tests
- Comment on PR when flaky tests found
- Inline comments made when changes are introduced + there is a flaky test in that file

:warning: Copilot helped me with the inline comments and split into multiple files 

**Background**
The work in this PR was originally developed and tested in [28981-inform-flakyness-via-gh-checks-api](https://github.com/camunda/camunda/pull/35129). That branch contained multiple exploratory and incremental commits. This PR cherry-picks the final version into a new branch from main.

<img width="984" height="970" alt="image" src="https://github.com/user-attachments/assets/61a79343-e14d-493c-bd0c-74135387b980" />


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
