### PR TITLE
Move MT property from standalone broker properties to application properties

### DIFF
--- a/dist/src/main/resources/application-broker.properties
+++ b/dist/src/main/resources/application-broker.properties
@@ -19,4 +19,3 @@ management.endpoint.health.group.startup.show-details=never
 
 #---
 spring.config.activate.on-profile=standalone
-camunda.security.multiTenancy.checksEnabled=${zeebe.broker.gateway.multiTenancy.enabled:false}

--- a/dist/src/main/resources/application.properties
+++ b/dist/src/main/resources/application.properties
@@ -101,3 +101,5 @@ springdoc.swagger-ui.urls[0].url=/rest-api.yaml
 # Spring metrics configuration
 management.metrics.distribution.percentiles-histogram.http.server.requests=true
 management.metrics.distribution.percentiles.http.server.requests=0.5,0.95,0.99
+
+camunda.security.multiTenancy.checksEnabled=${zeebe.broker.gateway.multiTenancy.enabled:false}

--- a/dist/src/test/java/io/camunda/application/commons/security/CamundaSecurityConfigurationTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/security/CamundaSecurityConfigurationTest.java
@@ -9,29 +9,25 @@ package io.camunda.application.commons.security;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import io.camunda.application.MainSupport;
 import io.camunda.application.commons.CommonsModuleConfiguration;
-import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.BeanCreationException;
+import org.springframework.boot.SpringApplication;
 
 public class CamundaSecurityConfigurationTest {
 
   @Test
   public void whenMultiTenancyEnabledAndApiUnprotectedThenFailsToStart() {
-    final var application =
-        MainSupport.createDefaultApplicationBuilder()
-            .sources(CommonsModuleConfiguration.class)
-            .build();
-
     final var mtProperty = "camunda.security.multiTenancy.checksEnabled";
     final var apiProperty = "camunda.security.authentication.unprotected-api";
-    application.setDefaultProperties(
-        Map.of(
-            mtProperty, true,
-            apiProperty, true));
+    System.setProperty(mtProperty, "true");
+    System.setProperty(apiProperty, "true");
 
-    assertThatThrownBy(application::run)
+    assertThatThrownBy(
+            () -> {
+              final SpringApplication app = new SpringApplication(CommonsModuleConfiguration.class);
+              app.run();
+            })
         .isInstanceOf(BeanCreationException.class)
         .cause()
         .isInstanceOf(IllegalStateException.class)


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This should be here temporarily to fix backwards compatibility for alpha7. With the unified configurations project this becomes obsolete. More context: https://camunda.slack.com/archives/C08E56YUUMS/p1753428843362529

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes N/A
