### PR TITLE
Ad-hoc sub-process: Rename AdHocSubProcessActivityActivationRecord to a generic instruction record

### DIFF
--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -912,7 +912,7 @@
         #     userTask: true
         #     variable: true
         #     variableDocument: true
-        #     adHocSubProcessActivityActivation: true
+        #     adHocSubProcessInstruction: true
         #
         #   retention:
         #     enabled: false
@@ -995,7 +995,7 @@
         #     userTask: true
         #     variable: true
         #     variableDocument: true
-        #     adHocSubProcessActivityActivation: true
+        #     adHocSubProcessInstruction: true
 
       # Camunda Exporter ----------
       # An example configuration for the camunda exporter:

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -825,7 +825,7 @@
         #     userTask: true
         #     variable: true
         #     variableDocument: true
-        #     adHocSubProcessActivityActivation: true
+        #     adHocSubProcessInstruction: true
         #
         #   retention:
         #     enabled: false
@@ -908,7 +908,7 @@
         #     userTask: true
         #     variable: true
         #     variableDocument: true
-        #     adHocSubProcessActivityActivation: true
+        #     adHocSubProcessInstruction: true
 
       # Camunda Exporter ----------
       # An example configuration for the camunda exporter:

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/TestSupport.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/TestSupport.java
@@ -68,8 +68,7 @@ public final class TestSupport {
       case BATCH_OPERATION_EXECUTION -> config.batchOperationExecution = value;
       case BATCH_OPERATION_LIFECYCLE_MANAGEMENT -> config.batchOperationLifecycleManagement = value;
       case BATCH_OPERATION_PARTITION_LIFECYCLE -> config.batchOperationPartitionLifecycle = value;
-      case AD_HOC_SUB_PROCESS_ACTIVITY_ACTIVATION ->
-          config.adHocSubProcessActivityActivation = value;
+      case AD_HOC_SUB_PROCESS_INSTRUCTION -> config.adHocSubProcessInstruction = value;
       case ASYNC_REQUEST -> config.asyncRequest = value;
       case USAGE_METRIC -> config.usageMetrics = value;
       default ->
@@ -123,8 +122,7 @@ public final class TestSupport {
       case BATCH_OPERATION_EXECUTION -> config.batchOperationExecution = value;
       case BATCH_OPERATION_LIFECYCLE_MANAGEMENT -> config.batchOperationLifecycleManagement = value;
       case BATCH_OPERATION_PARTITION_LIFECYCLE -> config.batchOperationPartitionLifecycle = value;
-      case AD_HOC_SUB_PROCESS_ACTIVITY_ACTIVATION ->
-          config.adHocSubProcessActivityActivation = value;
+      case AD_HOC_SUB_PROCESS_INSTRUCTION -> config.adHocSubProcessInstruction = value;
       case ASYNC_REQUEST -> config.asyncRequest = value;
       case USAGE_METRIC -> config.usageMetrics = value;
       default ->

--- a/service/src/main/java/io/camunda/service/AdHocSubProcessActivityServices.java
+++ b/service/src/main/java/io/camunda/service/AdHocSubProcessActivityServices.java
@@ -12,7 +12,7 @@ import io.camunda.service.AdHocSubProcessActivityServices.AdHocSubProcessActivat
 import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerActivateAdHocSubProcessActivityRequest;
-import io.camunda.zeebe.protocol.impl.record.value.adhocsubprocess.AdHocSubProcessActivityActivationRecord;
+import io.camunda.zeebe.protocol.impl.record.value.adhocsubprocess.AdHocSubProcessInstructionRecord;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
@@ -32,7 +32,7 @@ public class AdHocSubProcessActivityServices extends ApiServices<AdHocSubProcess
         brokerClient, securityContextProvider, authentication);
   }
 
