### PR TITLE
refactor: remove check if a query returned a single result in RDBMS

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/AbstractEntityReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/AbstractEntityReader.java
@@ -15,12 +15,9 @@ import io.camunda.db.rdbms.read.domain.DbQueryPage.KeySetPaginationFieldEntry;
 import io.camunda.db.rdbms.read.domain.DbQueryPage.Operator;
 import io.camunda.db.rdbms.read.domain.DbQuerySorting;
 import io.camunda.db.rdbms.sql.columns.SearchColumn;
-import io.camunda.search.exception.CamundaSearchException;
-import io.camunda.search.exception.ErrorMessages;
 import io.camunda.search.page.SearchQueryPage;
 import io.camunda.search.page.SearchQueryPage.SearchQueryResultType;
 import io.camunda.search.query.SearchQueryResult;
-import io.camunda.search.query.TypedSearchQuery;
 import io.camunda.search.sort.SortOption;
 import io.camunda.search.sort.SortOption.FieldSorting;
 import io.camunda.search.sort.SortOrder;
@@ -135,23 +132,6 @@ abstract class AbstractEntityReader<T> {
     }
 
     return keySetPagination;
-  }
-
-  protected void ensureSingleResultIfRequired(final List<T> hits, final TypedSearchQuery query) {
-    if (!SearchQueryResultType.SINGLE_RESULT.equals(query.page().resultType())) {
-      return;
-    }
-
-    // Requires some refactoring to move this check into a single place later
-    if (hits.isEmpty()) {
-      throw new CamundaSearchException(
-          ErrorMessages.ERROR_SINGLE_RESULT_NOT_FOUND.formatted(query),
-          CamundaSearchException.Reason.NOT_FOUND);
-    } else if (hits.size() > 1) {
-      throw new CamundaSearchException(
-          ErrorMessages.ERROR_SINGLE_RESULT_NOT_UNIQUE.formatted(query),
-          CamundaSearchException.Reason.NOT_UNIQUE);
-    }
   }
 
   protected final SearchQueryResult<T> buildSearchQueryResult(

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/AuthorizationDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/AuthorizationDbReader.java
@@ -70,7 +70,6 @@ public class AuthorizationDbReader extends AbstractEntityReader<AuthorizationEnt
     LOG.trace("[RDBMS DB] Search for authorizations with filter {}", dbQuery);
     final var totalHits = authorizationMapper.count(dbQuery);
     final var hits = authorizationMapper.search(dbQuery).stream().map(this::map).toList();
-    ensureSingleResultIfRequired(hits, query);
     return buildSearchQueryResult(totalHits, hits, dbSort);
   }
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/BatchOperationDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/BatchOperationDbReader.java
@@ -61,7 +61,6 @@ public class BatchOperationDbReader extends AbstractEntityReader<BatchOperationE
         batchOperationMapper.search(dbQuery).stream()
             .map(BatchOperationEntityMapper::toEntity)
             .toList();
-    ensureSingleResultIfRequired(hits, query);
     return buildSearchQueryResult(totalHits, hits, dbSort);
   }
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/BatchOperationItemDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/BatchOperationItemDbReader.java
@@ -49,7 +49,6 @@ public class BatchOperationItemDbReader extends AbstractEntityReader<BatchOperat
     LOG.trace("[RDBMS DB] Search for batch operation items with filter {}", dbQuery);
     final var totalHits = batchOperationMapper.countItems(dbQuery);
     final var hits = batchOperationMapper.searchItems(dbQuery);
-    ensureSingleResultIfRequired(hits, query);
     return buildSearchQueryResult(totalHits, hits, dbSort);
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/DecisionDefinitionDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/DecisionDefinitionDbReader.java
@@ -49,7 +49,6 @@ public class DecisionDefinitionDbReader extends AbstractEntityReader<DecisionDef
     LOG.trace("[RDBMS DB] Search for decision definition with filter {}", dbQuery);
     final var totalHits = decisionDefinitionMapper.count(dbQuery);
     final var hits = decisionDefinitionMapper.search(dbQuery);
