### PR TITLE
feat: hide tenant resources when tenants API disabled

### DIFF
--- a/identity/client/src/components/global/useGlobalRoutes.tsx
+++ b/identity/client/src/components/global/useGlobalRoutes.tsx
@@ -14,7 +14,11 @@ import Roles from "src/pages/roles";
 import Tenants from "src/pages/tenants";
 import MappingRules from "src/pages/mapping-rules";
 import Authorizations from "src/pages/authorizations";
-import { isOIDC, isCamundaGroupsEnabled } from "src/configuration";
+import {
+  isOIDC,
+  isCamundaGroupsEnabled,
+  isTenantsApiEnabled,
+} from "src/configuration";
 import { Paths } from "src/components/global/routePaths";
 
 export const useGlobalRoutes = () => {
@@ -50,6 +54,17 @@ export const useGlobalRoutes = () => {
       ]
     : [];
 
+  const tenantsDependentRoutes = isTenantsApiEnabled
+    ? [
+        {
+          path: `${Paths.tenants()}/*`,
+          key: Paths.tenants(),
+          label: t("tenants"),
+          element: <Tenants />,
+        },
+      ]
+    : [];
+
   const routes = [
     ...OIDCDependentRoutes,
     ...camundaGroupsDependentRoutes,
@@ -59,12 +74,7 @@ export const useGlobalRoutes = () => {
       label: t("roles"),
       element: <Roles />,
     },
-    {
-      path: `${Paths.tenants()}/*`,
-      key: Paths.tenants(),
-      label: t("tenants"),
-      element: <Tenants />,
-    },
+    ...tenantsDependentRoutes,
     {
       path: `${Paths.authorizations()}/*`,
       key: Paths.authorizations(),

--- a/identity/client/src/configuration/index.ts
+++ b/identity/client/src/configuration/index.ts
@@ -19,6 +19,7 @@ export const isCamundaGroupsEnabled = getEnvBoolean(
   "CAMUNDA_GROUPS_ENABLED",
   true,
 );
+export const isTenantsApiEnabled = getEnvBoolean("TENANTS_API_ENABLED", false);
 
 export const docsUrl = "https://docs.camunda.io";
 

--- a/identity/client/src/pages/authorizations/List.tsx
+++ b/identity/client/src/pages/authorizations/List.tsx
@@ -23,15 +23,20 @@ import {
   TabsTitle,
 } from "./components";
 import AuthorizationList from "./AuthorizationsList";
+import { isTenantsApiEnabled } from "src/configuration";
 
 const List: FC = () => {
   const { t } = useTranslate("authorizations");
-  const [activeTab, setActiveTab] = useState<string>(ResourceType.APPLICATION);
+
+  const allResourceTypes = Object.values(ResourceType);
+  const authorizationTabs = isTenantsApiEnabled
+    ? allResourceTypes
+    : allResourceTypes.filter((type) => type !== ResourceType.TENANT);
+
+  const [activeTab, setActiveTab] = useState<string>(authorizationTabs[0]);
   const { data, loading, reload, success } = useApi(searchAuthorization, {
     filter: { resourceType: activeTab },
   });
-
-  const authorizationTabs = Object.values(ResourceType);
 
   return (
     <Page>

--- a/identity/client/src/pages/authorizations/modals/AddModal.tsx
+++ b/identity/client/src/pages/authorizations/modals/AddModal.tsx
@@ -10,7 +10,7 @@ import { FC, useState } from "react";
 import { Dropdown, CheckboxGroup, Checkbox } from "@carbon/react";
 import { useApiCall } from "src/utility/api";
 import useTranslate from "src/utility/localization";
-import { isOIDC } from "src/configuration";
+import { isOIDC, isTenantsApiEnabled } from "src/configuration";
 import { FormModal, UseEntityModalProps } from "src/components/modal";
 import {
   Authorization,
@@ -86,14 +86,18 @@ const AddModal: FC<UseEntityModalProps<ResourceType>> = ({
   const [ownerType, setOwnerType] = useState<OwnerType>(OwnerType.USER);
   const [ownerId, setOwnerId] = useState("");
   const [resourceId, setResourceId] = useState("");
-  const [resourceType, setResourceType] =
-    useState<ResourceType>(defaultResourceType);
   const [permissionTypes, setPermissionTypes] = useState<
     Authorization["permissionTypes"]
   >([]);
 
   const ownerTypeItems = Object.values(OwnerType);
-  const resourceTypeItems = Object.values(ResourceType);
+  const allResourceTypes = Object.values(ResourceType);
+  const resourceTypeItems = isTenantsApiEnabled
+    ? allResourceTypes
+    : allResourceTypes.filter((type) => type !== ResourceType.TENANT);
+
+  const [resourceType, setResourceType] =
+    useState<ResourceType>(defaultResourceType);
 
   const handleChangeCheckbox = (checked: boolean, id: PermissionTypes) => {
     if (checked) {


### PR DESCRIPTION
## Description

- Add `isTenantsApiEnabled` configuration flag
- Hide tenant navigation and pages when tenants API is disabled
- Filter tenant resources from authorizations when disabled (resource list and modal input selections)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #35326
