### PR TITLE
feat: Add RDBMS exporter for message subscription

### DIFF
--- a/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.8.0.xml
+++ b/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.8.0.xml
@@ -649,4 +649,28 @@
     </createTable>
   </changeSet>
 
+  <changeSet id="create_message_subscription_table" author="georgios-goulos">
+    <createTable tableName="${prefix}MESSAGE_SUBSCRIPTION">
+      <column name="MESSAGE_SUBSCRIPTION_KEY" type="BIGINT">
+        <constraints primaryKey="true"/>
+      </column>
+      <column name="PROCESS_DEFINITION_ID" type="VARCHAR(255)"/>
+      <column name="PROCESS_DEFINITION_KEY" type="BIGINT"/>
+      <column name="PROCESS_INSTANCE_KEY" type="BIGINT"/>
+      <column name="FLOW_NODE_ID" type="VARCHAR(255)"/>
+      <column name="FLOW_NODE_INSTANCE_KEY" type="BIGINT"/>
+      <column name="MESSAGE_SUBSCRIPTION_TYPE" type="VARCHAR(20)"/>
+      <column name="DATE_TIME" type="TIMESTAMP WITH TIME ZONE(3)"/>
+      <column name="MESSAGE_NAME" type="VARCHAR(255)"/>
+      <column name="CORRELATION_KEY" type="VARCHAR(255)"/>
+      <column name="TENANT_ID" type="VARCHAR(255)"/>
+      <column name="PARTITION_ID" type="NUMBER"/>
+    </createTable>
+
+    <modifySql dbms="mariadb">
+      <!-- MariaDB doesn't support TIMESTAMP WITH TIME ZONE, but its TIMESTAMP type has already a time zone -->
+      <replace replace="TIMESTAMP WITH TIME ZONE" with="TIMESTAMP"/>
+    </modifySql>
+  </changeSet>
+
 </databaseChangeLog>

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/RdbmsService.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/RdbmsService.java
@@ -19,6 +19,7 @@ import io.camunda.db.rdbms.read.service.GroupDbReader;
 import io.camunda.db.rdbms.read.service.IncidentDbReader;
 import io.camunda.db.rdbms.read.service.JobDbReader;
 import io.camunda.db.rdbms.read.service.MappingRuleDbReader;
+import io.camunda.db.rdbms.read.service.MessageSubscriptionDbReader;
 import io.camunda.db.rdbms.read.service.ProcessDefinitionDbReader;
 import io.camunda.db.rdbms.read.service.ProcessInstanceDbReader;
 import io.camunda.db.rdbms.read.service.RoleDbReader;
