### PR TITLE
test: don't overwrite working directory if already set

### DIFF
--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestSpringApplication.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestSpringApplication.java
@@ -211,6 +211,13 @@ public abstract class TestSpringApplication<T extends TestSpringApplication<T>>
         "workingDirectory", new WorkingDirectory(directory, false), WorkingDirectory.class);
   }
 
+  /** Returns the broker's working directory if it is already set, or null otherwise. */
+  public final Path getWorkingDirectory() {
+    return Optional.ofNullable(bean(WorkingDirectory.class))
+        .map(WorkingDirectory::path)
+        .orElse(null);
+  }
+
   public final Optional<AuthenticationMethod> apiAuthenticationMethod() {
     if (property(AuthenticationProperties.API_UNPROTECTED, Boolean.class, true)) {
       return Optional.empty();

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/junit/ZeebeIntegrationExtension.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/junit/ZeebeIntegrationExtension.java
@@ -227,6 +227,9 @@ final class ZeebeIntegrationExtension
 
   private void setWorkingDirectory(
       final Path directory, final MemberId id, final TestStandaloneBroker broker) {
+    if (broker.getWorkingDirectory() != null) {
+      return;
+    }
     final Path workingDirectory = directory.resolve("broker-" + id.id());
     try {
       Files.createDirectory(workingDirectory);


### PR DESCRIPTION
This prevents `ZeebeIntegrationExtension` from overwriting a working directory if it was already specified by the user calling `TestSpringApplication#withWorkingDirectory` before.
