### PR TITLE
feat: ad-hoc sub-process: allow intermediate catch events without outgoing sequence flows

### DIFF
--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/AdHocSubProcessValidator.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/AdHocSubProcessValidator.java
@@ -20,7 +20,6 @@ import io.camunda.zeebe.model.bpmn.instance.AdHocSubProcess;
 import io.camunda.zeebe.model.bpmn.instance.EndEvent;
 import io.camunda.zeebe.model.bpmn.instance.ExtensionElements;
 import io.camunda.zeebe.model.bpmn.instance.FlowElement;
-import io.camunda.zeebe.model.bpmn.instance.IntermediateCatchEvent;
 import io.camunda.zeebe.model.bpmn.instance.StartEvent;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeAdHoc;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeAdHocImplementationType;
@@ -55,11 +54,6 @@ public final class AdHocSubProcessValidator implements ModelElementValidator<AdH
 
     if (hasEndEvent(flowElements)) {
       validationResultCollector.addError(0, "Must not contain an end event.");
-    }
-
-    if (hasSingleIntermediateCatchEvent(flowElements)) {
-      validationResultCollector.addError(
-          0, "Any intermediate catch event must have an outgoing sequence flow.");
     }
   }
 
@@ -105,12 +99,5 @@ public final class AdHocSubProcessValidator implements ModelElementValidator<AdH
 
   private static boolean hasEndEvent(final Collection<FlowElement> flowElements) {
     return flowElements.stream().anyMatch(EndEvent.class::isInstance);
-  }
-
-  private static boolean hasSingleIntermediateCatchEvent(
-      final Collection<FlowElement> flowElements) {
-    return flowElements.stream()
-        .filter(IntermediateCatchEvent.class::isInstance)
-        .anyMatch(flowElement -> ((IntermediateCatchEvent) flowElement).getOutgoing().isEmpty());
   }
 }

--- a/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/AdHocSubProcessValidatorTest.java
+++ b/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/AdHocSubProcessValidatorTest.java
@@ -108,11 +108,7 @@ class AdHocSubProcessValidatorTest {
         process(adHocSubProcess -> adHocSubProcess.intermediateCatchEvent().signal("signal"));
 
     // when/then
-    ProcessValidationUtil.assertThatProcessHasViolations(
-        process,
-        expect(
-            AdHocSubProcess.class,
-            "Any intermediate catch event must have an outgoing sequence flow."));
+    ProcessValidationUtil.assertThatProcessIsValid(process);
   }
 
   @Test


### PR DESCRIPTION
## Description

Allows to deploy an ad-hoc sub-process containing an intermediate catch event without outgoing sequence flows:

<img width="582" height="218" alt="image" src="https://github.com/user-attachments/assets/3b7ce48d-cb46-4635-9434-91dfcd4350de" />

Docs PR: https://github.com/camunda/camunda-docs/pull/6299

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #31576
closes https://github.com/camunda/ad-hoc-sub-process-phase-3/issues/23
