### PR TITLE
Return the user response when updating user

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/response/UpdateUserResponse.java
+++ b/clients/java/src/main/java/io/camunda/client/api/response/UpdateUserResponse.java
@@ -15,4 +15,33 @@
  */
 package io.camunda.client.api.response;
 
-public interface UpdateUserResponse {}
+public interface UpdateUserResponse {
+
+  /**
+   * Returns the key of the updated user.
+   *
+   * @return the key of the updated user.
+   */
+  String getUserKey();
+
+  /**
+   * Returns the username of the updated user.
+   *
+   * @return the username of the updated user.
+   */
+  String getUsername();
+
+  /**
+   * Returns the name of the updated user.
+   *
+   * @return the name of the updated user.
+   */
+  String getName();
+
+  /**
+   * Returns the email of the updated user.
+   *
+   * @return the email of the updated user.
+   */
+  String getEmail();
+}

--- a/clients/java/src/main/java/io/camunda/client/api/response/UpdateUserResponse.java
+++ b/clients/java/src/main/java/io/camunda/client/api/response/UpdateUserResponse.java
@@ -18,13 +18,6 @@ package io.camunda.client.api.response;
 public interface UpdateUserResponse {
 
   /**
-   * Returns the key of the updated user.
-   *
-   * @return the key of the updated user.
-   */
-  String getUserKey();
-
-  /**
    * Returns the username of the updated user.
    *
    * @return the username of the updated user.

--- a/clients/java/src/main/java/io/camunda/client/impl/command/UpdateUserCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/UpdateUserCommandImpl.java
@@ -22,7 +22,9 @@ import io.camunda.client.api.command.UpdateUserCommandStep1;
 import io.camunda.client.api.response.UpdateUserResponse;
 import io.camunda.client.impl.http.HttpCamundaFuture;
 import io.camunda.client.impl.http.HttpClient;
+import io.camunda.client.impl.response.UpdateUserResponseImpl;
 import io.camunda.client.protocol.rest.UserUpdateRequest;
+import io.camunda.client.protocol.rest.UserUpdateResult;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import org.apache.hc.client5.http.config.RequestConfig;
@@ -73,8 +75,15 @@ public class UpdateUserCommandImpl implements UpdateUserCommandStep1 {
     ArgumentUtil.ensureNotNullNorEmpty("name", request.getName());
     ArgumentUtil.ensureNotNullNorEmpty("email", request.getEmail());
     final HttpCamundaFuture<UpdateUserResponse> result = new HttpCamundaFuture<>();
+    final UpdateUserResponseImpl response = new UpdateUserResponseImpl();
+
     httpClient.put(
-        "/users/" + username, jsonMapper.toJson(request), httpRequestConfig.build(), result);
+        "/users/" + username,
+        jsonMapper.toJson(request),
+        httpRequestConfig.build(),
+        UserUpdateResult.class,
+        response::setResponse,
+        result);
     return result;
   }
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/response/UpdateUserResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/UpdateUserResponseImpl.java
@@ -20,15 +20,9 @@ import io.camunda.client.protocol.rest.UserUpdateResult;
 
 public class UpdateUserResponseImpl implements UpdateUserResponse {
 
-  private String userKey;
   private String username;
   private String name;
   private String email;
-
-  @Override
-  public String getUserKey() {
-    return userKey;
-  }
 
   @Override
   public String getUsername() {
@@ -46,7 +40,6 @@ public class UpdateUserResponseImpl implements UpdateUserResponse {
   }
 
   public UpdateUserResponseImpl setResponse(final UserUpdateResult userUpdateResult) {
-    userKey = userUpdateResult.getUserKey();
     name = userUpdateResult.getName();
     username = userUpdateResult.getUsername();
     email = userUpdateResult.getEmail();

--- a/clients/java/src/main/java/io/camunda/client/impl/response/UpdateUserResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/UpdateUserResponseImpl.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.response;
+
+import io.camunda.client.api.response.UpdateUserResponse;
+import io.camunda.client.protocol.rest.UserUpdateResult;
+
+public class UpdateUserResponseImpl implements UpdateUserResponse {
+
+  private String userKey;
+  private String username;
+  private String name;
+  private String email;
+
+  @Override
+  public String getUserKey() {
+    return userKey;
+  }
+
+  @Override
+  public String getUsername() {
+    return username;
+  }
+
+  @Override
+  public String getName() {
+    return name;
+  }
+
+  @Override
+  public String getEmail() {
+    return email;
+  }
+
+  public UpdateUserResponseImpl setResponse(final UserUpdateResult userUpdateResult) {
+    userKey = userUpdateResult.getUserKey();
+    name = userUpdateResult.getName();
+    username = userUpdateResult.getUsername();
+    email = userUpdateResult.getEmail();
+    return this;
+  }
+}

--- a/clients/java/src/test/java/io/camunda/client/user/UpdateUserTest.java
+++ b/clients/java/src/test/java/io/camunda/client/user/UpdateUserTest.java
@@ -15,11 +15,14 @@
  */
 package io.camunda.client.user;
 
+import static io.camunda.client.impl.http.HttpClientFactory.REST_API_PATH;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.github.tomakehurst.wiremock.http.RequestMethod;
 import io.camunda.client.protocol.rest.UserUpdateRequest;
 import io.camunda.client.util.ClientRestTest;
+import io.camunda.client.util.RestGatewayService;
 import org.junit.jupiter.api.Test;
 
 public class UpdateUserTest extends ClientRestTest {
@@ -38,6 +41,10 @@ public class UpdateUserTest extends ClientRestTest {
     assertThat(request.getName()).isEqualTo(NAME);
     assertThat(request.getEmail()).isEqualTo(EMAIL);
     assertThat(request.getPassword()).isEqualTo(PASSWORD);
+
+    final String requestPath = RestGatewayService.getLastRequest().getUrl();
+    assertThat(requestPath).isEqualTo(REST_API_PATH + "/users/" + USERNAME);
+    assertThat(RestGatewayService.getLastRequest().getMethod()).isEqualTo(RequestMethod.PUT);
   }
 
   @Test

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/UserAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/UserAuthorizationIT.java
@@ -14,6 +14,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ProblemException;
 import io.camunda.client.api.response.CreateUserResponse;
+import io.camunda.client.api.response.UpdateUserResponse;
 import io.camunda.client.api.search.enums.PermissionType;
 import io.camunda.client.api.search.enums.ResourceType;
 import io.camunda.it.util.TestHelper;
@@ -28,7 +29,6 @@ import io.camunda.zeebe.test.util.Strings;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
@@ -153,28 +153,17 @@ class UserAuthorizationIT {
     final String updatedName = "updated_name";
     final String updatedEmail = "updated_email@email.com";
 
-    adminClient
-        .newUpdateUserCommand(USER_1.username())
-        .name(updatedName)
-        .email(updatedEmail)
-        .send()
-        .join();
+    final UpdateUserResponse response =
+        adminClient
+            .newUpdateUserCommand(USER_1.username())
+            .name(updatedName)
+            .email(updatedEmail)
+            .send()
+            .join();
 
-    Awaitility.await("User is updated")
-        .ignoreExceptionsInstanceOf(ProblemException.class)
-        .untilAsserted(
-            () ->
-                assertThat(
-                        adminClient
-                            .newUsersSearchRequest()
-                            .filter(fn -> fn.username(USER_1.username()))
-                            .send()
-                            .join()
-                            .items()
-                            .getFirst())
-                    .matches(u -> u.getUsername().equals(USER_1.username()))
-                    .matches(u -> u.getEmail().equals(updatedEmail))
-                    .matches(u -> u.getName().equals(updatedName)));
+    assertThat(response.getUsername()).isEqualTo(USER_1.username());
+    assertThat(response.getName()).isEqualTo(updatedName);
+    assertThat(response.getEmail()).isEqualTo(updatedEmail);
   }
 
   @Test

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/UsersUpdateIntegrationTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/UsersUpdateIntegrationTest.java
@@ -12,6 +12,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ProblemException;
+import io.camunda.client.api.response.CreateUserResponse;
+import io.camunda.client.api.response.UpdateUserResponse;
 import io.camunda.client.api.search.response.SearchResponse;
 import io.camunda.client.api.search.response.User;
 import io.camunda.qa.util.multidb.MultiDbTest;
@@ -33,39 +35,30 @@ public class UsersUpdateIntegrationTest {
     final var updatedName = "Updated User Name";
     final var updatedEmail = "updated_email@email.com";
 
-    camundaClient
-        .newCreateUserCommand()
-        .username(username)
-        .password("password")
-        .name(name)
-        .email(email)
-        .send()
-        .join();
+    final CreateUserResponse createUserResponse =
+        camundaClient
+            .newCreateUserCommand()
+            .username(username)
+            .password("password")
+            .name(name)
+            .email(email)
+            .send()
+            .join();
     assertUserCreated(username);
 
     // when
-    camundaClient
-        .newUpdateUserCommand(username)
-        .name(updatedName)
-        .email(updatedEmail)
-        .send()
-        .join();
+    final UpdateUserResponse updateUserResponse =
+        camundaClient
+            .newUpdateUserCommand(username)
+            .name(updatedName)
+            .email(updatedEmail)
+            .send()
+            .join();
 
     // then
-    Awaitility.await("User is updated")
-        .ignoreExceptionsInstanceOf(ProblemException.class)
-        .untilAsserted(
-            () -> {
-              final SearchResponse<User> response =
-                  camundaClient
-                      .newUsersSearchRequest()
-                      .filter(fn -> fn.username(username))
-                      .send()
-                      .join();
-              assertThat(response.items().getFirst().getUsername()).isEqualTo(username);
-              assertThat(response.items().getFirst().getName()).isEqualTo(updatedName);
-              assertThat(response.items().getFirst().getEmail()).isEqualTo(updatedEmail);
-            });
+    assertThat(updateUserResponse.getUsername()).isEqualTo(username);
+    assertThat(updateUserResponse.getName()).isEqualTo(updatedName);
+    assertThat(updateUserResponse.getEmail()).isEqualTo(updatedEmail);
   }
 
   @Test

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -4747,8 +4747,12 @@ paths:
               $ref: "#/components/schemas/UserUpdateRequest"
         required: true
       responses:
-        "204":
+        "200":
           description: The user was updated successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UserUpdateResult"
         "400":
           $ref: "#/components/responses/InvalidData"
         "403":
@@ -7542,7 +7546,22 @@ components:
           type: "string"
         userKey:
           description: The key of the created user
-          type: string
+          type: "string"
+    UserUpdateResult:
+      type: object
+      properties:
+        username:
+          description: The username of the user.
+          type: "string"
+        name:
+          description: The name of the user.
+          type: "string"
+        email:
+          description: The email of the user.
+          type: "string"
+        userKey:
+          description: The key of the updated user
+          type: "string"
     UserSearchQuerySortRequest:
       type: object
       properties:

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -7559,9 +7559,6 @@ components:
         email:
           description: The email of the user.
           type: "string"
-        userKey:
-          description: The key of the updated user
-          type: "string"
     UserSearchQuerySortRequest:
       type: object
       properties:

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/ResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/ResponseMapper.java
@@ -578,7 +578,6 @@ public final class ResponseMapper {
   public static ResponseEntity<Object> toUserUpdateResponse(final UserRecord userRecord) {
     final var response =
         new UserUpdateResult()
-            .userKey(KeyUtil.keyToString(userRecord.getUserKey()))
             .username(userRecord.getUsername())
             .email(userRecord.getEmail())
             .name(userRecord.getName());

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/ResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/ResponseMapper.java
@@ -62,6 +62,7 @@ import io.camunda.zeebe.gateway.protocol.rest.TenantCreateResult;
 import io.camunda.zeebe.gateway.protocol.rest.TenantUpdateResult;
 import io.camunda.zeebe.gateway.protocol.rest.UserCreateResult;
 import io.camunda.zeebe.gateway.protocol.rest.UserTaskProperties;
+import io.camunda.zeebe.gateway.protocol.rest.UserUpdateResult;
 import io.camunda.zeebe.gateway.rest.util.KeyUtil;
 import io.camunda.zeebe.msgpack.value.LongValue;
 import io.camunda.zeebe.msgpack.value.ValueArray;
@@ -572,6 +573,16 @@ public final class ResponseMapper {
             .email(userRecord.getEmail())
             .name(userRecord.getName());
     return new ResponseEntity<>(response, HttpStatus.CREATED);
+  }
+
+  public static ResponseEntity<Object> toUserUpdateResponse(final UserRecord userRecord) {
+    final var response =
+        new UserUpdateResult()
+            .userKey(KeyUtil.keyToString(userRecord.getUserKey()))
+            .username(userRecord.getUsername())
+            .email(userRecord.getEmail())
+            .name(userRecord.getName());
+    return new ResponseEntity<>(response, HttpStatus.OK);
   }
 
   public static ResponseEntity<Object> toRoleCreateResponse(final RoleRecord roleRecord) {

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/UserController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/UserController.java
@@ -94,11 +94,12 @@ public class UserController {
   }
 
   private CompletableFuture<ResponseEntity<Object>> updateUser(final UserDTO request) {
-    return RequestMapper.executeServiceMethodWithNoContentResult(
+    return RequestMapper.executeServiceMethod(
         () ->
             userServices
                 .withAuthentication(authenticationProvider.getCamundaAuthentication())
-                .updateUser(request));
+                .updateUser(request),
+        ResponseMapper::toUserUpdateResponse);
   }
 
   @CamundaPostMapping(path = "/search")

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/UserControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/UserControllerTest.java
@@ -334,7 +334,7 @@ public class UserControllerTest extends RestControllerTest {
   }
 
   @Test
-  void updateUserShouldReturnNoContent() {
+  void updateUserShouldReturnOk() {
     // given
     final String username = "alice-test";
     final UserDTO user = new UserDTO(username, "Alice", "test+alice@camunda.com", null);
@@ -356,7 +356,7 @@ public class UserControllerTest extends RestControllerTest {
             new UserUpdateRequest().name(user.name()).email(user.email()).password(user.password()))
         .exchange()
         .expectStatus()
-        .isNoContent();
+        .isOk();
 
     verify(userServices, times(1)).updateUser(user);
   }


### PR DESCRIPTION
## Description

Currently, update user REST endpoint returns empty response.
We should return the full user response, just not the `password` and not `userKey`.

Reason for not returning `userKey` can be found [here](https://github.com/camunda/camunda/issues/35439)


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #33037
