### PR TITLE
refactor: fetch authorized application on request

### DIFF
--- a/authentication/pom.xml
+++ b/authentication/pom.xml
@@ -222,6 +222,11 @@
       <artifactId>zeebe-broker-client</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-search-client-query-transformer</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/authentication/src/main/java/io/camunda/authentication/CamundaOAuthPrincipalServiceImpl.java
+++ b/authentication/src/main/java/io/camunda/authentication/CamundaOAuthPrincipalServiceImpl.java
@@ -22,7 +22,6 @@ import io.camunda.security.auth.OidcGroupsLoader;
 import io.camunda.security.auth.OidcPrincipalLoader;
 import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.security.entity.AuthenticationMethod;
-import io.camunda.service.AuthorizationServices;
 import io.camunda.service.GroupServices;
 import io.camunda.service.MappingRuleServices;
 import io.camunda.service.RoleServices;
@@ -52,7 +51,6 @@ public class CamundaOAuthPrincipalServiceImpl implements CamundaOAuthPrincipalSe
   private final TenantServices tenantServices;
   private final RoleServices roleServices;
   private final GroupServices groupServices;
-  private final AuthorizationServices authorizationServices;
   private final OidcPrincipalLoader oidcPrincipalLoader;
   private final OidcGroupsLoader oidcGroupsLoader;
   private final String usernameClaim;
@@ -64,13 +62,11 @@ public class CamundaOAuthPrincipalServiceImpl implements CamundaOAuthPrincipalSe
       final TenantServices tenantServices,
       final RoleServices roleServices,
       final GroupServices groupServices,
