### PR TITLE
feat: restore from multiple backups

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/restore/RestoreApp.java
+++ b/dist/src/main/java/io/camunda/zeebe/restore/RestoreApp.java
@@ -39,7 +39,7 @@ public class RestoreApp implements ApplicationRunner {
 
   @Value("${backupId}")
   // Parsed from commandline Eg:-`--backupId=100`
-  private long backupId;
+  private long[] backupId;
 
   private final RestoreConfiguration restoreConfiguration;
   private final MeterRegistry meterRegistry;

--- a/zeebe/journal/src/main/java/io/camunda/zeebe/journal/JournalReader.java
+++ b/zeebe/journal/src/main/java/io/camunda/zeebe/journal/JournalReader.java
@@ -104,6 +104,9 @@ public interface JournalReader extends Iterator<JournalRecord>, AutoCloseable {
    */
   long seekToAsqn(long asqn, long indexUpperBound);
 
+  /** Get the index of the next record to be read. */
+  long getNextIndex();
+
   @Override
   void close();
 }

--- a/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournalReader.java
+++ b/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournalReader.java
@@ -41,10 +41,6 @@ class SegmentedJournalReader implements JournalReader {
     currentReader = currentSegment.createReader();
   }
 
-  long getNextIndex() {
-    return currentReader.getNextIndex();
-  }
-
   @Override
   public boolean hasNext() {
     final var stamp = journal.acquireReadlock();
@@ -160,6 +156,11 @@ class SegmentedJournalReader implements JournalReader {
         journal.releaseReadlock(stamp);
       }
     }
+  }
+
+  @Override
+  public long getNextIndex() {
+    return currentReader.getNextIndex();
   }
 
   @Override

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/ContinuousBackupIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/ContinuousBackupIT.java
@@ -8,9 +8,11 @@
 package io.camunda.zeebe.it.backup;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.awaitility.Awaitility.await;
 
 import com.google.cloud.storage.BucketInfo;
+import io.camunda.client.CamundaClient;
 import io.camunda.management.backups.StateCode;
 import io.camunda.zeebe.backup.gcs.GcsBackupConfig;
 import io.camunda.zeebe.backup.gcs.GcsBackupStore;
