### PR TITLE
fix: convert key to lowercase

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/IdentitySetupInitializer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/IdentitySetupInitializer.java
@@ -122,10 +122,10 @@ public final class IdentitySetupInitializer implements StreamProcessorLifecycleA
       final var roleId = assignmentsForRole.getKey();
       for (final var assignmentsForEntityType : assignmentsForRole.getValue().entrySet()) {
         final var entityType =
-            switch (assignmentsForEntityType.getKey()) {
+            switch (assignmentsForEntityType.getKey().toLowerCase()) {
               case "users" -> EntityType.USER;
               case "clients" -> EntityType.CLIENT;
-              case "mappingRules" -> EntityType.MAPPING_RULE;
+              case "mappingrules" -> EntityType.MAPPING_RULE;
               case "groups" -> EntityType.GROUP;
               case "roles" -> EntityType.ROLE;
               default ->


### PR DESCRIPTION
## Description

For the default roles, everything is mapped dynamically to String. So MAPPINGRULES in the env var becomes mappingrules . And the initializer expects camel case, but of course Spring isn't able to tell

## Related issue
#35980 
