### PR TITLE
Add sequence flow deleted handler to camunda exporter

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
@@ -51,6 +51,7 @@ import io.camunda.exporter.handlers.RoleCreateUpdateHandler;
 import io.camunda.exporter.handlers.RoleDeletedHandler;
 import io.camunda.exporter.handlers.RoleMemberAddedHandler;
 import io.camunda.exporter.handlers.RoleMemberRemovedHandler;
+import io.camunda.exporter.handlers.SequenceFlowDeletedHandler;
 import io.camunda.exporter.handlers.SequenceFlowHandler;
 import io.camunda.exporter.handlers.TaskCompletedMetricHandler;
 import io.camunda.exporter.handlers.TenantCreateUpdateHandler;
@@ -231,6 +232,8 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
             new IncidentHandler(
                 indexDescriptors.get(IncidentTemplate.class).getFullQualifiedName(), processCache),
             new SequenceFlowHandler(
+                indexDescriptors.get(SequenceFlowTemplate.class).getFullQualifiedName()),
+            new SequenceFlowDeletedHandler(
                 indexDescriptors.get(SequenceFlowTemplate.class).getFullQualifiedName()),
             new DecisionEvaluationHandler(
                 indexDescriptors.get(DecisionInstanceTemplate.class).getFullQualifiedName()),

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/SequenceFlowDeletedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/SequenceFlowDeletedHandler.java
@@ -45,8 +45,7 @@ public class SequenceFlowDeletedHandler
   @Override
   public List<String> generateIds(final Record<ProcessInstanceRecordValue> record) {
     final var recordValue = record.getValue();
-    return List.of(
-        String.format(ID_PATTERN, recordValue.getProcessInstanceKey(), recordValue.getElementId()));
+    return List.of(formatId(recordValue.getProcessInstanceKey(), recordValue.getElementId()));
   }
 
   @Override
