### PR TITLE
Add unified configuration for cluster metadata

### DIFF
--- a/configuration/pom.xml
+++ b/configuration/pom.xml
@@ -52,6 +52,10 @@
     </dependency>
 
     <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-cluster-config</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
@@ -71,17 +75,6 @@
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.assertj</groupId>
-      <artifactId>assertj-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>joda-time</groupId>
-      <artifactId>joda-time</artifactId>
     </dependency>
 
     <dependency>

--- a/configuration/pom.xml
+++ b/configuration/pom.xml
@@ -83,5 +83,18 @@
       <groupId>joda-time</groupId>
       <artifactId>joda-time</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 </project>

--- a/configuration/src/main/java/io/camunda/configuration/Camunda.java
+++ b/configuration/src/main/java/io/camunda/configuration/Camunda.java
@@ -17,4 +17,14 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public class Camunda {
 
   public static final String PREFIX = "camunda";
+
+  private Cluster cluster = new Cluster();
+
+  public Cluster getCluster() {
+    return cluster;
+  }
+
+  public void setCluster(final Cluster cluster) {
+    this.cluster = cluster;
+  }
 }

--- a/configuration/src/main/java/io/camunda/configuration/Cluster.java
+++ b/configuration/src/main/java/io/camunda/configuration/Cluster.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+public class Cluster {
+
+  /** Configuration for the distributed metadata manager in the cluster. */
+  private Metadata metadata = new Metadata();
+
+  public Metadata getMetadata() {
+    return metadata;
+  }
+
+  public void setMetadata(final Metadata metadata) {
+    this.metadata = metadata;
+  }
+}

--- a/configuration/src/main/java/io/camunda/configuration/Metadata.java
+++ b/configuration/src/main/java/io/camunda/configuration/Metadata.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import io.camunda.configuration.UnifiedConfigurationHelper.BackwardsCompatibilityMode;
+import io.camunda.zeebe.dynamic.config.gossip.ClusterConfigurationGossiperConfig;
+import java.time.Duration;
+
+public class Metadata {
+  private static final String PREFIX = "camunda.cluster.metadata.";
+
+  /**
+   * The delay between two sync requests in the ClusterConfigurationManager. A sync request is sent
+   * to another node to get the latest topology of the cluster.
+   */
+  private Duration syncDelay = ClusterConfigurationGossiperConfig.DEFAULT_SYNC_DELAY;
+
+  /** The timeout for a sync request in the ClusterConfigurationManager. */
+  private Duration syncRequestTimeout =
+      ClusterConfigurationGossiperConfig.DEFAULT_SYNC_REQUEST_TIMEOUT;
+
+  /** The number of nodes to which a cluster topology is gossiped. */
+  private int gossipFanout = ClusterConfigurationGossiperConfig.DEFAULT_GOSSIP_FANOUT;
+
+  public Duration getSyncDelay() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + "sync-delay", syncDelay, Duration.class, BackwardsCompatibilityMode.SUPPORTED);
+  }
+
+  public void setSyncDelay(final Duration syncDelay) {
+    this.syncDelay = syncDelay;
+  }
+
+  public Duration getSyncRequestTimeout() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + "sync-request-timeout",
+        syncRequestTimeout,
+        Duration.class,
+        BackwardsCompatibilityMode.SUPPORTED);
+  }
+
+  public void setSyncRequestTimeout(final Duration syncRequestTimeout) {
+    this.syncRequestTimeout = syncRequestTimeout;
+  }
+
+  public int getGossipFanout() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + "gossip-fanout",
+        gossipFanout,
+        Integer.class,
+        BackwardsCompatibilityMode.SUPPORTED);
+  }
+
+  public void setGossipFanout(final Integer gossipFanout) {
+    this.gossipFanout = gossipFanout;
+  }
+}

--- a/configuration/src/main/java/io/camunda/configuration/UnifiedConfigurationHelper.java
+++ b/configuration/src/main/java/io/camunda/configuration/UnifiedConfigurationHelper.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.configuration;
 
-import java.time.Duration;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
@@ -15,6 +14,7 @@ import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.convert.DurationStyle;
 import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Component;
 
@@ -231,7 +231,7 @@ public class UnifiedConfigurationHelper {
       case "String" -> (T) strValue;
       case "Integer" -> (T) Integer.valueOf(strValue);
       case "Boolean" -> (T) Boolean.valueOf(strValue);
-      case "Duration" -> (T) Duration.parse(strValue);
+      case "Duration" -> (T) DurationStyle.detectAndParse(strValue);
       default -> throw new IllegalArgumentException("Unsupported type: " + type);
     };
   }

