### PR TITLE
fix: add RuntimeInstruction value type to TestSupport classes

### DIFF
--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/TestSupport.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/TestSupport.java
@@ -71,6 +71,7 @@ public final class TestSupport {
       case AD_HOC_SUB_PROCESS_INSTRUCTION -> config.adHocSubProcessInstruction = value;
       case ASYNC_REQUEST -> config.asyncRequest = value;
       case USAGE_METRIC -> config.usageMetrics = value;
+      case RUNTIME_INSTRUCTION -> config.runtimeInstruction = value;
       default ->
           throw new IllegalArgumentException(
               "No known indexing configuration option for value type " + valueType);
@@ -125,6 +126,7 @@ public final class TestSupport {
       case AD_HOC_SUB_PROCESS_INSTRUCTION -> config.adHocSubProcessInstruction = value;
       case ASYNC_REQUEST -> config.asyncRequest = value;
       case USAGE_METRIC -> config.usageMetrics = value;
+      case RUNTIME_INSTRUCTION -> config.runtimeInstruction = value;
       default ->
           throw new IllegalArgumentException(
               "No known indexing configuration option for value type " + valueType);

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TestSupport.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TestSupport.java
@@ -72,6 +72,7 @@ public final class TestSupport {
       case AD_HOC_SUB_PROCESS_INSTRUCTION -> config.adHocSubProcessInstruction = value;
       case ASYNC_REQUEST -> config.asyncRequest = value;
       case USAGE_METRIC -> config.usageMetrics = value;
+      case RUNTIME_INSTRUCTION -> config.runtimeInstruction = value;
       default ->
           throw new IllegalArgumentException(
               "No known indexing configuration option for value type " + valueType);
@@ -128,6 +129,7 @@ public final class TestSupport {
       case AD_HOC_SUB_PROCESS_INSTRUCTION -> config.adHocSubProcessInstruction = value;
       case ASYNC_REQUEST -> config.asyncRequest = value;
       case USAGE_METRIC -> config.usageMetrics = value;
+      case RUNTIME_INSTRUCTION -> config.runtimeInstruction = value;
       default ->
           throw new IllegalArgumentException(
               "No known indexing configuration option for value type " + valueType);


### PR DESCRIPTION
## Description

This new instruction type is exportable and has already been added to other `TestSupport` classes, e.g. in ElasticSearch / Opensearch exporter ITs.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
