### PR TITLE
Enforce usage of AssertJ over JUnit for all assertions

### DIFF
--- a/authentication/src/test/java/io/camunda/authentication/CamundaOAuthPrincipalServiceTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/CamundaOAuthPrincipalServiceTest.java
@@ -9,7 +9,7 @@ package io.camunda.authentication;
 
 import static io.camunda.security.auth.OidcGroupsLoader.DERIVED_GROUPS_ARE_NOT_STRING_ARRAY;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
@@ -99,9 +99,9 @@ public class CamundaOAuthPrincipalServiceTest {
 
       // when
       final var exception =
-          assertThrows(
-              OAuth2AuthenticationException.class,
-              () -> camundaOAuthPrincipalService.loadOAuthContext(claims));
+          assertThatExceptionOfType(OAuth2AuthenticationException.class)
+              .isThrownBy(() -> camundaOAuthPrincipalService.loadOAuthContext(claims))
+              .actual();
 
       assertThat(exception.getMessage())
           .isEqualTo(
@@ -118,9 +118,9 @@ public class CamundaOAuthPrincipalServiceTest {
 
       // when
       final var exception =
-          assertThrows(
-              IllegalArgumentException.class,
-              () -> camundaOAuthPrincipalService.loadOAuthContext(claims));
+          assertThatExceptionOfType(IllegalArgumentException.class)
+              .isThrownBy(() -> camundaOAuthPrincipalService.loadOAuthContext(claims))
+              .actual();
 
       assertThat(exception.getMessage())
           .isEqualTo(
@@ -191,9 +191,9 @@ public class CamundaOAuthPrincipalServiceTest {
 
       // when
       final var exception =
-          assertThrows(
-              OAuth2AuthenticationException.class,
-              () -> camundaOAuthPrincipalService.loadOAuthContext(claims));
+          assertThatExceptionOfType(OAuth2AuthenticationException.class)
+              .isThrownBy(() -> camundaOAuthPrincipalService.loadOAuthContext(claims))
+              .actual();
 
       assertThat(exception.getMessage())
           .isEqualTo(
@@ -208,9 +208,9 @@ public class CamundaOAuthPrincipalServiceTest {
 
       // when
       final var exception =
-          assertThrows(
-              IllegalArgumentException.class,
-              () -> camundaOAuthPrincipalService.loadOAuthContext(claims));
+          assertThatExceptionOfType(IllegalArgumentException.class)
+              .isThrownBy(() -> camundaOAuthPrincipalService.loadOAuthContext(claims))
+              .actual();
 
       assertThat(exception.getMessage())
           .isEqualTo("Value for $['email'] is not a string. Please check your OIDC configuration.");
@@ -471,9 +471,9 @@ public class CamundaOAuthPrincipalServiceTest {
               "user1");
       // when
       final var exception =
-          assertThrows(
-              IllegalArgumentException.class,
-              () -> camundaOAuthPrincipalService.loadOAuthContext(claims));
+          assertThatExceptionOfType(IllegalArgumentException.class)
+              .isThrownBy(() -> camundaOAuthPrincipalService.loadOAuthContext(claims))
+              .actual();
 
       assertThat(exception.getMessage())
           .isEqualTo(DERIVED_GROUPS_ARE_NOT_STRING_ARRAY.formatted(GROUPS_CLAIM));

--- a/authentication/src/test/java/io/camunda/authentication/DefaultCamundaAuthenticationProviderTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/DefaultCamundaAuthenticationProviderTest.java
@@ -10,7 +10,6 @@ package io.camunda.authentication;
 import static io.camunda.zeebe.auth.Authorization.USER_TOKEN_CLAIMS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.algorithms.Algorithm;
@@ -73,7 +72,7 @@ public class DefaultCamundaAuthenticationProviderTest {
     final var claims = authenticationProvider.getCamundaAuthentication().claims();
 
     // then
-    assertNotNull(claims);
+    assertThat(claims).isNotNull();
     assertThat(claims).containsKey(Authorization.AUTHORIZED_USERNAME);
     assertThat(claims.get(Authorization.AUTHORIZED_USERNAME)).isEqualTo(username);
   }
@@ -107,7 +106,7 @@ public class DefaultCamundaAuthenticationProviderTest {
             authenticationProvider.getCamundaAuthentication().claims().get(USER_TOKEN_CLAIMS);
 
     // then
-    assertNotNull(claims);
+    assertThat(claims).isNotNull();
     assertThat(claims).containsKey("sub");
     assertThat(claims).containsKey("aud");
     assertThat(claims).containsKey("groups");

--- a/authentication/src/test/java/io/camunda/authentication/csrf/CsrfProtectionRequestMatcherTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/csrf/CsrfProtectionRequestMatcherTest.java
@@ -9,8 +9,7 @@ package io.camunda.authentication.csrf;
 
 import static com.google.common.net.HttpHeaders.AUTHORIZATION;
 import static com.google.common.net.HttpHeaders.REFERER;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.authentication.config.WebSecurityConfig;
 import io.camunda.security.configuration.AuthenticationConfiguration;
@@ -41,7 +40,7 @@ class CsrfProtectionRequestMatcherTest {
   void safeMethodsDoNotMatchForCsrf(final String method) {
     final var request = prepareMockRequest();
     request.setMethod(method);
-    assertFalse(matcher.matches(request));
+    assertThat(matcher.matches(request)).isFalse();
   }
 
   @ParameterizedTest
@@ -50,7 +49,7 @@ class CsrfProtectionRequestMatcherTest {
     final var request = prepareMockRequest();
     request.getSession(true);
     request.setMethod(method);
-    assertTrue(matcher.matches(request));
+    assertThat(matcher.matches(request)).isTrue();
   }
 
   @ParameterizedTest
@@ -58,7 +57,7 @@ class CsrfProtectionRequestMatcherTest {
   void whenUnprotectedApiIsOffAndApiCalledFromNonBrowser(final String method) {
     final var request = prepareMockRequest();
     request.setMethod(method);
-    assertFalse(matcher.matches(request));
+    assertThat(matcher.matches(request)).isFalse();
   }
 
   @ParameterizedTest
@@ -76,7 +75,7 @@ class CsrfProtectionRequestMatcherTest {
     final var request = prepareMockRequest();
     request.getSession(true);
     request.setServletPath(protectedUrls);
-    assertTrue(unprotectedApiMatcher.matches(request));
+    assertThat(unprotectedApiMatcher.matches(request)).isTrue();
   }
 
   @ParameterizedTest
@@ -90,7 +89,7 @@ class CsrfProtectionRequestMatcherTest {
   void whenUnprotectedApiIsOnAndApiCalledFromNonBrowser(final String protectedUrls) {
     final var request = prepareMockRequest();
     request.setServletPath(protectedUrls);
-    assertFalse(matcher.matches(request));
+    assertThat(matcher.matches(request)).isFalse();
   }
 
   @Test
@@ -98,7 +97,7 @@ class CsrfProtectionRequestMatcherTest {
     final var request = prepareMockRequest();
     request.addHeader(REFERER, "http://localhost/swagger-ui/index.html");
     request.getSession(true);
-    assertFalse(matcher.matches(request));
+    assertThat(matcher.matches(request)).isFalse();
   }
 
   @Test
@@ -106,21 +105,21 @@ class CsrfProtectionRequestMatcherTest {
     final var request = prepareMockRequest();
     request.addHeader(REFERER, "http://localhost/fake-swagger/index.html");
     request.getSession(true);
-    assertTrue(matcher.matches(request));
+    assertThat(matcher.matches(request)).isTrue();
   }
 
   @Test
   void bearerAuthorizedDoesNotMatchForCsrf() {
     final var request = prepareMockRequest();
     request.addHeader(AUTHORIZATION, "Bearer some-token");
-    assertFalse(matcher.matches(request));
+    assertThat(matcher.matches(request)).isFalse();
   }
 
   @Test
   void basicAuthorizedDoesNotMatchForCsrf() {
     final var request = prepareMockRequest();
     request.addHeader(AUTHORIZATION, "Basic some-creds");
-    assertFalse(matcher.matches(request));
+    assertThat(matcher.matches(request)).isFalse();
   }
 
   @ParameterizedTest
@@ -128,7 +127,7 @@ class CsrfProtectionRequestMatcherTest {
   void unprotectedPathsDoNotMatchForCsrf(final String path) {
     final var request = prepareMockRequest();
     request.setServletPath(path.replace("**", "/some/path").replace("*", "/some-path"));
-    assertFalse(matcher.matches(request));
+    assertThat(matcher.matches(request)).isFalse();
   }
 
   @ParameterizedTest
@@ -137,7 +136,7 @@ class CsrfProtectionRequestMatcherTest {
     final var request = prepareMockRequest();
     request.getSession(true);
     request.setServletPath(path.replace("**", "/some/path").replace("*", "/some-path"));
-    assertTrue(matcher.matches(request));
+    assertThat(matcher.matches(request)).isTrue();
   }
 
   @ParameterizedTest
@@ -145,7 +144,7 @@ class CsrfProtectionRequestMatcherTest {
   void protectedPathsDontMatchForCsrfFromBrowser(final String path) {
     final var request = prepareMockRequest();
     request.setServletPath(path.replace("**", "/some/path").replace("*", "/some-path"));
-    assertFalse(matcher.matches(request));
+    assertThat(matcher.matches(request)).isFalse();
   }
 
   private static Stream<Arguments> unprotectedPaths() {

--- a/build-tools/src/main/resources/check/.checkstyle.xml
+++ b/build-tools/src/main/resources/check/.checkstyle.xml
@@ -154,7 +154,14 @@
     </module>
 
     <module name="IllegalImport">
-      <property name="illegalPkgs" value="org.testcontainers.shaded,org.assertj.core.internal"/>
+      <property name="regexp" value="true"/>
+      <!--
+        Forbid importing shaded dependencies, prefer real dependencies instead;
+        Forbid importing internal AssertJ classes, use public API instead, as we cannot rely on their stability.
+        Forbid JUnit assertions, use AssertJ assertions, for consistency, and because they are generally more powerful.
+       -->
+      <property name="illegalPkgs" value="org\.testcontainers\.shaded,org\.assertj\.core\.internal"/>
+      <property name="illegalClasses" value="^org\.junit\.Assert.*$,^org\.junit\.jupiter\.api\.Assert.*$"/>
     </module>
   </module>
 </module>

--- a/clients/java/src/test/java/io/camunda/client/impl/http/ApiCallbackTest.java
+++ b/clients/java/src/test/java/io/camunda/client/impl/http/ApiCallbackTest.java
@@ -15,7 +15,7 @@
  */
 package io.camunda.client.impl.http;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
 import io.camunda.client.CredentialsProvider.StatusCode;
@@ -71,7 +71,7 @@ class ApiCallbackTest {
 
     // then
     verifyNoInteractions(retryAction);
-    assertTrue(response.isCompletedExceptionally());
+    assertThat(response.isCompletedExceptionally()).isTrue();
   }
 
   @Test
@@ -91,7 +91,7 @@ class ApiCallbackTest {
 
     // then: no new retry, future is exceptionally completed
     verify(retryAction, times(DEFAULT_REMAINING_RETRIES)).run();
-    assertTrue(response.isCompletedExceptionally());
+    assertThat(response.isCompletedExceptionally()).isTrue();
   }
 
   @Test
@@ -113,7 +113,7 @@ class ApiCallbackTest {
     // No retries left - should NOT call retryAction again
     apiCallback.completed(apiResponse);
     verifyNoInteractions(retryAction);
-    assertTrue(response.isCompletedExceptionally());
+    assertThat(response.isCompletedExceptionally()).isTrue();
   }
 
   @Test
@@ -129,6 +129,6 @@ class ApiCallbackTest {
 
     // Final attempt - should complete exceptionally, no further retry
     apiCallback.completed(apiResponse);
-    assertTrue(response.isCompletedExceptionally());
+    assertThat(response.isCompletedExceptionally()).isTrue();
   }
 }

--- a/clients/java/src/test/java/io/camunda/client/impl/http/DocumentDataConsumerTest.java
+++ b/clients/java/src/test/java/io/camunda/client/impl/http/DocumentDataConsumerTest.java
@@ -16,7 +16,7 @@
 package io.camunda.client.impl.http;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.mock;
@@ -100,7 +100,7 @@ public class DocumentDataConsumerTest {
 
     assertThat(reportedCapacity.get()).isEqualTo(data.length - 1);
     // error is thrown when data exceeds buffer capacity
-    assertThrows(IOException.class, () -> consumer.consume(ByteBuffer.wrap(data)));
+    assertThatCode(() -> consumer.consume(ByteBuffer.wrap(data))).isInstanceOf(IOException.class);
 
     final byte[] partialData = Arrays.copyOf(data, reportedCapacity.get());
     consumer.consume(ByteBuffer.wrap(partialData));

--- a/clients/java/src/test/java/io/camunda/client/impl/oauth/OAuthCredentialsCacheTest.java
+++ b/clients/java/src/test/java/io/camunda/client/impl/oauth/OAuthCredentialsCacheTest.java
@@ -17,7 +17,6 @@ package io.camunda.client.impl.oauth;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.Assert.assertTrue;
 
 import io.camunda.client.impl.CamundaClientCredentials;
 import java.io.File;
@@ -148,7 +147,7 @@ public final class OAuthCredentialsCacheTest {
 
     // now /some/root/.camunda -> /some/root/target
     // we will delete target, creating a dead link.
-    assertTrue(target.delete());
+    assertThat(target.delete()).isTrue();
 
     final File fileInContainer = new File(container, "/credentials");
     final OAuthCredentialsCache cache = new OAuthCredentialsCache(fileInContainer);

--- a/clients/java/src/test/java/io/camunda/client/process/rest/ResolveIncidentRestTest.java
+++ b/clients/java/src/test/java/io/camunda/client/process/rest/ResolveIncidentRestTest.java
@@ -22,7 +22,6 @@ import io.camunda.client.protocol.rest.JobUpdateRequest;
 import io.camunda.client.util.ClientRestTest;
 import io.camunda.client.util.RestGatewayPaths;
 import io.camunda.client.util.RestGatewayService;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class ResolveIncidentRestTest extends ClientRestTest {
@@ -61,7 +60,8 @@ public class ResolveIncidentRestTest extends ClientRestTest {
         .hasBodySatisfying(
             JobUpdateRequest.class,
             r -> {
-              Assertions.assertEquals(operationReference, r.getOperationReference());
+              org.assertj.core.api.Assertions.assertThat(r.getOperationReference())
+                  .isEqualTo(operationReference);
             });
   }
 }

--- a/clients/java/src/test/java/io/camunda/zeebe/client/impl/http/ApiCallbackTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/impl/http/ApiCallbackTest.java
@@ -15,7 +15,7 @@
  */
 package io.camunda.zeebe.client.impl.http;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
 import io.camunda.zeebe.client.CredentialsProvider.StatusCode;
@@ -71,7 +71,7 @@ class ApiCallbackTest {
 
     // then
     verifyNoInteractions(retryAction);
-    assertTrue(response.isCompletedExceptionally());
+    assertThat(response.isCompletedExceptionally()).isTrue();
   }
 
   @Test
@@ -91,7 +91,7 @@ class ApiCallbackTest {
 
     // then: no new retry, future is exceptionally completed
     verify(retryAction, times(DEFAULT_REMAINING_RETRIES)).run();
-    assertTrue(response.isCompletedExceptionally());
+    assertThat(response.isCompletedExceptionally()).isTrue();
   }
 
   @Test
@@ -113,7 +113,7 @@ class ApiCallbackTest {
     // No retries left - should NOT call retryAction again
     apiCallback.completed(apiResponse);
     verifyNoInteractions(retryAction);
-    assertTrue(response.isCompletedExceptionally());
+    assertThat(response.isCompletedExceptionally()).isTrue();
   }
 
   @Test
@@ -129,6 +129,6 @@ class ApiCallbackTest {
 
     // Final attempt - should complete exceptionally, no further retry
     apiCallback.completed(apiResponse);
-    assertTrue(response.isCompletedExceptionally());
+    assertThat(response.isCompletedExceptionally()).isTrue();
   }
 }

--- a/clients/java/src/test/java/io/camunda/zeebe/client/impl/http/DocumentDataConsumerTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/impl/http/DocumentDataConsumerTest.java
@@ -16,7 +16,7 @@
 package io.camunda.zeebe.client.impl.http;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.mock;
@@ -100,7 +100,7 @@ public class DocumentDataConsumerTest {
 
     assertThat(reportedCapacity.get()).isEqualTo(data.length - 1);
     // error is thrown when data exceeds buffer capacity
-    assertThrows(IOException.class, () -> consumer.consume(ByteBuffer.wrap(data)));
+    assertThatCode(() -> consumer.consume(ByteBuffer.wrap(data))).isInstanceOf(IOException.class);
 
     final byte[] partialData = Arrays.copyOf(data, reportedCapacity.get());
     consumer.consume(ByteBuffer.wrap(partialData));

--- a/clients/java/src/test/java/io/camunda/zeebe/client/impl/oauth/OAuthCredentialsCacheTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/impl/oauth/OAuthCredentialsCacheTest.java
@@ -17,7 +17,6 @@ package io.camunda.zeebe.client.impl.oauth;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.Assert.assertTrue;
 
 import io.camunda.zeebe.client.impl.ZeebeClientCredentials;
 import java.io.File;
@@ -148,7 +147,7 @@ public final class OAuthCredentialsCacheTest {
 
     // now /some/root/.camunda -> /some/root/target
     // we will delete target, creating a dead link.
-    assertTrue(target.delete());
+    assertThat(target.delete()).isTrue();
 
     final File fileInContainer = new File(container, "/credentials");
     final OAuthCredentialsCache cache = new OAuthCredentialsCache(fileInContainer);

--- a/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/spring/client/bean/factory/ReadJobWorkerValueTest.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/spring/client/bean/factory/ReadJobWorkerValueTest.java
@@ -16,8 +16,6 @@
 package io.camunda.spring.client.bean.factory;
 
 import static org.assertj.core.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.camunda.spring.client.annotation.AnnotationUtil;
 import io.camunda.spring.client.annotation.value.JobWorkerValue;
@@ -44,17 +42,17 @@ public class ReadJobWorkerValueTest {
     final Optional<JobWorkerValue> jobWorkerValue = AnnotationUtil.getJobWorkerValue(methodInfo);
 
     // then
-    assertTrue(jobWorkerValue.isPresent());
-    assertEquals("bar", jobWorkerValue.get().getType());
-    assertEquals("kermit", jobWorkerValue.get().getName());
-    assertEquals(Duration.ofMillis(100), jobWorkerValue.get().getTimeout());
-    assertEquals(-1, jobWorkerValue.get().getMaxJobsActive());
-    assertEquals(Duration.ofSeconds(-1), jobWorkerValue.get().getRequestTimeout());
-    assertEquals(Duration.ofMillis(-1), jobWorkerValue.get().getPollInterval());
-    assertEquals(false, jobWorkerValue.get().getAutoComplete());
-    assertEquals(List.of(), jobWorkerValue.get().getFetchVariables());
-    assertEquals(methodInfo, jobWorkerValue.get().getMethodInfo());
-    assertEquals(Duration.ofHours(1), jobWorkerValue.get().getStreamTimeout());
+    assertThat(jobWorkerValue.isPresent()).isTrue();
+    assertThat(jobWorkerValue.get().getType()).isEqualTo("bar");
+    assertThat(jobWorkerValue.get().getName()).isEqualTo("kermit");
+    assertThat(jobWorkerValue.get().getTimeout()).isEqualTo(Duration.ofMillis(100));
+    assertThat(jobWorkerValue.get().getMaxJobsActive()).isEqualTo(-1);
+    assertThat(jobWorkerValue.get().getRequestTimeout()).isEqualTo(Duration.ofSeconds(-1));
+    assertThat(jobWorkerValue.get().getPollInterval()).isEqualTo(Duration.ofMillis(-1));
+    assertThat(jobWorkerValue.get().getAutoComplete()).isEqualTo(false);
+    assertThat(jobWorkerValue.get().getFetchVariables()).isEqualTo(List.of());
+    assertThat(jobWorkerValue.get().getMethodInfo()).isEqualTo(methodInfo);
+    assertThat(jobWorkerValue.get().getStreamTimeout()).isEqualTo(Duration.ofHours(1));
   }
 
   @Test
@@ -66,7 +64,7 @@ public class ReadJobWorkerValueTest {
     final Optional<JobWorkerValue> jobWorkerValue = AnnotationUtil.getJobWorkerValue(methodInfo);
 
     // then
-    assertTrue(jobWorkerValue.isPresent());
+    assertThat(jobWorkerValue.isPresent()).isTrue();
     assertThat(jobWorkerValue.get().getTenantIds()).containsOnly("tenant-1");
   }
 
@@ -79,16 +77,16 @@ public class ReadJobWorkerValueTest {
     final Optional<JobWorkerValue> jobWorkerValue = AnnotationUtil.getJobWorkerValue(methodInfo);
 
     // then
-    assertTrue(jobWorkerValue.isPresent());
-    assertEquals("bar", jobWorkerValue.get().getType());
-    assertEquals("kermit", jobWorkerValue.get().getName());
-    assertEquals(Duration.ofMillis(100L), jobWorkerValue.get().getTimeout());
-    assertEquals(3, jobWorkerValue.get().getMaxJobsActive());
-    assertEquals(Duration.ofSeconds(500L), jobWorkerValue.get().getRequestTimeout());
-    assertEquals(Duration.ofSeconds(1L), jobWorkerValue.get().getPollInterval());
-    assertEquals(true, jobWorkerValue.get().getAutoComplete());
-    assertEquals(List.of("foo"), jobWorkerValue.get().getFetchVariables());
-    assertEquals(methodInfo, jobWorkerValue.get().getMethodInfo());
+    assertThat(jobWorkerValue.isPresent()).isTrue();
+    assertThat(jobWorkerValue.get().getType()).isEqualTo("bar");
+    assertThat(jobWorkerValue.get().getName()).isEqualTo("kermit");
+    assertThat(jobWorkerValue.get().getTimeout()).isEqualTo(Duration.ofMillis(100L));
+    assertThat(jobWorkerValue.get().getMaxJobsActive()).isEqualTo(3);
+    assertThat(jobWorkerValue.get().getRequestTimeout()).isEqualTo(Duration.ofSeconds(500L));
+    assertThat(jobWorkerValue.get().getPollInterval()).isEqualTo(Duration.ofSeconds(1L));
+    assertThat(jobWorkerValue.get().getAutoComplete()).isEqualTo(true);
+    assertThat(jobWorkerValue.get().getFetchVariables()).isEqualTo(List.of("foo"));
+    assertThat(jobWorkerValue.get().getMethodInfo()).isEqualTo(methodInfo);
   }
 
   private MethodInfo extract(final Class<?> clazz) {

--- a/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/spring/client/bean/factory/ReadZeebeDeploymentValueTest.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/spring/client/bean/factory/ReadZeebeDeploymentValueTest.java
@@ -16,7 +16,7 @@
 package io.camunda.spring.client.bean.factory;
 
 import static io.camunda.spring.client.annotation.AnnotationUtil.getDeploymentValue;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.spring.client.annotation.Deployment;
 import io.camunda.spring.client.annotation.value.DeploymentValue;
@@ -46,8 +46,8 @@ public class ReadZeebeDeploymentValueTest {
     final Optional<DeploymentValue> valueForClass = getDeploymentValue(classInfo);
 
     // then
-    assertTrue(valueForClass.isPresent());
-    assertEquals(expectedDeploymentValue, valueForClass.get());
+    assertThat(valueForClass.isPresent()).isTrue();
+    assertThat(valueForClass.get()).isEqualTo(expectedDeploymentValue);
   }
 
   @Test
@@ -66,8 +66,8 @@ public class ReadZeebeDeploymentValueTest {
     final Optional<DeploymentValue> valueForClass = getDeploymentValue(classInfo);
 
     // then
-    assertTrue(valueForClass.isPresent());
-    assertEquals(expectedDeploymentValue, valueForClass.get());
+    assertThat(valueForClass.isPresent()).isTrue();
+    assertThat(valueForClass.get()).isEqualTo(expectedDeploymentValue);
   }
 
   @Test
@@ -79,7 +79,7 @@ public class ReadZeebeDeploymentValueTest {
     final Optional<DeploymentValue> valueForClass = getDeploymentValue(classInfo);
 
     // then
-    assertFalse(valueForClass.isPresent());
+    assertThat(valueForClass.isPresent()).isFalse();
   }
 
   @Test
@@ -98,8 +98,8 @@ public class ReadZeebeDeploymentValueTest {
     final Optional<DeploymentValue> valueForClass = getDeploymentValue(classInfo);
 
     // then
-    assertTrue(valueForClass.isPresent());
-    assertEquals(expectedDeploymentValue, valueForClass.get());
+    assertThat(valueForClass.isPresent()).isTrue();
+    assertThat(valueForClass.get()).isEqualTo(expectedDeploymentValue);
   }
 
   @Test
@@ -118,8 +118,8 @@ public class ReadZeebeDeploymentValueTest {
     final Optional<DeploymentValue> valueForClass = getDeploymentValue(classInfo);
 
     // then
-    assertTrue(valueForClass.isPresent());
-    assertEquals(expectedDeploymentValue, valueForClass.get());
+    assertThat(valueForClass.isPresent()).isTrue();
+    assertThat(valueForClass.get()).isEqualTo(expectedDeploymentValue);
   }
 
   @Deployment(resources = "classpath*:/1.bpmn")

--- a/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/spring/client/jobhandling/parameter/VariableResolverTest.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/spring/client/jobhandling/parameter/VariableResolverTest.java
@@ -15,7 +15,7 @@
  */
 package io.camunda.spring.client.jobhandling.parameter;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
 import io.camunda.client.api.response.ActivatedJob;
@@ -46,7 +46,7 @@ class VariableResolverTest {
 
     final Object resolvedValue = resolver.resolve(jobClient, job);
 
-    assertNull(resolvedValue);
+    assertThat(resolvedValue).isNull();
   }
 
   @Test
@@ -55,6 +55,6 @@ class VariableResolverTest {
 
     final Object resolvedValue = resolver.resolve(jobClient, job);
 
-    assertEquals("test value", resolvedValue);
+    assertThat(resolvedValue).isEqualTo("test value");
   }
 }

--- a/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/spring/client/jobhandling/result/DefaultResultProcessorStrategyTest.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/spring/client/jobhandling/result/DefaultResultProcessorStrategyTest.java
@@ -15,10 +15,10 @@
  */
 package io.camunda.spring.client.jobhandling.result;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
 import io.camunda.spring.client.bean.MethodInfo;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 class DefaultResultProcessorStrategyTest {
@@ -33,6 +33,6 @@ class DefaultResultProcessorStrategyTest {
     // When
     final ResultProcessor resultProcessor = resultProcessorStrategy.createProcessor(methodInfo);
     // Then
-    Assertions.assertTrue(resultProcessor instanceof DefaultResultProcessor);
+    assertThat((resultProcessor instanceof DefaultResultProcessor)).isTrue();
   }
 }

--- a/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/spring/client/jobhandling/result/DefaultResultProcessorTest.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/spring/client/jobhandling/result/DefaultResultProcessorTest.java
@@ -15,10 +15,10 @@
  */
 package io.camunda.spring.client.jobhandling.result;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
 import io.camunda.client.api.response.ActivatedJob;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 class DefaultResultProcessorTest {
@@ -34,6 +34,6 @@ class DefaultResultProcessorTest {
     // When
     final Object resultValue = defaultResultProcessor.process(context);
     // Then
-    Assertions.assertEquals(inputValue, resultValue);
+    assertThat(resultValue).isEqualTo(inputValue);
   }
 }

--- a/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/spring/client/processor/DeploymentPostProcessorTest.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/spring/client/processor/DeploymentPostProcessorTest.java
@@ -15,7 +15,7 @@
  */
 package io.camunda.spring.client.processor;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
@@ -169,17 +169,17 @@ public class DeploymentPostProcessorTest {
 
   @Test
   public void shouldThrowExceptionOnNoResourcesToDeploy() {
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> {
-          // given
-          final ClassInfo classInfo =
-              ClassInfo.builder().bean(new WithNoClassPathResource()).build();
+    assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(
+            () -> {
+              // given
+              final ClassInfo classInfo =
+                  ClassInfo.builder().bean(new WithNoClassPathResource()).build();
 
-          // when
-          deploymentPostProcessor.configureFor(classInfo);
-          deploymentPostProcessor.start(client);
-        });
+              // when
+              deploymentPostProcessor.configureFor(classInfo);
+              deploymentPostProcessor.start(client);
+            });
   }
 
   private Process getProcess() {

--- a/configuration/pom.xml
+++ b/configuration/pom.xml
@@ -74,6 +74,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>joda-time</groupId>
       <artifactId>joda-time</artifactId>
     </dependency>

--- a/configuration/src/test/java/io/camunda/configuration/UnifiedConfigurationHelperTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/UnifiedConfigurationHelperTest.java
@@ -10,7 +10,8 @@ package io.camunda.configuration;
 import static io.camunda.configuration.UnifiedConfigurationHelper.BackwardsCompatibilityMode.NOT_SUPPORTED;
 import static io.camunda.configuration.UnifiedConfigurationHelper.BackwardsCompatibilityMode.SUPPORTED;
 import static io.camunda.configuration.UnifiedConfigurationHelper.BackwardsCompatibilityMode.SUPPORTED_ONLY_IF_VALUES_MATCH;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.Mockito.mock;
 
 import io.camunda.configuration.UnifiedConfigurationHelper.BackwardsCompatibilityMode;
@@ -61,7 +62,7 @@ class UnifiedConfigurationHelperTest {
             newProperty, newValue, String.class, mode);
 
     // then
-    assertEquals(result, "matchingValue");
+    assertThat(result).isEqualTo("matchingValue");
   }
 
   @Test
@@ -78,13 +79,12 @@ class UnifiedConfigurationHelperTest {
     setPropertyValues("legacy.prop2", "legacyValue2");
 
     // then
-    final UnifiedConfigurationException expectedException =
-        assertThrows(
-            UnifiedConfigurationException.class,
+    assertThatExceptionOfType(UnifiedConfigurationException.class)
+        .isThrownBy(
             () ->
                 UnifiedConfigurationHelper.validateLegacyConfiguration(
-                    newProperty, newValue, String.class, mode));
-    assertTrue(expectedException.getMessage().contains("Ambiguous legacy configuration"));
+                    newProperty, newValue, String.class, mode))
+        .withMessageContaining("Ambiguous legacy configuration");
   }
 
   @Test
@@ -101,13 +101,12 @@ class UnifiedConfigurationHelperTest {
     setPropertyValues("legacy.prop2", "legacyValue");
 
     // then
-    final UnifiedConfigurationException expectedException =
-        assertThrows(
-            UnifiedConfigurationException.class,
+    assertThatExceptionOfType(UnifiedConfigurationException.class)
+        .isThrownBy(
             () ->
                 UnifiedConfigurationHelper.validateLegacyConfiguration(
-                    newProperty, newValue, String.class, mode));
-    assertTrue(expectedException.getMessage().contains("Ambiguous configuration"));
+                    newProperty, newValue, String.class, mode))
+        .withMessageContaining("Ambiguous configuration");
   }
 
   @Test
@@ -125,7 +124,7 @@ class UnifiedConfigurationHelperTest {
     final String result =
         UnifiedConfigurationHelper.validateLegacyConfiguration(
             newProperty, newValue, String.class, mode);
-    assertEquals(result, "legacyValue1");
+    assertThat(result).isEqualTo("legacyValue1");
   }
 
   @Test
@@ -145,7 +144,7 @@ class UnifiedConfigurationHelperTest {
     final String result =
         UnifiedConfigurationHelper.validateLegacyConfiguration(
             newProperty, newValue, String.class, mode);
-    assertEquals(result, "defaultValue");
+    assertThat(result).isEqualTo("defaultValue");
   }
 
   @Test
@@ -165,7 +164,7 @@ class UnifiedConfigurationHelperTest {
     final String result =
         UnifiedConfigurationHelper.validateLegacyConfiguration(
             newProperty, sameValue, String.class, mode);
-    assertEquals(result, sameValue);
+    assertThat(result).isEqualTo(sameValue);
   }
 
   @Test
@@ -182,13 +181,12 @@ class UnifiedConfigurationHelperTest {
     setPropertyValues("legacy.prop2", "legacyValue");
 
     // then
-    final UnifiedConfigurationException expectedException =
-        assertThrows(
-            UnifiedConfigurationException.class,
+    assertThatExceptionOfType(UnifiedConfigurationException.class)
+        .isThrownBy(
             () ->
                 UnifiedConfigurationHelper.validateLegacyConfiguration(
-                    newProperty, newValue, String.class, mode));
-    assertTrue(expectedException.getMessage().contains("Ambiguous configuration"));
+                    newProperty, newValue, String.class, mode))
+        .withMessageContaining("Ambiguous configuration");
   }
 
   @Test
@@ -206,7 +204,7 @@ class UnifiedConfigurationHelperTest {
     final String result =
         UnifiedConfigurationHelper.validateLegacyConfiguration(
             newProperty, newValue, String.class, mode);
-    assertEquals(result, newValue);
+    assertThat(result).isEqualTo(newValue);
   }
 
   @Test
@@ -217,13 +215,12 @@ class UnifiedConfigurationHelperTest {
     final BackwardsCompatibilityMode mode = null;
 
     // then
-    final UnifiedConfigurationException expectedException =
-        assertThrows(
-            UnifiedConfigurationException.class,
+    assertThatExceptionOfType(UnifiedConfigurationException.class)
+        .isThrownBy(
             () ->
                 UnifiedConfigurationHelper.validateLegacyConfiguration(
-                    newProperty, newValue, String.class, mode));
-    assertTrue(expectedException.getMessage().contains("cannot be null"));
+                    newProperty, newValue, String.class, mode))
+        .withMessageContaining("cannot be null");
   }
 
   @Test
@@ -239,18 +236,14 @@ class UnifiedConfigurationHelperTest {
     setPropertyValues("legacy.prop2", "legacyValue");
 
     // then
-    final UnifiedConfigurationException expectedException =
-        assertThrows(
-            UnifiedConfigurationException.class,
+    assertThatExceptionOfType(UnifiedConfigurationException.class)
+        .isThrownBy(
             () ->
                 UnifiedConfigurationHelper.validateLegacyConfiguration(
-                    newProperty, newValue, String.class, mode));
-
-    assertTrue(
-        expectedException
-            .getMessage()
-            .contains("The following legacy configuration properties are no longer supported"));
-    assertTrue(expectedException.getMessage().contains("in favor of"));
+                    newProperty, newValue, String.class, mode))
+        .withMessageContaining(
+            "The following legacy configuration properties are no longer supported")
+        .withMessageContaining("in favor of");
   }
 
   @Test
@@ -264,7 +257,7 @@ class UnifiedConfigurationHelperTest {
     final String expected =
         UnifiedConfigurationHelper.validateLegacyConfiguration(
             newProperty, defaultValue, String.class, mode);
-    assertEquals(expected, defaultValue);
+    assertThat(expected).isEqualTo(defaultValue);
   }
 
   @Test
@@ -282,6 +275,6 @@ class UnifiedConfigurationHelperTest {
     final String actual =
         UnifiedConfigurationHelper.validateLegacyConfiguration(
             newProperty, defaultValue, String.class, mode);
-    assertEquals(expected, actual);
+    assertThat(actual).isEqualTo(expected);
   }
 }

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/mapper/UserTaskEntityMapperTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/mapper/UserTaskEntityMapperTest.java
@@ -8,7 +8,6 @@
 package io.camunda.db.rdbms.read.mapper;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertNull;
 
 import io.camunda.db.rdbms.write.domain.UserTaskDbModel;
 import io.camunda.db.rdbms.write.domain.UserTaskDbModel.Builder;
@@ -110,8 +109,8 @@ public class UserTaskEntityMapperTest {
     assertThat(entity.customHeaders()).isEqualTo(Map.of("key", "value"));
     assertThat(entity.creationDate())
         .isCloseTo(dbModel.creationDate(), new TemporalUnitWithinOffset(1, ChronoUnit.MILLIS));
-    assertNull(entity.completionDate());
-    assertNull(entity.dueDate());
-    assertNull(entity.followUpDate());
+    assertThat(entity.completionDate()).isNull();
+    assertThat(entity.dueDate()).isNull();
+    assertThat(entity.followUpDate()).isNull();
   }
 }

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/sql/columns/SearchColumnTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/sql/columns/SearchColumnTest.java
@@ -8,7 +8,7 @@
 package io.camunda.db.rdbms.sql.columns;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThatCode;
 
 import io.camunda.search.entities.BatchOperationEntity.BatchOperationItemState;
 import io.camunda.search.entities.DecisionInstanceEntity.DecisionDefinitionType;
@@ -111,7 +111,7 @@ public class SearchColumnTest {
   @ParameterizedTest(name = "{0}#{1}")
   @MethodSource("provideSearchColumns")
   void testAllGetPropertyValue(final String className, final SearchColumn<?> column) {
-    assertDoesNotThrow(() -> column.getPropertyType());
+    assertThatCode(() -> column.getPropertyType()).doesNotThrowAnyException();
   }
 
   @ParameterizedTest(name = "{0}#{1}")

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/sql/typehandler/WildcardTransformingStringTypeHandlerTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/sql/typehandler/WildcardTransformingStringTypeHandlerTest.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.db.rdbms.sql.typehandler;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.stream.Stream;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -20,7 +20,7 @@ class WildcardTransformingStringTypeHandlerTest {
   @MethodSource("provideElasticsearchQueries")
   void shouldTransformESWildcardToSQLWildcard(final String input, final String expected) {
     final String result = WildcardTransformingStringTypeHandler.transformParameter(input);
-    assertEquals(expected, result);
+    assertThat(result).isEqualTo(expected);
   }
 
   private static Stream<Arguments> provideElasticsearchQueries() {
@@ -47,6 +47,6 @@ class WildcardTransformingStringTypeHandlerTest {
   @MethodSource("provideSqlQueries")
   void shouldEscapeSqlWildcards(final String input, final String expected) {
     final String result = WildcardTransformingStringTypeHandler.transformParameter(input);
-    assertEquals(expected, result);
+    assertThat(result).isEqualTo(expected);
   }
 }

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/write/service/BatchOperationWriterTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/write/service/BatchOperationWriterTest.java
@@ -8,7 +8,6 @@
 package io.camunda.db.rdbms.write.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 
 import io.camunda.db.rdbms.sql.BatchOperationMapper.BatchOperationItemsDto;
 import io.camunda.db.rdbms.write.RdbmsWriterConfig;

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/write/service/HistoryCleanupServiceTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/write/service/HistoryCleanupServiceTest.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.db.rdbms.write.service;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.mock;
@@ -97,7 +97,7 @@ class HistoryCleanupServiceTest {
         historyCleanupService.cleanupHistory(PARTITION_ID, CLEANUP_DATE);
 
     // then
-    assertEquals(Duration.ofHours(1), nextCleanupInterval);
+    assertThat(nextCleanupInterval).isEqualTo(Duration.ofHours(1));
     verify(processInstanceWriter).cleanupHistory(PARTITION_ID, CLEANUP_DATE, 100);
     verify(flowNodeInstanceWriter).cleanupHistory(PARTITION_ID, CLEANUP_DATE, 100);
     verify(incidentWriter).cleanupHistory(PARTITION_ID, CLEANUP_DATE, 100);
@@ -127,7 +127,8 @@ class HistoryCleanupServiceTest {
         historyCleanupService.calculateNewDuration(Duration.ofHours(4), numDeletedRecords);
 
     // then
-    assertEquals(Duration.ofHours(8), nextDuration); // assuming minCleanupInterval is 1 hour
+    assertThat(nextDuration)
+        .isEqualTo(Duration.ofHours(8)); // assuming minCleanupInterval is 1 hour
   }
 
   @Test
@@ -149,7 +150,8 @@ class HistoryCleanupServiceTest {
         historyCleanupService.calculateNewDuration(Duration.ofHours(4), numDeletedRecords);
 
     // then
-    assertEquals(Duration.ofHours(2), nextDuration); // assuming minCleanupInterval is 1 hour
+    assertThat(nextDuration)
+        .isEqualTo(Duration.ofHours(2)); // assuming minCleanupInterval is 1 hour
   }
 
   @Test
@@ -171,6 +173,7 @@ class HistoryCleanupServiceTest {
         historyCleanupService.calculateNewDuration(Duration.ofHours(4), numDeletedRecords);
 
     // then
-    assertEquals(Duration.ofHours(4), nextDuration); // assuming minCleanupInterval is 1 hour
+    assertThat(nextDuration)
+        .isEqualTo(Duration.ofHours(4)); // assuming minCleanupInterval is 1 hour
   }
 }

--- a/dist/src/test/java/io/camunda/application/CamundaDockerIT.java
+++ b/dist/src/test/java/io/camunda/application/CamundaDockerIT.java
@@ -9,7 +9,7 @@ package io.camunda.application;
 
 import static io.camunda.webapps.schema.SupportedVersions.SUPPORTED_ELASTICSEARCH_VERSION;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.dockerjava.api.command.CreateContainerCmd;

--- a/dist/src/test/java/io/camunda/application/commons/console/ping/PingConsoleConfigurationTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/console/ping/PingConsoleConfigurationTest.java
@@ -7,7 +7,9 @@
  */
 package io.camunda.application.commons.console.ping;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -78,12 +80,13 @@ class PingConsoleConfigurationTest {
 
     // then
     final IllegalArgumentException exception =
-        assertThrows(
-            IllegalArgumentException.class,
-            new PingConsoleRunner(
-                    consolePingConfiguration, MANAGEMENT_SERVICES, APPLICATION_CONTEXT)
-                ::validateConfiguration);
-    assertEquals("Ping endpoint must not be null.", exception.getMessage());
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(
+                new PingConsoleRunner(
+                        consolePingConfiguration, MANAGEMENT_SERVICES, APPLICATION_CONTEXT)
+                    ::validateConfiguration)
+            .actual();
+    assertThat(exception.getMessage()).isEqualTo("Ping endpoint must not be null.");
   }
 
   @Test
@@ -101,12 +104,13 @@ class PingConsoleConfigurationTest {
 
     // then
     final IllegalArgumentException exception =
-        assertThrows(
-            IllegalArgumentException.class,
-            new PingConsoleRunner(
-                    consolePingConfiguration, MANAGEMENT_SERVICES, APPLICATION_CONTEXT)
-                ::validateConfiguration);
-    assertEquals("Ping endpoint 123 must be a valid URI.", exception.getMessage());
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(
+                new PingConsoleRunner(
+                        consolePingConfiguration, MANAGEMENT_SERVICES, APPLICATION_CONTEXT)
+                    ::validateConfiguration)
+            .actual();
+    assertThat(exception.getMessage()).isEqualTo("Ping endpoint 123 must be a valid URI.");
   }
 
   @Test
@@ -124,12 +128,13 @@ class PingConsoleConfigurationTest {
 
     // then
     final IllegalArgumentException exception =
-        assertThrows(
-            IllegalArgumentException.class,
-            new PingConsoleRunner(
-                    consolePingConfiguration, MANAGEMENT_SERVICES, APPLICATION_CONTEXT)
-                ::validateConfiguration);
-    assertEquals("Cluster ID must not be null or empty.", exception.getMessage());
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(
+                new PingConsoleRunner(
+                        consolePingConfiguration, MANAGEMENT_SERVICES, APPLICATION_CONTEXT)
+                    ::validateConfiguration)
+            .actual();
+    assertThat(exception.getMessage()).isEqualTo("Cluster ID must not be null or empty.");
   }
 
   @Test
@@ -147,12 +152,13 @@ class PingConsoleConfigurationTest {
 
     // then
     final IllegalArgumentException exception =
-        assertThrows(
-            IllegalArgumentException.class,
-            new PingConsoleRunner(
-                    consolePingConfiguration, MANAGEMENT_SERVICES, APPLICATION_CONTEXT)
-                ::validateConfiguration);
-    assertEquals("Cluster name must not be null or empty.", exception.getMessage());
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(
+                new PingConsoleRunner(
+                        consolePingConfiguration, MANAGEMENT_SERVICES, APPLICATION_CONTEXT)
+                    ::validateConfiguration)
+            .actual();
+    assertThat(exception.getMessage()).isEqualTo("Cluster name must not be null or empty.");
   }
 
   @Test
@@ -170,12 +176,13 @@ class PingConsoleConfigurationTest {
 
     // then
     final IllegalArgumentException exception =
-        assertThrows(
-            IllegalArgumentException.class,
-            new PingConsoleRunner(
-                    consolePingConfiguration, MANAGEMENT_SERVICES, APPLICATION_CONTEXT)
-                ::validateConfiguration);
-    assertEquals("Ping period must be greater than zero.", exception.getMessage());
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(
+                new PingConsoleRunner(
+                        consolePingConfiguration, MANAGEMENT_SERVICES, APPLICATION_CONTEXT)
+                    ::validateConfiguration)
+            .actual();
+    assertThat(exception.getMessage()).isEqualTo("Ping period must be greater than zero.");
   }
 
   @Test
@@ -196,12 +203,14 @@ class PingConsoleConfigurationTest {
 
     // then
     final IllegalArgumentException exception =
-        assertThrows(
-            IllegalArgumentException.class,
-            new PingConsoleRunner(
-                    consolePingConfiguration, MANAGEMENT_SERVICES, APPLICATION_CONTEXT)
-                ::validateConfiguration);
-    assertEquals("Number of max retries must be greater than zero.", exception.getMessage());
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(
+                new PingConsoleRunner(
+                        consolePingConfiguration, MANAGEMENT_SERVICES, APPLICATION_CONTEXT)
+                    ::validateConfiguration)
+            .actual();
+    assertThat(exception.getMessage())
+        .isEqualTo("Number of max retries must be greater than zero.");
   }
 
   @Test
@@ -222,12 +231,14 @@ class PingConsoleConfigurationTest {
 
     // then
     final IllegalArgumentException exception =
-        assertThrows(
-            IllegalArgumentException.class,
-            new PingConsoleRunner(
-                    consolePingConfiguration, MANAGEMENT_SERVICES, APPLICATION_CONTEXT)
-                ::validateConfiguration);
-    assertEquals("Retry delay multiplier must be greater than zero.", exception.getMessage());
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(
+                new PingConsoleRunner(
+                        consolePingConfiguration, MANAGEMENT_SERVICES, APPLICATION_CONTEXT)
+                    ::validateConfiguration)
+            .actual();
+    assertThat(exception.getMessage())
+        .isEqualTo("Retry delay multiplier must be greater than zero.");
   }
 
   @Test
@@ -244,10 +255,11 @@ class PingConsoleConfigurationTest {
             null);
 
     // then
-    assertDoesNotThrow(
-        () ->
-            new PingConsoleRunner(
-                consolePingConfiguration, MANAGEMENT_SERVICES, APPLICATION_CONTEXT));
+    assertThatCode(
+            () ->
+                new PingConsoleRunner(
+                    consolePingConfiguration, MANAGEMENT_SERVICES, APPLICATION_CONTEXT))
+        .doesNotThrowAnyException();
   }
 
   @Test
@@ -268,12 +280,13 @@ class PingConsoleConfigurationTest {
 
     // then
     final IllegalArgumentException exception =
-        assertThrows(
-            IllegalArgumentException.class,
-            new PingConsoleRunner(
-                    consolePingConfiguration, MANAGEMENT_SERVICES, APPLICATION_CONTEXT)
-                ::validateConfiguration);
-    assertEquals("Max retry delay must be greater than zero.", exception.getMessage());
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(
+                new PingConsoleRunner(
+                        consolePingConfiguration, MANAGEMENT_SERVICES, APPLICATION_CONTEXT)
+                    ::validateConfiguration)
+            .actual();
+    assertThat(exception.getMessage()).isEqualTo("Max retry delay must be greater than zero.");
   }
 
   @Test
@@ -294,12 +307,13 @@ class PingConsoleConfigurationTest {
 
     // then
     final IllegalArgumentException exception =
-        assertThrows(
-            IllegalArgumentException.class,
-            new PingConsoleRunner(
-                    consolePingConfiguration, MANAGEMENT_SERVICES, APPLICATION_CONTEXT)
-                ::validateConfiguration);
-    assertEquals("Min retry delay must be greater than zero.", exception.getMessage());
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(
+                new PingConsoleRunner(
+                        consolePingConfiguration, MANAGEMENT_SERVICES, APPLICATION_CONTEXT)
+                    ::validateConfiguration)
+            .actual();
+    assertThat(exception.getMessage()).isEqualTo("Min retry delay must be greater than zero.");
   }
 
   @Test
@@ -321,14 +335,14 @@ class PingConsoleConfigurationTest {
 
     // then
     final IllegalArgumentException exception =
-        assertThrows(
-            IllegalArgumentException.class,
-            new PingConsoleRunner(
-                    consolePingConfiguration, MANAGEMENT_SERVICES, APPLICATION_CONTEXT)
-                ::validateConfiguration);
-    assertEquals(
-        "Max retry delay must be greater than or equal to min retry delay.",
-        exception.getMessage());
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(
+                new PingConsoleRunner(
+                        consolePingConfiguration, MANAGEMENT_SERVICES, APPLICATION_CONTEXT)
+                    ::validateConfiguration)
+            .actual();
+    assertThat(exception.getMessage())
+        .isEqualTo("Max retry delay must be greater than or equal to min retry delay.");
   }
 
   @Test
@@ -344,10 +358,11 @@ class PingConsoleConfigurationTest {
             new RetryConfiguration(),
             null);
     // then
-    assertDoesNotThrow(
-        () ->
-            new PingConsoleRunner(
-                consolePingConfiguration, MANAGEMENT_SERVICES, APPLICATION_CONTEXT));
+    assertThatCode(
+            () ->
+                new PingConsoleRunner(
+                    consolePingConfiguration, MANAGEMENT_SERVICES, APPLICATION_CONTEXT))
+        .doesNotThrowAnyException();
   }
 
   @Test
@@ -364,10 +379,11 @@ class PingConsoleConfigurationTest {
             null);
 
     // then we assert that it is not throwing an exception due to the feature being disabled
-    assertDoesNotThrow(
-        () ->
-            new PingConsoleRunner(
-                consolePingConfiguration, MANAGEMENT_SERVICES, APPLICATION_CONTEXT));
+    assertThatCode(
+            () ->
+                new PingConsoleRunner(
+                    consolePingConfiguration, MANAGEMENT_SERVICES, APPLICATION_CONTEXT))
+        .doesNotThrowAnyException();
   }
 
   @Test

--- a/dist/src/test/java/io/camunda/application/commons/console/ping/PingConsoleRunnerIT.java
+++ b/dist/src/test/java/io/camunda/application/commons/console/ping/PingConsoleRunnerIT.java
@@ -12,8 +12,8 @@ import static com.github.tomakehurst.wiremock.client.WireMock.configureFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -116,6 +116,6 @@ public class PingConsoleRunnerIT {
     final JsonNode expected = mapper.readTree(expectedBody);
     final JsonNode actual = mapper.readTree(actualBody);
 
-    assertEquals(expected, actual, "JSON payload did not match expected structure");
+    assertThat(actual).as("JSON payload did not match expected structure").isEqualTo(expected);
   }
 }

--- a/document/store/src/test/java/io/camunda/document/store/aws/AwsDocumentStoreProviderTest.java
+++ b/document/store/src/test/java/io/camunda/document/store/aws/AwsDocumentStoreProviderTest.java
@@ -8,8 +8,7 @@
 package io.camunda.document.store.aws;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -48,7 +47,7 @@ public class AwsDocumentStoreProviderTest {
           provider.createDocumentStore(configuration, Executors.newSingleThreadExecutor());
 
       // then
-      assertNotNull(documentStore);
+      assertThat(documentStore).isNotNull();
     }
   }
 
@@ -62,9 +61,12 @@ public class AwsDocumentStoreProviderTest {
 
     // when / then
     final var ex =
-        assertThrows(
-            IllegalArgumentException.class,
-            () -> provider.createDocumentStore(configuration, Executors.newSingleThreadExecutor()));
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(
+                () ->
+                    provider.createDocumentStore(
+                        configuration, Executors.newSingleThreadExecutor()))
+            .actual();
     assertThat(ex.getMessage())
         .isEqualTo(
             "Failed to configure document store with id 'my-aws': missing required property 'BUCKET'");
@@ -84,9 +86,12 @@ public class AwsDocumentStoreProviderTest {
 
     // when / then
     final var ex =
-        assertThrows(
-            IllegalArgumentException.class,
-            () -> provider.createDocumentStore(configuration, Executors.newSingleThreadExecutor()));
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(
+                () ->
+                    provider.createDocumentStore(
+                        configuration, Executors.newSingleThreadExecutor()))
+            .actual();
     assertThat(ex.getMessage())
         .isEqualTo(
             "Failed to configure document store with id 'aws': 'BUCKET_TTL must be a number'");
@@ -107,9 +112,12 @@ public class AwsDocumentStoreProviderTest {
 
     // when / then
     final var ex =
-        assertThrows(
-            IllegalArgumentException.class,
-            () -> provider.createDocumentStore(configuration, Executors.newSingleThreadExecutor()));
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(
+                () ->
+                    provider.createDocumentStore(
+                        configuration, Executors.newSingleThreadExecutor()))
+            .actual();
     assertThat(ex.getMessage())
         .isEqualTo(
             "Failed to configure document store with id 'aws': 'BUCKET_PATH is invalid. Must not contain \\ character'");

--- a/document/store/src/test/java/io/camunda/document/store/aws/AwsDocumentStoreTest.java
+++ b/document/store/src/test/java/io/camunda/document/store/aws/AwsDocumentStoreTest.java
@@ -9,7 +9,6 @@ package io.camunda.document.store.aws;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import io.camunda.document.api.*;
@@ -107,8 +106,8 @@ class AwsDocumentStoreTest {
     final var result = documentStore.createDocument(request).join();
 
     // then
-    assertTrue(result.isRight());
-    assertEquals(documentId, result.get().documentId());
+    assertThat(result.isRight()).isTrue();
+    assertThat(result.get().documentId()).isEqualTo(documentId);
 
     final var putRequestCaptor = ArgumentCaptor.forClass(PutObjectRequest.class);
     verify(s3Client).putObject(putRequestCaptor.capture(), any(RequestBody.class));
@@ -142,8 +141,8 @@ class AwsDocumentStoreTest {
     final var result = documentStore.createDocument(request).join();
 
     // then
-    assertTrue(result.isLeft());
-    assertInstanceOf(DocumentAlreadyExists.class, result.getLeft());
+    assertThat(result.isLeft()).isTrue();
+    assertThat(result.getLeft()).isInstanceOf(DocumentAlreadyExists.class);
   }
 
   @Test
@@ -173,7 +172,7 @@ class AwsDocumentStoreTest {
 
     // then
     verify(s3Client).putObject(putObjectRequestCaptor.capture(), any(RequestBody.class));
-    assertEquals("NoAutoDelete=true", putObjectRequestCaptor.getValue().tagging());
+    assertThat(putObjectRequestCaptor.getValue().tagging()).isEqualTo("NoAutoDelete=true");
   }
 
   @Test
@@ -190,8 +189,8 @@ class AwsDocumentStoreTest {
     final var result = documentStore.createDocument(request).join();
 
     // then
-    assertTrue(result.isLeft());
-    assertInstanceOf(UnknownDocumentError.class, result.getLeft());
+    assertThat(result.isLeft()).isTrue();
+    assertThat(result.getLeft()).isInstanceOf(UnknownDocumentError.class);
   }
 
   @Test
@@ -209,8 +208,8 @@ class AwsDocumentStoreTest {
     final var result = documentStore.getDocument(documentId).join();
 
     // then
-    assertTrue(result.isRight());
-    assertEquals(expectedResponse, result.get());
+    assertThat(result.isRight()).isTrue();
+    assertThat(result.get()).isEqualTo(expectedResponse);
   }
 
   @Test
@@ -225,8 +224,8 @@ class AwsDocumentStoreTest {
     final var result = documentStore.getDocument(documentId).join();
 
     // then
-    assertTrue(result.isLeft());
-    assertInstanceOf(DocumentNotFound.class, result.getLeft());
+    assertThat(result.isLeft()).isTrue();
+    assertThat(result.getLeft()).isInstanceOf(DocumentNotFound.class);
     verify(s3Client).getObject(any(GetObjectRequest.class));
   }
 
@@ -244,8 +243,8 @@ class AwsDocumentStoreTest {
     final var result = documentStore.getDocument(documentId).join();
 
     // then
-    assertTrue(result.isLeft());
-    assertInstanceOf(DocumentNotFound.class, result.getLeft());
+    assertThat(result.isLeft()).isTrue();
+    assertThat(result.getLeft()).isInstanceOf(DocumentNotFound.class);
   }
 
   @Test
@@ -262,7 +261,7 @@ class AwsDocumentStoreTest {
     final var result = documentStore.verifyContentHash(documentId, contentHash).join();
 
     // then
-    assertTrue(result.isRight());
+    assertThat(result.isRight()).isTrue();
   }
 
   @Test
@@ -279,8 +278,8 @@ class AwsDocumentStoreTest {
     final var result = documentStore.verifyContentHash(documentId, "wronHash").join();
 
     // then
-    assertTrue(result.isLeft());
-    assertInstanceOf(DocumentHashMismatch.class, result.getLeft());
+    assertThat(result.isLeft()).isTrue();
+    assertThat(result.getLeft()).isInstanceOf(DocumentHashMismatch.class);
   }
 
   @Test
@@ -296,8 +295,8 @@ class AwsDocumentStoreTest {
     final var result = documentStore.verifyContentHash(documentId, contentHash).join();
 
     // then
-    assertTrue(result.isLeft());
-    assertInstanceOf(DocumentNotFound.class, result.getLeft());
+    assertThat(result.isLeft()).isTrue();
+    assertThat(result.getLeft()).isInstanceOf(DocumentNotFound.class);
   }
 
   @Test
@@ -313,8 +312,8 @@ class AwsDocumentStoreTest {
     final var result = documentStore.verifyContentHash(documentId, contentHash).join();
 
     // then
-    assertTrue(result.isLeft());
-    assertInstanceOf(InvalidInput.class, result.getLeft());
+    assertThat(result.isLeft()).isTrue();
+    assertThat(result.getLeft()).isInstanceOf(InvalidInput.class);
   }
 
   @Test
@@ -330,8 +329,8 @@ class AwsDocumentStoreTest {
     final var result = documentStore.verifyContentHash(documentId, contentHash).join();
 
     // then
-    assertTrue(result.isLeft());
-    assertInstanceOf(InvalidInput.class, result.getLeft());
+    assertThat(result.isLeft()).isTrue();
+    assertThat(result.getLeft()).isInstanceOf(InvalidInput.class);
   }
 
   @Test
@@ -346,8 +345,8 @@ class AwsDocumentStoreTest {
     final var result = documentStore.verifyContentHash(documentId, contentHash).join();
 
     // then
-    assertTrue(result.isLeft());
-    assertInstanceOf(UnknownDocumentError.class, result.getLeft());
+    assertThat(result.isLeft()).isTrue();
+    assertThat(result.getLeft()).isInstanceOf(UnknownDocumentError.class);
   }
 
   @Test
@@ -360,9 +359,10 @@ class AwsDocumentStoreTest {
     final var result = documentStore.createLink(documentId, durationInMillis).join();
 
     // then
-    assertTrue(result.isLeft());
-    assertInstanceOf(InvalidInput.class, result.getLeft());
-    assertEquals("Duration must be greater than 0", ((InvalidInput) result.getLeft()).message());
+    assertThat(result.isLeft()).isTrue();
+    assertThat(result.getLeft()).isInstanceOf(InvalidInput.class);
+    assertThat(((InvalidInput) result.getLeft()).message())
+        .isEqualTo("Duration must be greater than 0");
   }
 
   @Test
@@ -377,8 +377,8 @@ class AwsDocumentStoreTest {
     final var result = documentStore.createLink(documentId, durationInMillis).join();
 
     // then
-    assertTrue(result.isLeft());
-    assertInstanceOf(DocumentNotFound.class, result.getLeft());
+    assertThat(result.isLeft()).isTrue();
+    assertThat(result.getLeft()).isInstanceOf(DocumentNotFound.class);
   }
 
   @Test
@@ -396,8 +396,8 @@ class AwsDocumentStoreTest {
     final var result = documentStore.createLink(documentId, durationInMillis).join();
 
     // then
-    assertTrue(result.isLeft());
-    assertInstanceOf(DocumentNotFound.class, result.getLeft());
+    assertThat(result.isLeft()).isTrue();
+    assertThat(result.getLeft()).isInstanceOf(DocumentNotFound.class);
   }
 
   @Test
@@ -421,9 +421,9 @@ class AwsDocumentStoreTest {
     final var result = documentStore.createLink(documentId, durationInMillis).join();
 
     // then
-    assertTrue(result.isRight());
+    assertThat(result.isRight()).isTrue();
     final DocumentLink documentLink = result.get();
-    assertEquals("https://example.com", documentLink.link());
+    assertThat(documentLink.link()).isEqualTo("https://example.com");
 
     // Assert expiration time is within 1 second of the expected expiration time
     final OffsetDateTime expectedExpiration =
@@ -432,8 +432,9 @@ class AwsDocumentStoreTest {
     final Duration durationBetween = Duration.between(expectedExpiration, actualExpiration);
 
     // Assert that the difference between expected and actual expiration is within 1 second
-    assertTrue(
-        durationBetween.abs().getSeconds() <= 1, "Expiration times differ by more than 1 second");
+    assertThat(durationBetween.abs().getSeconds() <= 1)
+        .as("Expiration times differ by more than 1 second")
+        .isTrue();
   }
 
   @Test
@@ -449,8 +450,8 @@ class AwsDocumentStoreTest {
     final var result = documentStore.createLink(documentId, durationInMillis).join();
 
     // then
-    assertTrue(result.isLeft());
-    assertInstanceOf(UnknownDocumentError.class, result.getLeft());
+    assertThat(result.isLeft()).isTrue();
+    assertThat(result.getLeft()).isInstanceOf(UnknownDocumentError.class);
   }
 
   @Test

--- a/document/store/src/test/java/io/camunda/document/store/gcp/GcpDocumentStoreProviderTest.java
+++ b/document/store/src/test/java/io/camunda/document/store/gcp/GcpDocumentStoreProviderTest.java
@@ -8,8 +8,7 @@
 package io.camunda.document.store.gcp;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 
 import io.camunda.document.api.DocumentStore;
 import io.camunda.document.api.DocumentStoreConfiguration.DocumentStoreConfigurationRecord;
@@ -33,7 +32,7 @@ public class GcpDocumentStoreProviderTest {
         provider.createDocumentStore(configuration, Executors.newSingleThreadExecutor());
 
     // then
-    assertNotNull(documentStore);
+    assertThat(documentStore).isNotNull();
   }
 
   @Test
@@ -46,9 +45,12 @@ public class GcpDocumentStoreProviderTest {
 
     // when / then
     final var ex =
-        assertThrows(
-            IllegalArgumentException.class,
-            () -> provider.createDocumentStore(configuration, Executors.newSingleThreadExecutor()));
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(
+                () ->
+                    provider.createDocumentStore(
+                        configuration, Executors.newSingleThreadExecutor()))
+            .actual();
     assertThat(ex.getMessage())
         .isEqualTo(
             "Failed to configure document store with id 'my-gcp': missing required property 'BUCKET'");
@@ -68,7 +70,7 @@ public class GcpDocumentStoreProviderTest {
         provider.createDocumentStore(configuration, Executors.newSingleThreadExecutor());
 
     // then
-    assertNotNull(documentStore);
+    assertThat(documentStore).isNotNull();
   }
 
   @Test
@@ -86,6 +88,6 @@ public class GcpDocumentStoreProviderTest {
         provider.createDocumentStore(configuration, Executors.newSingleThreadExecutor());
 
     // then
-    assertNotNull(documentStore);
+    assertThat(documentStore).isNotNull();
   }
 }

--- a/document/store/src/test/java/io/camunda/document/store/localstorage/LocalStorageDocumentStoreProviderTest.java
+++ b/document/store/src/test/java/io/camunda/document/store/localstorage/LocalStorageDocumentStoreProviderTest.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.document.store.localstorage;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.document.api.DocumentStore;
 import io.camunda.document.api.DocumentStoreConfiguration.DocumentStoreConfigurationRecord;
@@ -33,6 +33,6 @@ class LocalStorageDocumentStoreProviderTest {
         provider.createDocumentStore(configuration, Executors.newSingleThreadExecutor());
 
     // then
-    assertNotNull(documentStore);
+    assertThat(documentStore).isNotNull();
   }
 }

--- a/document/store/src/test/java/io/camunda/document/store/localstorage/LocalStorageDocumentStoreTest.java
+++ b/document/store/src/test/java/io/camunda/document/store/localstorage/LocalStorageDocumentStoreTest.java
@@ -9,7 +9,6 @@ package io.camunda.document.store.localstorage;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mockStatic;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -64,15 +63,16 @@ class LocalStorageDocumentStoreTest {
     final var result = documentStore.createDocument(request).join();
 
     // then
-    assertTrue(result.isRight());
+    assertThat(result.isRight()).isTrue();
     final var documentReference = result.get();
-    assertEquals(documentId, documentReference.documentId());
-    assertEquals(
-        "577bac45ad58fe5ee4e7f50d2d39a955d65baa825a61a970ba790d579f78e40e",
-        documentReference.contentHash());
-    assertTrue(Files.exists(storagePath.resolve(documentId)));
-    assertTrue(
-        Files.exists(storagePath.resolve(documentId + LocalStorageDocumentStore.METADATA_SUFFIX)));
+    assertThat(documentReference.documentId()).isEqualTo(documentId);
+    assertThat(documentReference.contentHash())
+        .isEqualTo("577bac45ad58fe5ee4e7f50d2d39a955d65baa825a61a970ba790d579f78e40e");
+    assertThat(Files.exists(storagePath.resolve(documentId))).isTrue();
+    assertThat(
+            Files.exists(
+                storagePath.resolve(documentId + LocalStorageDocumentStore.METADATA_SUFFIX)))
+        .isTrue();
   }
 
   @Test
@@ -88,13 +88,15 @@ class LocalStorageDocumentStoreTest {
     final var result = documentStore.createDocument(request).join();
 
     // then
-    assertTrue(result.isRight());
+    assertThat(result.isRight()).isTrue();
 
     final var documentId = result.get().documentId();
     assertThat(documentId).isNotNull();
-    assertTrue(Files.exists(storagePath.resolve(documentId)));
-    assertTrue(
-        Files.exists(storagePath.resolve(documentId + LocalStorageDocumentStore.METADATA_SUFFIX)));
+    assertThat(Files.exists(storagePath.resolve(documentId))).isTrue();
+    assertThat(
+            Files.exists(
+                storagePath.resolve(documentId + LocalStorageDocumentStore.METADATA_SUFFIX)))
+        .isTrue();
   }
 
   @Test
@@ -112,8 +114,8 @@ class LocalStorageDocumentStoreTest {
     final var result = documentStore.createDocument(request).join();
 
     // then
-    assertTrue(result.isLeft());
-    assertInstanceOf(DocumentAlreadyExists.class, result.getLeft());
+    assertThat(result.isLeft()).isTrue();
+    assertThat(result.getLeft()).isInstanceOf(DocumentAlreadyExists.class);
   }
 
   @ParameterizedTest
@@ -131,7 +133,7 @@ class LocalStorageDocumentStoreTest {
     final var result = documentStore.createDocument(request).join();
 
     // then
-    assertInstanceOf(InvalidInput.class, result.getLeft());
+    assertThat(result.getLeft()).isInstanceOf(InvalidInput.class);
   }
 
   @Test
@@ -145,8 +147,8 @@ class LocalStorageDocumentStoreTest {
     final var result = documentStore.getDocument(documentId).join();
 
     // then
-    assertTrue(result.isRight());
-    assertNotNull(result.get().inputStream());
+    assertThat(result.isRight()).isTrue();
+    assertThat(result.get().inputStream()).isNotNull();
   }
 
   @Test
@@ -158,8 +160,8 @@ class LocalStorageDocumentStoreTest {
     final var result = documentStore.getDocument(documentId).join();
 
     // then
-    assertTrue(result.isLeft());
-    assertInstanceOf(DocumentNotFound.class, result.getLeft());
+    assertThat(result.isLeft()).isTrue();
+    assertThat(result.getLeft()).isInstanceOf(DocumentNotFound.class);
   }
 
   @ParameterizedTest
@@ -169,7 +171,7 @@ class LocalStorageDocumentStoreTest {
     final var result = documentStore.getDocument(documentId).join();
 
     // then
-    assertInstanceOf(InvalidInput.class, result.getLeft());
+    assertThat(result.getLeft()).isInstanceOf(InvalidInput.class);
   }
 
   @Test
@@ -183,10 +185,12 @@ class LocalStorageDocumentStoreTest {
     final var result = documentStore.deleteDocument(documentId).join();
 
     // then
-    assertTrue(result.isRight());
-    assertFalse(Files.exists(storagePath.resolve(documentId)));
-    assertFalse(
-        Files.exists(storagePath.resolve(documentId + LocalStorageDocumentStore.METADATA_SUFFIX)));
+    assertThat(result.isRight()).isTrue();
+    assertThat(Files.exists(storagePath.resolve(documentId))).isFalse();
+    assertThat(
+            Files.exists(
+                storagePath.resolve(documentId + LocalStorageDocumentStore.METADATA_SUFFIX)))
+        .isFalse();
   }
 
   @Test
@@ -199,8 +203,8 @@ class LocalStorageDocumentStoreTest {
     final var result = documentStore.createLink(documentId, durationInMillis).join();
 
     // then
-    assertTrue(result.isLeft());
-    assertInstanceOf(OperationNotSupported.class, result.getLeft());
+    assertThat(result.isLeft()).isTrue();
+    assertThat(result.getLeft()).isInstanceOf(OperationNotSupported.class);
   }
 
   @Test
@@ -216,7 +220,7 @@ class LocalStorageDocumentStoreTest {
     final var result = documentStore.verifyContentHash(documentId, contentHash).join();
 
     // then
-    assertTrue(result.isRight());
+    assertThat(result.isRight()).isTrue();
   }
 
   @Test
@@ -230,8 +234,8 @@ class LocalStorageDocumentStoreTest {
     final var result = documentStore.verifyContentHash(documentId, "incorrect-hash").join();
 
     // then
-    assertTrue(result.isLeft());
-    assertInstanceOf(DocumentHashMismatch.class, result.getLeft());
+    assertThat(result.isLeft()).isTrue();
+    assertThat(result.getLeft()).isInstanceOf(DocumentHashMismatch.class);
   }
 
   @Test
@@ -243,8 +247,8 @@ class LocalStorageDocumentStoreTest {
     final var result = documentStore.verifyContentHash(documentId, "contentHash").join();
 
     // then
-    assertTrue(result.isLeft());
-    assertInstanceOf(DocumentNotFound.class, result.getLeft());
+    assertThat(result.isLeft()).isTrue();
+    assertThat(result.getLeft()).isInstanceOf(DocumentNotFound.class);
   }
 
   @Test

--- a/migration/identity-migration/src/test/java/io/camunda/migration/identity/client/ConsoleClientIT.java
+++ b/migration/identity-migration/src/test/java/io/camunda/migration/identity/client/ConsoleClientIT.java
@@ -13,8 +13,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
@@ -108,19 +107,19 @@ public class ConsoleClientIT {
   @Test
   void testFetchMembers() {
     final ConsoleClient.Members members = consoleClient.fetchMembers();
-    assertNotNull(members);
-    assertEquals(1, members.members().size());
-    assertEquals("John Doe", members.members().getFirst().name());
-    assertEquals("user123", members.members().getFirst().userId());
-    assertEquals("user@example.com", members.members().getFirst().email());
-    assertEquals(2, members.members().getFirst().roles().size());
-    assertEquals(Role.ADMIN, members.members().getFirst().roles().get(0));
-    assertEquals(Role.DEVELOPER, members.members().getFirst().roles().get(1));
-    assertEquals(1, members.clients().size());
-    assertEquals("console-client", members.clients().getFirst().name());
-    assertEquals("client123", members.clients().getFirst().clientId());
-    assertEquals(2, members.clients().getFirst().permissions().size());
-    assertEquals(Permission.OPERATE, members.clients().getFirst().permissions().get(0));
-    assertEquals(Permission.ZEEBE, members.clients().getFirst().permissions().get(1));
+    assertThat(members).isNotNull();
+    assertThat(members.members().size()).isEqualTo(1);
+    assertThat(members.members().getFirst().name()).isEqualTo("John Doe");
+    assertThat(members.members().getFirst().userId()).isEqualTo("user123");
+    assertThat(members.members().getFirst().email()).isEqualTo("user@example.com");
+    assertThat(members.members().getFirst().roles().size()).isEqualTo(2);
+    assertThat(members.members().getFirst().roles().get(0)).isEqualTo(Role.ADMIN);
+    assertThat(members.members().getFirst().roles().get(1)).isEqualTo(Role.DEVELOPER);
+    assertThat(members.clients().size()).isEqualTo(1);
+    assertThat(members.clients().getFirst().name()).isEqualTo("console-client");
+    assertThat(members.clients().getFirst().clientId()).isEqualTo("client123");
+    assertThat(members.clients().getFirst().permissions().size()).isEqualTo(2);
+    assertThat(members.clients().getFirst().permissions().get(0)).isEqualTo(Permission.OPERATE);
+    assertThat(members.clients().getFirst().permissions().get(1)).isEqualTo(Permission.ZEEBE);
   }
 }

--- a/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/saas/GroupMigrationHandlerTest.java
+++ b/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/saas/GroupMigrationHandlerTest.java
@@ -8,7 +8,7 @@
 package io.camunda.migration.identity.handler.saas;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.never;
@@ -70,7 +70,7 @@ public class GroupMigrationHandlerTest {
     when(consoleClient.fetchMembers()).thenReturn(new Members(List.of(), List.of()));
 
     // when
-    assertThrows(NotImplementedException.class, migrationHandler::migrate);
+    assertThatExceptionOfType(NotImplementedException.class).isThrownBy(migrationHandler::migrate);
 
     // then
     verify(managementIdentityClient).fetchGroups(anyInt());

--- a/migration/process-migration/src/test/java/io/camunda/migration/process/it/ProcessMigratorIT.java
+++ b/migration/process-migration/src/test/java/io/camunda/migration/process/it/ProcessMigratorIT.java
@@ -8,7 +8,7 @@
 package io.camunda.migration.process.it;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 
 import io.camunda.migration.api.MigrationException;
 import io.camunda.migration.process.ProcessMigrator;
@@ -386,7 +386,8 @@ public class ProcessMigratorIT extends AdapterTest {
     properties.getRetry().setMaxRetries(2);
     properties.getRetry().setMinRetryDelay(Duration.ofSeconds(1));
 
-    final var ex = assertThrows(MigrationException.class, migrator::call);
+    final var ex =
+        assertThatExceptionOfType(MigrationException.class).isThrownBy(migrator::call).actual();
     assertThat(ex.getMessage()).isEqualTo("Failed to fetch last migrated process");
   }
 

--- a/operate/common/src/test/java/io/camunda/operate/connect/OpensearchConnectorTest.java
+++ b/operate/common/src/test/java/io/camunda/operate/connect/OpensearchConnectorTest.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.operate.connect;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -85,7 +85,7 @@ public class OpensearchConnectorTest {
     final OpenSearchAsyncClient client =
         opensearchConnector.createAsyncOsClient(opensearchProperties, new PluginRepository());
 
-    assertEquals(AwsSdk2Transport.class, client._transport().getClass());
+    assertThat(client._transport().getClass()).isEqualTo(AwsSdk2Transport.class);
   }
 
   @Test
@@ -102,7 +102,7 @@ public class OpensearchConnectorTest {
     final OpenSearchAsyncClient client =
         spyConnector.createAsyncOsClient(opensearchProperties, new PluginRepository());
 
-    assertEquals(ApacheHttpClient5Transport.class, client._transport().getClass());
+    assertThat(client._transport().getClass()).isEqualTo(ApacheHttpClient5Transport.class);
   }
 
   @Test
@@ -155,7 +155,7 @@ public class OpensearchConnectorTest {
     final OpenSearchClient client =
         opensearchConnector.createOsClient(opensearchProperties, new PluginRepository());
 
-    assertEquals(AwsSdk2Transport.class, client._transport().getClass());
+    assertThat(client._transport().getClass()).isEqualTo(AwsSdk2Transport.class);
   }
 
   @Test
@@ -172,7 +172,7 @@ public class OpensearchConnectorTest {
     final OpenSearchClient client =
         spyConnector.createOsClient(opensearchProperties, new PluginRepository());
 
-    assertEquals(ApacheHttpClient5Transport.class, client._transport().getClass());
+    assertThat(client._transport().getClass()).isEqualTo(ApacheHttpClient5Transport.class);
   }
 
   @Test

--- a/operate/common/src/test/java/io/camunda/operate/connect/OperateDateTimeFormatterTest.java
+++ b/operate/common/src/test/java/io/camunda/operate/connect/OperateDateTimeFormatterTest.java
@@ -8,7 +8,7 @@
 package io.camunda.operate.connect;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -88,28 +88,25 @@ public class OperateDateTimeFormatterTest {
 
     // Validate the datetime formatters were created correctly
     assertThat(underTest.getGeneralDateTimeFormatter().parse(DEFAULT_DATETIMESTRING)).isNotNull();
-    assertThrows(
-        DateTimeParseException.class,
-        () -> underTest.getGeneralDateTimeFormatter().parse(RFC1339_DATETIMESTRING));
+    assertThatExceptionOfType(DateTimeParseException.class)
+        .isThrownBy(() -> underTest.getGeneralDateTimeFormatter().parse(RFC1339_DATETIMESTRING));
     assertThat(underTest.getApiDateTimeFormatter().parse(RFC1339_DATETIMESTRING)).isNotNull();
-    assertThrows(
-        DateTimeParseException.class,
-        () -> underTest.getApiDateTimeFormatter().parse(DEFAULT_DATETIMESTRING));
+    assertThatExceptionOfType(DateTimeParseException.class)
+        .isThrownBy(() -> underTest.getApiDateTimeFormatter().parse(DEFAULT_DATETIMESTRING));
 
     // Validate the parse functions
     assertThat(underTest.parseGeneralDateTime(DEFAULT_DATETIMESTRING)).isNotNull();
-    assertThrows(
-        DateTimeParseException.class, () -> underTest.parseGeneralDateTime(RFC1339_DATETIMESTRING));
+    assertThatExceptionOfType(DateTimeParseException.class)
+        .isThrownBy(() -> underTest.parseGeneralDateTime(RFC1339_DATETIMESTRING));
     assertThat(underTest.parseApiDateTime(RFC1339_DATETIMESTRING)).isNotNull();
-    assertThrows(
-        DateTimeParseException.class, () -> underTest.parseApiDateTime(DEFAULT_DATETIMESTRING));
+    assertThatExceptionOfType(DateTimeParseException.class)
+        .isThrownBy(() -> underTest.parseApiDateTime(DEFAULT_DATETIMESTRING));
 
     // Validate the convert function
     assertThat(underTest.convertGeneralToApiDateTime(DEFAULT_DATETIMESTRING))
         .isEqualTo(RFC1339_DATETIMESTRING);
-    assertThrows(
-        DateTimeParseException.class,
-        () -> underTest.convertGeneralToApiDateTime(RFC1339_DATETIMESTRING));
+    assertThatExceptionOfType(DateTimeParseException.class)
+        .isThrownBy(() -> underTest.convertGeneralToApiDateTime(RFC1339_DATETIMESTRING));
   }
 
   @Test
@@ -133,21 +130,19 @@ public class OperateDateTimeFormatterTest {
 
     // Validate the datetime formatters were created correctly
     assertThat(underTest.getGeneralDateTimeFormatter().parse(DEFAULT_DATETIMESTRING)).isNotNull();
-    assertThrows(
-        DateTimeParseException.class,
-        () -> underTest.getGeneralDateTimeFormatter().parse(RFC1339_DATETIMESTRING));
+    assertThatExceptionOfType(DateTimeParseException.class)
+        .isThrownBy(() -> underTest.getGeneralDateTimeFormatter().parse(RFC1339_DATETIMESTRING));
     assertThat(underTest.getApiDateTimeFormatter().parse(DEFAULT_DATETIMESTRING)).isNotNull();
-    assertThrows(
-        DateTimeParseException.class,
-        () -> underTest.getApiDateTimeFormatter().parse(RFC1339_DATETIMESTRING));
+    assertThatExceptionOfType(DateTimeParseException.class)
+        .isThrownBy(() -> underTest.getApiDateTimeFormatter().parse(RFC1339_DATETIMESTRING));
 
     // Validate the parse functions
     assertThat(underTest.parseGeneralDateTime(DEFAULT_DATETIMESTRING)).isNotNull();
-    assertThrows(
-        DateTimeParseException.class, () -> underTest.parseGeneralDateTime(RFC1339_DATETIMESTRING));
+    assertThatExceptionOfType(DateTimeParseException.class)
+        .isThrownBy(() -> underTest.parseGeneralDateTime(RFC1339_DATETIMESTRING));
     assertThat(underTest.parseApiDateTime(DEFAULT_DATETIMESTRING)).isNotNull();
-    assertThrows(
-        DateTimeParseException.class, () -> underTest.parseApiDateTime(RFC1339_DATETIMESTRING));
+    assertThatExceptionOfType(DateTimeParseException.class)
+        .isThrownBy(() -> underTest.parseApiDateTime(RFC1339_DATETIMESTRING));
 
     // Validate the convert function
     assertThat(underTest.convertGeneralToApiDateTime(DEFAULT_DATETIMESTRING))

--- a/operate/importer-common/src/test/java/io/camunda/operate/zeebeimport/XXEPreventionTest.java
+++ b/operate/importer-common/src/test/java/io/camunda/operate/zeebeimport/XXEPreventionTest.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.operate.zeebeimport;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.operate.zeebeimport.util.XMLUtil;
 import java.io.ByteArrayInputStream;
@@ -49,6 +49,6 @@ public class XXEPreventionTest {
               }
             });
     // the file must not be read
-    assertEquals("", elementContent.toString());
+    assertThat(elementContent.toString()).isEqualTo("");
   }
 }

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/elasticsearch/FlowNodeStatisticsIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/elasticsearch/FlowNodeStatisticsIT.java
@@ -11,7 +11,6 @@ import static io.camunda.operate.qa.util.RestAPITestUtil.createGetAllProcessInst
 import static io.camunda.operate.util.TestUtil.createFlowNodeInstanceWithIncident;
 import static io.camunda.operate.util.TestUtil.createProcessInstance;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -124,9 +123,9 @@ public class FlowNodeStatisticsIT extends OperateAbstractIT {
         mockMvcTestRule.fromResponse(
             getRequest(QUERY_PROCESS_CORE_STATISTICS_URL), ProcessInstanceCoreStatisticsDto.class);
     // then return zero statistics
-    assertEquals(coreStatistics.getActive().longValue(), 0L);
-    assertEquals(coreStatistics.getRunning().longValue(), 0L);
-    assertEquals(coreStatistics.getWithIncidents().longValue(), 0L);
+    assertThat(coreStatistics.getActive().longValue()).isEqualTo(0L);
+    assertThat(coreStatistics.getRunning().longValue()).isEqualTo(0L);
+    assertThat(coreStatistics.getWithIncidents().longValue()).isEqualTo(0L);
 
     // given test data
     createData(PROCESS_KEY_DEMO_PROCESS);
@@ -137,9 +136,9 @@ public class FlowNodeStatisticsIT extends OperateAbstractIT {
         mockMvcTestRule.fromResponse(
             getRequest(QUERY_PROCESS_CORE_STATISTICS_URL), ProcessInstanceCoreStatisticsDto.class);
     // then return non-zero statistics
-    assertEquals(coreStatistics.getActive().longValue(), 6L);
-    assertEquals(coreStatistics.getRunning().longValue(), 12L);
-    assertEquals(coreStatistics.getWithIncidents().longValue(), 6L);
+    assertThat(coreStatistics.getActive().longValue()).isEqualTo(6L);
+    assertThat(coreStatistics.getRunning().longValue()).isEqualTo(12L);
+    assertThat(coreStatistics.getWithIncidents().longValue()).isEqualTo(6L);
   }
 
   @Test

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/it/CallActivityIncidentZeebeIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/it/CallActivityIncidentZeebeIT.java
@@ -14,7 +14,6 @@ import static io.camunda.operate.webapp.rest.ProcessInstanceRestService.PROCESS_
 import static io.camunda.operate.webapp.rest.dto.listview.ProcessInstanceStateDto.ACTIVE;
 import static io.camunda.operate.webapp.rest.dto.listview.ProcessInstanceStateDto.INCIDENT;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import io.camunda.operate.qa.util.RestAPITestUtil;
@@ -120,9 +119,9 @@ public class CallActivityIncidentZeebeIT extends OperateZeebeAbstractIT {
         mockMvcTestRule.fromResponse(
             getRequest(QUERY_PROCESS_CORE_STATISTICS_URL), ProcessInstanceCoreStatisticsDto.class);
     // then return zero statistics
-    assertEquals(6L, coreStatistics.getRunning().longValue());
-    assertEquals(4L, coreStatistics.getActive().longValue());
-    assertEquals(2L, coreStatistics.getWithIncidents().longValue());
+    assertThat(coreStatistics.getRunning().longValue()).isEqualTo(6L);
+    assertThat(coreStatistics.getActive().longValue()).isEqualTo(4L);
+    assertThat(coreStatistics.getWithIncidents().longValue()).isEqualTo(2L);
   }
 
   @Test

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/it/ListenerReaderIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/it/ListenerReaderIT.java
@@ -7,9 +7,7 @@
  */
 package io.camunda.operate.it;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
@@ -57,44 +55,44 @@ public class ListenerReaderIT extends OperateSearchAbstractIT {
     final ListenerResponseDto response = postListenerRequest("111", request);
     final List<ListenerDto> resultListeners = response.getListeners();
 
-    assertEquals(5L, response.getTotalCount());
-    assertEquals(5, resultListeners.size());
+    assertThat(response.getTotalCount()).isEqualTo(5L);
+    assertThat(resultListeners.size()).isEqualTo(5);
     // results should be ordered by finish date (latest first, but no date at the beginning)
     final ListenerDto actual4 = resultListeners.get(0);
-    assertEquals("22", actual4.getListenerKey());
-    assertEquals(ListenerType.TASK_LISTENER, actual4.getListenerType());
-    assertEquals(ListenerEventType.COMPLETING, actual4.getEvent());
-    assertEquals(ListenerState.FAILED, actual4.getState());
-    assertNull(actual4.getTime());
+    assertThat(actual4.getListenerKey()).isEqualTo("22");
+    assertThat(actual4.getListenerType()).isEqualTo(ListenerType.TASK_LISTENER);
+    assertThat(actual4.getEvent()).isEqualTo(ListenerEventType.COMPLETING);
+    assertThat(actual4.getState()).isEqualTo(ListenerState.FAILED);
+    assertThat(actual4.getTime()).isNull();
 
     final ListenerDto actual3 = resultListeners.get(1);
-    assertEquals("21", actual3.getListenerKey());
-    assertEquals(ListenerType.TASK_LISTENER, actual3.getListenerType());
-    assertEquals(ListenerEventType.UPDATING, actual3.getEvent());
-    assertEquals(ListenerState.ACTIVE, actual3.getState());
-    assertNull(actual3.getTime());
+    assertThat(actual3.getListenerKey()).isEqualTo("21");
+    assertThat(actual3.getListenerType()).isEqualTo(ListenerType.TASK_LISTENER);
+    assertThat(actual3.getEvent()).isEqualTo(ListenerEventType.UPDATING);
+    assertThat(actual3.getState()).isEqualTo(ListenerState.ACTIVE);
+    assertThat(actual3.getTime()).isNull();
 
     final ListenerDto actual0 = resultListeners.get(2);
-    assertEquals("12", actual0.getListenerKey());
-    assertEquals(ListenerType.EXECUTION_LISTENER, actual0.getListenerType());
-    assertEquals(ListenerEventType.END, actual0.getEvent());
-    assertEquals(ListenerState.COMPLETED, actual0.getState());
-    assertEquals("test_type", actual0.getJobType());
-    assertNotNull(actual0.getTime());
+    assertThat(actual0.getListenerKey()).isEqualTo("12");
+    assertThat(actual0.getListenerType()).isEqualTo(ListenerType.EXECUTION_LISTENER);
+    assertThat(actual0.getEvent()).isEqualTo(ListenerEventType.END);
+    assertThat(actual0.getState()).isEqualTo(ListenerState.COMPLETED);
+    assertThat(actual0.getJobType()).isEqualTo("test_type");
+    assertThat(actual0.getTime()).isNotNull();
 
     final ListenerDto actual1 = resultListeners.get(3);
-    assertEquals("11", actual1.getListenerKey());
-    assertEquals(ListenerType.EXECUTION_LISTENER, actual1.getListenerType());
-    assertEquals(ListenerEventType.START, actual1.getEvent());
-    assertEquals(ListenerState.COMPLETED, actual1.getState());
-    assertNotNull(actual1.getTime());
+    assertThat(actual1.getListenerKey()).isEqualTo("11");
+    assertThat(actual1.getListenerType()).isEqualTo(ListenerType.EXECUTION_LISTENER);
+    assertThat(actual1.getEvent()).isEqualTo(ListenerEventType.START);
+    assertThat(actual1.getState()).isEqualTo(ListenerState.COMPLETED);
+    assertThat(actual1.getTime()).isNotNull();
 
     final ListenerDto actual2 = resultListeners.get(4);
-    assertEquals("31", actual2.getListenerKey());
-    assertEquals(ListenerType.TASK_LISTENER, actual2.getListenerType());
-    assertEquals(ListenerEventType.ASSIGNING, actual2.getEvent());
-    assertEquals(ListenerState.UNKNOWN, actual2.getState());
-    assertNotNull(actual2.getTime());
+    assertThat(actual2.getListenerKey()).isEqualTo("31");
+    assertThat(actual2.getListenerType()).isEqualTo(ListenerType.TASK_LISTENER);
+    assertThat(actual2.getEvent()).isEqualTo(ListenerEventType.ASSIGNING);
+    assertThat(actual2.getState()).isEqualTo(ListenerState.UNKNOWN);
+    assertThat(actual2.getTime()).isNotNull();
   }
 
   @Test
@@ -104,30 +102,30 @@ public class ListenerReaderIT extends OperateSearchAbstractIT {
     final ListenerResponseDto response = postListenerRequest("111", request);
     final List<ListenerDto> resultListeners = response.getListeners();
 
-    assertEquals(3L, response.getTotalCount());
-    assertEquals(3, resultListeners.size());
+    assertThat(response.getTotalCount()).isEqualTo(3L);
+    assertThat(resultListeners.size()).isEqualTo(3);
     // results should only contain listeners with set flowNodeInstanceId == 1L
     final ListenerDto actual0 = resultListeners.get(0);
-    assertEquals("21", actual0.getListenerKey());
-    assertEquals(ListenerType.TASK_LISTENER, actual0.getListenerType());
-    assertEquals(ListenerEventType.UPDATING, actual0.getEvent());
-    assertEquals(ListenerState.ACTIVE, actual0.getState());
-    assertNull(actual0.getTime());
+    assertThat(actual0.getListenerKey()).isEqualTo("21");
+    assertThat(actual0.getListenerType()).isEqualTo(ListenerType.TASK_LISTENER);
+    assertThat(actual0.getEvent()).isEqualTo(ListenerEventType.UPDATING);
+    assertThat(actual0.getState()).isEqualTo(ListenerState.ACTIVE);
+    assertThat(actual0.getTime()).isNull();
 
     final ListenerDto actual1 = resultListeners.get(1);
-    assertEquals("12", actual1.getListenerKey());
-    assertEquals(ListenerType.EXECUTION_LISTENER, actual1.getListenerType());
-    assertEquals(ListenerEventType.END, actual1.getEvent());
-    assertEquals(ListenerState.COMPLETED, actual1.getState());
-    assertEquals("test_type", actual1.getJobType());
-    assertNotNull(actual1.getTime());
+    assertThat(actual1.getListenerKey()).isEqualTo("12");
+    assertThat(actual1.getListenerType()).isEqualTo(ListenerType.EXECUTION_LISTENER);
+    assertThat(actual1.getEvent()).isEqualTo(ListenerEventType.END);
+    assertThat(actual1.getState()).isEqualTo(ListenerState.COMPLETED);
+    assertThat(actual1.getJobType()).isEqualTo("test_type");
+    assertThat(actual1.getTime()).isNotNull();
 
     final ListenerDto actual2 = resultListeners.get(2);
-    assertEquals("11", actual2.getListenerKey());
-    assertEquals(ListenerType.EXECUTION_LISTENER, actual2.getListenerType());
-    assertEquals(ListenerEventType.START, actual2.getEvent());
-    assertEquals(ListenerState.COMPLETED, actual2.getState());
-    assertNotNull(actual2.getTime());
+    assertThat(actual2.getListenerKey()).isEqualTo("11");
+    assertThat(actual2.getListenerType()).isEqualTo(ListenerType.EXECUTION_LISTENER);
+    assertThat(actual2.getEvent()).isEqualTo(ListenerEventType.START);
+    assertThat(actual2.getState()).isEqualTo(ListenerState.COMPLETED);
+    assertThat(actual2.getTime()).isNotNull();
   }
 
   @Test
@@ -137,12 +135,12 @@ public class ListenerReaderIT extends OperateSearchAbstractIT {
     final ListenerResponseDto response1 = postListenerRequest("111", request1);
     final List<ListenerDto> resultListeners1 = response1.getListeners();
 
-    assertEquals(5L, response1.getTotalCount());
-    assertEquals(3, resultListeners1.size());
+    assertThat(response1.getTotalCount()).isEqualTo(5L);
+    assertThat(resultListeners1.size()).isEqualTo(3);
 
-    assertEquals("22", resultListeners1.get(0).getListenerKey());
-    assertEquals("21", resultListeners1.get(1).getListenerKey());
-    assertEquals("12", resultListeners1.get(2).getListenerKey());
+    assertThat(resultListeners1.get(0).getListenerKey()).isEqualTo("22");
+    assertThat(resultListeners1.get(1).getListenerKey()).isEqualTo("21");
+    assertThat(resultListeners1.get(2).getListenerKey()).isEqualTo("12");
 
     // next page - test searchAfter
     final SortValuesWrapper[] sortValuesAfter = resultListeners1.get(2).getSortValues();
@@ -154,11 +152,11 @@ public class ListenerReaderIT extends OperateSearchAbstractIT {
     final ListenerResponseDto response2 = postListenerRequest("111", request2);
     final List<ListenerDto> resultListeners2 = response2.getListeners();
 
-    assertEquals(5L, response2.getTotalCount());
-    assertEquals(2, resultListeners2.size());
+    assertThat(response2.getTotalCount()).isEqualTo(5L);
+    assertThat(resultListeners2.size()).isEqualTo(2);
 
-    assertEquals("11", resultListeners2.get(0).getListenerKey());
-    assertEquals("31", resultListeners2.get(1).getListenerKey());
+    assertThat(resultListeners2.get(0).getListenerKey()).isEqualTo("11");
+    assertThat(resultListeners2.get(1).getListenerKey()).isEqualTo("31");
 
     // test searchBefore (from last result)
     final SortValuesWrapper[] sortValuesBefore = resultListeners2.get(1).getSortValues();
@@ -170,12 +168,12 @@ public class ListenerReaderIT extends OperateSearchAbstractIT {
     final ListenerResponseDto response3 = postListenerRequest("111", request3);
     final List<ListenerDto> resultListeners3 = response3.getListeners();
 
-    assertEquals(5L, response3.getTotalCount());
-    assertEquals(3, resultListeners3.size());
+    assertThat(response3.getTotalCount()).isEqualTo(5L);
+    assertThat(resultListeners3.size()).isEqualTo(3);
 
-    assertEquals("21", resultListeners3.get(0).getListenerKey());
-    assertEquals("12", resultListeners3.get(1).getListenerKey());
-    assertEquals("11", resultListeners3.get(2).getListenerKey());
+    assertThat(resultListeners3.get(0).getListenerKey()).isEqualTo("21");
+    assertThat(resultListeners3.get(1).getListenerKey()).isEqualTo("12");
+    assertThat(resultListeners3.get(2).getListenerKey()).isEqualTo("11");
   }
 
   @Test
@@ -189,16 +187,16 @@ public class ListenerReaderIT extends OperateSearchAbstractIT {
     final ListenerResponseDto elResponse = postListenerRequest("111", elRequest);
     final List<ListenerDto> elResultListeners = elResponse.getListeners();
 
-    assertEquals(2L, elResponse.getTotalCount());
-    assertEquals(2, elResultListeners.size());
+    assertThat(elResponse.getTotalCount()).isEqualTo(2L);
+    assertThat(elResultListeners.size()).isEqualTo(2);
 
     final ListenerDto actual0 = elResultListeners.get(0);
-    assertEquals("12", actual0.getListenerKey());
-    assertEquals(ListenerType.EXECUTION_LISTENER, actual0.getListenerType());
+    assertThat(actual0.getListenerKey()).isEqualTo("12");
+    assertThat(actual0.getListenerType()).isEqualTo(ListenerType.EXECUTION_LISTENER);
 
     final ListenerDto actual1 = elResultListeners.get(1);
-    assertEquals("11", actual1.getListenerKey());
-    assertEquals(ListenerType.EXECUTION_LISTENER, actual1.getListenerType());
+    assertThat(actual1.getListenerKey()).isEqualTo("11");
+    assertThat(actual1.getListenerType()).isEqualTo(ListenerType.EXECUTION_LISTENER);
 
     // Request only Task Listeners
     final ListenerRequestDto tlRequest =
@@ -209,20 +207,20 @@ public class ListenerReaderIT extends OperateSearchAbstractIT {
     final ListenerResponseDto tlResponse = postListenerRequest("111", tlRequest);
     final List<ListenerDto> tlResultListeners = tlResponse.getListeners();
 
-    assertEquals(3L, tlResponse.getTotalCount());
-    assertEquals(3, tlResultListeners.size());
+    assertThat(tlResponse.getTotalCount()).isEqualTo(3L);
+    assertThat(tlResultListeners.size()).isEqualTo(3);
 
     final ListenerDto actual4 = tlResultListeners.get(0);
-    assertEquals("22", actual4.getListenerKey());
-    assertEquals(ListenerType.TASK_LISTENER, actual4.getListenerType());
+    assertThat(actual4.getListenerKey()).isEqualTo("22");
+    assertThat(actual4.getListenerType()).isEqualTo(ListenerType.TASK_LISTENER);
 
     final ListenerDto actual3 = tlResultListeners.get(1);
-    assertEquals("21", actual3.getListenerKey());
-    assertEquals(ListenerType.TASK_LISTENER, actual3.getListenerType());
+    assertThat(actual3.getListenerKey()).isEqualTo("21");
+    assertThat(actual3.getListenerType()).isEqualTo(ListenerType.TASK_LISTENER);
 
     final ListenerDto actual2 = tlResultListeners.get(2);
-    assertEquals("31", actual2.getListenerKey());
-    assertEquals(ListenerType.TASK_LISTENER, actual2.getListenerType());
+    assertThat(actual2.getListenerKey()).isEqualTo("31");
+    assertThat(actual2.getListenerType()).isEqualTo(ListenerType.TASK_LISTENER);
   }
 
   private void createData() throws IOException {

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/it/ProcessInstanceReaderIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/it/ProcessInstanceReaderIT.java
@@ -8,7 +8,7 @@
 package io.camunda.operate.it;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 
 import io.camunda.operate.store.NotFoundException;
 import io.camunda.operate.util.j5templates.OperateSearchAbstractIT;
@@ -100,13 +100,13 @@ public class ProcessInstanceReaderIT extends OperateSearchAbstractIT {
 
   @Test
   public void testGetProcessInstanceWithInvalidKey() {
-    assertThrows(NotFoundException.class, () -> processInstanceReader.getProcessInstanceByKey(1L));
+    assertThatExceptionOfType(NotFoundException.class)
+        .isThrownBy(() -> processInstanceReader.getProcessInstanceByKey(1L));
   }
 
   @Test
   public void testGetProcessInstanceWithOperationsWithInvalidKey() {
-    assertThrows(
-        NotFoundException.class,
-        () -> processInstanceReader.getProcessInstanceWithOperationsByKey(1L));
+    assertThatExceptionOfType(NotFoundException.class)
+        .isThrownBy(() -> processInstanceReader.getProcessInstanceWithOperationsByKey(1L));
   }
 }

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/it/ProcessInstanceWriterIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/it/ProcessInstanceWriterIT.java
@@ -8,7 +8,7 @@
 package io.camunda.operate.it;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 
 import io.camunda.operate.store.NotFoundException;
 import io.camunda.operate.util.j5templates.OperateSearchAbstractIT;
@@ -79,10 +79,11 @@ public class ProcessInstanceWriterIT extends OperateSearchAbstractIT {
 
     searchContainerManager.refreshIndices("*operate*");
 
-    assertThrows(
-        NotFoundException.class,
-        () ->
-            processInstanceReader.getProcessInstanceByKey(processInstance.getProcessInstanceKey()));
+    assertThatExceptionOfType(NotFoundException.class)
+        .isThrownBy(
+            () ->
+                processInstanceReader.getProcessInstanceByKey(
+                    processInstance.getProcessInstanceKey()));
     assertThatDependantsAreAlsoDeleted(processInstanceKey);
   }
 
@@ -122,9 +123,8 @@ public class ProcessInstanceWriterIT extends OperateSearchAbstractIT {
 
     searchContainerManager.refreshIndices("*operate*");
 
-    assertThrows(
-        NotFoundException.class,
-        () -> processInstanceReader.getProcessInstanceByKey(processInstanceKey));
+    assertThatExceptionOfType(NotFoundException.class)
+        .isThrownBy(() -> processInstanceReader.getProcessInstanceByKey(processInstanceKey));
     assertThatDependantsAreAlsoDeleted(processInstanceKey);
   }
 
@@ -150,9 +150,8 @@ public class ProcessInstanceWriterIT extends OperateSearchAbstractIT {
 
     searchContainerManager.refreshIndices("*operate*");
 
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> processInstanceWriter.deleteInstanceById(processInstanceKey));
+    assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(() -> processInstanceWriter.deleteInstanceById(processInstanceKey));
 
     // Cleanup so as not to interfere with other tests
     processInstance.setState(ProcessInstanceState.COMPLETED);

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/MockMvcTestRule.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/MockMvcTestRule.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.operate.util;
 
-import static org.junit.Assert.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.setup.MockMvcBuilders.webAppContextSetup;
 
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -62,8 +62,9 @@ public class MockMvcTestRule extends ExternalResource {
             .findAny()
             .orElse(null);
 
-    assertNotNull(
-        "the JSON message converter must not be null", this.mappingJackson2HttpMessageConverter);
+    assertThat(this.mappingJackson2HttpMessageConverter)
+        .as("the JSON message converter must not be null")
+        .isNotNull();
   }
 
   @Override

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/OpensearchOperateAbstractIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/OpensearchOperateAbstractIT.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.operate.util;
 
-import static org.junit.Assume.assumeTrue;
+import static org.assertj.core.api.Assumptions.assumeThat;
 
 import io.camunda.operate.conditions.DatabaseInfo;
 import org.junit.BeforeClass;
@@ -15,6 +15,6 @@ import org.junit.BeforeClass;
 public abstract class OpensearchOperateAbstractIT extends OperateAbstractIT {
   @BeforeClass
   public static void beforeClass() {
-    assumeTrue(DatabaseInfo.isOpensearch());
+    assumeThat(DatabaseInfo.isOpensearch()).isTrue();
   }
 }

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/OpensearchOperateZeebeRuleProvider.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/OpensearchOperateZeebeRuleProvider.java
@@ -9,7 +9,7 @@ package io.camunda.operate.util;
 
 import static io.camunda.operate.qa.util.ContainerVersionsUtil.ZEEBE_CURRENTVERSION_DOCKER_PROPERTY_NAME;
 import static io.camunda.operate.store.opensearch.dsl.RequestDSL.componentTemplateRequestBuilder;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ClientException;
@@ -78,10 +78,11 @@ public class OpensearchOperateZeebeRuleProvider implements OperateZeebeRuleProvi
     final IndexState newTemplate =
         IndexState.of(t -> t.settings(newSettings).mappings(template.mappings()));
     final var requestBuilder = componentTemplateRequestBuilder(prefix).template(newTemplate);
-    assertTrue(
-        zeebeRichOpenSearchClient
-            .template()
-            .createComponentTemplateWithRetries(requestBuilder.build()));
+    assertThat(
+            zeebeRichOpenSearchClient
+                .template()
+                .createComponentTemplateWithRetries(requestBuilder.build()))
+        .isTrue();
   }
 
   @Override

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/OperateTester.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/OperateTester.java
@@ -13,7 +13,6 @@ import static io.camunda.operate.webapp.rest.FlowNodeInstanceRestService.FLOW_NO
 import static io.camunda.operate.webapp.rest.ProcessInstanceRestService.PROCESS_INSTANCE_URL;
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertTrue;
 import static org.springframework.beans.factory.config.BeanDefinition.SCOPE_PROTOTYPE;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -942,7 +941,9 @@ public class OperateTester {
     final var start = System.currentTimeMillis();
     var deleted = false;
 
-    assertTrue(format("Index %s doesn't exist!", index), searchTestRule.indexExists(index));
+    assertThat(searchTestRule.indexExists(index))
+        .as(format("Index %s doesn't exist!", index))
+        .isTrue();
     LOGGER.info(format("Index exists %s", index));
 
     while (!deleted & System.currentTimeMillis() < start + maxWaitMillis) {
@@ -958,7 +959,9 @@ public class OperateTester {
       }
     }
 
-    assertTrue(format("Index %s was not deleted after %s ms!", index, maxWaitMillis), deleted);
+    assertThat(deleted)
+        .as(format("Index %s was not deleted after %s ms!", index, maxWaitMillis))
+        .isTrue();
   }
 
   public void performOneRoundOfImport() {

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/BackupControllerIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/BackupControllerIT.java
@@ -11,7 +11,6 @@ import static io.camunda.management.backups.HistoryStateCode.*;
 import static io.camunda.webapps.backup.repository.elasticsearch.ElasticsearchBackupRepository.SNAPSHOT_MISSING_EXCEPTION_TYPE;
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -472,7 +471,7 @@ public class BackupControllerIT {
             "No repository with name [%s] could be found.",
             operateProperties.getBackup().getRepositoryName());
     final String actualMessage = error.getMessage();
-    assertTrue(actualMessage.contains(expectedMessage));
+    assertThat(actualMessage.contains(expectedMessage)).isTrue();
     verify(elasticsearchClient, times(1)).snapshot();
   }
 
@@ -491,7 +490,7 @@ public class BackupControllerIT {
             "No repository with name [%s] could be found.",
             operateProperties.getBackup().getRepositoryName());
     final String actualMessage = error.getMessage();
-    assertTrue(actualMessage.contains(expectedMessage));
+    assertThat(actualMessage.contains(expectedMessage)).isTrue();
     verify(elasticsearchClient, times(1)).snapshot();
   }
 

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/api/v1/dao/DecisionDefinitionDaoIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/api/v1/dao/DecisionDefinitionDaoIT.java
@@ -13,7 +13,7 @@ import static io.camunda.webapps.schema.descriptors.index.DecisionIndex.DECISION
 import static io.camunda.webapps.schema.descriptors.index.DecisionIndex.VERSION;
 import static io.camunda.webapps.schema.entities.AbstractExporterEntity.DEFAULT_TENANT_ID;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 
 import io.camunda.operate.util.j5templates.OperateSearchAbstractIT;
 import io.camunda.operate.webapp.api.v1.entities.DecisionDefinition;
@@ -264,6 +264,6 @@ public class DecisionDefinitionDaoIT extends OperateSearchAbstractIT {
 
   @Test
   public void shouldThrowWhenKeyNotExists() {
-    assertThrows(ResourceNotFoundException.class, () -> dao.byKey(1L));
+    assertThatExceptionOfType(ResourceNotFoundException.class).isThrownBy(() -> dao.byKey(1L));
   }
 }

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/api/v1/dao/DecisionInstanceDaoIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/api/v1/dao/DecisionInstanceDaoIT.java
@@ -16,7 +16,7 @@ import static io.camunda.webapps.schema.descriptors.template.DecisionInstanceTem
 import static io.camunda.webapps.schema.descriptors.template.DecisionInstanceTemplate.STATE;
 import static io.camunda.webapps.schema.entities.AbstractExporterEntity.DEFAULT_TENANT_ID;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 
 import io.camunda.operate.connect.OperateDateTimeFormatter;
 import io.camunda.operate.util.j5templates.OperateSearchAbstractIT;
@@ -251,7 +251,7 @@ public class DecisionInstanceDaoIT extends OperateSearchAbstractIT {
 
   @Test
   public void shouldThrowWhenIdNotExists() {
-    assertThrows(ResourceNotFoundException.class, () -> dao.byId("test"));
+    assertThatExceptionOfType(ResourceNotFoundException.class).isThrownBy(() -> dao.byId("test"));
   }
 
   @Test

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/api/v1/dao/DecisionRequirementsDaoIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/api/v1/dao/DecisionRequirementsDaoIT.java
@@ -13,7 +13,7 @@ import static io.camunda.webapps.schema.descriptors.index.DecisionRequirementsIn
 import static io.camunda.webapps.schema.entities.AbstractExporterEntity.DEFAULT_TENANT_ID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 
 import io.camunda.operate.util.j5templates.OperateSearchAbstractIT;
 import io.camunda.operate.webapp.api.v1.entities.DecisionRequirements;
@@ -175,7 +175,7 @@ public class DecisionRequirementsDaoIT extends OperateSearchAbstractIT {
 
   @Test
   public void shouldThrowKeyNotExists() {
-    assertThrows(ResourceNotFoundException.class, () -> dao.byKey(1L));
+    assertThatExceptionOfType(ResourceNotFoundException.class).isThrownBy(() -> dao.byKey(1L));
   }
 
   @Test
@@ -242,6 +242,6 @@ public class DecisionRequirementsDaoIT extends OperateSearchAbstractIT {
 
   @Test
   public void shouldThrowXmlKeyNotExists() {
-    assertThrows(ResourceNotFoundException.class, () -> dao.xmlByKey(1L));
+    assertThatExceptionOfType(ResourceNotFoundException.class).isThrownBy(() -> dao.xmlByKey(1L));
   }
 }

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/api/v1/dao/FlowNodeInstanceDaoIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/api/v1/dao/FlowNodeInstanceDaoIT.java
@@ -9,7 +9,7 @@ package io.camunda.operate.webapp.api.v1.dao;
 
 import static io.camunda.webapps.schema.entities.AbstractExporterEntity.DEFAULT_TENANT_ID;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
@@ -204,7 +204,7 @@ public class FlowNodeInstanceDaoIT extends OperateSearchAbstractIT {
 
   @Test
   public void shouldThrowWhenKeyNotExists() {
-    assertThrows(ResourceNotFoundException.class, () -> dao.byKey(1L));
+    assertThatExceptionOfType(ResourceNotFoundException.class).isThrownBy(() -> dao.byKey(1L));
   }
 
   @Test

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/api/v1/dao/IncidentDaoIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/api/v1/dao/IncidentDaoIT.java
@@ -9,7 +9,7 @@ package io.camunda.operate.webapp.api.v1.dao;
 
 import static io.camunda.webapps.schema.entities.AbstractExporterEntity.DEFAULT_TENANT_ID;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 
 import io.camunda.operate.connect.OperateDateTimeFormatter;
 import io.camunda.operate.util.j5templates.OperateSearchAbstractIT;
@@ -244,7 +244,7 @@ public class IncidentDaoIT extends OperateSearchAbstractIT {
 
   @Test
   public void shouldThrowWhenKeyNotExists() {
-    assertThrows(ResourceNotFoundException.class, () -> dao.byKey(1L));
+    assertThatExceptionOfType(ResourceNotFoundException.class).isThrownBy(() -> dao.byKey(1L));
   }
 
   @Test

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/api/v1/dao/ProcessDefinitionDaoIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/api/v1/dao/ProcessDefinitionDaoIT.java
@@ -11,7 +11,7 @@ import static io.camunda.webapps.schema.descriptors.index.ProcessIndex.BPMN_PROC
 import static io.camunda.webapps.schema.entities.AbstractExporterEntity.DEFAULT_TENANT_ID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 
 import io.camunda.operate.util.j5templates.OperateSearchAbstractIT;
 import io.camunda.operate.webapp.api.v1.entities.ProcessDefinition;
@@ -108,7 +108,7 @@ public class ProcessDefinitionDaoIT extends OperateSearchAbstractIT {
 
   @Test
   public void shouldThrowWhenKeyNotExists() {
-    assertThrows(ResourceNotFoundException.class, () -> dao.byKey(1L));
+    assertThatExceptionOfType(ResourceNotFoundException.class).isThrownBy(() -> dao.byKey(1L));
   }
 
   @Test
@@ -132,7 +132,7 @@ public class ProcessDefinitionDaoIT extends OperateSearchAbstractIT {
 
   @Test
   public void showThrowWhenXmlByKeyNotExists() {
-    assertThrows(ResourceNotFoundException.class, () -> dao.xmlByKey(1L));
+    assertThatExceptionOfType(ResourceNotFoundException.class).isThrownBy(() -> dao.xmlByKey(1L));
   }
 
   @Test

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/api/v1/dao/ProcessInstanceDaoIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/api/v1/dao/ProcessInstanceDaoIT.java
@@ -10,7 +10,9 @@ package io.camunda.operate.webapp.api.v1.dao;
 import static io.camunda.operate.webapp.api.v1.entities.ProcessInstance.BPMN_PROCESS_ID;
 import static io.camunda.webapps.schema.entities.AbstractExporterEntity.DEFAULT_TENANT_ID;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 
 import io.camunda.operate.connect.OperateDateTimeFormatter;
 import io.camunda.operate.util.j5templates.OperateSearchAbstractIT;
@@ -34,7 +36,6 @@ import java.io.IOException;
 import java.time.OffsetDateTime;
 import java.util.List;
 import org.assertj.core.api.AssertionsForClassTypes;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -125,7 +126,7 @@ public class ProcessInstanceDaoIT extends OperateSearchAbstractIT {
 
   @Test
   public void shouldThrowForDeleteWhenKeyNotExists() {
-    assertThrows(ResourceNotFoundException.class, () -> dao.delete(1L));
+    assertThatCode(() -> dao.delete(1L)).isInstanceOf(ResourceNotFoundException.class);
   }
 
   @Test
@@ -140,7 +141,7 @@ public class ProcessInstanceDaoIT extends OperateSearchAbstractIT {
 
   @Test
   public void shouldThrowWhenByKeyNotExists() {
-    assertThrows(ResourceNotFoundException.class, () -> dao.byKey(1L));
+    assertThatThrownBy(() -> dao.byKey(1L)).isInstanceOf(ResourceNotFoundException.class);
   }
 
   @Test
@@ -305,8 +306,8 @@ public class ProcessInstanceDaoIT extends OperateSearchAbstractIT {
 
     searchContainerManager.refreshIndices("*operate*");
 
-    Assertions.assertThrows(
-        ResourceNotFoundException.class, () -> dao.byKey(processInstance.getProcessInstanceKey()));
+    assertThatExceptionOfType(ResourceNotFoundException.class)
+        .isThrownBy(() -> dao.byKey(processInstance.getProcessInstanceKey()));
     assertThatDependantsAreAlsoDeleted(processInstanceKey);
   }
 

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/api/v1/dao/VariableDaoIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/api/v1/dao/VariableDaoIT.java
@@ -9,7 +9,7 @@ package io.camunda.operate.webapp.api.v1.dao;
 
 import static io.camunda.webapps.schema.entities.AbstractExporterEntity.DEFAULT_TENANT_ID;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 
 import io.camunda.operate.util.j5templates.OperateSearchAbstractIT;
 import io.camunda.operate.webapp.api.v1.entities.Query;
@@ -106,7 +106,7 @@ public class VariableDaoIT extends OperateSearchAbstractIT {
 
   @Test
   public void shouldThrowWhenKeyNotExists() {
-    assertThrows(ResourceNotFoundException.class, () -> dao.byKey(1L));
+    assertThatExceptionOfType(ResourceNotFoundException.class).isThrownBy(() -> dao.byKey(1L));
   }
 
   @Test

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/api/v1/rest/ProcessInstanceQueryControllerIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/api/v1/rest/ProcessInstanceQueryControllerIT.java
@@ -10,8 +10,7 @@ package io.camunda.operate.webapp.api.v1.rest;
 import static io.camunda.operate.webapp.api.v1.entities.ProcessInstance.VERSION;
 import static io.camunda.operate.webapp.api.v1.rest.ProcessInstanceController.URI;
 import static io.camunda.operate.webapp.api.v1.rest.SearchController.SEARCH;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -136,8 +135,8 @@ public class ProcessInstanceQueryControllerIT {
     processInstance.setProcessVersion(5);
 
     final String jsonResult = springObjectMapper.writeValueAsString(processInstance);
-    assertFalse(jsonResult.contains("parentProcessInstanceKey"));
-    assertTrue(jsonResult.contains("parentKey"));
+    assertThat(jsonResult.contains("parentProcessInstanceKey")).isFalse();
+    assertThat(jsonResult.contains("parentKey")).isTrue();
   }
 
   @Test

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/security/AuthorizationIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/security/AuthorizationIT.java
@@ -8,7 +8,7 @@
 package io.camunda.operate.webapp.security;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.times;
@@ -66,13 +66,13 @@ public class AuthorizationIT {
             processId, PermissionType.DELETE_PROCESS_INSTANCE))
         .thenReturn(false);
 
-    assertThrows(
-        NotAuthorizedException.class,
-        () ->
-            processInstanceRestService.operation(
-                "23",
-                new CreateOperationRequestDto()
-                    .setOperationType(OperationType.DELETE_PROCESS_INSTANCE)));
+    assertThatExceptionOfType(NotAuthorizedException.class)
+        .isThrownBy(
+            () ->
+                processInstanceRestService.operation(
+                    "23",
+                    new CreateOperationRequestDto()
+                        .setOperationType(OperationType.DELETE_PROCESS_INSTANCE)));
     verifyNoInteractions(batchOperationWriter);
   }
 

--- a/operate/schema/src/test/java/io/camunda/operate/entities/ListenerStateTest.java
+++ b/operate/schema/src/test/java/io/camunda/operate/entities/ListenerStateTest.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.operate.entities;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.webapps.schema.entities.listener.ListenerState;
 import org.junit.jupiter.api.Test;
@@ -17,20 +17,20 @@ public class ListenerStateTest {
   @Test
   public void convertStatesFromZeebeJobs() {
     final ListenerState actual1 = ListenerState.fromZeebeJobIntent("MIGRATED");
-    assertEquals(actual1, ListenerState.ACTIVE);
+    assertThat(ListenerState.ACTIVE).isEqualTo(actual1);
     final ListenerState actual2 = ListenerState.fromZeebeJobIntent("FAILED");
-    assertEquals(actual2, ListenerState.FAILED);
+    assertThat(ListenerState.FAILED).isEqualTo(actual2);
     final ListenerState actual3 = ListenerState.fromZeebeJobIntent("COMPLETED");
-    assertEquals(actual3, ListenerState.COMPLETED);
+    assertThat(ListenerState.COMPLETED).isEqualTo(actual3);
     final ListenerState actual4 = ListenerState.fromZeebeJobIntent("TIMED_OUT");
-    assertEquals(actual4, ListenerState.TIMED_OUT);
+    assertThat(ListenerState.TIMED_OUT).isEqualTo(actual4);
     final ListenerState actual5 = ListenerState.fromZeebeJobIntent("CANCELED");
-    assertEquals(actual5, ListenerState.CANCELED);
+    assertThat(ListenerState.CANCELED).isEqualTo(actual5);
     final ListenerState actual6 = ListenerState.fromZeebeJobIntent("ERROR_THROWN");
-    assertEquals(actual6, ListenerState.FAILED);
+    assertThat(ListenerState.FAILED).isEqualTo(actual6);
     final ListenerState actual7 = ListenerState.fromZeebeJobIntent("TEST");
-    assertEquals(actual7, ListenerState.UNKNOWN);
+    assertThat(ListenerState.UNKNOWN).isEqualTo(actual7);
     final ListenerState actual8 = ListenerState.fromZeebeJobIntent(null);
-    assertEquals(actual8, ListenerState.UNKNOWN);
+    assertThat(ListenerState.UNKNOWN).isEqualTo(actual8);
   }
 }

--- a/operate/schema/src/test/java/io/camunda/operate/store/elasticsearch/ElasticsearchProcessStoreTest.java
+++ b/operate/schema/src/test/java/io/camunda/operate/store/elasticsearch/ElasticsearchProcessStoreTest.java
@@ -9,7 +9,7 @@ package io.camunda.operate.store.elasticsearch;
 
 import static io.camunda.webapps.schema.entities.AbstractExporterEntity.DEFAULT_TENANT_ID;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
@@ -98,7 +98,8 @@ public class ElasticsearchProcessStoreTest {
     when(mockHits.getTotalHits()).thenReturn(mockTotalHits);
     when(tenantAwareClient.search(any())).thenReturn(mockResponse);
 
-    assertThrows(NotFoundException.class, () -> underTest.getProcessByKey(123L));
+    assertThatExceptionOfType(NotFoundException.class)
+        .isThrownBy(() -> underTest.getProcessByKey(123L));
   }
 
   @Test
@@ -115,7 +116,8 @@ public class ElasticsearchProcessStoreTest {
     when(mockHits.getTotalHits()).thenReturn(mockTotalHits);
     when(tenantAwareClient.search(any())).thenReturn(mockResponse);
 
-    assertThrows(NotFoundException.class, () -> underTest.getProcessByKey(123L));
+    assertThatExceptionOfType(NotFoundException.class)
+        .isThrownBy(() -> underTest.getProcessByKey(123L));
   }
 
   @Test
@@ -123,7 +125,8 @@ public class ElasticsearchProcessStoreTest {
     when(processIndex.getAlias()).thenReturn("processIndexAlias");
     when(tenantAwareClient.search(any())).thenThrow(new IOException());
 
-    assertThrows(OperateRuntimeException.class, () -> underTest.getProcessByKey(123L));
+    assertThatExceptionOfType(OperateRuntimeException.class)
+        .isThrownBy(() -> underTest.getProcessByKey(123L));
   }
 
   @Test
@@ -140,7 +143,8 @@ public class ElasticsearchProcessStoreTest {
     when(mockHits.getTotalHits()).thenReturn(mockTotalHits);
     when(tenantAwareClient.search(any())).thenReturn(mockResponse);
 
-    assertThrows(NotFoundException.class, () -> underTest.getDiagramByKey(123L));
+    assertThatExceptionOfType(NotFoundException.class)
+        .isThrownBy(() -> underTest.getDiagramByKey(123L));
   }
 
   @Test
@@ -157,7 +161,8 @@ public class ElasticsearchProcessStoreTest {
     when(mockHits.getTotalHits()).thenReturn(mockTotalHits);
     when(tenantAwareClient.search(any())).thenReturn(mockResponse);
 
-    assertThrows(NotFoundException.class, () -> underTest.getDiagramByKey(123L));
+    assertThatExceptionOfType(NotFoundException.class)
+        .isThrownBy(() -> underTest.getDiagramByKey(123L));
   }
 
   @Test
@@ -165,7 +170,8 @@ public class ElasticsearchProcessStoreTest {
     when(processIndex.getAlias()).thenReturn("processIndexAlias");
     when(tenantAwareClient.search(any())).thenThrow(new IOException());
 
-    assertThrows(OperateRuntimeException.class, () -> underTest.getProcessByKey(123L));
+    assertThatExceptionOfType(OperateRuntimeException.class)
+        .isThrownBy(() -> underTest.getProcessByKey(123L));
   }
 
   @Test
@@ -173,9 +179,8 @@ public class ElasticsearchProcessStoreTest {
     when(processIndex.getAlias()).thenReturn("processIndexAlias");
     when(tenantAwareClient.search(any())).thenThrow(new IOException());
 
-    assertThrows(
-        OperateRuntimeException.class,
-        () -> underTest.getProcessesGrouped(DEFAULT_TENANT_ID, Set.of("demoProcess")));
+    assertThatExceptionOfType(OperateRuntimeException.class)
+        .isThrownBy(() -> underTest.getProcessesGrouped(DEFAULT_TENANT_ID, Set.of("demoProcess")));
   }
 
   @Test
@@ -183,11 +188,11 @@ public class ElasticsearchProcessStoreTest {
     when(processIndex.getAlias()).thenReturn("processIndexAlias");
     when(tenantAwareClient.search(any())).thenThrow(new IOException());
 
-    assertThrows(
-        OperateRuntimeException.class,
-        () ->
-            underTest.getProcessesIdsToProcessesWithFields(
-                Set.of("demoProcess", "demoProcess-1"), 10, "name", "bpmnProcessId", "key"));
+    assertThatExceptionOfType(OperateRuntimeException.class)
+        .isThrownBy(
+            () ->
+                underTest.getProcessesIdsToProcessesWithFields(
+                    Set.of("demoProcess", "demoProcess-1"), 10, "name", "bpmnProcessId", "key"));
   }
 
   @Test
@@ -204,7 +209,8 @@ public class ElasticsearchProcessStoreTest {
     when(mockHits.getTotalHits()).thenReturn(mockTotalHits);
     when(tenantAwareClient.search(any())).thenReturn(mockResponse);
 
-    assertThrows(NotFoundException.class, () -> underTest.getProcessInstanceListViewByKey(123L));
+    assertThatExceptionOfType(NotFoundException.class)
+        .isThrownBy(() -> underTest.getProcessInstanceListViewByKey(123L));
   }
 
   @Test
@@ -221,7 +227,8 @@ public class ElasticsearchProcessStoreTest {
     when(mockHits.getTotalHits()).thenReturn(mockTotalHits);
     when(tenantAwareClient.search(any())).thenReturn(mockResponse);
 
-    assertThrows(NotFoundException.class, () -> underTest.getProcessInstanceListViewByKey(123L));
+    assertThatExceptionOfType(NotFoundException.class)
+        .isThrownBy(() -> underTest.getProcessInstanceListViewByKey(123L));
   }
 
   @Test
@@ -229,8 +236,8 @@ public class ElasticsearchProcessStoreTest {
     when(listViewTemplate.getAlias()).thenReturn("listViewIndexAlias");
     when(tenantAwareClient.search(any())).thenThrow(new IOException());
 
-    assertThrows(
-        OperateRuntimeException.class, () -> underTest.getProcessInstanceListViewByKey(123L));
+    assertThatExceptionOfType(OperateRuntimeException.class)
+        .isThrownBy(() -> underTest.getProcessInstanceListViewByKey(123L));
   }
 
   @Test
@@ -238,8 +245,8 @@ public class ElasticsearchProcessStoreTest {
     when(listViewTemplate.getFullQualifiedName()).thenReturn("listViewIndexPath");
     when(tenantAwareClient.search(any())).thenThrow(new IOException());
 
-    assertThrows(
-        OperateRuntimeException.class, () -> underTest.getCoreStatistics(Set.of("demoProcess")));
+    assertThatExceptionOfType(OperateRuntimeException.class)
+        .isThrownBy(() -> underTest.getCoreStatistics(Set.of("demoProcess")));
   }
 
   @Test
@@ -256,9 +263,8 @@ public class ElasticsearchProcessStoreTest {
     when(mockHits.getTotalHits()).thenReturn(mockTotalHits);
     when(tenantAwareClient.search(any())).thenReturn(mockResponse);
 
-    assertThrows(
-        NotFoundException.class,
-        () -> underTest.getProcessInstanceTreePathById("PI_2251799813685251"));
+    assertThatExceptionOfType(NotFoundException.class)
+        .isThrownBy(() -> underTest.getProcessInstanceTreePathById("PI_2251799813685251"));
   }
 
   @Test
@@ -266,9 +272,8 @@ public class ElasticsearchProcessStoreTest {
     when(listViewTemplate.getAlias()).thenReturn("listViewIndexAlias");
     when(tenantAwareClient.search(any())).thenThrow(new IOException());
 
-    assertThrows(
-        OperateRuntimeException.class,
-        () -> underTest.getProcessInstanceTreePathById("PI_2251799813685251"));
+    assertThatExceptionOfType(OperateRuntimeException.class)
+        .isThrownBy(() -> underTest.getProcessInstanceTreePathById("PI_2251799813685251"));
   }
 
   @Test
@@ -276,17 +281,16 @@ public class ElasticsearchProcessStoreTest {
     when(listViewTemplate.getAlias()).thenReturn("listViewIndexAlias");
     when(tenantAwareClient.search(any())).thenThrow(new IOException());
 
-    assertThrows(
-        OperateRuntimeException.class,
-        () -> underTest.deleteProcessInstanceFromTreePath("2251799813685251"));
+    assertThatExceptionOfType(OperateRuntimeException.class)
+        .isThrownBy(() -> underTest.deleteProcessInstanceFromTreePath("2251799813685251"));
   }
 
   @Test
   public void testGetProcessInstancesByProcessAndStatesWithNullStates() {
     final Exception exception =
-        assertThrows(
-            OperateRuntimeException.class,
-            () -> underTest.getProcessInstancesByProcessAndStates(123L, null, 10, null));
+        assertThatExceptionOfType(OperateRuntimeException.class)
+            .isThrownBy(() -> underTest.getProcessInstancesByProcessAndStates(123L, null, 10, null))
+            .actual();
     assertThat(exception.getMessage())
         .isEqualTo("Parameter 'states' is needed to search by states.");
   }
@@ -294,9 +298,10 @@ public class ElasticsearchProcessStoreTest {
   @Test
   public void testGetProcessInstancesByProcessAndStatesWithEmptyStates() {
     final Exception exception =
-        assertThrows(
-            OperateRuntimeException.class,
-            () -> underTest.getProcessInstancesByProcessAndStates(123L, Set.of(), 10, null));
+        assertThatExceptionOfType(OperateRuntimeException.class)
+            .isThrownBy(
+                () -> underTest.getProcessInstancesByProcessAndStates(123L, Set.of(), 10, null))
+            .actual();
     assertThat(exception.getMessage())
         .isEqualTo("Parameter 'states' is needed to search by states.");
   }
@@ -307,11 +312,12 @@ public class ElasticsearchProcessStoreTest {
     when(tenantAwareClient.search(any())).thenThrow(new IOException());
 
     final Exception exception =
-        assertThrows(
-            OperateRuntimeException.class,
-            () ->
-                underTest.getProcessInstancesByProcessAndStates(
-                    123L, Set.of(ProcessInstanceState.COMPLETED), 10, null));
+        assertThatExceptionOfType(OperateRuntimeException.class)
+            .isThrownBy(
+                () ->
+                    underTest.getProcessInstancesByProcessAndStates(
+                        123L, Set.of(ProcessInstanceState.COMPLETED), 10, null))
+            .actual();
     assertThat(exception.getMessage())
         .contains("Failed to search process instances by processDefinitionKey");
   }
@@ -319,9 +325,9 @@ public class ElasticsearchProcessStoreTest {
   @Test
   public void testGetProcessInstancesByParentKeysWithNullKeys() {
     final Exception exception =
-        assertThrows(
-            OperateRuntimeException.class,
-            () -> underTest.getProcessInstancesByParentKeys(null, 10, null));
+        assertThatExceptionOfType(OperateRuntimeException.class)
+            .isThrownBy(() -> underTest.getProcessInstancesByParentKeys(null, 10, null))
+            .actual();
     assertThat(exception.getMessage())
         .isEqualTo("Parameter 'parentProcessInstanceKeys' is needed to search by parents.");
   }
@@ -329,9 +335,9 @@ public class ElasticsearchProcessStoreTest {
   @Test
   public void testGetProcessInstancesByParentKeysWithEmptyKeys() {
     final Exception exception =
-        assertThrows(
-            OperateRuntimeException.class,
-            () -> underTest.getProcessInstancesByParentKeys(Set.of(), 10, null));
+        assertThatExceptionOfType(OperateRuntimeException.class)
+            .isThrownBy(() -> underTest.getProcessInstancesByParentKeys(Set.of(), 10, null))
+            .actual();
     assertThat(exception.getMessage())
         .isEqualTo("Parameter 'parentProcessInstanceKeys' is needed to search by parents.");
   }
@@ -342,9 +348,9 @@ public class ElasticsearchProcessStoreTest {
     when(tenantAwareClient.search(any(), any())).thenThrow(new IOException());
 
     final Exception exception =
-        assertThrows(
-            OperateRuntimeException.class,
-            () -> underTest.getProcessInstancesByParentKeys(Set.of(123L), 10, null));
+        assertThatExceptionOfType(OperateRuntimeException.class)
+            .isThrownBy(() -> underTest.getProcessInstancesByParentKeys(Set.of(123L), 10, null))
+            .actual();
     assertThat(exception.getMessage())
         .contains("Failed to search process instances by parentProcessInstanceKeys");
   }
@@ -366,9 +372,8 @@ public class ElasticsearchProcessStoreTest {
     when(listViewTemplate.getAlias()).thenReturn("listViewIndexAlias");
     when(esClient.deleteByQuery(any(), eq(RequestOptions.DEFAULT))).thenThrow(new IOException());
 
-    assertThrows(
-        OperateRuntimeException.class,
-        () -> underTest.deleteProcessInstancesAndDependants(Set.of(123L)));
+    assertThatExceptionOfType(OperateRuntimeException.class)
+        .isThrownBy(() -> underTest.deleteProcessInstancesAndDependants(Set.of(123L)));
   }
 
   @Test
@@ -389,15 +394,17 @@ public class ElasticsearchProcessStoreTest {
     when(processIndex.getAlias()).thenReturn("processIndexAlias");
     when(esClient.deleteByQuery(any(), eq(RequestOptions.DEFAULT))).thenThrow(new IOException());
 
-    assertThrows(
-        OperateRuntimeException.class, () -> underTest.deleteProcessDefinitionsByKeys(123L, 234L));
+    assertThatExceptionOfType(OperateRuntimeException.class)
+        .isThrownBy(() -> underTest.deleteProcessDefinitionsByKeys(123L, 234L));
   }
 
   @Test
   public void testRefreshIndicesWithNullIndex() {
     final String[] indices = null;
     final Exception exception =
-        assertThrows(OperateRuntimeException.class, () -> underTest.refreshIndices(indices));
+        assertThatExceptionOfType(OperateRuntimeException.class)
+            .isThrownBy(() -> underTest.refreshIndices(indices))
+            .actual();
     assertThat(exception.getMessage())
         .isEqualTo("Refresh indices needs at least one index to refresh.");
   }
@@ -405,7 +412,9 @@ public class ElasticsearchProcessStoreTest {
   @Test
   public void testRefreshIndicesWithEmptyIndexArray() {
     final Exception exception =
-        assertThrows(OperateRuntimeException.class, () -> underTest.refreshIndices(new String[0]));
+        assertThatExceptionOfType(OperateRuntimeException.class)
+            .isThrownBy(() -> underTest.refreshIndices(new String[0]))
+            .actual();
     assertThat(exception.getMessage())
         .isEqualTo("Refresh indices needs at least one index to refresh.");
   }

--- a/operate/webapp/src/test/java/io/camunda/operate/elasticsearch/dao/GenericDAOTest.java
+++ b/operate/webapp/src/test/java/io/camunda/operate/elasticsearch/dao/GenericDAOTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.operate.elasticsearch.dao;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -20,7 +21,6 @@ import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestHighLevelClient;
 import org.elasticsearch.xcontent.XContentType;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -37,35 +37,35 @@ public class GenericDAOTest {
 
   @Test
   public void instantiateWithoutObjectMapperThrowsException() {
-    Assertions.assertThrows(
-        IllegalStateException.class,
-        () ->
-            new GenericDAO.Builder<MetricEntity, MetricIndex>()
-                .esClient(esClient)
-                .index(index)
-                .build());
+    assertThatExceptionOfType(IllegalStateException.class)
+        .isThrownBy(
+            () ->
+                new GenericDAO.Builder<MetricEntity, MetricIndex>()
+                    .esClient(esClient)
+                    .index(index)
+                    .build());
   }
 
   @Test
   public void instantiateWithoutESClientThrowsException() {
-    Assertions.assertThrows(
-        IllegalStateException.class,
-        () ->
-            new GenericDAO.Builder<MetricEntity, MetricIndex>()
-                .objectMapper(objectMapper)
-                .index(index)
-                .build());
+    assertThatExceptionOfType(IllegalStateException.class)
+        .isThrownBy(
+            () ->
+                new GenericDAO.Builder<MetricEntity, MetricIndex>()
+                    .objectMapper(objectMapper)
+                    .index(index)
+                    .build());
   }
 
   @Test
   public void instantiateWithoutIndexThrowsException() {
-    Assertions.assertThrows(
-        IllegalStateException.class,
-        () ->
-            new GenericDAO.Builder<MetricEntity, MetricIndex>()
-                .objectMapper(objectMapper)
-                .esClient(esClient)
-                .build());
+    assertThatExceptionOfType(IllegalStateException.class)
+        .isThrownBy(
+            () ->
+                new GenericDAO.Builder<MetricEntity, MetricIndex>()
+                    .objectMapper(objectMapper)
+                    .esClient(esClient)
+                    .build());
   }
 
   @Test

--- a/operate/webapp/src/test/java/io/camunda/operate/elasticsearch/reader/MetricReaderTest.java
+++ b/operate/webapp/src/test/java/io/camunda/operate/elasticsearch/reader/MetricReaderTest.java
@@ -12,7 +12,8 @@ import static io.camunda.operate.store.elasticsearch.dao.Query.whereEquals;
 import static io.camunda.webapps.schema.descriptors.index.MetricIndex.EVENT;
 import static io.camunda.webapps.schema.descriptors.index.MetricIndex.EVENT_TIME;
 import static io.camunda.webapps.schema.descriptors.index.MetricIndex.VALUE;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -25,7 +26,6 @@ import io.camunda.operate.store.elasticsearch.dao.UsageMetricDAO;
 import io.camunda.operate.store.elasticsearch.dao.response.AggregationResponse;
 import java.time.OffsetDateTime;
 import java.util.List;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -51,7 +51,7 @@ public class MetricReaderTest {
     final Long result = subject.retrieveProcessInstanceCount(oneHourBefore, now);
 
     // Then
-    assertEquals(result, 99L);
+    assertThat(99L).isEqualTo(result);
   }
 
   @Test
@@ -75,7 +75,7 @@ public class MetricReaderTest {
             .and(range(EVENT_TIME, oneHourBefore, now))
             .aggregate(MetricsStore.PROCESS_INSTANCES_AGG_NAME, VALUE, 1);
     final Query calledValue = entityCaptor.getValue();
-    assertEquals(expected, calledValue);
+    assertThat(calledValue).isEqualTo(expected);
   }
 
   @Test
@@ -84,9 +84,9 @@ public class MetricReaderTest {
     when(dao.searchWithAggregation(any())).thenReturn(new AggregationResponse(true));
 
     // Then
-    Assertions.assertThrows(
-        OperateRuntimeException.class,
-        () -> subject.retrieveProcessInstanceCount(OffsetDateTime.now(), OffsetDateTime.now()));
+    assertThatExceptionOfType(OperateRuntimeException.class)
+        .isThrownBy(
+            () -> subject.retrieveProcessInstanceCount(OffsetDateTime.now(), OffsetDateTime.now()));
   }
 
   @Test
@@ -101,7 +101,7 @@ public class MetricReaderTest {
     final Long result = subject.retrieveDecisionInstanceCount(oneHourBefore, now);
 
     // Then
-    assertEquals(result, 99L);
+    assertThat(99L).isEqualTo(result);
   }
 
   @Test
@@ -124,7 +124,7 @@ public class MetricReaderTest {
             .and(range(EVENT_TIME, oneHourBefore, now))
             .aggregate(MetricsStore.DECISION_INSTANCES_AGG_NAME, VALUE, 1);
     final Query calledValue = entityCaptor.getValue();
-    assertEquals(expected, calledValue);
+    assertThat(calledValue).isEqualTo(expected);
   }
 
   @Test
@@ -133,8 +133,9 @@ public class MetricReaderTest {
     when(dao.searchWithAggregation(any())).thenReturn(new AggregationResponse(true));
 
     // Then
-    Assertions.assertThrows(
-        OperateRuntimeException.class,
-        () -> subject.retrieveDecisionInstanceCount(OffsetDateTime.now(), OffsetDateTime.now()));
+    assertThatExceptionOfType(OperateRuntimeException.class)
+        .isThrownBy(
+            () ->
+                subject.retrieveDecisionInstanceCount(OffsetDateTime.now(), OffsetDateTime.now()));
   }
 }

--- a/operate/webapp/src/test/java/io/camunda/operate/webapp/api/v1/dao/opensearch/OpensearchKeyFilteringDaoTest.java
+++ b/operate/webapp/src/test/java/io/camunda/operate/webapp/api/v1/dao/opensearch/OpensearchKeyFilteringDaoTest.java
@@ -8,8 +8,8 @@
 package io.camunda.operate.webapp.api.v1.dao.opensearch;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -109,14 +109,17 @@ public class OpensearchKeyFilteringDaoTest {
     // Set the mocked opensearch client to throw an exception
     when(mockOpensearchClient.doc()).thenThrow(new RuntimeException());
 
-    final Exception exception = assertThrows(ServerException.class, () -> underTest.byKey(1L));
+    final Exception exception =
+        assertThatExceptionOfType(ServerException.class)
+            .isThrownBy(() -> underTest.byKey(1L))
+            .actual();
 
     assertThat(exception.getMessage()).isEqualTo(underTest.getByKeyServerReadErrorMessage(1L));
   }
 
   @Test
   public void testByKeyWithNullKey() {
-    assertThrows(ServerException.class, () -> underTest.byKey(null));
+    assertThatExceptionOfType(ServerException.class).isThrownBy(() -> underTest.byKey(null));
   }
 
   @Test
@@ -138,7 +141,9 @@ public class OpensearchKeyFilteringDaoTest {
     when(mockDocumentOperations.searchValues(any(), any())).thenReturn(Collections.emptyList());
 
     final Exception exception =
-        assertThrows(ResourceNotFoundException.class, () -> underTest.byKey(1L));
+        assertThatExceptionOfType(ResourceNotFoundException.class)
+            .isThrownBy(() -> underTest.byKey(1L))
+            .actual();
 
     assertThat(exception.getMessage()).isEqualTo(underTest.getByKeyNoResultsErrorMessage(1L));
   }
@@ -187,7 +192,10 @@ public class OpensearchKeyFilteringDaoTest {
     when(mockDocumentOperations.searchValues(any(), any()))
         .thenReturn(List.of(new Object(), new Object()));
 
-    final Exception exception = assertThrows(ServerException.class, () -> underTest.byKey(1L));
+    final Exception exception =
+        assertThatExceptionOfType(ServerException.class)
+            .isThrownBy(() -> underTest.byKey(1L))
+            .actual();
 
     assertThat(exception.getMessage()).isEqualTo(underTest.getByKeyTooManyResultsErrorMessage(1L));
   }
@@ -219,7 +227,7 @@ public class OpensearchKeyFilteringDaoTest {
 
   @Test
   public void testValidateKeyWithNull() {
-    assertThrows(ServerException.class, () -> underTest.validateKey(null));
+    assertThatExceptionOfType(ServerException.class).isThrownBy(() -> underTest.validateKey(null));
   }
 
   @Test

--- a/operate/webapp/src/test/java/io/camunda/operate/webapp/elasticsearch/reader/ElasticsearchListenerReaderTest.java
+++ b/operate/webapp/src/test/java/io/camunda/operate/webapp/elasticsearch/reader/ElasticsearchListenerReaderTest.java
@@ -7,8 +7,8 @@
  */
 package io.camunda.operate.webapp.elasticsearch.reader;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
@@ -40,15 +40,16 @@ public class ElasticsearchListenerReaderTest {
     when(jobTemplate.getAlias()).thenReturn("operate-job-8.6.0");
 
     final Exception exception =
-        assertThrows(
-            OperateRuntimeException.class,
-            () ->
-                underTest.getListenerExecutions(
-                    "1",
-                    new ListenerRequestDto()
-                        .setFlowNodeId("1")
-                        .setPageSize(10)
-                        .setSorting(new SortingDto().setSortBy(JobTemplate.TIME))));
-    assertTrue(exception.getMessage().contains("while searching for listeners"));
+        assertThatExceptionOfType(OperateRuntimeException.class)
+            .isThrownBy(
+                () ->
+                    underTest.getListenerExecutions(
+                        "1",
+                        new ListenerRequestDto()
+                            .setFlowNodeId("1")
+                            .setPageSize(10)
+                            .setSorting(new SortingDto().setSortBy(JobTemplate.TIME))))
+            .actual();
+    assertThat(exception.getMessage().contains("while searching for listeners")).isTrue();
   }
 }

--- a/operate/webapp/src/test/java/io/camunda/operate/webapp/elasticsearch/transform/ElasticsearchDataAggregatorTest.java
+++ b/operate/webapp/src/test/java/io/camunda/operate/webapp/elasticsearch/transform/ElasticsearchDataAggregatorTest.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.operate.webapp.elasticsearch.transform;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.when;
@@ -58,16 +58,15 @@ public class ElasticsearchDataAggregatorTest {
 
     final List<BatchOperationDto> actualBatchOperationDtos =
         underTest.enrichBatchEntitiesWithMetadata(testEntities);
-    assertEquals(
-        2,
-        actualBatchOperationDtos.size(),
-        "Two result entities expected but got " + actualBatchOperationDtos.size());
+    assertThat(actualBatchOperationDtos.size())
+        .as("Two result entities expected but got " + actualBatchOperationDtos.size())
+        .isEqualTo(2);
 
     final BatchOperationDto actual1 = actualBatchOperationDtos.get(0);
     final BatchOperationDto actual2 = actualBatchOperationDtos.get(1);
 
-    assertEquals(actual1, expectedDtos.get(0), "actual1 is not equal to expected DTO.");
-    assertEquals(actual2, expectedDtos.get(1), "actual2 is not equal to expected DTO.");
+    assertThat(expectedDtos.get(0)).as("actual1 is not equal to expected DTO.").isEqualTo(actual1);
+    assertThat(expectedDtos.get(1)).as("actual2 is not equal to expected DTO.").isEqualTo(actual2);
   }
 
   private String getTestMockJSONResponse() {

--- a/operate/webapp/src/test/java/io/camunda/operate/webapp/opensearch/reader/OpensearchListenerReaderTest.java
+++ b/operate/webapp/src/test/java/io/camunda/operate/webapp/opensearch/reader/OpensearchListenerReaderTest.java
@@ -7,8 +7,8 @@
  */
 package io.camunda.operate.webapp.opensearch.reader;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 import static org.mockito.Mockito.when;
 
 import io.camunda.operate.store.opensearch.client.sync.RichOpenSearchClient;
@@ -36,15 +36,16 @@ public class OpensearchListenerReaderTest {
     when(jobTemplate.getAlias()).thenReturn("operate-job-8.6.0");
 
     final Exception exception =
-        assertThrows(
-            RuntimeException.class,
-            () ->
-                underTest.getListenerExecutions(
-                    "1",
-                    new ListenerRequestDto()
-                        .setFlowNodeId("1")
-                        .setPageSize(10)
-                        .setSorting(new SortingDto().setSortBy(JobTemplate.TIME))));
-    assertTrue(exception.getMessage().equals("Exception to test exception handling."));
+        assertThatExceptionOfType(RuntimeException.class)
+            .isThrownBy(
+                () ->
+                    underTest.getListenerExecutions(
+                        "1",
+                        new ListenerRequestDto()
+                            .setFlowNodeId("1")
+                            .setPageSize(10)
+                            .setSorting(new SortingDto().setSortBy(JobTemplate.TIME))))
+            .actual();
+    assertThat(exception.getMessage().equals("Exception to test exception handling.")).isTrue();
   }
 }

--- a/operate/webapp/src/test/java/io/camunda/operate/webapp/opensearch/transform/OpensearchDataAggregatorTest.java
+++ b/operate/webapp/src/test/java/io/camunda/operate/webapp/opensearch/transform/OpensearchDataAggregatorTest.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.operate.webapp.opensearch.transform;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
@@ -60,19 +60,16 @@ public class OpensearchDataAggregatorTest {
 
     final List<BatchOperationDto> actualBatchOperationDtos =
         underTest.enrichBatchEntitiesWithMetadata(testEntities);
-    assertEquals(
-        2,
-        actualBatchOperationDtos.size(),
-        "Two result entities expected but got " + actualBatchOperationDtos.size());
+    assertThat(actualBatchOperationDtos.size())
+        .as("Two result entities expected but got " + actualBatchOperationDtos.size())
+        .isEqualTo(2);
 
-    assertEquals(
-        actualBatchOperationDtos.get(0),
-        expectedDtos.get(0),
-        "actual1 is not equal to expected DTO.");
-    assertEquals(
-        actualBatchOperationDtos.get(1),
-        expectedDtos.get(1),
-        "actual2 is not equal to expected DTO.");
+    assertThat(expectedDtos.get(0))
+        .as("actual1 is not equal to expected DTO.")
+        .isEqualTo(actualBatchOperationDtos.get(0));
+    assertThat(expectedDtos.get(1))
+        .as("actual2 is not equal to expected DTO.")
+        .isEqualTo(actualBatchOperationDtos.get(1));
   }
 
   private SearchResponse<OperationEntity> mockBasicResponse() {

--- a/operate/webapp/src/test/java/io/camunda/operate/webapp/rest/ProcessInstanceRestServiceTest.java
+++ b/operate/webapp/src/test/java/io/camunda/operate/webapp/rest/ProcessInstanceRestServiceTest.java
@@ -8,7 +8,7 @@
 package io.camunda.operate.webapp.rest;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
@@ -104,9 +104,9 @@ public class ProcessInstanceRestServiceTest {
         .thenReturn(false);
 
     final NotAuthorizedException exception =
-        assertThrows(
-            NotAuthorizedException.class,
-            () -> underTest.queryProcessInstanceById(processInstanceId));
+        assertThatExceptionOfType(NotAuthorizedException.class)
+            .isThrownBy(() -> underTest.queryProcessInstanceById(processInstanceId))
+            .actual();
 
     assertThat(exception.getMessage())
         .contains("No READ_PROCESS_INSTANCE permission for process instance");
@@ -125,9 +125,9 @@ public class ProcessInstanceRestServiceTest {
         .thenReturn(false);
 
     final NotAuthorizedException exception =
-        assertThrows(
-            NotAuthorizedException.class,
-            () -> underTest.queryIncidentsByProcessInstanceId(processInstanceId));
+        assertThatExceptionOfType(NotAuthorizedException.class)
+            .isThrownBy(() -> underTest.queryIncidentsByProcessInstanceId(processInstanceId))
+            .actual();
 
     assertThat(exception.getMessage())
         .contains("No READ_PROCESS_INSTANCE permission for process instance");
@@ -146,9 +146,9 @@ public class ProcessInstanceRestServiceTest {
         .thenReturn(false);
 
     final NotAuthorizedException exception =
-        assertThrows(
-            NotAuthorizedException.class,
-            () -> underTest.querySequenceFlowsByProcessInstanceId(processInstanceId));
+        assertThatExceptionOfType(NotAuthorizedException.class)
+            .isThrownBy(() -> underTest.querySequenceFlowsByProcessInstanceId(processInstanceId))
+            .actual();
 
     assertThat(exception.getMessage())
         .contains("No READ_PROCESS_INSTANCE permission for process instance");
@@ -167,9 +167,9 @@ public class ProcessInstanceRestServiceTest {
         .thenReturn(false);
 
     final NotAuthorizedException exception =
-        assertThrows(
-            NotAuthorizedException.class,
-            () -> underTest.getVariables(processInstanceId, new VariableRequestDto()));
+        assertThatExceptionOfType(NotAuthorizedException.class)
+            .isThrownBy(() -> underTest.getVariables(processInstanceId, new VariableRequestDto()))
+            .actual();
 
     assertThat(exception.getMessage())
         .contains("No READ_PROCESS_INSTANCE permission for process instance");
@@ -188,8 +188,9 @@ public class ProcessInstanceRestServiceTest {
         .thenReturn(false);
 
     final NotAuthorizedException exception =
-        assertThrows(
-            NotAuthorizedException.class, () -> underTest.getFlowNodeStates(processInstanceId));
+        assertThatExceptionOfType(NotAuthorizedException.class)
+            .isThrownBy(() -> underTest.getFlowNodeStates(processInstanceId))
+            .actual();
 
     assertThat(exception.getMessage())
         .contains("No READ_PROCESS_INSTANCE permission for process instance");
@@ -208,8 +209,9 @@ public class ProcessInstanceRestServiceTest {
         .thenReturn(false);
 
     final NotAuthorizedException exception =
-        assertThrows(
-            NotAuthorizedException.class, () -> underTest.getStatistics(processInstanceId));
+        assertThatExceptionOfType(NotAuthorizedException.class)
+            .isThrownBy(() -> underTest.getStatistics(processInstanceId))
+            .actual();
 
     assertThat(exception.getMessage())
         .contains("No READ_PROCESS_INSTANCE permission for process instance");
@@ -228,10 +230,12 @@ public class ProcessInstanceRestServiceTest {
         .thenReturn(false);
 
     final NotAuthorizedException exception =
-        assertThrows(
-            NotAuthorizedException.class,
-            () ->
-                underTest.getFlowNodeMetadata(processInstanceId, new FlowNodeMetadataRequestDto()));
+        assertThatExceptionOfType(NotAuthorizedException.class)
+            .isThrownBy(
+                () ->
+                    underTest.getFlowNodeMetadata(
+                        processInstanceId, new FlowNodeMetadataRequestDto()))
+            .actual();
 
     assertThat(exception.getMessage())
         .contains("No READ_PROCESS_INSTANCE permission for process instance");
@@ -250,13 +254,14 @@ public class ProcessInstanceRestServiceTest {
         .thenReturn(false);
 
     final NotAuthorizedException exception =
-        assertThrows(
-            NotAuthorizedException.class,
-            () ->
-                underTest.operation(
-                    processInstanceId,
-                    new CreateOperationRequestDto()
-                        .setOperationType(OperationType.DELETE_PROCESS_INSTANCE)));
+        assertThatExceptionOfType(NotAuthorizedException.class)
+            .isThrownBy(
+                () ->
+                    underTest.operation(
+                        processInstanceId,
+                        new CreateOperationRequestDto()
+                            .setOperationType(OperationType.DELETE_PROCESS_INSTANCE)))
+            .actual();
 
     assertThat(exception.getMessage())
         .contains("No DELETE_PROCESS_INSTANCE permission for process instance");
@@ -275,13 +280,14 @@ public class ProcessInstanceRestServiceTest {
         .thenReturn(false);
 
     final NotAuthorizedException exception =
-        assertThrows(
-            NotAuthorizedException.class,
-            () ->
-                underTest.operation(
-                    processInstanceId,
-                    new CreateOperationRequestDto()
-                        .setOperationType(OperationType.CANCEL_PROCESS_INSTANCE)));
+        assertThatExceptionOfType(NotAuthorizedException.class)
+            .isThrownBy(
+                () ->
+                    underTest.operation(
+                        processInstanceId,
+                        new CreateOperationRequestDto()
+                            .setOperationType(OperationType.CANCEL_PROCESS_INSTANCE)))
+            .actual();
 
     assertThat(exception.getMessage())
         .contains("No UPDATE_PROCESS_INSTANCE permission for process instance");
@@ -300,12 +306,14 @@ public class ProcessInstanceRestServiceTest {
         .thenReturn(false);
 
     final NotAuthorizedException exception =
-        assertThrows(
-            NotAuthorizedException.class,
-            () ->
-                underTest.operation(
-                    processInstanceId,
-                    new CreateOperationRequestDto().setOperationType(OperationType.ADD_VARIABLE)));
+        assertThatExceptionOfType(NotAuthorizedException.class)
+            .isThrownBy(
+                () ->
+                    underTest.operation(
+                        processInstanceId,
+                        new CreateOperationRequestDto()
+                            .setOperationType(OperationType.ADD_VARIABLE)))
+            .actual();
 
     assertThat(exception.getMessage())
         .contains("No UPDATE_PROCESS_INSTANCE permission for process instance");
@@ -324,8 +332,9 @@ public class ProcessInstanceRestServiceTest {
         .thenReturn(false);
 
     final NotAuthorizedException exception =
-        assertThrows(
-            NotAuthorizedException.class, () -> underTest.getVariable(processInstanceId, "var1"));
+        assertThatExceptionOfType(NotAuthorizedException.class)
+            .isThrownBy(() -> underTest.getVariable(processInstanceId, "var1"))
+            .actual();
 
     assertThat(exception.getMessage())
         .contains("No READ_PROCESS_INSTANCE permission for process instance");

--- a/operate/webapp/src/test/java/io/camunda/operate/webapp/rest/dto/listview/SortValuesWrapperTest.java
+++ b/operate/webapp/src/test/java/io/camunda/operate/webapp/rest/dto/listview/SortValuesWrapperTest.java
@@ -8,7 +8,7 @@
 package io.camunda.operate.webapp.rest.dto.listview;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -160,9 +160,8 @@ public class SortValuesWrapperTest {
       new SortValuesWrapper(objectMapper.writeValueAsString(tupleVal), Tuple.class)
     };
 
-    assertThrows(
-        OperateRuntimeException.class,
-        () -> SortValuesWrapper.convertSortValues(sortValuesWrappers, objectMapper));
+    assertThatExceptionOfType(OperateRuntimeException.class)
+        .isThrownBy(() -> SortValuesWrapper.convertSortValues(sortValuesWrappers, objectMapper));
   }
 
   @Test
@@ -172,9 +171,8 @@ public class SortValuesWrapperTest {
       new SortValuesWrapper(objectMapper.writeValueAsString(new Result("foo")), Result.class)
     };
 
-    assertThrows(
-        OperateRuntimeException.class,
-        () -> SortValuesWrapper.convertSortValues(sortValuesWrappers, objectMapper));
+    assertThatExceptionOfType(OperateRuntimeException.class)
+        .isThrownBy(() -> SortValuesWrapper.convertSortValues(sortValuesWrappers, objectMapper));
   }
 
   @Test

--- a/operate/webapp/src/test/java/io/camunda/operate/webapp/rest/validation/CreateBatchOperationRequestValidatorTest.java
+++ b/operate/webapp/src/test/java/io/camunda/operate/webapp/rest/validation/CreateBatchOperationRequestValidatorTest.java
@@ -8,8 +8,8 @@
 package io.camunda.operate.webapp.rest.validation;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -43,8 +43,9 @@ public class CreateBatchOperationRequestValidatorTest {
         new CreateBatchOperationRequestDto(null, OperationType.DELETE_PROCESS_INSTANCE);
 
     final InvalidRequestException exception =
-        assertThrows(
-            InvalidRequestException.class, () -> underTest.validate(batchOperationRequest));
+        assertThatExceptionOfType(InvalidRequestException.class)
+            .isThrownBy(() -> underTest.validate(batchOperationRequest))
+            .actual();
 
     assertThat(exception.getMessage()).isEqualTo("List view query must be defined.");
   }
@@ -55,8 +56,9 @@ public class CreateBatchOperationRequestValidatorTest {
         new CreateBatchOperationRequestDto(new ListViewQueryDto(), null);
 
     final InvalidRequestException exception =
-        assertThrows(
-            InvalidRequestException.class, () -> underTest.validate(batchOperationRequest));
+        assertThatExceptionOfType(InvalidRequestException.class)
+            .isThrownBy(() -> underTest.validate(batchOperationRequest))
+            .actual();
 
     assertThat(exception.getMessage()).isEqualTo("Operation type must be defined.");
   }
@@ -67,8 +69,9 @@ public class CreateBatchOperationRequestValidatorTest {
         new CreateBatchOperationRequestDto(new ListViewQueryDto(), OperationType.ADD_VARIABLE);
 
     final InvalidRequestException exception =
-        assertThrows(
-            InvalidRequestException.class, () -> underTest.validate(batchOperationRequest));
+        assertThatExceptionOfType(InvalidRequestException.class)
+            .isThrownBy(() -> underTest.validate(batchOperationRequest))
+            .actual();
 
     assertThat(exception.getMessage())
         .isEqualTo(
@@ -81,8 +84,9 @@ public class CreateBatchOperationRequestValidatorTest {
         new CreateBatchOperationRequestDto(new ListViewQueryDto(), OperationType.UPDATE_VARIABLE);
 
     final InvalidRequestException exception =
-        assertThrows(
-            InvalidRequestException.class, () -> underTest.validate(batchOperationRequest));
+        assertThatExceptionOfType(InvalidRequestException.class)
+            .isThrownBy(() -> underTest.validate(batchOperationRequest))
+            .actual();
 
     assertThat(exception.getMessage())
         .isEqualTo(
@@ -97,8 +101,9 @@ public class CreateBatchOperationRequestValidatorTest {
     batchOperationRequest.setMigrationPlan(null);
 
     final InvalidRequestException exception =
-        assertThrows(
-            InvalidRequestException.class, () -> underTest.validate(batchOperationRequest));
+        assertThatExceptionOfType(InvalidRequestException.class)
+            .isThrownBy(() -> underTest.validate(batchOperationRequest))
+            .actual();
 
     assertThat(exception.getMessage())
         .isEqualTo(
@@ -125,7 +130,7 @@ public class CreateBatchOperationRequestValidatorTest {
     final CreateBatchOperationRequestDto batchOperationRequest =
         new CreateBatchOperationRequestDto(new ListViewQueryDto(), OperationType.RESOLVE_INCIDENT);
 
-    assertDoesNotThrow(() -> underTest.validate(batchOperationRequest));
+    assertThatCode(() -> underTest.validate(batchOperationRequest)).doesNotThrowAnyException();
   }
 
   @Test
@@ -134,7 +139,7 @@ public class CreateBatchOperationRequestValidatorTest {
         new CreateBatchOperationRequestDto(
             new ListViewQueryDto(), OperationType.CANCEL_PROCESS_INSTANCE);
 
-    assertDoesNotThrow(() -> underTest.validate(batchOperationRequest));
+    assertThatCode(() -> underTest.validate(batchOperationRequest)).doesNotThrowAnyException();
   }
 
   @Test
@@ -143,7 +148,7 @@ public class CreateBatchOperationRequestValidatorTest {
         new CreateBatchOperationRequestDto(
             new ListViewQueryDto(), OperationType.DELETE_PROCESS_INSTANCE);
 
-    assertDoesNotThrow(() -> underTest.validate(batchOperationRequest));
+    assertThatCode(() -> underTest.validate(batchOperationRequest)).doesNotThrowAnyException();
   }
 
   @Test
@@ -152,7 +157,7 @@ public class CreateBatchOperationRequestValidatorTest {
         new CreateBatchOperationRequestDto(
             new ListViewQueryDto(), OperationType.DELETE_DECISION_DEFINITION);
 
-    assertDoesNotThrow(() -> underTest.validate(batchOperationRequest));
+    assertThatCode(() -> underTest.validate(batchOperationRequest)).doesNotThrowAnyException();
   }
 
   @Test
@@ -161,7 +166,7 @@ public class CreateBatchOperationRequestValidatorTest {
         new CreateBatchOperationRequestDto(
             new ListViewQueryDto(), OperationType.DELETE_PROCESS_DEFINITION);
 
-    assertDoesNotThrow(() -> underTest.validate(batchOperationRequest));
+    assertThatCode(() -> underTest.validate(batchOperationRequest)).doesNotThrowAnyException();
   }
 
   @Test
@@ -178,8 +183,9 @@ public class CreateBatchOperationRequestValidatorTest {
     for (final OperationType operationType : opTypes) {
       batchOperationRequest.setOperationType(operationType);
       final InvalidRequestException exception =
-          assertThrows(
-              InvalidRequestException.class, () -> underTest.validate(batchOperationRequest));
+          assertThatExceptionOfType(InvalidRequestException.class)
+              .isThrownBy(() -> underTest.validate(batchOperationRequest))
+              .actual();
       assertThat(exception.getMessage())
           .isEqualTo(
               String.format("Modifications field not supported for %s operation", operationType));
@@ -194,7 +200,7 @@ public class CreateBatchOperationRequestValidatorTest {
 
     batchOperationRequest.setModifications(List.of(new Modification()));
 
-    assertDoesNotThrow(() -> underTest.validate(batchOperationRequest));
+    assertThatCode(() -> underTest.validate(batchOperationRequest)).doesNotThrowAnyException();
     assertThat(batchOperationRequest.getModifications().size()).isEqualTo(1);
   }
 
@@ -210,7 +216,7 @@ public class CreateBatchOperationRequestValidatorTest {
                 new Modification().setModification(Type.ADD_TOKEN),
                 new Modification().setModification(Type.MOVE_TOKEN))));
 
-    assertDoesNotThrow(() -> underTest.validate(batchOperationRequest));
+    assertThatCode(() -> underTest.validate(batchOperationRequest)).doesNotThrowAnyException();
     assertThat(batchOperationRequest.getModifications().size()).isEqualTo(1);
     assertThat(batchOperationRequest.getModifications().get(0).getModification())
         .isEqualTo(Type.ADD_TOKEN);

--- a/operate/webapp/src/test/java/io/camunda/operate/webapp/rest/validation/CreateRequestOperationValidatorTest.java
+++ b/operate/webapp/src/test/java/io/camunda/operate/webapp/rest/validation/CreateRequestOperationValidatorTest.java
@@ -9,8 +9,8 @@ package io.camunda.operate.webapp.rest.validation;
 
 import static io.camunda.webapps.schema.entities.operation.OperationType.ADD_VARIABLE;
 import static io.camunda.webapps.schema.entities.operation.OperationType.UPDATE_VARIABLE;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
@@ -158,7 +158,7 @@ public class CreateRequestOperationValidatorTest {
         .thenReturn(List.of(failedOperation));
 
     // when - then
-    assertDoesNotThrow(() -> underTest.validate(request, "123"));
+    assertThatCode(() -> underTest.validate(request, "123")).doesNotThrowAnyException();
   }
 
   @ParameterizedTest(name = "should pass for {0} operation with valid scopeId, name, and value")
@@ -173,6 +173,6 @@ public class CreateRequestOperationValidatorTest {
     request.setVariableValue("val");
 
     // when - then
-    assertDoesNotThrow(() -> underTest.validate(request, "123"));
+    assertThatCode(() -> underTest.validate(request, "123")).doesNotThrowAnyException();
   }
 }

--- a/operate/webapp/src/test/java/io/camunda/operate/webapp/rest/validation/ModifyProcessInstanceRequestValidatorTest.java
+++ b/operate/webapp/src/test/java/io/camunda/operate/webapp/rest/validation/ModifyProcessInstanceRequestValidatorTest.java
@@ -8,7 +8,7 @@
 package io.camunda.operate.webapp.rest.validation;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 import static org.mockito.Mockito.when;
 
 import io.camunda.operate.webapp.elasticsearch.reader.ProcessInstanceReader;
@@ -43,7 +43,9 @@ public class ModifyProcessInstanceRequestValidatorTest {
         .thenReturn(null);
 
     final InvalidRequestException exception =
-        assertThrows(InvalidRequestException.class, () -> underTest.validate(request));
+        assertThatExceptionOfType(InvalidRequestException.class)
+            .isThrownBy(() -> underTest.validate(request))
+            .actual();
 
     assertThat(exception.getMessage())
         .isEqualTo(
@@ -60,7 +62,9 @@ public class ModifyProcessInstanceRequestValidatorTest {
         .thenReturn(new ProcessInstanceForListViewEntity());
 
     final InvalidRequestException exception =
-        assertThrows(InvalidRequestException.class, () -> underTest.validate(request));
+        assertThatExceptionOfType(InvalidRequestException.class)
+            .isThrownBy(() -> underTest.validate(request))
+            .actual();
 
     assertThat(exception.getMessage())
         .isEqualTo(
@@ -80,7 +84,9 @@ public class ModifyProcessInstanceRequestValidatorTest {
         .thenReturn(new ProcessInstanceForListViewEntity());
 
     final InvalidRequestException exception =
-        assertThrows(InvalidRequestException.class, () -> underTest.validate(request));
+        assertThatExceptionOfType(InvalidRequestException.class)
+            .isThrownBy(() -> underTest.validate(request))
+            .actual();
 
     assertThat(exception.getMessage())
         .isEqualTo(

--- a/operate/webapp/src/test/java/io/camunda/operate/webapp/rest/validation/ProcessInstanceRequestValidatorTest.java
+++ b/operate/webapp/src/test/java/io/camunda/operate/webapp/rest/validation/ProcessInstanceRequestValidatorTest.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.operate.webapp.rest.validation;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 
 import io.camunda.operate.webapp.rest.dto.listview.ListViewQueryDto;
 import io.camunda.operate.webapp.rest.exception.InvalidRequestException;
@@ -36,27 +36,27 @@ public class ProcessInstanceRequestValidatorTest {
   public void validateFlowNodeStatisticsRequestWithNoProcessId() {
     final ListViewQueryDto request = new ListViewQueryDto();
 
-    assertThrows(
-        InvalidRequestException.class,
-        () -> processInstanceRequestValidator.validateFlowNodeStatisticsRequest(request));
+    assertThatExceptionOfType(InvalidRequestException.class)
+        .isThrownBy(
+            () -> processInstanceRequestValidator.validateFlowNodeStatisticsRequest(request));
   }
 
   @Test
   public void validateFlowNodeStatisticsRequestWithBpmnProcessIdButNoVersion() {
     final ListViewQueryDto request = new ListViewQueryDto().setBpmnProcessId("demoProcess");
 
-    assertThrows(
-        InvalidRequestException.class,
-        () -> processInstanceRequestValidator.validateFlowNodeStatisticsRequest(request));
+    assertThatExceptionOfType(InvalidRequestException.class)
+        .isThrownBy(
+            () -> processInstanceRequestValidator.validateFlowNodeStatisticsRequest(request));
   }
 
   @Test
   public void validateFlowNodeStatisticsRequestWithMoreThanOneProcessDefinitionKey() {
     final ListViewQueryDto request = new ListViewQueryDto().setProcessIds(List.of("1", "2"));
 
-    assertThrows(
-        InvalidRequestException.class,
-        () -> processInstanceRequestValidator.validateFlowNodeStatisticsRequest(request));
+    assertThatExceptionOfType(InvalidRequestException.class)
+        .isThrownBy(
+            () -> processInstanceRequestValidator.validateFlowNodeStatisticsRequest(request));
   }
 
   @Test
@@ -67,8 +67,8 @@ public class ProcessInstanceRequestValidatorTest {
             .setProcessVersion(1)
             .setProcessIds(List.of("1"));
 
-    assertThrows(
-        InvalidRequestException.class,
-        () -> processInstanceRequestValidator.validateFlowNodeStatisticsRequest(request));
+    assertThatExceptionOfType(InvalidRequestException.class)
+        .isThrownBy(
+            () -> processInstanceRequestValidator.validateFlowNodeStatisticsRequest(request));
   }
 }

--- a/optimize/backend/src/test/java/io/camunda/optimize/rest/security/oauth/RoleValidatorTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/rest/security/oauth/RoleValidatorTest.java
@@ -7,9 +7,7 @@
  */
 package io.camunda.optimize.rest.security.oauth;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -38,7 +36,7 @@ class RoleValidatorTest {
     final OAuth2TokenValidatorResult result = validator.validate(token);
 
     // then
-    assertTrue(result.hasErrors());
+    assertThat(result.hasErrors()).isTrue();
   }
 
   @Test
@@ -56,7 +54,7 @@ class RoleValidatorTest {
     final OAuth2TokenValidatorResult result = validator.validate(token);
 
     // then
-    assertFalse(result.hasErrors());
+    assertThat(result.hasErrors()).isFalse();
   }
 
   @Test
@@ -77,7 +75,7 @@ class RoleValidatorTest {
     final OAuth2TokenValidatorResult result = validator.validate(token);
 
     // then
-    assertFalse(result.hasErrors());
+    assertThat(result.hasErrors()).isFalse();
   }
 
   @Test
@@ -95,8 +93,8 @@ class RoleValidatorTest {
     final OAuth2TokenValidatorResult result = validator.validate(token);
 
     // then
-    assertTrue(result.hasErrors());
-    assertEquals("invalid_token", result.getErrors().iterator().next().getErrorCode());
+    assertThat(result.hasErrors()).isTrue();
+    assertThat(result.getErrors().iterator().next().getErrorCode()).isEqualTo("invalid_token");
   }
 
   @Test
@@ -114,7 +112,7 @@ class RoleValidatorTest {
     final OAuth2TokenValidatorResult result = validator.validate(token);
 
     // then
-    assertTrue(result.hasErrors());
+    assertThat(result.hasErrors()).isTrue();
   }
 
   @Test
@@ -129,7 +127,7 @@ class RoleValidatorTest {
     final OAuth2TokenValidatorResult result = validator.validate(token);
 
     // then
-    assertTrue(result.hasErrors());
+    assertThat(result.hasErrors()).isTrue();
   }
 
   @Test
@@ -144,6 +142,6 @@ class RoleValidatorTest {
     final OAuth2TokenValidatorResult result = validator.validate(token);
 
     // then
-    assertTrue(result.hasErrors());
+    assertThat(result.hasErrors()).isTrue();
   }
 }

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/alert/CCSMAlertRecipientValidatorTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/alert/CCSMAlertRecipientValidatorTest.java
@@ -8,8 +8,8 @@
 package io.camunda.optimize.service.alert;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 import static org.mockito.Mockito.when;
 
 import io.camunda.optimize.dto.optimize.UserDto;
@@ -43,10 +43,11 @@ public class CCSMAlertRecipientValidatorTest {
         .thenReturn(List.of(TEST_USER_1, TEST_USER_2));
 
     // when/then
-    assertDoesNotThrow(
-        () ->
-            ccsmAlertRecipientValidator.validateAlertRecipientEmailAddresses(
-                emailsToValidate.stream().toList()));
+    assertThatCode(
+            () ->
+                ccsmAlertRecipientValidator.validateAlertRecipientEmailAddresses(
+                    emailsToValidate.stream().toList()))
+        .doesNotThrowAnyException();
   }
 
   @Test
@@ -56,10 +57,11 @@ public class CCSMAlertRecipientValidatorTest {
         .thenReturn(Collections.emptyList());
 
     // when/then
-    assertDoesNotThrow(
-        () ->
-            ccsmAlertRecipientValidator.validateAlertRecipientEmailAddresses(
-                Collections.emptyList()));
+    assertThatCode(
+            () ->
+                ccsmAlertRecipientValidator.validateAlertRecipientEmailAddresses(
+                    Collections.emptyList()))
+        .doesNotThrowAnyException();
   }
 
   @Test
@@ -70,11 +72,12 @@ public class CCSMAlertRecipientValidatorTest {
 
     // when/then
     final OptimizeAlertEmailValidationException thrown =
-        assertThrows(
-            OptimizeAlertEmailValidationException.class,
-            () ->
-                ccsmAlertRecipientValidator.validateAlertRecipientEmailAddresses(
-                    emailsToValidate.stream().toList()));
+        assertThatExceptionOfType(OptimizeAlertEmailValidationException.class)
+            .isThrownBy(
+                () ->
+                    ccsmAlertRecipientValidator.validateAlertRecipientEmailAddresses(
+                        emailsToValidate.stream().toList()))
+            .actual();
     assertThat(thrown.getAlertEmails()).containsExactly(TEST_EMAIL_2);
   }
 }

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/backup/BackupServiceTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/backup/BackupServiceTest.java
@@ -8,7 +8,7 @@
 package io.camunda.optimize.service.backup;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.doNothing;
@@ -65,7 +65,9 @@ public class BackupServiceTest {
 
     // when/then
     final OptimizeConfigurationException thrown =
-        assertThrows(OptimizeConfigurationException.class, () -> backupService.triggerBackup(123L));
+        assertThatExceptionOfType(OptimizeConfigurationException.class)
+            .isThrownBy(() -> backupService.triggerBackup(123L))
+            .actual();
     assertThat(thrown.getMessage())
         .isEqualTo(
             "Cannot execute backup request because no snapshot repository name found in Optimize "
@@ -85,7 +87,9 @@ public class BackupServiceTest {
 
     // when/then
     final OptimizeRuntimeException thrown =
-        assertThrows(OptimizeRuntimeException.class, () -> backupService.triggerBackup(123L));
+        assertThatExceptionOfType(OptimizeRuntimeException.class)
+            .isThrownBy(() -> backupService.triggerBackup(123L))
+            .actual();
     assertThat(thrown.getMessage())
         .isEqualTo("No repository with name [does_not_exist] could be found.");
   }
@@ -105,7 +109,9 @@ public class BackupServiceTest {
 
     // when
     final OptimizeConflictException thrown =
-        assertThrows(OptimizeConflictException.class, () -> backupService.triggerBackup(123L));
+        assertThatExceptionOfType(OptimizeConflictException.class)
+            .isThrownBy(() -> backupService.triggerBackup(123L))
+            .actual();
     assertThat(thrown.getMessage())
         .isEqualTo(
             "A backup with ID [123] already exists. Found snapshots: "
@@ -122,8 +128,9 @@ public class BackupServiceTest {
 
     // when/then
     final OptimizeConfigurationException thrown =
-        assertThrows(
-            OptimizeConfigurationException.class, () -> backupService.getSingleBackupInfo(123L));
+        assertThatExceptionOfType(OptimizeConfigurationException.class)
+            .isThrownBy(() -> backupService.getSingleBackupInfo(123L))
+            .actual();
     assertThat(thrown.getMessage())
         .isEqualTo(
             "Cannot execute backup request because no snapshot repository name found in Optimize "
@@ -143,7 +150,9 @@ public class BackupServiceTest {
 
     // when/then
     final OptimizeRuntimeException thrown =
-        assertThrows(OptimizeRuntimeException.class, () -> backupService.getSingleBackupInfo(123L));
+        assertThatExceptionOfType(OptimizeRuntimeException.class)
+            .isThrownBy(() -> backupService.getSingleBackupInfo(123L))
+            .actual();
     assertThat(thrown.getMessage())
         .isEqualTo("No repository with name [does_not_exist] could be found.");
   }
@@ -159,7 +168,9 @@ public class BackupServiceTest {
 
     // when/then
     final NotFoundException thrown =
-        assertThrows(NotFoundException.class, () -> backupService.getSingleBackupInfo(123L));
+        assertThatExceptionOfType(NotFoundException.class)
+            .isThrownBy(() -> backupService.getSingleBackupInfo(123L))
+            .actual();
     assertThat(thrown.getMessage()).isEqualTo("No Optimize backup with ID [123] could be found.");
   }
 
@@ -173,7 +184,9 @@ public class BackupServiceTest {
 
     // when/then
     final OptimizeConfigurationException thrown =
-        assertThrows(OptimizeConfigurationException.class, () -> backupService.getAllBackupInfo());
+        assertThatExceptionOfType(OptimizeConfigurationException.class)
+            .isThrownBy(() -> backupService.getAllBackupInfo())
+            .actual();
     assertThat(thrown.getMessage())
         .isEqualTo(
             "Cannot execute backup request because no snapshot repository name found in Optimize "
@@ -193,7 +206,9 @@ public class BackupServiceTest {
 
     // when/then
     final OptimizeRuntimeException thrown =
-        assertThrows(OptimizeRuntimeException.class, () -> backupService.getAllBackupInfo());
+        assertThatExceptionOfType(OptimizeRuntimeException.class)
+            .isThrownBy(() -> backupService.getAllBackupInfo())
+            .actual();
     assertThat(thrown.getMessage())
         .isEqualTo("No repository with name [does_not_exist] could be found.");
   }
@@ -220,7 +235,9 @@ public class BackupServiceTest {
 
     // when/then
     final OptimizeConfigurationException thrown =
-        assertThrows(OptimizeConfigurationException.class, () -> backupService.deleteBackup(123L));
+        assertThatExceptionOfType(OptimizeConfigurationException.class)
+            .isThrownBy(() -> backupService.deleteBackup(123L))
+            .actual();
     assertThat(thrown.getMessage())
         .isEqualTo(
             "Cannot execute backup request because no snapshot repository name found in Optimize "
@@ -240,7 +257,9 @@ public class BackupServiceTest {
 
     // when/then
     final OptimizeRuntimeException thrown =
-        assertThrows(OptimizeRuntimeException.class, () -> backupService.deleteBackup(123L));
+        assertThatExceptionOfType(OptimizeRuntimeException.class)
+            .isThrownBy(() -> backupService.deleteBackup(123L))
+            .actual();
     assertThat(thrown.getMessage())
         .isEqualTo("No repository with name [does_not_exist] could be found.");
   }

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/cleanup/CleanupSchedulerTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/cleanup/CleanupSchedulerTest.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.optimize.service.cleanup;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
@@ -94,7 +94,7 @@ public class CleanupSchedulerTest {
     final CleanupScheduler underTest = createOptimizeCleanupServiceToTest();
 
     // then
-    assertThrows(OptimizeConfigurationException.class, underTest::init);
+    assertThatExceptionOfType(OptimizeConfigurationException.class).isThrownBy(underTest::init);
   }
 
   private CleanupConfiguration getCleanupConfiguration() {

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/importing/ZeebeRecordFetcherTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/importing/ZeebeRecordFetcherTest.java
@@ -8,7 +8,7 @@
 package io.camunda.optimize.service.importing;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -277,9 +277,9 @@ public class ZeebeRecordFetcherTest {
 
   private void triggerFailedFetchAttempt() {
     final PositionBasedImportPage positionBasedImportPage = new PositionBasedImportPage();
-    assertThrows(
-        OptimizeRuntimeException.class,
-        () -> underTest.getZeebeRecordsForPrefixAndPartitionFrom(positionBasedImportPage));
+    assertThatExceptionOfType(OptimizeRuntimeException.class)
+        .isThrownBy(
+            () -> underTest.getZeebeRecordsForPrefixAndPartitionFrom(positionBasedImportPage));
   }
 
   private void triggerFetchAttemptForEmptyPage() {

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/report/ReportServiceConflictTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/report/ReportServiceConflictTest.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.optimize.service.report;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -109,9 +109,8 @@ public class ReportServiceConflictTest {
         .thenReturn(conflicts);
 
     // when
-    assertThrows(
-        OptimizeConflictException.class,
-        () -> underTest.updateSingleProcessReport("test1", updateDto, "user1", false));
+    assertThatExceptionOfType(OptimizeConflictException.class)
+        .isThrownBy(() -> underTest.updateSingleProcessReport("test1", updateDto, "user1", false));
   }
 
   @Test
@@ -152,9 +151,8 @@ public class ReportServiceConflictTest {
         .thenReturn(conflicts);
 
     // when
-    assertThrows(
-        OptimizeConflictException.class,
-        () -> underTest.updateSingleDecisionReport("test1", updateDto, "user1", false));
+    assertThatExceptionOfType(OptimizeConflictException.class)
+        .isThrownBy(() -> underTest.updateSingleDecisionReport("test1", updateDto, "user1", false));
   }
 
   @Test
@@ -190,8 +188,7 @@ public class ReportServiceConflictTest {
     when(reportRelationService.getConflictedItemsForDeleteReport(any())).thenReturn(conflicts);
 
     // when
-    assertThrows(
-        OptimizeConflictException.class,
-        () -> underTest.deleteReportAsUser("user1", "test1", false));
+    assertThatExceptionOfType(OptimizeConflictException.class)
+        .isThrownBy(() -> underTest.deleteReportAsUser("user1", "test1", false));
   }
 }

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/security/CCSMTokenServiceTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/security/CCSMTokenServiceTest.java
@@ -7,7 +7,8 @@
  */
 package io.camunda.optimize.service.security;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 import static org.mockito.Mockito.*;
 
 import com.google.common.collect.ImmutableList;
@@ -62,11 +63,11 @@ public class CCSMTokenServiceTest {
 
     final UserDto result = ccsmTokenService.getUserInfoFromToken(ID, ACCESS_TOKEN_VALUE);
 
-    assertEquals(ID, result.getId());
-    assertEquals(NAME, result.getFirstName());
-    assertEquals(EMAIL, result.getEmail());
-    assertNull(result.getLastName());
-    assertTrue(result.getRoles().isEmpty());
+    assertThat(result.getId()).isEqualTo(ID);
+    assertThat(result.getFirstName()).isEqualTo(NAME);
+    assertThat(result.getEmail()).isEqualTo(EMAIL);
+    assertThat(result.getLastName()).isNull();
+    assertThat(result.getRoles().isEmpty()).isTrue();
   }
 
   @Test
@@ -78,11 +79,11 @@ public class CCSMTokenServiceTest {
 
     final UserDto result = ccsmTokenService.getUserInfoFromToken(ID, ACCESS_TOKEN_VALUE);
 
-    assertEquals(ID, result.getId());
-    assertEquals(USERNAME, result.getFirstName());
-    assertEquals(EMAIL, result.getEmail());
-    assertNull(result.getLastName());
-    assertTrue(result.getRoles().isEmpty());
+    assertThat(result.getId()).isEqualTo(ID);
+    assertThat(result.getFirstName()).isEqualTo(USERNAME);
+    assertThat(result.getEmail()).isEqualTo(EMAIL);
+    assertThat(result.getLastName()).isNull();
+    assertThat(result.getRoles().isEmpty()).isTrue();
   }
 
   @Test
@@ -94,11 +95,11 @@ public class CCSMTokenServiceTest {
 
     final UserDto result = ccsmTokenService.getUserInfoFromToken(ID, ACCESS_TOKEN_VALUE);
 
-    assertEquals(ID, result.getId());
-    assertEquals(ID, result.getFirstName());
-    assertEquals(EMAIL, result.getEmail());
-    assertNull(result.getLastName());
-    assertTrue(result.getRoles().isEmpty());
+    assertThat(result.getId()).isEqualTo(ID);
+    assertThat(result.getFirstName()).isEqualTo(ID);
+    assertThat(result.getEmail()).isEqualTo(EMAIL);
+    assertThat(result.getLastName()).isNull();
+    assertThat(result.getRoles().isEmpty()).isTrue();
   }
 
   @Test
@@ -109,19 +110,18 @@ public class CCSMTokenServiceTest {
 
     final UserDto result = ccsmTokenService.getUserInfoFromToken(ID, ACCESS_TOKEN_VALUE);
 
-    assertEquals(ID, result.getId());
-    assertEquals(ID, result.getEmail());
-    assertEquals(NAME, result.getFirstName());
-    assertNull(result.getLastName());
-    assertTrue(result.getRoles().isEmpty());
+    assertThat(result.getId()).isEqualTo(ID);
+    assertThat(result.getEmail()).isEqualTo(ID);
+    assertThat(result.getFirstName()).isEqualTo(NAME);
+    assertThat(result.getLastName()).isNull();
+    assertThat(result.getRoles().isEmpty()).isTrue();
   }
 
   @Test
   void getUserInfoFromTokenInvalidTokenThrowsNotAuthorizedException() {
     when(accessToken.getPermissions()).thenReturn(ImmutableList.of());
 
-    assertThrows(
-        NotAuthorizedException.class,
-        () -> ccsmTokenService.getUserInfoFromToken(ID, ACCESS_TOKEN_VALUE));
+    assertThatExceptionOfType(NotAuthorizedException.class)
+        .isThrownBy(() -> ccsmTokenService.getUserInfoFromToken(ID, ACCESS_TOKEN_VALUE));
   }
 }

--- a/optimize/upgrade/src/test/java/io/camunda/optimize/upgrade/UpgradeStepsIT.java
+++ b/optimize/upgrade/src/test/java/io/camunda/optimize/upgrade/UpgradeStepsIT.java
@@ -10,7 +10,7 @@ package io.camunda.optimize.upgrade;
 import static io.camunda.optimize.service.db.DatabaseConstants.INDEX_SUFFIX_PRE_ROLLOVER;
 import static io.camunda.optimize.util.SuppressionConstants.SAME_PARAM_VALUE;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 
 import io.camunda.optimize.dto.optimize.query.MetadataDto;
 import io.camunda.optimize.exception.OptimizeIntegrationTestException;
@@ -498,7 +498,8 @@ public class UpgradeStepsIT extends AbstractUpgradeIT {
             .build();
 
     // when
-    assertThrows(UpgradeRuntimeException.class, () -> upgradeProcedure.performUpgrade(upgradePlan));
+    assertThatExceptionOfType(UpgradeRuntimeException.class)
+        .isThrownBy(() -> upgradeProcedure.performUpgrade(upgradePlan));
   }
 
   @Test

--- a/optimize/upgrade/src/test/java/io/camunda/optimize/upgrade/main/UpgradeProcedureTest.java
+++ b/optimize/upgrade/src/test/java/io/camunda/optimize/upgrade/main/UpgradeProcedureTest.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.optimize.upgrade.main;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
@@ -146,7 +146,8 @@ public class UpgradeProcedureTest {
 
     // when
     final UpgradePlan upgradePlan = createUpgradePlan();
-    assertThrows(UpgradeRuntimeException.class, () -> underTest.performUpgrade(upgradePlan));
+    assertThatExceptionOfType(UpgradeRuntimeException.class)
+        .isThrownBy(() -> underTest.performUpgrade(upgradePlan));
 
     // then the validation and execution happens in the expected order
     final InOrder inOrder = inOrder(createIndexStep, upgradeStepLogService);

--- a/optimize/util/optimize-commons/src/test/java/io/camunda/optimize/service/util/configuration/ConfigurationServiceTest.java
+++ b/optimize/util/optimize-commons/src/test/java/io/camunda/optimize/service/util/configuration/ConfigurationServiceTest.java
@@ -11,7 +11,7 @@ import static io.camunda.optimize.service.util.configuration.ConfigurationServic
 import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 
 import com.jayway.jsonpath.spi.mapper.MappingException;
 import io.camunda.optimize.service.exceptions.OptimizeConfigurationException;
@@ -537,7 +537,9 @@ public class ConfigurationServiceTest {
 
     // then
     final OptimizeConfigurationException exception =
-        assertThrows(OptimizeConfigurationException.class, () -> createConfiguration(locations));
+        assertThatExceptionOfType(OptimizeConfigurationException.class)
+            .isThrownBy(() -> createConfiguration(locations))
+            .actual();
     assertThat(exception).isNotNull();
     assertThat(exception.getMessage()).contains("Could not resolve system/environment variable");
   }

--- a/optimize/util/optimize-commons/src/test/java/io/camunda/optimize/service/util/configuration/ConfigurationValidatorTest.java
+++ b/optimize/util/optimize-commons/src/test/java/io/camunda/optimize/service/util/configuration/ConfigurationValidatorTest.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.optimize.service.util.configuration;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -40,6 +40,7 @@ public class ConfigurationValidatorTest {
     final ConfigurationValidator validator = new ConfigurationValidator();
 
     // when / then
-    assertThrows(NullPointerException.class, () -> validator.validate(configurationService));
+    assertThatExceptionOfType(NullPointerException.class)
+        .isThrownBy(() -> validator.validate(configurationService));
   }
 }

--- a/optimize/util/optimize-commons/src/test/java/io/camunda/optimize/service/util/configuration/ProxyConfigurationTest.java
+++ b/optimize/util/optimize-commons/src/test/java/io/camunda/optimize/service/util/configuration/ProxyConfigurationTest.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.optimize.service.util.configuration;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 
 import io.camunda.optimize.service.exceptions.OptimizeConfigurationException;
 import org.junit.jupiter.api.Test;
@@ -25,14 +25,16 @@ public class ProxyConfigurationTest {
   public void testValidateFailOnMissingHost() {
     final ProxyConfiguration proxyConfiguration = new ProxyConfiguration(true, null, 80, false);
 
-    assertThrows(OptimizeConfigurationException.class, () -> proxyConfiguration.validate());
+    assertThatExceptionOfType(OptimizeConfigurationException.class)
+        .isThrownBy(() -> proxyConfiguration.validate());
   }
 
   @Test
   public void testValidateFailOnEmptyHost() {
     final ProxyConfiguration proxyConfiguration = new ProxyConfiguration(true, "", 80, false);
 
-    assertThrows(OptimizeConfigurationException.class, () -> proxyConfiguration.validate());
+    assertThatExceptionOfType(OptimizeConfigurationException.class)
+        .isThrownBy(() -> proxyConfiguration.validate());
   }
 
   @Test
@@ -40,6 +42,7 @@ public class ProxyConfigurationTest {
     final ProxyConfiguration proxyConfiguration =
         new ProxyConfiguration(true, "localhost", null, false);
 
-    assertThrows(OptimizeConfigurationException.class, () -> proxyConfiguration.validate());
+    assertThatExceptionOfType(OptimizeConfigurationException.class)
+        .isThrownBy(() -> proxyConfiguration.validate());
   }
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/BatchOperationAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/BatchOperationAuthorizationIT.java
@@ -21,7 +21,7 @@ import static io.camunda.it.util.TestHelper.getScopedVariables;
 import static io.camunda.it.util.TestHelper.startScopedProcessInstance;
 import static io.camunda.it.util.TestHelper.waitForScopedProcessInstancesToStart;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ProblemException;
@@ -40,11 +40,11 @@ import java.time.Duration;
 import java.util.List;
 import java.util.UUID;
 import java.util.function.Consumer;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
-import org.junit.jupiter.api.function.Executable;
 
 @MultiDbTest
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
@@ -306,7 +306,7 @@ class BatchOperationAuthorizationIT {
   void shouldReturnForbiddenForUnauthorizedBatchOperation(
       @Authenticated(FORBIDDEN) final CamundaClient camundaClient) {
     // when
-    final Executable executeGet =
+    final ThrowingCallable executeGet =
         () ->
             camundaClient
                 .newCreateBatchOperationCommand()
@@ -316,7 +316,8 @@ class BatchOperationAuthorizationIT {
                 .join();
 
     // then
-    final var problemException = assertThrows(ProblemException.class, executeGet);
+    final var problemException =
+        assertThatExceptionOfType(ProblemException.class).isThrownBy(executeGet).actual();
     assertThat(problemException.code()).isEqualTo(403);
     assertThat(problemException.details().getDetail())
         .isEqualTo(

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/DecisionAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/DecisionAuthorizationIT.java
@@ -10,7 +10,7 @@ package io.camunda.it.auth;
 import static io.camunda.client.api.search.enums.PermissionType.*;
 import static io.camunda.client.api.search.enums.ResourceType.*;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ProblemException;
@@ -24,11 +24,11 @@ import io.camunda.qa.util.multidb.MultiDbTestApplication;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import java.time.Duration;
 import java.util.List;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
-import org.junit.jupiter.api.function.Executable;
 
 @MultiDbTest
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms")
@@ -98,11 +98,12 @@ class DecisionAuthorizationIT {
         getDecisionDefinitionKey(adminClient, DECISION_DEFINITION_ID_2);
 
     // when
-    final Executable executeGet =
+    final ThrowingCallable executeGet =
         () -> userClient.newDecisionDefinitionGetRequest(decisionDefinitionKey).send().join();
 
     // then
-    final var problemException = assertThrows(ProblemException.class, executeGet);
+    final var problemException =
+        assertThatExceptionOfType(ProblemException.class).isThrownBy(executeGet).actual();
     assertThat(problemException.code()).isEqualTo(403);
     assertThat(problemException.details().getDetail())
         .isEqualTo(
@@ -148,11 +149,12 @@ class DecisionAuthorizationIT {
         getDecisionRequirementsKey(adminClient, DECISION_REQUIREMENTS_ID_2);
 
     // when
-    final Executable executeGet =
+    final ThrowingCallable executeGet =
         () -> userClient.newDecisionRequirementsGetRequest(decisionRequirementsKey).send().join();
 
     // then
-    final var problemException = assertThrows(ProblemException.class, executeGet);
+    final var problemException =
+        assertThatExceptionOfType(ProblemException.class).isThrownBy(executeGet).actual();
     assertThat(problemException.code()).isEqualTo(403);
     assertThat(problemException.details().getDetail())
         .isEqualTo(

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/DecisionInstanceAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/DecisionInstanceAuthorizationIT.java
@@ -11,7 +11,7 @@ import static io.camunda.client.api.search.enums.PermissionType.*;
 import static io.camunda.client.api.search.enums.ResourceType.DECISION_DEFINITION;
 import static io.camunda.client.api.search.enums.ResourceType.RESOURCE;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ProblemException;
@@ -27,11 +27,11 @@ import io.camunda.qa.util.multidb.MultiDbTestApplication;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import java.time.Duration;
 import java.util.List;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
-import org.junit.jupiter.api.function.Executable;
 
 @MultiDbTest
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms")
@@ -100,11 +100,12 @@ class DecisionInstanceAuthorizationIT {
     final var decisionInstanceId = getDecisionInstanceId(adminClient, DECISION_DEFINITION_ID_2);
 
     // when
-    final Executable executeGet =
+    final ThrowingCallable executeGet =
         () -> userClient.newDecisionInstanceGetRequest(decisionInstanceId).send().join();
 
     // then
-    final var problemException = assertThrows(ProblemException.class, executeGet);
+    final var problemException =
+        assertThatExceptionOfType(ProblemException.class).isThrownBy(executeGet).actual();
     assertThat(problemException.code()).isEqualTo(403);
     assertThat(problemException.details().getDetail())
         .isEqualTo(

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/GroupAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/GroupAuthorizationIT.java
@@ -9,8 +9,8 @@ package io.camunda.it.auth;
 
 import static io.camunda.client.api.search.enums.PermissionType.*;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -35,10 +35,10 @@ import io.camunda.zeebe.protocol.record.value.EntityType;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import io.camunda.zeebe.test.util.Strings;
 import java.util.List;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
-import org.junit.jupiter.api.function.Executable;
 
 @MultiDbTest
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms")
@@ -162,10 +162,11 @@ class GroupAuthorizationIT {
   void getGroupByIdShouldReturnForbiddenIfUnauthorized(
       @Authenticated(RESTRICTED) final CamundaClient camundaClient) {
     // when
-    final Executable executeGet =
+    final ThrowingCallable executeGet =
         () -> camundaClient.newGroupGetRequest(GROUP_1.id()).send().join();
     // then
-    final var problemException = assertThrows(ProblemException.class, executeGet);
+    final var problemException =
+        assertThatExceptionOfType(ProblemException.class).isThrownBy(executeGet).actual();
     assertThat(problemException.code()).isEqualTo(403);
     assertThat(problemException.details().getDetail())
         .isEqualTo("Unauthorized to perform operation 'READ' on resource 'GROUP'");

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/ProcessAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/ProcessAuthorizationIT.java
@@ -12,7 +12,7 @@ import static io.camunda.client.api.search.enums.PermissionType.READ_PROCESS_DEF
 import static io.camunda.client.api.search.enums.ResourceType.PROCESS_DEFINITION;
 import static io.camunda.client.api.search.enums.ResourceType.RESOURCE;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ProblemException;
@@ -26,11 +26,11 @@ import io.camunda.qa.util.multidb.MultiDbTestApplication;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import java.time.Duration;
 import java.util.List;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
-import org.junit.jupiter.api.function.Executable;
 
 @MultiDbTest
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms")
@@ -110,11 +110,12 @@ class ProcessAuthorizationIT {
     final var processDefinitionKey = getProcessDefinitionKey(adminClient, "incident_process_v1");
 
     // when
-    final Executable executeGet =
+    final ThrowingCallable executeGet =
         () -> userClient.newProcessDefinitionGetRequest(processDefinitionKey).send().join();
 
     // then
-    final var problemException = assertThrows(ProblemException.class, executeGet);
+    final var problemException =
+        assertThatExceptionOfType(ProblemException.class).isThrownBy(executeGet).actual();
     assertThat(problemException.code()).isEqualTo(403);
     assertThat(problemException.details().getDetail())
         .isEqualTo(

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/ProcessInstanceAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/ProcessInstanceAuthorizationIT.java
@@ -11,7 +11,7 @@ import static io.camunda.client.api.search.enums.PermissionType.*;
 import static io.camunda.client.api.search.enums.ResourceType.PROCESS_DEFINITION;
 import static io.camunda.client.api.search.enums.ResourceType.RESOURCE;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ProblemException;
@@ -24,11 +24,11 @@ import io.camunda.qa.util.multidb.MultiDbTestApplication;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import java.time.Duration;
 import java.util.List;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
-import org.junit.jupiter.api.function.Executable;
 
 @MultiDbTest
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms")
@@ -128,10 +128,11 @@ class ProcessInstanceAuthorizationIT {
     // given
     final var processInstanceKey = getProcessInstanceKey(adminClient, PROCESS_ID_2);
     // when
-    final Executable executeGet =
+    final ThrowingCallable executeGet =
         () -> camundaClient.newProcessInstanceGetRequest(processInstanceKey).send().join();
     // then
-    final var problemException = assertThrows(ProblemException.class, executeGet);
+    final var problemException =
+        assertThatExceptionOfType(ProblemException.class).isThrownBy(executeGet).actual();
     assertThat(problemException.code()).isEqualTo(403);
     assertThat(problemException.details().getDetail())
         .isEqualTo(
@@ -173,10 +174,11 @@ class ProcessInstanceAuthorizationIT {
     // given
     final var elementInstanceKey = getAnyElementInstanceKey(adminClient, PROCESS_ID_2);
     // when
-    final Executable executeGet =
+    final ThrowingCallable executeGet =
         () -> camundaClient.newElementInstanceGetRequest(elementInstanceKey).send().join();
     // then
-    final var problemException = assertThrows(ProblemException.class, executeGet);
+    final var problemException =
+        assertThatExceptionOfType(ProblemException.class).isThrownBy(executeGet).actual();
     assertThat(problemException.code()).isEqualTo(403);
     assertThat(problemException.details().getDetail())
         .isEqualTo(
@@ -214,10 +216,11 @@ class ProcessInstanceAuthorizationIT {
     // given
     final var incidentKey = getAnyIncidentKey(adminClient, PROCESS_ID_1);
     // when
-    final Executable executeGet =
+    final ThrowingCallable executeGet =
         () -> camundaClient.newIncidentGetRequest(incidentKey).send().join();
     // then
-    final var problemException = assertThrows(ProblemException.class, executeGet);
+    final var problemException =
+        assertThatExceptionOfType(ProblemException.class).isThrownBy(executeGet).actual();
     assertThat(problemException.code()).isEqualTo(403);
     assertThat(problemException.details().getDetail())
         .isEqualTo(
@@ -259,10 +262,11 @@ class ProcessInstanceAuthorizationIT {
     final var processInstanceKey = getProcessInstanceKey(adminClient, PROCESS_ID_2);
     final var variableKey = getAnyVariableKey(adminClient, processInstanceKey);
     // when
-    final Executable executeGet =
+    final ThrowingCallable executeGet =
         () -> camundaClient.newVariableGetRequest(variableKey).send().join();
     // then
-    final var problemException = assertThrows(ProblemException.class, executeGet);
+    final var problemException =
+        assertThatExceptionOfType(ProblemException.class).isThrownBy(executeGet).actual();
     assertThat(problemException.code()).isEqualTo(403);
     assertThat(problemException.details().getDetail())
         .isEqualTo(

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/UserTaskAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/UserTaskAuthorizationIT.java
@@ -11,7 +11,7 @@ import static io.camunda.client.api.search.enums.PermissionType.*;
 import static io.camunda.client.api.search.enums.ResourceType.PROCESS_DEFINITION;
 import static io.camunda.client.api.search.enums.ResourceType.RESOURCE;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ProblemException;
@@ -24,11 +24,11 @@ import io.camunda.qa.util.multidb.MultiDbTestApplication;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import java.time.Duration;
 import java.util.List;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
-import org.junit.jupiter.api.function.Executable;
 
 @MultiDbTest
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms")
@@ -114,10 +114,11 @@ class UserTaskAuthorizationIT {
     // given
     final var userTaskKey = getUserTaskKey(adminClient, PROCESS_ID_2);
     // when
-    final Executable executeGet =
+    final ThrowingCallable executeGet =
         () -> camundaClient.newUserTaskGetRequest(userTaskKey).send().join();
     // then
-    final var problemException = assertThrows(ProblemException.class, executeGet);
+    final var problemException =
+        assertThatExceptionOfType(ProblemException.class).isThrownBy(executeGet).actual();
     assertThat(problemException.code()).isEqualTo(403);
     assertThat(problemException.details().getDetail())
         .isEqualTo(
@@ -144,10 +145,11 @@ class UserTaskAuthorizationIT {
     // given
     final var userTaskKey = getUserTaskKey(adminClient, PROCESS_ID_2);
     // when
-    final Executable executeGetForm =
+    final ThrowingCallable executeGetForm =
         () -> camundaClient.newUserTaskGetFormRequest(userTaskKey).send().join();
     // then
-    final var problemException = assertThrows(ProblemException.class, executeGetForm);
+    final var problemException =
+        assertThatExceptionOfType(ProblemException.class).isThrownBy(executeGetForm).actual();
     assertThat(problemException.code()).isEqualTo(403);
     assertThat(problemException.details().getDetail())
         .isEqualTo(
@@ -173,10 +175,13 @@ class UserTaskAuthorizationIT {
     // given
     final var userTaskKey = getUserTaskKey(adminClient, PROCESS_ID_1);
     // when
-    final Executable executeSearchVariables =
+    final ThrowingCallable executeSearchVariables =
         () -> camundaClient.newUserTaskVariableSearchRequest(userTaskKey).send().join();
     // then
-    final var problemException = assertThrows(ProblemException.class, executeSearchVariables);
+    final var problemException =
+        assertThatExceptionOfType(ProblemException.class)
+            .isThrownBy(executeSearchVariables)
+            .actual();
     assertThat(problemException.code()).isEqualTo(403);
     assertThat(problemException.details().getDetail())
         .isEqualTo(

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/backup/StandaloneBackupManagerIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/backup/StandaloneBackupManagerIT.java
@@ -9,7 +9,7 @@ package io.camunda.it.backup;
 
 import static java.time.Duration.ofSeconds;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.assertj.core.api.Fail.fail;
 
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import io.camunda.application.Profile;

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/CreateDocumentBatchTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/CreateDocumentBatchTest.java
@@ -9,7 +9,7 @@ package io.camunda.it.client;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.within;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.qa.util.multidb.MultiDbTest;
@@ -184,7 +184,10 @@ public class CreateDocumentBatchTest {
     final var command = camundaClient.newCreateDocumentBatchCommand().addDocument().done();
 
     // then
-    final var exception = assertThrows(IllegalArgumentException.class, command::send);
+    final var exception =
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(command::send)
+            .actual();
     assertThat(exception).hasMessageContaining("content");
   }
 
@@ -263,7 +266,8 @@ public class CreateDocumentBatchTest {
             .send();
 
     // then
-    final var exception = assertThrows(Exception.class, command::join);
+    final var exception =
+        assertThatExceptionOfType(Exception.class).isThrownBy(command::join).actual();
     assertThat(exception).hasMessageContaining("non-existing-store");
   }
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/CreateDocumentLinkTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/CreateDocumentLinkTest.java
@@ -8,12 +8,13 @@
 package io.camunda.it.client;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ProblemException;
 import io.camunda.client.api.response.DocumentReferenceResponse;
 import io.camunda.qa.util.multidb.MultiDbTest;
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -38,17 +39,17 @@ public class CreateDocumentLinkTest {
 
     // when
     final var exception =
-        assertThrowsExactly(
-            ProblemException.class,
-            () ->
-                camundaClient
-                    .newCreateDocumentLinkCommand(documentReference)
-                    .storeId(storeId)
-                    .send()
-                    .join());
-
-    // then
-    assertThat(exception.getMessage()).startsWith("Failed with code 400");
+        assertThatThrownBy(
+                () ->
+                    camundaClient
+                        .newCreateDocumentLinkCommand(documentReference)
+                        .storeId(storeId)
+                        .send()
+                        .join())
+            .isInstanceOf(ProblemException.class)
+            .hasMessageStartingWith("Failed with code 400")
+            .asInstanceOf(InstanceOfAssertFactories.throwable(ProblemException.class))
+            .actual();
     assertThat(exception.details().getStatus()).isEqualTo(400);
     assertThat(exception.details().getDetail())
         .contains("Document store with id 'invalid-document-store-id' does not exist");
@@ -62,15 +63,18 @@ public class CreateDocumentLinkTest {
 
     // when
     final var exception =
-        assertThrowsExactly(
-            ProblemException.class,
-            () ->
-                camundaClient
-                    .newCreateDocumentLinkCommand(documentId)
-                    .storeId(storeId)
-                    .contentHash(documentReference.getContentHash())
-                    .send()
-                    .join());
+        assertThatThrownBy(
+                () ->
+                    camundaClient
+                        .newCreateDocumentLinkCommand(documentId)
+                        .storeId(storeId)
+                        .contentHash(documentReference.getContentHash())
+                        .send()
+                        .join())
+            .isInstanceOf(ProblemException.class)
+            .hasMessageStartingWith("Failed with code 403")
+            .asInstanceOf(InstanceOfAssertFactories.throwable(ProblemException.class))
+            .actual();
 
     // then
     assertThat(exception.getMessage()).startsWith("Failed with code 403");

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/CreateDocumentTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/CreateDocumentTest.java
@@ -8,8 +8,8 @@
 package io.camunda.it.client;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.within;
-import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ProblemException;
@@ -57,16 +57,12 @@ public class CreateDocumentTest {
   public void shouldThrowIfContentIsNull() {
     // given
 
-    // when
-    final var exception =
-        assertThrowsExactly(
-            IllegalArgumentException.class,
+    // when/then
+    assertThatThrownBy(
             () ->
-                camundaClient.newCreateDocumentCommand().content((InputStream) null).send().join());
-
-    // then
-    assertThat(exception).isInstanceOf(IllegalArgumentException.class);
-    assertThat(exception.getMessage()).isEqualTo("content must not be null");
+                camundaClient.newCreateDocumentCommand().content((InputStream) null).send().join())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("content must not be null");
   }
 
   @Test
@@ -97,7 +93,12 @@ public class CreateDocumentTest {
             .documentId(documentId)
             .send();
 
-    final var exception = assertThrowsExactly(ProblemException.class, duplicateIdCommand::join);
+    final var exception =
+        (ProblemException)
+            assertThatThrownBy(duplicateIdCommand::join)
+                .isInstanceOf(ProblemException.class)
+                .isInstanceOf(ProblemException.class)
+                .actual();
 
     assertThat(exception.getMessage()).startsWith("Failed with code 409");
     assertThat(exception.details()).isNotNull();
@@ -134,7 +135,12 @@ public class CreateDocumentTest {
     // when
     final var createDocumentCommand =
         camundaClient.newCreateDocumentCommand().content(documentContent).storeId(storeId).send();
-    final var exception = assertThrowsExactly(ProblemException.class, createDocumentCommand::join);
+    final var exception =
+        (ProblemException)
+            assertThatThrownBy(createDocumentCommand::join)
+                .isInstanceOf(ProblemException.class)
+                .isInstanceOf(ProblemException.class)
+                .actual();
 
     // then
     assertThat(exception.getMessage()).startsWith("Failed with code 400");

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/DecisionInstanceSearchTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/DecisionInstanceSearchTest.java
@@ -13,7 +13,7 @@ import static io.camunda.it.util.TestHelper.waitUntilProcessInstanceIsEnded;
 import static io.camunda.qa.util.multidb.CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ProblemException;
@@ -398,9 +398,10 @@ class DecisionInstanceSearchTest {
     // when
     final var decisionInstanceId = "not-existing";
     final var problemException =
-        assertThrows(
-            ProblemException.class,
-            () -> camundaClient.newDecisionInstanceGetRequest(decisionInstanceId).send().join());
+        assertThatExceptionOfType(ProblemException.class)
+            .isThrownBy(
+                () -> camundaClient.newDecisionInstanceGetRequest(decisionInstanceId).send().join())
+            .actual();
     // then
     assertThat(problemException.code()).isEqualTo(404);
     assertThat(problemException.details().getDetail())

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/DecisionSearchTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/DecisionSearchTest.java
@@ -9,7 +9,7 @@ package io.camunda.it.client;
 
 import static io.camunda.qa.util.multidb.CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ProblemException;
@@ -173,9 +173,10 @@ class DecisionSearchTest {
     // when
     final long decisionKey = new Random().nextLong();
     final var problemException =
-        assertThrows(
-            ProblemException.class,
-            () -> camundaClient.newDecisionDefinitionGetXmlRequest(decisionKey).send().join());
+        assertThatExceptionOfType(ProblemException.class)
+            .isThrownBy(
+                () -> camundaClient.newDecisionDefinitionGetXmlRequest(decisionKey).send().join())
+            .actual();
     // then
     assertThat(problemException.code()).isEqualTo(404);
     assertThat(problemException.details().getDetail())
@@ -197,9 +198,10 @@ class DecisionSearchTest {
     // when
     final long decisionKey = new Random().nextLong();
     final var problemException =
-        assertThrows(
-            ProblemException.class,
-            () -> camundaClient.newDecisionDefinitionGetRequest(decisionKey).send().join());
+        assertThatExceptionOfType(ProblemException.class)
+            .isThrownBy(
+                () -> camundaClient.newDecisionDefinitionGetRequest(decisionKey).send().join())
+            .actual();
     // then
     assertThat(problemException.code()).isEqualTo(404);
     assertThat(problemException.details().getDetail())
@@ -570,13 +572,14 @@ class DecisionSearchTest {
     // when
     final long decisionRequirementsKey = new Random().nextLong();
     final var problemException =
-        assertThrows(
-            ProblemException.class,
-            () ->
-                camundaClient
-                    .newDecisionRequirementsGetRequest(decisionRequirementsKey)
-                    .send()
-                    .join());
+        assertThatExceptionOfType(ProblemException.class)
+            .isThrownBy(
+                () ->
+                    camundaClient
+                        .newDecisionRequirementsGetRequest(decisionRequirementsKey)
+                        .send()
+                        .join())
+            .actual();
     // then
     assertThat(problemException.code()).isEqualTo(404);
     assertThat(problemException.details().getDetail())

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/DeleteDocumentTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/DeleteDocumentTest.java
@@ -8,7 +8,7 @@
 package io.camunda.it.client;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ProblemException;
@@ -75,11 +75,11 @@ public class DeleteDocumentTest {
 
     // when
     final var exception =
-        assertThrowsExactly(
-            ProblemException.class,
-            () -> {
-              camundaClient.newDeleteDocumentCommand(documentId).send().join();
-            });
+        (ProblemException)
+            assertThatThrownBy(
+                    () -> camundaClient.newDeleteDocumentCommand(documentId).send().join())
+                .isInstanceOf(ProblemException.class)
+                .actual();
 
     // then
     assertThat(exception.details().getStatus()).isEqualTo(404);
@@ -98,7 +98,9 @@ public class DeleteDocumentTest {
         camundaClient.newCreateDocumentCommand().content(documentContent).storeId(storeId).send();
 
     // then
-    final var exception = assertThrowsExactly(ProblemException.class, command::join);
+    final var exception =
+        (ProblemException)
+            assertThatThrownBy(command::join).isInstanceOf(ProblemException.class).actual();
     assertThat(exception.getMessage()).startsWith("Failed with code 400");
     assertThat(exception.details()).isNotNull();
     assertThat(exception.details().getStatus()).isEqualTo(400);
@@ -108,9 +110,11 @@ public class DeleteDocumentTest {
 
   private void assertDocumentIsDeleted(final String documentId) {
     final var exception =
-        assertThrowsExactly(
-            ProblemException.class,
-            () -> camundaClient.newDocumentContentGetRequest(documentId).send().join());
+        (ProblemException)
+            assertThatThrownBy(
+                    () -> camundaClient.newDocumentContentGetRequest(documentId).send().join())
+                .isInstanceOf(ProblemException.class)
+                .actual();
     assertThat(exception.details().getStatus()).isEqualTo(404);
   }
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/GetDocumentContentTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/GetDocumentContentTest.java
@@ -8,7 +8,7 @@
 package io.camunda.it.client;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ProblemException;
@@ -59,7 +59,9 @@ public class GetDocumentContentTest {
     final var command = camundaClient.newDocumentContentGetRequest(documentId).send();
 
     // then
-    final var exception = assertThrowsExactly(ProblemException.class, command::join);
+    final var exception =
+        (ProblemException)
+            assertThatThrownBy(command::join).isInstanceOf(ProblemException.class).actual();
     assertThat(exception.getMessage()).startsWith("Failed with code 404");
     assertThat(exception.details()).isNotNull();
     assertThat(exception.details().getStatus()).isEqualTo(404);
@@ -78,7 +80,9 @@ public class GetDocumentContentTest {
         camundaClient.newDocumentContentGetRequest(documentId).storeId(storeId).send();
 
     // then
-    final var exception = assertThrowsExactly(ProblemException.class, command::join);
+    final var exception =
+        (ProblemException)
+            assertThatThrownBy(command::join).isInstanceOf(ProblemException.class).actual();
     assertThat(exception.getMessage()).startsWith("Failed with code 400");
     assertThat(exception.details()).isNotNull();
     assertThat(exception.details().getStatus()).isEqualTo(400);
@@ -93,7 +97,9 @@ public class GetDocumentContentTest {
         camundaClient.newDocumentContentGetRequest(documentReference.getDocumentId()).send();
 
     // then
-    final var exception = assertThrowsExactly(ProblemException.class, command::join);
+    final var exception =
+        (ProblemException)
+            assertThatThrownBy(command::join).isInstanceOf(ProblemException.class).actual();
     assertThat(exception.details()).isNotNull();
     assertThat(exception.details().getStatus()).isEqualTo(400);
     assertThat(exception.details().getDetail())
@@ -113,7 +119,9 @@ public class GetDocumentContentTest {
             .send();
 
     // then
-    final var exception = assertThrowsExactly(ProblemException.class, command::join);
+    final var exception =
+        (ProblemException)
+            assertThatThrownBy(command::join).isInstanceOf(ProblemException.class).actual();
     assertThat(exception.details()).isNotNull();
     assertThat(exception.details().getStatus()).isEqualTo(400);
     assertThat(exception.details().getDetail())

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/IncidentSearchTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/IncidentSearchTest.java
@@ -16,7 +16,7 @@ import static io.camunda.it.util.TestHelper.waitUntilIncidentsAreActive;
 import static io.camunda.it.util.TestHelper.waitUntilProcessInstanceHasIncidents;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
-import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ProblemException;
@@ -108,9 +108,11 @@ class IncidentSearchTest {
 
     // when / then
     final var exception =
-        assertThrowsExactly(
-            ProblemException.class,
-            () -> camundaClient.newIncidentGetRequest(invalidIncidentKey).send().join());
+        (ProblemException)
+            assertThatThrownBy(
+                    () -> camundaClient.newIncidentGetRequest(invalidIncidentKey).send().join())
+                .isInstanceOf(ProblemException.class)
+                .actual();
     assertThat(exception.getMessage()).startsWith("Failed with code 404");
     assertThat(exception.details()).isNotNull();
     assertThat(exception.details().getTitle()).isEqualTo("NOT_FOUND");

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessDefinitionSearchTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessDefinitionSearchTest.java
@@ -11,7 +11,7 @@ import static io.camunda.it.util.TestHelper.deployResource;
 import static io.camunda.it.util.TestHelper.waitForProcessesToBeDeployed;
 import static io.camunda.it.util.TestHelper.waitForStartFormsBeingExported;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ProblemException;
@@ -219,13 +219,15 @@ public class ProcessDefinitionSearchTest {
 
     // when / then
     final var exception =
-        assertThrowsExactly(
-            ProblemException.class,
-            () ->
-                camundaClient
-                    .newProcessDefinitionGetRequest(invalidProcessDefinitionKey)
-                    .send()
-                    .join());
+        (ProblemException)
+            assertThatThrownBy(
+                    () ->
+                        camundaClient
+                            .newProcessDefinitionGetRequest(invalidProcessDefinitionKey)
+                            .send()
+                            .join())
+                .isInstanceOf(ProblemException.class)
+                .actual();
     assertThat(exception.getMessage()).startsWith("Failed with code 404");
     assertThat(exception.details()).isNotNull();
     assertThat(exception.details().getTitle()).isEqualTo("NOT_FOUND");

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceIncidentSearchTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceIncidentSearchTest.java
@@ -14,7 +14,7 @@ import static io.camunda.it.util.TestHelper.waitForProcessesToBeDeployed;
 import static io.camunda.it.util.TestHelper.waitUntilIncidentsAreActive;
 import static io.camunda.it.util.TestHelper.waitUntilProcessInstanceHasIncidents;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ProblemException;
@@ -94,13 +94,15 @@ class ProcessInstanceIncidentSearchTest {
 
     // when
     final var exception =
-        assertThrowsExactly(
-            ProblemException.class,
-            () ->
-                camundaClient
-                    .newIncidentsByProcessInstanceSearchRequest(processInstanceKey)
-                    .send()
-                    .join());
+        (ProblemException)
+            assertThatThrownBy(
+                    () ->
+                        camundaClient
+                            .newIncidentsByProcessInstanceSearchRequest(processInstanceKey)
+                            .send()
+                            .join())
+                .isInstanceOf(ProblemException.class)
+                .actual();
 
     // then
     assertThat(exception.getMessage()).startsWith("Failed with code 404");

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceSearchTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceSearchTest.java
@@ -18,9 +18,9 @@ import static io.camunda.it.util.TestHelper.waitForProcessesToBeDeployed;
 import static io.camunda.it.util.TestHelper.waitUntilJobWorkerHasFailedJob;
 import static io.camunda.it.util.TestHelper.waitUntilProcessInstanceHasIncidents;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 import static org.awaitility.Awaitility.await;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ProblemException;
@@ -150,13 +150,15 @@ public class ProcessInstanceSearchTest {
 
     // when / then
     final var exception =
-        assertThrowsExactly(
-            ProblemException.class,
-            () ->
-                camundaClient
-                    .newProcessInstanceGetRequest(invalidProcessInstanceKey)
-                    .send()
-                    .join());
+        (ProblemException)
+            assertThatThrownBy(
+                    () ->
+                        camundaClient
+                            .newProcessInstanceGetRequest(invalidProcessInstanceKey)
+                            .send()
+                            .join())
+                .isInstanceOf(ProblemException.class)
+                .actual();
     assertThat(exception.getMessage()).startsWith("Failed with code 404");
     assertThat(exception.details()).isNotNull();
     assertThat(exception.details().getTitle()).isEqualTo("NOT_FOUND");
@@ -888,14 +890,15 @@ public class ProcessInstanceSearchTest {
 
     // when
     final var exception =
-        assertThrows(
-            IllegalArgumentException.class,
-            () ->
-                camundaClient
-                    .newProcessInstanceSearchRequest()
-                    .filter(f -> f.variables(Arrays.asList(vf -> vf.name("xyz"))))
-                    .send()
-                    .join());
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(
+                () ->
+                    camundaClient
+                        .newProcessInstanceSearchRequest()
+                        .filter(f -> f.variables(Arrays.asList(vf -> vf.name("xyz"))))
+                        .send()
+                        .join())
+            .actual();
     // then
     assertThat(exception.getMessage()).contains("Variable value cannot be null for variable 'xyz'");
   }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/UserTaskSearchTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/UserTaskSearchTest.java
@@ -10,7 +10,7 @@ package io.camunda.it.client;
 import static io.camunda.it.util.TestHelper.assertSorted;
 import static io.camunda.qa.util.multidb.CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ProblemException;
@@ -250,14 +250,16 @@ class UserTaskSearchTest {
 
     // when
     final var exception =
-        assertThrows(
-            IllegalArgumentException.class,
-            () ->
-                camundaClient
-                    .newUserTaskSearchRequest()
-                    .filter(f -> f.processInstanceVariables(List.of(vf -> vf.name("process01"))))
-                    .send()
-                    .join());
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(
+                () ->
+                    camundaClient
+                        .newUserTaskSearchRequest()
+                        .filter(
+                            f -> f.processInstanceVariables(List.of(vf -> vf.name("process01"))))
+                        .send()
+                        .join())
+            .actual();
     // then
     assertThat(exception.getMessage())
         .contains("Variable value cannot be null for variable 'process01'");
@@ -271,14 +273,15 @@ class UserTaskSearchTest {
 
     // when
     final var exception =
-        assertThrows(
-            IllegalArgumentException.class,
-            () ->
-                camundaClient
-                    .newUserTaskSearchRequest()
-                    .filter(f -> f.processInstanceVariables(variables))
-                    .send()
-                    .join());
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(
+                () ->
+                    camundaClient
+                        .newUserTaskSearchRequest()
+                        .filter(f -> f.processInstanceVariables(variables))
+                        .send()
+                        .join())
+            .actual();
     // then
     assertThat(exception.getMessage())
         .contains("Variable value cannot be null for variable 'process01'");
@@ -288,17 +291,18 @@ class UserTaskSearchTest {
   public void shouldThrowExceptionIfVariableValueEmptyFilter() {
     // when
     final var exception =
-        assertThrows(
-            IllegalArgumentException.class,
-            () ->
-                camundaClient
-                    .newUserTaskSearchRequest()
-                    .filter(
-                        f ->
-                            f.processInstanceVariables(
-                                List.of(vf -> vf.name("process01").value(v -> {}))))
-                    .send()
-                    .join());
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(
+                () ->
+                    camundaClient
+                        .newUserTaskSearchRequest()
+                        .filter(
+                            f ->
+                                f.processInstanceVariables(
+                                    List.of(vf -> vf.name("process01").value(v -> {}))))
+                        .send()
+                        .join())
+            .actual();
     // then
     assertThat(exception.getMessage())
         .contains("Variable value cannot be null for variable 'process01'");
@@ -613,9 +617,9 @@ class UserTaskSearchTest {
     // when
     final long userTaskKey = new Random().nextLong();
     final var problemException =
-        assertThrows(
-            ProblemException.class,
-            () -> camundaClient.newUserTaskGetRequest(userTaskKey).send().join());
+        assertThatExceptionOfType(ProblemException.class)
+            .isThrownBy(() -> camundaClient.newUserTaskGetRequest(userTaskKey).send().join())
+            .actual();
     // then
     assertThat(problemException.code()).isEqualTo(404);
     assertThat(problemException.details().getDetail())

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/VariableSearchTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/VariableSearchTest.java
@@ -9,7 +9,7 @@ package io.camunda.it.client;
 
 import static io.camunda.qa.util.multidb.CamundaMultiDBExtension.*;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ProblemException;
@@ -308,9 +308,9 @@ class VariableSearchTest {
     // when
     final long variableKey = new Random().nextLong();
     final var problemException =
-        assertThrows(
-            ProblemException.class,
-            () -> camundaClient.newVariableGetRequest(variableKey).send().join());
+        assertThatExceptionOfType(ProblemException.class)
+            .isThrownBy(() -> camundaClient.newVariableGetRequest(variableKey).send().join())
+            .actual();
 
     // then
     assertThat(problemException.code()).isEqualTo(404);

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/DecisionDefinitionTenancyIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/DecisionDefinitionTenancyIT.java
@@ -8,7 +8,7 @@
 package io.camunda.it.tenancy;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ProblemException;
@@ -144,13 +144,14 @@ public class DecisionDefinitionTenancyIT {
 
     // when
     final var exception =
-        assertThrowsExactly(
-            ProblemException.class,
-            () ->
-                camundaClient
-                    .newDecisionDefinitionGetRequest(decisionDefinition.getDecisionKey())
-                    .send()
-                    .join());
+        assertThatExceptionOfType(ProblemException.class)
+            .isThrownBy(
+                () ->
+                    camundaClient
+                        .newDecisionDefinitionGetRequest(decisionDefinition.getDecisionKey())
+                        .send()
+                        .join())
+            .actual();
 
     // then
     assertThat(exception.getMessage()).startsWith("Failed with code 404");

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/DecisionInstanceTenancyIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/DecisionInstanceTenancyIT.java
@@ -8,7 +8,7 @@
 package io.camunda.it.tenancy;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ProblemException;
@@ -151,13 +151,14 @@ public class DecisionInstanceTenancyIT {
 
     // when
     final var exception =
-        assertThrowsExactly(
-            ProblemException.class,
-            () ->
-                camundaClient
-                    .newDecisionInstanceGetRequest(decisionInstance.getDecisionInstanceId())
-                    .send()
-                    .join());
+        assertThatExceptionOfType(ProblemException.class)
+            .isThrownBy(
+                () ->
+                    camundaClient
+                        .newDecisionInstanceGetRequest(decisionInstance.getDecisionInstanceId())
+                        .send()
+                        .join())
+            .actual();
 
     // then
     assertThat(exception.getMessage()).startsWith("Failed with code 404");

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/DecisionRequirementsTenancyIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/DecisionRequirementsTenancyIT.java
@@ -8,7 +8,7 @@
 package io.camunda.it.tenancy;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ProblemException;
@@ -151,14 +151,15 @@ public class DecisionRequirementsTenancyIT {
 
     // when
     final var exception =
-        assertThrowsExactly(
-            ProblemException.class,
-            () ->
-                camundaClient
-                    .newDecisionRequirementsGetRequest(
-                        decisionRequirements.getDecisionRequirementsKey())
-                    .send()
-                    .join());
+        assertThatExceptionOfType(ProblemException.class)
+            .isThrownBy(
+                () ->
+                    camundaClient
+                        .newDecisionRequirementsGetRequest(
+                            decisionRequirements.getDecisionRequirementsKey())
+                        .send()
+                        .join())
+            .actual();
 
     // then
     assertThat(exception.getMessage()).startsWith("Failed with code 404");

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/ElementInstanceTenancyIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/ElementInstanceTenancyIT.java
@@ -8,7 +8,7 @@
 package io.camunda.it.tenancy;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ProblemException;
@@ -128,9 +128,10 @@ public class ElementInstanceTenancyIT {
 
     // when
     final var exception =
-        assertThrowsExactly(
-            ProblemException.class,
-            () -> camundaClient.newElementInstanceGetRequest(elementInstanceKey).send().join());
+        assertThatExceptionOfType(ProblemException.class)
+            .isThrownBy(
+                () -> camundaClient.newElementInstanceGetRequest(elementInstanceKey).send().join())
+            .actual();
     // then
     assertThat(exception.getMessage()).startsWith("Failed with code 404");
     assertThat(exception.details()).isNotNull();

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/IncidentTenancyIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/IncidentTenancyIT.java
@@ -8,7 +8,7 @@
 package io.camunda.it.tenancy;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ProblemException;
@@ -124,9 +124,9 @@ public class IncidentTenancyIT {
 
     // when
     final var exception =
-        assertThrowsExactly(
-            ProblemException.class,
-            () -> camundaClient.newIncidentGetRequest(incidentKey).send().join());
+        assertThatExceptionOfType(ProblemException.class)
+            .isThrownBy(() -> camundaClient.newIncidentGetRequest(incidentKey).send().join())
+            .actual();
     // then
     assertThat(exception.getMessage()).startsWith("Failed with code 404");
     assertThat(exception.details()).isNotNull();

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/ProcessDefinitionTenancyIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/ProcessDefinitionTenancyIT.java
@@ -8,7 +8,7 @@
 package io.camunda.it.tenancy;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ProblemException;
@@ -125,9 +125,14 @@ public class ProcessDefinitionTenancyIT {
 
     // when
     final var exception =
-        assertThrowsExactly(
-            ProblemException.class,
-            () -> camundaClient.newProcessDefinitionGetRequest(processDefinitionKey).send().join());
+        assertThatExceptionOfType(ProblemException.class)
+            .isThrownBy(
+                () ->
+                    camundaClient
+                        .newProcessDefinitionGetRequest(processDefinitionKey)
+                        .send()
+                        .join())
+            .actual();
     // then
     assertThat(exception.getMessage()).startsWith("Failed with code 404");
     assertThat(exception.details()).isNotNull();

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/ProcessInstanceTenancyIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/ProcessInstanceTenancyIT.java
@@ -8,7 +8,7 @@
 package io.camunda.it.tenancy;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ProblemException;
@@ -127,9 +127,10 @@ public class ProcessInstanceTenancyIT {
 
     // when
     final var exception =
-        assertThrowsExactly(
-            ProblemException.class,
-            () -> camundaClient.newProcessInstanceGetRequest(processInstanceKey).send().join());
+        assertThatExceptionOfType(ProblemException.class)
+            .isThrownBy(
+                () -> camundaClient.newProcessInstanceGetRequest(processInstanceKey).send().join())
+            .actual();
     // then
     assertThat(exception.getMessage()).startsWith("Failed with code 404");
     assertThat(exception.details()).isNotNull();

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/UserTaskTenancyIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/UserTaskTenancyIT.java
@@ -8,7 +8,7 @@
 package io.camunda.it.tenancy;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ProblemException;
@@ -124,9 +124,9 @@ public class UserTaskTenancyIT {
 
     // when
     final var exception =
-        assertThrowsExactly(
-            ProblemException.class,
-            () -> camundaClient.newUserTaskGetRequest(userTaskKey).send().join());
+        assertThatExceptionOfType(ProblemException.class)
+            .isThrownBy(() -> camundaClient.newUserTaskGetRequest(userTaskKey).send().join())
+            .actual();
 
     // then
     assertThat(exception.getMessage()).startsWith("Failed with code 404");

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/VariableTenancyIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/VariableTenancyIT.java
@@ -8,7 +8,7 @@
 package io.camunda.it.tenancy;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ProblemException;
@@ -124,9 +124,9 @@ public class VariableTenancyIT {
 
     // when
     final var exception =
-        assertThrowsExactly(
-            ProblemException.class,
-            () -> camundaClient.newVariableGetRequest(variableKey).send().join());
+        assertThatExceptionOfType(ProblemException.class)
+            .isThrownBy(() -> camundaClient.newVariableGetRequest(variableKey).send().join())
+            .actual();
 
     // then
     assertThat(exception.getMessage()).startsWith("Failed with code 404");

--- a/schema-manager/src/test/java/io/camunda/search/schema/SchemaManagerIT.java
+++ b/schema-manager/src/test/java/io/camunda/search/schema/SchemaManagerIT.java
@@ -16,7 +16,7 @@ import static io.camunda.search.test.utils.SearchDBExtension.CUSTOM_PREFIX;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 
 import co.elastic.clients.elasticsearch._types.ElasticsearchException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -937,7 +937,8 @@ public class SchemaManagerIT {
             .withMetrics(new SchemaManagerMetrics(registry));
 
     // when
-    assertThrows(SearchEngineException.class, () -> schemaManager.startup());
+    assertThatExceptionOfType(SearchEngineException.class)
+        .isThrownBy(() -> schemaManager.startup());
 
     // then
     final var measuredTime = registry.find("camunda.schema.init.time").timer();

--- a/search/search-client-elasticsearch/src/test/java/io/camunda/search/es/clients/ElasticsearchSearchClientTest.java
+++ b/search/search-client-elasticsearch/src/test/java/io/camunda/search/es/clients/ElasticsearchSearchClientTest.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.search.es.clients;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -44,8 +44,8 @@ class ElasticsearchSearchClientTest {
     when(client.search(any(SearchRequest.class), any())).thenThrow(IOException.class);
 
     // when & Assert
-    assertThrows(
-        CamundaSearchException.class, () -> searchClient.scroll(searchRequest, Object.class));
+    assertThatExceptionOfType(CamundaSearchException.class)
+        .isThrownBy(() -> searchClient.scroll(searchRequest, Object.class));
     verify(client, never()).scroll(any(Function.class), any());
     verify(client, never()).clearScroll(any(Function.class));
   }

--- a/search/search-client-elasticsearch/src/test/java/io/camunda/search/es/transformers/search/SearchGetRequestTransformerTest.java
+++ b/search/search-client-elasticsearch/src/test/java/io/camunda/search/es/transformers/search/SearchGetRequestTransformerTest.java
@@ -8,7 +8,7 @@
 package io.camunda.search.es.transformers.search;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 
 import co.elastic.clients.elasticsearch.core.GetRequest;
 import co.elastic.clients.elasticsearch.core.GetResponse;
@@ -69,12 +69,14 @@ public class SearchGetRequestTransformerTest {
 
   @Test
   public void shouldFailToBuildGetRequestWhenIdNotPresent() {
-    assertThrows(NullPointerException.class, () -> SearchGetRequest.of(b -> b.index("bar")));
+    assertThatExceptionOfType(NullPointerException.class)
+        .isThrownBy(() -> SearchGetRequest.of(b -> b.index("bar")));
   }
 
   @Test
   public void shouldFailToBuildGetRequestWhenIndexNotPresent() {
-    assertThrows(NullPointerException.class, () -> SearchGetRequest.of(b -> b.id("foo")));
+    assertThatExceptionOfType(NullPointerException.class)
+        .isThrownBy(() -> SearchGetRequest.of(b -> b.id("foo")));
   }
 
   record TestDocument(String id) {}

--- a/search/search-client-elasticsearch/src/test/java/io/camunda/search/es/transformers/search/SearchIndexRequestTransformerTest.java
+++ b/search/search-client-elasticsearch/src/test/java/io/camunda/search/es/transformers/search/SearchIndexRequestTransformerTest.java
@@ -8,7 +8,7 @@
 package io.camunda.search.es.transformers.search;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 
 import co.elastic.clients.elasticsearch._types.Result;
 import co.elastic.clients.elasticsearch._types.WriteResponseBase;
@@ -80,14 +80,14 @@ public class SearchIndexRequestTransformerTest {
 
   @Test
   public void shouldFailToBuildIndexRequestWhenIndexNotPresent() {
-    assertThrows(
-        NullPointerException.class,
-        () -> SearchIndexRequest.of(b -> b.document(new TestDocument("test"))));
+    assertThatExceptionOfType(NullPointerException.class)
+        .isThrownBy(() -> SearchIndexRequest.of(b -> b.document(new TestDocument("test"))));
   }
 
   @Test
   public void shouldFailToBuildIndexRequestWhenDocumentNotPresent() {
-    assertThrows(NullPointerException.class, () -> SearchIndexRequest.of(b -> b.index("bar")));
+    assertThatExceptionOfType(NullPointerException.class)
+        .isThrownBy(() -> SearchIndexRequest.of(b -> b.index("bar")));
   }
 
   record TestDocument(String id) {}

--- a/search/search-client-opensearch/src/test/java/io/camunda/search/os/clients/OpensearchSearchClientTest.java
+++ b/search/search-client-opensearch/src/test/java/io/camunda/search/os/clients/OpensearchSearchClientTest.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.search.os.clients;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -44,8 +44,8 @@ public class OpensearchSearchClientTest {
     when(client.search(any(SearchRequest.class), any())).thenThrow(IOException.class);
 
     // when & Assert
-    assertThrows(
-        CamundaSearchException.class, () -> searchClient.scroll(searchRequest, Object.class));
+    assertThatExceptionOfType(CamundaSearchException.class)
+        .isThrownBy(() -> searchClient.scroll(searchRequest, Object.class));
     verify(client, never()).scroll(any(Function.class), any());
     verify(client, never()).clearScroll(any(Function.class));
   }

--- a/search/search-client-opensearch/src/test/java/io/camunda/search/os/transformers/search/SearchGetRequestTransformerTest.java
+++ b/search/search-client-opensearch/src/test/java/io/camunda/search/os/transformers/search/SearchGetRequestTransformerTest.java
@@ -8,7 +8,7 @@
 package io.camunda.search.os.transformers.search;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 
 import io.camunda.search.clients.core.SearchGetRequest;
 import io.camunda.search.clients.core.SearchGetResponse;
@@ -69,12 +69,14 @@ public class SearchGetRequestTransformerTest {
 
   @Test
   public void shouldFailToBuildGetRequestWhenIdNotPresent() {
-    assertThrows(NullPointerException.class, () -> SearchGetRequest.of(b -> b.index("bar")));
+    assertThatExceptionOfType(NullPointerException.class)
+        .isThrownBy(() -> SearchGetRequest.of(b -> b.index("bar")));
   }
 
   @Test
   public void shouldFailToBuildGetRequestWhenIndexNotPresent() {
-    assertThrows(NullPointerException.class, () -> SearchGetRequest.of(b -> b.id("foo")));
+    assertThatExceptionOfType(NullPointerException.class)
+        .isThrownBy(() -> SearchGetRequest.of(b -> b.id("foo")));
   }
 
   record TestDocument(String id) {}

--- a/search/search-client-opensearch/src/test/java/io/camunda/search/os/transformers/search/SearchIndexRequestTransformerTest.java
+++ b/search/search-client-opensearch/src/test/java/io/camunda/search/os/transformers/search/SearchIndexRequestTransformerTest.java
@@ -8,7 +8,7 @@
 package io.camunda.search.os.transformers.search;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 
 import io.camunda.search.clients.core.SearchIndexRequest;
 import io.camunda.search.clients.core.SearchWriteResponse;
@@ -80,14 +80,14 @@ public class SearchIndexRequestTransformerTest {
 
   @Test
   public void shouldFailToBuildIndexRequestWhenIndexNotPresent() {
-    assertThrows(
-        NullPointerException.class,
-        () -> SearchIndexRequest.of(b -> b.document(new TestDocument("test"))));
+    assertThatExceptionOfType(NullPointerException.class)
+        .isThrownBy(() -> SearchIndexRequest.of(b -> b.document(new TestDocument("test"))));
   }
 
   @Test
   public void shouldFailToBuildIndexRequestWhenDocumentNotPresent() {
-    assertThrows(NullPointerException.class, () -> SearchIndexRequest.of(b -> b.index("bar")));
+    assertThatExceptionOfType(NullPointerException.class)
+        .isThrownBy(() -> SearchIndexRequest.of(b -> b.index("bar")));
   }
 
   record TestDocument(String id) {}

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/query/CursorTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/query/CursorTest.java
@@ -8,7 +8,6 @@
 package io.camunda.search.clients.transformers.query;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.List;
 import org.junit.jupiter.api.Test;

--- a/search/search-domain/src/test/java/io/camunda/util/ValueTypeUtilTest.java
+++ b/search/search-domain/src/test/java/io/camunda/util/ValueTypeUtilTest.java
@@ -7,7 +7,8 @@
  */
 package io.camunda.util;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 
 import io.camunda.search.entities.ValueTypeEnum;
 import org.junit.jupiter.api.Test;
@@ -16,111 +17,112 @@ public class ValueTypeUtilTest {
 
   @Test
   public void shouldReturnNullForNullValue() {
-    assertEquals(ValueTypeEnum.NULL, ValueTypeUtil.getValueType(null));
+    assertThat(ValueTypeUtil.getValueType(null)).isEqualTo(ValueTypeEnum.NULL);
   }
 
   @Test
   public void shouldReturnNullForStringNullValue() {
-    assertEquals(ValueTypeEnum.NULL, ValueTypeUtil.getValueType("null"));
+    assertThat(ValueTypeUtil.getValueType("null")).isEqualTo(ValueTypeEnum.NULL);
   }
 
   @Test
   public void shouldReturnStringForNonNumericString() {
-    assertEquals(ValueTypeEnum.STRING, ValueTypeUtil.getValueType("non-numeric"));
+    assertThat(ValueTypeUtil.getValueType("non-numeric")).isEqualTo(ValueTypeEnum.STRING);
   }
 
   @Test
   public void shouldReturnLongForIntegerString() {
-    assertEquals(ValueTypeEnum.LONG, ValueTypeUtil.getValueType("123456"));
+    assertThat(ValueTypeUtil.getValueType("123456")).isEqualTo(ValueTypeEnum.LONG);
   }
 
   @Test
   public void shouldReturnLongForBooleanLikeIntegerString() {
-    assertEquals(ValueTypeEnum.LONG, ValueTypeUtil.getValueType("1"));
+    assertThat(ValueTypeUtil.getValueType("1")).isEqualTo(ValueTypeEnum.LONG);
   }
 
   @Test
   public void shouldReturnStringForIntegerStringWithQuotes() {
-    assertEquals(ValueTypeEnum.STRING, ValueTypeUtil.getValueType("\"123456\""));
+    assertThat(ValueTypeUtil.getValueType("\"123456\"")).isEqualTo(ValueTypeEnum.STRING);
   }
 
   @Test
   public void shouldReturnDoubleForDoubleString() {
-    assertEquals(ValueTypeEnum.DOUBLE, ValueTypeUtil.getValueType("123.456"));
+    assertThat(ValueTypeUtil.getValueType("123.456")).isEqualTo(ValueTypeEnum.DOUBLE);
   }
 
   @Test
   public void shouldReturnStringForDoubleStringWithQuotes() {
-    assertEquals(ValueTypeEnum.STRING, ValueTypeUtil.getValueType("\"123.456\""));
+    assertThat(ValueTypeUtil.getValueType("\"123.456\"")).isEqualTo(ValueTypeEnum.STRING);
   }
 
   @Test
   public void shouldReturnLongForLongValue() {
-    assertEquals(ValueTypeEnum.LONG, ValueTypeUtil.getValueType(123456L));
+    assertThat(ValueTypeUtil.getValueType(123456L)).isEqualTo(ValueTypeEnum.LONG);
   }
 
   @Test
   public void shouldReturnDoubleForDoubleValue() {
-    assertEquals(ValueTypeEnum.DOUBLE, ValueTypeUtil.getValueType(123.456));
+    assertThat(ValueTypeUtil.getValueType(123.456)).isEqualTo(ValueTypeEnum.DOUBLE);
   }
 
   @Test
   public void shouldReturnBooleanForBooleanValue() {
-    assertEquals(ValueTypeEnum.BOOLEAN, ValueTypeUtil.getValueType(true));
+    assertThat(ValueTypeUtil.getValueType(true)).isEqualTo(ValueTypeEnum.BOOLEAN);
   }
 
   @Test
   public void shouldReturnBooleanForBooleanStringValue() {
-    assertEquals(ValueTypeEnum.BOOLEAN, ValueTypeUtil.getValueType("true"));
+    assertThat(ValueTypeUtil.getValueType("true")).isEqualTo(ValueTypeEnum.BOOLEAN);
   }
 
   @Test
   public void shouldReturnStringForBooleanStringValueWithQuotes() {
-    assertEquals(ValueTypeEnum.STRING, ValueTypeUtil.getValueType("\"true\""));
+    assertThat(ValueTypeUtil.getValueType("\"true\"")).isEqualTo(ValueTypeEnum.STRING);
   }
 
   @Test
   public void shouldMapStringToString() {
-    assertEquals("test", ValueTypeUtil.mapValueType("test", ValueTypeEnum.STRING));
+    assertThat(ValueTypeUtil.mapValueType("test", ValueTypeEnum.STRING)).isEqualTo("test");
   }
 
   @Test
   public void shouldMapStringToLong() {
-    assertEquals(123456L, ValueTypeUtil.mapValueType("123456", ValueTypeEnum.LONG));
+    assertThat(ValueTypeUtil.mapValueType("123456", ValueTypeEnum.LONG)).isEqualTo(123456L);
   }
 
   @Test
   public void shouldMapBooleanlikeStringToLong() {
-    assertEquals(123456L, ValueTypeUtil.mapValueType("123456", ValueTypeEnum.LONG));
+    assertThat(ValueTypeUtil.mapValueType("123456", ValueTypeEnum.LONG)).isEqualTo(123456L);
   }
 
   @Test
   public void shouldMapStringToDouble() {
-    assertEquals(123.456, ValueTypeUtil.mapValueType("123.456", ValueTypeEnum.DOUBLE));
+    assertThat(ValueTypeUtil.mapValueType("123.456", ValueTypeEnum.DOUBLE)).isEqualTo(123.456);
   }
 
   @Test
   public void shouldMapStringToBoolean() {
-    assertEquals("true", ValueTypeUtil.mapValueType("true", ValueTypeEnum.BOOLEAN));
+    assertThat(ValueTypeUtil.mapValueType("true", ValueTypeEnum.BOOLEAN)).isEqualTo("true");
   }
 
   @Test
   public void shouldMapLongToLong() {
-    assertEquals(123456L, ValueTypeUtil.mapValueType(123456L, ValueTypeEnum.LONG));
+    assertThat(ValueTypeUtil.mapValueType(123456L, ValueTypeEnum.LONG)).isEqualTo(123456L);
   }
 
   @Test
   public void shouldMapIntegerToLong() {
-    assertEquals(123456L, ValueTypeUtil.mapValueType(123456, ValueTypeEnum.LONG));
+    assertThat(ValueTypeUtil.mapValueType(123456, ValueTypeEnum.LONG)).isEqualTo(123456L);
   }
 
   @Test
   public void shouldMapDoubleToDouble() {
-    assertEquals(123.456, ValueTypeUtil.mapValueType(123.456, ValueTypeEnum.DOUBLE));
+    assertThat(ValueTypeUtil.mapValueType(123.456, ValueTypeEnum.DOUBLE)).isEqualTo(123.456);
   }
 
   @Test
   public void shouldReturnNullForUnsupportedType() {
-    assertThrows(IllegalArgumentException.class, () -> ValueTypeUtil.getValueType(new Object()));
+    assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(() -> ValueTypeUtil.getValueType(new Object()));
   }
 }

--- a/service/src/test/java/io/camunda/service/DecisionDefinitionServiceTest.java
+++ b/service/src/test/java/io/camunda/service/DecisionDefinitionServiceTest.java
@@ -8,7 +8,7 @@
 package io.camunda.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -29,9 +29,9 @@ import io.camunda.service.exception.ServiceException.Status;
 import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import java.util.List;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.function.Executable;
 
 public final class DecisionDefinitionServiceTest {
 
@@ -119,10 +119,11 @@ public final class DecisionDefinitionServiceTest {
                 Authorizations.DECISION_DEFINITION_READ_AUTHORIZATION));
 
     // when
-    final Executable executable = () -> services.getByKey(1L);
+    final ThrowingCallable executable = () -> services.getByKey(1L);
 
     // then
-    final var exception = assertThrows(ServiceException.class, executable);
+    final var exception =
+        assertThatExceptionOfType(ServiceException.class).isThrownBy(executable).actual();
     assertThat(exception.getMessage())
         .isEqualTo(
             "Unauthorized to perform operation 'READ_DECISION_DEFINITION' on resource 'DECISION_DEFINITION'");
@@ -141,10 +142,11 @@ public final class DecisionDefinitionServiceTest {
                 Authorizations.DECISION_DEFINITION_READ_AUTHORIZATION));
 
     // when
-    final Executable executable = () -> services.getDecisionDefinitionXml(1L);
+    final ThrowingCallable executable = () -> services.getDecisionDefinitionXml(1L);
 
     // then
-    final var exception = assertThrows(ServiceException.class, executable);
+    final var exception =
+        assertThatExceptionOfType(ServiceException.class).isThrownBy(executable).actual();
     assertThat(exception.getMessage())
         .isEqualTo(
             "Unauthorized to perform operation 'READ_DECISION_DEFINITION' on resource 'DECISION_DEFINITION'");

--- a/service/src/test/java/io/camunda/service/DecisionInstanceServiceTest.java
+++ b/service/src/test/java/io/camunda/service/DecisionInstanceServiceTest.java
@@ -8,7 +8,7 @@
 package io.camunda.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -26,9 +26,9 @@ import io.camunda.service.exception.ServiceException;
 import io.camunda.service.exception.ServiceException.Status;
 import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.function.Executable;
 
 class DecisionInstanceServiceTest {
 
@@ -114,10 +114,11 @@ class DecisionInstanceServiceTest {
             new ResourceAccessDeniedException(Authorizations.DECISION_INSTANCE_READ_AUTHORIZATION));
 
     // when
-    final Executable executable = () -> services.getById(decisionInstanceId);
+    final ThrowingCallable executable = () -> services.getById(decisionInstanceId);
 
     // then
-    final var exception = assertThrows(ServiceException.class, executable);
+    final var exception =
+        assertThatExceptionOfType(ServiceException.class).isThrownBy(executable).actual();
     assertThat(exception.getMessage())
         .isEqualTo(
             "Unauthorized to perform operation 'READ_DECISION_INSTANCE' on resource 'DECISION_DEFINITION'");

--- a/service/src/test/java/io/camunda/service/DecisionRequirementsServiceTest.java
+++ b/service/src/test/java/io/camunda/service/DecisionRequirementsServiceTest.java
@@ -8,7 +8,7 @@
 package io.camunda.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -103,7 +103,10 @@ public final class DecisionRequirementsServiceTest {
                 Authorizations.DECISION_REQUIREMENTS_READ_AUTHORIZATION));
 
     // then
-    final var exception = assertThrows(ServiceException.class, () -> services.getByKey(124L));
+    final var exception =
+        assertThatExceptionOfType(ServiceException.class)
+            .isThrownBy(() -> services.getByKey(124L))
+            .actual();
     assertThat(exception.getMessage())
         .isEqualTo(
             "Unauthorized to perform operation 'READ' on resource 'DECISION_REQUIREMENTS_DEFINITION'");
@@ -122,7 +125,9 @@ public final class DecisionRequirementsServiceTest {
 
     // then
     final var exception =
-        assertThrows(ServiceException.class, () -> services.getDecisionRequirementsXml(124L));
+        assertThatExceptionOfType(ServiceException.class)
+            .isThrownBy(() -> services.getDecisionRequirementsXml(124L))
+            .actual();
     assertThat(exception.getMessage())
         .isEqualTo(
             "Unauthorized to perform operation 'READ' on resource 'DECISION_REQUIREMENTS_DEFINITION'");

--- a/service/src/test/java/io/camunda/service/ElementInstanceServiceTest.java
+++ b/service/src/test/java/io/camunda/service/ElementInstanceServiceTest.java
@@ -8,8 +8,8 @@
 package io.camunda.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.instancio.Select.field;
-import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -30,11 +30,11 @@ import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import java.util.Map;
 import java.util.Set;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.instancio.Instancio;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.function.Executable;
 
 public final class ElementInstanceServiceTest {
 
@@ -133,9 +133,12 @@ public final class ElementInstanceServiceTest {
                   Authorizations.ELEMENT_INSTANCE_READ_AUTHORIZATION));
 
       // when
-      final Executable executeGetByKey = () -> services.getByKey(entity.flowNodeInstanceKey());
+      final ThrowingCallable executeGetByKey =
+          () -> services.getByKey(entity.flowNodeInstanceKey());
       // then
-      final var exception = assertThrowsExactly(ServiceException.class, executeGetByKey);
+      final var exception =
+          (ServiceException)
+              assertThatThrownBy(executeGetByKey).isInstanceOf(ServiceException.class).actual();
       assertThat(exception.getMessage())
           .isEqualTo(
               "Unauthorized to perform operation 'READ_PROCESS_INSTANCE' on resource 'PROCESS_DEFINITION'");

--- a/service/src/test/java/io/camunda/service/IncidentServiceTest.java
+++ b/service/src/test/java/io/camunda/service/IncidentServiceTest.java
@@ -8,7 +8,7 @@
 package io.camunda.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -23,9 +23,9 @@ import io.camunda.service.exception.ServiceException;
 import io.camunda.service.exception.ServiceException.Status;
 import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.function.Executable;
 
 public final class IncidentServiceTest {
 
@@ -79,9 +79,11 @@ public final class IncidentServiceTest {
     when(client.getIncident(any(Long.class)))
         .thenThrow(new ResourceAccessDeniedException(Authorizations.INCIDENT_READ_AUTHORIZATION));
     // when
-    final Executable executeGetByKey = () -> services.getByKey(1L);
+    final ThrowingCallable executeGetByKey = () -> services.getByKey(1L);
     // then
-    final var exception = assertThrowsExactly(ServiceException.class, executeGetByKey);
+    final var exception =
+        (ServiceException)
+            assertThatThrownBy(executeGetByKey).isInstanceOf(ServiceException.class).actual();
     assertThat(exception.getMessage())
         .isEqualTo(
             "Unauthorized to perform operation 'READ_PROCESS_INSTANCE' on resource 'PROCESS_DEFINITION'");

--- a/service/src/test/java/io/camunda/service/ProcessInstanceServiceTest.java
+++ b/service/src/test/java/io/camunda/service/ProcessInstanceServiceTest.java
@@ -8,7 +8,7 @@
 package io.camunda.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -49,9 +49,9 @@ import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstan
 import io.camunda.zeebe.protocol.record.value.BatchOperationType;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.function.Executable;
 import org.mockito.ArgumentCaptor;
 
 public final class ProcessInstanceServiceTest {
@@ -151,9 +151,11 @@ public final class ProcessInstanceServiceTest {
         .thenThrow(
             new ResourceAccessDeniedException(Authorizations.PROCESS_INSTANCE_READ_AUTHORIZATION));
     // when
-    final Executable executeGetByKey = () -> services.getByKey(1L);
+    final ThrowingCallable executeGetByKey = () -> services.getByKey(1L);
     // then
-    final var exception = assertThrowsExactly(ServiceException.class, executeGetByKey);
+    final var exception =
+        (ServiceException)
+            assertThatThrownBy(executeGetByKey).isInstanceOf(ServiceException.class).actual();
     assertThat(exception.getMessage())
         .isEqualTo(
             "Unauthorized to perform operation 'READ_PROCESS_INSTANCE' on resource 'PROCESS_DEFINITION'");
@@ -430,10 +432,13 @@ public final class ProcessInstanceServiceTest {
     final var query = new IncidentQuery.Builder().build();
 
     // when
-    final Executable executeGetByKey = () -> services.searchIncidents(processInstanceKey, query);
+    final ThrowingCallable executeGetByKey =
+        () -> services.searchIncidents(processInstanceKey, query);
 
     // then
-    final var exception = assertThrowsExactly(ServiceException.class, executeGetByKey);
+    final var exception =
+        (ServiceException)
+            assertThatThrownBy(executeGetByKey).isInstanceOf(ServiceException.class).actual();
     assertThat(exception.getMessage())
         .isEqualTo(
             "Unauthorized to perform operation 'READ_PROCESS_INSTANCE' on resource 'PROCESS_DEFINITION'");

--- a/service/src/test/java/io/camunda/service/TenantServiceTest.java
+++ b/service/src/test/java/io/camunda/service/TenantServiceTest.java
@@ -8,7 +8,7 @@
 package io.camunda.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -209,9 +209,11 @@ public class TenantServiceTest {
     when(client.getTenant(eq("tenant-id")))
         .thenThrow(new ResourceAccessDeniedException(Authorizations.TENANT_READER_AUTHORIZATION));
 
-    assertThat(
-            assertThrowsExactly(ServiceException.class, () -> services.getById("tenant-id"))
-                .getStatus())
-        .isEqualTo(Status.FORBIDDEN);
+    final var exception =
+        (ServiceException)
+            assertThatThrownBy(() -> services.getById("tenant-id"))
+                .isInstanceOf(ServiceException.class)
+                .actual();
+    assertThat(exception.getStatus()).isEqualTo(Status.FORBIDDEN);
   }
 }

--- a/service/src/test/java/io/camunda/service/VariableServiceTest.java
+++ b/service/src/test/java/io/camunda/service/VariableServiceTest.java
@@ -8,7 +8,7 @@
 package io.camunda.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -26,9 +26,9 @@ import io.camunda.service.exception.ServiceException.Status;
 import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import java.util.List;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.function.Executable;
 
 public class VariableServiceTest {
 
@@ -92,9 +92,12 @@ public class VariableServiceTest {
     when(client.getVariable(any(Long.class)))
         .thenThrow(new ResourceAccessDeniedException(Authorizations.VARIABLE_READ_AUTHORIZATION));
     // when
-    final Executable executeGetByKey = () -> services.getByKey(1L);
+    final ThrowingCallable executeGetByKey = () -> services.getByKey(1L);
+
     // then
-    final var exception = assertThrowsExactly(ServiceException.class, executeGetByKey);
+    final var exception =
+        (ServiceException)
+            assertThatThrownBy(executeGetByKey).isInstanceOf(ServiceException.class).actual();
     assertThat(exception.getMessage())
         .isEqualTo(
             "Unauthorized to perform operation 'READ_PROCESS_INSTANCE' on resource 'PROCESS_DEFINITION'");

--- a/service/src/test/java/io/camunda/service/license/CamundaLicenseTest.java
+++ b/service/src/test/java/io/camunda/service/license/CamundaLicenseTest.java
@@ -7,9 +7,7 @@
  */
 package io.camunda.service.license;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -48,7 +46,7 @@ public class CamundaLicenseTest {
     testLicense.initializeWithLicense(TEST_LICENSE);
 
     // then
-    assertTrue(testLicense.isValid());
+    assertThat(testLicense.isValid()).isTrue();
   }
 
   @Test
@@ -63,7 +61,7 @@ public class CamundaLicenseTest {
     testLicense.initializeWithLicense(TEST_LICENSE);
 
     // then
-    assertFalse(testLicense.isValid());
+    assertThat(testLicense.isValid()).isFalse();
   }
 
   @Test
@@ -83,7 +81,7 @@ public class CamundaLicenseTest {
     testLicense.initializeWithLicense(TEST_LICENSE);
 
     // then
-    assertEquals(LicenseType.PRODUCTION, testLicense.getLicenseType());
+    assertThat(testLicense.getLicenseType()).isEqualTo(LicenseType.PRODUCTION);
   }
 
   @Test
@@ -101,7 +99,7 @@ public class CamundaLicenseTest {
     testLicense.initializeWithLicense(TEST_LICENSE);
 
     // then
-    assertEquals(LicenseType.UNKNOWN, testLicense.getLicenseType());
+    assertThat(testLicense.getLicenseType()).isEqualTo(LicenseType.UNKNOWN);
   }
 
   @Test
@@ -121,8 +119,8 @@ public class CamundaLicenseTest {
     testLicense.initializeWithLicense(TEST_LICENSE);
 
     // then
-    assertEquals(LicenseType.SAAS, testLicense.getLicenseType());
-    assertTrue(testLicense.isValid());
+    assertThat(testLicense.getLicenseType()).isEqualTo(LicenseType.SAAS);
+    assertThat(testLicense.isValid()).isTrue();
   }
 
   @Test
@@ -143,7 +141,7 @@ public class CamundaLicenseTest {
     testLicense.initializeWithLicense(TEST_LICENSE);
 
     // then
-    assertEquals(true, testLicense.isCommercial());
+    assertThat(testLicense.isCommercial()).isTrue();
   }
 
   @Test
@@ -164,7 +162,7 @@ public class CamundaLicenseTest {
     testLicense.initializeWithLicense(TEST_LICENSE);
 
     // then
-    assertEquals(false, testLicense.isCommercial());
+    assertThat(testLicense.isCommercial()).isFalse();
   }
 
   @Test
@@ -186,7 +184,7 @@ public class CamundaLicenseTest {
     testLicense.initializeWithLicense(TEST_LICENSE);
 
     // then
-    assertEquals(testDate.toInstant().atOffset(ZoneOffset.UTC), testLicense.expiresAt());
+    assertThat(testLicense.expiresAt()).isEqualTo(testDate.toInstant().atOffset(ZoneOffset.UTC));
   }
 
   @Test
@@ -207,6 +205,6 @@ public class CamundaLicenseTest {
     testLicense.initializeWithLicense(TEST_LICENSE);
 
     // then
-    assertEquals(null, testLicense.expiresAt());
+    assertThat(testLicense.expiresAt()).isNull();
   }
 }

--- a/tasklist/importer-common/pom.xml
+++ b/tasklist/importer-common/pom.xml
@@ -107,6 +107,12 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/tasklist/importer-common/src/test/java/io/camunda/tasklist/zeebeimport/common/ProcessDefinitionDeletionProcessorTest.java
+++ b/tasklist/importer-common/src/test/java/io/camunda/tasklist/zeebeimport/common/ProcessDefinitionDeletionProcessorTest.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.tasklist.zeebeimport.common;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
 import io.camunda.tasklist.store.DraftVariableStore;
@@ -83,15 +83,15 @@ class ProcessDefinitionDeletionProcessorTest {
         processDefinitionDeletionProcessor.createProcessDefinitionDeleteRequests(
             processDefinitionId, Pair::of);
 
-    assertEquals(
-        List.of(
-            Pair.of(variableIndexName, variableTaskId1),
-            Pair.of(variableIndexName + "_06-10-2023", variableTaskId2),
-            Pair.of(draftVariableIndexName, draftVariableId),
-            Pair.of(taskIndexName, taskId1),
-            Pair.of(taskIndexName + "_06-10-2023", taskId2),
-            Pair.of(formIndexName, formId),
-            Pair.of(processIndexName, processDefinitionId)),
-        result);
+    assertThat(result)
+        .isEqualTo(
+            List.of(
+                Pair.of(variableIndexName, variableTaskId1),
+                Pair.of(variableIndexName + "_06-10-2023", variableTaskId2),
+                Pair.of(draftVariableIndexName, draftVariableId),
+                Pair.of(taskIndexName, taskId1),
+                Pair.of(taskIndexName + "_06-10-2023", taskId2),
+                Pair.of(formIndexName, formId),
+                Pair.of(processIndexName, processDefinitionId)));
   }
 }

--- a/tasklist/importer/pom.xml
+++ b/tasklist/importer/pom.xml
@@ -166,6 +166,11 @@
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/tasklist/importer/src/test/java/io/camunda/tasklist/zeebeimport/ImportListenerTestElasticSearch.java
+++ b/tasklist/importer/src/test/java/io/camunda/tasklist/zeebeimport/ImportListenerTestElasticSearch.java
@@ -7,9 +7,7 @@
  */
 package io.camunda.tasklist.zeebeimport;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
@@ -92,9 +90,9 @@ public class ImportListenerTestElasticSearch extends NoBeansTest {
     importJob.call();
 
     // then
-    assertTrue(importListener.isFinishedCalled());
-    assertFalse(importListener.isFailedCalled());
-    assertEquals(importListener.getImportBatch(), importBatchElasticSearch);
+    assertThat(importListener.isFinishedCalled()).isTrue();
+    assertThat(importListener.isFailedCalled()).isFalse();
+    assertThat(importBatchElasticSearch).isEqualTo(importListener.getImportBatch());
   }
 
   @Test
@@ -119,9 +117,9 @@ public class ImportListenerTestElasticSearch extends NoBeansTest {
     importJob.call();
 
     // then
-    assertTrue(importListener.isFailedCalled());
-    assertFalse(importListener.isFinishedCalled());
-    assertEquals(importListener.getImportBatch(), importBatchElasticSearch);
+    assertThat(importListener.isFailedCalled()).isTrue();
+    assertThat(importListener.isFinishedCalled()).isFalse();
+    assertThat(importBatchElasticSearch).isEqualTo(importListener.getImportBatch());
   }
 
   @Component

--- a/tasklist/importer/src/test/java/io/camunda/tasklist/zeebeimport/ImportListenerTestOpenSearch.java
+++ b/tasklist/importer/src/test/java/io/camunda/tasklist/zeebeimport/ImportListenerTestOpenSearch.java
@@ -7,9 +7,7 @@
  */
 package io.camunda.tasklist.zeebeimport;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
@@ -91,9 +89,9 @@ public class ImportListenerTestOpenSearch extends NoBeansTest {
     importJob.call();
 
     // then
-    assertTrue(importListener.isFinishedCalled());
-    assertFalse(importListener.isFailedCalled());
-    assertEquals(importListener.getImportBatch(), importBatchOpenSearch);
+    assertThat(importListener.isFinishedCalled()).isTrue();
+    assertThat(importListener.isFailedCalled()).isFalse();
+    assertThat(importBatchOpenSearch).isEqualTo(importListener.getImportBatch());
   }
 
   @Test
@@ -117,9 +115,9 @@ public class ImportListenerTestOpenSearch extends NoBeansTest {
     importJob.call();
 
     // then
-    assertTrue(importListener.isFailedCalled());
-    assertFalse(importListener.isFinishedCalled());
-    assertEquals(importListener.getImportBatch(), importBatchElasticSearch);
+    assertThat(importListener.isFailedCalled()).isTrue();
+    assertThat(importListener.isFinishedCalled()).isFalse();
+    assertThat(importBatchElasticSearch).isEqualTo(importListener.getImportBatch());
   }
 
   @Component

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/modules/OnlyImportIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/modules/OnlyImportIT.java
@@ -8,7 +8,7 @@
 package io.camunda.tasklist.modules;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 
 import io.camunda.tasklist.ImportModuleConfiguration;
 import io.camunda.tasklist.WebappModuleConfiguration;
@@ -32,15 +32,13 @@ public class OnlyImportIT extends ModuleIntegrationTest {
 
   @Test
   public void testWebappModuleIsNotPresent() {
-    assertThrows(
-        NoSuchBeanDefinitionException.class,
-        () -> applicationContext.getBean(WebappModuleConfiguration.class));
+    assertThatExceptionOfType(NoSuchBeanDefinitionException.class)
+        .isThrownBy(() -> applicationContext.getBean(WebappModuleConfiguration.class));
   }
 
   @Test
   public void testTasklistIndexControllerIsNotPresent() {
-    assertThrows(
-        NoSuchBeanDefinitionException.class,
-        () -> applicationContext.getBean(TasklistIndexController.class));
+    assertThatExceptionOfType(NoSuchBeanDefinitionException.class)
+        .isThrownBy(() -> applicationContext.getBean(TasklistIndexController.class));
   }
 }

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/modules/OnlyWebappIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/modules/OnlyWebappIT.java
@@ -8,7 +8,7 @@
 package io.camunda.tasklist.modules;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 
 import io.camunda.tasklist.ImportModuleConfiguration;
 import io.camunda.tasklist.WebappModuleConfiguration;
@@ -33,8 +33,7 @@ public class OnlyWebappIT extends ModuleIntegrationTest {
 
   @Test
   public void testImportModuleIsNotPresent() {
-    assertThrows(
-        NoSuchBeanDefinitionException.class,
-        () -> applicationContext.getBean(ImportModuleConfiguration.class));
+    assertThatExceptionOfType(NoSuchBeanDefinitionException.class)
+        .isThrownBy(() -> applicationContext.getBean(ImportModuleConfiguration.class));
   }
 }

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TasklistTester.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TasklistTester.java
@@ -9,7 +9,7 @@ package io.camunda.tasklist.util;
 
 import static io.camunda.tasklist.util.TestCheck.*;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.fail;
 import static org.springframework.beans.factory.config.BeanDefinition.SCOPE_PROTOTYPE;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/VariableSearchTermsQueryChunkIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/VariableSearchTermsQueryChunkIT.java
@@ -8,7 +8,6 @@
 package io.camunda.tasklist.webapp;
 
 import static io.camunda.tasklist.util.assertions.CustomAssertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -61,8 +60,9 @@ public class VariableSearchTermsQueryChunkIT extends TasklistZeebeIntegrationTes
 
     databaseTestExtension.setIndexMaxTermsCount(variableTemplate.getFullQualifiedName(), 5);
 
-    assertEquals(
-        5, databaseTestExtension.getIndexMaxTermsCount(variableTemplate.getFullQualifiedName()));
+    org.assertj.core.api.Assertions.assertThat(
+            databaseTestExtension.getIndexMaxTermsCount(variableTemplate.getFullQualifiedName()))
+        .isEqualTo(5);
 
     variableStore.refreshMaxTermsCount();
   }

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/zeebeimport/ZeebeImportAdHocSubProcessIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/zeebeimport/ZeebeImportAdHocSubProcessIT.java
@@ -8,10 +8,8 @@
 package io.camunda.tasklist.zeebeimport;
 
 import static io.camunda.tasklist.util.assertions.CustomAssertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.core.api.AssertionsForClassTypes.tuple;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.fail;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -62,9 +60,9 @@ public class ZeebeImportAdHocSubProcessIT extends TasklistZeebeIntegrationTest {
             .getProcessInstanceId();
 
     // then
-    assertNotNull(processInstanceId);
+    org.assertj.core.api.Assertions.assertThat(processInstanceId).isNotNull();
     final List<String> taskIds = taskStore.getTaskIdsByProcessInstanceId(processInstanceId);
-    assertEquals(3, taskIds.size());
+    org.assertj.core.api.Assertions.assertThat(taskIds.size()).isEqualTo(3);
 
     for (final String taskId : taskIds) {
       final TaskEntity entity = taskStore.getTask(taskId);

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/zeebeimport/ZeebeImportMigrateProcessTaskIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/zeebeimport/ZeebeImportMigrateProcessTaskIT.java
@@ -8,7 +8,6 @@
 package io.camunda.tasklist.zeebeimport;
 
 import static io.camunda.tasklist.util.assertions.CustomAssertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -143,7 +142,7 @@ public class ZeebeImportMigrateProcessTaskIT extends TasklistZeebeIntegrationTes
 
     final String newProcessDefKey = tester.getProcessDefinitionKey();
 
-    assertNotEquals(newProcessDefKey, oldProcessDefKey);
+    org.assertj.core.api.Assertions.assertThat(oldProcessDefKey).isNotEqualTo(newProcessDefKey);
 
     final var result =
         mockMvcHelper.doRequest(get(TasklistURIs.TASKS_URL_V1.concat("/{taskId}"), taskId));

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/zeebeimport/ZeebeUserTaskImportIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/zeebeimport/ZeebeUserTaskImportIT.java
@@ -9,9 +9,6 @@ package io.camunda.tasklist.zeebeimport;
 
 import static io.camunda.tasklist.util.assertions.CustomAssertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.tuple;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -70,16 +67,22 @@ public class ZeebeUserTaskImportIT extends TasklistZeebeIntegrationTest {
             .getTaskId();
 
     // then
-    assertNotNull(taskId);
+    org.assertj.core.api.Assertions.assertThat(taskId).isNotNull();
     final TaskEntity taskEntity = taskStore.getTask(taskId);
-    assertEquals(TaskImplementation.ZEEBE_USER_TASK, taskEntity.getImplementation());
-    assertEquals(TaskState.CREATED, taskEntity.getState());
-    assertNotNull(taskEntity.getCreationTime());
-    assertEquals(bpmnProcessId, taskEntity.getBpmnProcessId());
-    assertEquals(flowNodeBpmnId, taskEntity.getFlowNodeBpmnId());
-    assertEquals(tester.getProcessDefinitionKey(), taskEntity.getProcessDefinitionId());
-    assertEquals(tester.getProcessInstanceId(), taskEntity.getProcessInstanceId());
-    assertEquals(taskEntity.getPriority(), Integer.valueOf(TaskStore.DEFAULT_PRIORITY));
+    org.assertj.core.api.Assertions.assertThat(taskEntity.getImplementation())
+        .isEqualTo(TaskImplementation.ZEEBE_USER_TASK);
+    org.assertj.core.api.Assertions.assertThat(taskEntity.getState()).isEqualTo(TaskState.CREATED);
+    org.assertj.core.api.Assertions.assertThat(taskEntity.getCreationTime()).isNotNull();
+    org.assertj.core.api.Assertions.assertThat(taskEntity.getBpmnProcessId())
+        .isEqualTo(bpmnProcessId);
+    org.assertj.core.api.Assertions.assertThat(taskEntity.getFlowNodeBpmnId())
+        .isEqualTo(flowNodeBpmnId);
+    org.assertj.core.api.Assertions.assertThat(taskEntity.getProcessDefinitionId())
+        .isEqualTo(tester.getProcessDefinitionKey());
+    org.assertj.core.api.Assertions.assertThat(taskEntity.getProcessInstanceId())
+        .isEqualTo(tester.getProcessInstanceId());
+    org.assertj.core.api.Assertions.assertThat(Integer.valueOf(TaskStore.DEFAULT_PRIORITY))
+        .isEqualTo(taskEntity.getPriority());
   }
 
   @Test
@@ -121,7 +124,7 @@ public class ZeebeUserTaskImportIT extends TasklistZeebeIntegrationTest {
             .taskIsCreated(flowNodeBpmnId2)
             .getTaskId();
 
-    assertNotNull(taskId2);
+    org.assertj.core.api.Assertions.assertThat(taskId2).isNotNull();
 
     final var result =
         mockMvcHelper.doRequest(
@@ -158,11 +161,14 @@ public class ZeebeUserTaskImportIT extends TasklistZeebeIntegrationTest {
             .taskIsCreated(flowNodeBpmnId)
             .getTaskId();
     // then
-    assertNotNull(taskId);
+    org.assertj.core.api.Assertions.assertThat(taskId).isNotNull();
     final TaskEntity taskEntity = taskStore.getTask(taskId);
-    assertEquals(TaskImplementation.ZEEBE_USER_TASK, taskEntity.getImplementation());
-    assertTrue(taskEntity.getCustomHeaders().containsKey("testKey"));
-    assertEquals("testValue", taskEntity.getCustomHeaders().get("testKey"));
+    org.assertj.core.api.Assertions.assertThat(taskEntity.getImplementation())
+        .isEqualTo(TaskImplementation.ZEEBE_USER_TASK);
+    org.assertj.core.api.Assertions.assertThat(taskEntity.getCustomHeaders().containsKey("testKey"))
+        .isTrue();
+    org.assertj.core.api.Assertions.assertThat(taskEntity.getCustomHeaders().get("testKey"))
+        .isEqualTo("testValue");
   }
 
   private static Stream<Arguments> priorityOptions() {
@@ -189,9 +195,11 @@ public class ZeebeUserTaskImportIT extends TasklistZeebeIntegrationTest {
             .taskIsCreated(flowNodeBpmnId)
             .getTaskId();
     // then
-    assertNotNull(taskId);
+    org.assertj.core.api.Assertions.assertThat(taskId).isNotNull();
     final TaskEntity taskEntity = taskStore.getTask(taskId);
-    assertEquals(TaskImplementation.ZEEBE_USER_TASK, taskEntity.getImplementation());
-    assertEquals(taskEntity.getPriority(), taskEntityPriority);
+    org.assertj.core.api.Assertions.assertThat(taskEntity.getImplementation())
+        .isEqualTo(TaskImplementation.ZEEBE_USER_TASK);
+    org.assertj.core.api.Assertions.assertThat(taskEntityPriority)
+        .isEqualTo(taskEntity.getPriority());
   }
 }

--- a/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/api/rest/CustomCssRestServiceTest.java
+++ b/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/api/rest/CustomCssRestServiceTest.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.tasklist.webapp.api.rest;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
 import io.camunda.tasklist.webapp.rest.CustomCssRestService;
@@ -46,7 +46,7 @@ public class CustomCssRestServiceTest {
 
     customCssRestService.init();
 
-    assertEquals(cssContent, customCssRestService.getClientConfig());
+    assertThat(customCssRestService.getClientConfig()).isEqualTo(cssContent);
   }
 
   @Test
@@ -55,6 +55,6 @@ public class CustomCssRestServiceTest {
     final String result = customCssRestService.getClientConfig();
 
     // Assert
-    assertNull(result);
+    assertThat(result).isNull();
   }
 }

--- a/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/config/OpenApiConfigTest.java
+++ b/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/config/OpenApiConfigTest.java
@@ -8,7 +8,6 @@
 package io.camunda.tasklist.webapp.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -23,13 +22,13 @@ class OpenApiConfigTest {
   @Test
   void testInternalApiPaths() {
     final GroupedOpenApi result = openApiConfig.internalApiV1();
-    assertTrue(result.getPathsToMatch().contains("/v1/internal/**"));
+    assertThat(result.getPathsToMatch().contains("/v1/internal/**")).isTrue();
   }
 
   @Test
   void testExternalApiPaths() {
     final GroupedOpenApi result = openApiConfig.externalApiV1();
-    assertTrue(result.getPathsToMatch().contains("/v1/external/**"));
+    assertThat(result.getPathsToMatch().contains("/v1/external/**")).isTrue();
   }
 
   @Test

--- a/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/es/TaskValidatorTest.java
+++ b/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/es/TaskValidatorTest.java
@@ -7,8 +7,8 @@
  */
 package io.camunda.tasklist.webapp.es;
 
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -125,7 +125,8 @@ public class TaskValidatorTest {
     final TaskEntity task = new TaskEntity().setAssignee(TEST_USER).setState(TaskState.CREATED);
 
     // when - then
-    assertDoesNotThrow(() -> instance.validateCanPersistDraftTaskVariables(task));
+    assertThatCode(() -> instance.validateCanPersistDraftTaskVariables(task))
+        .doesNotThrowAnyException();
   }
 
   @Test
@@ -136,7 +137,8 @@ public class TaskValidatorTest {
         new TaskEntity().setAssignee("AnotherTestUser").setState(TaskState.CREATED);
 
     // when - then
-    assertDoesNotThrow(() -> instance.validateCanPersistDraftTaskVariables(task));
+    assertThatCode(() -> instance.validateCanPersistDraftTaskVariables(task))
+        .doesNotThrowAnyException();
   }
 
   @ParameterizedTest
@@ -210,7 +212,7 @@ public class TaskValidatorTest {
     final TaskEntity task = new TaskEntity().setAssignee(TEST_USER).setState(TaskState.CREATED);
 
     // when - then
-    assertDoesNotThrow(() -> instance.validateCanComplete(task));
+    assertThatCode(() -> instance.validateCanComplete(task)).doesNotThrowAnyException();
   }
 
   @Test
@@ -225,7 +227,7 @@ public class TaskValidatorTest {
     final TaskEntity task = new TaskEntity().setAssignee(TEST_USER).setState(TaskState.CREATED);
 
     // when - then
-    assertDoesNotThrow(() -> instance.validateCanComplete(task));
+    assertThatCode(() -> instance.validateCanComplete(task)).doesNotThrowAnyException();
   }
 
   @Test
@@ -236,7 +238,7 @@ public class TaskValidatorTest {
         new TaskEntity().setAssignee("AnotherTestUser").setState(TaskState.CREATED);
 
     // when - then
-    assertDoesNotThrow(() -> instance.validateCanComplete(task));
+    assertThatCode(() -> instance.validateCanComplete(task)).doesNotThrowAnyException();
   }
 
   @Test
@@ -246,7 +248,7 @@ public class TaskValidatorTest {
     final TaskEntity taskBefore = new TaskEntity().setAssignee(null).setState(TaskState.CREATED);
 
     // when - then
-    assertDoesNotThrow(() -> instance.validateCanAssign(taskBefore, true));
+    assertThatCode(() -> instance.validateCanAssign(taskBefore, true)).doesNotThrowAnyException();
   }
 
   @Test
@@ -257,7 +259,7 @@ public class TaskValidatorTest {
         new TaskEntity().setAssignee("previously assigned user").setState(TaskState.CREATED);
 
     // when - then
-    assertDoesNotThrow(() -> instance.validateCanAssign(taskBefore, true));
+    assertThatCode(() -> instance.validateCanAssign(taskBefore, true)).doesNotThrowAnyException();
   }
 
   @Test
@@ -268,7 +270,7 @@ public class TaskValidatorTest {
         new TaskEntity().setAssignee("previously assigned user").setState(TaskState.CREATED);
 
     // when - then
-    assertDoesNotThrow(() -> instance.validateCanAssign(taskBefore, true));
+    assertThatCode(() -> instance.validateCanAssign(taskBefore, true)).doesNotThrowAnyException();
   }
 
   @Test

--- a/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/es/cache/ProcessStoreElasticSearchTest.java
+++ b/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/es/cache/ProcessStoreElasticSearchTest.java
@@ -9,10 +9,7 @@ package io.camunda.tasklist.webapp.es.cache;
 
 import static io.camunda.client.api.command.CommandWithTenantStep.DEFAULT_TENANT_IDENTIFIER;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -97,8 +94,8 @@ class ProcessStoreElasticSearchTest {
     final ProcessEntity result = processStore.getProcessByBpmnProcessId("bpmnProcessId");
 
     // then
-    assertNotNull(result);
-    assertEquals("1", result.getId());
+    assertThat(result).isNotNull();
+    assertThat(result.getId()).isEqualTo("1");
   }
 
   @Test
@@ -107,9 +104,8 @@ class ProcessStoreElasticSearchTest {
     mockElasticSearchNotFound();
 
     // when and then
-    assertThrows(
-        NotFoundException.class,
-        () -> processStore.getProcessByBpmnProcessId("bpmnProcessId_not_exist"));
+    assertThatExceptionOfType(NotFoundException.class)
+        .isThrownBy(() -> processStore.getProcessByBpmnProcessId("bpmnProcessId_not_exist"));
   }
 
   @Test
@@ -121,17 +117,18 @@ class ProcessStoreElasticSearchTest {
 
     // when
     final TasklistRuntimeException thrown =
-        assertThrows(
-            TasklistRuntimeException.class,
-            () -> processStore.getProcessByBpmnProcessId("bpmnProcessId"));
+        assertThatExceptionOfType(TasklistRuntimeException.class)
+            .isThrownBy(() -> processStore.getProcessByBpmnProcessId("bpmnProcessId"))
+            .actual();
 
     // then
-    assertTrue(
-        thrown
-            .getMessage()
-            .contains(
-                "Exception occurred, while obtaining the process: "
-                    + mockedException.getMessage()));
+    assertThat(
+            thrown
+                .getMessage()
+                .contains(
+                    "Exception occurred, while obtaining the process: "
+                        + mockedException.getMessage()))
+        .isTrue();
   }
 
   // ** Test Get Process by Process Id ** //
@@ -144,7 +141,7 @@ class ProcessStoreElasticSearchTest {
     final ProcessEntity result = processStore.getProcess("1");
 
     // then
-    assertNotNull(result);
+    assertThat(result).isNotNull();
   }
 
   @Test
@@ -153,7 +150,8 @@ class ProcessStoreElasticSearchTest {
     mockElasticSearchNotFound();
 
     // given and then
-    assertThrows(TasklistRuntimeException.class, () -> processStore.getProcess("processId"));
+    assertThatExceptionOfType(TasklistRuntimeException.class)
+        .isThrownBy(() -> processStore.getProcess("processId"));
   }
 
   @Test
@@ -168,8 +166,10 @@ class ProcessStoreElasticSearchTest {
 
     // given and then
     final TasklistRuntimeException thrown =
-        assertThrows(TasklistRuntimeException.class, () -> processStore.getProcess(processId));
-    assertTrue(thrown.getMessage().contains(errorMessage));
+        assertThatExceptionOfType(TasklistRuntimeException.class)
+            .isThrownBy(() -> processStore.getProcess(processId))
+            .actual();
+    assertThat(thrown.getMessage().contains(errorMessage)).isTrue();
   }
 
   // ** Test get processes && And get processes with search condition ** //
@@ -219,8 +219,8 @@ class ProcessStoreElasticSearchTest {
         processStore.getProcesses("*", authorizations, DEFAULT_TENANT_IDENTIFIER, null);
 
     // then
-    assertNotNull(processes);
-    assertNotNull(processesWithCondition);
+    assertThat(processes).isNotNull();
+    assertThat(processesWithCondition).isNotNull();
   }
 
   @Test
@@ -241,8 +241,8 @@ class ProcessStoreElasticSearchTest {
         processStore.getProcesses("*", authorizations, DEFAULT_TENANT_IDENTIFIER, null);
 
     // then
-    assertNotNull(processes);
-    assertNotNull(processesWithCondition);
+    assertThat(processes).isNotNull();
+    assertThat(processesWithCondition).isNotNull();
   }
 
   private void mockAuthenticationOverIdentity(final Boolean isAuthorizated) {

--- a/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/es/cache/ProcessStoreOpenSearchTest.java
+++ b/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/es/cache/ProcessStoreOpenSearchTest.java
@@ -9,10 +9,7 @@ package io.camunda.tasklist.webapp.es.cache;
 
 import static io.camunda.client.api.command.CommandWithTenantStep.DEFAULT_TENANT_IDENTIFIER;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.any;
@@ -100,8 +97,8 @@ class ProcessStoreOpenSearchTest {
     final ProcessEntity result = processStore.getProcessByBpmnProcessId("bpmnProcessId");
 
     // then
-    assertNotNull(result);
-    assertEquals("1", result.getId());
+    assertThat(result).isNotNull();
+    assertThat(result.getId()).isEqualTo("1");
   }
 
   @Test
@@ -110,9 +107,8 @@ class ProcessStoreOpenSearchTest {
     mockOpenSearchNotFound();
 
     // when and then
-    assertThrows(
-        NotFoundException.class,
-        () -> processStore.getProcessByBpmnProcessId("bpmnProcessId_not_exist"));
+    assertThatExceptionOfType(NotFoundException.class)
+        .isThrownBy(() -> processStore.getProcessByBpmnProcessId("bpmnProcessId_not_exist"));
   }
 
   @Test
@@ -124,17 +120,18 @@ class ProcessStoreOpenSearchTest {
 
     // when
     final TasklistRuntimeException thrown =
-        assertThrows(
-            TasklistRuntimeException.class,
-            () -> processStore.getProcessByBpmnProcessId("bpmnProcessId"));
+        assertThatExceptionOfType(TasklistRuntimeException.class)
+            .isThrownBy(() -> processStore.getProcessByBpmnProcessId("bpmnProcessId"))
+            .actual();
 
     // then
-    assertTrue(
-        thrown
-            .getMessage()
-            .contains(
-                "Exception occurred, while obtaining the process: "
-                    + mockedException.getMessage()));
+    assertThat(
+            thrown
+                .getMessage()
+                .contains(
+                    "Exception occurred, while obtaining the process: "
+                        + mockedException.getMessage()))
+        .isTrue();
   }
 
   // ** Test Get Process by Process Id ** //
@@ -147,7 +144,7 @@ class ProcessStoreOpenSearchTest {
     final ProcessEntity result = processStore.getProcess("1");
 
     // then
-    assertNotNull(result);
+    assertThat(result).isNotNull();
   }
 
   @Test
@@ -156,7 +153,8 @@ class ProcessStoreOpenSearchTest {
     mockOpenSearchNotFound();
 
     // given and then
-    assertThrows(TasklistRuntimeException.class, () -> processStore.getProcess("processId"));
+    assertThatExceptionOfType(TasklistRuntimeException.class)
+        .isThrownBy(() -> processStore.getProcess("processId"));
   }
 
   @Test
@@ -171,8 +169,10 @@ class ProcessStoreOpenSearchTest {
 
     // given and then
     final TasklistRuntimeException thrown =
-        assertThrows(TasklistRuntimeException.class, () -> processStore.getProcess(processId));
-    assertTrue(thrown.getMessage().contains(errorMessage));
+        assertThatExceptionOfType(TasklistRuntimeException.class)
+            .isThrownBy(() -> processStore.getProcess(processId))
+            .actual();
+    assertThat(thrown.getMessage().contains(errorMessage)).isTrue();
   }
 
   // ** Test get processes && And get processes with search condition ** //
@@ -226,8 +226,8 @@ class ProcessStoreOpenSearchTest {
         processStore.getProcesses("*", authorizations, DEFAULT_TENANT_IDENTIFIER, null);
 
     // then
-    assertNotNull(processes);
-    assertNotNull(processesWithCondition);
+    assertThat(processes).isNotNull();
+    assertThat(processesWithCondition).isNotNull();
   }
 
   @Test
@@ -248,8 +248,8 @@ class ProcessStoreOpenSearchTest {
         processStore.getProcesses("*", authorizations, DEFAULT_TENANT_IDENTIFIER, null);
 
     // then
-    assertNotNull(processes);
-    assertNotNull(processesWithCondition);
+    assertThat(processes).isNotNull();
+    assertThat(processesWithCondition).isNotNull();
   }
 
   private void mockAuthenticationOverIdentity(final Boolean isAuthorizated) {

--- a/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/service/TaskServiceTest.java
+++ b/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/service/TaskServiceTest.java
@@ -11,8 +11,7 @@ import static io.camunda.client.api.command.CommandWithTenantStep.DEFAULT_TENANT
 import static java.util.Collections.emptySet;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
@@ -141,12 +140,14 @@ class TaskServiceTest {
     // When and Then
     // When / Then
     final InvalidRequestException exception =
-        assertThrows(InvalidRequestException.class, () -> instance.getTasks(taskQuery));
+        assertThatExceptionOfType(InvalidRequestException.class)
+            .isThrownBy(() -> instance.getTasks(taskQuery))
+            .actual();
 
     // Validate the exception message if needed
-    assertEquals(
-        "Only one of [searchAfter, searchAfterOrEqual, searchBefore, searchBeforeOrEqual] must be present in request.",
-        exception.getMessage());
+    assertThat(exception.getMessage())
+        .isEqualTo(
+            "Only one of [searchAfter, searchAfterOrEqual, searchBefore, searchBeforeOrEqual] must be present in request.");
   }
 
   @Test

--- a/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/util/ErrorHandlingUtilsTest.java
+++ b/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/util/ErrorHandlingUtilsTest.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.tasklist.webapp.util;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
 import io.camunda.client.api.ProblemDetail;
@@ -47,7 +47,7 @@ class ErrorHandlingUtilsTest {
             "detail": "Task is already in progress."
           }
           """;
-    assertEquals(expectedMessage, result);
+    assertThat(result).isEqualTo(expectedMessage);
   }
 
   @Test
@@ -70,7 +70,7 @@ class ErrorHandlingUtilsTest {
           }
           """
             .formatted(serviceException.getMessage());
-    assertEquals(expectedMessage, result);
+    assertThat(result).isEqualTo(expectedMessage);
   }
 
   @Test
@@ -90,7 +90,7 @@ class ErrorHandlingUtilsTest {
             "detail": "The request timed out while processing the task."
           }
           """;
-    assertEquals(expectedMessage, result);
+    assertThat(result).isEqualTo(expectedMessage);
   }
 
   @Test
@@ -109,7 +109,7 @@ class ErrorHandlingUtilsTest {
             "detail": "The request timed out while processing the task."
           }
           """;
-    assertEquals(expectedMessage, result);
+    assertThat(result).isEqualTo(expectedMessage);
   }
 
   @Test
@@ -121,7 +121,7 @@ class ErrorHandlingUtilsTest {
     final String result = ErrorHandlingUtils.getErrorMessageFromClientException(genericException);
 
     // Then
-    assertEquals("Generic error occurred", result);
+    assertThat(result).isEqualTo("Generic error occurred");
   }
 
   @Test
@@ -134,7 +134,7 @@ class ErrorHandlingUtilsTest {
     final String result = ErrorHandlingUtils.getErrorMessageFromServiceException(genericException);
 
     // Then
-    assertEquals("Generic error occurred", result);
+    assertThat(result).isEqualTo("Generic error occurred");
   }
 
   @Test
@@ -153,6 +153,6 @@ class ErrorHandlingUtilsTest {
             "detail": "An unexpected error occurred."
           }
           """;
-    assertEquals(expectedMessage, result);
+    assertThat(result).isEqualTo(expectedMessage);
   }
 }

--- a/testing/camunda-process-test-example/src/test/java/io/camunda/InvoiceApprovalTest.java
+++ b/testing/camunda-process-test-example/src/test/java/io/camunda/InvoiceApprovalTest.java
@@ -19,7 +19,6 @@ import static io.camunda.process.test.api.CamundaAssert.assertThat;
 import static io.camunda.process.test.api.assertions.ElementSelectors.byId;
 import static io.camunda.process.test.api.assertions.UserTaskSelectors.byElementId;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doThrow;
@@ -89,7 +88,8 @@ public class InvoiceApprovalTest {
             (jobClient, job) -> {
               addInvoiceJobWorkerCalled.set(true);
               // check input mapping
-              assertEquals("INV-1001", job.getVariablesAsMap().get("invoiceId"));
+              org.assertj.core.api.Assertions.assertThat(job.getVariablesAsMap().get("invoiceId"))
+                  .isEqualTo("INV-1001");
               jobClient
                   .newCompleteCommand(job)
                   // .variables(null) //  We could now also simulate setting some response values
@@ -125,7 +125,7 @@ public class InvoiceApprovalTest {
 
     // verify that side effects have happened
     Mockito.verify(archiveService).archiveInvoice("INV-1001", objectMapper.readTree(invoiceJson));
-    assertThat(addInvoiceJobWorkerCalled.get())
+    org.assertj.core.api.Assertions.assertThat(addInvoiceJobWorkerCalled.get())
         .as("add-invoice-to-accounting job worker called")
         .isTrue();
   }

--- a/webapps-backup/src/test/java/io/camunda/webapps/backup/repository/elasticsearch/ElasticsearchBackupRepositoryTest.java
+++ b/webapps-backup/src/test/java/io/camunda/webapps/backup/repository/elasticsearch/ElasticsearchBackupRepositoryTest.java
@@ -9,7 +9,7 @@ package io.camunda.webapps.backup.repository.elasticsearch;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 import static org.mockito.Answers.RETURNS_DEEP_STUBS;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
@@ -384,10 +384,9 @@ public class ElasticsearchBackupRepositoryTest {
         .thenReturn(snapshotResponse);
 
     // Test
-    assertThrows(
-        ResourceNotFoundException.class,
-        () -> backupRepository.findSnapshots("repository-name", 5L),
-        "No backup with id [5] found.");
+    assertThatExceptionOfType(ResourceNotFoundException.class)
+        .as("No backup with id [5] found.")
+        .isThrownBy(() -> backupRepository.findSnapshots("repository-name", 5L));
   }
 
   @Test

--- a/webapps-backup/src/test/java/io/camunda/webapps/backup/repository/opensearch/OpensearchBackupRepositoryTest.java
+++ b/webapps-backup/src/test/java/io/camunda/webapps/backup/repository/opensearch/OpensearchBackupRepositoryTest.java
@@ -10,8 +10,8 @@ package io.camunda.webapps.backup.repository.opensearch;
 import static io.camunda.webapps.backup.repository.opensearch.OpensearchBackupRepository.REPOSITORY_MISSING_EXCEPTION_TYPE;
 import static io.camunda.webapps.backup.repository.opensearch.OpensearchBackupRepository.SNAPSHOT_MISSING_EXCEPTION_TYPE;
 import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 import static org.assertj.core.api.AssertionsForClassTypes.fail;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
@@ -277,7 +277,9 @@ class OpensearchBackupRepositoryTest {
                     .build()));
 
     final var exception =
-        assertThrows(BackupException.class, () -> repository.validateRepositoryExists("repo"));
+        assertThatExceptionOfType(BackupException.class)
+            .isThrownBy(() -> repository.validateRepositoryExists("repo"))
+            .actual();
     assertThat(exception.getMessage()).isEqualTo("No repository with name [repo] could be found.");
   }
 
@@ -303,9 +305,9 @@ class OpensearchBackupRepositoryTest {
                                             .uuid("test"))))));
 
     final var exception =
-        assertThrows(
-            InvalidRequestException.class,
-            () -> repository.validateNoDuplicateBackupId("repo", 42L));
+        assertThatExceptionOfType(InvalidRequestException.class)
+            .isThrownBy(() -> repository.validateNoDuplicateBackupId("repo", 42L))
+            .actual();
     assertThat(exception.getMessage())
         .isEqualTo("A backup with ID [42] already exists. Found snapshots: [test]");
   }

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/cluster/AtomixClusterTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/cluster/AtomixClusterTest.java
@@ -17,9 +17,6 @@
 package io.atomix.cluster;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import io.atomix.cluster.discovery.BootstrapDiscoveryProvider;
 import io.atomix.utils.net.Address;
@@ -31,6 +28,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.assertj.core.api.Assertions;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -68,11 +66,11 @@ public class AtomixClusterTest {
     // when
     try {
       atomix.start().get(TIMEOUT_IN_S, TimeUnit.SECONDS);
-      fail("Expected ExecutionException");
+      Assertions.fail("Expected ExecutionException");
     } catch (final ExecutionException ex) {
       // then
-      assertTrue(ex.getCause() instanceof IllegalStateException);
-      assertEquals("Cluster instance is shutdown", ex.getCause().getMessage());
+      assertThat(ex.getCause() instanceof IllegalStateException).isTrue();
+      assertThat(ex.getCause().getMessage()).isEqualTo("Cluster instance is shutdown");
     }
   }
 
@@ -94,7 +92,7 @@ public class AtomixClusterTest {
             .build();
     cluster1.start().join();
 
-    assertEquals("foo", cluster1.getMembershipService().getLocalMember().id().id());
+    assertThat(cluster1.getMembershipService().getLocalMember().id().id()).isEqualTo("foo");
 
     final AtomixCluster cluster2 =
         AtomixCluster.builder(atomixClusterRule.registry)
@@ -106,7 +104,7 @@ public class AtomixClusterTest {
             .build();
     cluster2.start().join();
 
-    assertEquals("bar", cluster2.getMembershipService().getLocalMember().id().id());
+    assertThat(cluster2.getMembershipService().getLocalMember().id().id()).isEqualTo("bar");
 
     final AtomixCluster cluster3 =
         AtomixCluster.builder(atomixClusterRule.registry)
@@ -118,7 +116,7 @@ public class AtomixClusterTest {
             .build();
     cluster3.start().join();
 
-    assertEquals("baz", cluster3.getMembershipService().getLocalMember().id().id());
+    assertThat(cluster3.getMembershipService().getLocalMember().id().id()).isEqualTo("baz");
 
     final List<CompletableFuture<Void>> futures =
         Stream.of(cluster1, cluster2, cluster3)

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/cluster/messaging/impl/DefaultClusterEventServiceTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/cluster/messaging/impl/DefaultClusterEventServiceTest.java
@@ -18,7 +18,6 @@ package io.atomix.cluster.messaging.impl;
 
 import static io.camunda.zeebe.test.util.TestUtil.waitUntil;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
 
 import com.google.common.util.concurrent.MoreExecutors;
 import io.atomix.cluster.BootstrapService;
@@ -151,7 +150,7 @@ public class DefaultClusterEventServiceTest {
             topic,
             SERIALIZER::decode,
             message -> {
-              assertEquals("Hello world!", message);
+              assertThat(message).isEqualTo("Hello world!");
               events.add(1);
               latch.countDown();
             },
@@ -163,7 +162,7 @@ public class DefaultClusterEventServiceTest {
             topic,
             SERIALIZER::decode,
             message -> {
-              assertEquals("Hello world!", message);
+              assertThat(message).isEqualTo("Hello world!");
               events.add(2);
               latch.countDown();
             },
@@ -175,7 +174,7 @@ public class DefaultClusterEventServiceTest {
             topic,
             SERIALIZER::decode,
             message -> {
-              assertEquals("Hello world!", message);
+              assertThat(message).isEqualTo("Hello world!");
               events.add(3);
               latch.countDown();
             },
@@ -193,7 +192,7 @@ public class DefaultClusterEventServiceTest {
 
     // then
     assertThat(latch.await(2, TimeUnit.SECONDS)).isTrue();
-    assertEquals(3, events.size());
+    assertThat(events.size()).isEqualTo(3);
   }
 
   @Test
@@ -214,7 +213,7 @@ public class DefaultClusterEventServiceTest {
             topic1,
             SERIALIZER::decode,
             message -> {
-              assertEquals("Hello world!", message);
+              assertThat(message).isEqualTo("Hello world!");
               events.add(1);
               latch.countDown();
             },
@@ -226,7 +225,7 @@ public class DefaultClusterEventServiceTest {
             topic2,
             SERIALIZER::decode,
             message -> {
-              assertEquals("Hello world!", message);
+              assertThat(message).isEqualTo("Hello world!");
               events.add(2);
               latch.countDown();
             },
@@ -242,7 +241,7 @@ public class DefaultClusterEventServiceTest {
 
     // then
     assertThat(latch.await(2, TimeUnit.SECONDS)).isTrue();
-    assertEquals(2, events.size());
+    assertThat(events.size()).isEqualTo(2);
   }
 
   @Test
@@ -263,7 +262,7 @@ public class DefaultClusterEventServiceTest {
             topic,
             SERIALIZER::decode,
             message -> {
-              assertEquals("Hello world!", message);
+              assertThat(message).isEqualTo("Hello world!");
               events.add(1);
               latch.countDown();
             },
@@ -275,7 +274,7 @@ public class DefaultClusterEventServiceTest {
             topic,
             SERIALIZER::decode,
             message -> {
-              assertEquals("Hello world!", message);
+              assertThat(message).isEqualTo("Hello world!");
               events.add(2);
               latch.countDown();
             },
@@ -287,7 +286,7 @@ public class DefaultClusterEventServiceTest {
 
     // then
     assertThat(latch.await(2, TimeUnit.SECONDS)).isTrue();
-    assertEquals(2, events.size());
+    assertThat(events.size()).isEqualTo(2);
     assertThat(events).containsExactlyInAnyOrder(1, 2);
   }
 
@@ -314,7 +313,7 @@ public class DefaultClusterEventServiceTest {
             topic,
             SERIALIZER::decode,
             message -> {
-              assertEquals("Hello world!", message);
+              assertThat(message).isEqualTo("Hello world!");
               events.add(2);
               latch.countDown();
             },
@@ -327,7 +326,7 @@ public class DefaultClusterEventServiceTest {
 
     // then
     assertThat(latch.await(2, TimeUnit.SECONDS)).isTrue();
-    assertEquals(1, events.size());
+    assertThat(events.size()).isEqualTo(1);
   }
 
   @Test
@@ -347,7 +346,7 @@ public class DefaultClusterEventServiceTest {
             topic,
             SERIALIZER::decode,
             message -> {
-              assertEquals("Hello world!", message);
+              assertThat(message).isEqualTo("Hello world!");
               events.add(1);
               latch.countDown();
             },
@@ -368,7 +367,7 @@ public class DefaultClusterEventServiceTest {
     eventService2Restarted.broadcast(topic, "Hello world!", SERIALIZER::encode);
 
     assertThat(latch.await(2, TimeUnit.SECONDS)).isTrue();
-    assertEquals(1, events.size());
+    assertThat(events.size()).isEqualTo(1);
   }
 
   @Test
@@ -397,6 +396,6 @@ public class DefaultClusterEventServiceTest {
     eventService1.broadcast("test", "foo");
     eventService1.broadcast("test", "bar");
     awaitCompletion.await(10, TimeUnit.SECONDS);
-    assertEquals("bar", received.get());
+    assertThat(received.get()).isEqualTo("bar");
   }
 }

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/cluster/messaging/impl/MessageDecoderV1Test.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/cluster/messaging/impl/MessageDecoderV1Test.java
@@ -16,7 +16,7 @@
  */
 package io.atomix.cluster.messaging.impl;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
@@ -29,22 +29,22 @@ public class MessageDecoderV1Test {
   public void testDecodeCompactInt() throws Exception {
     ByteBuf buffer = Unpooled.buffer(5);
     MessageEncoderV1.writeInt(buffer, 10);
-    assertEquals(10, MessageDecoderV1.readInt(buffer));
+    assertThat(MessageDecoderV1.readInt(buffer)).isEqualTo(10);
 
     buffer = Unpooled.buffer(2);
     MessageEncoderV1.writeInt(buffer, 10);
-    assertEquals(10, MessageDecoderV1.readInt(buffer));
+    assertThat(MessageDecoderV1.readInt(buffer)).isEqualTo(10);
   }
 
   @Test
   public void testDecodeCompactLong() throws Exception {
     ByteBuf buffer = Unpooled.buffer(9);
     MessageEncoderV1.writeLong(buffer, 10);
-    assertEquals(10, MessageDecoderV1.readLong(buffer));
+    assertThat(MessageDecoderV1.readLong(buffer)).isEqualTo(10);
 
     buffer = Unpooled.buffer(2);
     MessageEncoderV1.writeLong(buffer, 10);
-    assertEquals(10, MessageDecoderV1.readLong(buffer));
+    assertThat(MessageDecoderV1.readLong(buffer)).isEqualTo(10);
   }
 
   @Test
@@ -52,7 +52,7 @@ public class MessageDecoderV1Test {
     final String payload = "huuhaa";
     ByteBuf byteBuf = Unpooled.wrappedBuffer(payload.getBytes(StandardCharsets.UTF_8));
     try {
-      assertEquals(payload, MessageDecoderV1.readString(byteBuf, payload.length()));
+      assertThat(MessageDecoderV1.readString(byteBuf, payload.length())).isEqualTo(payload);
     } finally {
       byteBuf.release();
     }
@@ -62,7 +62,7 @@ public class MessageDecoderV1Test {
       byteBuf.writeInt(1);
       byteBuf.writeBytes(bytes);
       byteBuf.readInt();
-      assertEquals(payload, MessageDecoderV1.readString(byteBuf, payload.length()));
+      assertThat(MessageDecoderV1.readString(byteBuf, payload.length())).isEqualTo(payload);
     } finally {
       byteBuf.release();
     }
@@ -75,7 +75,7 @@ public class MessageDecoderV1Test {
         Unpooled.directBuffer(payload.length())
             .writeBytes(payload.getBytes(StandardCharsets.UTF_8));
     try {
-      assertEquals(payload, MessageDecoderV1.readString(byteBuf, payload.length()));
+      assertThat(MessageDecoderV1.readString(byteBuf, payload.length())).isEqualTo(payload);
     } finally {
       byteBuf.release();
     }

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/cluster/messaging/impl/NettyMessagingServiceTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/cluster/messaging/impl/NettyMessagingServiceTest.java
@@ -16,8 +16,7 @@
  */
 package io.atomix.cluster.messaging.impl;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.*;
 
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.Uninterruptibles;
@@ -56,7 +55,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiFunction;
 import java.util.stream.Stream;
 import org.awaitility.Awaitility;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
@@ -409,7 +407,7 @@ final class NettyMessagingServiceTest {
             .sendAndReceive(
                 netty2.address(), subject, "hello world".getBytes(), Duration.ofSeconds(1))
             .join();
-        Assertions.fail();
+        fail("");
       } catch (final CompletionException e) {
         assertThat(e.getCause()).isInstanceOf(TimeoutException.class);
       }
@@ -435,7 +433,7 @@ final class NettyMessagingServiceTest {
               latch.await();
             } catch (final InterruptedException e1) {
               Thread.currentThread().interrupt();
-              Assertions.fail("InterruptedException");
+              fail("InterruptedException");
             }
             return "hello there".getBytes();
           };

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/cluster/protocol/SwimProtocolTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/cluster/protocol/SwimProtocolTest.java
@@ -21,7 +21,6 @@ import static io.atomix.cluster.protocol.GroupMembershipEvent.Type.MEMBER_REMOVE
 import static io.atomix.cluster.protocol.GroupMembershipEvent.Type.METADATA_CHANGED;
 import static io.atomix.cluster.protocol.GroupMembershipEvent.Type.REACHABILITY_CHANGED;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
 
 import com.google.common.collect.HashMultiset;
 import com.google.common.collect.Maps;
@@ -408,7 +407,7 @@ public class SwimProtocolTest extends ConcurrentTestCase {
 
   private void checkMembers(final Member member, final Member... members) {
     final SwimMembershipProtocol protocol = protocols.get(member.id());
-    assertEquals(Sets.newHashSet(members), protocol.getMembers());
+    assertThat(protocol.getMembers()).isEqualTo(Sets.newHashSet(members));
   }
 
   private void awaitMembers(final Member member, final Member... members) {

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/DeterministicSingleThreadContext.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/DeterministicSingleThreadContext.java
@@ -15,8 +15,6 @@
  */
 package io.atomix.raft;
 
-import static org.junit.Assert.fail;
-
 import io.atomix.cluster.MemberId;
 import io.atomix.utils.concurrent.Scheduled;
 import io.atomix.utils.concurrent.ScheduledFutureImpl;
@@ -24,6 +22,7 @@ import io.atomix.utils.concurrent.ThreadContext;
 import java.time.Duration;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import org.assertj.core.api.Assertions;
 import org.jmock.lib.concurrent.DeterministicScheduler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -119,7 +118,7 @@ public final class DeterministicSingleThreadContext implements ThreadContext {
         command.run();
       } catch (final Exception e) {
         LOGGER.error("Uncaught exception", e);
-        fail("Uncaught exception" + e);
+        Assertions.fail("Uncaught exception" + e);
       }
     }
   }

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftRule.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftRule.java
@@ -16,7 +16,6 @@
 package io.atomix.raft;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
 import io.atomix.cluster.ClusterMembershipService;
@@ -500,7 +499,7 @@ public final class RaftRule extends ExternalResource {
       throw new RuntimeException(e);
     }
 
-    assertTrue(errorMessage.get(), condition.getAsBoolean());
+    assertThat(condition.getAsBoolean()).as(errorMessage.get()).isTrue();
   }
 
   public void awaitCommit(final long commitIndex) throws Exception {

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftTest.java
@@ -20,9 +20,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 
 import com.google.common.collect.Maps;
@@ -73,6 +70,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import net.jodah.concurrentunit.ConcurrentTestCase;
 import org.apache.commons.lang3.RandomStringUtils;
+import org.assertj.core.api.Assertions;
 import org.awaitility.Awaitility;
 import org.junit.After;
 import org.junit.Before;
@@ -342,7 +340,7 @@ public class RaftTest extends ConcurrentTestCase {
 
     // then
     final double missedHeartBeats = roleMetrics.getHeartbeatMissCount();
-    assertThat(0.0, is(missedHeartBeats - startMissedHeartBeats));
+    assertThat(missedHeartBeats - startMissedHeartBeats).isZero();
   }
 
   @Test
@@ -604,7 +602,7 @@ public class RaftTest extends ConcurrentTestCase {
 
     @Override
     public void onWriteError(final Throwable error) {
-      fail("Unexpected write error: " + error.getMessage());
+      Assertions.fail("Unexpected write error: " + error.getMessage());
     }
 
     @Override
@@ -614,7 +612,7 @@ public class RaftTest extends ConcurrentTestCase {
 
     @Override
     public void onCommitError(final long index, final Throwable error) {
-      fail("Unexpected write error: " + error.getMessage());
+      Assertions.fail("Unexpected write error: " + error.getMessage());
     }
 
     public long awaitCommit() throws Exception {

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/utils/ForceConfigureQuorumTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/utils/ForceConfigureQuorumTest.java
@@ -8,7 +8,6 @@
 package io.atomix.raft.utils;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 
 import io.atomix.cluster.MemberId;
 import java.util.Set;

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/zeebe/ZeebeLogAppenderTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/zeebe/ZeebeLogAppenderTest.java
@@ -15,8 +15,7 @@
  */
 package io.atomix.raft.zeebe;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.base.Stopwatch;
 import io.atomix.raft.storage.log.IndexedRaftLogEntry;
@@ -77,8 +76,8 @@ public class ZeebeLogAppenderTest {
 
     // then
     final IndexedRaftLogEntry appended = appenderListener.pollWritten();
-    assertNotNull(appended);
-    assertEquals(0, appenderListener.getErrors().size());
+    assertThat(appended).isNotNull();
+    assertThat(appenderListener.getErrors().size()).isEqualTo(0);
   }
 
   @Test
@@ -88,8 +87,8 @@ public class ZeebeLogAppenderTest {
 
     // then
     final var committed = appenderListener.pollCommitted();
-    assertNotNull(committed);
-    assertEquals(0, appenderListener.getErrors().size());
+    assertThat(committed).isNotNull();
+    assertThat(appenderListener.getErrors().size()).isEqualTo(0);
   }
 
   @Test
@@ -102,9 +101,9 @@ public class ZeebeLogAppenderTest {
 
     // then
     final Throwable error = appenderListener.pollError();
-    assertNotNull(error);
-    assertEquals(0L, appenderListener.getWritten().size());
-    assertEquals(0L, appenderListener.getCommitted().size());
+    assertThat(error).isNotNull();
+    assertThat(appenderListener.getWritten().size()).isEqualTo(0L);
+    assertThat(appenderListener.getCommitted().size()).isEqualTo(0L);
   }
 
   private void append() {

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/zeebe/util/ZeebeTestHelper.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/zeebe/util/ZeebeTestHelper.java
@@ -15,7 +15,7 @@
  */
 package io.atomix.raft.zeebe.util;
 
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.atomix.raft.RaftServer.Role;
 import io.atomix.raft.partition.impl.RaftPartitionServer;
@@ -115,7 +115,7 @@ public class ZeebeTestHelper {
       result = predicate.getAsBoolean();
     }
 
-    assertTrue(result);
+    assertThat(result).isTrue();
   }
 
   public void awaitContains(

--- a/zeebe/atomix/utils/src/test/java/io/atomix/utils/ArraySizeHashPrinterTest.java
+++ b/zeebe/atomix/utils/src/test/java/io/atomix/utils/ArraySizeHashPrinterTest.java
@@ -16,7 +16,7 @@
  */
 package io.atomix.utils;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.atomix.utils.misc.ArraySizeHashPrinter;
 import org.junit.Test;
@@ -26,6 +26,6 @@ public class ArraySizeHashPrinterTest {
   @Test
   public void testArraySizeHashPrinter() throws Exception {
     final ArraySizeHashPrinter printer = ArraySizeHashPrinter.of(new byte[] {1, 2, 3});
-    assertEquals("byte[]{length=3, hash=30817}", printer.toString());
+    assertThat(printer.toString()).isEqualTo("byte[]{length=3, hash=30817}");
   }
 }

--- a/zeebe/atomix/utils/src/test/java/io/atomix/utils/TimestampPrinterTest.java
+++ b/zeebe/atomix/utils/src/test/java/io/atomix/utils/TimestampPrinterTest.java
@@ -16,7 +16,7 @@
  */
 package io.atomix.utils;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.atomix.utils.misc.TimestampPrinter;
 import org.junit.Ignore;
@@ -28,6 +28,6 @@ public class TimestampPrinterTest {
   @Ignore // Timestamp is environment specific
   public void testTimestampPrinter() throws Exception {
     final TimestampPrinter printer = TimestampPrinter.of(1);
-    assertEquals("1969-12-31 04:00:00,001", printer.toString());
+    assertThat(printer.toString()).isEqualTo("1969-12-31 04:00:00,001");
   }
 }

--- a/zeebe/atomix/utils/src/test/java/io/atomix/utils/concurrent/OrderedFutureTest.java
+++ b/zeebe/atomix/utils/src/test/java/io/atomix/utils/concurrent/OrderedFutureTest.java
@@ -16,11 +16,11 @@
  */
 package io.atomix.utils.concurrent;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
+import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
 /** Ordered completable future test. */
@@ -31,30 +31,30 @@ public class OrderedFutureTest {
   public void testOrderedCompletion() throws Throwable {
     final CompletableFuture<String> future = new OrderedFuture<>();
     final AtomicInteger order = new AtomicInteger();
-    future.whenComplete((r, e) -> assertEquals(1, order.incrementAndGet()));
-    future.whenComplete((r, e) -> assertEquals(2, order.incrementAndGet()));
+    future.whenComplete((r, e) -> assertThat(order.incrementAndGet()).isEqualTo(1));
+    future.whenComplete((r, e) -> assertThat(order.incrementAndGet()).isEqualTo(2));
     future.handle(
         (r, e) -> {
-          assertEquals(3, order.incrementAndGet());
-          assertEquals("foo", r);
+          assertThat(order.incrementAndGet()).isEqualTo(3);
+          assertThat(r).isEqualTo("foo");
           return "bar";
         });
-    future.thenRun(() -> assertEquals(3, order.incrementAndGet()));
+    future.thenRun(() -> assertThat(order.incrementAndGet()).isEqualTo(3));
     future.thenAccept(
         r -> {
-          assertEquals(5, order.incrementAndGet());
-          assertEquals("foo", r);
+          assertThat(order.incrementAndGet()).isEqualTo(5);
+          assertThat(r).isEqualTo("foo");
         });
     future.thenApply(
         r -> {
-          assertEquals(6, order.incrementAndGet());
-          assertEquals("foo", r);
+          assertThat(order.incrementAndGet()).isEqualTo(6);
+          assertThat(r).isEqualTo("foo");
           return "bar";
         });
     future.whenComplete(
         (r, e) -> {
-          assertEquals(7, order.incrementAndGet());
-          assertEquals("foo", r);
+          assertThat(order.incrementAndGet()).isEqualTo(7);
+          assertThat(r).isEqualTo("foo");
         });
     future.complete("foo");
   }
@@ -63,18 +63,18 @@ public class OrderedFutureTest {
   public void testOrderedFailure() throws Throwable {
     final CompletableFuture<String> future = new OrderedFuture<>();
     final AtomicInteger order = new AtomicInteger();
-    future.whenComplete((r, e) -> assertEquals(1, order.incrementAndGet()));
-    future.whenComplete((r, e) -> assertEquals(2, order.incrementAndGet()));
+    future.whenComplete((r, e) -> assertThat(order.incrementAndGet()).isEqualTo(1));
+    future.whenComplete((r, e) -> assertThat(order.incrementAndGet()).isEqualTo(2));
     future.handle(
         (r, e) -> {
-          assertEquals(3, order.incrementAndGet());
+          assertThat(order.incrementAndGet()).isEqualTo(3);
           return "bar";
         });
-    future.thenRun(() -> fail());
-    future.thenAccept(r -> fail());
+    future.thenRun(() -> Assertions.fail());
+    future.thenAccept(r -> Assertions.fail());
     future.exceptionally(
         e -> {
-          assertEquals(3, order.incrementAndGet());
+          assertThat(order.incrementAndGet()).isEqualTo(3);
           return "bar";
         });
     future.completeExceptionally(new RuntimeException("foo"));
@@ -83,19 +83,19 @@ public class OrderedFutureTest {
   /** Tests calling callbacks that are added after completion. */
   public void testAfterComplete() throws Throwable {
     final CompletableFuture<String> future = new OrderedFuture<>();
-    future.whenComplete((result, error) -> assertEquals("foo", result));
+    future.whenComplete((result, error) -> assertThat(result).isEqualTo("foo"));
     future.complete("foo");
     final AtomicInteger count = new AtomicInteger();
     future.whenComplete(
         (result, error) -> {
-          assertEquals("foo", result);
-          assertEquals(1, count.incrementAndGet());
+          assertThat(result).isEqualTo("foo");
+          assertThat(count.incrementAndGet()).isEqualTo(1);
         });
     future.thenAccept(
         result -> {
-          assertEquals("foo", result);
-          assertEquals(2, count.incrementAndGet());
+          assertThat(result).isEqualTo("foo");
+          assertThat(count.incrementAndGet()).isEqualTo(2);
         });
-    assertEquals(2, count.get());
+    assertThat(count.get()).isEqualTo(2);
   }
 }

--- a/zeebe/atomix/utils/src/test/java/io/atomix/utils/misc/StringUtilsTest.java
+++ b/zeebe/atomix/utils/src/test/java/io/atomix/utils/misc/StringUtilsTest.java
@@ -16,9 +16,7 @@
  */
 package io.atomix.utils.misc;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Test;
 
@@ -26,14 +24,14 @@ public class StringUtilsTest {
 
   @Test
   public void testNull() {
-    assertNull(StringUtils.split(null, ","));
+    assertThat(StringUtils.split(null, ",")).isNull();
   }
 
   @Test
   public void testFilter() {
     final String[] result = StringUtils.split("1,  ,,", ",");
-    assertNotNull(result);
-    assertEquals(1, result.length);
-    assertEquals("1", result[0]);
+    assertThat(result).isNotNull();
+    assertThat(result.length).isEqualTo(1);
+    assertThat(result[0]).isEqualTo("1");
   }
 }

--- a/zeebe/atomix/utils/src/test/java/io/atomix/utils/net/AddressTest.java
+++ b/zeebe/atomix/utils/src/test/java/io/atomix/utils/net/AddressTest.java
@@ -16,7 +16,7 @@
  */
 package io.atomix.utils.net;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.net.InetAddress;
 import org.junit.Test;
@@ -26,27 +26,27 @@ public class AddressTest {
   @Test
   public void testIPv4Address() throws Exception {
     final Address address = Address.from("127.0.0.1:5000");
-    assertEquals("127.0.0.1", address.host());
-    assertEquals(5000, address.port());
-    assertEquals("localhost", address.tryResolveAddress().getHostName());
-    assertEquals("127.0.0.1:5000", address.toString());
+    assertThat(address.host()).isEqualTo("127.0.0.1");
+    assertThat(address.port()).isEqualTo(5000);
+    assertThat(address.tryResolveAddress().getHostName()).isEqualTo("localhost");
+    assertThat(address.toString()).isEqualTo("127.0.0.1:5000");
   }
 
   @Test
   public void testIPv6Address() throws Exception {
     final Address address = Address.from("[fe80:cd00:0000:0cde:1257:0000:211e:729c]:5000");
-    assertEquals("fe80:cd00:0000:0cde:1257:0000:211e:729c", address.host());
-    assertEquals(5000, address.port());
-    assertEquals("fe80:cd00:0:cde:1257:0:211e:729c", address.tryResolveAddress().getHostName());
-    assertEquals("[fe80:cd00:0000:0cde:1257:0000:211e:729c]:5000", address.toString());
+    assertThat(address.host()).isEqualTo("fe80:cd00:0000:0cde:1257:0000:211e:729c");
+    assertThat(address.port()).isEqualTo(5000);
+    assertThat(address.tryResolveAddress().getHostName())
+        .isEqualTo("fe80:cd00:0:cde:1257:0:211e:729c");
+    assertThat(address.toString()).isEqualTo("[fe80:cd00:0000:0cde:1257:0000:211e:729c]:5000");
   }
 
   @Test
   public void testResolveAddress() throws Exception {
     final Address address = Address.from("localhost", 5000);
-    assertEquals(
-        InetAddress.getLoopbackAddress().getHostAddress(),
-        address.tryResolveAddress().getHostAddress());
-    assertEquals(5000, address.port());
+    assertThat(address.tryResolveAddress().getHostAddress())
+        .isEqualTo(InetAddress.getLoopbackAddress().getHostAddress());
+    assertThat(address.port()).isEqualTo(5000);
   }
 }

--- a/zeebe/atomix/utils/src/test/java/io/atomix/utils/serializer/NamespaceTest.java
+++ b/zeebe/atomix/utils/src/test/java/io/atomix/utils/serializer/NamespaceTest.java
@@ -15,7 +15,7 @@
  */
 package io.atomix.utils.serializer;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.Serializer;
@@ -36,7 +36,7 @@ public class NamespaceTest {
     final Object got = ns.deserialize(ser);
 
     // then
-    assertEquals(want, got);
+    assertThat(got).isEqualTo(want);
   }
 
   @Test
@@ -52,8 +52,8 @@ public class NamespaceTest {
     final Integer gotInteger = ns.deserialize(ns.serialize(expectedInteger));
 
     // then
-    assertEquals(expectedLong, gotLong);
-    assertEquals(expectedInteger, gotInteger);
+    assertThat(gotLong).isEqualTo(expectedLong);
+    assertThat(gotInteger).isEqualTo(expectedInteger);
   }
 
   private static final class NumberSerializer extends Serializer<Number> {

--- a/zeebe/atomix/utils/src/test/java/io/atomix/utils/serializer/serializers/AtomicSerializersTest.java
+++ b/zeebe/atomix/utils/src/test/java/io/atomix/utils/serializer/serializers/AtomicSerializersTest.java
@@ -16,8 +16,7 @@
  */
 package io.atomix.utils.serializer.serializers;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.io.ByteBufferInput;
@@ -75,7 +74,7 @@ public class AtomicSerializersTest {
     final AtomicLong deserialized = KRYO.readObject(input, AtomicLong.class);
 
     // then
-    assertEquals(32L, deserialized.get());
+    assertThat(deserialized.get()).isEqualTo(32L);
   }
 
   @Test
@@ -90,7 +89,7 @@ public class AtomicSerializersTest {
     final AtomicInteger deserialized = KRYO.readObject(input, AtomicInteger.class);
 
     // then
-    assertEquals(1000, deserialized.get());
+    assertThat(deserialized.get()).isEqualTo(1000);
   }
 
   @Test
@@ -105,6 +104,6 @@ public class AtomicSerializersTest {
     final AtomicBoolean deserialized = KRYO.readObject(input, AtomicBoolean.class);
 
     // then
-    assertTrue(deserialized.get());
+    assertThat(deserialized.get()).isTrue();
   }
 }

--- a/zeebe/atomix/utils/src/test/java/io/atomix/utils/serializer/serializers/ByteBufferSerializerTest.java
+++ b/zeebe/atomix/utils/src/test/java/io/atomix/utils/serializer/serializers/ByteBufferSerializerTest.java
@@ -16,9 +16,7 @@
  */
 package io.atomix.utils.serializer.serializers;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.io.ByteBufferInput;
@@ -77,9 +75,9 @@ public class ByteBufferSerializerTest {
     final ByteBuffer deserialized = KRYO.readObject(input, ByteBuffer.class);
 
     // then
-    assertEquals(capacity, deserialized.remaining());
-    assertEquals(capacity, deserialized.capacity());
-    assertEquals(value, deserialized.getLong(0));
+    assertThat(deserialized.remaining()).isEqualTo(capacity);
+    assertThat(deserialized.capacity()).isEqualTo(capacity);
+    assertThat(deserialized.getLong(0)).isEqualTo(value);
   }
 
   @Test
@@ -95,10 +93,10 @@ public class ByteBufferSerializerTest {
     final ByteBuffer deserialized = KRYO.readObject(input, ByteBuffer.class);
 
     // then
-    assertEquals(capacity, deserialized.remaining());
-    assertEquals(capacity, deserialized.capacity());
-    assertTrue(deserialized.isDirect());
-    assertEquals(value, deserialized.getLong(0));
+    assertThat(deserialized.remaining()).isEqualTo(capacity);
+    assertThat(deserialized.capacity()).isEqualTo(capacity);
+    assertThat(deserialized.isDirect()).isTrue();
+    assertThat(deserialized.getLong(0)).isEqualTo(value);
   }
 
   @Test
@@ -114,10 +112,10 @@ public class ByteBufferSerializerTest {
     final ByteBuffer deserialized = KRYO.readObject(input, ByteBuffer.class);
 
     // then
-    assertEquals(capacity, deserialized.remaining());
-    assertEquals(capacity, deserialized.capacity());
-    assertFalse(deserialized.isDirect());
-    assertEquals(value, deserialized.getLong(0));
+    assertThat(deserialized.remaining()).isEqualTo(capacity);
+    assertThat(deserialized.capacity()).isEqualTo(capacity);
+    assertThat(deserialized.isDirect()).isFalse();
+    assertThat(deserialized.getLong(0)).isEqualTo(value);
   }
 
   @Test
@@ -134,8 +132,8 @@ public class ByteBufferSerializerTest {
     final ByteBuffer deserialized = KRYO.readObject(input, ByteBuffer.class);
 
     // then
-    assertEquals(ByteOrder.LITTLE_ENDIAN, deserialized.order());
-    assertEquals(value, deserialized.getLong(0));
+    assertThat(deserialized.order()).isEqualTo(ByteOrder.LITTLE_ENDIAN);
+    assertThat(deserialized.getLong(0)).isEqualTo(value);
   }
 
   @Test
@@ -152,8 +150,8 @@ public class ByteBufferSerializerTest {
     final ByteBuffer deserialized = KRYO.readObject(input, ByteBuffer.class);
 
     // then
-    assertEquals(ByteOrder.BIG_ENDIAN, deserialized.order());
-    assertEquals(value, deserialized.getLong(0));
+    assertThat(deserialized.order()).isEqualTo(ByteOrder.BIG_ENDIAN);
+    assertThat(deserialized.getLong(0)).isEqualTo(value);
   }
 
   @Test
@@ -177,8 +175,8 @@ public class ByteBufferSerializerTest {
     final ByteBuffer deserialized = KRYO.readObject(input, ByteBuffer.class);
 
     // then
-    assertEquals(ByteOrder.BIG_ENDIAN, deserialized.order());
-    assertEquals(secondValue, deserialized.getInt(0));
+    assertThat(deserialized.order()).isEqualTo(ByteOrder.BIG_ENDIAN);
+    assertThat(deserialized.getInt(0)).isEqualTo(secondValue);
   }
 
   @Test
@@ -196,7 +194,7 @@ public class ByteBufferSerializerTest {
     final ByteBuffer deserialized = KRYO.readObject(input, ByteBuffer.class);
 
     // then
-    assertEquals(ByteOrder.BIG_ENDIAN, deserialized.order());
-    assertEquals(0, deserialized.capacity());
+    assertThat(deserialized.order()).isEqualTo(ByteOrder.BIG_ENDIAN);
+    assertThat(deserialized.capacity()).isEqualTo(0);
   }
 }

--- a/zeebe/auth/src/test/java/io/camunda/zeebe/auth/JwtDecoderTest.java
+++ b/zeebe/auth/src/test/java/io/camunda/zeebe/auth/JwtDecoderTest.java
@@ -8,7 +8,8 @@
 package io.camunda.zeebe.auth;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.algorithms.Algorithm;
@@ -49,12 +50,13 @@ public class JwtDecoderTest {
 
   @Test
   void shouldRaiseExceptionWhenTokenIsNull() {
-    assertThrows(IllegalArgumentException.class, () -> new JwtDecoder(null));
+    assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(() -> new JwtDecoder(null));
   }
 
   @Test
   void shouldRaiseExceptionWhenTokenIsEmpty() {
-    assertThrows(IllegalArgumentException.class, () -> new JwtDecoder(""));
+    assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> new JwtDecoder(""));
   }
 
   @Test
@@ -63,7 +65,7 @@ public class JwtDecoderTest {
     final var decoder = new JwtDecoder("invalid-token");
 
     // then
-    assertThrows(RuntimeException.class, decoder::decode);
+    assertThatThrownBy(decoder::decode).isInstanceOf(RuntimeException.class);
   }
 
   private String generateToken() {

--- a/zeebe/backup-stores/azure/src/test/java/io/camunda/zeebe/backup/azure/AzureBackupStoreContainerCredentialsIT.java
+++ b/zeebe/backup-stores/azure/src/test/java/io/camunda/zeebe/backup/azure/AzureBackupStoreContainerCredentialsIT.java
@@ -8,8 +8,7 @@
 package io.camunda.zeebe.backup.azure;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
+import static org.assertj.core.api.Assertions.assertThatCode;
 
 import com.azure.storage.blob.BlobContainerClient;
 import com.azure.storage.blob.BlobServiceClient;
@@ -51,9 +50,8 @@ public class AzureBackupStoreContainerCredentialsIT {
 
     // then we should fail to create the store since the container does not
     // exist yet.
-    assertThrowsExactly(
-        AzureBackupStoreException.ContainerDoesNotExist.class,
-        () -> new AzureBackupStore(azureBackupConfig));
+    assertThatCode(() -> new AzureBackupStore(azureBackupConfig))
+        .isInstanceOf(AzureBackupStoreException.ContainerDoesNotExist.class);
 
     // when we create the container
     new BlobServiceClientBuilder()
@@ -63,7 +61,7 @@ public class AzureBackupStoreContainerCredentialsIT {
         .create();
 
     // then we can create the store without any exceptions
-    assertDoesNotThrow(() -> new AzureBackupStore(azureBackupConfig));
+    assertThatCode(() -> new AzureBackupStore(azureBackupConfig)).doesNotThrowAnyException();
   }
 
   // The test for the user delegation token is not present due to the fact that the azurite

--- a/zeebe/bpmn-model/pom.xml
+++ b/zeebe/bpmn-model/pom.xml
@@ -65,12 +65,6 @@
       <scope>test</scope>
     </dependency>
 
-    <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest</artifactId>
-      <scope>test</scope>
-    </dependency>
-
   </dependencies>
 
   <build>

--- a/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/BpmnModelInstanceTest.java
+++ b/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/BpmnModelInstanceTest.java
@@ -15,9 +15,7 @@
  */
 package io.camunda.zeebe.model.bpmn;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.model.bpmn.instance.Definitions;
 import org.junit.Test;
@@ -36,7 +34,7 @@ public class BpmnModelInstanceTest {
     final BpmnModelInstance cloneInstance = modelInstance.clone();
     cloneInstance.getDefinitions().setId("TestId2");
 
-    assertThat(modelInstance.getDefinitions().getId(), is(equalTo("TestId")));
-    assertThat(cloneInstance.getDefinitions().getId(), is(equalTo("TestId2")));
+    assertThat(modelInstance.getDefinitions().getId()).isEqualTo("TestId");
+    assertThat(cloneInstance.getDefinitions().getId()).isEqualTo("TestId2");
   }
 }

--- a/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/DataObjectsTest.java
+++ b/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/DataObjectsTest.java
@@ -69,7 +69,7 @@ public class DataObjectsTest {
     final DataInputAssociation dataInputAssociation =
         scriptTask.getDataInputAssociations().iterator().next();
     final Collection<ItemAwareElement> sources = dataInputAssociation.getSources();
-    assertThat(sources.size()).isEqualTo(1);
+    assertThat(sources).hasSize(1);
     assertThat(sources.iterator().next()).isEqualTo(dataObjectReference);
   }
 

--- a/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/DefinitionsTest.java
+++ b/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/DefinitionsTest.java
@@ -33,11 +33,11 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import org.assertj.core.api.Assertions;
 import org.camunda.bpm.model.xml.ModelParseException;
 import org.camunda.bpm.model.xml.ModelReferenceException;
 import org.camunda.bpm.model.xml.ModelValidationException;
 import org.camunda.bpm.model.xml.impl.util.IoUtil;
-import org.junit.Assert;
 import org.junit.Test;
 
 /**
@@ -75,7 +75,7 @@ public class DefinitionsTest extends BpmnModelTest {
       Bpmn.readModelFromStream(
           getClass()
               .getResourceAsStream("DefinitionsTest.shouldNotImportWrongOrderedSequence.bpmn"));
-      Assert.fail("Model is invalid and should not pass the validation");
+      Assertions.fail("Model is invalid and should not pass the validation");
     } catch (final Exception e) {
       assertThat(e).isInstanceOf(ModelParseException.class);
     }
@@ -119,7 +119,7 @@ public class DefinitionsTest extends BpmnModelTest {
     try {
       Bpmn.validateModel(bpmnModelInstance);
     } catch (final ModelValidationException e) {
-      Assert.fail();
+      Assertions.fail();
     }
   }
 
@@ -145,7 +145,7 @@ public class DefinitionsTest extends BpmnModelTest {
     try {
       Bpmn.validateModel(bpmnModelInstance);
     } catch (final ModelValidationException e) {
-      Assert.fail();
+      Assertions.fail();
     }
 
     // convert the model to the XML string representation
@@ -217,7 +217,7 @@ public class DefinitionsTest extends BpmnModelTest {
         bpmnModelInstance.newInstance(MessageEventDefinition.class);
     try {
       anotherMessageEventDefinition.setMessage(anotherMessage);
-      Assert.fail(
+      Assertions.fail(
           "Message should not be added to message event definition, cause it is not part of the model");
     } catch (final Exception e) {
       assertThat(e).isInstanceOf(ModelReferenceException.class);
@@ -236,7 +236,7 @@ public class DefinitionsTest extends BpmnModelTest {
     try {
       Bpmn.validateModel(bpmnModelInstance);
     } catch (final ModelValidationException e) {
-      Assert.fail();
+      Assertions.fail();
     }
   }
 
@@ -284,7 +284,7 @@ public class DefinitionsTest extends BpmnModelTest {
     try {
       Bpmn.validateModel(bpmnModelInstance);
     } catch (final ModelValidationException e) {
-      Assert.fail();
+      Assertions.fail();
     }
   }
 }

--- a/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/ResourceRolesTest.java
+++ b/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/ResourceRolesTest.java
@@ -45,7 +45,7 @@ public class ResourceRolesTest {
   public void testGetPerformer() {
     final UserTask userTask = modelInstance.getModelElementById("_3");
     final Collection<ResourceRole> resourceRoles = userTask.getResourceRoles();
-    assertThat(resourceRoles.size()).isEqualTo(1);
+    assertThat(resourceRoles).hasSize(1);
     final ResourceRole resourceRole = resourceRoles.iterator().next();
     assertThat(resourceRole instanceof Performer).isTrue();
     assertThat(resourceRole.getName()).isEqualTo("Task performer");
@@ -55,7 +55,7 @@ public class ResourceRolesTest {
   public void testGetHumanPerformer() {
     final UserTask userTask = modelInstance.getModelElementById("_7");
     final Collection<ResourceRole> resourceRoles = userTask.getResourceRoles();
-    assertThat(resourceRoles.size()).isEqualTo(1);
+    assertThat(resourceRoles).hasSize(1);
     final ResourceRole resourceRole = resourceRoles.iterator().next();
     assertThat(resourceRole instanceof HumanPerformer).isTrue();
     assertThat(resourceRole.getName()).isEqualTo("Task human performer");
@@ -65,7 +65,7 @@ public class ResourceRolesTest {
   public void testGetPotentialOwner() {
     final UserTask userTask = modelInstance.getModelElementById("_9");
     final Collection<ResourceRole> resourceRoles = userTask.getResourceRoles();
-    assertThat(resourceRoles.size()).isEqualTo(1);
+    assertThat(resourceRoles).hasSize(1);
     final ResourceRole resourceRole = resourceRoles.iterator().next();
     assertThat(resourceRole instanceof PotentialOwner).isTrue();
     assertThat(resourceRole.getName()).isEqualTo("Task potential owner");

--- a/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/builder/ProcessBuilderTest.java
+++ b/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/builder/ProcessBuilderTest.java
@@ -28,7 +28,6 @@ import static io.camunda.zeebe.model.bpmn.BpmnTestConstants.USER_TASK_ID;
 import static io.camunda.zeebe.model.bpmn.impl.BpmnModelConstants.BPMN20_NS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Fail.fail;
-import static org.junit.Assert.assertEquals;
 
 import io.camunda.zeebe.model.bpmn.AssociationDirection;
 import io.camunda.zeebe.model.bpmn.Bpmn;
@@ -2148,10 +2147,10 @@ public class ProcessBuilderTest {
             .done();
 
     final String startName = ((FlowElement) instance.getModelElementById("start")).getName();
-    assertEquals("start", startName);
+    assertThat(startName).isEqualTo("start");
     final String userName = ((FlowElement) instance.getModelElementById("user")).getName();
-    assertEquals("user", userName);
+    assertThat(userName).isEqualTo("user");
     final String endName = ((FlowElement) instance.getModelElementById("end")).getName();
-    assertEquals("name", endName);
+    assertThat(endName).isEqualTo("name");
   }
 }

--- a/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/builder/di/DiGeneratorForFlowNodesTest.java
+++ b/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/builder/di/DiGeneratorForFlowNodesTest.java
@@ -29,9 +29,6 @@ import static io.camunda.zeebe.model.bpmn.BpmnTestConstants.TEST_CONDITION;
 import static io.camunda.zeebe.model.bpmn.BpmnTestConstants.TRANSACTION_ID;
 import static io.camunda.zeebe.model.bpmn.BpmnTestConstants.USER_TASK_ID;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
@@ -41,6 +38,7 @@ import io.camunda.zeebe.model.bpmn.instance.bpmndi.BpmnShape;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Iterator;
+import org.camunda.bpm.model.xml.instance.ModelElementInstance;
 import org.junit.After;
 import org.junit.Test;
 
@@ -63,13 +61,14 @@ public class DiGeneratorForFlowNodesTest {
 
     // then
     final Collection<BpmnDiagram> bpmnDiagrams = instance.getModelElementsByType(BpmnDiagram.class);
-    assertEquals(1, bpmnDiagrams.size());
+    assertThat(bpmnDiagrams).hasSize(1);
 
     final BpmnDiagram diagram = bpmnDiagrams.iterator().next();
-    assertNotNull(diagram.getId());
+    assertThat(diagram.getId()).isNotNull();
 
-    assertNotNull(diagram.getBpmnPlane());
-    assertEquals(diagram.getBpmnPlane().getBpmnElement(), instance.getModelElementById("process"));
+    assertThat(diagram.getBpmnPlane()).isNotNull();
+    assertThat((ModelElementInstance) instance.getModelElementById("process"))
+        .isEqualTo(diagram.getBpmnPlane().getBpmnElement());
   }
 
   @Test
@@ -83,7 +82,7 @@ public class DiGeneratorForFlowNodesTest {
 
     // then
     final Collection<BpmnShape> allShapes = instance.getModelElementsByType(BpmnShape.class);
-    assertEquals(2, allShapes.size());
+    assertThat(allShapes).hasSize(2);
 
     assertEventShapeProperties(START_EVENT_ID);
   }
@@ -99,7 +98,7 @@ public class DiGeneratorForFlowNodesTest {
 
     // then
     final Collection<BpmnShape> allShapes = instance.getModelElementsByType(BpmnShape.class);
-    assertEquals(2, allShapes.size());
+    assertThat(allShapes).hasSize(2);
 
     assertTaskShapeProperties(USER_TASK_ID);
   }
@@ -115,7 +114,7 @@ public class DiGeneratorForFlowNodesTest {
 
     // then
     final Collection<BpmnShape> allShapes = instance.getModelElementsByType(BpmnShape.class);
-    assertEquals(2, allShapes.size());
+    assertThat(allShapes).hasSize(2);
 
     assertTaskShapeProperties(SEND_TASK_ID);
   }
@@ -131,7 +130,7 @@ public class DiGeneratorForFlowNodesTest {
 
     // then
     final Collection<BpmnShape> allShapes = instance.getModelElementsByType(BpmnShape.class);
-    assertEquals(2, allShapes.size());
+    assertThat(allShapes).hasSize(2);
 
     assertTaskShapeProperties(SERVICE_TASK_ID);
   }
@@ -147,7 +146,7 @@ public class DiGeneratorForFlowNodesTest {
 
     // then
     final Collection<BpmnShape> allShapes = instance.getModelElementsByType(BpmnShape.class);
-    assertEquals(2, allShapes.size());
+    assertThat(allShapes).hasSize(2);
 
     assertTaskShapeProperties(TASK_ID);
   }
@@ -163,7 +162,7 @@ public class DiGeneratorForFlowNodesTest {
 
     // then
     final Collection<BpmnShape> allShapes = instance.getModelElementsByType(BpmnShape.class);
-    assertEquals(2, allShapes.size());
+    assertThat(allShapes).hasSize(2);
 
     assertTaskShapeProperties(TASK_ID);
   }
@@ -179,7 +178,7 @@ public class DiGeneratorForFlowNodesTest {
 
     // then
     final Collection<BpmnShape> allShapes = instance.getModelElementsByType(BpmnShape.class);
-    assertEquals(2, allShapes.size());
+    assertThat(allShapes).hasSize(2);
 
     assertTaskShapeProperties(TASK_ID);
   }
@@ -195,7 +194,7 @@ public class DiGeneratorForFlowNodesTest {
 
     // then
     final Collection<BpmnShape> allShapes = instance.getModelElementsByType(BpmnShape.class);
-    assertEquals(2, allShapes.size());
+    assertThat(allShapes).hasSize(2);
 
     assertTaskShapeProperties(TASK_ID);
   }
@@ -216,7 +215,7 @@ public class DiGeneratorForFlowNodesTest {
 
     // then
     final Collection<BpmnShape> allShapes = instance.getModelElementsByType(BpmnShape.class);
-    assertEquals(3, allShapes.size());
+    assertThat(allShapes).hasSize(3);
 
     assertEventShapeProperties(CATCH_ID);
   }
@@ -243,7 +242,7 @@ public class DiGeneratorForFlowNodesTest {
 
     // then
     final Collection<BpmnShape> allShapes = instance.getModelElementsByType(BpmnShape.class);
-    assertEquals(5, allShapes.size());
+    assertThat(allShapes).hasSize(5);
 
     assertEventShapeProperties(BOUNDARY_ID);
   }
@@ -264,7 +263,7 @@ public class DiGeneratorForFlowNodesTest {
 
     // then
     final Collection<BpmnShape> allShapes = instance.getModelElementsByType(BpmnShape.class);
-    assertEquals(3, allShapes.size());
+    assertThat(allShapes).hasSize(3);
 
     assertEventShapeProperties("inter");
   }
@@ -280,7 +279,7 @@ public class DiGeneratorForFlowNodesTest {
 
     // then
     final Collection<BpmnShape> allShapes = instance.getModelElementsByType(BpmnShape.class);
-    assertEquals(2, allShapes.size());
+    assertThat(allShapes).hasSize(2);
 
     assertEventShapeProperties(END_EVENT_ID);
   }
@@ -301,12 +300,12 @@ public class DiGeneratorForFlowNodesTest {
 
     // then
     final Collection<BpmnShape> allShapes = instance.getModelElementsByType(BpmnShape.class);
-    assertEquals(3, allShapes.size());
+    assertThat(allShapes).hasSize(3);
 
     final BpmnShape bpmnShapeSubProcess = findBpmnShape(SUB_PROCESS_ID);
-    assertNotNull(bpmnShapeSubProcess);
+    assertThat(bpmnShapeSubProcess).isNotNull();
     assertSubProcessSize(bpmnShapeSubProcess);
-    assertTrue(bpmnShapeSubProcess.isExpanded());
+    assertThat(bpmnShapeSubProcess.isExpanded()).isTrue();
   }
 
   @Test
@@ -330,15 +329,15 @@ public class DiGeneratorForFlowNodesTest {
 
     // then
     final Collection<BpmnShape> allShapes = instance.getModelElementsByType(BpmnShape.class);
-    assertEquals(6, allShapes.size());
+    assertThat(allShapes).hasSize(6);
 
     assertEventShapeProperties("innerStartEvent");
     assertTaskShapeProperties("innerUserTask");
     assertEventShapeProperties("innerEndEvent");
 
     final BpmnShape bpmnShapeSubProcess = findBpmnShape(SUB_PROCESS_ID);
-    assertNotNull(bpmnShapeSubProcess);
-    assertTrue(bpmnShapeSubProcess.isExpanded());
+    assertThat(bpmnShapeSubProcess).isNotNull();
+    assertThat(bpmnShapeSubProcess.isExpanded()).isTrue();
   }
 
   @Test
@@ -362,14 +361,14 @@ public class DiGeneratorForFlowNodesTest {
 
     // then
     final Collection<BpmnShape> allShapes = instance.getModelElementsByType(BpmnShape.class);
-    assertEquals(5, allShapes.size());
+    assertThat(allShapes).hasSize(5);
 
     assertEventShapeProperties("innerStartEvent");
     assertEventShapeProperties("innerEndEvent");
 
     final BpmnShape bpmnShapeEventSubProcess = findBpmnShape(SUB_PROCESS_ID);
-    assertNotNull(bpmnShapeEventSubProcess);
-    assertTrue(bpmnShapeEventSubProcess.isExpanded());
+    assertThat(bpmnShapeEventSubProcess).isNotNull();
+    assertThat(bpmnShapeEventSubProcess.isExpanded()).isTrue();
   }
 
   @Test
@@ -388,7 +387,7 @@ public class DiGeneratorForFlowNodesTest {
 
     // then
     final Collection<BpmnShape> allShapes = instance.getModelElementsByType(BpmnShape.class);
-    assertEquals(3, allShapes.size());
+    assertThat(allShapes).hasSize(3);
 
     assertTaskShapeProperties(CALL_ACTIVITY_ID);
   }
@@ -414,15 +413,15 @@ public class DiGeneratorForFlowNodesTest {
 
     // then
     final Collection<BpmnShape> allShapes = instance.getModelElementsByType(BpmnShape.class);
-    assertEquals(6, allShapes.size());
+    assertThat(allShapes).hasSize(6);
 
     assertEventShapeProperties("innerStartEvent");
     assertTaskShapeProperties("innerUserTask");
     assertEventShapeProperties("innerEndEvent");
 
     final BpmnShape bpmnShapeSubProcess = findBpmnShape(TRANSACTION_ID);
-    assertNotNull(bpmnShapeSubProcess);
-    assertTrue(bpmnShapeSubProcess.isExpanded());
+    assertThat(bpmnShapeSubProcess).isNotNull();
+    assertThat(bpmnShapeSubProcess.isExpanded()).isTrue();
   }
 
   @Test
@@ -441,7 +440,7 @@ public class DiGeneratorForFlowNodesTest {
 
     // then
     final Collection<BpmnShape> allShapes = instance.getModelElementsByType(BpmnShape.class);
-    assertEquals(3, allShapes.size());
+    assertThat(allShapes).hasSize(3);
 
     assertGatewayShapeProperties("and");
   }
@@ -462,7 +461,7 @@ public class DiGeneratorForFlowNodesTest {
 
     // then
     final Collection<BpmnShape> allShapes = instance.getModelElementsByType(BpmnShape.class);
-    assertEquals(3, allShapes.size());
+    assertThat(allShapes).hasSize(3);
 
     assertGatewayShapeProperties("inclusive");
   }
@@ -484,7 +483,7 @@ public class DiGeneratorForFlowNodesTest {
 
     // then
     final Collection<BpmnShape> allShapes = instance.getModelElementsByType(BpmnShape.class);
-    assertEquals(3, allShapes.size());
+    assertThat(allShapes).hasSize(3);
 
     assertGatewayShapeProperties("eventBased");
   }
@@ -505,28 +504,28 @@ public class DiGeneratorForFlowNodesTest {
 
     // then
     final Collection<BpmnShape> allShapes = instance.getModelElementsByType(BpmnShape.class);
-    assertEquals(3, allShapes.size());
+    assertThat(allShapes).hasSize(3);
 
     assertGatewayShapeProperties("or");
     final BpmnShape bpmnShape = findBpmnShape("or");
-    assertTrue(bpmnShape.isMarkerVisible());
+    assertThat(bpmnShape.isMarkerVisible()).isTrue();
   }
 
   protected void assertTaskShapeProperties(final String id) {
     final BpmnShape bpmnShapeTask = findBpmnShape(id);
-    assertNotNull(bpmnShapeTask);
+    assertThat(bpmnShapeTask).isNotNull();
     assertActivitySize(bpmnShapeTask);
   }
 
   protected void assertEventShapeProperties(final String id) {
     final BpmnShape bpmnShapeEvent = findBpmnShape(id);
-    assertNotNull(bpmnShapeEvent);
+    assertThat(bpmnShapeEvent).isNotNull();
     assertEventSize(bpmnShapeEvent);
   }
 
   protected void assertGatewayShapeProperties(final String id) {
     final BpmnShape bpmnShapeGateway = findBpmnShape(id);
-    assertNotNull(bpmnShapeGateway);
+    assertThat(bpmnShapeGateway).isNotNull();
     assertGatewaySize(bpmnShapeGateway);
   }
 

--- a/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/builder/di/DiGeneratorForSequenceFlowsTest.java
+++ b/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/builder/di/DiGeneratorForSequenceFlowsTest.java
@@ -19,8 +19,7 @@ import static io.camunda.zeebe.model.bpmn.BpmnTestConstants.END_EVENT_ID;
 import static io.camunda.zeebe.model.bpmn.BpmnTestConstants.SEQUENCE_FLOW_ID;
 import static io.camunda.zeebe.model.bpmn.BpmnTestConstants.START_EVENT_ID;
 import static io.camunda.zeebe.model.bpmn.BpmnTestConstants.USER_TASK_ID;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
@@ -56,7 +55,7 @@ public class DiGeneratorForSequenceFlowsTest {
             .done();
 
     final Collection<BpmnEdge> allEdges = instance.getModelElementsByType(BpmnEdge.class);
-    assertEquals(1, allEdges.size());
+    assertThat(allEdges).hasSize(1);
 
     assertBpmnEdgeExists(SEQUENCE_FLOW_ID);
   }
@@ -79,7 +78,7 @@ public class DiGeneratorForSequenceFlowsTest {
             .done();
 
     final Collection<BpmnEdge> allEdges = instance.getModelElementsByType(BpmnEdge.class);
-    assertEquals(3, allEdges.size());
+    assertThat(allEdges).hasSize(3);
 
     assertBpmnEdgeExists("s1");
     assertBpmnEdgeExists("s2");
@@ -106,7 +105,7 @@ public class DiGeneratorForSequenceFlowsTest {
             .done();
 
     final Collection<BpmnEdge> allEdges = instance.getModelElementsByType(BpmnEdge.class);
-    assertEquals(4, allEdges.size());
+    assertThat(allEdges).hasSize(4);
 
     assertBpmnEdgeExists("s1");
     assertBpmnEdgeExists("s2");
@@ -134,7 +133,7 @@ public class DiGeneratorForSequenceFlowsTest {
             .done();
 
     final Collection<BpmnEdge> allEdges = instance.getModelElementsByType(BpmnEdge.class);
-    assertEquals(4, allEdges.size());
+    assertThat(allEdges).hasSize(4);
 
     assertBpmnEdgeExists("s1");
     assertBpmnEdgeExists("s2");
@@ -162,7 +161,7 @@ public class DiGeneratorForSequenceFlowsTest {
             .done();
 
     final Collection<BpmnEdge> allEdges = instance.getModelElementsByType(BpmnEdge.class);
-    assertEquals(4, allEdges.size());
+    assertThat(allEdges).hasSize(4);
 
     assertBpmnEdgeExists("s1");
     assertBpmnEdgeExists("s2");
@@ -185,6 +184,6 @@ public class DiGeneratorForSequenceFlowsTest {
 
   protected void assertBpmnEdgeExists(final String id) {
     final BpmnEdge edge = findBpmnEdge(id);
-    assertNotNull(edge);
+    assertThat(edge).isNotNull();
   }
 }

--- a/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/test/AbstractModelElementInstanceTest.java
+++ b/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/test/AbstractModelElementInstanceTest.java
@@ -18,9 +18,9 @@ package io.camunda.zeebe.model.bpmn.test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.camunda.bpm.model.xml.test.assertions.ModelAssertions.assertThat;
-import static org.junit.Assert.fail;
 
 import java.util.Collection;
+import org.assertj.core.api.Assertions;
 import org.camunda.bpm.model.xml.Model;
 import org.camunda.bpm.model.xml.ModelInstance;
 import org.camunda.bpm.model.xml.impl.type.ModelElementTypeImpl;
@@ -95,13 +95,13 @@ public abstract class AbstractModelElementInstanceTest {
     if (assumption.isAbstract) {
       try {
         modelInstance.newInstance(modelElementType);
-        fail("Element type " + modelElementType.getTypeName() + " is abstract.");
+        Assertions.fail("Element type " + modelElementType.getTypeName() + " is abstract.");
       } catch (final DOMException e) {
         // expected exception
       } catch (final ModelTypeException e) {
         // expected exception
       } catch (final Exception e) {
-        fail("Unexpected exception " + e.getMessage());
+        Assertions.fail("Unexpected exception " + e.getMessage());
       }
     } else {
       final ModelElementInstance modelElementInstance = modelInstance.newInstance(modelElementType);
@@ -115,8 +115,7 @@ public abstract class AbstractModelElementInstanceTest {
     if (childElementAssumptions == null) {
       assertThatType().hasNoChildElements();
     } else {
-      assertThat(modelElementType.getChildElementTypes().size())
-          .isEqualTo(childElementAssumptions.size());
+      assertThat(modelElementType.getChildElementTypes()).hasSameSizeAs(childElementAssumptions);
       for (final ChildElementAssumption assumption : childElementAssumptions) {
         assertThatType().hasChildElements(assumption.childElementType);
         if (assumption.namespaceUri != null) {

--- a/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/AbstractZeebeValidationTest.java
+++ b/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/AbstractZeebeValidationTest.java
@@ -15,8 +15,6 @@
  */
 package io.camunda.zeebe.model.bpmn.validation;
 
-import static org.junit.Assert.fail;
-
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.model.bpmn.traversal.ModelWalker;
@@ -28,6 +26,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.stream.Collectors;
+import org.assertj.core.api.Assertions;
 import org.camunda.bpm.model.xml.validation.ValidationResult;
 import org.camunda.bpm.model.xml.validation.ValidationResults;
 import org.junit.Before;
@@ -118,7 +117,7 @@ public abstract class AbstractZeebeValidationTest {
     describeUnmatchedExpectations(sb, unmatchedExpectations);
     sb.append("\n");
     describeUnmatchedResults(sb, unmatchedResults);
-    fail(sb.toString());
+    Assertions.fail(sb.toString());
   }
 
   private static void describeUnmatchedResults(

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/repo/ExporterDescriptorTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/repo/ExporterDescriptorTest.java
@@ -8,7 +8,6 @@
 package io.camunda.zeebe.broker.exporter.repo;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 
 import io.camunda.zeebe.broker.exporter.util.ControlledTestExporter;
 import io.camunda.zeebe.broker.exporter.util.TestExporterFactory;

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/PartitionProcessingStateTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/PartitionProcessingStateTest.java
@@ -8,8 +8,6 @@
 package io.camunda.zeebe.broker.system.partitions.impl;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -46,14 +44,16 @@ class PartitionProcessingStateTest {
 
     // then
     assertThat(persistedProcessorPauseState).describedAs("Processor State file exists.").exists();
-    assertTrue(partitionProcessingState.isProcessingPaused());
+    org.assertj.core.api.Assertions.assertThat(partitionProcessingState.isProcessingPaused())
+        .isTrue();
 
     partitionProcessingState.resumeProcessing();
 
     assertThat(persistedProcessorPauseState)
         .describedAs("Processor State file does not exist.")
         .doesNotExist();
-    assertFalse(partitionProcessingState.isProcessingPaused());
+    org.assertj.core.api.Assertions.assertThat(partitionProcessingState.isProcessingPaused())
+        .isFalse();
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/subprocess/NonInterruptingEventSubprocessTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/subprocess/NonInterruptingEventSubprocessTest.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.engine.processing.bpmn.subprocess;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
+import static org.assertj.core.api.Assumptions.assumeThat;
 
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
@@ -200,7 +201,7 @@ public class NonInterruptingEventSubprocessTest {
   @Test
   public void shouldTriggerEventSubprocessTwice() {
     // Only run test if test-case is cyclic
-    org.junit.Assume.assumeTrue(cyclic);
+    assumeThat(cyclic).isTrue();
 
     // given
     final BpmnModelInstance model = eventSubprocModel(builder);
@@ -253,7 +254,7 @@ public class NonInterruptingEventSubprocessTest {
   @Test
   public void shouldTriggerEventSubprocessTwiceWithOwnLocalScopeVariable() {
     // Only run test if test-case is cyclic
-    org.junit.Assume.assumeTrue(cyclic);
+    assumeThat(cyclic).isTrue();
 
     // given
     final BpmnModelInstance model = eventSubprocModelWithLocalScopeVariable(builder);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeRuntimeValidationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeRuntimeValidationTest.java
@@ -8,7 +8,6 @@
 package io.camunda.zeebe.engine.processing.deployment.model.validation;
 
 import static io.camunda.zeebe.engine.processing.deployment.model.validation.ExpectedValidationResult.expect;
-import static org.junit.Assert.fail;
 
 import io.camunda.zeebe.el.ExpressionLanguage;
 import io.camunda.zeebe.el.ExpressionLanguageFactory;
@@ -39,6 +38,7 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.stream.Collectors;
+import org.assertj.core.api.Assertions;
 import org.camunda.bpm.model.xml.validation.ValidationResult;
 import org.camunda.bpm.model.xml.validation.ValidationResults;
 import org.junit.Before;
@@ -580,7 +580,7 @@ public final class ZeebeRuntimeValidationTest {
     describeUnmatchedExpectations(sb, unmatchedExpectations);
     sb.append("\n");
     describeUnmatchedResults(sb, unmatchedResults);
-    fail(sb.toString());
+    Assertions.fail(sb.toString());
   }
 
   private static void describeUnmatchedResults(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/OutputMappingIncidentTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/OutputMappingIncidentTest.java
@@ -11,7 +11,6 @@ import static io.camunda.zeebe.protocol.record.intent.IncidentIntent.CREATED;
 import static io.camunda.zeebe.protocol.record.intent.IncidentIntent.RESOLVED;
 import static java.util.Map.entry;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertTrue;
 
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.engine.util.client.DeploymentClient;
@@ -205,12 +204,13 @@ public class OutputMappingIncidentTest {
         .hasElementId(elementId);
     assertThat(resolvedIncidentRecord.getValue().getErrorMessage())
         .contains("Assertion failure on evaluate the expression");
-    assertTrue(
-        RecordingExporter.processInstanceRecords()
-            .withProcessInstanceKey(processInstanceKey)
-            .withElementType(BpmnElementType.PROCESS)
-            .withIntent(ProcessInstanceIntent.ELEMENT_COMPLETED)
-            .exists());
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementType(BpmnElementType.PROCESS)
+                .withIntent(ProcessInstanceIntent.ELEMENT_COMPLETED)
+                .exists())
+        .isTrue();
     final Map<String, String> variables = ProcessInstances.getCurrentVariables(processInstanceKey);
     assertThat(variables).contains(entry("foo", "1"));
     assertThat(variables).contains(entry("bar", "1"));
@@ -250,11 +250,12 @@ public class OutputMappingIncidentTest {
         .hasElementId(elementId);
     assertThat(resolvedIncidentRecord.getValue().getErrorMessage())
         .contains("Assertion failure on evaluate the expression");
-    assertTrue(
-        RecordingExporter.processInstanceRecords()
-            .withProcessInstanceKey(processInstanceKey)
-            .withElementType(BpmnElementType.PROCESS)
-            .withIntent(ProcessInstanceIntent.ELEMENT_TERMINATED)
-            .exists());
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementType(BpmnElementType.PROCESS)
+                .withIntent(ProcessInstanceIntent.ELEMENT_TERMINATED)
+                .exists())
+        .isTrue();
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/EventAppliersTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/EventAppliersTest.java
@@ -22,7 +22,6 @@ import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
 import io.camunda.zeebe.protocol.record.intent.management.CheckpointIntent;
 import java.util.Arrays;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -111,7 +110,7 @@ public class EventAppliersTest {
     final var actualVersion = eventAppliers.getLatestVersion(intent);
 
     // then
-    Assertions.assertEquals(expectedVersion, actualVersion);
+    assertThat(actualVersion).isEqualTo(expectedVersion);
   }
 
   @Test
@@ -128,7 +127,7 @@ public class EventAppliersTest {
     final var actualVersion = eventAppliers.getLatestVersion(intent);
 
     // then
-    Assertions.assertEquals(expectedVersion, actualVersion);
+    assertThat(actualVersion).isEqualTo(expectedVersion);
   }
 
   @Test
@@ -140,7 +139,7 @@ public class EventAppliersTest {
     final var actualVersion = eventAppliers.getLatestVersion(Intent.UNKNOWN);
 
     // then
-    Assertions.assertEquals(expectedVersion, actualVersion);
+    assertThat(actualVersion).isEqualTo(expectedVersion);
   }
 
   @Test
@@ -156,7 +155,7 @@ public class EventAppliersTest {
     final var actualVersion = eventAppliers.getLatestVersion(intent);
 
     // then
-    Assertions.assertEquals(expectedVersion, actualVersion);
+    assertThat(actualVersion).isEqualTo(expectedVersion);
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/deployment/DecisionStateMultiTenantTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/deployment/DecisionStateMultiTenantTest.java
@@ -9,7 +9,7 @@ package io.camunda.zeebe.engine.state.deployment;
 
 import static io.camunda.zeebe.util.buffer.BufferUtil.wrapString;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 
 import io.camunda.zeebe.db.ZeebeDbInconsistentException;
 import io.camunda.zeebe.engine.state.mutable.MutableDecisionState;
@@ -200,8 +200,9 @@ public class DecisionStateMultiTenantTest {
 
     // when then
     final var exception =
-        assertThrows(
-            ZeebeDbInconsistentException.class, () -> decisionState.storeDecisionRecord(decision));
+        assertThatExceptionOfType(ZeebeDbInconsistentException.class)
+            .isThrownBy(() -> decisionState.storeDecisionRecord(decision))
+            .actual();
     assertThat(exception)
         .hasMessage(
             """

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/message/MessageCorrelationStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/message/MessageCorrelationStateTest.java
@@ -8,12 +8,12 @@
 package io.camunda.zeebe.engine.state.message;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 
 import io.camunda.zeebe.db.ZeebeDbInconsistentException;
 import io.camunda.zeebe.engine.state.mutable.MutableMessageCorrelationState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.engine.util.ProcessingStateExtension;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -55,10 +55,10 @@ public class MessageCorrelationStateTest {
 
     // when - then
     final var exception =
-        Assertions.assertThrows(
-            ZeebeDbInconsistentException.class,
-            () -> state.putMessageCorrelation(messageKey, requestId, requestStreamId),
-            "Expected to insert new element, but element with key '1' already exists");
+        assertThatExceptionOfType(ZeebeDbInconsistentException.class)
+            .as("Expected to insert new element, but element with key '1' already exists")
+            .isThrownBy(() -> state.putMessageCorrelation(messageKey, requestId, requestStreamId))
+            .actual();
     assertThat(exception)
         .hasMessage("Key DbLong{1} in ColumnFamily MESSAGE_CORRELATION already exists");
   }
@@ -102,10 +102,10 @@ public class MessageCorrelationStateTest {
   void shouldNotRemoveNonExistingMessageCorrelation() {
     // when - then
     final var exception =
-        Assertions.assertThrows(
-            ZeebeDbInconsistentException.class,
-            () -> state.removeMessageCorrelation(1),
-            "Expected to delete existing element, but no element with key '1' found");
+        assertThatExceptionOfType(ZeebeDbInconsistentException.class)
+            .as("Expected to delete existing element, but no element with key '1' found")
+            .isThrownBy(() -> state.removeMessageCorrelation(1))
+            .actual();
     assertThat(exception)
         .hasMessage("Key DbLong{1} in ColumnFamily MESSAGE_CORRELATION does not exist");
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/migration/to_1_1/DbMigrationStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/migration/to_1_1/DbMigrationStateTest.java
@@ -23,7 +23,7 @@ import io.camunda.zeebe.protocol.impl.record.value.message.MessageSubscriptionRe
 import io.camunda.zeebe.protocol.impl.record.value.message.ProcessMessageSubscriptionRecord;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import java.util.ArrayList;
-import org.junit.jupiter.api.Assertions;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/BatchOperationLifecycleManagementHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/BatchOperationLifecycleManagementHandlerTest.java
@@ -25,7 +25,7 @@ import io.camunda.zeebe.util.DateUtil;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
-import org.junit.jupiter.api.Assertions;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/operation/AbstractOperationHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/operation/AbstractOperationHandlerTest.java
@@ -8,7 +8,6 @@
 package io.camunda.exporter.handlers.operation;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
@@ -36,7 +35,7 @@ abstract class AbstractOperationHandlerTest<R extends RecordValue> {
 
   @Test
   void testGetHandledValueType() {
-    assertEquals(underTest.getHandledValueType(), valueType);
+    assertThat(valueType).isEqualTo(underTest.getHandledValueType());
   }
 
   @Test

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/aws/AwsRequestSigningApacheInterceptorTest.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/aws/AwsRequestSigningApacheInterceptorTest.java
@@ -8,9 +8,7 @@
 package io.camunda.zeebe.exporter.opensearch.aws;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -79,7 +77,7 @@ class AwsRequestSigningApacheInterceptorTest {
     assertAwsHeaders(request);
     final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
     request.getEntity().writeTo(outputStream);
-    assertEquals(content, outputStream.toString());
+    assertThat(outputStream.toString()).isEqualTo(content);
   }
 
   @Test
@@ -98,7 +96,7 @@ class AwsRequestSigningApacheInterceptorTest {
     assertThat(request.getRequestLine().getMethod()).isEqualTo("POST");
     final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
     request.getEntity().writeTo(outputStream);
-    assertEquals(content, outputStream.toString());
+    assertThat(outputStream.toString()).isEqualTo(content);
     assertAwsHeaders(request);
   }
 
@@ -113,13 +111,14 @@ class AwsRequestSigningApacheInterceptorTest {
     context.setTargetHost(HttpHost.create("localhost"));
     interceptor.process(request, context);
 
-    assertTrue(request.getEntity().isRepeatable());
+    assertThat(request.getEntity().isRepeatable()).isTrue();
   }
 
   @Test
   void shouldThrowBadRequest() {
     final HttpRequest badRequest = new BasicHttpRequest("GET", "?#!@*%");
-    assertThrows(IOException.class, () -> interceptor.process(badRequest, new BasicHttpContext()));
+    assertThatExceptionOfType(IOException.class)
+        .isThrownBy(() -> interceptor.process(badRequest, new BasicHttpContext()));
   }
 
   private static void assertAwsHeaders(final HttpEntityEnclosingRequest request) {

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/DateUtilTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/DateUtilTest.java
@@ -8,7 +8,6 @@
 package io.camunda.exporter.rdbms;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertNull;
 
 import io.camunda.exporter.rdbms.utils.DateUtil;
 import java.time.OffsetDateTime;
@@ -63,7 +62,7 @@ public class DateUtilTest {
     final OffsetDateTime result = DateUtil.toOffsetDateTime(timestamp);
 
     // Then
-    assertNull(result);
+    assertThat(result).isNull();
   }
 
   @Test
@@ -75,7 +74,7 @@ public class DateUtilTest {
     final OffsetDateTime result = DateUtil.toOffsetDateTime(timestamp);
 
     // Then
-    assertNull(result);
+    assertThat(result).isNull();
   }
 
   @Test
@@ -87,6 +86,6 @@ public class DateUtilTest {
     final OffsetDateTime result = DateUtil.toOffsetDateTime(invalidTimestamp);
 
     // Then
-    assertNull(result);
+    assertThat(result).isNull();
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/RequestMapperTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/RequestMapperTest.java
@@ -8,7 +8,6 @@
 package io.camunda.zeebe.gateway.rest;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 
 import io.camunda.service.ProcessInstanceServices.ProcessInstanceMigrateBatchOperationRequest;
 import io.camunda.service.ProcessInstanceServices.ProcessInstanceModifyBatchOperationRequest;
@@ -45,7 +44,7 @@ class RequestMapperTest {
         RequestMapper.toProcessInstanceMigrationBatchOperationRequest(batchOperationInstruction);
 
     // then
-    assertTrue(result.isRight());
+    assertThat(result.isRight()).isTrue();
     final var request = result.get();
     assertThat(request.targetProcessDefinitionKey()).isEqualTo(123L);
     assertThat(request.mappingInstructions())
@@ -78,7 +77,7 @@ class RequestMapperTest {
         RequestMapper.toProcessInstanceMigrationBatchOperationRequest(batchOperationRequest);
 
     // then
-    assertTrue(result.isLeft());
+    assertThat(result.isLeft()).isTrue();
     final var problemDetail = result.getLeft();
     assertThat(problemDetail.getStatus()).isEqualTo(400); // Bad Request
     assertThat(problemDetail.getDetail()).contains("are required");
@@ -101,7 +100,7 @@ class RequestMapperTest {
         RequestMapper.toProcessInstanceModifyBatchOperationRequest(modificationRequest);
 
     // then
-    assertTrue(result.isRight());
+    assertThat(result.isRight()).isTrue();
     final var request = result.get();
     assertThat(request.moveInstructions())
         .hasSize(1)
@@ -128,7 +127,7 @@ class RequestMapperTest {
         RequestMapper.toProcessInstanceModifyBatchOperationRequest(modificationRequest);
 
     // then
-    assertTrue(result.isLeft());
+    assertThat(result.isLeft()).isTrue();
     final var problemDetail = result.getLeft();
     assertThat(problemDetail.getStatus()).isEqualTo(400);
     assertThat(problemDetail.getDetail()).isEqualTo("No targetElementId provided.");

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/setup/SetupControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/setup/SetupControllerTest.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.zeebe.gateway.rest.controller.setup;
 
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/AuthorizationControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/AuthorizationControllerTest.java
@@ -8,7 +8,7 @@
 package io.camunda.zeebe.gateway.rest.controller.usermanagement;
 
 import static io.camunda.zeebe.protocol.record.RejectionType.INVALID_ARGUMENT;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -107,12 +107,13 @@ public class AuthorizationControllerTest extends RestControllerTest {
     final var captor = ArgumentCaptor.forClass(CreateAuthorizationRequest.class);
     verify(authorizationServices, times(1)).createAuthorization(captor.capture());
     final var capturedRequest = captor.getValue();
-    assertEquals(ownerId, capturedRequest.ownerId());
-    assertEquals(authorizationRecord.getOwnerType(), capturedRequest.ownerType());
-    assertEquals(resourceId, capturedRequest.resourceId());
-    assertEquals(authorizationRecord.getResourceType(), capturedRequest.resourceType());
-    assertEquals(1, capturedRequest.permissionTypes().size());
-    assertEquals(authorizationRecord.getPermissionTypes(), capturedRequest.permissionTypes());
+    assertThat(capturedRequest.ownerId()).isEqualTo(ownerId);
+    assertThat(capturedRequest.ownerType()).isEqualTo(authorizationRecord.getOwnerType());
+    assertThat(capturedRequest.resourceId()).isEqualTo(resourceId);
+    assertThat(capturedRequest.resourceType()).isEqualTo(authorizationRecord.getResourceType());
+    assertThat(capturedRequest.permissionTypes().size()).isEqualTo(1);
+    assertThat(capturedRequest.permissionTypes())
+        .isEqualTo(authorizationRecord.getPermissionTypes());
   }
 
   @ParameterizedTest
@@ -202,13 +203,14 @@ public class AuthorizationControllerTest extends RestControllerTest {
     final var captor = ArgumentCaptor.forClass(UpdateAuthorizationRequest.class);
     verify(authorizationServices, times(1)).updateAuthorization(captor.capture());
     final var capturedRequest = captor.getValue();
-    assertEquals(authorizationKey, capturedRequest.authorizationKey());
-    assertEquals(ownerId, capturedRequest.ownerId());
-    assertEquals(authorizationRecord.getOwnerType(), capturedRequest.ownerType());
-    assertEquals(resourceId, capturedRequest.resourceId());
-    assertEquals(authorizationRecord.getResourceType(), capturedRequest.resourceType());
-    assertEquals(1, capturedRequest.permissionTypes().size());
-    assertEquals(authorizationRecord.getPermissionTypes(), capturedRequest.permissionTypes());
+    assertThat(capturedRequest.authorizationKey()).isEqualTo(authorizationKey);
+    assertThat(capturedRequest.ownerId()).isEqualTo(ownerId);
+    assertThat(capturedRequest.ownerType()).isEqualTo(authorizationRecord.getOwnerType());
+    assertThat(capturedRequest.resourceId()).isEqualTo(resourceId);
+    assertThat(capturedRequest.resourceType()).isEqualTo(authorizationRecord.getResourceType());
+    assertThat(capturedRequest.permissionTypes().size()).isEqualTo(1);
+    assertThat(capturedRequest.permissionTypes())
+        .isEqualTo(authorizationRecord.getPermissionTypes());
   }
 
   @ParameterizedTest

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/util/AdvancedSearchFilterUtilTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/util/AdvancedSearchFilterUtilTest.java
@@ -8,7 +8,6 @@
 package io.camunda.zeebe.gateway.rest.util;
 
 import static org.assertj.core.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.*;
 
 import io.camunda.search.filter.Operation;
 import io.camunda.search.filter.Operator;
@@ -140,11 +139,9 @@ class AdvancedSearchFilterUtilTest {
     filter.set$Eq(10);
 
     // when/then
-    final var ex =
-        assertThrowsExactly(
-            IllegalArgumentException.class,
-            () -> AdvancedSearchFilterUtil.mapToOperations(filter, Boolean.class));
-    assertThat(ex).hasMessage("Could not convert request value [10] to [java.lang.Boolean]");
+    assertThatThrownBy(() -> AdvancedSearchFilterUtil.mapToOperations(filter, Boolean.class))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Could not convert request value [10] to [java.lang.Boolean]");
   }
 
   @Test
@@ -154,10 +151,8 @@ class AdvancedSearchFilterUtilTest {
     filter.set$Eq("2023-11-11T10:10:10.1010+0100");
 
     // when/then
-    final var ex =
-        assertThrowsExactly(
-            IllegalArgumentException.class,
-            () -> AdvancedSearchFilterUtil.mapToOperations(filter, OffsetDateTime.class));
-    assertThat(ex).hasMessage("Failed to parse date-time: [2023-11-11T10:10:10.1010+0100]");
+    assertThatThrownBy(() -> AdvancedSearchFilterUtil.mapToOperations(filter, OffsetDateTime.class))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Failed to parse date-time: [2023-11-11T10:10:10.1010+0100]");
   }
 }

--- a/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/impl/broker/PublishMessageDispatchStrategyTest.java
+++ b/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/impl/broker/PublishMessageDispatchStrategyTest.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.zeebe.gateway.impl.broker;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.broker.client.api.BrokerClusterState;
 import io.camunda.zeebe.broker.client.api.BrokerTopologyListener;
@@ -40,10 +40,10 @@ final class PublishMessageDispatchStrategyTest {
             new TestBrokerClusterState(partitionCount), ClusterConfiguration.uninitialized());
 
     // then - the request is dispatched based on the partition count from the topology
-    assertEquals(
-        SubscriptionUtil.getSubscriptionPartitionId(
-            BufferUtil.wrapString(correlationKey), partitionCount),
-        dispatchStrategy.determinePartition(topologyManager));
+    assertThat(dispatchStrategy.determinePartition(topologyManager))
+        .isEqualTo(
+            SubscriptionUtil.getSubscriptionPartitionId(
+                BufferUtil.wrapString(correlationKey), partitionCount));
   }
 
   @Test
@@ -64,10 +64,10 @@ final class PublishMessageDispatchStrategyTest {
         new TestTopologyManager(new TestBrokerClusterState(partitionCount), clusterConfiguration);
 
     // then - the request is dispatched based on the routing state
-    assertEquals(
-        SubscriptionUtil.getSubscriptionPartitionId(
-            BufferUtil.wrapString(correlationKey), messagePartitionCount),
-        dispatchStrategy.determinePartition(topologyManager));
+    assertThat(dispatchStrategy.determinePartition(topologyManager))
+        .isEqualTo(
+            SubscriptionUtil.getSubscriptionPartitionId(
+                BufferUtil.wrapString(correlationKey), messagePartitionCount));
   }
 
   private record TestBrokerClusterState(int partitionCount) implements BrokerClusterState {

--- a/zeebe/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentsManagerTest.java
+++ b/zeebe/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentsManagerTest.java
@@ -26,7 +26,6 @@ import java.util.Objects;
 import org.agrona.CloseHelper;
 import org.agrona.collections.ArrayUtil;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -440,14 +439,14 @@ class SegmentsManagerTest {
 
     // First segment should be the one from the first journal
     final var firstSegment = segments.getFirstSegment();
-    Assertions.assertNotNull(firstSegment);
+    assertThat(firstSegment).isNotNull();
     assertThat(firstSegment.lastIndex()).isEqualTo(journal.getFirstSegment().lastIndex());
     assertThat(firstSegment.lastAsqn()).isEqualTo(journal.getFirstSegment().lastAsqn());
     assertThat(firstSegment.file().name()).isEqualTo("journal-1.log");
 
     // Last segment should be the one from the third journal
     final var lastSegment = segments.getLastSegment();
-    Assertions.assertNotNull(lastSegment);
+    assertThat(lastSegment).isNotNull();
     assertThat(lastSegment.lastIndex()).isEqualTo(secondaryJournal.getFirstSegment().lastIndex());
     assertThat(lastSegment.lastAsqn()).isEqualTo(secondaryJournal.getFirstSegment().lastAsqn());
     assertThat(lastSegment.file().name()).isEqualTo("journal-2.log");

--- a/zeebe/journal/src/test/java/io/camunda/zeebe/journal/file/SparseJournalIndexTest.java
+++ b/zeebe/journal/src/test/java/io/camunda/zeebe/journal/file/SparseJournalIndexTest.java
@@ -17,8 +17,6 @@
 package io.camunda.zeebe.journal.file;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
 
 import io.camunda.zeebe.journal.JournalRecord;
 import io.camunda.zeebe.journal.util.TestJournalRecord;
@@ -36,7 +34,7 @@ class SparseJournalIndexTest {
     final IndexInfo position = index.lookup(1);
 
     // then
-    assertNull(position);
+    assertThat(position).isNull();
   }
 
   public static JournalRecord asJournalRecord(final long index, final long asqn) {
@@ -56,9 +54,9 @@ class SparseJournalIndexTest {
     index.index(asJournalRecord(5, 5), 10);
 
     // then
-    assertEquals(5, index.lookup(5).index());
-    assertEquals(10, index.lookup(5).position());
-    assertEquals(5, index.lookupAsqn(5));
+    assertThat(index.lookup(5).index()).isEqualTo(5);
+    assertThat(index.lookup(5).position()).isEqualTo(10);
+    assertThat(index.lookupAsqn(5)).isEqualTo(5);
   }
 
   @Test
@@ -78,9 +76,9 @@ class SparseJournalIndexTest {
     index.index(asJournalRecord(8, 8), 16);
 
     // then
-    assertEquals(5, index.lookup(8).index());
-    assertEquals(10, index.lookup(8).position());
-    assertEquals(5, index.lookupAsqn(8));
+    assertThat(index.lookup(8).index()).isEqualTo(5);
+    assertThat(index.lookup(8).position()).isEqualTo(10);
+    assertThat(index.lookupAsqn(8)).isEqualTo(5);
   }
 
   @Test
@@ -102,9 +100,9 @@ class SparseJournalIndexTest {
     index.index(asJournalRecord(10, 10), 20);
 
     // then
-    assertEquals(10, index.lookup(10).index());
-    assertEquals(20, index.lookup(10).position());
-    assertEquals(10, index.lookupAsqn(10));
+    assertThat(index.lookup(10).index()).isEqualTo(10);
+    assertThat(index.lookup(10).position()).isEqualTo(20);
+    assertThat(index.lookupAsqn(10)).isEqualTo(10);
   }
 
   @Test
@@ -127,12 +125,12 @@ class SparseJournalIndexTest {
     index.deleteAfter(8);
 
     // then
-    assertEquals(5, index.lookup(8).index());
-    assertEquals(10, index.lookup(8).position());
-    assertEquals(5, index.lookup(10).index());
-    assertEquals(10, index.lookup(10).position());
-    assertEquals(5, index.lookupAsqn(80));
-    assertEquals(5, index.lookupAsqn(90));
+    assertThat(index.lookup(8).index()).isEqualTo(5);
+    assertThat(index.lookup(8).position()).isEqualTo(10);
+    assertThat(index.lookup(10).index()).isEqualTo(5);
+    assertThat(index.lookup(10).position()).isEqualTo(10);
+    assertThat(index.lookupAsqn(80)).isEqualTo(5);
+    assertThat(index.lookupAsqn(90)).isEqualTo(5);
   }
 
   @Test
@@ -156,14 +154,14 @@ class SparseJournalIndexTest {
     index.deleteAfter(4);
 
     // then
-    assertNull(index.lookup(4));
-    assertNull(index.lookup(5));
-    assertNull(index.lookup(8));
-    assertNull(index.lookup(10));
-    assertNull(index.lookupAsqn(40));
-    assertNull(index.lookupAsqn(50));
-    assertNull(index.lookupAsqn(80));
-    assertNull(index.lookupAsqn(100));
+    assertThat(index.lookup(4)).isNull();
+    assertThat(index.lookup(5)).isNull();
+    assertThat(index.lookup(8)).isNull();
+    assertThat(index.lookup(10)).isNull();
+    assertThat(index.lookupAsqn(40)).isNull();
+    assertThat(index.lookupAsqn(50)).isNull();
+    assertThat(index.lookupAsqn(80)).isNull();
+    assertThat(index.lookupAsqn(100)).isNull();
   }
 
   @Test
@@ -186,9 +184,9 @@ class SparseJournalIndexTest {
     index.deleteUntil(8);
 
     // then
-    assertNull(index.lookup(8));
-    assertEquals(10, index.lookup(10).index());
-    assertEquals(20, index.lookup(10).position());
+    assertThat(index.lookup(8)).isNull();
+    assertThat(index.lookup(10).index()).isEqualTo(10);
+    assertThat(index.lookup(10).position()).isEqualTo(20);
   }
 
   @Test
@@ -210,12 +208,12 @@ class SparseJournalIndexTest {
     index.deleteUntil(11);
 
     // then
-    assertNull(index.lookup(4));
-    assertNull(index.lookup(5));
-    assertNull(index.lookup(8));
-    assertNull(index.lookupAsqn(40));
-    assertNull(index.lookupAsqn(50));
-    assertNull(index.lookupAsqn(80));
+    assertThat(index.lookup(4)).isNull();
+    assertThat(index.lookup(5)).isNull();
+    assertThat(index.lookup(8)).isNull();
+    assertThat(index.lookupAsqn(40)).isNull();
+    assertThat(index.lookupAsqn(50)).isNull();
+    assertThat(index.lookupAsqn(80)).isNull();
   }
 
   @Test
@@ -232,13 +230,13 @@ class SparseJournalIndexTest {
     index.index(asJournalRecord(6, 6), 10);
 
     // then
-    assertNull(index.lookupAsqn(5, 1));
-    assertEquals(2, index.lookupAsqn(5, 3));
-    assertEquals(2, index.lookupAsqn(5, 3));
-    assertEquals(4, index.lookupAsqn(5, 4));
-    assertEquals(4, index.lookupAsqn(5, 5));
-    assertEquals(4, index.lookupAsqn(Long.MAX_VALUE, 5));
-    assertEquals(6, index.lookupAsqn(Long.MAX_VALUE, 6));
+    assertThat(index.lookupAsqn(5, 1)).isNull();
+    assertThat(index.lookupAsqn(5, 3)).isEqualTo(2);
+    assertThat(index.lookupAsqn(5, 3)).isEqualTo(2);
+    assertThat(index.lookupAsqn(5, 4)).isEqualTo(4);
+    assertThat(index.lookupAsqn(5, 5)).isEqualTo(4);
+    assertThat(index.lookupAsqn(Long.MAX_VALUE, 5)).isEqualTo(4);
+    assertThat(index.lookupAsqn(Long.MAX_VALUE, 6)).isEqualTo(6);
   }
 
   @Test

--- a/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/flowcontrol/RateMeasurementTest.java
+++ b/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/flowcontrol/RateMeasurementTest.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.zeebe.logstreams.impl.flowcontrol;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.Duration;
 import java.util.concurrent.atomic.AtomicLong;
@@ -25,7 +25,7 @@ class RateMeasurementTest {
     final double rate = rateMeasurement.rate();
 
     // then
-    assertEquals(0, rate);
+    assertThat(rate).isEqualTo(0);
   }
 
   @Test
@@ -42,7 +42,7 @@ class RateMeasurementTest {
     rateMeasurement.observe(12345);
 
     // then
-    assertEquals(12345 / observationWindow.toSeconds(), rateMeasurement.rate());
+    assertThat(rateMeasurement.rate()).isEqualTo(12345 / observationWindow.toSeconds());
   }
 
   @Test
@@ -60,6 +60,6 @@ class RateMeasurementTest {
     }
 
     // then
-    assertEquals(10, rateMeasurement.rate());
+    assertThat(rateMeasurement.rate()).isEqualTo(10);
   }
 }

--- a/zeebe/msgpack-value/src/test/java/io/camunda/zeebe/msgpack/DeltaEncodedLongArrayValueRandomizedPropertyTest.java
+++ b/zeebe/msgpack-value/src/test/java/io/camunda/zeebe/msgpack/DeltaEncodedLongArrayValueRandomizedPropertyTest.java
@@ -8,7 +8,6 @@
 package io.camunda.zeebe.msgpack;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 
 import io.camunda.zeebe.msgpack.spec.MsgPackReader;
 import io.camunda.zeebe.msgpack.spec.MsgPackWriter;
@@ -40,8 +39,8 @@ final class DeltaEncodedLongArrayValueRandomizedPropertyTest {
     result.read(reader);
 
     // then
-    assertArrayEquals(array, input.getValues());
-    assertArrayEquals(array, result.getValues());
+    assertThat(input.getValues()).containsExactly(array);
+    assertThat(result.getValues()).containsExactly(array);
   }
 
   @Property

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ClusteringRule.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ClusteringRule.java
@@ -103,8 +103,8 @@ import java.util.stream.IntStream;
 import org.agrona.CloseHelper;
 import org.agrona.LangUtil;
 import org.agrona.concurrent.UnsafeBuffer;
+import org.assertj.core.api.Assertions;
 import org.awaitility.Awaitility;
-import org.junit.Assert;
 import org.junit.rules.ExternalResource;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.Description;
@@ -615,7 +615,7 @@ public class ClusteringRule extends ExternalResource {
           assertion -> assertion.isComplete(clusterSize, partitionCount, replicationFactor));
     } catch (final Exception e) {
       LOG.error("Failed to restart cluster", e);
-      Assert.fail("Failed to restart cluster");
+      Assertions.fail("Failed to restart cluster");
     }
   }
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/ScaleUpPartitionsTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/ScaleUpPartitionsTest.java
@@ -14,7 +14,6 @@ import static io.camunda.zeebe.it.clustering.dynamic.Utils.deployProcessModel;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.fail;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import io.atomix.cluster.MemberId;
 import io.camunda.client.CamundaClient;
@@ -439,7 +438,7 @@ public class ScaleUpPartitionsTest {
         .untilAsserted(
             () -> {
               final var topology = clusterActuator.getTopology();
-              assertNotNull(topology.getRouting());
+              assertThat(topology.getRouting()).isNotNull();
               assertThat(topology.getRouting().getRequestHandling())
                   .isEqualTo(routingState.getRequestHandling());
               assertThat(topology.getRouting().getMessageCorrelation())

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/ExportingEndpointIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/ExportingEndpointIT.java
@@ -9,8 +9,6 @@ package io.camunda.zeebe.it.management;
 
 import static io.camunda.zeebe.test.StableValuePredicate.hasStableValue;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.zeebe.model.bpmn.Bpmn;
@@ -96,7 +94,7 @@ final class ExportingEndpointIT {
             .until(RecordingExporter.getRecords()::size, hasStableValue());
 
     // then
-    assertEquals(recordsAfterPause, recordsBeforePause);
+    assertThat(recordsBeforePause).isEqualTo(recordsAfterPause);
     Awaitility.await().untilAsserted(this::allPartitionsPausedExporting);
   }
 
@@ -174,7 +172,7 @@ final class ExportingEndpointIT {
             .until(RecordingExporter.getRecords()::size, hasStableValue());
 
     // then
-    assertEquals(recordsAfterRestart, recordsBeforePause);
+    assertThat(recordsBeforePause).isEqualTo(recordsAfterRestart);
     Awaitility.await().untilAsserted(this::allPartitionsPausedExporting);
   }
 
@@ -301,12 +299,13 @@ final class ExportingEndpointIT {
 
     assertThat(recordsAfterSoftPause).isGreaterThan(recordsBeforePause);
     // at least one partition should have a higher exported position
-    assertTrue(
-        exportedPositionPerPartition.entrySet().stream()
-            .anyMatch(
-                exportedPosition ->
-                    secondExportedPositionPerPartition.get(exportedPosition.getKey())
-                        > exportedPosition.getValue()));
+    assertThat(
+            exportedPositionPerPartition.entrySet().stream()
+                .anyMatch(
+                    exportedPosition ->
+                        secondExportedPositionPerPartition.get(exportedPosition.getKey())
+                            > exportedPosition.getValue()))
+        .isTrue();
   }
 
   @Test

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/processing/IdentitySetupInitializerIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/processing/IdentitySetupInitializerIT.java
@@ -8,7 +8,6 @@
 package io.camunda.zeebe.it.processing;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.camunda.application.commons.security.CamundaSecurityConfiguration.CamundaSecurityProperties;
 import io.camunda.client.CamundaClient;
@@ -79,7 +78,7 @@ final class IdentitySetupInitializerIT {
         .hasName(name)
         .hasEmail(email);
     final var passwordMatches = passwordEncoder.matches(password, createdUser.getPassword());
-    assertTrue(passwordMatches);
+    assertThat(passwordMatches).isTrue();
 
     assertThat(RecordingExporter.roleRecords(RoleIntent.CREATED).limit(4))
         .extracting(record -> record.getValue().getName())
@@ -147,7 +146,7 @@ final class IdentitySetupInitializerIT {
         .hasUsername(user1.getUsername())
         .hasName(user1.getName())
         .hasEmail(user1.getEmail());
-    assertTrue(passwordEncoder.matches(user1.getPassword(), firstUser.getPassword()));
+    assertThat(passwordEncoder.matches(user1.getPassword(), firstUser.getPassword())).isTrue();
 
     final var secondUser = record.getUsers().getLast();
     Assertions.assertThat(secondUser)
@@ -155,7 +154,7 @@ final class IdentitySetupInitializerIT {
         .hasUsername(user2.getUsername())
         .hasName(user2.getName())
         .hasEmail(user2.getEmail());
-    assertTrue(passwordEncoder.matches(user2.getPassword(), secondUser.getPassword()));
+    assertThat(passwordEncoder.matches(user2.getPassword(), secondUser.getPassword())).isTrue();
   }
 
   private void createBroker(

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/startup/BrokerReprocessingTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/startup/BrokerReprocessingTest.java
@@ -10,7 +10,6 @@ package io.camunda.zeebe.it.startup;
 import static java.util.Collections.singletonMap;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
-import static org.junit.Assert.fail;
 
 import io.camunda.client.api.response.ActivateJobsResponse;
 import io.camunda.client.api.response.ActivatedJob;
@@ -38,6 +37,7 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
+import org.assertj.core.api.Assertions;
 import org.awaitility.Awaitility;
 import org.junit.Rule;
 import org.junit.Test;
@@ -640,7 +640,7 @@ public final class BrokerReprocessingTest {
       brokerRule.purgeSnapshots();
     } catch (final Exception e) {
       e.printStackTrace();
-      fail(e.getMessage());
+      Assertions.fail(e.getMessage());
     }
 
     restartAction.run();

--- a/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/BufferedTaskResultBuilderTest.java
+++ b/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/BufferedTaskResultBuilderTest.java
@@ -8,7 +8,6 @@
 package io.camunda.zeebe.stream.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceCreationRecord;
 import io.camunda.zeebe.stream.api.FollowUpCommandMetadata;

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/MsgPackUtil.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/MsgPackUtil.java
@@ -8,7 +8,6 @@
 package io.camunda.zeebe.test.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertNotNull;
 
 import com.fasterxml.jackson.core.StreamReadConstraints;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -75,7 +74,7 @@ public final class MsgPackUtil {
   }
 
   public static void assertEquality(final byte[] actualMsgPack, final String expectedJson) {
-    assertNotNull("actual msg pack is null", actualMsgPack);
+    assertThat(actualMsgPack).as("actual msg pack is null").isNotNull();
     try {
       assertThat(MSGPACK_MAPPER.readTree(actualMsgPack))
           .isEqualTo(JsonUtil.JSON_MAPPER.readTree(expectedJson));
@@ -85,7 +84,7 @@ public final class MsgPackUtil {
   }
 
   public static void assertEquality(final DirectBuffer actualMsgPack, final String expectedJson) {
-    assertNotNull("actual msg pack is null", actualMsgPack);
+    assertThat(actualMsgPack).as("actual msg pack is null").isNotNull();
     final byte[] msgPackArray = new byte[actualMsgPack.capacity()];
     actualMsgPack.getBytes(0, msgPackArray);
     assertEquality(msgPackArray, expectedJson);
@@ -95,7 +94,7 @@ public final class MsgPackUtil {
       final DirectBuffer actualMsgPack,
       final String expectedJson,
       final String... excludedProperties) {
-    assertNotNull("actual msg pack is null", actualMsgPack);
+    assertThat(actualMsgPack).as("actual msg pack is null").isNotNull();
     final byte[] msgPackArray = new byte[actualMsgPack.capacity()];
     actualMsgPack.getBytes(0, msgPackArray);
     assertEqualityExcluding(msgPackArray, expectedJson, excludedProperties);
@@ -104,7 +103,7 @@ public final class MsgPackUtil {
   public static void assertEqualityExcluding(
       final byte[] actualMsgPack, final String expectedJson, final String... excludedProperties) {
 
-    assertNotNull("actual msg pack is null", actualMsgPack);
+    assertThat(actualMsgPack).as("actual msg pack is null").isNotNull();
 
     final JsonNode msgPackNode;
     final JsonNode jsonNode;

--- a/zeebe/util/src/test/java/io/camunda/zeebe/util/SubClassOfTest.java
+++ b/zeebe/util/src/test/java/io/camunda/zeebe/util/SubClassOfTest.java
@@ -8,7 +8,6 @@
 package io.camunda.zeebe.util;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 
 import org.junit.jupiter.api.Test;
 

--- a/zeebe/util/src/test/java/io/camunda/zeebe/util/retry/RetryDecoratorTest.java
+++ b/zeebe/util/src/test/java/io/camunda/zeebe/util/retry/RetryDecoratorTest.java
@@ -8,7 +8,7 @@
 package io.camunda.zeebe.util.retry;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -62,7 +62,9 @@ class RetryDecoratorTest {
 
     // when
     final var exception =
-        assertThrows(Exception.class, () -> retryDecorator.decorate("operation", runnable));
+        assertThatExceptionOfType(Exception.class)
+            .isThrownBy(() -> retryDecorator.decorate("operation", runnable))
+            .actual();
 
     // then
     verify(runnable, times(1)).run();

--- a/zeebe/zb-db/src/test/java/io/camunda/zeebe/db/impl/rocksdb/transaction/ForeignKeyCheckerTest.java
+++ b/zeebe/zb-db/src/test/java/io/camunda/zeebe/db/impl/rocksdb/transaction/ForeignKeyCheckerTest.java
@@ -7,8 +7,8 @@
  */
 package io.camunda.zeebe.db.impl.rocksdb.transaction;
 
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -81,12 +81,13 @@ final class ForeignKeyCheckerTest {
     when(tx.get(anyLong(), anyLong(), any(), anyInt())).thenReturn(null);
 
     // then
-    assertDoesNotThrow(
-        () ->
-            check.assertExists(
-                tx,
-                new DbForeignKey<>(
-                    key, TestColumnFamilies.TEST_COLUMN_FAMILY, MatchType.Full, (k) -> true)));
+    assertThatCode(
+            () ->
+                check.assertExists(
+                    tx,
+                    new DbForeignKey<>(
+                        key, TestColumnFamilies.TEST_COLUMN_FAMILY, MatchType.Full, (k) -> true)))
+        .doesNotThrowAnyException();
     assertThatThrownBy(
             () ->
                 check.assertExists(
@@ -144,11 +145,12 @@ final class ForeignKeyCheckerTest {
     cf1.insert(cf1Key, DbNil.INSTANCE);
 
     // then -- referring to key 1 does not throw
-    assertDoesNotThrow(
-        () ->
-            check.assertExists(
-                (ZeebeTransaction) txContext.getCurrentTransaction(),
-                new DbForeignKey<>(cf1Key, TestColumnFamilies.TEST_COLUMN_FAMILY)));
+    assertThatCode(
+            () ->
+                check.assertExists(
+                    (ZeebeTransaction) txContext.getCurrentTransaction(),
+                    new DbForeignKey<>(cf1Key, TestColumnFamilies.TEST_COLUMN_FAMILY)))
+        .doesNotThrowAnyException();
 
     db.close();
   }
@@ -178,8 +180,9 @@ final class ForeignKeyCheckerTest {
         new DbForeignKey<>(
             new DbLong(), TestColumnFamilies.TEST_COLUMN_FAMILY, MatchType.Prefix, (any) -> false);
     fk.inner().wrapLong(cf1Key.first().getValue());
-    assertDoesNotThrow(
-        () -> check.assertExists((ZeebeTransaction) txContext.getCurrentTransaction(), fk));
+    assertThatCode(
+            () -> check.assertExists((ZeebeTransaction) txContext.getCurrentTransaction(), fk))
+        .doesNotThrowAnyException();
 
     db.close();
   }


### PR DESCRIPTION
## Description

This PR enforces usage of AssertJ assertions over JUnit ones. This is done via Checkstyle in our main Checkstyle configuration file.

As part of this, I went through an automated refactoring exercise, replacing all JUnit assertions (including the `fail` calls) to `AssertJ`, but not the `Assumptions`, as that is not something `AssertJ` covers.

The motivation here is to push people to use the more flexible, more powerful assertion library AssertJ, and to keep consistency in our tests.

I've split the PR into multiple commits, more or less by "module", so it should also be possible to narrow changes there or revert if this is a must.

For posterity, this was done using OpenRewrite. I added the following to the `parent/pom.xml`'s plugin management section:

```xml
        <!-- Automated Refactoring -->
        <plugin>
          <groupId>org.openrewrite.maven</groupId>
          <artifactId>rewrite-maven-plugin</artifactId>
          <version>6.15.0</version>
          <configuration>
            <activeRecipes>
              <recipe>org.openrewrite.java.testing.assertj.JUnitAssertArrayEqualsToAssertThat</recipe>
              <recipe>org.openrewrite.java.testing.assertj.JUnitAssertEqualsToAssertThat</recipe>
              <recipe>org.openrewrite.java.testing.assertj.JUnitAssertFalseToAssertThat</recipe>
              <recipe>org.openrewrite.java.testing.assertj.JUnitAssertNotEqualsToAssertThat</recipe>
              <recipe>org.openrewrite.java.testing.assertj.JUnitAssertNotNullToAssertThat</recipe>
              <recipe>org.openrewrite.java.testing.assertj.JUnitAssertNullToAssertThat</recipe>
              <recipe>org.openrewrite.java.testing.assertj.JUnitAssertSameToAssertThat</recipe>
              <recipe>org.openrewrite.java.testing.assertj.JUnitAssertTrueToAssertThat</recipe>
              <recipe>org.openrewrite.java.testing.assertj.JUnitFailToAssertJFail</recipe>
              <recipe>org.openrewrite.java.testing.assertj.JUnitAssertThrowsToAssertExceptionType</recipe>
              <recipe>org.openrewrite.java.testing.assertj.JUnitAssertInstanceOfToAssertThat</recipe>
              <recipe>tech.picnic.errorprone.refasterrules.JUnitToAssertJRulesRecipes</recipe>
            </activeRecipes>
            <exportDatatables>true</exportDatatables>
            <exclusions>**/*.md,**/*.json,**/*.yaml,**/*.yml,**/*.js,**/*.ts,**/*.xml,**/.node,**/generated-sources,**/generated-test-sources,**/target</exclusions>
            <skipMavenParsing>true</skipMavenParsing>
          </configuration>
          <dependencies>
            <dependency>
              <groupId>org.openrewrite.recipe</groupId>
              <artifactId>rewrite-testing-frameworks</artifactId>
              <version>3.14.1</version>
            </dependency>
          </dependencies>
        </plugin>
```

I did not use the `JUnitToAssertJ` rule because it would also include JUnit best practices, which I thought were out of scope here.

As running this on the complete monorepo would overheat my laptop (and cause it to die), I ended up running this module by module, which is admittedly a bit slower, using this script:

```sh
for pom in $(ls ./**/pom.xml); do
  ./mvnw rewrite:run -pl "${pom%pom.xml}" -Dquickly -T1C
done
```

Perhaps someone with a better machine could simply run it on everything :smile: 