### PR TITLE
refactor: migrate identity tenants.spec.ts to OC

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityHeader.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityHeader.ts
@@ -12,6 +12,7 @@ export class IdentityHeader {
   readonly openSettingsButton: Locator;
   readonly logoutButton: Locator;
   readonly rolesTab: Locator;
+  readonly tenantsTab: Locator;
 
   constructor(page: Page) {
     this.openSettingsButton = page.getByRole('button', {
@@ -19,6 +20,7 @@ export class IdentityHeader {
     });
     this.logoutButton = page.getByRole('button', {name: 'Log out'});
     this.rolesTab = page.locator('nav a').filter({hasText: /^Roles$/});
+    this.tenantsTab = page.locator('nav a').filter({hasText: /^Tenants$/});
   }
 
   async logout() {
@@ -28,5 +30,9 @@ export class IdentityHeader {
 
   async navigateToRoles() {
     await this.rolesTab.click();
+  }
+
+  async navigateToTenants() {
+    await this.tenantsTab.click();
   }
 }

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/tenants.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/tenants.spec.ts
@@ -1,0 +1,81 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {expect} from '@playwright/test';
+import {test} from 'fixtures';
+import {LOGIN_CREDENTIALS, createTestData} from 'utils/constants';
+import {navigateToApp} from '@pages/UtilitiesPage';
+import {waitForItemInList} from 'utils/waitForItemInList';
+import {relativizePath, Paths} from 'utils/relativizePath';
+
+const USER = {
+  id: 'demo',
+  name: 'Demo',
+};
+
+test.describe.serial('tenants CRUD', () => {
+  let NEW_TENANT: NonNullable<ReturnType<typeof createTestData>['tenant']>;
+
+  test.beforeAll(() => {
+    const testData = createTestData({
+      tenant: true,
+      user: true,
+    });
+    NEW_TENANT = testData.tenant!;
+  });
+
+  test.beforeEach(async ({page, loginPage, identityHeader}) => {
+    await navigateToApp(page, 'identity');
+    await loginPage.login(
+      LOGIN_CREDENTIALS.username,
+      LOGIN_CREDENTIALS.password,
+    );
+    await expect(page).toHaveURL(relativizePath(Paths.users()));
+    await identityHeader.navigateToTenants();
+    await expect(page).toHaveURL(relativizePath(Paths.tenants()));
+  });
+
+  test.describe.serial('tenants CRUD', () => {
+    test('creates a tenant', async ({page, identityTenantsPage}) => {
+      await expect(
+        identityTenantsPage.tenantCell(NEW_TENANT.name),
+      ).toBeHidden();
+      await identityTenantsPage.createTenant(NEW_TENANT);
+      const item = identityTenantsPage.tenantCell(NEW_TENANT.name);
+      await waitForItemInList(page, item);
+    });
+
+    test('assign a user', async ({page, identityTenantsPage}) => {
+      await identityTenantsPage.openTenantDetails(NEW_TENANT.tenantId).click();
+      await identityTenantsPage.assignUserToTenant(USER);
+      const item = identityTenantsPage.userRow(USER.name);
+      await waitForItemInList(page, item, {
+        emptyStateLocator: identityTenantsPage.usersEmptyState,
+      });
+    });
+
+    test('remove a user', async ({page, identityTenantsPage}) => {
+      await identityTenantsPage.openTenantDetails(NEW_TENANT.tenantId).click();
+      await identityTenantsPage.removeUserFromTenant(USER.name);
+      const item = identityTenantsPage.userRow(USER.name);
+      await waitForItemInList(page, item, {
+        emptyStateLocator: identityTenantsPage.usersEmptyState,
+        shouldBeVisible: false,
+      });
+    });
+
+    test('delete a tenant', async ({page, identityTenantsPage}) => {
+      await expect(
+        identityTenantsPage.tenantCell(NEW_TENANT.name),
+      ).toBeVisible();
+      await identityTenantsPage.deleteTenant(NEW_TENANT.name);
+      const item = identityTenantsPage.tenantRow(NEW_TENANT.name);
+      await waitForItemInList(page, item, {shouldBeVisible: false});
+    });
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/constants.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/constants.ts
@@ -52,6 +52,18 @@ export const createEditedGroup = (customId?: string) => {
   };
 };
 
+// Create unique tenant group data with optional custom ID
+export const createUniqueTenant = (customId?: string) => {
+  const id = customId || generateUniqueId();
+  return {
+    tenantId: `tenant${id}`,
+    name: `Test Tenant ${id}`,
+    description: `Test tenant description ${id}`,
+  };
+};
+
+// Generic function to create specific test data with shared ID
+
 export const createUserAuthorization = (authRole: {name: string}) => ({
   ownerType: 'Role',
   ownerId: authRole.name,
@@ -76,6 +88,7 @@ export const createTestData = (options: {
   applicationAuth?: boolean;
   group?: boolean;
   editedGroup?: boolean;
+  tenant?: boolean;
 }) => {
   const {
     user = false,
@@ -84,6 +97,7 @@ export const createTestData = (options: {
     applicationAuth = false,
     group = false,
     editedGroup = false,
+    tenant = false,
   } = options;
   const sharedId = generateUniqueId();
 
@@ -94,6 +108,7 @@ export const createTestData = (options: {
     applicationAuth?: ReturnType<typeof createApplicationAuthorization>;
     group?: ReturnType<typeof createUniqueGroup>;
     editedGroup?: ReturnType<typeof createEditedGroup>;
+    tenant?: ReturnType<typeof createUniqueTenant>;
     id: string;
   } = {id: sharedId};
 
@@ -111,6 +126,10 @@ export const createTestData = (options: {
 
   if (editedGroup) {
     result.editedGroup = createEditedGroup(sharedId);
+  }
+
+  if (tenant) {
+    result.tenant = createUniqueTenant(sharedId);
   }
 
   // Create authorizations only if authRole is also created


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
This PR migrates the Identity tenants tests to the Orchestration Cluster e2e testing. It creates a new `tenants.spec.ts` test file with comprehensive CRUD operations for tenant management and adds supporting utilities and page object methods

🧪 [Successful test run](https://github.com/camunda/camunda/actions/runs/16565678079/job/46845160604), Tests failed due to below issues:
[Variable Editing Spinner issue](https://github.com/camunda/camunda/issues/34148)
[API 401 Issue](https://github.com/camunda/camunda/issues/35443)
## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #35721
