### PR TITLE
feat: adding hasStartForm to process-definition

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/ProcessDefinitionFilter.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/ProcessDefinitionFilter.java
@@ -85,8 +85,8 @@ public interface ProcessDefinitionFilter extends SearchRequestFilter {
   /**
    * Filters process definitions by having or not a form to start the process
    *
-   * @param formKey boolean to indicate how to filter
+   * @param hasStartForm boolean to indicate how to filter
    * @return the updated filter
    */
-  ProcessDefinitionFilter hasStartForm(final boolean formKey);
+  ProcessDefinitionFilter hasStartForm(final boolean hasStartForm);
 }

--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/ProcessDefinitionFilter.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/ProcessDefinitionFilter.java
@@ -81,4 +81,12 @@ public interface ProcessDefinitionFilter extends SearchRequestFilter {
    * @return the updated filter
    */
   ProcessDefinitionFilter tenantId(final String tenantId);
+
+  /**
+   * Filters process definitions by having or not a form to start the process
+   *
+   * @param formKey boolean to indicate how to filter
+   * @return the updated filter
+   */
+  ProcessDefinitionFilter hasFormKey(final boolean formKey);
 }

--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/ProcessDefinitionFilter.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/ProcessDefinitionFilter.java
@@ -88,5 +88,5 @@ public interface ProcessDefinitionFilter extends SearchRequestFilter {
    * @param formKey boolean to indicate how to filter
    * @return the updated filter
    */
-  ProcessDefinitionFilter hasFormKey(final boolean formKey);
+  ProcessDefinitionFilter hasStartForm(final boolean formKey);
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/ProcessDefinitionFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/ProcessDefinitionFilterImpl.java
@@ -79,6 +79,12 @@ public class ProcessDefinitionFilterImpl
     return this;
   }
 
+  @Override
+  public ProcessDefinitionFilter hasStartForm(final boolean formKey) {
+    filter.hasStartForm(formKey);
+    return this;
+  }
+
   public ProcessDefinitionFilter name(final Consumer<StringProperty> fn) {
     final StringProperty property = new StringPropertyImpl();
     fn.accept(property);
@@ -90,12 +96,6 @@ public class ProcessDefinitionFilterImpl
     final StringProperty property = new StringPropertyImpl();
     fn.accept(property);
     filter.setProcessDefinitionId(provideSearchRequestProperty(property));
-    return this;
-  }
-
-  @Override
-  public ProcessDefinitionFilter hasFormKey(final boolean formKey) {
-    filter.hasFormKey(formKey);
     return this;
   }
 

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/ProcessDefinitionFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/ProcessDefinitionFilterImpl.java
@@ -94,6 +94,12 @@ public class ProcessDefinitionFilterImpl
   }
 
   @Override
+  public ProcessDefinitionFilter hasFormKey(final boolean formKey) {
+    filter.hasFormKey(formKey);
+    return this;
+  }
+
+  @Override
   protected io.camunda.client.protocol.rest.ProcessDefinitionFilter getSearchRequestProperty() {
     return filter;
   }

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/ProcessDefinitionFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/ProcessDefinitionFilterImpl.java
@@ -80,8 +80,8 @@ public class ProcessDefinitionFilterImpl
   }
 
   @Override
