### PR TITLE
build: update maven license plugin configuration to not use deprecate…

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -39,7 +39,7 @@
     <nexus.release.repository>https://artifacts.camunda.com/artifactory/zeebe-io/</nexus.release.repository>
 
     <!-- Camunda License v1.0 header -->
-    <license.header>${maven.multiModuleProjectDirectory}/parent/COPYING-HEADER.txt</license.header>
+    <license.header.file>${maven.multiModuleProjectDirectory}/parent/COPYING-HEADER.txt</license.header.file>
 
     <plugin.version.flatten>1.7.1</plugin.version.flatten>
     <plugin.version.javadoc>3.11.2</plugin.version.javadoc>
@@ -198,20 +198,24 @@
           <artifactId>license-maven-plugin</artifactId>
           <version>${plugin.version.license}</version>
           <configuration>
-            <header>${license.header}</header>
-            <properties>
-              <owner>camunda services GmbH</owner>
-              <email>info@camunda.com</email>
-            </properties>
-            <includes>
-              <include>**/*.java</include>
-              <include>**/*.scala</include>
-            </includes>
-            <excludes>
-              <exclude>zeebe/benchmarks/project/**/*</exclude>
-              <exclude>operate/**/*</exclude>
-              <exclude>tasklist/**/*</exclude>
-            </excludes>
+            <licenseSets>
+              <licenseSet>
+                <header>${license.header.file}</header>
+                <properties>
+                  <owner>camunda services GmbH</owner>
+                  <email>info@camunda.com</email>
+                </properties>
+                <includes>
+                  <include>**/*.java</include>
+                  <include>**/*.scala</include>
+                </includes>
+                <excludes>
+                  <exclude>zeebe/benchmarks/project/**/*</exclude>
+                  <exclude>operate/**/*</exclude>
+                  <exclude>tasklist/**/*</exclude>
+                </excludes>
+              </licenseSet>
+            </licenseSets>
             <mapping>
               <java>SLASHSTAR_STYLE</java>
             </mapping>

--- a/clients/java/pom.xml
+++ b/clients/java/pom.xml
@@ -24,7 +24,7 @@
 
   <properties>
     <version.java>8</version.java>
-    <license.header>com/mycila/maven/plugin/license/templates/APACHE-2.txt</license.header>
+    <license.header.file>com/mycila/maven/plugin/license/templates/APACHE-2.txt</license.header.file>
     <openapi.dir>${maven.multiModuleProjectDirectory}/zeebe/gateway-protocol/src/main/proto</openapi.dir>
   </properties>
 

--- a/clients/spring-boot-starter-camunda-sdk/pom.xml
+++ b/clients/spring-boot-starter-camunda-sdk/pom.xml
@@ -21,7 +21,7 @@
 
   <properties>
     <version.java>17</version.java>
-    <license.header>com/mycila/maven/plugin/license/templates/APACHE-2.txt</license.header>
+    <license.header.file>com/mycila/maven/plugin/license/templates/APACHE-2.txt</license.header.file>
     <version.roaster>2.30.1.Final</version.roaster>
     <generated.test.sources.path>${project.build.directory}/generated-test-sources/java</generated.test.sources.path>
   </properties>

--- a/search/search-client-plugin/pom.xml
+++ b/search/search-client-plugin/pom.xml
@@ -24,7 +24,7 @@
   </licenses>
 
   <properties>
-    <license.header>com/mycila/maven/plugin/license/templates/APACHE-2.txt</license.header>
+    <license.header.file>com/mycila/maven/plugin/license/templates/APACHE-2.txt</license.header.file>
   </properties>
 
 </project>

--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -27,7 +27,7 @@
   </modules>
 
   <properties>
-    <license.header>com/mycila/maven/plugin/license/templates/APACHE-2.txt</license.header>
+    <license.header.file>com/mycila/maven/plugin/license/templates/APACHE-2.txt</license.header.file>
   </properties>
 
   <build>

--- a/zeebe/atomix/pom.xml
+++ b/zeebe/atomix/pom.xml
@@ -47,7 +47,7 @@
   </modules>
 
   <properties>
-    <license.header>com/mycila/maven/plugin/license/templates/APACHE-2.txt</license.header>
+    <license.header.file>com/mycila/maven/plugin/license/templates/APACHE-2.txt</license.header.file>
   </properties>
 
   <build>

--- a/zeebe/benchmarks/project/pom.xml
+++ b/zeebe/benchmarks/project/pom.xml
@@ -23,7 +23,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <license.header>com/mycila/maven/plugin/license/templates/APACHE-2.txt</license.header>
+    <license.header.file>com/mycila/maven/plugin/license/templates/APACHE-2.txt</license.header.file>
 
     <!-- java version -->
     <version.java>21</version.java>

--- a/zeebe/bpmn-model/pom.xml
+++ b/zeebe/bpmn-model/pom.xml
@@ -24,7 +24,7 @@
 
   <properties>
     <version.java>8</version.java>
-    <license.header>com/mycila/maven/plugin/license/templates/APACHE-2.txt</license.header>
+    <license.header.file>com/mycila/maven/plugin/license/templates/APACHE-2.txt</license.header.file>
   </properties>
 
   <dependencies>

--- a/zeebe/exporter-api/pom.xml
+++ b/zeebe/exporter-api/pom.xml
@@ -23,7 +23,7 @@
   </licenses>
 
   <properties>
-    <license.header>com/mycila/maven/plugin/license/templates/APACHE-2.txt</license.header>
+    <license.header.file>com/mycila/maven/plugin/license/templates/APACHE-2.txt</license.header.file>
   </properties>
 
   <dependencies>

--- a/zeebe/gateway-protocol-impl/pom.xml
+++ b/zeebe/gateway-protocol-impl/pom.xml
@@ -22,7 +22,7 @@
 
   <properties>
     <version.java>8</version.java>
-    <license.header>com/mycila/maven/plugin/license/templates/APACHE-2.txt</license.header>
+    <license.header.file>com/mycila/maven/plugin/license/templates/APACHE-2.txt</license.header.file>
     <proto.dir>${maven.multiModuleProjectDirectory}/zeebe/gateway-protocol/src/main/proto</proto.dir>
   </properties>
 

--- a/zeebe/journal/pom.xml
+++ b/zeebe/journal/pom.xml
@@ -18,7 +18,7 @@
   <properties>
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
-    <license.header>com/mycila/maven/plugin/license/templates/APACHE-2.txt</license.header>
+    <license.header.file>com/mycila/maven/plugin/license/templates/APACHE-2.txt</license.header.file>
   </properties>
 
   <dependencies>

--- a/zeebe/protocol/pom.xml
+++ b/zeebe/protocol/pom.xml
@@ -24,7 +24,7 @@
 
   <properties>
     <version.java>8</version.java>
-    <license.header>com/mycila/maven/plugin/license/templates/APACHE-2.txt</license.header>
+    <license.header.file>com/mycila/maven/plugin/license/templates/APACHE-2.txt</license.header.file>
     <protocol.version>6</protocol.version>
   </properties>
 


### PR DESCRIPTION
…d properties

## Description

<!-- Describe the goal and purpose of this PR. -->

Found this mildly annoying and we should aim to keep things clean. This PR moves the Maven License Plugin configuration to a `licenseSet`. Documentation [here](https://mathieu.carbou.me/license-maven-plugin/#plugin-declaration).

Tested with a `mvn license:check`, which still correctly formats eligible files as before

## Related issues

closes #36004 
