### PR TITLE
fix: rename mappings to mappingRules in initialization

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/CamundaOAuthPrincipalServiceImpl.java
+++ b/authentication/src/main/java/io/camunda/authentication/CamundaOAuthPrincipalServiceImpl.java
@@ -108,12 +108,12 @@ public class CamundaOAuthPrincipalServiceImpl implements CamundaOAuthPrincipalSe
         mappingRuleServices
             .withAuthentication(CamundaAuthentication.anonymous())
             .getMatchingMappingRules(claims);
-    final Set<String> mappingIds =
+    final Set<String> mappingRuleIds =
         mappingRules.map(MappingRuleEntity::mappingRuleId).collect(Collectors.toSet());
-    if (mappingIds.isEmpty()) {
+    if (mappingRuleIds.isEmpty()) {
       LOG.debug("No mappingRules found for these claims: {}", claims);
     } else {
-      ownerTypeToIds.put(MAPPING_RULE, mappingIds);
+      ownerTypeToIds.put(MAPPING_RULE, mappingRuleIds);
     }
 
     final Set<String> groups;
@@ -163,6 +163,6 @@ public class CamundaOAuthPrincipalServiceImpl implements CamundaOAuthPrincipalSe
         .withRoles(roles)
         .withGroupsClaimEnabled(groupsClaimPresent);
 
-    return new OAuthContext(mappingIds, authContextBuilder.build());
+    return new OAuthContext(mappingRuleIds, authContextBuilder.build());
   }
 }

--- a/qa/util/src/main/java/io/camunda/qa/util/cluster/TestCamundaApplication.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/cluster/TestCamundaApplication.java
@@ -9,7 +9,7 @@ package io.camunda.qa.util.cluster;
 
 import static io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker.DEFAULT_MAPPING_CLAIM_NAME;
 import static io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker.DEFAULT_MAPPING_CLAIM_VALUE;
-import static io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker.DEFAULT_MAPPING_ID;
+import static io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker.DEFAULT_MAPPING_RULE_ID;
 
 import io.atomix.cluster.MemberId;
 import io.camunda.application.Profile;
@@ -23,7 +23,7 @@ import io.camunda.configuration.beanoverrides.TasklistPropertiesOverride;
 import io.camunda.configuration.beans.BrokerBasedProperties;
 import io.camunda.identity.IdentityModuleConfiguration;
 import io.camunda.operate.OperateModuleConfiguration;
-import io.camunda.security.configuration.ConfiguredMapping;
+import io.camunda.security.configuration.ConfiguredMappingRule;
 import io.camunda.security.configuration.ConfiguredUser;
 import io.camunda.security.configuration.InitializationConfiguration;
 import io.camunda.security.entity.AuthenticationMethod;
@@ -110,8 +110,8 @@ public final class TestCamundaApplication extends TestSpringApplication<TestCamu
         .getInitialization()
         .getMappingRules()
         .add(
-            new ConfiguredMapping(
-                DEFAULT_MAPPING_ID, DEFAULT_MAPPING_CLAIM_NAME, DEFAULT_MAPPING_CLAIM_VALUE));
+            new ConfiguredMappingRule(
+                DEFAULT_MAPPING_RULE_ID, DEFAULT_MAPPING_CLAIM_NAME, DEFAULT_MAPPING_CLAIM_VALUE));
     securityConfig
         .getInitialization()
         .getDefaultRoles()
@@ -120,8 +120,8 @@ public final class TestCamundaApplication extends TestSpringApplication<TestCamu
             Map.of(
                 "users",
                 List.of(InitializationConfiguration.DEFAULT_USER_USERNAME),
-                "mappings",
-                List.of(DEFAULT_MAPPING_ID)));
+                "mappingRules",
+                List.of(DEFAULT_MAPPING_RULE_ID)));
 
     //noinspection resource
     withBean("config", brokerProperties, BrokerBasedProperties.class)

