### PR TITLE
fix: remove-34322-workaround

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/task-details.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/task-details.spec.ts
@@ -15,7 +15,6 @@ import {sleep} from 'utils/sleep';
 import {captureScreenshot, captureFailureVideo} from '@setup';
 
 test.beforeAll(async () => {
-  // Workaround for #34322: split deployments to avoid test failures caused by bulk deployment
   await deploy([
     './resources/usertask_to_be_completed.bpmn',
     './resources/user_task_with_form.bpmn',
@@ -27,8 +26,6 @@ test.beforeAll(async () => {
     './resources/form_with_checkbox.form',
     './resources/checklist_task_with_form.bpmn',
     './resources/form_with_checklist.form',
-  ]);
-  await deploy([
     './resources/date_and_time_task_with_form.bpmn',
     './resources/form_with_date_and_time.form',
     './resources/number_task_with_form.bpmn',
@@ -39,8 +36,6 @@ test.beforeAll(async () => {
     './resources/form_with_select.form',
     './resources/tag_list_task_with_form.bpmn',
     './resources/form_with_tag_list.form',
-  ]);
-  await deploy([
     './resources/text_templating_form_task.bpmn',
     './resources/form_with_text_templating.form',
     './resources/processWithDeployedForm.bpmn',


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Removes the workaround that was addressing bulk deployment test failures, as the underlying issue #34322  has been resolved.

🧪 [Successful test run](https://github.com/camunda/camunda/actions/runs/16498715353/job/46651093541)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
