### PR TITLE
Add sequence flow deleted handler to rdbms exporter

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/SequenceFlowWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/SequenceFlowWriter.java
@@ -47,6 +47,16 @@ public class SequenceFlowWriter {
             sequenceFlow));
   }
 
+  public void delete(final SequenceFlowDbModel sequenceFlow) {
+    executionQueue.executeInQueue(
+        new QueueItem(
+            ContextType.SEQUENCE_FLOW,
+            WriteStatementType.DELETE,
+            sequenceFlow.sequenceFlowId(),
+            "io.camunda.db.rdbms.sql.SequenceFlowMapper.delete",
+            sequenceFlow));
+  }
+
   public void scheduleForHistoryCleanup(
       final Long processInstanceKey, final OffsetDateTime historyCleanupDate) {
     executionQueue.executeInQueue(

--- a/db/rdbms/src/main/resources/mapper/SequenceFlowMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/SequenceFlowMapper.xml
@@ -144,4 +144,10 @@
     <include refid="io.camunda.db.rdbms.sql.Commons.historyCleanup"/>
   </delete>
 
+  <delete id="delete">
+    DELETE FROM ${prefix}SEQUENCE_FLOW
+    WHERE FLOW_NODE_ID = #{flowNodeId}
+      AND PROCESS_INSTANCE_KEY = #{processInstanceKey}
+  </delete>
+
 </mapper>

--- a/db/rdbms/src/main/resources/mapper/SequenceFlowMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/SequenceFlowMapper.xml
@@ -144,7 +144,7 @@
     <include refid="io.camunda.db.rdbms.sql.Commons.historyCleanup"/>
   </delete>
 
-  <delete id="delete">
+  <delete id="delete" parameterType="io.camunda.db.rdbms.write.domain.SequenceFlowDbModel">
     DELETE FROM ${prefix}SEQUENCE_FLOW
     WHERE FLOW_NODE_ID = #{flowNodeId}
       AND PROCESS_INSTANCE_KEY = #{processInstanceKey}


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

In a process instance migration (and other possible future scenarios where flows are “undone”), the exporter must mirror the engine’s lifecycle fully—not just insert “taken” events but also delete them when they’re rolled back or removed. Without a deletion handler, stale sequence flow records accumulate in the RDBMS, leading to misleading dashboards and unnecessary data growth. These changes close the loop on sequence flow lifecycle support in the RDBMS exporter.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #35362 
