### PR TITLE
fix: make batch operations section collapsed by default

### DIFF
--- a/monitor/grafana/zeebe.json
+++ b/monitor/grafana/zeebe.json
@@ -12,28 +12,28 @@
       "name": "VAR_CONTAINER",
       "type": "constant",
       "label": "container",
-      "value": ".*",
+      "value": "${VAR_CONTAINER}",
       "description": ""
     },
     {
       "name": "VAR_REGION",
       "type": "constant",
       "label": "region",
-      "value": ".*",
+      "value": "${VAR_REGION}",
       "description": ""
     },
     {
       "name": "VAR_URI",
       "type": "constant",
       "label": "uri",
-      "value": ".*",
+      "value": "${VAR_URI}",
       "description": ""
     },
     {
       "name": "VAR_GRPC_METHOD",
       "type": "constant",
       "label": "grpc_method",
-      "value": ".*",
+      "value": "${VAR_GRPC_METHOD}",
       "description": ""
     }
   ],
@@ -1161,7 +1161,7 @@
             "h": 2,
             "w": 5,
             "x": 8,
-            "y": 16
+            "y": 112
           },
           "id": 117,
           "maxDataPoints": 100,
@@ -1240,7 +1240,7 @@
             "h": 2,
             "w": 4,
             "x": 13,
-            "y": 16
+            "y": 112
           },
           "id": 655,
           "maxDataPoints": 100,
@@ -1345,7 +1345,7 @@
             "h": 6,
             "w": 8,
             "x": 0,
-            "y": 18
+            "y": 114
           },
           "id": 39,
           "options": {
@@ -1439,7 +1439,7 @@
             "h": 6,
             "w": 5,
             "x": 8,
-            "y": 18
+            "y": 114
           },
           "id": 190,
           "options": {
@@ -1529,7 +1529,7 @@
             "h": 6,
             "w": 4,
             "x": 13,
-            "y": 18
+            "y": 114
           },
           "id": 612,
           "options": {
@@ -1673,7 +1673,7 @@
             "h": 6,
             "w": 7,
             "x": 17,
-            "y": 18
+            "y": 114
           },
           "id": 33,
           "options": {
@@ -1791,7 +1791,7 @@
             "h": 11,
             "w": 24,
             "x": 0,
-            "y": 72
+            "y": 168
           },
           "id": 622,
           "maxPerRow": 3,
@@ -2187,7 +2187,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 17
+            "y": 113
           },
           "id": 192,
           "options": {
@@ -2300,7 +2300,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 17
+            "y": 113
           },
           "id": 602,
           "options": {
@@ -2422,7 +2422,7 @@
             "h": 6,
             "w": 5,
             "x": 0,
-            "y": 73
+            "y": 169
           },
           "id": 194,
           "options": {
@@ -2554,7 +2554,7 @@
             "h": 6,
             "w": 7,
             "x": 5,
-            "y": 73
+            "y": 169
           },
           "id": 199,
           "options": {
@@ -2693,7 +2693,7 @@
             "h": 4,
             "w": 7,
             "x": 12,
-            "y": 73
+            "y": 169
           },
           "id": 196,
           "options": {
@@ -2832,7 +2832,7 @@
             "h": 4,
             "w": 5,
             "x": 19,
-            "y": 73
+            "y": 169
           },
           "id": 200,
           "options": {
@@ -2971,7 +2971,7 @@
             "h": 8,
             "w": 5,
             "x": 12,
-            "y": 77
+            "y": 173
           },
           "id": 198,
           "options": {
@@ -3110,7 +3110,7 @@
             "h": 8,
             "w": 7,
             "x": 17,
-            "y": 77
+            "y": 173
           },
           "id": 268,
           "options": {
@@ -3214,7 +3214,7 @@
             "h": 6,
             "w": 5,
             "x": 0,
-            "y": 79
+            "y": 175
           },
           "id": 189,
           "options": {
@@ -3348,7 +3348,7 @@
             "h": 6,
             "w": 7,
             "x": 5,
-            "y": 79
+            "y": 175
           },
           "id": 201,
           "options": {
@@ -3471,7 +3471,7 @@
             "h": 6,
             "w": 12,
             "x": 0,
-            "y": 85
+            "y": 181
           },
           "id": 604,
           "interval": "1s",
@@ -3600,7 +3600,7 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 85
+            "y": 181
           },
           "id": 605,
           "interval": "1s",
@@ -3720,7 +3720,7 @@
             "h": 6,
             "w": 24,
             "x": 0,
