### PR TITLE
feat: Cover Operate V1 APIs with authorization checks

### DIFF
--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/StartupIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/StartupIT.java
@@ -71,7 +71,8 @@ public class StartupIT {
         .withEnv("CAMUNDA_OPERATE_ZEEBEELASTICSEARCH_PORT", String.valueOf(elsPort))
         .withEnv("CAMUNDA_OPERATE_ZEEBE_COMPATIBILITY_ENABLED", "true")
         .withEnv("CAMUNDA_DATABASE_URL", elasticsearchUrl)
-        .withEnv("CAMUNDA_SECURITY_AUTHENTICATION_UNPROTECTEDAPI", "true");
+        .withEnv("CAMUNDA_SECURITY_AUTHENTICATION_UNPROTECTEDAPI", "true")
+        .withEnv("CAMUNDA_SECURITY_AUTHORIZATIONS_ENABLED", "false");
 
     testContainerUtil.startOperateContainer(operateContainer, testContext);
     LOGGER.info("************ Operate started  ************");

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/api/v1/rest/DecisionDefinitionControllerIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/api/v1/rest/DecisionDefinitionControllerIT.java
@@ -11,6 +11,7 @@ import static io.camunda.operate.webapp.api.v1.rest.DecisionDefinitionController
 import static io.camunda.operate.webapp.api.v1.rest.SearchController.SEARCH;
 import static io.camunda.webapps.schema.descriptors.index.DecisionIndex.VERSION;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -22,8 +23,10 @@ import io.camunda.operate.util.apps.nobeans.TestApplicationWithNoBeans;
 import io.camunda.operate.webapp.api.v1.dao.DecisionDefinitionDao;
 import io.camunda.operate.webapp.api.v1.entities.DecisionDefinition;
 import io.camunda.operate.webapp.api.v1.entities.Query;
+import io.camunda.operate.webapp.api.v1.exceptions.ForbiddenException;
 import io.camunda.operate.webapp.api.v1.exceptions.ResourceNotFoundException;
 import io.camunda.operate.webapp.api.v1.exceptions.ServerException;
+import io.camunda.operate.webapp.security.permission.PermissionsService;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.Before;
@@ -32,6 +35,7 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
@@ -48,6 +52,7 @@ public class DecisionDefinitionControllerIT {
   private MockMvc mockMvc;
 
   @MockBean private DecisionDefinitionDao decisionDefinitionDao;
+  @MockBean private PermissionsService permissionsService;
 
   @Before
   public void setupMockMvc() {
@@ -162,6 +167,28 @@ public class DecisionDefinitionControllerIT {
     assertPostToWithFailed(DecisionDefinitionController.URI + SEARCH, "{}")
         .andExpect(status().isInternalServerError())
         .andExpect(content().string(expectedJSONContent));
+  }
+
+  @Test
+  public void shouldReturnForbiddenWhenUnauthorizedForByKey() throws Exception {
+    // given
+    doThrow(new ForbiddenException("Unauthorized"))
+        .when(permissionsService)
+        .verifyWildcardResourcePermission(any(), any());
+
+    // when - then
+    assertGetWithFailed(URI + "/235").andExpect(status().is(HttpStatus.FORBIDDEN.value()));
+  }
+
+  @Test
+  public void shouldReturnForbiddenWhenUnauthorizedForSearch() throws Exception {
+    // given
+    doThrow(new ForbiddenException("Unauthorized"))
+        .when(permissionsService)
+        .verifyWildcardResourcePermission(any(), any());
+
+    // when - then
+    assertPostToWithFailed(URI + SEARCH, "{}").andExpect(status().is(HttpStatus.FORBIDDEN.value()));
   }
 
   protected ResultActions assertGetToSucceed(final String endpoint) throws Exception {

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/api/v1/rest/DecisionInstanceControllerIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/api/v1/rest/DecisionInstanceControllerIT.java
@@ -10,6 +10,7 @@ package io.camunda.operate.webapp.api.v1.rest;
 import static io.camunda.operate.webapp.api.v1.rest.DecisionInstanceController.URI;
 import static io.camunda.operate.webapp.api.v1.rest.SearchController.SEARCH;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -21,8 +22,10 @@ import io.camunda.operate.util.apps.nobeans.TestApplicationWithNoBeans;
 import io.camunda.operate.webapp.api.v1.dao.DecisionInstanceDao;
 import io.camunda.operate.webapp.api.v1.entities.DecisionInstance;
 import io.camunda.operate.webapp.api.v1.entities.Query;
+import io.camunda.operate.webapp.api.v1.exceptions.ForbiddenException;
 import io.camunda.operate.webapp.api.v1.exceptions.ResourceNotFoundException;
 import io.camunda.operate.webapp.api.v1.exceptions.ServerException;
+import io.camunda.operate.webapp.security.permission.PermissionsService;
 import io.camunda.webapps.schema.descriptors.template.DecisionInstanceTemplate;
 import java.util.ArrayList;
 import java.util.List;
@@ -32,6 +35,7 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
@@ -48,6 +52,7 @@ public class DecisionInstanceControllerIT {
   private MockMvc mockMvc;
 
   @MockBean private DecisionInstanceDao decisionInstanceDao;
+  @MockBean private PermissionsService permissionsService;
 
   @Before
   public void setupMockMvc() {
@@ -167,6 +172,28 @@ public class DecisionInstanceControllerIT {
     assertPostToWithFailed(DecisionInstanceController.URI + SEARCH, "{}")
         .andExpect(status().isInternalServerError())
         .andExpect(content().string(expectedJSONContent));
+  }
+
+  @Test
+  public void shouldReturnForbiddenWhenUnauthorizedForByKey() throws Exception {
+    // given
+    doThrow(new ForbiddenException("Unauthorized"))
+        .when(permissionsService)
+        .verifyWildcardResourcePermission(any(), any());
+
+    // when - then
+    assertGetWithFailed(URI + "/235").andExpect(status().is(HttpStatus.FORBIDDEN.value()));
+  }
+
+  @Test
+  public void shouldReturnForbiddenWhenUnauthorizedForSearch() throws Exception {
+    // given
+    doThrow(new ForbiddenException("Unauthorized"))
+        .when(permissionsService)
+        .verifyWildcardResourcePermission(any(), any());
+
+    // when - then
+    assertPostToWithFailed(URI + SEARCH, "{}").andExpect(status().is(HttpStatus.FORBIDDEN.value()));
   }
 
   protected ResultActions assertGetToSucceed(final String endpoint) throws Exception {

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/api/v1/rest/DecisionRequirementsControllerIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/api/v1/rest/DecisionRequirementsControllerIT.java
@@ -12,6 +12,7 @@ import static io.camunda.operate.webapp.api.v1.rest.DecisionRequirementsControll
 import static io.camunda.operate.webapp.api.v1.rest.SearchController.SEARCH;
 import static io.camunda.webapps.schema.descriptors.index.DecisionIndex.VERSION;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -23,8 +24,10 @@ import io.camunda.operate.util.apps.nobeans.TestApplicationWithNoBeans;
 import io.camunda.operate.webapp.api.v1.dao.DecisionRequirementsDao;
 import io.camunda.operate.webapp.api.v1.entities.DecisionRequirements;
 import io.camunda.operate.webapp.api.v1.entities.Query;
+import io.camunda.operate.webapp.api.v1.exceptions.ForbiddenException;
 import io.camunda.operate.webapp.api.v1.exceptions.ResourceNotFoundException;
 import io.camunda.operate.webapp.api.v1.exceptions.ServerException;
+import io.camunda.operate.webapp.security.permission.PermissionsService;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.Before;
@@ -33,6 +36,7 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
@@ -49,6 +53,7 @@ public class DecisionRequirementsControllerIT {
   private MockMvc mockMvc;
 
   @MockBean private DecisionRequirementsDao decisionRequirementsDao;
+  @MockBean private PermissionsService permissionsService;
 
   @Before
   public void setupMockMvc() {
@@ -189,6 +194,39 @@ public class DecisionRequirementsControllerIT {
     assertPostToWithFailed(DecisionRequirementsController.URI + SEARCH, "{}")
         .andExpect(status().isInternalServerError())
         .andExpect(content().string(expectedJSONContent));
+  }
+
+  @Test
+  public void shouldReturnForbiddenWhenUnauthorizedForByKey() throws Exception {
+    // given
+    doThrow(new ForbiddenException("Unauthorized"))
+        .when(permissionsService)
+        .verifyWildcardResourcePermission(any(), any());
+
+    // when - then
+    assertGetWithFailed(URI + "/235").andExpect(status().is(HttpStatus.FORBIDDEN.value()));
+  }
+
+  @Test
+  public void shouldReturnForbiddenWhenUnauthorizedForByKeyXml() throws Exception {
+    // given
+    doThrow(new ForbiddenException("Unauthorized"))
+        .when(permissionsService)
+        .verifyWildcardResourcePermission(any(), any());
+
+    // when - then
+    assertGetWithFailed(URI + "/235" + AS_XML).andExpect(status().is(HttpStatus.FORBIDDEN.value()));
+  }
+
+  @Test
+  public void shouldReturnForbiddenWhenUnauthorizedForSearch() throws Exception {
+    // given
+    doThrow(new ForbiddenException("Unauthorized"))
+        .when(permissionsService)
+        .verifyWildcardResourcePermission(any(), any());
+
+    // when - then
+    assertPostToWithFailed(URI + SEARCH, "{}").andExpect(status().is(HttpStatus.FORBIDDEN.value()));
   }
 
   protected ResultActions assertGetToSucceed(final String endpoint) throws Exception {

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/api/v1/rest/FlowNodeInstanceControllerIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/api/v1/rest/FlowNodeInstanceControllerIT.java
@@ -10,6 +10,7 @@ package io.camunda.operate.webapp.api.v1.rest;
 import static io.camunda.operate.webapp.api.v1.rest.FlowNodeInstanceController.URI;
 import static io.camunda.operate.webapp.api.v1.rest.SearchController.SEARCH;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -23,14 +24,17 @@ import io.camunda.operate.webapp.api.v1.entities.FlowNodeInstance;
 import io.camunda.operate.webapp.api.v1.entities.Query;
 import io.camunda.operate.webapp.api.v1.entities.Query.Sort;
 import io.camunda.operate.webapp.api.v1.entities.Query.Sort.Order;
+import io.camunda.operate.webapp.api.v1.exceptions.ForbiddenException;
 import io.camunda.operate.webapp.api.v1.exceptions.ResourceNotFoundException;
 import io.camunda.operate.webapp.api.v1.exceptions.ServerException;
+import io.camunda.operate.webapp.security.permission.PermissionsService;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
@@ -43,9 +47,8 @@ import org.springframework.web.context.WebApplicationContext;
 public class FlowNodeInstanceControllerIT {
 
   @Autowired WebApplicationContext context;
-
+  @MockBean PermissionsService permissionsService;
   private MockMvc mockMvc;
-
   @MockBean private FlowNodeInstanceDao flowNodeInstanceDao;
 
   @Before
@@ -191,6 +194,28 @@ public class FlowNodeInstanceControllerIT {
     assertGetWithFailed(URI + "/235")
         .andExpect(status().isNotFound())
         .andExpect(content().string(expectedJSONContent));
+  }
+
+  @Test
+  public void shouldReturnForbiddenWhenUnauthorizedForByKey() throws Exception {
+    // given
+    doThrow(new ForbiddenException("Unauthorized"))
+        .when(permissionsService)
+        .verifyWildcardResourcePermission(any(), any());
+
+    // when - then
+    assertGetWithFailed(URI + "/235").andExpect(status().is(HttpStatus.FORBIDDEN.value()));
+  }
+
+  @Test
+  public void shouldReturnForbiddenWhenUnauthorizedForSearch() throws Exception {
+    // given
+    doThrow(new ForbiddenException("Unauthorized"))
+        .when(permissionsService)
+        .verifyWildcardResourcePermission(any(), any());
+
+    // when - then
+    assertPostToWithFailed(URI + SEARCH, "{}").andExpect(status().is(HttpStatus.FORBIDDEN.value()));
   }
 
   protected ResultActions assertGetWithFailed(final String endpoint) throws Exception {

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/api/v1/rest/ProcessDefinitionControllerIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/api/v1/rest/ProcessDefinitionControllerIT.java
@@ -12,6 +12,7 @@ import static io.camunda.operate.webapp.api.v1.rest.ProcessDefinitionController.
 import static io.camunda.operate.webapp.api.v1.rest.SearchController.SEARCH;
 import static io.camunda.webapps.schema.descriptors.index.ProcessIndex.VERSION;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -25,8 +26,10 @@ import io.camunda.operate.webapp.api.v1.entities.ProcessDefinition;
 import io.camunda.operate.webapp.api.v1.entities.Query;
 import io.camunda.operate.webapp.api.v1.entities.Query.Sort;
 import io.camunda.operate.webapp.api.v1.entities.Query.Sort.Order;
+import io.camunda.operate.webapp.api.v1.exceptions.ForbiddenException;
 import io.camunda.operate.webapp.api.v1.exceptions.ResourceNotFoundException;
 import io.camunda.operate.webapp.api.v1.exceptions.ServerException;
+import io.camunda.operate.webapp.security.permission.PermissionsService;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.Before;
@@ -35,6 +38,7 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
@@ -51,6 +55,7 @@ public class ProcessDefinitionControllerIT {
   private MockMvc mockMvc;
 
   @MockBean private ProcessDefinitionDao processDefinitionDao;
+  @MockBean private PermissionsService permissionsService;
 
   @Before
   public void setupMockMvc() {
@@ -186,6 +191,39 @@ public class ProcessDefinitionControllerIT {
     assertGetWithFailed(URI + "/235" + AS_XML)
         .andExpect(status().isInternalServerError())
         .andExpect(content().string(expectedJSONContent));
+  }
+
+  @Test
+  public void shouldReturnForbiddenWhenUnauthorizedForByKey() throws Exception {
+    // given
+    doThrow(new ForbiddenException("Unauthorized"))
+        .when(permissionsService)
+        .verifyWildcardResourcePermission(any(), any());
+
+    // when - then
+    assertGetWithFailed(URI + "/235").andExpect(status().is(HttpStatus.FORBIDDEN.value()));
+  }
+
+  @Test
+  public void shouldReturnForbiddenWhenUnauthorizedForByKeyXml() throws Exception {
+    // given
+    doThrow(new ForbiddenException("Unauthorized"))
+        .when(permissionsService)
+        .verifyWildcardResourcePermission(any(), any());
+
+    // when - then
+    assertGetWithFailed(URI + "/235" + AS_XML).andExpect(status().is(HttpStatus.FORBIDDEN.value()));
+  }
+
+  @Test
+  public void shouldReturnForbiddenWhenUnauthorizedForSearch() throws Exception {
+    // given
+    doThrow(new ForbiddenException("Unauthorized"))
+        .when(permissionsService)
+        .verifyWildcardResourcePermission(any(), any());
+
+    // when - then
+    assertPostToWithFailed(URI + SEARCH, "{}").andExpect(status().is(HttpStatus.FORBIDDEN.value()));
   }
 
   protected ResultActions assertGetToSucceed(final String endpoint) throws Exception {

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/api/v1/rest/VariableControllerIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/api/v1/rest/VariableControllerIT.java
@@ -10,6 +10,7 @@ package io.camunda.operate.webapp.api.v1.rest;
 import static io.camunda.operate.webapp.api.v1.rest.SearchController.SEARCH;
 import static io.camunda.operate.webapp.api.v1.rest.VariableController.URI;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -23,14 +24,17 @@ import io.camunda.operate.webapp.api.v1.entities.Query;
 import io.camunda.operate.webapp.api.v1.entities.Query.Sort;
 import io.camunda.operate.webapp.api.v1.entities.Query.Sort.Order;
 import io.camunda.operate.webapp.api.v1.entities.Variable;
+import io.camunda.operate.webapp.api.v1.exceptions.ForbiddenException;
 import io.camunda.operate.webapp.api.v1.exceptions.ResourceNotFoundException;
 import io.camunda.operate.webapp.api.v1.exceptions.ServerException;
+import io.camunda.operate.webapp.security.permission.PermissionsService;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
@@ -47,6 +51,7 @@ public class VariableControllerIT {
   private MockMvc mockMvc;
 
   @MockBean private VariableDao variableDao;
+  @MockBean private PermissionsService permissionsService;
 
   @Before
   public void setupMockMvc() {
@@ -155,6 +160,28 @@ public class VariableControllerIT {
     assertGetWithFailed(URI + "/235")
         .andExpect(status().isNotFound())
         .andExpect(content().string(expectedJSONContent));
+  }
+
+  @Test
+  public void shouldReturnForbiddenWhenUnauthorizedForByKey() throws Exception {
+    // given
+    doThrow(new ForbiddenException("Unauthorized"))
+        .when(permissionsService)
+        .verifyWildcardResourcePermission(any(), any());
+
+    // when - then
+    assertGetWithFailed(URI + "/235").andExpect(status().is(HttpStatus.FORBIDDEN.value()));
+  }
+
+  @Test
+  public void shouldReturnForbiddenWhenUnauthorizedForSearch() throws Exception {
+    // given
+    doThrow(new ForbiddenException("Unauthorized"))
+        .when(permissionsService)
+        .verifyWildcardResourcePermission(any(), any());
+
+    // when - then
+    assertPostToWithFailed(URI + SEARCH, "{}").andExpect(status().is(HttpStatus.FORBIDDEN.value()));
   }
 
   protected ResultActions assertGetWithFailed(final String endpoint) throws Exception {

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/exceptions/ForbiddenException.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/exceptions/ForbiddenException.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.operate.webapp.api.v1.exceptions;
+
+public class ForbiddenException extends APIException {
+
+  public static final String TYPE = "Forbidden resource access";
+
+  public ForbiddenException(final String message) {
+    super(message);
+  }
+}

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/rest/DecisionDefinitionController.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/rest/DecisionDefinitionController.java
@@ -8,6 +8,8 @@
 package io.camunda.operate.webapp.api.v1.rest;
 
 import static io.camunda.operate.webapp.api.v1.rest.DecisionDefinitionController.URI;
+import static io.camunda.zeebe.protocol.record.value.AuthorizationResourceType.DECISION_DEFINITION;
+import static io.camunda.zeebe.protocol.record.value.PermissionType.READ_DECISION_DEFINITION;
 
 import io.camunda.operate.webapp.api.v1.dao.DecisionDefinitionDao;
 import io.camunda.operate.webapp.api.v1.entities.DecisionDefinition;
@@ -16,9 +18,11 @@ import io.camunda.operate.webapp.api.v1.entities.Query;
 import io.camunda.operate.webapp.api.v1.entities.QueryValidator;
 import io.camunda.operate.webapp.api.v1.entities.Results;
 import io.camunda.operate.webapp.api.v1.exceptions.ClientException;
+import io.camunda.operate.webapp.api.v1.exceptions.ForbiddenException;
 import io.camunda.operate.webapp.api.v1.exceptions.ResourceNotFoundException;
 import io.camunda.operate.webapp.api.v1.exceptions.ServerException;
 import io.camunda.operate.webapp.api.v1.exceptions.ValidationException;
+import io.camunda.operate.webapp.security.permission.PermissionsService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -62,6 +66,8 @@ public class DecisionDefinitionController extends ErrorController
   private final QueryValidator<DecisionDefinition> queryValidator = new QueryValidator<>();
   @Autowired private DecisionDefinitionDao decisionDefinitionDao;
 
+  @Autowired private PermissionsService permissionsService;
+
   @Operation(
       summary = "Search decision definitions",
       security = {@SecurityRequirement(name = "bearer-key"), @SecurityRequirement(name = "cookie")},
@@ -87,7 +93,14 @@ public class DecisionDefinitionController extends ErrorController
             content =
                 @Content(
                     mediaType = MediaType.APPLICATION_PROBLEM_JSON_VALUE,
-                    schema = @Schema(implementation = Error.class)))
+                    schema = @Schema(implementation = Error.class))),
+        @ApiResponse(
+            description = ForbiddenException.TYPE,
+            responseCode = "403",
+            content =
+                @Content(
+                    mediaType = MediaType.APPLICATION_PROBLEM_JSON_VALUE,
+                    schema = @Schema(implementation = Error.class))),
       })
   @io.swagger.v3.oas.annotations.parameters.RequestBody(
       description = "Search examples",
@@ -139,6 +152,8 @@ public class DecisionDefinitionController extends ErrorController
       @RequestBody(required = false) Query<DecisionDefinition> query) {
     query = (query == null) ? new Query<>() : query;
     queryValidator.validate(query, DecisionDefinition.class, SEARCH_SORT_VALIDATOR);
+    permissionsService.verifyWildcardResourcePermission(
+        DECISION_DEFINITION, READ_DECISION_DEFINITION);
     return decisionDefinitionDao.search(query);
   }
 
@@ -162,6 +177,13 @@ public class DecisionDefinitionController extends ErrorController
                     mediaType = MediaType.APPLICATION_PROBLEM_JSON_VALUE,
                     schema = @Schema(implementation = Error.class))),
         @ApiResponse(
+            description = ForbiddenException.TYPE,
+            responseCode = "403",
+            content =
+                @Content(
+                    mediaType = MediaType.APPLICATION_PROBLEM_JSON_VALUE,
+                    schema = @Schema(implementation = Error.class))),
+        @ApiResponse(
             description = ResourceNotFoundException.TYPE,
             responseCode = "404",
             content =
@@ -173,6 +195,8 @@ public class DecisionDefinitionController extends ErrorController
   public DecisionDefinition byKey(
       @Parameter(description = "Key of decision definition", required = true) @PathVariable
           final Long key) {
+    permissionsService.verifyWildcardResourcePermission(
+        DECISION_DEFINITION, READ_DECISION_DEFINITION);
     return decisionDefinitionDao.byKey(key);
   }
 }

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/rest/DecisionInstanceController.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/rest/DecisionInstanceController.java
@@ -8,6 +8,8 @@
 package io.camunda.operate.webapp.api.v1.rest;
 
 import static io.camunda.operate.webapp.api.v1.rest.DecisionInstanceController.URI;
+import static io.camunda.zeebe.protocol.record.value.AuthorizationResourceType.DECISION_DEFINITION;
+import static io.camunda.zeebe.protocol.record.value.PermissionType.READ_DECISION_INSTANCE;
 
 import io.camunda.operate.webapp.api.v1.dao.DecisionInstanceDao;
 import io.camunda.operate.webapp.api.v1.entities.DecisionInstance;
@@ -18,6 +20,7 @@ import io.camunda.operate.webapp.api.v1.exceptions.ClientException;
 import io.camunda.operate.webapp.api.v1.exceptions.ResourceNotFoundException;
 import io.camunda.operate.webapp.api.v1.exceptions.ServerException;
 import io.camunda.operate.webapp.api.v1.exceptions.ValidationException;
+import io.camunda.operate.webapp.security.permission.PermissionsService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -41,6 +44,8 @@ public class DecisionInstanceController extends ErrorController {
   public static final String URI = "/v1/decision-instances";
   public static final String BY_ID = "/{id}";
   public static final String SEARCH = "/search";
+
+  @Autowired private PermissionsService permissionsService;
 
   @Autowired private DecisionInstanceDao decisionInstanceDao;
 
@@ -78,6 +83,8 @@ public class DecisionInstanceController extends ErrorController {
   public DecisionInstance byId(
       @Parameter(description = "Id of decision instance", required = true) @PathVariable
           final String id) {
+    permissionsService.verifyWildcardResourcePermission(
+        DECISION_DEFINITION, READ_DECISION_INSTANCE);
     return decisionInstanceDao.byId(id);
   }
 
@@ -161,6 +168,8 @@ public class DecisionInstanceController extends ErrorController {
       produces = {MediaType.APPLICATION_JSON_VALUE})
   public Results<DecisionInstance> search(
       @RequestBody(required = false) Query<DecisionInstance> query) {
+    permissionsService.verifyWildcardResourcePermission(
+        DECISION_DEFINITION, READ_DECISION_INSTANCE);
     query = (query == null) ? new Query<>() : query;
     return decisionInstanceDao.search(query);
   }

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/rest/DecisionRequirementsController.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/rest/DecisionRequirementsController.java
@@ -8,6 +8,8 @@
 package io.camunda.operate.webapp.api.v1.rest;
 
 import static io.camunda.operate.webapp.api.v1.rest.DecisionRequirementsController.URI;
+import static io.camunda.zeebe.protocol.record.value.AuthorizationResourceType.DECISION_REQUIREMENTS_DEFINITION;
+import static io.camunda.zeebe.protocol.record.value.PermissionType.READ;
 
 import io.camunda.operate.webapp.api.v1.dao.DecisionRequirementsDao;
 import io.camunda.operate.webapp.api.v1.entities.DecisionRequirements;
@@ -15,9 +17,11 @@ import io.camunda.operate.webapp.api.v1.entities.Error;
 import io.camunda.operate.webapp.api.v1.entities.Query;
 import io.camunda.operate.webapp.api.v1.entities.Results;
 import io.camunda.operate.webapp.api.v1.exceptions.ClientException;
+import io.camunda.operate.webapp.api.v1.exceptions.ForbiddenException;
 import io.camunda.operate.webapp.api.v1.exceptions.ResourceNotFoundException;
 import io.camunda.operate.webapp.api.v1.exceptions.ServerException;
 import io.camunda.operate.webapp.api.v1.exceptions.ValidationException;
+import io.camunda.operate.webapp.security.permission.PermissionsService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -44,6 +48,7 @@ public class DecisionRequirementsController extends ErrorController
   public static final String AS_XML = "/xml";
 
   @Autowired private DecisionRequirementsDao decisionRequirementsDao;
+  @Autowired private PermissionsService permissionsService;
 
   @Operation(
       summary = "Get decision requirements as XML by key",
@@ -65,6 +70,13 @@ public class DecisionRequirementsController extends ErrorController
                     mediaType = MediaType.APPLICATION_PROBLEM_JSON_VALUE,
                     schema = @Schema(implementation = Error.class))),
         @ApiResponse(
+            description = ForbiddenException.TYPE,
+            responseCode = "403",
+            content =
+                @Content(
+                    mediaType = MediaType.APPLICATION_PROBLEM_JSON_VALUE,
+                    schema = @Schema(implementation = Error.class))),
+        @ApiResponse(
             description = ResourceNotFoundException.TYPE,
             responseCode = "404",
             content =
@@ -79,6 +91,7 @@ public class DecisionRequirementsController extends ErrorController
   public String xmlByKey(
       @Parameter(description = "Key of decision requirements", required = true) @Valid @PathVariable
           final Long key) {
+    permissionsService.verifyWildcardResourcePermission(DECISION_REQUIREMENTS_DEFINITION, READ);
     return decisionRequirementsDao.xmlByKey(key);
   }
 
@@ -107,7 +120,14 @@ public class DecisionRequirementsController extends ErrorController
             content =
                 @Content(
                     mediaType = MediaType.APPLICATION_PROBLEM_JSON_VALUE,
-                    schema = @Schema(implementation = Error.class)))
+                    schema = @Schema(implementation = Error.class))),
+        @ApiResponse(
+            description = ForbiddenException.TYPE,
+            responseCode = "403",
+            content =
+                @Content(
+                    mediaType = MediaType.APPLICATION_PROBLEM_JSON_VALUE,
+                    schema = @Schema(implementation = Error.class))),
       })
   @io.swagger.v3.oas.annotations.parameters.RequestBody(
       description = "Search examples",
@@ -158,6 +178,7 @@ public class DecisionRequirementsController extends ErrorController
   public Results<DecisionRequirements> search(
       @RequestBody(required = false) Query<DecisionRequirements> query) {
     query = (query == null) ? new Query<>() : query;
+    permissionsService.verifyWildcardResourcePermission(DECISION_REQUIREMENTS_DEFINITION, READ);
     return decisionRequirementsDao.search(query);
   }
 
@@ -181,6 +202,13 @@ public class DecisionRequirementsController extends ErrorController
                     mediaType = MediaType.APPLICATION_PROBLEM_JSON_VALUE,
                     schema = @Schema(implementation = Error.class))),
         @ApiResponse(
+            description = ForbiddenException.TYPE,
+            responseCode = "403",
+            content =
+                @Content(
+                    mediaType = MediaType.APPLICATION_PROBLEM_JSON_VALUE,
+                    schema = @Schema(implementation = Error.class))),
+        @ApiResponse(
             description = ResourceNotFoundException.TYPE,
             responseCode = "404",
             content =
@@ -192,6 +220,7 @@ public class DecisionRequirementsController extends ErrorController
   public DecisionRequirements byKey(
       @Parameter(description = "Key of decision requirements", required = true) @PathVariable
           final Long key) {
+    permissionsService.verifyWildcardResourcePermission(DECISION_REQUIREMENTS_DEFINITION, READ);
     return decisionRequirementsDao.byKey(key);
   }
 }

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/rest/ErrorController.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/rest/ErrorController.java
@@ -9,6 +9,7 @@ package io.camunda.operate.webapp.api.v1.rest;
 
 import io.camunda.operate.webapp.api.v1.entities.Error;
 import io.camunda.operate.webapp.api.v1.exceptions.ClientException;
+import io.camunda.operate.webapp.api.v1.exceptions.ForbiddenException;
 import io.camunda.operate.webapp.api.v1.exceptions.ResourceNotFoundException;
 import io.camunda.operate.webapp.api.v1.exceptions.ServerException;
 import io.camunda.operate.webapp.api.v1.exceptions.ValidationException;
@@ -29,7 +30,23 @@ public abstract class ErrorController {
 
   @ResponseStatus(HttpStatus.FORBIDDEN)
   @ExceptionHandler(AccessDeniedException.class)
-  public ResponseEntity<Error> handleAccessDeniedException(AccessDeniedException exception) {
+  public ResponseEntity<Error> handleAccessDeniedException(final AccessDeniedException exception) {
+    logger.error(getSummary(exception));
+    logger.debug(exception.getMessage(), exception);
+    final Error error =
+        new Error()
+            .setType(exception.getClass().getSimpleName())
+            .setInstance(UUID.randomUUID().toString())
+            .setStatus(HttpStatus.FORBIDDEN.value())
+            .setMessage(exception.getMessage());
+    return ResponseEntity.status(HttpStatus.FORBIDDEN)
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+        .body(error);
+  }
+
+  @ResponseStatus(HttpStatus.FORBIDDEN)
+  @ExceptionHandler(ForbiddenException.class)
+  public ResponseEntity<Error> handleForbiddenException(final ForbiddenException exception) {
     logger.error(getSummary(exception));
     logger.debug(exception.getMessage(), exception);
     final Error error =
@@ -45,7 +62,7 @@ public abstract class ErrorController {
 
   @ResponseStatus(HttpStatus.BAD_REQUEST)
   @ExceptionHandler(ClientException.class)
-  public ResponseEntity<Error> handleInvalidRequest(ClientException exception) {
+  public ResponseEntity<Error> handleInvalidRequest(final ClientException exception) {
     logger.error(getSummary(exception));
     logger.debug(exception.getMessage(), exception);
     final Error error =
@@ -61,14 +78,14 @@ public abstract class ErrorController {
 
   @ResponseStatus(HttpStatus.BAD_REQUEST)
   @ExceptionHandler(Exception.class)
-  public ResponseEntity<Error> handleException(Exception exception) {
+  public ResponseEntity<Error> handleException(final Exception exception) {
     // Show client only detail message, log all messages
     return handleInvalidRequest(new ClientException(getOnlyDetailMessage(exception), exception));
   }
 
   @ResponseStatus(HttpStatus.BAD_REQUEST)
   @ExceptionHandler(ValidationException.class)
-  public ResponseEntity<Error> handleInvalidRequest(ValidationException exception) {
+  public ResponseEntity<Error> handleInvalidRequest(final ValidationException exception) {
     logger.error(getSummary(exception));
     logger.debug(exception.getMessage(), exception);
     final Error error =
@@ -84,7 +101,7 @@ public abstract class ErrorController {
 
   @ResponseStatus(HttpStatus.NOT_FOUND)
   @ExceptionHandler(ResourceNotFoundException.class)
-  public ResponseEntity<Error> handleNotFound(ResourceNotFoundException exception) {
+  public ResponseEntity<Error> handleNotFound(final ResourceNotFoundException exception) {
     logger.error(getSummary(exception));
     logger.debug(exception.getMessage(), exception);
     final Error error =
@@ -100,7 +117,7 @@ public abstract class ErrorController {
 
   @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
   @ExceptionHandler(ServerException.class)
-  public ResponseEntity<Error> handleServerException(ServerException exception) {
+  public ResponseEntity<Error> handleServerException(final ServerException exception) {
     logger.error(exception.getMessage(), exception);
     final Error error =
         new Error()

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/rest/ProcessDefinitionController.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/rest/ProcessDefinitionController.java
@@ -8,6 +8,8 @@
 package io.camunda.operate.webapp.api.v1.rest;
 
 import static io.camunda.operate.webapp.api.v1.rest.ProcessDefinitionController.URI;
+import static io.camunda.zeebe.protocol.record.value.AuthorizationResourceType.PROCESS_DEFINITION;
+import static io.camunda.zeebe.protocol.record.value.PermissionType.READ_PROCESS_DEFINITION;
 
 import io.camunda.operate.webapp.api.v1.dao.ProcessDefinitionDao;
 import io.camunda.operate.webapp.api.v1.entities.Error;
@@ -16,9 +18,11 @@ import io.camunda.operate.webapp.api.v1.entities.Query;
 import io.camunda.operate.webapp.api.v1.entities.QueryValidator;
 import io.camunda.operate.webapp.api.v1.entities.Results;
 import io.camunda.operate.webapp.api.v1.exceptions.ClientException;
+import io.camunda.operate.webapp.api.v1.exceptions.ForbiddenException;
 import io.camunda.operate.webapp.api.v1.exceptions.ResourceNotFoundException;
 import io.camunda.operate.webapp.api.v1.exceptions.ServerException;
 import io.camunda.operate.webapp.api.v1.exceptions.ValidationException;
+import io.camunda.operate.webapp.security.permission.PermissionsService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -50,6 +54,7 @@ public class ProcessDefinitionController extends ErrorController
   public static final String AS_XML = "/xml";
   private final QueryValidator<ProcessDefinition> queryValidator = new QueryValidator<>();
   @Autowired private ProcessDefinitionDao processDefinitionDao;
+  @Autowired private PermissionsService permissionsService;
 
   @Operation(
       summary = "Search process definitions",
@@ -73,6 +78,13 @@ public class ProcessDefinitionController extends ErrorController
         @ApiResponse(
             description = ValidationException.TYPE,
             responseCode = "400",
+            content =
+                @Content(
+                    mediaType = MediaType.APPLICATION_PROBLEM_JSON_VALUE,
+                    schema = @Schema(implementation = Error.class))),
+        @ApiResponse(
+            description = ForbiddenException.TYPE,
+            responseCode = "403",
             content =
                 @Content(
                     mediaType = MediaType.APPLICATION_PROBLEM_JSON_VALUE,
@@ -130,6 +142,8 @@ public class ProcessDefinitionController extends ErrorController
     logger.debug("search for query {}", query);
     query = (query == null) ? new Query<>() : query;
     queryValidator.validate(query, ProcessDefinition.class);
+    permissionsService.verifyWildcardResourcePermission(
+        PROCESS_DEFINITION, READ_PROCESS_DEFINITION);
     return processDefinitionDao.search(query);
   }
 
@@ -153,6 +167,13 @@ public class ProcessDefinitionController extends ErrorController
                     mediaType = MediaType.APPLICATION_PROBLEM_JSON_VALUE,
                     schema = @Schema(implementation = Error.class))),
         @ApiResponse(
+            description = ForbiddenException.TYPE,
+            responseCode = "403",
+            content =
+                @Content(
+                    mediaType = MediaType.APPLICATION_PROBLEM_JSON_VALUE,
+                    schema = @Schema(implementation = Error.class))),
+        @ApiResponse(
             description = ResourceNotFoundException.TYPE,
             responseCode = "404",
             content =
@@ -164,7 +185,8 @@ public class ProcessDefinitionController extends ErrorController
   public ProcessDefinition byKey(
       @Parameter(description = "Key of process definition", required = true) @Valid @PathVariable
           final Long key) {
-
+    permissionsService.verifyWildcardResourcePermission(
+        PROCESS_DEFINITION, READ_PROCESS_DEFINITION);
     return processDefinitionDao.byKey(key);
   }
 
@@ -188,6 +210,13 @@ public class ProcessDefinitionController extends ErrorController
                     mediaType = MediaType.APPLICATION_PROBLEM_JSON_VALUE,
                     schema = @Schema(implementation = Error.class))),
         @ApiResponse(
+            description = ForbiddenException.TYPE,
+            responseCode = "403",
+            content =
+                @Content(
+                    mediaType = MediaType.APPLICATION_PROBLEM_JSON_VALUE,
+                    schema = @Schema(implementation = Error.class))),
+        @ApiResponse(
             description = ResourceNotFoundException.TYPE,
             responseCode = "404",
             content =
@@ -202,6 +231,8 @@ public class ProcessDefinitionController extends ErrorController
   public String xmlByKey(
       @Parameter(description = "Key of process definition", required = true) @Valid @PathVariable
           final Long key) {
+    permissionsService.verifyWildcardResourcePermission(
+        PROCESS_DEFINITION, READ_PROCESS_DEFINITION);
     return processDefinitionDao.xmlByKey(key);
   }
 }

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/security/permission/PermissionsService.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/security/permission/PermissionsService.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.operate.webapp.security.permission;
 
+import io.camunda.operate.webapp.api.v1.exceptions.ForbiddenException;
 import io.camunda.security.auth.Authorization;
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.security.auth.CamundaAuthenticationProvider;
@@ -109,6 +110,16 @@ public class PermissionsService {
       final String decisionId, final PermissionType permissionType) {
     return hasPermissionForResourceType(
         decisionId, AuthorizationResourceType.DECISION_DEFINITION, permissionType);
+  }
+
+  public void verifyWildcardResourcePermission(
+      final AuthorizationResourceType resourceType, final PermissionType permissionType) {
+    if (!hasPermissionForResourceType(Authorization.WILDCARD, resourceType, permissionType)) {
+      throw new ForbiddenException(
+          "%s:%s:%s permissions required to access this resource."
+              .formatted(
+                  resourceType.toString(), Authorization.WILDCARD, permissionType.toString()));
+    }
   }
 
   /**

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/operate/OperateV1ApiPermissionsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/operate/OperateV1ApiPermissionsIT.java
@@ -1,0 +1,582 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.operate;
+
+import static io.camunda.client.api.search.enums.PermissionType.DELETE_PROCESS_INSTANCE;
+import static io.camunda.client.api.search.enums.PermissionType.READ;
+import static io.camunda.client.api.search.enums.PermissionType.READ_DECISION_DEFINITION;
+import static io.camunda.client.api.search.enums.PermissionType.READ_DECISION_INSTANCE;
+import static io.camunda.client.api.search.enums.PermissionType.READ_PROCESS_DEFINITION;
+import static io.camunda.client.api.search.enums.PermissionType.READ_PROCESS_INSTANCE;
+import static io.camunda.client.api.search.enums.ResourceType.DECISION_DEFINITION;
+import static io.camunda.client.api.search.enums.ResourceType.DECISION_REQUIREMENTS_DEFINITION;
+import static io.camunda.client.api.search.enums.ResourceType.PROCESS_DEFINITION;
+import static io.camunda.it.util.TestHelper.deployResource;
+import static io.camunda.it.util.TestHelper.startProcessInstance;
+import static io.camunda.it.util.TestHelper.waitForDecisionToBeEvaluated;
+import static io.camunda.it.util.TestHelper.waitForElementInstances;
+import static io.camunda.it.util.TestHelper.waitForProcessInstanceToBeTerminated;
+import static io.camunda.it.util.TestHelper.waitForProcessInstancesToStart;
+import static io.camunda.it.util.TestHelper.waitForProcessesToBeDeployed;
+import static io.camunda.it.util.TestHelper.waitUntilProcessInstanceHasIncidents;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import io.camunda.application.Profile;
+import io.camunda.client.CamundaClient;
+import io.camunda.qa.util.auth.GroupDefinition;
+import io.camunda.qa.util.auth.Membership;
+import io.camunda.qa.util.auth.Permissions;
+import io.camunda.qa.util.auth.RoleDefinition;
+import io.camunda.qa.util.auth.TestGroup;
+import io.camunda.qa.util.auth.TestRole;
+import io.camunda.qa.util.auth.TestUser;
+import io.camunda.qa.util.auth.UserDefinition;
+import io.camunda.qa.util.cluster.TestCamundaApplication;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.qa.util.multidb.MultiDbTestApplication;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.value.EntityType;
+import io.camunda.zeebe.test.util.Strings;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.http.HttpStatus;
+
+@MultiDbTest
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms")
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
+public class OperateV1ApiPermissionsIT {
+
+  @MultiDbTestApplication
+  static final TestCamundaApplication STANDALONE_CAMUNDA =
+      new TestCamundaApplication()
+          .withAuthorizationsEnabled()
+          .withBasicAuth()
+          .withAdditionalProfile(Profile.OPERATE)
+          .withProperty("camunda.tasklist.webappEnabled", "false");
+
+  // endpoint urls
+  private static final String PROCESS_INSTANCE_ENDPOINT = "v1/process-instances";
+  private static final String PROCESS_INSTANCE_GET_ENDPOINT_PATTERN =
+      PROCESS_INSTANCE_ENDPOINT + "/%s";
+  private static final String PROCESS_DEFINITION_ENDPOINT = "v1/process-definitions";
+  private static final String PROCESS_DEFINITION_GET_ENDPOINT_PATTERN =
+      PROCESS_DEFINITION_ENDPOINT + "/%s";
+  private static final String PROCESS_DEFINITION_GET_XML_ENDPOINT_PATTERN =
+      PROCESS_DEFINITION_ENDPOINT + "/%s/xml";
+  private static final String FLOWNODE_INSTANCES_ENDPOINT = "v1/flownode-instances";
+  private static final String FLOWNODE_INSTANCES_GET_ENDPOINT_PATTERN =
+      FLOWNODE_INSTANCES_ENDPOINT + "/%s";
+  private static final String INCIDENT_ENDPOINT = "v1/incidents";
+  private static final String INCIDENT_GET_ENDPOINT_PATTERN = INCIDENT_ENDPOINT + "/%s";
+  private static final String VARIABLES_ENDPOINT = "v1/variables";
+  private static final String VARIABLES_GET_ENDPOINT_PATTERN = VARIABLES_ENDPOINT + "/%s";
+
+  private static final String DECISION_DEFINITIONS_ENDPOINT = "v1/decision-definitions";
+  private static final String DECISION_DEFINITIONS_GET_ENDPOINT_PATTERN =
+      DECISION_DEFINITIONS_ENDPOINT + "/%s";
+
+  private static final String DECISION_INSTANCES_ENDPOINT = "v1/decision-instances";
+  private static final String DECISION_INSTANCES_GET_ENDPOINT_PATTERN =
+      DECISION_INSTANCES_ENDPOINT + "/%s";
+  private static final String DECISION_REQUIREMENTS_ENDPOINT = "v1/drd";
+  private static final String DECISION_REQUIREMENTS_GET_ENDPOINT_PATTERN =
+      DECISION_REQUIREMENTS_ENDPOINT + "/%s";
+  private static final String DECISION_REQUIREMENTS_GET_XML_ENDPOINT_PATTERN =
+      DECISION_REQUIREMENTS_ENDPOINT + "/%s/xml";
+
+  // searchable keys
+  private static final String PROCESS_ID = "processId";
+  private static long processInstanceKey;
+  private static long processDefinitionKey;
+  private static long flowNodeInstanceKey;
+  private static long incidentKey;
+  private static long variableKey;
+  private static long decisionDefinitionKey;
+  private static String decisionInstanceId;
+  private static long decisionRequirementsKey;
+
+  // Users
+  private static final String AUTHORIZED_USERNAME = "operateV1AuthorizedUser";
+  private static final String ROLE_AUTHORIZED_USERNAME = "operateV1RoleAuthorizedUser";
+  private static final String GROUP_AUTHORIZED_USERNAME = "operateV1GroupAuthorizedUser";
+  private static final String UNAUTHORIZED_USERNAME = "operateV1UnauthorizedUser";
+
+  private static final List<Permissions> AUTHORIZED_PERMISSIONS =
+      List.of(
+          new Permissions(PROCESS_DEFINITION, READ_PROCESS_DEFINITION, List.of("*")),
+          new Permissions(PROCESS_DEFINITION, READ_PROCESS_INSTANCE, List.of("*")),
+          new Permissions(PROCESS_DEFINITION, DELETE_PROCESS_INSTANCE, List.of("*")),
+          new Permissions(DECISION_DEFINITION, READ_DECISION_DEFINITION, List.of("*")),
+          new Permissions(DECISION_DEFINITION, READ_DECISION_INSTANCE, List.of("*")),
+          new Permissions(DECISION_REQUIREMENTS_DEFINITION, READ, List.of("*")));
+
+  @UserDefinition
+  private static final TestUser AUTHORIZED_USER =
+      new TestUser(AUTHORIZED_USERNAME, AUTHORIZED_USERNAME, AUTHORIZED_PERMISSIONS);
+
+  private static final String ROLE_ID = Strings.newRandomValidIdentityId();
+
+  @RoleDefinition
+  private static final TestRole AUTHORIZED_ROLE =
+      new TestRole(
+          ROLE_ID,
+          "operate_v1_auth_role",
+          AUTHORIZED_PERMISSIONS,
+          List.of(new Membership(ROLE_AUTHORIZED_USERNAME, EntityType.USER)));
+
+  @UserDefinition
+  private static final TestUser ROLE_AUTHORIZED_USER =
+      new TestUser(ROLE_AUTHORIZED_USERNAME, ROLE_AUTHORIZED_USERNAME, List.of());
+
+  private static final String GROUP_ID = Strings.newRandomValidIdentityId();
+
+  @GroupDefinition
+  private static final TestGroup AUTHORIZED_GROUP =
+      new TestGroup(
+          GROUP_ID,
+          "operate_v1_auth_group",
+          AUTHORIZED_PERMISSIONS,
+          List.of(new Membership(GROUP_AUTHORIZED_USERNAME, EntityType.USER)));
+
+  @UserDefinition
+  private static final TestUser GROUP_AUTHORIZED_USER =
+      new TestUser(GROUP_AUTHORIZED_USERNAME, GROUP_AUTHORIZED_USERNAME, List.of());
+
+  @UserDefinition
+  private static final TestUser UNAUTHORIZED_USER =
+      new TestUser(UNAUTHORIZED_USERNAME, UNAUTHORIZED_USERNAME, List.of());
+
+  @BeforeAll
+  public static void beforeAll(final CamundaClient adminClient) throws Exception {
+
+    // deploy process and start instance
+    processDefinitionKey =
+        deployResource(
+                adminClient,
+                Bpmn.createExecutableProcess(PROCESS_ID).startEvent().userTask().endEvent().done(),
+                "process.bpmn")
+            .getProcesses()
+            .getFirst()
+            .getProcessDefinitionKey();
+    waitForProcessesToBeDeployed(adminClient, 1);
+    processInstanceKey = startProcessInstance(adminClient, PROCESS_ID).getProcessInstanceKey();
+    waitForElementInstances(adminClient, f -> f.processInstanceKey(processInstanceKey), 2);
+    flowNodeInstanceKey =
+        adminClient
+            .newElementInstanceSearchRequest()
+            .filter(f -> f.processInstanceKey(processInstanceKey))
+            .send()
+            .join()
+            .items()
+            .getFirst()
+            .getElementInstanceKey();
+
+    // add variable
+    adminClient
+        .newSetVariablesCommand(processInstanceKey)
+        .variable("testVariableA", "a")
+        .local(false)
+        .send()
+        .join();
+    await()
+        .untilAsserted(
+            () ->
+                assertThat(adminClient.newVariableSearchRequest().send().join().items())
+                    .describedAs("Wait until variable exists")
+                    .hasSize(1));
+    variableKey =
+        adminClient.newVariableSearchRequest().send().join().items().getFirst().getVariableKey();
+    // create incident
+    await()
+        .untilAsserted(
+            () ->
+                assertThat(adminClient.newJobSearchRequest().send().join().items())
+                    .describedAs("Wait until job exists")
+                    .hasSize(1));
+    final long jobKey =
+        adminClient.newJobSearchRequest().send().join().items().getFirst().getJobKey();
+    adminClient.newFailCommand(jobKey).retries(0).send().join();
+    waitUntilProcessInstanceHasIncidents(adminClient, 1);
+    incidentKey =
+        adminClient.newIncidentSearchRequest().send().join().items().getFirst().getIncidentKey();
+
+    // DMN
+    final var decisionDeployment =
+        adminClient
+            .newDeployResourceCommand()
+            .addResourceFromClasspath(String.format("decisions/%s", "decision_model.dmn"))
+            .send()
+            .join()
+            .getDecisions()
+            .getFirst();
+    final long decisionKey = decisionDeployment.getDecisionKey();
+    final String dmnDecisionId = decisionDeployment.getDmnDecisionId();
+    deployResource(
+            adminClient,
+            Bpmn.createExecutableProcess("dmn_process")
+                .startEvent()
+                .businessRuleTask("dmn_task")
+                .zeebeCalledDecisionId(dmnDecisionId)
+                .zeebeResultVariable("{\"output1\": \"B\"}")
+                .endEvent()
+                .done(),
+            "dmn_process.bpmn")
+        .getProcesses()
+        .getFirst();
+    final long dmnInstanceKey =
+        startProcessInstance(adminClient, "dmn_process").getProcessInstanceKey();
+    waitForDecisionToBeEvaluated(adminClient, 1);
+    decisionDefinitionKey =
+        adminClient
+            .newDecisionDefinitionSearchRequest()
+            .send()
+            .join()
+            .items()
+            .getFirst()
+            .getDecisionKey();
+    decisionInstanceId =
+        adminClient
+            .newDecisionInstanceSearchRequest()
+            .send()
+            .join()
+            .items()
+            .getFirst()
+            .getDecisionInstanceId();
+    decisionRequirementsKey =
+        adminClient
+            .newDecisionRequirementsSearchRequest()
+            .send()
+            .join()
+            .items()
+            .getFirst()
+            .getDecisionRequirementsKey();
+  }
+
+  @ParameterizedTest
+  @MethodSource("getRequestParameters")
+  void shouldEvaluateGetRequest(
+      final String user, final String endpoint, final int expectedStatus, final String key)
+      throws Exception {
+    try (final var client = STANDALONE_CAMUNDA.newOperateClient(user, user)) {
+      final int statusCode = client.getRequest(endpoint, key).statusCode();
+      assertThat(statusCode).isEqualTo(expectedStatus);
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("searchRequestParameters")
+  void shouldEvaluateSearchRequest(
+      final String user, final String endpoint, final int expectedStatus) throws Exception {
+    try (final var client = STANDALONE_CAMUNDA.newOperateClient(user, user)) {
+      final int statusCode = client.searchRequest(endpoint, "{}").statusCode();
+      assertThat(statusCode).isEqualTo(expectedStatus);
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource({"deleteRequestParameters"})
+  void shouldEvaluateDeleteRequest(
+      final String user, final int expectedStatus, final CamundaClient adminClient)
+      throws Exception {
+    // start instance for deletion
+    final long processInstanceToDeleteKey =
+        startProcessInstance(adminClient, PROCESS_ID).getProcessInstanceKey();
+    waitForProcessInstancesToStart(
+        adminClient, f -> f.processInstanceKey(processInstanceToDeleteKey), 1);
+    adminClient.newCancelInstanceCommand(processInstanceToDeleteKey).send().join();
+    waitForProcessInstanceToBeTerminated(adminClient, processInstanceToDeleteKey);
+
+    try (final var client = STANDALONE_CAMUNDA.newOperateClient(user, user)) {
+      final int statusCode =
+          client.deleteRequest("v1/process-instances", processInstanceToDeleteKey).statusCode();
+      assertThat(statusCode).isEqualTo(expectedStatus);
+    }
+  }
+
+  private static Stream<Arguments> getRequestParameters() {
+    return Stream.of(
+        // Process Instances
+        Arguments.of(
+            AUTHORIZED_USERNAME,
+            PROCESS_INSTANCE_GET_ENDPOINT_PATTERN,
+            HttpStatus.OK.value(),
+            String.valueOf(processInstanceKey)),
+        Arguments.of(
+            ROLE_AUTHORIZED_USERNAME,
+            PROCESS_INSTANCE_GET_ENDPOINT_PATTERN,
+            HttpStatus.OK.value(),
+            String.valueOf(processInstanceKey)),
+        Arguments.of(
+            GROUP_AUTHORIZED_USERNAME,
+            PROCESS_INSTANCE_GET_ENDPOINT_PATTERN,
+            HttpStatus.OK.value(),
+            String.valueOf(processInstanceKey)),
+        Arguments.of(
+            UNAUTHORIZED_USERNAME,
+            PROCESS_INSTANCE_GET_ENDPOINT_PATTERN,
+            HttpStatus.FORBIDDEN.value(),
+            String.valueOf(processInstanceKey)),
+        // Process Definitions
+        Arguments.of(
+            AUTHORIZED_USERNAME,
+            PROCESS_DEFINITION_GET_ENDPOINT_PATTERN,
+            HttpStatus.OK.value(),
+            String.valueOf(processDefinitionKey)),
+        Arguments.of(
+            ROLE_AUTHORIZED_USERNAME,
+            PROCESS_DEFINITION_GET_ENDPOINT_PATTERN,
+            HttpStatus.OK.value(),
+            String.valueOf(processDefinitionKey)),
+        Arguments.of(
+            GROUP_AUTHORIZED_USERNAME,
+            PROCESS_DEFINITION_GET_ENDPOINT_PATTERN,
+            HttpStatus.OK.value(),
+            String.valueOf(processDefinitionKey)),
+        Arguments.of(
+            UNAUTHORIZED_USERNAME,
+            PROCESS_DEFINITION_GET_ENDPOINT_PATTERN,
+            HttpStatus.FORBIDDEN.value(),
+            String.valueOf(processDefinitionKey)),
+        Arguments.of(
+            AUTHORIZED_USERNAME,
+            PROCESS_DEFINITION_GET_XML_ENDPOINT_PATTERN,
+            HttpStatus.OK.value(),
+            String.valueOf(processDefinitionKey)),
+        Arguments.of(
+            ROLE_AUTHORIZED_USERNAME,
+            PROCESS_DEFINITION_GET_XML_ENDPOINT_PATTERN,
+            HttpStatus.OK.value(),
+            String.valueOf(processDefinitionKey)),
+        Arguments.of(
+            GROUP_AUTHORIZED_USERNAME,
+            PROCESS_DEFINITION_GET_XML_ENDPOINT_PATTERN,
+            HttpStatus.OK.value(),
+            String.valueOf(processDefinitionKey)),
+        Arguments.of(
+            UNAUTHORIZED_USERNAME,
+            PROCESS_DEFINITION_GET_XML_ENDPOINT_PATTERN,
+            HttpStatus.FORBIDDEN.value(),
+            String.valueOf(processDefinitionKey)),
+        // Flownode Instances
+        Arguments.of(
+            AUTHORIZED_USERNAME,
+            FLOWNODE_INSTANCES_GET_ENDPOINT_PATTERN,
+            HttpStatus.OK.value(),
+            String.valueOf(flowNodeInstanceKey)),
+        Arguments.of(
+            ROLE_AUTHORIZED_USERNAME,
+            FLOWNODE_INSTANCES_GET_ENDPOINT_PATTERN,
+            HttpStatus.OK.value(),
+            String.valueOf(flowNodeInstanceKey)),
+        Arguments.of(
+            GROUP_AUTHORIZED_USERNAME,
+            FLOWNODE_INSTANCES_GET_ENDPOINT_PATTERN,
+            HttpStatus.OK.value(),
+            String.valueOf(flowNodeInstanceKey)),
+        Arguments.of(
+            UNAUTHORIZED_USERNAME,
+            FLOWNODE_INSTANCES_GET_ENDPOINT_PATTERN,
+            HttpStatus.FORBIDDEN.value(),
+            String.valueOf(flowNodeInstanceKey)),
+        // Incident
+        Arguments.of(
+            AUTHORIZED_USERNAME,
+            INCIDENT_GET_ENDPOINT_PATTERN,
+            HttpStatus.OK.value(),
+            String.valueOf(incidentKey)),
+        Arguments.of(
+            ROLE_AUTHORIZED_USERNAME,
+            INCIDENT_GET_ENDPOINT_PATTERN,
+            HttpStatus.OK.value(),
+            String.valueOf(incidentKey)),
+        Arguments.of(
+            GROUP_AUTHORIZED_USERNAME,
+            INCIDENT_GET_ENDPOINT_PATTERN,
+            HttpStatus.OK.value(),
+            String.valueOf(incidentKey)),
+        Arguments.of(
+            UNAUTHORIZED_USERNAME,
+            INCIDENT_GET_ENDPOINT_PATTERN,
+            HttpStatus.FORBIDDEN.value(),
+            String.valueOf(incidentKey)),
+        // Variables
+        Arguments.of(
+            AUTHORIZED_USERNAME,
+            VARIABLES_GET_ENDPOINT_PATTERN,
+            HttpStatus.OK.value(),
+            String.valueOf(variableKey)),
+        Arguments.of(
+            ROLE_AUTHORIZED_USERNAME,
+            VARIABLES_GET_ENDPOINT_PATTERN,
+            HttpStatus.OK.value(),
+            String.valueOf(variableKey)),
+        Arguments.of(
+            GROUP_AUTHORIZED_USERNAME,
+            VARIABLES_GET_ENDPOINT_PATTERN,
+            HttpStatus.OK.value(),
+            String.valueOf(variableKey)),
+        Arguments.of(
+            UNAUTHORIZED_USERNAME,
+            VARIABLES_GET_ENDPOINT_PATTERN,
+            HttpStatus.FORBIDDEN.value(),
+            String.valueOf(variableKey)),
+        // Decision Definitions
+        Arguments.of(
+            AUTHORIZED_USERNAME,
+            DECISION_DEFINITIONS_GET_ENDPOINT_PATTERN,
+            HttpStatus.OK.value(),
+            String.valueOf(decisionDefinitionKey)),
+        Arguments.of(
+            ROLE_AUTHORIZED_USERNAME,
+            DECISION_DEFINITIONS_GET_ENDPOINT_PATTERN,
+            HttpStatus.OK.value(),
+            String.valueOf(decisionDefinitionKey)),
+        Arguments.of(
+            GROUP_AUTHORIZED_USERNAME,
+            DECISION_DEFINITIONS_GET_ENDPOINT_PATTERN,
+            HttpStatus.OK.value(),
+            String.valueOf(decisionDefinitionKey)),
+        Arguments.of(
+            UNAUTHORIZED_USERNAME,
+            DECISION_DEFINITIONS_GET_ENDPOINT_PATTERN,
+            HttpStatus.FORBIDDEN.value(),
+            String.valueOf(decisionDefinitionKey)),
+        // Decision Instances
+        Arguments.of(
+            AUTHORIZED_USERNAME,
+            DECISION_INSTANCES_GET_ENDPOINT_PATTERN,
+            HttpStatus.OK.value(),
+            String.valueOf(decisionInstanceId)),
+        Arguments.of(
+            ROLE_AUTHORIZED_USERNAME,
+            DECISION_INSTANCES_GET_ENDPOINT_PATTERN,
+            HttpStatus.OK.value(),
+            String.valueOf(decisionInstanceId)),
+        Arguments.of(
+            GROUP_AUTHORIZED_USERNAME,
+            DECISION_INSTANCES_GET_ENDPOINT_PATTERN,
+            HttpStatus.OK.value(),
+            String.valueOf(decisionInstanceId)),
+        Arguments.of(
+            UNAUTHORIZED_USERNAME,
+            DECISION_INSTANCES_GET_ENDPOINT_PATTERN,
+            HttpStatus.FORBIDDEN.value(),
+            String.valueOf(decisionInstanceId)),
+        // Decision Requirements
+        Arguments.of(
+            AUTHORIZED_USERNAME,
+            DECISION_REQUIREMENTS_GET_ENDPOINT_PATTERN,
+            HttpStatus.OK.value(),
+            String.valueOf(decisionRequirementsKey)),
+        Arguments.of(
+            ROLE_AUTHORIZED_USERNAME,
+            DECISION_REQUIREMENTS_GET_ENDPOINT_PATTERN,
+            HttpStatus.OK.value(),
+            String.valueOf(decisionRequirementsKey)),
+        Arguments.of(
+            GROUP_AUTHORIZED_USERNAME,
+            DECISION_REQUIREMENTS_GET_ENDPOINT_PATTERN,
+            HttpStatus.OK.value(),
+            String.valueOf(decisionRequirementsKey)),
+        Arguments.of(
+            UNAUTHORIZED_USERNAME,
+            DECISION_REQUIREMENTS_GET_ENDPOINT_PATTERN,
+            HttpStatus.FORBIDDEN.value(),
+            String.valueOf(decisionRequirementsKey)),
+        Arguments.of(
+            AUTHORIZED_USERNAME,
+            DECISION_REQUIREMENTS_GET_XML_ENDPOINT_PATTERN,
+            HttpStatus.OK.value(),
+            String.valueOf(decisionRequirementsKey)),
+        Arguments.of(
+            ROLE_AUTHORIZED_USERNAME,
+            DECISION_REQUIREMENTS_GET_XML_ENDPOINT_PATTERN,
+            HttpStatus.OK.value(),
+            String.valueOf(decisionRequirementsKey)),
+        Arguments.of(
+            GROUP_AUTHORIZED_USERNAME,
+            DECISION_REQUIREMENTS_GET_XML_ENDPOINT_PATTERN,
+            HttpStatus.OK.value(),
+            String.valueOf(decisionRequirementsKey)),
+        Arguments.of(
+            UNAUTHORIZED_USERNAME,
+            DECISION_REQUIREMENTS_GET_XML_ENDPOINT_PATTERN,
+            HttpStatus.FORBIDDEN.value(),
+            String.valueOf(decisionRequirementsKey)));
+  }
+
+  private static Stream<Arguments> searchRequestParameters() {
+    return Stream.of(
+        // Process Instances
+        Arguments.of(AUTHORIZED_USERNAME, PROCESS_INSTANCE_ENDPOINT, HttpStatus.OK.value()),
+        Arguments.of(ROLE_AUTHORIZED_USERNAME, PROCESS_INSTANCE_ENDPOINT, HttpStatus.OK.value()),
+        Arguments.of(GROUP_AUTHORIZED_USERNAME, PROCESS_INSTANCE_ENDPOINT, HttpStatus.OK.value()),
+        Arguments.of(
+            UNAUTHORIZED_USERNAME, PROCESS_INSTANCE_ENDPOINT, HttpStatus.FORBIDDEN.value()),
+        // Process Definitions
+        Arguments.of(AUTHORIZED_USERNAME, PROCESS_DEFINITION_ENDPOINT, HttpStatus.OK.value()),
+        Arguments.of(ROLE_AUTHORIZED_USERNAME, PROCESS_DEFINITION_ENDPOINT, HttpStatus.OK.value()),
+        Arguments.of(GROUP_AUTHORIZED_USERNAME, PROCESS_DEFINITION_ENDPOINT, HttpStatus.OK.value()),
+        Arguments.of(
+            UNAUTHORIZED_USERNAME, PROCESS_DEFINITION_ENDPOINT, HttpStatus.FORBIDDEN.value()),
+        // Flownode Instances
+        Arguments.of(AUTHORIZED_USERNAME, FLOWNODE_INSTANCES_ENDPOINT, HttpStatus.OK.value()),
+        Arguments.of(ROLE_AUTHORIZED_USERNAME, FLOWNODE_INSTANCES_ENDPOINT, HttpStatus.OK.value()),
+        Arguments.of(GROUP_AUTHORIZED_USERNAME, FLOWNODE_INSTANCES_ENDPOINT, HttpStatus.OK.value()),
+        Arguments.of(
+            UNAUTHORIZED_USERNAME, FLOWNODE_INSTANCES_ENDPOINT, HttpStatus.FORBIDDEN.value()),
+        // Incidents
+        Arguments.of(AUTHORIZED_USERNAME, INCIDENT_ENDPOINT, HttpStatus.OK.value()),
+        Arguments.of(ROLE_AUTHORIZED_USERNAME, INCIDENT_ENDPOINT, HttpStatus.OK.value()),
+        Arguments.of(GROUP_AUTHORIZED_USERNAME, INCIDENT_ENDPOINT, HttpStatus.OK.value()),
+        Arguments.of(UNAUTHORIZED_USERNAME, INCIDENT_ENDPOINT, HttpStatus.FORBIDDEN.value()),
+        // Variables
+        Arguments.of(AUTHORIZED_USERNAME, VARIABLES_ENDPOINT, HttpStatus.OK.value()),
+        Arguments.of(ROLE_AUTHORIZED_USERNAME, VARIABLES_ENDPOINT, HttpStatus.OK.value()),
+        Arguments.of(GROUP_AUTHORIZED_USERNAME, VARIABLES_ENDPOINT, HttpStatus.OK.value()),
+        Arguments.of(UNAUTHORIZED_USERNAME, VARIABLES_ENDPOINT, HttpStatus.FORBIDDEN.value()),
+        // Decision Definitions
+        Arguments.of(AUTHORIZED_USERNAME, DECISION_DEFINITIONS_ENDPOINT, HttpStatus.OK.value()),
+        Arguments.of(
+            ROLE_AUTHORIZED_USERNAME, DECISION_DEFINITIONS_ENDPOINT, HttpStatus.OK.value()),
+        Arguments.of(
+            GROUP_AUTHORIZED_USERNAME, DECISION_DEFINITIONS_ENDPOINT, HttpStatus.OK.value()),
+        Arguments.of(
+            UNAUTHORIZED_USERNAME, DECISION_DEFINITIONS_ENDPOINT, HttpStatus.FORBIDDEN.value()),
+        // Decision Instances
+        Arguments.of(AUTHORIZED_USERNAME, DECISION_INSTANCES_ENDPOINT, HttpStatus.OK.value()),
+        Arguments.of(ROLE_AUTHORIZED_USERNAME, DECISION_INSTANCES_ENDPOINT, HttpStatus.OK.value()),
+        Arguments.of(GROUP_AUTHORIZED_USERNAME, DECISION_INSTANCES_ENDPOINT, HttpStatus.OK.value()),
+        Arguments.of(
+            UNAUTHORIZED_USERNAME, DECISION_INSTANCES_ENDPOINT, HttpStatus.FORBIDDEN.value()),
+        // Decision Requirements
+        Arguments.of(AUTHORIZED_USERNAME, DECISION_REQUIREMENTS_ENDPOINT, HttpStatus.OK.value()),
+        Arguments.of(
+            ROLE_AUTHORIZED_USERNAME, DECISION_REQUIREMENTS_ENDPOINT, HttpStatus.OK.value()),
+        Arguments.of(
+            GROUP_AUTHORIZED_USERNAME, DECISION_REQUIREMENTS_ENDPOINT, HttpStatus.OK.value()),
+        Arguments.of(
+            UNAUTHORIZED_USERNAME, DECISION_REQUIREMENTS_ENDPOINT, HttpStatus.FORBIDDEN.value()));
+  }
+
+  private static Stream<Arguments> deleteRequestParameters() {
+    return Stream.of(
+        /* depends on fix for https://github.com/camunda/camunda/issues/36067
+        Arguments.of(AUTHORIZED_USERNAME, HttpStatus.OK.value()),
+        Arguments.of(ROLE_AUTHORIZED_USERNAME, HttpStatus.OK.value()),
+        Arguments.of(GROUP_AUTHORIZED_USERNAME, HttpStatus.OK.value()),
+        */
+        Arguments.of(UNAUTHORIZED_USERNAME, HttpStatus.FORBIDDEN.value()));
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/util/TestHelper.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/util/TestHelper.java
@@ -591,6 +591,18 @@ public final class TestHelper {
             });
   }
 
+  public static void waitForDecisionToBeEvaluated(
+      final CamundaClient camundaClient, final int expectedDecisionInstances) {
+    Awaitility.await("should deploy decision definitions and wait for import")
+        .atMost(Duration.ofSeconds(15))
+        .ignoreExceptions() // Ignore exceptions and continue retrying
+        .untilAsserted(
+            () -> {
+              final var result = camundaClient.newDecisionInstanceSearchRequest().send().join();
+              assertThat(result.items()).hasSize(expectedDecisionInstances);
+            });
+  }
+
   public static void waitUntilProcessInstanceHasIncidents(
       final CamundaClient camundaClient, final int expectedIncidents) {
     Awaitility.await("should wait until incidents are exists")

--- a/qa/util/src/main/java/io/camunda/qa/util/cluster/TestRestOperateClient.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/cluster/TestRestOperateClient.java
@@ -153,6 +153,36 @@ public class TestRestOperateClient implements AutoCloseable {
         processInstanceKey, new CreateOperationRequestDto(OperationType.RESOLVE_INCIDENT));
   }
 
+  public HttpResponse<String> getRequest(final String endpointUriFormat, final String key)
+      throws URISyntaxException, IOException, InterruptedException {
+    final String url = endpoint + endpointUriFormat.formatted(key);
+    final HttpRequest request = addAuthHeader(createBuilder(url)).GET().build();
+    return httpClient.send(request, BodyHandlers.ofString());
+  }
+
+  public HttpResponse<String> getRequest(final String endpointUriFormat, final long key)
+      throws URISyntaxException, IOException, InterruptedException {
+    return getRequest(endpointUriFormat, String.valueOf(key));
+  }
+
+  public HttpResponse<String> searchRequest(final String endpointUri, final String request)
+      throws URISyntaxException, IOException, InterruptedException {
+    final String url = endpoint + endpointUri + "/search";
+    final HttpRequest httpRequest =
+        addAuthHeader(createBuilder(url))
+            .POST(HttpRequest.BodyPublishers.ofString(request))
+            .header("Content-Type", "application/json")
+            .build();
+    return httpClient.send(httpRequest, BodyHandlers.ofString());
+  }
+
+  public HttpResponse<String> deleteRequest(final String endpointUri, final long key)
+      throws URISyntaxException, IOException, InterruptedException {
+    final String url = endpoint + endpointUri + "/" + key;
+    final HttpRequest request = addAuthHeader(createBuilder(url)).DELETE().build();
+    return httpClient.send(request, BodyHandlers.ofString());
+  }
+
   private Either<Exception, HttpResponse<String>> createProcessInstanceOperationRequest(
       final long processInstanceKey, final CreateOperationRequestDto operationRequestDto) {
     try {


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Covered Operate V1 endpoints with authorization checks that require blanket ("*") permissions for the requested resource type.

- Added authorization checks to all Operate V1 endpoints
- Users need "*" permissions on the resource related to the API to access it
- V1 API returns 403 error if the user is missing the needed permissions
- Integration Tests have been added to cover all endpoints and user/group/role permissions

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes https://github.com/camunda/camunda/issues/32408
