### PR TITLE
refactor: migrate groups tests to OC

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityAuthorizationsPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityAuthorizationsPage.ts
@@ -26,6 +26,7 @@ export class IdentityAuthorizationsPage {
   readonly deleteAuthorizationModal: Locator;
   readonly deleteAuthorizationSubButton: Locator;
   readonly selectAuthorizationRow: (name: string) => Locator;
+  readonly authorizationRowByOwnerId: (ownerId: string) => Locator;
   readonly selectResourceTypeTab: (resourceType: string) => Promise<void>;
   readonly resourceTypeComboBox: Locator;
   readonly getAuthorizationCell: (ownerId: string) => Locator;
@@ -38,6 +39,9 @@ export class IdentityAuthorizationsPage {
 
     this.selectAuthorizationRow = (name) =>
       this.authorizationsList.getByRole('row', {name: name});
+
+    this.authorizationRowByOwnerId = (ownerId) =>
+      this.authorizationsList.getByRole('row').filter({hasText: ownerId});
 
     this.createAuthorizationButton = page.getByRole('button', {
       name: 'Create authorization',
@@ -147,12 +151,6 @@ export class IdentityAuthorizationsPage {
     await expect(this.createAuthorizationModal).toBeHidden();
   }
 
-  async assertAuthorizationExists(values: string[]) {
-    for (let index = 0; index < values.length; index++) {
-      await this.selectAuthorizationRow(values[index]).isVisible();
-    }
-  }
-
   async clickDeleteAuthorizationButton(name: string) {
     await this.deleteAuthorizationButton(name).click();
   }
@@ -204,5 +202,21 @@ export class IdentityAuthorizationsPage {
   async selectAuthorizationOwner(authorization: {ownerId: string}) {
     await this.createAuthorizationOwnerComboBox.click();
     await this.createAuthorizationOwnerOption(authorization.ownerId).click();
+  }
+
+  async assertAuthorizationExists(
+    ownerId: string,
+    ownerType: string,
+    accessPermissions?: string[],
+  ) {
+    const authorizationRow = this.authorizationRowByOwnerId(ownerId);
+    await expect(authorizationRow).toBeVisible();
+    await expect(authorizationRow).toContainText(ownerType.toUpperCase());
+
+    if (accessPermissions) {
+      for (const permission of accessPermissions) {
+        await expect(authorizationRow).toContainText(permission.toUpperCase());
+      }
+    }
   }
 }

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityGroupsPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityGroupsPage.ts
@@ -39,6 +39,7 @@ export class IdentityGroupsPage {
   readonly searchBoxResult: Locator;
   readonly assignUserButtonModal: Locator;
   readonly selectGroupRow: (name: string) => Locator;
+  readonly groupCell: (name: string) => Locator;
 
   constructor(page: Page) {
     this.page = page;
@@ -46,6 +47,9 @@ export class IdentityGroupsPage {
 
     this.selectGroupRow = (name) =>
       this.groupsList.getByRole('row', {name: name});
+
+    this.groupCell = (name) =>
+      this.groupsList.getByRole('cell', {name, exact: true});
 
     this.createGroupButton = page.getByRole('button', {
       name: /Create( a)? group/,
@@ -142,7 +146,29 @@ export class IdentityGroupsPage {
       await this.createDescriptionField.fill(description);
     }
     await this.createGroupModalCreateButton.click();
-    await sleep(8000);
+    await expect(this.createGroupModal).toBeHidden();
+  }
+
+  async editGroup(
+    currentName: string,
+    newName: string,
+    newDescription?: string,
+  ) {
+    await this.editGroupButton(currentName).click();
+    await expect(this.editGroupModal).toBeVisible();
+    await this.editNameField.fill(newName);
+    if (newDescription) {
+      await this.editDescriptionField.fill(newDescription);
+    }
+    await this.editGroupModalUpdateButton.click();
+    await expect(this.editGroupModal).toBeHidden();
+  }
+
+  async deleteGroup(groupName: string) {
+    await this.deleteGroupButton(groupName).click();
+    await expect(this.deleteGroupModal).toBeVisible();
+    await this.deleteGroupModalDeleteButton.click();
+    await expect(this.deleteGroupModal).toBeHidden();
   }
 
   async assertGroupExists(groupName: string) {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/groups.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/groups.spec.ts
@@ -8,10 +8,88 @@
 
 import {expect} from '@playwright/test';
 import {test} from 'fixtures';
+import {relativizePath, Paths} from 'utils/relativizePath';
 import {navigateToApp} from '@pages/UtilitiesPage';
 import {captureScreenshot, captureFailureVideo} from '@setup';
+import {LOGIN_CREDENTIALS, createTestData} from 'utils/constants';
+import {waitForItemInList} from 'utils/waitForItemInList';
 
-test.describe('Groups page', () => {
+test.describe.serial('groups CRUD', () => {
+  let NEW_GROUP: NonNullable<ReturnType<typeof createTestData>['group']>;
+  let EDITED_GROUP: NonNullable<
+    ReturnType<typeof createTestData>['editedGroup']
+  >;
+
+  test.beforeAll(() => {
+    const testData = createTestData({
+      group: true,
+      editedGroup: true,
+    });
+    NEW_GROUP = testData.group!;
+    EDITED_GROUP = testData.editedGroup!;
+  });
+
+  test.beforeEach(async ({page, loginPage, identityGroupsPage}) => {
+    await navigateToApp(page, 'identity');
+    await loginPage.login(
+      LOGIN_CREDENTIALS.username,
+      LOGIN_CREDENTIALS.password,
+    );
+    await expect(page).toHaveURL(relativizePath(Paths.users()));
+    await identityGroupsPage.navigateToGroups();
+    await expect(page).toHaveURL(relativizePath(Paths.groups()));
+  });
+
+  test.afterEach(async ({page}, testInfo) => {
+    await captureScreenshot(page, testInfo);
+    await captureFailureVideo(page, testInfo);
+  });
+
+  test('creates a group', async ({page, identityGroupsPage}) => {
+    await identityGroupsPage.createGroup(
+      NEW_GROUP.groupId,
+      NEW_GROUP.name,
+      NEW_GROUP.description,
+    );
+
+    const item = identityGroupsPage.groupCell(NEW_GROUP.name);
+
+    await waitForItemInList(page, item, {
+      emptyStateLocator: identityGroupsPage.emptyState,
+    });
+
+    await expect(item).toBeVisible();
+  });
+
+  test('edits a group', async ({page, identityGroupsPage}) => {
+    await expect(identityGroupsPage.groupCell(NEW_GROUP.name)).toBeVisible();
+
+    await identityGroupsPage.editGroup(
+      NEW_GROUP.name,
+      EDITED_GROUP.name,
+      EDITED_GROUP.description,
+    );
+
+    const item = identityGroupsPage.groupCell(EDITED_GROUP.name);
+
+    await waitForItemInList(page, item);
+  });
+
+  test('deletes a group', async ({page, identityGroupsPage}) => {
+    await expect(identityGroupsPage.groupCell(EDITED_GROUP.name)).toBeVisible();
+
+    await identityGroupsPage.deleteGroup(EDITED_GROUP.name);
+
+    const item = identityGroupsPage.groupCell(EDITED_GROUP.name);
+
+    await waitForItemInList(page, item, {
+      shouldBeVisible: false,
+      emptyStateLocator: identityGroupsPage.emptyState,
+    });
+  });
+});
+
+test.describe('Groups functionalities', () => {
   test.beforeEach(async ({page, loginPage, identityGroupsPage}) => {
     await navigateToApp(page, 'identity');
     await loginPage.login('demo', 'demo');
@@ -28,37 +106,50 @@ test.describe('Groups page', () => {
     identityGroupsPage,
     identityAuthorizationsPage,
   }) => {
-    await identityGroupsPage.navigateToGroups();
-    await identityGroupsPage.createGroup(
-      'testGroup',
-      'testGroup',
-      'This is a test group',
-    );
-    await page.reload();
-    await identityGroupsPage.assertGroupExists('testGroup');
-    await identityGroupsPage.clickGroupId('testGroup');
-    await identityGroupsPage.assignUserToGroup('lisa', 'lisa@example.com');
-    await page.reload();
-    await identityAuthorizationsPage.navigateToAuthorizations();
-    await identityAuthorizationsPage.clickResourceType('Authorization');
-    await identityAuthorizationsPage.clickCreateAuthorizationButton();
-    await identityAuthorizationsPage.clickOwnerTypeDropdown();
-    await identityAuthorizationsPage.selectOwnerTypeFromDrowdown('Group');
-    await identityAuthorizationsPage.clickOwnerDropdown();
-    await identityAuthorizationsPage.selectOwnerFromDropdown('testGroup');
-    await identityAuthorizationsPage.fillResourceId('*');
-    await identityAuthorizationsPage.checkAccessPermissions([
-      'Update',
-      'Read',
-      'Create',
-      'Delete',
-    ]);
-    await identityAuthorizationsPage.clickCreateAuthorizationSubmitButton();
-    await page.reload();
-    await identityAuthorizationsPage.clickResourceType('Authorization');
-    await identityAuthorizationsPage.assertAuthorizationExists([
-      'Group',
-      'testGroup',
-    ]);
+    const testData = createTestData({
+      group: true,
+    });
+    const TEST_GROUP = testData.group!;
+
+    await test.step('Create test group', async () => {
+      await identityGroupsPage.navigateToGroups();
+      await identityGroupsPage.createGroup(
+        TEST_GROUP.groupId,
+        TEST_GROUP.name,
+        TEST_GROUP.description,
+      );
+
+      const item = identityGroupsPage.groupCell(TEST_GROUP.name);
+      await waitForItemInList(page, item, {
+        emptyStateLocator: identityGroupsPage.emptyState,
+      });
+      await expect(item).toBeVisible();
+    });
+
+    await test.step('Assign user to group', async () => {
+      await identityGroupsPage.clickGroupId(TEST_GROUP.name);
+      await identityGroupsPage.assignUserToGroup('lisa', 'lisa@example.com');
+      await page.reload();
+    });
+
+    await test.step('Create authorization for group', async () => {
+      await identityAuthorizationsPage.navigateToAuthorizations();
+      await identityAuthorizationsPage.createAuthorization({
+        ownerType: 'Group',
+        ownerId: TEST_GROUP.name,
+        resourceType: 'Authorization',
+        resourceId: '*',
+        accessPermissions: ['Update', 'Read', 'Create', 'Delete'],
+      });
+    });
+
+    await test.step('Verify authorization was created', async () => {
+      await identityAuthorizationsPage.clickResourceType('Authorization');
+      await identityAuthorizationsPage.assertAuthorizationExists(
+        TEST_GROUP.groupId,
+        'Group',
+        ['Update', 'Read', 'Create', 'Delete'],
+      );
+    });
   });
 });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/constants.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/constants.ts
@@ -33,6 +33,25 @@ export const createUniqueAuthRole = (customId?: string) => {
   };
 };
 
+// Create unique group with optional custom ID
+export const createUniqueGroup = (customId?: string) => {
+  const id = customId || generateUniqueId();
+  return {
+    groupId: `testgroup${id}`,
+    name: `Test Group ${id}`,
+    description: `Test group description ${id}`,
+  };
+};
+
+// Create unique edited group data with optional custom ID
+export const createEditedGroup = (customId?: string) => {
+  const id = customId || generateUniqueId();
+  return {
+    name: `Edited Group ${id}`,
+    description: `Edited group description ${id}`,
+  };
+};
+
 export const createUserAuthorization = (authRole: {name: string}) => ({
   ownerType: 'Role',
   ownerId: authRole.name,
@@ -55,12 +74,16 @@ export const createTestData = (options: {
   authRole?: boolean;
   userAuth?: boolean;
   applicationAuth?: boolean;
+  group?: boolean;
+  editedGroup?: boolean;
 }) => {
   const {
     user = false,
     authRole = false,
     userAuth = false,
     applicationAuth = false,
+    group = false,
+    editedGroup = false,
   } = options;
   const sharedId = generateUniqueId();
 
@@ -69,6 +92,8 @@ export const createTestData = (options: {
     authRole?: ReturnType<typeof createUniqueAuthRole>;
     userAuth?: ReturnType<typeof createUserAuthorization>;
     applicationAuth?: ReturnType<typeof createApplicationAuthorization>;
+    group?: ReturnType<typeof createUniqueGroup>;
+    editedGroup?: ReturnType<typeof createEditedGroup>;
     id: string;
   } = {id: sharedId};
 
@@ -78,6 +103,14 @@ export const createTestData = (options: {
 
   if (authRole) {
     result.authRole = createUniqueAuthRole(sharedId);
+  }
+
+  if (group) {
+    result.group = createUniqueGroup(sharedId);
+  }
+
+  if (editedGroup) {
+    result.editedGroup = createEditedGroup(sharedId);
   }
 
   // Create authorizations only if authRole is also created


### PR DESCRIPTION
## Description
Refactored `groups.spec.ts` to improve performance, reliability, and maintainability.

✅ **Key Changes**

* Moved CRUD tests from the **identity** test suite to the **OC cluster** test suite
* Optimized test execution with serial CRUD tests and parallel functional tests
* Enhanced page objects with new helpers: `groupCell()`, `editGroup()`, `deleteGroup()`
* Improved permission verification with updated `assertAuthorizationExists()` method
* Added unique test data generation to prevent conflicts and improve test isolation


🧪 **[Successful test run ](https://github.com/camunda/camunda/actions/runs/16519355595/job/46717492308)**, Failing tests due to below issues:
[Variable Editing Spinner issue](https://github.com/camunda/camunda/issues/34148)
[API 401 Issue](https://github.com/camunda/camunda/issues/35443)

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #35718 
