### PR TITLE
refactor: replace usage of CamundaPrincipal with the CamundaAuthenticationProvider

### DIFF
--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/elasticsearch/BatchOperationWriterZeebeIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/elasticsearch/BatchOperationWriterZeebeIT.java
@@ -65,7 +65,7 @@ public class BatchOperationWriterZeebeIT extends OperateZeebeAbstractIT {
     // when
     when(permissionsService.permissionsEnabled()).thenReturn(true);
     when(permissionsService.getProcessesWithPermission(PermissionType.UPDATE_PROCESS_INSTANCE))
-        .thenReturn(PermissionsService.ResourcesAllowed.all());
+        .thenReturn(PermissionsService.ResourcesAllowed.wildcard());
     final MvcResult mvcResult = postRequest(QUERY_CREATE_BATCH_OPERATIONS_URL, request);
 
     // then
@@ -138,7 +138,7 @@ public class BatchOperationWriterZeebeIT extends OperateZeebeAbstractIT {
     // when
     when(permissionsService.permissionsEnabled()).thenReturn(true);
     when(permissionsService.getProcessesWithPermission(PermissionType.DELETE_PROCESS_INSTANCE))
-        .thenReturn(PermissionsService.ResourcesAllowed.all());
+        .thenReturn(PermissionsService.ResourcesAllowed.wildcard());
 
     final MvcResult mvcResult = postRequest(QUERY_CREATE_BATCH_OPERATIONS_URL, request);
 
@@ -318,7 +318,7 @@ public class BatchOperationWriterZeebeIT extends OperateZeebeAbstractIT {
     // when
     when(permissionsService.permissionsEnabled()).thenReturn(true);
     when(permissionsService.getProcessesWithPermission(any(PermissionType.class)))
-        .thenReturn(PermissionsService.ResourcesAllowed.all());
+        .thenReturn(PermissionsService.ResourcesAllowed.wildcard());
     final ListViewQueryDto query = createGetAllProcessInstancesQuery();
     final CreateBatchOperationRequestDto request =
         new CreateBatchOperationRequestDto()

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/elasticsearch/DecisionIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/elasticsearch/DecisionIT.java
@@ -109,7 +109,7 @@ public class DecisionIT extends OperateAbstractIT {
     // when
     when(permissionsService.permissionsEnabled()).thenReturn(true);
     when(permissionsService.getDecisionsWithPermission(PermissionType.READ_DECISION_DEFINITION))
-        .thenReturn(PermissionsService.ResourcesAllowed.all());
+        .thenReturn(PermissionsService.ResourcesAllowed.wildcard());
     final MvcResult mvcResult = postRequest(QUERY_DECISION_GROUPED_URL, new DecisionRequestDto());
 
     // then
@@ -209,7 +209,7 @@ public class DecisionIT extends OperateAbstractIT {
         decision111, decision121, decision112, decision122, decision2, decision3);
 
     when(permissionsService.getDecisionsWithPermission(PermissionType.READ_DECISION_DEFINITION))
-        .thenReturn(PermissionsService.ResourcesAllowed.all());
+        .thenReturn(PermissionsService.ResourcesAllowed.wildcard());
 
     // when
     MvcResult mvcResult =
@@ -323,7 +323,7 @@ public class DecisionIT extends OperateAbstractIT {
         decision111, decision121, decision112, decision122, decision2, decision3);
 
     when(permissionsService.getDecisionsWithPermission(PermissionType.READ_DECISION_DEFINITION))
-        .thenReturn(PermissionsService.ResourcesAllowed.all());
+        .thenReturn(PermissionsService.ResourcesAllowed.wildcard());
 
     // when
     MvcResult mvcResult = postRequest(QUERY_DECISION_GROUPED_URL, new DecisionRequestDto());

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/elasticsearch/DecisionListQueryIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/elasticsearch/DecisionListQueryIT.java
@@ -579,7 +579,7 @@ public class DecisionListQueryIT extends OperateAbstractIT {
     // when
     when(permissionsService.permissionsEnabled()).thenReturn(true);
     when(permissionsService.getDecisionsWithPermission(PermissionType.READ_DECISION_INSTANCE))
-        .thenReturn(PermissionsService.ResourcesAllowed.all());
+        .thenReturn(PermissionsService.ResourcesAllowed.wildcard());
 
     final DecisionInstanceListRequestDto query = createGetAllDecisionInstancesRequest();
     final MvcResult mvcResult = postRequest(query(), query);

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/elasticsearch/IncidentStatisticsIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/elasticsearch/IncidentStatisticsIT.java
@@ -169,7 +169,7 @@ public class IncidentStatisticsIT extends OperateAbstractIT {
     // when
     when(permissionsService.permissionsEnabled()).thenReturn(true);
     when(permissionsService.getProcessesWithPermission(PermissionType.READ_PROCESS_DEFINITION))
-        .thenReturn(PermissionsService.ResourcesAllowed.all());
+        .thenReturn(PermissionsService.ResourcesAllowed.wildcard());
 
     // then
     final List<IncidentsByProcessGroupStatisticsDto> response = requestIncidentsByProcess();
@@ -216,7 +216,7 @@ public class IncidentStatisticsIT extends OperateAbstractIT {
     // when
     when(permissionsService.permissionsEnabled()).thenReturn(true);
     when(permissionsService.getProcessesWithPermission(PermissionType.READ_PROCESS_INSTANCE))
-        .thenReturn(PermissionsService.ResourcesAllowed.all());
+        .thenReturn(PermissionsService.ResourcesAllowed.wildcard());
 
     // then
     final List<IncidentsByErrorMsgStatisticsDto> response = requestIncidentsByError();

--- a/operate/webapp/pom.xml
+++ b/operate/webapp/pom.xml
@@ -30,10 +30,6 @@
       <artifactId>webapps-common</artifactId>
     </dependency>
     <dependency>
-      <groupId>io.camunda</groupId>
-      <artifactId>camunda-search-domain</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.agrona</groupId>
       <artifactId>agrona</artifactId>
     </dependency>

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/security/permission/PermissionsConfigurer.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/security/permission/PermissionsConfigurer.java
@@ -7,9 +7,10 @@
  */
 package io.camunda.operate.webapp.security.permission;
 
-import io.camunda.operate.webapp.security.tenant.TenantService;
+import io.camunda.security.auth.CamundaAuthenticationProvider;
 import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.security.impl.AuthorizationChecker;
+import io.camunda.security.reader.ResourceAccessProvider;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -20,7 +21,12 @@ public class PermissionsConfigurer {
   public PermissionsService getPermissionsService(
       final SecurityConfiguration securityConfiguration,
       final AuthorizationChecker authorizationChecker,
-      final TenantService tenantService) {
-    return new PermissionsService(securityConfiguration, authorizationChecker, tenantService);
+      final ResourceAccessProvider resourceAccessProvider,
+      final CamundaAuthenticationProvider authenticationProvider) {
+    return new PermissionsService(
+        securityConfiguration,
+        authorizationChecker,
+        resourceAccessProvider,
+        authenticationProvider);
   }
 }

--- a/operate/webapp/src/test/java/io/camunda/operate/webapp/rest/ProcessReaderTest.java
+++ b/operate/webapp/src/test/java/io/camunda/operate/webapp/rest/ProcessReaderTest.java
@@ -106,7 +106,7 @@ public class ProcessReaderTest {
 
     when(mockPermissionsService.permissionsEnabled()).thenReturn(true);
     when(mockPermissionsService.getProcessesWithPermission(PermissionType.READ_PROCESS_DEFINITION))
-        .thenReturn(ResourcesAllowed.all());
+        .thenReturn(ResourcesAllowed.wildcard());
 
     final String tenantId = "tenantId";
     when(mockProcessStore.getProcessesGrouped(tenantId, null)).thenReturn(new HashMap<>());


### PR DESCRIPTION
This removes the use of `CamundaPrincipal` in `PermissionsService` in Operate. Instead, it uses the `CamundaAuthenticationProvider` to get the current authentication.

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #35964