-  public ProcessDefinitionFilter hasStartForm(final boolean formKey) {
-    filter.hasStartForm(formKey);
+  public ProcessDefinitionFilter hasStartForm(final boolean hasStartForm) {
+    filter.hasStartForm(hasStartForm);
     return this;
   }
 

--- a/db/rdbms/src/main/resources/mapper/ProcessDefinitionMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/ProcessDefinitionMapper.xml
@@ -94,11 +94,11 @@
         #{value}
       </foreach>
     </if>
-    <if test="filter.hasFormKey != null">
-      <if test="filter.hasFormKey == true">
+    <if test="filter.hasStartForm != null">
+      <if test="filter.hasStartForm == true">
         AND FORM_ID IS NOT NULL
       </if>
-      <if test="filter.hasFormKey == false">
+      <if test="filter.hasStartForm == false">
         AND FORM_ID IS NULL
       </if>
     </if>

--- a/db/rdbms/src/main/resources/mapper/ProcessDefinitionMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/ProcessDefinitionMapper.xml
@@ -94,6 +94,14 @@
         #{value}
       </foreach>
     </if>
+    <if test="filter.hasFormKey != null">
+      <if test="filter.hasFormKey == true">
+        AND FORM_ID IS NOT NULL
+      </if>
+      <if test="filter.hasFormKey == false">
+        AND FORM_ID IS NULL
+      </if>
+    </if>
   </sql>
 
   <resultMap id="searchResultMap" type="io.camunda.search.entities.ProcessDefinitionEntity">

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/ProcessDefinitionFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/ProcessDefinitionFilterTransformer.java
@@ -13,7 +13,6 @@ import static io.camunda.search.clients.query.SearchQueryBuilders.intTerms;
 import static io.camunda.search.clients.query.SearchQueryBuilders.longTerms;
 import static io.camunda.search.clients.query.SearchQueryBuilders.stringOperations;
 import static io.camunda.search.clients.query.SearchQueryBuilders.stringTerms;
-import static io.camunda.search.clients.query.SearchQueryBuilders.term;
 import static io.camunda.webapps.schema.descriptors.IndexDescriptor.TENANT_ID;
 import static io.camunda.webapps.schema.descriptors.index.ProcessIndex.BPMN_PROCESS_ID;
 import static io.camunda.webapps.schema.descriptors.index.ProcessIndex.FORM_ID;
@@ -67,13 +66,14 @@ public class ProcessDefinitionFilterTransformer
   private SearchQuery getHasStartFormQuery(final Boolean hasStartForm) {
     if (hasStartForm != null) {
       return bool(b -> {
-        if (hasStartForm) {
-          b.must(List.of(SearchQueryBuilders.exists(FORM_ID)));
-        } else {
-          b.mustNot(List.of(SearchQueryBuilders.exists(FORM_ID)));
-        }
-        return b;
-      }).toSearchQuery();
+            if (hasStartForm) {
+              b.must(List.of(SearchQueryBuilders.exists(FORM_ID)));
+            } else {
+              b.mustNot(List.of(SearchQueryBuilders.exists(FORM_ID)));
+            }
+            return b;
+          })
+          .toSearchQuery();
     }
     return null;
   }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/ProcessDefinitionFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/ProcessDefinitionFilterTransformer.java
@@ -17,7 +17,6 @@ import static io.camunda.search.clients.query.SearchQueryBuilders.term;
 import static io.camunda.webapps.schema.descriptors.IndexDescriptor.TENANT_ID;
 import static io.camunda.webapps.schema.descriptors.index.ProcessIndex.BPMN_PROCESS_ID;
 import static io.camunda.webapps.schema.descriptors.index.ProcessIndex.FORM_ID;
-import static io.camunda.webapps.schema.descriptors.index.ProcessIndex.FORM_KEY;
 import static io.camunda.webapps.schema.descriptors.index.ProcessIndex.KEY;
 import static io.camunda.webapps.schema.descriptors.index.ProcessIndex.NAME;
 import static io.camunda.webapps.schema.descriptors.index.ProcessIndex.RESOURCE_NAME;
@@ -25,7 +24,6 @@ import static io.camunda.webapps.schema.descriptors.index.ProcessIndex.VERSION;
 import static io.camunda.webapps.schema.descriptors.index.ProcessIndex.VERSION_TAG;
 import static java.util.Optional.ofNullable;
 
-import io.camunda.search.clients.query.SearchBoolQuery;
 import io.camunda.search.clients.query.SearchQuery;
 import io.camunda.search.clients.query.SearchQueryBuilders;
 import io.camunda.search.filter.Operation;
@@ -53,7 +51,7 @@ public class ProcessDefinitionFilterTransformer
     ofNullable(intTerms(VERSION, filter.versions())).ifPresent(queries::add);
     ofNullable(stringTerms(VERSION_TAG, filter.versionTags())).ifPresent(queries::add);
     ofNullable(stringTerms(TENANT_ID, filter.tenantIds())).ifPresent(queries::add);
-    ofNullable(getFormKeyQuery(filter.hasFormKey())).ifPresent(queries::add);
+    ofNullable(getHasStartFormQuery(filter.hasStartForm())).ifPresent(queries::add);
     return and(queries);
   }
 
@@ -66,10 +64,10 @@ public class ProcessDefinitionFilterTransformer
     return stringOperations(BPMN_PROCESS_ID, processDefinitionIds);
   }
 
