### PR TITLE
Reject throwing error on jobs other than bpmn element kind

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobThrowErrorProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobThrowErrorProcessor.java
@@ -116,10 +116,14 @@ public class JobThrowErrorProcessor implements CommandProcessor<JobRecord> {
       final JobRecord job) {
     final long jobKey = command.getKey();
 
-    // Check if the job is of kind EXECUTION_LISTENER. Execution Listener jobs should not throw
-    // BPMN errors because the element is not in an ACTIVATED state.
     final var jobKind = job.getJobKind();
-    if (jobKind == JobKind.EXECUTION_LISTENER) {
+    if (jobKind != JobKind.BPMN_ELEMENT) {
+      /*
+       Throwing bpmn error is only supported for BPMN element jobs:
+       - Execution Listener jobs should not throw BPMN errors because the element is not in an
+         ACTIVATED state.
+       - Task Listener jobs simply don't support throwing BPMN errors yet.
+      */
       final long processInstanceKey = job.getProcessInstanceKey();
       commandControl.reject(
           RejectionType.INVALID_STATE,


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
For now, we do not support throwing bpmn errors on a task listener job. To avoid this leading to undefined behavior, we want to reject that operation. Likewise, we already rejected this for execution listeners. To avoid new job kinds having to deal with undefined behavior, we can simply deal with the supported case only: jobs of kind bpmn element.

## Related issues

closes #36048 