### PR TITLE
feat: expand Identity JwtDecoder with wider list of algorithms and JWT types

### DIFF
--- a/authentication/pom.xml
+++ b/authentication/pom.xml
@@ -121,6 +121,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.wiremock</groupId>
+      <artifactId>wiremock-standalone</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-oauth2-client</artifactId>
       <exclusions>
@@ -137,6 +142,10 @@
     <dependency>
       <groupId>com.nimbusds</groupId>
       <artifactId>oauth2-oidc-sdk</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.nimbusds</groupId>
+      <artifactId>nimbus-jose-jwt</artifactId>
     </dependency>
     <dependency>
       <groupId>io.camunda</groupId>

--- a/authentication/src/test/java/io/camunda/authentication/config/JwtDecoderTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/JwtDecoderTest.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.config;
+
+import static com.nimbusds.jose.JOSEObjectType.JWT;
+import static io.camunda.authentication.config.WebSecurityConfig.AT_JWT;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.fail;
+
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import com.github.tomakehurst.wiremock.matching.RequestPatternBuilder;
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JOSEObjectType;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSAlgorithm.Family;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.JWSSigner;
+import com.nimbusds.jose.crypto.ECDSASigner;
+import com.nimbusds.jose.crypto.RSASSASigner;
+import com.nimbusds.jose.jwk.Curve;
+import com.nimbusds.jose.jwk.ECKey;
+import com.nimbusds.jose.jwk.JWK;
+import com.nimbusds.jose.jwk.KeyUse;
+import com.nimbusds.jose.jwk.RSAKey;
+import com.nimbusds.jose.jwk.gen.ECKeyGenerator;
+import com.nimbusds.jose.jwk.gen.RSAKeyGenerator;
+import com.nimbusds.jwt.JWTClaimsSet.Builder;
+import com.nimbusds.jwt.SignedJWT;
+import io.camunda.authentication.config.controllers.WebSecurityConfigTestContext;
+import io.camunda.authentication.config.controllers.WebSecurityOidcTestContext;
+import java.util.Date;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+
+@SuppressWarnings("SpringBootApplicationProperties")
+@SpringBootTest(
+    classes = {
+      WebSecurityConfigTestContext.class,
+      WebSecurityOidcTestContext.class,
+      WebSecurityConfig.class
+    },
+    properties = {
+      "camunda.security.authentication.unprotected-api=false",
+      "camunda.security.authentication.method=oidc",
+      "camunda.security.authentication.oidc.client-id=example",
+      "camunda.security.authentication.oidc.redirect-uri=redirect.example.com",
+      "camunda.security.authentication.oidc.authorization-uri=authorization.example.com",
+      "camunda.security.authentication.oidc.token-uri=token.example.com",
+    })
+public class JwtDecoderTest extends AbstractWebSecurityConfigTest {
+
+  @RegisterExtension
+  static WireMockExtension wireMock =
+      WireMockExtension.newInstance().configureStaticDsl(true).build();
+
+  @Autowired private JwtDecoder decoder;
+
+  @DynamicPropertySource
+  static void registerWireMockProperties(final DynamicPropertyRegistry registry) {
+    registry.add(
+        "camunda.security.authentication.oidc.jwk-set-uri",
+        () -> "http://localhost:" + wireMock.getPort() + "/protocol/openid-connect/certs");
+  }
+
+  @ParameterizedTest
+  @MethodSource("basicAlgTestParameters")
+  public void testDecodeJwtWithNoAlgFieldInJwkResponse(
+      final JWSAlgorithm algorithm, final Curve curve) throws JOSEException {
+    final JwtKeys jwtKeys = new JwtKeys(algorithm, curve, JWT);
+
+    // remove alg field from mocked server response and assert it was removed to cover this use case
+    final String withoutAlg = jwtKeys.publicKey.replaceFirst(",\"alg\":\"[^\"]*\"", "");
+    final String authServerResponseBody = "{\"keys\":[" + withoutAlg + "]}";
+    assertThat(authServerResponseBody).doesNotContain("alg\":");
+    mockAuthServerResponse(authServerResponseBody);
+
+    assertThatCode(() -> decoder.decode(jwtKeys.serializedJwt)).doesNotThrowAnyException();
+    wireMock.getRuntimeInfo().getWireMock().verifyThat(1, RequestPatternBuilder.allRequests());
+  }
+
+  private static Stream<Arguments> basicAlgTestParameters() {
+    return Stream.of(
+        Arguments.of(JWSAlgorithm.RS256, null), Arguments.of(JWSAlgorithm.ES256, Curve.P_256));
+  }
+
+  @ParameterizedTest
+  @MethodSource("supportedJwsAlgorithms")
+  public void testDecodeJwtsWithNoTypeHeader(final JWSAlgorithm algorithm, final Curve curve)
+      throws JOSEException {
+    final JwtKeys jwtKeys = new JwtKeys(algorithm, curve, null);
+    final String authServerResponseBody = "{\"keys\":[" + jwtKeys.publicKey + "]}";
+    mockAuthServerResponse(authServerResponseBody);
+
+    assertThatCode(() -> decoder.decode(jwtKeys.serializedJwt)).doesNotThrowAnyException();
+    wireMock.getRuntimeInfo().getWireMock().verifyThat(1, RequestPatternBuilder.allRequests());
+  }
+
+  @ParameterizedTest
+  @MethodSource("supportedJwsAlgorithms")
+  public void testDecodeJwtsWithAtJwkTypeHeader(final JWSAlgorithm algorithm, final Curve curve)
+      throws JOSEException {
+    final JwtKeys jwtKeys = new JwtKeys(algorithm, curve, AT_JWT);
+    final String authServerResponseBody = "{\"keys\":[" + jwtKeys.publicKey + "]}";
+    mockAuthServerResponse(authServerResponseBody);
+
+    assertThatCode(() -> decoder.decode(jwtKeys.serializedJwt)).doesNotThrowAnyException();
+    wireMock.getRuntimeInfo().getWireMock().verifyThat(1, RequestPatternBuilder.allRequests());
+  }
+
+  @ParameterizedTest
+  @MethodSource("supportedJwsAlgorithms")
+  public void testDecodeJwtWithJwtTypeHeader(final JWSAlgorithm algorithm, final Curve curve)
+      throws JOSEException {
+    final JwtKeys jwtKeys = new JwtKeys(algorithm, curve, JWT);
+    final String authServerResponseBody = "{\"keys\":[" + jwtKeys.publicKey + "]}";
+    mockAuthServerResponse(authServerResponseBody);
+
+    assertThatCode(() -> decoder.decode(jwtKeys.serializedJwt)).doesNotThrowAnyException();
+    wireMock.getRuntimeInfo().getWireMock().verifyThat(1, RequestPatternBuilder.allRequests());
+  }
+
+  private static Stream<Arguments> supportedJwsAlgorithms() {
+    return Stream.of(
+        Arguments.of(JWSAlgorithm.RS256, null),
+        Arguments.of(JWSAlgorithm.RS384, null),
+        Arguments.of(JWSAlgorithm.RS512, null),
+        Arguments.of(JWSAlgorithm.ES256, Curve.P_256),
+        Arguments.of(JWSAlgorithm.ES384, Curve.P_384),
+        Arguments.of(JWSAlgorithm.ES512, Curve.P_521));
+  }
+
+  private void mockAuthServerResponse(final String authServerResponseBody) {
+    wireMock
+        .getRuntimeInfo()
+        .getWireMock()
+        .register(
+            WireMock.get(WireMock.urlMatching(".*/protocol/openid-connect/certs"))
+                .willReturn(WireMock.jsonResponse(authServerResponseBody, HttpStatus.OK.value())));
+  }
+
+  private static class JwtKeys {
+    JWK jwk;
+    String serializedJwt;
+    String publicKey;
+    JWSSigner jwsSigner;
+
+    JwtKeys(final JWSAlgorithm algorithm, final Curve curve, final JOSEObjectType type)
+        throws JOSEException {
+      if (Family.RSA.contains(algorithm)) {
+        jwk =
+            new RSAKeyGenerator(2048)
+                .algorithm(algorithm)
+                .keyID("123")
+                .keyUse(KeyUse.SIGNATURE)
+                .generate();
+        jwsSigner = new RSASSASigner((RSAKey) jwk);
+      } else if (Family.EC.contains(algorithm)) {
+        jwk =
+            new ECKeyGenerator(curve)
+                .algorithm(algorithm)
+                .keyID("345")
+                .keyUse(KeyUse.SIGNATURE)
+                .generate();
+        jwsSigner = new ECDSASigner((ECKey) jwk);
+      } else {
+        fail("unsupported algorithm type '%s'", algorithm);
+        throw new IllegalStateException("Unreachable");
+      }
+      serializedJwt = signAndSerialize(jwk, algorithm, type);
+      publicKey = jwk.toPublicJWK().toJSONString();
+    }
+
+    private String signAndSerialize(
+        final JWK jwk, final JWSAlgorithm alg, final JOSEObjectType type) throws JOSEException {
+      final SignedJWT jwt =
+          new SignedJWT(
+              new JWSHeader.Builder(alg).type(type).keyID(jwk.getKeyID()).build(),
+              new Builder()
+                  .subject("alice")
+                  .issuer("http://localhost")
+                  .expirationTime(new Date(new Date().getTime() + 60 * 1000))
+                  .build());
+      jwt.sign(jwsSigner);
+      return jwt.serialize();
+    }
+  }
+}


