### PR TITLE
feat:  job data v2 migration

### DIFF
--- a/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/v2/Details/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/v2/Details/index.test.tsx
@@ -333,4 +333,31 @@ describe('MetadataPopover <Details />', () => {
       screen.getByText(/"calledProcessDefinitionName"/),
     ).toBeInTheDocument();
   });
+
+  it('should display job data fields', async () => {
+    const incidentMetaData: V2MetaDataDto = {
+      ...baseMetaData,
+      instanceMetadata: {
+        ...baseMetaData.instanceMetadata!,
+        jobType: 'httpService',
+        jobWorker: 'worker-1',
+        jobDeadline: '2023-01-15T10:10:00.000Z',
+        jobCustomHeaders: {timeout: '30s'},
+        jobKey: '555666777',
+      },
+    };
+
+    const {user} = render(
+      <Details metaData={incidentMetaData} elementId="Activity_11ptrz9" />,
+      {wrapper: TestWrapper},
+    );
+
+    await user.click(screen.getByRole('button', {name: 'Show more metadata'}));
+
+    expect(screen.getByText(/"jobKey"/)).toBeInTheDocument();
+    expect(screen.getByText(/"jobCustomHeaders"/)).toBeInTheDocument();
+    expect(screen.getByText(/"jobDeadline"/)).toBeInTheDocument();
+    expect(screen.getByText(/"jobType"/)).toBeInTheDocument();
+    expect(screen.getByText(/"jobWorker"/)).toBeInTheDocument();
+  });
 });

--- a/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/v2/Details/mocks.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/v2/Details/mocks.tsx
@@ -43,7 +43,7 @@ const baseMetaData: V2MetaDataDto = {
     jobWorker: 'worker-1',
     jobDeadline: '2023-01-15T10:10:00.000Z',
     jobCustomHeaders: {timeout: '30s'},
-    jobId: '555666777',
+    jobKey: '555666777',
   },
   incident: null,
   incidentCount: 0,

--- a/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/v2/calledDecisions.test.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/v2/calledDecisions.test.tsx
@@ -40,6 +40,7 @@ import {mockIncidents} from 'modules/mocks/incidents';
 import {flowNodeMetaDataStore} from 'modules/stores/flowNodeMetaData';
 import {incidentsStore} from 'modules/stores/incidents';
 import {mockSearchIncidentsByProcessInstance} from 'modules/mocks/api/v2/incidents/searchIncidentsByProcessInstance';
