### PR TITLE
fix: return empty result when no owner ids and types given

### DIFF
--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/AuthorizationFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/AuthorizationFilterTransformer.java
@@ -33,12 +33,9 @@ public final class AuthorizationFilterTransformer
 
   @Override
   public SearchQuery toSearchQuery(final AuthorizationFilter filter) {
-    if (filter.ownerTypeToOwnerIds() != null && !filter.ownerTypeToOwnerIds().isEmpty()) {
-      return buildOwnerTypeToOwnerIdsQuery(filter);
-    }
-
     return and(
         buildCoreFilters(filter),
+        filter.ownerTypeToOwnerIds() != null ? buildOwnerTypeToOwnerIdsQuery(filter) : null,
         stringTerms(OWNER_ID, filter.ownerIds()),
         filter.ownerType() == null ? null : term(OWNER_TYPE, filter.ownerType()));
   }
@@ -54,7 +51,6 @@ public final class AuthorizationFilterTransformer
             .map(
                 entry ->
                     and(
-                        buildCoreFilters(filter),
                         term(OWNER_TYPE, entry.getKey().name()),
                         stringTerms(OWNER_ID, entry.getValue())))
             .toList());

--- a/security/security-services/pom.xml
+++ b/security/security-services/pom.xml
@@ -34,6 +34,21 @@
       <groupId>io.camunda</groupId>
       <artifactId>camunda-search-client-reader</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/security/security-services/src/test/java/io/camunda/security/impl/AuthorizationCheckerTest.java
+++ b/security/security-services/src/test/java/io/camunda/security/impl/AuthorizationCheckerTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.security.impl;
+
+import static io.camunda.zeebe.protocol.record.value.AuthorizationResourceType.APPLICATION;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.camunda.search.clients.reader.AuthorizationReader;
+import io.camunda.security.auth.Authorization;
+import io.camunda.security.auth.CamundaAuthentication;
+import io.camunda.security.auth.SecurityContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+public class AuthorizationCheckerTest {
+
+  @Mock private AuthorizationReader authorizationReader;
+  private AuthorizationChecker authorizationChecker;
+
+  @BeforeEach
+  public void setUp() {
+    authorizationChecker = new AuthorizationChecker(authorizationReader);
+  }
+
+  @Test
+  public void noResourceIdsReturnedWhenOwnerIdsIsEmpty() {
+    // given
+    final var authentication = mock(CamundaAuthentication.class);
+    final var authorization = mock(Authorization.class);
+    final var securityContext = mock(SecurityContext.class);
+    when(securityContext.authentication()).thenReturn(authentication);
+    when(securityContext.authorization()).thenReturn(authorization);
+
+    // when
+    final var result = authorizationChecker.retrieveAuthorizedResourceIds(securityContext);
+
+    // then
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  public void noPermissionTypesReturnedWhenOwnerIdsIsEmpty() {
+    // given
+    final var authentication = mock(CamundaAuthentication.class);
+
+    // when
+    final var result =
+        authorizationChecker.collectPermissionTypes("foo", APPLICATION, authentication);
+
+    // then
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  public void notAuthorizedWhenOwnerIdsIsEmpty() {
+    // given
+    final var authentication = mock(CamundaAuthentication.class);
+    final var authorization = mock(Authorization.class);
+    final var securityContext = mock(SecurityContext.class);
+    when(securityContext.authentication()).thenReturn(authentication);
+    when(securityContext.authorization()).thenReturn(authorization);
+
+    // when
+    final var result = authorizationChecker.isAuthorized("foo", securityContext);
+
+    // then
+    assertThat(result).isFalse();
+  }
+}


### PR DESCRIPTION
## Description

Deny any permission if no owner IDs and types are given.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #36080 
