### PR TITLE
[Backport stable/8.6] ci: make sure to verify camunda.Dockerfile in Unified CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -443,6 +443,7 @@ jobs:
           version: ${{ steps.build-camunda-docker.outputs.version }}
           platforms: ${{ env.DOCKER_PLATFORMS }}
           goldenfile: camunda-docker-labels.golden.json
+          dockerfile: camunda.Dockerfile
       - name: Run Docker tests
         run: |
           ./mvnw -f dist --no-snapshot-updates -DskipChecks -Dtest=CamundaDockerIT -Dsurefire.rerunFailingTestsCount=3 \


### PR DESCRIPTION
# Description
Backport of #35982 to `stable/8.6`.

relates to 