### PR TITLE
feat: allowing user-tasks to search by more than one tenantId

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/UserTaskFilter.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/UserTaskFilter.java
@@ -153,10 +153,18 @@ public interface UserTaskFilter extends SearchRequestFilter {
   /**
    * Filters user tasks by the specified tenant ID.
    *
-   * @param tenantId the tenant ID of the user task
+   * @param tenantId representing the tenant associated with this task
    * @return the updated filter
    */
   UserTaskFilter tenantId(final String tenantId);
+
+  /**
+   * Filters user tasks by the specified tenant ID.
+   *
+   * @param fn the {@link StringProperty} representing the tenantId associated with this task
+   * @return the updated filter
+   */
+  UserTaskFilter tenantId(final Consumer<StringProperty> fn);
 
   /**
    * Filters user tasks by the specified Process Definition Id.

--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/UserTaskFilter.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/UserTaskFilter.java
@@ -159,9 +159,9 @@ public interface UserTaskFilter extends SearchRequestFilter {
   UserTaskFilter tenantId(final String tenantId);
 
   /**
-   * Filters user tasks by the specified tenant ID.
+   * Filters user tasks by the specified tenantId using {@link StringProperty} consumer.
    *
-   * @param fn the {@link StringProperty} representing the tenantId associated with this task
+   * @param fn the {@link StringProperty} consumer of the user task
    * @return the updated filter
    */
   UserTaskFilter tenantId(final Consumer<StringProperty> fn);

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/UserTaskFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/UserTaskFilterImpl.java
@@ -144,7 +144,15 @@ public class UserTaskFilterImpl
 
   @Override
   public UserTaskFilter tenantId(final String tenantId) {
-    filter.setTenantId(tenantId);
+    tenantId(b -> b.eq(tenantId));
+    return this;
+  }
+
+  @Override
+  public UserTaskFilter tenantId(final Consumer<StringProperty> fn) {
+    final StringProperty property = new StringPropertyImpl();
+    fn.accept(property);
+    filter.setTenantId(provideSearchRequestProperty(property));
     return this;
   }
 

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/UserTaskFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/UserTaskFilterImpl.java
@@ -144,8 +144,7 @@ public class UserTaskFilterImpl
 
   @Override
   public UserTaskFilter tenantId(final String tenantId) {
-    tenantId(b -> b.eq(tenantId));
-    return this;
+    return tenantId(b -> b.eq(tenantId));
   }
 
   @Override

--- a/clients/java/src/test/java/io/camunda/client/usertask/SearchUserTaskTest.java
+++ b/clients/java/src/test/java/io/camunda/client/usertask/SearchUserTaskTest.java
@@ -200,7 +200,7 @@ public final class SearchUserTaskTest extends ClientRestTest {
 
     // then
     final UserTaskSearchQuery request = gatewayService.getLastRequest(UserTaskSearchQuery.class);
-    assertThat(request.getFilter().getTenantId()).isEqualTo("tenant1");
+    assertThat(request.getFilter().getTenantId().get$Eq()).isEqualTo("tenant1");
   }
 
   @Test

--- a/db/rdbms/src/main/resources/mapper/UserTaskMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/UserTaskMapper.xml
@@ -193,10 +193,9 @@
         separator=", ">#{value}
       </foreach>
     </if>
-    <if test="filter.tenantIds != null and !filter.tenantIds.isEmpty()">
-      AND ut.TENANT_ID IN
-      <foreach close=")" collection="filter.tenantIds" item="value" open="(" separator=", ">
-        #{value}
+    <if test="filter.tenantIdOperations != null and !filter.tenantIdOperations.isEmpty()">
+      <foreach collection="filter.tenantIdOperations" item="operation">
+        AND ut.TENANT_ID <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
       </foreach>
     </if>
 

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/UserTaskFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/UserTaskFilterTransformer.java
@@ -58,7 +58,7 @@ public class UserTaskFilterTransformer extends IndexFilterTransformer<UserTaskFi
     queries.addAll(getAssigneesQuery(filter.assigneeOperations()));
     queries.addAll(getPrioritiesQuery(filter.priorityOperations()));
     queries.addAll(getStatesQuery(filter.stateOperations()));
-    ofNullable(getTenantQuery(filter.tenantIds())).ifPresent(queries::add);
+    queries.addAll(getTenantQuery(filter.tenantIdOperations()));
     ofNullable(getElementInstanceKeyQuery(filter.elementInstanceKeys())).ifPresent(queries::add);
     queries.addAll(getCreationTimeQuery(filter.creationDateOperations()));
     queries.addAll(getCompletionTimeQuery(filter.completionDateOperations()));
@@ -136,8 +136,8 @@ public class UserTaskFilterTransformer extends IndexFilterTransformer<UserTaskFi
     return stringOperations(STATE, states);
   }
 