+
 import type {
   ElementInstance,
   ProcessInstance,

--- a/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/v2/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/v2/index.test.tsx
@@ -28,6 +28,7 @@ import {
   singleInstanceMetadata,
   incidentsByProcessKeyMetadata,
   processDefinitionMetadata,
+  jobMetadata,
 } from 'modules/mocks/metadata';
 import {mockFetchProcessInstanceIncidents} from 'modules/mocks/api/processInstances/fetchProcessInstanceIncidents';
 import {mockFetchFlowNodeMetadata} from 'modules/mocks/api/processInstances/fetchFlowNodeMetaData';
@@ -49,6 +50,8 @@ import {mockSearchIncidents} from 'modules/mocks/api/v2/incidents/searchIncident
 import {mockSearchIncidentsByProcessInstance} from 'modules/mocks/api/v2/incidents/searchIncidentsByProcessInstance';
 import {mockFetchProcessDefinition} from 'modules/mocks/api/v2/processDefinitions/fetchProcessDefinition';
 import {mockSearchProcessInstances} from 'modules/mocks/api/v2/processInstances/searchProcessInstances';
+import {mockSearchJobs} from 'modules/mocks/api/v2/jobs/searchJobs';
+import {mockSearchUserTasks} from 'modules/mocks/api/v2/userTasks/searchUserTasks';
 
 const MOCK_EXECUTION_DATE = '21 seconds';
 
@@ -106,6 +109,16 @@ describe('MetadataPopover', () => {
       page: {totalItems: 1},
     });
 
+    mockSearchProcessInstances().withSuccess({
+      items: [],
+      page: {totalItems: 0},
+    });
+
+    mockSearchUserTasks().withSuccess({
+      items: [],
+      page: {totalItems: 0},
+    });
+
     mockFetchFlownodeInstancesStatistics().withSuccess({
       items: [
         {
@@ -132,6 +145,13 @@ describe('MetadataPopover', () => {
       ],
     });
     mockFetchProcessInstanceIncidents().withSuccess(mockIncidents);
+
+    mockSearchJobs().withSuccess({
+      items: [],
+      page: {
+        totalItems: 0,
+      },
+    });
   });
 
   afterEach(() => {
@@ -274,6 +294,13 @@ describe('MetadataPopover', () => {
       page: {totalItems: 1},
     });
 
+    mockSearchJobs().withSuccess({
+      items: [jobMetadata],
+      page: {
+        totalItems: 1,
+      },
+    });
+
     processInstanceDetailsStore.setProcessInstance(
       createInstance({
         id: PROCESS_INSTANCE_ID,
@@ -321,15 +348,19 @@ describe('MetadataPopover', () => {
     expect(
       screen.getByText(/"jobDeadline": "2018-12-12 00:00:00"/),
     ).toBeInTheDocument();
+    expect(
+      screen.getByText(/"jobKey": "2251799813939822"/),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/"jobType": "io.camunda.zeebe:userTask"/),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/"jobRetries": 1/)).toBeInTheDocument();
+    expect(screen.getByText(/"jobWorker": ""/)).toBeInTheDocument();
+    expect(screen.getByText(/"jobCustomHeaders": {}/)).toBeInTheDocument();
     expect(screen.getByText(/"incidentErrorType": null/)).toBeInTheDocument();
     expect(
       screen.getByText(/"incidentErrorMessage": null/),
     ).toBeInTheDocument();
-    expect(screen.getByText(/"jobId": null/)).toBeInTheDocument();
-    expect(screen.getByText(/"jobType": null/)).toBeInTheDocument();
-    expect(screen.getByText(/"jobRetries": null/)).toBeInTheDocument();
-    expect(screen.getByText(/"jobWorker": null/)).toBeInTheDocument();
-    expect(screen.getByText(/"jobCustomHeaders": null/)).toBeInTheDocument();
     expect(
       screen.getByText(/"calledProcessInstanceKey": "229843728748927482"/),
     ).toBeInTheDocument();
@@ -560,8 +591,15 @@ describe('MetadataPopover', () => {
 
     renderPopover();
 
+    mockSearchJobs().withSuccess({
+      items: [jobMetadata],
+      page: {
+        totalItems: 1,
+      },
+    });
+
     expect(await screen.findByText(labels.retriesLeft)).toBeInTheDocument();
-    expect(screen.getByTestId('retries-left-count')).toHaveTextContent('2');
+    expect(screen.getByTestId('retries-left-count')).toHaveTextContent('1');
   });
 
   it('should fetch and display specific element instance when selected from history', async () => {

--- a/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/v2/index.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/v2/index.tsx
@@ -31,6 +31,7 @@ import {resolveIncidentErrorType} from './Incident/resolveIncidentErrorType';
 import {useProcessDefinitionKeyContext} from 'App/Processes/ListView/processDefinitionKeyContext';
 import {useProcessInstanceXml} from 'modules/queries/processDefinitions/useProcessInstanceXml';
 import {convertBpmnJsTypeToAPIType} from './convertBpmnJsTypeToAPIType';
+import {useJobs} from 'modules/queries/jobs/useJobs';
 
 type Props = {
   selectedFlowNodeRef?: SVGGraphicsElement | null;
@@ -163,13 +164,25 @@ const MetadataPopover = observer(({selectedFlowNodeRef}: Props) => {
       },
     );
 
+  const {data: jobSearchResult, isLoading: isSearchingJob} = useJobs({
+    payload: {
+      filter: {
+        elementInstanceKey: elementInstanceMetadata?.elementInstanceKey ?? '',
+        listenerEventType: 'UNSPECIFIED',
+      },
+    },
+    disabled: !elementInstanceMetadata?.elementInstanceKey,
+    select: (data) => data.pages?.flatMap((page) => page.items),
+  });
+
   if (
     elementId === undefined ||
     metaData === null ||
     (shouldFetchElementInstances && isSearchingElementInstances) ||
     (!!elementInstanceId && isFetchingInstance) ||
     isSearchingUserTasks ||
-    isSearchingProcessInstances
+    isSearchingProcessInstances ||
+    isSearchingJob
   ) {
     return null;
   }
@@ -207,6 +220,7 @@ const MetadataPopover = observer(({selectedFlowNodeRef}: Props) => {
               instanceMetadata: createV2InstanceMetadata(
                 instanceMetadata,
                 elementInstanceMetadata,
+                jobSearchResult?.[0],
                 processInstancesSearchResult?.items?.[0],
                 elementInstanceMetadata.type === 'USER_TASK'
                   ? userTask

--- a/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/v2/types.ts
+++ b/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/v2/types.ts
@@ -10,6 +10,7 @@ import type {MetaDataDto} from 'modules/api/processInstances/fetchFlowNodeMetaDa
 import type {
   ElementInstance,
   ProcessInstance,
+  Job,
   UserTask,
 } from '@vzeta/camunda-api-zod-schemas/8.8';
 
@@ -40,8 +41,8 @@ type V2InstanceMetadata = {
   jobType?: string | null;
   jobWorker?: string | null;
   jobDeadline?: string | null;
-  jobCustomHeaders: {[key: string]: string} | null;
-  jobId?: string | null;
+  jobCustomHeaders: Record<string, unknown> | null;
+  jobKey?: string | null;
 } & Partial<UserTask>;
 
 type V2MetaDataDto = Omit<MetaDataDto, 'instanceMetadata' | 'incident'> & {
@@ -73,6 +74,7 @@ type UserTaskSubset = Pick<
 function createV2InstanceMetadata(
   oldMetadata: MetaDataDto['instanceMetadata'],
   elementInstance: ElementInstance,
+  job?: Job,
   calledProcess?: ProcessInstance,
   userTask: Partial<UserTaskSubset> | null = {},
 ): V2InstanceMetadata {
@@ -98,12 +100,12 @@ function createV2InstanceMetadata(
     calledDecisionInstanceId: oldMetadata?.calledDecisionInstanceId ?? null,
     calledDecisionDefinitionName:
       oldMetadata?.calledDecisionDefinitionName ?? null,
-    jobRetries: oldMetadata?.jobRetries ?? null,
-    jobDeadline: oldMetadata?.jobDeadline ?? null,
-    jobId: oldMetadata?.jobId ?? null,
-    jobType: oldMetadata?.jobType ?? null,
-    jobWorker: oldMetadata?.jobWorker ?? null,
-    jobCustomHeaders: oldMetadata?.jobCustomHeaders ?? null,
+    jobRetries: job?.retries ?? null,
+    jobDeadline: job?.deadline ?? null,
+    jobKey: job?.jobKey ?? null,
+    jobType: job?.type ?? null,
+    jobWorker: job?.worker ?? null,
+    jobCustomHeaders: job?.customHeaders ?? null,
     elementInstanceKey: elementInstance.elementInstanceKey,
     elementId: elementInstance.elementId,
     elementName: elementInstance.elementName,

--- a/operate/client/src/modules/api/v2/processInstances/searchProcessInstances.ts
+++ b/operate/client/src/modules/api/v2/processInstances/searchProcessInstances.ts
@@ -10,7 +10,7 @@ import {
   endpoints,
   type QueryProcessInstancesRequestBody,
   type QueryProcessInstancesResponseBody,
-} from '@vzeta/camunda-api-zod-schemas';
+} from '@vzeta/camunda-api-zod-schemas/8.8';
 import {type RequestResult, requestWithThrow} from 'modules/request';
 
 const searchProcessInstances = async (

--- a/operate/client/src/modules/mocks/metadata.ts
+++ b/operate/client/src/modules/mocks/metadata.ts
@@ -7,6 +7,7 @@
  */
 
 import type {MetaDataDto} from 'modules/api/processInstances/fetchFlowNodeMetaData';
+import type {Job} from '@vzeta/camunda-api-zod-schemas/8.8';
 
 const FLOW_NODE_ID = 'StartEvent_1'; // this need to match the id from mockProcessXML
 const CALL_ACTIVITY_FLOW_NODE_ID = 'Activity_0zqism7'; // this need to match the id from mockCallActivityProcessXML
@@ -222,6 +223,30 @@ const processDefinitionMetadata = {
   version: 1,
 };
 
+const jobMetadata: Job = {
+  customHeaders: {},
+  elementId: 'Activity_0dex012',
+  elementInstanceKey: FLOW_NODE_INSTANCE_ID,
+  deadline: '2018-12-12 00:00:00',
+  endTime: '2025-07-23T10:14:48.597Z',
+  errorCode: '',
+  errorMessage: '',
+  hasFailedWithRetriesLeft: false,
+  jobKey: '2251799813939822',
+  kind: 'BPMN_ELEMENT',
+  listenerEventType: 'UNSPECIFIED',
+  processDefinitionId: 'signalEventProcess',
+  processDefinitionKey: '2251799813686708',
+  processInstanceKey: PROCESS_INSTANCE_ID,
+  retries: 1,
+  state: 'CANCELED',
+  tenantId: '<default>',
+  type: 'io.camunda.zeebe:userTask',
+  worker: '',
+  isDenied: false,
+  deniedReason: '',
+};
+
 export {
   baseMetadata as singleInstanceMetadata,
   incidentFlowNodeMetaData,
@@ -236,6 +261,7 @@ export {
   retriesLeftFlowNodeMetaData,
   incidentsByProcessKeyMetadata,
   processDefinitionMetadata,
+  jobMetadata,
   PROCESS_INSTANCE_ID,
   CALL_ACTIVITY_FLOW_NODE_ID,
   FLOW_NODE_ID,


### PR DESCRIPTION
## Description

Migrates MetadataPopover to use v2 job search endpoints for collecting job data

## Related issues

closes #33214 
