### PR TITLE
fix: align resource value type with 8.7 enum value

### DIFF
--- a/zeebe/protocol/src/main/resources/protocol.xml
+++ b/zeebe/protocol/src/main/resources/protocol.xml
@@ -59,12 +59,12 @@
       <validValue name="USER">41</validValue>
       <validValue name="CLOCK">42</validValue>
       <validValue name="AUTHORIZATION">43</validValue>
-      <validValue name="ROLE">44</validValue>
+      <validValue name="RESOURCE">44</validValue>
       <validValue name="TENANT">45</validValue>
       <validValue name="GROUP">46</validValue>
       <validValue name="MAPPING_RULE">47</validValue>
       <validValue name="IDENTITY_SETUP">48</validValue>
-      <validValue name="RESOURCE">49</validValue>
+      <validValue name="ROLE">49</validValue>
       <validValue name="BATCH_OPERATION_CREATION">50</validValue>
       <validValue name="BATCH_OPERATION_EXECUTION">51</validValue>
       <validValue name="BATCH_OPERATION_CHUNK">52</validValue>


### PR DESCRIPTION
Ensure that the ValueType enum retains the same order of values between version 8.7 and 8.8.

Due to a bad backport, the RESOURCE value type received a different value in version 8.7 than it had in 8.8.

This commit adjust the (unreleased) 8.8 values to align them with the 8.7 ValueType enum.

## Description

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #36057 
