### PR TITLE
ci: fix general UT artifact upload name and disable failing eslinting rule

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -292,7 +292,7 @@ jobs:
         uses: ./.github/actions/collect-test-artifacts
         if: ${{ failure() || cancelled() || steps.analyze-test-run.outputs.flakyTests != '' }}
         with:
-          name: "General / [UT]"
+          name: "General - [UT]"
       - name: Observe build status
         if: always()
         continue-on-error: true

--- a/operate/client/eslint.config.js
+++ b/operate/client/eslint.config.js
@@ -154,6 +154,7 @@ const config = defineConfig([
     rules: {
       ...testingLibraryPlugin.configs.react.rules,
       'testing-library/no-debugging-utils': 'error',
+      'testing-library/no-node-access': 'off',
     },
   },
 

--- a/tasklist/client/eslint.config.js
+++ b/tasklist/client/eslint.config.js
@@ -133,6 +133,7 @@ export default [
     rules: {
       ...testingLibraryPlugin.configs.react.rules,
       'testing-library/no-debugging-utils': 'error',
+      'testing-library/no-node-access': 'off',
     },
   },
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
The `Upload Test Artifacts` job is failing with the following error

```
With the provided path, there will be 1680 files uploaded
Error: The artifact name is not valid: Test results for General / [UT]. Contains the following character:  Forward slash /
          
Invalid characters include:  Double quote ", Colon :, Less than <, Greater than >, Vertical bar |, Asterisk *, Question mark ?, Carriage return \r, Line feed \n, Backslash \, Forward slash /
          
These characters are not allowed in the artifact name due to limitations with certain file systems such as NTFS. To maintain file system agnostic behavior, these characters are intentionally not allowed to prevent potential problems with downloads on different file systems.
```
Remove the `/` character in the upload name to fix the error

Tasklist and Operate FE Linting tests are getting consistent and 100s of failures on `Avoid direct Node access. Prefer using the methods from Testing Library  testing-library/no-node-access` This PR disabled that linting rule
## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
