### PR TITLE
Fix element instance APIs breaking when processes contain an ad-hoc sub-process

### DIFF
--- a/qa/acceptance-tests/src/test/resources/process/ad_hoc_sub_process.bpmn
+++ b/qa/acceptance-tests/src/test/resources/process/ad_hoc_sub_process.bpmn
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1kj358h" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.32.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.7.0">
-  <bpmn:process id="TestParentAdHocSubProcess" isExecutable="true">
-    <bpmn:adHocSubProcess id="TestAdHocSubProcess" name="Ad-Hoc Subprocess">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1kj358h" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.37.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.7.0">
+  <bpmn:process id="ad_hoc_sub_process" isExecutable="true">
+    <bpmn:adHocSubProcess id="adHocSubProcess" name="Ad-Hoc Subprocess">
       <bpmn:extensionElements>
         <zeebe:adHoc />
       </bpmn:extensionElements>
@@ -28,21 +28,18 @@
         <bpmn:outgoing>Flow_0h7ye31</bpmn:outgoing>
       </bpmn:userTask>
     </bpmn:adHocSubProcess>
-    <bpmn:endEvent id="EndEvent_1">
+    <bpmn:endEvent id="endEvent" name="End Event">
       <bpmn:incoming>Flow_1e1ppa1</bpmn:incoming>
     </bpmn:endEvent>
-    <bpmn:sequenceFlow id="Flow_1e1ppa1" sourceRef="TestAdHocSubProcess" targetRef="EndEvent_1" />
-    <bpmn:sequenceFlow id="Flow_1nmmpcw" sourceRef="StartEvent_1" targetRef="TestAdHocSubProcess" />
-    <bpmn:startEvent id="StartEvent_1">
+    <bpmn:sequenceFlow id="Flow_1e1ppa1" sourceRef="adHocSubProcess" targetRef="endEvent" />
+    <bpmn:sequenceFlow id="Flow_1nmmpcw" sourceRef="startEvent" targetRef="adHocSubProcess" />
+    <bpmn:startEvent id="startEvent" name="StartEvent">
       <bpmn:outgoing>Flow_1nmmpcw</bpmn:outgoing>
     </bpmn:startEvent>
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
-    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="TestParentAdHocSubProcess">
-      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
-        <dc:Bounds x="172" y="187" width="36" height="36" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_071g6t1_di" bpmnElement="TestAdHocSubProcess" isExpanded="true">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="ad_hoc_sub_process">
+      <bpmndi:BPMNShape id="Activity_071g6t1_di" bpmnElement="adHocSubProcess" isExpanded="true">
         <dc:Bounds x="280" y="70" width="350" height="270" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
@@ -50,28 +47,37 @@
         <dc:Bounds x="410" y="110" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1wiygn1_di" bpmnElement="TestUserTask">
-        <dc:Bounds x="330" y="215" width="100" height="80" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_18de575_di" bpmnElement="TestServiceTask">
         <dc:Bounds x="480" y="215" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1wiygn1_di" bpmnElement="TestUserTask">
+        <dc:Bounds x="330" y="215" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="Flow_0h7ye31_di" bpmnElement="Flow_0h7ye31">
         <di:waypoint x="430" y="255" />
         <di:waypoint x="480" y="255" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="Event_0nc2s10_di" bpmnElement="EndEvent_1">
+      <bpmndi:BPMNShape id="Event_0nc2s10_di" bpmnElement="endEvent">
         <dc:Bounds x="702" y="187" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="695" y="230" width="51" height="14" />
+        </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="Flow_1nmmpcw_di" bpmnElement="Flow_1nmmpcw">
-        <di:waypoint x="208" y="205" />
-        <di:waypoint x="280" y="205" />
-      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="startEvent">
+        <dc:Bounds x="172" y="187" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="166" y="230" width="52" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="Flow_1e1ppa1_di" bpmnElement="Flow_1e1ppa1">
         <di:waypoint x="630" y="205" />
         <di:waypoint x="702" y="205" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1nmmpcw_di" bpmnElement="Flow_1nmmpcw">
+        <di:waypoint x="208" y="205" />
+        <di:waypoint x="280" y="205" />
       </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/FlowNodeInstanceEntityTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/FlowNodeInstanceEntityTransformer.java
@@ -10,6 +10,7 @@ package io.camunda.search.clients.transformers.entity;
 import static io.camunda.search.entities.FlowNodeInstanceEntity.FlowNodeState.ACTIVE;
 import static io.camunda.search.entities.FlowNodeInstanceEntity.FlowNodeState.COMPLETED;
 import static io.camunda.search.entities.FlowNodeInstanceEntity.FlowNodeState.TERMINATED;
+import static io.camunda.search.entities.FlowNodeInstanceEntity.FlowNodeType.AD_HOC_SUB_PROCESS;
 import static io.camunda.search.entities.FlowNodeInstanceEntity.FlowNodeType.BOUNDARY_EVENT;
 import static io.camunda.search.entities.FlowNodeInstanceEntity.FlowNodeType.BUSINESS_RULE_TASK;
 import static io.camunda.search.entities.FlowNodeInstanceEntity.FlowNodeType.CALL_ACTIVITY;
@@ -76,6 +77,7 @@ public class FlowNodeInstanceEntityTransformer
       case PROCESS -> PROCESS;
       case SUB_PROCESS -> SUB_PROCESS;
       case EVENT_SUB_PROCESS -> EVENT_SUB_PROCESS;
+      case AD_HOC_SUB_PROCESS -> AD_HOC_SUB_PROCESS;
       case START_EVENT -> START_EVENT;
       case INTERMEDIATE_CATCH_EVENT -> INTERMEDIATE_CATCH_EVENT;
       case INTERMEDIATE_THROW_EVENT -> INTERMEDIATE_THROW_EVENT;


### PR DESCRIPTION
## Description

Fixes missing enum mapping in `FlowNodeInstanceEntityTransformer` to fix APIs breaking when an ad-hoc sub-process element is involved.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #36049 