-  public CompletableFuture<AdHocSubProcessActivityActivationRecord> activateActivities(
+  public CompletableFuture<AdHocSubProcessInstructionRecord> activateActivities(
       final AdHocSubProcessActivateActivitiesRequest request) {
     final var brokerRequest =
         new BrokerActivateAdHocSubProcessActivityRequest()

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TestSupport.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TestSupport.java
@@ -69,8 +69,7 @@ public final class TestSupport {
       case BATCH_OPERATION_EXECUTION -> config.batchOperationExecution = value;
       case BATCH_OPERATION_LIFECYCLE_MANAGEMENT -> config.batchOperationLifecycleManagement = value;
       case BATCH_OPERATION_PARTITION_LIFECYCLE -> config.batchOperationPartitionLifecycle = value;
-      case AD_HOC_SUB_PROCESS_ACTIVITY_ACTIVATION ->
-          config.adHocSubProcessActivityActivation = value;
+      case AD_HOC_SUB_PROCESS_INSTRUCTION -> config.adHocSubProcessInstruction = value;
       case ASYNC_REQUEST -> config.asyncRequest = value;
       case USAGE_METRIC -> config.usageMetrics = value;
       default ->
@@ -126,8 +125,7 @@ public final class TestSupport {
       case BATCH_OPERATION_EXECUTION -> config.batchOperationExecution = value;
       case BATCH_OPERATION_LIFECYCLE_MANAGEMENT -> config.batchOperationLifecycleManagement = value;
       case BATCH_OPERATION_PARTITION_LIFECYCLE -> config.batchOperationPartitionLifecycle = value;
-      case AD_HOC_SUB_PROCESS_ACTIVITY_ACTIVATION ->
-          config.adHocSubProcessActivityActivation = value;
+      case AD_HOC_SUB_PROCESS_INSTRUCTION -> config.adHocSubProcessInstruction = value;
       case ASYNC_REQUEST -> config.asyncRequest = value;
       case USAGE_METRIC -> config.usageMetrics = value;
       default ->

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestReader.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestReader.java
@@ -79,7 +79,7 @@ public class CommandApiRequestReader implements RequestReader {
     RECORDS_BY_TYPE.put(ValueType.USER_TASK, UserTaskRecord::new);
     RECORDS_BY_TYPE.put(ValueType.PROCESS_INSTANCE_MIGRATION, ProcessInstanceMigrationRecord::new);
     RECORDS_BY_TYPE.put(
-        ValueType.AD_HOC_SUB_PROCESS_ACTIVITY_ACTIVATION, AdHocSubProcessInstructionRecord::new);
+        ValueType.AD_HOC_SUB_PROCESS_INSTRUCTION, AdHocSubProcessInstructionRecord::new);
     RECORDS_BY_TYPE.put(ValueType.COMPENSATION_SUBSCRIPTION, CompensationSubscriptionRecord::new);
     RECORDS_BY_TYPE.put(ValueType.MESSAGE_CORRELATION, MessageCorrelationRecord::new);
     RECORDS_BY_TYPE.put(ValueType.USER, UserRecord::new);

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestReader.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestReader.java
@@ -14,7 +14,7 @@ import io.camunda.zeebe.broker.transport.RequestReaderException;
 import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
-import io.camunda.zeebe.protocol.impl.record.value.adhocsubprocess.AdHocSubProcessActivityActivationRecord;
+import io.camunda.zeebe.protocol.impl.record.value.adhocsubprocess.AdHocSubProcessInstructionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.AuthorizationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.IdentitySetupRecord;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.MappingRuleRecord;
@@ -79,8 +79,7 @@ public class CommandApiRequestReader implements RequestReader {
     RECORDS_BY_TYPE.put(ValueType.USER_TASK, UserTaskRecord::new);
     RECORDS_BY_TYPE.put(ValueType.PROCESS_INSTANCE_MIGRATION, ProcessInstanceMigrationRecord::new);
     RECORDS_BY_TYPE.put(
-        ValueType.AD_HOC_SUB_PROCESS_ACTIVITY_ACTIVATION,
-        AdHocSubProcessActivityActivationRecord::new);
+        ValueType.AD_HOC_SUB_PROCESS_ACTIVITY_ACTIVATION, AdHocSubProcessInstructionRecord::new);
     RECORDS_BY_TYPE.put(ValueType.COMPENSATION_SUBSCRIPTION, CompensationSubscriptionRecord::new);
     RECORDS_BY_TYPE.put(ValueType.MESSAGE_CORRELATION, MessageCorrelationRecord::new);
     RECORDS_BY_TYPE.put(ValueType.USER, UserRecord::new);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/BpmnProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/BpmnProcessors.java
@@ -344,7 +344,7 @@ public final class BpmnProcessors {
       final AuthorizationCheckBehavior authCheckBehavior,
       final KeyGenerator keyGenerator) {
     typedRecordProcessors.onCommand(
-        ValueType.AD_HOC_SUB_PROCESS_ACTIVITY_ACTIVATION,
+        ValueType.AD_HOC_SUB_PROCESS_INSTRUCTION,
         AdHocSubProcessInstructionIntent.ACTIVATE,
         new AdHocSubProcessActivityActivateProcessor(
             writers, processingState, authCheckBehavior, keyGenerator));

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/BpmnProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/BpmnProcessors.java
@@ -43,7 +43,7 @@ import io.camunda.zeebe.engine.state.mutable.MutableUserTaskState;
 import io.camunda.zeebe.engine.state.routing.RoutingInfo;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.record.ValueType;
-import io.camunda.zeebe.protocol.record.intent.AdHocSubProcessActivityActivationIntent;
+import io.camunda.zeebe.protocol.record.intent.AdHocSubProcessInstructionIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceBatchIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
@@ -345,7 +345,7 @@ public final class BpmnProcessors {
       final KeyGenerator keyGenerator) {
     typedRecordProcessors.onCommand(
         ValueType.AD_HOC_SUB_PROCESS_ACTIVITY_ACTIVATION,
-        AdHocSubProcessActivityActivationIntent.ACTIVATE,
+        AdHocSubProcessInstructionIntent.ACTIVATE,
         new AdHocSubProcessActivityActivateProcessor(
             writers, processingState, authCheckBehavior, keyGenerator));
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/BpmnProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/BpmnProcessors.java
@@ -9,7 +9,7 @@ package io.camunda.zeebe.engine.processing;
 
 import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.metrics.ProcessEngineMetrics;
-import io.camunda.zeebe.engine.processing.adhocsubprocess.AdHocSubProcessActivityActivateProcessor;
+import io.camunda.zeebe.engine.processing.adhocsubprocess.AdHocSubProcessInstructionActivateProcessor;
 import io.camunda.zeebe.engine.processing.bpmn.BpmnStreamProcessor;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
@@ -346,7 +346,7 @@ public final class BpmnProcessors {
     typedRecordProcessors.onCommand(
         ValueType.AD_HOC_SUB_PROCESS_INSTRUCTION,
         AdHocSubProcessInstructionIntent.ACTIVATE,
-        new AdHocSubProcessActivityActivateProcessor(
+        new AdHocSubProcessInstructionActivateProcessor(
             writers, processingState, authCheckBehavior, keyGenerator));
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/adhocsubprocess/AdHocSubProcessInstructionActivateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/adhocsubprocess/AdHocSubProcessInstructionActivateProcessor.java
@@ -34,7 +34,7 @@ import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
 import io.camunda.zeebe.util.Either;
 
-public class AdHocSubProcessActivityActivateProcessor
+public class AdHocSubProcessInstructionActivateProcessor
     implements TypedRecordProcessor<AdHocSubProcessInstructionRecord> {
 
   private static final String ERROR_MSG_AD_HOC_SUB_PROCESS_NOT_FOUND =
@@ -57,7 +57,7 @@ public class AdHocSubProcessActivityActivateProcessor
   private final AuthorizationCheckBehavior authCheckBehavior;
   private final KeyGenerator keyGenerator;
 
-  public AdHocSubProcessActivityActivateProcessor(
+  public AdHocSubProcessInstructionActivateProcessor(
       final Writers writers,
       final ProcessingState processingState,
       final AuthorizationCheckBehavior authCheckBehavior,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -18,7 +18,7 @@ import io.camunda.zeebe.engine.state.mutable.MutableProcessMessageSubscriptionSt
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.record.RecordValue;
-import io.camunda.zeebe.protocol.record.intent.AdHocSubProcessActivityActivationIntent;
+import io.camunda.zeebe.protocol.record.intent.AdHocSubProcessInstructionIntent;
 import io.camunda.zeebe.protocol.record.intent.AsyncRequestIntent;
 import io.camunda.zeebe.protocol.record.intent.AuthorizationIntent;
 import io.camunda.zeebe.protocol.record.intent.BatchOperationChunkIntent;
@@ -584,7 +584,7 @@ public final class EventAppliers implements EventApplier {
   }
 
   private void registerAdHocSubProcessActivityActivationAppliers() {
-    register(AdHocSubProcessActivityActivationIntent.ACTIVATED, NOOP_EVENT_APPLIER);
+    register(AdHocSubProcessInstructionIntent.ACTIVATED, NOOP_EVENT_APPLIER);
   }
 
   private void registerClockAppliers(final MutableProcessingState state) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/adhocsubprocess/ActivateAdHocSubProcessActivityTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/adhocsubprocess/ActivateAdHocSubProcessActivityTest.java
@@ -163,7 +163,8 @@ public class ActivateAdHocSubProcessActivityTest {
             RecordingExporter.adHocSubProcessActivityActivationRecords()
                 .withAdHocSubProcessInstanceKey(String.valueOf(adHocSubProcessInstanceKey))
                 .limit(record -> record.getIntent() == AdHocSubProcessInstructionIntent.ACTIVATED))
-        .extracting(r -> r.getValue().getElements().getFirst().getElementId(), Record::getIntent)
+        .extracting(
+            r -> r.getValue().getActivateElements().getFirst().getElementId(), Record::getIntent)
         .contains(tuple("A", AdHocSubProcessInstructionIntent.ACTIVATED));
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/adhocsubprocess/ActivateAdHocSubProcessActivityTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/adhocsubprocess/ActivateAdHocSubProcessActivityTest.java
@@ -18,7 +18,7 @@ import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordAssert;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.RejectionType;
-import io.camunda.zeebe.protocol.record.intent.AdHocSubProcessActivityActivationIntent;
+import io.camunda.zeebe.protocol.record.intent.AdHocSubProcessInstructionIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.SignalIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
@@ -162,11 +162,9 @@ public class ActivateAdHocSubProcessActivityTest {
     assertThat(
             RecordingExporter.adHocSubProcessActivityActivationRecords()
                 .withAdHocSubProcessInstanceKey(String.valueOf(adHocSubProcessInstanceKey))
-                .limit(
-                    record ->
-                        record.getIntent() == AdHocSubProcessActivityActivationIntent.ACTIVATED))
+                .limit(record -> record.getIntent() == AdHocSubProcessInstructionIntent.ACTIVATED))
         .extracting(r -> r.getValue().getElements().getFirst().getElementId(), Record::getIntent)
-        .contains(tuple("A", AdHocSubProcessActivityActivationIntent.ACTIVATED));
+        .contains(tuple("A", AdHocSubProcessInstructionIntent.ACTIVATED));
   }
 
   @Test
@@ -215,9 +213,9 @@ public class ActivateAdHocSubProcessActivityTest {
                 .limit(2))
         .extracting(Record::getRecordType, Record::getIntent)
         .contains(
-            tuple(RecordType.COMMAND, AdHocSubProcessActivityActivationIntent.ACTIVATE),
-            tuple(RecordType.COMMAND_REJECTION, AdHocSubProcessActivityActivationIntent.ACTIVATE))
-        .doesNotContain(tuple(RecordType.EVENT, AdHocSubProcessActivityActivationIntent.ACTIVATED));
+            tuple(RecordType.COMMAND, AdHocSubProcessInstructionIntent.ACTIVATE),
+            tuple(RecordType.COMMAND_REJECTION, AdHocSubProcessInstructionIntent.ACTIVATE))
+        .doesNotContain(tuple(RecordType.EVENT, AdHocSubProcessInstructionIntent.ACTIVATED));
   }
 
   @Test
@@ -245,8 +243,8 @@ public class ActivateAdHocSubProcessActivityTest {
                 .limit(2))
         .extracting(Record::getRecordType, Record::getIntent)
         .contains(
-            tuple(RecordType.COMMAND, AdHocSubProcessActivityActivationIntent.ACTIVATE),
-            tuple(RecordType.COMMAND_REJECTION, AdHocSubProcessActivityActivationIntent.ACTIVATE));
+            tuple(RecordType.COMMAND, AdHocSubProcessInstructionIntent.ACTIVATE),
+            tuple(RecordType.COMMAND_REJECTION, AdHocSubProcessInstructionIntent.ACTIVATE));
   }
 
   @Test
@@ -314,9 +312,9 @@ public class ActivateAdHocSubProcessActivityTest {
                 .limit(2))
         .extracting(Record::getRecordType, Record::getIntent)
         .contains(
-            tuple(RecordType.COMMAND, AdHocSubProcessActivityActivationIntent.ACTIVATE),
-            tuple(RecordType.COMMAND_REJECTION, AdHocSubProcessActivityActivationIntent.ACTIVATE))
-        .doesNotContain(tuple(RecordType.EVENT, AdHocSubProcessActivityActivationIntent.ACTIVATED));
+            tuple(RecordType.COMMAND, AdHocSubProcessInstructionIntent.ACTIVATE),
+            tuple(RecordType.COMMAND_REJECTION, AdHocSubProcessInstructionIntent.ACTIVATE))
+        .doesNotContain(tuple(RecordType.EVENT, AdHocSubProcessInstructionIntent.ACTIVATED));
   }
 
   private ProcessInstanceRecordStream recordsUntilSignal(final String signalName) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/adhocsubprocess/ActivateAdHocSubProcessActivityTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/adhocsubprocess/ActivateAdHocSubProcessActivityTest.java
@@ -160,7 +160,7 @@ public class ActivateAdHocSubProcessActivityTest {
         .activate();
 
     assertThat(
-            RecordingExporter.adHocSubProcessActivityActivationRecords()
+            RecordingExporter.adHocSubProcessInstructionRecords()
                 .withAdHocSubProcessInstanceKey(String.valueOf(adHocSubProcessInstanceKey))
                 .limit(record -> record.getIntent() == AdHocSubProcessInstructionIntent.ACTIVATED))
         .extracting(
@@ -209,7 +209,7 @@ public class ActivateAdHocSubProcessActivityTest {
                 .formatted(adHocSubProcessInstanceKey, nonExistingActivities));
 
     assertThat(
-            RecordingExporter.adHocSubProcessActivityActivationRecords()
+            RecordingExporter.adHocSubProcessInstructionRecords()
                 .withAdHocSubProcessInstanceKey(String.valueOf(adHocSubProcessInstanceKey))
                 .limit(2))
         .extracting(Record::getRecordType, Record::getIntent)
@@ -239,7 +239,7 @@ public class ActivateAdHocSubProcessActivityTest {
                 .formatted(nonExistingAdHocSubProcessInstanceKey));
 
     assertThat(
-            RecordingExporter.adHocSubProcessActivityActivationRecords()
+            RecordingExporter.adHocSubProcessInstructionRecords()
                 .withAdHocSubProcessInstanceKey(nonExistingAdHocSubProcessInstanceKey)
                 .limit(2))
         .extracting(Record::getRecordType, Record::getIntent)
@@ -308,7 +308,7 @@ public class ActivateAdHocSubProcessActivityTest {
                 .formatted(adHocSubProcessInstanceKey));
 
     assertThat(
-            RecordingExporter.adHocSubProcessActivityActivationRecords()
+            RecordingExporter.adHocSubProcessInstructionRecords()
                 .withAdHocSubProcessInstanceKey(String.valueOf(adHocSubProcessInstanceKey))
                 .limit(2))
         .extracting(Record::getRecordType, Record::getIntent)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/RecordToWrite.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/RecordToWrite.java
@@ -186,10 +186,10 @@ public final class RecordToWrite implements LogAppendEntry {
     return this;
   }
 
-  public RecordToWrite adHocSubProcessActivityActivation(
+  public RecordToWrite adHocSubProcessInstruction(
       final AdHocSubProcessInstructionRecordValue value) {
     recordMetadata
-        .valueType(ValueType.AD_HOC_SUB_PROCESS_ACTIVITY_ACTIVATION)
+        .valueType(ValueType.AD_HOC_SUB_PROCESS_INSTRUCTION)
         .intent(AdHocSubProcessInstructionIntent.ACTIVATE);
     unifiedRecordValue = (AdHocSubProcessInstructionRecord) value;
     return this;

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/RecordToWrite.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/RecordToWrite.java
@@ -10,7 +10,7 @@ package io.camunda.zeebe.engine.util;
 import io.camunda.zeebe.logstreams.log.LogAppendEntry;
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
-import io.camunda.zeebe.protocol.impl.record.value.adhocsubprocess.AdHocSubProcessActivityActivationRecord;
+import io.camunda.zeebe.protocol.impl.record.value.adhocsubprocess.AdHocSubProcessInstructionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobBatchRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageBatchRecord;
@@ -26,7 +26,7 @@ import io.camunda.zeebe.protocol.impl.record.value.timer.TimerRecord;
 import io.camunda.zeebe.protocol.impl.record.value.variable.VariableDocumentRecord;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
-import io.camunda.zeebe.protocol.record.intent.AdHocSubProcessActivityActivationIntent;
+import io.camunda.zeebe.protocol.record.intent.AdHocSubProcessInstructionIntent;
 import io.camunda.zeebe.protocol.record.intent.JobBatchIntent;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageBatchIntent;
@@ -40,7 +40,7 @@ import io.camunda.zeebe.protocol.record.intent.ProcessMessageSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.TimerIntent;
 import io.camunda.zeebe.protocol.record.intent.VariableDocumentIntent;
 import io.camunda.zeebe.protocol.record.intent.scaling.ScaleIntent;
-import io.camunda.zeebe.protocol.record.value.AdHocSubProcessActivityActivationRecordValue;
+import io.camunda.zeebe.protocol.record.value.AdHocSubProcessInstructionRecordValue;
 import io.camunda.zeebe.protocol.record.value.JobRecordValue;
 import io.camunda.zeebe.protocol.record.value.MessageBatchRecordValue;
 import io.camunda.zeebe.protocol.record.value.MessageRecordValue;
@@ -187,11 +187,11 @@ public final class RecordToWrite implements LogAppendEntry {
   }
 
   public RecordToWrite adHocSubProcessActivityActivation(
-      final AdHocSubProcessActivityActivationRecordValue value) {
+      final AdHocSubProcessInstructionRecordValue value) {
     recordMetadata
         .valueType(ValueType.AD_HOC_SUB_PROCESS_ACTIVITY_ACTIVATION)
-        .intent(AdHocSubProcessActivityActivationIntent.ACTIVATE);
-    unifiedRecordValue = (AdHocSubProcessActivityActivationRecord) value;
+        .intent(AdHocSubProcessInstructionIntent.ACTIVATE);
+    unifiedRecordValue = (AdHocSubProcessInstructionRecord) value;
     return this;
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/AdHocSubProcessActivityClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/AdHocSubProcessActivityClient.java
@@ -67,7 +67,7 @@ public class AdHocSubProcessActivityClient {
 
   public AdHocSubProcessActivityClient withElementIds(final String... elementIds) {
     for (final String elementId : elementIds) {
-      adHocSubProcessInstructionRecord.elements().add().setElementId(elementId);
+      adHocSubProcessInstructionRecord.activateElements().add().setElementId(elementId);
     }
     return this;
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/AdHocSubProcessActivityClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/AdHocSubProcessActivityClient.java
@@ -7,36 +7,36 @@
  */
 package io.camunda.zeebe.engine.util.client;
 
-import io.camunda.zeebe.protocol.impl.record.value.adhocsubprocess.AdHocSubProcessActivityActivationRecord;
+import io.camunda.zeebe.protocol.impl.record.value.adhocsubprocess.AdHocSubProcessInstructionRecord;
 import io.camunda.zeebe.protocol.record.Record;
-import io.camunda.zeebe.protocol.record.intent.AdHocSubProcessActivityActivationIntent;
-import io.camunda.zeebe.protocol.record.value.AdHocSubProcessActivityActivationRecordValue;
+import io.camunda.zeebe.protocol.record.intent.AdHocSubProcessInstructionIntent;
+import io.camunda.zeebe.protocol.record.value.AdHocSubProcessInstructionRecordValue;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import java.util.List;
 import java.util.function.Function;
 
 public class AdHocSubProcessActivityClient {
-  private static final Function<Long, Record<AdHocSubProcessActivityActivationRecordValue>>
+  private static final Function<Long, Record<AdHocSubProcessInstructionRecordValue>>
       SUCCESS_EXPECTATION =
           (position) ->
               RecordingExporter.adHocSubProcessActivityActivationRecords()
-                  .withIntent(AdHocSubProcessActivityActivationIntent.ACTIVATED)
+                  .withIntent(AdHocSubProcessInstructionIntent.ACTIVATED)
                   .withSourceRecordPosition(position)
                   .getFirst();
-  private static final Function<Long, Record<AdHocSubProcessActivityActivationRecordValue>>
+  private static final Function<Long, Record<AdHocSubProcessInstructionRecordValue>>
       REJECTION_EXPECTATION =
           (position) ->
               RecordingExporter.adHocSubProcessActivityActivationRecords()
                   .onlyCommandRejections()
-                  .withIntent(AdHocSubProcessActivityActivationIntent.ACTIVATE)
+                  .withIntent(AdHocSubProcessInstructionIntent.ACTIVATE)
                   .withSourceRecordPosition(position)
                   .getFirst();
 
   private final CommandWriter writer;
-  private final AdHocSubProcessActivityActivationRecord adHocSubProcessActivityActivationRecord =
-      new AdHocSubProcessActivityActivationRecord();
-  private Function<Long, Record<AdHocSubProcessActivityActivationRecordValue>> expectation =
+  private final AdHocSubProcessInstructionRecord adHocSubProcessInstructionRecord =
+      new AdHocSubProcessInstructionRecord();
+  private Function<Long, Record<AdHocSubProcessInstructionRecordValue>> expectation =
       SUCCESS_EXPECTATION;
   private List<String> authorizedTenantIds = List.of(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
 
@@ -44,11 +44,11 @@ public class AdHocSubProcessActivityClient {
     this.writer = writer;
   }
 
-  public Record<AdHocSubProcessActivityActivationRecordValue> activate() {
+  public Record<AdHocSubProcessInstructionRecordValue> activate() {
     final var position =
         writer.writeCommand(
-            AdHocSubProcessActivityActivationIntent.ACTIVATE,
-            adHocSubProcessActivityActivationRecord,
+            AdHocSubProcessInstructionIntent.ACTIVATE,
+            adHocSubProcessInstructionRecord,
             authorizedTenantIds.toArray(new String[0]));
 
     return expectation.apply(position);
@@ -61,14 +61,13 @@ public class AdHocSubProcessActivityClient {
 
   public AdHocSubProcessActivityClient withAdHocSubProcessInstanceKey(
       final String adHocSubProcessInstanceKey) {
-    adHocSubProcessActivityActivationRecord.setAdHocSubProcessInstanceKey(
-        adHocSubProcessInstanceKey);
+    adHocSubProcessInstructionRecord.setAdHocSubProcessInstanceKey(adHocSubProcessInstanceKey);
     return this;
   }
 
   public AdHocSubProcessActivityClient withElementIds(final String... elementIds) {
     for (final String elementId : elementIds) {
-      adHocSubProcessActivityActivationRecord.elements().add().setElementId(elementId);
+      adHocSubProcessInstructionRecord.elements().add().setElementId(elementId);
     }
     return this;
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/AdHocSubProcessActivityClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/AdHocSubProcessActivityClient.java
@@ -20,14 +20,14 @@ public class AdHocSubProcessActivityClient {
   private static final Function<Long, Record<AdHocSubProcessInstructionRecordValue>>
       SUCCESS_EXPECTATION =
           (position) ->
-              RecordingExporter.adHocSubProcessActivityActivationRecords()
+              RecordingExporter.adHocSubProcessInstructionRecords()
                   .withIntent(AdHocSubProcessInstructionIntent.ACTIVATED)
                   .withSourceRecordPosition(position)
                   .getFirst();
   private static final Function<Long, Record<AdHocSubProcessInstructionRecordValue>>
       REJECTION_EXPECTATION =
           (position) ->
-              RecordingExporter.adHocSubProcessActivityActivationRecords()
+              RecordingExporter.adHocSubProcessInstructionRecords()
                   .onlyCommandRejections()
                   .withIntent(AdHocSubProcessInstructionIntent.ACTIVATE)
                   .withSourceRecordPosition(position)

--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
@@ -105,7 +105,7 @@ public class ElasticsearchExporterConfiguration {
       case USER_TASK -> index.userTask;
       case COMPENSATION_SUBSCRIPTION -> index.compensationSubscription;
       case MESSAGE_CORRELATION -> index.messageCorrelation;
-      case AD_HOC_SUB_PROCESS_ACTIVITY_ACTIVATION -> index.adHocSubProcessActivityActivation;
+      case AD_HOC_SUB_PROCESS_INSTRUCTION -> index.adHocSubProcessInstruction;
       case ASYNC_REQUEST -> index.asyncRequest;
       default -> false;
     };
@@ -192,7 +192,7 @@ public class ElasticsearchExporterConfiguration {
     public boolean processMessageSubscription = true;
     public boolean variable = true;
     public boolean variableDocument = true;
-    public boolean adHocSubProcessActivityActivation = true;
+    public boolean adHocSubProcessInstruction = true;
 
     public boolean checkpoint = false;
     public boolean timer = true;
@@ -313,8 +313,8 @@ public class ElasticsearchExporterConfiguration {
           + signalSubscription
           + ", resourceDeletion="
           + resourceDeletion
-          + ", adHocSubProcessActivityActivation="
-          + adHocSubProcessActivityActivation
+          + ", adHocSubProcessInstruction="
+          + adHocSubProcessInstruction
           + ", commandDistribution="
           + commandDistribution
           + ", form="

--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterSchemaManager.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterSchemaManager.java
@@ -124,8 +124,8 @@ public class ElasticsearchExporterSchemaManager {
       if (index.processMessageSubscription) {
         createValueIndexTemplate(ValueType.PROCESS_MESSAGE_SUBSCRIPTION, version);
       }
-      if (index.adHocSubProcessActivityActivation) {
-        createValueIndexTemplate(ValueType.AD_HOC_SUB_PROCESS_ACTIVITY_ACTIVATION, version);
+      if (index.adHocSubProcessInstruction) {
+        createValueIndexTemplate(ValueType.AD_HOC_SUB_PROCESS_INSTRUCTION, version);
       }
       if (index.decisionRequirements) {
         createValueIndexTemplate(ValueType.DECISION_REQUIREMENTS, version);

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-ad-hoc-sub-process-instruction-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-ad-hoc-sub-process-instruction-template.json
@@ -1,6 +1,6 @@
 {
   "index_patterns": [
-    "zeebe-record_ad-hoc-subprocess-activity-activation_*"
+    "zeebe-record_ad-hoc-subprocess-instruction_*"
   ],
   "composed_of": [
     "zeebe-record"
@@ -14,7 +14,7 @@
       "index.queries.cache.enabled": false
     },
     "aliases": {
-      "zeebe-record-ad-hoc-subprocess-activity-activation": {}
+      "zeebe-record-ad-hoc-subprocess-instruction": {}
     },
     "mappings": {
       "properties": {
@@ -24,7 +24,7 @@
             "adHocSubProcessInstanceKey": {
               "type": "keyword"
             },
-            "elements": {
+            "activateElements": {
               "properties": {
                 "elementId": {
                   "type": "keyword"

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/TestSupport.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/TestSupport.java
@@ -68,8 +68,7 @@ final class TestSupport {
       case BATCH_OPERATION_EXECUTION -> config.batchOperationExecution = value;
       case BATCH_OPERATION_LIFECYCLE_MANAGEMENT -> config.batchOperationLifecycleManagement = value;
       case BATCH_OPERATION_PARTITION_LIFECYCLE -> config.batchOperationPartitionLifecycle = value;
-      case AD_HOC_SUB_PROCESS_ACTIVITY_ACTIVATION ->
-          config.adHocSubProcessActivityActivation = value;
+      case AD_HOC_SUB_PROCESS_INSTRUCTION -> config.adHocSubProcessInstruction = value;
       case ASYNC_REQUEST -> config.asyncRequest = value;
       case USAGE_METRIC -> config.usageMetrics = value;
       default ->

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporter.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporter.java
@@ -287,8 +287,8 @@ public class OpensearchExporter implements Exporter {
       if (index.processMessageSubscription) {
         createValueIndexTemplate(ValueType.PROCESS_MESSAGE_SUBSCRIPTION, version);
       }
-      if (index.adHocSubProcessActivityActivation) {
-        createValueIndexTemplate(ValueType.AD_HOC_SUB_PROCESS_ACTIVITY_ACTIVATION, version);
+      if (index.adHocSubProcessInstruction) {
+        createValueIndexTemplate(ValueType.AD_HOC_SUB_PROCESS_INSTRUCTION, version);
       }
       if (index.decisionRequirements) {
         createValueIndexTemplate(ValueType.DECISION_REQUIREMENTS, version);

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterConfiguration.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterConfiguration.java
@@ -104,7 +104,7 @@ public class OpensearchExporterConfiguration {
       case USER_TASK -> index.userTask;
       case COMPENSATION_SUBSCRIPTION -> index.compensationSubscription;
       case MESSAGE_CORRELATION -> index.messageCorrelation;
-      case AD_HOC_SUB_PROCESS_ACTIVITY_ACTIVATION -> index.adHocSubProcessActivityActivation;
+      case AD_HOC_SUB_PROCESS_INSTRUCTION -> index.adHocSubProcessInstruction;
       case ASYNC_REQUEST -> index.asyncRequest;
       default -> false;
     };
@@ -181,7 +181,7 @@ public class OpensearchExporterConfiguration {
     public boolean processMessageSubscription = true;
     public boolean variable = true;
     public boolean variableDocument = true;
-    public boolean adHocSubProcessActivityActivation = true;
+    public boolean adHocSubProcessInstruction = true;
 
     public boolean checkpoint = false;
     public boolean timer = true;
@@ -301,8 +301,8 @@ public class OpensearchExporterConfiguration {
           + signalSubscription
           + ", resourceDeletion="
           + resourceDeletion
-          + ", adHocSubProcessActivityActivation="
-          + adHocSubProcessActivityActivation
+          + ", adHocSubProcessInstruction="
+          + adHocSubProcessInstruction
           + ", recordDistribution="
           + commandDistribution
           + ", form="

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-ad-hoc-sub-process-instruction-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-ad-hoc-sub-process-instruction-template.json
@@ -1,6 +1,6 @@
 {
   "index_patterns": [
-    "zeebe-record_ad-hoc-subprocess-activity-activation_*"
+    "zeebe-record_ad-hoc-subprocess-instruction_*"
   ],
   "composed_of": [
     "zeebe-record"
@@ -14,7 +14,7 @@
       "index.queries.cache.enabled": false
     },
     "aliases": {
-      "zeebe-record-ad-hoc-subprocess-activity-activation": {}
+      "zeebe-record-ad-hoc-subprocess-instruction": {}
     },
     "mappings": {
       "properties": {
@@ -24,7 +24,7 @@
             "adHocSubProcessInstanceKey": {
               "type": "keyword"
             },
-            "elements": {
+            "activateElements": {
               "properties": {
                 "elementId": {
                   "type": "keyword"

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/TestSupport.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/TestSupport.java
@@ -69,8 +69,7 @@ final class TestSupport {
       case BATCH_OPERATION_EXECUTION -> config.batchOperationExecution = value;
       case BATCH_OPERATION_LIFECYCLE_MANAGEMENT -> config.batchOperationLifecycleManagement = value;
       case BATCH_OPERATION_PARTITION_LIFECYCLE -> config.batchOperationPartitionLifecycle = value;
-      case AD_HOC_SUB_PROCESS_ACTIVITY_ACTIVATION ->
-          config.adHocSubProcessActivityActivation = value;
+      case AD_HOC_SUB_PROCESS_INSTRUCTION -> config.adHocSubProcessInstruction = value;
       case ASYNC_REQUEST -> config.asyncRequest = value;
       case USAGE_METRIC -> config.usageMetrics = value;
       default ->

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AdHocSubProcessActivityControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AdHocSubProcessActivityControllerTest.java
@@ -21,7 +21,7 @@ import io.camunda.service.AdHocSubProcessActivityServices;
 import io.camunda.service.AdHocSubProcessActivityServices.AdHocSubProcessActivateActivitiesRequest;
 import io.camunda.service.AdHocSubProcessActivityServices.AdHocSubProcessActivateActivitiesRequest.AdHocSubProcessActivateActivityReference;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
-import io.camunda.zeebe.protocol.impl.record.value.adhocsubprocess.AdHocSubProcessActivityActivationRecord;
+import io.camunda.zeebe.protocol.impl.record.value.adhocsubprocess.AdHocSubProcessInstructionRecord;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
@@ -61,8 +61,7 @@ class AdHocSubProcessActivityControllerTest extends RestControllerTest {
     void shouldActivateActivities() {
       when(adHocSubProcessActivityServices.activateActivities(
               any(AdHocSubProcessActivateActivitiesRequest.class)))
-          .thenReturn(
-              CompletableFuture.completedFuture(new AdHocSubProcessActivityActivationRecord()));
+          .thenReturn(CompletableFuture.completedFuture(new AdHocSubProcessInstructionRecord()));
 
       webClient
           .post()

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerActivateAdHocSubProcessActivityRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerActivateAdHocSubProcessActivityRequest.java
@@ -20,9 +20,7 @@ public class BrokerActivateAdHocSubProcessActivityRequest
       new AdHocSubProcessInstructionRecord();
 
   public BrokerActivateAdHocSubProcessActivityRequest() {
-    super(
-        ValueType.AD_HOC_SUB_PROCESS_ACTIVITY_ACTIVATION,
-        AdHocSubProcessInstructionIntent.ACTIVATE);
+    super(ValueType.AD_HOC_SUB_PROCESS_INSTRUCTION, AdHocSubProcessInstructionIntent.ACTIVATE);
   }
 
   public BrokerActivateAdHocSubProcessActivityRequest setAdHocSubProcessInstanceKey(

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerActivateAdHocSubProcessActivityRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerActivateAdHocSubProcessActivityRequest.java
@@ -32,7 +32,7 @@ public class BrokerActivateAdHocSubProcessActivityRequest
   }
 
   public BrokerActivateAdHocSubProcessActivityRequest addElement(final String elementId) {
-    requestDto.elements().add().setElementId(elementId);
+    requestDto.activateElements().add().setElementId(elementId);
     return this;
   }
 

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerActivateAdHocSubProcessActivityRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerActivateAdHocSubProcessActivityRequest.java
@@ -8,21 +8,21 @@
 package io.camunda.zeebe.gateway.impl.broker.request;
 
 import io.camunda.zeebe.broker.client.api.dto.BrokerExecuteCommand;
-import io.camunda.zeebe.protocol.impl.record.value.adhocsubprocess.AdHocSubProcessActivityActivationRecord;
+import io.camunda.zeebe.protocol.impl.record.value.adhocsubprocess.AdHocSubProcessInstructionRecord;
 import io.camunda.zeebe.protocol.record.ValueType;
-import io.camunda.zeebe.protocol.record.intent.AdHocSubProcessActivityActivationIntent;
+import io.camunda.zeebe.protocol.record.intent.AdHocSubProcessInstructionIntent;
 import org.agrona.DirectBuffer;
 
 public class BrokerActivateAdHocSubProcessActivityRequest
-    extends BrokerExecuteCommand<AdHocSubProcessActivityActivationRecord> {
+    extends BrokerExecuteCommand<AdHocSubProcessInstructionRecord> {
 
-  private final AdHocSubProcessActivityActivationRecord requestDto =
-      new AdHocSubProcessActivityActivationRecord();
+  private final AdHocSubProcessInstructionRecord requestDto =
+      new AdHocSubProcessInstructionRecord();
 
   public BrokerActivateAdHocSubProcessActivityRequest() {
     super(
         ValueType.AD_HOC_SUB_PROCESS_ACTIVITY_ACTIVATION,
-        AdHocSubProcessActivityActivationIntent.ACTIVATE);
+        AdHocSubProcessInstructionIntent.ACTIVATE);
   }
 
   public BrokerActivateAdHocSubProcessActivityRequest setAdHocSubProcessInstanceKey(
@@ -37,14 +37,13 @@ public class BrokerActivateAdHocSubProcessActivityRequest
   }
 
   @Override
-  public AdHocSubProcessActivityActivationRecord getRequestWriter() {
+  public AdHocSubProcessInstructionRecord getRequestWriter() {
     return requestDto;
   }
 
   @Override
-  protected AdHocSubProcessActivityActivationRecord toResponseDto(final DirectBuffer buffer) {
-    final AdHocSubProcessActivityActivationRecord responseDto =
-        new AdHocSubProcessActivityActivationRecord();
+  protected AdHocSubProcessInstructionRecord toResponseDto(final DirectBuffer buffer) {
+    final AdHocSubProcessInstructionRecord responseDto = new AdHocSubProcessInstructionRecord();
     responseDto.wrap(buffer);
     return responseDto;
   }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/adhocsubprocess/AdHocSubProcessActivateElementInstruction.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/adhocsubprocess/AdHocSubProcessActivateElementInstruction.java
@@ -10,7 +10,7 @@ package io.camunda.zeebe.protocol.impl.record.value.adhocsubprocess;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.msgpack.value.ObjectValue;
-import io.camunda.zeebe.protocol.record.value.AdHocSubProcessInstructionRecordValue.AdHocSubProcessActivityActivationElementValue;
+import io.camunda.zeebe.protocol.record.value.AdHocSubProcessInstructionRecordValue.AdHocSubProcessActivateElementInstructionValue;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 
 @JsonIgnoreProperties({
@@ -18,12 +18,12 @@ import io.camunda.zeebe.util.buffer.BufferUtil;
   "encodedLength",
   "empty"
 })
-public final class AdHocSubProcessActivityActivationElement extends ObjectValue
-    implements AdHocSubProcessActivityActivationElementValue {
+public final class AdHocSubProcessActivateElementInstruction extends ObjectValue
+    implements AdHocSubProcessActivateElementInstructionValue {
 
   private final StringProperty elementId = new StringProperty("elementId");
 
-  public AdHocSubProcessActivityActivationElement() {
+  public AdHocSubProcessActivateElementInstruction() {
     super(1);
     declareProperty(elementId);
   }
@@ -33,7 +33,7 @@ public final class AdHocSubProcessActivityActivationElement extends ObjectValue
     return BufferUtil.bufferAsString(elementId.getValue());
   }
 
-  public AdHocSubProcessActivityActivationElement setElementId(final String elementId) {
+  public AdHocSubProcessActivateElementInstruction setElementId(final String elementId) {
     this.elementId.setValue(elementId);
     return this;
   }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/adhocsubprocess/AdHocSubProcessActivityActivationElement.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/adhocsubprocess/AdHocSubProcessActivityActivationElement.java
@@ -10,7 +10,7 @@ package io.camunda.zeebe.protocol.impl.record.value.adhocsubprocess;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.msgpack.value.ObjectValue;
-import io.camunda.zeebe.protocol.record.value.AdHocSubProcessActivityActivationRecordValue.AdHocSubProcessActivityActivationElementValue;
+import io.camunda.zeebe.protocol.record.value.AdHocSubProcessInstructionRecordValue.AdHocSubProcessActivityActivationElementValue;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 
 @JsonIgnoreProperties({

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/adhocsubprocess/AdHocSubProcessInstructionRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/adhocsubprocess/AdHocSubProcessInstructionRecord.java
@@ -24,14 +24,16 @@ public final class AdHocSubProcessInstructionRecord extends UnifiedRecordValue
 
   private final StringProperty adHocSubProcessInstanceKey =
       new StringProperty("adHocSubProcessInstanceKey", DEFAULT_STRING);
-  private final ArrayProperty<AdHocSubProcessActivityActivationElement> elements =
-      new ArrayProperty<>("elements", AdHocSubProcessActivityActivationElement::new);
+  private final ArrayProperty<AdHocSubProcessActivateElementInstruction> activateElements =
+      new ArrayProperty<>("activateElements", AdHocSubProcessActivateElementInstruction::new);
   private final StringProperty tenantId =
       new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
 
   public AdHocSubProcessInstructionRecord() {
     super(3);
-    declareProperty(adHocSubProcessInstanceKey).declareProperty(elements).declareProperty(tenantId);
+    declareProperty(adHocSubProcessInstanceKey)
+        .declareProperty(activateElements)
+        .declareProperty(tenantId);
   }
 
   @Override
@@ -46,21 +48,21 @@ public final class AdHocSubProcessInstructionRecord extends UnifiedRecordValue
   }
 
   @Override
-  public List<AdHocSubProcessActivityActivationElementValue> getElements() {
-    return elements.stream()
-        .map(AdHocSubProcessActivityActivationElementValue.class::cast)
+  public List<AdHocSubProcessActivateElementInstructionValue> getActivateElements() {
+    return activateElements.stream()
+        .map(AdHocSubProcessActivateElementInstructionValue.class::cast)
         .toList();
   }
 
   /**
-   * Returns the {@link ValueArray} of `elements` which then can have more elements added/removed.
-   * This is used in setting up test scenarios.
+   * Returns the {@link ValueArray} of `activateElements` which then can have more elements
+   * added/removed. This is used in setting up test scenarios.
    *
    * @return a {@link ValueArray} of flow nodes that can easily be added to.
    */
   @JsonIgnore
-  public ValueArray<AdHocSubProcessActivityActivationElement> elements() {
-    return elements;
+  public ValueArray<AdHocSubProcessActivateElementInstruction> activateElements() {
+    return activateElements;
   }
 
   @Override

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/adhocsubprocess/AdHocSubProcessInstructionRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/adhocsubprocess/AdHocSubProcessInstructionRecord.java
@@ -12,13 +12,13 @@ import io.camunda.zeebe.msgpack.property.ArrayProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.msgpack.value.ValueArray;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
-import io.camunda.zeebe.protocol.record.value.AdHocSubProcessActivityActivationRecordValue;
+import io.camunda.zeebe.protocol.record.value.AdHocSubProcessInstructionRecordValue;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.List;
 
-public final class AdHocSubProcessActivityActivationRecord extends UnifiedRecordValue
-    implements AdHocSubProcessActivityActivationRecordValue {
+public final class AdHocSubProcessInstructionRecord extends UnifiedRecordValue
+    implements AdHocSubProcessInstructionRecordValue {
 
   private static final String DEFAULT_STRING = "";
 
@@ -29,7 +29,7 @@ public final class AdHocSubProcessActivityActivationRecord extends UnifiedRecord
   private final StringProperty tenantId =
       new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
 
-  public AdHocSubProcessActivityActivationRecord() {
+  public AdHocSubProcessInstructionRecord() {
     super(3);
     declareProperty(adHocSubProcessInstanceKey).declareProperty(elements).declareProperty(tenantId);
   }
@@ -39,7 +39,7 @@ public final class AdHocSubProcessActivityActivationRecord extends UnifiedRecord
     return BufferUtil.bufferAsString(adHocSubProcessInstanceKey.getValue());
   }
 
-  public AdHocSubProcessActivityActivationRecord setAdHocSubProcessInstanceKey(
+  public AdHocSubProcessInstructionRecord setAdHocSubProcessInstanceKey(
       final String adHocSubProcessInstanceKey) {
     this.adHocSubProcessInstanceKey.setValue(adHocSubProcessInstanceKey);
     return this;
@@ -68,7 +68,7 @@ public final class AdHocSubProcessActivityActivationRecord extends UnifiedRecord
     return BufferUtil.bufferAsString(tenantId.getValue());
   }
 
-  public AdHocSubProcessActivityActivationRecord setTenantId(final String tenantId) {
+  public AdHocSubProcessInstructionRecord setTenantId(final String tenantId) {
     this.tenantId.setValue(tenantId);
     return this;
   }

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -2309,7 +2309,7 @@ final class JsonSerializableToJsonTest {
                       .setAdHocSubProcessInstanceKey("1234")
                       .setTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
 
-              adHocSubProcessInstructionRecord.elements().add().setElementId("123");
+              adHocSubProcessInstructionRecord.activateElements().add().setElementId("123");
 
               return adHocSubProcessInstructionRecord;
             },
@@ -2317,7 +2317,7 @@ final class JsonSerializableToJsonTest {
         {
           "adHocSubProcessInstanceKey": "1234",
           "tenantId": "<default>",
-          "elements": [
+          "activateElements": [
             {
               "elementId": "123"
             }
@@ -2336,7 +2336,7 @@ final class JsonSerializableToJsonTest {
         {
           "adHocSubProcessInstanceKey": "",
           "tenantId": "<default>",
-          "elements": []
+          "activateElements": []
         }
         """
       },

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -18,7 +18,7 @@ import io.camunda.zeebe.protocol.impl.record.CopiedRecord;
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.impl.record.VersionInfo;
-import io.camunda.zeebe.protocol.impl.record.value.adhocsubprocess.AdHocSubProcessActivityActivationRecord;
+import io.camunda.zeebe.protocol.impl.record.value.adhocsubprocess.AdHocSubProcessInstructionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.AuthorizationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.IdentitySetupRecord;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.MappingRuleRecord;
@@ -2298,20 +2298,20 @@ final class JsonSerializableToJsonTest {
       },
 
       /////////////////////////////////////////////////////////////////////////////////////////////
-      ////////////////////////// AdHocSubProcessActivityActivationRecord //////////////////////////
+      ////////////////////////// AdHocSubProcessInstructionRecord //////////////////////////
       /////////////////////////////////////////////////////////////////////////////////////////////
       {
-        "AdHocSubProcessActivityActivationRecord",
+        "AdHocSubProcessInstructionRecord",
         (Supplier<UnifiedRecordValue>)
             () -> {
-              final var adHocSubProcessActivityActivationRecord =
-                  new AdHocSubProcessActivityActivationRecord()
+              final var adHocSubProcessInstructionRecord =
+                  new AdHocSubProcessInstructionRecord()
                       .setAdHocSubProcessInstanceKey("1234")
                       .setTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
 
-              adHocSubProcessActivityActivationRecord.elements().add().setElementId("123");
+              adHocSubProcessInstructionRecord.elements().add().setElementId("123");
 
-              return adHocSubProcessActivityActivationRecord;
+              return adHocSubProcessInstructionRecord;
             },
         """
         {
@@ -2327,11 +2327,11 @@ final class JsonSerializableToJsonTest {
       },
 
       /////////////////////////////////////////////////////////////////////////////////////////////
-      /////////////////////// Empty AdHocSubProcessActivityActivationRecord ///////////////////////
+      /////////////////////// Empty AdHocSubProcessInstructionRecord ///////////////////////
       /////////////////////////////////////////////////////////////////////////////////////////////
       {
-        "Empty AdHocSubProcessActivityActivationRecord",
-        (Supplier<UnifiedRecordValue>) AdHocSubProcessActivityActivationRecord::new,
+        "Empty AdHocSubProcessInstructionRecord",
+        (Supplier<UnifiedRecordValue>) AdHocSubProcessInstructionRecord::new,
         """
         {
           "adHocSubProcessInstanceKey": "",

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/ValueTypeMapping.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/ValueTypeMapping.java
@@ -15,7 +15,7 @@
  */
 package io.camunda.zeebe.protocol.record;
 
-import io.camunda.zeebe.protocol.record.intent.AdHocSubProcessActivityActivationIntent;
+import io.camunda.zeebe.protocol.record.intent.AdHocSubProcessInstructionIntent;
 import io.camunda.zeebe.protocol.record.intent.AsyncRequestIntent;
 import io.camunda.zeebe.protocol.record.intent.AuthorizationIntent;
 import io.camunda.zeebe.protocol.record.intent.BatchOperationChunkIntent;
@@ -68,7 +68,7 @@ import io.camunda.zeebe.protocol.record.intent.VariableDocumentIntent;
 import io.camunda.zeebe.protocol.record.intent.VariableIntent;
 import io.camunda.zeebe.protocol.record.intent.management.CheckpointIntent;
 import io.camunda.zeebe.protocol.record.intent.scaling.ScaleIntent;
-import io.camunda.zeebe.protocol.record.value.AdHocSubProcessActivityActivationRecordValue;
+import io.camunda.zeebe.protocol.record.value.AdHocSubProcessInstructionRecordValue;
 import io.camunda.zeebe.protocol.record.value.AsyncRequestRecordValue;
 import io.camunda.zeebe.protocol.record.value.AuthorizationRecordValue;
 import io.camunda.zeebe.protocol.record.value.BatchOperationChunkRecordValue;
@@ -253,8 +253,7 @@ public final class ValueTypeMapping {
     mapping.put(
         ValueType.AD_HOC_SUB_PROCESS_ACTIVITY_ACTIVATION,
         new Mapping<>(
-            AdHocSubProcessActivityActivationRecordValue.class,
-            AdHocSubProcessActivityActivationIntent.class));
+            AdHocSubProcessInstructionRecordValue.class, AdHocSubProcessInstructionIntent.class));
     mapping.put(ValueType.FORM, new Mapping<>(Form.class, FormIntent.class));
     mapping.put(ValueType.RESOURCE, new Mapping<>(Resource.class, ResourceIntent.class));
     mapping.put(

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/ValueTypeMapping.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/ValueTypeMapping.java
@@ -251,7 +251,7 @@ public final class ValueTypeMapping {
         ValueType.PROCESS_INSTANCE_BATCH,
         new Mapping<>(ProcessInstanceBatchRecordValue.class, ProcessInstanceBatchIntent.class));
     mapping.put(
-        ValueType.AD_HOC_SUB_PROCESS_ACTIVITY_ACTIVATION,
+        ValueType.AD_HOC_SUB_PROCESS_INSTRUCTION,
         new Mapping<>(
             AdHocSubProcessInstructionRecordValue.class, AdHocSubProcessInstructionIntent.class));
     mapping.put(ValueType.FORM, new Mapping<>(Form.class, FormIntent.class));

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/AdHocSubProcessInstructionIntent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/AdHocSubProcessInstructionIntent.java
@@ -15,13 +15,13 @@
  */
 package io.camunda.zeebe.protocol.record.intent;
 
-public enum AdHocSubProcessActivityActivationIntent implements Intent {
+public enum AdHocSubProcessInstructionIntent implements Intent {
   ACTIVATE(0),
   ACTIVATED(1);
 
   private final short value;
 
-  AdHocSubProcessActivityActivationIntent(final int value) {
+  AdHocSubProcessInstructionIntent(final int value) {
     this.value = (short) value;
   }
 

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/Intent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/Intent.java
@@ -72,7 +72,7 @@ public interface Intent {
           BatchOperationIntent.class,
           BatchOperationChunkIntent.class,
           BatchOperationExecutionIntent.class,
-          AdHocSubProcessActivityActivationIntent.class,
+          AdHocSubProcessInstructionIntent.class,
           AsyncRequestIntent.class,
           UsageMetricIntent.class,
           MultiInstanceIntent.class);
@@ -152,7 +152,7 @@ public interface Intent {
       case PROCESS_INSTANCE_BATCH:
         return ProcessInstanceBatchIntent.from(intent);
       case AD_HOC_SUB_PROCESS_ACTIVITY_ACTIVATION:
-        return AdHocSubProcessActivityActivationIntent.from(intent);
+        return AdHocSubProcessInstructionIntent.from(intent);
       case FORM:
         return FormIntent.from(intent);
       case RESOURCE:
@@ -251,7 +251,7 @@ public interface Intent {
       case PROCESS_EVENT:
         return ProcessEventIntent.valueOf(intent);
       case AD_HOC_SUB_PROCESS_ACTIVITY_ACTIVATION:
-        return AdHocSubProcessActivityActivationIntent.valueOf(intent);
+        return AdHocSubProcessInstructionIntent.valueOf(intent);
       case DECISION:
         return DecisionIntent.valueOf(intent);
       case DECISION_REQUIREMENTS:

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/Intent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/Intent.java
@@ -151,7 +151,7 @@ public interface Intent {
         return CommandDistributionIntent.from(intent);
       case PROCESS_INSTANCE_BATCH:
         return ProcessInstanceBatchIntent.from(intent);
-      case AD_HOC_SUB_PROCESS_ACTIVITY_ACTIVATION:
+      case AD_HOC_SUB_PROCESS_INSTRUCTION:
         return AdHocSubProcessInstructionIntent.from(intent);
       case FORM:
         return FormIntent.from(intent);
@@ -250,7 +250,7 @@ public interface Intent {
         return DeploymentDistributionIntent.valueOf(intent);
       case PROCESS_EVENT:
         return ProcessEventIntent.valueOf(intent);
-      case AD_HOC_SUB_PROCESS_ACTIVITY_ACTIVATION:
+      case AD_HOC_SUB_PROCESS_INSTRUCTION:
         return AdHocSubProcessInstructionIntent.valueOf(intent);
       case DECISION:
         return DecisionIntent.valueOf(intent);

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AdHocSubProcessInstructionRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AdHocSubProcessInstructionRecordValue.java
@@ -17,21 +17,21 @@ package io.camunda.zeebe.protocol.record.value;
 
 import io.camunda.zeebe.protocol.record.ImmutableProtocol;
 import io.camunda.zeebe.protocol.record.RecordValue;
+import io.camunda.zeebe.protocol.record.intent.AdHocSubProcessInstructionIntent;
 import java.util.List;
 import org.immutables.value.Value;
 
 /**
- * Represents a command to activate activities in a given ad-hoc sub-process.
+ * Represents a command to modify a given ad-hoc sub-process.
  *
- * <p>See {@link io.camunda.zeebe.protocol.record.intent.AdHocSubProcessActivityActivationIntent}
- * for intents.
+ * <p>See {@link AdHocSubProcessInstructionIntent} for intents.
  */
 @Value.Immutable
-@ImmutableProtocol(builder = ImmutableAdHocSubProcessActivityActivationRecordValue.Builder.class)
-public interface AdHocSubProcessActivityActivationRecordValue extends RecordValue, TenantOwned {
+@ImmutableProtocol(builder = ImmutableAdHocSubProcessInstructionRecordValue.Builder.class)
+public interface AdHocSubProcessInstructionRecordValue extends RecordValue, TenantOwned {
 
   /**
-   * @return the instance key of the ad-hoc sub-process that will have its activities activated.
+   * @return the instance key of the ad-hoc sub-process to modify.
    */
   String getAdHocSubProcessInstanceKey();
 

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AdHocSubProcessInstructionRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AdHocSubProcessInstructionRecordValue.java
@@ -36,13 +36,14 @@ public interface AdHocSubProcessInstructionRecordValue extends RecordValue, Tena
   String getAdHocSubProcessInstanceKey();
 
   /**
-   * @return the list of flow node ids of the activities that need to be activated.
+   * @return the list of elements that should be activated.
    */
-  List<AdHocSubProcessActivityActivationElementValue> getElements();
+  List<AdHocSubProcessActivateElementInstructionValue> getActivateElements();
 
   @Value.Immutable
-  @ImmutableProtocol(builder = ImmutableAdHocSubProcessActivityActivationElementValue.Builder.class)
-  interface AdHocSubProcessActivityActivationElementValue {
+  @ImmutableProtocol(
+      builder = ImmutableAdHocSubProcessActivateElementInstructionValue.Builder.class)
+  interface AdHocSubProcessActivateElementInstructionValue {
     String getElementId();
   }
 }

--- a/zeebe/protocol/src/main/resources/protocol.xml
+++ b/zeebe/protocol/src/main/resources/protocol.xml
@@ -68,7 +68,7 @@
       <validValue name="BATCH_OPERATION_CREATION">50</validValue>
       <validValue name="BATCH_OPERATION_EXECUTION">51</validValue>
       <validValue name="BATCH_OPERATION_CHUNK">52</validValue>
-      <validValue name="AD_HOC_SUB_PROCESS_ACTIVITY_ACTIVATION">53</validValue>
+      <validValue name="AD_HOC_SUB_PROCESS_INSTRUCTION">53</validValue>
       <validValue name="BATCH_OPERATION_LIFECYCLE_MANAGEMENT">54</validValue>
       <validValue name="BATCH_OPERATION_PARTITION_LIFECYCLE">55</validValue>
       <validValue name="ASYNC_REQUEST">56</validValue>

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/TypedEventRegistry.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/TypedEventRegistry.java
@@ -9,7 +9,7 @@ package io.camunda.zeebe.stream.impl;
 
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.impl.record.value.AsyncRequestRecord;
-import io.camunda.zeebe.protocol.impl.record.value.adhocsubprocess.AdHocSubProcessActivityActivationRecord;
+import io.camunda.zeebe.protocol.impl.record.value.adhocsubprocess.AdHocSubProcessInstructionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.AuthorizationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.IdentitySetupRecord;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.MappingRuleRecord;
@@ -103,8 +103,7 @@ public final class TypedEventRegistry {
     registry.put(ValueType.DECISION_EVALUATION, DecisionEvaluationRecord.class);
     registry.put(ValueType.RESOURCE_DELETION, ResourceDeletionRecord.class);
     registry.put(
-        ValueType.AD_HOC_SUB_PROCESS_ACTIVITY_ACTIVATION,
-        AdHocSubProcessActivityActivationRecord.class);
+        ValueType.AD_HOC_SUB_PROCESS_ACTIVITY_ACTIVATION, AdHocSubProcessInstructionRecord.class);
     registry.put(ValueType.COMMAND_DISTRIBUTION, CommandDistributionRecord.class);
 
     registry.put(ValueType.CHECKPOINT, CheckpointRecord.class);

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/TypedEventRegistry.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/TypedEventRegistry.java
@@ -102,8 +102,7 @@ public final class TypedEventRegistry {
     registry.put(ValueType.DECISION_REQUIREMENTS, DecisionRequirementsRecord.class);
     registry.put(ValueType.DECISION_EVALUATION, DecisionEvaluationRecord.class);
     registry.put(ValueType.RESOURCE_DELETION, ResourceDeletionRecord.class);
-    registry.put(
-        ValueType.AD_HOC_SUB_PROCESS_ACTIVITY_ACTIVATION, AdHocSubProcessInstructionRecord.class);
+    registry.put(ValueType.AD_HOC_SUB_PROCESS_INSTRUCTION, AdHocSubProcessInstructionRecord.class);
     registry.put(ValueType.COMMAND_DISTRIBUTION, CommandDistributionRecord.class);
 
     registry.put(ValueType.CHECKPOINT, CheckpointRecord.class);

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/AdHocSubProcessActivityActivationRecordStream.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/AdHocSubProcessActivityActivationRecordStream.java
@@ -9,22 +9,21 @@ package io.camunda.zeebe.test.util.record;
 
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
-import io.camunda.zeebe.protocol.record.value.AdHocSubProcessActivityActivationRecordValue;
+import io.camunda.zeebe.protocol.record.value.AdHocSubProcessInstructionRecordValue;
 import java.util.stream.Stream;
 
 public class AdHocSubProcessActivityActivationRecordStream
     extends ExporterRecordStream<
-        AdHocSubProcessActivityActivationRecordValue,
-        AdHocSubProcessActivityActivationRecordStream> {
+        AdHocSubProcessInstructionRecordValue, AdHocSubProcessActivityActivationRecordStream> {
 
   public AdHocSubProcessActivityActivationRecordStream(
-      final Stream<Record<AdHocSubProcessActivityActivationRecordValue>> wrappedStream) {
+      final Stream<Record<AdHocSubProcessInstructionRecordValue>> wrappedStream) {
     super(wrappedStream);
   }
 
   @Override
   protected AdHocSubProcessActivityActivationRecordStream supply(
-      final Stream<Record<AdHocSubProcessActivityActivationRecordValue>> wrappedStream) {
+      final Stream<Record<AdHocSubProcessInstructionRecordValue>> wrappedStream) {
     return new AdHocSubProcessActivityActivationRecordStream(wrappedStream);
   }
 

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/AdHocSubProcessInstructionRecordStream.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/AdHocSubProcessInstructionRecordStream.java
@@ -12,28 +12,28 @@ import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.AdHocSubProcessInstructionRecordValue;
 import java.util.stream.Stream;
 
-public class AdHocSubProcessActivityActivationRecordStream
+public class AdHocSubProcessInstructionRecordStream
     extends ExporterRecordStream<
-        AdHocSubProcessInstructionRecordValue, AdHocSubProcessActivityActivationRecordStream> {
+        AdHocSubProcessInstructionRecordValue, AdHocSubProcessInstructionRecordStream> {
 
-  public AdHocSubProcessActivityActivationRecordStream(
+  public AdHocSubProcessInstructionRecordStream(
       final Stream<Record<AdHocSubProcessInstructionRecordValue>> wrappedStream) {
     super(wrappedStream);
   }
 
   @Override
-  protected AdHocSubProcessActivityActivationRecordStream supply(
+  protected AdHocSubProcessInstructionRecordStream supply(
       final Stream<Record<AdHocSubProcessInstructionRecordValue>> wrappedStream) {
-    return new AdHocSubProcessActivityActivationRecordStream(wrappedStream);
+    return new AdHocSubProcessInstructionRecordStream(wrappedStream);
   }
 
-  public AdHocSubProcessActivityActivationRecordStream withAdHocSubProcessInstanceKey(
+  public AdHocSubProcessInstructionRecordStream withAdHocSubProcessInstanceKey(
       final String adHocSubProcessInstanceKey) {
     return valueFilter(
         record -> record.getAdHocSubProcessInstanceKey().equals(adHocSubProcessInstanceKey));
   }
 
-  public AdHocSubProcessActivityActivationRecordStream limitToAdHocSubProcessInstanceCompleted() {
+  public AdHocSubProcessInstructionRecordStream limitToAdHocSubProcessInstanceCompleted() {
     return limit(
         r ->
             r.getIntent() == ProcessInstanceIntent.ELEMENT_COMPLETED

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
@@ -784,7 +784,7 @@ public class CompactRecordLogger {
 
     final var builder = new StringBuilder();
     builder
-        .append(String.format("ACTIVATE elements %s", value.getElements()))
+        .append(String.format("ACTIVATE elements %s", value.getActivateElements()))
         .append(
             String.format(
                 " in ad-hoc sub-process [%s]",

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
@@ -98,11 +98,11 @@ public class CompactRecordLogger {
           entry("COMPLETION_DENIED", "COMP_DENIED"),
           entry("UPDATE_DENIED", "UPDT_DENIED"),
           entry("SEQUENCE_FLOW_TAKEN", "SQ_FLW_TKN"),
+          entry("AD_HOC_SUB_PROCESS_INSTRUCTION", "AHSP_INST"),
           entry("PROCESS_INSTANCE_CREATION", "CREA"),
           entry("PROCESS_INSTANCE_MODIFICATION", "MOD"),
           entry("PROCESS_INSTANCE", "PI"),
           entry("PROCESS", "PROC"),
-          entry("AD_HOC_SUB_PROC_ACTIVITY_ACTIVATION", "AH_ACT"),
           entry("TIMER", "TIME"),
           entry("MESSAGE", "MSG"),
           entry("SUBSCRIPTION", "SUB"),
@@ -164,8 +164,7 @@ public class CompactRecordLogger {
     valueLoggers.put(
         ValueType.PROCESS_MESSAGE_SUBSCRIPTION, this::summarizeProcessInstanceSubscription);
     valueLoggers.put(
-        ValueType.AD_HOC_SUB_PROCESS_ACTIVITY_ACTIVATION,
-        this::summarizeAdHocSubProcessInstruction);
+        ValueType.AD_HOC_SUB_PROCESS_INSTRUCTION, this::summarizeAdHocSubProcessInstruction);
     valueLoggers.put(ValueType.VARIABLE, this::summarizeVariable);
     valueLoggers.put(ValueType.TIMER, this::summarizeTimer);
     valueLoggers.put(ValueType.ERROR, this::summarizeError);

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
@@ -24,7 +24,7 @@ import io.camunda.zeebe.protocol.record.intent.ClockIntent;
 import io.camunda.zeebe.protocol.record.intent.CommandDistributionIntent;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.protocol.record.intent.Intent;
-import io.camunda.zeebe.protocol.record.value.AdHocSubProcessActivityActivationRecordValue;
+import io.camunda.zeebe.protocol.record.value.AdHocSubProcessInstructionRecordValue;
 import io.camunda.zeebe.protocol.record.value.AsyncRequestRecordValue;
 import io.camunda.zeebe.protocol.record.value.ClockRecordValue;
 import io.camunda.zeebe.protocol.record.value.CommandDistributionRecordValue;
@@ -165,7 +165,7 @@ public class CompactRecordLogger {
         ValueType.PROCESS_MESSAGE_SUBSCRIPTION, this::summarizeProcessInstanceSubscription);
     valueLoggers.put(
         ValueType.AD_HOC_SUB_PROCESS_ACTIVITY_ACTIVATION,
-        this::summarizeAdHocSubProcessActivityActivation);
+        this::summarizeAdHocSubProcessInstruction);
     valueLoggers.put(ValueType.VARIABLE, this::summarizeVariable);
     valueLoggers.put(ValueType.TIMER, this::summarizeTimer);
     valueLoggers.put(ValueType.ERROR, this::summarizeError);
@@ -779,8 +779,8 @@ public class CompactRecordLogger {
     return result.toString();
   }
 
-  private String summarizeAdHocSubProcessActivityActivation(final Record<?> record) {
-    final var value = (AdHocSubProcessActivityActivationRecordValue) record.getValue();
+  private String summarizeAdHocSubProcessInstruction(final Record<?> record) {
+    final var value = (AdHocSubProcessInstructionRecordValue) record.getValue();
 
     final var builder = new StringBuilder();
     builder

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordingExporter.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordingExporter.java
@@ -462,9 +462,8 @@ public final class RecordingExporter implements Exporter {
     return resourceDeletionRecords().withIntent(intent);
   }
 
-  public static AdHocSubProcessActivityActivationRecordStream
-      adHocSubProcessActivityActivationRecords() {
-    return new AdHocSubProcessActivityActivationRecordStream(
+  public static AdHocSubProcessInstructionRecordStream adHocSubProcessInstructionRecords() {
+    return new AdHocSubProcessInstructionRecordStream(
         records(
             ValueType.AD_HOC_SUB_PROCESS_INSTRUCTION, AdHocSubProcessInstructionRecordValue.class));
   }

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordingExporter.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordingExporter.java
@@ -466,8 +466,7 @@ public final class RecordingExporter implements Exporter {
       adHocSubProcessActivityActivationRecords() {
     return new AdHocSubProcessActivityActivationRecordStream(
         records(
-            ValueType.AD_HOC_SUB_PROCESS_ACTIVITY_ACTIVATION,
-            AdHocSubProcessInstructionRecordValue.class));
+            ValueType.AD_HOC_SUB_PROCESS_INSTRUCTION, AdHocSubProcessInstructionRecordValue.class));
   }
 
   public static FormRecordStream formRecords() {

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordingExporter.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordingExporter.java
@@ -49,7 +49,7 @@ import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
 import io.camunda.zeebe.protocol.record.intent.VariableDocumentIntent;
 import io.camunda.zeebe.protocol.record.intent.VariableIntent;
 import io.camunda.zeebe.protocol.record.intent.scaling.ScaleIntent;
-import io.camunda.zeebe.protocol.record.value.AdHocSubProcessActivityActivationRecordValue;
+import io.camunda.zeebe.protocol.record.value.AdHocSubProcessInstructionRecordValue;
 import io.camunda.zeebe.protocol.record.value.AsyncRequestRecordValue;
 import io.camunda.zeebe.protocol.record.value.AuthorizationRecordValue;
 import io.camunda.zeebe.protocol.record.value.BatchOperationChunkRecordValue;
@@ -467,7 +467,7 @@ public final class RecordingExporter implements Exporter {
     return new AdHocSubProcessActivityActivationRecordStream(
         records(
             ValueType.AD_HOC_SUB_PROCESS_ACTIVITY_ACTIVATION,
-            AdHocSubProcessActivityActivationRecordValue.class));
+            AdHocSubProcessInstructionRecordValue.class));
   }
 
   public static FormRecordStream formRecords() {


### PR DESCRIPTION
## Description

- Renames `AdHocSubProcessActivityActivationRecord` to `AdHocSubProcessInstructionRecord` as it will handle more than just activity activation
- Renames the `elements` field to `activateElements` to indicate what the referenced elements refer to
- Renames `AdHocSubProcessActivityActivateProcessor` to `AdHocSubProcessInstructionActivateProcessor`
- Adapts indexes and other usages of record to new naming

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes https://github.com/camunda/ad-hoc-sub-process-phase-3/issues/8
