### PR TITLE
feat: hold the CamundaAuthentication while processing the request

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/DefaultCamundaAuthenticationProvider.java
+++ b/authentication/src/main/java/io/camunda/authentication/DefaultCamundaAuthenticationProvider.java
@@ -9,22 +9,38 @@ package io.camunda.authentication;
 
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.security.auth.CamundaAuthenticationConverter;
+import io.camunda.security.auth.CamundaAuthenticationHolder;
 import io.camunda.security.auth.CamundaAuthenticationProvider;
+import java.util.Optional;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 
 public class DefaultCamundaAuthenticationProvider implements CamundaAuthenticationProvider {
 
+  private final CamundaAuthenticationHolder holder;
   private final CamundaAuthenticationConverter<Authentication> converter;
 
   public DefaultCamundaAuthenticationProvider(
-      final CamundaAuthenticationDelegatingConverter converter) {
+      final CamundaAuthenticationHolder holder,
+      final CamundaAuthenticationConverter<Authentication> converter) {
+    this.holder = holder;
     this.converter = converter;
   }
 
   @Override
   public CamundaAuthentication getCamundaAuthentication() {
     final var springBasedAuthentication = SecurityContextHolder.getContext().getAuthentication();
-    return converter.convert(springBasedAuthentication);
+    return Optional.ofNullable(getFromHolderIfPresent(springBasedAuthentication))
+        .orElseGet(() -> convertAndSetInHolder(springBasedAuthentication));
+  }
+
+  private CamundaAuthentication getFromHolderIfPresent(final Authentication authentication) {
+    return Optional.ofNullable(authentication).map(principal -> holder.get()).orElse(null);
+  }
+
+  private CamundaAuthentication convertAndSetInHolder(final Authentication authentication) {
+    final var result = converter.convert(authentication);
+    Optional.ofNullable(result).filter(a -> !a.isAnonymous()).ifPresent(p -> holder.set(result));
+    return result;
   }
 }

--- a/authentication/src/main/java/io/camunda/authentication/holder/CamundaAuthenticationDelegatingHolder.java
+++ b/authentication/src/main/java/io/camunda/authentication/holder/CamundaAuthenticationDelegatingHolder.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.holder;
+
+import io.camunda.security.auth.CamundaAuthentication;
+import io.camunda.security.auth.CamundaAuthenticationHolder;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Delegating {@link CamundaAuthenticationHolder} responsible to delegate to a matching {@link
+ * CamundaAuthenticationHolder} to set and get a {@link CamundaAuthentication}. If no matching
+ * {@link CamundaAuthenticationHolder} is found, it results in a noop, and no exception is thrown.
+ */
+public class CamundaAuthenticationDelegatingHolder implements CamundaAuthenticationHolder {
+
+  private final List<CamundaAuthenticationHolder> holders;
+
+  public CamundaAuthenticationDelegatingHolder(final List<CamundaAuthenticationHolder> holders) {
+    this.holders = holders;
+  }
+
+  @Override
+  public boolean supports() {
+    return true;
+  }
+
+  /**
+   * Calls the matching {@link CamundaAuthenticationHolder} to set given {@link
+   * CamundaAuthentication}, if any found.
+   *
+   * <p>See {@link CamundaAuthenticationHolder#set(CamundaAuthentication)}
+   */
+  @Override
+  public void set(final CamundaAuthentication authentication) {
+    Optional.ofNullable(getMatchingHolder()).ifPresent(c -> c.set(authentication));
+  }
+
+  /**
+   * Calls the matching {@link CamundaAuthenticationHolder} to obtain a {@link
+   * CamundaAuthentication}, if any found.
+   *
+   * <p>See {@link CamundaAuthenticationHolder#get()}
+   */
+  @Override
+  public CamundaAuthentication get() {
+    return Optional.ofNullable(getMatchingHolder())
+        .map(CamundaAuthenticationHolder::get)
+        .orElse(null);
+  }
+
+  protected CamundaAuthenticationHolder getMatchingHolder() {
+    return holders.stream().filter(CamundaAuthenticationHolder::supports).findFirst().orElse(null);
+  }
+}

--- a/authentication/src/main/java/io/camunda/authentication/holder/HttpSessionBasedAuthenticationHolder.java
+++ b/authentication/src/main/java/io/camunda/authentication/holder/HttpSessionBasedAuthenticationHolder.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.holder;
+
+import io.camunda.security.auth.CamundaAuthentication;
+import io.camunda.security.auth.CamundaAuthenticationHolder;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
+import java.util.Optional;
+
+/**
+ * Associates a {@link CamundaAuthentication} to an existing {@link HttpSession}. As long as the
+ * {@link HttpSession} stays active, the same {@link CamundaAuthentication} is returned.
+ */
+public class HttpSessionBasedAuthenticationHolder implements CamundaAuthenticationHolder {
+
+  static final String CAMUNDA_AUTHENTICATION_SESSION_HOLDER_KEY =
+      "io.camunda.security.session:CamundaAuthentication";
+
+  private final HttpServletRequest request;
+
+  public HttpSessionBasedAuthenticationHolder(final HttpServletRequest request) {
+    this.request = request;
+  }
+
+  @Override
+  public boolean supports() {
+    return request.getSession(false) != null;
+  }
+
+  @Override
+  public void set(final CamundaAuthentication authentication) {
+    Optional.ofNullable(getHttpSession())
+        .ifPresent(session -> setCamundaAuthenticationInSession(session, authentication));
+  }
+
+  @Override
+  public CamundaAuthentication get() {
+    return Optional.ofNullable(getHttpSession())
+        .map(this::getCamundaAuthenticationFromSessionIfExists)
+        .orElse(null);
+  }
+
+  protected HttpSession getHttpSession() {
+    return request.getSession(false);
+  }
+
+  protected CamundaAuthentication getCamundaAuthenticationFromSessionIfExists(
+      final HttpSession session) {
+    return (CamundaAuthentication) session.getAttribute(CAMUNDA_AUTHENTICATION_SESSION_HOLDER_KEY);
+  }
+
+  protected void setCamundaAuthenticationInSession(
+      final HttpSession session, final CamundaAuthentication camundaAuthentication) {
+    session.setAttribute(CAMUNDA_AUTHENTICATION_SESSION_HOLDER_KEY, camundaAuthentication);
+  }
+
+  protected void removeCamundaAuthenticationInSession(final HttpSession session) {
+    session.removeAttribute(CAMUNDA_AUTHENTICATION_SESSION_HOLDER_KEY);
+  }
+}

