### PR TITLE
Improve authorization permission matching

### DIFF
--- a/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.8.0.xml
+++ b/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.8.0.xml
@@ -458,6 +458,7 @@
       <column name="OWNER_ID" type="VARCHAR(255)" />
       <column name="OWNER_TYPE" type="VARCHAR(255)" />
       <column name="RESOURCE_TYPE" type="VARCHAR(255)" />
+      <column name="RESOURCE_MATCHER" type="SMALLINT" />
       <column name="RESOURCE_ID" type="VARCHAR(255)" />
       <column name="PERMISSION_TYPE" type="VARCHAR(255)" />
     </createTable>

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/AuthorizationDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/AuthorizationDbReader.java
@@ -83,6 +83,7 @@ public class AuthorizationDbReader extends AbstractEntityReader<AuthorizationEnt
         model.ownerId(),
         model.ownerType(),
         model.resourceType(),
+        model.resourceMatcher(),
         model.resourceId(),
         new HashSet<>(model.permissionTypes()));
   }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/AuthorizationDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/AuthorizationDbModel.java
@@ -18,6 +18,7 @@ public class AuthorizationDbModel implements DbModel<AuthorizationDbModel> {
   private String ownerId;
   private String ownerType;
   private String resourceType;
+  private Short resourceMatcher;
   private String resourceId;
   private Set<PermissionType> permissionTypes;
 
@@ -53,6 +54,14 @@ public class AuthorizationDbModel implements DbModel<AuthorizationDbModel> {
     this.resourceType = resourceType;
   }
 
+  public Short resourceMatcher() {
+    return resourceMatcher;
+  }
+
+  public void resourceMatcher(final Short resourceMatcher) {
+    this.resourceMatcher = resourceMatcher;
+  }
+
   public String resourceId() {
     return resourceId;
   }
@@ -79,6 +88,7 @@ public class AuthorizationDbModel implements DbModel<AuthorizationDbModel> {
                 .authorizationKey(authorizationKey)
                 .ownerId(ownerId)
                 .ownerType(ownerType)
+                .resourceMatcher(resourceMatcher)
                 .resourceId(resourceId)
                 .resourceType(resourceType)
                 .permissionTypes(permissionTypes))
@@ -90,6 +100,7 @@ public class AuthorizationDbModel implements DbModel<AuthorizationDbModel> {
     private Long authorizationKey;
     private String ownerId;
     private String ownerType;
+    private Short resourceMatcher;
     private String resourceId;
     private String resourceType;
     private Set<PermissionType> permissionTypes;
@@ -116,6 +127,11 @@ public class AuthorizationDbModel implements DbModel<AuthorizationDbModel> {
       return this;
     }
 
+    public Builder resourceMatcher(final Short resourceMatcher) {
+      this.resourceMatcher = resourceMatcher;
+      return this;
+    }
+
     public Builder resourceId(final String resourceId) {
       this.resourceId = resourceId;
       return this;
@@ -132,6 +148,7 @@ public class AuthorizationDbModel implements DbModel<AuthorizationDbModel> {
       model.authorizationKey(authorizationKey);
       model.ownerId(ownerId);
       model.ownerType(ownerType);
+      model.resourceMatcher(resourceMatcher);
       model.resourceId(resourceId);
       model.resourceType(resourceType);
       model.permissionTypes(permissionTypes);

--- a/db/rdbms/src/main/resources/mapper/AuthorizationsMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/AuthorizationsMapper.xml
@@ -12,7 +12,7 @@
 
   <select id="count" parameterType="io.camunda.db.rdbms.read.domain.AuthorizationDbQuery">
     SELECT COUNT(*) FROM (
-    SELECT DISTINCT AUTHORIZATION_KEY, OWNER_ID, OWNER_TYPE, RESOURCE_TYPE, RESOURCE_ID
+    SELECT DISTINCT AUTHORIZATION_KEY, OWNER_ID, OWNER_TYPE, RESOURCE_TYPE, RESOURCE_MATCHER,RESOURCE_ID
     FROM ${prefix}AUTHORIZATIONS a
     <include refid="io.camunda.db.rdbms.sql.AuthorizationMapper.searchFilter"/>
     ) t
@@ -26,6 +26,7 @@
     t.OWNER_TYPE,
     t.RESOURCE_TYPE,
     a.PERMISSION_TYPE,
+    a.RESOURCE_MATCHER,
     a.RESOURCE_ID
     FROM (
     SELECT * FROM (
@@ -34,6 +35,7 @@
     OWNER_ID,
     OWNER_TYPE,
     RESOURCE_TYPE,
+    RESOURCE_MATCHER,
     RESOURCE_ID
     FROM ${prefix}AUTHORIZATIONS
     <include refid="io.camunda.db.rdbms.sql.AuthorizationMapper.searchFilter"/>
@@ -54,6 +56,7 @@
     <if test="filter.authorizationKey != null">AND AUTHORIZATION_KEY = #{filter.authorizationKey}</if>
     <if test="filter.ownerType != null">AND OWNER_TYPE = #{filter.ownerType}</if>
     <if test="filter.resourceType != null">AND RESOURCE_TYPE = #{filter.resourceType}</if>
+    <if test="filter.resourceMatcher != null">AND RESOURCE_MATCHER = #{filter.resourceMatcher}</if>
     <if test="filter.permissionTypes != null and !filter.permissionTypes.isEmpty()">
         AND PERMISSION_TYPE IN
       <foreach collection="filter.permissionTypes" item="value" open="(" separator=", "
@@ -80,6 +83,7 @@
     <id column="OWNER_ID" property="ownerId"/>
     <id column="OWNER_TYPE" property="ownerType"/>
     <id column="RESOURCE_TYPE" property="resourceType"/>
+    <id column="RESOURCE_MATCHER" property="resourceMatcher" />
     <id column="RESOURCE_ID" property="resourceId" />
     <collection property="permissionTypes"
       ofType="io.camunda.zeebe.protocol.record.value.PermissionType"
@@ -89,10 +93,10 @@
   </resultMap>
 
   <insert id="insert" parameterType="io.camunda.db.rdbms.write.domain.AuthorizationDbModel">
-    INSERT INTO ${prefix}AUTHORIZATIONS (AUTHORIZATION_KEY, OWNER_ID, OWNER_TYPE, RESOURCE_TYPE, RESOURCE_ID, PERMISSION_TYPE)
+    INSERT INTO ${prefix}AUTHORIZATIONS (AUTHORIZATION_KEY, OWNER_ID, OWNER_TYPE, RESOURCE_TYPE, RESOURCE_MATCHER, RESOURCE_ID, PERMISSION_TYPE)
     VALUES
     <foreach collection="permissionTypes" item="permissionType" separator=",">
-      (#{authorizationKey}, #{ownerId}, #{ownerType}, #{resourceType}, #{resourceId}, #{permissionType})
+      (#{authorizationKey}, #{ownerId}, #{ownerType}, #{resourceType}, #{resourceMatcher}, #{resourceId}, #{permissionType})
     </foreach>
   </insert>
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/authorization/AuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/authorization/AuthorizationIT.java
@@ -23,6 +23,7 @@ import io.camunda.search.filter.AuthorizationFilter;
 import io.camunda.search.page.SearchQueryPage;
 import io.camunda.search.query.AuthorizationQuery;
 import io.camunda.search.sort.AuthorizationSort;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import java.time.OffsetDateTime;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.TestTemplate;
@@ -59,7 +60,9 @@ public class AuthorizationIT {
     final RdbmsWriter rdbmsWriter = rdbmsService.createWriter(PARTITION_ID);
     final AuthorizationDbReader authorizationReader = rdbmsService.getAuthorizationReader();
 
-    final var authorization = AuthorizationFixtures.createRandomized(b -> b.resourceId("foo"));
+    final var authorization =
+        AuthorizationFixtures.createRandomized(
+            b -> b.resourceMatcher(AuthorizationResourceMatcher.ID.value()).resourceId("foo"));
     createAndSaveAuthorization(rdbmsWriter, authorization);
 
     final var authorizationUpdate =
@@ -69,6 +72,7 @@ public class AuthorizationIT {
                     .ownerId(authorization.ownerId())
                     .ownerType(authorization.ownerType())
                     .resourceType(authorization.resourceType())
+                    .resourceMatcher(AuthorizationResourceMatcher.ID.value())
                     .resourceId("bar")
                     .permissionTypes(authorization.permissionTypes()));
     rdbmsWriter.getAuthorizationWriter().updateAuthorization(authorizationUpdate);
@@ -81,6 +85,7 @@ public class AuthorizationIT {
             .orElse(null);
 
     assertThat(instance).isNotNull();
+    assertThat(instance.resourceMatcher()).isEqualTo(AuthorizationResourceMatcher.ID.value());
     assertThat(instance.resourceId()).isEqualTo("bar");
   }
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/authorization/AuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/authorization/AuthorizationIT.java
@@ -72,7 +72,7 @@ public class AuthorizationIT {
                     .ownerId(authorization.ownerId())
                     .ownerType(authorization.ownerType())
                     .resourceType(authorization.resourceType())
-                    .resourceMatcher(AuthorizationResourceMatcher.ID.value())
+                    .resourceMatcher(authorization.resourceMatcher())
                     .resourceId("bar")
                     .permissionTypes(authorization.permissionTypes()));
     rdbmsWriter.getAuthorizationWriter().updateAuthorization(authorizationUpdate);

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/AuthorizationFixtures.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/AuthorizationFixtures.java
@@ -12,6 +12,7 @@ import io.camunda.client.api.search.enums.ResourceType;
 import io.camunda.db.rdbms.write.RdbmsWriter;
 import io.camunda.db.rdbms.write.domain.AuthorizationDbModel;
 import io.camunda.db.rdbms.write.domain.AuthorizationDbModel.Builder;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import java.util.List;
 import java.util.Set;
@@ -37,6 +38,7 @@ public final class AuthorizationFixtures extends CommonFixtures {
             .ownerId(ownerId)
             .ownerType(randomEnum(OwnerType.class).name())
             .resourceType(randomEnum(ResourceType.class).name())
+            .resourceMatcher(AuthorizationResourceMatcher.ID.value())
             .resourceId(nextStringId())
             .permissionTypes(Set.of(randomPermissionType1, randomPermissionType2));
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/AuthorizationFixtures.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/AuthorizationFixtures.java
@@ -38,7 +38,7 @@ public final class AuthorizationFixtures extends CommonFixtures {
             .ownerId(ownerId)
             .ownerType(randomEnum(OwnerType.class).name())
             .resourceType(randomEnum(ResourceType.class).name())
-            .resourceMatcher(AuthorizationResourceMatcher.ID.value())
+            .resourceMatcher(randomEnum(AuthorizationResourceMatcher.class).value())
             .resourceId(nextStringId())
             .permissionTypes(Set.of(randomPermissionType1, randomPermissionType2));
 

--- a/search/search-client-elasticsearch/src/main/java/io/camunda/search/es/transformers/types/TypedValueTransformer.java
+++ b/search/search-client-elasticsearch/src/main/java/io/camunda/search/es/transformers/types/TypedValueTransformer.java
@@ -22,6 +22,8 @@ public final class TypedValueTransformer extends ElasticsearchTransformer<TypedV
   public FieldValue apply(final TypedValue value) {
     if (value.isString()) {
       return FieldValue.of(value.stringValue());
+    } else if (value.isShort()) {
+      return FieldValue.of(value.shortValue());
     } else if (value.isInteger()) {
       return FieldValue.of(value.intValue());
     } else if (value.isLong()) {

--- a/search/search-client-opensearch/src/main/java/io/camunda/search/os/transformers/types/TypedValueTransformer.java
+++ b/search/search-client-opensearch/src/main/java/io/camunda/search/os/transformers/types/TypedValueTransformer.java
@@ -22,6 +22,8 @@ public final class TypedValueTransformer extends OpensearchTransformer<TypedValu
   public FieldValue apply(final TypedValue value) {
     if (value.isString()) {
       return FieldValue.of(value.stringValue());
+    } else if (value.isShort()) {
+      return FieldValue.of(value.shortValue());
     } else if (value.isInteger()) {
       return FieldValue.of(value.intValue());
     } else if (value.isLong()) {

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/query/SearchQueryBuilders.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/query/SearchQueryBuilders.java
@@ -267,6 +267,10 @@ public final class SearchQueryBuilders {
     return fn.apply(term()).build();
   }
 
+  public static SearchQuery term(final String field, final Short value) {
+    return term((q) -> q.field(field).value(value)).toSearchQuery();
+  }
+
   public static SearchQuery term(final String field, final Integer value) {
     return term((q) -> q.field(field).value(value)).toSearchQuery();
   }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/query/SearchTermQuery.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/query/SearchTermQuery.java
@@ -29,6 +29,10 @@ public record SearchTermQuery(String field, TypedValue value, Boolean caseInsens
       return value(TypedValue.of(value));
     }
 
+    public Builder value(final short value) {
+      return value(TypedValue.of(value));
+    }
+
     public Builder value(final int value) {
       return value(TypedValue.of(value));
     }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/AuthorizationEntityTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/AuthorizationEntityTransformer.java
@@ -24,7 +24,7 @@ public class AuthorizationEntityTransformer
         value.getOwnerId(),
         value.getOwnerType(),
         value.getResourceType(),
-        value.getResourceMatcher().value(),
+        value.getResourceMatcher(),
         value.getResourceId(),
         new HashSet<>(value.getPermissionTypes()));
   }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/AuthorizationEntityTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/AuthorizationEntityTransformer.java
@@ -24,6 +24,7 @@ public class AuthorizationEntityTransformer
         value.getOwnerId(),
         value.getOwnerType(),
         value.getResourceType(),
+        value.getResourceMatcher().value(),
         value.getResourceId(),
         new HashSet<>(value.getPermissionTypes()));
   }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/AuthorizationFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/AuthorizationFilterTransformer.java
@@ -17,6 +17,7 @@ import static io.camunda.webapps.schema.descriptors.index.AuthorizationIndex.OWN
 import static io.camunda.webapps.schema.descriptors.index.AuthorizationIndex.OWNER_TYPE;
 import static io.camunda.webapps.schema.descriptors.index.AuthorizationIndex.PERMISSIONS_TYPES;
 import static io.camunda.webapps.schema.descriptors.index.AuthorizationIndex.RESOURCE_ID;
+import static io.camunda.webapps.schema.descriptors.index.AuthorizationIndex.RESOURCE_MATCHER;
 import static io.camunda.webapps.schema.descriptors.index.AuthorizationIndex.RESOURCE_TYPE;
 
 import io.camunda.search.clients.query.SearchQuery;
@@ -70,6 +71,7 @@ public final class AuthorizationFilterTransformer
     return and(
         filter.authorizationKey() == null ? null : term(ID, filter.authorizationKey()),
         stringTerms(RESOURCE_ID, filter.resourceIds()),
+        filter.resourceMatcher() == null ? null : term(RESOURCE_MATCHER, filter.resourceMatcher()),
         filter.resourceType() == null ? null : term(RESOURCE_TYPE, filter.resourceType()),
         filter.permissionTypes() == null
             ? null

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/sort/AuthorizationFieldSortingTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/sort/AuthorizationFieldSortingTransformer.java
@@ -11,6 +11,7 @@ import static io.camunda.webapps.schema.descriptors.index.AuthorizationIndex.ID;
 import static io.camunda.webapps.schema.descriptors.index.AuthorizationIndex.OWNER_ID;
 import static io.camunda.webapps.schema.descriptors.index.AuthorizationIndex.OWNER_TYPE;
 import static io.camunda.webapps.schema.descriptors.index.AuthorizationIndex.RESOURCE_ID;
+import static io.camunda.webapps.schema.descriptors.index.AuthorizationIndex.RESOURCE_MATCHER;
 import static io.camunda.webapps.schema.descriptors.index.AuthorizationIndex.RESOURCE_TYPE;
 
 public class AuthorizationFieldSortingTransformer implements FieldSortingTransformer {
@@ -21,6 +22,7 @@ public class AuthorizationFieldSortingTransformer implements FieldSortingTransfo
       case "ownerId" -> OWNER_ID;
       case "ownerType" -> OWNER_TYPE;
       case "resourceType" -> RESOURCE_TYPE;
+      case "resourceMatcher" -> RESOURCE_MATCHER;
       case "resourceId" -> RESOURCE_ID;
       default -> throw new IllegalArgumentException("Unknown field: " + domainField);
     };

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/types/TypedValue.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/types/TypedValue.java
@@ -38,6 +38,14 @@ public final record TypedValue(ValueType type, Object value) {
     return (double) value;
   }
 
+  public boolean isShort() {
+    return type == ValueType.SHORT;
+  }
+
+  public short shortValue() {
+    return (short) value;
+  }
+
   public boolean isInteger() {
     return type == ValueType.INTEGER;
   }
@@ -68,6 +76,10 @@ public final record TypedValue(ValueType type, Object value) {
 
   public String stringValue() {
     return (String) value;
+  }
+
+  public static TypedValue of(final short value) {
+    return new TypedValue(ValueType.SHORT, value);
   }
 
   public static TypedValue of(final int value) {
@@ -123,6 +135,7 @@ public final record TypedValue(ValueType type, Object value) {
 
   public enum ValueType {
     DOUBLE,
+    SHORT,
     INTEGER,
     LONG,
     BOOLEAN,

--- a/search/search-domain/src/main/java/io/camunda/search/entities/AuthorizationEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/AuthorizationEntity.java
@@ -17,5 +17,6 @@ public record AuthorizationEntity(
     String ownerId,
     String ownerType,
     String resourceType,
+    Short resourceMatcher,
     String resourceId,
     Set<PermissionType> permissionTypes) {}

--- a/search/search-domain/src/main/java/io/camunda/search/filter/AuthorizationFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/AuthorizationFilter.java
@@ -11,6 +11,7 @@ import static io.camunda.util.CollectionUtil.addValuesToList;
 import static io.camunda.util.CollectionUtil.collectValuesAsList;
 
 import io.camunda.util.ObjectBuilder;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.EntityType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import java.util.List;
@@ -21,6 +22,7 @@ public record AuthorizationFilter(
     Long authorizationKey,
     List<String> ownerIds,
     String ownerType,
+    Short resourceMatcher,
     List<String> resourceIds,
     String resourceType,
     List<PermissionType> permissionTypes,
@@ -31,6 +33,7 @@ public record AuthorizationFilter(
     private List<String> ownerIds;
     private String ownerType;
     private List<String> resourceIds;
+    private Short resourceMatcher;
     private String resourceType;
     private List<PermissionType> permissionTypes;
     private Map<EntityType, Set<String>> ownerTypeToOwnerIds;
@@ -51,6 +54,11 @@ public record AuthorizationFilter(
 
     public Builder ownerType(final String value) {
       ownerType = value;
+      return this;
+    }
+
+    public Builder resourceMatcher(final AuthorizationResourceMatcher value) {
+      resourceMatcher = value.value();
       return this;
     }
 
@@ -108,6 +116,7 @@ public record AuthorizationFilter(
           authorizationKey,
           ownerIds,
           ownerType,
+          resourceMatcher,
           resourceIds,
           resourceType,
           permissionTypes,

--- a/security/security-protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AuthorizationResourceMatcher.java
+++ b/security/security-protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AuthorizationResourceMatcher.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.protocol.record.value;
+
+public enum AuthorizationResourceMatcher {
+  UNSPECIFIED(0),
+  ANY(1),
+  ID(2);
+
+  private final short value;
+
+  AuthorizationResourceMatcher(final int value) {
+    this.value = (short) value;
+  }
+
+  public short getIntent() {
+    return value;
+  }
+
+  public static AuthorizationResourceMatcher from(final short value) {
+    switch (value) {
+      case 0:
+        return UNSPECIFIED;
+      case 1:
+        return ANY;
+      case 2:
+        return ID;
+      default:
+        return UNSPECIFIED;
+    }
+  }
+
+  public short value() {
+    return value;
+  }
+}

--- a/service/src/main/java/io/camunda/service/AuthorizationServices.java
+++ b/service/src/main/java/io/camunda/service/AuthorizationServices.java
@@ -23,6 +23,7 @@ import io.camunda.zeebe.gateway.impl.broker.request.BrokerAuthorizationRequest;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.AuthorizationRecord;
 import io.camunda.zeebe.protocol.record.intent.AuthorizationIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import java.util.Set;
@@ -66,6 +67,7 @@ public class AuthorizationServices
             .setOwnerId(request.ownerId())
             .setOwnerType(request.ownerType())
             .setResourceType(request.resourceType())
+            .setResourceMatcher(getResourceMatcher(request.resourceId()))
             .setResourceId(request.resourceId())
             .setPermissionTypes(request.permissionTypes());
     return sendBrokerRequest(brokerRequest);
@@ -95,10 +97,18 @@ public class AuthorizationServices
             .setAuthorizationKey(request.authorizationKey())
             .setOwnerId(request.ownerId())
             .setOwnerType(request.ownerType())
+            .setResourceMatcher(getResourceMatcher(request.resourceId()))
             .setResourceId(request.resourceId())
             .setResourceType(request.resourceType())
             .setPermissionTypes(request.permissionTypes());
     return sendBrokerRequest(brokerRequest);
+  }
+
+  private AuthorizationResourceMatcher getResourceMatcher(final String resourceId) {
+    // TODO: use WILDCARD constant or find another place to set the matcher
+    return "*".equals(resourceId)
+        ? AuthorizationResourceMatcher.ANY
+        : AuthorizationResourceMatcher.ID;
   }
 
   public record CreateAuthorizationRequest(

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/index/AuthorizationIndex.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/index/AuthorizationIndex.java
@@ -20,6 +20,7 @@ public class AuthorizationIndex extends AbstractIndexDescriptor implements Prio5
   public static final String OWNER_TYPE = "ownerType";
   public static final String RESOURCE_TYPE = "resourceType";
   public static final String PERMISSIONS_TYPES = "permissionTypes";
+  public static final String RESOURCE_MATCHER = "resourceMatcher";
   public static final String RESOURCE_ID = "resourceId";
 
   public AuthorizationIndex(final String indexPrefix, final boolean isElasticsearch) {

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/AuthorizationEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/AuthorizationEntity.java
@@ -18,6 +18,7 @@ public class AuthorizationEntity extends AbstractExporterEntity<AuthorizationEnt
   private String ownerId;
   private String ownerType;
   private String resourceType;
+  private Short resourceMatcher;
   private String resourceId;
   private Set<PermissionType> permissionTypes;
 
@@ -47,6 +48,15 @@ public class AuthorizationEntity extends AbstractExporterEntity<AuthorizationEnt
 
   public AuthorizationEntity setOwnerType(final String ownerType) {
     this.ownerType = ownerType;
+    return this;
+  }
+
+  public short getResourceMatcher() {
+    return resourceMatcher;
+  }
+
+  public AuthorizationEntity setResourceMatcher(final short resourceMatcher) {
+    this.resourceMatcher = resourceMatcher;
     return this;
   }
 

--- a/webapps-schema/src/main/resources/schema/elasticsearch/create/index/camunda-authorization.json
+++ b/webapps-schema/src/main/resources/schema/elasticsearch/create/index/camunda-authorization.json
@@ -17,6 +17,9 @@
       "resourceType": {
         "type": "keyword"
       },
+      "resourceMatcher": {
+        "type": "short"
+      },
       "resourceId": {
         "type": "keyword"
       },

--- a/webapps-schema/src/main/resources/schema/opensearch/create/index/camunda-authorization.json
+++ b/webapps-schema/src/main/resources/schema/opensearch/create/index/camunda-authorization.json
@@ -17,6 +17,9 @@
       "resourceType": {
         "type": "keyword"
       },
+      "resourceMatcher": {
+        "type": "short"
+      },
       "resourceId": {
         "type": "keyword"
       },

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/IdentitySetupInitializer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/IdentitySetupInitializer.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.protocol.impl.record.value.tenant.TenantRecord;
 import io.camunda.zeebe.protocol.impl.record.value.user.UserRecord;
 import io.camunda.zeebe.protocol.record.intent.IdentitySetupIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.DefaultRole;
 import io.camunda.zeebe.protocol.record.value.EntityType;
@@ -161,6 +162,7 @@ public final class IdentitySetupInitializer implements StreamProcessorLifecycleA
               .setOwnerType(AuthorizationOwnerType.ROLE)
               .setOwnerId(readOnlyAdminRoleId)
               .setResourceType(resourceType)
+              .setResourceMatcher(AuthorizationResourceMatcher.ANY)
               .setResourceId(WILDCARD_PERMISSION)
               .setPermissionTypes(readBasedPermissions));
     }
@@ -180,6 +182,7 @@ public final class IdentitySetupInitializer implements StreamProcessorLifecycleA
               .setOwnerType(AuthorizationOwnerType.ROLE)
               .setOwnerId(adminRoleId)
               .setResourceType(resourceType)
+              .setResourceMatcher(AuthorizationResourceMatcher.ANY)
               .setResourceId(WILDCARD_PERMISSION)
               .setPermissionTypes(resourceType.getSupportedPermissionTypes()));
     }
@@ -198,6 +201,7 @@ public final class IdentitySetupInitializer implements StreamProcessorLifecycleA
             .setOwnerType(AuthorizationOwnerType.ROLE)
             .setOwnerId(connectorsRoleId)
             .setResourceType(AuthorizationResourceType.PROCESS_DEFINITION)
+            .setResourceMatcher(AuthorizationResourceMatcher.ANY)
             .setResourceId(WILDCARD_PERMISSION)
             .setPermissionTypes(
                 Set.of(
@@ -208,6 +212,7 @@ public final class IdentitySetupInitializer implements StreamProcessorLifecycleA
             .setOwnerType(AuthorizationOwnerType.ROLE)
             .setOwnerId(connectorsRoleId)
             .setResourceType(AuthorizationResourceType.MESSAGE)
+            .setResourceMatcher(AuthorizationResourceMatcher.ANY)
             .setResourceId(WILDCARD_PERMISSION)
             .setPermissionTypes(Set.of(PermissionType.CREATE)));
     setupRecord.addTenantMember(
@@ -225,12 +230,14 @@ public final class IdentitySetupInitializer implements StreamProcessorLifecycleA
             new AuthorizationRecord()
                 .setOwnerId(rpaRoleId)
                 .setResourceType(AuthorizationResourceType.RESOURCE)
+                .setResourceMatcher(AuthorizationResourceMatcher.ANY)
                 .setResourceId(WILDCARD_PERMISSION)
                 .setPermissionTypes(Set.of(PermissionType.READ)))
         .addAuthorization(
             new AuthorizationRecord()
                 .setOwnerId(rpaRoleId)
                 .setResourceType(AuthorizationResourceType.PROCESS_DEFINITION)
+                .setResourceMatcher(AuthorizationResourceMatcher.ANY)
                 .setResourceId(WILDCARD_PERMISSION)
                 .setPermissionTypes(Set.of(PermissionType.UPDATE_PROCESS_INSTANCE)))
         .addTenantMember(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserCreateProcessor.java
@@ -25,6 +25,7 @@ import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.AuthorizationIntent;
 import io.camunda.zeebe.protocol.record.intent.UserIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
@@ -119,6 +120,7 @@ public class UserCreateProcessor implements DistributedTypedRecordProcessor<User
             .setOwnerId(username)
             .setOwnerType(AuthorizationOwnerType.USER)
             .setResourceType(AuthorizationResourceType.USER)
+            .setResourceMatcher(AuthorizationResourceMatcher.ID)
             .setResourceId(username)
             .setPermissionTypes(Set.of(PermissionType.READ, PermissionType.UPDATE));
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/PersistedAuthorization.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/PersistedAuthorization.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.msgpack.value.StringValue;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.AuthorizationRecord;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.util.buffer.BufferUtil;
@@ -31,6 +32,11 @@ public class PersistedAuthorization extends UnpackedObject implements DbValue {
   private final StringProperty ownerIdProp = new StringProperty("ownerId");
   private final EnumProperty<AuthorizationOwnerType> ownerTypeProp =
       new EnumProperty<>("ownerType", AuthorizationOwnerType.class);
+  private final EnumProperty<AuthorizationResourceMatcher> resourceMatcherProp =
+      new EnumProperty<>(
+          "resourceMatcher",
+          AuthorizationResourceMatcher.class,
+          AuthorizationResourceMatcher.UNSPECIFIED);
   private final StringProperty resourceIdProp = new StringProperty("resourceId");
   private final EnumProperty<AuthorizationResourceType> resourceTypeProp =
       new EnumProperty<>("resourceType", AuthorizationResourceType.class);
@@ -38,10 +44,11 @@ public class PersistedAuthorization extends UnpackedObject implements DbValue {
       new ArrayProperty<>("permissionTypes", StringValue::new);
 
   public PersistedAuthorization() {
-    super(6);
+    super(7);
     declareProperty(authorizationKeyProp)
         .declareProperty(ownerIdProp)
         .declareProperty(ownerTypeProp)
+        .declareProperty(resourceMatcherProp)
         .declareProperty(resourceIdProp)
         .declareProperty(resourceTypeProp)
         .declareProperty(permissionTypesProp);
@@ -51,6 +58,7 @@ public class PersistedAuthorization extends UnpackedObject implements DbValue {
     setAuthorizationKey(authorizationRecord.getAuthorizationKey())
         .setOwnerId(authorizationRecord.getOwnerId())
         .setOwnerType(authorizationRecord.getOwnerType())
+        .setResourceMatcher(authorizationRecord.getResourceMatcher())
         .setResourceId(authorizationRecord.getResourceId())
         .setResourceType(authorizationRecord.getResourceType())
         .setPermissionTypes(authorizationRecord.getPermissionTypes());
@@ -80,6 +88,16 @@ public class PersistedAuthorization extends UnpackedObject implements DbValue {
 
   public PersistedAuthorization setOwnerType(final AuthorizationOwnerType ownerType) {
     ownerTypeProp.setValue(ownerType);
+    return this;
+  }
+
+  public AuthorizationResourceMatcher getResourceMatcher() {
+    return resourceMatcherProp.getValue();
+  }
+
+  public PersistedAuthorization setResourceMatcher(
+      final AuthorizationResourceMatcher resourceMatcher) {
+    resourceMatcherProp.setValue(resourceMatcher);
     return this;
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AnonymousAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AnonymousAuthorizationTest.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.EntityType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
@@ -73,6 +74,7 @@ public class AnonymousAuthorizationTest {
         .newAuthorization()
         .withPermissions(PermissionType.CREATE)
         .withResourceType(AuthorizationResourceType.RESOURCE)
+        .withResourceMatcher(AuthorizationResourceMatcher.ANY)
         .withResourceId("*")
         .withOwnerId(user.getUsername())
         .withOwnerType(AuthorizationOwnerType.USER)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCheckBehaviorGroupsClaimsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCheckBehaviorGroupsClaimsTest.java
@@ -33,6 +33,7 @@ import io.camunda.zeebe.protocol.impl.record.value.authorization.RoleRecord;
 import io.camunda.zeebe.protocol.impl.record.value.tenant.TenantRecord;
 import io.camunda.zeebe.protocol.impl.record.value.user.UserRecord;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.EntityType;
 import io.camunda.zeebe.protocol.record.value.MappingRuleRecordValue;
@@ -267,11 +268,16 @@ final class AuthorizationCheckBehaviorGroupsClaimsTest {
       final String... resourceIds) {
     for (final String resourceId : resourceIds) {
       final var authorizationKey = random.nextLong();
+      final var resourceMatcher =
+          "*".equals(resourceId)
+              ? AuthorizationResourceMatcher.ANY
+              : AuthorizationResourceMatcher.ID;
       final var authorization =
           new AuthorizationRecord()
               .setAuthorizationKey(authorizationKey)
               .setOwnerId(ownerId)
               .setOwnerType(ownerType)
+              .setResourceMatcher(resourceMatcher)
               .setResourceId(resourceId)
               .setResourceType(resourceType)
               .setPermissionTypes(Set.of(permissionType));

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCheckBehaviorMultiTenancyTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCheckBehaviorMultiTenancyTest.java
@@ -38,6 +38,7 @@ import io.camunda.zeebe.protocol.impl.record.value.group.GroupRecord;
 import io.camunda.zeebe.protocol.impl.record.value.tenant.TenantRecord;
 import io.camunda.zeebe.protocol.impl.record.value.user.UserRecord;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.EntityType;
 import io.camunda.zeebe.protocol.record.value.MappingRuleRecordValue;
@@ -748,11 +749,16 @@ final class AuthorizationCheckBehaviorMultiTenancyTest {
       final String... resourceIds) {
     for (final String resourceId : resourceIds) {
       final var authorizationKey = random.nextLong();
+      final var resourceMatcher =
+          "*".equals(resourceId)
+              ? AuthorizationResourceMatcher.ANY
+              : AuthorizationResourceMatcher.ID;
       final var authorization =
           new AuthorizationRecord()
               .setAuthorizationKey(authorizationKey)
               .setOwnerId(ownerId)
               .setOwnerType(ownerType)
+              .setResourceMatcher(resourceMatcher)
               .setResourceId(resourceId)
               .setResourceType(resourceType)
               .setPermissionTypes(Set.of(permissionType));

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCheckBehaviorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCheckBehaviorTest.java
@@ -34,6 +34,7 @@ import io.camunda.zeebe.protocol.impl.record.value.authorization.RoleRecord;
 import io.camunda.zeebe.protocol.impl.record.value.group.GroupRecord;
 import io.camunda.zeebe.protocol.impl.record.value.user.UserRecord;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.EntityType;
 import io.camunda.zeebe.protocol.record.value.MappingRuleRecordValue;
@@ -391,13 +392,13 @@ final class AuthorizationCheckBehaviorTest {
     final var firstResourceId = UUID.randomUUID().toString();
     final var secondResourceId = UUID.randomUUID().toString();
     addPermission(
-        String.valueOf(firstMapping.getMappingRuleId()),
+        firstMapping.getMappingRuleId(),
         AuthorizationOwnerType.MAPPING_RULE,
         resourceType,
         permissionType,
         firstResourceId);
     addPermission(
-        String.valueOf(secondMapping.getMappingRuleId()),
+        secondMapping.getMappingRuleId(),
         AuthorizationOwnerType.MAPPING_RULE,
         resourceType,
         permissionType,
@@ -841,11 +842,16 @@ final class AuthorizationCheckBehaviorTest {
       final String... resourceIds) {
     for (final String resourceId : resourceIds) {
       final var authorizationKey = random.nextLong();
+      final var resourceMatcher =
+          "*".equals(resourceId)
+              ? AuthorizationResourceMatcher.ANY
+              : AuthorizationResourceMatcher.ID;
       final var authorization =
           new AuthorizationRecord()
               .setAuthorizationKey(authorizationKey)
               .setOwnerId(ownerId)
               .setOwnerType(ownerType)
+              .setResourceMatcher(resourceMatcher)
               .setResourceId(resourceId)
               .setResourceType(resourceType)
               .setPermissionTypes(Set.of(permissionType));

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCreateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCreateAuthorizationTest.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.AuthorizationIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.protocol.record.value.UserRecordValue;
@@ -62,6 +63,7 @@ public class AuthorizationCreateAuthorizationTest {
         .withOwnerId(user.getUsername())
         .withOwnerType(AuthorizationOwnerType.USER)
         .withResourceType(AuthorizationResourceType.RESOURCE)
+        .withResourceMatcher(AuthorizationResourceMatcher.ANY)
         .withResourceId("*")
         .withPermissions(PermissionType.CREATE)
         .create(DEFAULT_USER.getUsername());
@@ -87,6 +89,7 @@ public class AuthorizationCreateAuthorizationTest {
         .withOwnerId(user.getUsername())
         .withOwnerType(AuthorizationOwnerType.USER)
         .withResourceType(AuthorizationResourceType.RESOURCE)
+        .withResourceMatcher(AuthorizationResourceMatcher.ANY)
         .withResourceId("*")
         .withPermissions(PermissionType.CREATE)
         .create(user.getUsername());
@@ -112,6 +115,7 @@ public class AuthorizationCreateAuthorizationTest {
             .withOwnerId(user.getUsername())
             .withOwnerType(AuthorizationOwnerType.USER)
             .withResourceType(AuthorizationResourceType.RESOURCE)
+            .withResourceMatcher(AuthorizationResourceMatcher.ANY)
             .withResourceId("*")
             .withPermissions(PermissionType.CREATE)
             .expectRejection()
@@ -145,6 +149,7 @@ public class AuthorizationCreateAuthorizationTest {
         .withOwnerId(user.getUsername())
         .withOwnerType(AuthorizationOwnerType.USER)
         .withResourceType(authorization)
+        .withResourceMatcher(AuthorizationResourceMatcher.ANY)
         .withResourceId("*")
         .withPermissions(permissionType)
         .create(DEFAULT_USER.getUsername());

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationUpdateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationUpdateAuthorizationTest.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.AuthorizationIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.protocol.record.value.UserRecordValue;
@@ -61,6 +62,7 @@ public class AuthorizationUpdateAuthorizationTest {
             .withOwnerId(user.getUsername())
             .withOwnerType(AuthorizationOwnerType.USER)
             .withResourceType(AuthorizationResourceType.RESOURCE)
+            .withResourceMatcher(AuthorizationResourceMatcher.ANY)
             .withResourceId("*")
             .withPermissions(PermissionType.CREATE)
             .create(DEFAULT_USER.getUsername())
@@ -94,6 +96,7 @@ public class AuthorizationUpdateAuthorizationTest {
             .withOwnerId(user.getUsername())
             .withOwnerType(AuthorizationOwnerType.USER)
             .withResourceType(AuthorizationResourceType.RESOURCE)
+            .withResourceMatcher(AuthorizationResourceMatcher.ANY)
             .withResourceId("*")
             .withPermissions(PermissionType.CREATE)
             .create(DEFAULT_USER.getUsername())
@@ -126,6 +129,7 @@ public class AuthorizationUpdateAuthorizationTest {
             .withOwnerId(user.getUsername())
             .withOwnerType(AuthorizationOwnerType.USER)
             .withResourceType(AuthorizationResourceType.RESOURCE)
+            .withResourceMatcher(AuthorizationResourceMatcher.ANY)
             .withResourceId("*")
             .withPermissions(PermissionType.CREATE)
             .create(DEFAULT_USER.getUsername())
@@ -169,6 +173,7 @@ public class AuthorizationUpdateAuthorizationTest {
         .withOwnerId(user.getUsername())
         .withOwnerType(AuthorizationOwnerType.USER)
         .withResourceType(authorization)
+        .withResourceMatcher(AuthorizationResourceMatcher.ANY)
         .withResourceId("*")
         .withPermissions(permissionType)
         .create(DEFAULT_USER.getUsername());

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/CreateAuthorizationMultipartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/CreateAuthorizationMultipartitionTest.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.protocol.record.intent.AuthorizationIntent;
 import io.camunda.zeebe.protocol.record.intent.CommandDistributionIntent;
 import io.camunda.zeebe.protocol.record.intent.UserIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.CommandDistributionRecordValue;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
@@ -46,6 +47,7 @@ public class CreateAuthorizationMultipartitionTest {
             .newAuthorization()
             .withOwnerId("ownerId")
             .withOwnerType(AuthorizationOwnerType.USER)
+            .withResourceMatcher(AuthorizationResourceMatcher.ID)
             .withResourceId("resourceId")
             .withResourceType(AuthorizationResourceType.RESOURCE)
             .withPermissions(PermissionType.CREATE)
@@ -109,6 +111,7 @@ public class CreateAuthorizationMultipartitionTest {
         .newAuthorization()
         .withOwnerId("ownerId")
         .withOwnerType(AuthorizationOwnerType.USER)
+        .withResourceMatcher(AuthorizationResourceMatcher.ID)
         .withResourceId("resourceId")
         .withResourceType(AuthorizationResourceType.RESOURCE)
         .withPermissions(PermissionType.CREATE)
@@ -144,6 +147,7 @@ public class CreateAuthorizationMultipartitionTest {
         .newAuthorization()
         .withOwnerId("ownerId")
         .withOwnerType(AuthorizationOwnerType.USER)
+        .withResourceMatcher(AuthorizationResourceMatcher.ID)
         .withResourceId("resourceId")
         .withResourceType(AuthorizationResourceType.RESOURCE)
         .withPermissions(PermissionType.CREATE)
@@ -174,6 +178,7 @@ public class CreateAuthorizationMultipartitionTest {
             .newAuthorization()
             .withOwnerId(nonexistentMappingId)
             .withOwnerType(AuthorizationOwnerType.MAPPING_RULE)
+            .withResourceMatcher(AuthorizationResourceMatcher.ID)
             .withResourceId("resourceId")
             .withResourceType(AuthorizationResourceType.RESOURCE)
             .withPermissions(PermissionType.CREATE)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/CreateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/CreateAuthorizationTest.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
 import io.camunda.zeebe.protocol.record.value.AuthorizationRecordValue;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
@@ -37,6 +38,7 @@ public class CreateAuthorizationTest {
             .newAuthorization()
             .withOwnerId("ownerId")
             .withOwnerType(AuthorizationOwnerType.USER)
+            .withResourceMatcher(AuthorizationResourceMatcher.ID)
             .withResourceId("resourceId")
             .withResourceType(AuthorizationResourceType.RESOURCE)
             .withPermissions(PermissionType.CREATE)
@@ -67,6 +69,7 @@ public class CreateAuthorizationTest {
         .newAuthorization()
         .withOwnerId("ownerId")
         .withOwnerType(AuthorizationOwnerType.USER)
+        .withResourceMatcher(AuthorizationResourceMatcher.ID)
         .withResourceId("resourceId")
         .withResourceType(AuthorizationResourceType.RESOURCE)
         .withPermissions(PermissionType.CREATE)
@@ -77,6 +80,7 @@ public class CreateAuthorizationTest {
         .newAuthorization()
         .withOwnerId("ownerId")
         .withOwnerType(AuthorizationOwnerType.USER)
+        .withResourceMatcher(AuthorizationResourceMatcher.ID)
         .withResourceId("anotherResourceId")
         .withResourceType(AuthorizationResourceType.RESOURCE)
         .withPermissions(PermissionType.CREATE)
@@ -89,6 +93,7 @@ public class CreateAuthorizationTest {
             .newAuthorization()
             .withOwnerId("ownerId")
             .withOwnerType(AuthorizationOwnerType.USER)
+            .withResourceMatcher(AuthorizationResourceMatcher.ID)
             .withResourceId("resourceId")
             .withResourceType(AuthorizationResourceType.RESOURCE)
             .withPermissions(PermissionType.CREATE)
@@ -116,6 +121,7 @@ public class CreateAuthorizationTest {
             .newAuthorization()
             .withOwnerId("ownerId")
             .withOwnerType(AuthorizationOwnerType.USER)
+            .withResourceMatcher(AuthorizationResourceMatcher.ID)
             .withResourceId("resourceId")
             .withResourceType(resourceType)
             .withPermissions(
@@ -146,6 +152,7 @@ public class CreateAuthorizationTest {
             .newAuthorization()
             .withOwnerId(nonexistentMappingId)
             .withOwnerType(AuthorizationOwnerType.MAPPING_RULE)
+            .withResourceMatcher(AuthorizationResourceMatcher.ID)
             .withResourceId("resourceId")
             .withResourceType(AuthorizationResourceType.RESOURCE)
             .withPermissions(PermissionType.CREATE)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/DeleteAuthorizationMultipartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/DeleteAuthorizationMultipartitionTest.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.AuthorizationIntent;
 import io.camunda.zeebe.protocol.record.intent.CommandDistributionIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.CommandDistributionRecordValue;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
@@ -45,6 +46,7 @@ public class DeleteAuthorizationMultipartitionTest {
             .newAuthorization()
             .withOwnerId("ownerId")
             .withOwnerType(AuthorizationOwnerType.USER)
+            .withResourceMatcher(AuthorizationResourceMatcher.ID)
             .withResourceId("resourceId")
             .withResourceType(AuthorizationResourceType.RESOURCE)
             .withPermissions(PermissionType.CREATE)
@@ -114,6 +116,7 @@ public class DeleteAuthorizationMultipartitionTest {
             .newAuthorization()
             .withOwnerId("ownerId")
             .withOwnerType(AuthorizationOwnerType.USER)
+            .withResourceMatcher(AuthorizationResourceMatcher.ID)
             .withResourceId("resourceId")
             .withResourceType(AuthorizationResourceType.RESOURCE)
             .withPermissions(PermissionType.CREATE)
@@ -144,6 +147,7 @@ public class DeleteAuthorizationMultipartitionTest {
             .newAuthorization()
             .withOwnerId("ownerId")
             .withOwnerType(AuthorizationOwnerType.USER)
+            .withResourceMatcher(AuthorizationResourceMatcher.ID)
             .withResourceId("resourceId")
             .withResourceType(AuthorizationResourceType.RESOURCE)
             .withPermissions(PermissionType.CREATE)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/DeleteAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/DeleteAuthorizationTest.java
@@ -12,6 +12,7 @@ import static io.camunda.zeebe.protocol.record.Assertions.assertThat;
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
@@ -33,6 +34,7 @@ public class DeleteAuthorizationTest {
             .newAuthorization()
             .withOwnerId("ownerId")
             .withOwnerType(AuthorizationOwnerType.USER)
+            .withResourceMatcher(AuthorizationResourceMatcher.ID)
             .withResourceId("resourceId")
             .withResourceType(AuthorizationResourceType.RESOURCE)
             .withPermissions(PermissionType.CREATE)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/IdentitySetupInitializeTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/IdentitySetupInitializeTest.java
@@ -25,6 +25,7 @@ import io.camunda.zeebe.protocol.record.intent.RoleIntent;
 import io.camunda.zeebe.protocol.record.intent.TenantIntent;
 import io.camunda.zeebe.protocol.record.intent.UserIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.EntityType;
 import io.camunda.zeebe.protocol.record.value.MappingRuleRecordValue;
@@ -75,6 +76,7 @@ public class IdentitySetupInitializeTest {
         .withAuthorization(
             new AuthorizationRecord()
                 .setResourceType(AuthorizationResourceType.TENANT)
+                .setResourceMatcher(AuthorizationResourceMatcher.ID)
                 .setResourceId(tenantId)
                 .setPermissionTypes(Set.of(PermissionType.READ))
                 .setOwnerType(AuthorizationOwnerType.ROLE)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/UpdateAuthorizationMultipartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/UpdateAuthorizationMultipartitionTest.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.AuthorizationIntent;
 import io.camunda.zeebe.protocol.record.intent.CommandDistributionIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.CommandDistributionRecordValue;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
@@ -46,6 +47,7 @@ public class UpdateAuthorizationMultipartitionTest {
             .newAuthorization()
             .withOwnerId("ownerId")
             .withOwnerType(AuthorizationOwnerType.USER)
+            .withResourceMatcher(AuthorizationResourceMatcher.ID)
             .withResourceId("resourceId")
             .withResourceType(AuthorizationResourceType.RESOURCE)
             .withPermissions(PermissionType.CREATE)
@@ -115,6 +117,7 @@ public class UpdateAuthorizationMultipartitionTest {
             .newAuthorization()
             .withOwnerId("ownerId")
             .withOwnerType(AuthorizationOwnerType.USER)
+            .withResourceMatcher(AuthorizationResourceMatcher.ID)
             .withResourceId("resourceId")
             .withResourceType(AuthorizationResourceType.RESOURCE)
             .withPermissions(PermissionType.CREATE)
@@ -145,6 +148,7 @@ public class UpdateAuthorizationMultipartitionTest {
             .newAuthorization()
             .withOwnerId("ownerId")
             .withOwnerType(AuthorizationOwnerType.USER)
+            .withResourceMatcher(AuthorizationResourceMatcher.ID)
             .withResourceId("resourceId")
             .withResourceType(AuthorizationResourceType.RESOURCE)
             .withPermissions(PermissionType.CREATE)
@@ -176,6 +180,7 @@ public class UpdateAuthorizationMultipartitionTest {
             .newAuthorization()
             .withOwnerId("valid-owner")
             .withOwnerType(AuthorizationOwnerType.USER)
+            .withResourceMatcher(AuthorizationResourceMatcher.ID)
             .withResourceId("res-id")
             .withResourceType(AuthorizationResourceType.RESOURCE)
             .withPermissions(PermissionType.CREATE)
@@ -192,6 +197,7 @@ public class UpdateAuthorizationMultipartitionTest {
             .updateAuthorization(existingKey)
             .withOwnerId(nonexistentMappingRuleId)
             .withOwnerType(AuthorizationOwnerType.MAPPING_RULE)
+            .withResourceMatcher(AuthorizationResourceMatcher.ID)
             .withResourceId("res-id")
             .withResourceType(AuthorizationResourceType.RESOURCE)
             .withPermissions(PermissionType.CREATE)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/UpdateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/UpdateAuthorizationTest.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
 import io.camunda.zeebe.protocol.record.value.AuthorizationRecordValue;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
@@ -37,6 +38,7 @@ public class UpdateAuthorizationTest {
             .newAuthorization()
             .withOwnerId("ownerId")
             .withOwnerType(AuthorizationOwnerType.USER)
+            .withResourceMatcher(AuthorizationResourceMatcher.ID)
             .withResourceId("resourceId")
             .withResourceType(AuthorizationResourceType.RESOURCE)
             .withPermissions(PermissionType.CREATE)
@@ -51,6 +53,7 @@ public class UpdateAuthorizationTest {
             .updateAuthorization(authorizationKey)
             .withOwnerId("ownerId")
             .withOwnerType(AuthorizationOwnerType.GROUP)
+            .withResourceMatcher(AuthorizationResourceMatcher.ID)
             .withResourceId("resourceId")
             .withResourceType(AuthorizationResourceType.RESOURCE)
             .withPermissions(PermissionType.CREATE)
@@ -98,6 +101,7 @@ public class UpdateAuthorizationTest {
             .newAuthorization()
             .withOwnerId("ownerId")
             .withOwnerType(AuthorizationOwnerType.USER)
+            .withResourceMatcher(AuthorizationResourceMatcher.ID)
             .withResourceId("resourceId")
             .withResourceType(resourceType)
             .withPermissions(PermissionType.CREATE)
@@ -111,6 +115,7 @@ public class UpdateAuthorizationTest {
             .updateAuthorization(authorizationKey)
             .withOwnerId("ownerId")
             .withOwnerType(AuthorizationOwnerType.GROUP)
+            .withResourceMatcher(AuthorizationResourceMatcher.ID)
             .withResourceId("resourceId")
             .withResourceType(AuthorizationResourceType.RESOURCE)
             .withPermissions(PermissionType.ACCESS)
@@ -137,6 +142,7 @@ public class UpdateAuthorizationTest {
             .newAuthorization()
             .withOwnerId("existing-owner-id")
             .withOwnerType(AuthorizationOwnerType.USER)
+            .withResourceMatcher(AuthorizationResourceMatcher.ID)
             .withResourceId("resource-id")
             .withResourceType(AuthorizationResourceType.RESOURCE)
             .withPermissions(PermissionType.CREATE)
@@ -153,6 +159,7 @@ public class UpdateAuthorizationTest {
             .updateAuthorization(authorizationKey)
             .withOwnerId(nonexistentMappingRuleId)
             .withOwnerType(AuthorizationOwnerType.MAPPING_RULE)
+            .withResourceMatcher(AuthorizationResourceMatcher.ID)
             .withResourceId("resource-id")
             .withResourceType(AuthorizationResourceType.RESOURCE)
             .withPermissions(PermissionType.CREATE)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/AbstractBatchOperationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/AbstractBatchOperationTest.java
@@ -27,6 +27,7 @@ import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperation
 import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationProcessInstanceModificationPlan;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceMigrationMappingInstruction;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.BatchOperationType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
@@ -304,6 +305,7 @@ abstract class AbstractBatchOperationTest {
         .withOwnerId(user.getUsername())
         .withOwnerType(AuthorizationOwnerType.USER)
         .withResourceType(AuthorizationResourceType.BATCH)
+        .withResourceMatcher(AuthorizationResourceMatcher.ANY)
         .withResourceId("*")
         .create(DEFAULT_USER.getUsername());
   }
@@ -317,6 +319,7 @@ abstract class AbstractBatchOperationTest {
         .withOwnerId(user.getUsername())
         .withOwnerType(AuthorizationOwnerType.USER)
         .withResourceType(AuthorizationResourceType.PROCESS_DEFINITION)
+        .withResourceMatcher(AuthorizationResourceMatcher.ANY)
         .withResourceId("*")
         .create(DEFAULT_USER.getUsername());
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/clock/ClockPinAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/clock/ClockPinAuthorizationTest.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.ClockIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.protocol.record.value.UserRecordValue;
@@ -118,6 +119,7 @@ public class ClockPinAuthorizationTest {
         .withOwnerId(user.getUsername())
         .withOwnerType(AuthorizationOwnerType.USER)
         .withResourceType(authorization)
+        .withResourceMatcher(AuthorizationResourceMatcher.ANY)
         .withResourceId("*")
         .create(DEFAULT_USER.getUsername());
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateAuthorizationTest.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.protocol.record.value.UserRecordValue;
@@ -138,6 +139,7 @@ public class DeploymentCreateAuthorizationTest {
         .withOwnerId(user.getUsername())
         .withOwnerType(AuthorizationOwnerType.USER)
         .withResourceType(authorization)
+        .withResourceMatcher(AuthorizationResourceMatcher.ANY)
         .withResourceId("*")
         .create(DEFAULT_USER.getUsername());
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/MultiTenantDeploymentCreateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/MultiTenantDeploymentCreateAuthorizationTest.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.EntityType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
@@ -148,6 +149,7 @@ public class MultiTenantDeploymentCreateAuthorizationTest {
         .withOwnerId(user.getUsername())
         .withOwnerType(AuthorizationOwnerType.USER)
         .withResourceType(authorization)
+        .withResourceMatcher(AuthorizationResourceMatcher.ANY)
         .withResourceId("*")
         .create(DEFAULT_USER.getUsername());
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionIdempotencyTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionIdempotencyTest.java
@@ -75,6 +75,7 @@ import io.camunda.zeebe.protocol.record.intent.SignalIntent;
 import io.camunda.zeebe.protocol.record.intent.TenantIntent;
 import io.camunda.zeebe.protocol.record.intent.UserIntent;
 import io.camunda.zeebe.protocol.record.intent.scaling.ScaleIntent;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.BatchOperationCreationRecordValue;
 import io.camunda.zeebe.protocol.record.value.BatchOperationLifecycleManagementRecordValue;
@@ -179,6 +180,7 @@ public class CommandDistributionIdempotencyTest {
                       .authorization()
                       .newAuthorization()
                       .withOwnerId(user.getValue().getUsername())
+                      .withResourceMatcher(AuthorizationResourceMatcher.ANY)
                       .withResourceId("*")
                       .withResourceType(AuthorizationResourceType.USER)
                       .withPermissions(PermissionType.READ)
@@ -198,6 +200,7 @@ public class CommandDistributionIdempotencyTest {
                           .authorization()
                           .newAuthorization()
                           .withOwnerId(user.getValue().getUsername())
+                          .withResourceMatcher(AuthorizationResourceMatcher.ANY)
                           .withResourceId("*")
                           .withResourceType(AuthorizationResourceType.USER)
                           .withPermissions(PermissionType.READ)
@@ -221,6 +224,7 @@ public class CommandDistributionIdempotencyTest {
                           .authorization()
                           .newAuthorization()
                           .withOwnerId(user.getValue().getUsername())
+                          .withResourceMatcher(AuthorizationResourceMatcher.ANY)
                           .withResourceId("*")
                           .withResourceType(AuthorizationResourceType.USER)
                           .withPermissions(PermissionType.READ)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/dmn/DecisionEvaluationEvaluateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/dmn/DecisionEvaluationEvaluateAuthorizationTest.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.protocol.record.value.UserRecordValue;
@@ -134,6 +135,7 @@ public class DecisionEvaluationEvaluateAuthorizationTest {
         .withOwnerType(AuthorizationOwnerType.USER)
         .withResourceType(authorization)
         .withPermissions(permissionType)
+        .withResourceMatcher(AuthorizationResourceMatcher.ANY)
         .withResourceId("*")
         .create(DEFAULT_USER.getUsername());
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/IncidentResolveAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/IncidentResolveAuthorizationTest.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.protocol.record.value.UserRecordValue;
@@ -147,6 +148,7 @@ public class IncidentResolveAuthorizationTest {
         .withOwnerId(user.getUsername())
         .withOwnerType(AuthorizationOwnerType.USER)
         .withResourceType(authorization)
+        .withResourceMatcher(AuthorizationResourceMatcher.ANY)
         .withResourceId("*")
         .create(DEFAULT_USER.getUsername());
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/CompleteJobTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/CompleteJobTest.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.EntityType;
 import io.camunda.zeebe.protocol.record.value.JobBatchRecordValue;
@@ -71,6 +72,7 @@ public final class CompleteJobTest {
         .authorization()
         .newAuthorization()
         .withPermissions(PermissionType.UPDATE_PROCESS_INSTANCE)
+        .withResourceMatcher(AuthorizationResourceMatcher.ID)
         .withResourceId(PROCESS_ID)
         .withResourceType(AuthorizationResourceType.PROCESS_DEFINITION)
         .withOwnerId(username)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobCompleteAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobCompleteAuthorizationTest.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.protocol.record.value.UserRecordValue;
@@ -136,6 +137,7 @@ public class JobCompleteAuthorizationTest {
         .withOwnerId(user.getUsername())
         .withOwnerType(AuthorizationOwnerType.USER)
         .withResourceType(authorization)
+        .withResourceMatcher(AuthorizationResourceMatcher.ANY)
         .withResourceId("*")
         .create(DEFAULT_USER.getUsername());
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobFailAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobFailAuthorizationTest.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.protocol.record.value.UserRecordValue;
@@ -135,6 +136,7 @@ public class JobFailAuthorizationTest {
         .withOwnerId(user.getUsername())
         .withOwnerType(AuthorizationOwnerType.USER)
         .withResourceType(authorization)
+        .withResourceMatcher(AuthorizationResourceMatcher.ANY)
         .withResourceId("*")
         .create(DEFAULT_USER.getUsername());
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobUpdateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobUpdateAuthorizationTest.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.protocol.record.value.UserRecordValue;
@@ -143,6 +144,7 @@ public class JobUpdateAuthorizationTest {
         .withOwnerId(user.getUsername())
         .withOwnerType(AuthorizationOwnerType.USER)
         .withResourceType(authorization)
+        .withResourceMatcher(AuthorizationResourceMatcher.ANY)
         .withResourceId("*")
         .create(DEFAULT_USER.getUsername());
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/mappingrule/MappingRuleCreateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/mappingrule/MappingRuleCreateAuthorizationTest.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.MappingRuleIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.protocol.record.value.UserRecordValue;
@@ -153,6 +154,7 @@ public class MappingRuleCreateAuthorizationTest {
         .withOwnerId(user.getUsername())
         .withOwnerType(AuthorizationOwnerType.USER)
         .withResourceType(authorization)
+        .withResourceMatcher(AuthorizationResourceMatcher.ANY)
         .withResourceId("*")
         .create(DEFAULT_USER.getUsername());
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/mappingrule/MappingRuleUpdateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/mappingrule/MappingRuleUpdateAuthorizationTest.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.MappingRuleIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.protocol.record.value.UserRecordValue;
@@ -184,6 +185,7 @@ public class MappingRuleUpdateAuthorizationTest {
         .withOwnerId(user.getUsername())
         .withOwnerType(AuthorizationOwnerType.USER)
         .withResourceType(authorization)
+        .withResourceMatcher(AuthorizationResourceMatcher.ANY)
         .withResourceId("*")
         .create(DEFAULT_USER.getUsername());
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessagePublishAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessagePublishAuthorizationTest.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.MessageIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.protocol.record.value.UserRecordValue;
@@ -167,6 +168,7 @@ public class MessagePublishAuthorizationTest {
         .withOwnerId(user.getUsername())
         .withOwnerType(AuthorizationOwnerType.USER)
         .withResourceType(authorization)
+        .withResourceMatcher(AuthorizationResourceMatcher.ANY)
         .withResourceId("*")
         .create(DEFAULT_USER.getUsername());
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/role/RoleCreateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/role/RoleCreateAuthorizationTest.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.RoleIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.protocol.record.value.UserRecordValue;
@@ -116,6 +117,7 @@ public class RoleCreateAuthorizationTest {
         .withOwnerId(user.getUsername())
         .withOwnerType(AuthorizationOwnerType.USER)
         .withResourceType(authorization)
+        .withResourceMatcher(AuthorizationResourceMatcher.ANY)
         .withResourceId("*")
         .create(DEFAULT_USER.getUsername());
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/signal/SignalBroadcastAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/signal/SignalBroadcastAuthorizationTest.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.SignalIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.protocol.record.value.UserRecordValue;
@@ -168,6 +169,7 @@ public class SignalBroadcastAuthorizationTest {
         .withOwnerId(user.getUsername())
         .withOwnerType(AuthorizationOwnerType.USER)
         .withResourceType(authorization)
+        .withResourceMatcher(AuthorizationResourceMatcher.ANY)
         .withResourceId("*")
         .create(DEFAULT_USER.getUsername());
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/user/CreateInitialAdminUserAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/user/CreateInitialAdminUserAuthorizationTest.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.RoleIntent;
 import io.camunda.zeebe.protocol.record.intent.UserIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.EntityType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
@@ -70,6 +71,7 @@ public class CreateInitialAdminUserAuthorizationTest {
         .withOwnerType(AuthorizationOwnerType.ROLE)
         .withResourceType(AuthorizationResourceType.AUTHORIZATION)
         .withPermissions(PermissionType.CREATE)
+        .withResourceMatcher(AuthorizationResourceMatcher.ANY)
         .withResourceId("*")
         .create(DEFAULT_USER.getUsername());
     engine
@@ -79,6 +81,7 @@ public class CreateInitialAdminUserAuthorizationTest {
         .withOwnerType(AuthorizationOwnerType.ROLE)
         .withResourceType(AuthorizationResourceType.USER)
         .withPermissions(PermissionType.CREATE)
+        .withResourceMatcher(AuthorizationResourceMatcher.ANY)
         .withResourceId("*")
         .create(DEFAULT_USER.getUsername());
     engine
@@ -88,6 +91,7 @@ public class CreateInitialAdminUserAuthorizationTest {
         .withOwnerType(AuthorizationOwnerType.ROLE)
         .withResourceType(AuthorizationResourceType.ROLE)
         .withPermissions(PermissionType.UPDATE)
+        .withResourceMatcher(AuthorizationResourceMatcher.ANY)
         .withResourceId("*")
         .create(DEFAULT_USER.getUsername());
     engine
@@ -201,6 +205,7 @@ public class CreateInitialAdminUserAuthorizationTest {
         .withOwnerId(user.getUsername())
         .withOwnerType(AuthorizationOwnerType.USER)
         .withResourceType(authorization)
+        .withResourceMatcher(AuthorizationResourceMatcher.ANY)
         .withResourceId("*")
         .create(DEFAULT_USER.getUsername());
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/user/UserCreateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/user/UserCreateAuthorizationTest.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.UserIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.protocol.record.value.UserRecordValue;
@@ -127,6 +128,7 @@ public class UserCreateAuthorizationTest {
         .withOwnerId(user.getUsername())
         .withOwnerType(AuthorizationOwnerType.USER)
         .withResourceType(authorization)
+        .withResourceMatcher(AuthorizationResourceMatcher.ANY)
         .withResourceId("*")
         .create(DEFAULT_USER.getUsername());
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/MappingRuleAppliersTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/MappingRuleAppliersTest.java
@@ -25,6 +25,7 @@ import io.camunda.zeebe.protocol.impl.record.value.authorization.RoleRecord;
 import io.camunda.zeebe.protocol.impl.record.value.group.GroupRecord;
 import io.camunda.zeebe.protocol.impl.record.value.tenant.TenantRecord;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.EntityType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
@@ -180,6 +181,7 @@ public class MappingRuleAppliersTest {
         5L,
         new AuthorizationRecord()
             .setPermissionTypes(Set.of(PermissionType.READ))
+            .setResourceMatcher(AuthorizationResourceMatcher.ID)
             .setResourceId("process")
             .setResourceType(AuthorizationResourceType.PROCESS_DEFINITION)
             .setOwnerType(AuthorizationOwnerType.MAPPING_RULE)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/RoleAppliersTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/RoleAppliersTest.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.protocol.impl.record.value.authorization.AuthorizationRe
 import io.camunda.zeebe.protocol.impl.record.value.authorization.RoleRecord;
 import io.camunda.zeebe.protocol.impl.record.value.user.UserRecord;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.EntityType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
@@ -91,6 +92,7 @@ public class RoleAppliersTest {
         1L,
         new AuthorizationRecord()
             .setAuthorizationKey(1L)
+            .setResourceMatcher(AuthorizationResourceMatcher.ID)
             .setResourceId("role1")
             .setResourceType(AuthorizationResourceType.ROLE)
             .setPermissionTypes(Set.of(PermissionType.DELETE))
@@ -100,6 +102,7 @@ public class RoleAppliersTest {
         2L,
         new AuthorizationRecord()
             .setAuthorizationKey(2L)
+            .setResourceMatcher(AuthorizationResourceMatcher.ID)
             .setResourceId("role2")
             .setResourceType(AuthorizationResourceType.ROLE)
             .setPermissionTypes(Set.of(PermissionType.DELETE))

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/UserDeletedApplierTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/UserDeletedApplierTest.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.engine.util.ProcessingStateExtension;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.AuthorizationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.user.UserRecord;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -57,6 +58,7 @@ public class UserDeletedApplierTest {
         1L,
         new AuthorizationRecord()
             .setAuthorizationKey(1L)
+            .setResourceMatcher(AuthorizationResourceMatcher.ID)
             .setResourceId("process1")
             .setResourceType(PROCESS_DEFINITION)
             .setOwnerId(userRecord.getUsername())
@@ -66,6 +68,7 @@ public class UserDeletedApplierTest {
         2L,
         new AuthorizationRecord()
             .setAuthorizationKey(2L)
+            .setResourceMatcher(AuthorizationResourceMatcher.ID)
             .setResourceId("process2")
             .setResourceType(PROCESS_DEFINITION)
             .setOwnerId(userRecord.getUsername())
@@ -75,6 +78,7 @@ public class UserDeletedApplierTest {
         3L,
         new AuthorizationRecord()
             .setAuthorizationKey(3L)
+            .setResourceMatcher(AuthorizationResourceMatcher.ID)
             .setResourceId("definition1")
             .setResourceType(DECISION_DEFINITION)
             .setOwnerId(userRecord.getUsername())

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/AuthorizationClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/AuthorizationClient.java
@@ -12,6 +12,7 @@ import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.intent.AuthorizationIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
 import io.camunda.zeebe.protocol.record.value.AuthorizationRecordValue;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
@@ -71,6 +72,12 @@ public final class AuthorizationClient {
 
     public AuthorizationCreateClient withOwnerType(final AuthorizationOwnerType ownerType) {
       authorizationCreationRecord.setOwnerType(ownerType);
+      return this;
+    }
+
+    public AuthorizationCreateClient withResourceMatcher(
+        final AuthorizationResourceMatcher resourceMatcher) {
+      authorizationCreationRecord.setResourceMatcher(resourceMatcher);
       return this;
     }
 
@@ -189,6 +196,12 @@ public final class AuthorizationClient {
 
     public AuthorizationUpdateClient withOwnerType(final AuthorizationOwnerType ownerType) {
       authorizationUpdateRecord.setOwnerType(ownerType);
+      return this;
+    }
+
+    public AuthorizationUpdateClient withResourceMatcher(
+        final AuthorizationResourceMatcher resourceMatcher) {
+      authorizationUpdateRecord.setResourceMatcher(resourceMatcher);
       return this;
     }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/AuthorizationCreatedUpdatedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/AuthorizationCreatedUpdatedHandler.java
@@ -63,6 +63,7 @@ public class AuthorizationCreatedUpdatedHandler
         .setAuthorizationKey(value.getAuthorizationKey())
         .setOwnerId(value.getOwnerId())
         .setOwnerType(value.getOwnerType().name())
+        .setResourceMatcher(value.getResourceMatcher().value())
         .setResourceType(value.getResourceType().name())
         .setResourceId(value.getResourceId())
         .setPermissionTypes(new HashSet<>(value.getPermissionTypes()));

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/AuthorizationDeletedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/AuthorizationDeletedHandler.java
@@ -60,6 +60,7 @@ public class AuthorizationDeletedHandler
         .setOwnerId(value.getOwnerId())
         .setOwnerType(value.getOwnerType().name())
         .setResourceType(value.getResourceType().name())
+        .setResourceMatcher(value.getResourceMatcher().value())
         .setResourceId(value.getResourceId())
         .setPermissionTypes(new HashSet<>(value.getPermissionTypes()));
   }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/AuthorizationCreatedUpdatedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/AuthorizationCreatedUpdatedHandlerTest.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.AuthorizationIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
 import io.camunda.zeebe.protocol.record.value.AuthorizationRecordValue;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.ImmutableAuthorizationRecordValue;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
@@ -97,6 +98,7 @@ public class AuthorizationCreatedUpdatedHandlerTest {
             .withAuthorizationKey(456L)
             .withOwnerId("foo")
             .withOwnerType(AuthorizationOwnerType.USER)
+            .withResourceMatcher(AuthorizationResourceMatcher.ANY)
             .withResourceId("*")
             .withPermissionTypes(List.of(PermissionType.CREATE, PermissionType.DELETE))
             .build();
@@ -115,6 +117,7 @@ public class AuthorizationCreatedUpdatedHandlerTest {
             .setAuthorizationKey(789L)
             .setOwnerId("bar")
             .setOwnerType(AuthorizationOwnerType.GROUP.name())
+            .setResourceMatcher(AuthorizationResourceMatcher.ID.value())
             .setResourceId("resourceId")
             .setPermissionTypes(Set.of(PermissionType.UPDATE));
     underTest.updateEntity(authorizationRecord, authorizationEntity);
@@ -125,6 +128,8 @@ public class AuthorizationCreatedUpdatedHandlerTest {
     assertThat(authorizationEntity.getOwnerId()).isEqualTo(authorizationRecordValue.getOwnerId());
     assertThat(authorizationEntity.getOwnerType())
         .isEqualTo(authorizationRecordValue.getOwnerType().name());
+    assertThat(authorizationEntity.getResourceMatcher())
+        .isEqualTo(authorizationRecordValue.getResourceMatcher().value());
     assertThat(authorizationEntity.getResourceId())
         .isEqualTo(authorizationRecordValue.getResourceId());
     assertThat(authorizationEntity.getPermissionTypes())

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/AuthorizationExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/AuthorizationExportHandler.java
@@ -49,6 +49,7 @@ public class AuthorizationExportHandler implements RdbmsExportHandler<Authorizat
         .ownerId(authorization.getOwnerId())
         .ownerType(authorization.getOwnerType().name())
         .resourceType(authorization.getResourceType().name())
+        .resourceMatcher(authorization.getResourceMatcher().value())
         .resourceId(authorization.getResourceId())
         .permissionTypes(authorization.getPermissionTypes())
         .build();

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
@@ -127,6 +127,7 @@ import io.camunda.zeebe.gateway.protocol.rest.VariableResult;
 import io.camunda.zeebe.gateway.protocol.rest.VariableSearchQueryResult;
 import io.camunda.zeebe.gateway.protocol.rest.VariableSearchResult;
 import io.camunda.zeebe.gateway.rest.util.KeyUtil;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import java.util.Collections;
 import java.util.List;
@@ -1045,12 +1046,17 @@ public final class SearchQueryResponseMapper {
   }
 
   public static AuthorizationResult toAuthorization(final AuthorizationEntity authorization) {
+    // TODO: handle with WILDCARD constant
+    final var resourceId =
+        (AuthorizationResourceMatcher.ANY.value() == authorization.resourceMatcher())
+            ? "*"
+            : authorization.resourceId();
     return new AuthorizationResult()
         .authorizationKey(KeyUtil.keyToString(authorization.authorizationKey()))
         .ownerId(authorization.ownerId())
         .ownerType(OwnerTypeEnum.fromValue(authorization.ownerType()))
         .resourceType(ResourceTypeEnum.valueOf(authorization.resourceType()))
-        .resourceId(authorization.resourceId())
+        .resourceId(resourceId)
         .permissionTypes(
             authorization.permissionTypes().stream()
                 .map(PermissionType::name)

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/AuthorizationControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/AuthorizationControllerTest.java
@@ -26,6 +26,7 @@ import io.camunda.zeebe.gateway.protocol.rest.ResourceTypeEnum;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.AuthorizationRecord;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import java.net.URI;
@@ -79,6 +80,7 @@ public class AuthorizationControllerTest extends RestControllerTest {
             .setAuthorizationKey(authorizationKey)
             .setOwnerId(ownerId)
             .setOwnerType(AuthorizationOwnerType.USER)
+            .setResourceMatcher(AuthorizationResourceMatcher.ID)
             .setResourceId(resourceId)
             .setResourceType(AuthorizationResourceType.PROCESS_DEFINITION)
             .setPermissionTypes(Set.of(PermissionType.CREATE));
@@ -181,6 +183,7 @@ public class AuthorizationControllerTest extends RestControllerTest {
             .setAuthorizationKey(authorizationKey)
             .setOwnerId(ownerId)
             .setOwnerType(AuthorizationOwnerType.USER)
+            .setResourceMatcher(AuthorizationResourceMatcher.ID)
             .setResourceId(resourceId)
             .setResourceType(AuthorizationResourceType.PROCESS_DEFINITION)
             .setPermissionTypes(Set.of(PermissionType.CREATE));

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/AuthorizationQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/AuthorizationQueryControllerTest.java
@@ -26,6 +26,7 @@ import io.camunda.service.exception.ErrorMapper;
 import io.camunda.zeebe.gateway.protocol.rest.OwnerTypeEnum;
 import io.camunda.zeebe.gateway.protocol.rest.ResourceTypeEnum;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import java.util.List;
 import java.util.Set;
@@ -75,6 +76,7 @@ public class AuthorizationQueryControllerTest extends RestControllerTest {
                       "foo",
                       OwnerTypeEnum.USER.getValue(),
                       ResourceTypeEnum.PROCESS_DEFINITION.getValue(),
+                      AuthorizationResourceMatcher.ID.value(),
                       "2",
                       Set.of(PermissionType.CREATE))))
           .startCursor("f")
@@ -101,6 +103,7 @@ public class AuthorizationQueryControllerTest extends RestControllerTest {
             "ownerId",
             OwnerTypeEnum.USER.getValue(),
             ResourceTypeEnum.PROCESS_DEFINITION.getValue(),
+            AuthorizationResourceMatcher.ID.value(),
             "resourceId",
             Set.of(PermissionType.CREATE));
 

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerAuthorizationRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerAuthorizationRequest.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.protocol.impl.record.value.authorization.AuthorizationRe
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.AuthorizationIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.util.buffer.BufferWriter;
@@ -39,6 +40,12 @@ public class BrokerAuthorizationRequest extends BrokerExecuteCommand<Authorizati
 
   public BrokerAuthorizationRequest setOwnerType(final AuthorizationOwnerType ownerType) {
     requestDto.setOwnerType(ownerType);
+    return this;
+  }
+
+  public BrokerAuthorizationRequest setResourceMatcher(
+      final AuthorizationResourceMatcher resourceMatcher) {
+    requestDto.setResourceMatcher(resourceMatcher);
     return this;
   }
 

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/authorization/AuthorizationRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/authorization/AuthorizationRecord.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.msgpack.value.StringValue;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
 import io.camunda.zeebe.protocol.record.value.AuthorizationRecordValue;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.util.buffer.BufferUtil;
@@ -30,6 +31,7 @@ public final class AuthorizationRecord extends UnifiedRecordValue
   private static final StringValue AUTHORIZATION_KEY_KEY = new StringValue("authorizationKey");
   private static final StringValue OWNER_ID_KEY = new StringValue("ownerId");
   private static final StringValue OWNER_TYPE_KEY = new StringValue("ownerType");
+  private static final StringValue RESOURCE_MATCHER = new StringValue("resourceMatcher");
   private static final StringValue RESOURCE_ID_KEY = new StringValue("resourceId");
   private static final StringValue RESOURCE_TYPE_KEY = new StringValue("resourceType");
   private static final StringValue PERMISSION_TYPES_KEY = new StringValue("permissionTypes");
@@ -39,6 +41,11 @@ public final class AuthorizationRecord extends UnifiedRecordValue
   private final EnumProperty<AuthorizationOwnerType> ownerTypeProp =
       new EnumProperty<>(
           OWNER_TYPE_KEY, AuthorizationOwnerType.class, AuthorizationOwnerType.UNSPECIFIED);
+  private final EnumProperty<AuthorizationResourceMatcher> resourceMatcherProp =
+      new EnumProperty<>(
+          RESOURCE_MATCHER,
+          AuthorizationResourceMatcher.class,
+          AuthorizationResourceMatcher.UNSPECIFIED);
   private final StringProperty resourceIdProp = new StringProperty(RESOURCE_ID_KEY, "");
   private final EnumProperty<AuthorizationResourceType> resourceTypeProp =
       new EnumProperty<>(
@@ -49,10 +56,11 @@ public final class AuthorizationRecord extends UnifiedRecordValue
       new ArrayProperty<>(PERMISSION_TYPES_KEY, StringValue::new);
 
   public AuthorizationRecord() {
-    super(6);
+    super(7);
     declareProperty(authorizationKeyProp)
         .declareProperty(ownerIdProp)
         .declareProperty(ownerTypeProp)
+        .declareProperty(resourceMatcherProp)
         .declareProperty(resourceIdProp)
         .declareProperty(resourceTypeProp)
         .declareProperty(permissionTypesProp);
@@ -81,6 +89,17 @@ public final class AuthorizationRecord extends UnifiedRecordValue
   @Override
   public AuthorizationOwnerType getOwnerType() {
     return ownerTypeProp.getValue();
+  }
+
+  @Override
+  public AuthorizationResourceMatcher getResourceMatcher() {
+    return resourceMatcherProp.getValue();
+  }
+
+  public AuthorizationRecord setResourceMatcher(
+      final AuthorizationResourceMatcher resourceMatcher) {
+    resourceMatcherProp.setValue(resourceMatcher);
+    return this;
   }
 
   @Override

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -84,6 +84,7 @@ import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.BatchOperationType;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
@@ -2855,6 +2856,7 @@ final class JsonSerializableToJsonTest {
                     .setAuthorizationKey(1L)
                     .setOwnerId("ownerId")
                     .setOwnerType(AuthorizationOwnerType.USER)
+                    .setResourceMatcher(AuthorizationResourceMatcher.ID)
                     .setResourceId("resourceId")
                     .setResourceType(AuthorizationResourceType.RESOURCE)
                     .setPermissionTypes(Set.of(PermissionType.CREATE)),
@@ -2863,6 +2865,7 @@ final class JsonSerializableToJsonTest {
           "authorizationKey": 1,
           "ownerId": "ownerId",
           "ownerType": "USER",
+          "resourceMatcher": "ID",
           "resourceId": "resourceId",
           "resourceType": "RESOURCE",
           "permissionTypes": [
@@ -2882,6 +2885,7 @@ final class JsonSerializableToJsonTest {
           "authorizationKey": -1,
           "ownerId": "",
           "ownerType": "UNSPECIFIED",
+          "resourceMatcher": "UNSPECIFIED",
           "resourceId": "",
           "resourceType": "UNSPECIFIED",
           "permissionTypes": []
@@ -3194,6 +3198,7 @@ final class JsonSerializableToJsonTest {
                             .setOwnerId("id2")
                             .setOwnerType(AuthorizationOwnerType.MAPPING_RULE)
                             .setResourceType(AuthorizationResourceType.RESOURCE)
+                            .setResourceMatcher(AuthorizationResourceMatcher.ID)
                             .setResourceId("resource-id")
                             .setPermissionTypes(Set.of(PermissionType.CREATE))),
         """
@@ -3273,6 +3278,7 @@ final class JsonSerializableToJsonTest {
             "authorizationKey": -1,
             "ownerId": "id2",
             "ownerType": "MAPPING_RULE",
+            "resourceMatcher": "ID",
             "resourceId": "resource-id",
             "resourceType": "RESOURCE",
             "permissionTypes": ["CREATE"]

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AuthorizationRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AuthorizationRecordValue.java
@@ -30,6 +30,8 @@ public interface AuthorizationRecordValue extends RecordValue {
 
   AuthorizationOwnerType getOwnerType();
 
+  AuthorizationResourceMatcher getResourceMatcher();
+
   String getResourceId();
 
   AuthorizationResourceType getResourceType();


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Restructure the Authorizations and Permissions data model by adding an `AuthorizationResourceMatcher` enum that will provide context if the provided `resourceId` for the authorization/permission assignment is an actual String-based resource ID, or a wildcard character meant to allow the permission for all resources of the specified type.

The changes are applied to:
- the "entity" classes (`AuthorizationRecord (Zeebe)`, `PersistedAuthorization (RocksDb)`, `AuthorizationDbModel (RDBMS)`, and `AuthorizationEntity (WebApps/ES/OS)`)
- With the refactoring of the `AuthorizationRecord` and `PersistedAuthorization`, the new property is already persisted in RocksDB.
- For the new property to be persisted to secondary storage, the following was refactored:
   - Refactored RDBMS schema for Authorizations
   - Refactored ES/OS templates for Authorizations
   - Refactored ES/OS/RDBMS exporter handlers.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

related to #29453
closes #36156
