### PR TITLE
ci: monorepo reports notify owning team

### DIFF
--- a/.ci/scripts/ci/setup-medic-lookup.sh
+++ b/.ci/scripts/ci/setup-medic-lookup.sh
@@ -6,7 +6,8 @@
 # except in compliance with the Camunda License 1.0.
 #
 declare -A lookupTeamMedic
-lookupTeamMedic["Core Features"]="@core-features-medic"
-lookupTeamMedic["Data Layer"]="@data-layer-medic"
-lookupTeamMedic["Identity"]="@identity-medic"
-lookupTeamMedic["General"]="General Test flakiness, requires investigation"
+lookupTeamMedic["team-core-features"]="@core-features-medic"
+lookupTeamMedic["team-data-layer"]="@data-layer-medic"
+lookupTeamMedic["team-identity"]="@identity-medic"
+lookupTeamMedic["team-distributed-systems"]="Distributed Systems Medic" # no current medic slack handle
+lookupTeamMedic["General"]="General Test, requires investigation"

--- a/.ci/scripts/ci/setup-medic-lookup.sh
+++ b/.ci/scripts/ci/setup-medic-lookup.sh
@@ -6,8 +6,11 @@
 # except in compliance with the Camunda License 1.0.
 #
 declare -A lookupTeamMedic
-lookupTeamMedic["team-core-features"]="@core-features-medic"
-lookupTeamMedic["team-data-layer"]="@data-layer-medic"
-lookupTeamMedic["team-identity"]="@identity-medic"
+# @core-reatures-medic
+lookupTeamMedic["team-core-features"]="<!subteam^S08P2CU9V8W|core-features-medic>"
+# @data-layer-medic
+lookupTeamMedic["team-data-layer"]="<!subteam^S08P2CSC06S|data-layer-medic>"
+# @identity-medic
+lookupTeamMedic["team-identity"]="<!subteam^S053MF48SSH|identity-medic>"
 lookupTeamMedic["team-distributed-systems"]="Distributed Systems Medic" # no current medic slack handle
 lookupTeamMedic["General"]="General Test, requires investigation"

--- a/.ci/scripts/ci/setup-medic-lookup.sh
+++ b/.ci/scripts/ci/setup-medic-lookup.sh
@@ -1,0 +1,12 @@
+#
+# Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+# one or more contributor license agreements. See the NOTICE file distributed
+# with this work for additional information regarding copyright ownership.
+# Licensed under the Camunda License 1.0. You may not use this file
+# except in compliance with the Camunda License 1.0.
+#
+declare -A lookupTeamMedic
+lookupTeamMedic["Core Features"]="@core-features-medic"
+lookupTeamMedic["Data Layer"]="@data-layer-medic"
+lookupTeamMedic["Identity"]="@identity-medic"
+lookupTeamMedic["General"]="General Test flakiness, requires investigation"

--- a/.github/workflows/ci-operate.yml
+++ b/.github/workflows/ci-operate.yml
@@ -55,6 +55,7 @@ jobs:
     with:
       componentName: "Operate"
       suite: ${{ matrix.suite }}
+      suiteName: ${{ matrix.suiteName }}
 
   # Checks to see if Operate can properly build itself and a docker image
   build-operate-backend:
@@ -96,6 +97,7 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          user_description: "Core Features"
 
   operate-frontend-tests:
     if: inputs.runFeTests
@@ -171,7 +173,7 @@ jobs:
           job_name: "operate-ci/backup-restore"
           build_status: ${{ job.status }}
           user_reason: ${{ (steps.analyze-test-run.outputs.flakyTests != '') && 'flaky-tests' || '' }}
-          user_description: ${{ steps.analyze-test-run.outputs.flakyTests }}
+          user_description: "Data Layer"
           detailed_junit_flaky_tests: true
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}

--- a/.github/workflows/ci-operate.yml
+++ b/.github/workflows/ci-operate.yml
@@ -97,7 +97,7 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "Core Features"
+          user_description: "team-core-features"
 
   operate-frontend-tests:
     if: inputs.runFeTests
@@ -173,7 +173,7 @@ jobs:
           job_name: "operate-ci/backup-restore"
           build_status: ${{ job.status }}
           user_reason: ${{ (steps.analyze-test-run.outputs.flakyTests != '') && 'flaky-tests' || '' }}
-          user_description: "Data Layer"
+          user_description: "team-data-layer"
           detailed_junit_flaky_tests: true
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}

