### PR TITLE
Commands that do not support filtering should throw an exception

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/impl/search/request/ClientsByGroupSearchRequestImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/request/ClientsByGroupSearchRequestImpl.java
@@ -80,13 +80,13 @@ public class ClientsByGroupSearchRequestImpl
   @Override
   public ClientsByGroupSearchRequest filter(final ClientFilter value) {
     // This command doesn't support filtering
-    return null;
+    throw new UnsupportedOperationException("This command does not support filtering");
   }
 
   @Override
   public ClientsByGroupSearchRequest filter(final Consumer<ClientFilter> fn) {
     // This command doesn't support filtering
-    return null;
+    throw new UnsupportedOperationException("This command does not support filtering");
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/client/impl/search/request/ClientsByRoleSearchRequestImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/request/ClientsByRoleSearchRequestImpl.java
@@ -80,13 +80,13 @@ public class ClientsByRoleSearchRequestImpl
   @Override
   public ClientsByRoleSearchRequest filter(final ClientFilter value) {
     // This command doesn't support filtering
-    return this;
+    throw new UnsupportedOperationException("This command does not support filtering");
   }
 
   @Override
   public ClientsByRoleSearchRequest filter(final Consumer<ClientFilter> fn) {
     // This command doesn't support filtering
-    return this;
+    throw new UnsupportedOperationException("This command does not support filtering");
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/client/impl/search/request/GroupsByRoleSearchRequestImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/request/GroupsByRoleSearchRequestImpl.java
@@ -79,12 +79,14 @@ public class GroupsByRoleSearchRequestImpl
 
   @Override
   public GroupsByRoleSearchRequest filter(final RoleGroupFilter value) {
-    return this;
+    // this command does not support filtering
+    throw new UnsupportedOperationException("This command does not support filtering");
   }
 
   @Override
   public GroupsByRoleSearchRequest filter(final Consumer<RoleGroupFilter> fn) {
-    return this;
+    // this command does not support filtering
+    throw new UnsupportedOperationException("This command does not support filtering");
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/client/impl/search/request/UsersByGroupSearchRequestImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/request/UsersByGroupSearchRequestImpl.java
@@ -80,13 +80,13 @@ public class UsersByGroupSearchRequestImpl
   @Override
   public UsersByGroupSearchRequest filter(final GroupUserFilter value) {
     // This command doesn't support filtering
-    return this;
+    throw new UnsupportedOperationException("This command does not support filtering");
   }
 
   @Override
   public UsersByGroupSearchRequest filter(final Consumer<GroupUserFilter> fn) {
     // This command doesn't support filtering
-    return this;
+    throw new UnsupportedOperationException("This command does not support filtering");
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/client/impl/search/request/UsersByRoleSearchRequestImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/request/UsersByRoleSearchRequestImpl.java
@@ -80,13 +80,13 @@ public class UsersByRoleSearchRequestImpl
   @Override
   public UsersByRoleSearchRequest filter(final RoleUserFilter value) {
     // This command doesn't support filtering
-    return this;
+    throw new UnsupportedOperationException("This command does not support filtering");
   }
 
   @Override
   public UsersByRoleSearchRequest filter(final Consumer<RoleUserFilter> fn) {
     // This command doesn't support filtering
-    return this;
+    throw new UnsupportedOperationException("This command does not support filtering");
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/client/impl/search/request/UsersByTenantSearchRequestImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/request/UsersByTenantSearchRequestImpl.java
@@ -80,13 +80,13 @@ public class UsersByTenantSearchRequestImpl
   @Override
   public UsersByTenantSearchRequest filter(final TenantUserFilter value) {
     // This command doesn't support filtering
-    return null;
+    throw new UnsupportedOperationException("This command does not support filtering");
   }
 
   @Override
   public UsersByTenantSearchRequest filter(final Consumer<TenantUserFilter> fn) {
     // This command doesn't support filtering
-    return null;
+    throw new UnsupportedOperationException("This command does not support filtering");
   }
 
   @Override

--- a/clients/java/src/test/java/io/camunda/client/role/GroupsByRoleSearchRequestTest.java
+++ b/clients/java/src/test/java/io/camunda/client/role/GroupsByRoleSearchRequestTest.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.github.tomakehurst.wiremock.http.RequestMethod;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+import io.camunda.client.api.search.filter.RoleGroupFilter;
 import io.camunda.client.util.ClientRestTest;
 import org.junit.jupiter.api.Test;
 
@@ -61,5 +62,26 @@ public class GroupsByRoleSearchRequestTest extends ClientRestTest {
     assertThatThrownBy(() -> client.newGroupsByRoleSearchRequest(null).send().join())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("roleId must not be null");
+  }
+
+  @Test
+  void shouldRaiseExceptionWhenFilteringFunctionIsPresentWhenSearchingGroupsByRole() {
+    assertThatThrownBy(
+            () -> client.newGroupsByRoleSearchRequest(ROLE_ID).filter(fn -> {}).send().join())
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessageContaining("This command does not support filtering");
+  }
+
+  @Test
+  void shouldRaiseExceptionWhenFilteringIsPresentWhenSearchingGroupsByRole() {
+    assertThatThrownBy(
+            () ->
+                client
+                    .newGroupsByRoleSearchRequest(ROLE_ID)
+                    .filter(new RoleGroupFilter() {})
+                    .send()
+                    .join())
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessageContaining("This command does not support filtering");
   }
 }

--- a/clients/java/src/test/java/io/camunda/client/role/SearchRoleTest.java
+++ b/clients/java/src/test/java/io/camunda/client/role/SearchRoleTest.java
@@ -22,6 +22,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import com.github.tomakehurst.wiremock.http.RequestMethod;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
 import io.camunda.client.api.command.ProblemException;
+import io.camunda.client.api.search.filter.ClientFilter;
 import io.camunda.client.api.search.sort.ClientSort;
 import io.camunda.client.api.search.sort.RoleSort;
 import io.camunda.client.protocol.rest.ProblemDetail;
@@ -73,6 +74,27 @@ public class SearchRoleTest extends ClientRestTest {
     assertThatThrownBy(() -> client.newClientsByRoleSearchRequest("").send().join())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("roleId must not be empty");
+  }
+
+  @Test
+  void shouldRaiseExceptionWhenFilteringFunctionIsPresentWhenSearchingClientsByRole() {
+    assertThatThrownBy(
+            () -> client.newClientsByRoleSearchRequest(ROLE_ID).filter(fn -> {}).send().join())
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessageContaining("This command does not support filtering");
+  }
+
+  @Test
+  void shouldRaiseExceptionWhenFilteringIsPresentWhenSearchingClientsByRole() {
+    assertThatThrownBy(
+            () ->
+                client
+                    .newClientsByRoleSearchRequest(ROLE_ID)
+                    .filter(new ClientFilter() {})
+                    .send()
+                    .join())
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessageContaining("This command does not support filtering");
   }
 
   @Test

--- a/clients/java/src/test/java/io/camunda/client/role/UsersByRoleSearchRequestTest.java
+++ b/clients/java/src/test/java/io/camunda/client/role/UsersByRoleSearchRequestTest.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.github.tomakehurst.wiremock.http.RequestMethod;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+import io.camunda.client.api.search.filter.RoleUserFilter;
 import io.camunda.client.util.ClientRestTest;
 import org.junit.jupiter.api.Test;
 
@@ -60,5 +61,26 @@ public class UsersByRoleSearchRequestTest extends ClientRestTest {
     assertThatThrownBy(() -> client.newUsersByRoleSearchRequest(null).send().join())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("roleId must not be null");
+  }
+
+  @Test
+  void shouldRaiseExceptionWhenFilteringFunctionIsPresentWhenSearchingUsersByRole() {
+    assertThatThrownBy(
+            () -> client.newUsersByRoleSearchRequest(ROLE_ID).filter(fn -> {}).send().join())
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessageContaining("This command does not support filtering");
+  }
+
+  @Test
+  void shouldRaiseExceptionWhenFilteringIsPresentWhenSearchingUsersByRole() {
+    assertThatThrownBy(
+            () ->
+                client
+                    .newUsersByRoleSearchRequest(ROLE_ID)
+                    .filter(new RoleUserFilter() {})
+                    .send()
+                    .join())
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessageContaining("This command does not support filtering");
   }
 }

--- a/clients/java/src/test/java/io/camunda/client/tenant/SearchUsersByTenantTest.java
+++ b/clients/java/src/test/java/io/camunda/client/tenant/SearchUsersByTenantTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+import io.camunda.client.api.search.filter.TenantUserFilter;
 import io.camunda.client.util.ClientRestTest;
 import io.camunda.client.util.RestGatewayService;
 import org.junit.jupiter.api.Test;
@@ -61,5 +62,26 @@ public class SearchUsersByTenantTest extends ClientRestTest {
     assertThatThrownBy(() -> client.newUsersByTenantSearchRequest("").send().join())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("tenantId must not be empty");
+  }
+
+  @Test
+  void shouldRaiseExceptionWhenFilteringFunctionIsPresentWhenSearchingUsersByTenant() {
+    assertThatThrownBy(
+            () -> client.newUsersByTenantSearchRequest(TENANT_ID).filter(fn -> {}).send().join())
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessageContaining("This command does not support filtering");
+  }
+
+  @Test
+  void shouldRaiseExceptionWhenFilteringIsPresentWhenSearchingUsersByTenant() {
+    assertThatThrownBy(
+            () ->
+                client
+                    .newUsersByTenantSearchRequest(TENANT_ID)
+                    .filter(new TenantUserFilter() {})
+                    .send()
+                    .join())
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessageContaining("This command does not support filtering");
   }
 }


### PR DESCRIPTION
## Description

Currently, we have inconsistent behaviour for the commands that don't support filtering: we throw an exception, return null, or return the builder. That would be very confusing for the users.
We should throw an `UnsupportedOperationException` in these cases.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #36066
