### PR TITLE
fix: Truncate error message based on db vendor contraints (#35647)

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/config/VendorDatabaseProperties.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/config/VendorDatabaseProperties.java
@@ -18,10 +18,16 @@ public class VendorDatabaseProperties {
   private static final String VARIABLE_VALUE_PREVIEW_SIZE = "variableValue.previewSize";
 
   /**
-   * Optional property to limit the maximum size of variable values in bytes, if required by the
+   * Required property to specify the size of an Incident's errorMessage in characters. Longer error
+   * messages will be truncated to this size.
+   */
+  private static final String ERROR_MESSAGE_SIZE = "errorMessage.size";
+
+  /**
+   * Optional property to limit the maximum size of string column in bytes, if required by the
    * database vendor. If not set, no limit is applied.
    */
-  private static final String VARIABLE_VALUE_MAX_BYTES = "variableValue.maxBytes";
+  private static final String COLUMN_MAX_BYTES = "column.maxBytes";
 
   private static final String DISABLE_FK_BEFORE_TRUNCATE = "disableFkBeforeTruncate";
 
@@ -29,7 +35,8 @@ public class VendorDatabaseProperties {
 
   private final int variableValuePreviewSize;
   private final boolean disableFkBeforeTruncate;
-  private final Integer variableValueMaxBytes;
+  private final Integer columnMaxBytes;
+  private final int errorMessageSize;
 
   public VendorDatabaseProperties(final Properties properties) {
     this.properties = properties;
@@ -41,10 +48,15 @@ public class VendorDatabaseProperties {
     variableValuePreviewSize =
         Integer.parseInt(properties.getProperty(VARIABLE_VALUE_PREVIEW_SIZE));
 
-    if (!properties.containsKey(VARIABLE_VALUE_MAX_BYTES)) {
-      variableValueMaxBytes = null;
+    if (!properties.containsKey(ERROR_MESSAGE_SIZE)) {
+      throw new IllegalArgumentException("Property '" + ERROR_MESSAGE_SIZE + "' is missing");
+    }
+    errorMessageSize = Integer.parseInt(properties.getProperty(ERROR_MESSAGE_SIZE));
+
+    if (!properties.containsKey(COLUMN_MAX_BYTES)) {
+      columnMaxBytes = null;
     } else {
-      variableValueMaxBytes = Integer.parseInt(properties.getProperty(VARIABLE_VALUE_MAX_BYTES));
+      columnMaxBytes = Integer.parseInt(properties.getProperty(COLUMN_MAX_BYTES));
     }
 
     if (!properties.containsKey(DISABLE_FK_BEFORE_TRUNCATE)) {
@@ -59,8 +71,12 @@ public class VendorDatabaseProperties {
     return variableValuePreviewSize;
   }
 
-  public Integer variableValueMaxBytes() {
-    return variableValueMaxBytes;
+  public int errorMessageSize() {
+    return errorMessageSize;
+  }
+
+  public Integer columnMaxBytes() {
+    return columnMaxBytes;
   }
 
   public boolean disableFkBeforeTruncate() {

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/config/VendorDatabaseProperties.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/config/VendorDatabaseProperties.java
@@ -27,7 +27,7 @@ public class VendorDatabaseProperties {
    * Optional property to limit the maximum size of string column in bytes, if required by the
    * database vendor. If not set, no limit is applied.
    */
-  private static final String COLUMN_MAX_BYTES = "column.maxBytes";
+  private static final String CHAR_COLUMN_MAX_BYTES = "charColumn.maxBytes";
 
   private static final String DISABLE_FK_BEFORE_TRUNCATE = "disableFkBeforeTruncate";
 
@@ -35,7 +35,7 @@ public class VendorDatabaseProperties {
 
   private final int variableValuePreviewSize;
   private final boolean disableFkBeforeTruncate;
-  private final Integer columnMaxBytes;
+  private final Integer charColumnMaxBytes;
   private final int errorMessageSize;
 
   public VendorDatabaseProperties(final Properties properties) {
@@ -53,10 +53,10 @@ public class VendorDatabaseProperties {
     }
     errorMessageSize = Integer.parseInt(properties.getProperty(ERROR_MESSAGE_SIZE));
 
-    if (!properties.containsKey(COLUMN_MAX_BYTES)) {
-      columnMaxBytes = null;
+    if (!properties.containsKey(CHAR_COLUMN_MAX_BYTES)) {
+      charColumnMaxBytes = null;
     } else {
-      columnMaxBytes = Integer.parseInt(properties.getProperty(COLUMN_MAX_BYTES));
+      charColumnMaxBytes = Integer.parseInt(properties.getProperty(CHAR_COLUMN_MAX_BYTES));
     }
 
     if (!properties.containsKey(DISABLE_FK_BEFORE_TRUNCATE)) {
@@ -75,8 +75,8 @@ public class VendorDatabaseProperties {
     return errorMessageSize;
   }
 
-  public Integer columnMaxBytes() {
-    return columnMaxBytes;
+  public Integer charColumnMaxBytes() {
+    return charColumnMaxBytes;
   }
 
   public boolean disableFkBeforeTruncate() {

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriter.java
@@ -102,7 +102,7 @@ public class RdbmsWriter {
     decisionRequirementsWriter = new DecisionRequirementsWriter(executionQueue);
     flowNodeInstanceWriter = new FlowNodeInstanceWriter(executionQueue, flowNodeInstanceMapper);
     groupWriter = new GroupWriter(executionQueue);
-    incidentWriter = new IncidentWriter(executionQueue, incidentMapper);
+    incidentWriter = new IncidentWriter(executionQueue, incidentMapper, vendorDatabaseProperties);
     processDefinitionWriter = new ProcessDefinitionWriter(executionQueue);
     processInstanceWriter = new ProcessInstanceWriter(processInstanceMapper, executionQueue);
     tenantWriter = new TenantWriter(executionQueue);

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriter.java
@@ -113,7 +113,7 @@ public class RdbmsWriter {
     formWriter = new FormWriter(executionQueue);
     mappingRuleWriter = new MappingRuleWriter(executionQueue);
     batchOperationWriter = new BatchOperationWriter(batchOperationReader, executionQueue, config);
-    jobWriter = new JobWriter(executionQueue, jobMapper);
+    jobWriter = new JobWriter(executionQueue, jobMapper, vendorDatabaseProperties);
     sequenceFlowWriter = new SequenceFlowWriter(executionQueue, sequenceFlowMapper);
     usageMetricWriter = new UsageMetricWriter(executionQueue, usageMetricMapper);
     usageMetricTUWriter = new UsageMetricTUWriter(executionQueue, usageMetricTUMapper);

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/IncidentDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/IncidentDbModel.java
@@ -35,7 +35,7 @@ public record IncidentDbModel(
     OffsetDateTime historyCleanupDate)
     implements DbModel<IncidentDbModel> {
 
-  private static final Logger log = LoggerFactory.getLogger(IncidentDbModel.class);
+  private static final Logger LOG = LoggerFactory.getLogger(IncidentDbModel.class);
 
   @Override
   public IncidentDbModel copy(
@@ -67,7 +67,7 @@ public record IncidentDbModel(
     final var truncatedValue = TruncateUtil.truncateValue(errorMessage, sizeLimit, byteLimit);
 
     if (truncatedValue.length() < errorMessage.length()) {
-      log.warn(
+      LOG.warn(
           "Truncated error message for incident {}, original message was: {}",
           incidentKey,
           errorMessage);

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/VariableDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/VariableDbModel.java
@@ -11,10 +11,10 @@ import static io.camunda.util.ValueTypeUtil.mapBoolean;
 import static io.camunda.util.ValueTypeUtil.mapDouble;
 import static io.camunda.util.ValueTypeUtil.mapLong;
 
+import io.camunda.db.rdbms.write.util.TruncateUtil;
 import io.camunda.search.entities.ValueTypeEnum;
 import io.camunda.util.ObjectBuilder;
 import io.camunda.util.ValueTypeUtil;
-import java.nio.charset.StandardCharsets;
 import java.time.OffsetDateTime;
 import java.util.function.Function;
 
@@ -69,15 +69,9 @@ public record VariableDbModel(
     var isPreview = false;
 
     if (type == ValueTypeEnum.STRING && value != null) {
-      if (truncatedValue.length() > sizeLimit) {
-        truncatedValue = truncatedValue.substring(0, sizeLimit);
-        fullValue = value;
-        isPreview = true;
-      }
+      truncatedValue = TruncateUtil.truncateValue(truncatedValue, sizeLimit, byteLimit);
 
-      if ((byteLimit != null
-          && truncatedValue.getBytes(StandardCharsets.UTF_8).length > byteLimit)) {
-        truncatedValue = truncateBytes(truncatedValue, byteLimit);
+      if (truncatedValue.length() < value.length()) {
         fullValue = value;
         isPreview = true;
       }
@@ -98,35 +92,6 @@ public record VariableDbModel(
         tenantId,
         partitionId,
         historyCleanupDate);
-  }
-
-  /**
-   * Truncates the given string to ensure that its byte representation does not exceed the specified
-   * maximum byte size. This is necessary for DB vendors, which have a limit on the byte size for
-   * char columns. Currently, this is needed for Oracle's varchar2 only.
-   *
-   * @param original the original string to truncate
-   * @param maxBytes the maximum allowed byte size
-   * @return the truncated string, or an empty string if it cannot be truncated to fit within the
-   *     limit
-   */
-  private String truncateBytes(final String original, final int maxBytes) {
-    final byte[] bytes = original.getBytes(StandardCharsets.UTF_8);
-
-    if (bytes.length <= maxBytes) {
-      return original;
-    }
-
-    var truncatedVariable = original;
-
-    while (truncatedVariable.getBytes().length > maxBytes) {
-      truncatedVariable = truncatedVariable.substring(0, truncatedVariable.length() - 1);
-
-      if (truncatedVariable.getBytes().length <= maxBytes) {
-        return truncatedVariable;
-      }
-    }
-    return "";
   }
 
   public static class VariableDbModelBuilder implements ObjectBuilder<VariableDbModel> {

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/IncidentWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/IncidentWriter.java
@@ -61,7 +61,7 @@ public class IncidentWriter {
             incident.incidentKey(),
             "io.camunda.db.rdbms.sql.IncidentMapper.update",
             incident.truncateErrorMessage(
-                vendorDatabaseProperties.variableValuePreviewSize(),
+                vendorDatabaseProperties.errorMessageSize(),
                 vendorDatabaseProperties.columnMaxBytes())));
   }
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/IncidentWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/IncidentWriter.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.db.rdbms.write.service;
 
+import io.camunda.db.rdbms.config.VendorDatabaseProperties;
 import io.camunda.db.rdbms.sql.HistoryCleanupMapper;
 import io.camunda.db.rdbms.sql.HistoryCleanupMapper.CleanupHistoryDto;
 import io.camunda.db.rdbms.sql.IncidentMapper;
@@ -29,10 +30,15 @@ public class IncidentWriter {
 
   private final ExecutionQueue executionQueue;
   private final IncidentMapper mapper;
+  private final VendorDatabaseProperties vendorDatabaseProperties;
 
-  public IncidentWriter(final ExecutionQueue executionQueue, final IncidentMapper mapper) {
+  public IncidentWriter(
+      final ExecutionQueue executionQueue,
+      final IncidentMapper mapper,
+      final VendorDatabaseProperties vendorDatabaseProperties) {
     this.executionQueue = executionQueue;
     this.mapper = mapper;
+    this.vendorDatabaseProperties = vendorDatabaseProperties;
   }
 
   public void create(final IncidentDbModel incident) {
@@ -42,7 +48,9 @@ public class IncidentWriter {
             WriteStatementType.INSERT,
             incident.incidentKey(),
             "io.camunda.db.rdbms.sql.IncidentMapper.insert",
-            incident));
+            incident.truncateErrorMessage(
+                vendorDatabaseProperties.errorMessageSize(),
+                vendorDatabaseProperties.columnMaxBytes())));
   }
 
   public void update(final IncidentDbModel incident) {
@@ -52,7 +60,9 @@ public class IncidentWriter {
             WriteStatementType.UPDATE,
             incident.incidentKey(),
             "io.camunda.db.rdbms.sql.IncidentMapper.update",
-            incident));
+            incident.truncateErrorMessage(
+                vendorDatabaseProperties.variableValuePreviewSize(),
+                vendorDatabaseProperties.columnMaxBytes())));
   }
 
   public void resolve(final Long incidentKey) {

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/IncidentWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/IncidentWriter.java
@@ -50,7 +50,7 @@ public class IncidentWriter {
             "io.camunda.db.rdbms.sql.IncidentMapper.insert",
             incident.truncateErrorMessage(
                 vendorDatabaseProperties.errorMessageSize(),
-                vendorDatabaseProperties.columnMaxBytes())));
+                vendorDatabaseProperties.charColumnMaxBytes())));
   }
 
   public void update(final IncidentDbModel incident) {
@@ -62,7 +62,7 @@ public class IncidentWriter {
             "io.camunda.db.rdbms.sql.IncidentMapper.update",
             incident.truncateErrorMessage(
                 vendorDatabaseProperties.errorMessageSize(),
-                vendorDatabaseProperties.columnMaxBytes())));
+                vendorDatabaseProperties.charColumnMaxBytes())));
   }
 
   public void resolve(final Long incidentKey) {

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/JobWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/JobWriter.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.db.rdbms.write.service;
 
+import io.camunda.db.rdbms.config.VendorDatabaseProperties;
 import io.camunda.db.rdbms.sql.HistoryCleanupMapper;
 import io.camunda.db.rdbms.sql.HistoryCleanupMapper.CleanupHistoryDto;
 import io.camunda.db.rdbms.sql.JobMapper;
@@ -21,10 +22,15 @@ public class JobWriter {
 
   private final ExecutionQueue executionQueue;
   private final JobMapper mapper;
+  private final VendorDatabaseProperties vendorDatabaseProperties;
 
-  public JobWriter(final ExecutionQueue executionQueue, final JobMapper mapper) {
+  public JobWriter(
+      final ExecutionQueue executionQueue,
+      final JobMapper mapper,
+      final VendorDatabaseProperties vendorDatabaseProperties) {
     this.executionQueue = executionQueue;
     this.mapper = mapper;
+    this.vendorDatabaseProperties = vendorDatabaseProperties;
   }
 
   public void create(final JobDbModel job) {
@@ -34,7 +40,9 @@ public class JobWriter {
             WriteStatementType.INSERT,
             job.jobKey(),
             "io.camunda.db.rdbms.sql.JobMapper.insert",
-            job));
+            job.truncateErrorMessage(
+                vendorDatabaseProperties.errorMessageSize(),
+                vendorDatabaseProperties.columnMaxBytes())));
   }
 
   public void update(final JobDbModel job) {

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/JobWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/JobWriter.java
@@ -42,7 +42,7 @@ public class JobWriter {
             "io.camunda.db.rdbms.sql.JobMapper.insert",
             job.truncateErrorMessage(
                 vendorDatabaseProperties.errorMessageSize(),
-                vendorDatabaseProperties.columnMaxBytes())));
+                vendorDatabaseProperties.charColumnMaxBytes())));
   }
 
   public void update(final JobDbModel job) {

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/VariableWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/VariableWriter.java
@@ -42,7 +42,7 @@ public class VariableWriter {
             "io.camunda.db.rdbms.sql.VariableMapper.insert",
             variable.truncateValue(
                 vendorDatabaseProperties.variableValuePreviewSize(),
-                vendorDatabaseProperties.variableValueMaxBytes())));
+                vendorDatabaseProperties.columnMaxBytes())));
   }
 
   public void update(final VariableDbModel variable) {
@@ -54,7 +54,7 @@ public class VariableWriter {
             "io.camunda.db.rdbms.sql.VariableMapper.update",
             variable.truncateValue(
                 vendorDatabaseProperties.variableValuePreviewSize(),
-                vendorDatabaseProperties.variableValueMaxBytes())));
+                vendorDatabaseProperties.columnMaxBytes())));
   }
 
   public void scheduleForHistoryCleanup(

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/VariableWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/VariableWriter.java
@@ -42,7 +42,7 @@ public class VariableWriter {
             "io.camunda.db.rdbms.sql.VariableMapper.insert",
             variable.truncateValue(
                 vendorDatabaseProperties.variableValuePreviewSize(),
-                vendorDatabaseProperties.columnMaxBytes())));
+                vendorDatabaseProperties.charColumnMaxBytes())));
   }
 
   public void update(final VariableDbModel variable) {
@@ -54,7 +54,7 @@ public class VariableWriter {
             "io.camunda.db.rdbms.sql.VariableMapper.update",
             variable.truncateValue(
                 vendorDatabaseProperties.variableValuePreviewSize(),
-                vendorDatabaseProperties.columnMaxBytes())));
+                vendorDatabaseProperties.charColumnMaxBytes())));
   }
 
   public void scheduleForHistoryCleanup(

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/util/TruncateUtil.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/util/TruncateUtil.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.write.util;
+
+import static io.camunda.db.rdbms.write.util.TruncateUtil.truncateBytes;
+
+import java.nio.charset.StandardCharsets;
+
+public class TruncateUtil {
+
+  public static String truncateValue(
+      final String value, final int sizeLimit, final Integer byteLimit) {
+    var truncatedValue = value;
+
+    if (truncatedValue.length() > sizeLimit) {
+      truncatedValue = truncatedValue.substring(0, sizeLimit);
+    }
+
+    if ((byteLimit != null && truncatedValue.getBytes(StandardCharsets.UTF_8).length > byteLimit)) {
+      truncatedValue = truncateBytes(truncatedValue, byteLimit);
+    }
+    return truncatedValue;
+  }
+
+  /**
+   * Truncates the given string to ensure that its byte representation does not exceed the specified
+   * maximum byte size. This is necessary for DB vendors, which have a limit on the byte size for
+   * char columns. Currently, this is needed for Oracle's varchar2 only.
+   *
+   * @param original the original string to truncate
+   * @param maxBytes the maximum allowed byte size
+   * @return the truncated string, or an empty string if it cannot be truncated to fit within the
+   *     limit
+   */
+  public static String truncateBytes(final String original, final int maxBytes) {
+    final byte[] bytes = original.getBytes(StandardCharsets.UTF_8);
+
+    if (bytes.length <= maxBytes) {
+      return original;
+    }
+
+    var truncatedVariable = original;
+
+    while (truncatedVariable.getBytes().length > maxBytes) {
+      truncatedVariable = truncatedVariable.substring(0, truncatedVariable.length() - 1);
+
+      if (truncatedVariable.getBytes().length <= maxBytes) {
+        return truncatedVariable;
+      }
+    }
+    return "";
+  }
+}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/util/TruncateUtil.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/util/TruncateUtil.java
@@ -7,8 +7,6 @@
  */
 package io.camunda.db.rdbms.write.util;
 
-import static io.camunda.db.rdbms.write.util.TruncateUtil.truncateBytes;
-
 import java.nio.charset.StandardCharsets;
 
 public class TruncateUtil {
@@ -46,10 +44,10 @@ public class TruncateUtil {
 
     var truncatedVariable = original;
 
-    while (truncatedVariable.getBytes().length > maxBytes) {
+    while (truncatedVariable.getBytes(StandardCharsets.UTF_8).length > maxBytes) {
       truncatedVariable = truncatedVariable.substring(0, truncatedVariable.length() - 1);
 
-      if (truncatedVariable.getBytes().length <= maxBytes) {
+      if (truncatedVariable.getBytes(StandardCharsets.UTF_8).length <= maxBytes) {
         return truncatedVariable;
       }
     }

--- a/db/rdbms/src/main/resources/db/vendor-properties/h2.properties
+++ b/db/rdbms/src/main/resources/db/vendor-properties/h2.properties
@@ -9,5 +9,6 @@
 paging.after=LIMIT #{page.size} OFFSET #{page.from}
 keysetPaging.limit=LIMIT #{page.size}
 variableValue.previewSize=8191
+errorMessage.size=4000
 disableFkBeforeTruncate=true
 escapeChar='\\'

--- a/db/rdbms/src/main/resources/db/vendor-properties/mariadb.properties
+++ b/db/rdbms/src/main/resources/db/vendor-properties/mariadb.properties
@@ -9,5 +9,6 @@
 paging.after=LIMIT #{page.size} OFFSET #{page.from}
 keysetPaging.limit=LIMIT #{page.size}
 variableValue.previewSize=8191
+errorMessage.size=4000
 disableFkBeforeTruncate=true
 escapeChar='\\\\'

--- a/db/rdbms/src/main/resources/db/vendor-properties/oracle.properties
+++ b/db/rdbms/src/main/resources/db/vendor-properties/oracle.properties
@@ -10,6 +10,6 @@ paging.after=OFFSET #{page.from} ROWS FETCH NEXT #{page.size} ROWS ONLY
 keysetPaging.limit=FETCH NEXT #{page.size} ROWS ONLY
 variableValue.previewSize=4000
 errorMessage.size=4000
-column.maxBytes=4000
+charColumn.maxBytes=4000
 disableFkBeforeTruncate=false
 escapeChar='\\'

--- a/db/rdbms/src/main/resources/db/vendor-properties/oracle.properties
+++ b/db/rdbms/src/main/resources/db/vendor-properties/oracle.properties
@@ -9,6 +9,7 @@
 paging.after=OFFSET #{page.from} ROWS FETCH NEXT #{page.size} ROWS ONLY
 keysetPaging.limit=FETCH NEXT #{page.size} ROWS ONLY
 variableValue.previewSize=4000
-variableValue.maxBytes=4000
+errorMessage.size=4000
+column.maxBytes=4000
 disableFkBeforeTruncate=false
 escapeChar='\\'

--- a/db/rdbms/src/main/resources/db/vendor-properties/postgresql.properties
+++ b/db/rdbms/src/main/resources/db/vendor-properties/postgresql.properties
@@ -9,5 +9,6 @@
 paging.after=LIMIT #{page.size} OFFSET #{page.from}
 keysetPaging.limit=LIMIT #{page.size}
 variableValue.previewSize=8191
+errorMessage.size=4000
 disableFkBeforeTruncate=false
 escapeChar='\\'

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/write/domain/IncidentDbModelTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/write/domain/IncidentDbModelTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.write.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.search.entities.IncidentEntity.IncidentState;
+import org.junit.jupiter.api.Test;
+
+class IncidentDbModelTest {
+
+  @Test
+  void shouldTruncateErrorMessage() {
+    final IncidentDbModel truncatedMessage =
+        new IncidentDbModel.Builder()
+            .incidentKey(123L)
+            .processInstanceKey(456L)
+            .processDefinitionKey(789L)
+            .errorMessage("errorMessage")
+            .state(IncidentState.ACTIVE)
+            .tenantId("tenantId")
+            .build()
+            .truncateErrorMessage(10, null);
+
+    assertThat(truncatedMessage.errorMessage().length()).isEqualTo(10);
+    assertThat(truncatedMessage.errorMessage()).isEqualTo("errorMessa");
+  }
+
+  @Test
+  void shouldTruncateErrorMessageBytes() {
+    final IncidentDbModel truncatedMessage =
+        new IncidentDbModel.Builder()
+            .incidentKey(123L)
+            .processInstanceKey(456L)
+            .processDefinitionKey(789L)
+            .errorMessage("ääääääääää")
+            .state(IncidentState.ACTIVE)
+            .tenantId("tenantId")
+            .build()
+            .truncateErrorMessage(50, 5);
+
+    assertThat(truncatedMessage.errorMessage().length()).isEqualTo(2);
+    assertThat(truncatedMessage.errorMessage()).isEqualTo("ää");
+  }
+}

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/write/domain/JobDbModelTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/write/domain/JobDbModelTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.write.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.db.rdbms.write.domain.JobDbModel.Builder;
+import java.time.OffsetDateTime;
+import org.junit.jupiter.api.Test;
+
+class JobDbModelTest {
+
+  @Test
+  void shouldTruncateErrorMessage() {
+    final JobDbModel truncatedMessage =
+        new JobDbModel.Builder()
+            .errorMessage("errorMessage")
+            .jobKey(1L)
+            .processInstanceKey(2L)
+            .processDefinitionKey(3L)
+            .elementInstanceKey(4L)
+            .elementId("elementId")
+            .type("type")
+            .retries(1)
+            .worker("worker")
+            .deadline(OffsetDateTime.now())
+            .tenantId("tenantId")
+            .build()
+            .truncateErrorMessage(10, null);
+
+    assertThat(truncatedMessage.errorMessage().length()).isEqualTo(10);
+    assertThat(truncatedMessage.errorMessage()).isEqualTo("errorMessa");
+  }
+
+  @Test
+  void shouldTruncateErrorMessageBytes() {
+    final JobDbModel truncatedMessage =
+        new Builder()
+            .errorMessage("ääääääääää")
+            .jobKey(1L)
+            .processInstanceKey(2L)
+            .processDefinitionKey(3L)
+            .elementInstanceKey(4L)
+            .elementId("elementId")
+            .type("type")
+            .retries(1)
+            .worker("worker")
+            .deadline(OffsetDateTime.now())
+            .tenantId("tenantId")
+            .build()
+            .truncateErrorMessage(99, 5);
+
+    assertThat(truncatedMessage.errorMessage().length()).isEqualTo(2);
+    assertThat(truncatedMessage.errorMessage()).isEqualTo("ää");
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/incident/IncidentIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/incident/IncidentIT.java
@@ -53,6 +53,22 @@ public class IncidentIT {
   }
 
   @TestTemplate
+  public void shouldSaveAndFindIncidentWithLargeErrorMessageByKey(
+      final CamundaRdbmsTestApplication testApplication) {
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final RdbmsWriter rdbmsWriter = rdbmsService.createWriter(PARTITION_ID);
+    final IncidentDbReader incidentReader = rdbmsService.getIncidentReader();
+
+    final var original = IncidentFixtures.createRandomized(b -> b.errorMessage("x".repeat(9000)));
+    createAndSaveIncident(rdbmsWriter, original);
+
+    final var instance = incidentReader.findOne(original.incidentKey()).orElse(null);
+
+    assertThat(instance).isNotNull();
+    assertThat(instance.errorMessage().length()).isLessThan(original.errorMessage().length());
+  }
+
+  @TestTemplate
   public void shouldSaveAndResolveIncident(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriter rdbmsWriter = rdbmsService.createWriter(PARTITION_ID);


### PR DESCRIPTION
## Description

Incident errorMessage is truncated based on db vendor specific configuration for maxSize and maxBytes.

If the message is truncated the complete message is logged on level WARN.

## Related issues

closes #35647 