--- a/.github/workflows/ci-optimize.yml
+++ b/.github/workflows/ci-optimize.yml
@@ -104,7 +104,7 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "Core Features"
+          user_description: "team-core-features"
 
   hadolint:
     if: inputs.runBeTests
@@ -134,4 +134,4 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "Core Features"
+          user_description: "team-core-features"

--- a/.github/workflows/ci-optimize.yml
+++ b/.github/workflows/ci-optimize.yml
@@ -55,6 +55,7 @@ jobs:
     with:
       componentName: "Optimize"
       suite: ${{ matrix.suite }}
+      suiteName: ${{ matrix.suiteName }}
 
   optimize-frontend-unit-tests:
     name: "[UT] Front End / Core Features"
@@ -103,6 +104,7 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          user_description: "Core Features"
 
   hadolint:
     if: inputs.runBeTests
@@ -132,3 +134,4 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          user_description: "Core Features"

--- a/.github/workflows/ci-tasklist.yml
+++ b/.github/workflows/ci-tasklist.yml
@@ -55,6 +55,7 @@ jobs:
     with:
       componentName: "Tasklist"
       suite: ${{ matrix.suite }}
+      suiteName: ${{ matrix.suiteName }}
 
   tasklist-frontend-tests:
     name: "[UT] Front End"

--- a/.github/workflows/ci-webapp-run-ut-reuseable.yml
+++ b/.github/workflows/ci-webapp-run-ut-reuseable.yml
@@ -16,6 +16,10 @@ on:
         description: "The suite under test. ie, DataLayer or CoreFeatures"
         required: true
         type: string
+      suiteName:
+        description: "Well formatted name of the suite under test. ie, 'Data Layer' or 'Core Features'"
+        required: true
+        type: string
 
 env:
   GHA_BEST_PRACTICES_LINTER: enabled
@@ -78,7 +82,7 @@ jobs:
           job_name: "${{inputs.componentName}}-unit-tests/${{inputs.suite}}"
           build_status: ${{ job.status }}
           user_reason: ${{ (steps.analyze-test-run.outputs.flakyTests != '') && 'flaky-tests' || '' }}
-          user_description: "team: ${{inputs.suite}}"
+          user_description: "${{inputs.suiteName}}"
           detailed_junit_flaky_tests: true
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -300,7 +300,7 @@ jobs:
         with:
           build_status: ${{ job.status }}
           user_reason: ${{ (steps.analyze-test-run.outputs.flakyTests != '') && 'flaky-tests' || '' }}
-          user_description: ${{ steps.analyze-test-run.outputs.flakyTests }}
+          user_description: "General"
           detailed_junit_flaky_tests: true
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
@@ -386,7 +386,7 @@ jobs:
           job_name: "zeebe-unit-tests/${{ matrix.component }}-${{matrix.suite}}"
           build_status: ${{ job.status }}
           user_reason: ${{ (steps.analyze-test-run.outputs.flakyTests != '') && 'flaky-tests' || '' }}
-          user_description: "team: ${{matrix.suite}}"
+          user_description: "${{matrix.suiteName}}"
           detailed_junit_flaky_tests: true
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
@@ -478,7 +478,7 @@ jobs:
         with:
           build_status: ${{ job.status }}
           user_reason: ${{ (steps.analyze-test-run.outputs.flakyTests != '') && 'flaky-tests' || '' }}
-          user_description: ${{ steps.analyze-test-run.outputs.flakyTests }}
+          user_description: "General"
           detailed_junit_flaky_tests: true
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
@@ -576,7 +576,7 @@ jobs:
         with:
           build_status: ${{ job.status }}
           user_reason: ${{ (steps.analyze-test-run.outputs.flakyTests != '') && 'flaky-tests' || '' }}
-          user_description: ${{ steps.analyze-test-run.outputs.flakyTests }}
+          user_description: "General"
           detailed_junit_flaky_tests: true
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
@@ -642,7 +642,7 @@ jobs:
         with:
           build_status: ${{ job.status }}
           user_reason: ${{ (steps.analyze-test-run.outputs.flakyTests != '') && 'flaky-tests' || '' }}
-          user_description: ${{ steps.analyze-test-run.outputs.flakyTests }}
+          user_description: "General"
           detailed_junit_flaky_tests: true
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
@@ -699,7 +699,7 @@ jobs:
         with:
           build_status: ${{ job.status }}
           user_reason: ${{ (steps.analyze-test-run.outputs.flakyTests != '') && 'flaky-tests' || '' }}
