### PR TITLE
test: Stabilize flaky CPT tests

### DIFF
--- a/testing/camunda-process-test-java/pom.xml
+++ b/testing/camunda-process-test-java/pom.xml
@@ -181,6 +181,17 @@
         <artifactId>maven-failsafe-plugin</artifactId>
       </plugin>
 
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <systemPropertyVariables>
+            <!-- Set CPT's assertion timeout to 10 seconds for CI -->
+            <cptAssertionTimeout>PT10S</cptAssertionTimeout>
+          </systemPropertyVariables>
+        </configuration>
+      </plugin>
+
     </plugins>
 
   </build>

--- a/testing/camunda-process-test-java/pom.xml
+++ b/testing/camunda-process-test-java/pom.xml
@@ -186,7 +186,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <systemPropertyVariables>
-            <!-- Set CPT's assertion timeout to 10 seconds for CI -->
+            <!-- Set CPT's assertion timeout to 5 seconds for CI -->
             <cptAssertionTimeout>PT5S</cptAssertionTimeout>
           </systemPropertyVariables>
         </configuration>

--- a/testing/camunda-process-test-java/pom.xml
+++ b/testing/camunda-process-test-java/pom.xml
@@ -187,7 +187,7 @@
         <configuration>
           <systemPropertyVariables>
             <!-- Set CPT's assertion timeout to 10 seconds for CI -->
-            <cptAssertionTimeout>PT10S</cptAssertionTimeout>
+            <cptAssertionTimeout>PT5S</cptAssertionTimeout>
           </systemPropertyVariables>
         </configuration>
       </plugin>

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/DecisionInstanceAssertTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/DecisionInstanceAssertTest.java
@@ -31,7 +31,7 @@ import io.camunda.client.protocol.rest.EvaluatedDecisionOutputItem;
 import io.camunda.client.protocol.rest.MatchedDecisionRuleItem;
 import io.camunda.process.test.api.assertions.DecisionSelectors;
 import io.camunda.process.test.impl.assertions.CamundaDataSource;