@@ -59,9 +58,7 @@ public class SequenceFlowDeletedHandler
       final Record<ProcessInstanceRecordValue> record, final SequenceFlowEntity entity) {
     final var recordValue = record.getValue();
     entity
-        .setId(
-            String.format(
-                ID_PATTERN, recordValue.getProcessInstanceKey(), recordValue.getElementId()))
+        .setId(formatId(recordValue.getProcessInstanceKey(), recordValue.getElementId()))
         .setProcessInstanceKey(recordValue.getProcessInstanceKey())
         .setProcessDefinitionKey(recordValue.getProcessDefinitionKey())
         .setBpmnProcessId(recordValue.getBpmnProcessId())
@@ -78,5 +75,9 @@ public class SequenceFlowDeletedHandler
   @Override
   public String getIndexName() {
     return indexName;
+  }
+
+  private static String formatId(final long processInstanceKey, final String elementId) {
+    return String.format(ID_PATTERN, processInstanceKey, elementId);
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/SequenceFlowDeletedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/SequenceFlowDeletedHandler.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.handlers;
+
+import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.store.BatchRequest;
+import io.camunda.exporter.utils.ExporterUtil;
+import io.camunda.webapps.schema.entities.SequenceFlowEntity;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
+import java.util.List;
+
+public class SequenceFlowDeletedHandler
+    implements ExportHandler<SequenceFlowEntity, ProcessInstanceRecordValue> {
+
+  private static final String ID_PATTERN = "%s_%s";
+  private final String indexName;
+
+  public SequenceFlowDeletedHandler(final String indexName) {
+    this.indexName = indexName;
+  }
+
+  @Override
+  public ValueType getHandledValueType() {
+    return ValueType.PROCESS_INSTANCE;
+  }
+
+  @Override
+  public Class<SequenceFlowEntity> getEntityType() {
+    return SequenceFlowEntity.class;
+  }
+
+  @Override
+  public boolean handlesRecord(final Record<ProcessInstanceRecordValue> record) {
+    return record.getIntent().equals(ProcessInstanceIntent.SEQUENCE_FLOW_DELETED);
+  }
+
+  @Override
+  public List<String> generateIds(final Record<ProcessInstanceRecordValue> record) {
+    final var recordValue = record.getValue();
+    return List.of(
+        String.format(ID_PATTERN, recordValue.getProcessInstanceKey(), recordValue.getElementId()));
+  }
+
+  @Override
+  public SequenceFlowEntity createNewEntity(final String id) {
+    return new SequenceFlowEntity().setId(id);
+  }
+
+  @Override
+  public void updateEntity(
+      final Record<ProcessInstanceRecordValue> record, final SequenceFlowEntity entity) {
+    final var recordValue = record.getValue();
+    entity
+        .setId(
+            String.format(
+                ID_PATTERN, recordValue.getProcessInstanceKey(), recordValue.getElementId()))
+        .setProcessInstanceKey(recordValue.getProcessInstanceKey())
+        .setProcessDefinitionKey(recordValue.getProcessDefinitionKey())
+        .setBpmnProcessId(recordValue.getBpmnProcessId())
+        .setActivityId(recordValue.getElementId())
+        .setTenantId(ExporterUtil.tenantOrDefault(recordValue.getTenantId()));
+  }
+
+  @Override
+  public void flush(final SequenceFlowEntity entity, final BatchRequest batchRequest)
+      throws PersistenceException {
+    batchRequest.delete(indexName, entity.getId());
+  }
+
+  @Override
+  public String getIndexName() {
+    return indexName;
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/SequenceFlowHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/SequenceFlowHandler.java
@@ -44,8 +44,7 @@ public class SequenceFlowHandler
   @Override
   public List<String> generateIds(final Record<ProcessInstanceRecordValue> record) {
     final var recordValue = record.getValue();
-    return List.of(
-        String.format(ID_PATTERN, recordValue.getProcessInstanceKey(), recordValue.getElementId()));
+    return List.of(formatId(recordValue.getProcessInstanceKey(), recordValue.getElementId()));
   }
 
   @Override
@@ -58,9 +57,7 @@ public class SequenceFlowHandler
       final Record<ProcessInstanceRecordValue> record, final SequenceFlowEntity entity) {
     final var recordValue = record.getValue();
     entity
-        .setId(
-            String.format(
-                ID_PATTERN, recordValue.getProcessInstanceKey(), recordValue.getElementId()))
+        .setId(formatId(recordValue.getProcessInstanceKey(), recordValue.getElementId()))
         .setProcessInstanceKey(recordValue.getProcessInstanceKey())
         .setProcessDefinitionKey(recordValue.getProcessDefinitionKey())
         .setBpmnProcessId(recordValue.getBpmnProcessId())
@@ -76,5 +73,9 @@ public class SequenceFlowHandler
   @Override
   public String getIndexName() {
     return indexName;
+  }
+
+  private static String formatId(final long processInstanceKey, final String elementId) {
+    return String.format(ID_PATTERN, processInstanceKey, elementId);
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/SequenceFlowDeletedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/SequenceFlowDeletedHandlerTest.java
@@ -70,24 +70,26 @@ public class SequenceFlowDeletedHandlerTest {
   @Test
   void shouldGenerateIds() {
     // given
-    final ProcessInstanceRecordValue variableRecordValue =
+    final ProcessInstanceRecordValue sequenceFlowRecordValue =
         ImmutableProcessInstanceRecordValue.builder()
             .from(factory.generateObject(ProcessInstanceRecordValue.class))
             .build();
 
-    final io.camunda.zeebe.protocol.record.Record<ProcessInstanceRecordValue> variableRecord =
+    final io.camunda.zeebe.protocol.record.Record<ProcessInstanceRecordValue> sequenceFlowRecord =
         factory.generateRecord(
             ValueType.PROCESS_INSTANCE,
             r ->
                 r.withIntent(ProcessInstanceIntent.SEQUENCE_FLOW_DELETED)
-                    .withValue(variableRecordValue));
+                    .withValue(sequenceFlowRecordValue));
 
     // when
-    final var idList = underTest.generateIds(variableRecord);
+    final var idList = underTest.generateIds(sequenceFlowRecord);
     // then
     assertThat(idList)
         .containsExactly(
-            variableRecordValue.getProcessInstanceKey() + "_" + variableRecordValue.getElementId());
+            sequenceFlowRecordValue.getProcessInstanceKey()
+                + "_"
+                + sequenceFlowRecordValue.getElementId());
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/SequenceFlowDeletedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/SequenceFlowDeletedHandlerTest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.handlers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.entities.SequenceFlowEntity;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.ImmutableProcessInstanceRecordValue;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import java.util.Arrays;
+import org.junit.jupiter.api.Test;
+
+public class SequenceFlowDeletedHandlerTest {
+  private final ProtocolFactory factory = new ProtocolFactory();
+  private final String indexName = "sequence-flow";
+  private final SequenceFlowDeletedHandler underTest = new SequenceFlowDeletedHandler(indexName);
+
+  @Test
+  void testGetHandledValueType() {
+    assertThat(underTest.getHandledValueType()).isEqualTo(ValueType.PROCESS_INSTANCE);
+  }
+
+  @Test
+  void testGetEntityType() {
+    assertThat(underTest.getEntityType()).isEqualTo(SequenceFlowEntity.class);
+  }
+
+  @Test
+  void shouldHandleRecord() {
+    // given
+    final io.camunda.zeebe.protocol.record.Record<ProcessInstanceRecordValue>
+        processInstanceRecord =
+            factory.generateRecord(
+                ValueType.PROCESS_INSTANCE,
+                r -> r.withIntent(ProcessInstanceIntent.SEQUENCE_FLOW_DELETED));
+
+    // when - then
+    assertThat(underTest.handlesRecord(processInstanceRecord)).isTrue();
+  }
+
+  @Test
+  void shouldNotHandleRecord() {
+    // given
+    Arrays.stream(ProcessInstanceIntent.values())
+        .filter(intent -> intent != ProcessInstanceIntent.SEQUENCE_FLOW_DELETED)
+        .forEach(
+            intent -> {
+              final io.camunda.zeebe.protocol.record.Record<ProcessInstanceRecordValue>
+                  processInstanceRecord =
+                      factory.generateRecord(ValueType.PROCESS_INSTANCE, r -> r.withIntent(intent));
+
+              // when - then
+              assertThat(underTest.handlesRecord(processInstanceRecord)).isFalse();
+            });
+  }
+
+  @Test
+  void shouldGenerateIds() {
+    // given
+    final ProcessInstanceRecordValue variableRecordValue =
+        ImmutableProcessInstanceRecordValue.builder()
+            .from(factory.generateObject(ProcessInstanceRecordValue.class))
+            .build();
+
+    final io.camunda.zeebe.protocol.record.Record<ProcessInstanceRecordValue> variableRecord =
+        factory.generateRecord(
+            ValueType.PROCESS_INSTANCE,
+            r ->
+                r.withIntent(ProcessInstanceIntent.SEQUENCE_FLOW_DELETED)
+                    .withValue(variableRecordValue));
+
+    // when
+    final var idList = underTest.generateIds(variableRecord);
+    // then
+    assertThat(idList)
+        .containsExactly(
+            variableRecordValue.getProcessInstanceKey() + "_" + variableRecordValue.getElementId());
+  }
+
+  @Test
+  void shouldCreateNewEntity() {
+    // when
+    final var result = underTest.createNewEntity("id");
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.getId()).isEqualTo("id");
+  }
+
+  @Test
+  void shouldDeleteEntityOnFlush() {
+    // given
+    final SequenceFlowEntity inputEntity = new SequenceFlowEntity();
+    final BatchRequest mockRequest = mock(BatchRequest.class);
+
+    // when
+    underTest.flush(inputEntity, mockRequest);
+
+    // then
+    verify(mockRequest, times(1)).delete(indexName, inputEntity.getId());
+  }
+
+  @Test
+  void shouldUpdateEntityFromRecord() {
+    // given
+    final ProcessInstanceRecordValue processInstanceRecordValue =
+        ImmutableProcessInstanceRecordValue.builder()
+            .from(factory.generateObject(ProcessInstanceRecordValue.class))
+            .build();
+
+    final Record<ProcessInstanceRecordValue> variableRecord =
+        factory.generateRecord(
+            ValueType.PROCESS_INSTANCE,
+            r ->
+                r.withIntent(ProcessInstanceIntent.SEQUENCE_FLOW_DELETED)
+                    .withValue(processInstanceRecordValue));
+
+    // when
+    final SequenceFlowEntity sequenceFlowEntity = new SequenceFlowEntity();
+    underTest.updateEntity(variableRecord, sequenceFlowEntity);
+
+    // then
+    assertThat(sequenceFlowEntity.getId())
+        .isEqualTo(
+            processInstanceRecordValue.getProcessInstanceKey()
+                + "_"
+                + processInstanceRecordValue.getElementId());
+    assertThat(sequenceFlowEntity.getProcessInstanceKey())
+        .isEqualTo(processInstanceRecordValue.getProcessInstanceKey());
+    assertThat(sequenceFlowEntity.getProcessDefinitionKey())
+        .isEqualTo(processInstanceRecordValue.getProcessDefinitionKey());
+    assertThat(sequenceFlowEntity.getBpmnProcessId())
+        .isEqualTo(processInstanceRecordValue.getBpmnProcessId());
+    assertThat(sequenceFlowEntity.getActivityId())
+        .isEqualTo(processInstanceRecordValue.getElementId());
+    assertThat(sequenceFlowEntity.getTenantId())
+        .isEqualTo(processInstanceRecordValue.getTenantId());
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/SequenceFlowHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/SequenceFlowHandlerTest.java
@@ -68,24 +68,26 @@ public class SequenceFlowHandlerTest {
   @Test
   void shouldGenerateIds() {
     // given
-    final ProcessInstanceRecordValue variableRecordValue =
+    final ProcessInstanceRecordValue sequenceFlowRecordValue =
         ImmutableProcessInstanceRecordValue.builder()
             .from(factory.generateObject(ProcessInstanceRecordValue.class))
             .build();
 
-    final Record<ProcessInstanceRecordValue> variableRecord =
+    final Record<ProcessInstanceRecordValue> sequenceFlowRecord =
         factory.generateRecord(
             ValueType.PROCESS_INSTANCE,
             r ->
                 r.withIntent(ProcessInstanceIntent.SEQUENCE_FLOW_TAKEN)
-                    .withValue(variableRecordValue));
+                    .withValue(sequenceFlowRecordValue));
 
     // when
-    final var idList = underTest.generateIds(variableRecord);
+    final var idList = underTest.generateIds(sequenceFlowRecord);
     // then
     assertThat(idList)
         .containsExactly(
-            variableRecordValue.getProcessInstanceKey() + "_" + variableRecordValue.getElementId());
+            sequenceFlowRecordValue.getProcessInstanceKey()
+                + "_"
+                + sequenceFlowRecordValue.getElementId());
   }
 
   @Test


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR adds support for handling `SEQUENCE_FLOW_DELETED` events in the Camunda Exporter and covers it with unit tests. Specifically, it introduces a new `SequenceFlowDeletedHandler` that:

* Listens for records with intent ProcessInstanceIntent.SEQUENCE_FLOW_DELETED
* Computes the document ID as `<processInstanceKey>_<elementId>`
* Issues a delete request to Elasticsearch via the exporter’s BatchRequest.delete(...) API

**Why we need this change?**
During process instance migration, the engine emits `SEQUENCE_FLOW_DELETED` events for flows that were taken before migration and must be removed afterward. Without handling these deletion records, the exporter would leave behind unreferenced sequence flow documents, leading to inaccurate dashboards and stale data in Operate or custom search queries. By implementing a dedicated deletion handler, we ensure that when a process is migrated and its old flows are re‑created or remapped, the corresponding legacy entries are automatically purged from Elasticsearch, keeping the export in sync with the actual process state.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #35361 
