### PR TITLE
Journal reader handle overlapping segments

### DIFF
--- a/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/JournalIndex.java
+++ b/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/JournalIndex.java
@@ -66,6 +66,14 @@ interface JournalIndex {
   void deleteAfter(long indexExclusive);
 
   /**
+   * Delete a range of entries from the index, inclusive of the given indices.
+   *
+   * @param fromIndexInclusive the start index of the range to delete, inclusive
+   * @param toIndexInclusive the end index of the range to delete, inclusive
+   */
+  void deleteInRange(long fromIndexInclusive, long toIndexInclusive);
+
+  /**
    * Compacts the index until the next stored index (exclusively), which means everything lower then
    * the stored index will be removed.
    *

--- a/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentReader.java
+++ b/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentReader.java
@@ -109,6 +109,18 @@ final class SegmentReader implements Iterator<JournalRecord> {
     return currentIndex + 1;
   }
 
+  void truncateJournalIndex(final long fromIndexInclusive, final long toIndexInclusive) {
+    checkSegmentOpen();
+    index.deleteInRange(fromIndexInclusive, toIndexInclusive);
+
+    seek(fromIndexInclusive - 1);
+    if (hasNext()) {
+      final var position = buffer.position();
+      final var record = next();
+      index.index(record, position);
+    }
+  }
+
   private void checkSegmentOpen() {
     Preconditions.checkState(
         segment.isOpen(), "Segment is already closed. Reader must reset to a valid index.");

--- a/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentReader.java
+++ b/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentReader.java
@@ -109,18 +109,6 @@ final class SegmentReader implements Iterator<JournalRecord> {
     return currentIndex + 1;
   }
 
-  void truncateJournalIndex(final long fromIndexInclusive, final long toIndexInclusive) {
-    checkSegmentOpen();
-    index.deleteInRange(fromIndexInclusive, toIndexInclusive);
-
-    seek(fromIndexInclusive - 1);
-    if (hasNext()) {
-      final var position = buffer.position();
-      final var record = next();
-      index.index(record, position);
-    }
-  }
-
   private void checkSegmentOpen() {
     Preconditions.checkState(
         segment.isOpen(), "Segment is already closed. Reader must reset to a valid index.");

--- a/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentReader.java
+++ b/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentReader.java
@@ -76,6 +76,10 @@ final class SegmentReader implements Iterator<JournalRecord> {
   }
 
   void seek(final long index) {
+    seek(index, true);
+  }
+
+  void seek(final long index, final boolean shouldIndexIntermediateEntries) {
     checkSegmentOpen();
     final long firstIndex = segment.index();
     final long lastIndex = segment.lastIndex();
@@ -90,7 +94,7 @@ final class SegmentReader implements Iterator<JournalRecord> {
 
     // If the returned index is far away from the seekIndex, it is likely that this segment was not
     // indexed before. So we try to index them during the seek.
-    final boolean shouldIndex = !this.index.hasIndexed(index);
+    final boolean shouldIndex = !this.index.hasIndexed(index) && shouldIndexIntermediateEntries;
 
     while (getNextIndex() < index && hasNext()) {
       final var nextPosition = buffer.position();

--- a/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournalReader.java
+++ b/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournalReader.java
@@ -178,7 +178,7 @@ class SegmentedJournalReader implements JournalReader {
 
     if (index < currentReader.getNextIndex()) {
       rewind(index);
-    } else if (index > currentReader.getNextIndex()) {
+    } else if (index > currentReader.getNextIndex() || !currentReader.hasNext()) {
       forward(index);
     } else {
       currentReader.seek(index);

--- a/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentsManager.java
+++ b/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentsManager.java
@@ -284,7 +284,7 @@ final class SegmentsManager implements AutoCloseable {
       if (previousSegment != null && previousSegment.lastIndex() >= segment.index()) {
         // Segments are overlapping, remove the journal index entries in the segment's index range.
         // This is to avoid having an index lookup point to a position in the previous segment.
-        journalIndex.deleteInRange(segment.index(), segment.lastIndex() - 1);
+        journalIndex.deleteInRange(segment.index(), previousSegment.lastIndex());
       }
       previousSegment = segment;
       final Segment replacedSegment = segments.put(segment.descriptor().index(), segment);

--- a/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentsManager.java
+++ b/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentsManager.java
@@ -281,11 +281,9 @@ final class SegmentsManager implements AutoCloseable {
     // Load existing log segments from disk.
     Segment previousSegment = null;
     for (final Segment segment : loadSegments()) {
-      if (previousSegment != null) {
+      if (previousSegment != null && previousSegment.lastIndex() >= segment.index()) {
         // Segments contain overlaps
-        if (previousSegment.lastIndex() >= segment.index()) {
-          reIndexOverlap(segment);
-        }
+        reIndexOverlap(segment);
       }
       previousSegment = segment;
       final Segment replacedSegment = segments.put(segment.descriptor().index(), segment);

--- a/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SparseJournalIndex.java
+++ b/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SparseJournalIndex.java
@@ -19,7 +19,6 @@ import io.camunda.zeebe.journal.JournalRecord;
 import java.util.Map;
 import java.util.concurrent.ConcurrentNavigableMap;
 import java.util.concurrent.ConcurrentSkipListMap;
-import java.util.stream.LongStream;
 
 final class SparseJournalIndex implements JournalIndex {
 
@@ -87,14 +86,16 @@ final class SparseJournalIndex implements JournalIndex {
   @Override
   public void deleteInRange(final long fromIndexInclusive, final long toIndexInclusive) {
     indexToPosition.subMap(fromIndexInclusive, true, toIndexInclusive, true).clear();
-    LongStream.rangeClosed(fromIndexInclusive, toIndexInclusive)
-        .forEach(
-            index -> {
-              final var asqnEntry = indexToAsqn.remove(index);
-              if (asqnEntry != null) {
-                asqnToIndex.remove(asqnEntry);
-              }
-            });
+    final var indexToAsqnSubMap =
+        indexToAsqn.subMap(fromIndexInclusive, true, toIndexInclusive, true);
+    asqnToIndex
+        .subMap(
+            indexToAsqnSubMap.firstEntry().getValue(),
+            true,
+            indexToAsqnSubMap.lastEntry().getValue(),
+            true)
+        .clear();
+    indexToAsqnSubMap.clear();
   }
 
   @Override

--- a/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SparseJournalIndex.java
+++ b/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SparseJournalIndex.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.journal.JournalRecord;
 import java.util.Map;
 import java.util.concurrent.ConcurrentNavigableMap;
 import java.util.concurrent.ConcurrentSkipListMap;
+import java.util.stream.LongStream;
 
 final class SparseJournalIndex implements JournalIndex {
 
@@ -81,6 +82,19 @@ final class SparseJournalIndex implements JournalIndex {
       final boolean include = asqnEntryToDelete.getKey() > index;
       asqnToIndex.tailMap(asqnToDelete, include).clear();
     }
+  }
+
+  @Override
+  public void deleteInRange(final long fromIndexInclusive, final long toIndexInclusive) {
+    indexToPosition.subMap(fromIndexInclusive, true, toIndexInclusive, true).clear();
+    LongStream.rangeClosed(fromIndexInclusive, toIndexInclusive)
+        .forEach(
+            index -> {
+              final var asqnEntry = indexToAsqn.remove(index);
+              if (asqnEntry != null) {
+                asqnToIndex.remove(asqnEntry);
+              }
+            });
   }
 
   @Override

--- a/zeebe/journal/src/test/java/io/camunda/zeebe/journal/file/JournalTestHelper.java
+++ b/zeebe/journal/src/test/java/io/camunda/zeebe/journal/file/JournalTestHelper.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.journal.file;
+
+import io.camunda.zeebe.util.buffer.BufferWriter;
+import io.camunda.zeebe.util.buffer.DirectBufferWriter;
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import org.agrona.concurrent.UnsafeBuffer;
+
+public abstract class JournalTestHelper {
+  static final UnsafeBuffer DATA = new UnsafeBuffer("test".getBytes(StandardCharsets.UTF_8));
+  static final BufferWriter RECORD_DATA_WRITER = new DirectBufferWriter().wrap(DATA);
+  static final String JOURNAL_NAME = "journal";
+  static final char PART_SEPARATOR = '-';
+  static final char EXTENSION_SEPARATOR = '.';
+  static final String EXTENSION = "log";
+  static final String DATA_DIRECTORY = "data";
+
+  static void appendJournalEntries(
+      final SegmentedJournal journal, final BufferWriter entry, final int... asqns) {
+    Arrays.stream(asqns).forEach(asqn -> journal.append(asqn, entry));
+  }
+
+  static void appendJournalEntries(final SegmentedJournal journal, final int... asqns) {
+    Arrays.stream(asqns).forEach(asqn -> journal.append(asqn, RECORD_DATA_WRITER));
+  }
+
+  static SegmentedJournal openJournal(
+      final TestJournalFactory journalFactory, final Path directory) {
+    return journalFactory.journal(journalFactory.segmentsManager(directory));
+  }
+
+  static void mergeJournals(final Path directory, final Path... directories) {
+    mergeJournals(directory, JOURNAL_NAME, directories);
+  }
+
+  /**
+   * Merge segments from other directories into the current journal's data directory, incrementing
+   * the id to simulate later segments.
+   *
+   * @param directory primary directory where others will be merged into
+   * @param journalName
+   * @param directories
+   */
+  static void mergeJournals(
+      final Path directory, final String journalName, final Path... directories) {
+    final var dataDir = directory.resolve(DATA_DIRECTORY);
+    int maxSegmentId =
+        Arrays.stream(dataDir.toFile().listFiles(f -> Files.isRegularFile(f.toPath())))
+            .map(File::getName)
+            .map(SegmentFile::getSegmentIdFromPath)
+            .max(Comparator.naturalOrder())
+            .orElseThrow(() -> new IllegalStateException("No segments found in data directory."));
+
+    for (final Path dir : directories) {
+      final List<File> files =
+          Arrays.stream(
+                  dir.resolve(DATA_DIRECTORY)
+                      .toFile()
+                      .listFiles(f -> Files.isRegularFile(f.toPath())))
+              .sorted(Comparator.comparing(f -> SegmentFile.getSegmentIdFromPath(f.getName())))
+              .toList();
+      if (!files.isEmpty()) {
+        for (final File file : files) {
+          final String newName =
+              journalName + PART_SEPARATOR + (++maxSegmentId) + EXTENSION_SEPARATOR + EXTENSION;
+          try {
+            Files.move(file.toPath(), dataDir.resolve(newName));
+          } catch (final IOException e) {
+            throw new UncheckedIOException(e);
+          }
+        }
+      }
+    }
+  }
+}