--- a/authentication/src/main/java/io/camunda/authentication/holder/RequestContextBasedAuthenticationHolder.java
+++ b/authentication/src/main/java/io/camunda/authentication/holder/RequestContextBasedAuthenticationHolder.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.holder;
+
+import static org.springframework.web.context.request.RequestAttributes.SCOPE_REQUEST;
+
+import io.camunda.security.auth.CamundaAuthentication;
+import io.camunda.security.auth.CamundaAuthenticationHolder;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.web.context.request.RequestContextHolder;
+
+/**
+ * Associates a given {@link CamundaAuthentication} with the executing thread by using the {@link
+ * RequestContextHolder}, meaning the {@link CamundaAuthentication} is stored as a request
+ * attribute. {@link RequestContextBasedAuthenticationHolder This} ensures that the same {@link
+ * CamundaAuthentication} is returned while processing a request. However, Spring bounds the request
+ * attributes to the current thread. By default, the request attributes are not inheritable for
+ * child threads. When spawning new threads, it cannot guarantee to return the same instance of a
+ * {@link CamundaAuthentication} child threads.
+ *
+ * <p>{@link org.springframework.web.filter.RequestContextFilter} removes the {@link
+ * org.springframework.web.context.request.RequestAttributes} accordingly
+ */
+public class RequestContextBasedAuthenticationHolder implements CamundaAuthenticationHolder {
+
+  static final String CAMUNDA_AUTHENTICATION_REQUEST_HOLDER_KEY =
+      "io.camunda.security.request:CamundaAuthentication";
+
+  private final HttpServletRequest request;
+
+  public RequestContextBasedAuthenticationHolder(final HttpServletRequest request) {
+    this.request = request;
+  }
+
+  @Override
+  public boolean supports() {
+    return request.getSession(false) == null;
+  }
+
+  @Override
+  public void set(final CamundaAuthentication authentication) {
+    RequestContextHolder.currentRequestAttributes()
+        .setAttribute(CAMUNDA_AUTHENTICATION_REQUEST_HOLDER_KEY, authentication, SCOPE_REQUEST);
+  }
+
+  @Override
+  public CamundaAuthentication get() {
+    return (CamundaAuthentication)
+        RequestContextHolder.currentRequestAttributes()
+            .getAttribute(CAMUNDA_AUTHENTICATION_REQUEST_HOLDER_KEY, SCOPE_REQUEST);
+  }
+}

