### PR TITLE
feat: add Model Context Protocol (MCP) server support

### DIFF
--- a/.idea/runConfigurations/StandaloneCamunda_DEV.xml
+++ b/.idea/runConfigurations/StandaloneCamunda_DEV.xml
@@ -2,14 +2,16 @@
   <configuration default="false" name="StandaloneCamunda DEV" type="SpringBootApplicationConfigurationType" factoryName="Spring Boot">
     <option name="ACTIVE_PROFILES" value="identity,tasklist,operate,broker,consolidated-auth,dev,insecure" />
     <envs>
+      <env name="CAMUNDA_GATEWAY_MCP_ENABLED" value="true" />
+      <env name="CAMUNDA_SECURITY_AUTHENTICATION_UNPROTECTED-MCP" value="true" />
+      <env name="CAMUNDA_SECURITY_INITIALIZATION_DEFAULTROLES_ADMIN_USERS_0_" value="demo" />
+      <env name="CAMUNDA_SECURITY_INITIALIZATION_USERS_0_EMAIL" value="demo@example.com" />
+      <env name="CAMUNDA_SECURITY_INITIALIZATION_USERS_0_NAME" value="Demo" />
+      <env name="CAMUNDA_SECURITY_INITIALIZATION_USERS_0_PASSWORD" value="demo" />
+      <env name="CAMUNDA_SECURITY_INITIALIZATION_USERS_0_USERNAME" value="demo" />
       <env name="ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_ARGS_CONNECT_URL" value="http://localhost:9200" />
       <env name="ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_ARGS_INDEX_SHOULDWAITFORIMPORTERS" value="false" />
       <env name="ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_CLASSNAME" value="io.camunda.exporter.CamundaExporter" />
-      <env name="CAMUNDA_SECURITY_INITIALIZATION_USERS_0_NAME" value="Demo" />
-      <env name="CAMUNDA_SECURITY_INITIALIZATION_USERS_0_USERNAME" value="demo" />
-      <env name="CAMUNDA_SECURITY_INITIALIZATION_USERS_0_EMAIL" value="demo@example.com" />
-      <env name="CAMUNDA_SECURITY_INITIALIZATION_USERS_0_PASSWORD" value="demo" />
-      <env name="CAMUNDA_SECURITY_INITIALIZATION_DEFAULTROLES_ADMIN_USERS_0_" value="demo" />
     </envs>
     <module name="camunda-zeebe" />
     <option name="SPRING_BOOT_MAIN_CLASS" value="io.camunda.application.StandaloneCamunda" />

--- a/authentication/src/main/java/io/camunda/authentication/ConditionalOnProtectedMcp.java
+++ b/authentication/src/main/java/io/camunda/authentication/ConditionalOnProtectedMcp.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication;
+
+import io.camunda.authentication.ConditionalOnProtectedMcp.OnProtectedMcpCondition;
+import io.camunda.authentication.ConditionalOnUnprotectedMcp.McpUnprotectedCondition;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.context.annotation.Condition;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Documented
+@Conditional(OnProtectedMcpCondition.class)
+public @interface ConditionalOnProtectedMcp {
+
+  class OnProtectedMcpCondition implements Condition {
+    @Override
+    public boolean matches(final ConditionContext context, final AnnotatedTypeMetadata metadata) {
+      return !new McpUnprotectedCondition().matches(context, metadata);
+    }
+  }
+}

--- a/authentication/src/main/java/io/camunda/authentication/ConditionalOnUnprotectedMcp.java
+++ b/authentication/src/main/java/io/camunda/authentication/ConditionalOnUnprotectedMcp.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication;
+
+import io.camunda.authentication.ConditionalOnUnprotectedMcp.McpUnprotectedCondition;
+import io.camunda.authentication.config.AuthenticationProperties;
+import io.camunda.security.configuration.AuthenticationConfiguration;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.Optional;
+import org.springframework.context.annotation.Condition;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.core.env.Environment;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Documented
+@Conditional(McpUnprotectedCondition.class)
+public @interface ConditionalOnUnprotectedMcp {
+
+  class McpUnprotectedCondition implements Condition {
+
+    @Override
+    public boolean matches(final ConditionContext context, final AnnotatedTypeMetadata metadata) {
+      final Environment env = context.getEnvironment();
+      return Optional.ofNullable(
+              env.getProperty(AuthenticationProperties.MCP_UNPROTECTED, Boolean.class))
+          .orElse(AuthenticationConfiguration.DEFAULT_UNPROTECTED_MCP);
+    }
+  }
+}

