### PR TITLE
refactor: convert `UsernamePasswordAuthenticationToken` directly in `CamundaAuthenticationConverter

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/DefaultCamundaAuthenticationConverter.java
+++ b/authentication/src/main/java/io/camunda/authentication/DefaultCamundaAuthenticationConverter.java
@@ -72,11 +72,9 @@ public class DefaultCamundaAuthenticationConverter
 
     if (authenticationContext.username() != null) {
       final var authenticatedUsername = authenticationContext.username();
-      claims.put(Authorization.AUTHORIZED_USERNAME, authenticatedUsername);
       authenticationBuilder.user(authenticatedUsername);
     } else {
       final var authenticatedClientId = authenticationContext.clientId();
-      claims.put(Authorization.AUTHORIZED_CLIENT_ID, authenticatedClientId);
       authenticationBuilder.clientId(authenticatedClientId);
     }
 

--- a/authentication/src/main/java/io/camunda/authentication/DefaultCamundaAuthenticationProvider.java
+++ b/authentication/src/main/java/io/camunda/authentication/DefaultCamundaAuthenticationProvider.java
@@ -8,23 +8,46 @@
 package io.camunda.authentication;
 
 import io.camunda.security.auth.CamundaAuthentication;
+import io.camunda.security.auth.CamundaAuthenticationCache;
 import io.camunda.security.auth.CamundaAuthenticationConverter;
 import io.camunda.security.auth.CamundaAuthenticationProvider;
+import java.util.Optional;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 
 public class DefaultCamundaAuthenticationProvider implements CamundaAuthenticationProvider {
 
+  private final CamundaAuthenticationCache cache;
   private final CamundaAuthenticationConverter<Authentication> converter;
 
   public DefaultCamundaAuthenticationProvider(
-      final CamundaAuthenticationDelegatingConverter converter) {
+      final CamundaAuthenticationCache cache,
+      final CamundaAuthenticationConverter<Authentication> converter) {
+    this.cache = cache;
     this.converter = converter;
   }
 
   @Override
   public CamundaAuthentication getCamundaAuthentication() {
     final var springBasedAuthentication = SecurityContextHolder.getContext().getAuthentication();
-    return converter.convert(springBasedAuthentication);
+    return Optional.ofNullable(getFromCacheIfPresent(springBasedAuthentication))
+        .orElseGet(() -> convertAndCache(springBasedAuthentication));
+  }
+
+  private CamundaAuthentication getFromCacheIfPresent(final Authentication authentication) {
+    return Optional.ofNullable(authentication)
+        .map(Authentication::getPrincipal)
+        .map(cache::get)
+        .orElse(null);
+  }
+
+  private CamundaAuthentication convertAndCache(final Authentication authentication) {
+    final var result = converter.convert(authentication);
+    if (result != null && !result.isAnonymous()) {
+      Optional.ofNullable(authentication)
+          .map(Authentication::getPrincipal)
+          .ifPresent(p -> cache.put(p, result));
+    }
+    return result;
   }
 }

--- a/authentication/src/main/java/io/camunda/authentication/cache/CamundaAuthenticationDelegatingCache.java
+++ b/authentication/src/main/java/io/camunda/authentication/cache/CamundaAuthenticationDelegatingCache.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.cache;
+
+import io.camunda.security.auth.CamundaAuthentication;
+import io.camunda.security.auth.CamundaAuthenticationCache;
+import java.util.List;
+import java.util.Optional;
+
+public class CamundaAuthenticationDelegatingCache implements CamundaAuthenticationCache {
+
+  private final List<CamundaAuthenticationCache> caches;
+
+  public CamundaAuthenticationDelegatingCache(final List<CamundaAuthenticationCache> caches) {
+    this.caches = caches;
+  }
+
+  @Override
+  public boolean supports(final Object principal) {
+    return true;
+  }
+
+  @Override
+  public void put(final Object principal, final CamundaAuthentication authentication) {
+    Optional.ofNullable(getCache(principal)).ifPresent(c -> c.put(principal, authentication));
+  }
+
+  @Override
+  public CamundaAuthentication get(final Object principal) {
+    return Optional.ofNullable(getCache(principal)).map(c -> c.get(principal)).orElse(null);
+  }
+
+  @Override
+  public void remove(final Object principal) {
+    Optional.ofNullable(getCache(principal)).ifPresent(c -> c.remove(principal));
+  }
+
+  protected CamundaAuthenticationCache getCache(final Object principal) {
+    return caches.stream().filter(cache -> cache.supports(principal)).findFirst().orElse(null);
+  }
+}

--- a/authentication/src/main/java/io/camunda/authentication/cache/HttpSessionBasedAuthenticationCache.java
+++ b/authentication/src/main/java/io/camunda/authentication/cache/HttpSessionBasedAuthenticationCache.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.cache;
+
+import io.camunda.security.auth.CamundaAuthentication;
+import io.camunda.security.auth.CamundaAuthenticationCache;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
+import java.util.Optional;
+
+/**
+ * A {@link CamundaAuthenticationCache} that caches a {@link CamundaAuthentication} using the {@link
+ * HttpSession} as an underlying cache. If no {@link HttpSession} exists, any given {@link
+ * CamundaAuthentication} won't be cached.
+ */
+public class HttpSessionBasedAuthenticationCache implements CamundaAuthenticationCache {
+
+  static final String CAMUNDA_AUTHENTICATION_CACHE_KEY =
+      "io.camunda.security.session:CamundaAuthentication";
+
+  private final HttpServletRequest request;
+
+  public HttpSessionBasedAuthenticationCache(final HttpServletRequest request) {
+    this.request = request;
+  }
+
+  @Override
+  public boolean supports(final Object principal) {
+    return request.getSession(false) != null;
+  }
+
+  @Override
+  public void put(final Object principal, final CamundaAuthentication authentication) {
+    Optional.of(getHttpSession())
+        .ifPresent(session -> setCamundaAuthenticationInSession(session, authentication));
+  }
+
+  @Override
+  public CamundaAuthentication get(final Object principal) {
+    return Optional.of(getHttpSession())
+        .map(this::getCamundaAuthenticationFromSessionIfExists)
+        .orElse(null);
+  }
+
+  @Override
+  public void remove(final Object principal) {
+    Optional.of(getHttpSession()).ifPresent(this::removeCamundaAuthenticationInSession);
+  }
+
+  protected HttpSession getHttpSession() {
+    return request.getSession();
+  }
+
+  protected CamundaAuthentication getCamundaAuthenticationFromSessionIfExists(
+      final HttpSession session) {
+    return (CamundaAuthentication) session.getAttribute(CAMUNDA_AUTHENTICATION_CACHE_KEY);
+  }
+
+  protected void setCamundaAuthenticationInSession(
+      final HttpSession session, final CamundaAuthentication camundaAuthentication) {
+    session.setAttribute(CAMUNDA_AUTHENTICATION_CACHE_KEY, camundaAuthentication);
+  }
+
+  protected void removeCamundaAuthenticationInSession(final HttpSession session) {
+    session.removeAttribute(CAMUNDA_AUTHENTICATION_CACHE_KEY);
+  }
+}

--- a/authentication/src/main/java/io/camunda/authentication/cache/RequestContextBasedAuthenticationCache.java
+++ b/authentication/src/main/java/io/camunda/authentication/cache/RequestContextBasedAuthenticationCache.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.cache;
+
+import static org.springframework.web.context.request.RequestAttributes.SCOPE_REQUEST;
+
+import io.camunda.security.auth.CamundaAuthentication;
+import io.camunda.security.auth.CamundaAuthenticationCache;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.web.context.request.RequestContextHolder;
+
+/**
+ * A {@link CamundaAuthenticationCache} that caches a {@link CamundaAuthentication} using the {@link
+ * RequestContextHolder} as an underlying cache, meaning the {@link CamundaAuthentication} is stored
+ * as a request attribute. The cache ensures that the same {@link CamundaAuthentication} is returned
+ * while processing a request. However, Spring bounds the request attributes to the current thread.
+ * By default, the request attributes are not inheritable for child threads. When spawning new
+ * threads, it cannot guarantee to return the same instance of a {@link CamundaAuthentication} child
+ * threads.
+ */
+public class RequestContextBasedAuthenticationCache implements CamundaAuthenticationCache {
+
+  static final String CAMUNDA_AUTHENTICATION_CACHE_KEY =
+      "io.camunda.security.request:CamundaAuthentication";
+
+  private final HttpServletRequest request;
+
+  public RequestContextBasedAuthenticationCache(final HttpServletRequest request) {
+    this.request = request;
+  }
+
+  @Override
+  public boolean supports(final Object principal) {
+    return request.getSession(false) == null;
+  }
+
+  @Override
+  public void put(final Object principal, final CamundaAuthentication authentication) {
+    RequestContextHolder.currentRequestAttributes()
+        .setAttribute(CAMUNDA_AUTHENTICATION_CACHE_KEY, authentication, SCOPE_REQUEST);
+  }
+
+  @Override
+  public CamundaAuthentication get(final Object principal) {
+    return (CamundaAuthentication)
+        RequestContextHolder.currentRequestAttributes()
+            .getAttribute(CAMUNDA_AUTHENTICATION_CACHE_KEY, SCOPE_REQUEST);
+  }
+
+  @Override
+  public void remove(final Object principal) {
+    RequestContextHolder.currentRequestAttributes()
+        .removeAttribute(CAMUNDA_AUTHENTICATION_CACHE_KEY, SCOPE_REQUEST);
+  }
+}

--- a/authentication/src/test/java/io/camunda/authentication/DefaultCamundaAuthenticationConverterTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/DefaultCamundaAuthenticationConverterTest.java
@@ -1,0 +1,277 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication;
+
+import static io.camunda.zeebe.auth.Authorization.USER_TOKEN_CLAIMS;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import io.camunda.authentication.entity.AuthenticationContext.AuthenticationContextBuilder;
+import io.camunda.authentication.entity.CamundaJwtUser;
+import io.camunda.authentication.entity.CamundaOidcUser;
+import io.camunda.authentication.entity.CamundaUser.CamundaUserBuilder;
+import io.camunda.authentication.entity.OAuthContext;
+import io.camunda.security.auth.CamundaAuthenticationConverter;
+import io.camunda.service.TenantServices.TenantDTO;
+import io.camunda.zeebe.auth.Authorization;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.oidc.OidcIdToken;
+import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+public class DefaultCamundaAuthenticationConverterTest {
+
+  private CamundaAuthenticationConverter<Authentication> authenticationConverter;
+
+  @BeforeEach
+  void setup() throws Exception {
+    authenticationConverter = new DefaultCamundaAuthenticationConverter();
+  }
+
+  @Test
+  void shouldSupportCamundaPrincipal() {
+    // given
+    final var username = "username";
+    final var authentication = getUsernamePasswordAuthenticationInContext(username);
+
+    // when
+    final var supports = authenticationConverter.supports(authentication);
+
+    // then
+    assertThat(supports).isTrue();
+  }
+
+  @Test
+  void shouldNotSupportNoneCamundaPrincipal() {
+    // given
+    final var username = "username";
+    final var authentication = new UsernamePasswordAuthenticationToken(username, null);
+
+    // when
+    final var supports = authenticationConverter.supports(authentication);
+
+    // then
+    assertThat(supports).isFalse();
+  }
+
+  @Test
+  void authenticationContainsUsername() {
+    // given
+    final var username = "username";
+    final var authentication = getUsernamePasswordAuthenticationInContext(username);
+
+    // when
+    final var camundaAuthentication = authenticationConverter.convert(authentication);
+
+    // then
+    assertThat(camundaAuthentication).isNotNull();
+    assertThat(camundaAuthentication.authenticatedUsername()).isEqualTo(username);
+    assertThat(camundaAuthentication.claims().get(Authorization.AUTHORIZED_USERNAME))
+        .isEqualTo(username);
+  }
+
+  @Test
+  void authenticationContainsExtraClaimsWithOidcAuth() {
+    // given
+    final String usernameClaim = "sub";
+    final String usernameValue = "test-user";
+    final var authentication = getOidcAuthenticationInContext(usernameClaim, usernameValue, "aud1");
+
+    // when
+    final var camundaAuthentication = authenticationConverter.convert(authentication);
+
+    // then
+    assertThat(camundaAuthentication.authenticatedUsername()).isEqualTo(usernameValue);
+  }
+
+  @Test
+  void authenticationContainsExtraClaimsWithJwtAuth() {
+    // given
+    final String sub1 = "sub1";
+    final String aud1 = "aud1";
+    final var authentication = getJwtAuthenticationInContext(sub1, aud1);
+
+    // when
+    final var camundaAuthentication = authenticationConverter.convert(authentication);
+
+    // then
+    final var claims = (Map<String, Object>) camundaAuthentication.claims().get(USER_TOKEN_CLAIMS);
+    assertThat(claims).isNotNull();
+    assertThat(claims).containsKey("sub");
+    assertThat(claims).containsKey("aud");
+    assertThat(claims).containsKey("groups");
+    assertThat(claims.get("sub")).isEqualTo(sub1);
+    assertThat(claims.get("aud")).isEqualTo(aud1);
+    assertThat(claims.get("groups")).isEqualTo(List.of("g1", "g2"));
+  }
+
+  @Test
+  void authenticationContainsTenantIdsInAuthenticationContext() {
+    // given
+    final var username = "test-user";
+    final var tenants =
+        List.of(
+            new TenantDTO(1L, "tenant-1", "Tenant One", "First"),
+            new TenantDTO(2L, "tenant-2", "Tenant Two", "Second"));
+    final var authenticationContext =
+        new AuthenticationContextBuilder().withUsername(username).withTenants(tenants).build();
+
+    final var principal =
+        new CamundaOidcUser(
+            new DefaultOidcUser(
+                Collections.emptyList(),
+                new OidcIdToken(
+                    "tokenValue",
+                    Instant.now(),
+                    Instant.now().plusSeconds(3600),
+                    Map.of("sub", username))),
+            null,
+            Collections.emptySet(),
+            authenticationContext);
+
+    final var auth = new OAuth2AuthenticationToken(principal, List.of(), "oidc");
+
+    // when
+    final var camundaAuthentication = authenticationConverter.convert(auth);
+
+    // then
+    assertThat(camundaAuthentication.authenticatedTenantIds())
+        .containsExactlyInAnyOrder("tenant-1", "tenant-2");
+    assertThat(camundaAuthentication.authenticatedUsername()).isEqualTo(username);
+  }
+
+  @Test
+  void usernameIsSetInAuthenticationWhenOnAuthenticationContext() {
+    // given
+    final var username = "test-user";
+    final var authenticationContext =
+        new AuthenticationContextBuilder().withUsername(username).build();
+
+    final var principal =
+        new CamundaOidcUser(
+            new DefaultOidcUser(
+                Collections.emptyList(),
+                new OidcIdToken(
+                    "tokenValue",
+                    Instant.now(),
+                    Instant.now().plusSeconds(3600),
+                    Map.of("sub", username))),
+            null,
+            Collections.emptySet(),
+            authenticationContext);
+
+    final var auth = new OAuth2AuthenticationToken(principal, List.of(), "oidc");
+
+    // when
+    final var camundaAuthentication = authenticationConverter.convert(auth);
+
+    // then
+    assertThat(camundaAuthentication.authenticatedUsername()).isEqualTo(username);
+    assertThat(camundaAuthentication.authenticatedClientId()).isNull();
+  }
+
+  @Test
+  void clientIdIsSetInAuthenticationWhenOnAuthenticationContext() {
+    // given
+    final var clientId = "my-application";
+    final var authenticationContext =
+        new AuthenticationContextBuilder().withClientId(clientId).build();
+
+    final var principal =
+        new CamundaOidcUser(
+            new DefaultOidcUser(
+                Collections.emptyList(),
+                new OidcIdToken(
+                    "tokenValue",
+                    Instant.now(),
+                    Instant.now().plusSeconds(3600),
+                    Map.of("sub", clientId))),
+            null,
+            Collections.emptySet(),
+            authenticationContext);
+
+    final var auth = new OAuth2AuthenticationToken(principal, List.of(), "oidc");
+
+    // when
+    final var camundaAuthentication = authenticationConverter.convert(auth);
+
+    // then
+    assertThat(camundaAuthentication.authenticatedUsername()).isNull();
+    assertThat(camundaAuthentication.authenticatedClientId()).isEqualTo(clientId);
+  }
+
+  private Authentication getJwtAuthenticationInContext(final String sub, final String aud) {
+    final Jwt jwt =
+        new Jwt(
+            JWT.create()
+                .withIssuer("issuer1")
+                .withAudience(aud)
+                .withSubject(sub)
+                .sign(Algorithm.none()),
+            Instant.ofEpochSecond(10),
+            Instant.ofEpochSecond(100),
+            Map.of("alg", "RSA256"),
+            Map.of("sub", sub, "aud", aud, "groups", List.of("g1", "g2")));
+
+    return new CamundaJwtAuthenticationToken(
+        jwt,
+        new CamundaJwtUser(
+            jwt,
+            new OAuthContext(
+                new HashSet<>(),
+                new AuthenticationContextBuilder()
+                    .withUsername(sub)
+                    .withGroups(List.of("g1", "g2"))
+                    .build())),
+        null,
+        null);
+  }
+
+  private Authentication getOidcAuthenticationInContext(
+      final String usernameClaim, final String usernameValue, final String aud) {
+    final String tokenValue = "{}";
+    final Instant tokenIssuedAt = Instant.now().truncatedTo(ChronoUnit.SECONDS);
+    final Instant tokenExpiresAt = tokenIssuedAt.plus(1, ChronoUnit.DAYS);
+
+    return new OAuth2AuthenticationToken(
+        new CamundaOidcUser(
+            new DefaultOidcUser(
+                Collections.emptyList(),
+                new OidcIdToken(
+                    tokenValue,
+                    tokenIssuedAt,
+                    tokenExpiresAt,
+                    Map.of("aud", aud, usernameClaim, usernameValue))),
+            null,
+            Collections.emptySet(),
+            new AuthenticationContextBuilder().withUsername(usernameValue).build()),
+        List.of(),
+        "oidc");
+  }
+
+  private Authentication getUsernamePasswordAuthenticationInContext(final String username) {
+    return new UsernamePasswordAuthenticationToken(
+        CamundaUserBuilder.aCamundaUser()
+            .withUsername(username)
+            .withPassword("admin")
+            .withUserKey(1L)
+            .build(),
+        null);
+  }
+}

--- a/authentication/src/test/java/io/camunda/authentication/DefaultCamundaAuthenticationProviderTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/DefaultCamundaAuthenticationProviderTest.java
@@ -7,303 +7,95 @@
  */
 package io.camunda.authentication;
 
-import static io.camunda.zeebe.auth.Authorization.USER_TOKEN_CLAIMS;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
-import com.auth0.jwt.JWT;
-import com.auth0.jwt.algorithms.Algorithm;
-import io.camunda.authentication.entity.AuthenticationContext.AuthenticationContextBuilder;
-import io.camunda.authentication.entity.CamundaJwtUser;
-import io.camunda.authentication.entity.CamundaOidcUser;
-import io.camunda.authentication.entity.CamundaUser.CamundaUserBuilder;
-import io.camunda.authentication.entity.OAuthContext;
-import io.camunda.authentication.exception.CamundaAuthenticationException;
 import io.camunda.security.auth.CamundaAuthentication;
+import io.camunda.security.auth.CamundaAuthenticationCache;
 import io.camunda.security.auth.CamundaAuthenticationConverter;
 import io.camunda.security.auth.CamundaAuthenticationProvider;
-import io.camunda.service.TenantServices.TenantDTO;
-import io.camunda.zeebe.auth.Authorization;
-import java.time.Instant;
-import java.time.temporal.ChronoUnit;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.springframework.security.authentication.AbstractAuthenticationToken;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
-import org.springframework.security.oauth2.core.oidc.OidcIdToken;
-import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser;
-import org.springframework.security.oauth2.jwt.Jwt;
-import org.springframework.web.context.request.RequestAttributes;
-import org.springframework.web.context.request.RequestContextHolder;
 
 public class DefaultCamundaAuthenticationProviderTest {
 
-  @Mock private RequestAttributes requestAttributes;
+  @Mock CamundaAuthenticationCache cache;
+  @Mock private CamundaAuthenticationConverter<Authentication> authenticationConverter;
   private CamundaAuthenticationProvider authenticationProvider;
-  private CamundaAuthenticationConverter<Authentication> authenticationConverter;
 
   @BeforeEach
   void setup() throws Exception {
     MockitoAnnotations.openMocks(this).close();
-    RequestContextHolder.setRequestAttributes(requestAttributes);
-    authenticationConverter = new DefaultCamundaAuthenticationConverter();
+    authenticationConverter = mock(CamundaAuthenticationConverter.class);
+    cache = mock(CamundaAuthenticationCache.class);
     authenticationProvider =
-        new DefaultCamundaAuthenticationProvider(
-            new CamundaAuthenticationDelegatingConverter(List.of(authenticationConverter)));
+        new DefaultCamundaAuthenticationProvider(cache, authenticationConverter);
   }
 
   @Test
-  void tokenContainsUsernameWithBasicAuth() {
-
+  void shouldReturnAuthenticationFromCache() {
     // given
-    final var username = "username";
-    setUsernamePasswordAuthenticationInContext(username);
+    final var expectedAuthentication = CamundaAuthentication.of(b -> b.user("foo"));
+
+    final var mockAuthentication = mock(Authentication.class);
+    when(mockAuthentication.getPrincipal()).thenReturn("foo");
+    SecurityContextHolder.getContext().setAuthentication(mockAuthentication);
+    when(cache.get(any())).thenReturn(expectedAuthentication);
 
     // when
-    final var claims = authenticationProvider.getCamundaAuthentication().claims();
+    final var actualAuthentication = authenticationProvider.getCamundaAuthentication();
 
     // then
-    assertThat(claims).isNotNull();
-    assertThat(claims).containsKey(Authorization.AUTHORIZED_USERNAME);
-    assertThat(claims.get(Authorization.AUTHORIZED_USERNAME)).isEqualTo(username);
+    assertThat(actualAuthentication).isNotNull();
+    assertThat(actualAuthentication).isEqualTo(expectedAuthentication);
   }
 
   @Test
-  void tokenContainsExtraClaimsWithOidcAuth() {
+  void shouldConvertAndCacheAuthentication() {
     // given
-    final String usernameClaim = "sub";
-    final String usernameValue = "test-user";
-    setOidcAuthenticationInContext(usernameClaim, usernameValue, "aud1");
+    final var expectedAuthentication = CamundaAuthentication.of(b -> b.user("foo"));
+
+    final var mockAuthentication = mock(Authentication.class);
+    when(mockAuthentication.getPrincipal()).thenReturn("foo");
+    SecurityContextHolder.getContext().setAuthentication(mockAuthentication);
+    when(authenticationConverter.convert(eq(mockAuthentication)))
+        .thenReturn(expectedAuthentication);
 
     // when
-    final var authenticatedUsername =
-        authenticationProvider.getCamundaAuthentication().authenticatedUsername();
+    final var actualAuthentication = authenticationProvider.getCamundaAuthentication();
 
     // then
-    assertThat(authenticatedUsername).isEqualTo(usernameValue);
+    assertThat(actualAuthentication).isNotNull();
+    assertThat(actualAuthentication).isEqualTo(expectedAuthentication);
+    verify(cache).put(eq("foo"), eq(expectedAuthentication));
   }
 
   @Test
-  void tokenContainsExtraClaimsWithJwtAuth() {
-
+  void shouldConvertButNotCacheIfAnonymous() {
     // given
-    final String sub1 = "sub1";
-    final String aud1 = "aud1";
-    setJwtAuthenticationInContext(sub1, aud1);
+    final var expectedAuthentication = CamundaAuthentication.anonymous();
+
+    final var mockAuthentication = mock(Authentication.class);
+    when(mockAuthentication.getPrincipal()).thenReturn("foo");
+    SecurityContextHolder.getContext().setAuthentication(mockAuthentication);
+    when(authenticationConverter.convert(eq(mockAuthentication)))
+        .thenReturn(expectedAuthentication);
 
     // when
-    final var claims =
-        (Map<String, Object>)
-            authenticationProvider.getCamundaAuthentication().claims().get(USER_TOKEN_CLAIMS);
+    final var actualAuthentication = authenticationProvider.getCamundaAuthentication();
 
     // then
-    assertThat(claims).isNotNull();
-    assertThat(claims).containsKey("sub");
-    assertThat(claims).containsKey("aud");
-    assertThat(claims).containsKey("groups");
-    assertThat(claims.get("sub")).isEqualTo(sub1);
-    assertThat(claims.get("aud")).isEqualTo(aud1);
-    assertThat(claims.get("groups")).isEqualTo(List.of("g1", "g2"));
-  }
-
-  @Test
-  void tokenContainsTenantIdsInAuthenticationContext() {
-    // given
-    final var username = "test-user";
-    final var tenants =
-        List.of(
-            new TenantDTO(1L, "tenant-1", "Tenant One", "First"),
-            new TenantDTO(2L, "tenant-2", "Tenant Two", "Second"));
-    final var authenticationContext =
-        new AuthenticationContextBuilder().withUsername(username).withTenants(tenants).build();
-
-    final var principal =
-        new CamundaOidcUser(
-            new DefaultOidcUser(
-                Collections.emptyList(),
-                new OidcIdToken(
-                    "tokenValue",
-                    Instant.now(),
-                    Instant.now().plusSeconds(3600),
-                    Map.of("sub", username))),
-            null,
-            Collections.emptySet(),
-            authenticationContext);
-
-    final var auth = new OAuth2AuthenticationToken(principal, List.of(), "oidc");
-    SecurityContextHolder.getContext().setAuthentication(auth);
-
-    // when
-    final var authContext = authenticationProvider.getCamundaAuthentication();
-
-    // then
-    assertThat(authContext.authenticatedTenantIds())
-        .containsExactlyInAnyOrder("tenant-1", "tenant-2");
-    assertThat(authContext.authenticatedUsername()).isEqualTo(username);
-  }
-
-  @Test
-  void usernameIsSetInAuthenticationWhenOnAuthenticationContext() {
-    // given
-    final var username = "test-user";
-    final var authenticationContext =
-        new AuthenticationContextBuilder().withUsername(username).build();
-
-    final var principal =
-        new CamundaOidcUser(
-            new DefaultOidcUser(
-                Collections.emptyList(),
-                new OidcIdToken(
-                    "tokenValue",
-                    Instant.now(),
-                    Instant.now().plusSeconds(3600),
-                    Map.of("sub", username))),
-            null,
-            Collections.emptySet(),
-            authenticationContext);
-
-    final var auth = new OAuth2AuthenticationToken(principal, List.of(), "oidc");
-    SecurityContextHolder.getContext().setAuthentication(auth);
-
-    // when
-    final var authentication = authenticationProvider.getCamundaAuthentication();
-
-    // then
-    assertThat(authentication.authenticatedUsername()).isEqualTo(username);
-    assertThat(authentication.authenticatedClientId()).isNull();
-  }
-
-  @Test
-  void clientIdIsSetInAuthenticationWhenOnAuthenticationContext() {
-    // given
-    final var clientId = "my-application";
-    final var authenticationContext =
-        new AuthenticationContextBuilder().withClientId(clientId).build();
-
-    final var principal =
-        new CamundaOidcUser(
-            new DefaultOidcUser(
-                Collections.emptyList(),
-                new OidcIdToken(
-                    "tokenValue",
-                    Instant.now(),
-                    Instant.now().plusSeconds(3600),
-                    Map.of("sub", clientId))),
-            null,
-            Collections.emptySet(),
-            authenticationContext);
-
-    final var auth = new OAuth2AuthenticationToken(principal, List.of(), "oidc");
-    SecurityContextHolder.getContext().setAuthentication(auth);
-
-    // when
-    final var authContext = authenticationProvider.getCamundaAuthentication();
-
-    // then
-    assertThat(authContext.authenticatedUsername()).isNull();
-    assertThat(authContext.authenticatedClientId()).isEqualTo(clientId);
-  }
-
-  @Test
-  void shouldThrowExceptionWhenNoMatchingConverterFound() {
-    // given
-    SecurityContextHolder.getContext().setAuthentication(null);
-
-    // when / then
-    assertThatThrownBy(() -> authenticationProvider.getCamundaAuthentication())
-        .isInstanceOf(CamundaAuthenticationException.class);
-  }
-
-  @Test
-  void shouldReturnAnonymousCamundaAuthenticationWhenApiProtectionDisabled() {
-    // given
-    SecurityContextHolder.getContext().setAuthentication(null);
-    authenticationConverter = new DefaultCamundaAuthenticationConverter();
-    final var unprotectedAuthenticationConverter = new UnprotectedCamundaAuthenticationConverter();
-    authenticationProvider =
-        new DefaultCamundaAuthenticationProvider(
-            new CamundaAuthenticationDelegatingConverter(
-                List.of(unprotectedAuthenticationConverter, authenticationConverter)));
-
-    // when
-    final var authContext = authenticationProvider.getCamundaAuthentication();
-
-    // then
-    assertThat(authContext).isEqualTo(CamundaAuthentication.anonymous());
-  }
-
-  private void setJwtAuthenticationInContext(final String sub, final String aud) {
-    final Jwt jwt =
-        new Jwt(
-            JWT.create()
-                .withIssuer("issuer1")
-                .withAudience(aud)
-                .withSubject(sub)
-                .sign(Algorithm.none()),
-            Instant.ofEpochSecond(10),
-            Instant.ofEpochSecond(100),
-            Map.of("alg", "RSA256"),
-            Map.of("sub", sub, "aud", aud, "groups", List.of("g1", "g2")));
-
-    final AbstractAuthenticationToken token =
-        new CamundaJwtAuthenticationToken(
-            jwt,
-            new CamundaJwtUser(
-                jwt,
-                new OAuthContext(
-                    new HashSet<>(),
-                    new AuthenticationContextBuilder()
-                        .withUsername(sub)
-                        .withGroups(List.of("g1", "g2"))
-                        .build())),
-            null,
-            null);
-    SecurityContextHolder.getContext().setAuthentication(token);
-  }
-
-  private void setOidcAuthenticationInContext(
-      final String usernameClaim, final String usernameValue, final String aud) {
-    final String tokenValue = "{}";
-    final Instant tokenIssuedAt = Instant.now().truncatedTo(ChronoUnit.SECONDS);
-    final Instant tokenExpiresAt = tokenIssuedAt.plus(1, ChronoUnit.DAYS);
-
-    final var oauth2Authentication =
-        new OAuth2AuthenticationToken(
-            new CamundaOidcUser(
-                new DefaultOidcUser(
-                    Collections.emptyList(),
-                    new OidcIdToken(
-                        tokenValue,
-                        tokenIssuedAt,
-                        tokenExpiresAt,
-                        Map.of("aud", aud, usernameClaim, usernameValue))),
-                null,
-                Collections.emptySet(),
-                new AuthenticationContextBuilder().withUsername(usernameValue).build()),
-            List.of(),
-            "oidc");
-
-    SecurityContextHolder.getContext().setAuthentication(oauth2Authentication);
-  }
-
-  private void setUsernamePasswordAuthenticationInContext(final String username) {
-    final UsernamePasswordAuthenticationToken authenticationToken =
-        new UsernamePasswordAuthenticationToken(
-            CamundaUserBuilder.aCamundaUser()
-                .withUsername(username)
-                .withPassword("admin")
-                .withUserKey(1L)
-                .build(),
-            null);
-    SecurityContextHolder.getContext().setAuthentication(authenticationToken);
+    assertThat(actualAuthentication).isNotNull();
+    assertThat(actualAuthentication).isEqualTo(expectedAuthentication);
+    verify(cache, times(0)).put(eq("foo"), eq(expectedAuthentication));
   }
 }

--- a/authentication/src/test/java/io/camunda/authentication/cache/HttpSessionBasedAuthenticationCacheTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/cache/HttpSessionBasedAuthenticationCacheTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.cache;
+
+import static io.camunda.authentication.cache.HttpSessionBasedAuthenticationCache.CAMUNDA_AUTHENTICATION_CACHE_KEY;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.security.auth.CamundaAuthentication;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+public class HttpSessionBasedAuthenticationCacheTest {
+
+  @Mock private HttpServletRequest request;
+  private HttpSessionBasedAuthenticationCache cache;
+
+  @BeforeEach
+  void setup() {
+    request = mock(HttpServletRequest.class);
+    cache = new HttpSessionBasedAuthenticationCache(request);
+  }
+
+  @Test
+  public void shouldSupportWhenSessionExists() {
+    // given
+    final var anyCacheKey = new Object();
+    final var session = mock(HttpSession.class);
+    when(request.getSession(eq(false))).thenReturn(session);
+
+    // when
+    final var result = cache.supports(anyCacheKey);
+
+    // then
+    assertThat(result).isTrue();
+  }
+
+  @Test
+  public void shouldNotSupportWhenSessionDoesNotExist() {
+    // given
+    final var anyCacheKey = new Object();
+    when(request.getSession(eq(false))).thenReturn(null);
+
+    // when
+    final var result = cache.supports(anyCacheKey);
+
+    // then
+    assertThat(result).isFalse();
+  }
+
+  @Test
+  public void shouldReturnAuthentication() {
+    // given
+    final var anyCacheKey = new Object();
+    final var authentication = mock(CamundaAuthentication.class);
+    final var session = mock(HttpSession.class);
+
+    when(request.getSession()).thenReturn(session);
+    when(session.getAttribute(eq(CAMUNDA_AUTHENTICATION_CACHE_KEY))).thenReturn(authentication);
+
+    // when
+    final var result = cache.get(anyCacheKey);
+
+    // then
+    assertThat(result).isEqualTo(authentication);
+  }
+
+  @Test
+  public void shouldAddAuthenticationToSession() {
+    // given
+    final var anyCacheKey = new Object();
+    final var authentication = mock(CamundaAuthentication.class);
+    final var session = mock(HttpSession.class);
+
+    when(request.getSession()).thenReturn(session);
+
+    // when
+    cache.put(anyCacheKey, authentication);
+
+    // then
+    verify(session, times(1))
+        .setAttribute(eq(CAMUNDA_AUTHENTICATION_CACHE_KEY), eq(authentication));
+  }
+
+  @Test
+  public void shouldRemoveAuthenticationFromSession() {
+    // given
+    final var anyCacheKey = new Object();
+    final var session = mock(HttpSession.class);
+
+    when(request.getSession()).thenReturn(session);
+
+    // when
+    cache.remove(anyCacheKey);
+
+    // then
+    verify(session, times(1)).removeAttribute(eq(CAMUNDA_AUTHENTICATION_CACHE_KEY));
+  }
+}

--- a/authentication/src/test/java/io/camunda/authentication/cache/RequestContextBasedAuthenticationCacheTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/cache/RequestContextBasedAuthenticationCacheTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.cache;
+
+import static io.camunda.authentication.cache.RequestContextBasedAuthenticationCache.CAMUNDA_AUTHENTICATION_CACHE_KEY;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.web.context.request.RequestAttributes.SCOPE_REQUEST;
+
+import io.camunda.security.auth.CamundaAuthentication;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.web.context.request.RequestAttributes;
+import org.springframework.web.context.request.RequestContextHolder;
+
+public class RequestContextBasedAuthenticationCacheTest {
+
+  @Mock private RequestAttributes requestAttributes;
+  @Mock private HttpServletRequest request;
+  private RequestContextBasedAuthenticationCache cache;
+
+  @BeforeEach
+  void setup() throws Exception {
+    MockitoAnnotations.openMocks(this).close();
+    RequestContextHolder.setRequestAttributes(requestAttributes);
+    request = mock(HttpServletRequest.class);
+    cache = new RequestContextBasedAuthenticationCache(request);
+  }
+
+  @Test
+  public void shouldSupportWhenSessionExists() {
+    // given
+    final var anyCacheKey = new Object();
+    when(request.getSession(eq(false))).thenReturn(null);
+
+    // when
+    final var result = cache.supports(anyCacheKey);
+
+    // then
+    assertThat(result).isTrue();
+  }
+
+  @Test
+  public void shouldNotSupportWhenSessionDoesNotExist() {
+    // given
+    final var anyCacheKey = new Object();
+
+    final var session = mock(HttpSession.class);
+    when(request.getSession(eq(false))).thenReturn(session);
+
+    // when
+    final var result = cache.supports(anyCacheKey);
+
+    // then
+    assertThat(result).isFalse();
+  }
+
+  @Test
+  public void shouldReturnAuthentication() {
+    // given
+    final var anyCacheKey = new Object();
+    final var authentication = mock(CamundaAuthentication.class);
+    when(requestAttributes.getAttribute(eq(CAMUNDA_AUTHENTICATION_CACHE_KEY), eq(SCOPE_REQUEST)))
+        .thenReturn(authentication);
+
+    // when
+    final var result = cache.get(anyCacheKey);
+
+    // then
+    assertThat(result).isEqualTo(authentication);
+  }
+
+  @Test
+  public void shouldAddAuthenticationToRequest() {
+    // given
+    final var anyCacheKey = new Object();
+    final var authentication = mock(CamundaAuthentication.class);
+
+    // when
+    cache.put(anyCacheKey, authentication);
+
+    // then
+    verify(requestAttributes, times(1))
+        .setAttribute(eq(CAMUNDA_AUTHENTICATION_CACHE_KEY), eq(authentication), eq(SCOPE_REQUEST));
+  }
+
+  @Test
+  public void shouldRemoveAuthenticationFromRequest() {
+    // given
+    final var anyCacheKey = new Object();
+
+    // when
+    cache.remove(anyCacheKey);
+
+    // then
+    verify(requestAttributes, times(1))
+        .removeAttribute(eq(CAMUNDA_AUTHENTICATION_CACHE_KEY), eq(SCOPE_REQUEST));
+  }
+}

--- a/security/security-core/src/main/java/io/camunda/security/auth/CamundaAuthentication.java
+++ b/security/security-core/src/main/java/io/camunda/security/auth/CamundaAuthentication.java
@@ -10,8 +10,10 @@ package io.camunda.security.auth;
 import static java.util.Collections.unmodifiableList;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.camunda.zeebe.auth.Authorization;
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -26,7 +28,16 @@ public record CamundaAuthentication(
     @JsonProperty("authenticated_role_ids") List<String> authenticatedRoleIds,
     @JsonProperty("authenticated_tenant_ids") List<String> authenticatedTenantIds,
     @JsonProperty("authenticated_mapping_ids") List<String> authenticatedMappingIds,
-    @JsonProperty("claims") Map<String, Object> claims) {
+    @JsonProperty("claims") Map<String, Object> claims)
+    implements Serializable {
+
+  @JsonIgnore
+  public boolean isAnonymous() {
+    if (claims != null && claims.containsKey(Authorization.AUTHORIZED_ANONYMOUS_USER)) {
+      return ((boolean) claims.get(Authorization.AUTHORIZED_ANONYMOUS_USER));
+    }
+    return false;
+  }
 
   public static CamundaAuthentication none() {
     return of(b -> b);

--- a/security/security-core/src/main/java/io/camunda/security/auth/CamundaAuthenticationCache.java
+++ b/security/security-core/src/main/java/io/camunda/security/auth/CamundaAuthenticationCache.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.security.auth;
+
+public interface CamundaAuthenticationCache {
+
+  /**
+   * Returns to true, if {@link CamundaAuthenticationCache this} is responsible to cache a {@link
+   * CamundaAuthentication} for the given {@link Object principal}.
+   */
+  boolean supports(final Object principal);
+
+  /**
+   * Puts the given {@link CamundaAuthentication} into the cache later retrieval, once
+   * authentication has taken place. Used by <tt>ExceptionTranslationFilter</tt>.
+   *
+   * @param principal may be used as a cache key
+   * @param authentication to be cached
+   */
+  void put(final Object principal, final CamundaAuthentication authentication);
+
+  /**
+   * Get cached {@link CamundaAuthentication} by given principal.
+   *
+   * @param principal used as a cache key to retrieve the {@link CamundaAuthentication}
+   */
+  CamundaAuthentication get(final Object principal);
+
+  /**
+   * Optionally remove an {@link CamundaAuthentication} from the cache.
+   *
+   * @param principal whose authentication should be removed
+   */
+  void remove(final Object principal);
+}

--- a/security/security-core/src/main/java/io/camunda/security/reader/ResourceAccessController.java
+++ b/security/security-core/src/main/java/io/camunda/security/reader/ResourceAccessController.java
@@ -9,8 +9,6 @@ package io.camunda.security.reader;
 
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.security.auth.SecurityContext;
-import io.camunda.zeebe.auth.Authorization;
-import java.util.Optional;
 import java.util.function.Function;
 
 /**
@@ -54,12 +52,6 @@ public interface ResourceAccessController {
    * is anonymous. *
    */
   default boolean isAnonymousAuthentication(final CamundaAuthentication authentication) {
-    final var claims =
-        Optional.ofNullable(authentication).map(CamundaAuthentication::claims).orElse(null);
-
-    if (claims != null && claims.containsKey(Authorization.AUTHORIZED_ANONYMOUS_USER)) {
-      return ((boolean) claims.get(Authorization.AUTHORIZED_ANONYMOUS_USER));
-    }
-    return false;
+    return authentication.isAnonymous();
   }
 }

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -17,7 +17,10 @@
       <groupId>io.camunda</groupId>
       <artifactId>camunda-search-client</artifactId>
     </dependency>
-
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-auth</artifactId>
+    </dependency>
     <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>zeebe-broker-client</artifactId>

--- a/service/src/main/java/io/camunda/service/ApiServices.java
+++ b/service/src/main/java/io/camunda/service/ApiServices.java
@@ -7,6 +7,11 @@
  */
 package io.camunda.service;
 
+import static io.camunda.zeebe.auth.Authorization.AUTHORIZED_ANONYMOUS_USER;
+import static io.camunda.zeebe.auth.Authorization.AUTHORIZED_CLIENT_ID;
+import static io.camunda.zeebe.auth.Authorization.AUTHORIZED_USERNAME;
+import static io.camunda.zeebe.auth.Authorization.USER_GROUPS_CLAIMS;
+
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.exception.ErrorMapper;
 import io.camunda.service.security.SecurityContextProvider;
@@ -15,7 +20,9 @@ import io.camunda.zeebe.broker.client.api.dto.BrokerRequest;
 import io.camunda.zeebe.broker.client.api.dto.BrokerResponse;
 import io.camunda.zeebe.msgpack.value.DocumentValue;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
+import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 import org.agrona.DirectBuffer;
@@ -49,7 +56,9 @@ public abstract class ApiServices<T extends ApiServices<T>> {
 
   protected <R> CompletableFuture<BrokerResponse<R>> sendBrokerRequestWithFullResponse(
       final BrokerRequest<R> brokerRequest) {
-    brokerRequest.setAuthorization(authentication.claims());
+    final var authorizations =
+        Optional.ofNullable(authentication).map(this::toBrokerAuthorization).orElse(null);
+    brokerRequest.setAuthorization(authorizations);
     return brokerClient
         .sendRequest(brokerRequest)
         .handleAsync(
@@ -71,5 +80,29 @@ public abstract class ApiServices<T extends ApiServices<T>> {
     return value == null || value.isEmpty()
         ? DocumentValue.EMPTY_DOCUMENT
         : new UnsafeBuffer(MsgPackConverter.convertToMsgPack(value));
+  }
+
+  protected Map<String, Object> toBrokerAuthorization(final CamundaAuthentication authentication) {
+    final var username = authentication.authenticatedUsername();
+    final var clientId = authentication.authenticatedClientId();
+    final var claims = authentication.claims();
+
+    final var authorizations = new HashMap<String, Object>();
+
+    authorizations.put(AUTHORIZED_USERNAME, username);
+    authorizations.put(AUTHORIZED_CLIENT_ID, clientId);
+
+    if (claims != null) {
+      if (claims.containsKey(USER_GROUPS_CLAIMS)) {
+        authorizations.put(USER_GROUPS_CLAIMS, claims.get(USER_GROUPS_CLAIMS));
+      }
+
+      Optional.ofNullable(claims.get(USER_GROUPS_CLAIMS))
+          .ifPresent(v -> authorizations.put(USER_GROUPS_CLAIMS, claims.get(USER_GROUPS_CLAIMS)));
+      Optional.ofNullable(claims.get(AUTHORIZED_ANONYMOUS_USER))
+          .ifPresent(v -> authorizations.put(AUTHORIZED_ANONYMOUS_USER, v));
+    }
+
+    return authorizations;
   }
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
