### PR TITLE
feat: extract operationReference into reusable schema

### DIFF
--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -6642,12 +6642,7 @@ components:
       nullable: true
       properties:
         operationReference:
-          description: |
-            A reference key chosen by the user that will be part of all records resulting from this operation.
-            Must be > 0 if provided.
-          type: integer
-          format: int64
-          minimum: 1
+          $ref: '#/components/schemas/OperationReference'
     ElementInstanceSearchQuerySortRequest:
       type: object
       properties:
@@ -8903,12 +8898,7 @@ components:
         changeset:
           $ref: "#/components/schemas/JobChangeset"
         operationReference:
-          description: |
-            A reference key chosen by the user that will be part of all records resulting from this operation.
-            Must be > 0 if provided.
-          type: integer
-          format: int64
-          minimum: 1
+          $ref: '#/components/schemas/OperationReference'
       required:
         - changeset
     JobChangeset:
@@ -9768,7 +9758,13 @@ components:
         - ASC
         - DESC
       default: ASC
-
+    OperationReference:
+      description: |
+        A reference key chosen by the user that will be part of all records resulting from this operation.
+        Must be > 0 if provided.
+      type: integer
+      format: int64
+      minimum: 1
     MessageCorrelationRequest:
       type: object
       properties:
@@ -10096,12 +10092,7 @@ components:
       type: object
       properties:
         operationReference:
-          description: |
-            A reference key chosen by the user that will be part of all records resulting from this operation.
-            Must be >0 if provided.
-          type: integer
-          format: int64
-          minimum: 1
+          $ref: '#/components/schemas/OperationReference'
 
     ProcessInstanceCreationInstruction:
       type: object
@@ -10128,12 +10119,7 @@ components:
           description: The tenant ID of the process definition.
           type: string
         operationReference:
-          description: |
-            A reference key chosen by the user that will be part of all records resulting from this operation.
-            Must be >0 if provided.
-          type: integer
-          format: int64
-          minimum: 1
+          $ref: '#/components/schemas/OperationReference'
         startInstructions:
           description: |
             List of start instructions. By default, the process instance will start at
@@ -10286,11 +10272,7 @@ components:
           items:
             $ref: "#/components/schemas/MigrateProcessInstanceMappingInstruction"
         operationReference:
-          description: |
-            A reference key chosen by the user that will be part of all records resulting from this operation. Must be > 0 if provided.
-          type: integer
-          format: int64
-          minimum: 1
+          $ref: '#/components/schemas/OperationReference'
         targetProcessDefinitionKey:
           description: The key of process definition to migrate the process instance to.
           type: string
@@ -10315,11 +10297,7 @@ components:
       type: object
       properties:
         operationReference:
-          description: |
-            A reference key chosen by the user that will be part of all records resulting from this operation. Must be > 0 if provided.
-          type: integer
-          format: int64
-          minimum: 1
+          $ref: '#/components/schemas/OperationReference'
         activateInstructions:
           description: Instructions describing which elements should be activated in which scopes and which variables should be created.
           type: array
@@ -10407,12 +10385,7 @@ components:
           type: boolean
           default: false
         operationReference:
-          description: >
-            A reference key chosen by the user that will be part of all records resulting from this operation.
-            Must be > 0 if provided.
-          type: integer
-          format: int64
-          minimum: 1
+          $ref: '#/components/schemas/OperationReference'
       required:
         - variables
 
@@ -10421,12 +10394,7 @@ components:
       nullable: true
       properties:
         operationReference:
-          description: |
-            A reference key chosen by the user that will be part of all records resulting from this operation.
-            Must be > 0 if provided.
-          type: integer
-          format: int64
-          minimum: 1
+          $ref: '#/components/schemas/OperationReference'
 
     SignalBroadcastRequest:
       type: object


### PR DESCRIPTION
## Description

Extract `operationReference` property in `rest-api.yml` into reusable schema

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #34545
