### PR TITLE
ci: Tasklist and Operate Test Trigger adjustments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1019,7 +1019,7 @@ jobs:
 
 
   tasklist-ci:
-    if: needs.detect-changes.outputs.java-code-changes == 'true'
+    if: needs.detect-changes.outputs.java-code-changes == 'true' || needs.detect-changes.outputs.frontend-changes == 'true'
     name: "Tasklist"
     needs: [ detect-changes ]
     uses: ./.github/workflows/ci-tasklist.yml
@@ -1030,7 +1030,7 @@ jobs:
       runBeTests: ${{ needs.detect-changes.outputs.tasklist-backend-changes == 'true' || needs.detect-changes.outputs.zeebe-changes == 'true' }}
 
   operate-ci:
-    if: needs.detect-changes.outputs.java-code-changes == 'true'
+    if: needs.detect-changes.outputs.java-code-changes == 'true' || needs.detect-changes.outputs.frontend-changes == 'true'
     name: "Operate"
     needs: [ detect-changes ]
     uses: ./.github/workflows/ci-operate.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1027,7 +1027,7 @@ jobs:
     permissions: { }
     with:
       runFeTests: ${{ needs.detect-changes.outputs.tasklist-frontend-changes  == 'true' }}
-      runBeTests: ${{ needs.detect-changes.outputs.tasklist-backend-changes == 'true' }}
+      runBeTests: ${{ needs.detect-changes.outputs.tasklist-backend-changes == 'true' || needs.detect-changes.outputs.zeebe-changes == 'true' }}
 
   operate-ci:
     if: needs.detect-changes.outputs.java-code-changes == 'true'
@@ -1038,7 +1038,7 @@ jobs:
     permissions: { }
     with:
       runFeTests: ${{ needs.detect-changes.outputs.operate-frontend-changes == 'true' }}
-      runBeTests: ${{ needs.detect-changes.outputs.operate-backend-changes == 'true'}}
+      runBeTests: ${{ needs.detect-changes.outputs.operate-backend-changes == 'true' || needs.detect-changes.outputs.zeebe-changes == 'true'}}
 
   optimize-ci:
     if: ${{ needs.detect-changes.outputs.java-code-changes == 'true' || needs.detect-changes.outputs.frontend-changes == 'true' }}

--- a/.github/workflows/operate-ci-core-features.yml
+++ b/.github/workflows/operate-ci-core-features.yml
@@ -20,6 +20,8 @@ on:
       - 'parent/*'
       - 'pom.xml'
       - 'webapps-common/**'
+      - 'zeebe/**'
+      - 'clients/**'
   pull_request:
     paths:
       - '.ci/**'
@@ -31,6 +33,8 @@ on:
       - 'operate.Dockerfile'
       - 'parent/*'
       - 'webapps-common/**'
+      - 'zeebe/**'
+      - 'clients/**'
 permissions:
   contents: read
 

--- a/.github/workflows/operate-ci-data-layer.yml
+++ b/.github/workflows/operate-ci-data-layer.yml
@@ -21,6 +21,8 @@ on:
       - 'parent/*'
       - 'pom.xml'
       - 'webapps-common/**'
+      - 'zeebe/**'
+      - 'clients/**'
   pull_request:
     paths:
       - '.ci/**'
@@ -32,6 +34,8 @@ on:
       - 'operate.Dockerfile'
       - 'parent/*'
       - 'webapps-common/**'
+      - 'zeebe/**'
+      - 'clients/**'
 permissions:
   contents: read
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
https://github.com/camunda/camunda/pull/36151 was needed as integration tests for Operate and Tasklist were not run in https://github.com/camunda/camunda/pull/35685

This PR adjusts the tests triggers so that BE tests for Operate and Tasklist are triggered when there is a change to Zeebe. Legacy Integration tests for Operate should be triggered as well

Also make a change to the `ci-tasklist` and `ci-operate` jobs in Unified CI so that FE tests will properly trigger when there is a sole FE change.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes https://github.com/camunda/camunda/issues/36223
relates to https://camunda.slack.com/archives/C071KP5BTHB/p1753873431856259