-          user_description: ${{ steps.analyze-test-run.outputs.flakyTests }}
+          user_description: "General"
           detailed_junit_flaky_tests: true
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
@@ -869,7 +869,7 @@ jobs:
           job_name: "integration-tests/${{ matrix.group }}"
           build_status: ${{ job.status }}
           user_reason: ${{ (steps.analyze-test-run.outputs.flakyTests != '') && 'flaky-tests' || '' }}
-          user_description: ${{ steps.analyze-test-run.outputs.flakyTests }}
+          user_description: ${{ matrix.owner }}
           detailed_junit_flaky_tests: true
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
@@ -976,6 +976,7 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          user_description: "General"
 
   identity-frontend-tests:
     if: needs.detect-changes.outputs.identity-frontend-tests == 'true'
@@ -1015,6 +1016,7 @@ jobs:
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          user_description: "Identity"
 
 
   tasklist-ci:
@@ -1110,6 +1112,7 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          user_description: "General"
 
   openapi-lint:
     name: C8 REST OpenAPI linting
@@ -1145,6 +1148,7 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          user_description: "General"
 
   check-results:
     # Used by the merge queue to check all tests, including the unit test matrix.
@@ -1249,6 +1253,7 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          user_description: "General"
 
   # Dynamically generate the Docker tag (e.g., SNAPSHOT or X.Y-SNAPSHOT) and concurrency group based on branch name
   utils-get-snapshot-docker-tag-and-concurrency-group:
@@ -1315,3 +1320,4 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          user_description: "General"

--- a/.github/workflows/operate-ci-fe.yml
+++ b/.github/workflows/operate-ci-fe.yml
@@ -68,6 +68,7 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          user_description: "Core Features"
 
   # Code linting
   operate-fe-eslint:
@@ -96,6 +97,7 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          user_description: "Core Features"
 
   # description: This workflow runs a11y accessibility tests on Operate
   operate-fe-a11y-tests:
@@ -139,6 +141,7 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          user_description: "Core Features"
 
   operate-fe-visual-regression-tests:
     name: "Visual regression tests / Core Features"
@@ -181,6 +184,7 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          user_description: "Core Features"
 
   operate-update-screenshots:
     name: "Update Screenshots / Core Features"
@@ -222,3 +226,4 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          user_description: "Core Features"

--- a/.github/workflows/operate-ci-fe.yml
+++ b/.github/workflows/operate-ci-fe.yml
@@ -68,7 +68,7 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "Core Features"
+          user_description: "team-core-features"
 
   # Code linting
   operate-fe-eslint:
@@ -97,7 +97,7 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "Core Features"
+          user_description: "team-core-features"
 
   # description: This workflow runs a11y accessibility tests on Operate
   operate-fe-a11y-tests:
@@ -141,7 +141,7 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "Core Features"
+          user_description: "team-core-features"
 
   operate-fe-visual-regression-tests:
     name: "Visual regression tests / Core Features"
@@ -184,7 +184,7 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "Core Features"
+          user_description: "team-core-features"
 
   operate-update-screenshots:
     name: "Update Screenshots / Core Features"
@@ -226,4 +226,4 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "Core Features"
+          user_description: "team-core-features"

--- a/.github/workflows/operate-run-tests.yml
+++ b/.github/workflows/operate-run-tests.yml
@@ -46,3 +46,4 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          user_description: "Data Layer"

--- a/.github/workflows/operate-run-tests.yml
+++ b/.github/workflows/operate-run-tests.yml
@@ -46,4 +46,4 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "Data Layer"
+          user_description: "team-data-layer"

--- a/.github/workflows/statistics-daily.yml
+++ b/.github/workflows/statistics-daily.yml
@@ -99,7 +99,7 @@ jobs:
 
               printf "• %sx \`%s.%s\`%s\n\n" "$NUMBER_OF_FLAKES" "$TEST_CLASS_NAME" "$TEST_NAME" "$SUFFIX"
               # only notify if the owner is a team name and the number of flakes is above the threshold
-              if [ "${#TEST_OWNER}" -lt 20 ] && [ "${NUMBER_OF_FLAKES}" -ge "${FLAKY_TEST_THRESHOLD}" ]; then
+              if [ "${NUMBER_OF_FLAKES}" -ge "${FLAKY_TEST_THRESHOLD}" ]; then
                 if [[ -n "${lookupTeamMedic[$TEST_OWNER]}" ]]; then
                   printf "\t• %s\n" "${lookupTeamMedic[$TEST_OWNER]}"
                 fi

