### PR TITLE
Add `isCompletionConditionFulfilled` and `isCancelRemainingInstances` to ad-hoc sub-process JobResult

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/command/CompleteAdHocSubProcessResultStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/CompleteAdHocSubProcessResultStep1.java
@@ -27,6 +27,21 @@ public interface CompleteAdHocSubProcessResultStep1 extends CompleteJobResult {
    */
   CompleteAdHocSubProcessResultStep2 activateElement(String elementId);
 
+  /**
+   * Indicates whether the completion condition of the ad-hoc sub-process is fulfilled.
+   *
+   * @return this result
+   */
+  CompleteAdHocSubProcessResultStep1 completionConditionFulfilled(
+      boolean completionConditionFulfilled);
+
+  /**
+   * Indicates whether all remaining instances of the ad-hoc sub-process should be canceled.
+   *
+   * @return this result
+   */
+  CompleteAdHocSubProcessResultStep1 cancelRemainingInstances(boolean cancelRemainingInstances);
+
   interface CompleteAdHocSubProcessResultStep2
       extends CompleteAdHocSubProcessResultStep1,
           CommandWithVariables<CompleteAdHocSubProcessResultStep1> {

--- a/clients/java/src/main/java/io/camunda/client/impl/command/CompleteAdHocSubProcessJobResultImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/CompleteAdHocSubProcessJobResultImpl.java
@@ -28,6 +28,8 @@ public class CompleteAdHocSubProcessJobResultImpl
 
   private final List<ActivateElement> activateElements = new ArrayList<>();
   private ActivateElement latestActivateElement;
+  private boolean completionConditionFulfilled;
+  private boolean cancelRemainingInstances;
 
   public CompleteAdHocSubProcessJobResultImpl(final JsonMapper jsonMapper) {
     super(jsonMapper);
@@ -48,6 +50,28 @@ public class CompleteAdHocSubProcessJobResultImpl
     latestActivateElement = new ActivateElement().setElementId(elementId);
     activateElements.add(latestActivateElement);
     return this;
+  }
+
+  @Override
+  public CompleteAdHocSubProcessResultStep1 completionConditionFulfilled(
+      final boolean completionConditionFulfilled) {
+    this.completionConditionFulfilled = completionConditionFulfilled;
+    return this;
+  }
+
+  @Override
+  public CompleteAdHocSubProcessResultStep1 cancelRemainingInstances(
+      final boolean cancelRemainingInstances) {
+    this.cancelRemainingInstances = cancelRemainingInstances;
+    return this;
+  }
+
+  public boolean isCompletionConditionFulfilled() {
+    return completionConditionFulfilled;
+  }
+
+  public boolean isCancelRemainingInstances() {
+    return cancelRemainingInstances;
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/client/impl/command/CompleteJobCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/CompleteJobCommandImpl.java
@@ -205,13 +205,20 @@ public final class CompleteJobCommandImpl extends CommandWithVariables<CompleteJ
                   return activateElement;
                 })
             .collect(Collectors.toList());
-    resultRest.type(jobResult.getType()).activateElements(activateElements);
+    resultRest
+        .type(jobResult.getType())
+        .activateElements(activateElements)
+        .isCompletionConditionFulfilled(jobResult.isCompletionConditionFulfilled())
+        .isCancelRemainingInstances(jobResult.isCancelRemainingInstances());
     httpRequestObject.setResult(resultRest);
   }
 
   private void setGrpcJobResult(final CompleteAdHocSubProcessJobResultImpl jobResult) {
     final JobResult.Builder resultGrpc = JobResult.newBuilder();
-    resultGrpc.setType(jobResult.getType().getValue());
+    resultGrpc
+        .setType(jobResult.getType().getValue())
+        .setIsCompletionConditionFulfilled(jobResult.isCompletionConditionFulfilled())
+        .setIsCancelRemainingInstances(jobResult.isCancelRemainingInstances());
     jobResult.getActivateElements().stream()
         .map(
             element -> {

--- a/clients/java/src/test/java/io/camunda/client/job/CompleteJobTest.java
+++ b/clients/java/src/test/java/io/camunda/client/job/CompleteJobTest.java
@@ -665,7 +665,9 @@ public final class CompleteJobTest extends ClientTest {
                     .addActivateElements(
                         GatewayOuterClass.JobResultActivateElement.newBuilder()
                             .setElementId(elementId)
-                            .build()))
+                            .build())
+                    .setIsCompletionConditionFulfilled(false)
+                    .setIsCancelRemainingInstances(false))
             .build();
 
     assertThat(request).isEqualTo(expectedRequest);
@@ -699,7 +701,9 @@ public final class CompleteJobTest extends ClientTest {
                         GatewayOuterClass.JobResultActivateElement.newBuilder()
                             .setElementId(elementId)
                             .setVariables(variables)
-                            .build()))
+                            .build())
+                    .setIsCompletionConditionFulfilled(false)
+                    .setIsCancelRemainingInstances(false))
             .build();
 
     assertThat(request).isEqualTo(expectedRequest);