--- a/authentication/src/test/java/io/camunda/authentication/DefaultCamundaAuthenticationConverterTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/DefaultCamundaAuthenticationConverterTest.java
@@ -1,0 +1,277 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication;
+
+import static io.camunda.zeebe.auth.Authorization.USER_TOKEN_CLAIMS;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import io.camunda.authentication.entity.AuthenticationContext.AuthenticationContextBuilder;
+import io.camunda.authentication.entity.CamundaJwtUser;
+import io.camunda.authentication.entity.CamundaOidcUser;
+import io.camunda.authentication.entity.CamundaUser.CamundaUserBuilder;
+import io.camunda.authentication.entity.OAuthContext;
+import io.camunda.security.auth.CamundaAuthenticationConverter;
+import io.camunda.service.TenantServices.TenantDTO;
+import io.camunda.zeebe.auth.Authorization;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.oidc.OidcIdToken;
+import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+public class DefaultCamundaAuthenticationConverterTest {
+
+  private CamundaAuthenticationConverter<Authentication> authenticationConverter;
+
+  @BeforeEach
+  void setup() {
+    authenticationConverter = new DefaultCamundaAuthenticationConverter();
+  }
+
+  @Test
+  void shouldSupportCamundaPrincipal() {
+    // given
+    final var username = "username";
+    final var authentication = getUsernamePasswordAuthenticationInContext(username);
+
+    // when
+    final var supports = authenticationConverter.supports(authentication);
+
+    // then
+    assertThat(supports).isTrue();
+  }
+
+  @Test
+  void shouldNotSupportNoneCamundaPrincipal() {
+    // given
+    final var username = "username";
+    final var authentication = new UsernamePasswordAuthenticationToken(username, null);
+
+    // when
+    final var supports = authenticationConverter.supports(authentication);
+
+    // then
+    assertThat(supports).isFalse();
+  }
+
+  @Test
+  void authenticationContainsUsername() {
+    // given
+    final var username = "username";
+    final var authentication = getUsernamePasswordAuthenticationInContext(username);
+
+    // when
+    final var camundaAuthentication = authenticationConverter.convert(authentication);
+
+    // then
+    assertThat(camundaAuthentication).isNotNull();
+    assertThat(camundaAuthentication.authenticatedUsername()).isEqualTo(username);
+    assertThat(camundaAuthentication.claims().get(Authorization.AUTHORIZED_USERNAME))
+        .isEqualTo(username);
+  }
+
+  @Test
+  void authenticationContainsExtraClaimsWithOidcAuth() {
+    // given
+    final String usernameClaim = "sub";
+    final String usernameValue = "test-user";
+    final var authentication = getOidcAuthenticationInContext(usernameClaim, usernameValue, "aud1");
+
+    // when
+    final var camundaAuthentication = authenticationConverter.convert(authentication);
+
+    // then
+    assertThat(camundaAuthentication.authenticatedUsername()).isEqualTo(usernameValue);
+  }
+
+  @Test
+  void authenticationContainsExtraClaimsWithJwtAuth() {
+    // given
+    final String sub1 = "sub1";
+    final String aud1 = "aud1";
+    final var authentication = getJwtAuthenticationInContext(sub1, aud1);
+
+    // when
+    final var camundaAuthentication = authenticationConverter.convert(authentication);
+
+    // then
+    final var claims = (Map<String, Object>) camundaAuthentication.claims().get(USER_TOKEN_CLAIMS);
+    assertThat(claims).isNotNull();
+    assertThat(claims).containsKey("sub");
+    assertThat(claims).containsKey("aud");
+    assertThat(claims).containsKey("groups");
+    assertThat(claims.get("sub")).isEqualTo(sub1);
+    assertThat(claims.get("aud")).isEqualTo(aud1);
+    assertThat(claims.get("groups")).isEqualTo(List.of("g1", "g2"));
+  }
+
+  @Test
+  void authenticationContainsTenantIdsInAuthenticationContext() {
+    // given
+    final var username = "test-user";
+    final var tenants =
+        List.of(
+            new TenantDTO(1L, "tenant-1", "Tenant One", "First"),
+            new TenantDTO(2L, "tenant-2", "Tenant Two", "Second"));
+    final var authenticationContext =
+        new AuthenticationContextBuilder().withUsername(username).withTenants(tenants).build();
+
+    final var principal =
+        new CamundaOidcUser(
+            new DefaultOidcUser(
+                Collections.emptyList(),
+                new OidcIdToken(
+                    "tokenValue",
+                    Instant.now(),
+                    Instant.now().plusSeconds(3600),
+                    Map.of("sub", username))),
+            null,
+            Collections.emptySet(),
+            authenticationContext);
+
+    final var auth = new OAuth2AuthenticationToken(principal, List.of(), "oidc");
+
+    // when
+    final var camundaAuthentication = authenticationConverter.convert(auth);
+
+    // then
+    assertThat(camundaAuthentication.authenticatedTenantIds())
+        .containsExactlyInAnyOrder("tenant-1", "tenant-2");
+    assertThat(camundaAuthentication.authenticatedUsername()).isEqualTo(username);
+  }
+
+  @Test
+  void usernameIsSetInAuthenticationWhenOnAuthenticationContext() {
+    // given
+    final var username = "test-user";
+    final var authenticationContext =
+        new AuthenticationContextBuilder().withUsername(username).build();
+
+    final var principal =
+        new CamundaOidcUser(
+            new DefaultOidcUser(
+                Collections.emptyList(),
+                new OidcIdToken(
+                    "tokenValue",
+                    Instant.now(),
+                    Instant.now().plusSeconds(3600),
+                    Map.of("sub", username))),
+            null,
+            Collections.emptySet(),
+            authenticationContext);
+
+    final var auth = new OAuth2AuthenticationToken(principal, List.of(), "oidc");
+
+    // when
+    final var camundaAuthentication = authenticationConverter.convert(auth);
+
+    // then
+    assertThat(camundaAuthentication.authenticatedUsername()).isEqualTo(username);
+    assertThat(camundaAuthentication.authenticatedClientId()).isNull();
+  }
+
+  @Test
+  void clientIdIsSetInAuthenticationWhenOnAuthenticationContext() {
+    // given
+    final var clientId = "my-application";
+    final var authenticationContext =
+        new AuthenticationContextBuilder().withClientId(clientId).build();
+
+    final var principal =
+        new CamundaOidcUser(
+            new DefaultOidcUser(
+                Collections.emptyList(),
+                new OidcIdToken(
+                    "tokenValue",
+                    Instant.now(),
+                    Instant.now().plusSeconds(3600),
+                    Map.of("sub", clientId))),
+            null,
+            Collections.emptySet(),
+            authenticationContext);
+
+    final var auth = new OAuth2AuthenticationToken(principal, List.of(), "oidc");
+
+    // when
+    final var camundaAuthentication = authenticationConverter.convert(auth);
+
+    // then
+    assertThat(camundaAuthentication.authenticatedUsername()).isNull();
+    assertThat(camundaAuthentication.authenticatedClientId()).isEqualTo(clientId);
+  }
+
+  private Authentication getJwtAuthenticationInContext(final String sub, final String aud) {
+    final Jwt jwt =
+        new Jwt(
+            JWT.create()
+                .withIssuer("issuer1")
+                .withAudience(aud)
+                .withSubject(sub)
+                .sign(Algorithm.none()),
+            Instant.ofEpochSecond(10),
+            Instant.ofEpochSecond(100),
+            Map.of("alg", "RSA256"),
+            Map.of("sub", sub, "aud", aud, "groups", List.of("g1", "g2")));
+
+    return new CamundaJwtAuthenticationToken(
+        jwt,
+        new CamundaJwtUser(
+            jwt,
+            new OAuthContext(
+                new HashSet<>(),
+                new AuthenticationContextBuilder()
+                    .withUsername(sub)
+                    .withGroups(List.of("g1", "g2"))
+                    .build())),
+        null,
+        null);
+  }
+
+  private Authentication getOidcAuthenticationInContext(
+      final String usernameClaim, final String usernameValue, final String aud) {
+    final String tokenValue = "{}";
+    final Instant tokenIssuedAt = Instant.now().truncatedTo(ChronoUnit.SECONDS);
+    final Instant tokenExpiresAt = tokenIssuedAt.plus(1, ChronoUnit.DAYS);
+
+    return new OAuth2AuthenticationToken(
+        new CamundaOidcUser(
+            new DefaultOidcUser(
+                Collections.emptyList(),
+                new OidcIdToken(
+                    tokenValue,
+                    tokenIssuedAt,
+                    tokenExpiresAt,
+                    Map.of("aud", aud, usernameClaim, usernameValue))),
+            null,
+            Collections.emptySet(),
+            new AuthenticationContextBuilder().withUsername(usernameValue).build()),
+        List.of(),
+        "oidc");
+  }
+
+  private Authentication getUsernamePasswordAuthenticationInContext(final String username) {
+    return new UsernamePasswordAuthenticationToken(
+        CamundaUserBuilder.aCamundaUser()
+            .withUsername(username)
+            .withPassword("admin")
+            .withUserKey(1L)
+            .build(),
+        null);
+  }
+}