--- a/configuration/src/main/java/io/camunda/configuration/UnifiedConfigurationHelper.java
+++ b/configuration/src/main/java/io/camunda/configuration/UnifiedConfigurationHelper.java
@@ -64,9 +64,8 @@ public class UnifiedConfigurationHelper {
     final Set<String> legacyProperties = legacyPropertiesDict.get(newProperty);
 
     return switch (backwardsCompatibilityMode) {
-      case NOT_SUPPORTED -> {
-        yield backwardsCompatibilityNotSupported(legacyProperties, newProperty, newValue);
-      }
+      case NOT_SUPPORTED ->
+          backwardsCompatibilityNotSupported(legacyProperties, newProperty, newValue);
       case SUPPORTED_ONLY_IF_VALUES_MATCH -> {
         final T legacyValue = getLegacyValue(legacyProperties, expectedType);
         yield backwardsCompatibilitySupportedOnlyIfValuesMatch(
@@ -93,7 +92,7 @@ public class UnifiedConfigurationHelper {
       throw new UnifiedConfigurationException(
           String.format(
               "Ambiguous legacy configuration. Legacy properties: %s; Legacy values: %s",
-              String.join(", ", legacyProperties), legacyValues.toString()));
+              String.join(", ", legacyProperties), legacyValues));
     }
 
     return legacyValues.iterator().next();
@@ -113,7 +112,7 @@ public class UnifiedConfigurationHelper {
       // Legacy config: not present
       // We can return the newValue or default value
       return newValue;
-    } else if (legacyPresent && !newPresent) {
+    } else if (!newPresent) {
       // Legacy config: present
       // New config...: not present
       // The legacy configuration is no longer allowed -> error
@@ -137,14 +136,13 @@ public class UnifiedConfigurationHelper {
       final String newProperty,
       final T newValue) {
     final boolean legacyPresent = legacyConfigPresent(legacyProperties);
-    final boolean newPresent = newConfigPresent(newProperty);
 
     final String warningMessage =
         String.format(
             "The following legacy properties are no longer supported and should be removed in favor of '%s': %s",
             newProperty, String.join(", ", legacyProperties));
 
-    if ((!legacyPresent && !newPresent) || (!legacyPresent && newPresent)) {
+    if (!legacyPresent) {
       // Legacy config: not present
       // New config...: not present
       // or
@@ -187,12 +185,12 @@ public class UnifiedConfigurationHelper {
             "The following legacy configuration properties should be removed in favor of '%s': %s",
             newProperty, String.join(", ", legacyProperties));
 
-    if ((!legacyPresent && !newPresent) || (!legacyPresent && newPresent)) {
+    if (!legacyPresent) {
       // Legacy config: not present
       // New config...: not present
       // We can retrun the new default value
       return newValue;
-    } else if (legacyPresent && !newPresent) {
+    } else if (!newPresent) {
       // Legacy config: present
       // New config...: not present
       // We can return the legacy value

--- a/configuration/src/main/java/io/camunda/configuration/UnifiedConfigurationHelper.java
+++ b/configuration/src/main/java/io/camunda/configuration/UnifiedConfigurationHelper.java
@@ -18,7 +18,7 @@ import org.springframework.boot.convert.DurationStyle;
 import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Component;
 
-@Component
+@Component("unifiedConfigurationHelper")
 public class UnifiedConfigurationHelper {
 
   private static final Map<String, Set<String>> LEGACY_PROPERTIES =

--- a/configuration/src/main/java/io/camunda/configuration/UnifiedConfigurationHelper.java
+++ b/configuration/src/main/java/io/camunda/configuration/UnifiedConfigurationHelper.java
@@ -7,11 +7,11 @@
  */
 package io.camunda.configuration;
 
+import java.time.Duration;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import org.joda.time.Duration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/configuration/src/main/java/io/camunda/configuration/UnifiedConfigurationHelper.java
+++ b/configuration/src/main/java/io/camunda/configuration/UnifiedConfigurationHelper.java
@@ -38,16 +38,10 @@ public class UnifiedConfigurationHelper {
   private static Environment environment;
   private static Map<String, Set<String>> legacyPropertiesDict = LEGACY_PROPERTIES;
 
-  public UnifiedConfigurationHelper(@Autowired Environment environment) {
+  public UnifiedConfigurationHelper(@Autowired final Environment environment) {
     // We need to pin the environment object statically so that it can be used to perform the
     // fallback mechanism.
     UnifiedConfigurationHelper.environment = environment;
-  }
-
-  public enum BackwardsCompatibilityMode {
-    NOT_SUPPORTED,
-    SUPPORTED_ONLY_IF_VALUES_MATCH,
-    SUPPORTED
   }
 
   public static <T> T validateLegacyConfiguration(
@@ -207,7 +201,7 @@ public class UnifiedConfigurationHelper {
     }
   }
 
-  private static boolean legacyConfigPresent(Set<String> legacyProperties) {
+  private static boolean legacyConfigPresent(final Set<String> legacyProperties) {
     for (final String legacyProperty : legacyProperties) {
       if (environment.containsProperty(legacyProperty)) {
         return true;
@@ -217,7 +211,7 @@ public class UnifiedConfigurationHelper {
     return false;
   }
 
-  private static boolean newConfigPresent(String newProperty) {
+  private static boolean newConfigPresent(final String newProperty) {
     return environment.containsProperty(newProperty);
   }
 
@@ -236,14 +230,20 @@ public class UnifiedConfigurationHelper {
     };
   }
 
-  /* Setters used by tests to inject the mock objects */
-
   public static void setCustomLegacyProperties(
       final Map<String, Set<String>> legacyPropertiesDict) {
     UnifiedConfigurationHelper.legacyPropertiesDict = legacyPropertiesDict;
   }
 
+  /* Setters used by tests to inject the mock objects */
+
   public static void setCustomEnvironment(final Environment environment) {
     UnifiedConfigurationHelper.environment = environment;
+  }
+
+  public enum BackwardsCompatibilityMode {
+    NOT_SUPPORTED,
+    SUPPORTED_ONLY_IF_VALUES_MATCH,
+    SUPPORTED
   }
 }

--- a/configuration/src/main/java/io/camunda/configuration/UnifiedConfigurationHelper.java
+++ b/configuration/src/main/java/io/camunda/configuration/UnifiedConfigurationHelper.java
@@ -15,10 +15,10 @@ import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.annotation.ComponentScan;
 import org.springframework.core.env.Environment;
+import org.springframework.stereotype.Component;
 
-@ComponentScan("io.camunda.configuration")
+@Component
 public class UnifiedConfigurationHelper {
 
   private static final Map<String, Set<String>> LEGACY_PROPERTIES =
@@ -31,7 +31,13 @@ public class UnifiedConfigurationHelper {
               "camunda.tasklist.elasticsearch.url",
               "camunda.tasklist.zeebeElasticsearch.url"),
           "camunda.data.secondary-storage.type",
-          Set.of("camunda.database.type"));
+          Set.of("camunda.database.type"),
+          "camunda.cluster.metadata.sync-delay",
+          Set.of("zeebe.broker.cluster.configManager.gossip.syncDelay"),
+          "camunda.cluster.metadata.sync-request-timeout",
+          Set.of("zeebe.broker.cluster.configManager.gossip.syncRequestTimeout"),
+          "camunda.cluster.metadata.gossip-fanout",
+          Set.of("zeebe.broker.cluster.configManager.gossip.gossipFanout"));
 
   private static final Logger LOGGER = LoggerFactory.getLogger(UnifiedConfigurationHelper.class);
 

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
@@ -10,12 +10,14 @@ package io.camunda.configuration.beanoverrides;
 import io.camunda.configuration.UnifiedConfiguration;
 import io.camunda.configuration.beans.BrokerBasedProperties;
 import org.springframework.beans.BeanUtils;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.Profile;
 
 @Configuration
+@EnableConfigurationProperties(BrokerBasedProperties.class)
 @Profile(value = {"broker", "restore"})
 public class BrokerBasedPropertiesOverride {
 
@@ -23,9 +25,9 @@ public class BrokerBasedPropertiesOverride {
   private final BrokerBasedProperties legacyBrokerBasedProperties;
 
   public BrokerBasedPropertiesOverride(
-      UnifiedConfiguration unifiedConfiguration, BrokerBasedProperties properties) {
+      final UnifiedConfiguration unifiedConfiguration, final BrokerBasedProperties properties) {
     this.unifiedConfiguration = unifiedConfiguration;
-    this.legacyBrokerBasedProperties = properties;
+    legacyBrokerBasedProperties = properties;
   }
 
   @Bean

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
@@ -9,6 +9,7 @@ package io.camunda.configuration.beanoverrides;
 
 import io.camunda.configuration.UnifiedConfiguration;
 import io.camunda.configuration.beans.BrokerBasedProperties;
+import io.camunda.configuration.beans.LegacyBrokerBasedProperties;
 import io.camunda.zeebe.broker.system.configuration.ConfigManagerCfg;
 import io.camunda.zeebe.dynamic.config.gossip.ClusterConfigurationGossiperConfig;
 import org.springframework.beans.BeanUtils;
@@ -19,15 +20,16 @@ import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.Profile;
 
 @Configuration
-@EnableConfigurationProperties(BrokerBasedProperties.class)
+@EnableConfigurationProperties(LegacyBrokerBasedProperties.class)
 @Profile(value = {"broker", "restore"})
 public class BrokerBasedPropertiesOverride {
 
   private final UnifiedConfiguration unifiedConfiguration;
-  private final BrokerBasedProperties legacyBrokerBasedProperties;
+  private final LegacyBrokerBasedProperties legacyBrokerBasedProperties;
 
   public BrokerBasedPropertiesOverride(
-      final UnifiedConfiguration unifiedConfiguration, final BrokerBasedProperties properties) {
+      final UnifiedConfiguration unifiedConfiguration,
+      final LegacyBrokerBasedProperties properties) {
     this.unifiedConfiguration = unifiedConfiguration;
     legacyBrokerBasedProperties = properties;
   }

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
@@ -9,6 +9,8 @@ package io.camunda.configuration.beanoverrides;
 
 import io.camunda.configuration.UnifiedConfiguration;
 import io.camunda.configuration.beans.BrokerBasedProperties;
+import io.camunda.zeebe.broker.system.configuration.ConfigManagerCfg;
+import io.camunda.zeebe.dynamic.config.gossip.ClusterConfigurationGossiperConfig;
 import org.springframework.beans.BeanUtils;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -36,9 +38,26 @@ public class BrokerBasedPropertiesOverride {
     final BrokerBasedProperties override = new BrokerBasedProperties();
     BeanUtils.copyProperties(legacyBrokerBasedProperties, override);
 
-    // TODO: Populate the bean using unifiedConfiguration
-    //  override.setSampleField(unifiedConfiguration.getSampleField());
+    // from camunda.cluster.* sections
+    populateFromCluster(override);
+    // TODO: Populate the bean from rest of camunda.* sections
+    // populateFromData(override);
 
     return override;
+  }
+
+  private void populateFromCluster(final BrokerBasedProperties override) {
+    populateFromClusterMetadata(override);
+    // Rest of camunda.cluster.* sections
+  }
+
+  private void populateFromClusterMetadata(final BrokerBasedProperties override) {
+    final var metadata = unifiedConfiguration.getCamunda().getCluster().getMetadata();
+    final var syncDelay = metadata.getSyncDelay();
+    final var syncTimeout = metadata.getSyncRequestTimeout();
+    final var gossipFanout = metadata.getGossipFanout();
+    final var configManagerGossipConfig =
+        new ClusterConfigurationGossiperConfig(syncDelay, syncTimeout, gossipFanout);
+    override.getCluster().setConfigManager(new ConfigManagerCfg(configManagerGossipConfig));
   }
 }

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
@@ -16,12 +16,14 @@ import org.springframework.beans.BeanUtils;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.DependsOn;
 import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.Profile;
 
 @Configuration
 @EnableConfigurationProperties(LegacyBrokerBasedProperties.class)
 @Profile(value = {"broker", "restore"})
+@DependsOn("unifiedConfigurationHelper")
 public class BrokerBasedPropertiesOverride {
 
   private final UnifiedConfiguration unifiedConfiguration;

--- a/configuration/src/main/java/io/camunda/configuration/beans/BrokerBasedProperties.java
+++ b/configuration/src/main/java/io/camunda/configuration/beans/BrokerBasedProperties.java
@@ -8,7 +8,6 @@
 package io.camunda.configuration.beans;
 
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
-import org.springframework.boot.context.properties.ConfigurationProperties;
 
 // NOTE: This class has been moved away from dist. The reason for this is that as, for now,
 //  we're storing the unified configuration objects and beans in the configuration module,
@@ -21,5 +20,4 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 //  such refactoring happens, we can bring back GatewayBasedProperties within dist, as there will
 //  be no more circular dependency issues.
 
-@ConfigurationProperties("zeebe.broker")
 public class BrokerBasedProperties extends BrokerCfg {}

--- a/configuration/src/main/java/io/camunda/configuration/beans/LegacyBrokerBasedProperties.java
+++ b/configuration/src/main/java/io/camunda/configuration/beans/LegacyBrokerBasedProperties.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration.beans;
+
+import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties("zeebe.broker")
+public class LegacyBrokerBasedProperties extends BrokerCfg {}

--- a/configuration/src/test/java/io/camunda/configuration/ClusterMetadataTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/ClusterMetadataTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.configuration.beanoverrides.BrokerBasedPropertiesOverride;
+import io.camunda.configuration.beans.BrokerBasedProperties;
+import java.time.Duration;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+@SpringJUnitConfig({
+  UnifiedConfiguration.class,
+  BrokerBasedPropertiesOverride.class,
+  UnifiedConfigurationHelper.class
+})
+@ActiveProfiles("broker")
+public class ClusterMetadataTest {
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "camunda.cluster.metadata.sync-delay=30s",
+        "camunda.cluster.metadata.sync-request-timeout=15s",
+        "camunda.cluster.metadata.gossip-fanout=10",
+      })
+  class WithOnlyUnifiedConfigSet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithOnlyUnifiedConfigSet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldSetSyncDelay() {
+      assertThat(brokerCfg.getCluster().getConfigManager().gossip().syncDelay())
+          .isEqualTo(Duration.ofSeconds(30));
+    }
+
+    @Test
+    void shouldSetSyncRequestTimeout() {
+      assertThat(brokerCfg.getCluster().getConfigManager().gossip().syncRequestTimeout())
+          .isEqualTo(Duration.ofSeconds(15));
+    }
+
+    @Test
+    void shouldSetGossipFanout() {
+      assertThat(brokerCfg.getCluster().getConfigManager().gossip().gossipFanout()).isEqualTo(10);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "zeebe.broker.cluster.configManager.gossip.syncDelay=50s",
+        "zeebe.broker.cluster.configManager.gossip.syncRequestTimeout=30s",
+        "zeebe.broker.cluster.configManager.gossip.gossipFanout=200"
+      })
+  class WithOnlyLegacySet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithOnlyLegacySet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldSetSyncDelay() {
+      assertThat(brokerCfg.getCluster().getConfigManager().gossip().syncDelay())
+          .isEqualTo(Duration.ofSeconds(50));
+    }
+
+    @Test
+    void shouldSetSyncRequestTimeout() {
+      assertThat(brokerCfg.getCluster().getConfigManager().gossip().syncRequestTimeout())
+          .isEqualTo(Duration.ofSeconds(30));
+    }
+
+    @Test
+    void shouldSetGossipFanout() {
+      assertThat(brokerCfg.getCluster().getConfigManager().gossip().gossipFanout()).isEqualTo(200);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        // new
+        "camunda.cluster.metadata.sync-delay=30s",
+        "camunda.cluster.metadata.sync-request-timeout=15s",
+        "camunda.cluster.metadata.gossip-fanout=10",
+        // legacy
+        "zeebe.broker.cluster.configManager.gossip.syncDelay=5m",
+        "zeebe.broker.cluster.configManager.gossip.syncRequestTimeout=1m",
+        "zeebe.broker.cluster.configManager.gossip.gossipFanout=300"
+      })
+  class WithNewAndLegacySet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithNewAndLegacySet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldSetSyncDelayFromNew() {
+      assertThat(brokerCfg.getCluster().getConfigManager().gossip().syncDelay())
+          .isEqualTo(Duration.ofSeconds(30));
+    }
+
+    @Test
+    void shouldSetSyncRequestTimeoutFromNew() {
+      assertThat(brokerCfg.getCluster().getConfigManager().gossip().syncRequestTimeout())
+          .isEqualTo(Duration.ofSeconds(15));
+    }
+
+    @Test
+    void shouldSetGossipFanoutFromNew() {
+      assertThat(brokerCfg.getCluster().getConfigManager().gossip().gossipFanout()).isEqualTo(10);
+    }
+  }
+}

--- a/dist/src/main/java/io/camunda/application/StandaloneBroker.java
+++ b/dist/src/main/java/io/camunda/application/StandaloneBroker.java
@@ -9,6 +9,9 @@ package io.camunda.application;
 
 import io.camunda.application.commons.CommonsModuleConfiguration;
 import io.camunda.application.initializers.HealthConfigurationInitializer;
+import io.camunda.configuration.UnifiedConfiguration;
+import io.camunda.configuration.UnifiedConfigurationHelper;
+import io.camunda.configuration.beanoverrides.BrokerBasedPropertiesOverride;
 import io.camunda.zeebe.broker.BrokerModuleConfiguration;
 import org.springframework.boot.SpringBootConfiguration;
 
@@ -22,7 +25,12 @@ public class StandaloneBroker {
 
     final var standaloneBrokerApplication =
         MainSupport.createDefaultApplicationBuilder()
-            .sources(CommonsModuleConfiguration.class, BrokerModuleConfiguration.class)
+            .sources(
+                CommonsModuleConfiguration.class,
+                UnifiedConfiguration.class,
+                UnifiedConfigurationHelper.class,
+                BrokerBasedPropertiesOverride.class,
+                BrokerModuleConfiguration.class)
             .profiles(Profile.BROKER.getId(), Profile.STANDALONE.getId())
             .initializers(new HealthConfigurationInitializer())
             .build(args);

--- a/dist/src/main/java/io/camunda/application/StandaloneSchemaManager.java
+++ b/dist/src/main/java/io/camunda/application/StandaloneSchemaManager.java
@@ -11,7 +11,7 @@ import static io.camunda.zeebe.protocol.impl.record.RecordMetadata.CURRENT_BROKE
 
 import io.camunda.application.initializers.StandaloneSchemaManagerInitializer;
 import io.camunda.application.listeners.ApplicationErrorListener;
-import io.camunda.configuration.beans.BrokerBasedProperties;
+import io.camunda.configuration.beans.LegacyBrokerBasedProperties;
 import io.camunda.search.connect.configuration.ConnectConfiguration;
 import io.camunda.zeebe.broker.exporter.context.ExporterConfiguration;
 import io.camunda.zeebe.exporter.ElasticsearchExporterConfiguration;
@@ -51,9 +51,9 @@ import org.springframework.context.annotation.FullyQualifiedAnnotationBeanNameGe
 public class StandaloneSchemaManager implements CommandLineRunner {
 
   private static final Logger LOG = LoggerFactory.getLogger(StandaloneSchemaManager.class);
-  private final BrokerBasedProperties brokerProperties;
+  private final LegacyBrokerBasedProperties brokerProperties;
 
-  public StandaloneSchemaManager(final BrokerBasedProperties brokerProperties) {
+  public StandaloneSchemaManager(final LegacyBrokerBasedProperties brokerProperties) {
     this.brokerProperties = brokerProperties;
   }
 
@@ -101,7 +101,8 @@ public class StandaloneSchemaManager implements CommandLineRunner {
   }
 
   @EnableAutoConfiguration
-  @EnableConfigurationProperties(BrokerBasedProperties.class)
+  // TODO: Use unified configuration when it is available
+  @EnableConfigurationProperties(LegacyBrokerBasedProperties.class)
   @ComponentScan(
       basePackages = "io.camunda.application.commons.search",
       nameGenerator = FullyQualifiedAnnotationBeanNameGenerator.class)

--- a/dist/src/main/java/io/camunda/application/commons/configuration/BrokerBasedConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/configuration/BrokerBasedConfiguration.java
@@ -24,14 +24,12 @@ import java.time.Duration;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.context.LifecycleProperties;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 import org.springframework.web.filter.CompositeFilter;
 
 @Configuration(proxyBeanMethods = false)
-@EnableConfigurationProperties(BrokerBasedProperties.class)
 @Profile(value = {"broker", "restore"})
 public class BrokerBasedConfiguration {
 


### PR DESCRIPTION
## Description

This PR adds the properties from section `camunda.cluster.metadata` in unified config. 

The legacy properties are 
* `zeebe.broker.cluster.configManager.gossip.syncDelay`
* `zeebe.broker.cluster.configManager.gossip.syncRequestTimeout`
* `zeebe.broker.cluster.configManager.gossip.gossipFanout`

The new properties are 
* `camunda.cluster.metadata.sync-delay`
* `camunda.cluster.metadata.sync-request-timeout`
* `camunda.cluster.metadata.gossip-fanout`

Backwards compatibility is supported for these properties. That means, if legacy is set and new property is not set, legacy value will be used.

### Checklist

- [x] The legacy properties and the backwards compatibility strategy are updated in [schema doc](https://docs.google.com/spreadsheets/d/1R4epsy6DWemA8_76cUE6zOGUFbrXCXlM2reXnKFuz7Y/edit?gid=818158292#gid=818158292) 
- [x] The new property fields are documented in the code

## Related issues

related to #34906 
