### PR TITLE
fix: FEEL time & date expressions with zero seconds should not omit second

### DIFF
--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/ActivityInputMappingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/ActivityInputMappingTest.java
@@ -38,8 +38,8 @@ public final class ActivityInputMappingTest {
   private static final String A_TIME_VALUE = "\"04:20:00@Europe/Berlin\"";
   private static final String A_LOCAL_TIME_VALUE = "\"04:20\"";
   private static final String A_DATE_VALUE = "\"2021-02-24\"";
-  private static final String A_LOCAL_DATE_AND_TIME_VALUE = "\"2021-02-24T04:20\"";
-  private static final String A_DATE_AND_TIME_VALUE = "\"2021-02-24T04:20+01:00\"";
+  private static final String A_LOCAL_DATE_AND_TIME_VALUE = "\"2021-02-24T04:20:00\"";
+  private static final String A_DATE_AND_TIME_VALUE = "\"2021-02-24T04:20:00+01:00\"";
   private static final String A_DAY_TIME_DURATION_VALUE = "\"P1DT18H56M33S\"";
   private static final String A_YEAR_MONTH_DURATION_VALUE = "\"P2Y3M\"";
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/ActivityOutputMappingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/ActivityOutputMappingTest.java
@@ -41,8 +41,8 @@ public final class ActivityOutputMappingTest {
   private static final String A_TIME_VALUE = "\"04:20:00@Europe/Berlin\"";
   private static final String A_LOCAL_TIME_VALUE = "\"04:20\"";
   private static final String A_DATE_VALUE = "\"2021-02-24\"";
-  private static final String A_LOCAL_DATE_AND_TIME_VALUE = "\"2021-02-24T04:20\"";
-  private static final String A_DATE_AND_TIME_VALUE = "\"2021-02-24T04:20+01:00\"";
+  private static final String A_LOCAL_DATE_AND_TIME_VALUE = "\"2021-02-24T04:20:00\"";
+  private static final String A_DATE_AND_TIME_VALUE = "\"2021-02-24T04:20:00+01:00\"";
   private static final String A_DAY_TIME_DURATION_VALUE = "\"P1DT18H56M33S\"";
   private static final String A_YEAR_MONTH_DURATION_VALUE = "\"P2Y3M\"";
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/NoneEndEventOutputMappingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/NoneEndEventOutputMappingTest.java
@@ -39,8 +39,8 @@ public final class NoneEndEventOutputMappingTest {
   private static final String A_TIME_VALUE = "\"04:20:00@Europe/Berlin\"";
   private static final String A_LOCAL_TIME_VALUE = "\"04:20\"";
   private static final String A_DATE_VALUE = "\"2021-02-24\"";
-  private static final String A_LOCAL_DATE_AND_TIME_VALUE = "\"2021-02-24T04:20\"";
-  private static final String A_DATE_AND_TIME_VALUE = "\"2021-02-24T04:20+01:00\"";
+  private static final String A_LOCAL_DATE_AND_TIME_VALUE = "\"2021-02-24T04:20:00\"";
+  private static final String A_DATE_AND_TIME_VALUE = "\"2021-02-24T04:20:42+01:00\"";
   private static final String A_DAY_TIME_DURATION_VALUE = "\"P1DT18H56M33S\"";
   private static final String A_YEAR_MONTH_DURATION_VALUE = "\"P2Y3M\"";
   private static final String A_STRING = "\"foobar\"";

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/SignalEndEventInputMappingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/SignalEndEventInputMappingTest.java
@@ -40,8 +40,8 @@ public final class SignalEndEventInputMappingTest {
   private static final String A_TIME_VALUE = "\"04:20:00@Europe/Berlin\"";
   private static final String A_LOCAL_TIME_VALUE = "\"04:20\"";
   private static final String A_DATE_VALUE = "\"2021-02-24\"";
-  private static final String A_LOCAL_DATE_AND_TIME_VALUE = "\"2021-02-24T04:20\"";
-  private static final String A_DATE_AND_TIME_VALUE = "\"2021-02-24T04:20+01:00\"";
+  private static final String A_LOCAL_DATE_AND_TIME_VALUE = "\"2021-02-24T04:20:00\"";
+  private static final String A_DATE_AND_TIME_VALUE = "\"2021-02-24T04:20:00+01:00\"";
   private static final String A_DAY_TIME_DURATION_VALUE = "\"P1DT18H56M33S\"";
   private static final String A_YEAR_MONTH_DURATION_VALUE = "\"P2Y3M\"";
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/SignalEndEventOutputMappingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/SignalEndEventOutputMappingTest.java
@@ -41,8 +41,8 @@ public final class SignalEndEventOutputMappingTest {
   private static final String A_TIME_VALUE = "\"04:20:00@Europe/Berlin\"";
   private static final String A_LOCAL_TIME_VALUE = "\"04:20\"";
   private static final String A_DATE_VALUE = "\"2021-02-24\"";
-  private static final String A_LOCAL_DATE_AND_TIME_VALUE = "\"2021-02-24T04:20\"";
-  private static final String A_DATE_AND_TIME_VALUE = "\"2021-02-24T04:20+01:00\"";
+  private static final String A_LOCAL_DATE_AND_TIME_VALUE = "\"2021-02-24T04:20:33\"";
+  private static final String A_DATE_AND_TIME_VALUE = "\"2021-02-24T04:20:00+01:00\"";
   private static final String A_DAY_TIME_DURATION_VALUE = "\"P1DT18H56M33S\"";
   private static final String A_YEAR_MONTH_DURATION_VALUE = "\"P2Y3M\"";
   private static final String A_STRING = "\"foobar\"";

--- a/zeebe/expression-language/src/test/java/io/camunda/zeebe/el/EvaluationResultTest.java
+++ b/zeebe/expression-language/src/test/java/io/camunda/zeebe/el/EvaluationResultTest.java
@@ -129,6 +129,13 @@ public class EvaluationResultTest {
   }
 
   @Test
+  public void dateTimeExpressionWithZeroSeconds() {
+    final var evaluationResult = evaluateExpression("=date and time(\"2025-04-17T07:42:00Z\")");
+
+    assertThat(evaluationResult.toBuffer()).isEqualTo(asMsgPack("\"2025-04-17T07:42:00Z\""));
+  }
+
+  @Test
   public void localDateTimeExpression() {
     final var evaluationResult = evaluateExpression("=date and time(\"2020-04-01T10:31:10\")");
 
@@ -142,6 +149,20 @@ public class EvaluationResultTest {
     assertThat(evaluationResult.getNumber()).isNull();
     assertThat(evaluationResult.getList()).isNull();
     assertThat(evaluationResult.toBuffer()).isEqualTo(asMsgPack("\"2020-04-01T10:31:10\""));
+  }
+
+  @Test
+  public void localDateTimeExpressionWithZeroSeconds() {
+    final var evaluationResult = evaluateExpression("=date and time(\"2020-04-01T10:31:00\")");
+
+    assertThat(evaluationResult.toBuffer()).isEqualTo(asMsgPack("\"2020-04-01T10:31:00\""));
+  }
+
+  @Test
+  public void zonedTimeExpressionWithZeroSeconds() {
+    final var evaluationResult = evaluateExpression("=time(\"10:31:00Z\")");
+
+    assertThat(evaluationResult.toBuffer()).isEqualTo(asMsgPack("\"10:31:00Z\""));
   }
 
   @Test

--- a/zeebe/feel/src/main/java/io/camunda/zeebe/feel/impl/FeelToMessagePackTransformer.java
+++ b/zeebe/feel/src/main/java/io/camunda/zeebe/feel/impl/FeelToMessagePackTransformer.java
@@ -8,6 +8,8 @@
 package io.camunda.zeebe.feel.impl;
 
 import static io.camunda.zeebe.feel.impl.Loggers.LOGGER;
+import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE_TIME;
+import static java.time.format.DateTimeFormatter.ISO_ZONED_DATE_TIME;
 
 import io.camunda.zeebe.msgpack.spec.MsgPackWriter;
 import org.agrona.DirectBuffer;
@@ -95,8 +97,10 @@ public class FeelToMessagePackTransformer {
       case final ValTime time -> writeStringValue(time.value().format());
       case final ValLocalTime time -> writeStringValue(time.value().toString());
       case final ValDate date -> writeStringValue(date.value().toString());
-      case final ValDateTime dateTime -> writeStringValue(dateTime.value().toString());
-      case final ValLocalDateTime dateTime -> writeStringValue(dateTime.value().toString());
+      case final ValDateTime dateTime ->
+          writeStringValue(ISO_ZONED_DATE_TIME.format(dateTime.value()));
+      case final ValLocalDateTime dateTime ->
+          writeStringValue(ISO_LOCAL_DATE_TIME.format(dateTime.value()));
       case final ValDayTimeDuration duration -> writeStringValue(duration.toString());
       case final ValYearMonthDuration duration -> writeStringValue(duration.toString());
       default -> {


### PR DESCRIPTION
## Description

This PR fixes an issue where FEEL time and date expressions with zero seconds were incorrectly omitting the seconds component in their string representation. The fix ensures consistent ISO format output by using proper `DateTimeFormatter` constants instead of relying on default `toString()` methods.

- Replaces default `toString()` formatting with explicit ISO formatters for date-time values in the transformer
- Adds comprehensive test coverage for zero-seconds scenarios across different time/date types
- Updates existing test constants to include seconds for consistency with the new formatting behavior

## Related issues

closes #35658
