### PR TITLE
[POC] Resource id authorization check

### DIFF
--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/auth/DefaultResourceAccessProvider.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/auth/DefaultResourceAccessProvider.java
@@ -10,6 +10,7 @@ package io.camunda.search.clients.auth;
 import static io.camunda.security.auth.Authorization.WILDCARD;
 
 import io.camunda.security.auth.Authorization;
+import io.camunda.security.auth.AuthorizationScope.AuthorizationScopeFactory;
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.security.auth.SecurityContext;
 import io.camunda.security.impl.AuthorizationChecker;
@@ -47,7 +48,7 @@ public class DefaultResourceAccessProvider implements ResourceAccessProvider {
     final var securityContext = createSecurityContext(authentication, requiredAuthorization);
     final var resourceIds = authorizationChecker.retrieveAuthorizedResourceKeys(securityContext);
 
-    if (resourceIds.contains(WILDCARD)) {
+    if (resourceIds.contains(AuthorizationScopeFactory.wildcard())) {
       // no authorization check required, user can access
       // the respective resources.
       return ResourceAccess.wildcard(resultingAuthorization.resourceId(WILDCARD).build());
@@ -58,7 +59,7 @@ public class DefaultResourceAccessProvider implements ResourceAccessProvider {
     }
 
     final var authorizationWithResolvedResourceIds =
-        resultingAuthorization.resourceIds(resourceIds).build();
+        resultingAuthorization.authorizationScopes(resourceIds).build();
     return ResourceAccess.allowed(authorizationWithResolvedResourceIds);
   }
 

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/auth/DefaultResourceAccessProviderTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/auth/DefaultResourceAccessProviderTest.java
@@ -12,6 +12,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 import io.camunda.security.auth.Authorization;
+import io.camunda.security.auth.AuthorizationScope.AuthorizationScopeFactory;
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.security.impl.AuthorizationChecker;
 import java.util.List;
@@ -39,7 +40,8 @@ class DefaultResourceAccessProviderTest {
     final var authorization = Authorization.of(a -> a.processDefinition().readProcessDefinition());
 
     when(authorizationChecker.retrieveAuthorizedResourceKeys(any()))
-        .thenReturn(List.of("bar", "baz"));
+        .thenReturn(
+            List.of(AuthorizationScopeFactory.id("bar"), AuthorizationScopeFactory.id("baz")));
 
     // when
     final var result = resourceAccessProvider.resolveResourceAccess(authentication, authorization);
@@ -59,7 +61,8 @@ class DefaultResourceAccessProviderTest {
     final var authentication = CamundaAuthentication.of(a -> a.user("foo"));
     final var authorization = Authorization.of(a -> a.processDefinition().readProcessDefinition());
 
-    when(authorizationChecker.retrieveAuthorizedResourceKeys(any())).thenReturn(List.of("*"));
+    when(authorizationChecker.retrieveAuthorizedResourceKeys(any()))
+        .thenReturn(List.of(AuthorizationScopeFactory.wildcard()));
 
     // when
     final var result = resourceAccessProvider.resolveResourceAccess(authentication, authorization);

--- a/security/security-core/src/main/java/io/camunda/security/auth/Authorization.java
+++ b/security/security-core/src/main/java/io/camunda/security/auth/Authorization.java
@@ -155,6 +155,11 @@ public record Authorization(
       return this;
     }
 
+    public Builder authorizationScopes(final List<AuthorizationScope> authorizationScopes) {
+      resourceIds = authorizationScopes.stream().map(AuthorizationScope::resourceId).toList();
+      return this;
+    }
+
     public Authorization build() {
       return new Authorization(resourceType, permissionType, resourceIds);
     }

--- a/security/security-core/src/main/java/io/camunda/security/auth/AuthorizationScope.java
+++ b/security/security-core/src/main/java/io/camunda/security/auth/AuthorizationScope.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.security.auth;
+
+import static io.camunda.security.auth.Authorization.WILDCARD;
+
+import java.util.Objects;
+
+public record AuthorizationScope(MatcherType type, String resourceId) {
+
+  @Override
+  public boolean equals(final Object obj) {
+    final AuthorizationScope other = (AuthorizationScope) obj;
+    if (MatcherType.ANY == other.type) {
+      return true;
+    }
+    return resourceId.equals(other.resourceId);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(type, resourceId);
+  }
+
+  public static class AuthorizationScopeFactory {
+
+    public static AuthorizationScope wildcard() {
+      return new AuthorizationScope(AuthorizationScope.MatcherType.ANY, null);
+    }
+
+    public static AuthorizationScope id(final String resourceId) {
+      return new AuthorizationScope(AuthorizationScope.MatcherType.ID, resourceId);
+    }
+
+    public static AuthorizationScope of(final String resourceId) {
+      if (WILDCARD.equals(resourceId)) {
+        return wildcard();
+      }
+
+      return id(resourceId);
+    }
+  }
+
+  public enum MatcherType {
+    ANY,
+    ID
+  }
+}

--- a/service/src/main/java/io/camunda/service/security/SecurityContextProvider.java
+++ b/service/src/main/java/io/camunda/service/security/SecurityContextProvider.java
@@ -8,6 +8,7 @@
 package io.camunda.service.security;
 
 import io.camunda.security.auth.Authorization;
+import io.camunda.security.auth.AuthorizationScope.AuthorizationScopeFactory;
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.security.auth.SecurityContext;
 import io.camunda.security.auth.SecurityContext.Builder;
@@ -46,7 +47,8 @@ public class SecurityContextProvider {
       final Authorization authorization) {
     final var securityContext = provideSecurityContext(authentication, authorization);
     if (securityContext.requiresAuthorizationChecks()) {
-      return authorizationChecker.isAuthorized(resourceKey, securityContext);
+      return authorizationChecker.isAuthorized(
+          AuthorizationScopeFactory.of(resourceKey), securityContext);
     }
     return true;
   }

--- a/service/src/test/java/io/camunda/service/security/SecurityContextProviderTest.java
+++ b/service/src/test/java/io/camunda/service/security/SecurityContextProviderTest.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.camunda.security.auth.Authorization;
+import io.camunda.security.auth.AuthorizationScope.AuthorizationScopeFactory;
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.security.auth.SecurityContext;
 import io.camunda.security.configuration.SecurityConfiguration;
@@ -103,7 +104,7 @@ class SecurityContextProviderTest {
     assertThat(authorized).isTrue();
     verify(authorizationChecker)
         .isAuthorized(
-            "resourceKey",
+            AuthorizationScopeFactory.id("resourceKey"),
             SecurityContext.of(
                 s -> s.withAuthentication(authentication).withAuthorization(authorization)));
   }
@@ -124,7 +125,7 @@ class SecurityContextProviderTest {
     assertThat(authorized).isFalse();
     verify(authorizationChecker)
         .isAuthorized(
-            "resourceKey",
+            AuthorizationScopeFactory.id("resourceKey"),
             SecurityContext.of(
                 s -> s.withAuthentication(authentication).withAuthorization(authorization)));
   }

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/permission/TasklistPermissionServices.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/permission/TasklistPermissionServices.java
@@ -8,6 +8,7 @@
 package io.camunda.tasklist.webapp.permission;
 
 import io.camunda.security.auth.Authorization;
+import io.camunda.security.auth.AuthorizationScope;
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.security.auth.CamundaAuthenticationProvider;
 import io.camunda.security.configuration.SecurityConfiguration;
@@ -18,6 +19,7 @@ import io.camunda.tasklist.util.LazySupplier;
 import io.camunda.webapps.schema.entities.usertask.TaskEntity;
 import java.util.List;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -70,7 +72,9 @@ public class TasklistPermissionServices {
     final var securityContext =
         securityContextProvider.provideSecurityContext(
             authenticationSupplier.get(), CREATE_PROC_INST_AUTH_CHECK);
-    return authorizationChecker.retrieveAuthorizedResourceKeys(securityContext);
+    return authorizationChecker.retrieveAuthorizedResourceKeys(securityContext).stream()
+        .map(AuthorizationScope::resourceId)
+        .collect(Collectors.toList());
   }
 
   private boolean isAuthorizedForResource(

--- a/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/es/cache/ProcessStoreElasticSearchTest.java
+++ b/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/es/cache/ProcessStoreElasticSearchTest.java
@@ -20,6 +20,7 @@ import static org.mockito.Mockito.when;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.authentication.entity.AuthenticationContext;
 import io.camunda.authentication.entity.CamundaUser;
+import io.camunda.security.auth.AuthorizationScope.AuthorizationScopeFactory;
 import io.camunda.security.auth.CamundaAuthenticationProvider;
 import io.camunda.security.configuration.AuthorizationsConfiguration;
 import io.camunda.security.configuration.MultiTenancyConfiguration;
@@ -270,7 +271,8 @@ class ProcessStoreElasticSearchTest {
         .thenReturn(mock(io.camunda.security.auth.SecurityContext.class));
 
     if (isAuthorizated) {
-      when(authorizationChecker.retrieveAuthorizedResourceKeys(any())).thenReturn(List.of("*"));
+      when(authorizationChecker.retrieveAuthorizedResourceKeys(any()))
+          .thenReturn(List.of(AuthorizationScopeFactory.wildcard()));
     } else {
       when(authorizationChecker.retrieveAuthorizedResourceKeys(any())).thenReturn(List.of());
     }

--- a/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/es/cache/ProcessStoreOpenSearchTest.java
+++ b/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/es/cache/ProcessStoreOpenSearchTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.authentication.entity.CamundaUser;
+import io.camunda.security.auth.AuthorizationScope.AuthorizationScopeFactory;
 import io.camunda.security.auth.CamundaAuthenticationProvider;
 import io.camunda.security.configuration.AuthorizationsConfiguration;
 import io.camunda.security.configuration.MultiTenancyConfiguration;
@@ -274,7 +275,8 @@ class ProcessStoreOpenSearchTest {
         .thenReturn(mock(io.camunda.security.auth.SecurityContext.class));
 
     if (isAuthorizated) {
-      when(authorizationChecker.retrieveAuthorizedResourceKeys(any())).thenReturn(List.of("*"));
+      when(authorizationChecker.retrieveAuthorizedResourceKeys(any()))
+          .thenReturn(List.of(AuthorizationScopeFactory.wildcard()));
     } else {
       when(authorizationChecker.retrieveAuthorizedResourceKeys(any())).thenReturn(List.of());
     }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DeploymentTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DeploymentTransformer.java
@@ -74,6 +74,8 @@ public final class DeploymentTransformer {
         new RpaTransformer(
             keyGenerator, stateWriter, checksumGenerator, processingState.getResourceState());
 
+    // TODO: Add resource ID validators to the resourceTransformers. They already contain checks
+    //  for duplicate resource IDs (within a single deployment).
     resourceTransformers =
         Map.ofEntries(
             entry(".bpmn", bpmnResourceTransformer),

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchCollector.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchCollector.java
@@ -7,8 +7,8 @@
  */
 package io.camunda.zeebe.engine.processing.job;
 
-import static io.camunda.zeebe.engine.processing.identity.AuthorizationCheckBehavior.WILDCARD_PERMISSION;
-
+import io.camunda.security.auth.AuthorizationScope;
+import io.camunda.security.auth.AuthorizationScope.AuthorizationScopeFactory;
 import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.processing.identity.AuthorizationCheckBehavior;
 import io.camunda.zeebe.engine.processing.identity.AuthorizationCheckBehavior.AuthorizationRequest;
@@ -155,8 +155,8 @@ final class JobBatchCollector {
   }
 
   private boolean isAuthorizedForJob(
-      final JobRecord jobRecord, final Set<String> authorizedProcessIds) {
-    return authorizedProcessIds.contains(WILDCARD_PERMISSION)
+      final JobRecord jobRecord, final Set<AuthorizationScope> authorizedProcessIds) {
+    return authorizedProcessIds.contains(AuthorizationScopeFactory.wildcard())
         || authorizedProcessIds.contains(jobRecord.getBpmnProcessId());
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCheckBehaviorGroupsClaimsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCheckBehaviorGroupsClaimsTest.java
@@ -14,6 +14,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import io.camunda.security.auth.AuthorizationScope;
+import io.camunda.security.auth.AuthorizationScope.AuthorizationScopeFactory;
 import io.camunda.security.configuration.AuthorizationsConfiguration;
 import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.zeebe.engine.processing.identity.AuthorizationCheckBehavior;
@@ -91,7 +93,7 @@ final class AuthorizationCheckBehaviorGroupsClaimsTest {
     final var groups = List.of("group1", "group2");
     final var resourceType = AuthorizationResourceType.RESOURCE;
     final var permissionType = PermissionType.CREATE;
-    final var resourceId = UUID.randomUUID().toString();
+    final var resourceId = AuthorizationScopeFactory.id(UUID.randomUUID().toString());
     addPermission(
         groups.get(0), AuthorizationOwnerType.GROUP, resourceType, permissionType, resourceId);
     final var command = mockCommand(user.getUsername(), groups);
@@ -112,8 +114,8 @@ final class AuthorizationCheckBehaviorGroupsClaimsTest {
     final var groups = List.of("group1", "group2");
     final var resourceType = AuthorizationResourceType.RESOURCE;
     final var permissionType = PermissionType.CREATE;
-    final var resourceId1 = UUID.randomUUID().toString();
-    final var resourceId2 = UUID.randomUUID().toString();
+    final var resourceId1 = AuthorizationScopeFactory.id(UUID.randomUUID().toString());
+    final var resourceId2 = AuthorizationScopeFactory.id(UUID.randomUUID().toString());
     addPermission(
         groups.get(0),
         AuthorizationOwnerType.GROUP,
@@ -141,7 +143,7 @@ final class AuthorizationCheckBehaviorGroupsClaimsTest {
     final var groups = List.of("group1", "group2");
     final var resourceType = AuthorizationResourceType.RESOURCE;
     final var permissionType = PermissionType.CREATE;
-    final var resourceId = UUID.randomUUID().toString();
+    final var resourceId = AuthorizationScopeFactory.id(UUID.randomUUID().toString());
     addPermission(
         groups.get(0), AuthorizationOwnerType.GROUP, resourceType, permissionType, resourceId);
     final var command = mockCommandWithMappingRule(claimName, claimValue, groups);
@@ -165,7 +167,7 @@ final class AuthorizationCheckBehaviorGroupsClaimsTest {
 
     final var resourceType = AuthorizationResourceType.RESOURCE;
     final var permissionType = PermissionType.CREATE;
-    final var resourceId = UUID.randomUUID().toString();
+    final var resourceId = AuthorizationScopeFactory.id(UUID.randomUUID().toString());
     addPermission(
         role.getRoleId(), AuthorizationOwnerType.ROLE, resourceType, permissionType, resourceId);
     final var command = mockCommand(user.getUsername(), groups);
@@ -185,7 +187,7 @@ final class AuthorizationCheckBehaviorGroupsClaimsTest {
     final var user = createUser();
     final var resourceType = AuthorizationResourceType.RESOURCE;
     final var permissionType = PermissionType.CREATE;
-    final var resourceId = UUID.randomUUID().toString();
+    final var resourceId = AuthorizationScopeFactory.id(UUID.randomUUID().toString());
     addPermission(
         user.getUsername(), AuthorizationOwnerType.USER, resourceType, permissionType, resourceId);
     final var groups = List.of("group1", "group2");
@@ -264,15 +266,15 @@ final class AuthorizationCheckBehaviorGroupsClaimsTest {
       final AuthorizationOwnerType ownerType,
       final AuthorizationResourceType resourceType,
       final PermissionType permissionType,
-      final String... resourceIds) {
-    for (final String resourceId : resourceIds) {
+      final AuthorizationScope... authorizationScopes) {
+    for (final AuthorizationScope authorizationScope : authorizationScopes) {
       final var authorizationKey = random.nextLong();
       final var authorization =
           new AuthorizationRecord()
               .setAuthorizationKey(authorizationKey)
               .setOwnerId(ownerId)
               .setOwnerType(ownerType)
-              .setResourceId(resourceId)
+              .setResourceId(authorizationScope.resourceId())
               .setResourceType(resourceType)
               .setPermissionTypes(Set.of(permissionType));
       authorizationCreatedApplier.applyState(authorizationKey, authorization);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCheckBehaviorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCheckBehaviorTest.java
@@ -15,6 +15,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import io.camunda.security.auth.AuthorizationScope;
+import io.camunda.security.auth.AuthorizationScope.AuthorizationScopeFactory;
 import io.camunda.security.configuration.AuthorizationsConfiguration;
 import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.zeebe.engine.processing.identity.AuthorizationCheckBehavior;
@@ -92,7 +94,7 @@ final class AuthorizationCheckBehaviorTest {
     final var user = createUser();
     final var resourceType = AuthorizationResourceType.RESOURCE;
     final var permissionType = PermissionType.CREATE;
-    final var resourceId = UUID.randomUUID().toString();
+    final var resourceId = AuthorizationScopeFactory.of(UUID.randomUUID().toString());
     addPermission(
         user.getUsername(), AuthorizationOwnerType.USER, resourceType, permissionType, resourceId);
     final var command = mockCommand(user.getUsername());
@@ -130,8 +132,8 @@ final class AuthorizationCheckBehaviorTest {
     final var user = createUser();
     final var resourceType = AuthorizationResourceType.RESOURCE;
     final var permissionType = PermissionType.CREATE;
-    final var resourceId1 = UUID.randomUUID().toString();
-    final var resourceId2 = UUID.randomUUID().toString();
+    final var resourceId1 = AuthorizationScopeFactory.of(UUID.randomUUID().toString());
+    final var resourceId2 = AuthorizationScopeFactory.of(UUID.randomUUID().toString());
     addPermission(
         user.getUsername(),
         AuthorizationOwnerType.USER,
@@ -174,7 +176,7 @@ final class AuthorizationCheckBehaviorTest {
     final var role = createRoleAndAssignEntity(user.getUsername(), EntityType.USER);
     final var resourceType = AuthorizationResourceType.RESOURCE;
     final var permissionType = PermissionType.CREATE;
-    final var resourceId = UUID.randomUUID().toString();
+    final var resourceId = AuthorizationScopeFactory.of(UUID.randomUUID().toString());
     addPermission(
         role.getRoleId(), AuthorizationOwnerType.ROLE, resourceType, permissionType, resourceId);
     final var command = mockCommand(user.getUsername());
@@ -195,8 +197,8 @@ final class AuthorizationCheckBehaviorTest {
     final var role = createRoleAndAssignEntity(user.getUsername(), EntityType.USER);
     final var resourceType = AuthorizationResourceType.RESOURCE;
     final var permissionType = PermissionType.CREATE;
-    final var resourceId1 = UUID.randomUUID().toString();
-    final var resourceId2 = UUID.randomUUID().toString();
+    final var resourceId1 = AuthorizationScopeFactory.of(UUID.randomUUID().toString());
+    final var resourceId2 = AuthorizationScopeFactory.of(UUID.randomUUID().toString());
     addPermission(
         role.getRoleId(),
         AuthorizationOwnerType.ROLE,
@@ -222,7 +224,7 @@ final class AuthorizationCheckBehaviorTest {
     final var group = createGroupAndAssignEntity(user.getUsername(), EntityType.USER);
     final var resourceType = AuthorizationResourceType.RESOURCE;
     final var permissionType = PermissionType.CREATE;
-    final var resourceId = UUID.randomUUID().toString();
+    final var resourceId = AuthorizationScopeFactory.of(UUID.randomUUID().toString());
     addPermission(
         group.getGroupId(), AuthorizationOwnerType.GROUP, resourceType, permissionType, resourceId);
     final var command = mockCommand(user.getUsername());
@@ -244,8 +246,8 @@ final class AuthorizationCheckBehaviorTest {
     final var groupId = group.getGroupId();
     final var resourceType = AuthorizationResourceType.RESOURCE;
     final var permissionType = PermissionType.CREATE;
-    final var resourceId1 = UUID.randomUUID().toString();
-    final var resourceId2 = UUID.randomUUID().toString();
+    final var resourceId1 = AuthorizationScopeFactory.of(UUID.randomUUID().toString());
+    final var resourceId2 = AuthorizationScopeFactory.of(UUID.randomUUID().toString());
     addPermission(
         groupId,
         AuthorizationOwnerType.GROUP,
@@ -270,7 +272,7 @@ final class AuthorizationCheckBehaviorTest {
     final var user = createUser();
     final var resourceType = AuthorizationResourceType.RESOURCE;
     final var permissionType = PermissionType.CREATE;
-    final var resourceId = UUID.randomUUID().toString();
+    final var resourceId = AuthorizationScopeFactory.of(UUID.randomUUID().toString());
     addPermission(
         user.getUsername(), AuthorizationOwnerType.USER, resourceType, permissionType, resourceId);
     final var command = mockCommandWithAnonymousUser();
@@ -292,7 +294,7 @@ final class AuthorizationCheckBehaviorTest {
     final var mappingRule = createMappingRule(claimName, claimValue);
     final var resourceType = AuthorizationResourceType.RESOURCE;
     final var permissionType = PermissionType.CREATE;
-    final var resourceId = UUID.randomUUID().toString();
+    final var resourceId = AuthorizationScopeFactory.of(UUID.randomUUID().toString());
     addPermission(
         mappingRule.getMappingRuleId(),
         AuthorizationOwnerType.MAPPING_RULE,
@@ -319,7 +321,7 @@ final class AuthorizationCheckBehaviorTest {
     final var group = createGroupAndAssignEntity(mappingRuleId, EntityType.MAPPING_RULE);
     final var resourceType = AuthorizationResourceType.RESOURCE;
     final var permissionType = PermissionType.CREATE;
-    final var resourceId = UUID.randomUUID().toString();
+    final var resourceId = AuthorizationScopeFactory.of(UUID.randomUUID().toString());
     addPermission(
         group.getGroupId(), AuthorizationOwnerType.GROUP, resourceType, permissionType, resourceId);
     final var command = mockCommandWithMappingRule(claimName, claimValue);
@@ -343,7 +345,7 @@ final class AuthorizationCheckBehaviorTest {
         createRoleAndAssignEntity(mappingRule.getMappingRuleId(), EntityType.MAPPING_RULE);
     final var resourceType = AuthorizationResourceType.RESOURCE;
     final var permissionType = PermissionType.CREATE;
-    final var resourceId = UUID.randomUUID().toString();
+    final var resourceId = AuthorizationScopeFactory.of(UUID.randomUUID().toString());
     addPermission(
         role.getRoleId(), AuthorizationOwnerType.ROLE, resourceType, permissionType, resourceId);
 
@@ -388,8 +390,8 @@ final class AuthorizationCheckBehaviorTest {
 
     final var resourceType = AuthorizationResourceType.RESOURCE;
     final var permissionType = PermissionType.CREATE;
-    final var firstResourceId = UUID.randomUUID().toString();
-    final var secondResourceId = UUID.randomUUID().toString();
+    final var firstResourceId = AuthorizationScopeFactory.of(UUID.randomUUID().toString());
+    final var secondResourceId = AuthorizationScopeFactory.of(UUID.randomUUID().toString());
     addPermission(
         String.valueOf(firstMapping.getMappingRuleId()),
         AuthorizationOwnerType.MAPPING_RULE,
@@ -436,8 +438,8 @@ final class AuthorizationCheckBehaviorTest {
 
     final var resourceType = AuthorizationResourceType.RESOURCE;
     final var permissionType = PermissionType.CREATE;
-    final var firstResourceId = UUID.randomUUID().toString();
-    final var secondResourceId = UUID.randomUUID().toString();
+    final var firstResourceId = AuthorizationScopeFactory.of(UUID.randomUUID().toString());
+    final var secondResourceId = AuthorizationScopeFactory.of(UUID.randomUUID().toString());
     addPermission(
         firstMapping.getMappingRuleId(),
         AuthorizationOwnerType.MAPPING_RULE,
@@ -480,7 +482,7 @@ final class AuthorizationCheckBehaviorTest {
     final var mappingRule = createMappingRule(claimName, claimValue);
     final var resourceType = AuthorizationResourceType.RESOURCE;
     final var permissionType = PermissionType.CREATE;
-    final var resourceId = UUID.randomUUID().toString();
+    final var resourceId = AuthorizationScopeFactory.of(UUID.randomUUID().toString());
     addPermission(
         mappingRule.getMappingRuleId(),
         AuthorizationOwnerType.MAPPING_RULE,
@@ -507,7 +509,7 @@ final class AuthorizationCheckBehaviorTest {
     final var mappingRule = createMappingRule(claimName, claimValue);
     final var resourceType = AuthorizationResourceType.RESOURCE;
     final var permissionType = PermissionType.CREATE;
-    final var resourceId = UUID.randomUUID().toString();
+    final var resourceId = AuthorizationScopeFactory.of(UUID.randomUUID().toString());
     addPermission(
         mappingRule.getMappingRuleId(),
         AuthorizationOwnerType.MAPPING_RULE,
@@ -539,7 +541,7 @@ final class AuthorizationCheckBehaviorTest {
         createRoleAndAssignEntity(mappingRule.getMappingRuleId(), EntityType.MAPPING_RULE);
     final var resourceType = AuthorizationResourceType.RESOURCE;
     final var permissionType = PermissionType.CREATE;
-    final var resourceId = UUID.randomUUID().toString();
+    final var resourceId = AuthorizationScopeFactory.of(UUID.randomUUID().toString());
     addPermission(
         role.getRoleId(), AuthorizationOwnerType.ROLE, resourceType, permissionType, resourceId);
     final var command = mockCommandWithMappingRule(claimName, claimValue);
@@ -564,7 +566,7 @@ final class AuthorizationCheckBehaviorTest {
         createGroupAndAssignEntity(mappingRule.getMappingRuleId(), EntityType.MAPPING_RULE);
     final var resourceType = AuthorizationResourceType.RESOURCE;
     final var permissionType = PermissionType.CREATE;
-    final var resourceId = UUID.randomUUID().toString();
+    final var resourceId = AuthorizationScopeFactory.of(UUID.randomUUID().toString());
     addPermission(
         group.getGroupId(), AuthorizationOwnerType.GROUP, resourceType, permissionType, resourceId);
     final var command = mockCommandWithMappingRule(claimName, claimValue);
@@ -588,7 +590,7 @@ final class AuthorizationCheckBehaviorTest {
 
     final var resourceType = AuthorizationResourceType.RESOURCE;
     final var permissionType = PermissionType.CREATE;
-    final var resourceId = UUID.randomUUID().toString();
+    final var resourceId = AuthorizationScopeFactory.of(UUID.randomUUID().toString());
     addPermission(
         role.getRoleId(), AuthorizationOwnerType.ROLE, resourceType, permissionType, resourceId);
     final var command = mockCommand(user.getUsername());
@@ -611,7 +613,7 @@ final class AuthorizationCheckBehaviorTest {
 
     final var resourceType = AuthorizationResourceType.RESOURCE;
     final var permissionType = PermissionType.CREATE;
-    final var resourceId = UUID.randomUUID().toString();
+    final var resourceId = AuthorizationScopeFactory.of(UUID.randomUUID().toString());
     addPermission(
         role.getRoleId(), AuthorizationOwnerType.ROLE, resourceType, permissionType, resourceId);
     final var command = mockCommand(user.getUsername());
@@ -641,7 +643,7 @@ final class AuthorizationCheckBehaviorTest {
 
     final var resourceType = AuthorizationResourceType.RESOURCE;
     final var permissionType = PermissionType.CREATE;
-    final var resourceId = UUID.randomUUID().toString();
+    final var resourceId = AuthorizationScopeFactory.of(UUID.randomUUID().toString());
     addPermission(
         role.getRoleId(), AuthorizationOwnerType.ROLE, resourceType, permissionType, resourceId);
     final var command =
@@ -667,7 +669,7 @@ final class AuthorizationCheckBehaviorTest {
 
     final var resourceType = AuthorizationResourceType.RESOURCE;
     final var permissionType = PermissionType.CREATE;
-    final var resourceId = UUID.randomUUID().toString();
+    final var resourceId = AuthorizationScopeFactory.of(UUID.randomUUID().toString());
     addPermission(
         role.getRoleId(), AuthorizationOwnerType.ROLE, resourceType, permissionType, resourceId);
     final var command =
@@ -696,7 +698,7 @@ final class AuthorizationCheckBehaviorTest {
     final var clientId = createClientId();
     final var resourceType = AuthorizationResourceType.RESOURCE;
     final var permissionType = PermissionType.CREATE;
-    final var resourceId = UUID.randomUUID().toString();
+    final var resourceId = AuthorizationScopeFactory.of(UUID.randomUUID().toString());
     addPermission(
         clientId, AuthorizationOwnerType.CLIENT, resourceType, permissionType, resourceId);
     final var command = mockCommandWithClientId(clientId);
@@ -716,7 +718,7 @@ final class AuthorizationCheckBehaviorTest {
     final var clientId = createClientId();
     final var resourceType = AuthorizationResourceType.RESOURCE;
     final var permissionType = PermissionType.DELETE;
-    final var resourceId = UUID.randomUUID().toString();
+    final var resourceId = AuthorizationScopeFactory.of(UUID.randomUUID().toString());
     final var command = mockCommandWithClientId(clientId);
 
     // when
@@ -734,8 +736,8 @@ final class AuthorizationCheckBehaviorTest {
     final var clientId = createClientId();
     final var resourceType = AuthorizationResourceType.RESOURCE;
     final var permissionType = PermissionType.CREATE;
-    final var resourceId1 = UUID.randomUUID().toString();
-    final var resourceId2 = UUID.randomUUID().toString();
+    final var resourceId1 = AuthorizationScopeFactory.of(UUID.randomUUID().toString());
+    final var resourceId2 = AuthorizationScopeFactory.of(UUID.randomUUID().toString());
     addPermission(
         clientId,
         AuthorizationOwnerType.CLIENT,
@@ -838,15 +840,15 @@ final class AuthorizationCheckBehaviorTest {
       final AuthorizationOwnerType ownerType,
       final AuthorizationResourceType resourceType,
       final PermissionType permissionType,
-      final String... resourceIds) {
-    for (final String resourceId : resourceIds) {
+      final AuthorizationScope... authorizationScopes) {
+    for (final AuthorizationScope authorizationScope : authorizationScopes) {
       final var authorizationKey = random.nextLong();
       final var authorization =
           new AuthorizationRecord()
               .setAuthorizationKey(authorizationKey)
               .setOwnerId(ownerId)
               .setOwnerType(ownerType)
-              .setResourceId(resourceId)
+              .setResourceId(authorizationScope.resourceId())
               .setResourceType(resourceType)
               .setPermissionTypes(Set.of(permissionType));
       authorizationCreatedApplier.applyState(authorizationKey, authorization);

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/IdentifierPatterns.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/IdentifierPatterns.java
@@ -9,6 +9,10 @@ package io.camunda.zeebe.gateway.rest.validator;
 
 import java.util.regex.Pattern;
 
+/**
+ * Utility class containing patterns for validating identifiers used in the REST API. The pattern is
+ * used to validate String-based identifies such as User, Role, Group, Tenant, and Mapping IDs.
+ */
 public final class IdentifierPatterns {
 
   public static final int MAX_LENGTH = 256;


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR introduces an `AuthorizationScope` wrapper for `resourceIds` when they enter the `AuthorizationCheckBehavior` and `AuthorizationChecker` classes of the workflow engine and search layer.

The wrapper class is overlaid on the existing data model when the `resourceIds` are retrieved from the Zeebe runtime state and secondary storage. No adjustments are made to the underlying data model for Authorizations and Permissions.

The goal is to improve the readability of the code and simplify working with `resourceIds` through more lightweight changes.

I also investigated possible locations for hardening and extending ID validation of  String-based identifiers related to Identity entities and deployed resources.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

Related to #29453
