### PR TITLE
feat: add validation for string-encoded Long keys in REST API

### DIFF
--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/ErrorMessages.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/ErrorMessages.java
@@ -38,4 +38,6 @@ public final class ErrorMessages {
       "The provided %s contains illegal characters. It must match the pattern '%s'";
   public static final String ERROR_MESSAGE_NULL_VARIABLE_NAME = "Variable name must not be null";
   public static final String ERROR_MESSAGE_NULL_VARIABLE_VALUE = "Variable value must not be null";
+  public static final String ERROR_MESSAGE_INVALID_KEY_FORMAT =
+      "The provided %s '%s' is not a valid key. Expected a numeric value. Did you pass an entity id instead of an entity key?";
 }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/EvaluateDecisionRequestValidator.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/EvaluateDecisionRequestValidator.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.gateway.rest.validator;
 import static io.camunda.zeebe.gateway.rest.validator.ErrorMessages.ERROR_MESSAGE_AT_LEAST_ONE_FIELD;
 import static io.camunda.zeebe.gateway.rest.validator.ErrorMessages.ERROR_MESSAGE_ONLY_ONE_FIELD;
 import static io.camunda.zeebe.gateway.rest.validator.RequestValidator.validate;
+import static io.camunda.zeebe.gateway.rest.validator.RequestValidator.validateKeyFormat;
 
 import io.camunda.zeebe.gateway.protocol.rest.DecisionEvaluationInstruction;
 import java.util.List;
@@ -34,6 +35,9 @@ public class EvaluateDecisionRequestValidator {
                 ERROR_MESSAGE_ONLY_ONE_FIELD.formatted(
                     List.of("decisionDefinitionId", "decisionDefinitionKey")));
           }
+          // Validate decisionDefinitionKey format if provided
+          validateKeyFormat(
+              request.getDecisionDefinitionKey(), "decisionDefinitionKey", violations);
         });
   }
 }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/ProcessInstanceRequestValidator.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/ProcessInstanceRequestValidator.java
@@ -12,6 +12,7 @@ import static io.camunda.zeebe.gateway.rest.validator.ErrorMessages.ERROR_MESSAG
 import static io.camunda.zeebe.gateway.rest.validator.ErrorMessages.ERROR_MESSAGE_EMPTY_ATTRIBUTE;
 import static io.camunda.zeebe.gateway.rest.validator.ErrorMessages.ERROR_MESSAGE_ONLY_ONE_FIELD;
 import static io.camunda.zeebe.gateway.rest.validator.RequestValidator.validate;
+import static io.camunda.zeebe.gateway.rest.validator.RequestValidator.validateKeyFormat;
 import static io.camunda.zeebe.gateway.rest.validator.RequestValidator.validateOperationReference;
 
 import io.camunda.zeebe.gateway.protocol.rest.CancelProcessInstanceRequest;
@@ -47,6 +48,8 @@ public class ProcessInstanceRequestValidator {
                 ERROR_MESSAGE_ONLY_ONE_FIELD.formatted(
                     List.of("processDefinitionId", "processDefinitionKey")));
           }
+          // Validate processDefinitionKey format if provided
+          validateKeyFormat(request.getProcessDefinitionKey(), "processDefinitionKey", violations);
           validateOperationReference(request.getOperationReference(), violations);
         });
   }