@@ -750,7 +754,67 @@ public final class CompleteJobTest extends ClientTest {
                     .addActivateElements(
                         GatewayOuterClass.JobResultActivateElement.newBuilder()
                             .setElementId(elementId3)
-                            .build()))
+                            .build())
+                    .setIsCompletionConditionFulfilled(false)
+                    .setIsCancelRemainingInstances(false))
+            .build();
+
+    assertThat(request).isEqualTo(expectedRequest);
+  }
+
+  @Test
+  public void shouldCompleteAdHocSubProcessWithCompletionConditionFulfilled() {
+    // given
+    final ActivatedJob job = Mockito.mock(ActivatedJob.class);
+    Mockito.when(job.getKey()).thenReturn(12L);
+
+    // when
+    client
+        .newCompleteCommand(job)
+        .withResult(r -> r.forAdHocSubProcess().completionConditionFulfilled(true))
+        .send()
+        .join();
+
+    // then
+    final CompleteJobRequest request = gatewayService.getLastRequest();
+
+    final CompleteJobRequest expectedRequest =
+        CompleteJobRequest.newBuilder()
+            .setJobKey(job.getKey())
+            .setResult(
+                JobResult.newBuilder()
+                    .setType(AD_HOC_SUB_PROCESS_DISCRIMINATOR)
+                    .setIsCompletionConditionFulfilled(true)
+                    .setIsCancelRemainingInstances(false))
+            .build();
+
+    assertThat(request).isEqualTo(expectedRequest);
+  }
+
+  @Test
+  public void shouldCompleteAdHocSubProcessWithCancelRemainingInstances() {
+    // given
+    final ActivatedJob job = Mockito.mock(ActivatedJob.class);
+    Mockito.when(job.getKey()).thenReturn(12L);
+
+    // when
+    client
+        .newCompleteCommand(job)
+        .withResult(r -> r.forAdHocSubProcess().cancelRemainingInstances(true))
+        .send()
+        .join();
+
+    // then
+    final CompleteJobRequest request = gatewayService.getLastRequest();
+
+    final CompleteJobRequest expectedRequest =
+        CompleteJobRequest.newBuilder()
+            .setJobKey(job.getKey())
+            .setResult(
+                JobResult.newBuilder()
+                    .setType(AD_HOC_SUB_PROCESS_DISCRIMINATOR)
+                    .setIsCompletionConditionFulfilled(false)
+                    .setIsCancelRemainingInstances(true))
             .build();
 
     assertThat(request).isEqualTo(expectedRequest);

--- a/clients/java/src/test/java/io/camunda/client/job/rest/CompleteJobRestTest.java
+++ b/clients/java/src/test/java/io/camunda/client/job/rest/CompleteJobRestTest.java
@@ -616,4 +616,55 @@ class CompleteJobRestTest extends ClientRestTest {
 
     assertThat(request).isEqualTo(expectedRequest);
   }
+
+  @Test
+  void shouldCompleteAdHocSubProcessWithCompletionConditionFulfilled() {
+    // given
+    final long jobKey = 12;
+
+    // when
+    client
+        .newCompleteCommand(jobKey)
+        .withResult(r -> r.forAdHocSubProcess().completionConditionFulfilled(true))
+        .send()
+        .join();
+
+    // then
+    final JobCompletionRequest request = gatewayService.getLastRequest(JobCompletionRequest.class);
+
+    final JobCompletionRequest expectedRequest =
+        new JobCompletionRequest()
+            .result(
+                new JobResultAdHocSubProcess()
+                    .type(AD_HOC_SUB_PROCESS_DISCRIMINATOR)
+                    .isCompletionConditionFulfilled(true)
+                    .isCancelRemainingInstances(false));
+
+    assertThat(request).isEqualTo(expectedRequest);
+  }
+
+  @Test
+  void shouldCompleteAdHocSubProcessWithCancelRemainingInstances() {
+    // given
+    final long jobKey = 12;
+
+    // when
+    client
+        .newCompleteCommand(jobKey)
+        .withResult(r -> r.forAdHocSubProcess().cancelRemainingInstances(true))
+        .send()
+        .join();
+    // then
+    final JobCompletionRequest request = gatewayService.getLastRequest(JobCompletionRequest.class);
+
+    final JobCompletionRequest expectedRequest =
+        new JobCompletionRequest()
+            .result(
+                new JobResultAdHocSubProcess()
+                    .type(AD_HOC_SUB_PROCESS_DISCRIMINATOR)
+                    .isCompletionConditionFulfilled(false)
+                    .isCancelRemainingInstances(true));
+
+    assertThat(request).isEqualTo(expectedRequest);
+  }
 }

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-job-batch-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-job-batch-template.json
@@ -146,6 +146,12 @@
                           "enabled": false
                         }
                       }
