### PR TITLE
[Backport release-8.8.0-alpha7] test: exclude MULTI_INSTANCE record from being exportable

### DIFF
--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/TestSupport.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/TestSupport.java
@@ -173,7 +173,8 @@ public final class TestSupport {
             ValueType.GROUP,
             ValueType.MAPPING_RULE,
             ValueType.IDENTITY_SETUP,
-            ValueType.RESOURCE);
+            ValueType.RESOURCE,
+            ValueType.MULTI_INSTANCE);
     return EnumSet.complementOf(excludedValueTypes).stream();
   }
 }

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TestSupport.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TestSupport.java
@@ -157,7 +157,8 @@ public final class TestSupport {
             ValueType.GROUP,
             ValueType.MAPPING_RULE,
             ValueType.IDENTITY_SETUP,
-            ValueType.RESOURCE);
+            ValueType.RESOURCE,
+            ValueType.MULTI_INSTANCE);
     return EnumSet.complementOf(excludedValueTypes).stream();
   }
 }


### PR DESCRIPTION
# Description
Backport of #36074 to `release-8.8.0-alpha7`.

relates to https://camunda.slack.com/archives/C071KP5BTHB/p1753717403529199