### PR TITLE
ci: skip broken optimize-schema-integrity-tests module in test build

### DIFF
--- a/.github/workflows/ci-webapp-run-ut-reuseable.yml
+++ b/.github/workflows/ci-webapp-run-ut-reuseable.yml
@@ -56,6 +56,7 @@ jobs:
           -Dsurefire.failIfNoSpecifiedTests=false -B -T 2 --no-snapshot-updates
           -D forkCount=7 -D skipITs -D skipQaBuild=true -D skipChecks -Dskip.docker
           -D surefire.rerunFailingTestsCount=3 -D junitThreadCount=16 -P skipFrontendBuild
+          -pl '-:optimize-schema-integrity-tests'
           verify
           | tee "${BUILD_OUTPUT_FILE_PATH}"
       - name: Analyze Test Runs


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
The `optimize-schema-integrity-tests` module should not be built as it does not properly compile. Previously, it was skipped when test runs were executed. It should once again be skipped

The tests for `optimize-schema-integrity-tests` are run in `optimize-ci-data-layer.yml`, but are disabled as they currently do not properly work. They have been disabled since May with https://github.com/camunda/camunda/pull/31663. This module can safely be skipped as it is currently not providing value

This PR unblocks https://github.com/camunda/camunda/pull/35623 as it has test failures related to the `optimize-schema-integrity-tests` module 

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes https://github.com/camunda/camunda/issues/35922
