### PR TITLE
[CPT] test: Extract await into a behavior

### DIFF
--- a/testing/camunda-process-test-java/pom.xml
+++ b/testing/camunda-process-test-java/pom.xml
@@ -181,17 +181,6 @@
         <artifactId>maven-failsafe-plugin</artifactId>
       </plugin>
 
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <configuration>
-          <systemPropertyVariables>
-            <!-- Set CPT's assertion timeout to 5 seconds for CI -->
-            <cptAssertionTimeout>PT5S</cptAssertionTimeout>
-          </systemPropertyVariables>
-        </configuration>
-      </plugin>
-
     </plugins>
 
   </build>

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/CamundaAssert.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/CamundaAssert.java
@@ -337,5 +337,4 @@ public class CamundaAssert {
   static void reset() {
     CamundaAssert.DATA_SOURCE.remove();
   }
-
 }

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/CamundaAssert.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/CamundaAssert.java
@@ -31,9 +31,9 @@ import io.camunda.process.test.impl.assertions.CamundaDataSource;
 import io.camunda.process.test.impl.assertions.DecisionInstanceAssertj;
 import io.camunda.process.test.impl.assertions.ProcessInstanceAssertj;
 import io.camunda.process.test.impl.assertions.UserTaskAssertj;
+import io.camunda.process.test.impl.assertions.util.AwaitilityBehavior;
 import java.time.Duration;
 import java.util.function.Function;
-import org.awaitility.Awaitility;
 
 /**
  * The entry point for all assertions.
@@ -74,13 +74,18 @@ public class CamundaAssert {
   public static final Function<String, ElementSelector> DEFAULT_ELEMENT_SELECTOR =
       ElementSelectors::byId;
 
+  /** The default await behavior for the assertions. */
+  public static final CamundaAssertAwaitBehavior DEFAULT_AWAIT_BEHAVIOR = new AwaitilityBehavior();
+
   private static final ThreadLocal<CamundaDataSource> DATA_SOURCE = new ThreadLocal<>();
 
   private static Function<String, ElementSelector> elementSelector = DEFAULT_ELEMENT_SELECTOR;
 
+  private static CamundaAssertAwaitBehavior awaitBehavior = DEFAULT_AWAIT_BEHAVIOR;
+
   static {
-    Awaitility.setDefaultTimeout(DEFAULT_ASSERTION_TIMEOUT);
-    Awaitility.setDefaultPollInterval(DEFAULT_ASSERTION_INTERVAL);
+    setAssertionTimeout(DEFAULT_ASSERTION_TIMEOUT);
+    setAssertionInterval(DEFAULT_ASSERTION_INTERVAL);
   }
 
   // ======== Configuration options ========