-            "y": 91
+            "y": 187
           },
           "id": 543,
           "options": {
@@ -3814,7 +3814,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 97
+            "y": 193
           },
           "id": 561,
           "options": {
@@ -3912,7 +3912,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 97
+            "y": 193
           },
           "id": 594,
           "options": {
@@ -4732,7 +4732,7 @@
             "h": 8,
             "w": 6,
             "x": 0,
-            "y": 20
+            "y": 116
           },
           "id": 290,
           "options": {
@@ -4828,7 +4828,7 @@
             "h": 8,
             "w": 6,
             "x": 6,
-            "y": 20
+            "y": 116
           },
           "id": 291,
           "options": {
@@ -4924,7 +4924,7 @@
             "h": 8,
             "w": 6,
             "x": 12,
-            "y": 20
+            "y": 116
           },
           "id": 288,
           "options": {
@@ -5020,7 +5020,7 @@
             "h": 8,
             "w": 6,
             "x": 18,
-            "y": 20
+            "y": 116
           },
           "id": 289,
           "options": {
@@ -5130,7 +5130,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 92
+            "y": 188
           },
           "id": 102,
           "options": {
@@ -5186,7 +5186,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 92
+            "y": 188
           },
           "id": 112,
           "options": {
@@ -5324,7 +5324,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 100
+            "y": 196
           },
           "id": 105,
           "options": {
@@ -5379,7 +5379,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 100
+            "y": 196
           },
           "id": 106,
           "options": {
@@ -5501,7 +5501,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 135
+            "y": 231
           },
           "id": 182,
           "options": {
@@ -6197,7 +6197,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 22
+            "y": 118
           },
           "id": 579,
           "options": {
@@ -6288,7 +6288,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 22
+            "y": 118
           },
           "id": 580,
           "options": {
@@ -6383,7 +6383,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 78
+            "y": 174
           },
           "id": 285,
           "options": {
@@ -6492,7 +6492,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 78
+            "y": 174
           },
           "id": 286,
           "options": {
@@ -6971,7 +6971,7 @@
             "h": 5,
             "w": 24,
             "x": 0,
-            "y": 163
+            "y": 259
           },
           "id": 260,
           "options": {
@@ -7063,7 +7063,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 168
+            "y": 264
           },
           "id": 379,
           "options": {
@@ -7158,7 +7158,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 168
+            "y": 264
           },
           "id": 381,
           "options": {
@@ -7279,7 +7279,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 176
+            "y": 272
           },
           "id": 37,
           "options": {
@@ -7387,7 +7387,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 176
+            "y": 272
           },
           "id": 40,
           "options": {
@@ -7485,7 +7485,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 184
+            "y": 280
           },
           "id": 122,
           "options": {
@@ -7584,7 +7584,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 184
+            "y": 280
           },
           "id": 124,
           "options": {
@@ -7682,7 +7682,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 192
+            "y": 288
           },
           "id": 126,
           "options": {
@@ -7780,7 +7780,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 192
+            "y": 288
           },
           "id": 127,
           "options": {
@@ -7852,7 +7852,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 201
+            "y": 297
           },
           "id": 339,
           "options": {
@@ -7950,7 +7950,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 201
+            "y": 297
           },
           "id": 341,
           "options": {
@@ -8087,7 +8087,7 @@
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 209
+            "y": 305
           },
           "id": 343,
           "options": {
@@ -8211,7 +8211,7 @@
             "h": 10,
             "w": 12,
             "x": 12,
-            "y": 209
+            "y": 305
           },
           "id": 345,
           "options": {
@@ -8333,7 +8333,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 219
+            "y": 315
           },
           "id": 347,
           "options": {
@@ -8428,7 +8428,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 219
+            "y": 315
           },
           "id": 349,
           "options": {
@@ -8523,7 +8523,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 227
+            "y": 323
           },
           "id": 353,
           "options": {
@@ -8619,7 +8619,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 227
+            "y": 323
           },
           "id": 351,
           "options": {
@@ -8928,7 +8928,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 17
+            "y": 113
           },
           "id": 133,
           "options": {
@@ -9028,7 +9028,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 17
+            "y": 113
           },
           "id": 135,
           "options": {
@@ -9127,7 +9127,7 @@
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 73
+            "y": 169
           },
           "id": 28,
           "options": {
@@ -9251,7 +9251,7 @@
             "h": 10,
             "w": 24,
             "x": 0,
-            "y": 80
+            "y": 176
           },
           "id": 593,
           "options": {
@@ -9340,7 +9340,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 90
+            "y": 186
           },
           "id": 233,
           "options": {
@@ -9425,7 +9425,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 90
+            "y": 186
           },
           "id": 269,
           "options": {
@@ -9509,7 +9509,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 97
+            "y": 193
           },
           "id": 420,
           "options": {
@@ -9591,7 +9591,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 97
+            "y": 193
           },
           "id": 419,
           "options": {
@@ -9711,7 +9711,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 104
+            "y": 200
           },
           "id": 310,
           "options": {
@@ -9839,7 +9839,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 104
+            "y": 200
           },
           "id": 311,
           "options": {
@@ -9927,7 +9927,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 111
+            "y": 207
           },
           "id": 235,
           "options": {
@@ -10010,7 +10010,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 111
+            "y": 207
           },
           "id": 234,
           "options": {
@@ -10147,7 +10147,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 1319
+            "y": 1415
           },
           "id": 26,
           "options": {
@@ -10243,7 +10243,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 1319
+            "y": 1415
           },
           "id": 27,
           "options": {
@@ -10310,7 +10310,7 @@
             "h": 9,
             "w": 8,
             "x": 0,
-            "y": 1326
+            "y": 1422
           },
           "id": 22,
           "options": {
@@ -10404,7 +10404,7 @@
             "h": 9,
             "w": 8,
             "x": 8,
-            "y": 1326
+            "y": 1422
           },
           "id": 23,
           "options": {
@@ -10498,7 +10498,7 @@
             "h": 9,
             "w": 8,
             "x": 16,
-            "y": 1326
+            "y": 1422
           },
           "id": 24,
           "options": {
@@ -10607,7 +10607,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 1320
+            "y": 1416
           },
           "id": 164,
           "options": {
@@ -10763,7 +10763,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1328
+            "y": 1424
           },
           "id": 166,
           "options": {
@@ -10881,7 +10881,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1328
+            "y": 1424
           },
           "id": 168,
           "options": {
@@ -11031,7 +11031,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 1321
+            "y": 1417
           },
           "id": 278,
           "options": {
@@ -11170,7 +11170,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 1321
+            "y": 1417
           },
           "id": 283,
           "options": {
@@ -11266,7 +11266,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 1328
+            "y": 1424
           },
           "id": 373,
           "options": {
@@ -11363,7 +11363,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 1336
+            "y": 1432
           },
           "id": 363,
           "options": {
@@ -11460,7 +11460,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 1336
+            "y": 1432
           },
           "id": 406,
           "options": {
@@ -11557,7 +11557,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 1343
+            "y": 1439
           },
           "id": 79,
           "options": {
@@ -11654,7 +11654,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 1343
+            "y": 1439
           },
           "id": 114,
           "options": {
@@ -11708,7 +11708,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 1350
+            "y": 1446
           },
           "id": 86,
           "options": {
@@ -11829,7 +11829,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 1350
+            "y": 1446
           },
           "id": 305,
           "options": {
@@ -11894,7 +11894,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1357
+            "y": 1453
           },
           "id": 70,
           "options": {
@@ -12038,7 +12038,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1357
+            "y": 1453
           },
           "id": 72,
           "options": {
@@ -12137,7 +12137,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1365
+            "y": 1461
           },
           "id": 432,
           "interval": "1s",
@@ -12279,7 +12279,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1365
+            "y": 1461
           },
           "id": 95,
           "interval": "1s",
@@ -12398,7 +12398,7 @@
             "h": 5,
             "w": 24,
             "x": 0,
