### PR TITLE
Respond 204 No Content instead of 202 Accepted for member changes

### DIFF
--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -3055,7 +3055,7 @@ paths:
           schema:
             type: string
       responses:
-        "202":
+        "204":
           description: The role was assigned successfully to the user.
         "400":
           $ref: "#/components/responses/InvalidData"
@@ -3098,7 +3098,7 @@ paths:
           schema:
             type: string
       responses:
-        "202":
+        "204":
           description: The user was unassigned successfully from the role.
         "400":
           $ref: "#/components/responses/InvalidData"
@@ -3136,7 +3136,7 @@ paths:
           schema:
             type: string
       responses:
-        "202":
+        "204":
           description: The role was assigned successfully to the client.
         "400":
           $ref: "#/components/responses/InvalidData"
@@ -3179,7 +3179,7 @@ paths:
           schema:
             type: string
       responses:
-        "202":
+        "204":
           description: The role was unassigned successfully from the client.
         "400":
           $ref: "#/components/responses/InvalidData"
@@ -3250,7 +3250,7 @@ paths:
           schema:
             type: string
       responses:
-        "202":
+        "204":
           description: The role was assigned successfully to the group.
         "400":
           $ref: "#/components/responses/InvalidData"
@@ -3293,7 +3293,7 @@ paths:
           schema:
             type: string
       responses:
-        "202":
+        "204":
           description: The role was unassigned successfully from the group.
         "400":
           $ref: "#/components/responses/InvalidData"
@@ -3373,7 +3373,7 @@ paths:
           schema:
             type: string
       responses:
-        "202":
+        "204":
           description: The role was assigned successfully to the mapping rule.
         "400":
           $ref: "#/components/responses/InvalidData"
@@ -3416,7 +3416,7 @@ paths:
           schema:
             type: string
       responses:
-        "202":
+        "204":
           description: The role was unassigned successfully from the mapping rule.
         "400":
           $ref: "#/components/responses/InvalidData"
@@ -3799,7 +3799,7 @@ paths:
           schema:
             type: string
       responses:
-        "202":
+        "204":
           description: The user was assigned successfully to the group.
         "400":
           $ref: "#/components/responses/InvalidData"
@@ -3842,7 +3842,7 @@ paths:
           schema:
             type: string
       responses:
-        "202":
+        "204":
           description: The user was unassigned successfully from the group.
         "400":
           $ref: "#/components/responses/InvalidData"
@@ -3880,7 +3880,7 @@ paths:
           schema:
             type: string
       responses:
-        "202":
+        "204":
           description: The client was assigned successfully to the group.
         "400":
           $ref: "#/components/responses/InvalidData"
@@ -3923,7 +3923,7 @@ paths:
           schema:
             type: string
       responses:
-        "202":
+        "204":
           description: The client was unassigned successfully from the group.
         "400":
           $ref: "#/components/responses/InvalidData"
@@ -3961,7 +3961,7 @@ paths:
           schema:
             type: string
       responses:
-        "202":
+        "204":
           description: The mapping rule was assigned successfully to the group.
         "400":
           $ref: "#/components/responses/InvalidData"
@@ -4004,7 +4004,7 @@ paths:
           schema:
             type: string
       responses:
-        "202":
+        "204":
           description: The mapping rule was unassigned successfully from the group.
         "400":
           $ref: "#/components/responses/InvalidData"

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RequestMapper.java
@@ -521,12 +521,6 @@ public class RequestMapper {
         method, ignored -> ResponseEntity.noContent().build());
   }
 
