### PR TITLE
ci: run identity e2e tests from the OC

### DIFF
--- a/.github/workflows/identity-e2e-tests.yml
+++ b/.github/workflows/identity-e2e-tests.yml
@@ -20,6 +20,7 @@ on:
       - "zeebe/exporters/camunda-exporter/**"
       - "parent/*"
       - "pom.xml"
+      - "qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/**"
   pull_request:
     paths:
       - ".ci/**"
@@ -31,6 +32,7 @@ on:
       - "zeebe/exporters/camunda-exporter/**"
       - "parent/*"
       - "pom.xml"
+      - "qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/**"
 
 # Limit workflow to 1 concurrent run per ref (branch): new commit -> old runs are canceled to save costs
 # Exception for main branch: complete builds for every commit needed for confidenence
@@ -77,6 +79,12 @@ jobs:
       - name: Install Playwright
         run: yarn exec playwright install --with-deps chromium
         working-directory: ./identity/client
+      - name: Install QA Test Suite Dependencies
+        run: npm install
+        working-directory: ./qa/c8-orchestration-cluster-e2e-test-suite
+      - name: Install Playwright
+        run: npx playwright install --with-deps chromium
+        working-directory: ./qa/c8-orchestration-cluster-e2e-test-suite
       - name: Build backend
         run: ./mvnw clean install -DskipTests=true -DskipChecks -Dskip.fe.build=true -T1C -B -DskipRemoteStaging=true -Dmaven.deploy.skip=true
       - name: Start Identity
@@ -102,14 +110,27 @@ jobs:
           CAMUNDA_SECURITY_INITIALIZATION_USERS_0_NAME: Demo
           CAMUNDA_SECURITY_INITIALIZATION_USERS_0_EMAIL: demo@example.com
           CAMUNDA_SECURITY_INITIALIZATION_DEFAULTROLES_ADMIN_USERS_0: demo
+          CAMUNDA_SECURITY_INITIALIZATION_USERS_1_USERNAME: lisa
+          CAMUNDA_SECURITY_INITIALIZATION_USERS_1_PASSWORD: lisa
+          CAMUNDA_SECURITY_INITIALIZATION_USERS_1_NAME: lisa
+          CAMUNDA_SECURITY_INITIALIZATION_USERS_1_EMAIL: lisa@example.com
+          CAMUNDA_SECURITY_INITIALIZATION_DEFAULTROLES_ADMIN_USERS_1: lisa
+          CAMUNDA_SECURITY_INITIALIZATION_USERS_2_USERNAME: yuliia
+          CAMUNDA_SECURITY_INITIALIZATION_USERS_2_PASSWORD: yuliia
+          CAMUNDA_SECURITY_INITIALIZATION_USERS_2_NAME: Yuliia
+          CAMUNDA_SECURITY_INITIALIZATION_USERS_2_EMAIL: yuliia@example.com
+          CAMUNDA_SECURITY_INITIALIZATION_DEFAULTROLES_ADMIN_USERS_2: yuliia
       - name: Run tests
-        working-directory: ./identity/client
-        run: yarn run test:e2e
+        env:
+          LOCAL_TEST: "false"
+          CORE_APPLICATION_URL: http://localhost:8080
+        working-directory: qa/c8-orchestration-cluster-e2e-test-suite
+        run: npm run test -- --project=identity-e2e
       - uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: Playwright report
-          path: identity/client/playwright-report/
+          name: C8 Orchestration Cluster E2E Test Result
+          path: qa/c8-orchestration-cluster-e2e-test-suite/html-report
           retention-days: 30
       - name: Observe build status
         if: always()

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityRolesPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityRolesPage.ts
@@ -120,7 +120,7 @@ export class IdentityRolesPage {
 
     const item = this.roleCell(role.name);
 
-    await waitForItemInList(this.page, item);
+    await waitForItemInList(this.page, item, {timeout: 60000});
   }
 
   async clickRole(roleID: string) {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/playwright.config.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/playwright.config.ts
@@ -104,7 +104,7 @@ export default defineConfig({
     {
       name: 'identity-e2e',
       testMatch: ['tests/identity/*.spec.ts'],
-      use: devices['Desktop Edge'],
+      use: devices['Desktop Chrome'],
     },
   ],
   reporter:

--- a/qa/c8-orchestration-cluster-e2e-test-suite/playwright.config.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/playwright.config.ts
@@ -101,6 +101,11 @@ export default defineConfig({
       testIgnore: 'task-panel.spec.ts',
       teardown: 'chromium-subset',
     },
+    {
+      name: 'identity-e2e',
+      testMatch: ['tests/identity/*.spec.ts'],
+      use: devices['Desktop Edge'],
+    },
   ],
   reporter:
     process.env.INCLUDE_SLACK_REPORTER === 'true'

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/create-new-user.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/create-new-user.spec.ts
@@ -43,7 +43,7 @@ test.describe.parallel('login page', () => {
       name: TEST_USER.email,
     });
 
-    await waitForItemInList(page, item);
+    await waitForItemInList(page, item, {timeout: 60000});
 
     await expect(
       identityUsersPage.usersList.getByRole('cell', {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/tenants.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/tenants.spec.ts
@@ -47,7 +47,7 @@ test.describe.serial('tenants CRUD', () => {
       ).toBeHidden();
       await identityTenantsPage.createTenant(NEW_TENANT);
       const item = identityTenantsPage.tenantCell(NEW_TENANT.name);
-      await waitForItemInList(page, item);
+      await waitForItemInList(page, item, {timeout: 60000});
     });
 
     test('assign a user', async ({page, identityTenantsPage}) => {
@@ -56,6 +56,7 @@ test.describe.serial('tenants CRUD', () => {
       const item = identityTenantsPage.userRow(USER.name);
       await waitForItemInList(page, item, {
         emptyStateLocator: identityTenantsPage.usersEmptyState,
+        timeout: 60000,
       });
     });
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/users.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/users.spec.ts
@@ -58,6 +58,8 @@ test.describe.serial('users CRUD', () => {
   test('delete a user', async ({identityUsersPage}) => {
     await expect(identityUsersPage.userCell(EDITED_USER.name)).toBeVisible();
     await identityUsersPage.deleteUser(EDITED_USER);
-    await expect(identityUsersPage.userCell(EDITED_USER.name)).toBeHidden();
+    await expect(identityUsersPage.userCell(EDITED_USER.name)).toBeHidden({
+      timeout: 60000,
+    });
   });
 });


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Updates the Identity E2E workflow to execute tests from the unified Orchestration Cluster test suite instead of the legacy Identity client tests, enabling cross-component testing and modern test patterns.
This PR also increases timeouts to fix flakiness of tests

🔧 **Workflow Configuration**
- Added trigger path for OC identity tests: qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/**
- Updated test execution: npm run test -- --project=identity-e2e
- Added QA test suite dependency installation steps

👥 **Test Environment**
- Initialized test users: demo, lisa, yuliia (all with admin roles)
- Added environment variables: LOCAL_TEST=false, CORE_APPLICATION_URL=http://localhost:8080

📊 **Artifact Collection**
- Added actions/upload-artifact@v4 to enable debugging when needed

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).




🧪 **Testing**
Workflow is triggered, there i one failing test that i checked locally and getting the same error - checking if it is a bug or expected behavior, if it is expected will update the test in a separate PR

## Related issues

related to #35716
