### PR TITLE
Ad-hoc sub-process: Extend AHSP record with variables and cancel remaining instances attribute

### DIFF
--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-ad-hoc-sub-process-instruction-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-ad-hoc-sub-process-instruction-template.json
@@ -28,8 +28,14 @@
               "properties": {
                 "elementId": {
                   "type": "keyword"
+                },
+                "variables": {
+                  "enabled": false
                 }
               }
+            },
+            "isCancelRemainingInstances": {
+              "type": "boolean"
             },
             "tenantId": {
               "type": "keyword"

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-ad-hoc-sub-process-instruction-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-ad-hoc-sub-process-instruction-template.json
@@ -34,7 +34,7 @@
                 }
               }
             },
-            "isCancelRemainingInstances": {
+            "cancelRemainingInstances": {
               "type": "boolean"
             },
             "tenantId": {

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-ad-hoc-sub-process-instruction-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-ad-hoc-sub-process-instruction-template.json
@@ -28,8 +28,14 @@
               "properties": {
                 "elementId": {
                   "type": "keyword"
+                },
+                "variables": {
+                  "enabled": false
                 }
               }
+            },
+            "isCancelRemainingInstances": {
+              "type": "boolean"
             },
             "tenantId": {
               "type": "keyword"

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-ad-hoc-sub-process-instruction-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-ad-hoc-sub-process-instruction-template.json
@@ -34,7 +34,7 @@
                 }
               }
             },