-            "y": 1373
+            "y": 1469
           },
           "id": 205,
           "options": {
@@ -12525,7 +12525,7 @@
             "h": 5,
             "w": 24,
             "x": 0,
-            "y": 1438
+            "y": 1534
           },
           "id": 209,
           "options": {
@@ -12600,7 +12600,7 @@
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 1493
+            "y": 1589
           },
           "id": 396,
           "options": {
@@ -12665,7 +12665,7 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 1503
+            "y": 1599
           },
           "id": 215,
           "options": {
@@ -12781,7 +12781,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 92
+            "y": 188
           },
           "id": 180,
           "options": {
@@ -12877,7 +12877,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 100
+            "y": 196
           },
           "id": 368,
           "options": {
@@ -12974,7 +12974,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 100
+            "y": 196
           },
           "id": 411,
           "options": {
@@ -13070,7 +13070,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 107
+            "y": 203
           },
           "id": 300,
           "options": {
@@ -13141,7 +13141,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 107
+            "y": 203
           },
           "id": 89,
           "options": {
@@ -13225,7 +13225,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 114
+            "y": 210
           },
           "id": 401,
           "options": {
@@ -13348,7 +13348,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 114
+            "y": 210
           },
           "id": 416,
           "options": {
@@ -13441,7 +13441,7 @@
             "h": 6,
             "w": 12,
             "x": 0,
-            "y": 121
+            "y": 217
           },
           "id": 386,
           "options": {
@@ -13524,7 +13524,7 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 121
+            "y": 217
           },
           "id": 81,
           "options": {
@@ -13609,7 +13609,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 127
+            "y": 223
           },
           "id": 426,
           "options": {
@@ -13731,7 +13731,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 127
+            "y": 223
           },
           "id": 427,
           "options": {
@@ -13797,7 +13797,7 @@
             "h": 6,
             "w": 12,
             "x": 0,
-            "y": 134
+            "y": 230
           },
           "id": 78,
           "options": {
@@ -13879,7 +13879,7 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 134
+            "y": 230
           },
           "id": 391,
           "options": {
@@ -13963,7 +13963,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 140
+            "y": 236
           },
           "id": 559,
           "options": {
@@ -14082,7 +14082,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 140
+            "y": 236
           },
           "id": 560,
           "options": {
@@ -14191,7 +14191,7 @@
             "h": 6,
             "w": 24,
             "x": 0,
-            "y": 93
+            "y": 189
           },
           "id": 356,
           "options": {
@@ -14251,7 +14251,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 99
+            "y": 195
           },
           "id": 357,
           "options": {
@@ -14335,7 +14335,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 99
+            "y": 195
           },
           "id": 358,
           "options": {
@@ -14457,7 +14457,7 @@
             "h": 9,
             "w": 8,
             "x": 0,
-            "y": 107
+            "y": 203
           },
           "id": 586,
           "options": {
@@ -14553,7 +14553,7 @@
             "h": 9,
             "w": 8,
             "x": 8,
-            "y": 107
+            "y": 203
           },
           "id": 589,
           "options": {
@@ -14649,7 +14649,7 @@
             "h": 9,
             "w": 8,
             "x": 16,
-            "y": 107
+            "y": 203
           },
           "id": 590,
           "options": {
@@ -14745,7 +14745,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 116
+            "y": 212
           },
           "id": 606,
           "options": {
@@ -14844,7 +14844,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 116
+            "y": 212
           },
           "id": 607,
           "options": {
@@ -14953,7 +14953,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 124
+            "y": 220
           },
           "id": 608,
           "options": {
@@ -15045,7 +15045,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 124
+            "y": 220
           },
           "id": 609,
           "options": {
@@ -15141,7 +15141,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 132
+            "y": 228
           },
           "id": 610,
           "options": {
@@ -15251,7 +15251,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 132
+            "y": 228
           },
           "id": 611,
           "options": {
@@ -15313,7 +15313,7 @@
             "h": 9,
             "w": 6,
             "x": 0,
-            "y": 140
+            "y": 236
           },
           "id": 588,
           "options": {
@@ -15383,7 +15383,7 @@
             "h": 9,
             "w": 6,
             "x": 6,
-            "y": 140
+            "y": 236
           },
           "id": 591,
           "options": {
@@ -15454,7 +15454,7 @@
             "h": 9,
             "w": 5,
             "x": 12,
-            "y": 140
+            "y": 236
           },
           "id": 592,
           "options": {
@@ -15531,7 +15531,7 @@
             "h": 9,
             "w": 7,
             "x": 17,
-            "y": 140
+            "y": 236
           },
           "id": 613,
           "options": {
@@ -15648,7 +15648,7 @@
             "h": 12,
             "w": 12,
             "x": 0,
-            "y": 96
+            "y": 192
           },
           "id": 154,
           "options": {
@@ -15745,7 +15745,7 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 96
+            "y": 192
           },
           "id": 144,
           "options": {
@@ -15841,7 +15841,7 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 102
+            "y": 198
           },
           "id": 142,
           "options": {
@@ -15938,7 +15938,7 @@
             "h": 12,
             "w": 12,
             "x": 0,
-            "y": 108
+            "y": 204
           },
           "id": 151,
           "options": {
@@ -16035,7 +16035,7 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 108
+            "y": 204
           },
           "id": 152,
           "options": {
@@ -16132,7 +16132,7 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 114
+            "y": 210
           },
           "id": 150,
           "options": {
@@ -16229,7 +16229,7 @@
             "h": 13,
             "w": 12,
             "x": 0,
-            "y": 120
+            "y": 216
           },
           "id": 147,
           "options": {
@@ -16326,7 +16326,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 120
+            "y": 216
           },
           "id": 149,
           "options": {
@@ -16422,7 +16422,7 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 127
+            "y": 223
           },
           "id": 148,
           "options": {
@@ -16518,7 +16518,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 133
+            "y": 229
           },
           "id": 155,
           "options": {
@@ -16614,7 +16614,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 133
+            "y": 229
           },
           "id": 156,
           "options": {
@@ -16708,7 +16708,7 @@
             "h": 6,
             "w": 6,
             "x": 0,
-            "y": 141
+            "y": 237
           },
           "id": 158,
           "options": {
@@ -16805,7 +16805,7 @@
             "h": 6,
             "w": 6,
             "x": 6,
-            "y": 141
+            "y": 237
           },
           "id": 157,
           "options": {
@@ -16901,7 +16901,7 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 141
+            "y": 237
           },
           "id": 146,
           "options": {
@@ -16997,7 +16997,7 @@
             "h": 7,
             "w": 6,
             "x": 0,
-            "y": 147
+            "y": 243
           },
           "id": 159,
           "options": {
@@ -17093,7 +17093,7 @@
             "h": 7,
             "w": 6,
             "x": 6,
-            "y": 147
+            "y": 243
           },
           "id": 160,
           "options": {
@@ -17190,7 +17190,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 147
+            "y": 243
           },
           "id": 153,
           "options": {
@@ -17289,7 +17289,7 @@
             "h": 11,
             "w": 24,
             "x": 0,
-            "y": 154
+            "y": 250
           },
           "id": 603,
           "options": {
@@ -17338,1128 +17338,1129 @@
         "y": 15
       },
       "id": 671,