-      final AuthorizationServices authorizationServices,
       final SecurityConfiguration securityConfiguration) {
     this.mappingRuleServices = mappingRuleServices;
     this.tenantServices = tenantServices;
     this.roleServices = roleServices;
     this.groupServices = groupServices;
-    this.authorizationServices = authorizationServices;
     usernameClaim = securityConfiguration.getAuthentication().getOidc().getUsernameClaim();
     clientIdClaim = securityConfiguration.getAuthentication().getOidc().getClientIdClaim();
     groupsClaim = securityConfiguration.getAuthentication().getOidc().getGroupsClaim();
@@ -154,13 +150,7 @@ public class CamundaOAuthPrincipalServiceImpl implements CamundaOAuthPrincipalSe
             .map(TenantDTO::fromEntity)
             .toList();
 
-    final var authorizedApplications =
-        authorizationServices
-            .withAuthentication(CamundaAuthentication.anonymous())
-            .getAuthorizedApplications(ownerTypeToIds);
-
     authContextBuilder
-        .withAuthorizedApplications(authorizedApplications)
         .withTenants(tenants)
         .withGroups(groups.stream().toList())
         .withRoles(roles.stream().toList())

--- a/authentication/src/main/java/io/camunda/authentication/entity/AuthenticationContext.java
+++ b/authentication/src/main/java/io/camunda/authentication/entity/AuthenticationContext.java
@@ -16,7 +16,6 @@ public record AuthenticationContext(
     String username,
     String clientId,
     List<String> roles,
-    List<String> authorizedApplications,
     List<TenantDTO> tenants,
     List<String> groups,
     boolean groupsClaimEnabled)
@@ -26,7 +25,6 @@ public record AuthenticationContext(
     private String username;
     private String clientId;
     private List<String> roles = new ArrayList<>();
-    private List<String> authorizedApplications = new ArrayList<>();
     private List<TenantDTO> tenants = new ArrayList<>();
     private List<String> groups = new ArrayList<>();
     private boolean groupsClaimEnabled = false;
@@ -43,12 +41,6 @@ public record AuthenticationContext(
 
     public AuthenticationContextBuilder withRoles(final List<String> roles) {
       this.roles = roles;
-      return this;
-    }
-
-    public AuthenticationContextBuilder withAuthorizedApplications(
-        final List<String> authorizedApplications) {
-      this.authorizedApplications = authorizedApplications;
       return this;
     }
 
@@ -69,7 +61,7 @@ public record AuthenticationContext(
 
     public AuthenticationContext build() {
       return new AuthenticationContext(
-          username, clientId, roles, authorizedApplications, tenants, groups, groupsClaimEnabled);
+          username, clientId, roles, tenants, groups, groupsClaimEnabled);
     }
   }
 }

--- a/authentication/src/main/java/io/camunda/authentication/entity/CamundaUser.java
+++ b/authentication/src/main/java/io/camunda/authentication/entity/CamundaUser.java
@@ -101,7 +101,6 @@ public final class CamundaUser extends User implements CamundaPrincipal {
     private String email;
     private List<String> roles = List.of();
     private List<? extends GrantedAuthority> authorities = List.of();
-    private List<String> authorizedApplications = List.of();
     private List<TenantDTO> tenants = List.of();
     private List<String> groups = List.of();
     private String salesPlanType;
@@ -149,12 +148,6 @@ public final class CamundaUser extends User implements CamundaPrincipal {
       return this;
     }
 
-    public CamundaUserBuilder withAuthorizedApplications(
-        final List<String> authorizedApplications) {
-      this.authorizedApplications = Objects.requireNonNullElse(authorizedApplications, List.of());
-      return this;
-    }
-
     public CamundaUserBuilder withTenants(final List<TenantDTO> tenants) {
       this.tenants = Objects.requireNonNullElse(tenants, List.of());
       return this;
@@ -191,7 +184,6 @@ public final class CamundaUser extends User implements CamundaPrincipal {
           new AuthenticationContextBuilder()
               .withUsername(username)
               .withRoles(roles)
-              .withAuthorizedApplications(authorizedApplications)
               .withTenants(tenants)
               .withGroups(groups)
               .build(),

--- a/authentication/src/main/java/io/camunda/authentication/service/BasicCamundaUserService.java
+++ b/authentication/src/main/java/io/camunda/authentication/service/BasicCamundaUserService.java
@@ -7,11 +7,16 @@
  */
 package io.camunda.authentication.service;
 
+import static io.camunda.service.authorization.Authorizations.APPLICATION_ACCESS_AUTHORIZATION;
+
 import io.camunda.authentication.ConditionalOnAuthenticationMethod;
 import io.camunda.authentication.entity.AuthenticationContext;
 import io.camunda.authentication.entity.CamundaUser;
 import io.camunda.authentication.entity.CamundaUserDTO;
+import io.camunda.security.auth.CamundaAuthenticationProvider;
 import io.camunda.security.entity.AuthenticationMethod;
+import io.camunda.security.reader.ResourceAccessProvider;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.context.annotation.Profile;
 import org.springframework.security.core.Authentication;
@@ -22,6 +27,17 @@ import org.springframework.stereotype.Service;
 @ConditionalOnAuthenticationMethod(AuthenticationMethod.BASIC)
 @Profile("consolidated-auth")
 public class BasicCamundaUserService implements CamundaUserService {
+
+  private final CamundaAuthenticationProvider authenticationProvider;
+  private final ResourceAccessProvider resourceAccessProvider;
+
+  public BasicCamundaUserService(
+      final CamundaAuthenticationProvider authenticationProvider,
+      final ResourceAccessProvider resourceAccessProvider) {
+    this.authenticationProvider = authenticationProvider;
+    this.resourceAccessProvider = resourceAccessProvider;
+  }
+
   private Optional<CamundaUser> getCurrentCamundaUser() {
     return Optional.ofNullable(SecurityContextHolder.getContext().getAuthentication())
         .map(Authentication::getPrincipal)
@@ -30,6 +46,7 @@ public class BasicCamundaUserService implements CamundaUserService {
 
   @Override
   public CamundaUserDTO getCurrentUser() {
+    final var authorizedApplications = getAuthorizedApplications();
     return getCurrentCamundaUser()
         .map(
             user -> {
@@ -40,7 +57,7 @@ public class BasicCamundaUserService implements CamundaUserService {
                   user.getDisplayName(),
                   user.getDisplayName(), // migrated for historical purposes username -> displayName
                   user.getEmail(),
-                  auth.authorizedApplications(),
+                  authorizedApplications,
                   auth.tenants(),
                   auth.groups(),
                   auth.roles(),
@@ -54,5 +71,15 @@ public class BasicCamundaUserService implements CamundaUserService {
   @Override
   public String getUserToken() {
     return null;
+  }
+
+  protected List<String> getAuthorizedApplications() {
+    final var authentication = authenticationProvider.getCamundaAuthentication();
+    final var applicationAccess =
+        resourceAccessProvider.resolveResourceAccess(
+            authentication, APPLICATION_ACCESS_AUTHORIZATION);
+    return applicationAccess.allowed()
+        ? applicationAccess.authorization().resourceIds()
+        : List.of();
   }
 }

--- a/authentication/src/test/java/io/camunda/authentication/CamundaOAuthPrincipalServiceTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/CamundaOAuthPrincipalServiceTest.java
@@ -23,7 +23,6 @@ import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.security.configuration.AuthenticationConfiguration;
 import io.camunda.security.configuration.OidcAuthenticationConfiguration;
 import io.camunda.security.configuration.SecurityConfiguration;
-import io.camunda.service.AuthorizationServices;
 import io.camunda.service.GroupServices;
 import io.camunda.service.MappingRuleServices;
 import io.camunda.service.RoleServices;
@@ -58,7 +57,6 @@ public class CamundaOAuthPrincipalServiceTest {
     @Mock private TenantServices tenantServices;
     @Mock private RoleServices roleServices;
     @Mock private GroupServices groupServices;
-    @Mock private AuthorizationServices authorizationServices;
     @Mock private SecurityConfiguration securityConfiguration;
     @Mock private AuthenticationConfiguration authenticationConfiguration;
     @Mock private OidcAuthenticationConfiguration oidcAuthenticationConfiguration;
@@ -79,8 +77,6 @@ public class CamundaOAuthPrincipalServiceTest {
           .thenReturn(roleServices);
       when(groupServices.withAuthentication(any(CamundaAuthentication.class)))
           .thenReturn(groupServices);
-      when(authorizationServices.withAuthentication(any(CamundaAuthentication.class)))
-          .thenReturn(authorizationServices);
 
       camundaOAuthPrincipalService =
           new CamundaOAuthPrincipalServiceImpl(
@@ -88,7 +84,6 @@ public class CamundaOAuthPrincipalServiceTest {
               tenantServices,
               roleServices,
               groupServices,
-              authorizationServices,
               securityConfiguration);
     }
 
@@ -150,7 +145,6 @@ public class CamundaOAuthPrincipalServiceTest {
     @Mock private TenantServices tenantServices;
     @Mock private RoleServices roleServices;
     @Mock private GroupServices groupServices;
-    @Mock private AuthorizationServices authorizationServices;
     @Mock private SecurityConfiguration securityConfiguration;
     @Mock private AuthenticationConfiguration authenticationConfiguration;
     @Mock private OidcAuthenticationConfiguration oidcAuthenticationConfiguration;
@@ -171,17 +165,10 @@ public class CamundaOAuthPrincipalServiceTest {
           .thenReturn(roleServices);
       when(groupServices.withAuthentication(any(CamundaAuthentication.class)))
           .thenReturn(groupServices);
-      when(authorizationServices.withAuthentication(any(CamundaAuthentication.class)))
-          .thenReturn(authorizationServices);
 
       camundaOAuthPrincipalService =
           new CamundaOAuthPrincipalServiceImpl(
-              mappingServices,
-              tenantServices,
-              roleServices,
-              groupServices,
-              authorizationServices,
-              securityConfiguration);
+              mappingServices, tenantServices, roleServices, groupServices, securityConfiguration);
     }
 
     @Test
@@ -265,18 +252,6 @@ public class CamundaOAuthPrincipalServiceTest {
                   Set.of("roleR1", "roleGroup"))))
           .thenReturn(List.of(tenantT1, groupTenant));
 
-      when(authorizationServices.getAuthorizedApplications(
-              Map.of(
-                  EntityType.MAPPING_RULE,
-                  Set.of("test-id", "test-id-2"),
-                  EntityType.GROUP,
-                  Set.of("group-g1"),
-                  EntityType.USER,
-                  Set.of("foo@camunda.test"),
-                  EntityType.ROLE,
-                  Set.of("roleR1", "roleGroup"))))
-          .thenReturn(List.of("*"));
-
       // when
       final OAuthContext oAuthContext = camundaOAuthPrincipalService.loadOAuthContext(claims);
 
@@ -289,7 +264,6 @@ public class CamundaOAuthPrincipalServiceTest {
       assertThat(authenticationContext.groups()).containsExactly("group-g1");
       assertThat(authenticationContext.tenants())
           .containsAll(List.of(TenantDTO.fromEntity(tenantT1), TenantDTO.fromEntity(groupTenant)));
-      assertThat(authenticationContext.authorizedApplications()).containsAll(Set.of("*"));
     }
 
     @Test
@@ -338,18 +312,6 @@ public class CamundaOAuthPrincipalServiceTest {
                   Set.of("roleR1"))))
           .thenReturn(List.of(tenantEntity1, tenantEntity2));
 
-      when(authorizationServices.getAuthorizedApplications(
-              Map.of(
-                  EntityType.MAPPING_RULE,
-                  Set.of("map-1", "map-2"),
-                  EntityType.GROUP,
-                  Set.of("group-g1"),
-                  EntityType.USER,
-                  Set.of("scooby-doo"),
-                  EntityType.ROLE,
-                  Set.of("roleR1"))))
-          .thenReturn(List.of("app-1", "app-2"));
-
       // when
       final OAuthContext oAuthContext = camundaOAuthPrincipalService.loadOAuthContext(claims);
 
@@ -364,8 +326,6 @@ public class CamundaOAuthPrincipalServiceTest {
       assertThat(authenticationContext.tenants())
           .containsExactlyInAnyOrder(
               TenantDTO.fromEntity(tenantEntity1), TenantDTO.fromEntity(tenantEntity2));
-      assertThat(authenticationContext.authorizedApplications())
-          .containsExactlyInAnyOrder("app-1", "app-2");
     }
   }
 
@@ -376,7 +336,6 @@ public class CamundaOAuthPrincipalServiceTest {
     @Mock private TenantServices tenantServices;
     @Mock private RoleServices roleServices;
     @Mock private GroupServices groupServices;
-    @Mock private AuthorizationServices authorizationServices;
     @Mock private SecurityConfiguration securityConfiguration;
     @Mock private AuthenticationConfiguration authenticationConfiguration;
     @Mock private OidcAuthenticationConfiguration oidcAuthenticationConfiguration;
@@ -398,17 +357,10 @@ public class CamundaOAuthPrincipalServiceTest {
           .thenReturn(roleServices);
       when(groupServices.withAuthentication(any(CamundaAuthentication.class)))
           .thenReturn(groupServices);
-      when(authorizationServices.withAuthentication(any(CamundaAuthentication.class)))
-          .thenReturn(authorizationServices);
 
       camundaOAuthPrincipalService =
           new CamundaOAuthPrincipalServiceImpl(
-              mappingServices,
-              tenantServices,
-              roleServices,
-              groupServices,
-              authorizationServices,
-              securityConfiguration);
+              mappingServices, tenantServices, roleServices, groupServices, securityConfiguration);
     }
 
     @Test
@@ -444,12 +396,7 @@ public class CamundaOAuthPrincipalServiceTest {
 
       camundaOAuthPrincipalService =
           new CamundaOAuthPrincipalServiceImpl(
-              mappingServices,
-              tenantServices,
-              roleServices,
-              groupServices,
-              authorizationServices,
-              securityConfiguration);
+              mappingServices, tenantServices, roleServices, groupServices, securityConfiguration);
       final Map<String, Object> claims =
           Map.of("groups", Map.of("name", GROUP1_NAME, "id", "idp-g1-id"), "sub", "user1");
       // when

--- a/authentication/src/test/java/io/camunda/authentication/CamundaOidcUserServiceTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/CamundaOidcUserServiceTest.java
@@ -71,7 +71,6 @@ public class CamundaOidcUserServiceTest {
                 new AuthenticationContext.AuthenticationContextBuilder()
                     .withUsername("test")
                     .withRoles(List.of(roleR1))
-                    .withAuthorizedApplications(List.of("*"))
                     .withGroups(List.of("G1"))
                     .withTenants(List.of(new TenantDTO(1L, "tenant-1", "Tenant One", "desc")))
                     .build()));
@@ -90,8 +89,6 @@ public class CamundaOidcUserServiceTest {
     assertThat(authenticationContext.tenants()).hasSize(1);
     assertThat(authenticationContext.tenants().get(0).tenantId()).isEqualTo("tenant-1");
     assertThat(authenticationContext.groups()).containsExactly("G1");
-
-    assertThat(authenticationContext.authorizedApplications()).containsAll(Set.of("*"));
   }
 
   @Test

--- a/authentication/src/test/java/io/camunda/authentication/OidcCamundaUserServiceTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/OidcCamundaUserServiceTest.java
@@ -37,7 +37,7 @@ public class OidcCamundaUserServiceTest {
 
   @BeforeEach
   public void setUp() throws Exception {
-    oidcCamundaUserService = new OidcCamundaUserService();
+    oidcCamundaUserService = new OidcCamundaUserService(null, null);
   }
 
   @Test

--- a/authentication/src/test/java/io/camunda/authentication/config/controllers/WebSecurityConfigTestContext.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/controllers/WebSecurityConfigTestContext.java
@@ -8,8 +8,12 @@
 package io.camunda.authentication.config.controllers;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.authentication.DefaultCamundaAuthenticationProvider;
 import io.camunda.authentication.handler.AuthFailureHandler;
+import io.camunda.search.clients.auth.DisabledResourceAccessProvider;
+import io.camunda.security.auth.CamundaAuthenticationProvider;
 import io.camunda.security.configuration.SecurityConfiguration;
+import io.camunda.security.reader.ResourceAccessProvider;
 import io.camunda.service.RoleServices;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -43,6 +47,16 @@ public class WebSecurityConfigTestContext {
   @Bean
   public RoleServices createRoleServices() {
     return new RoleServices(null, null, null, null);
+  }
+
+  @Bean
+  public CamundaAuthenticationProvider createCamundaAuthenticationProvider() {
+    return new DefaultCamundaAuthenticationProvider(null, null);
+  }
+
+  @Bean
+  public ResourceAccessProvider createResourceAccessProvider() {
+    return new DisabledResourceAccessProvider();
   }
 
   /**

--- a/authentication/src/test/java/io/camunda/authentication/service/BasicCamundaUserServiceTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/service/BasicCamundaUserServiceTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.service;
+
+import static io.camunda.authentication.entity.CamundaUser.CamundaUserBuilder.aCamundaUser;
+import static io.camunda.security.auth.Authorization.withAuthorization;
+import static io.camunda.service.authorization.Authorizations.APPLICATION_ACCESS_AUTHORIZATION;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.camunda.security.auth.CamundaAuthentication;
+import io.camunda.security.auth.CamundaAuthenticationProvider;
+import io.camunda.security.reader.ResourceAccess;
+import io.camunda.security.reader.ResourceAccessProvider;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+public class BasicCamundaUserServiceTest {
+
+  @Mock private CamundaAuthenticationProvider authenticationProvider;
+  @Mock private ResourceAccessProvider resourceAccessProvider;
+  private BasicCamundaUserService userService;
+
+  @BeforeEach
+  public void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this).close();
+
+    final var user =
+        aCamundaUser()
+            .withName("Foo Bar")
+            .withUsername("foo@bar.com")
+            .withPassword("foobar")
+            .build();
+    final var authentication = Mockito.mock(Authentication.class);
+    when(authentication.getPrincipal()).thenReturn(user);
+
+    final var securityContext = Mockito.mock(SecurityContext.class);
+    Mockito.when(securityContext.getAuthentication()).thenReturn(authentication);
+    SecurityContextHolder.setContext(securityContext);
+
+    userService = new BasicCamundaUserService(authenticationProvider, resourceAccessProvider);
+  }
+
+  @Test
+  void shouldIncludeAuthorizedApplications() {
+    // given
+    final var allowedAuthorization = withAuthorization(APPLICATION_ACCESS_AUTHORIZATION, "operate");
+    final var authentication = mock(CamundaAuthentication.class);
+    when(authenticationProvider.getCamundaAuthentication()).thenReturn(authentication);
+    when(resourceAccessProvider.resolveResourceAccess(
+            eq(authentication), eq(APPLICATION_ACCESS_AUTHORIZATION)))
+        .thenReturn(ResourceAccess.allowed(allowedAuthorization));
+
+    // when
+    final var currentUser = userService.getCurrentUser();
+
+    // then
+    assertThat(currentUser.authorizedApplications()).containsExactlyInAnyOrder("operate");
+  }
+
+  @Test
+  void shouldContainWildcardInAuthorizedApplications() {
+    // given
+    final var allowedAuthorization = withAuthorization(APPLICATION_ACCESS_AUTHORIZATION, "*");
+    final var authentication = mock(CamundaAuthentication.class);
+    when(authenticationProvider.getCamundaAuthentication()).thenReturn(authentication);
+    when(resourceAccessProvider.resolveResourceAccess(
+            eq(authentication), eq(APPLICATION_ACCESS_AUTHORIZATION)))
+        .thenReturn(ResourceAccess.wildcard(allowedAuthorization));
+
+    // when
+    final var currentUser = userService.getCurrentUser();
+
+    // then
+    assertThat(currentUser.authorizedApplications()).containsExactlyInAnyOrder("*");
+  }
+
+  @Test
+  void shouldReturnEmptyListOfAuthorizedApplicationIfDenied() {
+    // given
+    final var authentication = mock(CamundaAuthentication.class);
+    when(authenticationProvider.getCamundaAuthentication()).thenReturn(authentication);
+    when(resourceAccessProvider.resolveResourceAccess(
+            eq(authentication), eq(APPLICATION_ACCESS_AUTHORIZATION)))
+        .thenReturn(ResourceAccess.denied(APPLICATION_ACCESS_AUTHORIZATION));
+
+    // when
+    final var currentUser = userService.getCurrentUser();
+
+    // then
+    assertThat(currentUser.authorizedApplications()).isEmpty();
+  }
+}

--- a/authentication/src/test/java/io/camunda/authentication/service/OidcCamundaUserServiceTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/service/OidcCamundaUserServiceTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.service;
+
+import static io.camunda.security.auth.Authorization.withAuthorization;
+import static io.camunda.service.authorization.Authorizations.APPLICATION_ACCESS_AUTHORIZATION;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.camunda.authentication.entity.AuthenticationContext.AuthenticationContextBuilder;
+import io.camunda.authentication.entity.CamundaOidcUser;
+import io.camunda.authentication.entity.OAuthContext;
+import io.camunda.security.auth.CamundaAuthentication;
+import io.camunda.security.auth.CamundaAuthenticationProvider;
+import io.camunda.security.reader.ResourceAccess;
+import io.camunda.security.reader.ResourceAccessProvider;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+
+public class OidcCamundaUserServiceTest {
+
+  @Mock private CamundaAuthenticationProvider authenticationProvider;
+  @Mock private ResourceAccessProvider resourceAccessProvider;
+  private OidcCamundaUserService userService;
+
+  @BeforeEach
+  public void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this).close();
+
+    final var oidcUser = mock(OidcUser.class);
+    when(oidcUser.getName()).thenReturn("foo");
+    final var user =
+        new CamundaOidcUser(
+            oidcUser,
+            "a-token",
+            new OAuthContext(null, new AuthenticationContextBuilder().withUsername("foo").build()));
+    final var authentication = Mockito.mock(Authentication.class);
+    when(authentication.getPrincipal()).thenReturn(user);
+
+    final var securityContext = Mockito.mock(SecurityContext.class);
+    Mockito.when(securityContext.getAuthentication()).thenReturn(authentication);
+    SecurityContextHolder.setContext(securityContext);
+
+    userService = new OidcCamundaUserService(authenticationProvider, resourceAccessProvider);
+  }
+
+  @Test
+  void shouldIncludeAuthorizedApplications() {
+    // given
+    final var allowedAuthorization = withAuthorization(APPLICATION_ACCESS_AUTHORIZATION, "operate");
+    final var authentication = mock(CamundaAuthentication.class);
+    when(authenticationProvider.getCamundaAuthentication()).thenReturn(authentication);
+    when(resourceAccessProvider.resolveResourceAccess(
+            eq(authentication), eq(APPLICATION_ACCESS_AUTHORIZATION)))
+        .thenReturn(ResourceAccess.allowed(allowedAuthorization));
+
+    // when
+    final var currentUser = userService.getCurrentUser();
+
+    // then
+    assertThat(currentUser.authorizedApplications()).containsExactlyInAnyOrder("operate");
+  }
+
+  @Test
+  void shouldContainWildcardInAuthorizedApplications() {
+    // given
+    final var allowedAuthorization = withAuthorization(APPLICATION_ACCESS_AUTHORIZATION, "*");
+    final var authentication = mock(CamundaAuthentication.class);
+    when(authenticationProvider.getCamundaAuthentication()).thenReturn(authentication);
+    when(resourceAccessProvider.resolveResourceAccess(
+            eq(authentication), eq(APPLICATION_ACCESS_AUTHORIZATION)))
+        .thenReturn(ResourceAccess.wildcard(allowedAuthorization));
+
+    // when
+    final var currentUser = userService.getCurrentUser();
+
+    // then
+    assertThat(currentUser.authorizedApplications()).containsExactlyInAnyOrder("*");
+  }
+
+  @Test
+  void shouldReturnEmptyListOfAuthorizedApplicationIfDenied() {
+    // given
+    final var authentication = mock(CamundaAuthentication.class);
+    when(authenticationProvider.getCamundaAuthentication()).thenReturn(authentication);
+    when(resourceAccessProvider.resolveResourceAccess(
+            eq(authentication), eq(APPLICATION_ACCESS_AUTHORIZATION)))
+        .thenReturn(ResourceAccess.denied(APPLICATION_ACCESS_AUTHORIZATION));
+
+    // when
+    final var currentUser = userService.getCurrentUser();
+
+    // then
+    assertThat(currentUser.authorizedApplications()).isEmpty();
+  }
+}

--- a/dist/src/main/java/io/camunda/application/commons/migration/IdentityMigrationModuleConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/migration/IdentityMigrationModuleConfiguration.java
@@ -25,7 +25,6 @@ import io.camunda.search.clients.MappingRuleSearchClient;
 import io.camunda.search.clients.RoleSearchClient;
 import io.camunda.search.clients.SearchClientsProxy;
 import io.camunda.search.clients.TenantSearchClient;
-import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.service.AuthorizationServices;
 import io.camunda.service.GroupServices;
 import io.camunda.service.MappingRuleServices;
@@ -71,14 +70,9 @@ public class IdentityMigrationModuleConfiguration {
   public AuthorizationServices authorizationServices(
       final BrokerClient brokerClient,
       final SecurityContextProvider securityContextProvider,
-      final AuthorizationSearchClient authorizationSearchClient,
-      final SecurityConfiguration securityConfiguration) {
+      final AuthorizationSearchClient authorizationSearchClient) {
     return new AuthorizationServices(
-        brokerClient,
-        securityContextProvider,
-        authorizationSearchClient,
-        null,
-        securityConfiguration);
+        brokerClient, securityContextProvider, authorizationSearchClient, null);
   }
 
   @Bean

--- a/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
@@ -31,7 +31,6 @@ import io.camunda.search.clients.UserSearchClient;
 import io.camunda.search.clients.UserTaskSearchClient;
 import io.camunda.search.clients.VariableSearchClient;
 import io.camunda.search.clients.reader.AuthorizationReader;
-import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.security.impl.AuthorizationChecker;
 import io.camunda.service.AdHocSubProcessActivityServices;
 import io.camunda.service.AuthorizationServices;
@@ -259,14 +258,9 @@ public class CamundaServicesConfiguration {
   public AuthorizationServices authorizationServices(
       final BrokerClient brokerClient,
       final SecurityContextProvider securityContextProvider,
-      final AuthorizationSearchClient authorizationSearchClient,
-      final SecurityConfiguration securityConfiguration) {
+      final AuthorizationSearchClient authorizationSearchClient) {
     return new AuthorizationServices(
-        brokerClient,
-        securityContextProvider,
-        authorizationSearchClient,
-        null,
-        securityConfiguration);
+        brokerClient, securityContextProvider, authorizationSearchClient, null);
   }
 
   @Bean

--- a/search/search-domain/src/main/java/io/camunda/search/filter/AuthorizationFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/AuthorizationFilter.java
@@ -82,6 +82,26 @@ public record AuthorizationFilter(
       return this;
     }
 
+    private Map<EntityType, Set<String>> getValidOwnerTypeToOwnerIdsOrThrow() {
+      if (ownerTypeToOwnerIds == null || ownerTypeToOwnerIds.isEmpty()) {
+        return null;
+      }
+
+      final var ownerTypeWithoutOwnerIds =
+          ownerTypeToOwnerIds.entrySet().stream()
+              .filter(e -> e.getValue() == null || e.getValue().isEmpty())
+              .findFirst();
+
+      if (ownerTypeWithoutOwnerIds.isPresent()) {
+        final var message =
+            "Owner type to owner ids must not contain entries without a value: %s"
+                .formatted(ownerTypeWithoutOwnerIds.get());
+        throw new IllegalArgumentException(message);
+      }
+
+      return ownerTypeToOwnerIds;
+    }
+
     @Override
     public AuthorizationFilter build() {
       return new AuthorizationFilter(
@@ -91,7 +111,7 @@ public record AuthorizationFilter(
           resourceIds,
           resourceType,
           permissionTypes,
-          ownerTypeToOwnerIds);
+          getValidOwnerTypeToOwnerIdsOrThrow());
     }
   }
 }

--- a/service/src/main/java/io/camunda/service/AuthorizationServices.java
+++ b/service/src/main/java/io/camunda/service/AuthorizationServices.java
@@ -13,10 +13,8 @@ import static io.camunda.service.authorization.Authorizations.AUTHORIZATION_READ
 import io.camunda.search.clients.AuthorizationSearchClient;
 import io.camunda.search.entities.AuthorizationEntity;
 import io.camunda.search.query.AuthorizationQuery;
-import io.camunda.search.query.SearchQueryBuilders;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.auth.CamundaAuthentication;
-import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.service.search.core.SearchQueryService;
 import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
@@ -26,39 +24,28 @@ import io.camunda.zeebe.protocol.impl.record.value.authorization.AuthorizationRe
 import io.camunda.zeebe.protocol.record.intent.AuthorizationIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
-import io.camunda.zeebe.protocol.record.value.EntityType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
-import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-import java.util.stream.Collectors;
 
 public class AuthorizationServices
     extends SearchQueryService<AuthorizationServices, AuthorizationQuery, AuthorizationEntity> {
 
   private final AuthorizationSearchClient authorizationSearchClient;
-  private final SecurityConfiguration securityConfiguration;
 
   public AuthorizationServices(
       final BrokerClient brokerClient,
       final SecurityContextProvider securityContextProvider,
       final AuthorizationSearchClient authorizationSearchClient,
-      final CamundaAuthentication authentication,
-      final SecurityConfiguration securityConfiguration) {
+      final CamundaAuthentication authentication) {
     super(brokerClient, securityContextProvider, authentication);
     this.authorizationSearchClient = authorizationSearchClient;
-    this.securityConfiguration = securityConfiguration;
   }
 
   @Override
   public AuthorizationServices withAuthentication(final CamundaAuthentication authentication) {
     return new AuthorizationServices(
-        brokerClient,
-        securityContextProvider,
-        authorizationSearchClient,
-        authentication,
-        securityConfiguration);
+        brokerClient, securityContextProvider, authorizationSearchClient, authentication);
   }
 
   @Override
@@ -70,35 +57,6 @@ public class AuthorizationServices
                     securityContextProvider.provideSecurityContext(
                         authentication, AUTHORIZATION_READ_AUTHORIZATION))
                 .searchAuthorizations(query));
-  }
-
-  public List<String> getAuthorizedApplications(
-      final Map<EntityType, Set<String>> ownerTypeToOwnerIds) {
-    if (!securityConfiguration.getAuthorizations().isEnabled()) {
-      // if authorizations are not enabled, we default to a wildcard authorization which is
-      // needed for frontend side checks
-      return List.of("*");
-    }
-
-    if (ownerTypeToOwnerIds == null || ownerTypeToOwnerIds.isEmpty()) {
-      // if no ownerIds are provided, we return an empty list to be defensive, we can't work out
-      // which applications the user has access to if we don't know the ownerIds
-      return List.of();
-    }
-
-    return search(
-            SearchQueryBuilders.authorizationSearchQuery(
-                fn ->
-                    fn.filter(
-                            f ->
-                                f.resourceType(AuthorizationResourceType.APPLICATION.name())
-                                    .permissionTypes(PermissionType.ACCESS)
-                                    .ownerTypeToOwnerIds(ownerTypeToOwnerIds))
-                        .page(p -> p.size(1))))
-        .items()
-        .stream()
-        .map(AuthorizationEntity::resourceId)
-        .collect(Collectors.toList());
   }
 
   public CompletableFuture<AuthorizationRecord> createAuthorization(

--- a/service/src/main/java/io/camunda/service/authorization/Authorizations.java
+++ b/service/src/main/java/io/camunda/service/authorization/Authorizations.java
@@ -7,6 +7,9 @@
  */
 package io.camunda.service.authorization;
 
+import static io.camunda.zeebe.protocol.record.value.AuthorizationResourceType.APPLICATION;
+import static io.camunda.zeebe.protocol.record.value.PermissionType.ACCESS;
+
 import io.camunda.search.entities.AuthorizationEntity;
 import io.camunda.search.entities.BatchOperationEntity;
 import io.camunda.search.entities.DecisionDefinitionEntity;
@@ -28,6 +31,9 @@ import io.camunda.search.entities.VariableEntity;
 import io.camunda.security.auth.Authorization;
 
 public abstract class Authorizations {
+
+  public static final Authorization<Object> APPLICATION_ACCESS_AUTHORIZATION =
+      Authorization.of(a -> a.resourceType(APPLICATION).permissionType(ACCESS));
 
   public static final Authorization<AuthorizationEntity> AUTHORIZATION_READ_AUTHORIZATION =
       Authorization.of(a -> a.authorization().read());

--- a/service/src/test/java/io/camunda/service/AuthorizationServiceTest.java
+++ b/service/src/test/java/io/camunda/service/AuthorizationServiceTest.java
@@ -17,10 +17,8 @@ import io.camunda.search.entities.AuthorizationEntity;
 import io.camunda.search.filter.AuthorizationFilter;
 import io.camunda.search.query.SearchQueryBuilders;
 import io.camunda.search.query.SearchQueryResult;
-import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
-import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -28,20 +26,14 @@ public class AuthorizationServiceTest {
 
   private AuthorizationServices services;
   private AuthorizationSearchClient client;
-  private SecurityConfiguration securityConfiguration;
 
   @BeforeEach
   public void before() {
-    securityConfiguration = new SecurityConfiguration();
     client = mock(AuthorizationSearchClient.class);
     when(client.withSecurityContext(any())).thenReturn(client);
     services =
         new AuthorizationServices(
-            mock(BrokerClient.class),
-            mock(SecurityContextProvider.class),
-            client,
-            null,
-            securityConfiguration);
+            mock(BrokerClient.class), mock(SecurityContextProvider.class), client, null);
   }
 
   @Test
@@ -58,54 +50,6 @@ public class AuthorizationServiceTest {
 
     // then
     assertThat(searchQueryResult).isEqualTo(result);
-  }
-
-  @Test
-  public void noApplicationAuthorizationWhenAuthorizationsEnabled() {
-    // given
-    securityConfiguration.getAuthorizations().setEnabled(true);
-
-    // when
-    final var authorizedApplications = services.getAuthorizedApplications(Map.of());
-
-    // then
-    assertThat(authorizedApplications).isEmpty();
-  }
-
-  @Test
-  public void wildcardApplicationAuthorizationWhenAuthorizationsDisabled() {
-    // given
-    securityConfiguration.getAuthorizations().setEnabled(false);
-
-    // when
-    final var authorizedApplications = services.getAuthorizedApplications(Map.of());
-
-    // then
-    assertThat(authorizedApplications).containsExactly("*");
-  }
-
-  @Test
-  public void noAuthorizedApplicationsWhenOwnerIdsIsEmpty() {
-    // given
-    securityConfiguration.getAuthorizations().setEnabled(true);
-
-    // when
-    final var authorizedApplications = services.getAuthorizedApplications(Map.of());
-
-    // then
-    assertThat(authorizedApplications).isEmpty();
-  }
-
-  @Test
-  public void noAuthorizedApplicationsWhenOwnerIdsIsNull() {
-    // given
-    securityConfiguration.getAuthorizations().setEnabled(true);
-
-    // when
-    final var authorizedApplications = services.getAuthorizedApplications(null);
-
-    // then
-    assertThat(authorizedApplications).isEmpty();
   }
 
   @Test


### PR DESCRIPTION
## Description

Removes the caching of "authorized" applications within the authenticated principal. Instead, fetch the authorized application when needed:

1. When calling the `GET /v2/authentication/me/` endpoint, it will resolve the authorization applications.
2. When accessing the app like `http://localhost:8080/tasklist` and the principal is authenticated, it will check if the principal has access to the application (in that case `tasklist`)

Only authorized applications are needed in these two cases, but not in all others. So, resolving them would be limited to these two cases. That approach allows users to be granted application access without the need to log out.

Note: This PR does not tackle the case where a principal gets assigned to a group/role/mapping and, by that, granted access to an additional application (e.g., Tasklist). In that case, the principal would still need to log out so that the memberships are refreshed/resolved, granting the principal access to the application.

Additionally, it contains a minor fix that ensures that the `AuthorizationFilter#ownerTypeToOwnerIds` is valid to avoid any unexpected behavior by granting a principal with random access to resources.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #36035
