### PR TITLE
Ad-hoc sub-process: disallow interrupting event subprocesses

### DIFF
--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/SubProcessValidator.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/SubProcessValidator.java
@@ -108,5 +108,10 @@ public class SubProcessValidator implements ModelElementValidator<SubProcess> {
         });
 
     ModelUtil.verifyEventDefinition(start, error -> validationResultCollector.addError(0, error));
+
+    if (start.isInterrupting() && element.getParentElement() instanceof AdHocSubProcess) {
+      validationResultCollector.addError(
+          0, "An interrupting event subprocess is not allowed inside an ad-hoc subprocess");
+    }
   }
 }


### PR DESCRIPTION
## Description

Updates the validation for ad-hoc sub-processes to disallow interrupting event sub-processes as this construct is not supported.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes https://github.com/camunda/ad-hoc-sub-process-phase-3/issues/18