-    ensureSingleResultIfRequired(hits, query);
     return buildSearchQueryResult(totalHits, hits, dbSort);
   }
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/DecisionInstanceDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/DecisionInstanceDbReader.java
@@ -58,7 +58,6 @@ public class DecisionInstanceDbReader extends AbstractEntityReader<DecisionInsta
     final var totalHits = decisionInstanceMapper.count(dbQuery);
     final var hits = enhanceEntities(decisionInstanceMapper.search(dbQuery), query.resultConfig());
 
-    ensureSingleResultIfRequired(hits, query);
     return buildSearchQueryResult(totalHits, hits, dbSort);
   }
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/DecisionRequirementsDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/DecisionRequirementsDbReader.java
@@ -53,7 +53,6 @@ public class DecisionRequirementsDbReader extends AbstractEntityReader<DecisionR
     LOG.trace("[RDBMS DB] Search for decision requirements with filter {}", dbQuery);
     final var totalHits = decisionRequirementsMapper.count(dbQuery);
     final var hits = decisionRequirementsMapper.search(dbQuery);
-    ensureSingleResultIfRequired(hits, query);
     return buildSearchQueryResult(totalHits, hits, dbSort);
   }
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/FlowNodeInstanceDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/FlowNodeInstanceDbReader.java
@@ -49,7 +49,6 @@ public class FlowNodeInstanceDbReader extends AbstractEntityReader<FlowNodeInsta
     LOG.trace("[RDBMS DB] Search for process instance with filter {}", dbQuery);
     final var totalHits = flowNodeInstanceMapper.count(dbQuery);
     final var hits = flowNodeInstanceMapper.search(dbQuery);
-    ensureSingleResultIfRequired(hits, query);
     return buildSearchQueryResult(totalHits, hits, dbSort);
   }
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/FormDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/FormDbReader.java
@@ -46,7 +46,6 @@ public class FormDbReader extends AbstractEntityReader<FormEntity> implements Fo
     LOG.trace("[RDBMS DB] Search for form with filter {}", dbQuery);
     final var totalHits = formMapper.count(dbQuery);
     final var hits = formMapper.search(dbQuery);
-    ensureSingleResultIfRequired(hits, query);
     return buildSearchQueryResult(totalHits, hits, dbSort);
   }
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/GroupDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/GroupDbReader.java
@@ -47,7 +47,6 @@ public class GroupDbReader extends AbstractEntityReader<GroupEntity> implements 
     LOG.trace("[RDBMS DB] Search for groups with filter {}", dbQuery);
     final var totalHits = groupMapper.count(dbQuery);
     final var hits = groupMapper.search(dbQuery).stream().map(this::map).toList();
-    ensureSingleResultIfRequired(hits, query);
     return buildSearchQueryResult(totalHits, hits, dbSort);
   }
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/IncidentDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/IncidentDbReader.java
@@ -47,7 +47,6 @@ public class IncidentDbReader extends AbstractEntityReader<IncidentEntity>
     LOG.trace("[RDBMS DB] Search for incident with filter {}", dbQuery);
     final var totalHits = incidentMapper.count(dbQuery);
     final var hits = incidentMapper.search(dbQuery);
-    ensureSingleResultIfRequired(hits, query);
     return buildSearchQueryResult(totalHits, hits, dbSort);
   }
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/JobDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/JobDbReader.java
@@ -42,7 +42,6 @@ public class JobDbReader extends AbstractEntityReader<JobEntity> implements JobR
     LOG.trace("[RDBMS DB] Search for jobs with filter {}", dbQuery);
     final var totalHits = jobMapper.count(dbQuery);
     final var hits = jobMapper.search(dbQuery).stream().map(JobEntityMapper::toEntity).toList();
-    ensureSingleResultIfRequired(hits, query);
     return buildSearchQueryResult(totalHits, hits, dbSort);
   }
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/MappingRuleDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/MappingRuleDbReader.java
@@ -48,7 +48,6 @@ public class MappingRuleDbReader extends AbstractEntityReader<MappingRuleEntity>
     LOG.trace("[RDBMS DB] Search for mapping with filter {}", dbQuery);
     final var totalHits = mappingMapper.count(dbQuery);
     final var hits = mappingMapper.search(dbQuery);