@@ -92,7 +97,7 @@ public class CamundaAssert {
    * @see #DEFAULT_ASSERTION_TIMEOUT
    */
   public static void setAssertionTimeout(final Duration assertionTimeout) {
-    Awaitility.setDefaultTimeout(assertionTimeout);
+    awaitBehavior.setAssertionTimeout(assertionTimeout);
   }
 
   /**
@@ -102,7 +107,7 @@ public class CamundaAssert {
    * @see #DEFAULT_ASSERTION_INTERVAL
    */
   public static void setAssertionInterval(final Duration assertionInterval) {
-    Awaitility.setDefaultPollInterval(assertionInterval);
+    awaitBehavior.setAssertionInterval(assertionInterval);
   }
 
   /**
@@ -113,6 +118,20 @@ public class CamundaAssert {
    */
   public static void setElementSelector(final Function<String, ElementSelector> elementSelector) {
     CamundaAssert.elementSelector = elementSelector;
+  }
+
+  static CamundaAssertAwaitBehavior getAwaitBehavior() {
+    return awaitBehavior;
+  }
+
+  /**
+   * Configures the await behavior for the assertions.
+   *
+   * @param awaitBehavior the behavior to use for waiting
+   * @see #DEFAULT_AWAIT_BEHAVIOR
+   */
+  public static void setAwaitBehavior(final CamundaAssertAwaitBehavior awaitBehavior) {
+    CamundaAssert.awaitBehavior = awaitBehavior;
   }
 
   // ======== Assertions ========
@@ -205,7 +224,8 @@ public class CamundaAssert {
    */
   public static ProcessInstanceAssert assertThatProcessInstance(
       final ProcessInstanceSelector processInstanceSelector) {
-    return new ProcessInstanceAssertj(getDataSource(), processInstanceSelector, elementSelector);
+    return new ProcessInstanceAssertj(
+        getDataSource(), awaitBehavior, processInstanceSelector, elementSelector);
   }
 
   /**
@@ -222,7 +242,8 @@ public class CamundaAssert {
 
   private static ProcessInstanceAssertj createProcessInstanceAssertj(
       final long processInstanceKey) {
-    return new ProcessInstanceAssertj(getDataSource(), processInstanceKey, elementSelector);
+    return new ProcessInstanceAssertj(
+        getDataSource(), awaitBehavior, processInstanceKey, elementSelector);
   }
 
   /**
@@ -233,7 +254,7 @@ public class CamundaAssert {
    * @see io.camunda.process.test.api.assertions.UserTaskSelectors
    */
   public static UserTaskAssert assertThatUserTask(final UserTaskSelector userTaskSelector) {
-    return new UserTaskAssertj(getDataSource(), userTaskSelector);
+    return new UserTaskAssertj(getDataSource(), awaitBehavior, userTaskSelector);
   }
 
   /**
@@ -255,7 +276,7 @@ public class CamundaAssert {
    * @see io.camunda.process.test.api.assertions.DecisionSelectors
    */
   public static DecisionInstanceAssert assertThatDecision(final DecisionSelector decisionSelector) {
-    return new DecisionInstanceAssertj(getDataSource(), decisionSelector);
+    return new DecisionInstanceAssertj(getDataSource(), awaitBehavior, decisionSelector);
   }
 
   /**
@@ -277,7 +298,8 @@ public class CamundaAssert {
    */
   public static DecisionInstanceAssertj assertThatDecision(
       final EvaluateDecisionResponse response) {
-    return new DecisionInstanceAssertj(getDataSource(), DecisionSelectors.byResponse(response));
+    return new DecisionInstanceAssertj(
+        getDataSource(), awaitBehavior, DecisionSelectors.byResponse(response));
   }
 
   /**
@@ -315,4 +337,5 @@ public class CamundaAssert {
   static void reset() {
     CamundaAssert.DATA_SOURCE.remove();
   }
+
 }

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/CamundaAssertAwaitBehavior.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/CamundaAssertAwaitBehavior.java
@@ -18,7 +18,7 @@ package io.camunda.process.test.api;
 import java.time.Duration;
 import java.util.concurrent.Callable;
 import java.util.function.Consumer;
-import org.junit.function.ThrowingRunnable;
+import org.assertj.core.api.SoftAssertionsProvider.ThrowingRunnable;
 
 /**
  * A behavior for waiting until a given assertion is satisfied.

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/CamundaAssertAwaitBehavior.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/CamundaAssertAwaitBehavior.java
@@ -1,9 +1,17 @@
 /*
- * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
- * one or more contributor license agreements. See the NOTICE file distributed
- * with this work for additional information regarding copyright ownership.
- * Licensed under the Camunda License 1.0. You may not use this file
- * except in compliance with the Camunda License 1.0.
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package io.camunda.process.test.api;
 

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/CamundaAssertAwaitBehavior.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/CamundaAssertAwaitBehavior.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.process.test.api;
+
+import java.time.Duration;
+import java.util.concurrent.Callable;
+import java.util.function.Consumer;
+import org.junit.function.ThrowingRunnable;
+
+/**
+ * A behavior for waiting until a given assertion is satisfied.
+ *
+ * <p>It is used to compensate the delay for assertions caused by the asynchronous processing of
+ * Camunda.
+ */
+public interface CamundaAssertAwaitBehavior {
+
+  /**
+   * Wait until the given assertion is satisfied.
+   *
+   * @param assertion the assertion to be satisfied
+   * @throws AssertionError if the assertion is not satisfied
+   */
+  void untilAsserted(final ThrowingRunnable assertion) throws AssertionError;
+
+  /**
+   * Wait until the given assertion is satisfied.
+   *
+   * @param supplier supplies the value for the assertion
+   * @param assertion the assertion to be satisfied
+   * @param <T> the value type
+   * @throws AssertionError if the assertion is not satisfied
+   */
+  default <T> void untilAsserted(final Callable<T> supplier, final Consumer<T> assertion)
+      throws AssertionError {
+    untilAsserted(
+        () -> {
+          final T value = supplier.call();
+          assertion.accept(value);
+        });
+  }
+
+  /**
+   * Set the timeout of the assertion.
+   *
+   * @param assertionTimeout the assertion's timeout
+   */
+  void setAssertionTimeout(final Duration assertionTimeout);
+
+  /**
+   * Set the interval between the assertion attempts.
+   *
+   * @param assertionInterval the assertion's interval
+   */
+  void setAssertionInterval(final Duration assertionInterval);
+}

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/CamundaProcessTestExtension.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/CamundaProcessTestExtension.java
@@ -131,7 +131,11 @@ public class CamundaProcessTestExtension
             runtime.getCamundaMonitoringApiAddress(), runtime.getCamundaRestApiAddress());
 
     camundaProcessTestContext =
-        new CamundaProcessTestContextImpl(runtime, createdClients::add, camundaManagementClient);
+        new CamundaProcessTestContextImpl(
+            runtime,
+            createdClients::add,
+            camundaManagementClient,
+            CamundaAssert.getAwaitBehavior());
 
     // put in store
     final Store store = context.getStore(NAMESPACE);

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/IncidentAssertj.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/IncidentAssertj.java
@@ -17,20 +17,16 @@ package io.camunda.process.test.impl.assertions;
 
 import static org.apache.commons.lang3.StringUtils.abbreviate;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
 
-import io.camunda.client.api.command.ClientException;
 import io.camunda.client.api.search.enums.IncidentState;
 import io.camunda.client.api.search.filter.IncidentFilter;
 import io.camunda.client.api.search.response.Incident;
+import io.camunda.process.test.api.CamundaAssertAwaitBehavior;
 import java.util.Arrays;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import org.assertj.core.api.AbstractAssert;
-import org.awaitility.Awaitility;
-import org.awaitility.core.ConditionTimeoutException;
 
 public class IncidentAssertj extends AbstractAssert<ElementAssertj, String> {
 
@@ -40,10 +36,15 @@ public class IncidentAssertj extends AbstractAssert<ElementAssertj, String> {
       Arrays.asList(IncidentState.ACTIVE, IncidentState.PENDING, IncidentState.MIGRATED);
 
   private final CamundaDataSource dataSource;
+  private final CamundaAssertAwaitBehavior awaitBehavior;
 
-  protected IncidentAssertj(final CamundaDataSource dataSource, final String failureMessagePrefix) {
+  protected IncidentAssertj(
+      final CamundaDataSource dataSource,
+      final CamundaAssertAwaitBehavior awaitBehavior,
+      final String failureMessagePrefix) {
     super(failureMessagePrefix, IncidentAssertj.class);
     this.dataSource = dataSource;
+    this.awaitBehavior = awaitBehavior;
   }
 
   public void hasNoActiveIncidents(final long processInstanceKey) {
@@ -81,27 +82,7 @@ public class IncidentAssertj extends AbstractAssert<ElementAssertj, String> {
 
   private void awaitIncidentAssertion(
       final Consumer<IncidentFilter> filter, final Consumer<List<Incident>> assertion) {
-
-    // If await() times out, the exception doesn't contain the assertion error. Use a reference to
-    // store the error's failure message.
-    final AtomicReference<String> failureMessage = new AtomicReference<>("?");
-    try {
-      Awaitility.await()
-          .ignoreException(ClientException.class)
-          .untilAsserted(
-              () -> dataSource.findIncidents(filter),
-              incidents -> {
-                try {
-                  assertion.accept(incidents);
-                } catch (final AssertionError e) {
-                  failureMessage.set(e.getMessage());
-                  throw e;
-                }
-              });
-
-    } catch (final ConditionTimeoutException ignore) {
-      fail(failureMessage.get());
-    }
+    awaitBehavior.untilAsserted(() -> dataSource.findIncidents(filter), assertion);
   }
 
   private String collectIncidentReports(final List<Incident> incidents) {

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/util/AwaitilityBehavior.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/util/AwaitilityBehavior.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.process.test.impl.assertions.util;
+
+import static org.assertj.core.api.Assertions.fail;
+
+import io.camunda.client.api.command.ClientException;
+import io.camunda.process.test.api.CamundaAssert;
+import io.camunda.process.test.api.CamundaAssertAwaitBehavior;
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicReference;
+import org.awaitility.Awaitility;
+import org.awaitility.core.ConditionTimeoutException;
+import org.junit.function.ThrowingRunnable;
+
+public class AwaitilityBehavior implements CamundaAssertAwaitBehavior {
+
+  private Duration assertionTimeout = CamundaAssert.DEFAULT_ASSERTION_TIMEOUT;
+  private Duration assertionInterval = CamundaAssert.DEFAULT_ASSERTION_INTERVAL;
+
+  @Override
+  public void untilAsserted(final ThrowingRunnable assertion) throws AssertionError {
+    // If await() times out, the exception doesn't contain the assertion error. Use a reference to
+    // store the error's failure message.
+    final AtomicReference<String> failureMessage = new AtomicReference<>("<no assertion error>");
+    try {
+      Awaitility.await()
+          .timeout(assertionTimeout)
+          .pollInterval(assertionInterval)
+          .ignoreException(ClientException.class)
+          .untilAsserted(
+              () -> {
+                try {
+                  assertion.run();
+                } catch (final AssertionError e) {
+                  failureMessage.set(e.getMessage());
+                  throw e;
+                }
+              });
+
+    } catch (final ConditionTimeoutException ignore) {
+      fail(failureMessage.get());
+    }
+  }
+
+  @Override
+  public void setAssertionTimeout(final Duration assertionTimeout) {
+    this.assertionTimeout = assertionTimeout;
+  }
+
+  @Override
+  public void setAssertionInterval(final Duration assertionInterval) {
+    this.assertionInterval = assertionInterval;
+  }
+}

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/util/AwaitilityBehavior.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/util/AwaitilityBehavior.java
@@ -1,9 +1,17 @@
 /*
- * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
- * one or more contributor license agreements. See the NOTICE file distributed
- * with this work for additional information regarding copyright ownership.
- * Licensed under the Camunda License 1.0. You may not use this file
- * except in compliance with the Camunda License 1.0.
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package io.camunda.process.test.impl.assertions.util;
 

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/util/AwaitilityBehavior.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/util/AwaitilityBehavior.java
@@ -28,6 +28,9 @@ import org.awaitility.core.ConditionTimeoutException;
 
 public class AwaitilityBehavior implements CamundaAssertAwaitBehavior {
 
+  private static final String INITIAL_FAILURE_MESSAGE =
+      "<No assertion error occurred. Maybe, the assertion timed out before it could be tested.>";
+
   private Duration assertionTimeout = CamundaAssert.DEFAULT_ASSERTION_TIMEOUT;
   private Duration assertionInterval = CamundaAssert.DEFAULT_ASSERTION_INTERVAL;
 
@@ -35,7 +38,7 @@ public class AwaitilityBehavior implements CamundaAssertAwaitBehavior {
   public void untilAsserted(final ThrowingRunnable assertion) throws AssertionError {
     // If await() times out, the exception doesn't contain the assertion error. Use a reference to
     // store the error's failure message.
-    final AtomicReference<String> failureMessage = new AtomicReference<>("<no assertion error>");
+    final AtomicReference<String> failureMessage = new AtomicReference<>(INITIAL_FAILURE_MESSAGE);
     try {
       Awaitility.await()
           .timeout(assertionTimeout)

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/util/AwaitilityBehavior.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/util/AwaitilityBehavior.java
@@ -22,9 +22,9 @@ import io.camunda.process.test.api.CamundaAssert;
 import io.camunda.process.test.api.CamundaAssertAwaitBehavior;
 import java.time.Duration;
 import java.util.concurrent.atomic.AtomicReference;
+import org.assertj.core.api.SoftAssertionsProvider.ThrowingRunnable;
 import org.awaitility.Awaitility;
 import org.awaitility.core.ConditionTimeoutException;
-import org.junit.function.ThrowingRunnable;
 
 public class AwaitilityBehavior implements CamundaAssertAwaitBehavior {
 

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/DecisionInstanceAssertTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/DecisionInstanceAssertTest.java
@@ -31,6 +31,7 @@ import io.camunda.client.protocol.rest.EvaluatedDecisionOutputItem;
 import io.camunda.client.protocol.rest.MatchedDecisionRuleItem;
 import io.camunda.process.test.api.assertions.DecisionSelectors;
 import io.camunda.process.test.impl.assertions.CamundaDataSource;
+import io.camunda.process.test.utils.CamundaAssertExpectFailure;
 import io.camunda.process.test.utils.CamundaAssertExtension;
 import java.util.Arrays;
 import java.util.Collections;
@@ -186,6 +187,7 @@ public class DecisionInstanceAssertTest {
     }
 
     @Test
+    @CamundaAssertExpectFailure
     public void evaluationFailure() {
       // when
       mockDecisionInstanceSearch(decisionInstance(d -> d.state(DecisionInstanceStateEnum.FAILED)));
@@ -230,6 +232,7 @@ public class DecisionInstanceAssertTest {
     }
 
     @Test
+    @CamundaAssertExpectFailure
     public void assertionFailureWithStringMatch() {
       // when
       mockDecisionInstanceSearch(decisionInstanceWithAnswers(STRING_RESULT));
@@ -249,6 +252,7 @@ public class DecisionInstanceAssertTest {
     }
 
     @Test
+    @CamundaAssertExpectFailure
     public void assertionFailureWithMapMatch() {
       // when
       mockDecisionInstanceSearch(decisionInstanceWithAnswers(MAP_RESULT));
@@ -268,6 +272,7 @@ public class DecisionInstanceAssertTest {
     }
 
     @Test
+    @CamundaAssertExpectFailure
     public void assertionFailureWithListMatch() {
       // when
       mockDecisionInstanceSearch(decisionInstanceWithAnswers(LIST_RESULT));
@@ -321,6 +326,7 @@ public class DecisionInstanceAssertTest {
     }
 
     @Test
+    @CamundaAssertExpectFailure
     public void hasNotMatched() {
       // when
       mockDecisionInstanceSearch(decisionInstanceWithAnswers("outputValue", singleRule()));
@@ -357,6 +363,7 @@ public class DecisionInstanceAssertTest {
     }
 
     @Test
+    @CamundaAssertExpectFailure
     public void hasMatched() {
       // when
       mockDecisionInstanceSearch(decisionInstanceWithAnswers("outputValue", singleRule()));
@@ -369,6 +376,7 @@ public class DecisionInstanceAssertTest {
     }
 
     @Test
+    @CamundaAssertExpectFailure
     public void hasMatchedPartial() {
       // when
       mockDecisionInstanceSearch(decisionInstanceWithAnswers("outputValue", multiRule()));

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/ElementAssertTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/ElementAssertTest.java
@@ -27,6 +27,7 @@ import io.camunda.client.api.search.filter.ElementInstanceFilter;
 import io.camunda.client.api.search.response.ElementInstance;
 import io.camunda.process.test.api.assertions.ElementSelectors;
 import io.camunda.process.test.impl.assertions.CamundaDataSource;
+import io.camunda.process.test.utils.CamundaAssertExpectFailure;
 import io.camunda.process.test.utils.CamundaAssertExtension;
 import io.camunda.process.test.utils.ElementInstanceBuilder;
 import io.camunda.process.test.utils.ProcessInstanceBuilder;
@@ -116,6 +117,7 @@ public class ElementAssertTest {
     }
 
     @Test
+    @CamundaAssertExpectFailure
     void shouldFailWithStringSelector() {
       // when
       when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
@@ -158,6 +160,7 @@ public class ElementAssertTest {
     }
 
     @Test
+    @CamundaAssertExpectFailure
     void shouldFailWithByIdSelector() {
       // when
       when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
@@ -193,6 +196,7 @@ public class ElementAssertTest {
     }
 
     @Test
+    @CamundaAssertExpectFailure
     void shouldFailWithByNameSelector() {
       // when
       when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
@@ -272,6 +276,7 @@ public class ElementAssertTest {
     }
 
     @Test
+    @CamundaAssertExpectFailure
     void shouldFailIfElementsNotFound() {
       // given
       final ElementInstance elementInstanceA = newActiveElementInstance("A");
@@ -294,6 +299,7 @@ public class ElementAssertTest {
     }
 
     @Test
+    @CamundaAssertExpectFailure
     void shouldFailIfElementsNotActive() {
       // given
       final ElementInstance elementInstanceA = newActiveElementInstance("A");
@@ -317,6 +323,7 @@ public class ElementAssertTest {
     }
 
     @Test
+    @CamundaAssertExpectFailure
     void shouldFailWithSameElementId() {
       // given
       final ElementInstance elementInstanceA = newActiveElementInstance("A");
@@ -338,6 +345,7 @@ public class ElementAssertTest {
     }
 
     @Test
+    @CamundaAssertExpectFailure
     void shouldFailIfProcessInstanceNotFound() {
       // given
       when(camundaDataSource.findProcessInstances(any())).thenReturn(Collections.emptyList());
@@ -408,6 +416,7 @@ public class ElementAssertTest {
     }
 
     @Test
+    @CamundaAssertExpectFailure
     void shouldFailIfElementsNotFound() {
       // given
       final ElementInstance elementInstanceA = newCompletedElementInstance("A");
@@ -432,6 +441,7 @@ public class ElementAssertTest {
     }
 
     @Test
+    @CamundaAssertExpectFailure
     void shouldFailIfElementsNotCompleted() {
       // given
       final ElementInstance elementInstanceA = newCompletedElementInstance("A");
@@ -453,6 +463,7 @@ public class ElementAssertTest {
     }
 
     @Test
+    @CamundaAssertExpectFailure
     void shouldFailWithSameElementId() {
       // given
       final ElementInstance elementInstanceA = newCompletedElementInstance("A");
@@ -474,6 +485,7 @@ public class ElementAssertTest {
     }
 
     @Test
+    @CamundaAssertExpectFailure
     void shouldFailIfProcessInstanceNotFound() {
       // given
       when(camundaDataSource.findProcessInstances(any())).thenReturn(Collections.emptyList());
@@ -544,6 +556,7 @@ public class ElementAssertTest {
     }
 
     @Test
+    @CamundaAssertExpectFailure
     void shouldFailIfElementsNotFound() {
       // given
       final ElementInstance elementInstanceA = newTerminatedElementInstance("A");
@@ -568,6 +581,7 @@ public class ElementAssertTest {
     }
 
     @Test
+    @CamundaAssertExpectFailure
     void shouldFailIfElementsNotTerminated() {
       // given
       final ElementInstance elementInstanceA = newCompletedElementInstance("A");
@@ -589,6 +603,7 @@ public class ElementAssertTest {
     }
 
     @Test
+    @CamundaAssertExpectFailure
     void shouldFailWithSameElementId() {
       // given
       final ElementInstance elementInstanceA = newCompletedElementInstance("A");
@@ -610,6 +625,7 @@ public class ElementAssertTest {
     }
 
     @Test
+    @CamundaAssertExpectFailure
     void shouldFailIfProcessInstanceNotFound() {
       // given
       when(camundaDataSource.findProcessInstances(any())).thenReturn(Collections.emptyList());
@@ -660,6 +676,7 @@ public class ElementAssertTest {
     }
 
     @Test
+    @CamundaAssertExpectFailure
     void shouldFailIfNumberIsGreater() {
       // given
       final ElementInstance elementInstance1 = newActiveElementInstance("A");
@@ -682,6 +699,7 @@ public class ElementAssertTest {
     }
 
     @Test
+    @CamundaAssertExpectFailure
     void shouldFailIfNumberIsLess() {
       // given
       final ElementInstance elementInstanceA = newActiveElementInstance("A");
@@ -703,6 +721,7 @@ public class ElementAssertTest {
     }
 
     @Test
+    @CamundaAssertExpectFailure
     void shouldFailIfNotActive() {
       // given
       final ElementInstance elementInstanceA1 = newCompletedElementInstance("A");
@@ -725,6 +744,7 @@ public class ElementAssertTest {
     }
 
     @Test
+    @CamundaAssertExpectFailure
     void shouldFailIfNotCreated() {
       // given
       when(camundaDataSource.findElementInstances(any())).thenReturn(Collections.emptyList());
@@ -759,6 +779,7 @@ public class ElementAssertTest {
     }
 
     @Test
+    @CamundaAssertExpectFailure
     void shouldFailIfExpectedZero() {
       // given
       when(camundaDataSource.findElementInstances(any()))
@@ -777,6 +798,7 @@ public class ElementAssertTest {
     }
 
     @Test
+    @CamundaAssertExpectFailure
     void shouldFailIfNumberIsNegative() {
       // when
       when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
@@ -845,6 +867,7 @@ public class ElementAssertTest {
     }
 
     @Test
+    @CamundaAssertExpectFailure
     void shouldFailIfNumberIsGreater() {
       // given
       final ElementInstance elementInstance1 = newCompletedElementInstance("A");
@@ -867,6 +890,7 @@ public class ElementAssertTest {
     }
 
     @Test
+    @CamundaAssertExpectFailure
     void shouldFailIfNumberIsLess() {
       // given
       final ElementInstance elementInstanceA = newCompletedElementInstance("A");
@@ -888,6 +912,7 @@ public class ElementAssertTest {
     }
 
     @Test
+    @CamundaAssertExpectFailure
     void shouldFailIfNotCompleted() {
       // given
       final ElementInstance elementInstanceA1 = newTerminatedElementInstance("A");
@@ -910,6 +935,7 @@ public class ElementAssertTest {
     }
 
     @Test
+    @CamundaAssertExpectFailure
     void shouldFailIfNotCreated() {
       // given
       when(camundaDataSource.findElementInstances(any())).thenReturn(Collections.emptyList());
@@ -944,6 +970,7 @@ public class ElementAssertTest {
     }
 
     @Test
+    @CamundaAssertExpectFailure
     void shouldFailIfExpectedZero() {
       // given
       when(camundaDataSource.findElementInstances(any()))
@@ -962,6 +989,7 @@ public class ElementAssertTest {
     }
 
     @Test
+    @CamundaAssertExpectFailure
     void shouldFailIfNumberIsNegative() {
       // when
       when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
@@ -1030,6 +1058,7 @@ public class ElementAssertTest {
     }
 
     @Test
+    @CamundaAssertExpectFailure
     void shouldFailIfNumberIsGreater() {
       // given
       final ElementInstance elementInstance1 = newTerminatedElementInstance("A");
@@ -1052,6 +1081,7 @@ public class ElementAssertTest {
     }
 
     @Test
+    @CamundaAssertExpectFailure
     void shouldFailIfNumberIsLess() {
       // given
       final ElementInstance elementInstanceA = newTerminatedElementInstance("A");
@@ -1073,6 +1103,7 @@ public class ElementAssertTest {
     }
 
     @Test
+    @CamundaAssertExpectFailure
     void shouldFailIfNotTerminated() {
       // given
       final ElementInstance elementInstanceA1 = newCompletedElementInstance("A");
@@ -1095,6 +1126,7 @@ public class ElementAssertTest {
     }
 
     @Test
+    @CamundaAssertExpectFailure
     void shouldFailIfNotCreated() {
       // given
       when(camundaDataSource.findElementInstances(any())).thenReturn(Collections.emptyList());
@@ -1129,6 +1161,7 @@ public class ElementAssertTest {
     }
 
     @Test
+    @CamundaAssertExpectFailure
     void shouldFailIfExpectedZero() {
       // given
       when(camundaDataSource.findElementInstances(any()))
@@ -1147,6 +1180,7 @@ public class ElementAssertTest {
     }
 
     @Test
+    @CamundaAssertExpectFailure
     void shouldFailIfNumberIsNegative() {
       // when
       when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
@@ -1195,6 +1229,7 @@ public class ElementAssertTest {
     }
 
     @Test
+    @CamundaAssertExpectFailure
     void shouldFailIfElementsAreActive() {
       // given
       final ElementInstance elementInstanceA = newActiveElementInstance("A");
@@ -1219,6 +1254,7 @@ public class ElementAssertTest {
     }
 
     @Test
+    @CamundaAssertExpectFailure
     void shouldFailIfElementsAreCompleted() {
       // given
       final ElementInstance elementInstanceA = newCompletedElementInstance("A");
@@ -1243,6 +1279,7 @@ public class ElementAssertTest {
     }
 
     @Test
+    @CamundaAssertExpectFailure
     void shouldFailIfElementsAreTerminated() {
       // given
       final ElementInstance elementInstanceA = newTerminatedElementInstance("A");
@@ -1267,6 +1304,7 @@ public class ElementAssertTest {
     }
 
     @Test
+    @CamundaAssertExpectFailure
     void shouldFailIfProcessInstanceNotFound() {
       // given
       when(camundaDataSource.findProcessInstances(any())).thenReturn(Collections.emptyList());
@@ -1318,6 +1356,7 @@ public class ElementAssertTest {
     }
 
     @Test
+    @CamundaAssertExpectFailure
     void shouldFailIfElementsAreActive() {
       // given
       when(camundaDataSource.findElementInstances(any()))
@@ -1338,6 +1377,7 @@ public class ElementAssertTest {
     }
 
     @Test
+    @CamundaAssertExpectFailure
     void shouldFailIfProcessInstanceNotFound() {
       // given
       when(camundaDataSource.findProcessInstances(any())).thenReturn(Collections.emptyList());
@@ -1433,6 +1473,7 @@ public class ElementAssertTest {
     }
 
     @Test
+    @CamundaAssertExpectFailure
     void shouldFailIfOneElementIsNotCompleted() {
       // given
       when(camundaDataSource.findElementInstances(any()))
@@ -1458,6 +1499,7 @@ public class ElementAssertTest {
     }
 
     @Test
+    @CamundaAssertExpectFailure
     void shouldFailIfElementsAreCompletedInADifferentOrder() {
       // given
       when(camundaDataSource.findElementInstances(any()))
@@ -1562,6 +1604,7 @@ public class ElementAssertTest {
     }
 
     @Test
+    @CamundaAssertExpectFailure
     void shouldFailIfElementsAreNotActive() {
       // given
       when(camundaDataSource.findElementInstances(any()))
@@ -1588,6 +1631,7 @@ public class ElementAssertTest {
     }
 
     @Test
+    @CamundaAssertExpectFailure
     void shouldFailIfOtherElementsAreActive() {
       // given
       when(camundaDataSource.findElementInstances(any()))
@@ -1611,6 +1655,7 @@ public class ElementAssertTest {
     }
 
     @Test
+    @CamundaAssertExpectFailure
     void shouldFailIfElementsAreNotActiveAndOtherElementsAreActive() {
       // given
       when(camundaDataSource.findElementInstances(any()))

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/IncidentAssertTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/IncidentAssertTest.java
@@ -23,6 +23,7 @@ import io.camunda.client.api.search.enums.IncidentErrorType;
 import io.camunda.client.api.search.enums.IncidentState;
 import io.camunda.client.api.search.response.Incident;
 import io.camunda.process.test.impl.assertions.CamundaDataSource;
+import io.camunda.process.test.utils.CamundaAssertExpectFailure;
 import io.camunda.process.test.utils.CamundaAssertExtension;
 import io.camunda.process.test.utils.IncidentBuilder;
 import io.camunda.process.test.utils.ProcessInstanceBuilder;
@@ -112,6 +113,7 @@ public class IncidentAssertTest {
 
     @ParameterizedTest(name = "{0}")
     @ArgumentsSource(ActiveIncidentsProvider.class)
+    @CamundaAssertExpectFailure
     void shouldFailIfActiveIncidentsFound(final String label, final Incident incident) {
       // given
       when(camundaDataSource.findIncidents(any())).thenReturn(Collections.singletonList(incident));
@@ -129,6 +131,7 @@ public class IncidentAssertTest {
     }
 
     @Test
+    @CamundaAssertExpectFailure
     void shouldFormatMultipleActiveIncidents() {
       // given
       final List<Incident> incidents =
@@ -205,6 +208,7 @@ public class IncidentAssertTest {
     }
 
     @Test
+    @CamundaAssertExpectFailure
     void shouldFailIfOnlyResolvedIncidentsAreFound() {
       // given
       when(camundaDataSource.findIncidents(any()))
@@ -222,6 +226,7 @@ public class IncidentAssertTest {
     }
 
     @Test
+    @CamundaAssertExpectFailure
     void shouldFailIfNoIncidentsFound() {
       // given
       when(camundaDataSource.findIncidents(any())).thenReturn(Collections.emptyList());

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/ProcessInstanceAssertTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/ProcessInstanceAssertTest.java
@@ -16,7 +16,6 @@
 package io.camunda.process.test.api;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -29,6 +28,7 @@ import io.camunda.client.api.search.response.ElementInstance;
 import io.camunda.client.api.search.response.Variable;
 import io.camunda.process.test.api.assertions.ProcessInstanceSelectors;
 import io.camunda.process.test.impl.assertions.CamundaDataSource;
+import io.camunda.process.test.utils.CamundaAssertExpectFailure;
 import io.camunda.process.test.utils.CamundaAssertExtension;
 import io.camunda.process.test.utils.ElementInstanceBuilder;
 import io.camunda.process.test.utils.ProcessInstanceBuilder;
@@ -118,6 +118,7 @@ public class ProcessInstanceAssertTest {
     }
 
     @Test
+    @CamundaAssertExpectFailure
     void shouldFailWithProcessInstanceEvent() {
       // given
       when(processInstanceEvent.getProcessInstanceKey()).thenReturn(COMPLETED_PROCESS_INSTANCE_KEY);
@@ -148,6 +149,7 @@ public class ProcessInstanceAssertTest {
     }
 
     @Test
+    @CamundaAssertExpectFailure
     void shouldFailWithProcessInstanceResult() {
       // given
       when(processInstanceResult.getProcessInstanceKey())
@@ -178,6 +180,7 @@ public class ProcessInstanceAssertTest {
     }
 
     @Test
+    @CamundaAssertExpectFailure
     void shouldFailWithByKeySelector() {
       // when
       Assertions.assertThatThrownBy(
@@ -206,6 +209,7 @@ public class ProcessInstanceAssertTest {
     }
 
     @Test
+    @CamundaAssertExpectFailure
     void shouldFailWithByProcessIdSelector() {
       // when
       Assertions.assertThatThrownBy(
@@ -241,6 +245,7 @@ public class ProcessInstanceAssertTest {
     }
 
     @Test
+    @CamundaAssertExpectFailure
     void shouldFailIfCompleted() {
       // given
       when(camundaDataSource.findProcessInstances(any()))
@@ -260,6 +265,7 @@ public class ProcessInstanceAssertTest {
     }
 
     @Test
+    @CamundaAssertExpectFailure
     void shouldFailIfTerminated() {
       // given
       when(camundaDataSource.findProcessInstances(any()))
@@ -279,6 +285,7 @@ public class ProcessInstanceAssertTest {
     }
 
     @Test
+    @CamundaAssertExpectFailure
     void shouldFailIfNotFound() {
       // given
       when(camundaDataSource.findProcessInstances(any())).thenReturn(Collections.emptyList());
@@ -314,6 +321,7 @@ public class ProcessInstanceAssertTest {
     }
 
     @Test
+    @CamundaAssertExpectFailure
     void shouldFailIfTerminated() {
       // given
       when(camundaDataSource.findProcessInstances(any()))
@@ -355,6 +363,7 @@ public class ProcessInstanceAssertTest {
     }
 
     @Test
+    @CamundaAssertExpectFailure
     void shouldFailIfActive() {
       // given
       when(camundaDataSource.findProcessInstances(any()))
@@ -372,10 +381,11 @@ public class ProcessInstanceAssertTest {
               "Process instance [key: %d] should be completed but was active.",
               PROCESS_INSTANCE_KEY);
 
-      verify(camundaDataSource, atLeast(2)).findProcessInstances(any());
+      verify(camundaDataSource).findProcessInstances(any());
     }
 
     @Test
+    @CamundaAssertExpectFailure
     void shouldFailIfNotFound() {
       // given
       when(camundaDataSource.findProcessInstances(any())).thenReturn(Collections.emptyList());
@@ -412,6 +422,7 @@ public class ProcessInstanceAssertTest {
     }
 
     @Test
+    @CamundaAssertExpectFailure
     void shouldFailIfCompleted() {
       // given
       when(camundaDataSource.findProcessInstances(any()))
@@ -453,6 +464,7 @@ public class ProcessInstanceAssertTest {
     }
 
     @Test
+    @CamundaAssertExpectFailure
     void shouldFailIfActive() {
       // given
       when(camundaDataSource.findProcessInstances(any()))
@@ -470,10 +482,11 @@ public class ProcessInstanceAssertTest {
               "Process instance [key: %d] should be terminated but was active.",
               PROCESS_INSTANCE_KEY);
 
-      verify(camundaDataSource, atLeast(2)).findProcessInstances(any());
+      verify(camundaDataSource).findProcessInstances(any());
     }
 
     @Test
+    @CamundaAssertExpectFailure
     void shouldFailIfNotFound() {
       // given
       when(camundaDataSource.findProcessInstances(any())).thenReturn(Collections.emptyList());
@@ -541,6 +554,7 @@ public class ProcessInstanceAssertTest {
     }
 
     @Test
+    @CamundaAssertExpectFailure
     void shouldFailIfNotCreated() {
       // given
       when(camundaDataSource.findProcessInstances(any())).thenReturn(Collections.emptyList());

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/UserTaskAssertTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/UserTaskAssertTest.java
@@ -25,6 +25,7 @@ import io.camunda.client.protocol.rest.UserTaskResult;
 import io.camunda.client.protocol.rest.UserTaskStateEnum;
 import io.camunda.process.test.api.assertions.UserTaskSelectors;
 import io.camunda.process.test.impl.assertions.CamundaDataSource;
+import io.camunda.process.test.utils.CamundaAssertExpectFailure;
 import io.camunda.process.test.utils.CamundaAssertExtension;
 import java.util.Arrays;
 import java.util.Collections;
@@ -177,6 +178,7 @@ public class UserTaskAssertTest {
     }
 
     @Test
+    @CamundaAssertExpectFailure
     public void failsWithConciseErrorMessageWhenNoTaskFound() {
       when(camundaDataSource.findUserTasks(any())).thenReturn(Collections.emptyList());
 
@@ -186,6 +188,7 @@ public class UserTaskAssertTest {
     }
 
     @Test
+    @CamundaAssertExpectFailure
     public void failsWithConciseErrorMessageWhenTaskHasWrongState() {
       // when
       final UserTask completedTask =
@@ -254,6 +257,7 @@ public class UserTaskAssertTest {
     }
 
     @Test
+    @CamundaAssertExpectFailure
     public void hasPriorityFailureMessage() {
       // when
       when(camundaDataSource.findUserTasks(any()))
@@ -323,6 +327,7 @@ public class UserTaskAssertTest {
     }
 
     @Test
+    @CamundaAssertExpectFailure
     public void hasElementIdFailureMessage() {
       // when
       when(camundaDataSource.findUserTasks(any()))
@@ -390,6 +395,7 @@ public class UserTaskAssertTest {
     }
 
     @Test
+    @CamundaAssertExpectFailure
     public void hasNameFailureMessage() {
       // when
       when(camundaDataSource.findUserTasks(any()))
@@ -458,7 +464,8 @@ public class UserTaskAssertTest {
     }
 
     @Test
-    public void hasAssigneeFailureMesasge() {
+    @CamundaAssertExpectFailure
+    public void hasAssigneeFailureMessage() {
       // when
       when(camundaDataSource.findUserTasks(any()))
           .thenReturn(
@@ -527,6 +534,7 @@ public class UserTaskAssertTest {
     }
 
     @Test
+    @CamundaAssertExpectFailure
     public void hasDueDateFailureMessage() {
       // when
       when(camundaDataSource.findUserTasks(any()))
@@ -597,6 +605,7 @@ public class UserTaskAssertTest {
     }
 
     @Test
+    @CamundaAssertExpectFailure
     public void hasCompletionDateFailureMessage() {
       // when
       when(camundaDataSource.findUserTasks(any()))
@@ -668,6 +677,7 @@ public class UserTaskAssertTest {
     }
 
     @Test
+    @CamundaAssertExpectFailure
     public void hasFollowUpDateFailureMessage() {
       // when
       when(camundaDataSource.findUserTasks(any()))
@@ -738,6 +748,7 @@ public class UserTaskAssertTest {
     }
 
     @Test
+    @CamundaAssertExpectFailure
     public void hasCreationDateFailureMessage() {
       // when
       when(camundaDataSource.findUserTasks(any()))
@@ -844,6 +855,7 @@ public class UserTaskAssertTest {
     }
 
     @Test
+    @CamundaAssertExpectFailure
     public void hasCandidateGroupFailureMessage() {
       // when
       when(camundaDataSource.findUserTasks(any()))
@@ -864,6 +876,7 @@ public class UserTaskAssertTest {
     }
 
     @Test
+    @CamundaAssertExpectFailure
     public void hasCandidateGroupsFailureMessage() {
       // when
       when(camundaDataSource.findUserTasks(any()))

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/VariableAssertTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/VariableAssertTest.java
@@ -27,6 +27,7 @@ import io.camunda.client.api.search.response.Variable;
 import io.camunda.process.test.api.assertions.ElementSelectors;
 import io.camunda.process.test.impl.assertions.CamundaDataSource;
 import io.camunda.process.test.impl.assertions.util.AssertionJsonMapper;
+import io.camunda.process.test.utils.CamundaAssertExpectFailure;
 import io.camunda.process.test.utils.CamundaAssertExtension;
 import io.camunda.process.test.utils.ElementInstanceBuilder;
 import io.camunda.process.test.utils.ProcessInstanceBuilder;
@@ -176,6 +177,7 @@ public class VariableAssertTest {
     }
 
     @Test
+    @CamundaAssertExpectFailure
     void shouldFailIfVariableNotExist() {
       // given
       final Variable variableA = newVariable("a", "1");
@@ -198,6 +200,7 @@ public class VariableAssertTest {
     }
 
     @Test
+    @CamundaAssertExpectFailure
     void shouldFailIfProcessInstanceNotFound() {
       // given
       when(camundaDataSource.findProcessInstances(any())).thenReturn(Collections.emptyList());
@@ -287,6 +290,7 @@ public class VariableAssertTest {
     }
 
     @Test
+    @CamundaAssertExpectFailure
     void shouldFailIfVariableNotExist() {
       // given
       final Variable variableA = newVariable("a", "1");
@@ -307,6 +311,7 @@ public class VariableAssertTest {
     }
 
     @Test
+    @CamundaAssertExpectFailure
     void shouldFailIfVariableHasDifferentValue() {
       // given
       final Variable variableA = newVariable("a", "1");
@@ -328,6 +333,7 @@ public class VariableAssertTest {
 
     @ParameterizedTest
     @MethodSource("io.camunda.process.test.api.VariableAssertTest#variableValues")
+    @CamundaAssertExpectFailure
     void shouldFailWithMessage(final String variableValue) {
       // given
       final Variable variableA = newVariable("a", variableValue);
@@ -347,6 +353,7 @@ public class VariableAssertTest {
     }
 
     @Test
+    @CamundaAssertExpectFailure
     void shouldFailIfProcessInstanceNotFound() {
       // given
       when(camundaDataSource.findProcessInstances(any())).thenReturn(Collections.emptyList());
@@ -453,6 +460,7 @@ public class VariableAssertTest {
     }
 
     @Test
+    @CamundaAssertExpectFailure
     void shouldFailIfOneVariableNotExist() {
       // given
       final Variable variableA = newVariable("a", "1");
@@ -477,6 +485,7 @@ public class VariableAssertTest {
     }
 
     @Test
+    @CamundaAssertExpectFailure
     void shouldFailIfVariableHasDifferentValue() {
       // given
       final Variable variableA = newVariable("a", "1");
@@ -503,6 +512,7 @@ public class VariableAssertTest {
 
     @ParameterizedTest
     @MethodSource("io.camunda.process.test.api.VariableAssertTest#variableValues")
+    @CamundaAssertExpectFailure
     void shouldFailWithMessage(final String variableValue) {
       // given
       final Variable variableA = newVariable("a", variableValue);
@@ -525,6 +535,7 @@ public class VariableAssertTest {
     }
 
     @Test
+    @CamundaAssertExpectFailure
     void shouldFailIfProcessInstanceNotFound() {
       // given
       when(camundaDataSource.findProcessInstances(any())).thenReturn(Collections.emptyList());
@@ -693,6 +704,7 @@ public class VariableAssertTest {
     }
 
     @Test
+    @CamundaAssertExpectFailure
     void shouldHaveSensibleErrorMessageWhenAssertionFails() {
       // given
       when(camundaDataSource.findGlobalVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
@@ -729,6 +741,7 @@ public class VariableAssertTest {
     }
 
     @Test
+    @CamundaAssertExpectFailure
     void shouldHaveSensibleErrorMessageWhenJsonMappingFails() {
       // given
       when(camundaDataSource.findGlobalVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
@@ -750,6 +763,7 @@ public class VariableAssertTest {
     }
 
     @Test
+    @CamundaAssertExpectFailure
     void shouldHaveSensibleErrorMessageWhenNoVariablesFound() {
       // given
       when(camundaDataSource.findGlobalVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
@@ -769,6 +783,7 @@ public class VariableAssertTest {
     }
 
     @Test
+    @CamundaAssertExpectFailure
     void shouldConvertCheckedExceptions() {
       // given
       when(camundaDataSource.findGlobalVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/utils/CamundaAssertExpectFailure.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/utils/CamundaAssertExpectFailure.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.utils;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/** An annotation for a test method that verifies an assertion failure message. */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface CamundaAssertExpectFailure {}

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/utils/DevAwaitBehavior.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/utils/DevAwaitBehavior.java
@@ -30,6 +30,9 @@ import org.awaitility.core.TerminalFailureException;
 
 public final class DevAwaitBehavior implements CamundaAssertAwaitBehavior {
 
+  private static final String INITIAL_FAILURE_MESSAGE =
+      "<No assertion error occurred. Maybe, the assertion timed out before it could be tested.>";
+
   private final boolean expectFailure;
 
   private Duration assertionTimeout = CamundaAssert.DEFAULT_ASSERTION_TIMEOUT;
@@ -49,7 +52,7 @@ public final class DevAwaitBehavior implements CamundaAssertAwaitBehavior {
 
   @Override
   public void untilAsserted(final ThrowingRunnable assertion) throws AssertionError {
-    final AtomicReference<String> failureMessage = new AtomicReference<>("<no assertion error>");
+    final AtomicReference<String> failureMessage = new AtomicReference<>(INITIAL_FAILURE_MESSAGE);
     final AtomicBoolean failFastCondition = new AtomicBoolean(false);
 
     try {

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/utils/DevAwaitBehavior.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/utils/DevAwaitBehavior.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.utils;
+
+import static org.assertj.core.api.Assertions.fail;
+
+import io.camunda.client.api.command.ClientException;
+import io.camunda.process.test.api.CamundaAssert;
+import io.camunda.process.test.api.CamundaAssertAwaitBehavior;
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import org.awaitility.Awaitility;
+import org.awaitility.core.ConditionTimeoutException;
+import org.awaitility.core.TerminalFailureException;
+import org.junit.function.ThrowingRunnable;
+
+public class DevAwaitBehavior implements CamundaAssertAwaitBehavior {
+
+  private final boolean expectFailure;
+
+  private Duration assertionTimeout = CamundaAssert.DEFAULT_ASSERTION_TIMEOUT;
+  private Duration assertionInterval = Duration.ZERO;
+
+  private DevAwaitBehavior(final boolean expectFailure) {
+    this.expectFailure = expectFailure;
+  }
+
+  public static DevAwaitBehavior expectFailure() {
+    return new DevAwaitBehavior(true);
+  }
+
+  public static DevAwaitBehavior expectSuccess() {
+    return new DevAwaitBehavior(false);
+  }
+
+  @Override
+  public void untilAsserted(final ThrowingRunnable assertion) throws AssertionError {
+    final AtomicReference<String> failureMessage = new AtomicReference<>("<no assertion error>");
+    final AtomicBoolean failFastCondition = new AtomicBoolean(false);
+
+    try {
+      Awaitility.await()
+          .failFast(failFastCondition::get)
+          .timeout(assertionTimeout)
+          .pollInterval(assertionInterval)
+          .ignoreException(ClientException.class)
+          .untilAsserted(
+              () -> {
+                try {
+                  assertion.run();
+                } catch (final AssertionError e) {
+                  failureMessage.set(e.getMessage());
+
+                  if (expectFailure) {
+                    failFastCondition.set(true);
+                  }
+                  throw e;
+                }
+              });
+    } catch (final ConditionTimeoutException | TerminalFailureException ignore) {
+      fail(failureMessage.get());
+    }
+  }
+
+  @Override
+  public void setAssertionTimeout(final Duration assertionTimeout) {
+    this.assertionTimeout = assertionTimeout;
+  }
+
+  @Override
+  public void setAssertionInterval(final Duration assertionInterval) {
+    this.assertionInterval = assertionInterval;
+  }
+}

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/utils/DevAwaitBehavior.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/utils/DevAwaitBehavior.java
@@ -23,10 +23,10 @@ import io.camunda.process.test.api.CamundaAssertAwaitBehavior;
 import java.time.Duration;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
+import org.assertj.core.api.SoftAssertionsProvider.ThrowingRunnable;
 import org.awaitility.Awaitility;
 import org.awaitility.core.ConditionTimeoutException;
 import org.awaitility.core.TerminalFailureException;
-import org.junit.function.ThrowingRunnable;
 
 public final class DevAwaitBehavior implements CamundaAssertAwaitBehavior {
 

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/utils/DevAwaitBehavior.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/utils/DevAwaitBehavior.java
@@ -28,7 +28,7 @@ import org.awaitility.core.ConditionTimeoutException;
 import org.awaitility.core.TerminalFailureException;
 import org.junit.function.ThrowingRunnable;
 
-public class DevAwaitBehavior implements CamundaAssertAwaitBehavior {
+public final class DevAwaitBehavior implements CamundaAssertAwaitBehavior {
 
   private final boolean expectFailure;
 

--- a/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/api/CamundaProcessTestExecutionListener.java
+++ b/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/api/CamundaProcessTestExecutionListener.java
@@ -108,7 +108,11 @@ public class CamundaProcessTestExecutionListener implements TestExecutionListene
             runtime.getCamundaMonitoringApiAddress(), runtime.getCamundaRestApiAddress());
 
     camundaProcessTestContext =
-        new CamundaProcessTestContextImpl(runtime, createdClients::add, camundaManagementClient);
+        new CamundaProcessTestContextImpl(
+            runtime,
+            createdClients::add,
+            camundaManagementClient,
+            CamundaAssert.getAwaitBehavior());
   }
 
   @Override


### PR DESCRIPTION
## Description

- Create an abstraction around the Awaitility util to replace the behavior for unit tests. 
- Create a new await behavior for unit tests that allows to verify an assertion failure message effectively by stopping
 after the assertion failed.
- Add the new annotation `@CamundaAssertExpectFailure` to all test methods that verify an assertion failure message.

On my machine, these changes reduce the execution time of CPT's unit test from > 8 minutes to 4 seconds (CI: > 3 min vs. 20 s). :rocket:  