+                    },
+                    "completionConditionFulfilled": {
+                      "type": "boolean"
+                    },
+                    "cancelRemainingInstances": {
+                      "type": "boolean"
                     }
                   }
                 }

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-job-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-job-template.json
@@ -127,6 +127,12 @@
                       "enabled": false
                     }
                   }
+                },
+                "completionConditionFulfilled": {
+                  "type": "boolean"
+                },
+                "cancelRemainingInstances": {
+                  "type": "boolean"
                 }
               }
             }

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-job-batch-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-job-batch-template.json
@@ -146,6 +146,12 @@
                           "enabled": false
                         }
                       }
+                    },
+                    "completionConditionFulfilled": {
+                      "type": "boolean"
+                    },
+                    "cancelRemainingInstances": {
+                      "type": "boolean"
                     }
                   }
                 }

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-job-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-job-template.json
@@ -127,6 +127,12 @@
                       "enabled": false
                     }
                   }
+                },
+                "completionConditionFulfilled": {
+                  "type": "boolean"
+                },
+                "cancelRemainingInstances": {
+                  "type": "boolean"
                 }
               }
             }

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/RequestMapper.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/RequestMapper.java
@@ -228,7 +228,10 @@ public final class RequestMapper extends RequestUtil {
 
   private static JobResult getAdHocSubProcessJobResult(final GatewayOuterClass.JobResult result) {
     final JobResult jobResult = new JobResult();
-    jobResult.setType(JobResultType.from(result.getType()));
+    jobResult
+        .setType(JobResultType.from(result.getType()))
+        .setCompletionConditionFulfilled(result.getIsCompletionConditionFulfilled())
+        .setCancelRemainingInstances(result.getIsCancelRemainingInstances());
     result.getActivateElementsList().stream()
         .map(
             element -> {

--- a/zeebe/gateway-protocol/src/main/proto/gateway.proto
+++ b/zeebe/gateway-protocol/src/main/proto/gateway.proto
@@ -186,6 +186,10 @@ message JobResult{
   optional string type = 4;
   // The list of elements that should be activated after the job is completed. Only relevant for ad-hoc subprocesses.
   repeated JobResultActivateElement activateElements = 5;
+  // Indicates whether the completion condition of the job is fulfilled. Only relevant for ad-hoc subprocesses.
+  optional bool isCompletionConditionFulfilled = 6;
+  // Indicates whether active instances of the ad-hoc subprocess should be cancelled. Only relevant for ad-hoc subprocesses.
+  optional bool isCancelRemainingInstances = 7;
 }
 
 message JobResultCorrections {

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -8871,6 +8871,16 @@ components:
               description: Indicates which elements need to be activated in the ad-hoc subprocess.
               items:
                 $ref: "#/components/schemas/JobResultActivateElement"
+            isCompletionConditionFulfilled:
+              type: boolean
+              description: Indicates whether the completion condition of the ad-hoc subprocess is fulfilled.
+              default: false
+              nullable: false
+            isCancelRemainingInstances:
+              type: boolean
+              description: Indicates whether the remaining instances of the ad-hoc subprocess should be canceled.
+              default: false
+              nullable: false
     JobResultActivateElement:
       type: object
       properties:

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RequestMapper.java
@@ -986,7 +986,10 @@ public class RequestMapper {
 
   private static JobResult getJobResult(final JobResultAdHocSubProcess result) {
     final JobResult jobResult = new JobResult();
-    jobResult.setType(JobResultType.from(result.getType().getValue()));
+    jobResult
+        .setType(JobResultType.from(result.getType().getValue()))
+        .setCompletionConditionFulfilled(result.getIsCompletionConditionFulfilled())
+        .setCancelRemainingInstances(result.getIsCancelRemainingInstances());
     result.getActivateElements().stream()
         .map(
             element -> {

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobResult.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobResult.java
@@ -41,6 +41,10 @@ public class JobResult extends UnpackedObject implements JobResultValue {
   private static final StringValue CORRECTIONS_KEY = new StringValue("corrections");
   private static final StringValue DENIED_REASON_KEY = new StringValue("deniedReason");
   private static final StringValue ACTIVATE_ELEMENTS_KEY = new StringValue("activateElements");
+  private static final StringValue COMPLETION_CONDITION_FULFILLED_KEY =
+      new StringValue("isCompletionConditionFulfilled");
+  private static final StringValue CANCEL_REMAINING_INSTANCES_KEY =
+      new StringValue("isCancelRemainingInstances");
 
   private final EnumProperty<JobResultType> typeProp =
       new EnumProperty<>(TYPE_KEY, JobResultType.class, JobResultType.USER_TASK);
@@ -57,15 +61,21 @@ public class JobResult extends UnpackedObject implements JobResultValue {
   // Ad-hoc subprocess properties
   private final ArrayProperty<JobResultActivateElement> activateElementsProp =
       new ArrayProperty<>(ACTIVATE_ELEMENTS_KEY, JobResultActivateElement::new);
+  private final BooleanProperty isCompletionConditionFulfilledProp =
+      new BooleanProperty(COMPLETION_CONDITION_FULFILLED_KEY, false);
+  private final BooleanProperty isCancelRemainingInstancesProp =
+      new BooleanProperty(CANCEL_REMAINING_INSTANCES_KEY, false);
 
   public JobResult() {
-    super(6);
+    super(8);
     declareProperty(typeProp)
         .declareProperty(deniedProp)
         .declareProperty(correctionsProp)
         .declareProperty(correctedAttributesProp)
         .declareProperty(deniedReasonProp)
-        .declareProperty(activateElementsProp);
+        .declareProperty(activateElementsProp)
+        .declareProperty(isCompletionConditionFulfilledProp)
+        .declareProperty(isCancelRemainingInstancesProp);
   }
 
   /** Sets all properties to current instance from provided user task job data */
@@ -76,6 +86,8 @@ public class JobResult extends UnpackedObject implements JobResultValue {
     setCorrections(result.getCorrections());
     setDeniedReason(result.getDeniedReason());
     setActivateElements(result.getActivateElements());
+    setCompletionConditionFulfilled(result.isCompletionConditionFulfilled());
+    setCancelRemainingInstances(result.isCancelRemainingInstances());
   }
 
   @Override
@@ -149,6 +161,26 @@ public class JobResult extends UnpackedObject implements JobResultValue {
     activateElementsProp.reset();
     elements.forEach(
         element -> activateElementsProp.add().copyFrom((JobResultActivateElement) element));
+    return this;
+  }
+
+  @Override
+  public boolean isCompletionConditionFulfilled() {
+    return isCompletionConditionFulfilledProp.getValue();
+  }
+
+  public JobResult setCompletionConditionFulfilled(final boolean completionConditionFulfilled) {
+    isCompletionConditionFulfilledProp.setValue(completionConditionFulfilled);
+    return this;
+  }
+
+  @Override
+  public boolean isCancelRemainingInstances() {
+    return isCancelRemainingInstancesProp.getValue();
+  }
+
+  public JobResult setCancelRemainingInstances(final boolean cancelRemainingInstances) {
+    isCancelRemainingInstancesProp.setValue(cancelRemainingInstances);
     return this;
   }
 

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -730,7 +730,9 @@ final class JsonSerializableToJsonTest {
                                   .setVariables(VARIABLES_MSGPACK),
                               new JobResultActivateElement()
                                   .setElementId("sauron")
-                                  .setVariables(VARIABLES_MSGPACK)));
+                                  .setVariables(VARIABLES_MSGPACK)))
+                      .setCompletionConditionFulfilled(true)
+                      .setCancelRemainingInstances(true);
 
               jobRecord
                   .setWorker(wrapString(worker))
@@ -820,7 +822,9 @@ final class JsonSerializableToJsonTest {
                       "foo": "bar"
                     }
                   }
-                ]
+                ],
+                "completionConditionFulfilled": true,
+                "cancelRemainingInstances": true
               }
             }
           ],
@@ -900,7 +904,9 @@ final class JsonSerializableToJsonTest {
                                   .setVariables(VARIABLES_MSGPACK),
                               new JobResultActivateElement()
                                   .setElementId("sauron")
-                                  .setVariables(VARIABLES_MSGPACK)));
+                                  .setVariables(VARIABLES_MSGPACK)))
+                      .setCompletionConditionFulfilled(true)
+                      .setCancelRemainingInstances(true);
 
               final Map<String, String> customHeaders =
                   Collections.singletonMap("workerVersion", "42");