--- a/.github/workflows/statistics-daily.yml
+++ b/.github/workflows/statistics-daily.yml
@@ -49,18 +49,18 @@ jobs:
         run: |
           gcloud info
 
+      - name: Setup Medic Lookup
+        run: |
+          bash .ci/scripts/ci/setup-medic-lookup.sh
+
       - name: Create message with BigQuery data
         id: message
         env:
           GH_TOKEN: ${{ github.token }}
         shell: bash
         run: |
-          # keep in sync with the array in statistics-weekly.yml
-          declare -A lookupTeamMedic
-          lookupTeamMedic["Core Features"]="@core-features-medic"
-          lookupTeamMedic["Data Layer"]="@data-layer-medic"
-          lookupTeamMedic["Identity"]="@identity-medic"
-          lookupTeamMedic["General"]="General Test flakiness, requires investigation"
+          chmod +x .ci/scripts/ci/setup-medic-lookup.sh
+          source .ci/scripts/ci/setup-medic-lookup.sh
 
           # number of tests that need to fail before notifying team medic
           FLAKY_TEST_THRESHOLD=5

--- a/.github/workflows/statistics-daily.yml
+++ b/.github/workflows/statistics-daily.yml
@@ -79,7 +79,7 @@ jobs:
               FULLY_QUALIFIED_TEST_CLASS_NAME=$(echo "$top_flakytest" | jq -r '.test_class_name')
               TEST_CLASS_NAME="${FULLY_QUALIFIED_TEST_CLASS_NAME##*.}"
               TEST_NAME=$(echo "$top_flakytest" | jq -r '.test_name')
-              TEST_OWNER=$(echo "$top_flakytest" | jq -r '.user_decription')
+              TEST_OWNER=$(echo "$top_flakytest" | jq -r '.user_description')
               SUFFIX=""
 
               # Try to find GH issues about related flaky tests:

--- a/.github/workflows/statistics-daily.yml
+++ b/.github/workflows/statistics-daily.yml
@@ -63,7 +63,7 @@ jobs:
           source .ci/scripts/ci/setup-medic-lookup.sh
 
           # number of tests that need to fail before notifying team medic
-          FLAKY_TEST_THRESHOLD=20
+          FLAKY_TEST_THRESHOLD=10
           # shellcheck disable=SC2016
           NUMBER_OF_ALL_JOBS=$(bq query --format=json --use_legacy_sql=false --quiet=true 'SELECT COUNT(*) as number_of_all_jobs FROM `ci-30-162810.prod_ci_analytics.build_status_v2` WHERE TIMESTAMP_SUB(TIMESTAMP_TRUNC(CURRENT_TIMESTAMP, DAY), INTERVAL 1 DAY)<=report_time AND report_time<=TIMESTAMP_TRUNC(CURRENT_TIMESTAMP, DAY) AND ci_url="https://github.com/camunda/camunda"' | jq -r '.[0].number_of_all_jobs')
           # shellcheck disable=SC2016

--- a/.github/workflows/statistics-daily.yml
+++ b/.github/workflows/statistics-daily.yml
@@ -55,6 +55,15 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         shell: bash
         run: |
+          # keep in sync with the array in statistics-weekly.yml
+          declare -A lookupTeamMedic
+          lookupTeamMedic["Core Features"]="@core-features-medic"
+          lookupTeamMedic["Data Layer"]="@data-layer-medic"
+          lookupTeamMedic["Identity"]="@identity-medic"
+          lookupTeamMedic["General"]="General Test flakiness, requires investigation"
+
+          # number of tests that need to fail before notifying team medic
+          FLAKY_TEST_THRESHOLD=5
           # shellcheck disable=SC2016
           NUMBER_OF_ALL_JOBS=$(bq query --format=json --use_legacy_sql=false --quiet=true 'SELECT COUNT(*) as number_of_all_jobs FROM `ci-30-162810.prod_ci_analytics.build_status_v2` WHERE TIMESTAMP_SUB(TIMESTAMP_TRUNC(CURRENT_TIMESTAMP, DAY), INTERVAL 1 DAY)<=report_time AND report_time<=TIMESTAMP_TRUNC(CURRENT_TIMESTAMP, DAY) AND ci_url="https://github.com/camunda/camunda"' | jq -r '.[0].number_of_all_jobs')
           # shellcheck disable=SC2016