--- a/zeebe/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentedJournalReaderTest.java
+++ b/zeebe/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentedJournalReaderTest.java
@@ -22,10 +22,14 @@ import io.camunda.zeebe.journal.JournalRecord;
 import io.camunda.zeebe.journal.record.RecordData;
 import io.camunda.zeebe.journal.record.SBESerializer;
 import io.camunda.zeebe.journal.util.MockJournalMetastore;
+import io.camunda.zeebe.util.FileUtil;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.stream.IntStream;
 import org.agrona.CloseHelper;
 import org.agrona.DirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
@@ -180,11 +184,9 @@ class SegmentedJournalReaderTest {
         JournalTestHelper.openJournal(journalFactory, directory.resolve("secondary"));
 
     JournalTestHelper.appendJournalEntries(journal, 1, 2, 3);
-    journal.getLastSegment().updateDescriptor();
 
     secondaryJournal.reset(3);
     JournalTestHelper.appendJournalEntries(secondaryJournal, 3, 4, 5);
-    secondaryJournal.getLastSegment().updateDescriptor();
     journal.close();
     secondaryJournal.close();
 
@@ -223,7 +225,6 @@ class SegmentedJournalReaderTest {
         JournalTestHelper.openJournal(journalFactory, directory.resolve("secondary"));
     secondaryJournal.reset(2);
     JournalTestHelper.appendJournalEntries(secondaryJournal, 2, 3, 4);
-    secondaryJournal.getLastSegment().updateDescriptor();
     secondaryJournal.close();
 
     journalFactory = new TestJournalFactory(5);
@@ -231,7 +232,6 @@ class SegmentedJournalReaderTest {
         JournalTestHelper.openJournal(journalFactory, directory.resolve("third"));
     thirdJournal.reset(3);
     JournalTestHelper.appendJournalEntries(thirdJournal, 3, 4, 5, 6, 7);
-    thirdJournal.getLastSegment().updateDescriptor();
     thirdJournal.close();
 
     JournalTestHelper.mergeJournals(
@@ -271,7 +271,6 @@ class SegmentedJournalReaderTest {
         JournalTestHelper.openJournal(journalFactory, directory.resolve("secondary"));
     secondaryJournal.reset(2);
     JournalTestHelper.appendJournalEntries(secondaryJournal, 2, 3, 4);
-    secondaryJournal.getLastSegment().updateDescriptor();
     secondaryJournal.close();
 
     journalFactory = new TestJournalFactory(5);
@@ -279,7 +278,6 @@ class SegmentedJournalReaderTest {
         JournalTestHelper.openJournal(journalFactory, directory.resolve("third"));
     thirdJournal.reset(3);
     JournalTestHelper.appendJournalEntries(thirdJournal, 3, 4, 5, 6, 7);
-    thirdJournal.getLastSegment().updateDescriptor();
     thirdJournal.close();
 
     JournalTestHelper.mergeJournals(

--- a/zeebe/journal/src/test/java/io/camunda/zeebe/journal/file/SparseJournalIndexTest.java
+++ b/zeebe/journal/src/test/java/io/camunda/zeebe/journal/file/SparseJournalIndexTest.java
@@ -22,7 +22,6 @@ import io.camunda.zeebe.journal.JournalRecord;
 import io.camunda.zeebe.journal.util.TestJournalRecord;
 import java.util.stream.IntStream;
 import java.util.stream.LongStream;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 /** Sparse journal index test. */
@@ -283,26 +282,26 @@ class SparseJournalIndexTest {
         .forEach(
             i -> {
               final var info = index.lookup(i);
-              Assertions.assertNotNull(info);
-              assertEquals(2, info.index());
-              assertEquals(4, info.position());
-              assertEquals(2, index.lookupAsqn(4));
+              assertThat(info).isNotNull();
+              assertThat(info.index()).isEqualTo(2);
+              assertThat(info.position()).isEqualTo(4);
+              assertThat(index.lookupAsqn(i)).isEqualTo(2);
             });
 
     IntStream.rangeClosed(1, 2)
         .forEach(
             i -> {
-              assertEquals(i, index.lookup(i).index());
-              assertEquals(i * 2, index.lookup(i).position());
-              assertEquals(i, index.lookupAsqn(i));
+              assertThat(index.lookup(i).index()).isEqualTo(i);
+              assertThat(index.lookup(i).position()).isEqualTo(i * 2);
+              assertThat(index.lookupAsqn(i)).isEqualTo(i);
             });
 
     IntStream.rangeClosed(8, 10)
         .forEach(
             i -> {
-              assertEquals(i, index.lookup(i).index());
-              assertEquals(i * 2, index.lookup(i).position());
-              assertEquals(i, index.lookupAsqn(i));
+              assertThat(index.lookup(i).index()).isEqualTo(i);
+              assertThat(index.lookup(i).position()).isEqualTo(i * 2);
+              assertThat(index.lookupAsqn(i)).isEqualTo(i);
             });
   }
 }


### PR DESCRIPTION
## Description

Enable the `JournalReader` to handle possible overlaps between segments while iterating through entries and also while seeking to specific indices. 

Notable changes:
- When replacing a finished current open segment in the `SegmentedJournalReader` we now may have to skip through multiple segments due to possible overlaps. Also, we can expect that the  replaced segment's start index is not the exact next in sequence to the one we previously have read in the previous segment - so we have to seek forward in the new segment
- When loading segments into a fresh journal, we remove any possible overlapping indexed positions for that range
- We preemptively check whether the reader has an available next record to fast forward the current segment to avoid having the reader reset to a possible overlapping position in an unexpected index
- When seeking through the journal we make sure that in case we traversing within an overlap we do not index the positions on the overlapping segment

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #35522