--- a/qa/util/src/main/java/io/camunda/qa/util/cluster/TestCamundaApplication.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/cluster/TestCamundaApplication.java
@@ -108,7 +108,7 @@ public final class TestCamundaApplication extends TestSpringApplication<TestCamu
                 InitializationConfiguration.DEFAULT_USER_EMAIL));
     securityConfig
         .getInitialization()
-        .getMappings()
+        .getMappingRules()
         .add(
             new ConfiguredMapping(
                 DEFAULT_MAPPING_ID, DEFAULT_MAPPING_CLAIM_NAME, DEFAULT_MAPPING_CLAIM_VALUE));

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/CamundaMultiDBExtension.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/CamundaMultiDBExtension.java
@@ -367,7 +367,8 @@ public class CamundaMultiDBExtension
       keycloak.realms().create(realm);
     }
     setupUserInKeycloak(
-        TestStandaloneBroker.DEFAULT_MAPPING_ID, TestStandaloneBroker.DEFAULT_MAPPING_CLAIM_VALUE);
+        TestStandaloneBroker.DEFAULT_MAPPING_RULE_ID,
+        TestStandaloneBroker.DEFAULT_MAPPING_CLAIM_VALUE);
 
     return keycloakContainer;
   }

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/OidcCamundaClientTestFactory.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/OidcCamundaClientTestFactory.java
@@ -44,7 +44,7 @@ public final class OidcCamundaClientTestFactory implements CamundaClientTestFact
     adminCamundaClient =
         createAuthenticatedClient(
             application.application(),
-            TestStandaloneBroker.DEFAULT_MAPPING_ID,
+            TestStandaloneBroker.DEFAULT_MAPPING_RULE_ID,
             TestStandaloneBroker.DEFAULT_MAPPING_CLAIM_VALUE);
   }
 

--- a/security/security-core/src/main/java/io/camunda/security/configuration/ConfiguredMappingRule.java
+++ b/security/security-core/src/main/java/io/camunda/security/configuration/ConfiguredMappingRule.java
@@ -9,29 +9,29 @@ package io.camunda.security.configuration;
 
 import static io.camunda.security.util.ArgumentUtil.ensureNotNullOrEmpty;
 
