### PR TITLE
refactor: use post instead of put for batch operation management endpoints

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/impl/command/CancelBatchOperationCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/CancelBatchOperationCommandImpl.java
@@ -47,7 +47,7 @@ public final class CancelBatchOperationCommandImpl implements CancelBatchOperati
   @Override
   public CamundaFuture<Void> send() {
     final HttpCamundaFuture<Void> result = new HttpCamundaFuture<>();
-    httpClient.put(
+    httpClient.post(
         "/batch-operations/" + batchOperationKey + "/cancellation",
         null,
         httpRequestConfig.build(),

--- a/clients/java/src/main/java/io/camunda/client/impl/command/ResumeBatchOperationCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/ResumeBatchOperationCommandImpl.java
@@ -47,7 +47,7 @@ public final class ResumeBatchOperationCommandImpl implements ResumeBatchOperati
   @Override
   public CamundaFuture<Void> send() {
     final HttpCamundaFuture<Void> result = new HttpCamundaFuture<>();
-    httpClient.put(
+    httpClient.post(
         "/batch-operations/" + batchOperationKey + "/resumption",
         null,
         httpRequestConfig.build(),

--- a/clients/java/src/main/java/io/camunda/client/impl/command/SuspendBatchOperationCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/SuspendBatchOperationCommandImpl.java
@@ -47,7 +47,7 @@ public final class SuspendBatchOperationCommandImpl implements SuspendBatchOpera
   @Override
   public CamundaFuture<Void> send() {
     final HttpCamundaFuture<Void> result = new HttpCamundaFuture<>();
-    httpClient.put(
+    httpClient.post(
         "/batch-operations/" + batchOperationKey + "/suspension",
         null,
         httpRequestConfig.build(),

--- a/clients/java/src/test/java/io/camunda/client/batchoperation/CancelBatchOperationTest.java
+++ b/clients/java/src/test/java/io/camunda/client/batchoperation/CancelBatchOperationTest.java
@@ -32,7 +32,7 @@ public final class CancelBatchOperationTest extends ClientRestTest {
 
     // then
     final LoggedRequest request = RestGatewayService.getLastRequest();
-    assertThat(request.getMethod()).isEqualTo(RequestMethod.PUT);
+    assertThat(request.getMethod()).isEqualTo(RequestMethod.POST);
     assertThat(request.getUrl()).isEqualTo("/v2/batch-operations/batch-123/cancellation");
   }
 }

--- a/clients/java/src/test/java/io/camunda/client/batchoperation/ResumeBatchOperationTest.java
+++ b/clients/java/src/test/java/io/camunda/client/batchoperation/ResumeBatchOperationTest.java
@@ -32,7 +32,7 @@ public final class ResumeBatchOperationTest extends ClientRestTest {
 
     // then
     final LoggedRequest request = RestGatewayService.getLastRequest();
-    assertThat(request.getMethod()).isEqualTo(RequestMethod.PUT);
+    assertThat(request.getMethod()).isEqualTo(RequestMethod.POST);
     assertThat(request.getUrl()).isEqualTo("/v2/batch-operations/batch-123/resumption");
   }
 }

--- a/clients/java/src/test/java/io/camunda/client/batchoperation/SuspendBatchOperationTest.java
+++ b/clients/java/src/test/java/io/camunda/client/batchoperation/SuspendBatchOperationTest.java
@@ -32,7 +32,7 @@ public final class SuspendBatchOperationTest extends ClientRestTest {
 
     // then
     final LoggedRequest request = RestGatewayService.getLastRequest();
-    assertThat(request.getMethod()).isEqualTo(RequestMethod.PUT);
+    assertThat(request.getMethod()).isEqualTo(RequestMethod.POST);
     assertThat(request.getUrl()).isEqualTo("/v2/batch-operations/batch-123/suspension");
   }
 }

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -5242,7 +5242,7 @@ paths:
           $ref: "#/components/responses/InternalServerError"
 
   /batch-operations/{batchOperationKey}/cancellation:
-    put:
+    post:
       tags:
         - Batch operation
       operationId: cancelBatchOperation
@@ -5260,10 +5260,7 @@ paths:
             type: string
       requestBody:
         content:
-          application/json:
-            schema:
-              type: object
-              nullable: true
+          application/json: {}
         required: false
       responses:
         "204":
@@ -5283,7 +5280,7 @@ paths:
           $ref: "#/components/responses/InternalServerError"
 
   /batch-operations/{batchOperationKey}/suspension:
-    put:
+    post:
       tags:
         - Batch operation
       operationId: suspendBatchOperation
@@ -5301,10 +5298,7 @@ paths:
             type: string
       requestBody:
         content:
-          application/json:
-            schema:
-              type: object
-              nullable: true
+          application/json: {}
         required: false
       responses:
         "204":
@@ -5326,7 +5320,7 @@ paths:
           $ref: "#/components/responses/ServiceUnavailable"
 
   /batch-operations/{batchOperationKey}/resumption:
-    put:
+    post:
       tags:
         - Batch operation
       operationId: resumeBatchOperation
@@ -5344,10 +5338,7 @@ paths:
             type: string
       requestBody:
         content:
-          application/json:
-            schema:
-              type: object
-              nullable: true
+          application/json: {}
         required: false
       responses:
         "204":

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/BatchOperationController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/BatchOperationController.java
@@ -21,7 +21,6 @@ import io.camunda.zeebe.gateway.rest.SearchQueryRequestMapper;
 import io.camunda.zeebe.gateway.rest.SearchQueryResponseMapper;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaGetMapping;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaPostMapping;
-import io.camunda.zeebe.gateway.rest.annotation.CamundaPutMapping;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -63,7 +62,7 @@ public class BatchOperationController {
         .fold(RestErrorMapper::mapProblemToResponse, this::search);
   }
 
-  @CamundaPutMapping(path = "/{batchOperationKey}/cancellation")
+  @CamundaPostMapping(path = "/{batchOperationKey}/cancellation")
   public ResponseEntity<Object> cancelBatchOperation(@PathVariable final String batchOperationKey) {
     return RequestMapper.executeServiceMethodWithNoContentResult(
             () ->
@@ -73,7 +72,7 @@ public class BatchOperationController {
         .join();
   }
 
-  @CamundaPutMapping(path = "/{batchOperationKey}/suspension")
+  @CamundaPostMapping(path = "/{batchOperationKey}/suspension")
   public ResponseEntity<Object> suspendBatchOperation(
       @PathVariable final String batchOperationKey) {
     return RequestMapper.executeServiceMethodWithNoContentResult(
@@ -84,7 +83,7 @@ public class BatchOperationController {
         .join();
   }
 
-  @CamundaPutMapping(path = "/{batchOperationKey}/resumption")
+  @CamundaPostMapping(path = "/{batchOperationKey}/resumption")
   public ResponseEntity<Object> resumeBatchOperation(@PathVariable final String batchOperationKey) {
     return RequestMapper.executeServiceMethodWithNoContentResult(
             () ->

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/BatchOperationController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/BatchOperationController.java
@@ -62,7 +62,9 @@ public class BatchOperationController {
         .fold(RestErrorMapper::mapProblemToResponse, this::search);
   }
 
-  @CamundaPostMapping(path = "/{batchOperationKey}/cancellation")
+  @CamundaPostMapping(
+      path = "/{batchOperationKey}/cancellation",
+      consumes = {})
   public ResponseEntity<Object> cancelBatchOperation(@PathVariable final String batchOperationKey) {
     return RequestMapper.executeServiceMethodWithNoContentResult(
             () ->
@@ -72,7 +74,9 @@ public class BatchOperationController {
         .join();
   }
 
-  @CamundaPostMapping(path = "/{batchOperationKey}/suspension")
+  @CamundaPostMapping(
+      path = "/{batchOperationKey}/suspension",
+      consumes = {})
   public ResponseEntity<Object> suspendBatchOperation(
       @PathVariable final String batchOperationKey) {
     return RequestMapper.executeServiceMethodWithNoContentResult(
@@ -83,7 +87,9 @@ public class BatchOperationController {
         .join();
   }
 
-  @CamundaPostMapping(path = "/{batchOperationKey}/resumption")
+  @CamundaPostMapping(
+      path = "/{batchOperationKey}/resumption",
+      consumes = {})
   public ResponseEntity<Object> resumeBatchOperation(@PathVariable final String batchOperationKey) {
     return RequestMapper.executeServiceMethodWithNoContentResult(
             () ->

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/BatchOperationControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/BatchOperationControllerTest.java
@@ -230,8 +230,9 @@ class BatchOperationControllerTest extends RestControllerTest {
         .thenReturn(CompletableFuture.completedFuture(null));
 
     webClient
-        .put()
+        .post()
         .uri("/v2/batch-operations/{key}/cancellation", batchOperationKey)
+        .contentType(MediaType.APPLICATION_JSON)
         .exchange()
         .expectStatus()
         .isNoContent();
@@ -244,8 +245,9 @@ class BatchOperationControllerTest extends RestControllerTest {
         .thenReturn(CompletableFuture.completedFuture(null));
 
     webClient
-        .put()
+        .post()
         .uri("/v2/batch-operations/{key}/suspension", batchOperationKey)
+        .contentType(MediaType.APPLICATION_JSON)
         .exchange()
         .expectStatus()
         .isNoContent();
@@ -258,8 +260,9 @@ class BatchOperationControllerTest extends RestControllerTest {
         .thenReturn(CompletableFuture.completedFuture(null));
 
     webClient
-        .put()
+        .post()
         .uri("/v2/batch-operations/{key}/resumption", batchOperationKey)
+        .contentType(MediaType.APPLICATION_JSON)
         .exchange()
         .expectStatus()
         .isNoContent();


### PR DESCRIPTION
## Description

To be consistent with other management endpoints, we want to use POST instead of PUT for the three batch operation management endpoints:

* cancel
* suspend
* resume

See also here the Slack discussion: https://camunda.slack.com/archives/C089U9BSWEM/p1753099334204799


## Related issues

closes #35804
