### PR TITLE
fix: prevent ActivateJobsCommand timeout before the server

### DIFF
--- a/clients/java/src/main/java/io/camunda/zeebe/client/ClientProperties.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/ClientProperties.java
@@ -99,6 +99,11 @@ public final class ClientProperties {
   public static final String DEFAULT_REQUEST_TIMEOUT = "zeebe.client.requestTimeout";
 
   /**
+   * @see ZeebeClientBuilder#defaultRequestTimeoutOffset(Duration)
+   */
+  public static final String DEFAULT_REQUEST_TIMEOUT_OFFSET = "camunda.client.requestTimeoutOffset";
+
+  /**
    * @see ZeebeClientBuilder#usePlaintext()
    */
   public static final String USE_PLAINTEXT_CONNECTION = "zeebe.client.security.plaintext";

--- a/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClientBuilder.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClientBuilder.java
@@ -145,6 +145,18 @@ public interface ZeebeClientBuilder {
   /** The request timeout used if not overridden by the command. Default is 10 seconds. */
   ZeebeClientBuilder defaultRequestTimeout(Duration requestTimeout);
 
+  /**
+   * The request timeout client offset is used in commands where the {@link
+   * #defaultRequestTimeout(Duration)} is also passed to the server. This ensures that the client
+   * timeout does not occur before the server timeout.
+   *
+   * <p>The client-side timeout for these commands is calculated as the sum of {@code
+   * defaultRequestTimeout} and {@code defaultRequestTimeoutOffset}.
+   *
+   * <p>Default is 1 second.
+   */
+  ZeebeClientBuilder defaultRequestTimeoutOffset(Duration requestTimeoutOffset);
+
   /** Use a plaintext connection between the client and the gateway. */
   ZeebeClientBuilder usePlaintext();
 

--- a/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClientConfiguration.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClientConfiguration.java
@@ -90,6 +90,11 @@ public interface ZeebeClientConfiguration {
   Duration getDefaultRequestTimeout();
 
   /**
+   * @see ZeebeClientBuilder#defaultRequestTimeoutOffset(Duration)
+   */
+  Duration getDefaultRequestTimeoutOffset();
+
+  /**
    * @see ZeebeClientBuilder#usePlaintext()
    */
   boolean isPlaintextConnectionEnabled();

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/ActivateJobsCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/ActivateJobsCommandStep1.java
@@ -101,5 +101,20 @@ public interface ActivateJobsCommandStep1
      *     it to the broker.
      */
     ActivateJobsCommandStep3 fetchVariables(String... fetchVariables);
+
+    /**
+     * Sets the request timeout for the command.
+     *
+     * <p>Additionally, it sets the HTTP response timeout to the specified value, incremented by the
+     * offset defined in {@link
+     * io.camunda.zeebe.client.ZeebeClientConfiguration#getDefaultRequestTimeoutOffset()} (default 1
+     * second), ensuring that the client timeout does not occur before the server timeout.
+     *
+     * @see FinalCommandStep#requestTimeout(Duration)
+     * @param requestTimeout the request timeout
+     * @return the configured command
+     */
+    @Override
+    FinalCommandStep<ActivateJobsResponse> requestTimeout(Duration requestTimeout);
   }
 }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientBuilderImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientBuilderImpl.java
@@ -23,6 +23,7 @@ import static io.camunda.zeebe.client.ClientProperties.DEFAULT_JOB_WORKER_NAME;
 import static io.camunda.zeebe.client.ClientProperties.DEFAULT_JOB_WORKER_TENANT_IDS;
 import static io.camunda.zeebe.client.ClientProperties.DEFAULT_MESSAGE_TIME_TO_LIVE;
 import static io.camunda.zeebe.client.ClientProperties.DEFAULT_REQUEST_TIMEOUT;
+import static io.camunda.zeebe.client.ClientProperties.DEFAULT_REQUEST_TIMEOUT_OFFSET;
 import static io.camunda.zeebe.client.ClientProperties.DEFAULT_TENANT_ID;
 import static io.camunda.zeebe.client.ClientProperties.GATEWAY_ADDRESS;
 import static io.camunda.zeebe.client.ClientProperties.GRPC_ADDRESS;
@@ -102,6 +103,7 @@ public final class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeCl
   private Duration defaultJobPollInterval = Duration.ofMillis(100);
   private Duration defaultMessageTimeToLive = DEFAULT_MESSAGE_TTL;
   private Duration defaultRequestTimeout = Duration.ofSeconds(10);
+  private Duration defaultRequestTimeoutOffset = Duration.ofSeconds(1);
   private boolean usePlaintextConnection = false;
   private String certificatePath;
   private CredentialsProvider credentialsProvider;
@@ -174,6 +176,11 @@ public final class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeCl
   @Override
   public Duration getDefaultRequestTimeout() {
     return defaultRequestTimeout;
+  }
+
+  @Override
+  public Duration getDefaultRequestTimeoutOffset() {
+    return defaultRequestTimeoutOffset;
   }
 
   @Override
@@ -312,6 +319,11 @@ public final class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeCl
         properties,
         DEFAULT_REQUEST_TIMEOUT,
         value -> defaultRequestTimeout(Duration.ofMillis(Long.parseLong(value))));