-public class ConfiguredMapping {
+public class ConfiguredMappingRule {
 
-  private String mappingId;
+  private String mappingRuleId;
   private String claimName;
   private String claimValue;
 
-  public ConfiguredMapping(
-      final String mappingId, final String claimName, final String claimValue) {
-    ensureNotNullOrEmpty("mappingId", mappingId);
+  public ConfiguredMappingRule(
+      final String mappingRuleId, final String claimName, final String claimValue) {
+    ensureNotNullOrEmpty("mappingRuleId", mappingRuleId);
     ensureNotNullOrEmpty("claimName", claimName);
     ensureNotNullOrEmpty("claimValue", claimValue);
-    this.mappingId = mappingId;
+    this.mappingRuleId = mappingRuleId;
     this.claimName = claimName;
     this.claimValue = claimValue;
   }
 
-  public String getMappingId() {
-    return mappingId;
+  public String getMappingRuleId() {
+    return mappingRuleId;
   }
 
-  public void setMappingId(final String mappingId) {
-    ensureNotNullOrEmpty("mappingId", mappingId);
-    this.mappingId = mappingId;
+  public void setMappingRuleId(final String mappingRuleId) {
+    ensureNotNullOrEmpty("mappingRuleId", mappingRuleId);
+    this.mappingRuleId = mappingRuleId;
   }
 
   public String getClaimName() {

--- a/security/security-core/src/main/java/io/camunda/security/configuration/InitializationConfiguration.java
+++ b/security/security-core/src/main/java/io/camunda/security/configuration/InitializationConfiguration.java
@@ -21,7 +21,7 @@ public class InitializationConfiguration {
   public static final String DEFAULT_USER_EMAIL = "demo@example.com";
 
   private List<ConfiguredUser> users = new ArrayList<>();
-  private List<ConfiguredMapping> mappingRules = new ArrayList<>();
+  private List<ConfiguredMappingRule> mappingRules = new ArrayList<>();
   private Map<String, Map<String, Collection<String>>> defaultRoles = new HashMap<>();
 
   public List<ConfiguredUser> getUsers() {
@@ -32,11 +32,11 @@ public class InitializationConfiguration {
     this.users = users;
   }
 
-  public List<ConfiguredMapping> getMappingRules() {
+  public List<ConfiguredMappingRule> getMappingRules() {
     return mappingRules;
   }
 
-  public void setMappingRules(final List<ConfiguredMapping> mappingRules) {
+  public void setMappingRules(final List<ConfiguredMappingRule> mappingRules) {
     this.mappingRules = mappingRules;
   }
 

--- a/security/security-core/src/main/java/io/camunda/security/configuration/InitializationConfiguration.java
+++ b/security/security-core/src/main/java/io/camunda/security/configuration/InitializationConfiguration.java
@@ -21,7 +21,7 @@ public class InitializationConfiguration {
   public static final String DEFAULT_USER_EMAIL = "demo@example.com";
 
   private List<ConfiguredUser> users = new ArrayList<>();
-  private List<ConfiguredMapping> mappings = new ArrayList<>();
+  private List<ConfiguredMapping> mappingRules = new ArrayList<>();
   private Map<String, Map<String, Collection<String>>> defaultRoles = new HashMap<>();
 
   public List<ConfiguredUser> getUsers() {
@@ -32,12 +32,12 @@ public class InitializationConfiguration {
     this.users = users;
   }
 
-  public List<ConfiguredMapping> getMappings() {
-    return mappings;
+  public List<ConfiguredMapping> getMappingRules() {
+    return mappingRules;
   }
 
-  public void setMappings(final List<ConfiguredMapping> mappings) {
-    this.mappings = mappings;
+  public void setMappingRules(final List<ConfiguredMapping> mappingRules) {
+    this.mappingRules = mappingRules;
   }
 
   public Map<String, Map<String, Collection<String>>> getDefaultRoles() {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/IdentitySetupInitializer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/IdentitySetupInitializer.java
@@ -102,10 +102,10 @@ public final class IdentitySetupInitializer implements StreamProcessorLifecycleA
             mapping ->
                 setupRecord.addMappingRule(
                     new MappingRuleRecord()
-                        .setMappingRuleId(mapping.getMappingId())
+                        .setMappingRuleId(mapping.getMappingRuleId())
                         .setClaimName(mapping.getClaimName())
                         .setClaimValue(mapping.getClaimValue())
-                        .setName(mapping.getMappingId())));
+                        .setName(mapping.getMappingRuleId())));
 
     setupRecord.setDefaultTenant(
         new TenantRecord().setTenantId(DEFAULT_TENANT_ID).setName(DEFAULT_TENANT_NAME));

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/IdentitySetupInitializer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/IdentitySetupInitializer.java
@@ -97,7 +97,7 @@ public final class IdentitySetupInitializer implements StreamProcessorLifecycleA
                         .setPassword(passwordEncoder.encode(user.getPassword()))));
 
     initialization
-        .getMappings()
+        .getMappingRules()
         .forEach(
             mapping ->
                 setupRecord.addMappingRule(
@@ -125,7 +125,7 @@ public final class IdentitySetupInitializer implements StreamProcessorLifecycleA
             switch (assignmentsForEntityType.getKey()) {
               case "users" -> EntityType.USER;
               case "clients" -> EntityType.CLIENT;
-              case "mappings" -> EntityType.MAPPING_RULE;
+              case "mappingRules" -> EntityType.MAPPING_RULE;
               case "groups" -> EntityType.GROUP;
               case "roles" -> EntityType.ROLE;
               default ->

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/OidcAuthOverGrpcIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/OidcAuthOverGrpcIT.java
@@ -84,13 +84,13 @@ public class OidcAuthOverGrpcIT {
                 oidcConfig.setRedirectUri("example.com");
 
                 c.getInitialization()
-                    .setMappings(
+                    .setMappingRules(
                         List.of(
                             new ConfiguredMapping(
                                 DEFAULT_USER_ID, USER_ID_CLAIM_NAME, DEFAULT_USER_ID)));
                 c.getInitialization()
                     .getDefaultRoles()
-                    .put("admin", Map.of("mappings", List.of(DEFAULT_USER_ID)));
+                    .put("admin", Map.of("mappingRules", List.of(DEFAULT_USER_ID)));
               });
 
   @BeforeAll

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/OidcAuthOverGrpcIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/OidcAuthOverGrpcIT.java
@@ -17,7 +17,7 @@ import io.camunda.client.api.search.enums.OwnerType;
 import io.camunda.client.api.search.enums.PermissionType;
 import io.camunda.client.api.search.enums.ResourceType;
 import io.camunda.client.impl.oauth.OAuthCredentialsProviderBuilder;
-import io.camunda.security.configuration.ConfiguredMapping;
+import io.camunda.security.configuration.ConfiguredMappingRule;
 import io.camunda.security.entity.AuthenticationMethod;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
@@ -86,7 +86,7 @@ public class OidcAuthOverGrpcIT {
                 c.getInitialization()
                     .setMappingRules(
                         List.of(
-                            new ConfiguredMapping(
+                            new ConfiguredMappingRule(
                                 DEFAULT_USER_ID, USER_ID_CLAIM_NAME, DEFAULT_USER_ID)));
                 c.getInitialization()
                     .getDefaultRoles()

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/OidcAuthOverRestIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/OidcAuthOverRestIT.java
@@ -17,7 +17,7 @@ import io.camunda.client.api.search.enums.OwnerType;
 import io.camunda.client.api.search.enums.PermissionType;
 import io.camunda.client.api.search.enums.ResourceType;
 import io.camunda.client.impl.oauth.OAuthCredentialsProviderBuilder;
-import io.camunda.security.configuration.ConfiguredMapping;
+import io.camunda.security.configuration.ConfiguredMappingRule;
 import io.camunda.security.entity.AuthenticationMethod;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
@@ -86,7 +86,7 @@ public class OidcAuthOverRestIT {
                 c.getInitialization()
                     .setMappingRules(
                         List.of(
-                            new ConfiguredMapping(
+                            new ConfiguredMappingRule(
                                 DEFAULT_USER_ID, USER_ID_CLAIM_NAME, DEFAULT_USER_ID)));
                 c.getInitialization()
                     .getDefaultRoles()

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/OidcAuthOverRestIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/OidcAuthOverRestIT.java
@@ -84,7 +84,7 @@ public class OidcAuthOverRestIT {
                 oidcConfig.setRedirectUri("example.com");
 
                 c.getInitialization()
-                    .setMappings(
+                    .setMappingRules(
                         List.of(
                             new ConfiguredMapping(
                                 DEFAULT_USER_ID, USER_ID_CLAIM_NAME, DEFAULT_USER_ID)));

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/security/headers/SecurityHeadersOidcIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/security/headers/SecurityHeadersOidcIT.java
@@ -105,7 +105,7 @@ public class SecurityHeadersOidcIT extends SecurityHeadersBaseIT {
                 oidcConfig.setRedirectUri(EXAMPLE_REDIRECT_URI);
 
                 c.getInitialization()
-                    .setMappings(
+                    .setMappingRules(
                         List.of(new ConfiguredMapping(USER_ID, USER_ID_CLAIM_NAME, USER_ID)));
                 c.getInitialization()
                     .getDefaultRoles()

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/security/headers/SecurityHeadersOidcIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/security/headers/SecurityHeadersOidcIT.java
@@ -29,7 +29,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import dasniko.testcontainers.keycloak.KeycloakContainer;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.impl.oauth.OAuthCredentialsProviderBuilder;
-import io.camunda.security.configuration.ConfiguredMapping;
+import io.camunda.security.configuration.ConfiguredMappingRule;
 import io.camunda.security.configuration.headers.ContentSecurityPolicyConfig;
 import io.camunda.security.configuration.headers.PermissionsPolicyConfig;
 import io.camunda.security.entity.AuthenticationMethod;
@@ -106,7 +106,7 @@ public class SecurityHeadersOidcIT extends SecurityHeadersBaseIT {
 
                 c.getInitialization()
                     .setMappingRules(
-                        List.of(new ConfiguredMapping(USER_ID, USER_ID_CLAIM_NAME, USER_ID)));
+                        List.of(new ConfiguredMappingRule(USER_ID, USER_ID_CLAIM_NAME, USER_ID)));
                 c.getInitialization()
                     .getDefaultRoles()
                     .put(ADMIN_ROLE, Map.of(USERS_KEY, List.of(USER_ID)));

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneBroker.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneBroker.java
@@ -16,7 +16,7 @@ import io.camunda.application.commons.search.SearchEngineDatabaseConfiguration.S
 import io.camunda.application.commons.security.CamundaSecurityConfiguration.CamundaSecurityProperties;
 import io.camunda.authentication.config.AuthenticationProperties;
 import io.camunda.configuration.beans.BrokerBasedProperties;
-import io.camunda.security.configuration.ConfiguredMapping;
+import io.camunda.security.configuration.ConfiguredMappingRule;
 import io.camunda.security.configuration.ConfiguredUser;
 import io.camunda.security.configuration.InitializationConfiguration;
 import io.camunda.security.entity.AuthenticationMethod;
@@ -42,7 +42,7 @@ import org.springframework.util.unit.DataSize;
 @SuppressWarnings("UnusedReturnValue")
 public final class TestStandaloneBroker extends TestSpringApplication<TestStandaloneBroker>
     implements TestGateway<TestStandaloneBroker>, TestStandaloneApplication<TestStandaloneBroker> {
-  public static final String DEFAULT_MAPPING_ID = "default";
+  public static final String DEFAULT_MAPPING_RULE_ID = "default";
   public static final String DEFAULT_MAPPING_CLAIM_NAME = "client_id";
   public static final String DEFAULT_MAPPING_CLAIM_VALUE = "default";
   private static final String RECORDING_EXPORTER_ID = "recordingExporter";
@@ -86,8 +86,8 @@ public final class TestStandaloneBroker extends TestSpringApplication<TestStanda
         .getInitialization()
         .getMappingRules()
         .add(
-            new ConfiguredMapping(
-                DEFAULT_MAPPING_ID, DEFAULT_MAPPING_CLAIM_NAME, DEFAULT_MAPPING_CLAIM_VALUE));
+            new ConfiguredMappingRule(
+                DEFAULT_MAPPING_RULE_ID, DEFAULT_MAPPING_CLAIM_NAME, DEFAULT_MAPPING_CLAIM_VALUE));
     securityConfig
         .getInitialization()
         .getDefaultRoles()
@@ -97,7 +97,7 @@ public final class TestStandaloneBroker extends TestSpringApplication<TestStanda
                 "users",
                 List.of(InitializationConfiguration.DEFAULT_USER_USERNAME),
                 "mappingRules",
-                List.of(DEFAULT_MAPPING_ID)));
+                List.of(DEFAULT_MAPPING_RULE_ID)));
 
     withBean("securityConfig", securityConfig, CamundaSecurityProperties.class);
     withProperty(

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneBroker.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneBroker.java
@@ -84,7 +84,7 @@ public final class TestStandaloneBroker extends TestSpringApplication<TestStanda
                 InitializationConfiguration.DEFAULT_USER_EMAIL));
     securityConfig
         .getInitialization()
-        .getMappings()
+        .getMappingRules()
         .add(
             new ConfiguredMapping(
                 DEFAULT_MAPPING_ID, DEFAULT_MAPPING_CLAIM_NAME, DEFAULT_MAPPING_CLAIM_VALUE));
@@ -96,7 +96,7 @@ public final class TestStandaloneBroker extends TestSpringApplication<TestStanda
             Map.of(
                 "users",
                 List.of(InitializationConfiguration.DEFAULT_USER_USERNAME),
-                "mappings",
+                "mappingRules",
                 List.of(DEFAULT_MAPPING_ID)));
 
     withBean("securityConfig", securityConfig, CamundaSecurityProperties.class);


### PR DESCRIPTION
## Description

rename mapping to mapping rule in config and auth classes

## Related issues

closes #35809 
