### PR TITLE
feat: add check method to TaskResultBuilder for a list of commands

### DIFF
--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/scheduling/TaskResultBuilder.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/scheduling/TaskResultBuilder.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.stream.api.scheduling;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.stream.api.FollowUpCommandMetadata;
+import java.util.List;
 
 /** Here the interface is just a suggestion. Can be whatever PDT team thinks is best to work with */
 public interface TaskResultBuilder {
@@ -45,6 +46,15 @@ public interface TaskResultBuilder {
       final Intent intent,
       final UnifiedRecordValue value,
       final FollowUpCommandMetadata metadata);
+
+  /**
+   * Checks if a whole list of records can be added to the result builder.
+   *
+   * @return returns <code>true</code> if the whole list of records still fit into the result,
+   *     <code>false</code> otherwise
+   */
+  boolean canAppendRecords(
+      final List<? extends UnifiedRecordValue> value, final FollowUpCommandMetadata metadata);
 
   TaskResult build();
 }

--- a/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/BufferedTaskResultBuilderTest.java
+++ b/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/BufferedTaskResultBuilderTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.stream.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceCreationRecord;
+import io.camunda.zeebe.stream.api.FollowUpCommandMetadata;
+import io.camunda.zeebe.stream.api.scheduling.ScheduledCommandCache.NoopScheduledCommandCache;
+import io.camunda.zeebe.stream.api.scheduling.ScheduledCommandCache.StagedScheduledCommandCache;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class BufferedTaskResultBuilderTest {
+
+  @Test
+  void canAppendEmptyRecordList() {
+    final var cache = new NoopScheduledCommandCache();
+    final var builder = new BufferedTaskResultBuilder((count, size) -> size < 1000, cache);
+
+    assertThat(builder.canAppendRecords(List.of(), FollowUpCommandMetadata.empty())).isTrue();
+  }
+
+  @Test
+  void canAppendSingleRecord() {
+    final var cache = Mockito.mock(StagedScheduledCommandCache.class);
+    final var builder = new BufferedTaskResultBuilder((count, size) -> size < 1000, cache);
+
+    final var records = List.of(new ProcessInstanceCreationRecord());
+
+    assertThat(builder.canAppendRecords(records, FollowUpCommandMetadata.empty())).isTrue();
+  }
+
+  @Test
+  void canAppendRecords() {
+    final var cache = Mockito.mock(StagedScheduledCommandCache.class);
+    final var builder = new BufferedTaskResultBuilder((count, size) -> size < 1000, cache);
+
+    final var records =
+        List.of(
+            new ProcessInstanceCreationRecord(),
+            new ProcessInstanceCreationRecord(),
+            new ProcessInstanceCreationRecord());
+
+    assertThat(builder.canAppendRecords(records, FollowUpCommandMetadata.empty()))
+        .isTrue(); // size should be 801
+  }
+
+  @Test
+  void cannotAppendRecords() {
+    final var cache = Mockito.mock(StagedScheduledCommandCache.class);
+    final var builder = new BufferedTaskResultBuilder((count, size) -> size < 1000, cache);
+
+    final var records =
+        List.of(
+            new ProcessInstanceCreationRecord(),
+            new ProcessInstanceCreationRecord(),
+            new ProcessInstanceCreationRecord(),
+            new ProcessInstanceCreationRecord(),
+            new ProcessInstanceCreationRecord());
+
+    assertThat(builder.canAppendRecords(records, FollowUpCommandMetadata.empty()))
+        .isFalse(); // size should be 1335
+  }
+}


### PR DESCRIPTION
## Description

Split from PR https://github.com/camunda/camunda/pull/35583, already partially reviewed by Nicolas.

For zeebe batch operations it is necessary to add a whole list of records to the TaskResultBuilder atomically. For this I added a canAppendRecords() method to the TaskResultBuilder to check if a list of records and their follow-up-metadata can fir into the used record batch. 

The method does not actually add the records but just calculates their potential size. 

## Related issues

relates to #35435 