@@ -61,6 +62,7 @@ public class RdbmsService {
   private final JobDbReader jobReader;
   private final UsageMetricsDbReader usageMetricReader;
   private final UsageMetricTUDbReader usageMetricTUDbReader;
+  private final MessageSubscriptionDbReader messageSubscriptionReader;
 
   public RdbmsService(
       final RdbmsWriterFactory rdbmsWriterFactory,
@@ -85,7 +87,8 @@ public class RdbmsService {
       final BatchOperationItemDbReader batchOperationItemReader,
       final JobDbReader jobReader,
       final UsageMetricsDbReader usageMetricReader,
-      final UsageMetricTUDbReader usageMetricTUDbReader) {
+      final UsageMetricTUDbReader usageMetricTUDbReader,
+      final MessageSubscriptionDbReader messageSubscriptionReader) {
     this.rdbmsWriterFactory = rdbmsWriterFactory;
     this.authorizationReader = authorizationReader;
     this.decisionRequirementsReader = decisionRequirementsReader;
@@ -109,6 +112,7 @@ public class RdbmsService {
     this.jobReader = jobReader;
     this.usageMetricReader = usageMetricReader;
     this.usageMetricTUDbReader = usageMetricTUDbReader;
+    this.messageSubscriptionReader = messageSubscriptionReader;
   }
 
   public AuthorizationDbReader getAuthorizationReader() {
@@ -197,6 +201,10 @@ public class RdbmsService {
 
   public JobDbReader getJobReader() {
     return jobReader;
+  }
+
+  public MessageSubscriptionDbReader getMessageSubscriptionReader() {
+    return messageSubscriptionReader;
   }
 
   public RdbmsWriter createWriter(final long partitionId) { // todo fix in all itests afterwards?

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/domain/MessageSubscriptionDbQuery.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/domain/MessageSubscriptionDbQuery.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.read.domain;
+
+import io.camunda.search.entities.MessageSubscriptionEntity;
+import io.camunda.search.filter.FilterBuilders;
+import io.camunda.search.filter.MessageSubscriptionFilter;
+import io.camunda.util.ObjectBuilder;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Function;
+
+public record MessageSubscriptionDbQuery(
+    MessageSubscriptionFilter filter,
+    DbQuerySorting<MessageSubscriptionEntity> sort,
+    DbQueryPage page) {
+  public static MessageSubscriptionDbQuery of(
+      final Function<Builder, ObjectBuilder<MessageSubscriptionDbQuery>> fn) {
+    return fn.apply(new MessageSubscriptionDbQuery.Builder()).build();
+  }
+
+  public static final class Builder implements ObjectBuilder<MessageSubscriptionDbQuery> {
+    private static final MessageSubscriptionFilter EMPTY_FILTER =
+        FilterBuilders.messageSubscription().build();
+
+    private MessageSubscriptionFilter filter;
+    private DbQuerySorting<MessageSubscriptionEntity> sort;
+    private DbQueryPage page;
+
+    public Builder filter(final MessageSubscriptionFilter value) {
+      filter = value;
+      return this;
+    }
+
+    public Builder sort(final DbQuerySorting<MessageSubscriptionEntity> value) {
+      sort = value;
+      return this;
+    }
+
+    public Builder page(final DbQueryPage value) {
+      page = value;
+      return this;
+    }
+
+    public Builder filter(
+        final Function<MessageSubscriptionFilter.Builder, ObjectBuilder<MessageSubscriptionFilter>>
+            fn) {
+      return filter(FilterBuilders.messageSubscription(fn));
+    }
+
+    public Builder sort(
+        final Function<
+                DbQuerySorting.Builder<MessageSubscriptionEntity>,
+                ObjectBuilder<DbQuerySorting<MessageSubscriptionEntity>>>
+            fn) {
+      return sort(DbQuerySorting.of(fn));
+    }
+
+    @Override
+    public MessageSubscriptionDbQuery build() {
+      filter = Objects.requireNonNullElse(filter, EMPTY_FILTER);
+      sort = Objects.requireNonNullElse(sort, new DbQuerySorting<>(List.of()));
+      return new MessageSubscriptionDbQuery(filter, sort, page);
+    }
+  }
+}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/MessageSubscriptionEntityMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/MessageSubscriptionEntityMapper.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.read.mapper;
+
+import io.camunda.db.rdbms.write.domain.MessageSubscriptionDbModel;
+import io.camunda.search.entities.MessageSubscriptionEntity;
+
+public class MessageSubscriptionEntityMapper {
+
+  public static MessageSubscriptionEntity toEntity(
+      final MessageSubscriptionDbModel messageSubscriptionDbModel) {
+    return MessageSubscriptionEntity.builder()
+        .messageSubscriptionKey(messageSubscriptionDbModel.messageSubscriptionKey())
+        .processDefinitionId(messageSubscriptionDbModel.processDefinitionId())
+        .processDefinitionKey(messageSubscriptionDbModel.processDefinitionKey())
+        .processInstanceKey(messageSubscriptionDbModel.processInstanceKey())
+        .flowNodeId(messageSubscriptionDbModel.flowNodeId())
+        .flowNodeInstanceKey(messageSubscriptionDbModel.flowNodeInstanceKey())
+        .messageSubscriptionType(messageSubscriptionDbModel.messageSubscriptionType())
+        .dateTime(messageSubscriptionDbModel.dateTime())
+        .messageName(messageSubscriptionDbModel.messageName())
+        .correlationKey(messageSubscriptionDbModel.correlationKey())
+        .tenantId(messageSubscriptionDbModel.tenantId())
+        .build();
+  }
+}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/MessageSubscriptionMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/MessageSubscriptionMapper.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.sql;
+
+import io.camunda.db.rdbms.read.domain.MessageSubscriptionDbQuery;
+import io.camunda.db.rdbms.write.domain.MessageSubscriptionDbModel;
+import java.util.List;
+
+public interface MessageSubscriptionMapper extends HistoryCleanupMapper {
+
+  void insert(MessageSubscriptionDbModel messageSubscription);
+
+  void update(MessageSubscriptionDbModel messageSubscription);
+
+  Long count(MessageSubscriptionDbQuery filter);
+
+  List<MessageSubscriptionDbModel> search(MessageSubscriptionDbQuery filter);
+}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/columns/MessageSubscriptionColumn.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/columns/MessageSubscriptionColumn.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.sql.columns;
+
+import io.camunda.search.entities.MessageSubscriptionEntity;
+
+public enum MessageSubscriptionColumn implements SearchColumn<MessageSubscriptionEntity> {
+  MESSAGE_SUBSCRIPTION_KEY("messageSubscriptionKey"),
+  PROCESS_DEFINITION_ID("processDefinitionId"),
+  PROCESS_DEFINITION_KEY("processDefinitionKey"),
+  PROCESS_INSTANCE_KEY("processInstanceKey"),
+  FLOW_NODE_ID("flowNodeId"),
+  FLOW_NODE_INSTANCE_KEY("flowNodeInstanceKey"),
+  MESSAGE_SUBSCRIPTION_TYPE("messageSubscriptionType"),
+  DATE_TIME("dateTime"),
+  MESSAGE_NAME("messageName"),
+  CORRELATION_KEY("correlationKey"),
+  TENANT_ID("tenantId");
+
+  private final String property;
+
+  MessageSubscriptionColumn(final String property) {
+    this.property = property;
+  }
+
+  @Override
+  public String property() {
+    return property;
+  }
+
+  @Override
+  public Class<MessageSubscriptionEntity> getEntityClass() {
+    return MessageSubscriptionEntity.class;
+  }
+}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriter.java
@@ -14,6 +14,7 @@ import io.camunda.db.rdbms.sql.DecisionInstanceMapper;
 import io.camunda.db.rdbms.sql.FlowNodeInstanceMapper;
 import io.camunda.db.rdbms.sql.IncidentMapper;
 import io.camunda.db.rdbms.sql.JobMapper;
+import io.camunda.db.rdbms.sql.MessageSubscriptionMapper;
 import io.camunda.db.rdbms.sql.ProcessInstanceMapper;
 import io.camunda.db.rdbms.sql.PurgeMapper;
 import io.camunda.db.rdbms.sql.SequenceFlowMapper;
@@ -35,6 +36,7 @@ import io.camunda.db.rdbms.write.service.HistoryCleanupService;
 import io.camunda.db.rdbms.write.service.IncidentWriter;
 import io.camunda.db.rdbms.write.service.JobWriter;
 import io.camunda.db.rdbms.write.service.MappingRuleWriter;
+import io.camunda.db.rdbms.write.service.MessageSubscriptionWriter;
 import io.camunda.db.rdbms.write.service.ProcessDefinitionWriter;
 import io.camunda.db.rdbms.write.service.ProcessInstanceWriter;
 import io.camunda.db.rdbms.write.service.RdbmsPurger;
@@ -73,6 +75,7 @@ public class RdbmsWriter {
   private final SequenceFlowWriter sequenceFlowWriter;
   private final UsageMetricWriter usageMetricWriter;
   private final UsageMetricTUWriter usageMetricTUWriter;
+  private final MessageSubscriptionWriter messageSubscriptionWriter;
 
   private final HistoryCleanupService historyCleanupService;
 
@@ -94,7 +97,8 @@ public class RdbmsWriter {
       final SequenceFlowMapper sequenceFlowMapper,
       final UsageMetricMapper usageMetricMapper,
       final UsageMetricTUMapper usageMetricTUMapper,
-      final BatchOperationMapper batchOperationMapper) {
+      final BatchOperationMapper batchOperationMapper,
+      final MessageSubscriptionMapper messageSubscriptionMapper) {
     this.executionQueue = executionQueue;
     this.exporterPositionService = exporterPositionService;
     rdbmsPurger = new RdbmsPurger(purgeMapper, vendorDatabaseProperties);
@@ -127,7 +131,10 @@ public class RdbmsWriter {
     sequenceFlowWriter = new SequenceFlowWriter(executionQueue, sequenceFlowMapper);
     usageMetricWriter = new UsageMetricWriter(executionQueue, usageMetricMapper);
     usageMetricTUWriter = new UsageMetricTUWriter(executionQueue, usageMetricTUMapper);
+    messageSubscriptionWriter =
+        new MessageSubscriptionWriter(executionQueue, messageSubscriptionMapper);
 
+    // TODO: Do I need to update this?
     historyCleanupService =
         new HistoryCleanupService(
             config,
@@ -225,6 +232,10 @@ public class RdbmsWriter {
 
   public UsageMetricTUWriter getUsageMetricTUWriter() {
     return usageMetricTUWriter;
+  }
+
+  public MessageSubscriptionWriter getMessageSubscriptionWriter() {
+    return messageSubscriptionWriter;
   }
 
   public ExporterPositionService getExporterPositionService() {

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriterFactory.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriterFactory.java
@@ -15,6 +15,7 @@ import io.camunda.db.rdbms.sql.ExporterPositionMapper;
 import io.camunda.db.rdbms.sql.FlowNodeInstanceMapper;
 import io.camunda.db.rdbms.sql.IncidentMapper;
 import io.camunda.db.rdbms.sql.JobMapper;
+import io.camunda.db.rdbms.sql.MessageSubscriptionMapper;
 import io.camunda.db.rdbms.sql.ProcessInstanceMapper;
 import io.camunda.db.rdbms.sql.PurgeMapper;
 import io.camunda.db.rdbms.sql.SequenceFlowMapper;
@@ -45,6 +46,7 @@ public class RdbmsWriterFactory {
   private final UsageMetricMapper usageMetricMapper;
   private final UsageMetricTUMapper usageMetricTUMapper;
   private final BatchOperationMapper batchOperationMapper;
+  private final MessageSubscriptionMapper messageSubscriptionMapper;
 
   public RdbmsWriterFactory(
       final SqlSessionFactory sqlSessionFactory,
@@ -63,7 +65,8 @@ public class RdbmsWriterFactory {
       final SequenceFlowMapper sequenceFlowMapper,
       final UsageMetricMapper usageMetricMapper,
       final UsageMetricTUMapper usageMetricTUMapper,
-      final BatchOperationMapper batchOperationMapper) {
+      final BatchOperationMapper batchOperationMapper,
+      final MessageSubscriptionMapper messageSubscriptionMapper) {
     this.sqlSessionFactory = sqlSessionFactory;
     this.exporterPositionMapper = exporterPositionMapper;
     this.vendorDatabaseProperties = vendorDatabaseProperties;
@@ -81,6 +84,7 @@ public class RdbmsWriterFactory {
     this.usageMetricMapper = usageMetricMapper;
     this.usageMetricTUMapper = usageMetricTUMapper;
     this.batchOperationMapper = batchOperationMapper;
+    this.messageSubscriptionMapper = messageSubscriptionMapper;
   }
 
   public RdbmsWriter createWriter(final RdbmsWriterConfig config) {
@@ -105,6 +109,7 @@ public class RdbmsWriterFactory {
         sequenceFlowMapper,
         usageMetricMapper,
         usageMetricTUMapper,
-        batchOperationMapper);
+        batchOperationMapper,
+        messageSubscriptionMapper);
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/MessageSubscriptionDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/MessageSubscriptionDbModel.java
@@ -1,0 +1,272 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.write.domain;
+
+import io.camunda.search.entities.MessageSubscriptionEntity.MessageSubscriptionType;
+import io.camunda.util.ObjectBuilder;
+import java.time.OffsetDateTime;
+import java.util.function.Function;
+
+public class MessageSubscriptionDbModel implements Copyable<MessageSubscriptionDbModel> {
+  private Long messageSubscriptionKey;
+  private String processDefinitionId;
+  private Long processDefinitionKey;
+  private Long processInstanceKey;
+  private String flowNodeId;
+  private Long flowNodeInstanceKey;
+  private MessageSubscriptionType messageSubscriptionType;
+  private OffsetDateTime dateTime;
+  private String messageName;
+  private String correlationKey;
+  private String tenantId;
+  private int partitionId;
+
+  public MessageSubscriptionDbModel(final Long messageSubscriptionKey) {
+    this.messageSubscriptionKey = messageSubscriptionKey;
+  }
+
+  public MessageSubscriptionDbModel(
+      final Long messageSubscriptionKey,
+      final String processDefinitionId,
+      final Long processDefinitionKey,
+      final Long processInstanceKey,
+      final String flowNodeId,
+      final Long flowNodeInstanceKey,
+      final MessageSubscriptionType messageSubscriptionType,
+      final OffsetDateTime dateTime,
+      final String messageName,
+      final String correlationKey,
+      final String tenantId,
+      final int partitionId) {
+    this.messageSubscriptionKey = messageSubscriptionKey;
+    this.processDefinitionId = processDefinitionId;
+    this.processDefinitionKey = processDefinitionKey;
+    this.processInstanceKey = processInstanceKey;
+    this.flowNodeId = flowNodeId;
+    this.flowNodeInstanceKey = flowNodeInstanceKey;
+    this.messageSubscriptionType = messageSubscriptionType;
+    this.dateTime = dateTime;
+    this.messageName = messageName;
+    this.correlationKey = correlationKey;
+    this.tenantId = tenantId;
+    this.partitionId = partitionId;
+  }
+
+  public Long messageSubscriptionKey() {
+    return messageSubscriptionKey;
+  }
+
+  public void setMessageSubscriptionKey(final Long messageSubscriptionKey) {
+    this.messageSubscriptionKey = messageSubscriptionKey;
+  }
+
+  public String processDefinitionId() {
+    return processDefinitionId;
+  }
+
+  public void setProcessDefinitionId(final String processDefinitionId) {
+    this.processDefinitionId = processDefinitionId;
+  }
+
+  public Long processDefinitionKey() {
+    return processDefinitionKey;
+  }
+
+  public void setProcessDefinitionKey(final Long processDefinitionKey) {
+    this.processDefinitionKey = processDefinitionKey;
+  }
+
+  public Long processInstanceKey() {
+    return processInstanceKey;
+  }
+
+  public void setProcessInstanceKey(final Long processInstanceKey) {
+    this.processInstanceKey = processInstanceKey;
+  }
+
+  public String flowNodeId() {
+    return flowNodeId;
+  }
+
+  public void setFlowNodeId(final String flowNodeId) {
+    this.flowNodeId = flowNodeId;
+  }
+
+  public Long flowNodeInstanceKey() {
+    return flowNodeInstanceKey;
+  }
+
+  public void setFlowNodeInstanceKey(final Long flowNodeInstanceKey) {
+    this.flowNodeInstanceKey = flowNodeInstanceKey;
+  }
+
+  public MessageSubscriptionType messageSubscriptionType() {
+    return messageSubscriptionType;
+  }
+
+  public void setMessageSubscriptionType(final MessageSubscriptionType messageSubscriptionType) {
+    this.messageSubscriptionType = messageSubscriptionType;
+  }
+
+  public OffsetDateTime dateTime() {
+    return dateTime;
+  }
+
+  public void setDateTime(final OffsetDateTime dateTime) {
+    this.dateTime = dateTime;
+  }
+
+  public String messageName() {
+    return messageName;
+  }
+
+  public void setMessageName(final String messageName) {
+    this.messageName = messageName;
+  }
+
+  public String correlationKey() {
+    return correlationKey;
+  }
+
+  public void setCorrelationKey(final String correlationKey) {
+    this.correlationKey = correlationKey;
+  }
+
+  public String tenantId() {
+    return tenantId;
+  }
+
+  public void setTenantId(final String tenantId) {
+    this.tenantId = tenantId;
+  }
+
+  public int partitionId() {
+    return partitionId;
+  }
+
+  public MessageSubscriptionDbModel setPartitionId(final int partitionId) {
+    this.partitionId = partitionId;
+    return this;
+  }
+
+  @Override
+  public MessageSubscriptionDbModel copy(
+      final Function<
+              ObjectBuilder<MessageSubscriptionDbModel>, ObjectBuilder<MessageSubscriptionDbModel>>
+          copyFunction) {
+    return copyFunction.apply(toBuilder()).build();
+  }
+
+  public ObjectBuilder<MessageSubscriptionDbModel> toBuilder() {
+    return new Builder()
+        .messageSubscriptionKey(messageSubscriptionKey)
+        .processDefinitionId(processDefinitionId)
+        .processDefinitionKey(processDefinitionKey)
+        .processInstanceKey(processInstanceKey)
+        .flowNodeId(flowNodeId)
+        .flowNodeInstanceKey(flowNodeInstanceKey)
+        .messageSubscriptionType(messageSubscriptionType)
+        .dateTime(dateTime)
+        .messageName(messageName)
+        .correlationKey(correlationKey)
+        .tenantId(tenantId)
+        .partitionId(partitionId);
+  }
+
+  public static class Builder implements ObjectBuilder<MessageSubscriptionDbModel> {
+    private Long messageSubscriptionKey;
+    private String processDefinitionId;
+    private Long processDefinitionKey;
+    private Long processInstanceKey;
+    private String flowNodeId;
+    private Long flowNodeInstanceKey;
+    private MessageSubscriptionType messageSubscriptionType;
+    private OffsetDateTime dateTime;
+    private String messageName;
+    private String correlationKey;
+    private String tenantId;
+    private int partitionId;
+
+    public Builder messageSubscriptionKey(final Long messageSubscriptionKey) {
+      this.messageSubscriptionKey = messageSubscriptionKey;
+      return this;
+    }
+
+    public Builder processDefinitionId(final String processDefinitionId) {
+      this.processDefinitionId = processDefinitionId;
+      return this;
+    }
+
+    public Builder processDefinitionKey(final Long processDefinitionKey) {
+      this.processDefinitionKey = processDefinitionKey;
+      return this;
+    }
+
+    public Builder processInstanceKey(final Long processInstanceKey) {
+      this.processInstanceKey = processInstanceKey;
+      return this;
+    }
+
+    public Builder flowNodeId(final String flowNodeId) {
+      this.flowNodeId = flowNodeId;
+      return this;
+    }
+
+    public Builder flowNodeInstanceKey(final Long flowNodeInstanceKey) {
+      this.flowNodeInstanceKey = flowNodeInstanceKey;
+      return this;
+    }
+
+    public Builder messageSubscriptionType(final MessageSubscriptionType messageSubscriptionType) {
+      this.messageSubscriptionType = messageSubscriptionType;
+      return this;
+    }
+
+    public Builder dateTime(final OffsetDateTime dateTime) {
+      this.dateTime = dateTime;
+      return this;
+    }
+
+    public Builder messageName(final String messageName) {
+      this.messageName = messageName;
+      return this;
+    }
+
+    public Builder correlationKey(final String correlationKey) {
+      this.correlationKey = correlationKey;
+      return this;
+    }
+
+    public Builder tenantId(final String tenantId) {
+      this.tenantId = tenantId;
+      return this;
+    }
+
+    public Builder partitionId(final int partitionId) {
+      this.partitionId = partitionId;
+      return this;
+    }
+
+    @Override
+    public MessageSubscriptionDbModel build() {
+      return new MessageSubscriptionDbModel(
+          messageSubscriptionKey,
+          processDefinitionId,
+          processDefinitionKey,
+          processInstanceKey,
+          flowNodeId,
+          flowNodeInstanceKey,
+          messageSubscriptionType,
+          dateTime,
+          messageName,
+          correlationKey,
+          tenantId,
+          partitionId);
+    }
+  }
+}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/queue/ContextType.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/queue/ContextType.java
@@ -28,7 +28,8 @@ public enum ContextType {
   JOB(false),
   SEQUENCE_FLOW(false),
   USAGE_METRIC(false),
-  USAGE_METRIC_TU(false);
+  USAGE_METRIC_TU(false),
+  MESSAGE_SUBSCRIPTION(false);
 
   private final boolean preserveOrder;
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/MessageSubscriptionWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/MessageSubscriptionWriter.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.write.service;
+
+import io.camunda.db.rdbms.sql.MessageSubscriptionMapper;
+import io.camunda.db.rdbms.write.domain.MessageSubscriptionDbModel;
+import io.camunda.db.rdbms.write.queue.ContextType;
+import io.camunda.db.rdbms.write.queue.ExecutionQueue;
+import io.camunda.db.rdbms.write.queue.QueueItem;
+import io.camunda.db.rdbms.write.queue.WriteStatementType;
+
+public class MessageSubscriptionWriter {
+
+  private final ExecutionQueue executionQueue;
+  private final MessageSubscriptionMapper mapper;
+
+  public MessageSubscriptionWriter(
+      final ExecutionQueue executionQueue, final MessageSubscriptionMapper mapper) {
+    this.executionQueue = executionQueue;
+    this.mapper = mapper;
+  }
+
+  public void create(final MessageSubscriptionDbModel messageSubscription) {
+    executionQueue.executeInQueue(
+        new QueueItem(
+            ContextType.MESSAGE_SUBSCRIPTION,
+            WriteStatementType.INSERT,
+            messageSubscription.messageSubscriptionKey(),
+            "io.camunda.db.rdbms.sql.MessageSubscriptionMapper.insert",
+            messageSubscription));
+  }
+
+  public void update(final MessageSubscriptionDbModel messageSubscription) {
+    executionQueue.executeInQueue(
+        new QueueItem(
+            ContextType.MESSAGE_SUBSCRIPTION,
+            WriteStatementType.UPDATE,
+            messageSubscription.messageSubscriptionKey(),
+            "io.camunda.db.rdbms.sql.MessageSubscriptionMapper.update",
+            messageSubscription));
+  }
+}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/RdbmsPurger.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/RdbmsPurger.java
@@ -33,6 +33,7 @@ public class RdbmsPurger {
           "USERS",
           "FORM",
           "MAPPING_RULES",
+          "MESSAGE_SUBSCRIPTION",
           "TENANT_MEMBER",
           "TENANT",
           "ROLE_MEMBER",

--- a/db/rdbms/src/main/resources/mapper/MessageSubscriptionMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/MessageSubscriptionMapper.xml
@@ -1,0 +1,182 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+  ~ Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+  ~ one or more contributor license agreements. See the NOTICE file distributed
+  ~ with this work for additional information regarding copyright ownership.
+  ~ Licensed under the Camunda License 1.0. You may not use this file
+  ~ except in compliance with the Camunda License 1.0.
+  -->
+<!DOCTYPE mapper
+  PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+  "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="io.camunda.db.rdbms.sql.MessageSubscriptionMapper">
+
+  <select id="count" resultType="java.lang.Long">
+    SELECT COUNT(*)
+    FROM ${prefix}MESSAGE_SUBSCRIPTION
+    <include refid="io.camunda.db.rdbms.sql.MessageSubscriptionMapper.searchFilter" />
+  </select>
+
+  <!-- default search statement for databases supporting LIMIT/OFFSET-->
+  <select id="search"
+    parameterType="io.camunda.db.rdbms.read.domain.MessageSubscriptionDbQuery"
+    resultMap="io.camunda.db.rdbms.sql.MessageSubscriptionMapper.searchResultMap">
+    SELECT * FROM (
+    SELECT
+    MESSAGE_SUBSCRIPTION_KEY,
+    PROCESS_DEFINITION_ID,
+    PROCESS_DEFINITION_KEY,
+    PROCESS_INSTANCE_KEY,
+    FLOW_NODE_ID,
+    FLOW_NODE_INSTANCE_KEY,
+    MESSAGE_SUBSCRIPTION_TYPE,
+    DATE_TIME,
+    MESSAGE_NAME,
+    CORRELATION_KEY,
+    TENANT_ID,
+    PARTITION_ID
+    FROM ${prefix}MESSAGE_SUBSCRIPTION
+
+    <include refid="io.camunda.db.rdbms.sql.MessageSubscriptionMapper.searchFilter" />
+    ) t
+    <include refid="io.camunda.db.rdbms.sql.Commons.keySetPageFilter" />
+    <include refid="io.camunda.db.rdbms.sql.Commons.orderBy" />
+    <include refid="io.camunda.db.rdbms.sql.Commons.paging" />
+  </select>
+
+  <sql id="searchFilter">
+    WHERE 1 = 1
+    <!-- basic filter -->
+    <if test="filter.messageSubscriptionKeyOperations != null and !filter.messageSubscriptionKeyOperations.isEmpty()">
+      <foreach collection="filter.messageSubscriptionKeyOperations" item="operation">
+        AND MESSAGE_SUBSCRIPTION_KEY
+        <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+      </foreach>
+    </if>
+    <if test="filter.processDefinitionIdOperations != null and !filter.processDefinitionIdOperations.isEmpty()">
+      <foreach collection="filter.processDefinitionIdOperations" item="operation">
+        AND PROCESS_DEFINITION_ID
+        <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+      </foreach>
+    </if>
+    <if test="filter.processDefinitionKeyOperations != null and !filter.processDefinitionKeyOperations.isEmpty()">
+      <foreach collection="filter.processDefinitionKeyOperations" item="operation">
+        AND PROCESS_DEFINITION_KEY
+        <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+      </foreach>
+    </if>
+    <if test="filter.processInstanceKeyOperations != null and !filter.processInstanceKeyOperations.isEmpty()">
+      <foreach collection="filter.processInstanceKeyOperations" item="operation">
+        AND PROCESS_INSTANCE_KEY
+        <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+      </foreach>
+    </if>
+    <if test="filter.flowNodeIdOperations != null and !filter.flowNodeIdOperations.isEmpty()">
+      <foreach collection="filter.flowNodeIdOperations" item="operation">
+        AND FLOW_NODE_ID
+        <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+      </foreach>
+    </if>
+    <if test="filter.flowNodeInstanceKeyOperations != null and !filter.flowNodeInstanceKeyOperations.isEmpty()">
+      <foreach collection="filter.flowNodeInstanceKeyOperations" item="operation">
+        AND FLOW_NODE_INSTANCE_KEY
+        <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+      </foreach>
+    </if>
+    <if test="filter.messageSubscriptionTypeOperations != null and !filter.messageSubscriptionTypeOperations.isEmpty()">
+      <foreach collection="filter.messageSubscriptionTypeOperations" item="operation">
+        AND MESSAGE_SUBSCRIPTION_TYPE
+        <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+      </foreach>
+    </if>
+    <if test="filter.dateTimeOperations != null and !filter.dateTimeOperations.isEmpty()">
+      <foreach collection="filter.dateTimeOperations" item="operation">
+        AND DATE_TIME
+        <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+      </foreach>
+    </if>
+    <if test="filter.messageNameOperations != null and !filter.messageNameOperations.isEmpty()">
+      <foreach collection="filter.messageNameOperations" item="operation">
+        AND MESSAGE_NAME
+        <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+      </foreach>
+    </if>
+    <if test="filter.correlationKeyOperations != null and !filter.correlationKeyOperations.isEmpty()">
+      <foreach collection="filter.correlationKeyOperations" item="operation">
+        AND CORRELATION_KEY
+        <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+      </foreach>
+    </if>
+    <if test="filter.tenantIdOperations != null and !filter.tenantIdOperations.isEmpty()">
+      <foreach collection="filter.tenantIdOperations" item="operation">
+        AND TENANT_ID
+        <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+      </foreach>
+    </if>
+  </sql>
+
+  <resultMap id="searchResultMap" type="io.camunda.db.rdbms.write.domain.MessageSubscriptionDbModel">
+    <constructor>
+      <idArg column="MESSAGE_SUBSCRIPTION_KEY" javaType="java.lang.Long" />
+    </constructor>
+    <result column="PROCESS_DEFINITION_ID" property="processDefinitionId" javaType="java.lang.String" />
+    <result column="PROCESS_DEFINITION_KEY" property="processDefinitionKey" javaType="java.lang.Long" />
+    <result column="PROCESS_INSTANCE_KEY" property="processInstanceKey" javaType="java.lang.Long" />
+    <result column="FLOW_NODE_ID" property="flowNodeId" javaType="java.lang.String" />
+    <result column="FLOW_NODE_INSTANCE_KEY" property="flowNodeInstanceKey" javaType="java.lang.Long" />
+    <result column="MESSAGE_SUBSCRIPTION_TYPE" property="messageSubscriptionType" javaType="io.camunda.search.entities.MessageSubscriptionEntity$MessageSubscriptionType" />
+    <result column="DATE_TIME" property="dateTime" javaType="java.time.OffsetDateTime" />
+    <result column="MESSAGE_NAME" property="messageName" javaType="java.lang.String" />
+    <result column="CORRELATION_KEY" property="correlationKey" javaType="java.lang.String" />
+    <result column="TENANT_ID" property="tenantId" javaType="java.lang.String" />
+    <result column="PARTITION_ID" property="partitionId" javaType="java.lang.Integer" />
+  </resultMap>
+
+
+  <insert id="insert" parameterType="io.camunda.db.rdbms.write.domain.MessageSubscriptionDbModel">
+    INSERT INTO ${prefix}MESSAGE_SUBSCRIPTION (
+                                               MESSAGE_SUBSCRIPTION_KEY,
+                                               PROCESS_DEFINITION_ID,
+                                               PROCESS_DEFINITION_KEY,
+                                               PROCESS_INSTANCE_KEY,
+                                               FLOW_NODE_ID,
+                                               FLOW_NODE_INSTANCE_KEY,
+                                               MESSAGE_SUBSCRIPTION_TYPE,
+                                               DATE_TIME,
+                                               MESSAGE_NAME,
+                                               CORRELATION_KEY,
+                                               TENANT_ID,
+                                               PARTITION_ID
+    )
+    VALUES (
+            #{messageSubscriptionKey},
+            #{processDefinitionId},
+            #{processDefinitionKey},
+            #{processInstanceKey},
+            #{flowNodeId},
+            #{flowNodeInstanceKey},
+            #{messageSubscriptionType},
+            #{dateTime, jdbcType=TIMESTAMP},
+            #{messageName},
+            #{correlationKey},
+            #{tenantId},
+            #{partitionId}
+    )
+  </insert>
+
+  <update id="update" parameterType="io.camunda.db.rdbms.write.domain.MessageSubscriptionDbModel">
+    UPDATE ${prefix}MESSAGE_SUBSCRIPTION
+    SET PROCESS_DEFINITION_ID = #{processDefinitionId},
+        PROCESS_DEFINITION_KEY =  #{processDefinitionKey},
+        PROCESS_INSTANCE_KEY = #{processInstanceKey},
+        FLOW_NODE_ID = #{flowNodeId},
+        FLOW_NODE_INSTANCE_KEY = #{flowNodeInstanceKey},
+        MESSAGE_SUBSCRIPTION_TYPE = #{messageSubscriptionType},
+        DATE_TIME = #{dateTime, jdbcType=TIMESTAMP},
+        MESSAGE_NAME = #{messageName},
+        CORRELATION_KEY = #{correlationKey},
+        TENANT_ID = #{tenantId}
+    WHERE MESSAGE_SUBSCRIPTION_KEY = #{messageSubscriptionKey}
+  </update>
+</mapper>

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/mapper/MessageSubscriptionEntityMapperTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/mapper/MessageSubscriptionEntityMapperTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.read.mapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.db.rdbms.write.domain.MessageSubscriptionDbModel;
+import io.camunda.search.entities.MessageSubscriptionEntity.MessageSubscriptionType;
+import java.time.OffsetDateTime;
+import org.junit.jupiter.api.Test;
+
+public class MessageSubscriptionEntityMapperTest {
+
+  @Test
+  public void testToEntity() {
+    // Given
+    final var model =
+        new MessageSubscriptionDbModel.Builder()
+            .messageSubscriptionKey(1L)
+            .processDefinitionId("processDefinitionId")
+            .processDefinitionKey(1L)
+            .processInstanceKey(1L)
+            .flowNodeId("flowNodeId")
+            .flowNodeInstanceKey(1L)
+            .messageSubscriptionType(MessageSubscriptionType.CORRELATED)
+            .dateTime(OffsetDateTime.now().plusDays(1))
+            .messageName("testMessageName")
+            .correlationKey("testCorrelationKey")
+            .tenantId("tenantId")
+            .build();
+
+    // When
+    final var entity = MessageSubscriptionEntityMapper.toEntity(model);
+
+    // Then
+    assertThat(entity).usingRecursiveComparison().isEqualTo(model);
+  }
+}

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/sql/columns/SearchColumnTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/sql/columns/SearchColumnTest.java
@@ -20,6 +20,7 @@ import io.camunda.search.entities.IncidentEntity.IncidentState;
 import io.camunda.search.entities.JobEntity.JobKind;
 import io.camunda.search.entities.JobEntity.JobState;
 import io.camunda.search.entities.JobEntity.ListenerEventType;
+import io.camunda.search.entities.MessageSubscriptionEntity.MessageSubscriptionType;
 import io.camunda.search.entities.ProcessInstanceEntity.ProcessInstanceState;
 import io.camunda.zeebe.util.collection.Tuple;
 import java.time.OffsetDateTime;
@@ -100,7 +101,12 @@ public class SearchColumnTest {
               ListenerEventType.class,
               List.of(
                   Tuple.of(ListenerEventType.START, ListenerEventType.START),
-                  Tuple.of(ListenerEventType.START, "START"))));
+                  Tuple.of(ListenerEventType.START, "START"))),
+          Map.entry(
+              MessageSubscriptionType.class,
+              List.of(
+                  Tuple.of(MessageSubscriptionType.CREATED, MessageSubscriptionType.CREATED),
+                  Tuple.of(MessageSubscriptionType.CREATED, "CREATED"))));
 
   private static List<Object[]> provideSearchColumns() {
     return SearchColumnUtils.findAll().stream()

--- a/dist/src/main/java/io/camunda/application/commons/rdbms/MyBatisConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/rdbms/MyBatisConfiguration.java
@@ -20,6 +20,7 @@ import io.camunda.db.rdbms.sql.GroupMapper;
 import io.camunda.db.rdbms.sql.IncidentMapper;
 import io.camunda.db.rdbms.sql.JobMapper;
 import io.camunda.db.rdbms.sql.MappingRuleMapper;
+import io.camunda.db.rdbms.sql.MessageSubscriptionMapper;
 import io.camunda.db.rdbms.sql.ProcessDefinitionMapper;
 import io.camunda.db.rdbms.sql.ProcessInstanceMapper;
 import io.camunda.db.rdbms.sql.PurgeMapper;
@@ -263,6 +264,12 @@ public class MyBatisConfiguration {
   public MapperFactoryBean<UsageMetricTUMapper> usageMetricTUMapper(
       final SqlSessionFactory sqlSessionFactory) {
     return createMapperFactoryBean(sqlSessionFactory, UsageMetricTUMapper.class);
+  }
+
+  @Bean
+  MapperFactoryBean<MessageSubscriptionMapper> messageSubscriptionMapper(
+      final SqlSessionFactory sqlSessionFactory) {
+    return createMapperFactoryBean(sqlSessionFactory, MessageSubscriptionMapper.class);
   }
 
   private <T> MapperFactoryBean<T> createMapperFactoryBean(

--- a/dist/src/main/java/io/camunda/application/commons/rdbms/RdbmsConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/rdbms/RdbmsConfiguration.java
@@ -50,6 +50,7 @@ import io.camunda.db.rdbms.sql.GroupMapper;
 import io.camunda.db.rdbms.sql.IncidentMapper;
 import io.camunda.db.rdbms.sql.JobMapper;
 import io.camunda.db.rdbms.sql.MappingRuleMapper;
+import io.camunda.db.rdbms.sql.MessageSubscriptionMapper;
 import io.camunda.db.rdbms.sql.ProcessDefinitionMapper;
 import io.camunda.db.rdbms.sql.ProcessInstanceMapper;
 import io.camunda.db.rdbms.sql.PurgeMapper;
@@ -189,8 +190,9 @@ public class RdbmsConfiguration {
   }
 
   @Bean
-  public MessageSubscriptionDbReader messageSubscriptionDbReader() {
-    return new MessageSubscriptionDbReader();
+  public MessageSubscriptionDbReader messageSubscriptionDbReader(
+      final MessageSubscriptionMapper messageSubscriptionMapper) {
+    return new MessageSubscriptionDbReader(messageSubscriptionMapper);
   }
 
   @Bean
@@ -248,7 +250,8 @@ public class RdbmsConfiguration {
       final SequenceFlowMapper sequenceFlowMapper,
       final UsageMetricMapper usageMetricMapper,
       final UsageMetricTUMapper usageMetricTUMapper,
-      final BatchOperationMapper batchOperationMapper) {
+      final BatchOperationMapper batchOperationMapper,
+      final MessageSubscriptionMapper messageSubscriptionMapper) {
     return new RdbmsWriterFactory(
         sqlSessionFactory,
         exporterPositionMapper,
@@ -266,7 +269,8 @@ public class RdbmsConfiguration {
         sequenceFlowMapper,
         usageMetricMapper,
         usageMetricTUMapper,
-        batchOperationMapper);
+        batchOperationMapper,
+        messageSubscriptionMapper);
   }
 
   @Bean
@@ -293,7 +297,8 @@ public class RdbmsConfiguration {
       final BatchOperationItemDbReader batchOperationItemReader,
       final JobDbReader jobReader,
       final UsageMetricsDbReader usageMetricReader,
-      final UsageMetricTUDbReader usageMetricTUDbReader) {
+      final UsageMetricTUDbReader usageMetricTUDbReader,
+      final MessageSubscriptionDbReader messageSubscriptionReader) {
     return new RdbmsService(
         rdbmsWriterFactory,
         authorizationReader,
@@ -317,6 +322,7 @@ public class RdbmsConfiguration {
         batchOperationItemReader,
         jobReader,
         usageMetricReader,
-        usageMetricTUDbReader);
+        usageMetricTUDbReader,
+        messageSubscriptionReader);
   }
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsExporterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsExporterIT.java
@@ -47,6 +47,7 @@ import io.camunda.zeebe.protocol.record.intent.AuthorizationIntent;
 import io.camunda.zeebe.protocol.record.intent.GroupIntent;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.protocol.record.intent.MappingRuleIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessMessageSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.RoleIntent;
 import io.camunda.zeebe.protocol.record.intent.TenantIntent;
 import io.camunda.zeebe.protocol.record.intent.UserIntent;
@@ -122,7 +123,7 @@ class RdbmsExporterIT {
     final var key =
         ((ProcessInstanceRecordValue) processInstanceRecord.getValue()).getProcessInstanceKey();
     final var processInstance = rdbmsService.getProcessInstanceReader().findOne(key);
-    assertThat(processInstance).isNotNull();
+    assertThat(processInstance).isNotEmpty();
 
     // given
     final var processInstanceCompletedRecord = getProcessInstanceCompletedRecord(1L, key);
@@ -148,7 +149,7 @@ class RdbmsExporterIT {
     final var key =
         ((ProcessInstanceRecordValue) rootProcessInstanceRecord.getValue()).getProcessInstanceKey();
     final var processInstance = rdbmsService.getProcessInstanceReader().findOne(key);
-    assertThat(processInstance).isNotNull();
+    assertThat(processInstance).isNotEmpty();
 
     // given
     final var rootProcessInstanceCompletedRecord =
@@ -225,7 +226,7 @@ class RdbmsExporterIT {
     final var key =
         ((ProcessInstanceRecordValue) processInstanceRecord.getValue()).getProcessInstanceKey();
     final var processInstance = rdbmsService.getProcessInstanceReader().findOne(key);
-    assertThat(processInstance).isNotNull();
+    assertThat(processInstance).isNotEmpty();
 
     final var variable = rdbmsService.getVariableReader().findOne(variableCreated.getKey());
     final VariableRecordValue variableRecordValue =
@@ -272,7 +273,7 @@ class RdbmsExporterIT {
     // then
     final var key = ((UserTaskRecordValue) userTaskRecord.getValue()).getUserTaskKey();
     final var userTask = rdbmsService.getUserTaskReader().findOne(key);
-    assertThat(userTask).isNotNull();
+    assertThat(userTask).isNotEmpty();
   }
 
   @Test
@@ -587,7 +588,27 @@ class RdbmsExporterIT {
     // then
     final var formKey = ((Form) formCreatedRecord.getValue()).getFormKey();
     final var formEntity = rdbmsService.getFormReader().findOne(formKey);
-    assertThat(formEntity).isNotNull();
+    assertThat(formEntity).isNotEmpty();
+  }
+
+  @Test
+  public void shouldExportMessageSubscription() {
+    // given
+    final var messageSubscriptionRecord =
+        ImmutableRecord.builder()
+            .from(RecordFixtures.FACTORY.generateRecord(ValueType.PROCESS_MESSAGE_SUBSCRIPTION))
+            .withIntent(ProcessMessageSubscriptionIntent.CREATED)
+            .withPosition(2L)
+            .withTimestamp(System.currentTimeMillis())
+            .build();
+
+    // when
+    exporter.export(messageSubscriptionRecord);
+
+    // then
+    final var messageSubscription =
+        rdbmsService.getMessageSubscriptionReader().findOne(messageSubscriptionRecord.getKey());
+    assertThat(messageSubscription).isNotEmpty();
   }
 
   @Test
@@ -602,7 +623,7 @@ class RdbmsExporterIT {
     final var mappingRuleId =
         ((MappingRuleRecordValue) mappingRuleCreatedRecord.getValue()).getMappingRuleId();
     final var mappingRule = rdbmsService.getMappingRuleReader().findOne(mappingRuleId);
-    assertThat(mappingRule).isNotNull();
+    assertThat(mappingRule).isNotEmpty();
 
     // given
     final var mappingDeletedRecord = mappingRuleCreatedRecord.withIntent(MappingRuleIntent.DELETED);

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporterWrapper.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporterWrapper.java
@@ -21,6 +21,7 @@ import io.camunda.exporter.rdbms.handlers.GroupExportHandler;
 import io.camunda.exporter.rdbms.handlers.IncidentExportHandler;
 import io.camunda.exporter.rdbms.handlers.JobExportHandler;
 import io.camunda.exporter.rdbms.handlers.MappingRuleExportHandler;
+import io.camunda.exporter.rdbms.handlers.MessageSubscriptionExportHandler;
 import io.camunda.exporter.rdbms.handlers.ProcessExportHandler;
 import io.camunda.exporter.rdbms.handlers.ProcessInstanceExportHandler;
 import io.camunda.exporter.rdbms.handlers.ProcessInstanceIncidentExportHandler;
@@ -180,6 +181,9 @@ public class RdbmsExporterWrapper implements Exporter {
         ValueType.USAGE_METRIC,
         new UsageMetricExportHandler(
             rdbmsWriter.getUsageMetricWriter(), rdbmsWriter.getUsageMetricTUWriter()));
+    builder.withHandler(
+        ValueType.PROCESS_MESSAGE_SUBSCRIPTION,
+        new MessageSubscriptionExportHandler(rdbmsWriter.getMessageSubscriptionWriter()));
   }
 
   private void createBatchOperationHandlers(

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/MessageSubscriptionExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/MessageSubscriptionExportHandler.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.rdbms.handlers;
+
+import static io.camunda.exporter.rdbms.utils.DateUtil.toOffsetDateTime;
+
+import io.camunda.db.rdbms.write.domain.MessageSubscriptionDbModel;
+import io.camunda.db.rdbms.write.service.MessageSubscriptionWriter;
+import io.camunda.exporter.rdbms.RdbmsExportHandler;
+import io.camunda.search.entities.MessageSubscriptionEntity.MessageSubscriptionType;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.Intent;
+import io.camunda.zeebe.protocol.record.intent.ProcessMessageSubscriptionIntent;
+import io.camunda.zeebe.protocol.record.value.ProcessMessageSubscriptionRecordValue;
+import java.time.Instant;
+import java.util.Set;
+
+public class MessageSubscriptionExportHandler
+    implements RdbmsExportHandler<ProcessMessageSubscriptionRecordValue> {
+
+  // TODO: We could also export CORRELATED, but we don't do that for ES/OS.
+  private static final Set<Intent> STATES =
+      Set.of(ProcessMessageSubscriptionIntent.CREATED, ProcessMessageSubscriptionIntent.MIGRATED);
+  private final MessageSubscriptionWriter messageSubscriptionWriter;
+
+  public MessageSubscriptionExportHandler(
+      final MessageSubscriptionWriter messageSubscriptionWriter) {
+    this.messageSubscriptionWriter = messageSubscriptionWriter;
+  }
+
+  @Override
+  public boolean canExport(final Record<ProcessMessageSubscriptionRecordValue> record) {
+    return STATES.contains(record.getIntent());
+  }
+
+  @Override
+  public void export(final Record<ProcessMessageSubscriptionRecordValue> record) {
+    if (record.getIntent() == ProcessMessageSubscriptionIntent.CREATED) {
+      messageSubscriptionWriter.create(map(record));
+    } else if (record.getIntent() == ProcessMessageSubscriptionIntent.MIGRATED) {
+      messageSubscriptionWriter.update(map(record));
+    }
+  }
+
+  private MessageSubscriptionDbModel map(
+      final Record<ProcessMessageSubscriptionRecordValue> record) {
+    final ProcessMessageSubscriptionRecordValue value = record.getValue();
+    return new MessageSubscriptionDbModel.Builder()
+        .messageSubscriptionKey(record.getKey())
+        .processDefinitionId(value.getBpmnProcessId())
+        .processDefinitionKey(null) // TODO: Check if we need this
+        .processInstanceKey(value.getProcessInstanceKey())
+        .flowNodeId(value.getElementId())
+        .flowNodeInstanceKey(value.getElementInstanceKey())
+        .messageSubscriptionType(MessageSubscriptionType.valueOf(record.getIntent().name()))
+        .dateTime(toOffsetDateTime(Instant.ofEpochMilli(record.getTimestamp())))
+        .messageName(value.getMessageName())
+        .correlationKey(value.getCorrelationKey())
+        .tenantId(value.getTenantId())
+        .partitionId(record.getPartitionId())
+        .build();
+  }
+}


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Introduces the RDBMS exporter for message subscriptions.

This PR also adds some basic search functionality to support an integration test.

Further acceptance tests that cover searching with RDBMS will be added in the next PR.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

Relates to https://github.com/camunda/camunda/issues/34445
