### PR TITLE
refactor: migrate authorizations.spec.ts to OC

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/fixtures.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/fixtures.ts
@@ -25,6 +25,7 @@ import {IdentityUsersPage} from '@pages/IdentityUsersPage';
 import {IdentityMappingsPage} from '@pages/IdentityMappingsPage';
 import {IdentityRolesPage} from '@pages/IdentityRolesPage';
 import {IdentityTenantsPage} from '@pages/IdentityTenantsPage';
+import {IdentityRolesDetailsPage} from '@pages/IdentityRolesDetailsPage';
 
 import {sleep} from 'utils/sleep';
 
@@ -48,6 +49,7 @@ type PlaywrightFixtures = {
   identityMappingsPage: IdentityMappingsPage;
   identityRolesPage: IdentityRolesPage;
   identityTenantsPage: IdentityTenantsPage;
+  identityRolesDetailsPage: IdentityRolesDetailsPage;
 };
 
 const test = base.extend<PlaywrightFixtures>({
@@ -144,6 +146,10 @@ const test = base.extend<PlaywrightFixtures>({
 
   identityTenantsPage: async ({page}, use) => {
     await use(new IdentityTenantsPage(page));
+  },
+
+  identityRolesDetailsPage: async ({page}, use) => {
+    await use(new IdentityRolesDetailsPage(page));
   },
 });
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityHeader.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityHeader.ts
@@ -11,16 +11,22 @@ import {Page, Locator} from '@playwright/test';
 export class IdentityHeader {
   readonly openSettingsButton: Locator;
   readonly logoutButton: Locator;
+  readonly rolesTab: Locator;
 
   constructor(page: Page) {
     this.openSettingsButton = page.getByRole('button', {
       name: 'Open Settings',
     });
     this.logoutButton = page.getByRole('button', {name: 'Log out'});
+    this.rolesTab = page.locator('nav a').filter({hasText: /^Roles$/});
   }
 
   async logout() {
     await this.openSettingsButton.click();
     await this.logoutButton.click();
+  }
+
+  async navigateToRoles() {
+    await this.rolesTab.click();
   }
 }

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityRolesDetailsPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityRolesDetailsPage.ts
@@ -1,0 +1,101 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {Page, Locator, expect} from '@playwright/test';
+import {waitForItemInList} from 'utils/waitForItemInList';
+
+export class IdentityRolesDetailsPage {
+  private page: Page;
+  readonly assignedUsersList: Locator;
+  readonly assignUserButton: Locator;
+  readonly unassignUserButton: (rowName?: string) => Locator;
+  readonly assignUserModal: Locator;
+  readonly closeAssignUserModal: Locator;
+  readonly assignUserModalSearchField: Locator;
+  readonly assignUserModalSearchResult: Locator;
+  readonly assignUserModalCancelButton: Locator;
+  readonly assignUserModalAssignButton: Locator;
+  readonly unassignUserModal: Locator;
+  readonly closeUnassignUserModal: Locator;
+  readonly unassignUserModalCancelButton: Locator;
+  readonly unassignUserModalRemoveButton: Locator;
+  readonly emptyState: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.assignedUsersList = page.getByRole('table');
+    this.assignUserButton = page.getByRole('button', {
+      name: 'assign user',
+    });
+    this.unassignUserButton = (rowName) =>
+      this.assignedUsersList
+        .getByRole('row', {name: rowName})
+        .getByLabel('Remove');
+    this.assignUserModal = page.getByRole('dialog', {
+      name: 'Assign user',
+    });
+    this.closeAssignUserModal = this.assignUserModal.getByRole('button', {
+      name: 'Close',
+    });
+    this.assignUserModalSearchField =
+      this.assignUserModal.getByRole('searchbox');
+    this.assignUserModalSearchResult =
+      this.assignUserModal.getByRole('listbox');
+    this.assignUserModalCancelButton = this.assignUserModal.getByRole(
+      'button',
+      {
+        name: 'Cancel',
+      },
+    );
+    this.assignUserModalAssignButton = this.assignUserModal.getByRole(
+      'button',
+      {
+        name: 'assign user',
+      },
+    );
+    this.unassignUserModal = page.getByRole('dialog', {name: 'remove user'});
+    this.closeUnassignUserModal = this.unassignUserModal.getByRole('button', {
+      name: 'Close',
+    });
+    this.unassignUserModalCancelButton = this.unassignUserModal.getByRole(
+      'button',
+      {
+        name: 'Cancel',
+      },
+    );
+    this.unassignUserModalRemoveButton = this.unassignUserModal.getByRole(
+      'button',
+      {
+        name: 'remove user',
+      },
+    );
+    this.emptyState = page.getByText('Assign users to this Role');
+  }
+
+  async assignUser(user: {
+    username: string;
+    name: string;
+    email: string;
+    password: string;
+  }) {
+    await this.assignUserButton.click();
+    await expect(this.assignUserModal).toBeVisible();
+    await this.assignUserModalSearchField.fill(user.username);
+    await this.assignUserModalSearchResult.getByText(user.name).click();
+    await this.assignUserModalAssignButton.click();
+    await expect(this.assignUserModal).toBeHidden();
+
+    const item = this.assignedUsersList.getByRole('cell', {
+      name: user.email,
+    });
+
+    await waitForItemInList(this.page, item, {
+      emptyStateLocator: this.emptyState,
+    });
+  }
+}

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityUsersPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityUsersPage.ts
@@ -8,7 +8,6 @@
 
 import {Page, Locator, expect} from '@playwright/test';
 import {relativizePath, Paths} from 'utils/relativizePath';
-import {sleep} from 'utils/sleep';
 import {waitForItemInList} from 'utils/waitForItemInList';
 
 export class IdentityUsersPage {
@@ -39,6 +38,7 @@ export class IdentityUsersPage {
   readonly deleteUserModalCancelButton: Locator;
   readonly deleteUserModalDeleteButton: Locator;
   readonly emptyState: Locator;
+  readonly userCell: (name: string) => Locator;
 
   constructor(page: Page) {
     this.page = page;
@@ -153,6 +153,8 @@ export class IdentityUsersPage {
     );
 
     this.emptyState = page.getByText('No users created yet', {exact: true});
+    this.userCell = (name) =>
+      this.usersList.getByRole('cell', {name, exact: true});
   }
 
   async navigateToUsers() {
@@ -173,7 +175,7 @@ export class IdentityUsersPage {
     await this.createPasswordField.fill(user.password);
     await this.createRepeatPasswordField.fill(user.password);
     await this.createUserModalCreateButton.click();
-    await expect(this.createUserModal).not.toBeVisible();
+    await expect(this.createUserModal).toBeHidden();
 
     const item = this.usersList.getByRole('cell', {
       name: user.email,
@@ -188,7 +190,7 @@ export class IdentityUsersPage {
     await this.deleteUserButton(user.username).click();
     await expect(this.deleteUserModal).toBeVisible();
     await this.deleteUserModalDeleteButton.click();
-    await expect(this.deleteUserModal).not.toBeVisible();
+    await expect(this.deleteUserModal).toBeHidden();
 
     const item = this.usersList.getByRole('cell', {
       name: user.email,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/authorizations.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/authorizations.spec.ts
@@ -1,0 +1,166 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {expect} from '@playwright/test';
+import {test} from 'fixtures';
+import {
+  LOGIN_CREDENTIALS,
+  createTestData,
+  createApplicationAuthorization,
+} from 'utils/constants';
+import {waitForItemInList} from 'utils/waitForItemInList';
+import {relativizePath, Paths} from 'utils/relativizePath';
+import {captureScreenshot, captureFailureVideo} from '@setup';
+
+test.describe.serial('authorizations CRUD', () => {
+  let NEW_USER: NonNullable<ReturnType<typeof createTestData>['user']>;
+  let NEW_AUTH_ROLE: NonNullable<ReturnType<typeof createTestData>['authRole']>;
+  let NEW_USER_AUTHORIZATION: NonNullable<
+    ReturnType<typeof createTestData>['userAuth']
+  >;
+  let NEW_APPLICATION_AUTHORIZATION: NonNullable<
+    ReturnType<typeof createApplicationAuthorization>
+  >;
+  test.beforeAll(() => {
+    // Create test data once for the entire serial test suite
+    const testData = createTestData({
+      user: true,
+      authRole: true,
+      userAuth: true,
+      applicationAuth: true,
+    });
+    NEW_USER = testData.user!;
+    NEW_AUTH_ROLE = testData.authRole!;
+    NEW_USER_AUTHORIZATION = testData.userAuth!;
+    NEW_APPLICATION_AUTHORIZATION = testData.applicationAuth!;
+  });
+
+  test.beforeEach(async ({page, loginPage, identityAuthorizationsPage}) => {
+    await identityAuthorizationsPage.navigateToAuthorizations();
+    await loginPage.login(
+      LOGIN_CREDENTIALS.username,
+      LOGIN_CREDENTIALS.password,
+    );
+    await expect(page).toHaveURL(relativizePath(Paths.authorizations()));
+  });
+
+  test.afterEach(async ({page}, testInfo) => {
+    await captureScreenshot(page, testInfo);
+    await captureFailureVideo(page, testInfo);
+  });
+
+  test('create user authorization', async ({
+    page,
+    identityUsersPage,
+    identityRolesPage,
+    identityRolesDetailsPage,
+    identityAuthorizationsPage,
+    identityHeader,
+    loginPage,
+  }) => {
+    await test.step(`Create new user`, async () => {
+      await identityUsersPage.navigateToUsers();
+      await identityUsersPage.createUser(NEW_USER);
+    });
+
+    await test.step(`Login as new user and check users list`, async () => {
+      await identityHeader.logout();
+
+      await loginPage.login(NEW_USER.username, NEW_USER.password);
+      await expect(page).toHaveURL(relativizePath(Paths.users()));
+      await expect(identityUsersPage.userCell('demo@example.com')).toBeHidden();
+      await expect(identityUsersPage.userCell(NEW_USER.email)).toBeVisible();
+    });
+
+    await test.step(`Login as main user and create role and assign the new user to it`, async () => {
+      await identityHeader.logout();
+
+      await loginPage.login(
+        LOGIN_CREDENTIALS.username,
+        LOGIN_CREDENTIALS.password,
+      );
+      await expect(page).toHaveURL(relativizePath(Paths.users()));
+      await identityHeader.navigateToRoles();
+      await expect(page).toHaveURL(relativizePath(Paths.roles()));
+
+      await identityRolesPage.createRole(NEW_AUTH_ROLE);
+      await identityRolesPage.clickRole(NEW_AUTH_ROLE.id);
+
+      await identityRolesDetailsPage.assignUser(NEW_USER);
+
+      await identityAuthorizationsPage.navigateToAuthorizations();
+      await expect(page).toHaveURL(relativizePath(Paths.authorizations()));
+    });
+
+    await test.step(`Assign authorization to new user`, async () => {
+      await identityAuthorizationsPage.createAuthorization(
+        NEW_USER_AUTHORIZATION,
+      );
+      await identityHeader.logout();
+      await loginPage.login(NEW_USER.username, NEW_USER.password);
+      await expect(page).toHaveURL(relativizePath(Paths.forbidden('identity')));
+    });
+  });
+
+  test('create application authorization', async ({
+    identityUsersPage,
+    identityAuthorizationsPage,
+    identityHeader,
+    loginPage,
+  }) => {
+    await identityAuthorizationsPage.createAuthorization(
+      NEW_APPLICATION_AUTHORIZATION,
+    );
+    await identityHeader.logout();
+    await loginPage.login(NEW_USER.username, NEW_USER.password);
+    await expect(identityUsersPage.userCell(NEW_USER.email)).toBeVisible();
+    await expect(identityUsersPage.userCell('demo@example.com')).toBeVisible();
+  });
+
+  test('delete an authorization', async ({
+    page,
+    identityHeader,
+    loginPage,
+    identityUsersPage,
+    identityAuthorizationsPage,
+  }) => {
+    await test.step(`Delete Authorization of new user`, async () => {
+      await identityAuthorizationsPage.clickDeleteAuthorizationButton(
+        NEW_AUTH_ROLE.id,
+      );
+      await expect(
+        identityAuthorizationsPage.deleteAuthorizationModal,
+      ).toBeVisible();
+      await identityAuthorizationsPage.clickDeleteAuthorizationSubButton();
+      await expect(
+        identityAuthorizationsPage.deleteAuthorizationModal,
+      ).toBeHidden();
+      const item = identityAuthorizationsPage.getAuthorizationCell(
+        NEW_AUTH_ROLE.id,
+      );
+      await waitForItemInList(page, item, {shouldBeVisible: false});
+    });
+
+    await test.step(`Logout and login with new user and assert authorization`, async () => {
+      await identityHeader.logout();
+      await loginPage.login(NEW_USER.username, NEW_USER.password);
+      await expect(page).toHaveURL(relativizePath(Paths.forbidden('identity')));
+      await identityHeader.logout();
+    });
+
+    await test.step(`Logout and login with main user and delete created user`, async () => {
+      await loginPage.login(
+        LOGIN_CREDENTIALS.username,
+        LOGIN_CREDENTIALS.password,
+      );
+      await identityUsersPage.deleteUser(NEW_USER);
+      const userItem = identityUsersPage.userCell(NEW_USER.username);
+      await waitForItemInList(page, userItem, {shouldBeVisible: false});
+    });
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/constants.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/constants.ts
@@ -7,3 +7,92 @@
  */
 
 export const LOGIN_CREDENTIALS = {username: 'demo', password: 'demo'};
+
+// Generate a simple random alphanumeric string for test isolation
+export const generateUniqueId = () => {
+  return Math.random().toString(36).substring(2, 10);
+};
+
+// Create unique user with optional custom ID
+export const createUniqueUser = (customId?: string) => {
+  const id = customId || generateUniqueId();
+  return {
+    username: `authtest${id}`,
+    name: `Auth Test ${id}`,
+    email: `auth${id}@test.com`,
+    password: 'authtest123',
+  };
+};
+
+// Create unique auth role with optional custom ID
+export const createUniqueAuthRole = (customId?: string) => {
+  const id = customId || generateUniqueId();
+  return {
+    id: `authrole${id}`,
+    name: `Auth role ${id}`,
+  };
+};
+
+export const createUserAuthorization = (authRole: {name: string}) => ({
+  ownerType: 'Role',
+  ownerId: authRole.name,
+  resourceType: 'User',
+  resourceId: '*',
+  accessPermissions: ['update', 'create', 'read', 'delete'],
+});
+
+export const createApplicationAuthorization = (authRole: {name: string}) => ({
+  ownerType: 'Role',
+  ownerId: authRole.name,
+  resourceType: 'Application',
+  resourceId: '*',
+  accessPermissions: ['access'],
+});
+
+// Generic function to create specific test data with shared ID
+export const createTestData = (options: {
+  user?: boolean;
+  authRole?: boolean;
+  userAuth?: boolean;
+  applicationAuth?: boolean;
+}) => {
+  const {
+    user = false,
+    authRole = false,
+    userAuth = false,
+    applicationAuth = false,
+  } = options;
+  const sharedId = generateUniqueId();
+
+  const result: {
+    user?: ReturnType<typeof createUniqueUser>;
+    authRole?: ReturnType<typeof createUniqueAuthRole>;
+    userAuth?: ReturnType<typeof createUserAuthorization>;
+    applicationAuth?: ReturnType<typeof createApplicationAuthorization>;
+    id: string;
+  } = {id: sharedId};
+
+  if (user) {
+    result.user = createUniqueUser(sharedId);
+  }
+
+  if (authRole) {
+    result.authRole = createUniqueAuthRole(sharedId);
+  }
+
+  // Create authorizations only if authRole is also created
+  if (userAuth && result.authRole) {
+    result.userAuth = createUserAuthorization(result.authRole);
+  }
+
+  if (applicationAuth && result.authRole) {
+    result.applicationAuth = createApplicationAuthorization(result.authRole);
+  }
+
+  return result;
+};
+
+export const NEW_AUTH_ROLE = {
+  id: 'authrole',
+  name: 'Auth role',
+};

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/relativizePath.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/relativizePath.ts
@@ -10,8 +10,8 @@ export const Paths = {
   login(application: string): string {
     return `/${application}/login`;
   },
-  forbidden() {
-    return '/forbidden';
+  forbidden(application: string): string {
+    return `/${application}/forbidden`;
   },
   mappings() {
     return '/identity/mappings';

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/waitForItemInList.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/waitForItemInList.ts
@@ -15,17 +15,23 @@ export const waitForItemInList = async (
     shouldBeVisible?: boolean;
     timeout?: number;
     emptyStateLocator?: Locator;
+    clickAuthorizationsPageTab?: () => Promise<void>;
   },
 ) => {
   const {
     shouldBeVisible = true,
     timeout = 10000,
     emptyStateLocator,
+    clickAuthorizationsPageTab,
   } = options || {};
 
   const poll = expect.poll(
     async () => {
       await page.reload();
+
+      if (clickAuthorizationsPageTab) {
+        await clickAuthorizationsPageTab();
+      }
 
       if (emptyStateLocator) {
         await Promise.race([


### PR DESCRIPTION
## Description


This PR migrates the `authorizations.spec.ts` test file  from identity test suite to  the Orchestration Cluster test suite architecture, creating a comprehensive end-to-end test for authorization CRUD operations in the Identity service.

- Implements a new authorization test spec with user and role creation, authorization assignment
- Adds utility functions for generating unique test data and creating authorization objects
- Updates existing page objects to support the authorization workflow with new methods and locators

🧪 Successful test run [here](https://github.com/camunda/camunda/actions/runs/16496406448/job/46643163108)
The failing tests are due to the following bugs:
https://github.com/camunda/camunda/issues/35443
https://github.com/camunda/camunda/issues/34148
<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes  #35717