-  private SearchQuery getFormKeyQuery(final Boolean hasFormKey) {
-    if (hasFormKey != null) {
+  private SearchQuery getHasStartFormQuery(final Boolean hasStartForm) {
+    if (hasStartForm != null) {
       return bool(b -> {
-        if (hasFormKey) {
+        if (hasStartForm) {
           b.must(List.of(SearchQueryBuilders.exists(FORM_ID)));
         } else {
           b.mustNot(List.of(SearchQueryBuilders.exists(FORM_ID)));

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/ProcessDefinitionFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/ProcessDefinitionFilterTransformer.java
@@ -12,8 +12,11 @@ import static io.camunda.search.clients.query.SearchQueryBuilders.intTerms;
 import static io.camunda.search.clients.query.SearchQueryBuilders.longTerms;
 import static io.camunda.search.clients.query.SearchQueryBuilders.stringOperations;
 import static io.camunda.search.clients.query.SearchQueryBuilders.stringTerms;
+import static io.camunda.search.clients.query.SearchQueryBuilders.term;
 import static io.camunda.webapps.schema.descriptors.IndexDescriptor.TENANT_ID;
 import static io.camunda.webapps.schema.descriptors.index.ProcessIndex.BPMN_PROCESS_ID;
+import static io.camunda.webapps.schema.descriptors.index.ProcessIndex.FORM_ID;
+import static io.camunda.webapps.schema.descriptors.index.ProcessIndex.FORM_KEY;
 import static io.camunda.webapps.schema.descriptors.index.ProcessIndex.KEY;
 import static io.camunda.webapps.schema.descriptors.index.ProcessIndex.NAME;
 import static io.camunda.webapps.schema.descriptors.index.ProcessIndex.RESOURCE_NAME;
@@ -40,6 +43,7 @@ public class ProcessDefinitionFilterTransformer
   public SearchQuery toSearchQuery(final ProcessDefinitionFilter filter) {
     final var queries = new ArrayList<SearchQuery>();
     ofNullable(longTerms(KEY, filter.processDefinitionKeys())).ifPresent(queries::add);
+
     ofNullable(getNamesQuery(filter.nameOperations())).ifPresent(queries::addAll);
     ofNullable(getProcessDefinitionIdsQuery(filter.processDefinitionIdOperations()))
         .ifPresent(queries::addAll);
@@ -47,7 +51,7 @@ public class ProcessDefinitionFilterTransformer
     ofNullable(intTerms(VERSION, filter.versions())).ifPresent(queries::add);
     ofNullable(stringTerms(VERSION_TAG, filter.versionTags())).ifPresent(queries::add);
     ofNullable(stringTerms(TENANT_ID, filter.tenantIds())).ifPresent(queries::add);
-
+    ofNullable(getFormKeyQuery(filter.hasFormKey())).ifPresent(queries::add);
     return and(queries);
   }
 
@@ -58,6 +62,13 @@ public class ProcessDefinitionFilterTransformer
   private List<SearchQuery> getProcessDefinitionIdsQuery(
       final List<Operation<String>> processDefinitionIds) {
     return stringOperations(BPMN_PROCESS_ID, processDefinitionIds);
+  }
+
+  private SearchQuery getFormKeyQuery(final Boolean hasFormKey) {
+    if (hasFormKey != null) {
+      return term(FORM_KEY, hasFormKey);
+    }
+    return null;
   }
 
   @Override

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/ProcessDefinitionQueryTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/ProcessDefinitionQueryTransformerTest.java
@@ -103,8 +103,8 @@ public final class ProcessDefinitionQueryTransformerTest extends AbstractTransfo
 
   @ParameterizedTest
   @ValueSource(booleans = {true, false})
-  public void shouldQueryByHasFormKey(final boolean hasFormKey) {
-    final var filter = FilterBuilders.processDefinition(f -> f.hasFormKey(hasFormKey));
+  public void shouldQueryByHasStartForm(final boolean hasStartForm) {
+    final var filter = FilterBuilders.processDefinition(f -> f.hasStartForm(hasStartForm));
 
     // when
     final var searchRequest = transformQuery(filter);
@@ -115,8 +115,8 @@ public final class ProcessDefinitionQueryTransformerTest extends AbstractTransfo
     // then
     assertThat(searchRequest.queryOption())
         .isInstanceOfSatisfying(SearchBoolQuery.class, boolQuery -> {
-          final var innerQuery = hasFormKey ? boolQuery.must().get(0).queryOption() : boolQuery.mustNot().get(0).queryOption();
-          final var boolQueryMustOrNot = hasFormKey ? boolQuery.must() : boolQuery.mustNot();
+          final var innerQuery = hasStartForm ? boolQuery.must().get(0).queryOption() : boolQuery.mustNot().get(0).queryOption();
+          final var boolQueryMustOrNot = hasStartForm ? boolQuery.must() : boolQuery.mustNot();
 
           assertThat(boolQueryMustOrNot)
               .hasSize(1);

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/ProcessDefinitionQueryTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/ProcessDefinitionQueryTransformerTest.java
@@ -114,20 +114,22 @@ public final class ProcessDefinitionQueryTransformerTest extends AbstractTransfo
 
     // then
     assertThat(searchRequest.queryOption())
-        .isInstanceOfSatisfying(SearchBoolQuery.class, boolQuery -> {
-          final var innerQuery = hasStartForm ? boolQuery.must().get(0).queryOption() : boolQuery.mustNot().get(0).queryOption();
-          final var boolQueryMustOrNot = hasStartForm ? boolQuery.must() : boolQuery.mustNot();
+        .isInstanceOfSatisfying(
+            SearchBoolQuery.class,
+            boolQuery -> {
+              final var innerQuery =
+                  hasStartForm
+                      ? boolQuery.must().get(0).queryOption()
+                      : boolQuery.mustNot().get(0).queryOption();
+              final var boolQueryMustOrNot = hasStartForm ? boolQuery.must() : boolQuery.mustNot();
 
-          assertThat(boolQueryMustOrNot)
-              .hasSize(1);
+              assertThat(boolQueryMustOrNot).hasSize(1);
 
-          assertThat(innerQuery)
-              .isInstanceOf(SearchExistsQuery.class);
+              assertThat(innerQuery).isInstanceOf(SearchExistsQuery.class);
 
-          final var existsQuery = (SearchExistsQuery) innerQuery;
-          assertThat(existsQuery.field())
-              .isEqualTo("formId");
-        });
+              final var existsQuery = (SearchExistsQuery) innerQuery;
+              assertThat(existsQuery.field()).isEqualTo("formId");
+            });
   }
 
   @Test

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/ProcessDefinitionQueryTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/ProcessDefinitionQueryTransformerTest.java
@@ -110,18 +110,13 @@ public final class ProcessDefinitionQueryTransformerTest extends AbstractTransfo
     final var searchRequest = transformQuery(filter);
 
     // then
-    final var queryVariant = searchRequest.queryOption();
-
-    // then
     assertThat(searchRequest.queryOption())
         .isInstanceOfSatisfying(
             SearchBoolQuery.class,
             boolQuery -> {
-              final var innerQuery =
-                  hasStartForm
-                      ? boolQuery.must().get(0).queryOption()
-                      : boolQuery.mustNot().get(0).queryOption();
               final var boolQueryMustOrNot = hasStartForm ? boolQuery.must() : boolQuery.mustNot();
+              assertThat(boolQueryMustOrNot).hasSize(1);
+              final var innerQuery = boolQueryMustOrNot.get(0).queryOption();
 
               assertThat(boolQueryMustOrNot).hasSize(1);
 

--- a/search/search-domain/src/main/java/io/camunda/search/filter/ProcessDefinitionFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/ProcessDefinitionFilter.java
@@ -24,7 +24,8 @@ public record ProcessDefinitionFilter(
     List<String> resourceNames,
     List<Integer> versions,
     List<String> versionTags,
-    List<String> tenantIds)
+    List<String> tenantIds,
+    Boolean hasFormKey)
     implements FilterBase {
 
   public static final class Builder implements ObjectBuilder<ProcessDefinitionFilter> {
@@ -37,6 +38,7 @@ public record ProcessDefinitionFilter(
     private List<String> resourceNames;
     private List<Integer> versions;
     private List<String> versionTags;
+    private Boolean hasFormKey;
 
     public Builder processDefinitionKeys(final List<Long> values) {
       processDefinitionKeys = addValuesToList(processDefinitionKeys, values);
@@ -119,6 +121,11 @@ public record ProcessDefinitionFilter(
       return this;
     }
 
+    public Builder hasFormKey(final Boolean hasFormKey){
+      this.hasFormKey = hasFormKey;
+      return this;
+    }
+
     @Override
     public ProcessDefinitionFilter build() {
       return new ProcessDefinitionFilter(
@@ -129,7 +136,10 @@ public record ProcessDefinitionFilter(
           Objects.requireNonNullElse(resourceNames, Collections.emptyList()),
           Objects.requireNonNullElse(versions, Collections.emptyList()),
           Objects.requireNonNullElse(versionTags, Collections.emptyList()),
-          Objects.requireNonNullElse(tenantIds, Collections.emptyList()));
+          Objects.requireNonNullElse(tenantIds, Collections.emptyList()),
+          hasFormKey);
     }
+
+
   }
 }

--- a/search/search-domain/src/main/java/io/camunda/search/filter/ProcessDefinitionFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/ProcessDefinitionFilter.java
@@ -25,7 +25,7 @@ public record ProcessDefinitionFilter(
     List<Integer> versions,
     List<String> versionTags,
     List<String> tenantIds,
-    Boolean hasFormKey)
+    Boolean hasStartForm)
     implements FilterBase {
 
   public static final class Builder implements ObjectBuilder<ProcessDefinitionFilter> {
@@ -38,7 +38,7 @@ public record ProcessDefinitionFilter(
     private List<String> resourceNames;
     private List<Integer> versions;
     private List<String> versionTags;
-    private Boolean hasFormKey;
+    private Boolean hasStartForm;
 
     public Builder processDefinitionKeys(final List<Long> values) {
       processDefinitionKeys = addValuesToList(processDefinitionKeys, values);
@@ -121,8 +121,8 @@ public record ProcessDefinitionFilter(
       return this;
     }
 
-    public Builder hasFormKey(final Boolean hasFormKey){
-      this.hasFormKey = hasFormKey;
+    public Builder hasStartForm(final Boolean hasStartForm){
+      this.hasStartForm = hasStartForm;
       return this;
     }
 
@@ -137,7 +137,7 @@ public record ProcessDefinitionFilter(
           Objects.requireNonNullElse(versions, Collections.emptyList()),
           Objects.requireNonNullElse(versionTags, Collections.emptyList()),
           Objects.requireNonNullElse(tenantIds, Collections.emptyList()),
-          hasFormKey);
+          hasStartForm);
     }
 
 

--- a/search/search-domain/src/main/java/io/camunda/search/filter/ProcessDefinitionFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/ProcessDefinitionFilter.java
@@ -121,7 +121,7 @@ public record ProcessDefinitionFilter(
       return this;
     }
 
-    public Builder hasStartForm(final Boolean hasStartForm){
+    public Builder hasStartForm(final Boolean hasStartForm) {
       this.hasStartForm = hasStartForm;
       return this;
     }
@@ -139,7 +139,5 @@ public record ProcessDefinitionFilter(
           Objects.requireNonNullElse(tenantIds, Collections.emptyList()),
           hasStartForm);
     }
-
-
   }
 }

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -5994,7 +5994,7 @@ components:
         processDefinitionKey:
           description: The key for this process definition.
           type: string
-        hasFormKey:
+        hasStartForm:
           description: Indicates whether the start event of the process has an associated Form Key.
           type: boolean
     ProcessDefinitionSearchQueryResult:
@@ -6032,7 +6032,7 @@ components:
         processDefinitionKey:
           description: The key for this process definition.
           type: string
-        hasFormKey:
+        hasStartForm:
           description: Indicates whether the start event of the process has an associated Form Key.
           type: boolean
     ProcessInstanceSearchQuerySortRequest:

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -5994,6 +5994,9 @@ components:
         processDefinitionKey:
           description: The key for this process definition.
           type: string
+        hasFormKey:
+          description: Indicates whether the start event of the process has an associated Form Key.
+          type: boolean
     ProcessDefinitionSearchQueryResult:
       type: object
       allOf:
@@ -6029,6 +6032,9 @@ components:
         processDefinitionKey:
           description: The key for this process definition.
           type: string
+        hasFormKey:
+          description: Indicates whether the start event of the process has an associated Form Key.
+          type: boolean
     ProcessInstanceSearchQuerySortRequest:
       type: object
       properties:

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
@@ -942,7 +942,7 @@ public final class SearchQueryRequestMapper {
                   .map(mapToOperations(String.class))
                   .ifPresent(builder::processDefinitionIdOperations);
               Optional.ofNullable(f.getTenantId()).ifPresent(builder::tenantIds);
-              Optional.ofNullable(f.getHasFormKey()).ifPresent(builder::hasFormKey);
+              Optional.ofNullable(f.getHasStartForm()).ifPresent(builder::hasStartForm);
             });
     return builder.build();
   }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
@@ -942,6 +942,7 @@ public final class SearchQueryRequestMapper {
                   .map(mapToOperations(String.class))
                   .ifPresent(builder::processDefinitionIdOperations);
               Optional.ofNullable(f.getTenantId()).ifPresent(builder::tenantIds);
+              Optional.ofNullable(f.getHasFormKey()).ifPresent(builder::hasFormKey);
             });
     return builder.build();
   }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
@@ -132,6 +132,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.stream.Collectors;
+import org.apache.commons.lang3.StringUtils;
 
 public final class SearchQueryResponseMapper {
 
@@ -502,7 +503,8 @@ public final class SearchQueryResponseMapper {
         .version(entity.version())
         .versionTag(entity.versionTag())
         .processDefinitionId(entity.processDefinitionId())
-        .tenantId(entity.tenantId());
+        .tenantId(entity.tenantId())
+        .hasFormKey(StringUtils.isNotBlank(entity.formId()));
   }
 
   private static List<ProcessInstanceResult> toProcessInstances(

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
@@ -504,7 +504,7 @@ public final class SearchQueryResponseMapper {
         .versionTag(entity.versionTag())
         .processDefinitionId(entity.processDefinitionId())
         .tenantId(entity.tenantId())
-        .hasFormKey(StringUtils.isNotBlank(entity.formId()));
+        .hasStartForm(StringUtils.isNotBlank(entity.formId()));
   }
 
   private static List<ProcessInstanceResult> toProcessInstances(

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessDefinitionQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessDefinitionQueryControllerTest.java
@@ -70,7 +70,7 @@ public class ProcessDefinitionQueryControllerTest extends RestControllerTest {
           "version": 5,
           "versionTag": "alpha",
           "tenantId": "<default>",
-          "hasFormKey": true
+          "hasStartForm": true
       }""";
   static final String EXPECTED_SEARCH_RESPONSE =
       """
@@ -84,7 +84,7 @@ public class ProcessDefinitionQueryControllerTest extends RestControllerTest {
                   "version": 5,
                   "versionTag": "alpha",
                   "tenantId": "<default>",
-                  "hasFormKey": true
+                  "hasStartForm": true
               }
           ],
           "page": {

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessDefinitionQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessDefinitionQueryControllerTest.java
@@ -69,7 +69,8 @@ public class ProcessDefinitionQueryControllerTest extends RestControllerTest {
           "resourceName": "complexProcess.bpmn",
           "version": 5,
           "versionTag": "alpha",
-          "tenantId": "<default>"
+          "tenantId": "<default>",
+          "hasFormKey": true
       }""";
   static final String EXPECTED_SEARCH_RESPONSE =
       """
@@ -82,7 +83,8 @@ public class ProcessDefinitionQueryControllerTest extends RestControllerTest {
                   "resourceName": "complexProcess.bpmn",
                   "version": 5,
                   "versionTag": "alpha",
-                  "tenantId": "<default>"
+                  "tenantId": "<default>",
+                  "hasFormKey": true
               }
           ],
           "page": {
@@ -492,7 +494,7 @@ public class ProcessDefinitionQueryControllerTest extends RestControllerTest {
 
   @ParameterizedTest
   @MethodSource("provideAdvancedSearchParameters")
-  void shouldSearchTasksWithAdvancedFilter(
+  void shouldSearchProcessWithAdvancedFilter(
       final String filterString, final ProcessDefinitionFilter filter) {
     // given
     final var request =
@@ -522,4 +524,5 @@ public class ProcessDefinitionQueryControllerTest extends RestControllerTest {
     verify(processDefinitionServices)
         .search(new ProcessDefinitionQuery.Builder().filter(filter).build());
   }
+
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessDefinitionQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessDefinitionQueryControllerTest.java
@@ -524,5 +524,4 @@ public class ProcessDefinitionQueryControllerTest extends RestControllerTest {
     verify(processDefinitionServices)
         .search(new ProcessDefinitionQuery.Builder().filter(filter).build());
   }
-
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
This PR adds a new property as part of the ProcessDefinition Query Response and also a new Filter allowing to filter processes that have or not Forms on the start event.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #31048 