@@ -67,6 +70,10 @@ public class ProcessInstanceRequestValidator {
         violations -> {
           if (request.getTargetProcessDefinitionKey() == null) {
             violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("targetProcessDefinitionKey"));
+          } else {
+            // Validate targetProcessDefinitionKey format
+            validateKeyFormat(
+                request.getTargetProcessDefinitionKey(), "targetProcessDefinitionKey", violations);
           }
           if (request.getMappingInstructions() == null
               || request.getMappingInstructions().isEmpty()) {
@@ -83,6 +90,10 @@ public class ProcessInstanceRequestValidator {
         violations -> {
           if (request.getTargetProcessDefinitionKey() == null) {
             violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("targetProcessDefinitionKey"));
+          } else {
+            // Validate targetProcessDefinitionKey format
+            validateKeyFormat(
+                request.getTargetProcessDefinitionKey(), "targetProcessDefinitionKey", violations);
           }
           if (request.getMappingInstructions() == null
               || request.getMappingInstructions().isEmpty()) {
@@ -153,6 +164,13 @@ public class ProcessInstanceRequestValidator {
         (instruction) -> instruction.getElementInstanceKey() != null,
         violations,
         ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("elementInstanceKey"));
+    // Also validate the format of elementInstanceKey values
+    instructions.stream()
+        .filter(instruction -> instruction.getElementInstanceKey() != null)
+        .forEach(
+            instruction ->
+                validateKeyFormat(
+                    instruction.getElementInstanceKey(), "elementInstanceKey", violations));
   }
 
   private static void validateMoveBatchInstructions(

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/RequestValidator.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/RequestValidator.java
@@ -9,10 +9,12 @@ package io.camunda.zeebe.gateway.rest.validator;
 
 import static io.camunda.zeebe.gateway.rest.validator.ErrorMessages.ERROR_MESSAGE_DATE_PARSING;
 import static io.camunda.zeebe.gateway.rest.validator.ErrorMessages.ERROR_MESSAGE_INVALID_ATTRIBUTE_VALUE;
+import static io.camunda.zeebe.gateway.rest.validator.ErrorMessages.ERROR_MESSAGE_INVALID_KEY_FORMAT;
 import static io.camunda.zeebe.protocol.record.RejectionType.INVALID_ARGUMENT;
 
 import io.camunda.zeebe.gateway.protocol.rest.Changeset;
 import io.camunda.zeebe.gateway.rest.RestErrorMapper;
+import io.camunda.zeebe.gateway.rest.util.KeyUtil;
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
@@ -67,6 +69,20 @@ public final class RequestValidator {
       violations.add(
           ERROR_MESSAGE_INVALID_ATTRIBUTE_VALUE.formatted(
               "operationReference", operationReference, "> 0"));
+    }
+  }
+
+  /**
+   * Validates that a string-encoded key can be parsed as a valid Long.
+   *
+   * @param keyValue the string value to validate
+   * @param fieldName the name of the field for error messaging
+   * @param violations the list to add validation errors to
+   */
+  public static void validateKeyFormat(
+      final String keyValue, final String fieldName, final List<String> violations) {
+    if (keyValue != null && KeyUtil.tryParseLong(keyValue).isEmpty()) {
+      violations.add(ERROR_MESSAGE_INVALID_KEY_FORMAT.formatted(fieldName, keyValue));
     }
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/validator/EvaluateDecisionRequestValidatorTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/validator/EvaluateDecisionRequestValidatorTest.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.validator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.gateway.protocol.rest.DecisionEvaluationInstruction;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.http.ProblemDetail;
+
+@DisplayName("EvaluateDecisionRequestValidator Tests")
+class EvaluateDecisionRequestValidatorTest {
+
+  @Test
+  @DisplayName("Should accept valid decisionDefinitionKey format")
+  void shouldAcceptValidDecisionDefinitionKey() {
+    final var request = new DecisionEvaluationInstruction();
+    request.setDecisionDefinitionKey("123456789");
+
+    final Optional<ProblemDetail> result =
+        EvaluateDecisionRequestValidator.validateEvaluateDecisionRequest(request);
+
+    assertThat(result).isEmpty();
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"abc", "12.34", "12abc", "", " "})
+  @DisplayName("Should reject invalid decisionDefinitionKey formats")
+  void shouldRejectInvalidDecisionDefinitionKey(String invalidKey) {
+    final var request = new DecisionEvaluationInstruction();
+    request.setDecisionDefinitionKey(invalidKey);
+
+    final Optional<ProblemDetail> result =
+        EvaluateDecisionRequestValidator.validateEvaluateDecisionRequest(request);
+
+    assertThat(result).isPresent();
+    final ProblemDetail problem = result.get();
+    assertThat(problem.getTitle()).isEqualTo("INVALID_ARGUMENT");
+    assertThat(problem.getDetail()).contains("decisionDefinitionKey");
+    assertThat(problem.getDetail())
+        .contains(
+            "is not a valid key. Expected a numeric value. Did you pass an entity id instead of an entity key?");
+  }
+
+  @Test
+  @DisplayName("Should accept null decisionDefinitionKey when decisionDefinitionId is provided")
+  void shouldAcceptNullDecisionDefinitionKeyWhenIdProvided() {
+    final var request = new DecisionEvaluationInstruction();
+    request.setDecisionDefinitionKey(null);
+    request.setDecisionDefinitionId("decision-id");
+
+    final Optional<ProblemDetail> result =
+        EvaluateDecisionRequestValidator.validateEvaluateDecisionRequest(request);
+
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  @DisplayName("Should reject when both decisionDefinitionKey and decisionDefinitionId are null")
+  void shouldRejectWhenBothKeyAndIdAreNull() {
+    final var request = new DecisionEvaluationInstruction();
+    request.setDecisionDefinitionKey(null);
+    request.setDecisionDefinitionId(null);
+
+    final Optional<ProblemDetail> result =
+        EvaluateDecisionRequestValidator.validateEvaluateDecisionRequest(request);
+
+    assertThat(result).isPresent();
+    final ProblemDetail problem = result.get();
+    assertThat(problem.getDetail())
+        .contains("At least one of [decisionDefinitionId, decisionDefinitionKey] is required");
+  }
+
+  @Test
+  @DisplayName(
+      "Should reject when both decisionDefinitionKey and decisionDefinitionId are provided")
+  void shouldRejectWhenBothKeyAndIdProvided() {
+    final var request = new DecisionEvaluationInstruction();
+    request.setDecisionDefinitionKey("123456789");
+    request.setDecisionDefinitionId("decision-id");
+
+    final Optional<ProblemDetail> result =
+        EvaluateDecisionRequestValidator.validateEvaluateDecisionRequest(request);
+
+    assertThat(result).isPresent();
+    final ProblemDetail problem = result.get();
+    assertThat(problem.getDetail())
+        .contains("Only one of [decisionDefinitionId, decisionDefinitionKey] is allowed");
+  }
+
+  @Test
+  @DisplayName("Should handle edge case Long values")
+  void shouldHandleEdgeCaseLongValues() {
+    final var request = new DecisionEvaluationInstruction();
+
+    // Test with maximum Long value
+    request.setDecisionDefinitionKey(String.valueOf(Long.MAX_VALUE));
+
+    final Optional<ProblemDetail> result =
+        EvaluateDecisionRequestValidator.validateEvaluateDecisionRequest(request);
+
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  @DisplayName("Should reject Long values that are too large")
+  void shouldRejectLongValuesTooLarge() {
+    final var request = new DecisionEvaluationInstruction();
+    // Create a number larger than Long.MAX_VALUE
+    request.setDecisionDefinitionKey("99999999999999999999999999999");
+
+    final Optional<ProblemDetail> result =
+        EvaluateDecisionRequestValidator.validateEvaluateDecisionRequest(request);
+
+    assertThat(result).isPresent();
+    final ProblemDetail problem = result.get();
+    assertThat(problem.getTitle()).isEqualTo("INVALID_ARGUMENT");
+    assertThat(problem.getDetail()).contains("decisionDefinitionKey");
+    assertThat(problem.getDetail())
+        .contains(
+            "is not a valid key. Expected a numeric value. Did you pass an entity id instead of an entity key?");
+  }
+
+  @Test
+  @DisplayName("Should accept zero as valid Long value")
+  void shouldAcceptZeroAsValidLong() {
+    final var request = new DecisionEvaluationInstruction();
+    request.setDecisionDefinitionKey("0");
+
+    final Optional<ProblemDetail> result =
+        EvaluateDecisionRequestValidator.validateEvaluateDecisionRequest(request);
+
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  @DisplayName("Should accept negative Long values")
+  void shouldAcceptNegativeLongValues() {
+    final var request = new DecisionEvaluationInstruction();
+    request.setDecisionDefinitionKey("-123456789");
+
+    final Optional<ProblemDetail> result =
+        EvaluateDecisionRequestValidator.validateEvaluateDecisionRequest(request);
+
+    assertThat(result).isEmpty();
+  }
+}

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/validator/ProcessInstanceRequestValidatorTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/validator/ProcessInstanceRequestValidatorTest.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.validator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.gateway.protocol.rest.ProcessInstanceCreationInstruction;
+import io.camunda.zeebe.gateway.protocol.rest.ProcessInstanceMigrationBatchOperationPlan;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.http.ProblemDetail;
+
+@DisplayName("ProcessInstanceRequestValidator Tests")
+class ProcessInstanceRequestValidatorTest {
+
+  @Test
+  @DisplayName("Should accept valid processDefinitionKey format")
+  void shouldAcceptValidProcessDefinitionKey() {
+    final var request = new ProcessInstanceCreationInstruction();
+    request.setProcessDefinitionKey("123456789");
+
+    final Optional<ProblemDetail> result =
+        ProcessInstanceRequestValidator.validateCreateProcessInstanceRequest(request);
+
+    assertThat(result).isEmpty();
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"abc", "12.34", "12abc", "", " "})
+  @DisplayName("Should reject invalid processDefinitionKey formats")
+  void shouldRejectInvalidProcessDefinitionKey(String invalidKey) {
+    final var request = new ProcessInstanceCreationInstruction();
+    request.setProcessDefinitionKey(invalidKey);
+
+    final Optional<ProblemDetail> result =
+        ProcessInstanceRequestValidator.validateCreateProcessInstanceRequest(request);
+
+    assertThat(result).isPresent();
+    final ProblemDetail problem = result.get();
+    assertThat(problem.getTitle()).isEqualTo("INVALID_ARGUMENT");
+    assertThat(problem.getDetail()).contains("processDefinitionKey");
+    assertThat(problem.getDetail())
+        .contains(
+            "is not a valid key. Expected a numeric value. Did you pass an entity id instead of an entity key?");
+  }
+
+  @Test
+  @DisplayName("Should accept null processDefinitionKey when processDefinitionId is provided")
+  void shouldAcceptNullProcessDefinitionKeyWhenIdProvided() {
+    final var request = new ProcessInstanceCreationInstruction();
+    request.setProcessDefinitionKey(null);
+    request.setProcessDefinitionId("process-id");
+
+    final Optional<ProblemDetail> result =
+        ProcessInstanceRequestValidator.validateCreateProcessInstanceRequest(request);
+
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  @DisplayName("Should reject when both processDefinitionKey and processDefinitionId are null")
+  void shouldRejectWhenBothKeyAndIdAreNull() {
+    final var request = new ProcessInstanceCreationInstruction();
+    request.setProcessDefinitionKey(null);
+    request.setProcessDefinitionId(null);
+
+    final Optional<ProblemDetail> result =
+        ProcessInstanceRequestValidator.validateCreateProcessInstanceRequest(request);
+
+    assertThat(result).isPresent();
+    final ProblemDetail problem = result.get();
+    assertThat(problem.getDetail())
+        .contains("At least one of [processDefinitionId, processDefinitionKey] is required");
+  }
+
+  @Test
+  @DisplayName("Should reject when both processDefinitionKey and processDefinitionId are provided")
+  void shouldRejectWhenBothKeyAndIdProvided() {
+    final var request = new ProcessInstanceCreationInstruction();
+    request.setProcessDefinitionKey("123456789");
+    request.setProcessDefinitionId("process-id");
+
+    final Optional<ProblemDetail> result =
+        ProcessInstanceRequestValidator.validateCreateProcessInstanceRequest(request);
+
+    assertThat(result).isPresent();
+    final ProblemDetail problem = result.get();
+    assertThat(problem.getDetail())
+        .contains("Only one of [processDefinitionId, processDefinitionKey] is allowed");
+  }
+
+  @Test
+  @DisplayName("Should accept valid targetProcessDefinitionKey format in migration request")
+  void shouldAcceptValidTargetProcessDefinitionKey() {
+    final var request = new ProcessInstanceMigrationBatchOperationPlan();
+    request.setTargetProcessDefinitionKey("987654321");
+    request.setMappingInstructions(java.util.List.of());
+
+    final Optional<ProblemDetail> result =
+        ProcessInstanceRequestValidator.validateMigrateProcessInstanceBatchOperationRequest(
+            request);
+
+    // Should have validation error for empty mappingInstructions, but not for key format
+    assertThat(result).isPresent();
+    final ProblemDetail problem = result.get();
+    assertThat(problem.getDetail()).contains("mappingInstructions");
+    assertThat(problem.getDetail())
+        .doesNotContain("targetProcessDefinitionKey must be a valid Long");
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"xyz", "99.99", "99xyz", "", " "})
+  @DisplayName("Should reject invalid targetProcessDefinitionKey formats in migration request")
+  void shouldRejectInvalidTargetProcessDefinitionKey(String invalidKey) {
+    final var request = new ProcessInstanceMigrationBatchOperationPlan();
+    request.setTargetProcessDefinitionKey(invalidKey);
+    request.setMappingInstructions(java.util.List.of());
+
+    final Optional<ProblemDetail> result =
+        ProcessInstanceRequestValidator.validateMigrateProcessInstanceBatchOperationRequest(
+            request);
+
+    assertThat(result).isPresent();
+    final ProblemDetail problem = result.get();
+    assertThat(problem.getTitle()).isEqualTo("INVALID_ARGUMENT");
+    assertThat(problem.getDetail()).contains("targetProcessDefinitionKey");
+    assertThat(problem.getDetail())
+        .contains(
+            "is not a valid key. Expected a numeric value. Did you pass an entity id instead of an entity key?");
+  }
+
+  @Test
+  @DisplayName("Should handle edge case Long values")
+  void shouldHandleEdgeCaseLongValues() {
+    final var request = new ProcessInstanceCreationInstruction();
+
+    // Test with maximum Long value
+    request.setProcessDefinitionKey(String.valueOf(Long.MAX_VALUE));
+
+    final Optional<ProblemDetail> result =
+        ProcessInstanceRequestValidator.validateCreateProcessInstanceRequest(request);
+
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  @DisplayName("Should reject Long values that are too large")
+  void shouldRejectLongValuesTooLarge() {
+    final var request = new ProcessInstanceCreationInstruction();
+    // Create a number larger than Long.MAX_VALUE
+    request.setProcessDefinitionKey("99999999999999999999999999999");
+
+    final Optional<ProblemDetail> result =
+        ProcessInstanceRequestValidator.validateCreateProcessInstanceRequest(request);
+
+    assertThat(result).isPresent();
+    final ProblemDetail problem = result.get();
+    assertThat(problem.getTitle()).isEqualTo("INVALID_ARGUMENT");
+    assertThat(problem.getDetail()).contains("processDefinitionKey");
+    assertThat(problem.getDetail())
+        .contains(
+            "is not a valid key. Expected a numeric value. Did you pass an entity id instead of an entity key?");
+  }
+
+  @Test
+  @DisplayName("Should accept zero as valid Long value")
+  void shouldAcceptZeroAsValidLong() {
+    final var request = new ProcessInstanceCreationInstruction();
+    request.setProcessDefinitionKey("0");
+
+    final Optional<ProblemDetail> result =
+        ProcessInstanceRequestValidator.validateCreateProcessInstanceRequest(request);
+
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  @DisplayName("Should accept negative Long values")
+  void shouldAcceptNegativeLongValues() {
+    final var request = new ProcessInstanceCreationInstruction();
+    request.setProcessDefinitionKey("-123456789");
+
+    final Optional<ProblemDetail> result =
+        ProcessInstanceRequestValidator.validateCreateProcessInstanceRequest(request);
+
+    assertThat(result).isEmpty();
+  }
+}

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/validator/RequestValidatorTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/validator/RequestValidatorTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.validator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+@DisplayName("RequestValidator Tests")
+class RequestValidatorTest {
+
+  @Test
+  @DisplayName("Should accept valid Long string format")
+  void shouldAcceptValidLongStringFormat() {
+    final List<String> violations = new ArrayList<>();
+    RequestValidator.validateKeyFormat("123456789", "testField", violations);
+
+    assertThat(violations).isEmpty();
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"abc", "12.34", "12abc", "", " "})
+  @DisplayName("Should reject invalid Long string formats")
+  void shouldRejectInvalidLongStringFormats(String invalidKey) {
+    final List<String> violations = new ArrayList<>();
+    RequestValidator.validateKeyFormat(invalidKey, "testField", violations);
+
+    assertThat(violations).hasSize(1);
+    assertThat(violations.get(0)).contains("testField");
+    assertThat(violations.get(0)).contains("is not a valid key");
+  }
+
+  @Test
+  @DisplayName("Should accept null values")
+  void shouldAcceptNullValues() {
+    final List<String> violations = new ArrayList<>();
+    RequestValidator.validateKeyFormat(null, "testField", violations);
+
+    assertThat(violations).isEmpty();
+  }
+
+  @Test
+  @DisplayName("Should accept maximum Long value")
+  void shouldAcceptMaximumLongValue() {
+    final List<String> violations = new ArrayList<>();
+    RequestValidator.validateKeyFormat(String.valueOf(Long.MAX_VALUE), "testField", violations);
+
+    assertThat(violations).isEmpty();
+  }
+
+  @Test
+  @DisplayName("Should accept minimum Long value")
+  void shouldAcceptMinimumLongValue() {
+    final List<String> violations = new ArrayList<>();
+    RequestValidator.validateKeyFormat(String.valueOf(Long.MIN_VALUE), "testField", violations);
+
+    assertThat(violations).isEmpty();
+  }
+
+  @Test
+  @DisplayName("Should reject values larger than Long.MAX_VALUE")
+  void shouldRejectValuesLargerThanLongMaxValue() {
+    final List<String> violations = new ArrayList<>();
+    RequestValidator.validateKeyFormat("99999999999999999999999999999", "testField", violations);
+
+    assertThat(violations).hasSize(1);
+    assertThat(violations.get(0)).contains("testField");
+    assertThat(violations.get(0)).contains("is not a valid key");
+  }
+
+  @Test
+  @DisplayName("Should accept zero as valid Long value")
+  void shouldAcceptZeroAsValidLongValue() {
+    final List<String> violations = new ArrayList<>();
+    RequestValidator.validateKeyFormat("0", "testField", violations);
+
+    assertThat(violations).isEmpty();
+  }
+
+  @Test
+  @DisplayName("Should accept negative Long values")
+  void shouldAcceptNegativeLongValues() {
+    final List<String> violations = new ArrayList<>();
+    RequestValidator.validateKeyFormat("-123456789", "testField", violations);
+
+    assertThat(violations).isEmpty();
+  }
+
+  @Test
+  @DisplayName("Should include field name in error message")
+  void shouldIncludeFieldNameInErrorMessage() {
+    final List<String> violations = new ArrayList<>();
+    RequestValidator.validateKeyFormat("invalid", "customFieldName", violations);
+
+    assertThat(violations).hasSize(1);
+    assertThat(violations.get(0)).contains("customFieldName");
+    assertThat(violations.get(0)).contains("is not a valid key");
+  }
+
+  @Test
+  @DisplayName("Should handle leading and trailing whitespace")
+  void shouldHandleLeadingAndTrailingWhitespace() {
+    final List<String> violations = new ArrayList<>();
+    RequestValidator.validateKeyFormat("  123456789  ", "testField", violations);
+
+    // Should reject because KeyUtil.tryParseLong() is strict about format
+    assertThat(violations).hasSize(1);
+    assertThat(violations.get(0)).contains("testField");
+    assertThat(violations.get(0)).contains("is not a valid key");
+  }
+}


### PR DESCRIPTION
- Add generic validateKeyFormat() method to RequestValidator for safe Long parsing
- Implement validation for processDefinitionKey and targetProcessDefinitionKey
- Implement validation for decisionDefinitionKey in decision evaluation
- Add comprehensive test coverage for all validation scenarios
- Provide helpful error messages guiding users about key vs ID usage

Signed-off-by: Josh Wulf <josh.wulf@camunda.com>

## Description

Sends back 400 Bad Request responses with descriptive messages when a non-numeric value is passed as an entity key on a request. fixes "Enhance error message for API requests containing invalid entity keys".

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->

## Related issues

closes #36024


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210878532660236