@@ -74,6 +83,7 @@ jobs:
               FULLY_QUALIFIED_TEST_CLASS_NAME=$(echo "$top_flakytest" | jq -r '.test_class_name')
               TEST_CLASS_NAME="${FULLY_QUALIFIED_TEST_CLASS_NAME##*.}"
               TEST_NAME=$(echo "$top_flakytest" | jq -r '.test_name')
+              TEST_OWNER=$(echo "$top_flakytest" | jq -r '.user_decription')
               SUFFIX=""
 
               # Try to find GH issues about related flaky tests:
@@ -88,6 +98,12 @@ jobs:
               fi
 
               printf "• %sx \`%s.%s\`%s\n\n" "$NUMBER_OF_FLAKES" "$TEST_CLASS_NAME" "$TEST_NAME" "$SUFFIX"
+              # only notify if the owner is a team name and the number of flakes is above the threshold
+              if [ "${#TEST_OWNER}" -lt 20 ] && [ "${NUMBER_OF_FLAKES}" -ge "${FLAKY_TEST_THRESHOLD}" ]; then
+                if [[ -n "${lookupTeamMedic[$TEST_OWNER]}" ]]; then
+                  printf "\t• %s\n" "${lookupTeamMedic[$TEST_OWNER]}"
+                fi
+              fi
 
             done
             echo ""

--- a/.github/workflows/statistics-daily.yml
+++ b/.github/workflows/statistics-daily.yml
@@ -63,7 +63,7 @@ jobs:
           source .ci/scripts/ci/setup-medic-lookup.sh
 
           # number of tests that need to fail before notifying team medic
-          FLAKY_TEST_THRESHOLD=5
+          FLAKY_TEST_THRESHOLD=20
           # shellcheck disable=SC2016
           NUMBER_OF_ALL_JOBS=$(bq query --format=json --use_legacy_sql=false --quiet=true 'SELECT COUNT(*) as number_of_all_jobs FROM `ci-30-162810.prod_ci_analytics.build_status_v2` WHERE TIMESTAMP_SUB(TIMESTAMP_TRUNC(CURRENT_TIMESTAMP, DAY), INTERVAL 1 DAY)<=report_time AND report_time<=TIMESTAMP_TRUNC(CURRENT_TIMESTAMP, DAY) AND ci_url="https://github.com/camunda/camunda"' | jq -r '.[0].number_of_all_jobs')
           # shellcheck disable=SC2016

--- a/.github/workflows/statistics-daily.yml
+++ b/.github/workflows/statistics-daily.yml
@@ -49,17 +49,13 @@ jobs:
         run: |
           gcloud info
 
-      - name: Setup Medic Lookup
-        run: |
-          bash .ci/scripts/ci/setup-medic-lookup.sh
-
       - name: Create message with BigQuery data
         id: message
         env:
           GH_TOKEN: ${{ github.token }}
         shell: bash
         run: |
-          chmod +x .ci/scripts/ci/setup-medic-lookup.sh
+          # use setup-medic-lookup.sh to set up lookupTeamMedic lookup array
           source .ci/scripts/ci/setup-medic-lookup.sh
 
           # number of tests that need to fail before notifying team medic

--- a/.github/workflows/statistics-weekly.yml
+++ b/.github/workflows/statistics-weekly.yml
@@ -57,12 +57,9 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         shell: bash
         run: |
-          # keep in sync with the array in statistics-daily.yml
-          declare -A lookupTeamMedic
-          lookupTeamMedic["Core Features"]="@core-features-medic"
-          lookupTeamMedic["Data Layer"]="@data-layer-medic"
-          lookupTeamMedic["Identity"]="@identity-medic"
-          lookupTeamMedic["General"]="General Test failure, requires investigation"
+          # use setup-medic-lookup.sh to set up lookupTeamMedic lookup array
+          chmod +x .ci/scripts/ci/setup-medic-lookup.sh
+          source .ci/scripts/ci/setup-medic-lookup.sh
 
           # number of tests that need to fail before notifying team medic
           FAILED_TEST_THRESHOLD=5

--- a/.github/workflows/statistics-weekly.yml
+++ b/.github/workflows/statistics-weekly.yml
@@ -92,7 +92,7 @@ jobs:
               printf "• %sx \`%s.%s\`%s\n\n" "$NUMBER_OF_FAILS" "$TEST_CLASS_NAME" "$TEST_NAME" "$SUFFIX"
 
               # only notify team medic if the owner is a team name and the number of failures is above the threshold