+
+    BuilderUtils.applyIfNotNull(
+        properties,
+        DEFAULT_REQUEST_TIMEOUT_OFFSET,
+        value -> defaultRequestTimeoutOffset(Duration.ofMillis(Long.parseLong(value))));
 
     BuilderUtils.applyIfNotNull(
         properties,
@@ -466,6 +478,12 @@ public final class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeCl
   @Override
   public ZeebeClientBuilder defaultRequestTimeout(final Duration requestTimeout) {
     defaultRequestTimeout = requestTimeout;
+    return this;
+  }
+
+  @Override
+  public ZeebeClientBuilder defaultRequestTimeoutOffset(final Duration requestTimeoutOffset) {
+    defaultRequestTimeoutOffset = requestTimeoutOffset;
     return this;
   }
 
@@ -625,6 +643,7 @@ public final class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeCl
     BuilderUtils.appendProperty(sb, "defaultJobPollInterval", defaultJobPollInterval);
     BuilderUtils.appendProperty(sb, "defaultMessageTimeToLive", defaultMessageTimeToLive);
     BuilderUtils.appendProperty(sb, "defaultRequestTimeout", defaultRequestTimeout);
+    BuilderUtils.appendProperty(sb, "defaultRequestTimeoutOffset", defaultRequestTimeoutOffset);
     BuilderUtils.appendProperty(sb, "overrideAuthority", overrideAuthority);
     BuilderUtils.appendProperty(sb, "maxMessageSize", maxMessageSize);
     BuilderUtils.appendProperty(sb, "maxMetadataSize", maxMetadataSize);

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientCloudBuilderImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientCloudBuilderImpl.java
@@ -208,6 +208,12 @@ public class ZeebeClientCloudBuilderImpl
   }
 
   @Override