-            "isCancelRemainingInstances": {
+            "cancelRemainingInstances": {
               "type": "boolean"
             },
             "tenantId": {

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerActivateAdHocSubProcessActivityRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerActivateAdHocSubProcessActivityRequest.java
@@ -34,6 +34,18 @@ public class BrokerActivateAdHocSubProcessActivityRequest
     return this;
   }
 
+  public BrokerActivateAdHocSubProcessActivityRequest addElement(
+      final String elementId, final DirectBuffer variables) {
+    requestDto.activateElements().add().setElementId(elementId).setVariables(variables);
+    return this;
+  }
+
+  public BrokerActivateAdHocSubProcessActivityRequest cancelRemainingInstances(
+      final boolean cancelRemainingInstances) {
+    requestDto.cancelRemainingInstances(cancelRemainingInstances);
+    return this;
+  }
+
   @Override
   public AdHocSubProcessInstructionRecord getRequestWriter() {
     return requestDto;

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/adhocsubprocess/AdHocSubProcessActivateElementInstruction.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/adhocsubprocess/AdHocSubProcessActivateElementInstruction.java
@@ -8,10 +8,14 @@
 package io.camunda.zeebe.protocol.impl.record.value.adhocsubprocess;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.camunda.zeebe.msgpack.property.DocumentProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.msgpack.value.ObjectValue;
+import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.record.value.AdHocSubProcessInstructionRecordValue.AdHocSubProcessActivateElementInstructionValue;
 import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.util.Map;
+import org.agrona.DirectBuffer;
 
 @JsonIgnoreProperties({
   /* These fields are inherited from ObjectValue; there have no purpose in exported JSON records*/
@@ -22,10 +26,12 @@ public final class AdHocSubProcessActivateElementInstruction extends ObjectValue
     implements AdHocSubProcessActivateElementInstructionValue {
 
   private final StringProperty elementId = new StringProperty("elementId");
+  private final DocumentProperty variables = new DocumentProperty("variables");
 
   public AdHocSubProcessActivateElementInstruction() {
-    super(1);
+    super(2);
     declareProperty(elementId);
+    declareProperty(variables);
   }
 
   @Override
@@ -35,6 +41,16 @@ public final class AdHocSubProcessActivateElementInstruction extends ObjectValue
 
   public AdHocSubProcessActivateElementInstruction setElementId(final String elementId) {
     this.elementId.setValue(elementId);
+    return this;
+  }
+
+  @Override
+  public Map<String, Object> getVariables() {
+    return MsgPackConverter.convertToMap(variables.getValue());
+  }
+
+  public AdHocSubProcessActivateElementInstruction setVariables(final DirectBuffer variables) {
+    this.variables.setValue(variables);
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/adhocsubprocess/AdHocSubProcessInstructionRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/adhocsubprocess/AdHocSubProcessInstructionRecord.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.protocol.impl.record.value.adhocsubprocess;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.zeebe.msgpack.property.ArrayProperty;
+import io.camunda.zeebe.msgpack.property.BooleanProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.msgpack.value.ValueArray;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
@@ -26,13 +27,16 @@ public final class AdHocSubProcessInstructionRecord extends UnifiedRecordValue
       new StringProperty("adHocSubProcessInstanceKey", DEFAULT_STRING);
   private final ArrayProperty<AdHocSubProcessActivateElementInstruction> activateElements =
       new ArrayProperty<>("activateElements", AdHocSubProcessActivateElementInstruction::new);
+  private final BooleanProperty cancelRemainingInstances =
+      new BooleanProperty("isCancelRemainingInstances", false);
   private final StringProperty tenantId =
       new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
 
   public AdHocSubProcessInstructionRecord() {
-    super(3);
+    super(4);
     declareProperty(adHocSubProcessInstanceKey)
         .declareProperty(activateElements)
+        .declareProperty(cancelRemainingInstances)
         .declareProperty(tenantId);
   }
 
@@ -52,6 +56,17 @@ public final class AdHocSubProcessInstructionRecord extends UnifiedRecordValue
     return activateElements.stream()
         .map(AdHocSubProcessActivateElementInstructionValue.class::cast)
         .toList();
+  }
+
+  @Override
+  public boolean isCancelRemainingInstances() {
+    return cancelRemainingInstances.getValue();
+  }
+
+  public AdHocSubProcessInstructionRecord cancelRemainingInstances(
+      final boolean cancelRemainingInstances) {
+    this.cancelRemainingInstances.setValue(cancelRemainingInstances);
+    return this;
   }
 
   /**

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -2310,6 +2310,13 @@ final class JsonSerializableToJsonTest {
                       .setTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
 
               adHocSubProcessInstructionRecord.activateElements().add().setElementId("123");
+              adHocSubProcessInstructionRecord
+                  .activateElements()
+                  .add()
+                  .setElementId("234")
+                  .setVariables(VARIABLES_MSGPACK);
+
+              adHocSubProcessInstructionRecord.cancelRemainingInstances(true);
 
               return adHocSubProcessInstructionRecord;
             },
@@ -2319,9 +2326,17 @@ final class JsonSerializableToJsonTest {
           "tenantId": "<default>",
           "activateElements": [
             {
-              "elementId": "123"
+              "elementId": "123",
+              "variables": {}
+            },
+            {
+              "elementId": "234",
+              "variables": {
+                "foo": "bar"
+              }
             }
-          ]
+          ],
+          "cancelRemainingInstances": true
         }
         """
       },
@@ -2336,7 +2351,8 @@ final class JsonSerializableToJsonTest {
         {
           "adHocSubProcessInstanceKey": "",
           "tenantId": "<default>",
-          "activateElements": []
+          "activateElements": [],
+          "cancelRemainingInstances": false
         }
         """
       },

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AdHocSubProcessInstructionRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AdHocSubProcessInstructionRecordValue.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.protocol.record.ImmutableProtocol;
 import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.intent.AdHocSubProcessInstructionIntent;
 import java.util.List;
+import java.util.Map;
 import org.immutables.value.Value;
 
 /**
@@ -40,10 +41,15 @@ public interface AdHocSubProcessInstructionRecordValue extends RecordValue, Tena
    */
   List<AdHocSubProcessActivateElementInstructionValue> getActivateElements();
 
+  boolean isCancelRemainingInstances();
+
   @Value.Immutable
   @ImmutableProtocol(
       builder = ImmutableAdHocSubProcessActivateElementInstructionValue.Builder.class)
   interface AdHocSubProcessActivateElementInstructionValue {
     String getElementId();
+
+    /** Returns the variables of this instruction. Can be empty. */
+    Map<String, Object> getVariables();
   }
 }


### PR DESCRIPTION
Based on https://github.com/camunda/camunda/pull/35965 - needs to be merged first

## Description

Updates the `AdHocSubProcessInstructionRecord` to:

- Add `variables` to the elements to activate
- Add `isCancelRemainingInstances` flag to control how to deal with still running instances

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes https://github.com/camunda/ad-hoc-sub-process-phase-3/issues/9