-              if [ "${#TEST_OWNER}" -lt 20 ] && [ "${NUMBER_OF_FAILS}" -ge "${FAILED_TEST_THRESHOLD}" ]; then
+              if [ "${NUMBER_OF_FAILS}" -ge "${FAILED_TEST_THRESHOLD}" ]; then
                 if [[ -n "${lookupTeamMedic[$TEST_OWNER]}" ]]; then
                   printf "\t• %s\n" "${lookupTeamMedic[$TEST_OWNER]}"
                 fi

--- a/.github/workflows/statistics-weekly.yml
+++ b/.github/workflows/statistics-weekly.yml
@@ -74,7 +74,7 @@ jobs:
               FULLY_QUALIFIED_TEST_CLASS_NAME=$(echo "$top_failingtest" | jq -r '.test_class_name')
               TEST_CLASS_NAME="${FULLY_QUALIFIED_TEST_CLASS_NAME##*.}"
               TEST_NAME=$(echo "$top_failingtest" | jq -r '.test_name')
-              TEST_OWNER=$(echo "$top_failingtest" | jq -r '.user_decription')
+              TEST_OWNER=$(echo "$top_failingtest" | jq -r '.user_description')
               SUFFIX=""
 
               # Try to find GH issues about related (failing) tests:

--- a/.github/workflows/statistics-weekly.yml
+++ b/.github/workflows/statistics-weekly.yml
@@ -58,7 +58,6 @@ jobs:
         shell: bash
         run: |
           # use setup-medic-lookup.sh to set up lookupTeamMedic lookup array
-          chmod +x .ci/scripts/ci/setup-medic-lookup.sh
           source .ci/scripts/ci/setup-medic-lookup.sh
 
           # number of tests that need to fail before notifying team medic

--- a/.github/workflows/statistics-weekly.yml
+++ b/.github/workflows/statistics-weekly.yml
@@ -57,6 +57,15 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         shell: bash
         run: |
+          # keep in sync with the array in statistics-daily.yml
+          declare -A lookupTeamMedic
+          lookupTeamMedic["Core Features"]="@core-features-medic"
+          lookupTeamMedic["Data Layer"]="@data-layer-medic"
+          lookupTeamMedic["Identity"]="@identity-medic"
+          lookupTeamMedic["General"]="General Test failure, requires investigation"
+
+          # number of tests that need to fail before notifying team medic
+          FAILED_TEST_THRESHOLD=5
           # shellcheck disable=SC2016
           TOP5_FAILINGTESTS=$(bq query --format=json --use_legacy_sql=false --quiet=true 'SELECT test_class_name, test_name, COUNT(*) as number_of_fails FROM `ci-30-162810.prod_ci_analytics.test_status_v1` ts LEFT OUTER JOIN `ci-30-162810.prod_ci_analytics.build_status_v2` bs ON ts.ci_url=bs.ci_url AND ts.build_id=bs.build_id AND ts.job_name=bs.job_name WHERE TIMESTAMP_SUB(TIMESTAMP_TRUNC(CURRENT_TIMESTAMP, DAY), INTERVAL 7 DAY)<=ts.report_time AND ts.report_time<=TIMESTAMP_TRUNC(CURRENT_TIMESTAMP, DAY) AND ts.ci_url="https://github.com/camunda/camunda" AND test_status = "failure" AND ((build_trigger="merge_group" AND build_base_ref="refs/heads/main") OR (build_trigger="push" AND build_ref="refs/heads/main")) GROUP BY test_class_name, test_name ORDER BY number_of_fails DESC LIMIT 5')
 
@@ -69,6 +78,7 @@ jobs:
               FULLY_QUALIFIED_TEST_CLASS_NAME=$(echo "$top_failingtest" | jq -r '.test_class_name')
               TEST_CLASS_NAME="${FULLY_QUALIFIED_TEST_CLASS_NAME##*.}"
               TEST_NAME=$(echo "$top_failingtest" | jq -r '.test_name')
+              TEST_OWNER=$(echo "$top_failingtest" | jq -r '.user_decription')
               SUFFIX=""
 
               # Try to find GH issues about related (failing) tests:
@@ -83,6 +93,13 @@ jobs:
               fi
 
               printf "• %sx \`%s.%s\`%s\n\n" "$NUMBER_OF_FAILS" "$TEST_CLASS_NAME" "$TEST_NAME" "$SUFFIX"
+
+              # only notify team medic if the owner is a team name and the number of failures is above the threshold
+              if [ "${#TEST_OWNER}" -lt 20 ] && [ "${NUMBER_OF_FAILS}" -ge "${FAILED_TEST_THRESHOLD}" ]; then
+                if [[ -n "${lookupTeamMedic[$TEST_OWNER]}" ]]; then
+                  printf "\t• %s\n" "${lookupTeamMedic[$TEST_OWNER]}"
+                fi
+              fi
 
             done
             echo ""

