### PR TITLE
[Backport stable/8.5] fix: use benchmark broker url as grpc address only

### DIFF
--- a/zeebe/benchmarks/project/src/main/java/io/camunda/zeebe/Starter.java
+++ b/zeebe/benchmarks/project/src/main/java/io/camunda/zeebe/Starter.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.client.ZeebeClientBuilder;
 import io.camunda.zeebe.config.AppCfg;
 import io.camunda.zeebe.config.StarterCfg;
 import io.camunda.zeebe.util.logging.ThrottledLogger;
+import java.net.URI;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
@@ -184,7 +185,7 @@ public class Starter extends App {
   private ZeebeClient createZeebeClient() {
     final ZeebeClientBuilder builder =
         ZeebeClient.newClientBuilder()
-            .gatewayAddress(appCfg.getBrokerUrl())
+            .grpcAddress(URI.create(appCfg.getBrokerUrl()))
             .numJobWorkerExecutionThreads(0)
             .withProperties(System.getProperties())
             .withInterceptors(monitoringInterceptor);

--- a/zeebe/benchmarks/project/src/main/java/io/camunda/zeebe/Worker.java
+++ b/zeebe/benchmarks/project/src/main/java/io/camunda/zeebe/Worker.java
@@ -24,6 +24,7 @@ import io.camunda.zeebe.config.AppCfg;
 import io.camunda.zeebe.config.WorkerCfg;
 import io.camunda.zeebe.util.logging.ThrottledLogger;
 import io.micrometer.core.instrument.Tags;
+import java.net.URI;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.concurrent.ArrayBlockingQueue;
@@ -111,7 +112,7 @@ public class Worker extends App {
             : workerCfg.getCompletionDelay().multipliedBy(6);
     final ZeebeClientBuilder builder =
         ZeebeClient.newClientBuilder()
-            .gatewayAddress(appCfg.getBrokerUrl())
+            .grpcAddress(URI.create(appCfg.getBrokerUrl()))
             .numJobWorkerExecutionThreads(workerCfg.getThreads())
             .defaultJobWorkerName(workerCfg.getWorkerName())
             .defaultJobTimeout(timeout)


### PR DESCRIPTION
# Description
Backport of #35979 to `stable/8.5`.

relates to 