### PR TITLE
refactor: migrate users.spec.ts to OC

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityUsersPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityUsersPage.ts
@@ -98,10 +98,8 @@ export class IdentityUsersPage {
         exact: true,
       },
     );
-
     this.editUserModal = page.getByRole('dialog', {
       name: 'Edit user',
-      exact: true,
     });
     this.closeEditUserModal = this.editUserModal.getByRole('button', {
       name: 'Close',
@@ -184,6 +182,18 @@ export class IdentityUsersPage {
     await waitForItemInList(this.page, item, {
       emptyStateLocator: this.emptyState,
     });
+  }
+
+  async editUser(
+    currentUser: {email: string},
+    updatedUser: {name: string; email: string},
+  ) {
+    await this.editUserButton(currentUser.email).click();
+    await expect(this.editUserModal).toBeVisible();
+    await this.editNameField.fill(updatedUser.name);
+    await this.editEmailField.fill(updatedUser.email);
+    await this.editUserModalUpdateButton.click();
+    await expect(this.editUserModal).toBeHidden();
   }
 
   async deleteUser(user: {username: string; email: string}) {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/common-flows/identity-users-flows.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/common-flows/identity-users-flows.spec.ts
@@ -1,0 +1,73 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {test} from 'fixtures';
+import {navigateToApp} from '@pages/UtilitiesPage';
+import {expect} from '@playwright/test';
+import {captureScreenshot, captureFailureVideo} from '@setup';
+import {relativizePath, Paths} from 'utils/relativizePath';
+
+test.describe('Users Page Tests', () => {
+  test.beforeEach(async ({loginPage, page}) => {
+    await navigateToApp(page, 'identity');
+    await loginPage.login('demo', 'demo');
+  });
+
+  test.afterEach(async ({page}, testInfo) => {
+    await captureScreenshot(page, testInfo);
+    await captureFailureVideo(page, testInfo);
+  });
+
+  const TEST_USER = {
+    username: 'yuliia',
+    password: 'yuliia',
+    email: 'yuliia@example.com',
+  };
+
+  test('Admin user can delete user', async ({
+    page,
+    loginPage,
+    identityUsersPage,
+    identityHeader,
+  }) => {
+    await expect(identityUsersPage.usersList).toBeVisible();
+    await expect(identityUsersPage.usersList).toContainText(TEST_USER.username);
+    await identityUsersPage.deleteUser(TEST_USER);
+    await identityHeader.logout();
+    await expect(page).toHaveURL(
+      `${relativizePath(Paths.login('identity'))}?next=/identity/`,
+    );
+
+    await test.step(`Deleted user cannot access Identity`, async () => {
+      await navigateToApp(page, `identity`);
+      await loginPage.login(TEST_USER.username, TEST_USER.password);
+      await expect(page).toHaveURL(new RegExp(`identity`));
+      await expect(loginPage.errorMessage).toContainText(
+        /Username and [Pp]assword do(?: not|n't) match/,
+      );
+    });
+
+    await test.step(`Deleted user cannot access Tasklist`, async () => {
+      await navigateToApp(page, `tasklist`);
+      await loginPage.login('yuliia', 'yuliia');
+      await expect(page).toHaveURL(new RegExp(`tasklist`));
+      await expect(loginPage.errorMessage).toContainText(
+        /Username and [Pp]assword do(?: not|n't) match/,
+      );
+    });
+
+    await test.step(`Deleted user cannot access Operate`, async () => {
+      await navigateToApp(page, `operate`);
+      await loginPage.login('yuliia', 'yuliia');
+      await expect(page).toHaveURL(new RegExp(`operate`));
+      await expect(loginPage.errorMessage).toContainText(
+        /Username and [Pp]assword do(?: not|n't) match/,
+      );
+    });
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/users.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/users.spec.ts
@@ -6,16 +6,35 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {test} from 'fixtures';
-import {navigateToApp} from '@pages/UtilitiesPage';
 import {expect} from '@playwright/test';
-import {captureScreenshot, captureFailureVideo} from '@setup';
+import {test} from 'fixtures';
 import {relativizePath, Paths} from 'utils/relativizePath';
+import {LOGIN_CREDENTIALS, createTestData} from 'utils/constants';
+import {waitForItemInList} from 'utils/waitForItemInList';
+import {navigateToApp} from '@pages/UtilitiesPage';
+import {captureScreenshot, captureFailureVideo} from '@setup';
 
-test.describe('Users Page Tests', () => {
-  test.beforeEach(async ({loginPage, page}) => {
-    await navigateToApp(page, 'identity');
-    await loginPage.login('demo', 'demo');
+test.beforeEach(async ({page, loginPage}) => {
+  await navigateToApp(page, 'identity');
+  await loginPage.login(LOGIN_CREDENTIALS.username, LOGIN_CREDENTIALS.password);
+  await expect(page).toHaveURL(relativizePath(Paths.users()));
+});
+
+test.describe.serial('users CRUD', () => {
+  let NEW_USER: NonNullable<ReturnType<typeof createTestData>['user']>;
+  let EDITED_USER: typeof NEW_USER;
+
+  test.beforeAll(() => {
+    const testData = createTestData({
+      user: true,
+    });
+    NEW_USER = testData.user!;
+    EDITED_USER = {
+      ...NEW_USER,
+      name: `Edited ${NEW_USER.name}`,
+      email: `edited.${NEW_USER.email}`,
+      password: `edited${NEW_USER.password}`,
+    };
   });
 
   test.afterEach(async ({page}, testInfo) => {
@@ -23,51 +42,22 @@ test.describe('Users Page Tests', () => {
     await captureFailureVideo(page, testInfo);
   });
 
-  const TEST_USER = {
-    username: 'yuliia',
-    password: 'yuliia',
-    email: 'yuliia@example.com',
-  };
+  test('create a user', async ({identityUsersPage}) => {
+    await expect(identityUsersPage.userCell('demo@example.com')).toBeVisible();
+    await identityUsersPage.createUser(NEW_USER);
+    await expect(identityUsersPage.userCell(NEW_USER.email)).toBeVisible();
+  });
 
-  test('Admin user can delete user', async ({
-    page,
-    loginPage,
-    identityUsersPage,
-    identityHeader,
-  }) => {
-    await expect(identityUsersPage.usersList).toBeVisible();
-    await expect(identityUsersPage.usersList).toContainText(TEST_USER.username);
-    await identityUsersPage.deleteUser(TEST_USER);
-    await identityHeader.logout();
-    await expect(page).toHaveURL(
-      `${relativizePath(Paths.login('identity'))}?next=/identity/`,
-    );
+  test('edit a user', async ({identityUsersPage, page}) => {
+    await expect(identityUsersPage.userCell(NEW_USER.email)).toBeVisible();
+    await identityUsersPage.editUser(NEW_USER, EDITED_USER);
+    const item = identityUsersPage.userCell(EDITED_USER.email);
+    await waitForItemInList(page, item);
+  });
 
-    await test.step(`Deleted user cannot access Identity`, async () => {
-      await navigateToApp(page, `identity`);
-      await loginPage.login(TEST_USER.username, TEST_USER.password);
-      await expect(page).toHaveURL(new RegExp(`identity`));
-      await expect(loginPage.errorMessage).toContainText(
-        /Username and [Pp]assword do(?: not|n't) match/,
-      );
-    });
-
-    await test.step(`Deleted user cannot access Tasklist`, async () => {
-      await navigateToApp(page, `tasklist`);
-      await loginPage.login('yuliia', 'yuliia');
-      await expect(page).toHaveURL(new RegExp(`tasklist`));
-      await expect(loginPage.errorMessage).toContainText(
-        /Username and [Pp]assword do(?: not|n't) match/,
-      );
-    });
-
-    await test.step(`Deleted user cannot access Operate`, async () => {
-      await navigateToApp(page, `operate`);
-      await loginPage.login('yuliia', 'yuliia');
-      await expect(page).toHaveURL(new RegExp(`operate`));
-      await expect(loginPage.errorMessage).toContainText(
-        /Username and [Pp]assword do(?: not|n't) match/,
-      );
-    });
+  test('delete a user', async ({identityUsersPage}) => {
+    await expect(identityUsersPage.userCell(EDITED_USER.name)).toBeVisible();
+    await identityUsersPage.deleteUser(EDITED_USER);
+    await expect(identityUsersPage.userCell(EDITED_USER.name)).toBeHidden();
   });
 });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/.auth
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/.auth
@@ -1,1 +1,25 @@
-{}
+{
+  "cookies": [
+    {
+      "name": "camunda-session",
+      "value": "E6460CA4AB66AA3B1AF33B0DB43E4609",
+      "domain": "localhost",
+      "path": "/",
+      "expires": -1,
+      "httpOnly": true,
+      "secure": false,
+      "sameSite": "Lax"
+    },
+    {
+      "name": "X-CSRF-TOKEN",
+      "value": "a76bbda0-3856-4640-9919-7a0c5b008e03",
+      "domain": "localhost",
+      "path": "/",
+      "expires": -1,
+      "httpOnly": true,
+      "secure": true,
+      "sameSite": "Lax"
+    }
+  ],
+  "origins": []
+}


### PR DESCRIPTION
## Description
This PR migrates `users.spec.ts` from identity test suite to OC
Changes Made:
✅ Core Migration
- Replaced hardcoded test data with createTestData() for unique test isolation
- Converted inline locators to [userCell()](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) page object methods
- Added [editUser()](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) function to encapsulate user editing workflow

✅ Test Organization
- Moved "Admin user can delete user" test to common-flows/identity-users-flows.spec.ts as Test validates deletion across Identity, Tasklist, and Operate components

🧪 [Successful test run](https://github.com/camunda/camunda/actions/runs/16588583464/job/46918786612), Tests failed due to below issues:
https://github.com/camunda/camunda/issues/34148
https://github.com/camunda/camunda/issues/35443
## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #35722
