### PR TITLE
Add search clients in tenant command to Java Client

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/CamundaClient.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClient.java
@@ -115,6 +115,7 @@ import io.camunda.client.api.search.request.BatchOperationItemSearchRequest;
 import io.camunda.client.api.search.request.BatchOperationSearchRequest;
 import io.camunda.client.api.search.request.ClientsByGroupSearchRequest;
 import io.camunda.client.api.search.request.ClientsByRoleSearchRequest;
+import io.camunda.client.api.search.request.ClientsByTenantSearchRequest;
 import io.camunda.client.api.search.request.DecisionDefinitionSearchRequest;
 import io.camunda.client.api.search.request.DecisionInstanceSearchRequest;
 import io.camunda.client.api.search.request.DecisionRequirementsSearchRequest;
@@ -1292,6 +1293,22 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    * @return a builder for the clients by group search request
    */
   ClientsByGroupSearchRequest newClientsByGroupSearchRequest(String groupId);
+
+  /**
+   * Executes a search request to query clients by tenant.
+   *
+   * <pre>
+   * camundaClient
+   *   .newClientsByTenantSearchRequest("tenantId")
+   *   .sort((s) -> s.clientId().asc())
+   *   .page((p) -> p.limit(100))
+   *   .send();
+   * </pre>
+   *
+   * @param tenantId the ID of the tenant
+   * @return a builder for the clients by tenant search request
+   */
+  ClientsByTenantSearchRequest newClientsByTenantSearchRequest(String tenantId);
 
   /**
    * Command to assign a role to a tenant.

--- a/clients/java/src/main/java/io/camunda/client/api/search/request/ClientsByTenantSearchRequest.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/request/ClientsByTenantSearchRequest.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.search.request;
+
+import io.camunda.client.api.search.filter.ClientFilter;
+import io.camunda.client.api.search.response.Client;
+import io.camunda.client.api.search.sort.ClientSort;
+
+public interface ClientsByTenantSearchRequest
+    extends TypedSearchRequest<ClientFilter, ClientSort, ClientsByTenantSearchRequest>,
+        FinalSearchRequestStep<Client> {}

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
@@ -126,6 +126,7 @@ import io.camunda.client.api.search.request.BatchOperationItemSearchRequest;
 import io.camunda.client.api.search.request.BatchOperationSearchRequest;
 import io.camunda.client.api.search.request.ClientsByGroupSearchRequest;
 import io.camunda.client.api.search.request.ClientsByRoleSearchRequest;
+import io.camunda.client.api.search.request.ClientsByTenantSearchRequest;
 import io.camunda.client.api.search.request.DecisionDefinitionSearchRequest;
 import io.camunda.client.api.search.request.DecisionInstanceSearchRequest;
 import io.camunda.client.api.search.request.DecisionRequirementsSearchRequest;
@@ -254,6 +255,7 @@ import io.camunda.client.impl.search.request.BatchOperationItemSearchRequestImpl
 import io.camunda.client.impl.search.request.BatchOperationSearchRequestImpl;
 import io.camunda.client.impl.search.request.ClientsByGroupSearchRequestImpl;
 import io.camunda.client.impl.search.request.ClientsByRoleSearchRequestImpl;
+import io.camunda.client.impl.search.request.ClientsByTenantSearchRequestImpl;
 import io.camunda.client.impl.search.request.DecisionDefinitionSearchRequestImpl;
 import io.camunda.client.impl.search.request.DecisionInstanceSearchRequestImpl;
 import io.camunda.client.impl.search.request.DecisionRequirementsSearchRequestImpl;
@@ -901,6 +903,11 @@ public final class CamundaClientImpl implements CamundaClient {
   @Override
   public ClientsByGroupSearchRequest newClientsByGroupSearchRequest(final String groupId) {
     return new ClientsByGroupSearchRequestImpl(httpClient, jsonMapper, groupId);
+  }
+
+  @Override
+  public ClientsByTenantSearchRequest newClientsByTenantSearchRequest(final String tenantId) {
+    return new ClientsByTenantSearchRequestImpl(httpClient, jsonMapper, tenantId);
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/client/impl/search/request/ClientsByTenantSearchRequestImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/request/ClientsByTenantSearchRequestImpl.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.search.request;
+
+import static io.camunda.client.api.search.request.SearchRequestBuilders.clientSort;
+import static io.camunda.client.api.search.request.SearchRequestBuilders.searchRequestPage;
+
+import io.camunda.client.api.CamundaFuture;
+import io.camunda.client.api.JsonMapper;
+import io.camunda.client.api.search.filter.ClientFilter;
+import io.camunda.client.api.search.request.ClientsByTenantSearchRequest;
+import io.camunda.client.api.search.request.FinalSearchRequestStep;
+import io.camunda.client.api.search.request.SearchRequestPage;
+import io.camunda.client.api.search.response.Client;
+import io.camunda.client.api.search.response.SearchResponse;
+import io.camunda.client.api.search.sort.ClientSort;
+import io.camunda.client.impl.command.ArgumentUtil;
+import io.camunda.client.impl.http.HttpCamundaFuture;
+import io.camunda.client.impl.http.HttpClient;
+import io.camunda.client.impl.search.response.SearchResponseMapper;
+import io.camunda.client.protocol.rest.TenantClientSearchQueryRequest;
+import io.camunda.client.protocol.rest.TenantClientSearchResult;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import org.apache.hc.client5.http.config.RequestConfig;
+
+public class ClientsByTenantSearchRequestImpl
+    extends TypedSearchRequestPropertyProvider<TenantClientSearchQueryRequest>
+    implements ClientsByTenantSearchRequest {
+
+  private final TenantClientSearchQueryRequest request;
+  private final String tenantId;
+  private final HttpClient httpClient;
+  private final JsonMapper jsonMapper;
+  private final RequestConfig.Builder httpRequestConfig;
+
+  public ClientsByTenantSearchRequestImpl(
+      final HttpClient httpClient, final JsonMapper jsonMapper, final String tenantId) {
+    this.httpClient = httpClient;
+    this.jsonMapper = jsonMapper;
+    this.tenantId = tenantId;
+    httpRequestConfig = httpClient.newRequestConfig();
+    request = new TenantClientSearchQueryRequest();
+  }
+
+  @Override
+  public FinalSearchRequestStep<Client> requestTimeout(final Duration requestTimeout) {
+    httpRequestConfig.setResponseTimeout(requestTimeout.toMillis(), TimeUnit.MILLISECONDS);
+    return this;
+  }
+
+  @Override
+  public CamundaFuture<SearchResponse<Client>> send() {
+    ArgumentUtil.ensureNotNullNorEmpty("tenantId", tenantId);
+    final HttpCamundaFuture<SearchResponse<Client>> result = new HttpCamundaFuture<>();
+    httpClient.post(
+        String.format("/tenants/%s/clients/search", tenantId),
+        jsonMapper.toJson(request),
+        httpRequestConfig.build(),
+        TenantClientSearchResult.class,
+        SearchResponseMapper::toTenantClientsResponse,
+        result);
+    return result;
+  }
+
+  @Override
+  public ClientsByTenantSearchRequest filter(final ClientFilter value) {
+    // This command doesn't support filtering
+    return null;
+  }
+
+  @Override
+  public ClientsByTenantSearchRequest filter(final Consumer<ClientFilter> fn) {
+    // This command doesn't support filtering
+    return null;
+  }
+
+  @Override
+  public ClientsByTenantSearchRequest page(final SearchRequestPage value) {
+    request.setPage(provideSearchRequestProperty(value));
+    return this;
+  }
+
+  @Override
+  public ClientsByTenantSearchRequest page(final Consumer<SearchRequestPage> fn) {
+    return page(searchRequestPage(fn));
+  }
+
+  @Override
+  public ClientsByTenantSearchRequest sort(final ClientSort value) {
+    request.setSort(
+        SearchRequestSortMapper.toTenantClientSearchQuerySortRequest(
+            provideSearchRequestProperty(value)));
+    return this;
+  }
+
+  @Override
+  public ClientsByTenantSearchRequest sort(final Consumer<ClientSort> fn) {
+    return sort(clientSort(fn));
+  }
+
+  @Override
+  protected TenantClientSearchQueryRequest getSearchRequestProperty() {
+    return request;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/search/request/ClientsByTenantSearchRequestImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/request/ClientsByTenantSearchRequestImpl.java
@@ -80,13 +80,13 @@ public class ClientsByTenantSearchRequestImpl
   @Override
   public ClientsByTenantSearchRequest filter(final ClientFilter value) {
     // This command doesn't support filtering
-    return null;
+    throw new UnsupportedOperationException("This command does not support filtering");
   }
 
   @Override
   public ClientsByTenantSearchRequest filter(final Consumer<ClientFilter> fn) {
     // This command doesn't support filtering
-    return null;
+    throw new UnsupportedOperationException("This command does not support filtering");
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/client/impl/search/request/SearchRequestSortMapper.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/request/SearchRequestSortMapper.java
@@ -231,6 +231,21 @@ public class SearchRequestSortMapper {
         .collect(Collectors.toList());
   }
 
+  public static List<TenantClientSearchQuerySortRequest> toTenantClientSearchQuerySortRequest(
+      final List<SearchRequestSort> requests) {
+    return requests.stream()
+        .map(
+            r -> {
+              final TenantClientSearchQuerySortRequest request =
+                  new TenantClientSearchQuerySortRequest();
+              request.setField(
+                  TenantClientSearchQuerySortRequest.FieldEnum.fromValue(r.getField()));
+              request.setOrder(r.getOrder());
+              return request;
+            })
+        .collect(Collectors.toList());
+  }
+
   public static List<GroupSearchQuerySortRequest> toGroupSearchQuerySortRequest(
       final List<SearchRequestSort> requests) {
     return requests.stream()

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/SearchResponseMapper.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/SearchResponseMapper.java
@@ -207,6 +207,19 @@ public final class SearchResponseMapper {
     return new ClientImpl(response.getClientId());
   }
 
+  public static SearchResponse<Client> toTenantClientsResponse(
+      final TenantClientSearchResult response) {
+    final SearchResponsePage page = toSearchResponsePage(response.getPage());
+    final List<Client> instances =
+        toSearchResponseInstances(
+            response.getItems(), SearchResponseMapper::toTenantClientResponse);
+    return new SearchResponseImpl<>(instances, page);
+  }
+
+  public static Client toTenantClientResponse(final TenantClientResult response) {
+    return new ClientImpl(response.getClientId());
+  }
+
   public static Role toRoleResponse(final RoleResult response) {
     return new RoleImpl(response.getRoleId(), response.getName(), response.getDescription());
   }

--- a/clients/java/src/test/java/io/camunda/client/tenant/SearchClientByTenantTest.java
+++ b/clients/java/src/test/java/io/camunda/client/tenant/SearchClientByTenantTest.java
@@ -19,6 +19,7 @@ import static io.camunda.client.impl.http.HttpClientFactory.REST_API_PATH;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.github.tomakehurst.wiremock.http.RequestMethod;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
 import io.camunda.client.util.ClientRestTest;
 import io.camunda.client.util.RestGatewayService;
@@ -36,18 +37,25 @@ public class SearchClientByTenantTest extends ClientRestTest {
     // then
     final String requestPath = RestGatewayService.getLastRequest().getUrl();
     assertThat(requestPath).isEqualTo(REST_API_PATH + "/tenants/" + TENANT_ID + "/clients/search");
+    assertThat(RestGatewayService.getLastRequest().getMethod()).isEqualTo(RequestMethod.POST);
   }
 
   @Test
-  void shouldIncludeSortInSearchRequestBody() {
+  void shouldIncludeSortAndPaginationInSearchRequestBody() {
     // when
-    client.newClientsByTenantSearchRequest(TENANT_ID).sort(s -> s.clientId().desc()).send().join();
+    client
+        .newClientsByTenantSearchRequest(TENANT_ID)
+        .sort(s -> s.clientId().desc())
+        .page(p -> p.limit(2))
+        .send()
+        .join();
 
     // then
     final LoggedRequest lastRequest = RestGatewayService.getLastRequest();
     final String requestBody = lastRequest.getBodyAsString();
 
     assertThat(requestBody).contains("\"sort\":[{\"field\":\"clientId\",\"order\":\"DESC\"}]");
+    assertThat(requestBody).contains("\"page\":{\"limit\":2}");
   }
 
   @Test

--- a/clients/java/src/test/java/io/camunda/client/tenant/SearchClientByTenantTest.java
+++ b/clients/java/src/test/java/io/camunda/client/tenant/SearchClientByTenantTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.tenant;
+
+import static io.camunda.client.impl.http.HttpClientFactory.REST_API_PATH;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+import io.camunda.client.util.ClientRestTest;
+import io.camunda.client.util.RestGatewayService;
+import org.junit.jupiter.api.Test;
+
+public class SearchClientByTenantTest extends ClientRestTest {
+
+  private static final String TENANT_ID = "tenant-123";
+
+  @Test
+  void shouldSendSearchRequestForClientsByTenant() {
+    // when
+    client.newClientsByTenantSearchRequest(TENANT_ID).send().join();
+
+    // then
+    final String requestPath = RestGatewayService.getLastRequest().getUrl();
+    assertThat(requestPath).isEqualTo(REST_API_PATH + "/tenants/" + TENANT_ID + "/clients/search");
+  }
+
+  @Test
+  void shouldIncludeSortInSearchRequestBody() {
+    // when
+    client.newClientsByTenantSearchRequest(TENANT_ID).sort(s -> s.clientId().desc()).send().join();
+
+    // then
+    final LoggedRequest lastRequest = RestGatewayService.getLastRequest();
+    final String requestBody = lastRequest.getBodyAsString();
+
+    assertThat(requestBody).contains("\"sort\":[{\"field\":\"clientId\",\"order\":\"DESC\"}]");
+  }
+
+  @Test
+  void shouldRaiseExceptionOnNullTenantId() {
+    assertThatThrownBy(() -> client.newClientsByTenantSearchRequest(null).send().join())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("tenantId must not be null");
+  }
+
+  @Test
+  void shouldRaiseExceptionOnEmptyTenantId() {
+    assertThatThrownBy(() -> client.newClientsByTenantSearchRequest("").send().join())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("tenantId must not be empty");
+  }
+}

--- a/clients/java/src/test/java/io/camunda/client/tenant/SearchClientByTenantTest.java
+++ b/clients/java/src/test/java/io/camunda/client/tenant/SearchClientByTenantTest.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.github.tomakehurst.wiremock.http.RequestMethod;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+import io.camunda.client.api.search.filter.ClientFilter;
 import io.camunda.client.util.ClientRestTest;
 import io.camunda.client.util.RestGatewayService;
 import org.junit.jupiter.api.Test;
@@ -70,5 +71,26 @@ public class SearchClientByTenantTest extends ClientRestTest {
     assertThatThrownBy(() -> client.newClientsByTenantSearchRequest("").send().join())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("tenantId must not be empty");
+  }
+
+  @Test
+  void shouldRaiseExceptionWhenSettingFilter() {
+    assertThatThrownBy(
+            () -> client.newClientsByTenantSearchRequest(TENANT_ID).filter(fn -> {}).send().join())
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessageContaining("This command does not support filtering");
+  }
+
+  @Test
+  void shouldRaiseExceptionWhenSettingFiltering() {
+    assertThatThrownBy(
+            () ->
+                client
+                    .newClientsByTenantSearchRequest(TENANT_ID)
+                    .filter(new ClientFilter() {})
+                    .send()
+                    .join())
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessageContaining("This command does not support filtering");
   }
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/TenantAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/TenantAuthorizationIT.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ProblemException;
+import io.camunda.client.api.search.response.Client;
 import io.camunda.client.api.search.response.SearchResponse;
 import io.camunda.client.api.search.response.Tenant;
 import io.camunda.client.api.search.response.TenantUser;
@@ -30,12 +31,22 @@ import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.qa.util.multidb.MultiDbTestApplication;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import io.camunda.zeebe.test.util.Strings;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpRequest.BodyPublishers;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandlers;
 import java.time.Duration;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.List;
 import java.util.UUID;
 import org.assertj.core.api.Assertions;
 import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
@@ -57,6 +68,8 @@ class TenantAuthorizationIT {
   private static final String RESTRICTED = "restrictedUser";
   private static final String UNAUTHORIZED = "unauthorizedUser";
   private static final Duration AWAIT_TIMEOUT = Duration.ofSeconds(15);
+  private static final String TENANT_ID_1 = "tenant1";
+  private static final String TENANT_ID_2 = "tenant2";
 
   @UserDefinition
   private static final TestUser ADMIN_USER =
@@ -74,15 +87,17 @@ class TenantAuthorizationIT {
       new TestUser(
           RESTRICTED,
           PASSWORD,
-          List.of(new Permissions(TENANT, READ, List.of("tenant1", "tenant2"))));
+          List.of(new Permissions(TENANT, READ, List.of(TENANT_ID_1, TENANT_ID_2))));
 
   @UserDefinition
   private static final TestUser UNAUTHORIZED_USER = new TestUser(UNAUTHORIZED, PASSWORD, List.of());
 
+  @AutoClose private static final HttpClient HTTP_CLIENT = HttpClient.newHttpClient();
+
   @BeforeAll
   static void setUp(@Authenticated(ADMIN) final CamundaClient adminClient) {
-    createTenant(adminClient, "tenant1");
-    createTenant(adminClient, "tenant2");
+    createTenant(adminClient, TENANT_ID_1);
+    createTenant(adminClient, TENANT_ID_2);
 
     Awaitility.await("should create tenants and import in ES")
         .atMost(AWAIT_TIMEOUT)
@@ -92,7 +107,7 @@ class TenantAuthorizationIT {
               final var tenantsSearchResponse = adminClient.newTenantsSearchRequest().send().join();
               Assertions.assertThat(
                       tenantsSearchResponse.items().stream().map(Tenant::getTenantId).toList())
-                  .containsAll(Arrays.asList("tenant1", "tenant2"));
+                  .containsAll(Arrays.asList(TENANT_ID_1, TENANT_ID_2));
             });
   }
 
@@ -107,7 +122,7 @@ class TenantAuthorizationIT {
     assertThat(tenantSearchResponse.items())
         .hasSize(2)
         .map(Tenant::getTenantId)
-        .containsExactlyInAnyOrder("tenant1", "tenant2");
+        .containsExactlyInAnyOrder(TENANT_ID_1, TENANT_ID_2);
   }
 
   @Test
@@ -125,17 +140,17 @@ class TenantAuthorizationIT {
   void getByIdShouldReturnAuthorizedTenant(
       @Authenticated(RESTRICTED) final CamundaClient userClient) {
     // when
-    final Tenant tenant = userClient.newTenantGetRequest("tenant1").send().join();
+    final Tenant tenant = userClient.newTenantGetRequest(TENANT_ID_1).send().join();
 
     // then
-    assertThat(tenant.getTenantId()).isEqualTo("tenant1");
+    assertThat(tenant.getTenantId()).isEqualTo(TENANT_ID_1);
   }
 
   @Test
   void getByIdShouldReturnForbiddenForUnauthorizedTenantId(
       @Authenticated(UNAUTHORIZED) final CamundaClient userClient) {
     // when/then
-    assertThatThrownBy(() -> userClient.newTenantGetRequest("tenant1").send().join())
+    assertThatThrownBy(() -> userClient.newTenantGetRequest(TENANT_ID_1).send().join())
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Unauthorized to perform operation 'READ' on resource 'TENANT'");
   }
@@ -144,7 +159,7 @@ class TenantAuthorizationIT {
   void searchUsersByTenantShouldReturnEmptyListIfUnauthorized(
       @Authenticated(UNAUTHORIZED) final CamundaClient camundaClient) {
     final SearchResponse<TenantUser> response =
-        camundaClient.newUsersByTenantSearchRequest("tenant1").send().join();
+        camundaClient.newUsersByTenantSearchRequest(TENANT_ID_1).send().join();
     Assertions.assertThat(response.items()).isEmpty();
   }
 
@@ -163,7 +178,12 @@ class TenantAuthorizationIT {
         .send()
         .join();
 
-    adminClient.newAssignUserToTenantCommand().username(userName).tenantId("tenant1").send().join();
+    adminClient
+        .newAssignUserToTenantCommand()
+        .username(userName)
+        .tenantId(TENANT_ID_1)
+        .send()
+        .join();
 
     // when/then
     Awaitility.await("Search returns correct users")
@@ -171,10 +191,61 @@ class TenantAuthorizationIT {
         .untilAsserted(
             () -> {
               final SearchResponse<TenantUser> response =
-                  adminClient.newUsersByTenantSearchRequest("tenant1").send().join();
+                  adminClient.newUsersByTenantSearchRequest(TENANT_ID_1).send().join();
               Assertions.assertThat(response.items().stream().map(TenantUser::getUsername).toList())
                   .contains(userName);
             });
+  }
+
+  @Test
+  void shouldSearchClientsByTenantIfAuthorized(
+      @Authenticated(ADMIN) final CamundaClient adminClient)
+      throws URISyntaxException, IOException, InterruptedException {
+    // given
+    final String clientId = Strings.newRandomValidIdentityId();
+    assignClientToTenant(
+        adminClient.getConfiguration().getRestAddress().toString(), ADMIN, TENANT_ID_1, clientId);
+
+    // when/then
+    Awaitility.await("Search returns clients by tenant")
+        .ignoreExceptionsInstanceOf(ProblemException.class)
+        .untilAsserted(
+            () -> {
+              final SearchResponse<Client> response =
+                  adminClient.newClientsByTenantSearchRequest(TENANT_ID_1).send().join();
+              Assertions.assertThat(response.items().stream().map(Client::getClientId))
+                  .contains(clientId);
+            });
+  }
+
+  @Test
+  void searchClientsByTenantShouldReturnEmptyListIfUnauthorized(
+      @Authenticated(UNAUTHORIZED) final CamundaClient camundaClient) {
+    final SearchResponse<Client> response =
+        camundaClient.newClientsByTenantSearchRequest(TENANT_ID_1).send().join();
+    Assertions.assertThat(response.items()).isEmpty();
+  }
+
+  // TODO once available in #35767, this test should use the client to make the request
+  private static void assignClientToTenant(
+      final String restAddress, final String username, final String tenantId, final String clientId)
+      throws URISyntaxException, IOException, InterruptedException {
+    final var encodedCredentials =
+        Base64.getEncoder().encodeToString("%s:%s".formatted(username, PASSWORD).getBytes());
+    final HttpRequest request =
+        HttpRequest.newBuilder()
+            .uri(
+                new URI(
+                    "%s%s%s%s%s"
+                        .formatted(restAddress, "v2/tenants/", tenantId, "/clients/", clientId)))
+            .PUT(BodyPublishers.ofString(""))
+            .header("Authorization", "Basic %s".formatted(encodedCredentials))
+            .build();
+
+    // Send the request and get the response
+    final HttpResponse<String> response = HTTP_CLIENT.send(request, BodyHandlers.ofString());
+
+    assertThat(response.statusCode()).isEqualTo(204);
   }
 
   private static void createTenant(final CamundaClient adminClient, final String tenantId) {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ClientsByTenantIntegrationTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ClientsByTenantIntegrationTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.command.ProblemException;
+import io.camunda.client.api.search.response.Client;
+import io.camunda.client.api.search.response.SearchResponse;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.zeebe.test.util.Strings;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpRequest.BodyPublishers;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandlers;
+import org.assertj.core.api.AssertionsForClassTypes;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AutoClose;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+
+@MultiDbTest
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms")
+public class ClientsByTenantIntegrationTest {
+
+  private static CamundaClient camundaClient;
+  private static final String TENANT_ID = Strings.newRandomValidIdentityId();
+
+  @AutoClose private static final HttpClient HTTP_CLIENT = HttpClient.newHttpClient();
+
+  @BeforeAll
+  static void setup() {
+    camundaClient.newCreateTenantCommand().tenantId(TENANT_ID).name("tenantName").send().join();
+  }
+
+  @Test
+  void shouldSearchClientsByTenantAndSort()
+      throws URISyntaxException, IOException, InterruptedException {
+    // given
+    final var firstClientId = "aClientId";
+    final var secondClientId = "bClientId";
+
+    // when
+    assignClientToTenant(
+        camundaClient.getConfiguration().getRestAddress().toString(), TENANT_ID, firstClientId);
+    assignClientToTenant(
+        camundaClient.getConfiguration().getRestAddress().toString(), TENANT_ID, secondClientId);
+
+    // then
+    Awaitility.await("Clients are assigned to the tenant and can be searched")
+        .ignoreExceptionsInstanceOf(ProblemException.class)
+        .untilAsserted(
+            () -> {
+              final SearchResponse<Client> result =
+                  camundaClient
+                      .newClientsByTenantSearchRequest(TENANT_ID)
+                      .sort(s -> s.clientId().desc())
+                      .send()
+                      .join();
+              assertThat(result.items())
+                  .map(Client::getClientId)
+                  .containsExactly(secondClientId, firstClientId);
+            });
+  }
+
+  @Test
+  void searchClientsShouldReturnEmptyListWhenSearchingForNonExistingTenantId() {
+    final var clientsSearchResponse =
+        camundaClient.newClientsByTenantSearchRequest("someTenantId").send().join();
+    assertThat(clientsSearchResponse.items()).isEmpty();
+  }
+
+  @Test
+  void shouldRejectClientsByTenantSearchIfMissingTenantId() {
+    // when / then
+    assertThatThrownBy(() -> camundaClient.newClientsByTenantSearchRequest(null).send().join())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("tenantId must not be null");
+  }
+
+  @Test
+  void shouldRejectClientsByTenantSearchIfEmptyTenantId() {
+    // when / then
+    assertThatThrownBy(() -> camundaClient.newClientsByTenantSearchRequest("").send().join())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("tenantId must not be empty");
+  }
+
+  // TODO once available in #35767, this test should use the client to make the request
+  private static void assignClientToTenant(
+      final String restAddress, final String tenantId, final String clientId)
+      throws URISyntaxException, IOException, InterruptedException {
+    final HttpRequest request =
+        HttpRequest.newBuilder()
+            .uri(
+                new URI(
+                    "%s%s%s%s%s"
+                        .formatted(restAddress, "v2/tenants/", tenantId, "/clients/", clientId)))
+            .PUT(BodyPublishers.ofString(""))
+            .build();
+
+    // Send the request and get the response
+    final HttpResponse<String> response = HTTP_CLIENT.send(request, BodyHandlers.ofString());
+
+    AssertionsForClassTypes.assertThat(response.statusCode()).isEqualTo(204);
+  }
+}


### PR DESCRIPTION
## Description

Add command to search Clients in Tenant to Java Client.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #35217
