### PR TITLE
refactor: migrate roles.spec.ts to OC

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityRolesPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityRolesPage.ts
@@ -94,7 +94,9 @@ export class IdentityRolesPage {
     );
     this.deleteRoleModalDeleteButton = this.deleteRoleModal.getByRole(
       'button',
-      {name: 'Delete role'},
+      {
+        name: 'Delete role',
+      },
     );
     this.roleCell = (roleID: string) =>
       this.rolesList.getByRole('cell', {name: roleID, exact: true});
@@ -124,5 +126,12 @@ export class IdentityRolesPage {
   async clickRole(roleID: string) {
     await expect(this.roleCell(roleID)).toBeVisible({timeout: 60000});
     await this.roleCell(roleID).click();
+  }
+
+  async deleteRole(roleName: string) {
+    await this.deleteRoleButton(roleName).click();
+    await expect(this.deleteRoleModal).toBeVisible();
+    await this.deleteRoleModalDeleteButton.click();
+    await expect(this.deleteRoleModal).toBeHidden();
   }
 }

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/roles.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/roles.spec.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {expect} from '@playwright/test';
+import {test} from 'fixtures';
+import {relativizePath, Paths} from 'utils/relativizePath';
+import {LOGIN_CREDENTIALS, createTestData} from 'utils/constants';
+import {navigateToApp} from '@pages/UtilitiesPage';
+import {captureFailureVideo, captureScreenshot} from '@setup';
+
+test.describe.serial('roles CRUD', () => {
+  let NEW_ROLE: NonNullable<ReturnType<typeof createTestData>['authRole']>;
+
+  test.beforeAll(() => {
+    const testData = createTestData({
+      authRole: true,
+    });
+    NEW_ROLE = testData.authRole!;
+  });
+
+  test.beforeEach(async ({page, loginPage, identityHeader}) => {
+    await navigateToApp(page, 'identity');
+    await loginPage.login(
+      LOGIN_CREDENTIALS.username,
+      LOGIN_CREDENTIALS.password,
+    );
+    await expect(page).toHaveURL(relativizePath(Paths.users()));
+    await identityHeader.navigateToRoles();
+    await expect(page).toHaveURL(relativizePath(Paths.roles()));
+  });
+
+  test.afterEach(async ({page}, testInfo) => {
+    await captureScreenshot(page, testInfo);
+    await captureFailureVideo(page, testInfo);
+  });
+
+  test('creates a role', async ({identityRolesPage}) => {
+    await expect(identityRolesPage.roleCell('Admin')).toBeVisible();
+    await identityRolesPage.createRole(NEW_ROLE);
+  });
+
+  test('deletes a role', async ({page, identityRolesPage}) => {
+    const item = identityRolesPage.roleCell(NEW_ROLE.name);
+    await expect(item).toBeVisible();
+    await identityRolesPage.deleteRole(NEW_ROLE.name);
+    await page.reload();
+    await expect(item).toBeHidden();
+  });
+});


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Refactored `roles.spec.ts` to improve performance, reliability, and maintainability.

✅ **Key Changes**

* Moved CRUD tests from the **identity** test suite to the **OC cluster** test suite
* Added unique test data generation to prevent conflicts and improve test isolation


🧪 [Successful test run](https://github.com/camunda/camunda/actions/runs/16521494890), Failing tests due to below issues:
[Variable Editing Spinner issue](https://github.com/camunda/camunda/issues/34148)
[API 401 Issue](https://github.com/camunda/camunda/issues/35443)

📝 [Confluence page](https://confluence.camunda.com/spaces/HAN/pages/262669277/Automated+Testing+Distributions+Overview) updated with the new tests
## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #35720