@@ -989,7 +995,9 @@ final class JsonSerializableToJsonTest {
                   "foo": "bar"
                 }
               }
-            ]
+            ],
+            "completionConditionFulfilled": true,
+            "cancelRemainingInstances": true
           }
         }
         """
@@ -1037,7 +1045,9 @@ final class JsonSerializableToJsonTest {
               "candidateUsersList": [],
               "priority": -1
             },
-            "activateElements": []
+            "activateElements": [],
+            "completionConditionFulfilled": false,
+            "cancelRemainingInstances": false
           }
         }
         """
@@ -1090,7 +1100,9 @@ final class JsonSerializableToJsonTest {
               "candidateUsersList": [],
               "priority": -1
             },
-            "activateElements": []
+            "activateElements": [],
+            "completionConditionFulfilled": false,
+            "cancelRemainingInstances": false
           }
         }
         """

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/JobRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/JobRecordValue.java
@@ -174,6 +174,17 @@ public interface JobRecordValue
      *     well as variables that need to be set on the scope of each of these elements.
      */
     List<JobResultActivateElementValue> getActivateElements();
+
+    /**
+     * @return whether the completion condition is fulfilled. This is used to determine if the
+     *     ad-hoc sub-process should be completed.
+     */
+    boolean isCompletionConditionFulfilled();
+
+    /**
+     * @return whether the remaining instances of the ad-hoc sub-process should be canceled.
+     */
+    boolean isCancelRemainingInstances();
   }
 
   /**


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Adds two new properties to the `JobResult`:
- `isCompletionConditionFulfilled` will be used to determine if the ad-hoc sub-process can complete upon job completion.
- `isCancelRemainingInstances` will be used to determine if any remaining instances must be cancelled upon job completion.

The properties can be set through the Camunda Client using:

```java
    client
        .newCompleteCommand(jobKey)
        .withResult(r -> r.forAdHocSubProcess().completionConditionFulfilled(true))
        .send()
        .join();
```

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes https://github.com/camunda/ad-hoc-sub-process-phase-3/issues/5