-  public static <BrokerResponseT>
-      CompletableFuture<ResponseEntity<Object>> executeServiceMethodWithAcceptedResult(
-          final Supplier<CompletableFuture<BrokerResponseT>> method) {
-    return RequestMapper.executeServiceMethod(method, ignored -> ResponseEntity.accepted().build());
-  }
-
   public static Either<ProblemDetail, DeployResourcesRequest> toDeployResourceRequest(
       final List<MultipartFile> resources,
       final String tenantId,

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupController.java
@@ -239,7 +239,7 @@ public class GroupController {
   }
 
   public CompletableFuture<ResponseEntity<Object>> assignMember(final GroupMemberDTO request) {
-    return RequestMapper.executeServiceMethodWithAcceptedResult(
+    return RequestMapper.executeServiceMethodWithNoContentResult(
         () ->
             groupServices
                 .withAuthentication(authenticationProvider.getCamundaAuthentication())
@@ -322,7 +322,7 @@ public class GroupController {
   }
 
   public CompletableFuture<ResponseEntity<Object>> unassignMember(final GroupMemberDTO request) {
-    return RequestMapper.executeServiceMethodWithAcceptedResult(
+    return RequestMapper.executeServiceMethodWithNoContentResult(
         () ->
             groupServices
                 .withAuthentication(authenticationProvider.getCamundaAuthentication())

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleController.java
@@ -259,7 +259,7 @@ public class RoleController {
 
   private CompletableFuture<ResponseEntity<Object>> addMemberToRole(
       final RoleMemberRequest request) {
-    return RequestMapper.executeServiceMethodWithAcceptedResult(
+    return RequestMapper.executeServiceMethodWithNoContentResult(
         () ->
             roleServices
                 .withAuthentication(authenticationProvider.getCamundaAuthentication())
@@ -330,7 +330,7 @@ public class RoleController {
   private CompletableFuture<ResponseEntity<Object>> removeMemberFromRole(
       final RoleMemberRequest request) {
 
-    return RequestMapper.executeServiceMethodWithAcceptedResult(
+    return RequestMapper.executeServiceMethodWithNoContentResult(
         () ->
             roleServices
                 .withAuthentication(authenticationProvider.getCamundaAuthentication())

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupControllerTest.java
@@ -590,7 +590,7 @@ public class GroupControllerTest {
     }
 
     @Test
-    void shouldAssignUserToGroupAndReturnAccepted() {
+    void shouldAssignUserToGroupAndReturnNoContent() {
       // given
       final String groupId = "111";
       final String username = "222";
@@ -604,7 +604,7 @@ public class GroupControllerTest {
           .accept(MediaType.APPLICATION_JSON)
           .exchange()
           .expectStatus()
-          .isAccepted();
+          .isNoContent();
 
       // then
       verify(groupServices, times(1)).assignMember(request);
@@ -671,7 +671,7 @@ public class GroupControllerTest {
     }
 
     @Test
-    void shouldAssignMemberToGroupAndReturnAccepted() {
+    void shouldAssignMemberToGroupAndReturnNoContent() {
       // given
       final var groupId = Strings.newRandomValidIdentityId();
       final var mappingRuleId = Strings.newRandomValidIdentityId();
@@ -685,7 +685,7 @@ public class GroupControllerTest {
           .accept(MediaType.APPLICATION_JSON)
           .exchange()
           .expectStatus()
-          .isAccepted();
+          .isNoContent();
 
       // then
       verify(groupServices, times(1)).assignMember(request);
@@ -810,7 +810,7 @@ public class GroupControllerTest {
     }
 
     @Test
-    void shouldUnassignUserToGroupAndReturnAccepted() {
+    void shouldUnassignUserToGroupAndReturnNoContent() {
       // given
       final String groupId = "111";
       final String username = "222";
@@ -824,7 +824,7 @@ public class GroupControllerTest {
           .accept(MediaType.APPLICATION_JSON)
           .exchange()
           .expectStatus()
-          .isAccepted();
+          .isNoContent();
 
       // then
       verify(groupServices, times(1)).removeMember(request);
@@ -891,7 +891,7 @@ public class GroupControllerTest {
     }
 
     @Test
-    void shouldUnassignMemberFromGroupAndReturnAccepted() {
+    void shouldUnassignMemberFromGroupAndReturnNoContent() {
       // given
       final var groupId = Strings.newRandomValidIdentityId();
       final var mappingRuleId = Strings.newRandomValidIdentityId();
@@ -905,7 +905,7 @@ public class GroupControllerTest {
           .accept(MediaType.APPLICATION_JSON)
           .exchange()
           .expectStatus()
-          .isAccepted();
+          .isNoContent();
 
       // then
       verify(groupServices, times(1)).removeMember(request);

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleControllerTest.java
@@ -413,7 +413,7 @@ public class RoleControllerTest extends RestControllerTest {
   }
 
   @Test
-  void shouldAssignUserToRoleAndReturnAccepted() {
+  void shouldAssignUserToRoleAndReturnNoContent() {
     // given
     final var roleId = "roleId";
     final var username = "username";
@@ -428,14 +428,14 @@ public class RoleControllerTest extends RestControllerTest {
         .accept(MediaType.APPLICATION_JSON)
         .exchange()
         .expectStatus()
-        .isAccepted();
+        .isNoContent();
 
     // then
     verify(roleServices, times(1)).addMember(request);
   }
 
   @Test
-  void shouldAssignMappingToRoleAndReturnAccepted() {
+  void shouldAssignMappingToRoleAndReturnNoContent() {
     // given
     final var roleId = Strings.newRandomValidIdentityId();
     final var mappingRuleId = Strings.newRandomValidIdentityId();
@@ -449,7 +449,7 @@ public class RoleControllerTest extends RestControllerTest {
         .accept(MediaType.APPLICATION_JSON)
         .exchange()
         .expectStatus()
-        .isAccepted();
+        .isNoContent();
 
     // then
     verify(roleServices, times(1)).addMember(request);
@@ -573,7 +573,7 @@ public class RoleControllerTest extends RestControllerTest {
   }
 
   @Test
-  void shouldUnassignMappingFromRoleAndReturnAccepted() {
+  void shouldUnassignMappingFromRoleAndReturnNoContent() {
     // given
     final var roleId = Strings.newRandomValidIdentityId();
     final var mappingRuleId = Strings.newRandomValidIdentityId();
@@ -588,7 +588,7 @@ public class RoleControllerTest extends RestControllerTest {
         .accept(MediaType.APPLICATION_JSON)
         .exchange()
         .expectStatus()
-        .isAccepted();
+        .isNoContent();
 
     // then
     verify(roleServices, times(1)).removeMember(request);
@@ -766,7 +766,7 @@ public class RoleControllerTest extends RestControllerTest {
   }
 
   @Test
-  void shouldUnassignUserFromRoleAndReturnAccepted() {
+  void shouldUnassignUserFromRoleAndReturnNoContent() {
     // given
     final var roleId = "roleId";
     final var username = "username";
@@ -781,7 +781,7 @@ public class RoleControllerTest extends RestControllerTest {
         .accept(MediaType.APPLICATION_JSON)
         .exchange()
         .expectStatus()
-        .isAccepted();
+        .isNoContent();
 
     // then
     verify(roleServices, times(1)).removeMember(request);
@@ -900,7 +900,7 @@ public class RoleControllerTest extends RestControllerTest {
   }
 
   @Test
-  void shouldAssignGroupToRoleAndReturnAccepted() {
+  void shouldAssignGroupToRoleAndReturnNoContent() {
     // given
     final var roleId = "roleId";
     final var groupId = "groupId";
@@ -915,7 +915,7 @@ public class RoleControllerTest extends RestControllerTest {
         .accept(MediaType.APPLICATION_JSON)
         .exchange()
         .expectStatus()
-        .isAccepted();
+        .isNoContent();
 
     // then
     verify(roleServices, times(1)).addMember(request);
@@ -1036,7 +1036,7 @@ public class RoleControllerTest extends RestControllerTest {
   }
 
   @Test
-  void shouldUnassignGroupFromRoleAndReturnAccepted() {
+  void shouldUnassignGroupFromRoleAndReturnNoContent() {
     // given
     final var roleId = "roleId";
     final var groupId = "groupId";
@@ -1051,7 +1051,7 @@ public class RoleControllerTest extends RestControllerTest {
         .accept(MediaType.APPLICATION_JSON)
         .exchange()
         .expectStatus()
-        .isAccepted();
+        .isNoContent();
 
     // then
     verify(roleServices, times(1)).removeMember(request);


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR changes the success response code from `202 Accepted` to `204 No Content` for the following endpoints:
- `PUT /roles/{roleId}/users/{username}`: Assign a role to a user
- `PUT /roles/{roleId}/clients/{clientId}`: Assign a role to a client
- `PUT /roles/{roleId}/groups/{groupId}`: Assign a role from a group
- `PUT /roles/{roleId}/mapping-rules/{mappingRuleId}`: Assign a role to a mapping rule
- `PUT /groups/{groupId}/users/{username}`: Assign a user to a group
- `PUT /groups/{groupId}/clients/{clientId}`: Assign a client to a group
- `PUT /groups/{groupId}/mapping-rules/{mappingRuleId}`: Assign a mapping rule to a group
- `DELETE /roles/{roleId}/users/{username}`: Unassign a user from a role
- `DELETE /roles/{roleId}/clients/{clientId}`: Unassign a role from a client
- `DELETE /roles/{roleId}/groups/{groupId}`: Unassign a role from a group
- `DELETE /roles/{roleId}/mapping-rules/{mappingRuleId}`: Unassign a role to a mapping rule
- `DELETE /groups/{groupId}/users/{username}`: Unassign a user to a group
- `DELETE /groups/{groupId}/clients/{clientId}`: Unassign a client to a group
- `DELETE /groups/{groupId}/mapping-rules/{mappingRuleId}`: Unassign a mapping rule to a group

202 Accepted is meant to be used for asynchronous processing, where the server has accepted the request and will process it.

204 No Content is meant to be used for synchronous processing, where the server has already processed the request and there is simply no content to respond.

In our case, the responses are always sent after the action has already taken place. For example, when assigning a role to a user the response is sent after the role was assigned to the user successfully. In other words, we won't continue processing the request because it was already processed. Using 204 No Content is thus a better fit for these endpoints.

## Related issues

closes #31817
