### PR TITLE
fix: schedule jobs stream recreation

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/CamundaFuture.java
+++ b/clients/java/src/main/java/io/camunda/client/api/CamundaFuture.java
@@ -32,6 +32,13 @@ public interface CamundaFuture<T> extends Future<T>, CompletionStage<T> {
   T join();
 
   /**
+   * Like {@link #cancel(boolean)} but allows providing a cause.
+   *
+   * @param cause cause for cancellation can be `null`
+   */
+  boolean cancel(boolean mayInterruptIfRunning, Throwable cause);
+
+  /**
    * Like {@link #get(long, TimeUnit)} but throws runtime exceptions.
    *
    * @throws ClientStatusException on gRPC errors

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientFutureImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientFutureImpl.java
@@ -65,9 +65,10 @@ public class CamundaClientFutureImpl<ClientResponse, BrokerResponse>
   public boolean cancel(final boolean mayInterruptIfRunning, final Throwable cause) {
     if (mayInterruptIfRunning && clientCall != null) {
       clientCall.cancel("Client call explicitly cancelled by user", cause);
+      return true;
+    } else {
+      return super.cancel(mayInterruptIfRunning);
     }
-
-    return super.cancel(mayInterruptIfRunning);
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientFutureImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientFutureImpl.java
@@ -58,8 +58,13 @@ public class CamundaClientFutureImpl<ClientResponse, BrokerResponse>
 
   @Override
   public boolean cancel(final boolean mayInterruptIfRunning) {
+    return cancel(mayInterruptIfRunning, null);
+  }
+
+  @Override
+  public boolean cancel(final boolean mayInterruptIfRunning, final Throwable cause) {
     if (mayInterruptIfRunning && clientCall != null) {
-      clientCall.cancel("Client call explicitly cancelled by user", null);
+      clientCall.cancel("Client call explicitly cancelled by user", cause);
     }
 
     return super.cancel(mayInterruptIfRunning);

--- a/clients/java/src/main/java/io/camunda/client/impl/http/HttpCamundaFuture.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/http/HttpCamundaFuture.java
@@ -48,7 +48,7 @@ public class HttpCamundaFuture<RespT> extends CompletableFuture<RespT>
   }
 
   @Override
-  public boolean cancel(final boolean mayInterruptIfRunning) {
+  public boolean cancel(final boolean mayInterruptIfRunning, final Throwable cause) {
     if (transportFuture != null) {
       transportFuture.cancel(mayInterruptIfRunning);
     }

--- a/clients/java/src/main/java/io/camunda/client/impl/worker/JobStreamerImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/worker/JobStreamerImpl.java
@@ -24,10 +24,12 @@ import io.camunda.client.api.worker.BackoffSupplier;
 import io.camunda.client.api.worker.JobClient;
 import io.camunda.client.impl.Loggers;
 import io.grpc.Status;
+import io.grpc.StatusException;
 import io.grpc.StatusRuntimeException;
 import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
@@ -46,7 +48,7 @@ final class JobStreamerImpl implements JobStreamer {
   private final Duration timeout;
   private final List<String> fetchVariables;
   private final List<String> tenantIds;
-  private final Duration requestTimeout;
+  private final Duration streamTimeout;
   private final BackoffSupplier backoffSupplier;
   private final ScheduledExecutorService executor;
   private final Lock streamLock;
@@ -63,6 +65,9 @@ final class JobStreamerImpl implements JobStreamer {
   @GuardedBy("streamLock")
   private long retryDelay;
 
+  @GuardedBy("streamLock")
+  private ScheduledFuture<?> scheduledRecreationTriggerTask;
+
   public JobStreamerImpl(
       final JobClient jobClient,
       final String jobType,
@@ -70,7 +75,7 @@ final class JobStreamerImpl implements JobStreamer {
       final Duration timeout,
       final List<String> fetchVariables,
       final List<String> tenantIds,
-      final Duration requestTimeout,
+      final Duration streamTimeout,
       final BackoffSupplier backoffSupplier,
       final ScheduledExecutorService executor) {
     this.jobClient = jobClient;
@@ -79,7 +84,7 @@ final class JobStreamerImpl implements JobStreamer {
     this.timeout = timeout;
     this.fetchVariables = fetchVariables;
     this.tenantIds = tenantIds;
-    this.requestTimeout = requestTimeout;
+    this.streamTimeout = streamTimeout;
     this.backoffSupplier = backoffSupplier;
     this.executor = executor;
 
@@ -165,16 +170,20 @@ final class JobStreamerImpl implements JobStreamer {
       command = command.fetchVariables(fetchVariables);
     }
 
-    return command.requestTimeout(requestTimeout);
+    return command;
   }
 
   @GuardedBy("streamLock")
   private void lockedClose() {
-    LOGGER.debug("Closing job stream for type '{}' and worker '{}", jobType, workerName);
+    LOGGER.debug("Closing job stream for type '{}' and worker '{}'", jobType, workerName);
     isClosed = true;
+    if (scheduledRecreationTriggerTask != null) {
+      scheduledRecreationTriggerTask.cancel(true);
+    }
     if (streamControl != null) {
       streamControl.cancel(true);
     }
+    LOGGER.debug("Closed job stream for type '{}' and worker '{}'", jobType, workerName);
   }
 
   @GuardedBy("streamLock")
@@ -188,6 +197,53 @@ final class JobStreamerImpl implements JobStreamer {
     control.whenCompleteAsync((ignored, error) -> handleStreamComplete(error), executor);
     streamControl = control;
     LOGGER.debug("Opened job stream of type '{}' for worker '{}'", jobType, workerName);
+
+    if (streamTimeout != null) {
+      LOGGER.debug(
+          "Scheduling recreation of the job stream of type '{}' for worker '{}' after '{}s'",
+          jobType,
+          workerName,
+          streamTimeout.getSeconds());
+      if (scheduledRecreationTriggerTask != null && !scheduledRecreationTriggerTask.isDone()) {
+        scheduledRecreationTriggerTask.cancel(true);
+      }
+      scheduledRecreationTriggerTask =
+          executor.schedule(
+              () -> triggerRecreation(streamControl),
+              streamTimeout.toMillis(),
+              TimeUnit.MILLISECONDS);
+    }
+  }
+
+  private void triggerRecreation(final CamundaFuture<StreamJobsResponse> streamControl) {
+    try {
+      streamLock.lockInterruptibly();
+    } catch (final InterruptedException e) {
+      Thread.currentThread().interrupt();
+      return;
+    }
+
+    try {
+      if (!isClosed) {
+        if (this.streamControl == streamControl) {
+          LOGGER.debug(
+              "Job streaming timeout reached for type '{}' and worker '{}'. Closing existing stream.",
+              jobType,
+              workerName);
+          // cancellation will trigger lockedHandleStreamComplete, which will reopen the stream
+          this.streamControl.cancel(
+              true, Status.CANCELLED.withCause(new StreamingTimeoutException()).asException());
+          this.streamControl = null;
+        } else if (!streamControl.isDone()) {
+          LOGGER.error(
+              "Job stream for type '{}' and worker '{}' is a different instance than for which the streaming timeout hit",
+              jobType,
+              workerName);
+        }
+      }
+    } finally {
+      streamLock.unlock();
+    }
   }
 
   @GuardedBy("streamLock")
@@ -198,6 +254,19 @@ final class JobStreamerImpl implements JobStreamer {
     }
 
     if (error != null) {
+      if (error instanceof StatusRuntimeException) {
+        final StatusRuntimeException statusError = (StatusRuntimeException) error;
+        if (statusError.getStatus().getCode() == Status.CANCELLED.getCode()
+            && statusError.getCause() instanceof StatusException
+            && statusError.getCause().getCause() instanceof StreamingTimeoutException) {
+          LOGGER.debug(
+              "Recreating job stream for type '{}' and worker '{}' after timeout",
+              jobType,
+              workerName);
+          lockedOpen();
+          return;
+        }
+      }
       logStreamError(error);
       retryDelay = backoffSupplier.supplyRetryDelay(retryDelay);
       LOGGER
@@ -223,4 +292,6 @@ final class JobStreamerImpl implements JobStreamer {
 
     LOGGER.warn(errorMsg, jobType, workerName, error);
   }
+
+  private static final class StreamingTimeoutException extends RuntimeException {}
 }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/ZeebeFuture.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/ZeebeFuture.java
@@ -37,6 +37,13 @@ public interface ZeebeFuture<T> extends Future<T>, CompletionStage<T> {
   T join();
 
   /**
+   * Like {@link #cancel(boolean)} but allows providing a cause.
+   *
+   * @param cause cause for cancellation can be `null`
+   */
+  boolean cancel(boolean mayInterruptIfRunning, Throwable cause);
+
+  /**
    * Like {@link #get(long, TimeUnit)} but throws runtime exceptions.
    *
    * @throws ClientStatusException on gRPC errors

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientFutureImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientFutureImpl.java
@@ -66,9 +66,10 @@ public class ZeebeClientFutureImpl<ClientResponse, BrokerResponse>
   public boolean cancel(final boolean mayInterruptIfRunning, final Throwable cause) {
     if (mayInterruptIfRunning && clientCall != null) {
       clientCall.cancel("Client call explicitly cancelled by user", cause);
+      return true;
+    } else {
+      return super.cancel(mayInterruptIfRunning);
     }
-
-    return super.cancel(mayInterruptIfRunning);
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientFutureImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientFutureImpl.java
@@ -59,8 +59,13 @@ public class ZeebeClientFutureImpl<ClientResponse, BrokerResponse>
 
   @Override
   public boolean cancel(final boolean mayInterruptIfRunning) {
+    return cancel(mayInterruptIfRunning, null);
+  }
+
+  @Override
+  public boolean cancel(final boolean mayInterruptIfRunning, final Throwable cause) {
     if (mayInterruptIfRunning && clientCall != null) {
-      clientCall.cancel("Client call explicitly cancelled by user", null);
+      clientCall.cancel("Client call explicitly cancelled by user", cause);
     }
 
     return super.cancel(mayInterruptIfRunning);

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/http/HttpZeebeFuture.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/http/HttpZeebeFuture.java
@@ -47,7 +47,7 @@ public class HttpZeebeFuture<RespT> extends CompletableFuture<RespT> implements 
   }
 
   @Override
-  public boolean cancel(final boolean mayInterruptIfRunning) {
+  public boolean cancel(final boolean mayInterruptIfRunning, final Throwable cause) {
     if (transportFuture != null) {
       transportFuture.cancel(mayInterruptIfRunning);
     }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/worker/JobStreamerImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/worker/JobStreamerImpl.java
@@ -24,10 +24,12 @@ import io.camunda.zeebe.client.api.worker.BackoffSupplier;
 import io.camunda.zeebe.client.api.worker.JobClient;
 import io.camunda.zeebe.client.impl.Loggers;
 import io.grpc.Status;
+import io.grpc.StatusException;
 import io.grpc.StatusRuntimeException;
 import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
@@ -46,7 +48,7 @@ final class JobStreamerImpl implements JobStreamer {
   private final Duration timeout;
   private final List<String> fetchVariables;
   private final List<String> tenantIds;
-  private final Duration requestTimeout;
+  private final Duration streamTimeout;
   private final BackoffSupplier backoffSupplier;
   private final ScheduledExecutorService executor;
   private final Lock streamLock;
@@ -63,6 +65,9 @@ final class JobStreamerImpl implements JobStreamer {
   @GuardedBy("streamLock")
   private long retryDelay;
 
+  @GuardedBy("streamLock")
+  private ScheduledFuture<?> scheduledRecreationTriggerTask;
+
   public JobStreamerImpl(
       final JobClient jobClient,
       final String jobType,
@@ -70,7 +75,7 @@ final class JobStreamerImpl implements JobStreamer {
       final Duration timeout,
       final List<String> fetchVariables,
       final List<String> tenantIds,
-      final Duration requestTimeout,
+      final Duration streamTimeout,
       final BackoffSupplier backoffSupplier,
       final ScheduledExecutorService executor) {
     this.jobClient = jobClient;
@@ -79,7 +84,7 @@ final class JobStreamerImpl implements JobStreamer {
     this.timeout = timeout;
     this.fetchVariables = fetchVariables;
     this.tenantIds = tenantIds;
-    this.requestTimeout = requestTimeout;
+    this.streamTimeout = streamTimeout;
     this.backoffSupplier = backoffSupplier;
     this.executor = executor;
 
@@ -165,16 +170,20 @@ final class JobStreamerImpl implements JobStreamer {
       command = command.fetchVariables(fetchVariables);
     }
 
-    return command.requestTimeout(requestTimeout);
+    return command;
   }
 
   @GuardedBy("streamLock")
   private void lockedClose() {
-    LOGGER.debug("Closing job stream for type '{}' and worker '{}", jobType, workerName);
+    LOGGER.debug("Closing job stream for type '{}' and worker '{}'", jobType, workerName);
     isClosed = true;
+    if (scheduledRecreationTriggerTask != null) {
+      scheduledRecreationTriggerTask.cancel(true);
+    }
     if (streamControl != null) {
       streamControl.cancel(true);
     }
+    LOGGER.debug("Closed job stream for type '{}' and worker '{}'", jobType, workerName);
   }
 
   @GuardedBy("streamLock")
@@ -188,6 +197,53 @@ final class JobStreamerImpl implements JobStreamer {
     control.whenCompleteAsync((ignored, error) -> handleStreamComplete(error), executor);
     streamControl = control;
     LOGGER.debug("Opened job stream of type '{}' for worker '{}'", jobType, workerName);
+
+    if (streamTimeout != null) {
+      LOGGER.debug(
+          "Scheduling recreation of the job stream of type '{}' for worker '{}' after '{}s'",
+          jobType,
+          workerName,
+          streamTimeout.getSeconds());
+      if (scheduledRecreationTriggerTask != null && !scheduledRecreationTriggerTask.isDone()) {
+        scheduledRecreationTriggerTask.cancel(true);
+      }
+      scheduledRecreationTriggerTask =
+          executor.schedule(
+              () -> triggerRecreation(streamControl),
+              streamTimeout.toMillis(),
+              TimeUnit.MILLISECONDS);
+    }
+  }
+
+  private void triggerRecreation(final ZeebeFuture<StreamJobsResponse> streamControl) {
+    try {
+      streamLock.lockInterruptibly();
+    } catch (final InterruptedException e) {
+      Thread.currentThread().interrupt();
+      return;
+    }
+
+    try {
+      if (!isClosed) {
+        if (this.streamControl == streamControl) {
+          LOGGER.debug(
+              "Job streaming timeout reached for type '{}' and worker '{}'. Closing existing stream.",
+              jobType,
+              workerName);
+          // cancellation will trigger lockedHandleStreamComplete, which will reopen the stream
+          this.streamControl.cancel(
+              true, Status.CANCELLED.withCause(new StreamingTimeoutException()).asException());
+          this.streamControl = null;
+        } else if (!streamControl.isDone()) {
+          LOGGER.error(
+              "Job stream for type '{}' and worker '{}' is a different instance than for which the streaming timeout hit",
+              jobType,
+              workerName);
+        }
+      }
+    } finally {
+      streamLock.unlock();
+    }
   }
 
   @GuardedBy("streamLock")
@@ -198,6 +254,19 @@ final class JobStreamerImpl implements JobStreamer {
     }
 
     if (error != null) {
+      if (error instanceof StatusRuntimeException) {
+        final StatusRuntimeException statusError = (StatusRuntimeException) error;
+        if (statusError.getStatus().getCode() == Status.CANCELLED.getCode()
+            && statusError.getCause() instanceof StatusException
+            && statusError.getCause().getCause() instanceof StreamingTimeoutException) {
+          LOGGER.debug(
+              "Recreating job stream for type '{}' and worker '{}' after timeout",
+              jobType,
+              workerName);
+          lockedOpen();
+          return;
+        }
+      }
       logStreamError(error);
       retryDelay = backoffSupplier.supplyRetryDelay(retryDelay);
       LOGGER
@@ -223,4 +292,6 @@ final class JobStreamerImpl implements JobStreamer {
 
     LOGGER.warn(errorMsg, jobType, workerName, error);
   }
+
+  private static final class StreamingTimeoutException extends RuntimeException {}
 }

--- a/clients/java/src/test/java/io/camunda/client/impl/worker/JobWorkerBuilderImplTest.java
+++ b/clients/java/src/test/java/io/camunda/client/impl/worker/JobWorkerBuilderImplTest.java
@@ -141,7 +141,7 @@ class JobWorkerBuilderImplTest {
   }
 
   @Test
-  void shouldUseStreamTimeoutInsteadOfRequestTimeout() {
+  void shouldNotSetRequestTimeoutOnStreamCommand() {
     // given
     final StreamJobsCommandStep3 lastStep = Mockito.mock(Answers.RETURNS_SELF);
     Mockito.when(jobClient.newStreamJobsCommand().jobType(anyString()).consumer(any()))
@@ -162,30 +162,7 @@ class JobWorkerBuilderImplTest {
         .open();
 
     // then
-    verify(lastStep, atLeast(1)).requestTimeout(Duration.ofHours(5));
-  }
-
-  @Test
-  void shouldTimeoutStreamAfterEightHours() {
-    // given
-    final StreamJobsCommandStep3 lastStep = Mockito.mock(Answers.RETURNS_SELF);
-    Mockito.when(jobClient.newStreamJobsCommand().jobType(anyString()).consumer(any()))
-        .thenReturn(lastStep);
-    Mockito.when(lastStep.tenantIds(anyList())).thenReturn(lastStep);
-    Mockito.when(lastStep.send()).thenReturn(Mockito.mock());
-
-    // when
-    jobWorkerBuilder
-        .jobType("type")
-        .handler((c, j) -> {})
-        .timeout(1)
-        .name("test")
-        .maxJobsActive(30)
-        .streamEnabled(true)
-        .open();
-
-    // then
-    verify(lastStep, atLeast(1)).requestTimeout(Duration.ofHours(8));
+    verify(lastStep, never()).requestTimeout(any());
   }
 
   @Test

--- a/clients/java/src/test/java/io/camunda/zeebe/client/impl/worker/JobStreamImplTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/impl/worker/JobStreamImplTest.java
@@ -80,7 +80,7 @@ final class JobStreamImplTest {
             new ZeebeClientBuilderImpl(),
             new ZeebeObjectMapper(),
             ignored -> false);
-    jobStreamer = createStreamer();
+    jobStreamer = createStreamer(Duration.ofHours(8));
   }
 
   @AfterEach
@@ -176,7 +176,29 @@ final class JobStreamImplTest {
     assertThat(service.streams).isEmpty();
   }
 
-  private JobStreamerImpl createStreamer() {
+  @Test
+  void shouldReopenStreamOnStreamingTimeout() {
+    // given
+    final Duration streamingTimeout = Duration.ofSeconds(2);
+    jobStreamer = createStreamer(streamingTimeout);
+
+    jobStreamer.openStreamer(ignored -> {});
+    final ServerCallStreamObserver<GatewayOuterClass.ActivatedJob> initialStream =
+        service.lastStream();
+
+    // when
+    scheduler.tick(streamingTimeout.toMillis(), TimeUnit.MILLISECONDS);
+    scheduler.runUntilIdle();
+
+    // then
+    final ServerCallStreamObserver<GatewayOuterClass.ActivatedJob> recreatedStream =
+        service.lastStream();
+    assertThat(recreatedStream).isNotNull().isNotEqualTo(initialStream);
+    assertThat(initialStream.isCancelled()).isTrue();
+    assertThat(recreatedStream.isCancelled()).isFalse();
+  }
+
+  private JobStreamerImpl createStreamer(final Duration streamingTimeout) {
     return new JobStreamerImpl(
         client,
         "type",
@@ -184,7 +206,7 @@ final class JobStreamImplTest {
         Duration.ofSeconds(10),
         Arrays.asList("foo", "bar"),
         Arrays.asList("test-tenant"),
-        Duration.ofHours(8),
+        streamingTimeout,
         ignored -> 10_000L,
         scheduler);
   }

--- a/clients/java/src/test/java/io/camunda/zeebe/client/impl/worker/JobWorkerBuilderImplTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/impl/worker/JobWorkerBuilderImplTest.java
@@ -141,7 +141,7 @@ class JobWorkerBuilderImplTest {
   }
 
   @Test
-  void shouldUseStreamTimeoutInsteadOfRequestTimeout() {
+  void shouldNotSetRequestTimeoutOnStreamCommand() {
     // given
     final StreamJobsCommandStep3 lastStep = Mockito.mock(Answers.RETURNS_SELF);
     Mockito.when(jobClient.newStreamJobsCommand().jobType(anyString()).consumer(any()))
@@ -162,30 +162,7 @@ class JobWorkerBuilderImplTest {
         .open();
 
     // then
-    verify(lastStep, atLeast(1)).requestTimeout(Duration.ofHours(5));
-  }
-
-  @Test
-  void shouldTimeoutStreamAfterEightHours() {
-    // given
-    final StreamJobsCommandStep3 lastStep = Mockito.mock(Answers.RETURNS_SELF);
-    Mockito.when(jobClient.newStreamJobsCommand().jobType(anyString()).consumer(any()))
-        .thenReturn(lastStep);
-    Mockito.when(lastStep.tenantIds(anyList())).thenReturn(lastStep);
-    Mockito.when(lastStep.send()).thenReturn(Mockito.mock());
-
-    // when
-    jobWorkerBuilder
-        .jobType("type")
-        .handler((c, j) -> {})
-        .timeout(1)
-        .name("test")
-        .maxJobsActive(30)
-        .streamEnabled(true)
-        .open();
-
-    // then
-    verify(lastStep, atLeast(1)).requestTimeout(Duration.ofHours(8));
+    verify(lastStep, never()).requestTimeout(any());
   }
 
   @Test

--- a/clients/java/src/test/resources/log4j2-test.xml
+++ b/clients/java/src/test/resources/log4j2-test.xml
@@ -9,6 +9,7 @@
 
   <Loggers>
     <Logger name="io.camunda.zeebe" level="debug"/>
+    <Logger name="io.camunda.client" level="debug"/>
 
     <Root level="info">
       <AppenderRef ref="Console"/>


### PR DESCRIPTION
## Description

Previously the streamingTimeout was used as request timeout on the job stream control,
this lead to unnecessary warning logs when the timeout hit and the stream got closed to be recreated.

With this, the stream control is scheduled to get cancelled and immediately recreated with only debug log statements.

In order to differentiate whether the cancellation was initiated in order to recreate the stream immediately, a dedicated Exception type is passed to the cancel method on the underlying `ClientCallStreamObserver` and checked for in the `lockedHandleStreamComplete`.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #31577
