### PR TITLE
[Backport release-8.8.0-alpha7] fix: load Identity client config from relative path

### DIFF
--- a/identity/client/index.html
+++ b/identity/client/index.html
@@ -11,7 +11,7 @@
 <html lang="en" xmlns:th="http://www.thymeleaf.org">
   <head>
     <base href="/" th:attr="href=${contextPath}"/>
-    <script type="text/javascript" src="/identity/config.js"></script>
+    <script type="text/javascript" src="./config.js"></script>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Camunda Identity</title>


### PR DESCRIPTION
# Description
Backport of #36136 to `release-8.8.0-alpha7`.

relates to #36130