### PR TITLE
ci: make sure to verify camunda.Dockerfile in Unified CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -997,6 +997,7 @@ jobs:
           version: ${{ steps.build-camunda-docker.outputs.version }}
           platforms: ${{ env.DOCKER_PLATFORMS }}
           goldenfile: camunda-docker-labels.golden.json
+          dockerfile: camunda.Dockerfile
       - name: Create build output log file
         run: echo "BUILD_OUTPUT_FILE_PATH=$(mktemp)" >> "$GITHUB_ENV"
       - name: Run Docker tests


### PR DESCRIPTION
## Description

As [reported](https://camunda.slack.com/archives/C0914D4VDGW/p1753432256203679?thread_ts=1753282308.837269&cid=C0914D4VDGW) by @jjettenCamunda the logic to verify the Docker labels of the `camunda/camunda` Docker images produced by `camunda.Dockerfile` is incorrect, since instead it compares with `Dockerfile`. This flaw was unnoticed until now as both Dockerfiles are (mostly) identical.

Example failure when Dockerfiles diverge: https://github.com/camunda/camunda/actions/runs/16516761874/job/46709136896?pr=35923#step:8:10

This PR fixes the logic by explicitly stating to compare against the `camunda.Dockerfile` which is consistent with previous commands.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

None
