### PR TITLE
refactor: switch default auth profile to consolidated-auth and cleanup unused profiles

### DIFF
--- a/dist/src/main/java/io/camunda/application/Profile.java
+++ b/dist/src/main/java/io/camunda/application/Profile.java
@@ -32,9 +32,6 @@ public enum Profile {
   // authentication profiles
   CONSOLIDATED_AUTH("consolidated-auth"),
   IDENTITY_AUTH("identity-auth"),
-  SSO_AUTH("sso-auth"),
-  DEFAULT_AUTH_PROFILE("auth"),
-  LDAP_AUTH_PROFILE("ldap-auth"),
 
   // migration profiles
   IDENTITY_MIGRATION("identity-migration"),
@@ -50,11 +47,6 @@ public enum Profile {
 
   public String getId() {
     return id;
-  }
-
-  public static Set<Profile> getAuthProfiles() {
-    return Set.of(
-        CONSOLIDATED_AUTH, DEFAULT_AUTH_PROFILE, IDENTITY_AUTH, LDAP_AUTH_PROFILE, SSO_AUTH);
   }
 
   public static Set<Profile> getWebappProfiles() {

--- a/dist/src/main/java/io/camunda/application/initializers/DefaultAuthenticationInitializer.java
+++ b/dist/src/main/java/io/camunda/application/initializers/DefaultAuthenticationInitializer.java
@@ -7,18 +7,16 @@
  */
 package io.camunda.application.initializers;
 
-import static io.camunda.application.Profile.DEFAULT_AUTH_PROFILE;
-import static io.camunda.application.Profile.getAuthProfiles;
+import static io.camunda.application.Profile.CONSOLIDATED_AUTH;
 import static io.camunda.application.Profile.getWebappProfiles;
 
-import io.camunda.application.Profile;
 import io.camunda.authentication.config.AuthenticationProperties;
 import java.util.Set;
 import org.springframework.context.ApplicationContextInitializer;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.core.env.Environment;
 
-/** Adds the "auth" if none of the {@link Profile#getAuthProfiles()} is set as an active profile. */
+/** Adds the "consolidated-auth" profile if it's not set */
 public class DefaultAuthenticationInitializer
     implements ApplicationContextInitializer<ConfigurableApplicationContext> {
 
@@ -26,7 +24,7 @@ public class DefaultAuthenticationInitializer
   public void initialize(final ConfigurableApplicationContext context) {
     final var env = context.getEnvironment();
     if (shouldApplyDefaultAuthenticationProfile(env)) {
-      env.addActiveProfile(DEFAULT_AUTH_PROFILE.getId());
+      env.addActiveProfile(CONSOLIDATED_AUTH.getId());
     }
   }
 
@@ -35,7 +33,8 @@ public class DefaultAuthenticationInitializer
       return false;
     }
     final Set<String> activeProfiles = Set.of(environment.getActiveProfiles());
-    return webappProfileIsPresent(activeProfiles) && !authProfileIsPresent(activeProfiles);
+    return webappProfileIsPresent(activeProfiles)
+        && !consolidatedAuthProfileIsPresent(activeProfiles);
   }
 
   private boolean webappProfileIsPresent(final Set<String> activeProfiles) {
@@ -43,7 +42,7 @@ public class DefaultAuthenticationInitializer
         .anyMatch(profile -> activeProfiles.contains(profile.getId()));
   }
 
-  private boolean authProfileIsPresent(final Set<String> activeProfiles) {
-    return getAuthProfiles().stream().anyMatch(profile -> activeProfiles.contains(profile.getId()));
+  private boolean consolidatedAuthProfileIsPresent(final Set<String> activeProfiles) {
+    return activeProfiles.contains(CONSOLIDATED_AUTH.getId());
   }
 }

--- a/dist/src/main/java/io/camunda/application/initializers/WebappsConfigurationInitializer.java
+++ b/dist/src/main/java/io/camunda/application/initializers/WebappsConfigurationInitializer.java
@@ -8,9 +8,7 @@
 package io.camunda.application.initializers;
 
 import static io.camunda.application.Profile.IDENTITY;
-import static io.camunda.application.Profile.IDENTITY_AUTH;
 import static io.camunda.application.Profile.OPERATE;
-import static io.camunda.application.Profile.SSO_AUTH;
 import static io.camunda.application.Profile.TASKLIST;
 import static io.camunda.authentication.config.AuthenticationProperties.METHOD;
 
@@ -34,8 +32,6 @@ public class WebappsConfigurationInitializer
       "server.servlet.session.cookie.name";
   private static final Set<String> WEBAPPS_PROFILES =
       Set.of(OPERATE.getId(), TASKLIST.getId(), IDENTITY.getId());
-  private static final Set<String> LOGIN_DELEGATED_PROFILES =
-      Set.of(IDENTITY_AUTH.getId(), SSO_AUTH.getId());
 
   @Override
   public void initialize(final ConfigurableApplicationContext context) {
@@ -61,11 +57,6 @@ public class WebappsConfigurationInitializer
   }
 
   private boolean isLoginDelegated(final ConfigurableApplicationContext context) {
-    final var activeProfiles = Arrays.asList(context.getEnvironment().getActiveProfiles());
-    if (activeProfiles.stream().anyMatch(LOGIN_DELEGATED_PROFILES::contains)) {
-      return true;
-    }
-
     final var authenticationMethodProperty = context.getEnvironment().getProperty(METHOD);
     final var authenticationMethod = AuthenticationMethod.parse(authenticationMethodProperty);
     return authenticationMethod.isPresent()

--- a/operate/common/src/main/java/io/camunda/operate/testhelpers/StatefulRestTemplate.java
+++ b/operate/common/src/main/java/io/camunda/operate/testhelpers/StatefulRestTemplate.java
@@ -76,7 +76,7 @@ public class StatefulRestTemplate extends RestTemplate {
         new StatefulHttpComponentsClientHttpRequestFactory(httpClient, httpContext);
     super.setRequestFactory(statefulHttpComponentsClientHttpRequestFactory);
 
-    // We set the interceptors here so they capture the non overridden methods
+    // We set the interceptors here so they capture the non-overridden methods
     final var interceptors = new ArrayList<>(super.getInterceptors());
     interceptors.add(new BasicAuthenticationInterceptor(USERNAME, PASSWORD));
     super.setInterceptors(interceptors);

--- a/operate/qa/util/src/main/java/io/camunda/operate/qa/util/TestContainerUtil.java
+++ b/operate/qa/util/src/main/java/io/camunda/operate/qa/util/TestContainerUtil.java
@@ -401,11 +401,7 @@ public class TestContainerUtil {
         .withEnv("CAMUNDA_OPERATE_ZEEBE_COMPATIBILITY_ENABLED", "true")
         .withEnv("CAMUNDA_SECURITY_AUTHENTICATION_UNPROTECTEDAPI", "false")
         .withEnv("CAMUNDA_SECURITY_AUTHENTICATION_METHOD", "BASIC")
-        .withEnv("CAMUNDA_SECURITY_AUTHORIZATIONS_ENABLED", "false")
-        .withEnv("CAMUNDA_SECURITY_INITIALIZATION_USERS_0_USERNAME", "demo")
-        .withEnv("CAMUNDA_SECURITY_INITIALIZATION_USERS_0_PASSWORD", "demo")
-        .withEnv("CAMUNDA_SECURITY_INITIALIZATION_USERS_0_NAME", "Demo")
-        .withEnv("CAMUNDA_SECURITY_INITIALIZATION_USERS_0_EMAIL", "demo@example.com");
+        .withEnv("CAMUNDA_SECURITY_AUTHORIZATIONS_ENABLED", "false");
     final Map<String, String> customEnvs = testContext.getOperateContainerEnvs();
     customEnvs.forEach(operateContainer::withEnv);
 
@@ -530,8 +526,7 @@ public class TestContainerUtil {
           .withEnv("CAMUNDA_SECURITY_INITIALIZATION_USERS_0_USERNAME", "demo")
           .withEnv("CAMUNDA_SECURITY_INITIALIZATION_USERS_0_PASSWORD", "demo")
           .withEnv("CAMUNDA_SECURITY_INITIALIZATION_USERS_0_NAME", "Demo")
-          .withEnv("CAMUNDA_SECURITY_INITIALIZATION_USERS_0_EMAIL", "demo@example.com")
-          .withEnv("CAMUNDA_SECURITY_INITIALIZATION_DEFAULTROLES_ADMIN_USERS_0", "demo");
+          .withEnv("CAMUNDA_SECURITY_INITIALIZATION_USERS_0_EMAIL", "demo@example.com");
 
       if (testContext.getPartitionCount() != null) {
         broker.withEnv(

--- a/tasklist/qa/backup-restore-tests/src/test/java/io/camunda/tasklist/qa/backup/TasklistAPICaller.java
+++ b/tasklist/qa/backup-restore-tests/src/test/java/io/camunda/tasklist/qa/backup/TasklistAPICaller.java
@@ -60,8 +60,6 @@ public class TasklistAPICaller {
   private static final Logger LOGGER = LoggerFactory.getLogger(TasklistAPICaller.class);
   private static final String COMPLETE_TASK_MUTATION_PATTERN =
       "mutation {completeTask(taskId: \"%s\", variables: [%s]){id name assignee taskState completionTime}}";
-  private static final String USERNAME = "demo";
-  private static final String PASSWORD = "demo";
 
   @Autowired private BiFunction<String, Integer, StatefulRestTemplate> statefulRestTemplateFactory;
 
@@ -101,7 +99,6 @@ public class TasklistAPICaller {
       statefulRestTemplate =
           statefulRestTemplateFactory.apply(
               testContext.getExternalTasklistHost(), testContext.getExternalTasklistPort());
-      statefulRestTemplate.loginWhenNeeded(USERNAME, PASSWORD);
       mgmtRestTemplate =
           statefulRestTemplateFactory.apply(
               testContext.getExternalTasklistHost(), testContext.getExternalTasklistMgmtPort());

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/StartupIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/StartupIT.java
@@ -68,7 +68,8 @@ public class StartupIT {
         .withEnv("CAMUNDA_TASKLIST_ELASTICSEARCH_URL", elasticSearchUrl)
         .withEnv("CAMUNDA_TASKLIST_ZEEBEELASTICSEARCH_URL", elasticSearchUrl)
         .withEnv("CAMUNDA_DATABASE_URL", elasticSearchUrl)
-        .withEnv("CAMUNDA_TASKLIST_ZEEBE_COMPATIBILITY_ENABLED", "true");
+        .withEnv("CAMUNDA_TASKLIST_ZEEBE_COMPATIBILITY_ENABLED", "true")
+        .withEnv("CAMUNDA_SECURITY_AUTHENTICATION_UNPROTECTEDAPI", "true");
 
     testContainerUtil.startTasklistContainer(tasklistContainer, VERSION, testContext);
     LOGGER.info("************ Tasklist started  ************");
@@ -77,7 +78,7 @@ public class StartupIT {
     final ResponseEntity<String> clientConfig =
         restTemplate.getForEntity(
             String.format(
-                "http://%s:%s/tasklist/client-config.js",
+                "http://%s:%s/v2/topology",
                 testContext.getExternalTasklistHost(), testContext.getExternalTasklistPort()),
             String.class);
 

--- a/tasklist/qa/util/src/main/java/io/camunda/tasklist/qa/util/TestContainerUtil.java
+++ b/tasklist/qa/util/src/main/java/io/camunda/tasklist/qa/util/TestContainerUtil.java
@@ -465,6 +465,16 @@ public class TestContainerUtil {
         tasklistContainer.withEnv(
             "CAMUNDA_TASKLIST_ZEEBEELASTICSEARCH_PREFIX", testContext.getZeebeIndexPrefix());
       }
+
+      tasklistContainer
+          .withEnv("SPRING_PROFILES_ACTIVE", "consolidated-auth")
+          .withEnv("CAMUNDA_SECURITY_AUTHENTICATION_UNPROTECTEDAPI", "false")
+          .withEnv("CAMUNDA_SECURITY_AUTHORIZATIONS_ENABLED", "false")
+          .withEnv("CAMUNDA_SECURITY_AUTHENTICATION_METHOD", "BASIC")
+          .withEnv("CAMUNDA_SECURITY_INITIALIZATION_USERS_0_USERNAME", "demo")
+          .withEnv("CAMUNDA_SECURITY_INITIALIZATION_USERS_0_PASSWORD", "demo")
+          .withEnv("CAMUNDA_SECURITY_INITIALIZATION_USERS_0_NAME", "Demo")
+          .withEnv("CAMUNDA_SECURITY_INITIALIZATION_USERS_0_EMAIL", "demo@example.com");
     }
 
     final String zeebeContactPoint = testContext.getInternalZeebeContactPoint();
@@ -481,7 +491,11 @@ public class TestContainerUtil {
               .withNetwork(testContext.getNetwork())
               .withEnv("ZEEBE_BROKER_GATEWAY_ENABLE", "true")
               .withEnv("CAMUNDA_SECURITY_AUTHENTICATION_UNPROTECTEDAPI", "true")
-              .withEnv("CAMUNDA_SECURITY_AUTHORIZATIONS_ENABLED", "false");
+              .withEnv("CAMUNDA_SECURITY_AUTHORIZATIONS_ENABLED", "false")
+              .withEnv("CAMUNDA_SECURITY_INITIALIZATION_USERS_0_USERNAME", "demo")
+              .withEnv("CAMUNDA_SECURITY_INITIALIZATION_USERS_0_PASSWORD", "demo")
+              .withEnv("CAMUNDA_SECURITY_INITIALIZATION_USERS_0_NAME", "Demo")
+              .withEnv("CAMUNDA_SECURITY_INITIALIZATION_USERS_0_EMAIL", "demo@example.com");
 
       if (testContext.getZeebeDataFolder() != null) {
         broker.withCreateContainerCmdModifier(

--- a/tasklist/qa/util/src/main/java/io/camunda/tasklist/qa/util/rest/StatefulRestTemplate.java
+++ b/tasklist/qa/util/src/main/java/io/camunda/tasklist/qa/util/rest/StatefulRestTemplate.java
@@ -9,12 +9,11 @@ package io.camunda.tasklist.qa.util.rest;
 
 import static org.springframework.beans.factory.config.BeanDefinition.SCOPE_PROTOTYPE;
 
-import io.camunda.tasklist.exceptions.TasklistRuntimeException;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.util.function.Consumer;
+import java.util.ArrayList;
 import org.apache.hc.client5.http.classic.HttpClient;
 import org.apache.hc.client5.http.cookie.BasicCookieStore;
 import org.apache.hc.client5.http.cookie.CookieStore;
@@ -24,6 +23,7 @@ import org.apache.hc.core5.http.protocol.BasicHttpContext;
 import org.apache.hc.core5.http.protocol.HttpContext;
 import org.springframework.context.annotation.Scope;
 import org.springframework.http.*;
+import org.springframework.http.client.support.BasicAuthenticationInterceptor;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 import org.springframework.web.client.RestTemplate;
@@ -35,12 +35,8 @@ import org.springframework.web.client.RestTemplate;
 @Component
 @Scope(SCOPE_PROTOTYPE)
 public class StatefulRestTemplate extends RestTemplate {
-
-  private static final String LOGIN_URL_PATTERN = "/api/login?username=%s&password=%s";
-  private static final String CSRF_TOKEN_HEADER_NAME = "TASKLIST-X-CSRF-TOKEN";
-
-  private static final String USERNAME_DEFAULT = "demo";
-  private static final String PASSWORD_DEFAULT = "demo";
+  private static final String USERNAME = "demo";
+  private static final String PASSWORD = "demo";
 
   private final String host;
   private final Integer port;
@@ -49,10 +45,9 @@ public class StatefulRestTemplate extends RestTemplate {
   private final HttpContext httpContext;
   private final StatefulHttpComponentsClientHttpRequestFactory
       statefulHttpComponentsClientHttpRequestFactory;
-  private String csrfToken;
-  private String contextPath;
+  private final String contextPath;
 
-  public StatefulRestTemplate(String host, Integer port, String contextPath) {
+  public StatefulRestTemplate(final String host, final Integer port, final String contextPath) {
     super();
     this.host = host;
     this.port = port;
@@ -64,6 +59,11 @@ public class StatefulRestTemplate extends RestTemplate {
     statefulHttpComponentsClientHttpRequestFactory =
         new StatefulHttpComponentsClientHttpRequestFactory(httpClient, httpContext);
     super.setRequestFactory(statefulHttpComponentsClientHttpRequestFactory);
+
+    // We set the interceptors here so they capture the non-overridden methods
+    final var interceptors = new ArrayList<>(super.getInterceptors());
+    interceptors.add(new BasicAuthenticationInterceptor(USERNAME, PASSWORD));
+    super.setInterceptors(interceptors);
   }
 
   public HttpClient getHttpClient() {
@@ -82,33 +82,7 @@ public class StatefulRestTemplate extends RestTemplate {
     return statefulHttpComponentsClientHttpRequestFactory;
   }
 
-  public void loginWhenNeeded() {
-    loginWhenNeeded(USERNAME_DEFAULT, PASSWORD_DEFAULT);
-  }
-
-  public void loginWhenNeeded(String username, String password) {
-    // log in only once
-    if (getCookieStore().getCookies().isEmpty()) {
-      final ResponseEntity<Object> response = tryLoginAs(username, password);
-      if (!response.getStatusCode().equals(HttpStatus.NO_CONTENT)) {
-        throw new TasklistRuntimeException(
-            String.format(
-                "Unable to login user %s to %s:%s. Response: %s", username, host, port, response));
-      }
-      //      saveCSRFTokenWhenAvailable(response);
-    }
-  }
-
-  private ResponseEntity<Object> tryLoginAs(final String username, final String password) {
-    try {
-      return postForEntity(
-          getURL(String.format(LOGIN_URL_PATTERN, username, password)), null, Object.class);
-    } catch (Exception e) {
-      throw new TasklistRuntimeException("Unable to connect to Operate ", e);
-    }
-  }
-
-  public URI getURL(String urlPart) {
+  public URI getURL(final String urlPart) {
     try {
       final String path;
       if (contextPath.endsWith("/") && urlPart.startsWith("/")) {
@@ -119,23 +93,19 @@ public class StatefulRestTemplate extends RestTemplate {
       }
 
       return new URL(String.format("http://%s:%s%s", host, port, path)).toURI();
-    } catch (URISyntaxException | MalformedURLException e) {
+    } catch (final URISyntaxException | MalformedURLException e) {
       throw new RuntimeException("Error occurred while constructing URL", e);
     }
   }
 
-  public URI getURL(String urlPart, String urlParams) {
+  public URI getURL(final String urlPart, final String urlParams) {
     if (StringUtils.isEmpty(urlParams)) {
       return getURL(urlPart);
     }
     try {
       return new URL(String.format("%s?%s", getURL(urlPart), urlParams)).toURI();
-    } catch (URISyntaxException | MalformedURLException e) {
+    } catch (final URISyntaxException | MalformedURLException e) {
       throw new RuntimeException("Error occurred while constructing URL", e);
     }
-  }
-
-  public Consumer<HttpHeaders> getCsrfHeader() {
-    return (header) -> header.add(CSRF_TOKEN_HEADER_NAME, csrfToken);
   }
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

With the removal of the legacy authentication code in https://github.com/camunda/camunda/issues/29426, this PR updates the default authentication profile to be `consolidated-auth` instead of `auth`. I also take this opportunity to simplify the logic in the initialiser and remove the unused auth profiles.

## Related issues

Related to https://github.com/camunda/camunda/issues/29426
