### PR TITLE
ci: fix failing CI health submission

### DIFF
--- a/.github/workflows/camunda-helm-integration.yml
+++ b/.github/workflows/camunda-helm-integration.yml
@@ -50,6 +50,8 @@ jobs:
     timeout-minutes: 5
     permissions: {}  # GITHUB_TOKEN unused in this job
     steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
       - name: Import Secrets
         id: secrets
         uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b # v3.4.0


### PR DESCRIPTION
## Description

Fixes the error popping up in https://github.com/camunda/camunda/actions/runs/16488269708

Using `uses: ./.github/actions/observe-build-status` in a GHA job requires having `uses: actions/checkout` first, but the notification job didn't do that. This PR fixes that.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

None
