### PR TITLE
Remove not valid permission from migration app

### DIFF
--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/MigrationUtil.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/MigrationUtil.java
@@ -97,14 +97,13 @@ public class MigrationUtil {
       result.add(PermissionType.READ_PROCESS_DEFINITION);
       result.add(PermissionType.READ_PROCESS_INSTANCE);
     }
-    if (permissions.contains("UPDATE_PROCESS_INSTANCE")) {
+    if (permissions.contains("UPDATE_PROCESS_INSTANCE")
+        || permissions.contains("DELETE")
+        || permissions.contains("DELETE_PROCESS_INSTANCE")) {
       result.add(PermissionType.UPDATE_PROCESS_INSTANCE);
     }
     if (permissions.contains("START_PROCESS_INSTANCE")) {
       result.add(PermissionType.CREATE_PROCESS_INSTANCE);
-    }
-    if (permissions.contains("DELETE") || permissions.contains("DELETE_PROCESS_INSTANCE")) {
-      result.add(PermissionType.DELETE_PROCESS_INSTANCE);
     }
     return result;
   }

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/saas/StaticEntities.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/saas/StaticEntities.java
@@ -91,8 +91,7 @@ public class StaticEntities {
                   PermissionType.READ_PROCESS_DEFINITION,
                   PermissionType.READ_PROCESS_INSTANCE,
                   PermissionType.UPDATE_PROCESS_INSTANCE,
-                  PermissionType.CREATE_PROCESS_INSTANCE,
-                  PermissionType.DELETE_PROCESS_INSTANCE)),
+                  PermissionType.CREATE_PROCESS_INSTANCE)),
           new CreateAuthorizationRequest(
               OPERATIONS_ENGINEER_ROLE_ID,
               AuthorizationOwnerType.ROLE,
@@ -204,8 +203,7 @@ public class StaticEntities {
             Set.of(
                 PermissionType.UPDATE_PROCESS_INSTANCE,
                 PermissionType.UPDATE_USER_TASK,
-                PermissionType.CREATE_PROCESS_INSTANCE,
-                PermissionType.DELETE_PROCESS_INSTANCE)),
+                PermissionType.CREATE_PROCESS_INSTANCE)),
         new CreateAuthorizationRequest(
             clientId,
             AuthorizationOwnerType.CLIENT,
@@ -247,10 +245,7 @@ public class StaticEntities {
             AuthorizationOwnerType.CLIENT,
             "*",
             AuthorizationResourceType.PROCESS_DEFINITION,
-            Set.of(
-                PermissionType.READ_PROCESS_DEFINITION,
-                PermissionType.READ_PROCESS_INSTANCE,
-                PermissionType.DELETE_PROCESS_INSTANCE)),
+            Set.of(PermissionType.READ_PROCESS_DEFINITION, PermissionType.READ_PROCESS_INSTANCE)),
         new CreateAuthorizationRequest(
             clientId,
             AuthorizationOwnerType.CLIENT,

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/sm/StaticEntities.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/sm/StaticEntities.java
@@ -207,8 +207,7 @@ public class StaticEntities {
                     Set.of(
                         PermissionType.READ_PROCESS_DEFINITION,
                         PermissionType.READ_PROCESS_INSTANCE,
-                        PermissionType.UPDATE_PROCESS_INSTANCE,
-                        PermissionType.DELETE_PROCESS_INSTANCE)),
+                        PermissionType.UPDATE_PROCESS_INSTANCE)),
                 new CreateAuthorizationRequest(
                     ownerId,
                     ownerType,
@@ -301,8 +300,7 @@ public class StaticEntities {
                     Set.of(
                         PermissionType.UPDATE_PROCESS_INSTANCE,
                         PermissionType.UPDATE_USER_TASK,
-                        PermissionType.CREATE_PROCESS_INSTANCE,
-                        PermissionType.DELETE_PROCESS_INSTANCE)),
+                        PermissionType.CREATE_PROCESS_INSTANCE)),
                 new CreateAuthorizationRequest(
                     ownerId,
                     ownerType,

--- a/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/saas/ClientMigrationHandlerTest.java
+++ b/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/saas/ClientMigrationHandlerTest.java
@@ -114,7 +114,6 @@ public class ClientMigrationHandlerTest {
                     PermissionType.UPDATE_PROCESS_INSTANCE,
                     PermissionType.UPDATE_USER_TASK,
                     PermissionType.CREATE_PROCESS_INSTANCE,
-                    PermissionType.DELETE_PROCESS_INSTANCE,
                     PermissionType.READ_PROCESS_DEFINITION,
                     PermissionType.READ_PROCESS_INSTANCE)),
             tuple(

--- a/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/sm/ClientMigrationHandlerTest.java
+++ b/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/sm/ClientMigrationHandlerTest.java
@@ -159,7 +159,6 @@ public class ClientMigrationHandlerTest {
                 AuthorizationResourceType.PROCESS_DEFINITION,
                 Set.of(
                     PermissionType.UPDATE_USER_TASK,
-                    PermissionType.DELETE_PROCESS_INSTANCE,
                     PermissionType.UPDATE_PROCESS_INSTANCE,
                     PermissionType.CREATE_PROCESS_INSTANCE,
                     PermissionType.READ_PROCESS_INSTANCE,

--- a/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/sm/KeycloakRoleMigrationHandlerTest.java
+++ b/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/sm/KeycloakRoleMigrationHandlerTest.java
@@ -174,7 +174,6 @@ public class KeycloakRoleMigrationHandlerTest {
                 Set.of(
                     PermissionType.READ_PROCESS_DEFINITION,
                     PermissionType.READ_PROCESS_INSTANCE,
-                    PermissionType.DELETE_PROCESS_INSTANCE,
                     PermissionType.UPDATE_PROCESS_INSTANCE)),
             tuple(
                 "role_1",
@@ -260,8 +259,7 @@ public class KeycloakRoleMigrationHandlerTest {
                     PermissionType.READ_USER_TASK,
                     PermissionType.UPDATE_PROCESS_INSTANCE,
                     PermissionType.UPDATE_USER_TASK,
-                    PermissionType.CREATE_PROCESS_INSTANCE,
-                    PermissionType.DELETE_PROCESS_INSTANCE)));
+                    PermissionType.CREATE_PROCESS_INSTANCE)));
   }
 
   @Test