-      "panels": [],
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 4,
+            "x": 0,
+            "y": 16
+          },
+          "id": 675,
+          "options": {
+            "minVizHeight": 75,
+            "minVizWidth": 75,
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showThresholdLabels": false,
+            "showThresholdMarkers": true,
+            "sizing": "auto"
+          },
+          "pluginVersion": "12.0.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "disableTextWrap": false,
+              "editorMode": "builder",
+              "expr": "sum(zeebe_batchoperations_events_total{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\", action=\"COMPLETED\"})",
+              "fullMetaSearch": false,
+              "includeNullMetadata": true,
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A",
+              "useBackend": false
+            }
+          ],
+          "title": "Total Completed",
+          "type": "gauge"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                }
+              },
+              "mappings": []
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 10,
+            "x": 4,
+            "y": 16
+          },
+          "id": 676,
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "right",
+              "showLegend": true,
+              "values": [
+                "value",
+                "percent"
+              ]
+            },
+            "pieType": "pie",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.0.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "disableTextWrap": false,
+              "editorMode": "builder",
+              "expr": "sum by(type) (zeebe_batchoperations_events_total{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\", action=\"COMPLETED\"})",
+              "fullMetaSearch": false,
+              "includeNullMetadata": true,
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A",
+              "useBackend": false
+            }
+          ],
+          "title": "Total completed by Type",
+          "type": "piechart"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                }
+              },
+              "mappings": []
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 10,
+            "x": 14,
+            "y": 16
+          },
+          "id": 677,
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "right",
+              "showLegend": true,
+              "values": [
+                "value",
+                "percent"
+              ]
+            },
+            "pieType": "pie",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.0.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "disableTextWrap": false,
+              "editorMode": "builder",
+              "expr": "sum by(type) (zeebe_batchoperations_items_sum{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\"})",
+              "fullMetaSearch": false,
+              "includeNullMetadata": true,
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A",
+              "useBackend": false
+            }
+          ],
+          "title": "Total Items by Type",
+          "type": "piechart"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "description": "Number of executed queries to the secondary database for batch operation.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 24
+          },
+          "id": 667,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.0.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "disableTextWrap": false,
+              "editorMode": "code",
+              "expr": "sum by(partition, pod) (increase(zeebe_batchoperations_queries_total{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\", pod=~\"$pod\"}[$__rate_interval]))",
+              "fullMetaSearch": false,
+              "includeNullMetadata": true,
+              "legendFormat": "{{pod}} Partition {{partition}}",
+              "range": true,
+              "refId": "A",
+              "useBackend": false
+            }
+          ],
+          "title": "Executed Queries against 2nd Database",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "continuous-GrYlRd"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "gradientMode": "scheme",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "smooth",
+                "lineWidth": 3,
+                "pointSize": 10,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 24
+          },
+          "id": 683,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "hidden",
+              "placement": "right",
+              "showLegend": false
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.0.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "sum by(partition, pod) (increase(zeebe_batchoperations_queries_total{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\", pod=~\"$pod\", queryStatus=\"failed\"}[$__rate_interval]))",
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Total Failed Queries",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "scaleDistribution": {
+                  "type": "linear"
+                }
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 32
+          },
+          "id": 670,
+          "options": {
+            "calculate": false,
+            "cellGap": 2,
+            "color": {
+              "exponent": 0.5,
+              "fill": "dark-orange",
+              "mode": "scheme",
+              "reverse": false,
+              "scale": "exponential",
+              "scheme": "Spectral",
+              "steps": 128
+            },
+            "exemplars": {
+              "color": "rgba(255,0,255,0.7)"
+            },
+            "filterValues": {
+              "le": 1e-9
+            },
+            "legend": {
+              "show": true
+            },
+            "rowsFrame": {
+              "layout": "auto"
+            },
+            "tooltip": {
+              "mode": "single",
+              "showColorScale": false,
+              "yHistogram": false
+            },
+            "yAxis": {
+              "axisPlacement": "left",
+              "reverse": false,
+              "unit": "dtdurations"
+            }
+          },
+          "pluginVersion": "12.0.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "disableTextWrap": false,
+              "editorMode": "code",
+              "expr": "sum(increase(zeebe_batchoperations_execution_latency_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\", batchOperationLatency=\"TOTAL_QUERY_LATENCY\"}[$__rate_interval])) by (le)",
+              "format": "heatmap",
+              "fullMetaSearch": false,
+              "includeNullMetadata": true,
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A",
+              "useBackend": false
+            }
+          ],
+          "title": "Total Query Latency",
+          "type": "heatmap"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "description": "Time needed for execution all items",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "scaleDistribution": {
+                  "type": "linear"
+                }
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 32
+          },
+          "id": 673,
+          "options": {
+            "calculate": false,
+            "cellGap": 1,
+            "color": {
+              "exponent": 0.5,
+              "fill": "dark-orange",
+              "mode": "scheme",
+              "reverse": false,
+              "scale": "exponential",
+              "scheme": "Spectral",
+              "steps": 128
+            },
+            "exemplars": {
+              "color": "rgba(255,0,255,0.7)"
+            },
+            "filterValues": {
+              "le": 1e-9
+            },
+            "legend": {
+              "show": true
+            },
+            "rowsFrame": {
+              "layout": "auto"
+            },
+            "tooltip": {
+              "mode": "single",
+              "showColorScale": false,
+              "yHistogram": false
+            },
+            "yAxis": {
+              "axisPlacement": "left",
+              "reverse": false,
+              "unit": "dtdurations"
+            }
+          },
+          "pluginVersion": "12.0.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "sum(increase(zeebe_batchoperations_execution_latency_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\", batchOperationLatency=\"TOTAL_EXECUTION_LATENCY\"}[$__rate_interval])) by (le)",
+              "format": "heatmap",
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Total Execution Latency",
+          "type": "heatmap"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "scaleDistribution": {
+                  "type": "linear"
+                }
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 40
+          },
+          "id": 669,
+          "maxDataPoints": 494,
+          "options": {
+            "calculate": false,
+            "cellGap": 2,
+            "cellValues": {
+              "unit": ""
+            },
+            "color": {
+              "exponent": 0.5,
+              "fill": "dark-orange",
+              "mode": "scheme",
+              "reverse": false,
+              "scale": "exponential",
+              "scheme": "Spectral",
+              "steps": 128
+            },
+            "exemplars": {
+              "color": "rgba(255,0,255,0.7)"
+            },
+            "filterValues": {
+              "le": 1e-9
+            },
+            "legend": {
+              "show": false
+            },
+            "rowsFrame": {
+              "layout": "auto"
+            },
+            "tooltip": {
+              "mode": "single",
+              "showColorScale": false,
+              "yHistogram": false
+            },
+            "yAxis": {
+              "axisPlacement": "left",
+              "reverse": false,
+              "unit": "dtdurations"
+            }
+          },
+          "pluginVersion": "12.0.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "disableTextWrap": false,
+              "editorMode": "builder",
+              "expr": "sum by(le) (increase(zeebe_batchoperations_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\"}[$__rate_interval]))",
+              "format": "heatmap",
+              "fullMetaSearch": false,
+              "includeNullMetadata": true,
+              "interval": "",
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A",
+              "useBackend": false
+            }
+          ],
+          "title": "Total Duration",
+          "type": "heatmap"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "smooth",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 40
+          },
+          "id": 674,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "hidden",
+              "placement": "right",
+              "showLegend": false
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.0.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "disableTextWrap": false,
+              "editorMode": "code",
+              "expr": "sum by(type) (increase(zeebe_batchoperations_duration_seconds_sum{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\"}[$__rate_interval]))",
+              "format": "time_series",
+              "fullMetaSearch": false,
+              "includeNullMetadata": true,
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A",
+              "useBackend": false
+            }
+          ],
+          "title": "Total Duration per Type",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "description": "The Latency when creating the first execute command until it gets executed",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "scaleDistribution": {
+                  "type": "linear"
+                }
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 48
+          },
+          "id": 678,
+          "options": {
+            "calculate": false,
+            "cellGap": 2,
+            "color": {
+              "exponent": 0.5,
+              "fill": "dark-orange",
+              "mode": "scheme",
+              "reverse": false,
+              "scale": "exponential",
+              "scheme": "Spectral",
+              "steps": 128
+            },
+            "exemplars": {
+              "color": "rgba(255,0,255,0.7)"
+            },
+            "filterValues": {
+              "le": 1e-9
+            },
+            "legend": {
+              "show": true
+            },
+            "rowsFrame": {
+              "layout": "auto"
+            },
+            "tooltip": {
+              "mode": "single",
+              "showColorScale": false,
+              "yHistogram": false
+            },
+            "yAxis": {
+              "axisPlacement": "left",
+              "reverse": false,
+              "unit": "dtdurations"
+            }
+          },
+          "pluginVersion": "12.0.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "disableTextWrap": false,
+              "editorMode": "code",
+              "expr": "sum(increase(zeebe_batchoperations_execution_latency_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\", batchOperationLatency=\"START_EXECUTE_LATENCY\"}[$__rate_interval])) by (le)",
+              "format": "heatmap",
+              "fullMetaSearch": false,
+              "includeNullMetadata": true,
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A",
+              "useBackend": false
+            }
+          ],
+          "title": "Start - Execute Latency",
+          "type": "heatmap"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "scaleDistribution": {
+                  "type": "linear"
+                }
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 48
+          },
+          "id": 668,
+          "options": {
+            "calculate": false,
+            "cellGap": 1,
+            "color": {
+              "exponent": 0.5,
+              "fill": "dark-orange",
+              "mode": "scheme",
+              "reverse": false,
+              "scale": "exponential",
+              "scheme": "Oranges",
+              "steps": 128
+            },
+            "exemplars": {
+              "color": "rgba(255,0,255,0.7)"
+            },
+            "filterValues": {
+              "le": 1e-9
+            },
+            "legend": {
+              "show": false
+            },
+            "rowsFrame": {
+              "layout": "auto"
+            },
+            "tooltip": {
+              "mode": "single",
+              "showColorScale": false,
+              "yHistogram": false
+            },
+            "yAxis": {
+              "axisPlacement": "left",
+              "reverse": false
+            }
+          },
+          "pluginVersion": "12.0.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "disableTextWrap": false,
+              "editorMode": "builder",
+              "exemplar": false,
+              "expr": "sum by(le) (increase(zeebe_batchoperations_items_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\"}[$__rate_interval]))",
+              "format": "heatmap",
+              "fullMetaSearch": false,
+              "includeNullMetadata": true,
+              "instant": false,
+              "interval": "",
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A",
+              "useBackend": false
+            }
+          ],
+          "title": "Items",
+          "type": "heatmap"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "scaleDistribution": {
+                  "type": "linear"
+                }
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 56
+          },
+          "id": 672,
+          "options": {
+            "calculate": false,
+            "cellGap": 2,
+            "color": {
+              "exponent": 0.5,
+              "fill": "dark-orange",
+              "mode": "scheme",
+              "reverse": false,
+              "scale": "exponential",
+              "scheme": "Spectral",
+              "steps": 128
+            },
+            "exemplars": {
+              "color": "rgba(255,0,255,0.7)"
+            },
+            "filterValues": {
+              "le": 1e-9
+            },
+            "legend": {
+              "show": true
+            },
+            "rowsFrame": {
+              "layout": "auto"
+            },
+            "tooltip": {
+              "mode": "single",
+              "showColorScale": false,
+              "yHistogram": false
+            },
+            "yAxis": {
+              "axisPlacement": "left",
+              "reverse": false,
+              "unit": "dtdurations"
+            }
+          },
+          "pluginVersion": "12.0.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "sum(increase(zeebe_batchoperations_execution_latency_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\", batchOperationLatency=\"EXECUTE_CYCLE_LATENCY\"}[$__rate_interval])) by (le)",
+              "format": "heatmap",
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Execution Cycle Latency",
+          "type": "heatmap"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "description": "Total number of executed batch operation lifecycle events (created, started, executed, completed, failed, cancelled, suspended, resumed) per partition and batch operation type",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 56
+          },
+          "id": 665,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.0.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "disableTextWrap": false,
+              "editorMode": "code",
+              "expr": "sum by(action) (increase(zeebe_batchoperations_events_total{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\", pod=~\"$pod\"}[$__rate_interval]))",
+              "fullMetaSearch": false,
+              "includeNullMetadata": true,
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A",
+              "useBackend": false
+            }
+          ],
+          "title": "Batch Operation Lifecycle Events",
+          "type": "timeseries"
+        }
+      ],
       "title": "Batch Operations",
       "type": "row"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 4,
