### PR TITLE
Feat/bo add init intent and records

### DIFF
--- a/docs/zeebe/batch-operation.md
+++ b/docs/zeebe/batch-operation.md
@@ -214,28 +214,40 @@ This record is used when lifecycle records are distributed from a follower parti
 | `batchOperationKey` | The primary key of the batch operation            |
 | `sourcePartitionId` | The partition this record is originally sent from |
 
+#### BatchOperationInitializationRecord
+
+This record is used when the batch operation scheduler initializes the batch operation. It contains
+the last searchResultCursor, which is used in the next scheduler run.
+
+|       Property       |                     Description                      |
+|----------------------|------------------------------------------------------|
+| `batchOperationKey`  | The primary key of the batch operation               |
+| `searchResultCursor` | The last endCursor of the last applied search result |
+
 #### BatchOperationIntent
 
-|       Property        |                  Record                   |                                            Description                                            |
-|-----------------------|-------------------------------------------|---------------------------------------------------------------------------------------------------|
-| `CREATE`              | `BatchOperationCreationRecord`            | Request to create a new batch operation                                                           |
-| `CREATED`             | `BatchOperationCreationRecord`            | Response event when a batch operation was created successfully                                    |
-| `START`               | `BatchOperationLifecycleManagementRecord` | Internal command record to append a `STARTED` record from the scheduler                           |
-| `STARTED`             | `BatchOperationLifecycleManagementRecord` | Marks a batch operation as started. This starts the init phase, not the execution.                |
-| `FAIL`                | `BatchOperationCreationRecord`            | Internal command record to mark a batch operation partition as failed from the scheduler          |
-| `FAILED`              | --                                        | Not used?                                                                                         |
-| `CANCEL`              | `BatchOperationLifecycleManagementRecord` | User command record to cancel a running batch operation                                           |
-| `CANCELED`            | `BatchOperationLifecycleManagementRecord` | Marks a batch operation as canceled. This stops any execution loop indefinitely.                  |
-| `SUSPEND`             | `BatchOperationLifecycleManagementRecord` | User command record to suspend a running batch operation                                          |
-| `SUSPENDED`           | `BatchOperationLifecycleManagementRecord` | Marks a batch operation as suspended. This stops any execution loop until it it is resumed again. |
-| `RESUME`              | `BatchOperationLifecycleManagementRecord` | User command record to resume a suspended batch operation                                         |
-| `RESUMED`             | `BatchOperationLifecycleManagementRecord` | Marks a batch operation as resumed.                                                               |
-| `COMPLETE`            | --                                        | Not used?                                                                                         |
-| `COMPLETED`           | `BatchOperationLifecycleManagementRecord` | Marks a batch operation as completed. All partitions have either failed or finished.              |
-| `COMPLETE_PARTITION`  | `BatchOperationPartitionLifecycleRecord`  | Used to notify the leader partition, that a partition completed its processing.                   |
-| `PARTITION_COMPLETED` | `BatchOperationPartitionLifecycleRecord`  | Marks a single partition as completed for this batch operation.                                   |
-| `FAIL_PARTITION`      | `BatchOperationPartitionLifecycleRecord`  | Used to notify the leader partition, that a partition failed its init phase.                      |
-| `PARTITION_FAILED`    | `BatchOperationPartitionLifecycleRecord`  | Marks a single partition as failed for this batch operation.                                      |
+|          Property          |                  Record                   |                                            Description                                            |
+|----------------------------|-------------------------------------------|---------------------------------------------------------------------------------------------------|
+| `CREATE`                   | `BatchOperationCreationRecord`            | Request to create a new batch operation                                                           |
+| `CREATED`                  | `BatchOperationCreationRecord`            | Response event when a batch operation was created successfully                                    |
+| `START`                    | `BatchOperationLifecycleManagementRecord` | Internal command record to append a `STARTED` record from the scheduler                           |
+| `STARTED`                  | `BatchOperationLifecycleManagementRecord` | Marks a batch operation as started. This starts the init phase, not the execution.                |
+| `FAIL`                     | `BatchOperationCreationRecord`            | Internal command record to mark a batch operation partition as failed from the scheduler          |
+| `FAILED`                   | --                                        | Not used?                                                                                         |
+| `CANCEL`                   | `BatchOperationLifecycleManagementRecord` | User command record to cancel a running batch operation                                           |
+| `CANCELED`                 | `BatchOperationLifecycleManagementRecord` | Marks a batch operation as canceled. This stops any execution loop indefinitely.                  |
+| `SUSPEND`                  | `BatchOperationLifecycleManagementRecord` | User command record to suspend a running batch operation                                          |
+| `SUSPENDED`                | `BatchOperationLifecycleManagementRecord` | Marks a batch operation as suspended. This stops any execution loop until it it is resumed again. |
+| `RESUME`                   | `BatchOperationLifecycleManagementRecord` | User command record to resume a suspended batch operation                                         |
+| `RESUMED`                  | `BatchOperationLifecycleManagementRecord` | Marks a batch operation as resumed.                                                               |
+| `COMPLETE`                 | --                                        | Not used?                                                                                         |
+| `COMPLETED`                | `BatchOperationLifecycleManagementRecord` | Marks a batch operation as completed. All partitions have either failed or finished.              |
+| `COMPLETE_PARTITION`       | `BatchOperationPartitionLifecycleRecord`  | Used to notify the leader partition, that a partition completed its processing.                   |
+| `PARTITION_COMPLETED`      | `BatchOperationPartitionLifecycleRecord`  | Marks a single partition as completed for this batch operation.                                   |
+| `FAIL_PARTITION`           | `BatchOperationPartitionLifecycleRecord`  | Used to notify the leader partition, that a partition failed its init phase.                      |
+| `PARTITION_FAILED`         | `BatchOperationPartitionLifecycleRecord`  | Marks a single partition as failed for this batch operation.                                      |
+| `CONTINUE_INITIALIZATION`  | `BatchOperationInitializationRecord`      | Continues the initialization of a batch operation in the next scheduler run.                      |
+| `INITIALIZATION_CONTINUED` | `BatchOperationInitializationRecord`      | Continues the initialization of a batch operation in the next scheduler run.                      |
 
 #### BatchOperationChunkIntent
 

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/TestSupport.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/TestSupport.java
@@ -68,6 +68,7 @@ public final class TestSupport {
       case BATCH_OPERATION_EXECUTION -> config.batchOperationExecution = value;
       case BATCH_OPERATION_LIFECYCLE_MANAGEMENT -> config.batchOperationLifecycleManagement = value;
       case BATCH_OPERATION_PARTITION_LIFECYCLE -> config.batchOperationPartitionLifecycle = value;
+      case BATCH_OPERATION_INITIALIZATION -> config.batchOperationInitialization = value;
       case AD_HOC_SUB_PROCESS_ACTIVITY_ACTIVATION ->
           config.adHocSubProcessActivityActivation = value;
       case ASYNC_REQUEST -> config.asyncRequest = value;
@@ -123,6 +124,7 @@ public final class TestSupport {
       case BATCH_OPERATION_EXECUTION -> config.batchOperationExecution = value;
       case BATCH_OPERATION_LIFECYCLE_MANAGEMENT -> config.batchOperationLifecycleManagement = value;
       case BATCH_OPERATION_PARTITION_LIFECYCLE -> config.batchOperationPartitionLifecycle = value;
+      case BATCH_OPERATION_INITIALIZATION -> config.batchOperationInitialization = value;
       case AD_HOC_SUB_PROCESS_ACTIVITY_ACTIVATION ->
           config.adHocSubProcessActivityActivation = value;
       case ASYNC_REQUEST -> config.asyncRequest = value;

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TestSupport.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TestSupport.java
@@ -69,6 +69,7 @@ public final class TestSupport {
       case BATCH_OPERATION_EXECUTION -> config.batchOperationExecution = value;
       case BATCH_OPERATION_LIFECYCLE_MANAGEMENT -> config.batchOperationLifecycleManagement = value;
       case BATCH_OPERATION_PARTITION_LIFECYCLE -> config.batchOperationPartitionLifecycle = value;
+      case BATCH_OPERATION_INITIALIZATION -> config.batchOperationInitialization = value;
       case AD_HOC_SUB_PROCESS_ACTIVITY_ACTIVATION ->
           config.adHocSubProcessActivityActivation = value;
       case ASYNC_REQUEST -> config.asyncRequest = value;
@@ -126,6 +127,7 @@ public final class TestSupport {
       case BATCH_OPERATION_EXECUTION -> config.batchOperationExecution = value;
       case BATCH_OPERATION_LIFECYCLE_MANAGEMENT -> config.batchOperationLifecycleManagement = value;
       case BATCH_OPERATION_PARTITION_LIFECYCLE -> config.batchOperationPartitionLifecycle = value;
+      case BATCH_OPERATION_INITIALIZATION -> config.batchOperationInitialization = value;
       case AD_HOC_SUB_PROCESS_ACTIVITY_ACTIVATION ->
           config.adHocSubProcessActivityActivation = value;
       case ASYNC_REQUEST -> config.asyncRequest = value;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/BatchOperationInitializationContinuedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/BatchOperationInitializationContinuedApplier.java
@@ -25,6 +25,7 @@ public class BatchOperationInitializationContinuedApplier
   @Override
   public void applyState(
       final long batchOperationKey, final BatchOperationInitializationRecord value) {
-    batchOperationState.continueInitialization(batchOperationKey, value.getSearchResultCursor());
+    batchOperationState.continueInitialization(
+        batchOperationKey, value.getSearchResultCursor(), value.getSearchQueryPageSize());
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/BatchOperationInitializationContinuedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/BatchOperationInitializationContinuedApplier.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableBatchOperationState;
+import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationInitializationRecord;
+import io.camunda.zeebe.protocol.record.intent.BatchOperationIntent;
+
+public class BatchOperationInitializationContinuedApplier
+    implements TypedEventApplier<BatchOperationIntent, BatchOperationInitializationRecord> {
+
+  private final MutableBatchOperationState batchOperationState;
+
+  public BatchOperationInitializationContinuedApplier(
+      final MutableBatchOperationState batchOperationState) {
+    this.batchOperationState = batchOperationState;
+  }
+
+  @Override
+  public void applyState(
+      final long batchOperationKey, final BatchOperationInitializationRecord value) {
+    batchOperationState.continueInitialization(batchOperationKey, value.getSearchResultCursor());
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -623,6 +623,9 @@ public final class EventAppliers implements EventApplier {
         BatchOperationIntent.STARTED,
         new BatchOperationStartedApplier(state.getBatchOperationState()));
     register(
+        BatchOperationIntent.INITIALIZATION_CONTINUED,
+        new BatchOperationInitializationContinuedApplier(state.getBatchOperationState()));
+    register(
         BatchOperationIntent.FAILED,
         new BatchOperationFailedApplier(state.getBatchOperationState()));
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/batchoperation/DbBatchOperationState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/batchoperation/DbBatchOperationState.java
@@ -109,6 +109,25 @@ public class DbBatchOperationState implements MutableBatchOperationState {
   }
 
   @Override
+  public void continueInitialization(
+      final long batchOperationKey, final String searchResultCursor) {
+    LOGGER.trace("Setting the next init step for batch operation with key {}", batchOperationKey);
+    batchKey.wrapLong(batchOperationKey);
+    final var batchOperation = get(batchOperationKey);
+    if (batchOperation.isPresent()) {
+      batchOperation.get().setInitializationSearchCursor(searchResultCursor);
+      batchOperationColumnFamily.update(batchKey, batchOperation.get());
+
+      // again add to pending batch operations, since it is not yet started and needs at least one
+      // more initialization step
+      pendingBatchOperationColumnFamily.upsert(batchKey, DbNil.INSTANCE);
+    } else {
+      LOGGER.error(
+          "Batch operation with key {} not found, cannot set next init step.", batchOperationKey);
+    }
+  }
+
+  @Override
   public void fail(final long batchOperationKey) {
     LOGGER.trace("Failing batch operation with key {}", batchOperationKey);
     batchKey.wrapLong(batchOperationKey);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/batchoperation/DbBatchOperationState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/batchoperation/DbBatchOperationState.java
@@ -110,12 +110,15 @@ public class DbBatchOperationState implements MutableBatchOperationState {
 
   @Override
   public void continueInitialization(
-      final long batchOperationKey, final String searchResultCursor) {
+      final long batchOperationKey,
+      final String searchResultCursor,
+      final int searchQueryPageSize) {
     LOGGER.trace("Setting the next init step for batch operation with key {}", batchOperationKey);
     batchKey.wrapLong(batchOperationKey);
     final var batchOperation = get(batchOperationKey);
     if (batchOperation.isPresent()) {
       batchOperation.get().setInitializationSearchCursor(searchResultCursor);
+      batchOperation.get().setInitializationSearchQueryPageSize(searchQueryPageSize);
       batchOperationColumnFamily.update(batchKey, batchOperation.get());
 
       // again add to pending batch operations, since it is not yet started and needs at least one

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/batchoperation/PersistedBatchOperation.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/batchoperation/PersistedBatchOperation.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.engine.state.batchoperation;
 
+import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
+
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.zeebe.db.DbValue;
 import io.camunda.zeebe.msgpack.UnpackedObject;
@@ -18,6 +20,7 @@ import io.camunda.zeebe.msgpack.property.EnumProperty;
 import io.camunda.zeebe.msgpack.property.IntegerProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.ObjectProperty;
+import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.msgpack.value.IntegerValue;
 import io.camunda.zeebe.msgpack.value.LongValue;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
@@ -101,6 +104,9 @@ public class PersistedBatchOperation extends UnpackedObject implements DbValue {
    */
   private final DocumentProperty authenticationProp = new DocumentProperty("authentication");
 
+  private final StringProperty initializationSearchCursorProp =
+      new StringProperty("initializationSearchCursor", "");
+
   /**
    * The partition ids that are part of the batch operation. This is used to track which partitions
    * existed when the batch operation was created and on which partitions the batch operation runs.
@@ -119,7 +125,7 @@ public class PersistedBatchOperation extends UnpackedObject implements DbValue {
       new ArrayProperty<>("errors", BatchOperationError::new);
 
   public PersistedBatchOperation() {
-    super(14);
+    super(15);
     declareProperty(keyProp)
         .declareProperty(batchOperationTypeProp)
         .declareProperty(statusProp)
@@ -128,6 +134,7 @@ public class PersistedBatchOperation extends UnpackedObject implements DbValue {
         .declareProperty(modificationPlanProp)
         .declareProperty(chunkKeysProp)
         .declareProperty(initializedProp)
+        .declareProperty(initializationSearchCursorProp)
         .declareProperty(authenticationProp)
         .declareProperty(partitionsProp)
         .declareProperty(finishedPartitionsProp)
@@ -256,6 +263,15 @@ public class PersistedBatchOperation extends UnpackedObject implements DbValue {
 
   public PersistedBatchOperation setAuthentication(final DirectBuffer authentication) {
     authenticationProp.setValue(authentication);
+    return this;
+  }
+
+  public String getInitializationSearchCursor() {
+    return bufferAsString(initializationSearchCursorProp.getValue());
+  }
+
+  public PersistedBatchOperation setInitializationSearchCursor(final String cursor) {
+    initializationSearchCursorProp.setValue(cursor);
     return this;
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/batchoperation/PersistedBatchOperation.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/batchoperation/PersistedBatchOperation.java
@@ -107,6 +107,9 @@ public class PersistedBatchOperation extends UnpackedObject implements DbValue {
   private final StringProperty initializationSearchCursorProp =
       new StringProperty("initializationSearchCursor", "");
 
+  private final IntegerProperty initializationSearchQueryPageSizeProp =
+      new IntegerProperty("initializationSearchQueryPageSize", -1);
+
   /**
    * The partition ids that are part of the batch operation. This is used to track which partitions
    * existed when the batch operation was created and on which partitions the batch operation runs.
@@ -125,7 +128,7 @@ public class PersistedBatchOperation extends UnpackedObject implements DbValue {
       new ArrayProperty<>("errors", BatchOperationError::new);
 
   public PersistedBatchOperation() {
-    super(15);
+    super(16);
     declareProperty(keyProp)
         .declareProperty(batchOperationTypeProp)
         .declareProperty(statusProp)
@@ -135,6 +138,7 @@ public class PersistedBatchOperation extends UnpackedObject implements DbValue {
         .declareProperty(chunkKeysProp)
         .declareProperty(initializedProp)
         .declareProperty(initializationSearchCursorProp)
+        .declareProperty(initializationSearchQueryPageSizeProp)
         .declareProperty(authenticationProp)
         .declareProperty(partitionsProp)
         .declareProperty(finishedPartitionsProp)
@@ -272,6 +276,15 @@ public class PersistedBatchOperation extends UnpackedObject implements DbValue {
 
   public PersistedBatchOperation setInitializationSearchCursor(final String cursor) {
     initializationSearchCursorProp.setValue(cursor);
+    return this;
+  }
+
+  public int getInitializationSearchQueryPageSize() {
+    return initializationSearchQueryPageSizeProp.getValue();
+  }
+
+  public PersistedBatchOperation setInitializationSearchQueryPageSize(final int pageSize) {
+    initializationSearchQueryPageSizeProp.setValue(pageSize);
     return this;
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableBatchOperationState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableBatchOperationState.java
@@ -29,6 +29,14 @@ public interface MutableBatchOperationState extends BatchOperationState {
   void start(final long batchOperationKey);
 
   /**
+   * Sets the next step for the batch operation init phase.
+   *
+   * @param batchOperationKey the key of the batch operation to mark as started
+   * @param searchResultCursor the cursor of the search client to use for the next step
+   */
+  void continueInitialization(final long batchOperationKey, final String searchResultCursor);
+
+  /**
    * Marks a batch operation as failed.
    *
    * @param batchOperationKey the key of the batch operation to mark as failed

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableBatchOperationState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableBatchOperationState.java
@@ -33,8 +33,10 @@ public interface MutableBatchOperationState extends BatchOperationState {
    *
    * @param batchOperationKey the key of the batch operation to mark as started
    * @param searchResultCursor the cursor of the search client to use for the next step
+   * @param searchQueryPageSize the page size to use for the next step
    */
-  void continueInitialization(final long batchOperationKey, final String searchResultCursor);
+  void continueInitialization(
+      final long batchOperationKey, final String searchResultCursor, int searchQueryPageSize);
 
   /**
    * Marks a batch operation as failed.

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/batchoperation/BatchOperationStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/batchoperation/BatchOperationStateTest.java
@@ -214,11 +214,12 @@ public class BatchOperationStateTest {
     state.start(1L);
 
     // when
-    state.continueInitialization(batchOperationKey, "123");
+    state.continueInitialization(batchOperationKey, "123", 100);
 
     // then
     assertThat(state.getNextPendingBatchOperation().get().getKey()).isEqualTo(batchOperationKey);
     assertThat(state.get(1).get().getInitializationSearchCursor()).isEqualTo("123");
+    assertThat(state.get(1).get().getInitializationSearchQueryPageSize()).isEqualTo(100);
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/batchoperation/BatchOperationStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/batchoperation/BatchOperationStateTest.java
@@ -203,6 +203,25 @@ public class BatchOperationStateTest {
   }
 
   @Test
+  void batchShouldBePendingWhenInitializationContinues() {
+    // given
+    final var batchOperationKey = 1L;
+    final var batchRecord =
+        new BatchOperationCreationRecord()
+            .setBatchOperationKey(batchOperationKey)
+            .setBatchOperationType(BatchOperationType.CANCEL_PROCESS_INSTANCE);
+    state.create(batchOperationKey, batchRecord);
+    state.start(1L);
+
+    // when
+    state.continueInitialization(batchOperationKey, "123");
+
+    // then
+    assertThat(state.getNextPendingBatchOperation().get().getKey()).isEqualTo(batchOperationKey);
+    assertThat(state.get(1).get().getInitializationSearchCursor()).isEqualTo("123");
+  }
+
+  @Test
   void startedBatchShouldBeInitialized() {
     // given
     final var batchOperationKey = 1L;

--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
@@ -216,6 +216,7 @@ public class ElasticsearchExporterConfiguration {
     public boolean batchOperationExecution = false;
     public boolean batchOperationLifecycleManagement = false;
     public boolean batchOperationPartitionLifecycle = false;
+    public boolean batchOperationInitialization = false;
 
     public boolean asyncRequest = false;
 

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/TestSupport.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/TestSupport.java
@@ -68,6 +68,7 @@ final class TestSupport {
       case BATCH_OPERATION_EXECUTION -> config.batchOperationExecution = value;
       case BATCH_OPERATION_LIFECYCLE_MANAGEMENT -> config.batchOperationLifecycleManagement = value;
       case BATCH_OPERATION_PARTITION_LIFECYCLE -> config.batchOperationPartitionLifecycle = value;
+      case BATCH_OPERATION_INITIALIZATION -> config.batchOperationInitialization = value;
       case AD_HOC_SUB_PROCESS_ACTIVITY_ACTIVATION ->
           config.adHocSubProcessActivityActivation = value;
       case ASYNC_REQUEST -> config.asyncRequest = value;
@@ -124,6 +125,7 @@ final class TestSupport {
             ValueType.BATCH_OPERATION_EXECUTION,
             ValueType.BATCH_OPERATION_LIFECYCLE_MANAGEMENT,
             ValueType.BATCH_OPERATION_PARTITION_LIFECYCLE,
+            ValueType.BATCH_OPERATION_INITIALIZATION,
             ValueType.USAGE_METRIC);
     return EnumSet.complementOf(excludedValueTypes).stream();
   }

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterConfiguration.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterConfiguration.java
@@ -206,6 +206,7 @@ public class OpensearchExporterConfiguration {
     public boolean batchOperationExecution = false;
     public boolean batchOperationLifecycleManagement = false;
     public boolean batchOperationPartitionLifecycle = false;
+    public boolean batchOperationInitialization = false;
 
     public boolean asyncRequest = false;
 

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/TestSupport.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/TestSupport.java
@@ -69,6 +69,7 @@ final class TestSupport {
       case BATCH_OPERATION_EXECUTION -> config.batchOperationExecution = value;
       case BATCH_OPERATION_LIFECYCLE_MANAGEMENT -> config.batchOperationLifecycleManagement = value;
       case BATCH_OPERATION_PARTITION_LIFECYCLE -> config.batchOperationPartitionLifecycle = value;
+      case BATCH_OPERATION_INITIALIZATION -> config.batchOperationInitialization = value;
       case AD_HOC_SUB_PROCESS_ACTIVITY_ACTIVATION ->
           config.adHocSubProcessActivityActivation = value;
       case ASYNC_REQUEST -> config.asyncRequest = value;
@@ -125,6 +126,7 @@ final class TestSupport {
             ValueType.BATCH_OPERATION_EXECUTION,
             ValueType.BATCH_OPERATION_LIFECYCLE_MANAGEMENT,
             ValueType.BATCH_OPERATION_PARTITION_LIFECYCLE,
+            ValueType.BATCH_OPERATION_INITIALIZATION,
             ValueType.USAGE_METRIC);
     return EnumSet.complementOf(excludedValueTypes).stream();
   }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/batchoperation/BatchOperationInitializationRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/batchoperation/BatchOperationInitializationRecord.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.protocol.impl.record.value.batchoperation;
+
+import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
+
+import io.camunda.zeebe.msgpack.property.LongProperty;
+import io.camunda.zeebe.msgpack.property.StringProperty;
+import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.record.value.BatchOperationInitializationRecordValue;
+
+public final class BatchOperationInitializationRecord extends UnifiedRecordValue
+    implements BatchOperationInitializationRecordValue {
+
+  public static final String PROP_BATCH_OPERATION_KEY = "batchOperationKey";
+  public static final String PROP_SEARCH_RESULT_CURSOR_KEY = "searchResultCursor";
+
+  private final LongProperty batchOperationKeyProp = new LongProperty(PROP_BATCH_OPERATION_KEY);
+  private final StringProperty searchResultCursorProp =
+      new StringProperty(PROP_SEARCH_RESULT_CURSOR_KEY);
+
+  public BatchOperationInitializationRecord() {
+    super(2);
+    declareProperty(batchOperationKeyProp).declareProperty(searchResultCursorProp);
+  }
+
+  @Override
+  public long getBatchOperationKey() {
+    return batchOperationKeyProp.getValue();
+  }
+
+  public BatchOperationInitializationRecord setBatchOperationKey(final Long batchOperationKey) {
+    batchOperationKeyProp.reset();
+    batchOperationKeyProp.setValue(batchOperationKey);
+    return this;
+  }
+
+  @Override
+  public String getSearchResultCursor() {
+    return bufferAsString(searchResultCursorProp.getValue());
+  }
+
+  public BatchOperationInitializationRecord setSearchResultCursor(final String cursor) {
+    searchResultCursorProp.reset();
+    searchResultCursorProp.setValue(cursor);
+    return this;
+  }
+
+  public void wrap(final BatchOperationInitializationRecord record) {
+    setBatchOperationKey(record.getBatchOperationKey());
+    setSearchResultCursor(record.getSearchResultCursor());
+  }
+}

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/batchoperation/BatchOperationInitializationRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/batchoperation/BatchOperationInitializationRecord.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.protocol.impl.record.value.batchoperation;
 
 import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
 
+import io.camunda.zeebe.msgpack.property.IntegerProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
@@ -19,14 +20,19 @@ public final class BatchOperationInitializationRecord extends UnifiedRecordValue
 
   public static final String PROP_BATCH_OPERATION_KEY = "batchOperationKey";
   public static final String PROP_SEARCH_RESULT_CURSOR_KEY = "searchResultCursor";
+  public static final String PROP_SEARCH_QUERY_PAGE_SIZE = "searchQueryPageSize";
 
   private final LongProperty batchOperationKeyProp = new LongProperty(PROP_BATCH_OPERATION_KEY);
   private final StringProperty searchResultCursorProp =
       new StringProperty(PROP_SEARCH_RESULT_CURSOR_KEY);
+  private final IntegerProperty searchQueryPageSize =
+      new IntegerProperty(PROP_SEARCH_QUERY_PAGE_SIZE);
 
   public BatchOperationInitializationRecord() {
-    super(2);
-    declareProperty(batchOperationKeyProp).declareProperty(searchResultCursorProp);
+    super(3);
+    declareProperty(batchOperationKeyProp)
+        .declareProperty(searchResultCursorProp)
+        .declareProperty(searchQueryPageSize);
   }
 
   @Override
@@ -51,8 +57,20 @@ public final class BatchOperationInitializationRecord extends UnifiedRecordValue
     return this;
   }
 
+  @Override
+  public int getSearchQueryPageSize() {
+    return searchQueryPageSize.getValue();
+  }
+
+  public BatchOperationInitializationRecord setSearchQueryPageSize(final int pageSize) {
+    searchQueryPageSize.reset();
+    searchQueryPageSize.setValue(pageSize);
+    return this;
+  }
+
   public void wrap(final BatchOperationInitializationRecord record) {
     setBatchOperationKey(record.getBatchOperationKey());
     setSearchResultCursor(record.getSearchResultCursor());
+    setSearchQueryPageSize(record.getSearchQueryPageSize());
   }
 }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/ValueTypeMapping.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/ValueTypeMapping.java
@@ -73,6 +73,7 @@ import io.camunda.zeebe.protocol.record.value.AuthorizationRecordValue;
 import io.camunda.zeebe.protocol.record.value.BatchOperationChunkRecordValue;
 import io.camunda.zeebe.protocol.record.value.BatchOperationCreationRecordValue;
 import io.camunda.zeebe.protocol.record.value.BatchOperationExecutionRecordValue;
+import io.camunda.zeebe.protocol.record.value.BatchOperationInitializationRecordValue;
 import io.camunda.zeebe.protocol.record.value.BatchOperationLifecycleManagementRecordValue;
 import io.camunda.zeebe.protocol.record.value.BatchOperationPartitionLifecycleRecordValue;
 import io.camunda.zeebe.protocol.record.value.ClockRecordValue;
@@ -301,6 +302,9 @@ public final class ValueTypeMapping {
         ValueType.BATCH_OPERATION_PARTITION_LIFECYCLE,
         new Mapping<>(
             BatchOperationPartitionLifecycleRecordValue.class, BatchOperationIntent.class));
+    mapping.put(
+        ValueType.BATCH_OPERATION_INITIALIZATION,
+        new Mapping<>(BatchOperationInitializationRecordValue.class, BatchOperationIntent.class));
     mapping.put(
         ValueType.ASYNC_REQUEST,
         new Mapping<>(AsyncRequestRecordValue.class, AsyncRequestIntent.class));

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/BatchOperationIntent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/BatchOperationIntent.java
@@ -33,7 +33,9 @@ public enum BatchOperationIntent implements Intent {
   COMPLETE_PARTITION((short) 14),
   PARTITION_COMPLETED((short) 15),
   FAIL_PARTITION((short) 16),
-  PARTITION_FAILED((short) 17);
+  PARTITION_FAILED((short) 17),
+  CONTINUE_INITIALIZATION((short) 18),
+  INITIALIZATION_CONTINUED((short) 19);
 
   private final short value;
 
@@ -83,6 +85,10 @@ public enum BatchOperationIntent implements Intent {
         return FAIL_PARTITION;
       case 17:
         return PARTITION_FAILED;
+      case 18:
+        return CONTINUE_INITIALIZATION;
+      case 19:
+        return INITIALIZATION_CONTINUED;
       default:
         return Intent.UNKNOWN;
     }
@@ -105,6 +111,7 @@ public enum BatchOperationIntent implements Intent {
       case COMPLETED:
       case PARTITION_COMPLETED:
       case PARTITION_FAILED:
+      case INITIALIZATION_CONTINUED:
         return true;
       default:
         return false;

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/Intent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/Intent.java
@@ -192,6 +192,8 @@ public interface Intent {
         return BatchOperationIntent.from(intent);
       case BATCH_OPERATION_PARTITION_LIFECYCLE:
         return BatchOperationIntent.from(intent);
+      case BATCH_OPERATION_INITIALIZATION:
+        return BatchOperationIntent.from(intent);
       case ASYNC_REQUEST:
         return AsyncRequestIntent.from(intent);
       case USAGE_METRIC:
@@ -304,6 +306,8 @@ public interface Intent {
       case BATCH_OPERATION_LIFECYCLE_MANAGEMENT:
         return BatchOperationIntent.valueOf(intent);
       case BATCH_OPERATION_PARTITION_LIFECYCLE:
+        return BatchOperationIntent.valueOf(intent);
+      case BATCH_OPERATION_INITIALIZATION:
         return BatchOperationIntent.valueOf(intent);
       case ASYNC_REQUEST:
         return AsyncRequestIntent.valueOf(intent);

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/BatchOperationInitializationRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/BatchOperationInitializationRecordValue.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.protocol.record.value;
+
+import io.camunda.zeebe.protocol.record.ImmutableProtocol;
+import io.camunda.zeebe.protocol.record.RecordValue;
+import org.immutables.value.Value;
+
+/**
+ * This record is used to mark a batch operation as "still in initialization" phase. It is needed
+ * when the number of found items is too large for a single RecordBatch and must be split into
+ * multiple runs.
+ */
+@Value.Immutable
+@ImmutableProtocol(builder = ImmutableBatchOperationInitializationRecordValue.Builder.class)
+public interface BatchOperationInitializationRecordValue
+    extends BatchOperationRelated, RecordValue {
+
+  /**
+   * The last search result cursor that was used to find items for the batch operation.
+   *
+   * @return the search result cursor
+   */
+  String getSearchResultCursor();
+}

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/BatchOperationInitializationRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/BatchOperationInitializationRecordValue.java
@@ -35,4 +35,12 @@ public interface BatchOperationInitializationRecordValue
    * @return the search result cursor
    */
   String getSearchResultCursor();
+
+  /**
+   * The page size used for the search query that found items for the batch operation. When errors
+   * occur during initialization, this value is used to reduce the pageSize.
+   *
+   * @return the current page size of the search query
+   */
+  int getSearchQueryPageSize();
 }

--- a/zeebe/protocol/src/main/resources/protocol.xml
+++ b/zeebe/protocol/src/main/resources/protocol.xml
@@ -73,6 +73,7 @@
       <validValue name="BATCH_OPERATION_PARTITION_LIFECYCLE">55</validValue>
       <validValue name="ASYNC_REQUEST">56</validValue>
       <validValue name="USAGE_METRIC">57</validValue>
+      <validValue name="BATCH_OPERATION_INITIALIZATION">58</validValue>
 
       <!-- Management records / record not related to process automation -->
       <!-- value 252 was used for "REDISTRIBUTION, do not use-->

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/TypedEventRegistry.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/TypedEventRegistry.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.protocol.impl.record.value.authorization.RoleRecord;
 import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationChunkRecord;
 import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationCreationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationExecutionRecord;
+import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationInitializationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationLifecycleManagementRecord;
 import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationPartitionLifecycleRecord;
 import io.camunda.zeebe.protocol.impl.record.value.clock.ClockRecord;
@@ -135,6 +136,8 @@ public final class TypedEventRegistry {
     registry.put(
         ValueType.BATCH_OPERATION_PARTITION_LIFECYCLE,
         BatchOperationPartitionLifecycleRecord.class);
+    registry.put(
+        ValueType.BATCH_OPERATION_INITIALIZATION, BatchOperationInitializationRecord.class);
     registry.put(ValueType.ASYNC_REQUEST, AsyncRequestRecord.class);
 
     EVENT_REGISTRY = Collections.unmodifiableMap(registry);


### PR DESCRIPTION
## Description

This PR add a new record value and a new pair of intents:
- `BatchOperationIntent.CONTINUE_INIZIALIZATION` / `INITIALIZATION_CONTINUED`: Used to mark the init phase of a batch operation in the BatchOperationExecutionScheduler as not finished/ongoing and that another run in the scheduler
- `BatchOperationInitializationRecord`: Used to transport the last searchResultCursor of the init phase in the scheduler. That will be used by the next scheduler run to continue item fetching

Most other changes are collateral due to failing tests in dependent modules

## Related issues

relates to #35435 