-    ensureSingleResultIfRequired(hits, query);
     return buildSearchQueryResult(totalHits, hits, dbSort);
   }
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/MappingRuleReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/MappingRuleReader.java
@@ -44,7 +44,6 @@ public class MappingRuleReader extends AbstractEntityReader<MappingRuleEntity> {
     LOG.trace("[RDBMS DB] Search for mapping rule with filter {}", dbQuery);
     final var totalHits = mappingRuleMapper.count(dbQuery);
     final var hits = mappingRuleMapper.search(dbQuery);
-    ensureSingleResultIfRequired(hits, query);
     return buildSearchQueryResult(totalHits, hits, dbSort);
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/ProcessDefinitionDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/ProcessDefinitionDbReader.java
@@ -49,7 +49,6 @@ public class ProcessDefinitionDbReader extends AbstractEntityReader<ProcessDefin
     LOG.trace("[RDBMS DB] Search for process instance with filter {}", dbQuery);
     final var totalHits = processDefinitionMapper.count(dbQuery);
     final var hits = processDefinitionMapper.search(dbQuery);
-    ensureSingleResultIfRequired(hits, query);
     return buildSearchQueryResult(totalHits, hits, dbSort);
   }
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/ProcessInstanceDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/ProcessInstanceDbReader.java
@@ -55,7 +55,6 @@ public class ProcessInstanceDbReader extends AbstractEntityReader<ProcessInstanc
     LOG.trace("[RDBMS DB] Search for process instance with filter {}", dbQuery);
     final var totalHits = processInstanceMapper.count(dbQuery);
     final var hits = processInstanceMapper.search(dbQuery);
-    ensureSingleResultIfRequired(hits, query);
     return buildSearchQueryResult(totalHits, hits, dbSort);
   }
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/RoleDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/RoleDbReader.java
@@ -47,7 +47,6 @@ public class RoleDbReader extends AbstractEntityReader<RoleEntity> implements Ro
     LOG.trace("[RDBMS DB] Search for roles with filter {}", dbQuery);
     final var totalHits = roleMapper.count(dbQuery);
     final var hits = roleMapper.search(dbQuery).stream().map(this::map).toList();
-    ensureSingleResultIfRequired(hits, query);
     return buildSearchQueryResult(totalHits, hits, dbSort);
   }
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/TenantDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/TenantDbReader.java
@@ -47,7 +47,6 @@ public class TenantDbReader extends AbstractEntityReader<TenantEntity> implement
     LOG.trace("[RDBMS DB] Search for tenants with filter {}", dbQuery);
     final var totalHits = tenantMapper.count(dbQuery);
     final var hits = tenantMapper.search(dbQuery).stream().map(this::map).toList();
-    ensureSingleResultIfRequired(hits, query);
     return buildSearchQueryResult(totalHits, hits, dbSort);
   }
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/UserDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/UserDbReader.java
@@ -46,7 +46,6 @@ public class UserDbReader extends AbstractEntityReader<UserEntity> implements Us
     LOG.trace("[RDBMS DB] Search for users with filter {}", dbQuery);
     final var totalHits = userMapper.count(dbQuery);
     final var hits = userMapper.search(dbQuery);
-    ensureSingleResultIfRequired(hits, query);
     return buildSearchQueryResult(totalHits, hits, dbSort);
   }
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/UserTaskDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/UserTaskDbReader.java
@@ -50,7 +50,6 @@ public class UserTaskDbReader extends AbstractEntityReader<UserTaskEntity>
     final var totalHits = userTaskMapper.count(dbQuery);
     final var hits =
         userTaskMapper.search(dbQuery).stream().map(UserTaskEntityMapper::toEntity).toList();
-    ensureSingleResultIfRequired(hits, query);
     return buildSearchQueryResult(totalHits, hits, dbSort);
   }
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/VariableDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/VariableDbReader.java
@@ -49,7 +49,6 @@ public class VariableDbReader extends AbstractEntityReader<VariableEntity>
     LOG.trace("[RDBMS DB] Search for variables with filter {}", query);
     final var totalHits = variableMapper.count(dbQuery);
     final var hits = variableMapper.search(dbQuery);
-    ensureSingleResultIfRequired(hits, query);
     return buildSearchQueryResult(totalHits, hits, dbSort);
   }
 


### PR DESCRIPTION
## Description

This removes the check in the RDBMS if a query returns a single result. The check already happens in the `CamundaSearchClients`.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
