### PR TITLE
feat: zeebe dashboard can select multiple namespaces

### DIFF
--- a/monitor/grafana/zeebe.json
+++ b/monitor/grafana/zeebe.json
@@ -25253,6 +25253,7 @@
         },
         "definition": "label_values(atomix_role{cluster=~\"$cluster\"}, namespace)",
         "includeAll": true,
+        "multi": true,
         "name": "namespace",
         "options": [],
         "query": {
@@ -25348,6 +25349,6 @@
   "timezone": "",
   "title": "Zeebe",
   "uid": "zeebe-dashboard",
-  "version": 38,
+  "version": 43,
   "weekStart": ""
 }


### PR DESCRIPTION
This makes comparison of benchmarks easier because you can look at multiple deployments in the same graph.