### PR DESCRIPTION
## Description

As part of [Migrate existing OIDC integration tests to use consolidated-auth setup](https://github.com/camunda/camunda/issues/31998), found Tasklist test [JwtDecoderIt](https://github.com/camunda/camunda/blob/e962c73f5016be7e2ffd2d51d58e548998814ee3/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/security/oauth/JwtDecoderIT.java) (_now deleted_). The test covered some functionality not found in Identity:
* Supporting a wider range of JWS signature algorithms: RS256, RS384, RS512, ES256, ES384, ES512.
* Allowing the `at+jwk` JWT type in the `typ` header, along with the default value `JWT` and omitting the `typ` header altogether.
  * NOTE: any other `typ` header values are not supported and will cause a failure, this is intended by design. Identity had only the default setting up to this point (`JWT` and `null`).
  * https://datatracker.ietf.org/doc/html/rfc9068#name-header

## Origin of Port

The changes in TaskList stem from an incident fix: [Issue verifying token signatures when JWKs use the ES256 algorithm](https://github.com/camunda/camunda/issues/23727)
along with: [Operate and Tasklist wrongfully expect JWT authentication tokens to define the typ property in their header](https://github.com/camunda/camunda/issues/29314)

The above issues introduced the configuration changes.
The ported tests are adapted to Identity, and simplified.

## Related issues

https://github.com/camunda/camunda/issues/31998
