### PR TITLE
feat: add basic cluster properties to unified config

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/Cluster.java
+++ b/configuration/src/main/java/io/camunda/configuration/Cluster.java
@@ -7,10 +7,38 @@
  */
 package io.camunda.configuration;
 
+import java.util.Set;
+
 public class Cluster {
+
+  private static final String PREFIX = "camunda.cluster.";
+  private static final String LEGACY_NODEID_PROPERTY = "zeebe.broker.cluster.nodeId";
+  private static final String LEGACY_PARTITION_COUNT_PROPERTY =
+      "zeebe.broker.cluster.partitionsCount";
+  private static final String LEGACY_REPLICATION_FACTOR_PROPERTY =
+      "zeebe.broker.cluster.replicationFactor";
+  private static final String LEGACY_SIZE_PROPERTY = "zeebe.broker.cluster.clusterSize";
 
   /** Configuration for the distributed metadata manager in the cluster. */
   private Metadata metadata = new Metadata();
+
+  /**
+   * Specifies the unique id of this broker node in a cluster. The id should be between 0 and number
+   * of nodes in the cluster (exclusive).
+   */
+  private int nodeId = 0;
+
+  /** The number of partitions in the cluster. */
+  private int partitionCount = 1;
+
+  /**
+   * The number of replicas for each partition in the cluster. The replication factor cannot be
+   * greater than the number of nodes in the cluster.
+   */
+  private int replicationFactor = 1;
+
+  /** The number of nodes in the cluster. */
+  private int size = 1;
 
   public Metadata getMetadata() {
     return metadata;
@@ -18,5 +46,57 @@ public class Cluster {
 
   public void setMetadata(final Metadata metadata) {
     this.metadata = metadata;
+  }
+
+  public int getNodeId() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + "node-id",
+        nodeId,
+        Integer.class,
+        UnifiedConfigurationHelper.BackwardsCompatibilityMode.SUPPORTED,
+        Set.of(LEGACY_NODEID_PROPERTY));
+  }
+
+  public void setNodeId(final int nodeId) {
+    this.nodeId = nodeId;
+  }
+
+  public int getPartitionCount() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + "partition-count",
+        partitionCount,
+        Integer.class,
+        UnifiedConfigurationHelper.BackwardsCompatibilityMode.SUPPORTED,
+        Set.of(LEGACY_PARTITION_COUNT_PROPERTY));
+  }
+
+  public void setPartitionCount(final int partitionCount) {
+    this.partitionCount = partitionCount;
+  }
+
+  public int getReplicationFactor() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + "replication-factor",
+        replicationFactor,
+        Integer.class,
+        UnifiedConfigurationHelper.BackwardsCompatibilityMode.SUPPORTED,
+        Set.of(LEGACY_REPLICATION_FACTOR_PROPERTY));
+  }
+
+  public void setReplicationFactor(final int replicationFactor) {
+    this.replicationFactor = replicationFactor;
+  }
+
+  public int getSize() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + "size",
+        size,
+        Integer.class,
+        UnifiedConfigurationHelper.BackwardsCompatibilityMode.SUPPORTED,
+        Set.of(LEGACY_SIZE_PROPERTY));
+  }
+
+  public void setSize(final int size) {
+    this.size = size;
   }
 }

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
@@ -51,6 +51,13 @@ public class BrokerBasedPropertiesOverride {
   }
 
   private void populateFromCluster(final BrokerBasedProperties override) {
+    final var cluster = unifiedConfiguration.getCamunda().getCluster();
+
+    override.getCluster().setNodeId(cluster.getNodeId());
+    override.getCluster().setPartitionsCount(cluster.getPartitionCount());
+    override.getCluster().setReplicationFactor(cluster.getReplicationFactor());
+    override.getCluster().setClusterSize(cluster.getSize());
+
     populateFromClusterMetadata(override);
     // Rest of camunda.cluster.* sections
   }

