### PR TITLE
Fix Selector In Flaky Test

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/task-details.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/task-details.spec.ts
@@ -207,7 +207,7 @@ test.describe('task details page', () => {
     await taskPanelPage.filterBy('Completed');
     await taskPanelPage.assertCompletedHeadingVisible();
     await taskPanelPage.openTask('Zeebe_user_task');
-    await expect(page.getByText('zeebeVar')).toBeVisible({timeout: 60000});
+    await expect(page.getByText('zeebeVar', { exact: true })).toBeVisible({timeout: 60000});
     await expect(taskDetailsPage.assignToMeButton).toBeHidden();
     await expect(taskDetailsPage.unassignButton).toBeHidden();
     await expect(taskDetailsPage.completeTaskButton).toBeHidden();


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

On the nightly test run, a selector in the `complete zeebe and job worker tasks` test needed to be updated. This PR contains this update.

Successful test run can be seen [here](https://github.com/camunda/camunda/actions/runs/16463900668).

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