--- a/authentication/src/test/java/io/camunda/authentication/DefaultCamundaAuthenticationProviderTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/DefaultCamundaAuthenticationProviderTest.java
@@ -7,303 +7,94 @@
  */
 package io.camunda.authentication;
 
-import static io.camunda.zeebe.auth.Authorization.USER_TOKEN_CLAIMS;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
-import com.auth0.jwt.JWT;
-import com.auth0.jwt.algorithms.Algorithm;
-import io.camunda.authentication.entity.AuthenticationContext.AuthenticationContextBuilder;
-import io.camunda.authentication.entity.CamundaJwtUser;
-import io.camunda.authentication.entity.CamundaOidcUser;
-import io.camunda.authentication.entity.CamundaUser.CamundaUserBuilder;
-import io.camunda.authentication.entity.OAuthContext;
-import io.camunda.authentication.exception.CamundaAuthenticationException;
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.security.auth.CamundaAuthenticationConverter;
+import io.camunda.security.auth.CamundaAuthenticationHolder;
 import io.camunda.security.auth.CamundaAuthenticationProvider;
-import io.camunda.service.TenantServices.TenantDTO;
-import io.camunda.zeebe.auth.Authorization;
-import java.time.Instant;
-import java.time.temporal.ChronoUnit;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.springframework.security.authentication.AbstractAuthenticationToken;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
-import org.springframework.security.oauth2.core.oidc.OidcIdToken;
-import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser;
-import org.springframework.security.oauth2.jwt.Jwt;
-import org.springframework.web.context.request.RequestAttributes;
-import org.springframework.web.context.request.RequestContextHolder;
 
 public class DefaultCamundaAuthenticationProviderTest {
 
-  @Mock private RequestAttributes requestAttributes;
+  @Mock CamundaAuthenticationHolder holder;
+  @Mock private CamundaAuthenticationConverter<Authentication> authenticationConverter;
   private CamundaAuthenticationProvider authenticationProvider;
-  private CamundaAuthenticationConverter<Authentication> authenticationConverter;
 
   @BeforeEach
   void setup() throws Exception {
     MockitoAnnotations.openMocks(this).close();
-    RequestContextHolder.setRequestAttributes(requestAttributes);
-    authenticationConverter = new DefaultCamundaAuthenticationConverter();
+    authenticationConverter = mock(CamundaAuthenticationConverter.class);
+    holder = mock(CamundaAuthenticationHolder.class);
     authenticationProvider =
-        new DefaultCamundaAuthenticationProvider(
-            new CamundaAuthenticationDelegatingConverter(List.of(authenticationConverter)));
+        new DefaultCamundaAuthenticationProvider(holder, authenticationConverter);
   }
 
   @Test
-  void tokenContainsUsernameWithBasicAuth() {
-
+  void shouldReturnAuthenticationFromHolder() {
     // given
-    final var username = "username";
-    setUsernamePasswordAuthenticationInContext(username);
+    final var expectedAuthentication = CamundaAuthentication.of(b -> b.user("foo"));
+
+    final var mockAuthentication = mock(Authentication.class);
+    when(mockAuthentication.getPrincipal()).thenReturn("foo");
+    SecurityContextHolder.getContext().setAuthentication(mockAuthentication);
+    when(holder.get()).thenReturn(expectedAuthentication);
 
     // when
-    final var claims = authenticationProvider.getCamundaAuthentication().claims();
+    final var actualAuthentication = authenticationProvider.getCamundaAuthentication();
 
     // then
-    assertThat(claims).isNotNull();
-    assertThat(claims).containsKey(Authorization.AUTHORIZED_USERNAME);
-    assertThat(claims.get(Authorization.AUTHORIZED_USERNAME)).isEqualTo(username);
+    assertThat(actualAuthentication).isNotNull();
+    assertThat(actualAuthentication).isEqualTo(expectedAuthentication);
   }
 
   @Test
-  void tokenContainsExtraClaimsWithOidcAuth() {
+  void shouldConvertAndHoldAuthentication() {
     // given
-    final String usernameClaim = "sub";
-    final String usernameValue = "test-user";
-    setOidcAuthenticationInContext(usernameClaim, usernameValue, "aud1");
+    final var expectedAuthentication = CamundaAuthentication.of(b -> b.user("foo"));
+
+    final var mockAuthentication = mock(Authentication.class);
+    when(mockAuthentication.getPrincipal()).thenReturn("foo");
+    SecurityContextHolder.getContext().setAuthentication(mockAuthentication);
+    when(authenticationConverter.convert(eq(mockAuthentication)))
+        .thenReturn(expectedAuthentication);
 
     // when
-    final var authenticatedUsername =
-        authenticationProvider.getCamundaAuthentication().authenticatedUsername();
+    final var actualAuthentication = authenticationProvider.getCamundaAuthentication();
 
     // then
-    assertThat(authenticatedUsername).isEqualTo(usernameValue);
+    assertThat(actualAuthentication).isNotNull();
+    assertThat(actualAuthentication).isEqualTo(expectedAuthentication);
+    verify(holder).set(eq(expectedAuthentication));
   }
 
   @Test
-  void tokenContainsExtraClaimsWithJwtAuth() {
-
+  void shouldConvertButNotCacheIfAnonymous() {
     // given
-    final String sub1 = "sub1";
-    final String aud1 = "aud1";
-    setJwtAuthenticationInContext(sub1, aud1);
+    final var expectedAuthentication = CamundaAuthentication.anonymous();
+
+    final var mockAuthentication = mock(Authentication.class);
+    when(mockAuthentication.getPrincipal()).thenReturn("foo");
+    SecurityContextHolder.getContext().setAuthentication(mockAuthentication);
+    when(authenticationConverter.convert(eq(mockAuthentication)))
+        .thenReturn(expectedAuthentication);
 
     // when
-    final var claims =
-        (Map<String, Object>)
-            authenticationProvider.getCamundaAuthentication().claims().get(USER_TOKEN_CLAIMS);
+    final var actualAuthentication = authenticationProvider.getCamundaAuthentication();
 
     // then
-    assertThat(claims).isNotNull();
-    assertThat(claims).containsKey("sub");
-    assertThat(claims).containsKey("aud");
-    assertThat(claims).containsKey("groups");
-    assertThat(claims.get("sub")).isEqualTo(sub1);
-    assertThat(claims.get("aud")).isEqualTo(aud1);
-    assertThat(claims.get("groups")).isEqualTo(List.of("g1", "g2"));
-  }
-
-  @Test
-  void tokenContainsTenantIdsInAuthenticationContext() {
-    // given
-    final var username = "test-user";
-    final var tenants =
-        List.of(
-            new TenantDTO(1L, "tenant-1", "Tenant One", "First"),
-            new TenantDTO(2L, "tenant-2", "Tenant Two", "Second"));
-    final var authenticationContext =
-        new AuthenticationContextBuilder().withUsername(username).withTenants(tenants).build();
-
-    final var principal =
-        new CamundaOidcUser(
-            new DefaultOidcUser(
-                Collections.emptyList(),
-                new OidcIdToken(
-                    "tokenValue",
-                    Instant.now(),
-                    Instant.now().plusSeconds(3600),
-                    Map.of("sub", username))),
-            null,
-            Collections.emptySet(),
-            authenticationContext);
-
-    final var auth = new OAuth2AuthenticationToken(principal, List.of(), "oidc");
-    SecurityContextHolder.getContext().setAuthentication(auth);
-
-    // when
-    final var authContext = authenticationProvider.getCamundaAuthentication();
-
-    // then
-    assertThat(authContext.authenticatedTenantIds())
-        .containsExactlyInAnyOrder("tenant-1", "tenant-2");
-    assertThat(authContext.authenticatedUsername()).isEqualTo(username);
-  }
-
-  @Test
-  void usernameIsSetInAuthenticationWhenOnAuthenticationContext() {
-    // given
-    final var username = "test-user";
-    final var authenticationContext =
-        new AuthenticationContextBuilder().withUsername(username).build();
-
-    final var principal =
-        new CamundaOidcUser(
-            new DefaultOidcUser(
-                Collections.emptyList(),
-                new OidcIdToken(
-                    "tokenValue",
-                    Instant.now(),
-                    Instant.now().plusSeconds(3600),
-                    Map.of("sub", username))),
-            null,
-            Collections.emptySet(),
-            authenticationContext);
-
-    final var auth = new OAuth2AuthenticationToken(principal, List.of(), "oidc");
-    SecurityContextHolder.getContext().setAuthentication(auth);
-
-    // when
-    final var authentication = authenticationProvider.getCamundaAuthentication();
-
-    // then
-    assertThat(authentication.authenticatedUsername()).isEqualTo(username);
-    assertThat(authentication.authenticatedClientId()).isNull();
-  }
-
-  @Test
-  void clientIdIsSetInAuthenticationWhenOnAuthenticationContext() {
-    // given
-    final var clientId = "my-application";
-    final var authenticationContext =
-        new AuthenticationContextBuilder().withClientId(clientId).build();
-
-    final var principal =
-        new CamundaOidcUser(
-            new DefaultOidcUser(
-                Collections.emptyList(),
-                new OidcIdToken(
-                    "tokenValue",
-                    Instant.now(),
-                    Instant.now().plusSeconds(3600),
-                    Map.of("sub", clientId))),
-            null,
-            Collections.emptySet(),
-            authenticationContext);
-
-    final var auth = new OAuth2AuthenticationToken(principal, List.of(), "oidc");
-    SecurityContextHolder.getContext().setAuthentication(auth);
-
-    // when
-    final var authContext = authenticationProvider.getCamundaAuthentication();
-
-    // then
-    assertThat(authContext.authenticatedUsername()).isNull();
-    assertThat(authContext.authenticatedClientId()).isEqualTo(clientId);
-  }
-
-  @Test
-  void shouldThrowExceptionWhenNoMatchingConverterFound() {
-    // given
-    SecurityContextHolder.getContext().setAuthentication(null);
-
-    // when / then
-    assertThatThrownBy(() -> authenticationProvider.getCamundaAuthentication())
-        .isInstanceOf(CamundaAuthenticationException.class);
-  }
-
-  @Test
-  void shouldReturnAnonymousCamundaAuthenticationWhenApiProtectionDisabled() {
-    // given
-    SecurityContextHolder.getContext().setAuthentication(null);
-    authenticationConverter = new DefaultCamundaAuthenticationConverter();
-    final var unprotectedAuthenticationConverter = new UnprotectedCamundaAuthenticationConverter();
-    authenticationProvider =
-        new DefaultCamundaAuthenticationProvider(
-            new CamundaAuthenticationDelegatingConverter(
-                List.of(unprotectedAuthenticationConverter, authenticationConverter)));
-
-    // when
-    final var authContext = authenticationProvider.getCamundaAuthentication();
-
-    // then
-    assertThat(authContext).isEqualTo(CamundaAuthentication.anonymous());
-  }
-
-  private void setJwtAuthenticationInContext(final String sub, final String aud) {
-    final Jwt jwt =
-        new Jwt(
-            JWT.create()
-                .withIssuer("issuer1")
-                .withAudience(aud)
-                .withSubject(sub)
-                .sign(Algorithm.none()),
-            Instant.ofEpochSecond(10),
-            Instant.ofEpochSecond(100),
-            Map.of("alg", "RSA256"),
-            Map.of("sub", sub, "aud", aud, "groups", List.of("g1", "g2")));
-
-    final AbstractAuthenticationToken token =
-        new CamundaJwtAuthenticationToken(
-            jwt,
-            new CamundaJwtUser(
-                jwt,
-                new OAuthContext(
-                    new HashSet<>(),
-                    new AuthenticationContextBuilder()
-                        .withUsername(sub)
-                        .withGroups(List.of("g1", "g2"))
-                        .build())),
-            null,
-            null);
-    SecurityContextHolder.getContext().setAuthentication(token);
-  }
-
-  private void setOidcAuthenticationInContext(
-      final String usernameClaim, final String usernameValue, final String aud) {
-    final String tokenValue = "{}";
-    final Instant tokenIssuedAt = Instant.now().truncatedTo(ChronoUnit.SECONDS);
-    final Instant tokenExpiresAt = tokenIssuedAt.plus(1, ChronoUnit.DAYS);
-
-    final var oauth2Authentication =
-        new OAuth2AuthenticationToken(
-            new CamundaOidcUser(
-                new DefaultOidcUser(
-                    Collections.emptyList(),
-                    new OidcIdToken(
-                        tokenValue,
-                        tokenIssuedAt,
-                        tokenExpiresAt,
-                        Map.of("aud", aud, usernameClaim, usernameValue))),
-                null,
-                Collections.emptySet(),
-                new AuthenticationContextBuilder().withUsername(usernameValue).build()),
-            List.of(),
-            "oidc");
-
-    SecurityContextHolder.getContext().setAuthentication(oauth2Authentication);
-  }
-
-  private void setUsernamePasswordAuthenticationInContext(final String username) {
-    final UsernamePasswordAuthenticationToken authenticationToken =
-        new UsernamePasswordAuthenticationToken(
-            CamundaUserBuilder.aCamundaUser()
-                .withUsername(username)
-                .withPassword("admin")
-                .withUserKey(1L)
-                .build(),
-            null);
-    SecurityContextHolder.getContext().setAuthentication(authenticationToken);
+    assertThat(actualAuthentication).isNotNull();
+    assertThat(actualAuthentication).isEqualTo(expectedAuthentication);
+    verify(holder, times(0)).set(eq(expectedAuthentication));
   }
 }

--- a/authentication/src/test/java/io/camunda/authentication/holder/HttpSessionBasedAuthenticationHolderTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/holder/HttpSessionBasedAuthenticationHolderTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.holder;
+
+import static io.camunda.authentication.holder.HttpSessionBasedAuthenticationHolder.CAMUNDA_AUTHENTICATION_SESSION_HOLDER_KEY;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.security.auth.CamundaAuthentication;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+public class HttpSessionBasedAuthenticationHolderTest {
+
+  @Mock private HttpServletRequest request;
+  private HttpSessionBasedAuthenticationHolder holder;
+
+  @BeforeEach
+  void setup() {
+    request = mock(HttpServletRequest.class);
+    holder = new HttpSessionBasedAuthenticationHolder(request);
+  }
+
+  @Test
+  public void shouldSupportWhenSessionExists() {
+    // given
+    final var session = mock(HttpSession.class);
+    when(request.getSession(eq(false))).thenReturn(session);
+
+    // when
+    final var result = holder.supports();
+
+    // then
+    assertThat(result).isTrue();
+  }
+
+  @Test
+  public void shouldNotSupportWhenSessionDoesNotExist() {
+    // given
+    when(request.getSession(eq(false))).thenReturn(null);
+
+    // when
+    final var result = holder.supports();
+
+    // then
+    assertThat(result).isFalse();
+  }
+
+  @Test
+  public void shouldReturnAuthentication() {
+    // given
+    final var authentication = mock(CamundaAuthentication.class);
+    final var session = mock(HttpSession.class);
+
+    when(request.getSession(eq(false))).thenReturn(session);
+    when(session.getAttribute(eq(CAMUNDA_AUTHENTICATION_SESSION_HOLDER_KEY)))
+        .thenReturn(authentication);
+
+    // when
+    final var result = holder.get();
+
+    // then
+    assertThat(result).isEqualTo(authentication);
+  }
+
+  @Test
+  public void shouldAddAuthenticationToSession() {
+    // given
+    final var authentication = mock(CamundaAuthentication.class);
+    final var session = mock(HttpSession.class);
+
+    when(request.getSession(eq(false))).thenReturn(session);
+
+    // when
+    holder.set(authentication);
+
+    // then
+    verify(session, times(1))
+        .setAttribute(eq(CAMUNDA_AUTHENTICATION_SESSION_HOLDER_KEY), eq(authentication));
+  }
+}

--- a/authentication/src/test/java/io/camunda/authentication/holder/RequestContextBasedAuthenticationHolderTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/holder/RequestContextBasedAuthenticationHolderTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.holder;
+
+import static io.camunda.authentication.holder.RequestContextBasedAuthenticationHolder.CAMUNDA_AUTHENTICATION_REQUEST_HOLDER_KEY;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.web.context.request.RequestAttributes.SCOPE_REQUEST;
+
+import io.camunda.security.auth.CamundaAuthentication;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.web.context.request.RequestAttributes;
+import org.springframework.web.context.request.RequestContextHolder;
+
+public class RequestContextBasedAuthenticationHolderTest {
+
+  @Mock private RequestAttributes requestAttributes;
+  @Mock private HttpServletRequest request;
+  private RequestContextBasedAuthenticationHolder holder;
+
+  @BeforeEach
+  void setup() throws Exception {
+    MockitoAnnotations.openMocks(this).close();
+    RequestContextHolder.setRequestAttributes(requestAttributes);
+    request = mock(HttpServletRequest.class);
+    holder = new RequestContextBasedAuthenticationHolder(request);
+  }
+
+  @Test
+  public void shouldSupportWhenSessionExists() {
+    // given
+    when(request.getSession(eq(false))).thenReturn(null);
+
+    // when
+    final var result = holder.supports();
+
+    // then
+    assertThat(result).isTrue();
+  }
+
+  @Test
+  public void shouldNotSupportWhenSessionDoesNotExist() {
+    // given
+    final var session = mock(HttpSession.class);
+    when(request.getSession(eq(false))).thenReturn(session);
+
+    // when
+    final var result = holder.supports();
+
+    // then
+    assertThat(result).isFalse();
+  }
+
+  @Test
+  public void shouldReturnAuthentication() {
+    // given
+    final var authentication = mock(CamundaAuthentication.class);
+    when(requestAttributes.getAttribute(
+            eq(CAMUNDA_AUTHENTICATION_REQUEST_HOLDER_KEY), eq(SCOPE_REQUEST)))
+        .thenReturn(authentication);
+
+    // when
+    final var result = holder.get();
+
+    // then
+    assertThat(result).isEqualTo(authentication);
+  }
+
+  @Test
+  public void shouldAddAuthenticationToRequest() {
+    // given
+    final var authentication = mock(CamundaAuthentication.class);
+
+    // when
+    holder.set(authentication);
+
+    // then
+    verify(requestAttributes, times(1))
+        .setAttribute(
+            eq(CAMUNDA_AUTHENTICATION_REQUEST_HOLDER_KEY), eq(authentication), eq(SCOPE_REQUEST));
+  }
+}

--- a/dist/src/main/java/io/camunda/application/commons/rest/RestApiConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/rest/RestApiConfiguration.java
@@ -13,10 +13,15 @@ import io.camunda.authentication.ConditionalOnUnprotectedApi;
 import io.camunda.authentication.DefaultCamundaAuthenticationConverter;
 import io.camunda.authentication.DefaultCamundaAuthenticationProvider;
 import io.camunda.authentication.UnprotectedCamundaAuthenticationConverter;
+import io.camunda.authentication.holder.CamundaAuthenticationDelegatingHolder;
+import io.camunda.authentication.holder.HttpSessionBasedAuthenticationHolder;
+import io.camunda.authentication.holder.RequestContextBasedAuthenticationHolder;
 import io.camunda.security.auth.CamundaAuthenticationConverter;
+import io.camunda.security.auth.CamundaAuthenticationHolder;
 import io.camunda.security.auth.CamundaAuthenticationProvider;
 import io.camunda.zeebe.gateway.rest.ConditionalOnRestGatewayEnabled;
 import io.camunda.zeebe.gateway.rest.config.GatewayRestConfiguration;
+import jakarta.servlet.http.HttpServletRequest;
 import java.util.List;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -38,14 +43,28 @@ public class RestApiConfiguration {
   }
 
   @Bean
+  public CamundaAuthenticationHolder requestContextBasedAuthenticationHolder(
+      final HttpServletRequest request) {
+    return new RequestContextBasedAuthenticationHolder(request);
+  }
+
+  @Bean
+  public CamundaAuthenticationHolder httpSessionBasedAuthenticationHolder(
+      final HttpServletRequest request) {
+    return new HttpSessionBasedAuthenticationHolder(request);
+  }
+
+  @Bean
   public CamundaAuthenticationConverter<Authentication> camundaAuthenticationConverter() {
     return new DefaultCamundaAuthenticationConverter();
   }
 
   @Bean
   public CamundaAuthenticationProvider camundaAuthenticationProvider(
+      final List<CamundaAuthenticationHolder> holders,
       final List<CamundaAuthenticationConverter<Authentication>> converters) {
     return new DefaultCamundaAuthenticationProvider(
+        new CamundaAuthenticationDelegatingHolder(holders),
         new CamundaAuthenticationDelegatingConverter(converters));
   }
 

--- a/security/security-core/src/main/java/io/camunda/security/auth/CamundaAuthentication.java
+++ b/security/security-core/src/main/java/io/camunda/security/auth/CamundaAuthentication.java
@@ -10,8 +10,10 @@ package io.camunda.security.auth;
 import static java.util.Collections.unmodifiableList;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.camunda.zeebe.auth.Authorization;
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -26,7 +28,16 @@ public record CamundaAuthentication(
     @JsonProperty("authenticated_role_ids") List<String> authenticatedRoleIds,
     @JsonProperty("authenticated_tenant_ids") List<String> authenticatedTenantIds,
     @JsonProperty("authenticated_mapping_ids") List<String> authenticatedMappingIds,
-    @JsonProperty("claims") Map<String, Object> claims) {
+    @JsonProperty("claims") Map<String, Object> claims)
+    implements Serializable {
+
+  @JsonIgnore
+  public boolean isAnonymous() {
+    if (claims != null && claims.containsKey(Authorization.AUTHORIZED_ANONYMOUS_USER)) {
+      return ((boolean) claims.get(Authorization.AUTHORIZED_ANONYMOUS_USER));
+    }
+    return false;
+  }
 
   public static CamundaAuthentication none() {
     return of(b -> b);

--- a/security/security-core/src/main/java/io/camunda/security/auth/CamundaAuthenticationHolder.java
+++ b/security/security-core/src/main/java/io/camunda/security/auth/CamundaAuthenticationHolder.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.security.auth;
+
+/**
+ * Associates a given {@link CamundaAuthentication} with the current execution thread processing the
+ * request.
+ */
+public interface CamundaAuthenticationHolder {
+
+  /**
+   * Returns to true, if {@link CamundaAuthenticationHolder this} could hold a {@link
+   * CamundaAuthentication}.
+   */
+  boolean supports();
+
+  /**
+   * Associates a given {@link CamundaAuthentication} with the current thread of execution while
+   * processing the request.
+   */
+  void set(final CamundaAuthentication authentication);
+
+  /** Obtains the current {@link CamundaAuthentication}, or null if not present. */
+  CamundaAuthentication get();
+}

--- a/security/security-core/src/main/java/io/camunda/security/reader/ResourceAccessController.java
+++ b/security/security-core/src/main/java/io/camunda/security/reader/ResourceAccessController.java
@@ -9,8 +9,6 @@ package io.camunda.security.reader;
 
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.security.auth.SecurityContext;
-import io.camunda.zeebe.auth.Authorization;
-import java.util.Optional;
 import java.util.function.Function;
 
 /**
@@ -54,12 +52,6 @@ public interface ResourceAccessController {
    * is anonymous. *
    */
   default boolean isAnonymousAuthentication(final CamundaAuthentication authentication) {
-    final var claims =
-        Optional.ofNullable(authentication).map(CamundaAuthentication::claims).orElse(null);
-
-    if (claims != null && claims.containsKey(Authorization.AUTHORIZED_ANONYMOUS_USER)) {
-      return ((boolean) claims.get(Authorization.AUTHORIZED_ANONYMOUS_USER));
-    }
-    return false;
+    return authentication.isAnonymous();
   }
 }


### PR DESCRIPTION
## Description

It provides a `CamundaAuthenticationHolder` that associates a `CamundaAuthentication` with the executing thread. This PR implements two types of caches:
1. `HttpSessionBasedAuthenticationHolder` holds the `CamundaAuthentication` in  the `HttpSession`
2. `RequestContextBasedAuthenticationHolder` holds the `CamundaAuthentication` as a request attribute belonging to the current thread.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #36034
