### PR TITLE
Describe IntelliJ GatewayOuterClass workaround in contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -256,6 +256,11 @@ You can run the Camunda distribution via IntelliJ for development purposes.
 - If you receive an error on saving the project structure settings regarding the
   `zeebe-gateway-protocol` not being able to contain the `src/main/proto` directory, fix this by
   removing the mentioned source root from `zeebe-gateway-protocol` module in the _Modules_ tab.
+- If you notice errors in files referencing `GatewayOuterClass` (or its inner classes), you may need
+  to increase the maximum file size for which IntelliJ provides code assistance. To do this,
+  `Help -> Edit Custom Properties` and add the following line:
+  `idea.max.intellisense.filesize=9999`. For more details, check
+  https://github.com/camunda/camunda/issues/36041.
 
 ### Test execution
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
This workaround is necessary because our GatewayOuterClass has grown above the default filesize that IntelliJ provides code assistance for: 2500 kilobytes (2.56 MB). With 9999 kilobytes, we should have enough space for the foreseeable future.

## Related issues

closes #36041 
