### PR TITLE
fix: prevent NPE for SendTask with publish message implementation

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnElementProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnElementProcessors.java
@@ -31,6 +31,7 @@ import io.camunda.zeebe.engine.processing.bpmn.task.JobWorkerTaskProcessor;
 import io.camunda.zeebe.engine.processing.bpmn.task.ManualTaskProcessor;
 import io.camunda.zeebe.engine.processing.bpmn.task.ReceiveTaskProcessor;
 import io.camunda.zeebe.engine.processing.bpmn.task.ScriptTaskProcessor;
+import io.camunda.zeebe.engine.processing.bpmn.task.SendTaskProcessor;
 import io.camunda.zeebe.engine.processing.bpmn.task.UndefinedTaskProcessor;
 import io.camunda.zeebe.engine.processing.bpmn.task.UserTaskProcessor;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlowElement;
@@ -60,8 +61,7 @@ public final class BpmnElementProcessors {
         BpmnElementType.SCRIPT_TASK,
         new ScriptTaskProcessor(bpmnBehaviors, stateTransitionBehavior));
     processors.put(
-        BpmnElementType.SEND_TASK,
-        new JobWorkerTaskProcessor(bpmnBehaviors, stateTransitionBehavior));
+        BpmnElementType.SEND_TASK, new SendTaskProcessor(bpmnBehaviors, stateTransitionBehavior));
     processors.put(
         BpmnElementType.USER_TASK, new UserTaskProcessor(bpmnBehaviors, stateTransitionBehavior));
     processors.put(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/task/SendTaskProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/task/SendTaskProcessor.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.bpmn.task;
+
+import io.camunda.zeebe.engine.processing.bpmn.BpmnElementContext;
+import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
+import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnStateTransitionBehavior;
+import io.camunda.zeebe.engine.processing.common.Failure;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableSendTask;
+import io.camunda.zeebe.protocol.record.value.ErrorType;
+import io.camunda.zeebe.util.Either;
+
+public final class SendTaskProcessor extends JobWorkerTaskSupportingProcessor<ExecutableSendTask> {
+
+  private static final Either<Failure, ?> UNSUPPORTED_IMPLEMENTATION_RESULT =
+      Either.left(
+          new Failure(
+              "Currently, only job worker-based implementation is supported for 'sendTask'. "
+                  + "To recover, model the task using a 'zeebe:taskDefinition' with a valid job type, "
+                  + "deploy the updated process version, and migrate the instance to it.",
+              ErrorType.UNKNOWN));
+
+  public SendTaskProcessor(
+      final BpmnBehaviors bpmnBehaviors,
+      final BpmnStateTransitionBehavior stateTransitionBehavior) {
+    super(bpmnBehaviors, stateTransitionBehavior);
+  }
+
+  @Override
+  public Class<ExecutableSendTask> getType() {
+    return ExecutableSendTask.class;
+  }
+
+  @Override
+  protected boolean isJobBehavior(
+      final ExecutableSendTask element, final BpmnElementContext context) {
+    final var jobWorkerProperties = element.getJobWorkerProperties();
+    return jobWorkerProperties != null && jobWorkerProperties.getType() != null;
+  }
+
+  @Override
+  protected Either<Failure, ?> onActivateInternal(
+      final ExecutableSendTask element, final BpmnElementContext context) {
+    return UNSUPPORTED_IMPLEMENTATION_RESULT;
+  }
+
+  @Override
+  protected Either<Failure, ?> onFinalizeActivationInternal(
+      final ExecutableSendTask element, final BpmnElementContext context) {
+    return UNSUPPORTED_IMPLEMENTATION_RESULT;
+  }
+
+  @Override
+  protected Either<Failure, ?> onCompleteInternal(
+      final ExecutableSendTask element, final BpmnElementContext context) {
+    return UNSUPPORTED_IMPLEMENTATION_RESULT;
+  }
+
+  @Override
+  protected Either<Failure, ?> onFinalizeCompletionInternal(
+      final ExecutableSendTask element, final BpmnElementContext context) {
+    return UNSUPPORTED_IMPLEMENTATION_RESULT;
+  }
+
+  @Override
+  protected TransitionOutcome onTerminateInternal(
+      final ExecutableSendTask element, final BpmnElementContext context) {
+    return TransitionOutcome.CONTINUE;
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableSendTask.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableSendTask.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.deployment.model.element;
+
+/*
+ * Placeholder model for the executable BPMN Send Task.
+ *
+ * Currently, Send Tasks in Zeebe only support job worker-based implementations.
+ * This class extends ExecutableJobWorkerTask to expose job worker properties
+ * required for the supported use case.
+ *
+ * Once support for additional implementations (e.g., publish message-based) is introduced,
+ * this class should be updated to support those properties directly
+ * (similar to ExecutableScriptTask or ExecutableBusinessRuleTask).
+ */
+public final class ExecutableSendTask extends ExecutableJobWorkerTask {
+
+  public ExecutableSendTask(final String id) {
+    super(id);
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/FlowElementInstantiationTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/FlowElementInstantiationTransformer.java
@@ -25,6 +25,7 @@ import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableJob
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableProcess;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableReceiveTask;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableScriptTask;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableSendTask;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableSequenceFlow;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableStartEvent;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableUserTask;
@@ -94,7 +95,7 @@ public final class FlowElementInstantiationTransformer
     ELEMENT_FACTORIES.put(ParallelGateway.class, ExecutableFlowNode::new);
     ELEMENT_FACTORIES.put(ReceiveTask.class, ExecutableReceiveTask::new);
     ELEMENT_FACTORIES.put(ScriptTask.class, ExecutableScriptTask::new);
-    ELEMENT_FACTORIES.put(SendTask.class, ExecutableJobWorkerTask::new);
+    ELEMENT_FACTORIES.put(SendTask.class, ExecutableSendTask::new);
     ELEMENT_FACTORIES.put(SequenceFlow.class, ExecutableSequenceFlow::new);
     ELEMENT_FACTORIES.put(ServiceTask.class, ExecutableJobWorkerTask::new);
     ELEMENT_FACTORIES.put(StartEvent.class, ExecutableStartEvent::new);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/SendTaskTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/SendTaskTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.bpmn.activity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.Assertions;
+import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.value.ErrorType;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestWatcher;
+
+public final class SendTaskTest {
+
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+  @Rule public final TestWatcher watcher = new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldCreateIncidentForNotSupportedSendTaskImplementation() {
+    // given
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            "process.bpmn",
+            Bpmn.createExecutableProcess("process")
+                .startEvent()
+                .sendTask("task")
+                // sendTask with publish message implementation isn't supported yet
+                .message(m -> m.name("msg").zeebeCorrelationKeyExpression("123"))
+                .endEvent()
+                .done())
+        .deploy();
+
+    // when
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId("process").create();
+
+    // then
+    final var incident =
+        RecordingExporter.incidentRecords()
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementId("task")
+            .getFirst();
+
+    Assertions.assertThat(incident.getValue())
+        .hasErrorType(ErrorType.UNKNOWN)
+        .hasErrorMessage(
+            "Currently, only job worker-based implementation is supported for 'sendTask'. "
+                + "To recover, model the task using a 'zeebe:taskDefinition' with a valid job type, "
+                + "deploy the updated process version, and migrate the instance to it.");
+  }
+
+  @Test
+  public void shouldRecoverFromIncidentViaProcessMigration() {
+    // given: deploy process with unsupported publish-message SendTask implementation
+    final var processV1 =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .sendTask("task")
+            .message(m -> m.name("msg").zeebeCorrelationKeyExpression("123")) // unsupported
+            .endEvent()
+            .done();
+
+    ENGINE.deployment().withXmlResource("process-v1.bpmn", processV1).deploy();
+
+    // create a process instance (definition version 1)
+    final long instanceKey = ENGINE.processInstance().ofBpmnProcessId("process").create();
+
+    // wait for incident
+    final var incident =
+        RecordingExporter.incidentRecords()
+            .withProcessInstanceKey(instanceKey)
+            .withElementId("task")
+            .withIntent(IncidentIntent.CREATED)
+            .getFirst();
+
+    // deploy v2 process with a correct SendTask (job worker-based implementation)
+    final var processV2 =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .sendTask("task", t -> t.zeebeJobType("send-task-job"))
+            .endEvent()
+            .done();
+
+    final long newDefinitionKey =
+        ENGINE
+            .deployment()
+            .withXmlResource("process-v2.bpmn", processV2)
+            .deploy()
+            .getValue()
+            .getProcessesMetadata()
+            .getFirst()
+            .getProcessDefinitionKey();
+
+    // when: migrate the instance to the new version
+    ENGINE
+        .processInstance()
+        .withInstanceKey(instanceKey)
+        .migration()
+        .withTargetProcessDefinitionKey(newDefinitionKey)
+        .addMappingInstruction("task", "task")
+        .migrate();
+
+    // resolve the incident after migration
+    ENGINE.incident().ofInstance(instanceKey).withKey(incident.getKey()).resolve();
+
+    // then: a job should be created for the SendTask
+    assertThat(
+            RecordingExporter.jobRecords(JobIntent.CREATED)
+                .withProcessInstanceKey(instanceKey)
+                .withElementId("task")
+                .withType("send-task-job")
+                .exists())
+        .as("Job for SendTask should be created after incident resolution")
+        .isTrue();
+  }
+}


### PR DESCRIPTION
## Description

This PR prevent a `NullPointerException` when a Send Task is modeled with a publish-message implementation (that is not supported yet). Instead of crashing on activation, the engine now creates a clear incident and allows the instance to be terminated cleanly.

### What changed:
- Introduced a dedicated `SendTaskProcessor` (with `ExecutableSendTask`).
- If job-worker properties are present -> proceed as usual.
- If they’re missing (publish-message path) -> raise an incident with a helpful message.
- Implemented proper termination for this path (cancel related work, resolve incident, transition to `TERMINATED`).
- Added tests for incident creation and successful termination.

#### ErrorType
- Uses `ErrorType.UNKNOWN` for now (based on a [quick discussion](https://camunda.slack.com/archives/C08G19SQ1BM/p1756991336652469) we agreed a new error type is not needed at this point).

### Next
- A separate PR will improve validation to reject Send Tasks with a publish-message implementation at deployment time.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #34190 
