### PR TITLE
Operate archiver Reindex failures

### DIFF
--- a/monitor/grafana/dashboards/data_layer.json
+++ b/monitor/grafana/dashboards/data_layer.json
@@ -19,7 +19,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 8,
+  "id": 4,
   "links": [],
   "panels": [
     {
@@ -98,7 +98,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 9
+            "y": 17
           },
           "id": 43,
           "options": {
@@ -242,7 +242,7 @@
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 3
+            "y": 11
           },
           "id": 32,
           "options": {
@@ -359,7 +359,7 @@
             "h": 5,
             "w": 24,
             "x": 0,
-            "y": 10
+            "y": 18
           },
           "id": 33,
           "options": {
@@ -485,7 +485,7 @@
             "h": 8,
             "w": 8,
             "x": 0,
-            "y": 15
+            "y": 23
           },
           "id": 34,
           "options": {
@@ -592,7 +592,7 @@
             "h": 8,
             "w": 8,
             "x": 8,
-            "y": 15
+            "y": 23
           },
           "id": 35,
           "options": {
@@ -699,7 +699,7 @@
             "h": 8,
             "w": 8,
             "x": 16,
-            "y": 15
+            "y": 23
           },
           "id": 36,
           "options": {
@@ -802,7 +802,7 @@
             "h": 5,
             "w": 24,
             "x": 0,
-            "y": 23
+            "y": 31
           },
           "id": 37,
           "options": {
@@ -946,6 +946,104 @@
             }
           ],
           "title": "Operate Archiver (Average Reindex Duration)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "default": true,
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "description": "Tracks exceptions during reindex operations.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 4
+          },
+          "id": 49,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "PBFA97CFB590B2093"
+              },
+              "editorMode": "code",
+              "expr": "increase(operate_archival_reindex_failures_total{namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])",
+              "instant": false,
+              "legendFormat": "{{exception}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Operate Archiver (Reindex Failures)",
           "type": "timeseries"
         }
       ],
@@ -1095,7 +1193,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -1276,7 +1375,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -1374,7 +1474,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -1456,7 +1557,7 @@
             "h": 8,
             "w": 10,
             "x": 0,
-            "y": 169
+            "y": 177
           },
           "id": 22,
           "options": {
@@ -1542,7 +1643,7 @@
             "h": 8,
             "w": 11,
             "x": 10,
-            "y": 169
+            "y": 177
           },
           "id": 23,
           "options": {
@@ -1643,7 +1744,7 @@
             "h": 8,
             "w": 3,
             "x": 21,
-            "y": 169
+            "y": 177
           },
           "id": 24,
           "options": {
@@ -1703,7 +1804,7 @@
             "h": 10,
             "w": 11,
             "x": 0,
-            "y": 177
+            "y": 185
           },
           "id": 25,
           "options": {
@@ -1830,7 +1931,7 @@
             "h": 10,
             "w": 8,
             "x": 11,
-            "y": 177
+            "y": 185
           },
           "id": 26,
           "options": {
@@ -1907,7 +2008,7 @@
             "h": 10,
             "w": 5,
             "x": 19,
-            "y": 177
+            "y": 185
           },
           "id": 27,
           "options": {

--- a/operate/common/src/main/java/io/camunda/operate/Metrics.java
+++ b/operate/common/src/main/java/io/camunda/operate/Metrics.java
@@ -52,6 +52,8 @@ public class Metrics {
   public static final String COUNTER_NAME_ARCHIVED = "archived.process.instances";
   public static final String COUNTER_NAME_IMPORT_FNI_TREE_PATH_CACHE_RESULT =
       "import.fni.tree.path.cache.result";
+  public static final String COUNTER_NAME_REINDEX_FAILURES = "archival.reindex.failures";
+  public static final String COUNTER_NAME_DELETE_FAILURES = "archival.delete.failures";
 
   // Gauges:
   public static final String GAUGE_IMPORT_QUEUE_SIZE = OPERATE_NAMESPACE + "import.queue.size";


### PR DESCRIPTION
## Description

Adds a metric to track reindex failures for the operate archiver, this is coupled with an additional log that will help in debugging once the error is noticed by the panel.

<img width="1448" height="833" alt="image" src="https://github.com/user-attachments/assets/5ecfcc62-428a-48fb-b94d-b5e29f319f4e" />


snapshot:
https://snapshots.raintank.io/dashboard/snapshot/02TXcR3hzuZTFnenxbqfWSoYQ6XPhva8

## Related issues

closes #34744 