--- a/authentication/src/main/java/io/camunda/authentication/config/AuthenticationProperties.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/AuthenticationProperties.java
@@ -13,12 +13,9 @@ import io.camunda.security.entity.AuthenticationMethod;
 public final class AuthenticationProperties {
   public static final String METHOD = "camunda.security.authentication.method";
   public static final String API_UNPROTECTED = "camunda.security.authentication.unprotected-api";
+  public static final String MCP_UNPROTECTED = "camunda.security.authentication.unprotected-mcp";
 
   private AuthenticationProperties() {}
-
-  public static String getUnprotectedApiEnvVar() {
-    return API_UNPROTECTED.replace(".", "_").replace("-", "").toUpperCase();
-  }
 
   public static void applyToSecurityConfig(
       final SecurityConfiguration securityConfig, final String key, final Object value) {
@@ -30,6 +27,10 @@ public final class AuthenticationProperties {
           securityConfig
               .getAuthentication()
               .setUnprotectedApi(Boolean.parseBoolean(String.valueOf(value)));
+      case MCP_UNPROTECTED ->
+          securityConfig
+              .getAuthentication()
+              .setUnprotectedMcp(Boolean.parseBoolean(String.valueOf(value)));
       default -> {}
     }
   }

--- a/authentication/src/test/java/io/camunda/authentication/csrf/CsrfProtectionRequestMatcherTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/csrf/CsrfProtectionRequestMatcherTest.java
@@ -13,7 +13,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.camunda.authentication.config.WebSecurityConfig;
-import io.camunda.security.configuration.AuthenticationConfiguration;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Stream;
@@ -31,8 +30,6 @@ class CsrfProtectionRequestMatcherTest {
 
   @BeforeEach
   void beforeEach() {
-    final var authConfig = new AuthenticationConfiguration();
-    authConfig.setUnprotectedApi(false);
     matcher = new CsrfProtectionRequestMatcher();
   }
 
@@ -70,8 +67,6 @@ class CsrfProtectionRequestMatcherTest {
         "/api/process-instances/123/sequence-flows"
       })
   void whenUnprotectedApiIsOnAndApiCalledFromBrowser(final String protectedUrls) {
-    final var authConfig = new AuthenticationConfiguration();
-    authConfig.setUnprotectedApi(true);
     final var unprotectedApiMatcher = new CsrfProtectionRequestMatcher();
     final var request = prepareMockRequest();
     request.getSession(true);

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -95,6 +95,11 @@
 
     <dependency>
       <groupId>io.camunda</groupId>
+      <artifactId>zeebe-gateway-mcp</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
       <artifactId>zeebe-logstreams</artifactId>
     </dependency>
 

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -464,6 +464,11 @@
     </dependency>
 
     <dependency>
+      <groupId>io.projectreactor</groupId>
+      <artifactId>reactor-core</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>io.micrometer</groupId>
       <artifactId>micrometer-commons</artifactId>
     </dependency>

--- a/dist/src/main/java/io/camunda/application/commons/mcp/McpConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/mcp/McpConfiguration.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.application.commons.mcp;
+
+import io.camunda.zeebe.gateway.mcp.ConditionalOnMcpGatewayEnabled;
+import jakarta.annotation.PostConstruct;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ComponentScan(basePackages = "io.camunda.zeebe.gateway.mcp")
+@ConditionalOnMcpGatewayEnabled
+public class McpConfiguration {
+  /**
+   * Enables automatic context propagation in Reactor, which allows the ThreadLocals to be restored
+   * automatically for each new subscription. We need this to ensure that the Spring Authentication
+   * context is shared with all MCP tools registered as they are using Reactor behind the scene to
+   * orchestrate tool calls.
+   */
+  @PostConstruct
+  void enableContextPropagation() {
+    // after this, every new subscription restores the ThreadLocals that
+    // were present when the chain was assembled
+    reactor.core.publisher.Hooks.enableAutomaticContextPropagation();
+  }
+}

--- a/dist/src/main/java/io/camunda/application/commons/security/CamundaSecurityConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/security/CamundaSecurityConfiguration.java
@@ -27,6 +27,10 @@ public class CamundaSecurityConfiguration {
       "CAMUNDA_SECURITY_AUTHENTICATION_UNPROTECTEDAPI";
 
   @VisibleForTesting
+  public static final String UNPROTECTED_MCP_ENV_VAR =
+      "CAMUNDA_SECURITY_AUTHENTICATION_UNPROTECTEDMCP";
+
+  @VisibleForTesting
   public static final String AUTHORIZATION_CHECKS_ENV_VAR =
       "CAMUNDA_SECURITY_AUTHORIZATIONS_ENABLED";
 
@@ -47,10 +51,11 @@ public class CamundaSecurityConfiguration {
   public void validate() {
     final var multiTenancyEnabled = camundaSecurityProperties.getMultiTenancy().isChecksEnabled();
     final var apiUnprotected = camundaSecurityProperties.getAuthentication().getUnprotectedApi();
+    final var mcpUnprotected = camundaSecurityProperties.getAuthentication().getUnprotectedMcp();
 
-    if (multiTenancyEnabled && apiUnprotected) {
+    if (multiTenancyEnabled && (apiUnprotected || mcpUnprotected)) {
       throw new IllegalStateException(
-          "Multi-tenancy is enabled (%s=%b), but the API is unprotected (%s=%b). Please enable API protection if you want to make use of multi-tenancy."
+          "Multi-tenancy is enabled (%s=%b), but the API or MCP is unprotected (%s=%b). Please enable API and MCP protection if you want to make use of multi-tenancy."
               .formatted(
                   "camunda.security.multiTenancy.checksEnabled",
                   true,

--- a/dist/src/test/java/io/camunda/application/commons/security/CamundaSecurityConfigurationTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/security/CamundaSecurityConfigurationTest.java
@@ -36,7 +36,88 @@ public class CamundaSecurityConfigurationTest {
         .cause()
         .isInstanceOf(IllegalStateException.class)
         .hasMessage(
-            "Multi-tenancy is enabled (%s=true), but the API is unprotected (%s=true). Please enable API protection if you want to make use of multi-tenancy."
-                .formatted(mtProperty, apiProperty));
+            "Multi-tenancy is enabled (%s=%b), but the API or MCP is unprotected (%s=%b). Please enable API and MCP protection if you want to make use of multi-tenancy."
+                .formatted(
+                    "camunda.security.multi-tenancy.enabled",
+                    true,
+                    "camunda.security.authentication.unprotected-api",
+                    true));
+  }
+
+  @Test
+  public void whenMultiTenancyEnabledAndMcpUnprotectedThenFailsToStart() {
+    final var application =
+        MainSupport.createDefaultApplicationBuilder()
+            .sources(CommonsModuleConfiguration.class)
+            .build();
+
+    final var mtProperty = "camunda.security.multi-tenancy.enabled";
+    final var mcpProperty = "camunda.security.authentication.unprotected-mcp";
+    application.setDefaultProperties(
+        Map.of(
+            mtProperty, true,
+            mcpProperty, true));
+
+    assertThatThrownBy(application::run)
+        .isInstanceOf(BeanCreationException.class)
+        .cause()
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage(
+            "Multi-tenancy is enabled (%s=%b), but the API or MCP is unprotected (%s=%b). Please enable API and MCP protection if you want to make use of multi-tenancy."
+                .formatted(
+                    "camunda.security.multi-tenancy.enabled",
+                    true,
+                    "camunda.security.authentication.unprotected-api",
+                    true));
+  }
+
+  @Test
+  public void whenMultiTenancyEnabledAndBothApiAndMcpUnprotectedThenFailsToStart() {
+    final var application =
+        MainSupport.createDefaultApplicationBuilder()
+            .sources(CommonsModuleConfiguration.class)
+            .build();
+
+    final var mtProperty = "camunda.security.multi-tenancy.enabled";
+    final var apiProperty = "camunda.security.authentication.unprotected-api";
+    final var mcpProperty = "camunda.security.authentication.unprotected-mcp";
+    application.setDefaultProperties(
+        Map.of(
+            mtProperty, true,
+            apiProperty, true,
+            mcpProperty, true));
+
+    assertThatThrownBy(application::run)
+        .isInstanceOf(BeanCreationException.class)
+        .cause()
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage(
+            "Multi-tenancy is enabled (%s=%b), but the API or MCP is unprotected (%s=%b). Please enable API and MCP protection if you want to make use of multi-tenancy."
+                .formatted(
+                    "camunda.security.multi-tenancy.enabled",
+                    true,
+                    "camunda.security.authentication.unprotected-api",
+                    true));
+  }
+
+  @Test
+  public void whenMultiTenancyEnabledAndBothApiAndMcpProtectedThenStartsSuccessfully() {
+    final var application =
+        MainSupport.createDefaultApplicationBuilder()
+            .sources(CommonsModuleConfiguration.class)
+            .build();
+
+    final var mtProperty = "camunda.security.multi-tenancy.enabled";
+    final var apiProperty = "camunda.security.authentication.unprotected-api";
+    final var mcpProperty = "camunda.security.authentication.unprotected-mcp";
+    application.setDefaultProperties(
+        Map.of(
+            mtProperty, true,
+            apiProperty, false,
+            mcpProperty, false));
+
+    // This should not throw an exception
+    final var context = application.run();
+    context.close();
   }
 }

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -71,6 +71,7 @@
     <version.junit>5.13.4</version.junit>
     <version.junit4>4.13.2</version.junit4>
     <version.log4j>2.25.1</version.log4j>
+    <version.mcp-sdk>0.10.0</version.mcp-sdk>
     <version.minlog>1.3.1</version.minlog>
     <version.mockito>5.18.0</version.mockito>
     <version.model>7.7.0</version.model>
@@ -104,6 +105,7 @@
     <version.rest-assured>5.5.5</version.rest-assured>
     <version.spring>6.2.8</version.spring>
     <version.spring-security>6.5.2</version.spring-security>
+    <version.spring-ai>1.1.0-SNAPSHOT</version.spring-ai>
     <version.spring-boot>3.4.7</version.spring-boot>
     <version.tomcat>10.1.43</version.tomcat>
     <version.concurrentunit>0.4.6</version.concurrentunit>
@@ -556,6 +558,12 @@
 
       <dependency>
         <groupId>io.camunda</groupId>
+        <artifactId>zeebe-gateway-mcp</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.camunda</groupId>
         <artifactId>zeebe-gateway-rest</artifactId>
         <version>${project.version}</version>
       </dependency>
@@ -992,6 +1000,22 @@
         <groupId>org.springframework.security</groupId>
         <artifactId>spring-security-bom</artifactId>
         <version>${version.spring-security}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>org.springframework.ai</groupId>
+        <artifactId>spring-ai-bom</artifactId>
+        <version>${version.spring-ai}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>io.modelcontextprotocol.sdk</groupId>
+        <artifactId>mcp-bom</artifactId>
+        <version>${version.mcp-sdk}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -2187,8 +2211,30 @@
 
   </dependencies>
 
-  <build>
+  <!-- Added repository snapshots for MCP libraries provided by Spring -->
+  <repositories>
+    <repository>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <id>spring-snapshots</id>
+      <name>Spring Snapshots</name>
+      <url>https://repo.spring.io/snapshot</url>
+    </repository>
+    <repository>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+      <id>central-portal-snapshots</id>
+      <name>Central Portal Snapshots</name>
+      <url>https://central.sonatype.com/repository/maven-snapshots/</url>
+    </repository>
+  </repositories>
 
+  <build>
     <pluginManagement>
       <plugins>
         <!-- MAVEN COMPILER -->

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -71,7 +71,7 @@
     <version.junit>5.13.4</version.junit>
     <version.junit4>4.13.2</version.junit4>
     <version.log4j>2.25.1</version.log4j>
-    <version.mcp-sdk>0.10.0</version.mcp-sdk>
+    <version.mcp-sdk>0.14.1</version.mcp-sdk>
     <version.minlog>1.3.1</version.minlog>
     <version.mockito>5.18.0</version.mockito>
     <version.model>7.7.0</version.model>
@@ -105,7 +105,7 @@
     <version.rest-assured>5.5.5</version.rest-assured>
     <version.spring>6.2.8</version.spring>
     <version.spring-security>6.5.2</version.spring-security>
-    <version.spring-ai>1.1.0-SNAPSHOT</version.spring-ai>
+    <version.spring-ai>1.1.0-M3</version.spring-ai>
     <version.spring-boot>3.4.7</version.spring-boot>
     <version.tomcat>10.1.43</version.tomcat>
     <version.concurrentunit>0.4.6</version.concurrentunit>

--- a/qa/acceptance-tests/pom.xml
+++ b/qa/acceptance-tests/pom.xml
@@ -393,11 +393,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.springframework.ai</groupId>
-      <artifactId>spring-ai-model</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>tasklist-webapp</artifactId>
       <scope>test</scope>
@@ -412,6 +407,12 @@
       <artifactId>tasklist-common</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-gateway-mcp</artifactId>
+      <scope>test</scope>
+    </dependency>
+
     <dependency>
       <groupId>org.agrona</groupId>
       <artifactId>agrona</artifactId>

--- a/qa/acceptance-tests/pom.xml
+++ b/qa/acceptance-tests/pom.xml
@@ -388,6 +388,16 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>io.modelcontextprotocol.sdk</groupId>
+      <artifactId>mcp</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.ai</groupId>
+      <artifactId>spring-ai-model</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>tasklist-webapp</artifactId>
       <scope>test</scope>

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/mcp/IncidentMcpToolTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/mcp/IncidentMcpToolTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.mcp;
+
+import static io.camunda.it.util.TestHelper.deployResource;
+import static io.camunda.it.util.TestHelper.startProcessInstance;
+import static io.camunda.it.util.TestHelper.waitForProcessInstancesToStart;
+import static io.camunda.it.util.TestHelper.waitForProcessesToBeDeployed;
+import static io.camunda.it.util.TestHelper.waitUntilIncidentsAreActive;
+import static io.camunda.it.util.TestHelper.waitUntilProcessInstanceHasIncidents;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.response.Process;
+import io.camunda.client.api.search.response.Incident;
+import io.camunda.qa.util.auth.Authenticated;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.qa.util.multidb.MultiDbTestApplication;
+import io.camunda.zeebe.gateway.mcp.tools.incident.IncidentSearchResponse;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.test.util.JsonUtil;
+import io.modelcontextprotocol.client.McpSyncClient;
+import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
+import io.modelcontextprotocol.spec.McpSchema.TextContent;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+@MultiDbTest
+public class IncidentMcpToolTest {
+
+  @Authenticated
+  private static McpSyncClient mcpClient;
+
+  @MultiDbTestApplication
+  static final TestStandaloneBroker BROKER =
+      new TestStandaloneBroker().withBasicAuth().withProperty("camunda.gateway.mcp.enabled", true);
+
+  private static final List<Process> deployedProcesses = new ArrayList<>();
+  private static final int AMOUNT_OF_INCIDENTS = 3;
+  private static Incident incident;
+
+  @BeforeAll
+  public static void setup(@Authenticated CamundaClient camundaClient) {
+    final var processes =
+        List.of("service_tasks_v1.bpmn", "service_tasks_v2.bpmn", "incident_process_v1.bpmn");
+    processes.forEach(
+        process ->
+            deployedProcesses.addAll(
+                deployResource(camundaClient, String.format("process/%s", process))
+                    .getProcesses()));
+
+    waitForProcessesToBeDeployed(camundaClient, 3);
+
+    startProcessInstance(camundaClient, "service_tasks_v1");
+    startProcessInstance(camundaClient, "service_tasks_v2", "{\"path\":222}");
+    startProcessInstance(camundaClient, "incident_process_v1");
+    startProcessInstance(camundaClient, "incident_process_v1");
+    startProcessInstance(camundaClient, "incident_process_v1");
+
+    waitForProcessInstancesToStart(camundaClient, 5);
+    waitUntilProcessInstanceHasIncidents(camundaClient, AMOUNT_OF_INCIDENTS);
+    waitUntilIncidentsAreActive(camundaClient, AMOUNT_OF_INCIDENTS);
+
+    incident = camundaClient.newIncidentSearchRequest().send().join().items().getFirst();
+
+    mcpClient.initialize();
+  }
+
+  @Test
+  void shouldSuccessfullyRetrieveIncidentsByProcessDefinitionKeys() {
+    // when
+    var callResult = mcpClient.callTool(new CallToolRequest("searchIncidents", """
+        {
+           "filter": {
+              "processDefinitionIds": ["%s"]
+           }
+        }
+        """.formatted("incident_process_v1")));
+
+    // then
+    assertThat(callResult.isError()).isFalse();
+
+    // Parse the result content to IncidentSearchResponse using JsonUtil
+    var responseContent = (TextContent) callResult.content().getFirst();
+    var incidentSearchResponse = JsonUtil.fromJson(responseContent.text(), IncidentSearchResponse.class);
+
+    // Assert that the number of incidents equals 3
+    assertThat(incidentSearchResponse.incidents()).hasSize(AMOUNT_OF_INCIDENTS);
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/mcp/McpDisabledTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/mcp/McpDisabledTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.mcp;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.qa.util.multidb.MultiDbTestApplication;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneApplication;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.cluster.TestZeebePort;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import org.junit.jupiter.api.Test;
+
+@MultiDbTest
+public class McpDisabledTest {
+
+  private static CamundaClient camundaClient;
+
+  @MultiDbTestApplication
+  private static final TestStandaloneApplication<?> APPLICATION = new TestStandaloneBroker();
+
+  @Test
+  void shouldReturn404OnMcpEndpoints() throws Exception {
+    try (final var httpClient = HttpClient.newHttpClient()) {
+      // Test /sse endpoint
+      final var sseRequest =
+          HttpRequest.newBuilder()
+              .uri(APPLICATION.uri("http", TestZeebePort.REST, "sse"))
+              .GET()
+              .build();
+
+      final var sseResponse = httpClient.send(sseRequest, HttpResponse.BodyHandlers.ofString());
+      assertThat(sseResponse.statusCode()).isEqualTo(404);
+
+      // Test /mcp/message endpoint
+      final var mcpRequest =
+          HttpRequest.newBuilder()
+              .uri(APPLICATION.uri("http", TestZeebePort.REST, "mcp", "message"))
+              .POST(HttpRequest.BodyPublishers.noBody())
+              .build();
+
+      final var mcpResponse = httpClient.send(mcpRequest, HttpResponse.BodyHandlers.ofString());
+      assertThat(mcpResponse.statusCode()).isEqualTo(404);
+    }
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/mcp/McpEnabledBasicAuthTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/mcp/McpEnabledBasicAuthTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.mcp;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.qa.util.multidb.MultiDbTestApplication;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.modelcontextprotocol.client.McpSyncClient;
+import io.modelcontextprotocol.spec.McpSchema.ListToolsResult;
+import org.junit.jupiter.api.Test;
+
+@MultiDbTest
+public class McpEnabledBasicAuthTest {
+
+  private static McpSyncClient mcpClient;
+
+  @MultiDbTestApplication
+  static final TestStandaloneBroker BROKER =
+      new TestStandaloneBroker().withBasicAuth().withProperty("camunda.gateway.mcp.enabled", true);
+
+  @Test
+  void shouldReturnSuccessOnMcpEndpoints() throws Exception {
+    mcpClient.initialize();
+    final ListToolsResult listToolsResult = mcpClient.listTools();
+    assertThat(listToolsResult.tools()).isNotEmpty();
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/mcp/McpEnabledBasicAuthTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/mcp/McpEnabledBasicAuthTest.java
@@ -22,7 +22,7 @@ public class McpEnabledBasicAuthTest {
   private static McpSyncClient mcpClient;
 
   @MultiDbTestApplication
-  static final TestStandaloneBroker BROKER =
+  private static final TestStandaloneBroker BROKER =
       new TestStandaloneBroker().withBasicAuth().withProperty("camunda.gateway.mcp.enabled", true);
 
   @Test

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/mcp/McpEnabledNoAuthTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/mcp/McpEnabledNoAuthTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.mcp;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.qa.util.multidb.MultiDbTestApplication;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.modelcontextprotocol.client.McpSyncClient;
+import io.modelcontextprotocol.spec.McpSchema.ListToolsResult;
+import org.junit.jupiter.api.Test;
+
+@MultiDbTest
+public class McpEnabledNoAuthTest {
+
+  private static McpSyncClient mcpClient;
+
+  @MultiDbTestApplication
+  static final TestStandaloneBroker BROKER =
+      new TestStandaloneBroker().withProperty("camunda.gateway.mcp.enabled", true);
+
+  @Test
+  void shouldReturnSuccessOnMcpEndpoints() throws Exception {
+    mcpClient.initialize();
+    final ListToolsResult listToolsResult = mcpClient.listTools();
+    assertThat(listToolsResult.tools()).isNotEmpty();
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/mcp/McpEnabledNoAuthTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/mcp/McpEnabledNoAuthTest.java
@@ -22,7 +22,7 @@ public class McpEnabledNoAuthTest {
   private static McpSyncClient mcpClient;
 
   @MultiDbTestApplication
-  static final TestStandaloneBroker BROKER =
+  private static final TestStandaloneBroker BROKER =
       new TestStandaloneBroker().withProperty("camunda.gateway.mcp.enabled", true);
 
   @Test

--- a/qa/util/pom.xml
+++ b/qa/util/pom.xml
@@ -170,6 +170,11 @@
     </dependency>
 
     <dependency>
+      <groupId>io.modelcontextprotocol.sdk</groupId>
+      <artifactId>mcp</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
       <scope>compile</scope>

--- a/qa/util/src/main/java/io/camunda/qa/util/auth/Authenticated.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/auth/Authenticated.java
@@ -20,7 +20,7 @@ import java.lang.annotation.Target;
  * org.junit.jupiter.api.TestTemplate} or {@link CamundaMultiDbExtension}. When applied, this
  * indicates that the {@link CamundaClient} should be created with the provided user's credentials.
  */
-@Target(ElementType.PARAMETER)
+@Target({ElementType.FIELD, ElementType.PARAMETER})
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 public @interface Authenticated {

--- a/qa/util/src/main/java/io/camunda/qa/util/cluster/TestCamundaApplication.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/cluster/TestCamundaApplication.java
@@ -97,6 +97,7 @@ public final class TestCamundaApplication extends TestSpringApplication<TestCamu
     securityConfig = new CamundaSecurityProperties();
     securityConfig.getAuthorizations().setEnabled(false);
     securityConfig.getAuthentication().setUnprotectedApi(true);
+    securityConfig.getAuthentication().setUnprotectedMcp(true);
     securityConfig
         .getInitialization()
         .getUsers()
@@ -129,6 +130,9 @@ public final class TestCamundaApplication extends TestSpringApplication<TestCamu
         .withProperty(
             AuthenticationProperties.API_UNPROTECTED,
             securityConfig.getAuthentication().getUnprotectedApi())
+        .withProperty(
+            AuthenticationProperties.MCP_UNPROTECTED,
+            securityConfig.getAuthentication().getUnprotectedMcp())
         .withAdditionalProfile(Profile.BROKER)
         .withAdditionalProfile(Profile.OPERATE)
         .withAdditionalProfile(Profile.TASKLIST)

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/BasicAuthMcpClientTestFactory.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/BasicAuthMcpClientTestFactory.java
@@ -22,15 +22,13 @@ import java.time.Duration;
 import java.util.Base64;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import javax.annotation.Nullable;
 import org.agrona.CloseHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public final class BasicAuthMcpClientTestFactory implements McpClientTestFactory {
 
-  private static final Logger LOGGER =
-      LoggerFactory.getLogger(BasicAuthMcpClientTestFactory.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(BasicAuthMcpClientTestFactory.class);
 
   private final Map<String, McpSyncClient> cachedClients = new ConcurrentHashMap<>();
 
@@ -43,12 +41,9 @@ public final class BasicAuthMcpClientTestFactory implements McpClientTestFactory
   public McpSyncClient getMcpClient(
       final TestGateway<?> gateway, final Authenticated authenticated) {
     if (authenticated == null) {
-      LOGGER.info(
-          "Creating unauthorized Mcp client for broker address '{}", gateway.restAddress());
-      var transport = newTransport(gateway.restAddress(), null);
-      return McpClient.sync(transport)
-          .requestTimeout(Duration.ofSeconds(10))
-          .build();
+      LOGGER.info("Creating unauthorized Mcp client for broker address '{}", gateway.restAddress());
+      final var transport = newTransport(gateway.restAddress(), null);
+      return McpClient.sync(transport).requestTimeout(Duration.ofSeconds(10)).build();
     }
 
     LOGGER.info(
@@ -63,12 +58,9 @@ public final class BasicAuthMcpClientTestFactory implements McpClientTestFactory
     return createAuthenticatedClient(application.application(), TestUser.DEFAULT);
   }
 
-  private McpSyncClient createAuthenticatedClient(
-      final TestGateway<?> gateway, TestUser testUser) {
+  private McpSyncClient createAuthenticatedClient(final TestGateway<?> gateway, TestUser testUser) {
     final var transport = newTransport(gateway.restAddress(), testUser);
-    return McpClient.sync(transport)
-        .requestTimeout(Duration.ofSeconds(10))
-        .build();
+    return McpClient.sync(transport).requestTimeout(Duration.ofSeconds(10)).build();
   }
 
   @Override
@@ -76,14 +68,18 @@ public final class BasicAuthMcpClientTestFactory implements McpClientTestFactory
     CloseHelper.quietCloseAll(cachedClients.values());
   }
 
-  private static McpClientTransport newTransport(URI url, @Nullable TestUser testUser) {
-    var builder = HttpClientSseClientTransport.builder(url.toString());
+  private static McpClientTransport newTransport(URI url, TestUser testUser) {
+    final var builder = HttpClientSseClientTransport.builder(url.toString());
     if (testUser != null) {
       builder.customizeRequest(
-          r -> r.header("Authorization", "Basic " + Base64.getEncoder()
-              .encodeToString((testUser.username() + ":" + testUser.password()).getBytes(
-                  StandardCharsets.UTF_8)))
-      );
+          r ->
+              r.header(
+                  "Authorization",
+                  "Basic "
+                      + Base64.getEncoder()
+                          .encodeToString(
+                              (testUser.username() + ":" + testUser.password())
+                                  .getBytes(StandardCharsets.UTF_8))));
     }
     return builder.build();
   }

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/BasicAuthMcpClientTestFactory.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/BasicAuthMcpClientTestFactory.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.qa.util.multidb;
+
+import io.camunda.qa.util.auth.Authenticated;
+import io.camunda.qa.util.auth.TestUser;
+import io.camunda.qa.util.multidb.CamundaMultiDBExtension.ApplicationUnderTest;
+import io.camunda.security.configuration.InitializationConfiguration;
+import io.camunda.zeebe.qa.util.cluster.TestGateway;
+import io.modelcontextprotocol.client.McpClient;
+import io.modelcontextprotocol.client.McpSyncClient;
+import io.modelcontextprotocol.client.transport.HttpClientSseClientTransport;
+import io.modelcontextprotocol.spec.McpClientTransport;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Base64;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import javax.annotation.Nullable;
+import org.agrona.CloseHelper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class BasicAuthMcpClientTestFactory implements McpClientTestFactory {
+
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(BasicAuthMcpClientTestFactory.class);
+
+  private final Map<String, McpSyncClient> cachedClients = new ConcurrentHashMap<>();
+
+  public BasicAuthMcpClientTestFactory(final ApplicationUnderTest application) {
+    cachedClients.put(
+        InitializationConfiguration.DEFAULT_USER_USERNAME, createDefaultUserClient(application));
+  }
+
+  @Override
+  public McpSyncClient getMcpClient(
+      final TestGateway<?> gateway, final Authenticated authenticated) {
+    if (authenticated == null) {
+      LOGGER.info(
+          "Creating unauthorized Mcp client for broker address '{}", gateway.restAddress());
+      var transport = newTransport(gateway.restAddress(), null);
+      return McpClient.sync(transport)
+          .requestTimeout(Duration.ofSeconds(10))
+          .build();
+    }
+
+    LOGGER.info(
+        "Retrieving Mcp client for user '{}' and broker address '{}",
+        authenticated.value(),
+        gateway.restAddress());
+    final var username = authenticated.value();
+    return cachedClients.get(username);
+  }
+
+  private McpSyncClient createDefaultUserClient(final ApplicationUnderTest application) {
+    return createAuthenticatedClient(application.application(), TestUser.DEFAULT);
+  }
+
+  private McpSyncClient createAuthenticatedClient(
+      final TestGateway<?> gateway, TestUser testUser) {
+    final var transport = newTransport(gateway.restAddress(), testUser);
+    return McpClient.sync(transport)
+        .requestTimeout(Duration.ofSeconds(10))
+        .build();
+  }
+
+  @Override
+  public void close() {
+    CloseHelper.quietCloseAll(cachedClients.values());
+  }
+
+  private static McpClientTransport newTransport(URI url, @Nullable TestUser testUser) {
+    var builder = HttpClientSseClientTransport.builder(url.toString());
+    if (testUser != null) {
+      builder.customizeRequest(
+          r -> r.header("Authorization", "Basic " + Base64.getEncoder()
+              .encodeToString((testUser.username() + ":" + testUser.password()).getBytes(
+                  StandardCharsets.UTF_8)))
+      );
+    }
+    return builder.build();
+  }
+}

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/McpClientTestFactory.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/McpClientTestFactory.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.qa.util.multidb;
+
+import io.camunda.qa.util.auth.Authenticated;
+import io.camunda.zeebe.qa.util.cluster.TestGateway;
+import io.modelcontextprotocol.client.McpSyncClient;
+
+public interface McpClientTestFactory extends AutoCloseable {
+
+  /** Returns an MCP client for the given gateway and authenticated user */
+  McpSyncClient getMcpClient(final TestGateway<?> gateway, final Authenticated authenticated);
+}

--- a/security/security-core/src/main/java/io/camunda/security/configuration/AuthenticationConfiguration.java
+++ b/security/security-core/src/main/java/io/camunda/security/configuration/AuthenticationConfiguration.java
@@ -12,18 +12,28 @@ import io.camunda.security.entity.AuthenticationMethod;
 public class AuthenticationConfiguration {
   public static final AuthenticationMethod DEFAULT_METHOD = AuthenticationMethod.BASIC;
   public static final boolean DEFAULT_UNPROTECTED_API = false;
+  public static final boolean DEFAULT_UNPROTECTED_MCP = false;
 
   private AuthenticationMethod method = DEFAULT_METHOD;
   private OidcAuthenticationConfiguration oidcAuthenticationConfiguration =
       new OidcAuthenticationConfiguration();
   private boolean unprotectedApi = DEFAULT_UNPROTECTED_API;
+  private boolean unprotectedMcp = DEFAULT_UNPROTECTED_MCP;
 
   public boolean getUnprotectedApi() {
     return unprotectedApi;
   }
 
+  public boolean getUnprotectedMcp() {
+    return unprotectedMcp;
+  }
+
   public void setUnprotectedApi(final boolean value) {
     unprotectedApi = value;
+  }
+
+  public void setUnprotectedMcp(final boolean value) {
+    unprotectedMcp = value;
   }
 
   public AuthenticationMethod getMethod() {

--- a/security/security-core/src/main/java/io/camunda/security/configuration/SecurityConfigurations.java
+++ b/security/security-core/src/main/java/io/camunda/security/configuration/SecurityConfigurations.java
@@ -16,6 +16,7 @@ public class SecurityConfigurations {
         securityConfiguration.getAuthentication();
     authenticationConfiguration.setMethod(AuthenticationMethod.BASIC);
     authenticationConfiguration.setUnprotectedApi(true);
+    authenticationConfiguration.setUnprotectedMcp(true);
     securityConfiguration.getAuthorizations().setEnabled(false);
     return securityConfiguration;
   }

--- a/zeebe/gateway-mcp/pom.xml
+++ b/zeebe/gateway-mcp/pom.xml
@@ -6,9 +6,7 @@
   ~ Licensed under the Camunda License 1.0. You may not use this file
   ~ except in compliance with the Camunda License 1.0.
   -->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
@@ -77,13 +75,33 @@
 
     <dependency>
       <groupId>org.springframework</groupId>
+      <artifactId>spring-core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework</groupId>
       <artifactId>spring-context</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-webmvc</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot</artifactId>
     </dependency>
 
     <!-- Jackson for JSON handling -->
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
     </dependency>
 
     <!-- Logging -->
@@ -98,12 +116,6 @@
       <groupId>org.mockito</groupId>
       <artifactId>mockito-junit-jupiter</artifactId>
       <version>5.18.0</version>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-test</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/zeebe/gateway-mcp/pom.xml
+++ b/zeebe/gateway-mcp/pom.xml
@@ -1,0 +1,148 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+  ~ one or more contributor license agreements. See the NOTICE file distributed
+  ~ with this work for additional information regarding copyright ownership.
+  ~ Licensed under the Camunda License 1.0. You may not use this file
+  ~ except in compliance with the Camunda License 1.0.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>io.camunda</groupId>
+    <artifactId>zeebe-parent</artifactId>
+    <version>8.8.0-SNAPSHOT</version>
+    <relativePath>../../parent/pom.xml</relativePath>
+  </parent>
+  <artifactId>zeebe-gateway-mcp</artifactId>
+  <packaging>jar</packaging>
+  <name>Zeebe Gateway MCP Server</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.modelcontextprotocol.sdk</groupId>
+      <artifactId>mcp-spring-webmvc</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.ai</groupId>
+      <artifactId>spring-ai-model</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.ai</groupId>
+      <artifactId>spring-ai-mcp</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.modelcontextprotocol.sdk</groupId>
+      <artifactId>mcp</artifactId>
+    </dependency>
+
+    <!-- Zeebe dependencies -->
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-service</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-search-domain</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-security-core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-authentication</artifactId>
+    </dependency>
+
+    <!-- Spring dependencies -->
+
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-beans</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-autoconfigure</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-context</artifactId>
+    </dependency>
+
+    <!-- Jackson for JSON handling -->
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+    </dependency>
+
+    <!-- Logging -->
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+
+    <!-- Test dependencies -->
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-junit-jupiter</artifactId>
+      <version>5.18.0</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/zeebe/gateway-mcp/src/main/java/io/camunda/zeebe/gateway/mcp/ConditionalOnMcpGatewayEnabled.java
+++ b/zeebe/gateway-mcp/src/main/java/io/camunda/zeebe/gateway/mcp/ConditionalOnMcpGatewayEnabled.java
@@ -24,7 +24,5 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplicat
 @Target({ElementType.TYPE, ElementType.METHOD})
 @Documented
 @ConditionalOnWebApplication
-@ConditionalOnProperty(
-    name = "camunda.gateway.mcp.enabled",
-    havingValue = "true")
+@ConditionalOnProperty(name = "camunda.gateway.mcp.enabled", havingValue = "true")
 public @interface ConditionalOnMcpGatewayEnabled {}

--- a/zeebe/gateway-mcp/src/main/java/io/camunda/zeebe/gateway/mcp/ConditionalOnMcpGatewayEnabled.java
+++ b/zeebe/gateway-mcp/src/main/java/io/camunda/zeebe/gateway/mcp/ConditionalOnMcpGatewayEnabled.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.mcp;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
+
+/**
+ * The MCP server is disabled when either the {@code zeebe.broker.gateway.enable} or {@code
+ * camunda.gateway.mcp.enabled} property is set to {@code false}. By default, the gateway is enabled
+ * but MCP is disabled, so MCP must be explicitly enabled.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Documented
+@ConditionalOnWebApplication
+@ConditionalOnProperty(
+    name = "camunda.gateway.mcp.enabled",
+    havingValue = "true")
+public @interface ConditionalOnMcpGatewayEnabled {}

--- a/zeebe/gateway-mcp/src/main/java/io/camunda/zeebe/gateway/mcp/config/GatewayMcpConfiguration.java
+++ b/zeebe/gateway-mcp/src/main/java/io/camunda/zeebe/gateway/mcp/config/GatewayMcpConfiguration.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.mcp.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.zeebe.gateway.mcp.tools.incident.ClusterIncidentsTool;
+import io.camunda.zeebe.gateway.mcp.tools.incident.IncidentSearchRequest;
+import io.modelcontextprotocol.server.McpServer;
+import io.modelcontextprotocol.server.McpServer.SyncSpecification;
+import io.modelcontextprotocol.server.McpServerFeatures;
+import io.modelcontextprotocol.server.McpSyncServer;
+import io.modelcontextprotocol.server.transport.WebMvcSseServerTransportProvider;
+import io.modelcontextprotocol.spec.McpSchema.Implementation;
+import io.modelcontextprotocol.spec.McpSchema.ServerCapabilities;
+import io.modelcontextprotocol.spec.McpServerTransportProvider;
+import java.util.List;
+import java.util.Objects;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.ai.mcp.McpToolUtils;
+import org.springframework.ai.tool.StaticToolCallbackProvider;
+import org.springframework.ai.tool.ToolCallback;
+import org.springframework.ai.tool.ToolCallbackProvider;
+import org.springframework.ai.tool.function.FunctionToolCallback;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.util.CollectionUtils;
+import org.springframework.web.servlet.function.RouterFunction;
+import org.springframework.web.servlet.function.ServerResponse;
+
+@Configuration
+@ComponentScan(basePackages = "io.camunda.zeebe.gateway.mcp.tools")
+@EnableConfigurationProperties(GatewayMcpProperties.class)
+public class GatewayMcpConfiguration {
+
+  private static final Logger logger = LoggerFactory.getLogger(GatewayMcpConfiguration.class);
+
+  @Bean
+  ToolCallback incidentSearchToolCallback(final ClusterIncidentsTool clusterIncidentsTool) {
+    return FunctionToolCallback.builder("searchIncidents", clusterIncidentsTool::searchIncidents)
+        .description("Search for incidents in the Camunda cluster")
+        .inputType(IncidentSearchRequest.class)
+        .build();
+  }
+
+  @Bean
+  public ToolCallbackProvider tools(List<ToolCallback> toolCallbacks) {
+    return new StaticToolCallbackProvider(toolCallbacks);
+  }
+
+  /** Server configuration for Model Context Protocol (MCP) using Web MVC. */
+  @Bean
+  public WebMvcSseServerTransportProvider webMvcSseServerTransportProvider(
+      ObjectProvider<ObjectMapper> objectMapperProvider) {
+    ObjectMapper objectMapper = objectMapperProvider.getIfAvailable(ObjectMapper::new);
+    return new WebMvcSseServerTransportProvider(objectMapper, "", "/mcp/message", "/sse");
+  }
+
+  @Bean
+  public RouterFunction<ServerResponse> mvcMcpRouterFunction(
+      WebMvcSseServerTransportProvider transportProvider) {
+    return transportProvider.getRouterFunction();
+  }
+
+  @Bean
+  public McpSyncServer mcpSyncServer(
+      GatewayMcpProperties serverProperties,
+      McpServerTransportProvider transportProvider,
+      List<ToolCallbackProvider> toolCallbackProvider) {
+    // Create the server
+    Implementation serverInfo =
+        new Implementation(serverProperties.getServerName(), serverProperties.getVersion());
+    SyncSpecification serverBuilder = McpServer.sync(transportProvider).serverInfo(serverInfo);
+
+    // Add tools available
+    List<ToolCallback> providerToolCallbacks =
+        toolCallbackProvider.stream()
+            .map(pr -> List.of(pr.getToolCallbacks()))
+            .flatMap(List::stream)
+            .filter(Objects::nonNull)
+            .toList();
+
+    var toolSpecifications = this.toSyncToolSpecifications(providerToolCallbacks);
+
+    if (!CollectionUtils.isEmpty(toolSpecifications)) {
+      serverBuilder.tools(toolSpecifications);
+      logger.info("Registered tools: {}", toolSpecifications.size());
+    }
+
+    serverBuilder.capabilities(ServerCapabilities.builder().tools(false).build());
+    serverBuilder.requestTimeout(serverProperties.getRequestTimeout());
+
+    return serverBuilder.build();
+  }
+
+  private List<McpServerFeatures.SyncToolSpecification> toSyncToolSpecifications(
+      List<ToolCallback> tools) {
+    return tools.stream().map(McpToolUtils::toSyncToolSpecification).toList();
+  }
+}

--- a/zeebe/gateway-mcp/src/main/java/io/camunda/zeebe/gateway/mcp/config/GatewayMcpConfiguration.java
+++ b/zeebe/gateway-mcp/src/main/java/io/camunda/zeebe/gateway/mcp/config/GatewayMcpConfiguration.java
@@ -41,7 +41,7 @@ import org.springframework.web.servlet.function.ServerResponse;
 @EnableConfigurationProperties(GatewayMcpProperties.class)
 public class GatewayMcpConfiguration {
 
-  private static final Logger logger = LoggerFactory.getLogger(GatewayMcpConfiguration.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(GatewayMcpConfiguration.class);
 
   @Bean
   ToolCallback incidentSearchToolCallback(final ClusterIncidentsTool clusterIncidentsTool) {
@@ -60,7 +60,7 @@ public class GatewayMcpConfiguration {
   @Bean
   public WebMvcSseServerTransportProvider webMvcSseServerTransportProvider(
       ObjectProvider<ObjectMapper> objectMapperProvider) {
-    ObjectMapper objectMapper = objectMapperProvider.getIfAvailable(ObjectMapper::new);
+    final ObjectMapper objectMapper = objectMapperProvider.getIfAvailable(ObjectMapper::new);
     return new WebMvcSseServerTransportProvider(objectMapper, "", "/mcp/message", "/sse");
   }
 
@@ -76,23 +76,24 @@ public class GatewayMcpConfiguration {
       McpServerTransportProvider transportProvider,
       List<ToolCallbackProvider> toolCallbackProvider) {
     // Create the server
-    Implementation serverInfo =
+    final Implementation serverInfo =
         new Implementation(serverProperties.getServerName(), serverProperties.getVersion());
-    SyncSpecification serverBuilder = McpServer.sync(transportProvider).serverInfo(serverInfo);
+    final SyncSpecification serverBuilder =
+        McpServer.sync(transportProvider).serverInfo(serverInfo);
 
     // Add tools available
-    List<ToolCallback> providerToolCallbacks =
+    final List<ToolCallback> providerToolCallbacks =
         toolCallbackProvider.stream()
             .map(pr -> List.of(pr.getToolCallbacks()))
             .flatMap(List::stream)
             .filter(Objects::nonNull)
             .toList();
 
-    var toolSpecifications = this.toSyncToolSpecifications(providerToolCallbacks);
+    final var toolSpecifications = this.toSyncToolSpecifications(providerToolCallbacks);
 
     if (!CollectionUtils.isEmpty(toolSpecifications)) {
       serverBuilder.tools(toolSpecifications);
-      logger.info("Registered tools: {}", toolSpecifications.size());
+      LOGGER.info("Registered tools: {}", toolSpecifications.size());
     }
 
     serverBuilder.capabilities(ServerCapabilities.builder().tools(false).build());

--- a/zeebe/gateway-mcp/src/main/java/io/camunda/zeebe/gateway/mcp/config/GatewayMcpProperties.java
+++ b/zeebe/gateway-mcp/src/main/java/io/camunda/zeebe/gateway/mcp/config/GatewayMcpProperties.java
@@ -19,8 +19,10 @@ public class GatewayMcpProperties {
   /** MCP server name exposed to MCP clients. */
   private String serverName = "Camunda Orchestration cluster MCP";
 
-  /** Camunda Orchestration cluster MCP Implementation version.
-   * TODO(mathieu) change this to be the project version.*/
+  /**
+   * Camunda Orchestration cluster MCP Implementation version. TODO(mathieu) change this to be the
+   * project version.
+   */
   private String version = "1.0.0";
 
   private Duration requestTimeout = Duration.ofSeconds(20);

--- a/zeebe/gateway-mcp/src/main/java/io/camunda/zeebe/gateway/mcp/config/GatewayMcpProperties.java
+++ b/zeebe/gateway-mcp/src/main/java/io/camunda/zeebe/gateway/mcp/config/GatewayMcpProperties.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.mcp.config;
+
+import java.time.Duration;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "camunda.gateway.mcp")
+public class GatewayMcpProperties {
+
+  /** Whether the MCP server is enabled. Default is false. */
+  private boolean enabled = false;
+
+  /** MCP server name exposed to MCP clients. */
+  private String serverName = "Camunda Orchestration cluster MCP";
+
+  /** Camunda Orchestration cluster MCP Implementation version.
+   * TODO(mathieu) change this to be the project version.*/
+  private String version = "1.0.0";
+
+  private Duration requestTimeout = Duration.ofSeconds(20);
+
+  public boolean isEnabled() {
+    return enabled;
+  }
+
+  public void setEnabled(final boolean enabled) {
+    this.enabled = enabled;
+  }
+
+  public String getServerName() {
+    return serverName;
+  }
+
+  public void setServerName(final String serverName) {
+    this.serverName = serverName;
+  }
+
+  public String getVersion() {
+    return version;
+  }
+
+  public void setVersion(final String version) {
+    this.version = version;
+  }
+
+  public Duration getRequestTimeout() {
+    return requestTimeout;
+  }
+
+  public void setRequestTimeout(final Duration requestTimeout) {
+    this.requestTimeout = requestTimeout;
+  }
+}

--- a/zeebe/gateway-mcp/src/main/java/io/camunda/zeebe/gateway/mcp/tools/incident/ClusterIncidentsTool.java
+++ b/zeebe/gateway-mcp/src/main/java/io/camunda/zeebe/gateway/mcp/tools/incident/ClusterIncidentsTool.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.mcp.tools.incident;
+
+import static io.camunda.zeebe.gateway.mcp.tools.incident.IncidentMapper.buildIncidentQuery;
+
+import io.camunda.search.entities.IncidentEntity;
+import io.camunda.search.query.IncidentQuery;
+import io.camunda.search.query.SearchQueryResult;
+import io.camunda.security.auth.CamundaAuthenticationProvider;
+import io.camunda.service.IncidentServices;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ClusterIncidentsTool {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ClusterIncidentsTool.class);
+
+  private final IncidentServices incidentServices;
+  private final CamundaAuthenticationProvider authenticationProvider;
+
+  public ClusterIncidentsTool(
+      final IncidentServices incidentServices,
+      final CamundaAuthenticationProvider authenticationProvider) {
+    this.incidentServices = incidentServices;
+    this.authenticationProvider = authenticationProvider;
+  }
+
+  public IncidentSearchResponse searchIncidents(IncidentSearchRequest request) {
+    try {
+      LOG.debug("Searching for incidents with request: {}", request);
+
+      // Build the incident query
+      final IncidentQuery query = buildIncidentQuery(request);
+
+      // Execute the search with default authentication
+      final SearchQueryResult<IncidentEntity> result =
+          incidentServices
+              .withAuthentication(authenticationProvider.getCamundaAuthentication())
+              .search(query);
+
+      // Convert results to DTOs
+      final List<Incident> incidents =
+          result.items().stream().map(IncidentMapper::toIncident).collect(Collectors.toList());
+
+      LOG.debug("Found {} incidents", incidents.size());
+      return new IncidentSearchResponse(incidents, result.total(), null);
+
+    } catch (final Exception e) {
+      LOG.error("Error searching for incidents", e);
+      return new IncidentSearchResponse(null, null, "Error searching incidents: " + e.getMessage());
+    }
+  }
+}

--- a/zeebe/gateway-mcp/src/main/java/io/camunda/zeebe/gateway/mcp/tools/incident/Incident.java
+++ b/zeebe/gateway-mcp/src/main/java/io/camunda/zeebe/gateway/mcp/tools/incident/Incident.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.mcp.tools.incident;
+
+public record Incident(
+    Long key,
+    Long processInstanceKey,
+    Long processDefinitionKey,
+    String type,
+    String state,
+    String errorMessage,
+    String errorType,
+    String flowNodeId,
+    Long flowNodeInstanceKey,
+    String creationTime,
+    Long jobKey,
+    String tenantId) {}

--- a/zeebe/gateway-mcp/src/main/java/io/camunda/zeebe/gateway/mcp/tools/incident/IncidentMapper.java
+++ b/zeebe/gateway-mcp/src/main/java/io/camunda/zeebe/gateway/mcp/tools/incident/IncidentMapper.java
@@ -1,0 +1,233 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.mcp.tools.incident;
+
+import static io.camunda.search.query.SearchQueryBuilders.incidentSearchQuery;
+
+import io.camunda.search.entities.IncidentEntity;
+import io.camunda.search.filter.FilterBuilders;
+import io.camunda.search.page.SearchQueryPage;
+import io.camunda.search.query.IncidentQuery;
+
+public class IncidentMapper {
+
+  public static IncidentQuery buildIncidentQuery(final IncidentSearchRequest request) {
+    if (request == null) {
+      return incidentSearchQuery().build();
+    }
+
+    final var queryBuilder = incidentSearchQuery();
+
+    // Apply filter if present
+    if (request.filter() != null) {
+      queryBuilder.filter(buildIncidentFilter(request.filter()));
+    }
+
+    // Apply sort if present
+    if (request.sort() != null && !request.sort().isEmpty()) {
+      queryBuilder.sort(buildIncidentSort(request.sort()));
+    }
+
+    // Apply pagination if present
+    if (request.page() != null) {
+      queryBuilder.page(buildSearchQueryPage(request.page()));
+    }
+
+    return queryBuilder.build();
+  }
+
+  private static io.camunda.search.filter.IncidentFilter buildIncidentFilter(
+      final IncidentSearchRequest.IncidentFilter filter) {
+    final var filterBuilder = FilterBuilders.incident();
+
+    if (filter.processInstanceKeys() != null && !filter.processInstanceKeys().isEmpty()) {
+      filterBuilder.processInstanceKeys(
+          filter.processInstanceKeys().getFirst(),
+          filter
+              .processInstanceKeys()
+              .subList(1, filter.processInstanceKeys().size())
+              .toArray(new Long[0]));
+    }
+
+    if (filter.processDefinitionKeys() != null && !filter.processDefinitionKeys().isEmpty()) {
+      filterBuilder.processDefinitionKeys(
+          filter.processDefinitionKeys().getFirst(),
+          filter
+              .processDefinitionKeys()
+              .subList(1, filter.processDefinitionKeys().size())
+              .toArray(new Long[0]));
+    }
+
+    if (filter.processDefinitionIds() != null && !filter.processDefinitionIds().isEmpty()) {
+      filterBuilder.processDefinitionIds(
+          filter.processDefinitionIds().getFirst(),
+          filter
+              .processDefinitionIds()
+              .subList(1, filter.processDefinitionIds().size())
+              .toArray(new String[0]));
+    }
+
+    if (filter.incidentKeys() != null && !filter.incidentKeys().isEmpty()) {
+      filterBuilder.incidentKeys(
+          filter.incidentKeys().getFirst(),
+          filter.incidentKeys().subList(1, filter.incidentKeys().size()).toArray(new Long[0]));
+    }
+
+    if (filter.states() != null && !filter.states().isEmpty()) {
+      filterBuilder.states(
+          filter.states().getFirst(),
+          filter.states().subList(1, filter.states().size()).toArray(new String[0]));
+    }
+
+    if (filter.errorTypes() != null && !filter.errorTypes().isEmpty()) {
+      filterBuilder.errorTypes(
+          filter.errorTypes().getFirst(),
+          filter.errorTypes().subList(1, filter.errorTypes().size()).toArray(new String[0]));
+    }
+
+    if (filter.errorMessages() != null && !filter.errorMessages().isEmpty()) {
+      filterBuilder.errorMessages(
+          filter.errorMessages().getFirst(),
+          filter.errorMessages().subList(1, filter.errorMessages().size()).toArray(new String[0]));
+    }
+
+    if (filter.flowNodeIds() != null && !filter.flowNodeIds().isEmpty()) {
+      filterBuilder.flowNodeIds(
+          filter.flowNodeIds().getFirst(),
+          filter.flowNodeIds().subList(1, filter.flowNodeIds().size()).toArray(new String[0]));
+    }
+
+    if (filter.flowNodeInstanceKeys() != null && !filter.flowNodeInstanceKeys().isEmpty()) {
+      filterBuilder.flowNodeInstanceKeys(
+          filter.flowNodeInstanceKeys().getFirst(),
+          filter
+              .flowNodeInstanceKeys()
+              .subList(1, filter.flowNodeInstanceKeys().size())
+              .toArray(new Long[0]));
+    }
+
+    if (filter.creationTimeFrom() != null) {
+      filterBuilder.creationTimeOperations(
+          io.camunda.search.filter.Operation.gte(filter.creationTimeFrom()));
+    }
+
+    if (filter.creationTimeTo() != null) {
+      filterBuilder.creationTimeOperations(
+          io.camunda.search.filter.Operation.lte(filter.creationTimeTo()));
+    }
+
+    if (filter.jobKeys() != null && !filter.jobKeys().isEmpty()) {
+      filterBuilder.jobKeys(
+          filter.jobKeys().getFirst(),
+          filter.jobKeys().subList(1, filter.jobKeys().size()).toArray(new Long[0]));
+    }
+
+    if (filter.tenantIds() != null && !filter.tenantIds().isEmpty()) {
+      filterBuilder.tenantIds(
+          filter.tenantIds().getFirst(),
+          filter.tenantIds().subList(1, filter.tenantIds().size()).toArray(new String[0]));
+    }
+
+    return filterBuilder.build();
+  }
+
+  private static io.camunda.search.sort.IncidentSort buildIncidentSort(
+      final java.util.List<IncidentSearchRequest.IncidentSort> sorts) {
+    final var sortBuilder = io.camunda.search.sort.SortOptionBuilders.incident();
+
+    for (final var sort : sorts) {
+      if (sort.field() != null) {
+        final boolean isDesc = "desc".equalsIgnoreCase(sort.order());
+
+        switch (sort.field().toLowerCase()) {
+          case "key":
+            if (isDesc) {
+              sortBuilder.incidentKey().desc();
+            } else {
+              sortBuilder.incidentKey().asc();
+            }
+            break;
+          case "creationtime":
+            if (isDesc) {
+              sortBuilder.creationTime().desc();
+            } else {
+              sortBuilder.creationTime().asc();
+            }
+            break;
+          case "state":
+            if (isDesc) {
+              sortBuilder.state().desc();
+            } else {
+              sortBuilder.state().asc();
+            }
+            break;
+          case "errortype":
+            if (isDesc) {
+              sortBuilder.errorType().desc();
+            } else {
+              sortBuilder.errorType().asc();
+            }
+            break;
+          case "processinstancekey":
+            if (isDesc) {
+              sortBuilder.processInstanceKey().desc();
+            } else {
+              sortBuilder.processInstanceKey().asc();
+            }
+            break;
+          case "processdefinitionkey":
+            if (isDesc) {
+              sortBuilder.processDefinitionKey().desc();
+            } else {
+              sortBuilder.processDefinitionKey().asc();
+            }
+            break;
+          default:
+            // Default to sorting by key if field is not recognized
+            if (isDesc) {
+              sortBuilder.incidentKey().desc();
+            } else {
+              sortBuilder.incidentKey().asc();
+            }
+            break;
+        }
+      }
+    }
+
+    return sortBuilder.build();
+  }
+
+  private static SearchQueryPage buildSearchQueryPage(
+      final IncidentSearchRequest.IncidentPage page) {
+    return SearchQueryPage.of(
+        p -> {
+          if (page.size() != null && page.size() > 0) {
+            p.size(Math.min(page.size(), 100)); // Cap at 100
+          }
+          // Note: searchAfter functionality may need to be implemented differently
+          // based on the actual SearchQueryPage builder capabilities
+          return p;
+        });
+  }
+
+  public static Incident toIncident(final IncidentEntity entity) {
+    return new Incident(
+        entity.incidentKey(),
+        entity.processInstanceKey(),
+        entity.processDefinitionKey(),
+        entity.errorType() != null ? entity.errorType().name() : null,
+        entity.state() != null ? entity.state().name() : null,
+        entity.errorMessage(),
+        entity.errorType() != null ? entity.errorType().name() : null,
+        entity.flowNodeId(),
+        entity.flowNodeInstanceKey(),
+        entity.creationTime() != null ? entity.creationTime().toString() : null,
+        entity.jobKey(),
+        entity.tenantId());
+  }
+}

--- a/zeebe/gateway-mcp/src/main/java/io/camunda/zeebe/gateway/mcp/tools/incident/IncidentSearchRequest.java
+++ b/zeebe/gateway-mcp/src/main/java/io/camunda/zeebe/gateway/mcp/tools/incident/IncidentSearchRequest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.mcp.tools.incident;
+
+import com.fasterxml.jackson.annotation.JsonClassDescription;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+import java.time.OffsetDateTime;
+import java.util.List;
+
+@JsonClassDescription("Search for incidents in the Camunda cluster")
+public record IncidentSearchRequest(
+    @JsonPropertyDescription("Filter criteria for incidents") IncidentFilter filter,
+    @JsonPropertyDescription("Sort criteria for incident results") List<IncidentSort> sort,
+    @JsonPropertyDescription("Pagination settings") IncidentPage page) {
+
+  public record IncidentFilter(
+      @JsonPropertyDescription("Process instance keys to filter by") List<Long> processInstanceKeys,
+      @JsonPropertyDescription("Process definition keys to filter by")
+          List<Long> processDefinitionKeys,
+      @JsonPropertyDescription("Process definition IDs to filter by")
+          List<String> processDefinitionIds,
+      @JsonPropertyDescription("Incident keys to filter by") List<Long> incidentKeys,
+      @JsonPropertyDescription("Incident states to filter by (ACTIVE, RESOLVED, PENDING, MIGRATED)")
+          List<String> states,
+      @JsonPropertyDescription("Error types to filter by") List<String> errorTypes,
+      @JsonPropertyDescription("Error messages to filter by (partial matches supported)")
+          List<String> errorMessages,
+      @JsonPropertyDescription("Flow node IDs to filter by") List<String> flowNodeIds,
+      @JsonPropertyDescription("Flow node instance keys to filter by")
+          List<Long> flowNodeInstanceKeys,
+      @JsonPropertyDescription("Creation time range start") OffsetDateTime creationTimeFrom,
+      @JsonPropertyDescription("Creation time range end") OffsetDateTime creationTimeTo,
+      @JsonPropertyDescription("Job keys to filter by") List<Long> jobKeys,
+      @JsonPropertyDescription("Tenant IDs to filter by") List<String> tenantIds) {}
+
+  public record IncidentSort(
+      @JsonPropertyDescription(
+              "Field to sort by (key, creationTime, state, errorType, processInstanceKey, processDefinitionKey)")
+          String field,
+      @JsonPropertyDescription("Sort order (asc, desc)") String order) {}
+
+  public record IncidentPage(
+      @JsonPropertyDescription("Number of results to return (default: 20, max: 100)") Integer size,
+      @JsonPropertyDescription("Search after values for pagination") List<Object> searchAfter) {}
+}

--- a/zeebe/gateway-mcp/src/main/java/io/camunda/zeebe/gateway/mcp/tools/incident/IncidentSearchResponse.java
+++ b/zeebe/gateway-mcp/src/main/java/io/camunda/zeebe/gateway/mcp/tools/incident/IncidentSearchResponse.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.mcp.tools.incident;
+
+import java.util.List;
+
+public record IncidentSearchResponse(List<Incident> incidents, Long total, String error) {}

--- a/zeebe/gateway-mcp/src/test/java/io/camunda/zeebe/gateway/mcp/tools/incident/ClusterIncidentsToolTest.java
+++ b/zeebe/gateway-mcp/src/test/java/io/camunda/zeebe/gateway/mcp/tools/incident/ClusterIncidentsToolTest.java
@@ -1,0 +1,424 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.mcp.tools.incident;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.search.entities.IncidentEntity;
+import io.camunda.search.query.IncidentQuery;
+import io.camunda.search.query.SearchQueryResult;
+import io.camunda.security.auth.CamundaAuthentication;
+import io.camunda.security.auth.CamundaAuthenticationProvider;
+import io.camunda.service.IncidentServices;
+import io.camunda.zeebe.gateway.mcp.tools.incident.IncidentSearchRequest.IncidentFilter;
+import io.camunda.zeebe.gateway.mcp.tools.incident.IncidentSearchRequest.IncidentPage;
+import io.camunda.zeebe.gateway.mcp.tools.incident.IncidentSearchRequest.IncidentSort;
+import java.time.OffsetDateTime;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ClusterIncidentsToolTest {
+
+  @Mock private IncidentServices incidentServices;
+  @Mock private CamundaAuthenticationProvider authenticationProvider;
+
+  private ClusterIncidentsTool clusterIncidentsTool;
+
+  @BeforeEach
+  void setUp() {
+    clusterIncidentsTool = new ClusterIncidentsTool(incidentServices, authenticationProvider);
+
+    // Mock authentication
+    final var authentication = mock(CamundaAuthentication.class);
+    when(authenticationProvider.getCamundaAuthentication()).thenReturn(authentication);
+  }
+
+  @Test
+  void shouldExecuteSuccessfulIncidentSearch() {
+    // given
+    final var incidentEntity = createMockIncidentEntity();
+    final var searchResult = mock(SearchQueryResult.class);
+    when(searchResult.items()).thenReturn(List.of(incidentEntity));
+    when(searchResult.total()).thenReturn(1L);
+
+    final var authenticatedServices = mock(IncidentServices.class);
+    when(incidentServices.withAuthentication(any(CamundaAuthentication.class)))
+        .thenReturn(authenticatedServices);
+    when(authenticatedServices.search(any(IncidentQuery.class))).thenReturn(searchResult);
+
+    final var request = createIncidentSearchRequest();
+
+    // when
+    final IncidentSearchResponse response = clusterIncidentsTool.searchIncidents(request);
+
+    // then
+    assertThat(response).isNotNull();
+    assertThat(response.incidents()).hasSize(1);
+    assertThat(response.total()).isEqualTo(1L);
+    assertThat(response.error()).isNull();
+    verify(authenticatedServices).search(any(IncidentQuery.class));
+  }
+
+  @Test
+  void shouldHandleEmptySearchResults() {
+    // given
+    final var searchResult = mock(SearchQueryResult.class);
+    when(searchResult.items()).thenReturn(List.of());
+    when(searchResult.total()).thenReturn(0L);
+
+    final var authenticatedServices = mock(IncidentServices.class);
+    when(incidentServices.withAuthentication(any(CamundaAuthentication.class)))
+        .thenReturn(authenticatedServices);
+    when(authenticatedServices.search(any(IncidentQuery.class))).thenReturn(searchResult);
+
+    final var request = createIncidentSearchRequest();
+
+    // when
+    final IncidentSearchResponse response = clusterIncidentsTool.searchIncidents(request);
+
+    // then
+    assertThat(response).isNotNull();
+    assertThat(response.incidents()).isEmpty();
+    assertThat(response.total()).isEqualTo(0L);
+    assertThat(response.error()).isNull();
+  }
+
+  @Test
+  void shouldHandleServiceException() {
+    // given
+    final var authenticatedServices = mock(IncidentServices.class);
+    when(incidentServices.withAuthentication(any(CamundaAuthentication.class)))
+        .thenReturn(authenticatedServices);
+    when(authenticatedServices.search(any(IncidentQuery.class)))
+        .thenThrow(new RuntimeException("Service unavailable"));
+
+    final var request = createIncidentSearchRequest();
+
+    // when
+    final IncidentSearchResponse response = clusterIncidentsTool.searchIncidents(request);
+
+    // then
+    assertThat(response).isNotNull();
+    assertThat(response.incidents()).isNull();
+    assertThat(response.total()).isNull();
+    assertThat(response.error()).isEqualTo("Error searching incidents: Service unavailable");
+  }
+
+  @Test
+  void shouldHandleNullRequest() {
+    // given
+    final var searchResult = mock(SearchQueryResult.class);
+    when(searchResult.items()).thenReturn(List.of());
+    when(searchResult.total()).thenReturn(0L);
+
+    final var authenticatedServices = mock(IncidentServices.class);
+    when(incidentServices.withAuthentication(any(CamundaAuthentication.class)))
+        .thenReturn(authenticatedServices);
+    when(authenticatedServices.search(any(IncidentQuery.class))).thenReturn(searchResult);
+
+    // when
+    final IncidentSearchResponse response = clusterIncidentsTool.searchIncidents(null);
+
+    // then
+    assertThat(response).isNotNull();
+    assertThat(response.incidents()).isEmpty();
+    assertThat(response.total()).isEqualTo(0L);
+    assertThat(response.error()).isNull();
+    verify(authenticatedServices).search(any(IncidentQuery.class));
+  }
+
+  @Test
+  void shouldProcessComplexFilterRequest() {
+    // given
+    final var incidentEntity = createMockIncidentEntity();
+    final var searchResult = mock(SearchQueryResult.class);
+    when(searchResult.items()).thenReturn(List.of(incidentEntity));
+    when(searchResult.total()).thenReturn(1L);
+
+    final var authenticatedServices = mock(IncidentServices.class);
+    when(incidentServices.withAuthentication(any(CamundaAuthentication.class)))
+        .thenReturn(authenticatedServices);
+    when(authenticatedServices.search(any(IncidentQuery.class))).thenReturn(searchResult);
+
+    final var filter =
+        new IncidentFilter(
+            List.of(1L, 2L), // processInstanceKeys
+            List.of(100L), // processDefinitionKeys
+            List.of("process-id"), // processDefinitionIds
+            List.of(500L), // incidentKeys
+            List.of("ACTIVE"), // states
+            List.of("JOB_NO_RETRIES"), // errorTypes
+            List.of("error message"), // errorMessages
+            List.of("task-1"), // flowNodeIds
+            List.of(300L), // flowNodeInstanceKeys
+            OffsetDateTime.now().minusDays(1), // creationTimeFrom
+            OffsetDateTime.now(), // creationTimeTo
+            List.of(600L), // jobKeys
+            List.of("tenant-1")); // tenantIds
+
+    final var sort = List.of(new IncidentSort("creationTime", "desc"));
+    final var page = new IncidentPage(50, List.of("search", "after"));
+    final var request = new IncidentSearchRequest(filter, sort, page);
+
+    // when
+    final IncidentSearchResponse response = clusterIncidentsTool.searchIncidents(request);
+
+    // then
+    assertThat(response).isNotNull();
+    assertThat(response.incidents()).hasSize(1);
+    assertThat(response.total()).isEqualTo(1L);
+    assertThat(response.error()).isNull();
+    verify(authenticatedServices).search(any(IncidentQuery.class));
+  }
+
+  private IncidentEntity createMockIncidentEntity() {
+    final var entity = mock(IncidentEntity.class);
+    when(entity.incidentKey()).thenReturn(123L);
+    when(entity.processInstanceKey()).thenReturn(456L);
+    when(entity.processDefinitionKey()).thenReturn(789L);
+    when(entity.errorType()).thenReturn(IncidentEntity.ErrorType.JOB_NO_RETRIES);
+    when(entity.state()).thenReturn(IncidentEntity.IncidentState.ACTIVE);
+    when(entity.errorMessage()).thenReturn("Test error message");
+    when(entity.flowNodeId()).thenReturn("task-1");
+    when(entity.flowNodeInstanceKey()).thenReturn(111L);
+    when(entity.creationTime()).thenReturn(OffsetDateTime.parse("2024-01-01T10:00:00Z"));
+    when(entity.jobKey()).thenReturn(222L);
+    when(entity.tenantId()).thenReturn("tenant-1");
+    return entity;
+  }
+
+  @Test
+  void shouldVerifyCorrectQueryBuilding() {
+    // given
+    final var searchResult = mock(SearchQueryResult.class);
+    when(searchResult.items()).thenReturn(List.of());
+    when(searchResult.total()).thenReturn(0L);
+
+    final var authenticatedServices = mock(IncidentServices.class);
+    when(incidentServices.withAuthentication(any(CamundaAuthentication.class)))
+        .thenReturn(authenticatedServices);
+    when(authenticatedServices.search(any(IncidentQuery.class))).thenReturn(searchResult);
+
+    final var filter = new IncidentFilter(
+        List.of(123L), // processInstanceKeys
+        List.of(456L), // processDefinitionKeys
+        List.of("test-process"), // processDefinitionIds
+        null, null, null, null, null, null, null, null, null, null);
+
+    final var request = new IncidentSearchRequest(filter, null, null);
+
+    // when
+    clusterIncidentsTool.searchIncidents(request);
+
+    // then
+    verify(authenticatedServices).search(any(IncidentQuery.class));
+    verify(incidentServices).withAuthentication(any(CamundaAuthentication.class));
+  }
+
+  @Test
+  void shouldHandleEmptyFilterLists() {
+    // given
+    final var searchResult = mock(SearchQueryResult.class);
+    when(searchResult.items()).thenReturn(List.of());
+    when(searchResult.total()).thenReturn(0L);
+
+    final var authenticatedServices = mock(IncidentServices.class);
+    when(incidentServices.withAuthentication(any(CamundaAuthentication.class)))
+        .thenReturn(authenticatedServices);
+    when(authenticatedServices.search(any(IncidentQuery.class))).thenReturn(searchResult);
+
+    final var filter = new IncidentFilter(
+        List.of(), // empty processInstanceKeys
+        List.of(), // empty processDefinitionKeys
+        List.of(), // empty processDefinitionIds
+        List.of(), // empty incidentKeys
+        List.of(), // empty states
+        List.of(), // empty errorTypes
+        List.of(), // empty errorMessages
+        List.of(), // empty flowNodeIds
+        List.of(), // empty flowNodeInstanceKeys
+        null, null,
+        List.of(), // empty jobKeys
+        List.of()); // empty tenantIds
+
+    final var request = new IncidentSearchRequest(filter, null, null);
+
+    // when
+    final IncidentSearchResponse response = clusterIncidentsTool.searchIncidents(request);
+
+    // then
+    assertThat(response).isNotNull();
+    assertThat(response.incidents()).isEmpty();
+    assertThat(response.error()).isNull();
+  }
+
+  @Test
+  void shouldHandlePaginationLimits() {
+    // given
+    final var searchResult = mock(SearchQueryResult.class);
+    when(searchResult.items()).thenReturn(List.of());
+    when(searchResult.total()).thenReturn(0L);
+
+    final var authenticatedServices = mock(IncidentServices.class);
+    when(incidentServices.withAuthentication(any(CamundaAuthentication.class)))
+        .thenReturn(authenticatedServices);
+    when(authenticatedServices.search(any(IncidentQuery.class))).thenReturn(searchResult);
+
+    final var page = new IncidentPage(150, null); // size over limit
+    final var request = new IncidentSearchRequest(null, null, page);
+
+    // when
+    final IncidentSearchResponse response = clusterIncidentsTool.searchIncidents(request);
+
+    // then
+    assertThat(response).isNotNull();
+    assertThat(response.error()).isNull();
+    verify(authenticatedServices).search(any(IncidentQuery.class));
+  }
+
+  @Test
+  void shouldHandleAllSortFields() {
+    // given
+    final var searchResult = mock(SearchQueryResult.class);
+    when(searchResult.items()).thenReturn(List.of());
+    when(searchResult.total()).thenReturn(0L);
+
+    final var authenticatedServices = mock(IncidentServices.class);
+    when(incidentServices.withAuthentication(any(CamundaAuthentication.class)))
+        .thenReturn(authenticatedServices);
+    when(authenticatedServices.search(any(IncidentQuery.class))).thenReturn(searchResult);
+
+    final var sorts = List.of(
+        new IncidentSort("key", "asc"),
+        new IncidentSort("creationTime", "desc"),
+        new IncidentSort("state", "asc"),
+        new IncidentSort("errorType", "desc"),
+        new IncidentSort("processInstanceKey", "asc"),
+        new IncidentSort("processDefinitionKey", "desc"),
+        new IncidentSort("unknownField", "asc") // should default to key
+    );
+    final var request = new IncidentSearchRequest(null, sorts, null);
+
+    // when
+    final IncidentSearchResponse response = clusterIncidentsTool.searchIncidents(request);
+
+    // then
+    assertThat(response).isNotNull();
+    assertThat(response.error()).isNull();
+    verify(authenticatedServices).search(any(IncidentQuery.class));
+  }
+
+  @Test
+  void shouldVerifyIncidentMappingFromEntity() {
+    // given
+    final var incidentEntity = createMockIncidentEntity();
+    final var searchResult = mock(SearchQueryResult.class);
+    when(searchResult.items()).thenReturn(List.of(incidentEntity));
+    when(searchResult.total()).thenReturn(1L);
+
+    final var authenticatedServices = mock(IncidentServices.class);
+    when(incidentServices.withAuthentication(any(CamundaAuthentication.class)))
+        .thenReturn(authenticatedServices);
+    when(authenticatedServices.search(any(IncidentQuery.class))).thenReturn(searchResult);
+
+    final var request = createIncidentSearchRequest();
+
+    // when
+    final IncidentSearchResponse response = clusterIncidentsTool.searchIncidents(request);
+
+    // then
+    assertThat(response.incidents()).hasSize(1);
+    final var incident = response.incidents().get(0);
+    assertThat(incident.key()).isEqualTo(123L);
+    assertThat(incident.processInstanceKey()).isEqualTo(456L);
+    assertThat(incident.processDefinitionKey()).isEqualTo(789L);
+    assertThat(incident.errorType()).isEqualTo("JOB_NO_RETRIES");
+    assertThat(incident.state()).isEqualTo("ACTIVE");
+    assertThat(incident.errorMessage()).isEqualTo("Test error message");
+    assertThat(incident.flowNodeId()).isEqualTo("task-1");
+    assertThat(incident.flowNodeInstanceKey()).isEqualTo(111L);
+    assertThat(incident.creationTime()).isEqualTo("2024-01-01T10:00Z");
+    assertThat(incident.jobKey()).isEqualTo(222L);
+    assertThat(incident.tenantId()).isEqualTo("tenant-1");
+  }
+
+  @Test
+  void shouldHandleNullEntityFields() {
+    // given
+    final var incidentEntity = mock(IncidentEntity.class);
+    when(incidentEntity.incidentKey()).thenReturn(123L);
+    when(incidentEntity.processInstanceKey()).thenReturn(456L);
+    when(incidentEntity.processDefinitionKey()).thenReturn(789L);
+    when(incidentEntity.errorType()).thenReturn(null);
+    when(incidentEntity.state()).thenReturn(null);
+    when(incidentEntity.errorMessage()).thenReturn(null);
+    when(incidentEntity.flowNodeId()).thenReturn(null);
+    when(incidentEntity.flowNodeInstanceKey()).thenReturn(null);
+    when(incidentEntity.creationTime()).thenReturn(null);
+    when(incidentEntity.jobKey()).thenReturn(null);
+    when(incidentEntity.tenantId()).thenReturn(null);
+
+    final var searchResult = mock(SearchQueryResult.class);
+    when(searchResult.items()).thenReturn(List.of(incidentEntity));
+    when(searchResult.total()).thenReturn(1L);
+
+    final var authenticatedServices = mock(IncidentServices.class);
+    when(incidentServices.withAuthentication(any(CamundaAuthentication.class)))
+        .thenReturn(authenticatedServices);
+    when(authenticatedServices.search(any(IncidentQuery.class))).thenReturn(searchResult);
+
+    final var request = createIncidentSearchRequest();
+
+    // when
+    final IncidentSearchResponse response = clusterIncidentsTool.searchIncidents(request);
+
+    // then
+    assertThat(response.incidents()).hasSize(1);
+    final var incident = response.incidents().get(0);
+    assertThat(incident.key()).isEqualTo(123L);
+    assertThat(incident.processInstanceKey()).isEqualTo(456L);
+    assertThat(incident.processDefinitionKey()).isEqualTo(789L);
+    assertThat(incident.errorType()).isNull();
+    assertThat(incident.state()).isNull();
+    assertThat(incident.errorMessage()).isNull();
+    assertThat(incident.flowNodeId()).isNull();
+    assertThat(incident.flowNodeInstanceKey()).isNull();
+    assertThat(incident.creationTime()).isNull();
+    assertThat(incident.jobKey()).isNull();
+    assertThat(incident.tenantId()).isNull();
+  }
+
+  private IncidentSearchRequest createIncidentSearchRequest() {
+    final var filter =
+        new IncidentFilter(
+            List.of(1L), // processInstanceKeys
+            null, // processDefinitionKeys
+            null, // processDefinitionIds
+            null, // incidentKeys
+            List.of("ACTIVE"), // states
+            null, // errorTypes
+            null, // errorMessages
+            null, // flowNodeIds
+            null, // flowNodeInstanceKeys
+            null, // creationTimeFrom
+            null, // creationTimeTo
+            null, // jobKeys
+            null); // tenantIds
+
+    return new IncidentSearchRequest(filter, null, null);
+  }
+}

--- a/zeebe/gateway-mcp/src/test/java/io/camunda/zeebe/gateway/mcp/tools/incident/ClusterIncidentsToolTest.java
+++ b/zeebe/gateway-mcp/src/test/java/io/camunda/zeebe/gateway/mcp/tools/incident/ClusterIncidentsToolTest.java
@@ -213,11 +213,21 @@ class ClusterIncidentsToolTest {
         .thenReturn(authenticatedServices);
     when(authenticatedServices.search(any(IncidentQuery.class))).thenReturn(searchResult);
 
-    final var filter = new IncidentFilter(
-        List.of(123L), // processInstanceKeys
-        List.of(456L), // processDefinitionKeys
-        List.of("test-process"), // processDefinitionIds
-        null, null, null, null, null, null, null, null, null, null);
+    final var filter =
+        new IncidentFilter(
+            List.of(123L), // processInstanceKeys
+            List.of(456L), // processDefinitionKeys
+            List.of("test-process"), // processDefinitionIds
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null);
 
     final var request = new IncidentSearchRequest(filter, null, null);
 
@@ -241,19 +251,19 @@ class ClusterIncidentsToolTest {
         .thenReturn(authenticatedServices);
     when(authenticatedServices.search(any(IncidentQuery.class))).thenReturn(searchResult);
 
-    final var filter = new IncidentFilter(
-        List.of(), // empty processInstanceKeys
-        List.of(), // empty processDefinitionKeys
-        List.of(), // empty processDefinitionIds
-        List.of(), // empty incidentKeys
-        List.of(), // empty states
-        List.of(), // empty errorTypes
-        List.of(), // empty errorMessages
-        List.of(), // empty flowNodeIds
-        List.of(), // empty flowNodeInstanceKeys
-        null, null,
-        List.of(), // empty jobKeys
-        List.of()); // empty tenantIds
+    final var filter =
+        new IncidentFilter(
+            List.of(), // empty processInstanceKeys
+            List.of(), // empty processDefinitionKeys
+            List.of(), // empty processDefinitionIds
+            List.of(), // empty incidentKeys
+            List.of(), // empty states
+            List.of(), // empty errorTypes
+            List.of(), // empty errorMessages
+            List.of(), // empty flowNodeIds
+            List.of(), // empty flowNodeInstanceKeys
+            null, null, List.of(), // empty jobKeys
+            List.of()); // empty tenantIds
 
     final var request = new IncidentSearchRequest(filter, null, null);
 
@@ -302,15 +312,16 @@ class ClusterIncidentsToolTest {
         .thenReturn(authenticatedServices);
     when(authenticatedServices.search(any(IncidentQuery.class))).thenReturn(searchResult);
 
-    final var sorts = List.of(
-        new IncidentSort("key", "asc"),
-        new IncidentSort("creationTime", "desc"),
-        new IncidentSort("state", "asc"),
-        new IncidentSort("errorType", "desc"),
-        new IncidentSort("processInstanceKey", "asc"),
-        new IncidentSort("processDefinitionKey", "desc"),
-        new IncidentSort("unknownField", "asc") // should default to key
-    );
+    final var sorts =
+        List.of(
+            new IncidentSort("key", "asc"),
+            new IncidentSort("creationTime", "desc"),
+            new IncidentSort("state", "asc"),
+            new IncidentSort("errorType", "desc"),
+            new IncidentSort("processInstanceKey", "asc"),
+            new IncidentSort("processDefinitionKey", "desc"),
+            new IncidentSort("unknownField", "asc") // should default to key
+            );
     final var request = new IncidentSearchRequest(null, sorts, null);
 
     // when

--- a/zeebe/gateway-mcp/src/test/java/io/camunda/zeebe/gateway/mcp/tools/incident/IncidentMapperTest.java
+++ b/zeebe/gateway-mcp/src/test/java/io/camunda/zeebe/gateway/mcp/tools/incident/IncidentMapperTest.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.mcp.tools.incident;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.camunda.search.entities.IncidentEntity;
+import io.camunda.search.query.IncidentQuery;
+import io.camunda.zeebe.gateway.mcp.tools.incident.IncidentSearchRequest.IncidentFilter;
+import io.camunda.zeebe.gateway.mcp.tools.incident.IncidentSearchRequest.IncidentPage;
+import io.camunda.zeebe.gateway.mcp.tools.incident.IncidentSearchRequest.IncidentSort;
+import java.time.OffsetDateTime;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class IncidentMapperTest {
+
+  @Test
+  void shouldReturnEmptyQueryWhenRequestIsNull() {
+    // when
+    final IncidentQuery result = IncidentMapper.buildIncidentQuery((IncidentSearchRequest) null);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.filter()).isNotNull();
+    assertThat(result.sort()).isNotNull();
+    assertThat(result.page()).isNotNull();
+  }
+
+  @Test
+  void shouldBuildQueryWithFilter() {
+    // given
+    final var filter =
+        new IncidentFilter(
+            List.of(1L, 2L), // processInstanceKeys
+            List.of(100L), // processDefinitionKeys
+            List.of("process-id"), // processDefinitionIds
+            List.of(500L), // incidentKeys
+            List.of("ACTIVE"), // states
+            List.of("JOB_NO_RETRIES"), // errorTypes
+            List.of("error message"), // errorMessages
+            List.of("task-1"), // flowNodeIds
+            List.of(300L), // flowNodeInstanceKeys
+            OffsetDateTime.now().minusDays(1), // creationTimeFrom
+            OffsetDateTime.now(), // creationTimeTo
+            List.of(600L), // jobKeys
+            List.of("tenant-1")); // tenantIds
+    final var request = new IncidentSearchRequest(filter, null, null);
+
+    // when
+    final IncidentQuery result = IncidentMapper.buildIncidentQuery(request);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.filter()).isNotNull();
+  }
+
+  @Test
+  void shouldBuildQueryWithSort() {
+    // given
+    final var sorts =
+        List.of(new IncidentSort("key", "desc"), new IncidentSort("creationTime", "asc"));
+    final var request = new IncidentSearchRequest(null, sorts, null);
+
+    // when
+    final IncidentQuery result = IncidentMapper.buildIncidentQuery(request);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.sort()).isNotNull();
+    assertThat(result.sort().getFieldSortings()).hasSize(2);
+  }
+
+  @Test
+  void shouldBuildQueryWithPage() {
+    // given
+    final var page = new IncidentPage(50, List.of("search", "after", "values"));
+    final var request = new IncidentSearchRequest(null, null, page);
+
+    // when
+    final IncidentQuery result = IncidentMapper.buildIncidentQuery(request);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.page()).isNotNull();
+    assertThat(result.page().size()).isEqualTo(50);
+  }
+
+  @Test
+  void shouldCapPageSizeAt100() {
+    // given
+    final var page = new IncidentPage(200, null);
+    final var request = new IncidentSearchRequest(null, null, page);
+
+    // when
+    final IncidentQuery result = IncidentMapper.buildIncidentQuery(request);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.page()).isNotNull();
+    assertThat(result.page().size()).isEqualTo(100);
+  }
+
+  @Test
+  void shouldConvertIncidentEntityToIncident() {
+    // given
+    final var entity = mock(IncidentEntity.class);
+    when(entity.incidentKey()).thenReturn(123L);
+    when(entity.processInstanceKey()).thenReturn(456L);
+    when(entity.processDefinitionKey()).thenReturn(789L);
+    when(entity.errorType())
+        .thenReturn(io.camunda.search.entities.IncidentEntity.ErrorType.JOB_NO_RETRIES);
+    when(entity.state()).thenReturn(io.camunda.search.entities.IncidentEntity.IncidentState.ACTIVE);
+    when(entity.errorMessage()).thenReturn("Test error message");
+    when(entity.flowNodeId()).thenReturn("task-1");
+    when(entity.flowNodeInstanceKey()).thenReturn(111L);
+    when(entity.creationTime()).thenReturn(OffsetDateTime.parse("2024-01-01T10:00:00Z"));
+    when(entity.jobKey()).thenReturn(222L);
+    when(entity.tenantId()).thenReturn("tenant-1");
+
+    // when
+    final Incident result = IncidentMapper.toIncident(entity);
+
+    // then
+    assertThat(result.key()).isEqualTo(123L);
+    assertThat(result.processInstanceKey()).isEqualTo(456L);
+    assertThat(result.processDefinitionKey()).isEqualTo(789L);
+    assertThat(result.type()).isEqualTo("JOB_NO_RETRIES");
+    assertThat(result.state()).isEqualTo("ACTIVE");
+    assertThat(result.errorMessage()).isEqualTo("Test error message");
+    assertThat(result.errorType()).isEqualTo("JOB_NO_RETRIES");
+    assertThat(result.flowNodeId()).isEqualTo("task-1");
+    assertThat(result.flowNodeInstanceKey()).isEqualTo(111L);
+    assertThat(result.creationTime()).isEqualTo("2024-01-01T10:00Z");
+    assertThat(result.jobKey()).isEqualTo(222L);
+    assertThat(result.tenantId()).isEqualTo("tenant-1");
+  }
+
+  @Test
+  void shouldHandleNullValuesInIncidentEntity() {
+    // given
+    final var entity = mock(IncidentEntity.class);
+    when(entity.incidentKey()).thenReturn(123L);
+    when(entity.processInstanceKey()).thenReturn(456L);
+    when(entity.processDefinitionKey()).thenReturn(789L);
+    when(entity.errorType()).thenReturn(null);
+    when(entity.state()).thenReturn(null);
+    when(entity.errorMessage()).thenReturn(null);
+    when(entity.flowNodeId()).thenReturn(null);
+    when(entity.flowNodeInstanceKey()).thenReturn(null);
+    when(entity.creationTime()).thenReturn(null);
+    when(entity.jobKey()).thenReturn(null);
+    when(entity.tenantId()).thenReturn(null);
+
+    // when
+    final Incident result = IncidentMapper.toIncident(entity);
+
+    // then
+    assertThat(result.key()).isEqualTo(123L);
+    assertThat(result.processInstanceKey()).isEqualTo(456L);
+    assertThat(result.processDefinitionKey()).isEqualTo(789L);
+    assertThat(result.type()).isNull();
+    assertThat(result.state()).isNull();
+    assertThat(result.errorMessage()).isNull();
+    assertThat(result.errorType()).isNull();
+    assertThat(result.flowNodeId()).isNull();
+    assertThat(result.flowNodeInstanceKey()).isNull();
+    assertThat(result.creationTime()).isNull();
+    assertThat(result.jobKey()).isNull();
+    assertThat(result.tenantId()).isNull();
+  }
+}

--- a/zeebe/pom.xml
+++ b/zeebe/pom.xml
@@ -36,6 +36,7 @@
     <module>gateway</module>
     <module>gateway-grpc</module>
     <module>gateway-rest</module>
+    <module>gateway-mcp</module>
     <module>exporter-api</module>
     <module>exporter-common</module>
     <module>exporter-test</module>

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestSpringApplication.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestSpringApplication.java
@@ -184,7 +184,10 @@ public abstract class TestSpringApplication<T extends TestSpringApplication<T>>
   }
 
   protected T withUnauthenticatedAccess(final boolean unprotectedApi) {
-    return withProperty(AuthenticationProperties.API_UNPROTECTED, unprotectedApi);
+    return withAdditionalProperties(
+        Map.of(
+            AuthenticationProperties.API_UNPROTECTED, unprotectedApi,
+            AuthenticationProperties.MCP_UNPROTECTED, unprotectedApi));
   }
 
   public final T withUnauthenticatedAccess() {

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneBroker.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneBroker.java
@@ -73,6 +73,7 @@ public final class TestStandaloneBroker extends TestSpringApplication<TestStanda
     securityConfig = new CamundaSecurityProperties();
     securityConfig.getAuthorizations().setEnabled(false);
     securityConfig.getAuthentication().setUnprotectedApi(true);
+    securityConfig.getAuthentication().setUnprotectedMcp(true);
     securityConfig
         .getInitialization()
         .getUsers()
@@ -103,6 +104,9 @@ public final class TestStandaloneBroker extends TestSpringApplication<TestStanda
     withProperty(
         AuthenticationProperties.API_UNPROTECTED,
         securityConfig.getAuthentication().getUnprotectedApi());
+    withProperty(
+        AuthenticationProperties.MCP_UNPROTECTED,
+        securityConfig.getAuthentication().getUnprotectedMcp());
     // by default, we don't want to create the schema as ES/OS containers may not be used in the
     // current test
     withCreateSchema(false);

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneGateway.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneGateway.java
@@ -36,6 +36,7 @@ public final class TestStandaloneGateway extends TestSpringApplication<TestStand
 
     securityConfig = new CamundaSecurityProperties();
     securityConfig.getAuthentication().setUnprotectedApi(true);
+    securityConfig.getAuthentication().setUnprotectedMcp(true);
     securityConfig.getAuthorizations().setEnabled(false);
     //noinspection resource
     withBean("securityConfig", securityConfig, CamundaSecurityProperties.class);

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/JsonUtil.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/JsonUtil.java
@@ -52,6 +52,15 @@ public final class JsonUtil {
     }
   }
 
+  public static <T> T fromJson(final String json, final Class<T> clazz) {
+    try {
+      return JSON_MAPPER.readValue(json, clazz);
+    } catch (final IOException e) {
+      throw new AssertionError(
+          String.format("Failed to deserialize json '%s' to '%s'", json, clazz.getSimpleName()), e);
+    }
+  }
+
   public static String toJson(final Object o) {
     try {
       return JSON_MAPPER.writeValueAsString(o);


### PR DESCRIPTION
## 📌 Summary
Add **Model Context Protocol (MCP)** support to Camunda 8 Gateway so that LLM‑powered clients can query operational data (starting with incident search) securely and in real time.

## 🚀 Background  
[Model Context Protocol (MCP)](https://modelcontextprotocol.io/specification/2025-06-18) is an open standard that defines how AI agents exchange messages and call tools—think of it as **“USB‑C for AI.”**  
Spring AI provides a Boot starter that automatically wires MCP into Spring Boot, exposing Server‑Sent‑Events (SSE) and message endpoints out of the box ([docs](https://docs.spring.io/spring-ai/reference/api/mcp/mcp-overview.html), [SSE transport](https://docs.spring.io/spring-ai/reference/api/mcp/mcp-server-boot-starter-docs.html)).

This PR turns the Camunda Gateway into an MCP server, enabling AI agents to retrieve incidents and, later, manage process instances.

## 🛠 Implementation Highlights

<img width="2560" height="1562" alt="image" src="https://github.com/user-attachments/assets/029db15d-1015-489e-b9a9-7d7f6cee426c" />

### 1 — Gateway‑MCP Module `zeebe/gateway-mcp`
| File | Responsibilities |
|------|------------------|
| `GatewayMcpConfiguration.java` | *Auto‑configures* the MCP server, registers `WebMvcSseServerTransportProvider`, and converts Spring beans into MCP tool specs. |
| `GatewayMcpProperties.java` | Externalises settings (`camunda.gateway.mcp.*`), **disabled by default** for safety. |

This version of the implementation exposes 2 endpoints still:
* `GET /sse` – establish stream  
* `POST /mcp/message` – send client messages  

But [further version of the protocol](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#streamable-http) will likely reduce it to `/see` only.

Probably wait for release of [this change](https://github.com/modelcontextprotocol/java-sdk/pull/337), introducing `HttpClientStreamableHttpTransport`

### 2 — Incident Search Tool `tools/incident`
* **`ClusterIncidentsTool.java`** integrates with `IncidentServices` and enforces Spring‑Security authentication ().  
* Rich filter object (`processDefinitionIds`, `states`, `errorTypes`, etc.) and paginated JSON responses match [Camunda 8 Incident Search API](https://docs.camunda.io/docs/apis-tools/operate-api/specifications/search-3/).

### 3 — Security & Context Propagation
* Only supports Basic authentication for now (OIDC to be added but should be easy to support)
* Conditional beans `@ConditionalOnProtectedMcp` / `@ConditionalOnUnprotectedMcp` let operators pick **protected** (Basic) or **open** modes.
* `McpConfiguration.java` enables **Reactor context propagation** so `SecurityContext` survives async tool execution.

### 4 — Notable Design Decisions
| Decision | Rationale |
|----------|-----------|
| **Reactor context propagation ON** | Preserves authentication in async MCP sessions. |
| **Dual‑mode auth** | Makes local dev easy while keeping prod secure by default. |
| **Service‑layer integration** | Re‑uses `IncidentServices` instead of raw Operate REST, ensuring business rules and multi‑tenancy checks remain intact. |

## 🔧 How to Enable Locally
```properties
# application.yaml or .env
camunda.gateway.mcp.enabled=true
```

- Run Camunda using `StandaloneCamunda DEV` (no auth)
```
CAMUNDA_GATEWAY_MCP_ENABLED=true
CAMUNDA_SECURITY_AUTHENTICATION_UNPROTECTED-MCP=true
```
- `npm install -g @modelcontextprotocol/inspector`
- `npx @modelcontextprotocol/inspector`

<img width="1999" height="1045" alt="image" src="https://github.com/user-attachments/assets/7faf872e-c1e5-4d9a-884c-6341957519f3" />

## 🔜 Future Work
- Additional tools – process‑instance operations, tasklist queries
- OAuth 2 / OIDC – enterprise‑grade auth provider
- JSON‑Schema validation for request bodies
- Tenant isolation enhancements
- Audit logging of tool invocations

Closes: https://github.com/camunda/camunda/issues/35865