### PR TITLE
refactor: return role ids instead role names

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/CamundaOAuthPrincipalServiceImpl.java
+++ b/authentication/src/main/java/io/camunda/authentication/CamundaOAuthPrincipalServiceImpl.java
@@ -137,10 +137,13 @@ public class CamundaOAuthPrincipalServiceImpl implements CamundaOAuthPrincipalSe
     final var roles =
         roleServices
             .withAuthentication(CamundaAuthentication.anonymous())
-            .getRolesByMemberTypeAndMemberIds(ownerTypeToIds);
-    final var roleIds = roles.stream().map(RoleEntity::roleId).collect(Collectors.toSet());
-    if (!roleIds.isEmpty()) {
-      ownerTypeToIds.put(EntityType.ROLE, roleIds);
+            .getRolesByMemberTypeAndMemberIds(ownerTypeToIds)
+            .stream()
+            .map(RoleEntity::roleId)
+            .collect(Collectors.toSet());
+
+    if (!roles.isEmpty()) {
+      ownerTypeToIds.put(EntityType.ROLE, roles);
     }
 
     final var tenants =
@@ -160,7 +163,7 @@ public class CamundaOAuthPrincipalServiceImpl implements CamundaOAuthPrincipalSe
         .withAuthorizedApplications(authorizedApplications)
         .withTenants(tenants)
         .withGroups(groups.stream().toList())
-        .withRoles(roles)
+        .withRoles(roles.stream().toList())
         .withGroupsClaimEnabled(groupsClaimPresent);
 
     return new OAuthContext(mappingRuleIds, authContextBuilder.build());

--- a/authentication/src/main/java/io/camunda/authentication/CamundaUserDetailsService.java
+++ b/authentication/src/main/java/io/camunda/authentication/CamundaUserDetailsService.java
@@ -77,23 +77,21 @@ public class CamundaUserDetailsService implements UserDetailsService {
     final var roles =
         roleServices
             .withAuthentication(CamundaAuthentication.anonymous())
-            .getRolesByUserAndGroups(username, groups);
-    final var roleIds = roles.stream().map(RoleEntity::roleId).collect(Collectors.toSet());
+            .getRolesByUserAndGroups(username, groups)
+            .stream()
+            .map(RoleEntity::roleId)
+            .collect(Collectors.toSet());
 
     final var authorizedApplications =
         authorizationServices
             .withAuthentication(CamundaAuthentication.anonymous())
             .getAuthorizedApplications(
-                Map.of(
-                    EntityType.USER,
-                    Set.of(storedUser.username()),
-                    EntityType.ROLE,
-                    roles.stream().map(RoleEntity::roleId).collect(Collectors.toSet())));
+                Map.of(EntityType.USER, Set.of(storedUser.username()), EntityType.ROLE, roles));
 
     final var tenants =
         tenantServices
             .withAuthentication(CamundaAuthentication.anonymous())
-            .getTenantsByUserAndGroupsAndRoles(username, groups, roleIds)
+            .getTenantsByUserAndGroupsAndRoles(username, groups, roles)
             .stream()
             .map(TenantDTO::fromEntity)
             .toList();
@@ -105,7 +103,7 @@ public class CamundaUserDetailsService implements UserDetailsService {
         .withPassword(storedUser.password())
         .withEmail(storedUser.email())
         .withAuthorizedApplications(authorizedApplications)
-        .withRoles(roles)
+        .withRoles(roles.stream().toList())
         .withTenants(tenants)
         .withGroups(groups.stream().toList())
         .withCanLogout(true)

--- a/authentication/src/main/java/io/camunda/authentication/DefaultCamundaAuthenticationConverter.java
+++ b/authentication/src/main/java/io/camunda/authentication/DefaultCamundaAuthenticationConverter.java
@@ -10,7 +10,6 @@ package io.camunda.authentication;
 import io.camunda.authentication.entity.CamundaOAuthPrincipal;
 import io.camunda.authentication.entity.CamundaPrincipal;
 import io.camunda.authentication.exception.CamundaAuthenticationException;
-import io.camunda.search.entities.RoleEntity;
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.security.auth.CamundaAuthentication.Builder;
 import io.camunda.security.auth.CamundaAuthenticationConverter;
@@ -58,8 +57,7 @@ public class DefaultCamundaAuthenticationConverter
     final var authenticationBuilder = new Builder();
     final var authenticationContext = camundaPrincipal.getAuthenticationContext();
 
-    authenticationBuilder.roleIds(
-        authenticationContext.roles().stream().map(RoleEntity::roleId).toList());
+    authenticationBuilder.roleIds(authenticationContext.roles());
 
     authenticationBuilder.tenants(
         authenticationContext.tenants().stream().map(TenantDTO::tenantId).toList());

--- a/authentication/src/main/java/io/camunda/authentication/entity/AuthenticationContext.java
+++ b/authentication/src/main/java/io/camunda/authentication/entity/AuthenticationContext.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.authentication.entity;
 
-import io.camunda.search.entities.RoleEntity;
 import io.camunda.service.TenantServices.TenantDTO;
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -16,7 +15,7 @@ import java.util.List;
 public record AuthenticationContext(
     String username,
     String clientId,
-    List<RoleEntity> roles,
+    List<String> roles,
     List<String> authorizedApplications,
     List<TenantDTO> tenants,
     List<String> groups,
@@ -26,7 +25,7 @@ public record AuthenticationContext(
   public static final class AuthenticationContextBuilder {
     private String username;
     private String clientId;
-    private List<RoleEntity> roles = new ArrayList<>();
+    private List<String> roles = new ArrayList<>();
     private List<String> authorizedApplications = new ArrayList<>();
     private List<TenantDTO> tenants = new ArrayList<>();
     private List<String> groups = new ArrayList<>();
@@ -42,7 +41,7 @@ public record AuthenticationContext(
       return this;
     }
 
-    public AuthenticationContextBuilder withRoles(final List<RoleEntity> roles) {
+    public AuthenticationContextBuilder withRoles(final List<String> roles) {
       this.roles = roles;
       return this;
     }

--- a/authentication/src/main/java/io/camunda/authentication/entity/CamundaUser.java
+++ b/authentication/src/main/java/io/camunda/authentication/entity/CamundaUser.java
@@ -8,7 +8,6 @@
 package io.camunda.authentication.entity;
 
 import io.camunda.authentication.entity.AuthenticationContext.AuthenticationContextBuilder;
-import io.camunda.search.entities.RoleEntity;
 import io.camunda.security.entity.ClusterMetadata;
 import io.camunda.service.TenantServices.TenantDTO;
 import java.util.Collections;
@@ -100,7 +99,7 @@ public final class CamundaUser extends User implements CamundaPrincipal {
     private String username;
     private String password;
     private String email;
-    private List<RoleEntity> roles = List.of();
+    private List<String> roles = List.of();
     private List<? extends GrantedAuthority> authorities = List.of();
     private List<String> authorizedApplications = List.of();
     private List<TenantDTO> tenants = List.of();
@@ -140,7 +139,7 @@ public final class CamundaUser extends User implements CamundaPrincipal {
       return this;
     }
 
-    public CamundaUserBuilder withRoles(final List<RoleEntity> roles) {
+    public CamundaUserBuilder withRoles(final List<String> roles) {
       this.roles = Objects.requireNonNullElse(roles, List.of());
       return this;
     }

--- a/authentication/src/main/java/io/camunda/authentication/service/BasicCamundaUserService.java
+++ b/authentication/src/main/java/io/camunda/authentication/service/BasicCamundaUserService.java
@@ -11,7 +11,6 @@ import io.camunda.authentication.ConditionalOnAuthenticationMethod;
 import io.camunda.authentication.entity.AuthenticationContext;
 import io.camunda.authentication.entity.CamundaUser;
 import io.camunda.authentication.entity.CamundaUserDTO;
-import io.camunda.search.entities.RoleEntity;
 import io.camunda.security.entity.AuthenticationMethod;
 import java.util.Optional;
 import org.springframework.context.annotation.Profile;
@@ -44,7 +43,7 @@ public class BasicCamundaUserService implements CamundaUserService {
                   auth.authorizedApplications(),
                   auth.tenants(),
                   auth.groups(),
-                  auth.roles().stream().map(RoleEntity::name).toList(),
+                  auth.roles(),
                   user.getSalesPlanType(),
                   user.getC8Links(),
                   user.canLogout());

--- a/authentication/src/main/java/io/camunda/authentication/service/OidcCamundaUserService.java
+++ b/authentication/src/main/java/io/camunda/authentication/service/OidcCamundaUserService.java
@@ -12,7 +12,6 @@ import io.camunda.authentication.entity.AuthenticationContext;
 import io.camunda.authentication.entity.CamundaOAuthPrincipal;
 import io.camunda.authentication.entity.CamundaOidcUser;
 import io.camunda.authentication.entity.CamundaUserDTO;
-import io.camunda.search.entities.RoleEntity;
 import io.camunda.security.entity.AuthenticationMethod;
 import io.camunda.security.entity.ClusterMetadata.AppName;
 import jakarta.json.Json;
@@ -53,7 +52,7 @@ public class OidcCamundaUserService implements CamundaUserService {
                   auth.authorizedApplications(),
                   auth.tenants(),
                   auth.groups(),
-                  auth.roles().stream().map(RoleEntity::name).toList(),
+                  auth.roles(),
                   SALES_PLAN_TYPE,
                   C8_LINKS,
                   true);

--- a/authentication/src/test/java/io/camunda/authentication/CamundaOAuthPrincipalServiceTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/CamundaOAuthPrincipalServiceTest.java
@@ -284,7 +284,8 @@ public class CamundaOAuthPrincipalServiceTest {
       assertThat(oAuthContext).isNotNull();
       assertThat(oAuthContext.mappingIds()).isEqualTo(Set.of("test-id", "test-id-2"));
       final AuthenticationContext authenticationContext = oAuthContext.authenticationContext();
-      assertThat(authenticationContext.roles()).containsAll(Set.of(roleR1, groupRole));
+      assertThat(authenticationContext.roles())
+          .containsAll(Set.of(roleR1.roleId(), groupRole.roleId()));
       assertThat(authenticationContext.groups()).containsExactly("group-g1");
       assertThat(authenticationContext.tenants())
           .containsAll(List.of(TenantDTO.fromEntity(tenantT1), TenantDTO.fromEntity(groupTenant)));
@@ -358,7 +359,7 @@ public class CamundaOAuthPrincipalServiceTest {
 
       final AuthenticationContext authenticationContext = oAuthContext.authenticationContext();
       assertThat(authenticationContext.username()).isEqualTo("scooby-doo");
-      assertThat(authenticationContext.roles()).containsExactly(roleR1);
+      assertThat(authenticationContext.roles()).containsExactly(roleR1.roleId());
       assertThat(authenticationContext.groups()).containsExactly("group-g1");
       assertThat(authenticationContext.tenants())
           .containsExactlyInAnyOrder(

--- a/authentication/src/test/java/io/camunda/authentication/CamundaOidcUserServiceTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/CamundaOidcUserServiceTest.java
@@ -13,7 +13,6 @@ import static org.mockito.Mockito.when;
 import io.camunda.authentication.entity.AuthenticationContext;
 import io.camunda.authentication.entity.CamundaOidcUser;
 import io.camunda.authentication.entity.OAuthContext;
-import io.camunda.search.entities.RoleEntity;
 import io.camunda.service.TenantServices.TenantDTO;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
@@ -63,7 +62,7 @@ public class CamundaOidcUserServiceTest {
             "group", "G1");
     when(jwtDecoder.decode(TOKEN_VALUE)).thenReturn(createJwt(TOKEN_VALUE, claims));
 
-    final var roleR1 = new RoleEntity(8L, "roleR1", "Role R1", "R1 description");
+    final var roleR1 = "roleR1";
 
     when(camundaOAuthPrincipalService.loadOAuthContext(claims))
         .thenReturn(

--- a/authentication/src/test/java/io/camunda/authentication/CamundaUserDetailsServiceTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/CamundaUserDetailsServiceTest.java
@@ -111,7 +111,8 @@ public class CamundaUserDetailsServiceTest {
     assertThat(user.getAuthenticationContext().username()).isEqualTo(TEST_USER_ID);
     assertThat(user.getAuthenticationContext().authorizedApplications())
         .containsExactlyInAnyOrder("operate", "identity");
-    assertThat(user.getAuthenticationContext().roles()).isEqualTo(List.of(adminRole, groupRole));
+    assertThat(user.getAuthenticationContext().roles())
+        .isEqualTo(List.of(adminRole.roleId(), groupRole.roleId()));
     assertThat(user.getAuthenticationContext().groups()).isEqualTo(List.of(adminGroup.groupId()));
     assertThat(user.getAuthenticationContext().tenants())
         .isEqualTo(List.of(TenantDTO.fromEntity(adminTenant), TenantDTO.fromEntity(groupTenant)));

--- a/authentication/src/test/java/io/camunda/authentication/session/WebSessionMapperTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/session/WebSessionMapperTest.java
@@ -12,7 +12,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.camunda.authentication.entity.CamundaUser.CamundaUserBuilder;
 import io.camunda.authentication.session.WebSessionMapper.SpringBasedWebSessionAttributeConverter;
 import io.camunda.search.entities.PersistentWebSessionEntity;
-import io.camunda.search.entities.RoleEntity;
 import java.io.Serializable;
 import java.time.Duration;
 import java.time.Instant;
@@ -46,7 +45,7 @@ public class WebSessionMapperTest {
                 .withUsername("test")
                 .withPassword("admin")
                 .withUserKey(1L)
-                .withRoles(List.of(new RoleEntity(1L, "testRole", "testRole", "description")))
+                .withRoles(List.of("testRole"))
                 .build(),
             null);
     securityContext.setAuthentication(authenticationToken);
@@ -138,7 +137,7 @@ public class WebSessionMapperTest {
                 .withUsername("test")
                 .withPassword("admin")
                 .withUserKey(1L)
-                .withRoles(List.of(new RoleEntity(1L, "testRole", "testRole", "description")))
+                .withRoles(List.of("testRole"))
                 .build(),
             null);
     securityContext.setAuthentication(authenticationToken);


### PR DESCRIPTION
## Description

When returning the current authenticated user, it contains the role IDs instead of the role names. That way, it is aligned with the groups.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #36077 
