### PR TITLE
feat: add validation for mandatory fields in create new mapping rule …

### DIFF
--- a/identity/client/src/components/form/TextField.tsx
+++ b/identity/client/src/components/form/TextField.tsx
@@ -42,14 +42,16 @@ export type TextFieldProps = {
   placeholder?: string;
   cols?: number;
   autoFocus?: boolean;
-  onBlur?: () => void;
+  onBlur?: (newValue: string) => void;
   readOnly?: boolean;
   onChange?: (newValue: string) => void;
+  validate?: (newValue: string) => boolean;
 } & (TextInputProps | TextAreaProps | PasswordInputProps);
 
 const TextField: FC<TextFieldProps> = ({
   onChange,
   onBlur,
+  validate,
   errors = [],
   value,
   helperText,
@@ -75,10 +77,18 @@ const TextField: FC<TextFieldProps> = ({
     placeholder: placeholder,
     onChange: (
       e: ChangeEvent<HTMLInputElement> | React.ChangeEvent<HTMLTextAreaElement>,
-    ) => onChange?.(e.currentTarget.value),
+    ) => {
+      onChange?.(e.currentTarget.value);
+      validate?.(e.currentTarget.value);
+    },
     invalid: errors && errors.length > 0,
     invalidText: errors?.map((e) => t(e)).join(" "),
-    onBlur: onBlur,
+    onBlur: (
+      e: ChangeEvent<HTMLInputElement> | React.ChangeEvent<HTMLTextAreaElement>,
+    ) => {
+      onBlur?.(e.currentTarget.value);
+      validate?.(e.currentTarget.value);
+    },
     readOnly: readOnly,
     ...(autoFocus && { "data-modal-primary-focus": true }),
   };

--- a/identity/client/src/pages/mapping-rules/List.tsx
+++ b/identity/client/src/pages/mapping-rules/List.tsx
@@ -16,7 +16,7 @@ import EntityList from "src/components/entityList";
 import { documentationHref } from "src/components/documentation";
 import { TranslatedErrorInlineNotification } from "src/components/notifications/InlineNotification";
 import useModal, { useEntityModal } from "src/components/modal/useModal";
-import AddModal from "src/pages/mapping-rules/modals/AddModal";
+import { AddModal } from "src/pages/mapping-rules/modals/add-modal";
 import { searchMappingRule } from "src/utility/api/mapping-rules";
 import DeleteModal from "src/pages/mapping-rules/modals/DeleteModal";
 import EditModal from "src/pages/mapping-rules/modals/EditModal";

--- a/identity/client/src/pages/mapping-rules/modals/add-modal/AddModal.tsx
+++ b/identity/client/src/pages/mapping-rules/modals/add-modal/AddModal.tsx
@@ -17,11 +17,12 @@ import {
   CustomStack,
   EqualSignContainer,
   MappingRuleContainer,
-} from "./components";
+} from "../components";
 import { spacing05 } from "@carbon/elements";
 import { Stack } from "@carbon/react";
+import { useValidation } from "./use-validation";
 
-const AddMappingRuleModal: FC<UseModalProps> = ({
+export const AddMappingRuleModal: FC<UseModalProps> = ({
   open,
   onClose,
   onSuccess,
@@ -36,9 +37,25 @@ const AddMappingRuleModal: FC<UseModalProps> = ({
   const [claimName, setClaimName] = useState("");
   const [claimValue, setClaimValue] = useState("");
 
-  const submitDisabled = loading || !mappingRuleName;
+  const submitDisabled = loading;
+
+  const {
+    isMappingRuleIdValid,
+    isMappingRuleNameValid,
+    isClaimNameValid,
+    isClaimValueValid,
+    validateMappingRuleId,
+    validateMappingRuleName,
+    validateClaimName,
+    validateClaimValue,
+    validateForm,
+  } = useValidation({ mappingRuleId, mappingRuleName, claimName, claimValue });
 
   const handleSubmit = async () => {
+    if (!validateForm()) {
+      return;
+    }
+
     const { success } = await apiCall({
       mappingRuleId: mappingRuleId,
       name: mappingRuleName,
@@ -73,16 +90,20 @@ const AddMappingRuleModal: FC<UseModalProps> = ({
         label={t("mappingRuleId")}
         placeholder={t("enterMappingRuleId")}
         onChange={setMappingRuleId}
+        validate={validateMappingRuleId}
         value={mappingRuleId}
         helperText={t("uniqueIdForMappingRule")}
+        errors={isMappingRuleIdValid ? [] : [t("mappingRuleIdRequired")]}
         autoFocus
       />
       <TextField
         label={t("mappingRuleName")}
         placeholder={t("enterMappingRuleName")}
         onChange={setMappingRuleName}
+        validate={validateMappingRuleName}
         value={mappingRuleName}
         helperText={t("uniqueNameForMappingRule")}
+        errors={isMappingRuleNameValid ? [] : [t("mappingRuleNameRequired")]}
       />
       <MappingRuleContainer>
         <Stack gap={spacing05}>
@@ -92,16 +113,20 @@ const AddMappingRuleModal: FC<UseModalProps> = ({
               label={t("claimName")}
               placeholder={t("enterClaimName")}
               onChange={setClaimName}
+              validate={validateClaimName}
               value={claimName}
               helperText={t("customClaimName")}
+              errors={isClaimNameValid ? [] : [t("claimNameRequired")]}
             />
             <EqualSignContainer>=</EqualSignContainer>
             <TextField
               label={t("claimValue")}
               placeholder={t("enterClaimValue")}
               onChange={setClaimValue}
+              validate={validateClaimValue}
               value={claimValue}
               helperText={t("valueForClaim")}
+              errors={isClaimValueValid ? [] : [t("claimValueRequired")]}
             />
           </CustomStack>
         </Stack>
@@ -109,5 +134,3 @@ const AddMappingRuleModal: FC<UseModalProps> = ({
     </FormModal>
   );
 };
-
-export default AddMappingRuleModal;

--- a/identity/client/src/pages/mapping-rules/modals/add-modal/index.ts
+++ b/identity/client/src/pages/mapping-rules/modals/add-modal/index.ts
@@ -1,0 +1,9 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+export { AddMappingRuleModal as AddModal } from "./AddModal";

--- a/identity/client/src/pages/mapping-rules/modals/add-modal/use-validation.ts
+++ b/identity/client/src/pages/mapping-rules/modals/add-modal/use-validation.ts
@@ -1,0 +1,78 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import { useState } from "react";
+
+interface UseValidationProps {
+  mappingRuleId: string;
+  mappingRuleName: string;
+  claimName: string;
+  claimValue: string;
+}
+
+export const useValidation = ({
+  mappingRuleId,
+  mappingRuleName,
+  claimName,
+  claimValue,
+}: UseValidationProps) => {
+  const [isMappingRuleIdValid, setIsMappingRuleIdValid] =
+    useState<boolean>(true);
+  const [isMappingRuleNameValid, setIsMappingRuleNameValid] =
+    useState<boolean>(true);
+  const [isClaimNameValid, setIsClaimNameValid] = useState<boolean>(true);
+  const [isClaimValueValid, setIsClaimValueValid] = useState<boolean>(true);
+
+  const validateMappingRuleId = (value: string) =>
+    validateField(value, setIsMappingRuleIdValid);
+
+  const validateMappingRuleName = (value: string) =>
+    validateField(value, setIsMappingRuleNameValid);
+
+  const validateClaimName = (value: string) =>
+    validateField(value, setIsClaimNameValid);
+
+  const validateClaimValue = (value: string) =>
+    validateField(value, setIsClaimValueValid);
+
+  const validateForm = () => {
+    const _isMappingRuleIdValid = validateMappingRuleId(mappingRuleId);
+    const _isMappingRuleNameValid = validateMappingRuleName(mappingRuleName);
+    const _isClaimNameValid = validateClaimName(claimName);
+    const _isClaimValueValid = validateClaimValue(claimValue);
+    return (
+      _isMappingRuleIdValid &&
+      _isMappingRuleNameValid &&
+      _isClaimNameValid &&
+      _isClaimValueValid
+    );
+  };
+
+  return {
+    isMappingRuleIdValid,
+    isMappingRuleNameValid,
+    isClaimNameValid,
+    isClaimValueValid,
+    validateMappingRuleId,
+    validateMappingRuleName,
+    validateClaimName,
+    validateClaimValue,
+    validateForm,
+  };
+};
+
+const isNonEmpty = (value: string) => value.trim() !== "";
+
+const validateField = (
+  value: string,
+  setValidity: (isValid: boolean) => void,
+) => {
+  const valid = isNonEmpty(value);
+  setValidity(valid);
+  return valid;
+};

--- a/identity/client/src/utility/localization/en/mappingRules.json
+++ b/identity/client/src/utility/localization/en/mappingRules.json
@@ -30,5 +30,9 @@
   "enterClaimValue": "Enter claim value",
   "valueForClaim": "Enter the value for the claim",
   "mappingRuleUpdated": "Mapping rule updated",
-  "mappingRuleUpdatedSuccessfully": "You have successfully updated mapping rule {{ name }}"
+  "mappingRuleUpdatedSuccessfully": "You have successfully updated mapping rule {{ name }}",
+  "mappingRuleIdRequired": "Mapping rule ID is required",
+  "mappingRuleNameRequired": "Mapping rule name is required",
+  "claimNameRequired": "Claim name is required",
+  "claimValueRequired": "Claim value is required"
 }


### PR DESCRIPTION
…modal

## Description

<!-- Describe the goal and purpose of this PR. -->
See description of the [linked issue](https://github.com/camunda/camunda/issues/33461).

### Note for the reviewer
- There is no consistent pattern for form validation in the application. I found two approaches and both performs the validation only on blur and the submit button is disabled initially.
- Since both the approaches are not the best in terms of UX, I followed a different pattern after discussion with @lmbateman 
  - The validation errors are not shown initially, but the submit button is enabled
  - On clicking submit, the validation runs, submit is blocked if validation fails and errors are shown
  - When the user is typing in a field, the validation is run for that field and error message is removed if input is valid
  - Validation is also run on blur
  
  cc: @gastonpillet01 @volodymyr-melnykc @RomanKostka 
  
  
https://github.com/user-attachments/assets/e833120e-bc35-46e8-b785-98d0086e668f


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #33461 