--- a/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/sm/OidcRoleMigrationHandlerTest.java
+++ b/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/sm/OidcRoleMigrationHandlerTest.java
@@ -179,7 +179,6 @@ public class OidcRoleMigrationHandlerTest {
                 Set.of(
                     PermissionType.READ_PROCESS_DEFINITION,
                     PermissionType.READ_PROCESS_INSTANCE,
-                    PermissionType.DELETE_PROCESS_INSTANCE,
                     PermissionType.UPDATE_PROCESS_INSTANCE)),
             tuple(
                 "role_1",
@@ -265,8 +264,7 @@ public class OidcRoleMigrationHandlerTest {
                     PermissionType.READ_USER_TASK,
                     PermissionType.UPDATE_PROCESS_INSTANCE,
                     PermissionType.UPDATE_USER_TASK,
-                    PermissionType.CREATE_PROCESS_INSTANCE,
-                    PermissionType.DELETE_PROCESS_INSTANCE)));
+                    PermissionType.CREATE_PROCESS_INSTANCE)));
   }
 
   @Test

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/migration/KeycloakIdentityMigrationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/migration/KeycloakIdentityMigrationIT.java
@@ -262,7 +262,6 @@ public class KeycloakIdentityMigrationIT {
                 ResourceType.PROCESS_DEFINITION,
                 Set.of(
                     PermissionType.READ_PROCESS_DEFINITION,
-                    PermissionType.DELETE_PROCESS_INSTANCE,
                     PermissionType.UPDATE_PROCESS_INSTANCE,
                     PermissionType.READ_PROCESS_INSTANCE)),
             tuple(
@@ -281,7 +280,6 @@ public class KeycloakIdentityMigrationIT {
                 ResourceType.PROCESS_DEFINITION,
                 Set.of(
                     PermissionType.CREATE_PROCESS_INSTANCE,
-                    PermissionType.DELETE_PROCESS_INSTANCE,
                     PermissionType.UPDATE_PROCESS_INSTANCE,
                     PermissionType.UPDATE_USER_TASK)),
             tuple(
@@ -394,8 +392,7 @@ public class KeycloakIdentityMigrationIT {
                 ResourceType.PROCESS_DEFINITION,
                 Set.of(
                     PermissionType.READ_PROCESS_DEFINITION,
-                    PermissionType.READ_PROCESS_INSTANCE,
-                    PermissionType.DELETE_PROCESS_INSTANCE)),
+                    PermissionType.READ_PROCESS_INSTANCE)),
             tuple(
                 "groupb",
                 OwnerType.GROUP,

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/migration/OidcIdentityMigrationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/migration/OidcIdentityMigrationIT.java
@@ -176,7 +176,6 @@ public class OidcIdentityMigrationIT {
                 ResourceType.PROCESS_DEFINITION,
                 Set.of(
                     PermissionType.READ_PROCESS_DEFINITION,
-                    PermissionType.DELETE_PROCESS_INSTANCE,
                     PermissionType.UPDATE_PROCESS_INSTANCE,
                     PermissionType.READ_PROCESS_INSTANCE)),
             tuple(
@@ -195,7 +194,6 @@ public class OidcIdentityMigrationIT {
                 ResourceType.PROCESS_DEFINITION,
                 Set.of(
                     PermissionType.CREATE_PROCESS_INSTANCE,
-                    PermissionType.DELETE_PROCESS_INSTANCE,
                     PermissionType.UPDATE_PROCESS_INSTANCE,
                     PermissionType.UPDATE_USER_TASK)),
             tuple(

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/migration/SaaSIdentityMigrationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/migration/SaaSIdentityMigrationIT.java
@@ -314,8 +314,7 @@ public class SaaSIdentityMigrationIT {
                     PermissionType.READ_USER_TASK,
                     PermissionType.UPDATE_PROCESS_INSTANCE,
                     PermissionType.UPDATE_USER_TASK,
-                    PermissionType.CREATE_PROCESS_INSTANCE,
-                    PermissionType.DELETE_PROCESS_INSTANCE)),
+                    PermissionType.CREATE_PROCESS_INSTANCE)),
             tuple(
                 DEVELOPER_ROLE_ID,
                 OwnerType.ROLE,
@@ -353,8 +352,7 @@ public class SaaSIdentityMigrationIT {
                     PermissionType.READ_PROCESS_DEFINITION,
                     PermissionType.READ_PROCESS_INSTANCE,
                     PermissionType.UPDATE_PROCESS_INSTANCE,
-                    PermissionType.CREATE_PROCESS_INSTANCE,
-                    PermissionType.DELETE_PROCESS_INSTANCE)),
+                    PermissionType.CREATE_PROCESS_INSTANCE)),
             tuple(
                 OPERATIONS_ENGINEER_ROLE_ID,
                 OwnerType.ROLE,
@@ -481,8 +479,7 @@ public class SaaSIdentityMigrationIT {
                     PermissionType.READ_PROCESS_DEFINITION,
                     PermissionType.READ_PROCESS_INSTANCE,
                     PermissionType.UPDATE_PROCESS_INSTANCE,
-                    PermissionType.CREATE_PROCESS_INSTANCE,
-                    PermissionType.DELETE_PROCESS_INSTANCE)),
+                    PermissionType.CREATE_PROCESS_INSTANCE)),
             tuple(
                 "user1@email.com",
                 OwnerType.USER,
@@ -552,7 +549,6 @@ public class SaaSIdentityMigrationIT {
                     PermissionType.UPDATE_PROCESS_INSTANCE,
                     PermissionType.UPDATE_USER_TASK,
                     PermissionType.CREATE_PROCESS_INSTANCE,
-                    PermissionType.DELETE_PROCESS_INSTANCE,
                     PermissionType.READ_PROCESS_DEFINITION,
                     PermissionType.READ_PROCESS_INSTANCE)),
             tuple(


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Since there is no delete process instance concept in the OC at this time, the permission `DELETE_PROCESS_INSTANCE ` has to be removed and not migrated. Cancelling a PI in the OC requires `UPDATE_PROCESS_INSTANCE ` permission

## Related issues

related to #35901 
