### PR TITLE
Clean up user column family on user deleted event

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UserDeletedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UserDeletedApplier.java
@@ -23,6 +23,6 @@ public class UserDeletedApplier implements TypedEventApplier<UserIntent, UserRec
   @Override
   public void applyState(final long key, final UserRecord value) {
     final var username = value.getUsername();
-    userState.delete(username);
+    userState.deleteByUsername(username);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UserDeletedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UserDeletedApplier.java
@@ -23,6 +23,7 @@ public class UserDeletedApplier implements TypedEventApplier<UserIntent, UserRec
   @Override
   public void applyState(final long key, final UserRecord value) {
     final var username = value.getUsername();
+    userState.deleteByUserKey(value.getUserKey());
     userState.deleteByUsername(username);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableUserState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableUserState.java
@@ -17,4 +17,6 @@ public interface MutableUserState extends UserState {
   void update(final UserRecord user);
 
   void deleteByUsername(final String username);
+
+  void deleteByUserKey(long userKey);
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableUserState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableUserState.java
@@ -16,5 +16,5 @@ public interface MutableUserState extends UserState {
 
   void update(final UserRecord user);
 
-  void delete(final String username);
+  void deleteByUsername(final String username);
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/user/DbUserState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/user/DbUserState.java
@@ -62,7 +62,7 @@ public class DbUserState implements UserState, MutableUserState {
   }
 
   @Override
-  public void delete(final String username) {
+  public void deleteByUsername(final String username) {
     this.username.wrapString(username);
     usersColumnFamily.deleteExisting(this.username);
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/user/DbUserState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/user/DbUserState.java
@@ -68,6 +68,12 @@ public class DbUserState implements UserState, MutableUserState {
   }
 
   @Override
+  public void deleteByUserKey(final long userKey) {
+    this.userKey.wrapLong(userKey);
+    userKeyByUsernameColumnFamily.deleteExisting(this.userKey);
+  }
+
+  @Override
   public Optional<PersistedUser> getUser(final String username) {
     this.username.wrapString(username);
     return Optional.ofNullable(usersColumnFamily.get(this.username, PersistedUser::new));

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/user/DbUserState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/user/DbUserState.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.engine.state.immutable.UserState;
 import io.camunda.zeebe.engine.state.mutable.MutableUserState;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
 import io.camunda.zeebe.protocol.impl.record.value.user.UserRecord;
+import io.camunda.zeebe.util.VisibleForTesting;
 import java.util.Optional;
 
 public class DbUserState implements UserState, MutableUserState {
@@ -79,5 +80,15 @@ public class DbUserState implements UserState, MutableUserState {
 
     return Optional.ofNullable(username)
         .flatMap(dbUsername -> getUser(dbUsername.inner().toString()));
+  }
+
+  @VisibleForTesting
+  ColumnFamily<DbString, PersistedUser> getUsersColumnFamily() {
+    return usersColumnFamily;
+  }
+
+  @VisibleForTesting
+  ColumnFamily<DbLong, DbForeignKey<DbString>> getUserKeyByUsernameColumnFamily() {
+    return userKeyByUsernameColumnFamily;
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/user/UserStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/user/UserStateTest.java
@@ -153,9 +153,9 @@ public class UserStateTest {
     assertThat(persistedUserAfterUpdate.getEmail()).isEqualTo(updatedEmail);
   }
 
-  @DisplayName("should delete a user")
+  @DisplayName("a deleted user should not be found by username")
   @Test
-  void shouldDeleteAUser() {
+  void shouldNotFindUserByUsernameAfterDelete() {
     final var userKey = 1L;
     final var username = "username" + UUID.randomUUID();
     final var name = "name" + UUID.randomUUID();
@@ -172,11 +172,34 @@ public class UserStateTest {
     userState.create(user);
 
     assertThat(userState.getUser(username)).isNotEmpty();
-    assertThat(userState.getUser(userKey)).isNotEmpty();
 
     userState.delete(username);
 
     assertThat(userState.getUser(username)).isEmpty();
+  }
+
+  @DisplayName("a deleted user should not be found by key")
+  @Test
+  void shouldNotFindUserByKeyAfterDelete() {
+    final var userKey = 1L;
+    final var username = "username" + UUID.randomUUID();
+    final var name = "name" + UUID.randomUUID();
+    final var password = "password" + UUID.randomUUID();
+    final var email = "email" + UUID.randomUUID();
+
+    final UserRecord user =
+        new UserRecord()
+            .setUserKey(userKey)
+            .setUsername(username)
+            .setName(name)
+            .setPassword(password)
+            .setEmail(email);
+    userState.create(user);
+
+    assertThat(userState.getUser(userKey)).isNotEmpty();
+
+    userState.delete(username);
+
     assertThat(userState.getUser(userKey)).isEmpty();
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/user/UserStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/user/UserStateTest.java
@@ -172,10 +172,12 @@ public class UserStateTest {
     userState.create(user);
 
     assertThat(userState.getUser(username)).isNotEmpty();
+    assertThat(userState.getUser(userKey)).isNotEmpty();
 
     userState.delete(username);
 
     assertThat(userState.getUser(username)).isEmpty();
+    assertThat(userState.getUser(userKey)).isEmpty();
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/user/UserStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/user/UserStateTest.java
@@ -224,7 +224,7 @@ public class UserStateTest {
 
       assertThat(userState.getUser(username)).isNotEmpty();
 
-      userState.delete(username);
+      userState.deleteByUsername(username);
 
       assertThat(userState.getUser(username)).isEmpty();
     }
@@ -249,7 +249,7 @@ public class UserStateTest {
 
       assertThat(userState.getUser(userKey)).isNotEmpty();
 
-      userState.delete(username);
+      userState.deleteByUsername(username);
 
       assertThat(userState.getUser(userKey)).isEmpty();
     }
@@ -270,7 +270,7 @@ public class UserStateTest {
       assertThat(userState.getUser(user.getUserKey())).isNotEmpty();
 
       // when
-      userState.delete(user.getUsername());
+      userState.deleteByUsername(user.getUsername());
 
       // then
       final var dbUserState = (DbUserState) userState;

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/user/UserStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/user/UserStateTest.java
@@ -204,6 +204,11 @@ public class UserStateTest {
   @Nested
   class DeleteUserTests {
 
+    private void deleteUser(final UserRecord user) {
+      userState.deleteByUserKey(user.getUserKey());
+      userState.deleteByUsername(user.getUsername());
+    }
+
     @DisplayName("a deleted user should not be found by username")
     @Test
     void shouldNotFindUserByUsernameAfterDelete() {
@@ -224,8 +229,7 @@ public class UserStateTest {
 
       assertThat(userState.getUser(username)).isNotEmpty();
 
-      userState.deleteByUsername(username);
-      userState.deleteByUserKey(user.getUserKey());
+      deleteUser(user);
 
       assertThat(userState.getUser(username)).isEmpty();
     }
@@ -250,8 +254,7 @@ public class UserStateTest {
 
       assertThat(userState.getUser(userKey)).isNotEmpty();
 
-      userState.deleteByUsername(username);
-      userState.deleteByUserKey(user.getUserKey());
+      deleteUser(user);
 
       assertThat(userState.getUser(userKey)).isEmpty();
     }
@@ -272,8 +275,7 @@ public class UserStateTest {
       assertThat(userState.getUser(user.getUserKey())).isNotEmpty();
 
       // when
-      userState.deleteByUsername(user.getUsername());
-      userState.deleteByUserKey(user.getUserKey());
+      deleteUser(user);
 
       // then
       final var dbUserState = (DbUserState) userState;

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/user/UserStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/user/UserStateTest.java
@@ -225,6 +225,7 @@ public class UserStateTest {
       assertThat(userState.getUser(username)).isNotEmpty();
 
       userState.deleteByUsername(username);
+      userState.deleteByUserKey(user.getUserKey());
 
       assertThat(userState.getUser(username)).isEmpty();
     }
@@ -250,6 +251,7 @@ public class UserStateTest {
       assertThat(userState.getUser(userKey)).isNotEmpty();
 
       userState.deleteByUsername(username);
+      userState.deleteByUserKey(user.getUserKey());
 
       assertThat(userState.getUser(userKey)).isEmpty();
     }
@@ -271,6 +273,7 @@ public class UserStateTest {
 
       // when
       userState.deleteByUsername(user.getUsername());
+      userState.deleteByUserKey(user.getUserKey());
 
       // then
       final var dbUserState = (DbUserState) userState;


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This adjusts how we delete a user from the state on the User DELETED event.

Note that the event applier was not yet available in 8.7, so it can be safely modified.

## Related issues

closes #35404 
