### PR TITLE
[Backport release-8.8.0-alpha7] fix: add RuntimeInstruction value type to TestSupport classes

### DIFF
--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/TestSupport.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/TestSupport.java
@@ -71,6 +71,7 @@ public final class TestSupport {
       case AD_HOC_SUB_PROCESS_INSTRUCTION -> config.adHocSubProcessInstruction = value;
       case ASYNC_REQUEST -> config.asyncRequest = value;
       case USAGE_METRIC -> config.usageMetrics = value;
+      case RUNTIME_INSTRUCTION -> config.runtimeInstruction = value;
       default ->
           throw new IllegalArgumentException(
               "No known indexing configuration option for value type " + valueType);
@@ -125,6 +126,7 @@ public final class TestSupport {
       case AD_HOC_SUB_PROCESS_INSTRUCTION -> config.adHocSubProcessInstruction = value;
       case ASYNC_REQUEST -> config.asyncRequest = value;
       case USAGE_METRIC -> config.usageMetrics = value;
+      case RUNTIME_INSTRUCTION -> config.runtimeInstruction = value;
       default ->
           throw new IllegalArgumentException(
               "No known indexing configuration option for value type " + valueType);

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TestSupport.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TestSupport.java
@@ -72,6 +72,7 @@ public final class TestSupport {
       case AD_HOC_SUB_PROCESS_INSTRUCTION -> config.adHocSubProcessInstruction = value;
       case ASYNC_REQUEST -> config.asyncRequest = value;
       case USAGE_METRIC -> config.usageMetrics = value;
+      case RUNTIME_INSTRUCTION -> config.runtimeInstruction = value;
       default ->
           throw new IllegalArgumentException(
               "No known indexing configuration option for value type " + valueType);
@@ -128,6 +129,7 @@ public final class TestSupport {
       case AD_HOC_SUB_PROCESS_INSTRUCTION -> config.adHocSubProcessInstruction = value;
       case ASYNC_REQUEST -> config.asyncRequest = value;
       case USAGE_METRIC -> config.usageMetrics = value;
+      case RUNTIME_INSTRUCTION -> config.runtimeInstruction = value;
       default ->
           throw new IllegalArgumentException(
               "No known indexing configuration option for value type " + valueType);


### PR DESCRIPTION
# Description
Backport of #36151 to `release-8.8.0-alpha7`.

relates to 