--- a/.github/workflows/tasklist-backup-restore-tests-reusable.yml
+++ b/.github/workflows/tasklist-backup-restore-tests-reusable.yml
@@ -69,7 +69,7 @@ jobs:
           job_name: "tasklist-ci/backup-restore"
           build_status: ${{ job.status }}
           user_reason: ${{ (steps.analyze-test-run.outputs.flakyTests != '') && 'flaky-tests' || '' }}
-          user_description: ${{ steps.analyze-test-run.outputs.flakyTests }}
+          user_description: "Data Layer"
           detailed_junit_flaky_tests: true
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}

--- a/.github/workflows/tasklist-backup-restore-tests-reusable.yml
+++ b/.github/workflows/tasklist-backup-restore-tests-reusable.yml
@@ -69,7 +69,7 @@ jobs:
           job_name: "tasklist-ci/backup-restore"
           build_status: ${{ job.status }}
           user_reason: ${{ (steps.analyze-test-run.outputs.flakyTests != '') && 'flaky-tests' || '' }}
-          user_description: "Data Layer"
+          user_description: "team-data-layer"
           detailed_junit_flaky_tests: true
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}

--- a/.github/workflows/tasklist-ci-fe-reusable.yml
+++ b/.github/workflows/tasklist-ci-fe-reusable.yml
@@ -38,6 +38,7 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          user_description: "Core Features"
 
   fe-eslint:
     name: "ESLint / Core Features"
@@ -65,6 +66,7 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          user_description: "Core Features"
 
   fe-stylelint:
     name: "Stylelint / Core Features"
@@ -92,6 +94,7 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          user_description: "Core Features"
 
   fe-tests:
     name: "Run Unit Tests / Core Features"
@@ -119,6 +122,7 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          user_description: "Core Features"
 
   fe-visual-regression-tests:
     name: "Visual regression tests / Core Features"
@@ -161,6 +165,7 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          user_description: "Core Features"
 
   fe-a11y-tests:
     name: "a11y tests / Core Features"
@@ -203,3 +208,4 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          user_description: "Core Features"

--- a/.github/workflows/tasklist-ci-fe-reusable.yml
+++ b/.github/workflows/tasklist-ci-fe-reusable.yml
@@ -38,7 +38,7 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "Core Features"
+          user_description: "team-core-features"
 
   fe-eslint:
     name: "ESLint / Core Features"
@@ -66,7 +66,7 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "Core Features"
+          user_description: "team-core-features"
 
   fe-stylelint:
     name: "Stylelint / Core Features"
@@ -94,7 +94,7 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "Core Features"
+          user_description: "team-core-features"
 
   fe-tests:
     name: "Run Unit Tests / Core Features"
@@ -122,7 +122,7 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "Core Features"
+          user_description: "team-core-features"
 
   fe-visual-regression-tests:
     name: "Visual regression tests / Core Features"
@@ -165,7 +165,7 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "Core Features"
+          user_description: "team-core-features"
 
   fe-a11y-tests:
     name: "a11y tests / Core Features"
@@ -208,4 +208,4 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "Core Features"
+          user_description: "team-core-features"

--- a/.github/workflows/tasklist-docker-tests.yml
+++ b/.github/workflows/tasklist-docker-tests.yml
@@ -59,3 +59,4 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          user_description: "Core Features"

--- a/.github/workflows/tasklist-docker-tests.yml
+++ b/.github/workflows/tasklist-docker-tests.yml
@@ -59,4 +59,4 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "Core Features"
+          user_description: "team-core-features"

--- a/.github/workflows/zeebe-ci.yml
+++ b/.github/workflows/zeebe-ci.yml
@@ -105,7 +105,7 @@ jobs:
           job_name: "smoke-tests/${{ matrix.os }}-${{ matrix.arch }}"
           build_status: ${{ job.status }}
           user_reason: ${{ (steps.analyze-test-run.outputs.flakyTests != '') && 'flaky-tests' || '' }}
-          user_description: ${{ steps.analyze-test-run.outputs.flakyTests }}
+          user_description: "Core Features"
           detailed_junit_flaky_tests: ${{ matrix.os != 'macos' && matrix.os != 'windows' }}  # feature only supported on Linux for now
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
@@ -157,7 +157,7 @@ jobs:
         with:
           build_status: ${{ job.status }}
           user_reason: ${{ (steps.analyze-test-run.outputs.flakyTests != '') && 'flaky-tests' || '' }}