@@ -31,10 +33,12 @@ import io.camunda.zeebe.util.FileUtil;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.time.Duration;
+import java.util.Map;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.util.unit.DataSize;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
@@ -107,21 +111,7 @@ final class ContinuousBackupIT {
   void canRestoreFromMultipleBackups() throws IOException {
     // given - three backups with some initial data
     try (final var client = broker.newClientBuilder().build()) {
-      final var process =
-          client
-              .newDeployResourceCommand()
-              .addProcessModel(
-                  Bpmn.createExecutableProcess("process")
-                      .startEvent()
-                      .serviceTask("task", t -> t.zeebeJobType("task"))
-                      .endEvent()
-                      .done(),
-                  "process.bpmn")
-              .send()
-              .join()
-              .getProcesses()
-              .getFirst()
-              .getProcessDefinitionKey();
+      final var process = deployTestProcess(client);
       client.newCreateInstanceCommand().processDefinitionKey(process).send().join();
       takeAndAwaitBackup(1L);
       client.newCreateInstanceCommand().processDefinitionKey(process).send().join();
@@ -140,7 +130,7 @@ final class ContinuousBackupIT {
         new TestRestoreApp()
             .withBrokerConfig(this::configureBroker)
             .withWorkingDirectory(dataDirectory)
-            .withBackupId(new long[] {1, 2, 3})
+            .withBackupId(1, 2, 3)
             .start();
     restore.close();
 
@@ -153,6 +143,72 @@ final class ContinuousBackupIT {
       for (final var job : jobs.getJobs()) {
         client.newCompleteCommand(job.getKey()).send().join();
       }
+    }
+  }
+
+  @Test
+  void restoreFailsOnGapsBetweenBackups() throws IOException {
+    // given - three backups spanning over multiple segments with snapshots in between
+    try (final var client = broker.newClientBuilder().build()) {
+      final var process = deployTestProcess(client);
+
+      createManyInstances(client, process);
+      takeAndAwaitBackup(1L);
+
+      partitionsActuator.takeSnapshot();
+      createManyInstances(client, process);
+      takeAndAwaitBackup(2L);
+
+      partitionsActuator.takeSnapshot();
+      createManyInstances(client, process);
+      takeAndAwaitBackup(3L);
+    }
+
+    // when/then - restoring from backup 1 and 3, but skipping backup 2
+    broker.stop();
+    final var dataDirectory = Path.of(broker.brokerConfig().getData().getDirectory()).getParent();
+    FileUtil.deleteFolder(dataDirectory);
+    FileUtil.ensureDirectoryExists(dataDirectory);
+    final var restore =
+        new TestRestoreApp()
+            .withBrokerConfig(this::configureBroker)
+            .withWorkingDirectory(dataDirectory)
+            .withBackupId(1, 3);
+
+    // then restore will fail
+    assertThatThrownBy(restore::start)
+        .rootCause()
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("Cannot find a record at checkpoint position");
+
+    restore.close();
+  }
+
+  private static long deployTestProcess(final CamundaClient client) {
+    return client
+        .newDeployResourceCommand()
+        .addProcessModel(
+            Bpmn.createExecutableProcess("process")
+                .startEvent()
+                .serviceTask("task", t -> t.zeebeJobType("task"))
+                .endEvent()
+                .done(),
+            "process.bpmn")
+        .send()
+        .join()
+        .getProcesses()
+        .getFirst()
+        .getProcessDefinitionKey();
+  }
+
+  private static void createManyInstances(final CamundaClient client, final long process) {
+    for (int i = 0; i < 100; i++) {
+      client
+          .newCreateInstanceCommand()
+          .processDefinitionKey(process)
+          .variables(Map.of("test", RandomStringUtils.insecure().nextAlphabetic(100_000)))
+          .send()
+          .join();
     }
   }
 
@@ -195,5 +251,7 @@ final class ContinuousBackupIT {
     gcsConfig.setHost(GCS.externalEndpoint());
     cfg.getData().getBackup().setGcs(gcsConfig);
     cfg.getData().getBackup().setStore(BackupStoreType.GCS);
+    cfg.getData().setLogSegmentSize(DataSize.ofMegabytes(1));
+    cfg.getNetwork().setMaxMessageSize(DataSize.ofKilobytes(500));
   }
 }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/ContinuousBackupIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/ContinuousBackupIT.java
@@ -214,7 +214,7 @@ final class ContinuousBackupIT {
 
   void takeAndAwaitBackup(final long backupId) {
     backupActuator.take(backupId);
-    await("snapshot is completed")
+    await("backup is completed")
         .ignoreExceptions()
         .untilAsserted(
             () ->

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestRestoreApp.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestRestoreApp.java
@@ -13,14 +13,16 @@ import io.camunda.configuration.beans.BrokerBasedProperties;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.qa.util.actuator.HealthActuator;
 import io.camunda.zeebe.restore.RestoreApp;
+import java.util.Arrays;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 import org.springframework.boot.WebApplicationType;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 
 /** Represents an instance of the {@link RestoreApp} Spring application. */
 public final class TestRestoreApp extends TestSpringApplication<TestRestoreApp> {
   private final BrokerBasedProperties config;
-  private Long backupId;
+  private long[] backupId;
 
   public TestRestoreApp() {
     this(new BrokerBasedProperties());
@@ -56,7 +58,12 @@ public final class TestRestoreApp extends TestSpringApplication<TestRestoreApp> 
 
   @Override
   protected String[] commandLineArgs() {
-    return backupId == null ? super.commandLineArgs() : new String[] {"--backupId=" + backupId};
+    return backupId == null
+        ? super.commandLineArgs()
+        : new String[] {
+          "--backupId="
+              + Arrays.stream(backupId).mapToObj(Long::toString).collect(Collectors.joining(","))
+        };
   }
 
   @Override
@@ -69,7 +76,7 @@ public final class TestRestoreApp extends TestSpringApplication<TestRestoreApp> 
     return this;
   }
 
-  public TestRestoreApp withBackupId(final long backupId) {
+  public TestRestoreApp withBackupId(final long... backupId) {
     this.backupId = backupId;
     return this;
   }

--- a/zeebe/restore/pom.xml
+++ b/zeebe/restore/pom.xml
@@ -74,6 +74,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.agrona</groupId>
+      <artifactId>agrona</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>zeebe-logstreams</artifactId>
       <scope>test</scope>
@@ -97,11 +102,6 @@
       <scope>test</scope>
     </dependency>
 
-    <dependency>
-      <groupId>org.agrona</groupId>
-      <artifactId>agrona</artifactId>
-      <scope>test</scope>
-    </dependency>
     <dependency>
       <groupId>io.micrometer</groupId>
       <artifactId>micrometer-core</artifactId>

--- a/zeebe/restore/src/test/java/io/camunda/zeebe/restore/PartitionRestoreServiceTest.java
+++ b/zeebe/restore/src/test/java/io/camunda/zeebe/restore/PartitionRestoreServiceTest.java
@@ -19,6 +19,7 @@ import io.atomix.raft.partition.RaftPartition;
 import io.camunda.zeebe.backup.api.Backup;
 import io.camunda.zeebe.backup.common.BackupIdentifierImpl;
 import io.camunda.zeebe.backup.management.BackupService;
+import io.camunda.zeebe.journal.CheckedJournalException.FlushException;
 import io.camunda.zeebe.journal.JournalMetaStore;
 import io.camunda.zeebe.journal.file.SegmentedJournal;
 import io.camunda.zeebe.logstreams.log.LogStreamWriter.WriteFailure;
@@ -130,7 +131,7 @@ class PartitionRestoreServiceTest {
   }
 
   @Test
-  void shouldRestoreToDataDirectory() throws IOException {
+  void shouldRestoreToDataDirectory() throws IOException, FlushException {
     // given
     // write something to the journal
     appendRecord(1, "data");


### PR DESCRIPTION
This extends the restore application so that it can also restore from multiple backups, as long as they are contiguous.

The restored journal is crafted so that we don't have to deal with overlaps between backups. More details in 784d46e2acdac19ed342c747037abf108ba35d4e.

We verify that the backups are contiguous by asserting that each backup also contains the previous backup checkpoint record.

closes #34316
closes #34314 because we no longer need to deal with overlaps