-        "x": 0,
-        "y": 16
-      },
-      "id": 675,
-      "options": {
-        "minVizHeight": 75,
-        "minVizWidth": 75,
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showThresholdLabels": false,
-        "showThresholdMarkers": true,
-        "sizing": "auto"
-      },
-      "pluginVersion": "12.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "disableTextWrap": false,
-          "editorMode": "builder",
-          "expr": "sum(zeebe_batchoperations_events_total{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\", action=\"COMPLETED\"})",
-          "fullMetaSearch": false,
-          "includeNullMetadata": true,
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A",
-          "useBackend": false
-        }
-      ],
-      "title": "Total Completed",
-      "type": "gauge"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            }
-          },
-          "mappings": []
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 10,
-        "x": 4,
-        "y": 16
-      },
-      "id": 676,
-      "options": {
-        "legend": {
-          "displayMode": "list",
-          "placement": "right",
-          "showLegend": true,
-          "values": [
-            "value",
-            "percent"
-          ]
-        },
-        "pieType": "pie",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "disableTextWrap": false,
-          "editorMode": "builder",
-          "expr": "sum by(type) (zeebe_batchoperations_events_total{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\", action=\"COMPLETED\"})",
-          "fullMetaSearch": false,
-          "includeNullMetadata": true,
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A",
-          "useBackend": false
-        }
-      ],
-      "title": "Total completed by Type",
-      "type": "piechart"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            }
-          },
-          "mappings": []
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 10,
-        "x": 14,
-        "y": 16
-      },
-      "id": 677,
-      "options": {
-        "legend": {
-          "displayMode": "list",
-          "placement": "right",
-          "showLegend": true,
-          "values": [
-            "value",
-            "percent"
-          ]
-        },
-        "pieType": "pie",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "disableTextWrap": false,
-          "editorMode": "builder",
-          "expr": "sum by(type) (zeebe_batchoperations_items_sum{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\"})",
-          "fullMetaSearch": false,
-          "includeNullMetadata": true,
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A",
-          "useBackend": false
-        }
-      ],
-      "title": "Total Items by Type",
-      "type": "piechart"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "Number of executed queries to the secondary database for batch operation.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 24
-      },
-      "id": 667,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "disableTextWrap": false,
-          "editorMode": "code",
-          "expr": "sum by(partition, pod) (increase(zeebe_batchoperations_queries_total{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\", pod=~\"$pod\"}[$__rate_interval]))",
-          "fullMetaSearch": false,
-          "includeNullMetadata": true,
-          "legendFormat": "{{pod}} Partition {{partition}}",
-          "range": true,
-          "refId": "A",
-          "useBackend": false
-        }
-      ],
-      "title": "Executed Queries against 2nd Database",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "continuous-GrYlRd"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 20,
-            "gradientMode": "scheme",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "smooth",
-            "lineWidth": 3,
-            "pointSize": 10,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 24
-      },
-      "id": 683,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "hidden",
-          "placement": "right",
-          "showLegend": false
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "expr": "sum by(partition, pod) (increase(zeebe_batchoperations_queries_total{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\", pod=~\"$pod\", queryStatus=\"failed\"}[$__rate_interval]))",
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Total Failed Queries",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "custom": {
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "scaleDistribution": {
-              "type": "linear"
-            }
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 32
-      },
-      "id": 670,
-      "options": {
-        "calculate": false,
-        "cellGap": 2,
-        "color": {
-          "exponent": 0.5,
-          "fill": "dark-orange",
-          "mode": "scheme",
-          "reverse": false,
-          "scale": "exponential",
-          "scheme": "Spectral",
-          "steps": 128
-        },
-        "exemplars": {
-          "color": "rgba(255,0,255,0.7)"
-        },
-        "filterValues": {
-          "le": 1e-9
-        },
-        "legend": {
-          "show": true
-        },
-        "rowsFrame": {
-          "layout": "auto"
-        },
-        "tooltip": {
-          "mode": "single",
-          "showColorScale": false,
-          "yHistogram": false
-        },
-        "yAxis": {
-          "axisPlacement": "left",
-          "reverse": false,
-          "unit": "dtdurations"
-        }
-      },
-      "pluginVersion": "12.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "disableTextWrap": false,
-          "editorMode": "code",
-          "expr": "sum(increase(zeebe_batchoperations_execution_latency_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\", batchOperationLatency=\"TOTAL_QUERY_LATENCY\"}[$__rate_interval])) by (le)",
-          "format": "heatmap",
-          "fullMetaSearch": false,
-          "includeNullMetadata": true,
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A",
-          "useBackend": false
-        }
-      ],
-      "title": "Total Query Latency",
-      "type": "heatmap"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "Time needed for execution all items",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "scaleDistribution": {
-              "type": "linear"
-            }
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 32
-      },
-      "id": 673,
-      "options": {
-        "calculate": false,
-        "cellGap": 1,
-        "color": {
-          "exponent": 0.5,
-          "fill": "dark-orange",
-          "mode": "scheme",
-          "reverse": false,
-          "scale": "exponential",
-          "scheme": "Spectral",
-          "steps": 128
-        },
-        "exemplars": {
-          "color": "rgba(255,0,255,0.7)"
-        },
-        "filterValues": {
-          "le": 1e-9
-        },
-        "legend": {
-          "show": true
-        },
-        "rowsFrame": {
-          "layout": "auto"
-        },
-        "tooltip": {
-          "mode": "single",
-          "showColorScale": false,
-          "yHistogram": false
-        },
-        "yAxis": {
-          "axisPlacement": "left",
-          "reverse": false,
-          "unit": "dtdurations"
-        }
-      },
-      "pluginVersion": "12.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "expr": "sum(increase(zeebe_batchoperations_execution_latency_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\", batchOperationLatency=\"TOTAL_EXECUTION_LATENCY\"}[$__rate_interval])) by (le)",
-          "format": "heatmap",
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Total Execution Latency",
-      "type": "heatmap"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "custom": {
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "scaleDistribution": {
-              "type": "linear"
-            }
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 40
-      },
-      "id": 669,
-      "maxDataPoints": 494,
-      "options": {
-        "calculate": false,
-        "cellGap": 2,
-        "cellValues": {
-          "unit": ""
-        },
-        "color": {
-          "exponent": 0.5,
-          "fill": "dark-orange",
-          "mode": "scheme",
-          "reverse": false,
-          "scale": "exponential",
-          "scheme": "Spectral",
-          "steps": 128
-        },
-        "exemplars": {
-          "color": "rgba(255,0,255,0.7)"
-        },
-        "filterValues": {
-          "le": 1e-9
-        },
-        "legend": {
-          "show": false
-        },
-        "rowsFrame": {
-          "layout": "auto"
-        },
-        "tooltip": {
-          "mode": "single",
-          "showColorScale": false,
-          "yHistogram": false
-        },
-        "yAxis": {
-          "axisPlacement": "left",
-          "reverse": false,
-          "unit": "dtdurations"
-        }
-      },
-      "pluginVersion": "12.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "disableTextWrap": false,
-          "editorMode": "builder",
-          "expr": "sum by(le) (increase(zeebe_batchoperations_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\"}[$__rate_interval]))",
-          "format": "heatmap",
-          "fullMetaSearch": false,
-          "includeNullMetadata": true,
-          "interval": "",
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A",
-          "useBackend": false
-        }
-      ],
-      "title": "Total Duration",
-      "type": "heatmap"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "smooth",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 40
-      },
-      "id": 674,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "hidden",
-          "placement": "right",
-          "showLegend": false
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "disableTextWrap": false,
-          "editorMode": "code",
-          "expr": "sum by(type) (increase(zeebe_batchoperations_duration_seconds_sum{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\"}[$__rate_interval]))",
-          "format": "time_series",
-          "fullMetaSearch": false,
-          "includeNullMetadata": true,
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A",
-          "useBackend": false
-        }
-      ],
-      "title": "Total Duration per Type",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "The Latency when creating the first execute command until it gets executed",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "scaleDistribution": {
-              "type": "linear"
-            }
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 48
-      },
-      "id": 678,
-      "options": {
-        "calculate": false,
-        "cellGap": 2,
-        "color": {
-          "exponent": 0.5,
-          "fill": "dark-orange",
-          "mode": "scheme",
-          "reverse": false,
-          "scale": "exponential",
-          "scheme": "Spectral",
-          "steps": 128
-        },
-        "exemplars": {
-          "color": "rgba(255,0,255,0.7)"
-        },
-        "filterValues": {
-          "le": 1e-9
-        },
-        "legend": {
-          "show": true
-        },
-        "rowsFrame": {
-          "layout": "auto"
-        },
-        "tooltip": {
-          "mode": "single",
-          "showColorScale": false,
-          "yHistogram": false
-        },
-        "yAxis": {
-          "axisPlacement": "left",
-          "reverse": false,
-          "unit": "dtdurations"
-        }
-      },
-      "pluginVersion": "12.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "disableTextWrap": false,
-          "editorMode": "code",
-          "expr": "sum(increase(zeebe_batchoperations_execution_latency_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\", batchOperationLatency=\"START_EXECUTE_LATENCY\"}[$__rate_interval])) by (le)",
-          "format": "heatmap",
-          "fullMetaSearch": false,
-          "includeNullMetadata": true,
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A",
-          "useBackend": false
-        }
-      ],
-      "title": "Start - Execute Latency",
-      "type": "heatmap"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "custom": {
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "scaleDistribution": {
-              "type": "linear"
-            }
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 48
-      },
-      "id": 668,
-      "options": {
-        "calculate": false,
-        "cellGap": 1,
-        "color": {
-          "exponent": 0.5,
-          "fill": "dark-orange",
-          "mode": "scheme",
-          "reverse": false,
-          "scale": "exponential",
-          "scheme": "Oranges",
-          "steps": 128
-        },
-        "exemplars": {
-          "color": "rgba(255,0,255,0.7)"
-        },
-        "filterValues": {
-          "le": 1e-9
-        },
-        "legend": {
-          "show": false
-        },
-        "rowsFrame": {
-          "layout": "auto"
-        },
-        "tooltip": {
-          "mode": "single",
-          "showColorScale": false,
-          "yHistogram": false
-        },
-        "yAxis": {
-          "axisPlacement": "left",
-          "reverse": false
-        }
-      },
-      "pluginVersion": "12.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "disableTextWrap": false,
-          "editorMode": "builder",
-          "exemplar": false,
-          "expr": "sum by(le) (increase(zeebe_batchoperations_items_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\"}[$__rate_interval]))",
-          "format": "heatmap",
-          "fullMetaSearch": false,
-          "includeNullMetadata": true,
-          "instant": false,
-          "interval": "",
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A",
-          "useBackend": false
-        }
-      ],
-      "title": "Items",
-      "type": "heatmap"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "custom": {
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "scaleDistribution": {
-              "type": "linear"
-            }
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 56
-      },
-      "id": 672,
-      "options": {
-        "calculate": false,
-        "cellGap": 2,
-        "color": {
-          "exponent": 0.5,
-          "fill": "dark-orange",
-          "mode": "scheme",
-          "reverse": false,
-          "scale": "exponential",
-          "scheme": "Spectral",
-          "steps": 128
-        },
-        "exemplars": {
-          "color": "rgba(255,0,255,0.7)"
-        },
-        "filterValues": {
-          "le": 1e-9
-        },
-        "legend": {
-          "show": true
-        },
-        "rowsFrame": {
-          "layout": "auto"
-        },
-        "tooltip": {
-          "mode": "single",
-          "showColorScale": false,
-          "yHistogram": false
-        },
-        "yAxis": {
-          "axisPlacement": "left",
-          "reverse": false,
-          "unit": "dtdurations"
-        }
-      },
-      "pluginVersion": "12.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "expr": "sum(increase(zeebe_batchoperations_execution_latency_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\", batchOperationLatency=\"EXECUTE_CYCLE_LATENCY\"}[$__rate_interval])) by (le)",
-          "format": "heatmap",
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Execution Cycle Latency",
-      "type": "heatmap"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "Total number of executed batch operation lifecycle events (created, started, executed, completed, failed, cancelled, suspended, resumed) per partition and batch operation type",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 56
-      },
-      "id": 665,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "disableTextWrap": false,
-          "editorMode": "code",
-          "expr": "sum by(action) (increase(zeebe_batchoperations_events_total{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\", pod=~\"$pod\"}[$__rate_interval]))",
-          "fullMetaSearch": false,
-          "includeNullMetadata": true,
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A",
-          "useBackend": false
-        }
-      ],
-      "title": "Batch Operation Lifecycle Events",
-      "type": "timeseries"
     },
     {
       "collapsed": true,
@@ -18467,7 +18468,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 64
+        "y": 16
       },
       "id": 50,
       "panels": [
@@ -18495,7 +18496,7 @@
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 275
+            "y": 371
           },
           "id": 20,
           "options": {
@@ -18618,7 +18619,7 @@
             "h": 10,
             "w": 12,
             "x": 12,
-            "y": 275
+            "y": 371
           },
           "id": 255,
           "options": {
@@ -18673,7 +18674,7 @@
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 285
+            "y": 381
           },
           "id": 21,
           "options": {
@@ -18795,7 +18796,7 @@
             "h": 10,
             "w": 12,
             "x": 12,
-            "y": 285
+            "y": 381
           },
           "id": 185,
           "options": {
@@ -18896,7 +18897,7 @@
             "h": 10,
             "w": 24,
             "x": 0,
-            "y": 295
+            "y": 391
           },
           "id": 52,
           "options": {
@@ -18942,7 +18943,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 65
+        "y": 17
       },
       "id": 615,
       "panels": [
@@ -18970,7 +18971,7 @@
             "h": 9,
             "w": 10,
             "x": 0,
-            "y": 17
+            "y": 113
           },
           "id": 616,
           "options": {
@@ -19063,7 +19064,7 @@
             "h": 9,
             "w": 3,
             "x": 10,
-            "y": 17
+            "y": 113
           },
           "id": 617,
           "options": {
@@ -19166,7 +19167,7 @@
             "h": 9,
             "w": 11,
             "x": 13,
-            "y": 17
+            "y": 113
           },
           "id": 621,
           "options": {
@@ -19223,7 +19224,7 @@
             "h": 5,
             "w": 24,
             "x": 0,
-            "y": 74
+            "y": 170
           },
           "id": 618,
           "options": {
@@ -19346,7 +19347,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 79
+            "y": 175
           },
           "id": 628,
           "options": {
@@ -19458,7 +19459,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 79
+            "y": 175
           },
           "id": 623,
           "options": {
@@ -19516,7 +19517,7 @@
             "h": 6,
             "w": 12,
             "x": 0,
-            "y": 86
+            "y": 182
           },
           "id": 626,
           "options": {
@@ -19658,7 +19659,7 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 86
+            "y": 182
           },
           "id": 627,
           "options": {
@@ -19769,7 +19770,7 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 92
+            "y": 188
           },
           "id": 643,
           "options": {
@@ -19843,7 +19844,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 101
+            "y": 197
           },
           "id": 647,
           "options": {
@@ -19928,7 +19929,7 @@
             "h": 8,
             "w": 8,
             "x": 0,
-            "y": 109
+            "y": 205
           },
           "id": 646,
           "options": {
@@ -20027,7 +20028,7 @@
             "h": 8,
             "w": 8,
             "x": 8,
-            "y": 109
+            "y": 205
           },
           "id": 645,
           "options": {
@@ -20110,7 +20111,7 @@
             "h": 8,
             "w": 8,
             "x": 16,
-            "y": 109
+            "y": 205
           },
           "id": 658,
           "options": {
@@ -20178,7 +20179,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 66
+        "y": 18
       },
       "id": 629,
       "panels": [
@@ -20206,7 +20207,7 @@
             "h": 9,
             "w": 10,
             "x": 0,
-            "y": 127
+            "y": 223
           },
           "id": 630,
           "options": {
@@ -20292,7 +20293,7 @@
             "h": 9,
             "w": 11,
             "x": 10,
-            "y": 127
+            "y": 223
           },
           "id": 636,
           "options": {
@@ -20393,7 +20394,7 @@
             "h": 9,
             "w": 3,
             "x": 21,
-            "y": 127
+            "y": 223
           },
           "id": 631,
           "options": {
@@ -20453,7 +20454,7 @@
             "h": 10,
             "w": 10,
             "x": 0,
-            "y": 136
+            "y": 232
           },
           "id": 633,
           "options": {
@@ -20579,7 +20580,7 @@
             "h": 10,
             "w": 9,
             "x": 10,
-            "y": 136
+            "y": 232
           },
           "id": 634,
           "options": {
@@ -20655,7 +20656,7 @@
             "h": 10,
             "w": 5,
             "x": 19,
-            "y": 136
+            "y": 232
           },
           "id": 635,
           "options": {
@@ -20707,7 +20708,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 67
+        "y": 19
       },
       "id": 176,
       "panels": [
@@ -20745,7 +20746,7 @@
             "h": 6,
             "w": 24,
             "x": 0,
-            "y": 718
+            "y": 814
           },
           "id": 170,
           "maxPerRow": 6,