-          user_description: ${{ steps.analyze-test-run.outputs.flakyTests }}
+          user_description: "Core Features"
           detailed_junit_flaky_tests: true
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
@@ -222,7 +222,7 @@ jobs:
         with:
           build_status: ${{ job.status }}
           user_reason: ${{ (steps.analyze-test-run.outputs.flakyTests != '') && 'flaky-tests' || '' }}
-          user_description: ${{ steps.analyze-test-run.outputs.flakyTests }}
+          user_description: "Core Features"
           detailed_junit_flaky_tests: true
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
@@ -279,7 +279,7 @@ jobs:
         with:
           build_status: ${{ job.status }}
           user_reason: ${{ (steps.analyze-test-run.outputs.flakyTests != '') && 'flaky-tests' || '' }}
-          user_description: ${{ steps.analyze-test-run.outputs.flakyTests }}
+          user_description: "Core Features"
           detailed_junit_flaky_tests: true
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
@@ -350,6 +350,7 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          user_description: "Core Features"
 
   test-summary:
     # Used by the merge queue to check all tests, including the unit test matrix.
@@ -420,6 +421,7 @@ jobs:
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          user_description: "Core Features"
   deploy-benchmark-images:
     name: Deploy benchmark images
     timeout-minutes: 5
@@ -466,6 +468,7 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          user_description: "Core Features"
   deploy-snyk-projects:
     name: Deploy Snyk development projects
     needs: [ test-summary ]
@@ -520,3 +523,4 @@ jobs:
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          user_description: "Core Features"

--- a/.github/workflows/zeebe-ci.yml
+++ b/.github/workflows/zeebe-ci.yml
@@ -105,7 +105,7 @@ jobs:
           job_name: "smoke-tests/${{ matrix.os }}-${{ matrix.arch }}"
           build_status: ${{ job.status }}
           user_reason: ${{ (steps.analyze-test-run.outputs.flakyTests != '') && 'flaky-tests' || '' }}
-          user_description: "Core Features"
+          user_description: "team-distributed-systems"
           detailed_junit_flaky_tests: ${{ matrix.os != 'macos' && matrix.os != 'windows' }}  # feature only supported on Linux for now
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
@@ -157,7 +157,7 @@ jobs:
         with:
           build_status: ${{ job.status }}
           user_reason: ${{ (steps.analyze-test-run.outputs.flakyTests != '') && 'flaky-tests' || '' }}
-          user_description: "Core Features"
+          user_description: "team-distributed-systems"
           detailed_junit_flaky_tests: true
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
@@ -222,7 +222,7 @@ jobs:
         with:
           build_status: ${{ job.status }}
           user_reason: ${{ (steps.analyze-test-run.outputs.flakyTests != '') && 'flaky-tests' || '' }}
-          user_description: "Core Features"
+          user_description: "team-core-features"
           detailed_junit_flaky_tests: true
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
@@ -279,7 +279,7 @@ jobs:
         with:
           build_status: ${{ job.status }}
           user_reason: ${{ (steps.analyze-test-run.outputs.flakyTests != '') && 'flaky-tests' || '' }}
-          user_description: "Core Features"
+          user_description: "team-distributed-systems"
           detailed_junit_flaky_tests: true
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
@@ -350,7 +350,7 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "Core Features"
+          user_description: "team-distributed-systems"
 
   test-summary:
     # Used by the merge queue to check all tests, including the unit test matrix.
@@ -421,7 +421,7 @@ jobs:
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
-          user_description: "Core Features"
+          user_description: "team-distributed-systems"
   deploy-benchmark-images:
     name: Deploy benchmark images
     timeout-minutes: 5
@@ -468,7 +468,7 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "Core Features"
+          user_description: "team-distributed-systems"
   deploy-snyk-projects:
     name: Deploy Snyk development projects
     needs: [ test-summary ]
@@ -523,4 +523,4 @@ jobs:
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
-          user_description: "Core Features"
+          user_description: "General"


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Use the `user_description` field in the `observe-build-status` to send the owning team to the backing testing statistics BigQuery Database.

Use this field in the `statistics-daily.yml` and `statistics-weekly.yml` jobs to notify the owning team's medic. Only notify when a configured flaky/failed test threshold number is breached. These two jobs send slack messages to the #top-monorepo-ci channel

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes https://github.com/camunda/product-hub/issues/2825