-import java.time.Duration;
+import io.camunda.process.test.utils.CamundaAssertExtension;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -40,7 +40,6 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -48,7 +47,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-@ExtendWith(MockitoExtension.class)
+@ExtendWith({CamundaAssertExtension.class, MockitoExtension.class})
 public class DecisionInstanceAssertTest {
 
   private static final String NAME = "name";
@@ -69,14 +68,6 @@ public class DecisionInstanceAssertTest {
   @BeforeEach
   void configureAssertions() {
     CamundaAssert.initialize(camundaDataSource);
-    CamundaAssert.setAssertionInterval(Duration.ZERO);
-    CamundaAssert.setAssertionTimeout(Duration.ofSeconds(3));
-  }
-
-  @AfterEach
-  void resetAssertions() {
-    CamundaAssert.setAssertionInterval(CamundaAssert.DEFAULT_ASSERTION_INTERVAL);
-    CamundaAssert.setAssertionTimeout(CamundaAssert.DEFAULT_ASSERTION_TIMEOUT);
   }
 
   private void mockDecisionInstanceSearch(final DecisionInstance mockedResult) {

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/ElementAssertTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/ElementAssertTest.java
@@ -27,9 +27,9 @@ import io.camunda.client.api.search.filter.ElementInstanceFilter;
 import io.camunda.client.api.search.response.ElementInstance;
 import io.camunda.process.test.api.assertions.ElementSelectors;
 import io.camunda.process.test.impl.assertions.CamundaDataSource;
+import io.camunda.process.test.utils.CamundaAssertExtension;
 import io.camunda.process.test.utils.ElementInstanceBuilder;
 import io.camunda.process.test.utils.ProcessInstanceBuilder;
-import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.function.Consumer;
@@ -44,7 +44,7 @@ import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-@ExtendWith(MockitoExtension.class)
+@ExtendWith({CamundaAssertExtension.class, MockitoExtension.class})
 public class ElementAssertTest {
 
   private static final long PROCESS_INSTANCE_KEY = 1L;
@@ -55,14 +55,6 @@ public class ElementAssertTest {
   @BeforeEach
   void configureAssertions() {
     CamundaAssert.initialize(camundaDataSource);
-    CamundaAssert.setAssertionInterval(Duration.ZERO);
-    CamundaAssert.setAssertionTimeout(Duration.ofSeconds(1));
-  }
-
-  @AfterEach
-  void resetAssertions() {
-    CamundaAssert.setAssertionInterval(CamundaAssert.DEFAULT_ASSERTION_INTERVAL);
-    CamundaAssert.setAssertionTimeout(CamundaAssert.DEFAULT_ASSERTION_TIMEOUT);
   }
 
   @BeforeEach

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/IncidentAssertTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/IncidentAssertTest.java
@@ -23,15 +23,14 @@ import io.camunda.client.api.search.enums.IncidentErrorType;
 import io.camunda.client.api.search.enums.IncidentState;
 import io.camunda.client.api.search.response.Incident;
 import io.camunda.process.test.impl.assertions.CamundaDataSource;
+import io.camunda.process.test.utils.CamundaAssertExtension;
 import io.camunda.process.test.utils.IncidentBuilder;
 import io.camunda.process.test.utils.ProcessInstanceBuilder;
-import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Stream;
 import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -44,7 +43,7 @@ import org.junit.jupiter.params.provider.ArgumentsSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-@ExtendWith(MockitoExtension.class)
+@ExtendWith({CamundaAssertExtension.class, MockitoExtension.class})
 public class IncidentAssertTest {
 
   private static final long PROCESS_INSTANCE_KEY = 1L;
@@ -55,14 +54,6 @@ public class IncidentAssertTest {
   @BeforeEach
   void configureAssertions() {
     CamundaAssert.initialize(camundaDataSource);
-    CamundaAssert.setAssertionInterval(Duration.ZERO);
-    CamundaAssert.setAssertionTimeout(Duration.ofSeconds(1));
-  }
-
-  @AfterEach
-  void resetAssertions() {
-    CamundaAssert.setAssertionInterval(CamundaAssert.DEFAULT_ASSERTION_INTERVAL);
-    CamundaAssert.setAssertionTimeout(CamundaAssert.DEFAULT_ASSERTION_TIMEOUT);
   }
 
   @BeforeEach

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/ProcessInstanceAssertTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/ProcessInstanceAssertTest.java
@@ -29,15 +29,14 @@ import io.camunda.client.api.search.response.ElementInstance;
 import io.camunda.client.api.search.response.Variable;
 import io.camunda.process.test.api.assertions.ProcessInstanceSelectors;
 import io.camunda.process.test.impl.assertions.CamundaDataSource;
+import io.camunda.process.test.utils.CamundaAssertExtension;
 import io.camunda.process.test.utils.ElementInstanceBuilder;
 import io.camunda.process.test.utils.ProcessInstanceBuilder;
 import io.camunda.process.test.utils.VariableBuilder;
-import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.function.Consumer;
 import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -47,7 +46,7 @@ import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-@ExtendWith(MockitoExtension.class)
+@ExtendWith({CamundaAssertExtension.class, MockitoExtension.class})
 public class ProcessInstanceAssertTest {
 
   private static final long PROCESS_INSTANCE_KEY = 1L;
@@ -61,14 +60,6 @@ public class ProcessInstanceAssertTest {
   @BeforeEach
   void configureAssertions() {
     CamundaAssert.initialize(camundaDataSource);
-    CamundaAssert.setAssertionInterval(Duration.ZERO);
-    CamundaAssert.setAssertionTimeout(Duration.ofSeconds(1));
-  }
-
-  @AfterEach
-  void resetAssertions() {
-    CamundaAssert.setAssertionInterval(CamundaAssert.DEFAULT_ASSERTION_INTERVAL);
-    CamundaAssert.setAssertionTimeout(CamundaAssert.DEFAULT_ASSERTION_TIMEOUT);
   }
 
   @Nested

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/UserTaskAssertTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/UserTaskAssertTest.java
@@ -25,12 +25,11 @@ import io.camunda.client.protocol.rest.UserTaskResult;
 import io.camunda.client.protocol.rest.UserTaskStateEnum;
 import io.camunda.process.test.api.assertions.UserTaskSelectors;
 import io.camunda.process.test.impl.assertions.CamundaDataSource;
-import java.time.Duration;
+import io.camunda.process.test.utils.CamundaAssertExtension;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -38,21 +37,13 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-@ExtendWith(MockitoExtension.class)
+@ExtendWith({CamundaAssertExtension.class, MockitoExtension.class})
 public class UserTaskAssertTest {
   @Mock private CamundaDataSource camundaDataSource;
 
   @BeforeEach
   void configureAssertions() {
     CamundaAssert.initialize(camundaDataSource);
-    CamundaAssert.setAssertionInterval(Duration.ZERO);
-    CamundaAssert.setAssertionTimeout(Duration.ofSeconds(1));
-  }
-
-  @AfterEach
-  void resetAssertions() {
-    CamundaAssert.setAssertionInterval(CamundaAssert.DEFAULT_ASSERTION_INTERVAL);
-    CamundaAssert.setAssertionTimeout(CamundaAssert.DEFAULT_ASSERTION_TIMEOUT);
   }
 
   @Test

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/VariableAssertTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/VariableAssertTest.java
@@ -27,10 +27,10 @@ import io.camunda.client.api.search.response.Variable;
 import io.camunda.process.test.api.assertions.ElementSelectors;
 import io.camunda.process.test.impl.assertions.CamundaDataSource;
 import io.camunda.process.test.impl.assertions.util.AssertionJsonMapper;
+import io.camunda.process.test.utils.CamundaAssertExtension;
 import io.camunda.process.test.utils.ElementInstanceBuilder;
 import io.camunda.process.test.utils.ProcessInstanceBuilder;
 import io.camunda.process.test.utils.VariableBuilder;
-import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -40,7 +40,6 @@ import java.util.stream.Stream;
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.assertj.core.api.ThrowingConsumer;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -51,7 +50,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-@ExtendWith(MockitoExtension.class)
+@ExtendWith({CamundaAssertExtension.class, MockitoExtension.class})
 public class VariableAssertTest {
 
   private static final long PROCESS_INSTANCE_KEY = 1L;
@@ -69,14 +68,6 @@ public class VariableAssertTest {
   @BeforeEach
   void configureAssertions() {
     CamundaAssert.initialize(camundaDataSource);
-    CamundaAssert.setAssertionInterval(Duration.ZERO);
-    CamundaAssert.setAssertionTimeout(Duration.ofSeconds(1));
-  }
-
-  @AfterEach
-  void resetAssertions() {
-    CamundaAssert.setAssertionInterval(CamundaAssert.DEFAULT_ASSERTION_INTERVAL);
-    CamundaAssert.setAssertionTimeout(CamundaAssert.DEFAULT_ASSERTION_TIMEOUT);
   }
 
   @BeforeEach

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/utils/CamundaAssertExtension.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/utils/CamundaAssertExtension.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.utils;
+
+import io.camunda.process.test.api.CamundaAssert;
+import java.time.Duration;
+import java.time.format.DateTimeParseException;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+public class CamundaAssertExtension implements BeforeEachCallback, AfterEachCallback {
+
+  private static final String PROPERTY_KEY_ASSERTION_TIMEOUT = "cptAssertionTimeout";
+
+  private static final Duration ASSERTION_TIMEOUT = Duration.ofSeconds(1);
+  private static final Duration ASSERTION_INTERVAL = Duration.ofMillis(10);
+
+  @Override
+  public void beforeEach(final ExtensionContext context) {
+    final String assertionTimeout =
+        System.getProperty(PROPERTY_KEY_ASSERTION_TIMEOUT, ASSERTION_TIMEOUT.toString());
+    try {
+      CamundaAssert.setAssertionInterval(ASSERTION_INTERVAL);
+      CamundaAssert.setAssertionTimeout(Duration.parse(assertionTimeout));
+    } catch (final DateTimeParseException e) {
+      // ignore, fallback to defaults
+    }
+  }
+
+  @Override
+  public void afterEach(final ExtensionContext context) {
+    CamundaAssert.setAssertionInterval(CamundaAssert.DEFAULT_ASSERTION_INTERVAL);
+    CamundaAssert.setAssertionTimeout(CamundaAssert.DEFAULT_ASSERTION_TIMEOUT);
+  }
+}


### PR DESCRIPTION
## Description

Some CPT tests fail frequently in the CI builds because the assertion timeout is too low.

Harmonize the assertion timeout for all CPT tests by introducing a new JUnit extension that sets the timeout instead of the individual tests.

For local development, use a timeout of 1 second. For CI, set the timeout to 10 seconds via Maven plugin configuration.

## Related issues

Fix flaky test case: `VariableAssertTest.shouldSatisfyConditionsForLocalVariables`
