### PR TITLE
[Backport release-8.8.0-alpha7] test: fix flakiness in user task migration tests by awaiting `CREATED` state

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/migration/usertask/AssignUserTaskMigrationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/migration/usertask/AssignUserTaskMigrationIT.java
@@ -61,7 +61,7 @@ public class AssignUserTaskMigrationIT extends UserTaskMigrationHelper {
         startProcessInstance(
             migrator.getCamundaClient(),
             PROCESS_DEFINITION_KEYS.get(TaskImplementation.ZEEBE_USER_TASK));
-    final var taskKey = waitFor88TaskToBeImportedReturningId(migrator, piKey);
+    final var taskKey = waitFor88CreatedTaskToBeImportedReturningId(migrator, piKey);
 
     final var res =
         migrator
@@ -80,7 +80,7 @@ public class AssignUserTaskMigrationIT extends UserTaskMigrationHelper {
         startProcessInstance(
             migrator.getCamundaClient(),
             PROCESS_DEFINITION_KEYS.get(TaskImplementation.ZEEBE_USER_TASK));
-    final var taskKey = waitFor88TaskToBeImportedReturningId(migrator, piKey);
+    final var taskKey = waitFor88CreatedTaskToBeImportedReturningId(migrator, piKey);
 
     migrator.getCamundaClient().newUserTaskAssignCommand(taskKey).assignee("demo").send().join();
 
@@ -108,7 +108,7 @@ public class AssignUserTaskMigrationIT extends UserTaskMigrationHelper {
         startProcessInstance(
             migrator.getCamundaClient(),
             PROCESS_DEFINITION_KEYS.get(TaskImplementation.JOB_WORKER));
-    final var taskKey = waitFor88TaskToBeImportedReturningId(migrator, piKey);
+    final var taskKey = waitFor88CreatedTaskToBeImportedReturningId(migrator, piKey);
 
     final var res =
         migrator

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/migration/usertask/CompleteUserTaskMigrationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/migration/usertask/CompleteUserTaskMigrationIT.java
@@ -59,7 +59,7 @@ public class CompleteUserTaskMigrationIT extends UserTaskMigrationHelper {
         startProcessInstance(
             migrator.getCamundaClient(),
             PROCESS_DEFINITION_KEYS.get(TaskImplementation.ZEEBE_USER_TASK));
-    final var taskKey = waitFor88TaskToBeImportedReturningId(migrator, piKey);
+    final var taskKey = waitFor88CreatedTaskToBeImportedReturningId(migrator, piKey);
 
     final var res =
         migrator.getTasklistClient().withAuthentication("demo", "demo").completeUserTask(taskKey);
@@ -75,7 +75,7 @@ public class CompleteUserTaskMigrationIT extends UserTaskMigrationHelper {
         startProcessInstance(
             migrator.getCamundaClient(),
             PROCESS_DEFINITION_KEYS.get(TaskImplementation.ZEEBE_USER_TASK));
-    final var taskKey = waitFor88TaskToBeImportedReturningId(migrator, piKey);
+    final var taskKey = waitFor88CreatedTaskToBeImportedReturningId(migrator, piKey);
 
     migrator.getCamundaClient().newUserTaskCompleteCommand(taskKey).send().join();
 
@@ -101,7 +101,7 @@ public class CompleteUserTaskMigrationIT extends UserTaskMigrationHelper {
         startProcessInstance(
             migrator.getCamundaClient(),
             PROCESS_DEFINITION_KEYS.get(TaskImplementation.JOB_WORKER));
-    final var taskKey = waitFor88TaskToBeImportedReturningId(migrator, piKey);
+    final var taskKey = waitFor88CreatedTaskToBeImportedReturningId(migrator, piKey);
 
     final var res =
         migrator.getTasklistClient().withAuthentication("demo", "demo").completeUserTask(taskKey);

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/migration/usertask/UnassignUserTaskMigrationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/migration/usertask/UnassignUserTaskMigrationIT.java
@@ -59,7 +59,7 @@ public class UnassignUserTaskMigrationIT extends UserTaskMigrationHelper {
         startProcessInstance(
             migrator.getCamundaClient(),
             PROCESS_DEFINITION_KEYS.get(TaskImplementation.ZEEBE_USER_TASK));
-    final var taskKey = waitFor88TaskToBeImportedReturningId(migrator, piKey);
+    final var taskKey = waitFor88CreatedTaskToBeImportedReturningId(migrator, piKey);
 
     final var res =
         migrator.getTasklistClient().withAuthentication("demo", "demo").unassignUserTask(taskKey);
@@ -75,7 +75,7 @@ public class UnassignUserTaskMigrationIT extends UserTaskMigrationHelper {
         startProcessInstance(
             migrator.getCamundaClient(),
             PROCESS_DEFINITION_KEYS.get(TaskImplementation.ZEEBE_USER_TASK));
-    final var taskKey = waitFor88TaskToBeImportedReturningId(migrator, piKey);
+    final var taskKey = waitFor88CreatedTaskToBeImportedReturningId(migrator, piKey);
 
     migrator.getCamundaClient().newUserTaskUnassignCommand(taskKey).send().join();
 
@@ -101,7 +101,7 @@ public class UnassignUserTaskMigrationIT extends UserTaskMigrationHelper {
         startProcessInstance(
             migrator.getCamundaClient(),
             PROCESS_DEFINITION_KEYS.get(TaskImplementation.JOB_WORKER));
-    final var taskKey = waitFor88TaskToBeImportedReturningId(migrator, piKey);
+    final var taskKey = waitFor88CreatedTaskToBeImportedReturningId(migrator, piKey);
 
     final var res =
         migrator.getTasklistClient().withAuthentication("demo", "demo").unassignUserTask(taskKey);

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/migration/usertask/UnassignUserTaskMigrationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/migration/usertask/UnassignUserTaskMigrationIT.java
@@ -100,7 +100,7 @@ public class UnassignUserTaskMigrationIT extends UserTaskMigrationHelper {
     final var piKey =
         startProcessInstance(
             migrator.getCamundaClient(),
-            PROCESS_DEFINITION_KEYS.get(TaskImplementation.ZEEBE_USER_TASK));
+            PROCESS_DEFINITION_KEYS.get(TaskImplementation.JOB_WORKER));
     final var taskKey = waitFor88TaskToBeImportedReturningId(migrator, piKey);
 
     final var res =

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/migration/usertask/UserTaskMigrationHelper.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/migration/usertask/UserTaskMigrationHelper.java
@@ -22,6 +22,7 @@ import io.camunda.webapps.schema.descriptors.template.TaskTemplate;
 import io.camunda.webapps.schema.entities.usertask.TaskEntity;
 import io.camunda.webapps.schema.entities.usertask.TaskEntity.TaskImplementation;
 import io.camunda.webapps.schema.entities.usertask.TaskJoinRelationship.TaskJoinRelationshipType;
+import io.camunda.webapps.schema.entities.usertask.TaskState;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.builder.UserTaskBuilder;
 import java.net.URI;
@@ -142,13 +143,14 @@ public abstract class UserTaskMigrationHelper {
         SearchQueryBuilders.and(
             SearchQueryBuilders.term(TaskTemplate.PROCESS_INSTANCE_ID, piKey),
             SearchQueryBuilders.term(
-                TaskTemplate.JOIN_FIELD_NAME, TaskJoinRelationshipType.TASK.getType()));
+                TaskTemplate.JOIN_FIELD_NAME, TaskJoinRelationshipType.TASK.getType()),
+            SearchQueryBuilders.term(TaskTemplate.STATE, TaskState.CREATED.name()));
     final var req =
         SearchQueryRequest.of(
             s ->
                 s.query(processInstanceQuery)
                     .index(migrator.indexFor(TaskTemplate.class).getAlias()));
-    Awaitility.await("Wait for tasks to be imported")
+    Awaitility.await("Wait for tasks with CREATED state to be imported")
         .ignoreExceptions()
         .pollInterval(Duration.ofSeconds(1))
         .atMost(Duration.ofSeconds(30))

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/migration/usertask/UserTaskMigrationHelper.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/migration/usertask/UserTaskMigrationHelper.java
@@ -135,7 +135,7 @@ public abstract class UserTaskMigrationHelper {
     return userTaskKey.get();
   }
 
-  protected long waitFor88TaskToBeImportedReturningId(
+  protected long waitFor88CreatedTaskToBeImportedReturningId(
       final CamundaMigrator migrator, final long piKey) {
     final AtomicLong userTaskKey = new AtomicLong();
 


### PR DESCRIPTION
# Description
Backport of #36141 to `release-8.8.0-alpha7`.

relates to #36139