--- a/configuration/src/test/java/io/camunda/configuration/ClusterPropertiesTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/ClusterPropertiesTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.configuration.beanoverrides.BrokerBasedPropertiesOverride;
+import io.camunda.configuration.beans.BrokerBasedProperties;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+@SpringJUnitConfig({
+  UnifiedConfiguration.class,
+  BrokerBasedPropertiesOverride.class,
+  UnifiedConfigurationHelper.class
+})
+@ActiveProfiles("broker")
+public class ClusterPropertiesTest {
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "camunda.cluster.node-id=7",
+        "camunda.cluster.partition-count=5",
+        "camunda.cluster.replication-factor=3",
+        "camunda.cluster.size=10"
+      })
+  class WithOnlyUnifiedConfigSet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithOnlyUnifiedConfigSet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldSetClusterProperties() {
+      assertThat(brokerCfg.getCluster().getNodeId()).isEqualTo(7);
+      assertThat(brokerCfg.getCluster().getPartitionsCount()).isEqualTo(5);
+      assertThat(brokerCfg.getCluster().getReplicationFactor()).isEqualTo(3);
+      assertThat(brokerCfg.getCluster().getClusterSize()).isEqualTo(10);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "zeebe.broker.cluster.nodeId=11",
+        "zeebe.broker.cluster.partitionsCount=6",
+        "zeebe.broker.cluster.replicationFactor=4",
+        "zeebe.broker.cluster.clusterSize=12"
+      })
+  class WithOnlyLegacySet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithOnlyLegacySet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldSetClusterPropertiesFromLegacy() {
+      assertThat(brokerCfg.getCluster().getNodeId()).isEqualTo(11);
+      assertThat(brokerCfg.getCluster().getPartitionsCount()).isEqualTo(6);
+      assertThat(brokerCfg.getCluster().getReplicationFactor()).isEqualTo(4);
+      assertThat(brokerCfg.getCluster().getClusterSize()).isEqualTo(12);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        // new
+        "camunda.cluster.node-id=21",
+        "camunda.cluster.partition-count=8",
+        "camunda.cluster.replication-factor=5",
+        "camunda.cluster.size=15",
+        // legacy
+        "zeebe.broker.cluster.nodeId=99",
+        "zeebe.broker.cluster.partitionsCount=99",
+        "zeebe.broker.cluster.replicationFactor=99",
+        "zeebe.broker.cluster.clusterSize=99"
+      })
+  class WithNewAndLegacySet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithNewAndLegacySet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldSetClusterPropertiesFromNew() {
+      assertThat(brokerCfg.getCluster().getNodeId()).isEqualTo(21);
+      assertThat(brokerCfg.getCluster().getPartitionsCount()).isEqualTo(8);
+      assertThat(brokerCfg.getCluster().getReplicationFactor()).isEqualTo(5);
+      assertThat(brokerCfg.getCluster().getClusterSize()).isEqualTo(15);
+    }
+  }
+}


### PR DESCRIPTION
## Description

This PR adds the following configuration properties in unified config 

- `camunda.cluster.size`
- `camunda.cluster.node-id`
- `camunda.cluster.partition-count`
- `camunda.cluster.replication-factor`

to replace legacy properties

- `zeebe.broker.cluster.clusterSize`
- `zeebe.broker.cluster.nodeId`
- `zeebe.broker.cluster.partitionsCount`
- `zeebe.broker.cluster.replicationFactor`

PS:- The references to the legacy properties in default .properties and .yaml are not replaced with the new properties. This is because adding the new properties will break many deployments that overwrite the legacy properties because the new properties are defined in these files and the fall back strategy will chose the new property.

## Checklist

- [x] The legacy properties and the backwards compatibility strategy are updated in [schema doc].(https://docs.google.com/spreadsheets/d/1R4epsy6DWemA8_76cUE6zOGUFbrXCXlM2reXnKFuz7Y/edit?gid=818158292#gid=818158292)
- [x] The new property fields are documented in the code.

## Related issues

related to #34906 
