### PR TITLE
Downgrade surefire version to 3.5.2 to allow running ArchUnit tests in the CI

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,7 +5,7 @@
     "config:recommended"
   ],
   "commitMessagePrefix": "deps:",
-  "baseBranches": [
+  "baseBranchPatterns": [
     "/^stable\\/8\\.([5-9]|[1-9][0-9])/",
     "stable/operate-8.5",
     "main"

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -312,6 +312,16 @@
       "addLabels": [
         "automerge"
       ]
+    },
+    {
+      "description": "Skip maven-surefire-plugin updates, as 3.5.3 version has a bug preventing ArchUnit tests from running. https://issues.apache.org/jira/browse/SUREFIRE-2298",
+      "matchManagers": [
+        "maven"
+      ],
+      "matchPackageNames": [
+        "org.apache.maven.plugins:maven-surefire-plugin"
+      ],
+      "enabled": false
     }
   ],
   "dockerfile": {

--- a/clients/java/src/main/java/io/camunda/client/api/command/enums/JobResultType.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/enums/JobResultType.java
@@ -13,18 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.camunda.client.api.command;
+package io.camunda.client.api.command.enums;
 
-import io.camunda.client.api.command.enums.JobResultType;
-
-public interface CompleteJobResult {
-
-  /**
-   * Get the type of the job result. Depending on the type, different fields will be set on the
-   * request. These fields are used to perform follow-up actions on the job upon completion. Eg:
-   * changing the assignee of a user task, or activating certain elements of an ad-hoc sub process.
-   *
-   * @return the type of the job result
-   */
-  JobResultType getType();
+public enum JobResultType {
+  USER_TASK,
+  AD_HOC_SUB_PROCESS
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/command/CompleteAdHocSubProcessJobResultImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/CompleteAdHocSubProcessJobResultImpl.java
@@ -18,7 +18,7 @@ package io.camunda.client.impl.command;
 import io.camunda.client.api.JsonMapper;
 import io.camunda.client.api.command.CompleteAdHocSubProcessResultStep1;
 import io.camunda.client.api.command.CompleteAdHocSubProcessResultStep1.CompleteAdHocSubProcessResultStep2;
-import io.camunda.client.protocol.rest.JobResult.TypeEnum;
+import io.camunda.client.api.command.enums.JobResultType;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -40,8 +40,8 @@ public class CompleteAdHocSubProcessJobResultImpl
   }
 
   @Override
-  public TypeEnum getType() {
-    return TypeEnum.AD_HOC_SUB_PROCESS;
+  public JobResultType getType() {
+    return JobResultType.AD_HOC_SUB_PROCESS;
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/client/impl/command/CompleteUserTaskJobResultImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/CompleteUserTaskJobResultImpl.java
@@ -17,7 +17,7 @@ package io.camunda.client.impl.command;
 
 import io.camunda.client.api.command.CompleteUserTaskJobResultStep1;
 import io.camunda.client.api.command.JobResultCorrections;
-import io.camunda.client.protocol.rest.JobResult.TypeEnum;
+import io.camunda.client.api.command.enums.JobResultType;
 import java.util.List;
 import java.util.function.UnaryOperator;
 
@@ -115,7 +115,7 @@ public class CompleteUserTaskJobResultImpl implements CompleteUserTaskJobResultS
   }
 
   @Override
-  public TypeEnum getType() {
-    return TypeEnum.USER_TASK;
+  public JobResultType getType() {
+    return JobResultType.USER_TASK;
   }
 }

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -221,7 +221,7 @@
     <plugin.version.shade>3.6.0</plugin.version.shade>
     <plugin.version.sonar>3.9.1.2184</plugin.version.sonar>
     <plugin.version.spotbugs>4.9.3.2</plugin.version.spotbugs>
-    <plugin.version.surefire>3.5.3</plugin.version.surefire>
+    <plugin.version.surefire>3.5.2</plugin.version.surefire>
     <plugin.version.versions>2.18.0</plugin.version.versions>
     <plugin.version.frontend-maven>1.15.1</plugin.version.frontend-maven>
     <plugin.version.maven-source>3.3.1</plugin.version.maven-source>

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessDefinitionQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessDefinitionQueryControllerTest.java
@@ -519,7 +519,7 @@ public class ProcessDefinitionQueryControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_JSON)
         .expectBody()
-        .json(EXPECTED_SEARCH_RESPONSE);
+        .json(EXPECTED_SEARCH_RESPONSE, JsonCompareMode.STRICT);
 
     verify(processDefinitionServices)
         .search(new ProcessDefinitionQuery.Builder().filter(filter).build());

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/authentication/SaasTokenControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/authentication/SaasTokenControllerTest.java
@@ -17,6 +17,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.json.JsonCompareMode;
 
 class SaasTokenControllerTest {
   private static final String BASE_PATH = "/v2/authentication/me";
@@ -67,7 +68,7 @@ class SaasTokenControllerTest {
           .expectStatus()
           .isOk()
           .expectBody()
-          .json("{b: 'blah'}");
+          .json("{b: 'blah'}", JsonCompareMode.STRICT);
     }
 
     @Test


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
ArchUnit tests are not run by maven in the CI, [example](https://github.com/camunda/camunda/actions/runs/16575771445/job/46879594559)
```
[INFO] Tests run: 0, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 6.988 s -- in io.camunda.zeebe.ForbidWebStereotypeTest
```

This is due to a bug in surefire plugin in 3.5.3 version. see https://github.com/TNG/ArchUnit/issues/1442 and https://issues.apache.org/jira/browse/SUREFIRE-2298
Downgrading it to 3.5.2 and stopping Renovate from updating it, until it gets fixed

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