-  private SearchQuery getTenantQuery(final List<String> tenant) {
-    return stringTerms(TENANT_ID, tenant);
+  private List<SearchQuery> getTenantQuery(final List<Operation<String>> tenant) {
+   return stringOperations(TENANT_ID, tenant);
   }
 
   private SearchQuery getBpmnProcessIdQuery(final List<String> bpmnProcessId) {

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/UserTaskFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/UserTaskFilterTransformer.java
@@ -137,7 +137,7 @@ public class UserTaskFilterTransformer extends IndexFilterTransformer<UserTaskFi
   }
 
   private List<SearchQuery> getTenantQuery(final List<Operation<String>> tenant) {
-   return stringOperations(TENANT_ID, tenant);
+    return stringOperations(TENANT_ID, tenant);
   }
 
   private SearchQuery getBpmnProcessIdQuery(final List<String> bpmnProcessId) {

--- a/search/search-domain/src/main/java/io/camunda/search/filter/UserTaskFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/UserTaskFilter.java
@@ -30,7 +30,7 @@ public record UserTaskFilter(
     List<Long> processDefinitionKeys,
     List<Operation<String>> candidateUserOperations,
     List<Operation<String>> candidateGroupOperations,
-    List<String> tenantIds,
+    List<Operation<String>> tenantIdOperations,
     List<VariableValueFilter> processInstanceVariableFilter,
     List<VariableValueFilter> localVariableFilters,
     List<Long> elementInstanceKeys,
@@ -54,7 +54,7 @@ public record UserTaskFilter(
     private List<Long> processDefinitionKeys;
     private List<Operation<String>> candidateUserOperations;
     private List<Operation<String>> candidateGroupOperations;
-    private List<String> tenantIds;
+    private List<Operation<String>> tenantIdOperations;
     private List<VariableValueFilter> processInstanceVariableFilters;
     private List<VariableValueFilter> localVariableFilters;
     private List<Long> elementInstanceKeys;
@@ -197,12 +197,18 @@ public record UserTaskFilter(
       return candidateGroupOperations(collectValues(operation, operations));
     }
 
-    public Builder tenantIds(final String... values) {
-      return tenantIds(collectValuesAsList(values));
+    public Builder tenantIds(final String value, final String... values) {
+      return candidateGroupOperations(FilterUtil.mapDefaultToOperation(value, values));
     }
 
-    public Builder tenantIds(final List<String> values) {
-      tenantIds = addValuesToList(tenantIds, values);
+    @SafeVarargs
+    public final Builder tenantIdOperations(
+        final Operation<String> operation, final Operation<String>... operations) {
+      return tenantIdOperations(collectValues(operation, operations));
+    }
+
+    public Builder tenantIdOperations(final List<Operation<String>> operations) {
+      tenantIdOperations = addValuesToList(candidateGroupOperations, operations);
       return this;
     }
 
@@ -288,7 +294,7 @@ public record UserTaskFilter(
           Objects.requireNonNullElse(processDefinitionKeys, Collections.emptyList()),
           Objects.requireNonNullElse(candidateUserOperations, Collections.emptyList()),
           Objects.requireNonNullElse(candidateGroupOperations, Collections.emptyList()),
-          Objects.requireNonNullElse(tenantIds, Collections.emptyList()),
+          Objects.requireNonNullElse(tenantIdOperations, Collections.emptyList()),
           Objects.requireNonNullElse(processInstanceVariableFilters, Collections.emptyList()),
           Objects.requireNonNullElse(localVariableFilters, Collections.emptyList()),
           Objects.requireNonNullElse(elementInstanceKeys, Collections.emptyList()),

--- a/search/search-domain/src/main/java/io/camunda/search/filter/UserTaskFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/UserTaskFilter.java
@@ -198,7 +198,7 @@ public record UserTaskFilter(
     }
 
     public Builder tenantIds(final String value, final String... values) {
-      return candidateGroupOperations(FilterUtil.mapDefaultToOperation(value, values));
+      return tenantIdOperations(FilterUtil.mapDefaultToOperation(value, values));
     }
 
     @SafeVarargs
@@ -208,7 +208,7 @@ public record UserTaskFilter(
     }
 
     public Builder tenantIdOperations(final List<Operation<String>> operations) {
-      tenantIdOperations = addValuesToList(candidateGroupOperations, operations);
+      tenantIdOperations = addValuesToList(tenantIdOperations, operations);
       return this;
     }
 

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -5649,8 +5649,9 @@ components:
           allOf:
             - $ref: "#/components/schemas/StringFilterProperty"
         tenantId:
-          type: string
           description: Tenant ID of this user task.
+          allOf:
+            - $ref: "#/components/schemas/StringFilterProperty"
         processDefinitionId:
           type: string
           description: The ID of the process definition.

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
@@ -1212,7 +1212,9 @@ public final class SearchQueryRequestMapper {
       Optional.ofNullable(filter.getProcessInstanceKey())
           .map(KeyUtil::keyToLong)
           .ifPresent(builder::processInstanceKeys);
-      Optional.ofNullable(filter.getTenantId()).ifPresent(builder::tenantIds);
+      Optional.ofNullable(filter.getTenantId())
+          .map(mapToOperations(String.class))
+          .ifPresent(builder::tenantIdOperations);
       Optional.ofNullable(filter.getElementInstanceKey())
           .map(KeyUtil::keyToLong)
           .ifPresent(builder::elementInstanceKeys);

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/UserTaskQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/UserTaskQueryControllerTest.java
@@ -848,6 +848,10 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
         streamBuilder,
         "assignee",
         ops -> new UserTaskFilter.Builder().assigneeOperations(ops).build());
+    stringOperationTestCases(
+        streamBuilder,
+        "tenantId",
+        ops -> new UserTaskFilter.Builder().tenantIdOperations(ops).build());
 
     return streamBuilder.build();
   }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
I'm adding the advanced filter for tenantId allowing it to be searched using "$in" and covering regression.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #34206
