### PR TITLE
feat: Extend the Ad-hoc sub-process activate API to pass variables and cancelRemainingInstances

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/command/ActivateAdHocSubProcessActivitiesCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/ActivateAdHocSubProcessActivitiesCommandStep1.java
@@ -77,6 +77,15 @@ public interface ActivateAdHocSubProcessActivitiesCommandStep1 {
     return activateElements(Arrays.asList(elementIds));
   }
 
+  /**
+   * Set whether to cancel remaining instances of the ad-hoc sub-process.
+   *
+   * @param cancelRemainingInstances true to cancel remaining instances, false otherwise
+   * @return the builder for this command
+   */
+  ActivateAdHocSubProcessActivitiesCommandStep2 cancelRemainingInstances(
+      boolean cancelRemainingInstances);
+
   interface ActivateAdHocSubProcessActivitiesCommandStep2
       extends ActivateAdHocSubProcessActivitiesCommandStep1,
           FinalCommandStep<ActivateAdHocSubProcessActivitiesResponse> {}

--- a/clients/java/src/main/java/io/camunda/client/api/command/ActivateAdHocSubProcessActivitiesCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/ActivateAdHocSubProcessActivitiesCommandStep1.java
@@ -18,6 +18,7 @@ package io.camunda.client.api.command;
 import io.camunda.client.api.response.ActivateAdHocSubProcessActivitiesResponse;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Map;
 
 public interface ActivateAdHocSubProcessActivitiesCommandStep1 {
 
@@ -29,6 +30,17 @@ public interface ActivateAdHocSubProcessActivitiesCommandStep1 {
    * @return the builder for this command
    */
   ActivateAdHocSubProcessActivitiesCommandStep2 activateElement(final String elementId);
+
+  /**
+   * Create an {@link io.camunda.client.protocol.rest.AdHocSubProcessActivateActivitiesInstruction}
+   * for the given element id with variables.
+   *
+   * @param elementId the id of the element to activate
+   * @param variables variables to be set when activating the element
+   * @return the builder for this command
+   */
+  ActivateAdHocSubProcessActivitiesCommandStep2 activateElement(
+      final String elementId, final Map<String, Object> variables);
 
   /**
    * Create an {@link io.camunda.client.protocol.rest.AdHocSubProcessActivateActivitiesInstruction}

--- a/clients/java/src/main/java/io/camunda/client/api/command/ActivateAdHocSubProcessActivitiesCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/ActivateAdHocSubProcessActivitiesCommandStep1.java
@@ -88,5 +88,6 @@ public interface ActivateAdHocSubProcessActivitiesCommandStep1 {
 
   interface ActivateAdHocSubProcessActivitiesCommandStep2
       extends ActivateAdHocSubProcessActivitiesCommandStep1,
+          CommandWithVariables<ActivateAdHocSubProcessActivitiesCommandStep2>,
           FinalCommandStep<ActivateAdHocSubProcessActivitiesResponse> {}
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/command/ActivateAdHocSubProcessActivitiesCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/ActivateAdHocSubProcessActivitiesCommandImpl.java
@@ -31,6 +31,7 @@ import java.util.concurrent.TimeUnit;
 import org.apache.hc.client5.http.config.RequestConfig;
 
 public final class ActivateAdHocSubProcessActivitiesCommandImpl
+    extends CommandWithVariables<ActivateAdHocSubProcessActivitiesCommandStep2>
     implements ActivateAdHocSubProcessActivitiesCommandStep1,
         ActivateAdHocSubProcessActivitiesCommandStep2 {
 
@@ -39,12 +40,14 @@ public final class ActivateAdHocSubProcessActivitiesCommandImpl
   private final RequestConfig.Builder httpRequestConfig;
 
   private final String adHocSubProcessInstanceKey;
+  private AdHocSubProcessActivateActivityReference latestActivateElement;
   private final AdHocSubProcessActivateActivitiesInstruction httpRequestObject;
 
   public ActivateAdHocSubProcessActivitiesCommandImpl(
       final HttpClient httpClient,
       final JsonMapper jsonMapper,
       final String adHocSubProcessInstanceKey) {
+    super(jsonMapper);
     this.httpClient = httpClient;
     this.jsonMapper = jsonMapper;
     httpRequestConfig = httpClient.newRequestConfig();
@@ -55,22 +58,22 @@ public final class ActivateAdHocSubProcessActivitiesCommandImpl
 
   @Override
   public ActivateAdHocSubProcessActivitiesCommandStep2 activateElement(final String elementId) {
-    httpRequestObject.addElementsItem(
-        new AdHocSubProcessActivateActivityReference().elementId(elementId));
+    latestActivateElement = new AdHocSubProcessActivateActivityReference().elementId(elementId);
+    httpRequestObject.addElementsItem(latestActivateElement);
     return this;
   }
 
   @Override
   public ActivateAdHocSubProcessActivitiesCommandStep2 activateElement(
       final String elementId, final Map<String, Object> variables) {
-    httpRequestObject.addElementsItem(
-        new AdHocSubProcessActivateActivityReference().elementId(elementId).variables(variables));
+    activateElement(elementId);
+    latestActivateElement.setVariables(variables);
     return this;
   }
 
   @Override
   public ActivateAdHocSubProcessActivitiesCommandStep2 cancelRemainingInstances(
-      boolean cancelRemainingInstances) {
+      final boolean cancelRemainingInstances) {
     httpRequestObject.cancelRemainingInstances(cancelRemainingInstances);
     return this;
   }
@@ -92,5 +95,12 @@ public final class ActivateAdHocSubProcessActivitiesCommandImpl
         httpRequestConfig.build(),
         result);
     return result;
+  }
+
+  @Override
+  protected ActivateAdHocSubProcessActivitiesCommandStep2 setVariablesInternal(
+      final String variables) {
+    latestActivateElement.setVariables(jsonMapper.fromJsonAsMap(variables));
+    return this;
   }
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/command/ActivateAdHocSubProcessActivitiesCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/ActivateAdHocSubProcessActivitiesCommandImpl.java
@@ -26,6 +26,7 @@ import io.camunda.client.impl.http.HttpClient;
 import io.camunda.client.protocol.rest.AdHocSubProcessActivateActivitiesInstruction;
 import io.camunda.client.protocol.rest.AdHocSubProcessActivateActivityReference;
 import java.time.Duration;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import org.apache.hc.client5.http.config.RequestConfig;
 
@@ -56,6 +57,14 @@ public final class ActivateAdHocSubProcessActivitiesCommandImpl
   public ActivateAdHocSubProcessActivitiesCommandStep2 activateElement(final String elementId) {
     httpRequestObject.addElementsItem(
         new AdHocSubProcessActivateActivityReference().elementId(elementId));
+    return this;
+  }
+
+  @Override
+  public ActivateAdHocSubProcessActivitiesCommandStep2 activateElement(
+      final String elementId, final Map<String, Object> variables) {
+    httpRequestObject.addElementsItem(
+        new AdHocSubProcessActivateActivityReference().elementId(elementId).variables(variables));
     return this;
   }
 

--- a/clients/java/src/main/java/io/camunda/client/impl/command/ActivateAdHocSubProcessActivitiesCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/ActivateAdHocSubProcessActivitiesCommandImpl.java
@@ -69,6 +69,13 @@ public final class ActivateAdHocSubProcessActivitiesCommandImpl
   }
 
   @Override
+  public ActivateAdHocSubProcessActivitiesCommandStep2 cancelRemainingInstances(
+      boolean cancelRemainingInstances) {
+    httpRequestObject.cancelRemainingInstances(cancelRemainingInstances);
+    return this;
+  }
+
+  @Override
   public FinalCommandStep<ActivateAdHocSubProcessActivitiesResponse> requestTimeout(
       final Duration requestTimeout) {
     httpRequestConfig.setResponseTimeout(requestTimeout.toMillis(), TimeUnit.MILLISECONDS);

--- a/clients/java/src/test/java/io/camunda/client/adhocsubprocess/AdHocSubProcessActivityActivationTest.java
+++ b/clients/java/src/test/java/io/camunda/client/adhocsubprocess/AdHocSubProcessActivityActivationTest.java
@@ -141,6 +141,47 @@ public class AdHocSubProcessActivityActivationTest extends ClientRestTest {
     assertThat(elementB.getVariables()).isEmpty();
   }
 
+  @Test
+  void shouldSetCancelRemainingInstancesToTrue() {
+    client
+        .newActivateAdHocSubProcessActivitiesCommand(AD_HOC_SUBPROCESS_INSTANCE_KEY)
+        .activateElement("A")
+        .cancelRemainingInstances(true)
+        .send()
+        .join();
+
+    final AdHocSubProcessActivateActivitiesInstruction request =
+        gatewayService.getLastRequest(AdHocSubProcessActivateActivitiesInstruction.class);
+    assertThat(request.getCancelRemainingInstances()).isTrue();
+  }
+
+  @Test
+  void shouldSetCancelRemainingInstancesToFalse() {
+    client
+        .newActivateAdHocSubProcessActivitiesCommand(AD_HOC_SUBPROCESS_INSTANCE_KEY)
+        .activateElement("A")
+        .cancelRemainingInstances(false)
+        .send()
+        .join();
+
+    final AdHocSubProcessActivateActivitiesInstruction request =
+        gatewayService.getLastRequest(AdHocSubProcessActivateActivitiesInstruction.class);
+    assertThat(request.getCancelRemainingInstances()).isFalse();
+  }
+
+  @Test
+  void shouldDefaultCancelRemainingInstancesToFalse() {
+    client
+        .newActivateAdHocSubProcessActivitiesCommand(AD_HOC_SUBPROCESS_INSTANCE_KEY)
+        .activateElement("A")
+        .send()
+        .join();
+
+    final AdHocSubProcessActivateActivitiesInstruction request =
+        gatewayService.getLastRequest(AdHocSubProcessActivateActivitiesInstruction.class);
+    assertThat(request.getCancelRemainingInstances()).isFalse();
+  }
+
   static Stream<
           Function<
               ActivateAdHocSubProcessActivitiesCommandStep1,

--- a/service/src/main/java/io/camunda/service/AdHocSubProcessActivityServices.java
+++ b/service/src/main/java/io/camunda/service/AdHocSubProcessActivityServices.java
@@ -46,7 +46,8 @@ public class AdHocSubProcessActivityServices extends ApiServices<AdHocSubProcess
                 brokerRequest.addElement(
                     element.elementId(), getDocumentOrEmpty(element.variables())));
 
-    brokerRequest.cancelRemainingInstances(request.cancelRemainingInstances);
+    brokerRequest.cancelRemainingInstances(
+        request.cancelRemainingInstances != null && request.cancelRemainingInstances());
 
     return sendBrokerRequest(brokerRequest);
   }

--- a/service/src/main/java/io/camunda/service/AdHocSubProcessActivityServices.java
+++ b/service/src/main/java/io/camunda/service/AdHocSubProcessActivityServices.java
@@ -46,11 +46,15 @@ public class AdHocSubProcessActivityServices extends ApiServices<AdHocSubProcess
                 brokerRequest.addElement(
                     element.elementId(), getDocumentOrEmpty(element.variables())));
 
+    brokerRequest.cancelRemainingInstances(request.cancelRemainingInstances);
+
     return sendBrokerRequest(brokerRequest);
   }
 
   public record AdHocSubProcessActivateActivitiesRequest(
-      String adHocSubProcessInstanceKey, List<AdHocSubProcessActivateActivityReference> elements) {
+      String adHocSubProcessInstanceKey,
+      List<AdHocSubProcessActivateActivityReference> elements,
+      Boolean cancelRemainingInstances) {
     public record AdHocSubProcessActivateActivityReference(
         String elementId, Map<String, Object> variables) {}
   }

--- a/service/src/main/java/io/camunda/service/AdHocSubProcessActivityServices.java
+++ b/service/src/main/java/io/camunda/service/AdHocSubProcessActivityServices.java
@@ -46,8 +46,7 @@ public class AdHocSubProcessActivityServices extends ApiServices<AdHocSubProcess
                 brokerRequest.addElement(
                     element.elementId(), getDocumentOrEmpty(element.variables())));
 
-    brokerRequest.cancelRemainingInstances(
-        request.cancelRemainingInstances != null && request.cancelRemainingInstances());
+    brokerRequest.cancelRemainingInstances(request.cancelRemainingInstances());
 
     return sendBrokerRequest(brokerRequest);
   }
@@ -55,7 +54,7 @@ public class AdHocSubProcessActivityServices extends ApiServices<AdHocSubProcess
   public record AdHocSubProcessActivateActivitiesRequest(
       String adHocSubProcessInstanceKey,
       List<AdHocSubProcessActivateActivityReference> elements,
-      Boolean cancelRemainingInstances) {
+      boolean cancelRemainingInstances) {
     public record AdHocSubProcessActivateActivityReference(
         String elementId, Map<String, Object> variables) {}
   }

--- a/service/src/main/java/io/camunda/service/AdHocSubProcessActivityServices.java
+++ b/service/src/main/java/io/camunda/service/AdHocSubProcessActivityServices.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerActivateAdHocSubProcessActivityRequest;
 import io.camunda.zeebe.protocol.impl.record.value.adhocsubprocess.AdHocSubProcessInstructionRecord;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
 public class AdHocSubProcessActivityServices extends ApiServices<AdHocSubProcessActivityServices> {
@@ -38,15 +39,19 @@ public class AdHocSubProcessActivityServices extends ApiServices<AdHocSubProcess
         new BrokerActivateAdHocSubProcessActivityRequest()
             .setAdHocSubProcessInstanceKey(request.adHocSubProcessInstanceKey());
 
-    request.elements().stream()
-        .map(AdHocSubProcessActivateActivityReference::elementId)
-        .forEach(brokerRequest::addElement);
+    request
+        .elements()
+        .forEach(
+            element ->
+                brokerRequest.addElement(
+                    element.elementId(), getDocumentOrEmpty(element.variables())));
 
     return sendBrokerRequest(brokerRequest);
   }
 
   public record AdHocSubProcessActivateActivitiesRequest(
       String adHocSubProcessInstanceKey, List<AdHocSubProcessActivateActivityReference> elements) {
-    public record AdHocSubProcessActivateActivityReference(String elementId) {}
+    public record AdHocSubProcessActivateActivityReference(
+        String elementId, Map<String, Object> variables) {}
   }
 }

--- a/service/src/test/java/io/camunda/service/AdHocSubProcessActivityServicesTest.java
+++ b/service/src/test/java/io/camunda/service/AdHocSubProcessActivityServicesTest.java
@@ -1,0 +1,271 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.security.auth.CamundaAuthentication;
+import io.camunda.service.AdHocSubProcessActivityServices.AdHocSubProcessActivateActivitiesRequest;
+import io.camunda.service.AdHocSubProcessActivityServices.AdHocSubProcessActivateActivitiesRequest.AdHocSubProcessActivateActivityReference;
+import io.camunda.service.security.SecurityContextProvider;
+import io.camunda.zeebe.broker.client.api.BrokerClient;
+import io.camunda.zeebe.broker.client.api.dto.BrokerResponse;
+import io.camunda.zeebe.gateway.impl.broker.request.BrokerActivateAdHocSubProcessActivityRequest;
+import io.camunda.zeebe.protocol.impl.record.value.adhocsubprocess.AdHocSubProcessInstructionRecord;
+import io.camunda.zeebe.protocol.record.value.AdHocSubProcessInstructionRecordValue.AdHocSubProcessActivateElementInstructionValue;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+public class AdHocSubProcessActivityServicesTest {
+
+  private AdHocSubProcessActivityServices services;
+  private BrokerClient brokerClient;
+
+  @BeforeEach
+  public void before() {
+    brokerClient = mock(BrokerClient.class);
+    final SecurityContextProvider securityContextProvider = mock(SecurityContextProvider.class);
+    final CamundaAuthentication authentication = CamundaAuthentication.none();
+    services =
+        new AdHocSubProcessActivityServices(brokerClient, securityContextProvider, authentication);
+  }
+
+  @Test
+  public void shouldActivateActivitiesWithEmptyVariables() {
+    // given
+    final String adHocSubProcessInstanceKey = "123456";
+    final String elementId = "activity1";
+    final AdHocSubProcessActivateActivityReference element =
+        new AdHocSubProcessActivateActivityReference(elementId, Map.of());
+    final AdHocSubProcessActivateActivitiesRequest request =
+        new AdHocSubProcessActivateActivitiesRequest(adHocSubProcessInstanceKey, List.of(element));
+
+    final AdHocSubProcessInstructionRecord expectedResponse =
+        new AdHocSubProcessInstructionRecord();
+    final BrokerResponse<AdHocSubProcessInstructionRecord> brokerResponse =
+        new BrokerResponse<>(expectedResponse);
+
+    when(brokerClient.sendRequest(any(BrokerActivateAdHocSubProcessActivityRequest.class)))
+        .thenReturn(CompletableFuture.completedFuture(brokerResponse));
+
+    // when
+    final AdHocSubProcessInstructionRecord result = services.activateActivities(request).join();
+
+    // then
+    assertThat(result).isEqualTo(expectedResponse);
+
+    // verify broker request was called correctly
+    final ArgumentCaptor<BrokerActivateAdHocSubProcessActivityRequest> requestCaptor =
+        ArgumentCaptor.forClass(BrokerActivateAdHocSubProcessActivityRequest.class);
+    verify(brokerClient).sendRequest(requestCaptor.capture());
+
+    final BrokerActivateAdHocSubProcessActivityRequest capturedRequest = requestCaptor.getValue();
+    assertThat(capturedRequest.getRequestWriter().getAdHocSubProcessInstanceKey())
+        .isEqualTo(adHocSubProcessInstanceKey);
+  }
+
+  @Test
+  public void shouldActivateActivitiesWithVariables() {
+    // given
+    final String adHocSubProcessInstanceKey = "123456";
+    final String elementId = "activity1";
+    final Map<String, Object> variables = Map.of("key1", "value1", "key2", 42);
+    final AdHocSubProcessActivateActivityReference element =
+        new AdHocSubProcessActivateActivityReference(elementId, variables);
+    final AdHocSubProcessActivateActivitiesRequest request =
+        new AdHocSubProcessActivateActivitiesRequest(adHocSubProcessInstanceKey, List.of(element));
+
+    final AdHocSubProcessInstructionRecord expectedResponse =
+        mock(AdHocSubProcessInstructionRecord.class);
+    final BrokerResponse<AdHocSubProcessInstructionRecord> brokerResponse =
+        new BrokerResponse<>(expectedResponse);
+
+    when(brokerClient.sendRequest(any(BrokerActivateAdHocSubProcessActivityRequest.class)))
+        .thenReturn(CompletableFuture.completedFuture(brokerResponse));
+
+    // when
+    final AdHocSubProcessInstructionRecord result = services.activateActivities(request).join();
+
+    // then
+    assertThat(result).isEqualTo(expectedResponse);
+
+    // verify broker request was called correctly
+    final ArgumentCaptor<BrokerActivateAdHocSubProcessActivityRequest> requestCaptor =
+        ArgumentCaptor.forClass(BrokerActivateAdHocSubProcessActivityRequest.class);
+    verify(brokerClient).sendRequest(requestCaptor.capture());
+
+    final BrokerActivateAdHocSubProcessActivityRequest capturedRequest = requestCaptor.getValue();
+    assertThat(capturedRequest.getRequestWriter().getAdHocSubProcessInstanceKey())
+        .isEqualTo(adHocSubProcessInstanceKey);
+  }
+
+  @Test
+  public void shouldActivateMultipleActivities() {
+    // given
+    final String adHocSubProcessInstanceKey = "123456";
+    final AdHocSubProcessActivateActivityReference element1 =
+        new AdHocSubProcessActivateActivityReference("activity1", Map.of("var1", "value1"));
+    final AdHocSubProcessActivateActivityReference element2 =
+        new AdHocSubProcessActivateActivityReference("activity2", Map.of("var2", "value2"));
+    final AdHocSubProcessActivateActivitiesRequest request =
+        new AdHocSubProcessActivateActivitiesRequest(
+            adHocSubProcessInstanceKey, List.of(element1, element2));
+
+    final AdHocSubProcessInstructionRecord expectedResponse =
+        new AdHocSubProcessInstructionRecord();
+    final BrokerResponse<AdHocSubProcessInstructionRecord> brokerResponse =
+        new BrokerResponse<>(expectedResponse);
+
+    when(brokerClient.sendRequest(any(BrokerActivateAdHocSubProcessActivityRequest.class)))
+        .thenReturn(CompletableFuture.completedFuture(brokerResponse));
+
+    // when
+    final AdHocSubProcessInstructionRecord result = services.activateActivities(request).join();
+
+    // then
+    assertThat(result).isEqualTo(expectedResponse);
+
+    // verify broker request was called correctly
+    final ArgumentCaptor<BrokerActivateAdHocSubProcessActivityRequest> requestCaptor =
+        ArgumentCaptor.forClass(BrokerActivateAdHocSubProcessActivityRequest.class);
+    verify(brokerClient).sendRequest(requestCaptor.capture());
+
+    final BrokerActivateAdHocSubProcessActivityRequest capturedRequest = requestCaptor.getValue();
+    assertThat(capturedRequest.getRequestWriter().getAdHocSubProcessInstanceKey())
+        .isEqualTo(adHocSubProcessInstanceKey);
+    assertThat(capturedRequest.getRequestWriter().getActivateElements()).hasSize(2);
+    assertThat(capturedRequest.getRequestWriter().getActivateElements())
+        .filteredOn(AdHocSubProcessActivateElementInstructionValue::getElementId, "activity1")
+        .extracting(AdHocSubProcessActivateElementInstructionValue::getVariables)
+        .containsExactly(Map.of("var1", "value1"));
+    assertThat(capturedRequest.getRequestWriter().getActivateElements())
+        .filteredOn(AdHocSubProcessActivateElementInstructionValue::getElementId, "activity2")
+        .extracting(AdHocSubProcessActivateElementInstructionValue::getVariables)
+        .containsExactly(Map.of("var2", "value2"));
+  }
+
+  @Test
+  public void shouldActivateActivitiesWithNullVariables() {
+    // given
+    final String adHocSubProcessInstanceKey = "123456";
+    final String elementId = "activity1";
+    final AdHocSubProcessActivateActivityReference element =
+        new AdHocSubProcessActivateActivityReference(elementId, null);
+    final AdHocSubProcessActivateActivitiesRequest request =
+        new AdHocSubProcessActivateActivitiesRequest(adHocSubProcessInstanceKey, List.of(element));
+
+    final AdHocSubProcessInstructionRecord expectedResponse =
+        new AdHocSubProcessInstructionRecord();
+    final BrokerResponse<AdHocSubProcessInstructionRecord> brokerResponse =
+        new BrokerResponse<>(expectedResponse);
+
+    when(brokerClient.sendRequest(any(BrokerActivateAdHocSubProcessActivityRequest.class)))
+        .thenReturn(CompletableFuture.completedFuture(brokerResponse));
+
+    // when
+    final AdHocSubProcessInstructionRecord result = services.activateActivities(request).join();
+
+    // then
+    assertThat(result).isEqualTo(expectedResponse);
+
+    // verify broker request was called correctly
+    final ArgumentCaptor<BrokerActivateAdHocSubProcessActivityRequest> requestCaptor =
+        ArgumentCaptor.forClass(BrokerActivateAdHocSubProcessActivityRequest.class);
+    verify(brokerClient).sendRequest(requestCaptor.capture());
+
+    final BrokerActivateAdHocSubProcessActivityRequest capturedRequest = requestCaptor.getValue();
+    assertThat(capturedRequest.getRequestWriter().getAdHocSubProcessInstanceKey())
+        .isEqualTo(adHocSubProcessInstanceKey);
+  }
+
+  @Test
+  public void shouldReturnNewInstanceWithAuthentication() {
+    // given
+    final CamundaAuthentication newAuthentication = mock(CamundaAuthentication.class);
+
+    // when
+    final AdHocSubProcessActivityServices newServices =
+        services.withAuthentication(newAuthentication);
+
+    // then
+    assertThat(newServices).isNotSameAs(services);
+    assertThat(newServices).isInstanceOf(AdHocSubProcessActivityServices.class);
+  }
+
+  @Test
+  public void shouldHandleEmptyElementsList() {
+    // given
+    final String adHocSubProcessInstanceKey = "123456";
+    final AdHocSubProcessActivateActivitiesRequest request =
+        new AdHocSubProcessActivateActivitiesRequest(adHocSubProcessInstanceKey, List.of());
+
+    final AdHocSubProcessInstructionRecord expectedResponse =
+        new AdHocSubProcessInstructionRecord();
+    final BrokerResponse<AdHocSubProcessInstructionRecord> brokerResponse =
+        new BrokerResponse<>(expectedResponse);
+
+    when(brokerClient.sendRequest(any(BrokerActivateAdHocSubProcessActivityRequest.class)))
+        .thenReturn(CompletableFuture.completedFuture(brokerResponse));
+
+    // when
+    final AdHocSubProcessInstructionRecord result = services.activateActivities(request).join();
+
+    // then
+    assertThat(result).isEqualTo(expectedResponse);
+
+    // verify broker request was called correctly
+    final ArgumentCaptor<BrokerActivateAdHocSubProcessActivityRequest> requestCaptor =
+        ArgumentCaptor.forClass(BrokerActivateAdHocSubProcessActivityRequest.class);
+    verify(brokerClient).sendRequest(requestCaptor.capture());
+
+    final BrokerActivateAdHocSubProcessActivityRequest capturedRequest = requestCaptor.getValue();
+    assertThat(capturedRequest.getRequestWriter().getAdHocSubProcessInstanceKey())
+        .isEqualTo(adHocSubProcessInstanceKey);
+    assertThat(capturedRequest.getRequestWriter().getActivateElements()).isEmpty();
+  }
+
+  @Test
+  public void shouldPropagateCompletableFutureFromBrokerClient() {
+    // given
+    final String adHocSubProcessInstanceKey = "123456";
+    final AdHocSubProcessActivateActivityReference element =
+        new AdHocSubProcessActivateActivityReference("activity1", Map.of());
+    final AdHocSubProcessActivateActivitiesRequest request =
+        new AdHocSubProcessActivateActivitiesRequest(adHocSubProcessInstanceKey, List.of(element));
+
+    final CompletableFuture<BrokerResponse<AdHocSubProcessInstructionRecord>> brokerFuture =
+        new CompletableFuture<>();
+
+    when(brokerClient.sendRequest(any(BrokerActivateAdHocSubProcessActivityRequest.class)))
+        .thenReturn(brokerFuture);
+
+    // when
+    final CompletableFuture<AdHocSubProcessInstructionRecord> result =
+        services.activateActivities(request);
+
+    // then
+    assertThat(result).isNotCompleted();
+
+    // complete the broker future
+    final AdHocSubProcessInstructionRecord expectedResponse =
+        new AdHocSubProcessInstructionRecord();
+    final BrokerResponse<AdHocSubProcessInstructionRecord> brokerResponse =
+        new BrokerResponse<>(expectedResponse);
+    brokerFuture.complete(brokerResponse);
+
+    assertThat(result.join()).isEqualTo(expectedResponse);
+  }
+}

--- a/service/src/test/java/io/camunda/service/AdHocSubProcessActivityServicesTest.java
+++ b/service/src/test/java/io/camunda/service/AdHocSubProcessActivityServicesTest.java
@@ -43,14 +43,11 @@ public class AdHocSubProcessActivityServicesTest {
 
   private AdHocSubProcessActivityServices services;
 
-  @Mock
-  private BrokerClient brokerClient;
+  @Mock private BrokerClient brokerClient;
 
-  @Mock
-  private SecurityContextProvider securityContextProvider;
+  @Mock private SecurityContextProvider securityContextProvider;
 
-  @Captor
-  private ArgumentCaptor<BrokerActivateAdHocSubProcessActivityRequest> requestCaptor;
+  @Captor private ArgumentCaptor<BrokerActivateAdHocSubProcessActivityRequest> requestCaptor;
 
   @BeforeEach
   public void before() {
@@ -201,7 +198,8 @@ public class AdHocSubProcessActivityServicesTest {
   public void shouldHandleEmptyElementsList() {
     // given
     final AdHocSubProcessActivateActivitiesRequest request =
-        new AdHocSubProcessActivateActivitiesRequest(AD_HOC_SUB_PROCESS_INSTANCE_KEY, List.of(), true);
+        new AdHocSubProcessActivateActivitiesRequest(
+            AD_HOC_SUB_PROCESS_INSTANCE_KEY, List.of(), true);
 
     final AdHocSubProcessInstructionRecord expectedResponse =
         new AdHocSubProcessInstructionRecord();
@@ -279,7 +277,6 @@ public class AdHocSubProcessActivityServicesTest {
     // then
     assertThat(result).isEqualTo(expectedResponse);
 
-
     final BrokerActivateAdHocSubProcessActivityRequest capturedRequest = requestCaptor.getValue();
     assertThat(capturedRequest.getRequestWriter().getAdHocSubProcessInstanceKey())
         .isEqualTo(AD_HOC_SUB_PROCESS_INSTANCE_KEY);
@@ -288,7 +285,6 @@ public class AdHocSubProcessActivityServicesTest {
   }
 
   private static Stream<Arguments> cancelRemainingInstancesProvider() {
-    return Stream.of(
-        Arguments.of(true), Arguments.of(false), Arguments.of((Boolean) null));
+    return Stream.of(Arguments.of(true), Arguments.of(false), Arguments.of((Boolean) null));
   }
 }

--- a/service/src/test/java/io/camunda/service/AdHocSubProcessActivityServicesTest.java
+++ b/service/src/test/java/io/camunda/service/AdHocSubProcessActivityServicesTest.java
@@ -380,5 +380,6 @@ public class AdHocSubProcessActivityServicesTest {
     final BrokerActivateAdHocSubProcessActivityRequest capturedRequest = requestCaptor.getValue();
     assertThat(capturedRequest.getRequestWriter().getAdHocSubProcessInstanceKey())
         .isEqualTo(adHocSubProcessInstanceKey);
+    assertThat(capturedRequest.getRequestWriter().isCancelRemainingInstances()).isFalse();
   }
 }

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -6848,6 +6848,10 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/AdHocSubProcessActivateActivityReference"
+        cancelRemainingInstances:
+          description: Whether to cancel remaining instances of the ad-hoc sub-process.
+          type: boolean
+          default: false
       required:
         - elements
     AdHocSubProcessActivateActivityReference:

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -6856,6 +6856,10 @@ components:
         elementId:
           description: The ID of the element that should be activated.
           type: string
+        variables:
+          description: Variables to be set when activating the element.
+          type: object
+          additionalProperties: true
       required:
         - elementId
     DecisionDefinitionSearchQuerySortRequest:

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RequestMapper.java
@@ -872,7 +872,9 @@ public class RequestMapper {
                 request.getElements().stream()
                     .map(
                         element ->
-                            new AdHocSubProcessActivateActivityReference(element.getElementId()))
+                            new AdHocSubProcessActivateActivityReference(
+                                element.getElementId(),
+                                getMapOrEmpty(element, e -> e.getVariables())))
                     .toList()));
   }
 

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RequestMapper.java
@@ -876,7 +876,8 @@ public class RequestMapper {
                                 element.getElementId(),
                                 getMapOrEmpty(element, e -> e.getVariables())))
                     .toList(),
-                request.getCancelRemainingInstances()));
+                request.getCancelRemainingInstances() != null
+                    && request.getCancelRemainingInstances()));
   }
 
   private static List<ProcessInstanceModificationActivateInstruction>

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RequestMapper.java
@@ -875,7 +875,8 @@ public class RequestMapper {
                             new AdHocSubProcessActivateActivityReference(
                                 element.getElementId(),
                                 getMapOrEmpty(element, e -> e.getVariables())))
-                    .toList()));
+                    .toList(),
+                request.getCancelRemainingInstances()));
   }
 
   private static List<ProcessInstanceModificationActivateInstruction>

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/RequestMapperTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/RequestMapperTest.java
@@ -9,11 +9,8 @@ package io.camunda.zeebe.gateway.rest;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.camunda.service.AdHocSubProcessActivityServices.AdHocSubProcessActivateActivitiesRequest;
 import io.camunda.service.ProcessInstanceServices.ProcessInstanceMigrateBatchOperationRequest;
 import io.camunda.service.ProcessInstanceServices.ProcessInstanceModifyBatchOperationRequest;
-import io.camunda.zeebe.gateway.protocol.rest.AdHocSubProcessActivateActivitiesInstruction;
-import io.camunda.zeebe.gateway.protocol.rest.AdHocSubProcessActivateActivityReference;
 import io.camunda.zeebe.gateway.protocol.rest.MigrateProcessInstanceMappingInstruction;
 import io.camunda.zeebe.gateway.protocol.rest.ProcessInstanceFilter;
 import io.camunda.zeebe.gateway.protocol.rest.ProcessInstanceMigrationBatchOperationPlan;
@@ -22,11 +19,7 @@ import io.camunda.zeebe.gateway.protocol.rest.ProcessInstanceModificationBatchOp
 import io.camunda.zeebe.gateway.protocol.rest.ProcessInstanceModificationMoveBatchOperationInstruction;
 import io.camunda.zeebe.util.Either;
 import java.util.List;
-import java.util.Map;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
-import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.springframework.http.ProblemDetail;
 
 class RequestMapperTest {
@@ -138,137 +131,5 @@ class RequestMapperTest {
     final var problemDetail = result.getLeft();
     assertThat(problemDetail.getStatus()).isEqualTo(400);
     assertThat(problemDetail.getDetail()).isEqualTo("No targetElementId provided.");
-  }
-
-  @Test
-  void shouldMapToAdHocSubProcessActivateActivitiesRequest() {
-    // given
-    final var element1 = new AdHocSubProcessActivateActivityReference();
-    element1.setElementId("activity1");
-    element1.setVariables(Map.of("var1", "value1", "count", 42));
-
-    final var element2 = new AdHocSubProcessActivateActivityReference();
-    element2.setElementId("activity2");
-    element2.setVariables(Map.of("var2", "value2"));
-
-    final var instruction = new AdHocSubProcessActivateActivitiesInstruction();
-    instruction.setElements(List.of(element1, element2));
-    instruction.setCancelRemainingInstances(true);
-
-    // when
-    final Either<ProblemDetail, AdHocSubProcessActivateActivitiesRequest> result =
-        RequestMapper.toAdHocSubProcessActivateActivitiesRequest("123456", instruction);
-
-    // then
-    assertThat(result.isRight()).isTrue();
-
-    final var request = result.get();
-    assertThat(request.adHocSubProcessInstanceKey()).isEqualTo("123456");
-    assertThat(request.cancelRemainingInstances()).isTrue();
-    assertThat(request.elements())
-        .hasSize(2)
-        .satisfies(
-            elements -> {
-              assertThat(elements.get(0).elementId()).isEqualTo("activity1");
-              assertThat(elements.get(0).variables())
-                  .containsExactlyInAnyOrderEntriesOf(Map.of("var1", "value1", "count", 42));
-              assertThat(elements.get(1).elementId()).isEqualTo("activity2");
-              assertThat(elements.get(1).variables())
-                  .containsExactlyInAnyOrderEntriesOf(Map.of("var2", "value2"));
-            });
-  }
-
-  @ParameterizedTest
-  @CsvSource({"true,true", "false,false", ",false"})
-  void shouldMapToAdHocSubProcessActivateActivitiesRequestHandlingCancelRemainingInstances(
-      final Boolean cancelRemainingInstances, final boolean expectedValue) {
-    // given
-    final var element = new AdHocSubProcessActivateActivityReference();
-    element.setElementId("activity1");
-
-    final var instruction = new AdHocSubProcessActivateActivitiesInstruction();
-    instruction.setElements(List.of(element));
-
-    if (cancelRemainingInstances != null) {
-      instruction.setCancelRemainingInstances(cancelRemainingInstances);
-    }
-
-    // when
-    final Either<ProblemDetail, AdHocSubProcessActivateActivitiesRequest> result =
-        RequestMapper.toAdHocSubProcessActivateActivitiesRequest("123456", instruction);
-
-    // then
-    assertThat(result.isRight()).isTrue();
-    assertThat(result.get().cancelRemainingInstances()).isEqualTo(expectedValue);
-  }
-
-  @ParameterizedTest
-  @NullAndEmptySource
-  void shouldMapToAdHocSubProcessActivateActivitiesRequestWithEmptyVariables(
-      final Map<String, Object> variables) {
-    // given
-    final var element = new AdHocSubProcessActivateActivityReference();
-    element.setElementId("activity1");
-    element.setVariables(variables);
-
-    final var instruction = new AdHocSubProcessActivateActivitiesInstruction();
-    instruction.setElements(List.of(element));
-    instruction.setCancelRemainingInstances(true);
-
-    // when
-    final Either<ProblemDetail, AdHocSubProcessActivateActivitiesRequest> result =
-        RequestMapper.toAdHocSubProcessActivateActivitiesRequest("123456", instruction);
-
-    // then
-    assertThat(result.isRight()).isTrue();
-    assertThat(result.get().elements())
-        .hasSize(1)
-        .first()
-        .satisfies(
-            e -> {
-              assertThat(e.elementId()).isEqualTo("activity1");
-              assertThat(e.variables()).isEmpty();
-            });
-  }
-
-  @Test
-  void shouldReturnProblemDetailForAdHocSubProcessActivationRequestWithMissingElementId() {
-    // given
-    final var element = new AdHocSubProcessActivateActivityReference();
-    element.setElementId(null); // Invalid - null element ID
-
-    final var instruction = new AdHocSubProcessActivateActivitiesInstruction();
-    instruction.setElements(List.of(element));
-    instruction.setCancelRemainingInstances(true);
-
-    // when
-    final Either<ProblemDetail, AdHocSubProcessActivateActivitiesRequest> result =
-        RequestMapper.toAdHocSubProcessActivateActivitiesRequest("123456", instruction);
-
-    // then
-    assertThat(result.isLeft()).isTrue();
-    final var problemDetail = result.getLeft();
-    assertThat(problemDetail.getStatus()).isEqualTo(400);
-    assertThat(problemDetail.getTitle()).isEqualTo("INVALID_ARGUMENT");
-    assertThat(problemDetail.getDetail()).isEqualTo("No elements[0].elementId provided.");
-  }
-
-  @Test
-  void shouldReturnProblemDetailForAdHocSubProcessActivationRequestWithEmptyElementsToActivate() {
-    // given
-    final var instruction = new AdHocSubProcessActivateActivitiesInstruction();
-    instruction.setElements(List.of());
-    instruction.setCancelRemainingInstances(true);
-
-    // when
-    final Either<ProblemDetail, AdHocSubProcessActivateActivitiesRequest> result =
-        RequestMapper.toAdHocSubProcessActivateActivitiesRequest("123456", instruction);
-
-    // then
-    assertThat(result.isLeft()).isTrue();
-    final var problemDetail = result.getLeft();
-    assertThat(problemDetail.getStatus()).isEqualTo(400);
-    assertThat(problemDetail.getTitle()).isEqualTo("INVALID_ARGUMENT");
-    assertThat(problemDetail.getDetail()).isEqualTo("No elements provided.");
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/RequestMapperTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/RequestMapperTest.java
@@ -160,7 +160,7 @@ class RequestMapperTest {
             adHocSubProcessInstanceKey, instruction);
 
     // then
-    assertTrue(result.isRight());
+    assertThat(result.isRight()).isTrue();
     final var request = result.get();
     assertThat(request.adHocSubProcessInstanceKey()).isEqualTo(adHocSubProcessInstanceKey);
     assertThat(request.cancelRemainingInstances()).isTrue();
@@ -196,7 +196,7 @@ class RequestMapperTest {
             adHocSubProcessInstanceKey, instruction);
 
     // then
-    assertTrue(result.isRight());
+    assertThat(result.isRight()).isTrue();
     final var request = result.get();
     assertThat(request.adHocSubProcessInstanceKey()).isEqualTo(adHocSubProcessInstanceKey);
     assertThat(request.cancelRemainingInstances()).isFalse();
@@ -224,7 +224,7 @@ class RequestMapperTest {
             adHocSubProcessInstanceKey, instruction);
 
     // then
-    assertTrue(result.isRight());
+    assertThat(result.isRight()).isTrue();
     final var request = result.get();
     assertThat(request.adHocSubProcessInstanceKey()).isEqualTo(adHocSubProcessInstanceKey);
     assertThat(request.cancelRemainingInstances()).isNull();
@@ -251,7 +251,7 @@ class RequestMapperTest {
             adHocSubProcessInstanceKey, instruction);
 
     // then
-    assertTrue(result.isRight());
+    assertThat(result.isRight()).isTrue();
     final var request = result.get();
     assertThat(request.elements()).hasSize(1);
     assertThat(request.elements().get(0).elementId()).isEqualTo("activity1");
@@ -277,7 +277,7 @@ class RequestMapperTest {
             adHocSubProcessInstanceKey, instruction);
 
     // then
-    assertTrue(result.isRight());
+    assertThat(result.isRight()).isTrue();
     final var request = result.get();
     assertThat(request.elements()).hasSize(1);
     assertThat(request.elements().get(0).elementId()).isEqualTo("activity1");
@@ -302,7 +302,7 @@ class RequestMapperTest {
             adHocSubProcessInstanceKey, instruction);
 
     // then
-    assertTrue(result.isLeft());
+    assertThat(result.isLeft()).isTrue();
     final var problemDetail = result.getLeft();
     assertThat(problemDetail.getStatus()).isEqualTo(400); // Bad Request
     assertThat(problemDetail.getDetail()).contains("elementId");
@@ -323,7 +323,7 @@ class RequestMapperTest {
             adHocSubProcessInstanceKey, instruction);
 
     // then
-    assertTrue(result.isLeft());
+    assertThat(result.isLeft()).isTrue();
     final var problemDetail = result.getLeft();
     assertThat(problemDetail.getTitle()).isEqualTo("INVALID_ARGUMENT");
     assertThat(problemDetail.getStatus()).isEqualTo(400);

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AdHocSubProcessActivityControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AdHocSubProcessActivityControllerTest.java
@@ -81,7 +81,8 @@ class AdHocSubProcessActivityControllerTest extends RestControllerTest {
                 },
                 {"elementId": "B"},
                 {"elementId": "C"}
-              ]
+              ],
+              "cancelRemainingInstances": true
             }
             """)
           .exchange()
@@ -94,6 +95,7 @@ class AdHocSubProcessActivityControllerTest extends RestControllerTest {
                   request -> {
                     assertThat(request.adHocSubProcessInstanceKey())
                         .isEqualTo(AD_HOC_SUBPROCESS_INSTANCE_KEY);
+                    assertThat(request.cancelRemainingInstances()).isTrue();
 
                     assertThat(request.elements())
                         .extracting(AdHocSubProcessActivateActivityReference::elementId)

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AdHocSubProcessActivityControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AdHocSubProcessActivityControllerTest.java
@@ -22,6 +22,7 @@ import io.camunda.service.AdHocSubProcessActivityServices.AdHocSubProcessActivat
 import io.camunda.service.AdHocSubProcessActivityServices.AdHocSubProcessActivateActivitiesRequest.AdHocSubProcessActivateActivityReference;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
 import io.camunda.zeebe.protocol.impl.record.value.adhocsubprocess.AdHocSubProcessInstructionRecord;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
@@ -72,7 +73,12 @@ class AdHocSubProcessActivityControllerTest extends RestControllerTest {
               """
             {
               "elements": [
-                {"elementId": "A"},
+                {
+                   "elementId": "A",
+                   "variables": {
+                      "key": "value"
+                   }
+                },
                 {"elementId": "B"},
                 {"elementId": "C"}
               ]
@@ -92,6 +98,11 @@ class AdHocSubProcessActivityControllerTest extends RestControllerTest {
                     assertThat(request.elements())
                         .extracting(AdHocSubProcessActivateActivityReference::elementId)
                         .containsExactly("A", "B", "C");
+
+                    assertThat(request.elements())
+                        .filteredOn(AdHocSubProcessActivateActivityReference::elementId, "A")
+                        .extracting(AdHocSubProcessActivateActivityReference::variables)
+                        .containsExactly(Map.of("key", "value"));
                   }));
     }
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AdHocSubProcessActivityControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AdHocSubProcessActivityControllerTest.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.gateway.rest.controller;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.assertArg;
@@ -19,10 +20,8 @@ import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.security.auth.CamundaAuthenticationProvider;
 import io.camunda.service.AdHocSubProcessActivityServices;
 import io.camunda.service.AdHocSubProcessActivityServices.AdHocSubProcessActivateActivitiesRequest;
-import io.camunda.service.AdHocSubProcessActivityServices.AdHocSubProcessActivateActivitiesRequest.AdHocSubProcessActivateActivityReference;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
 import io.camunda.zeebe.protocol.impl.record.value.adhocsubprocess.AdHocSubProcessInstructionRecord;
-import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
@@ -31,6 +30,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
@@ -58,8 +58,9 @@ class AdHocSubProcessActivityControllerTest extends RestControllerTest {
 
     private static final String AD_HOC_SUBPROCESS_INSTANCE_KEY = "123456789";
 
-    @Test
-    void shouldActivateActivities() {
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void shouldActivateActivities(final boolean cancelRemainingInstances) {
       when(adHocSubProcessActivityServices.activateActivities(
               any(AdHocSubProcessActivateActivitiesRequest.class)))
           .thenReturn(CompletableFuture.completedFuture(new AdHocSubProcessInstructionRecord()));
@@ -71,20 +72,24 @@ class AdHocSubProcessActivityControllerTest extends RestControllerTest {
           .contentType(MediaType.APPLICATION_JSON)
           .bodyValue(
               """
-            {
-              "elements": [
-                {
-                   "elementId": "A",
-                   "variables": {
-                      "key": "value"
-                   }
-                },
-                {"elementId": "B"},
-                {"elementId": "C"}
-              ],
-              "cancelRemainingInstances": true
-            }
-            """)
+              {
+                "elements": [
+                  {
+                     "elementId": "A",
+                     "variables": {
+                        "key": "value"
+                     }
+                  },
+                  {
+                      "elementId": "B",
+                      "variables":  {}
+                  },
+                  {"elementId": "C"}
+                ],
+                "cancelRemainingInstances": %b
+              }
+              """
+                  .formatted(cancelRemainingInstances))
           .exchange()
           .expectStatus()
           .isNoContent();
@@ -95,16 +100,64 @@ class AdHocSubProcessActivityControllerTest extends RestControllerTest {
                   request -> {
                     assertThat(request.adHocSubProcessInstanceKey())
                         .isEqualTo(AD_HOC_SUBPROCESS_INSTANCE_KEY);
-                    assertThat(request.cancelRemainingInstances()).isTrue();
+                    assertThat(request.cancelRemainingInstances())
+                        .isEqualTo(cancelRemainingInstances);
 
                     assertThat(request.elements())
-                        .extracting(AdHocSubProcessActivateActivityReference::elementId)
-                        .containsExactly("A", "B", "C");
+                        .satisfiesExactly(
+                            element -> {
+                              assertThat(element.elementId()).isEqualTo("A");
+                              assertThat(element.variables())
+                                  .containsExactly(entry("key", "value"));
+                            },
+                            element -> {
+                              assertThat(element.elementId()).isEqualTo("B");
+                              assertThat(element.variables()).isEmpty();
+                            },
+                            element -> {
+                              assertThat(element.elementId()).isEqualTo("C");
+                              assertThat(element.variables()).isEmpty();
+                            });
+                  }));
+    }
+
+    @Test
+    void shouldActivateActivitiesWithMissingCancelRemainingActivitiesFlag() {
+      when(adHocSubProcessActivityServices.activateActivities(
+              any(AdHocSubProcessActivateActivitiesRequest.class)))
+          .thenReturn(CompletableFuture.completedFuture(new AdHocSubProcessInstructionRecord()));
+
+      webClient
+          .post()
+          .uri(ACTIVATE_ACTIVITIES_URL, AD_HOC_SUBPROCESS_INSTANCE_KEY)
+          .accept(MediaType.APPLICATION_JSON)
+          .contentType(MediaType.APPLICATION_JSON)
+          .bodyValue(
+              """
+                  {
+                    "elements": [
+                      {"elementId": "A"}
+                    ]
+                  }
+                  """)
+          .exchange()
+          .expectStatus()
+          .isNoContent();
+
+      verify(adHocSubProcessActivityServices)
+          .activateActivities(
+              assertArg(
+                  request -> {
+                    assertThat(request.adHocSubProcessInstanceKey())
+                        .isEqualTo(AD_HOC_SUBPROCESS_INSTANCE_KEY);
+                    assertThat(request.cancelRemainingInstances()).isFalse();
 
                     assertThat(request.elements())
-                        .filteredOn(AdHocSubProcessActivateActivityReference::elementId, "A")
-                        .extracting(AdHocSubProcessActivateActivityReference::variables)
-                        .containsExactly(Map.of("key", "value"));
+                        .satisfiesExactly(
+                            element -> {
+                              assertThat(element.elementId()).isEqualTo("A");
+                              assertThat(element.variables()).isEmpty();
+                            });
                   }));
     }
 


### PR DESCRIPTION
## Description

We extend the [API](https://docs.camunda.io/docs/next/apis-tools/orchestration-cluster-api-rest/specifications/activate-ad-hoc-sub-process-activities/) to activate elements of an ad-hoc sub-process to pass variables for the elements. Additionally, we support to cancel remaining instances with the activation of new elements.

```
curl -L 'http://localhost:8080/v2/element-instances/ad-hoc-activities/:adHocSubProcessInstanceKey/activation' \
-H 'Content-Type: application/json' \
-d '{
  "elements": [
    {
      "elementId": "string",
      "variables": {}
    }
  ],
  "cancelRemainingInstances": true
}'
```

## Additional changes

- Added `AdHocSubProcessActivityServicesTest`



## Related issues

closes https://github.com/camunda/ad-hoc-sub-process-phase-3/issues/22