+  public ZeebeClientBuilder defaultRequestTimeoutOffset(final Duration requestTimeoutOffset) {
+    innerBuilder.defaultRequestTimeoutOffset(requestTimeoutOffset);
+    return this;
+  }
+
+  @Override
   public ZeebeClientBuilder usePlaintext() {
     innerBuilder.usePlaintext();
     return this;

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/ActivateJobsCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/ActivateJobsCommandImpl.java
@@ -61,6 +61,7 @@ public final class ActivateJobsCommandImpl
 
   private final Set<String> defaultTenantIds;
   private final Set<String> customTenantIds;
+  private final ZeebeClientConfiguration config;
 
   public ActivateJobsCommandImpl(
       final GatewayStub asyncStub,
@@ -68,6 +69,7 @@ public final class ActivateJobsCommandImpl
       final ZeebeClientConfiguration config,
       final JsonMapper jsonMapper,
       final Predicate<StatusCode> retryPredicate) {
+    this.config = config;
     this.asyncStub = asyncStub;
     this.httpClient = httpClient;
     httpRequestConfig = httpClient.newRequestConfig();
@@ -142,7 +144,10 @@ public final class ActivateJobsCommandImpl
     grpcRequestObjectBuilder.setRequestTimeout(requestTimeout.toMillis());
     httpRequestObject.setRequestTimeout(requestTimeout.toMillis());
     this.requestTimeout = requestTimeout;
-    httpRequestConfig.setResponseTimeout(requestTimeout.toMillis(), TimeUnit.MILLISECONDS);
+    // increment response timeout so client doesn't time out before the server
+    final long offsetMillis = config.getDefaultRequestTimeoutOffset().toMillis();
+    httpRequestConfig.setResponseTimeout(
+        requestTimeout.toMillis() + offsetMillis, TimeUnit.MILLISECONDS);
     return this;
   }
 

--- a/clients/java/src/test/java/io/camunda/zeebe/client/ZeebeClientTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/ZeebeClientTest.java
@@ -18,6 +18,7 @@ package io.camunda.zeebe.client;
 import static io.camunda.zeebe.client.ClientProperties.CLOUD_REGION;
 import static io.camunda.zeebe.client.ClientProperties.DEFAULT_JOB_WORKER_TENANT_IDS;
 import static io.camunda.zeebe.client.ClientProperties.DEFAULT_REQUEST_TIMEOUT;
+import static io.camunda.zeebe.client.ClientProperties.DEFAULT_REQUEST_TIMEOUT_OFFSET;
 import static io.camunda.zeebe.client.ClientProperties.DEFAULT_TENANT_ID;
 import static io.camunda.zeebe.client.ClientProperties.GRPC_ADDRESS;
 import static io.camunda.zeebe.client.ClientProperties.MAX_MESSAGE_SIZE;
@@ -998,5 +999,20 @@ public final class ZeebeClientTest extends ClientTest {
 
     // then
     assertThat(builder.getDefaultRequestTimeout()).isEqualTo(Duration.ofSeconds(1));
+  }
+
+  @Test
+  public void shouldSetRequestTimeoutOffsetInMillis() {
+    // given
+    final Properties properties = new Properties();
+    final ZeebeClientBuilderImpl builder = new ZeebeClientBuilderImpl();
+    properties.setProperty(DEFAULT_REQUEST_TIMEOUT_OFFSET, "100");
+    builder.withProperties(properties);
+
+    // when
+    builder.build();
+
+    // then
+    assertThat(builder.getDefaultRequestTimeoutOffset()).isEqualTo(Duration.ofMillis(100));
   }
 }

--- a/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/configuration/ZeebeClientConfigurationImpl.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/configuration/ZeebeClientConfigurationImpl.java
@@ -139,6 +139,12 @@ public class ZeebeClientConfigurationImpl implements ZeebeClientConfiguration {
   }
 
   @Override
+  public Duration getDefaultRequestTimeoutOffset() {
+    return ofNullable(camundaClientProperties.getZeebe().getRequestTimeoutOffset())
+        .orElse(DEFAULT.getDefaultRequestTimeoutOffset());
+  }
+
+  @Override
   public boolean isPlaintextConnectionEnabled() {
     return plaintext;
   }

--- a/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/properties/common/ZeebeClientProperties.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/properties/common/ZeebeClientProperties.java
@@ -29,6 +29,7 @@ public class ZeebeClientProperties extends ApiProperties {
   private DataSize maxMessageSize;
   private DataSize maxMetadataSize;
   private Duration requestTimeout;
+  private Duration requestTimeoutOffset;
   private String caCertificatePath;
   private Duration keepAlive;
   private String overrideAuthority;
@@ -76,6 +77,14 @@ public class ZeebeClientProperties extends ApiProperties {
 
   public void setRequestTimeout(final Duration requestTimeout) {
     this.requestTimeout = requestTimeout;
+  }
+
+  public Duration getRequestTimeoutOffset() {
+    return requestTimeoutOffset;
+  }
+
+  public void setRequestTimeoutOffset(final Duration requestTimeoutOffset) {
+    this.requestTimeoutOffset = requestTimeoutOffset;
   }
 
   public String getCaCertificatePath() {


### PR DESCRIPTION
## Description

- Configure ActivateJobsCommand's response timeout slightly higher than the request timeout
- Add client/java property for activate jobs response timeout offset
- Backport of https://github.com/camunda/camunda/pull/31802

## Related issues

related to https://github.com/camunda/camunda/issues/28466