@@ -20829,7 +20830,7 @@
             "h": 6,
             "w": 12,
             "x": 0,
-            "y": 730
+            "y": 826
           },
           "id": 174,
           "options": {
@@ -20905,7 +20906,7 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 730
+            "y": 826
           },
           "id": 265,
           "options": {
@@ -20959,7 +20960,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 68
+        "y": 20
       },
       "id": 315,
       "panels": [
@@ -20985,7 +20986,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1327
+            "y": 1423
           },
           "id": 329,
           "options": {
@@ -21051,7 +21052,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1327
+            "y": 1423
           },
           "id": 319,
           "options": {
@@ -21111,7 +21112,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1335
+            "y": 1431
           },
           "id": 323,
           "maxDataPoints": 25,
@@ -21202,7 +21203,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1335
+            "y": 1431
           },
           "id": 325,
           "options": {
@@ -21300,7 +21301,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1343
+            "y": 1439
           },
           "id": 313,
           "options": {
@@ -21359,7 +21360,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1343
+            "y": 1439
           },
           "id": 321,
           "options": {
@@ -21455,7 +21456,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1351
+            "y": 1447
           },
           "id": 335,
           "options": {
@@ -21513,7 +21514,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1351
+            "y": 1447
           },
           "id": 317,
           "options": {
@@ -21575,7 +21576,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1359
+            "y": 1455
           },
           "id": 327,
           "options": {
@@ -21621,7 +21622,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 69
+        "y": 21
       },
       "id": 434,
       "panels": [
@@ -21650,7 +21651,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 280
+            "y": 376
           },
           "id": 538,
           "options": {
@@ -21735,7 +21736,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 280
+            "y": 376
           },
           "id": 540,
           "options": {
@@ -21860,7 +21861,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 288
+            "y": 384
           },
           "id": 444,
           "options": {
@@ -21970,7 +21971,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 288
+            "y": 384
           },
           "id": 446,
           "options": {
@@ -22079,7 +22080,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 296
+            "y": 392
           },
           "id": 440,
           "options": {
@@ -22174,7 +22175,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 296
+            "y": 392
           },
           "id": 442,
           "options": {
@@ -22216,7 +22217,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 70
+        "y": 22
       },
       "id": 545,
       "panels": [
@@ -22245,7 +22246,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 281
+            "y": 377
           },
           "id": 547,
           "options": {
@@ -22368,7 +22369,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 281
+            "y": 377
           },
           "id": 549,
           "options": {
@@ -22411,7 +22412,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 71
+        "y": 23
       },
       "id": 565,
       "panels": [
@@ -22480,7 +22481,7 @@
             "h": 6,
             "w": 8,
             "x": 0,
-            "y": 282
+            "y": 378
           },
           "id": 562,
           "options": {
@@ -22579,7 +22580,7 @@
             "h": 6,
             "w": 9,
             "x": 8,
-            "y": 282
+            "y": 378
           },
           "id": 563,
           "options": {
@@ -22678,7 +22679,7 @@
             "h": 6,
             "w": 7,
             "x": 17,
-            "y": 282
+            "y": 378
           },
           "id": 564,
           "options": {
@@ -22730,7 +22731,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 72
+        "y": 24
       },
       "id": 569,
       "panels": [
@@ -22799,7 +22800,7 @@
             "h": 6,
             "w": 8,
             "x": 0,
-            "y": 283
+            "y": 379
           },
           "id": 566,
           "options": {
@@ -22897,7 +22898,7 @@
             "h": 6,
             "w": 8,
             "x": 8,
-            "y": 283
+            "y": 379
           },
           "id": 567,
           "options": {
@@ -22995,7 +22996,7 @@
             "h": 6,
             "w": 8,
             "x": 16,
-            "y": 283
+            "y": 379
           },
           "id": 568,
           "options": {
@@ -23038,7 +23039,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 73
+        "y": 25
       },
       "id": 572,
       "panels": [
@@ -23125,7 +23126,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 284
+            "y": 380
           },
           "id": 573,
           "options": {
@@ -23251,7 +23252,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 284
+            "y": 380
           },
           "id": 574,
           "options": {
@@ -23365,7 +23366,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 292
+            "y": 388
           },
           "id": 600,
           "options": {
@@ -23468,7 +23469,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 292
+            "y": 388
           },
           "id": 601,
           "options": {
@@ -23564,7 +23565,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 300
+            "y": 396
           },
           "id": 575,
           "options": {
@@ -23605,7 +23606,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 74
+        "y": 26
       },
       "id": 576,
       "panels": [
@@ -23673,7 +23674,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 743
+            "y": 839
           },
           "id": 570,
           "options": {
@@ -23779,7 +23780,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 743
+            "y": 839
           },
           "id": 577,
           "options": {
@@ -23884,7 +23885,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 751
+            "y": 847
           },
           "id": 578,
           "options": {
@@ -23980,7 +23981,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 751
+            "y": 847
           },
           "id": 571,
           "options": {
@@ -24022,7 +24023,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 75
+        "y": 27
       },
       "id": 581,
       "panels": [
@@ -24086,7 +24087,7 @@
             "h": 8,
             "w": 8,
             "x": 0,
-            "y": 1350
+            "y": 1446
           },
           "id": 582,
           "options": {
@@ -24177,7 +24178,7 @@
             "h": 8,
             "w": 8,
             "x": 8,
-            "y": 1350
+            "y": 1446
           },
           "id": 583,
           "options": {
@@ -24269,7 +24270,7 @@
             "h": 8,
             "w": 8,
             "x": 16,
-            "y": 1350
+            "y": 1446
           },
           "id": 584,
           "options": {
@@ -24311,7 +24312,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 76
+        "y": 28
       },
       "id": 595,
       "panels": [
@@ -24374,7 +24375,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 287
+            "y": 383
           },
           "id": 596,
           "options": {
@@ -24471,7 +24472,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 287
+            "y": 383
           },
           "id": 597,
           "options": {
@@ -24533,7 +24534,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 295
+            "y": 391
           },
           "id": 598,
           "options": {
@@ -24658,7 +24659,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 295
+            "y": 391
           },
           "id": 599,
           "options": {
@@ -24711,7 +24712,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 77
+        "y": 29
       },
       "id": 679,
       "panels": [
@@ -24780,7 +24781,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 77
+            "y": 173
           },
           "id": 680,
           "options": {
@@ -24878,7 +24879,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 77
+            "y": 173
           },
           "id": 666,
           "options": {
@@ -24935,7 +24936,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 85
+            "y": 181
           },
           "id": 681,
           "options": {
@@ -25033,7 +25034,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 85
+            "y": 181
           },
           "id": 682,
           "options": {
@@ -25115,7 +25116,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 78
+        "y": 30
       },
       "id": 662,
       "panels": [
@@ -25187,7 +25188,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 288
+            "y": 384
           },
           "id": 664,
           "maxPerRow": 6,


### PR DESCRIPTION
## Description

The batch operation visualisations where somehow not part of the corresponding section. Fixed that. 

<img width="364" height="114" alt="Screenshot 2025-07-23 at 14 41 11" src="https://github.com/user-attachments/assets/4e4d8f90-6432-474a-88b3-f74f7ac73427" />

## Related issues

relates to #34532 
