### PR TITLE
refactor: Store only tenant ids in the authentication context

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/CamundaOAuthPrincipalServiceImpl.java
+++ b/authentication/src/main/java/io/camunda/authentication/CamundaOAuthPrincipalServiceImpl.java
@@ -17,6 +17,7 @@ import io.camunda.authentication.entity.OAuthContext;
 import io.camunda.search.entities.GroupEntity;
 import io.camunda.search.entities.MappingRuleEntity;
 import io.camunda.search.entities.RoleEntity;
+import io.camunda.search.entities.TenantEntity;
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.security.auth.OidcGroupsLoader;
 import io.camunda.security.auth.OidcPrincipalLoader;
@@ -26,7 +27,6 @@ import io.camunda.service.GroupServices;
 import io.camunda.service.MappingRuleServices;
 import io.camunda.service.RoleServices;
 import io.camunda.service.TenantServices;
-import io.camunda.service.TenantServices.TenantDTO;
 import io.camunda.zeebe.protocol.record.value.EntityType;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -147,7 +147,7 @@ public class CamundaOAuthPrincipalServiceImpl implements CamundaOAuthPrincipalSe
             .withAuthentication(CamundaAuthentication.anonymous())
             .getTenantsByMemberTypeAndMemberIds(ownerTypeToIds)
             .stream()
-            .map(TenantDTO::fromEntity)
+            .map(TenantEntity::tenantId)
             .toList();
 
     authContextBuilder

--- a/authentication/src/main/java/io/camunda/authentication/CamundaUserDetailsService.java
+++ b/authentication/src/main/java/io/camunda/authentication/CamundaUserDetailsService.java
@@ -11,12 +11,12 @@ import static io.camunda.authentication.entity.CamundaUser.CamundaUserBuilder.aC
 
 import io.camunda.search.entities.GroupEntity;
 import io.camunda.search.entities.RoleEntity;
+import io.camunda.search.entities.TenantEntity;
 import io.camunda.search.query.SearchQueryBuilders;
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.GroupServices;
 import io.camunda.service.RoleServices;
 import io.camunda.service.TenantServices;
-import io.camunda.service.TenantServices.TenantDTO;
 import io.camunda.service.UserServices;
 import io.camunda.zeebe.protocol.record.value.EntityType;
 import java.util.Objects;
@@ -81,7 +81,7 @@ public class CamundaUserDetailsService implements UserDetailsService {
             .withAuthentication(CamundaAuthentication.anonymous())
             .getTenantsByUserAndGroupsAndRoles(username, groups, roles)
             .stream()
-            .map(TenantDTO::fromEntity)
+            .map(TenantEntity::tenantId)
             .toList();
 
     return aCamundaUser()

--- a/authentication/src/main/java/io/camunda/authentication/DefaultCamundaAuthenticationConverter.java
+++ b/authentication/src/main/java/io/camunda/authentication/DefaultCamundaAuthenticationConverter.java
@@ -13,7 +13,6 @@ import io.camunda.authentication.exception.CamundaAuthenticationException;
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.security.auth.CamundaAuthentication.Builder;
 import io.camunda.security.auth.CamundaAuthenticationConverter;
-import io.camunda.service.TenantServices.TenantDTO;
 import io.camunda.zeebe.auth.Authorization;
 import java.util.HashMap;
 import java.util.Map;
@@ -58,10 +57,7 @@ public class DefaultCamundaAuthenticationConverter
     final var authenticationContext = camundaPrincipal.getAuthenticationContext();
 
     authenticationBuilder.roleIds(authenticationContext.roles());
-
-    authenticationBuilder.tenants(
-        authenticationContext.tenants().stream().map(TenantDTO::tenantId).toList());
-
+    authenticationBuilder.tenants(authenticationContext.tenants());
     authenticationBuilder.groupIds(authenticationContext.groups());
 
     if (authenticationContext.groupsClaimEnabled()) {

--- a/authentication/src/main/java/io/camunda/authentication/entity/AuthenticationContext.java
+++ b/authentication/src/main/java/io/camunda/authentication/entity/AuthenticationContext.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.authentication.entity;
 
-import io.camunda.service.TenantServices.TenantDTO;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
@@ -16,7 +15,7 @@ public record AuthenticationContext(
     String username,
     String clientId,
     List<String> roles,
-    List<TenantDTO> tenants,
+    List<String> tenants,
     List<String> groups,
     boolean groupsClaimEnabled)
     implements Serializable {
@@ -25,7 +24,7 @@ public record AuthenticationContext(
     private String username;
     private String clientId;
     private List<String> roles = new ArrayList<>();
-    private List<TenantDTO> tenants = new ArrayList<>();
+    private List<String> tenants = new ArrayList<>();
     private List<String> groups = new ArrayList<>();
     private boolean groupsClaimEnabled = false;
 
@@ -44,7 +43,7 @@ public record AuthenticationContext(
       return this;
     }
 
-    public AuthenticationContextBuilder withTenants(final List<TenantDTO> tenants) {
+    public AuthenticationContextBuilder withTenants(final List<String> tenants) {
       this.tenants = tenants;
       return this;
     }

--- a/authentication/src/main/java/io/camunda/authentication/entity/CamundaUser.java
+++ b/authentication/src/main/java/io/camunda/authentication/entity/CamundaUser.java
@@ -9,7 +9,6 @@ package io.camunda.authentication.entity;
 
 import io.camunda.authentication.entity.AuthenticationContext.AuthenticationContextBuilder;
 import io.camunda.security.entity.ClusterMetadata;
-import io.camunda.service.TenantServices.TenantDTO;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -101,7 +100,7 @@ public final class CamundaUser extends User implements CamundaPrincipal {
     private String email;
     private List<String> roles = List.of();
     private List<? extends GrantedAuthority> authorities = List.of();
-    private List<TenantDTO> tenants = List.of();
+    private List<String> tenants = List.of();
     private List<String> groups = List.of();
     private String salesPlanType;
     private Map<ClusterMetadata.AppName, String> c8Links = Map.of();
@@ -148,7 +147,7 @@ public final class CamundaUser extends User implements CamundaPrincipal {
       return this;
     }
 
-    public CamundaUserBuilder withTenants(final List<TenantDTO> tenants) {
+    public CamundaUserBuilder withTenants(final List<String> tenants) {
       this.tenants = Objects.requireNonNullElse(tenants, List.of());
       return this;
     }

--- a/authentication/src/main/java/io/camunda/authentication/entity/CamundaUserDTO.java
+++ b/authentication/src/main/java/io/camunda/authentication/entity/CamundaUserDTO.java
@@ -7,8 +7,8 @@
  */
 package io.camunda.authentication.entity;
 
+import io.camunda.search.entities.TenantEntity;
 import io.camunda.security.entity.ClusterMetadata;
-import io.camunda.service.TenantServices.TenantDTO;
 import java.util.List;
 import java.util.Map;
 
@@ -19,7 +19,7 @@ public record CamundaUserDTO(
     String username,
     String email,
     List<String> authorizedApplications,
-    List<TenantDTO> tenants,
+    List<TenantEntity> tenants,
     List<String> groups,
     List<String> roles,
     String salesPlanType,

--- a/authentication/src/test/java/io/camunda/authentication/CamundaOAuthPrincipalServiceTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/CamundaOAuthPrincipalServiceTest.java
@@ -27,7 +27,6 @@ import io.camunda.service.GroupServices;
 import io.camunda.service.MappingRuleServices;
 import io.camunda.service.RoleServices;
 import io.camunda.service.TenantServices;
-import io.camunda.service.TenantServices.TenantDTO;
 import io.camunda.zeebe.protocol.record.value.EntityType;
 import java.util.List;
 import java.util.Map;
@@ -263,7 +262,7 @@ public class CamundaOAuthPrincipalServiceTest {
           .containsAll(Set.of(roleR1.roleId(), groupRole.roleId()));
       assertThat(authenticationContext.groups()).containsExactly("group-g1");
       assertThat(authenticationContext.tenants())
-          .containsAll(List.of(TenantDTO.fromEntity(tenantT1), TenantDTO.fromEntity(groupTenant)));
+          .containsAll(List.of(tenantT1.tenantId(), groupTenant.tenantId()));
     }
 
     @Test
@@ -324,8 +323,7 @@ public class CamundaOAuthPrincipalServiceTest {
       assertThat(authenticationContext.roles()).containsExactly(roleR1.roleId());
       assertThat(authenticationContext.groups()).containsExactly("group-g1");
       assertThat(authenticationContext.tenants())
-          .containsExactlyInAnyOrder(
-              TenantDTO.fromEntity(tenantEntity1), TenantDTO.fromEntity(tenantEntity2));
+          .containsExactlyInAnyOrder(tenantEntity1.tenantId(), tenantEntity2.tenantId());
     }
   }
 

--- a/authentication/src/test/java/io/camunda/authentication/CamundaOidcUserServiceTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/CamundaOidcUserServiceTest.java
@@ -13,7 +13,6 @@ import static org.mockito.Mockito.when;
 import io.camunda.authentication.entity.AuthenticationContext;
 import io.camunda.authentication.entity.CamundaOidcUser;
 import io.camunda.authentication.entity.OAuthContext;
-import io.camunda.service.TenantServices.TenantDTO;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
@@ -72,7 +71,7 @@ public class CamundaOidcUserServiceTest {
                     .withUsername("test")
                     .withRoles(List.of(roleR1))
                     .withGroups(List.of("G1"))
-                    .withTenants(List.of(new TenantDTO(1L, "tenant-1", "Tenant One", "desc")))
+                    .withTenants(List.of("tenant-1"))
                     .build()));
 
     // when
@@ -87,7 +86,7 @@ public class CamundaOidcUserServiceTest {
     final AuthenticationContext authenticationContext = camundaUser.getAuthenticationContext();
     assertThat(authenticationContext.roles()).containsAll(Set.of(roleR1));
     assertThat(authenticationContext.tenants()).hasSize(1);
-    assertThat(authenticationContext.tenants().get(0).tenantId()).isEqualTo("tenant-1");
+    assertThat(authenticationContext.tenants().getFirst()).isEqualTo("tenant-1");
     assertThat(authenticationContext.groups()).containsExactly("G1");
   }
 

--- a/authentication/src/test/java/io/camunda/authentication/CamundaUserDetailsServiceTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/CamundaUserDetailsServiceTest.java
@@ -22,7 +22,6 @@ import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.GroupServices;
 import io.camunda.service.RoleServices;
 import io.camunda.service.TenantServices;
-import io.camunda.service.TenantServices.TenantDTO;
 import io.camunda.service.UserServices;
 import io.camunda.zeebe.protocol.record.value.EntityType;
 import java.util.Collections;
@@ -100,7 +99,7 @@ public class CamundaUserDetailsServiceTest {
         .isEqualTo(List.of(adminRole.roleId(), groupRole.roleId()));
     assertThat(user.getAuthenticationContext().groups()).isEqualTo(List.of(adminGroup.groupId()));
     assertThat(user.getAuthenticationContext().tenants())
-        .isEqualTo(List.of(TenantDTO.fromEntity(adminTenant), TenantDTO.fromEntity(groupTenant)));
+        .isEqualTo(List.of(adminTenant.tenantId(), groupTenant.tenantId()));
   }
 
   @Test

--- a/authentication/src/test/java/io/camunda/authentication/DefaultCamundaAuthenticationConverterTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/DefaultCamundaAuthenticationConverterTest.java
@@ -18,7 +18,6 @@ import io.camunda.authentication.entity.CamundaOidcUser;
 import io.camunda.authentication.entity.CamundaUser.CamundaUserBuilder;
 import io.camunda.authentication.entity.OAuthContext;
 import io.camunda.security.auth.CamundaAuthenticationConverter;
-import io.camunda.service.TenantServices.TenantDTO;
 import io.camunda.zeebe.auth.Authorization;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
@@ -125,10 +124,7 @@ public class DefaultCamundaAuthenticationConverterTest {
   void authenticationContainsTenantIdsInAuthenticationContext() {
     // given
     final var username = "test-user";
-    final var tenants =
-        List.of(
-            new TenantDTO(1L, "tenant-1", "Tenant One", "First"),
-            new TenantDTO(2L, "tenant-2", "Tenant Two", "Second"));
+    final var tenants = List.of("tenant-1", "tenant-2");
     final var authenticationContext =
         new AuthenticationContextBuilder().withUsername(username).withTenants(tenants).build();
 

--- a/authentication/src/test/java/io/camunda/authentication/OidcCamundaUserServiceTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/OidcCamundaUserServiceTest.java
@@ -37,7 +37,7 @@ public class OidcCamundaUserServiceTest {
 
   @BeforeEach
   public void setUp() throws Exception {
-    oidcCamundaUserService = new OidcCamundaUserService(null, null);
+    oidcCamundaUserService = new OidcCamundaUserService(null, null, null);
   }
 
   @Test

--- a/db/rdbms/src/main/resources/mapper/TenantMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/TenantMapper.xml
@@ -35,7 +35,10 @@
   <sql id="searchFilter">
     WHERE 1 = 1
     <if test="filter.key != null">AND TENANT_KEY = #{filter.key}</if>
-    <if test="filter.tenantId != null">AND TENANT_ID = #{filter.tenantId}</if>
+    <if test="filter.tenantIds != null and !filter.tenantIds.isEmpty()">
+      AND TENANT_ID IN
+      <foreach collection="filter.tenantIds" item="value" open="(" separator=", " close=")">#{value}</foreach>
+    </if>
     <if test="filter.name != null">AND NAME = #{filter.name}</if>
   </sql>
 

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/handler/sm/TenantMigrationHandler.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/handler/sm/TenantMigrationHandler.java
@@ -21,8 +21,8 @@ import io.camunda.migration.identity.dto.Tenant;
 import io.camunda.migration.identity.handler.MigrationHandler;
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.TenantServices;
-import io.camunda.service.TenantServices.TenantDTO;
 import io.camunda.service.TenantServices.TenantMemberRequest;
+import io.camunda.service.TenantServices.TenantRequest;
 import io.camunda.zeebe.protocol.record.value.EntityType;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -80,7 +80,7 @@ public class TenantMigrationHandler extends MigrationHandler<Tenant> {
           if (!tenant.tenantId().equals(DEFAULT_TENANT_IDENTIFIER)) {
             tenantId = normalizeID(tenant.tenantId());
             try {
-              final var tenantDto = new TenantDTO(null, tenantId, tenant.name(), null);
+              final var tenantDto = new TenantRequest(null, tenantId, tenant.name(), null);
               retryOnBackpressure(
                   () -> tenantService.createTenant(tenantDto).join(),
                   "Failed to create tenant with ID: " + tenantId);

--- a/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/sm/KeycloakTenantMigrationHandlerTest.java
+++ b/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/sm/KeycloakTenantMigrationHandlerTest.java
@@ -24,8 +24,8 @@ import io.camunda.migration.identity.dto.Group;
 import io.camunda.migration.identity.dto.Tenant;
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.TenantServices;
-import io.camunda.service.TenantServices.TenantDTO;
 import io.camunda.service.TenantServices.TenantMemberRequest;
+import io.camunda.service.TenantServices.TenantRequest;
 import io.camunda.service.exception.ErrorMapper;
 import io.camunda.zeebe.broker.client.api.BrokerErrorException;
 import io.camunda.zeebe.broker.client.api.BrokerRejectionException;
@@ -77,7 +77,7 @@ public class KeycloakTenantMigrationHandlerTest {
                 new Tenant("tenant1", "Tenant 1"),
                 new Tenant("tenant2", "Tenant 2"),
                 new Tenant("<default>", "Default Tenant")));
-    when(tenantServices.createTenant(any(TenantDTO.class)))
+    when(tenantServices.createTenant(any(TenantRequest.class)))
         .thenReturn(CompletableFuture.completedFuture(null));
     when(tenantServices.addMember(any(TenantMemberRequest.class)))
         .thenReturn(CompletableFuture.completedFuture(null));
@@ -111,7 +111,7 @@ public class KeycloakTenantMigrationHandlerTest {
     migrationHandler.migrate();
 
     // then
-    final var tenantCapture = ArgumentCaptor.forClass(TenantDTO.class);
+    final var tenantCapture = ArgumentCaptor.forClass(TenantRequest.class);
     verify(tenantServices, times(2)).createTenant(tenantCapture.capture());
     final var capturedTenants = tenantCapture.getAllValues();
     assertThat(capturedTenants).hasSize(2);
@@ -160,7 +160,7 @@ public class KeycloakTenantMigrationHandlerTest {
     migrationHandler.migrate();
 
     // then
-    verify(tenantServices, times(0)).createTenant(any(TenantDTO.class));
+    verify(tenantServices, times(0)).createTenant(any(TenantRequest.class));
     verify(tenantServices, times(0)).addMember(any(TenantMemberRequest.class));
     verify(managementIdentityClient, times(1)).fetchTenants();
   }
@@ -173,7 +173,7 @@ public class KeycloakTenantMigrationHandlerTest {
                 new Tenant("tenant1", "Tenant 1"),
                 new Tenant("tenant2", "Tenant 2"),
                 new Tenant("<default>", "Default Tenant")));
-    when(tenantServices.createTenant(any(TenantDTO.class)))
+    when(tenantServices.createTenant(any(TenantRequest.class)))
         .thenReturn(CompletableFuture.completedFuture(null));
 
     when(managementIdentityClient.fetchTenantUsers(anyString()))
@@ -188,7 +188,7 @@ public class KeycloakTenantMigrationHandlerTest {
 
     // then
     // only for the non default tenants
-    verify(tenantServices, times(2)).createTenant(any(TenantDTO.class));
+    verify(tenantServices, times(2)).createTenant(any(TenantRequest.class));
     verify(tenantServices, times(0)).addMember(any(TenantMemberRequest.class));
     verify(managementIdentityClient, times(1)).fetchTenants();
     // once for every tenant
@@ -202,7 +202,7 @@ public class KeycloakTenantMigrationHandlerTest {
     // given
     when(managementIdentityClient.fetchTenants())
         .thenReturn(List.of(new Tenant("tenant1", "Tenant 1"), new Tenant("tenant2", "Tenant 2")));
-    when(tenantServices.createTenant(any(TenantDTO.class)))
+    when(tenantServices.createTenant(any(TenantRequest.class)))
         .thenReturn(
             CompletableFuture.failedFuture(
                 ErrorMapper.mapError(
@@ -243,7 +243,7 @@ public class KeycloakTenantMigrationHandlerTest {
     migrationHandler.migrate();
 
     // then
-    verify(tenantServices, times(2)).createTenant(any(TenantDTO.class));
+    verify(tenantServices, times(2)).createTenant(any(TenantRequest.class));
     verify(tenantServices, times(9)).addMember(any(TenantMemberRequest.class));
   }
 
@@ -256,7 +256,7 @@ public class KeycloakTenantMigrationHandlerTest {
                 new Tenant("tenant1", "Tenant 1"),
                 new Tenant("tenant2", "Tenant 2"),
                 new Tenant("<default>", "Default Tenant")));
-    when(tenantServices.createTenant(any(TenantDTO.class)))
+    when(tenantServices.createTenant(any(TenantRequest.class)))
         .thenReturn(
             CompletableFuture.failedFuture(
                 ErrorMapper.mapError(
@@ -295,7 +295,7 @@ public class KeycloakTenantMigrationHandlerTest {
     migrationHandler.migrate();
 
     // then
-    verify(tenantServices, times(3)).createTenant(any(TenantDTO.class));
+    verify(tenantServices, times(3)).createTenant(any(TenantRequest.class));
     verify(tenantServices, times(12)).addMember(any(TenantMemberRequest.class));
   }
 
@@ -308,7 +308,7 @@ public class KeycloakTenantMigrationHandlerTest {
                 new Tenant("tenant1", "Tenant 1"),
                 new Tenant("tenant2", "Tenant 2"),
                 new Tenant("<default>", "Default Tenant")));
-    when(tenantServices.createTenant(any(TenantDTO.class)))
+    when(tenantServices.createTenant(any(TenantRequest.class)))
         .thenReturn(CompletableFuture.completedFuture(null));
     when(tenantServices.addMember(any(TenantMemberRequest.class)))
         .thenReturn(
@@ -347,7 +347,7 @@ public class KeycloakTenantMigrationHandlerTest {
     migrationHandler.migrate();
 
     // then
-    verify(tenantServices, times(2)).createTenant(any(TenantDTO.class));
+    verify(tenantServices, times(2)).createTenant(any(TenantRequest.class));
     verify(tenantServices, times(13)).addMember(any(TenantMemberRequest.class));
   }
 }

--- a/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/sm/OidcTenantMigrationHandlerTest.java
+++ b/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/sm/OidcTenantMigrationHandlerTest.java
@@ -19,8 +19,8 @@ import io.camunda.migration.identity.config.IdentityMigrationProperties.Mode;
 import io.camunda.migration.identity.dto.Tenant;
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.TenantServices;
-import io.camunda.service.TenantServices.TenantDTO;
 import io.camunda.service.TenantServices.TenantMemberRequest;
+import io.camunda.service.TenantServices.TenantRequest;
 import io.camunda.service.exception.ErrorMapper;
 import io.camunda.zeebe.broker.client.api.BrokerErrorException;
 import io.camunda.zeebe.broker.client.api.BrokerRejectionException;
@@ -71,14 +71,14 @@ public class OidcTenantMigrationHandlerTest {
                 new Tenant("tenant1", "Tenant 1"),
                 new Tenant("tenant2", "Tenant 2"),
                 new Tenant("<default>", "Default Tenant")));
-    when(tenantServices.createTenant(any(TenantDTO.class)))
+    when(tenantServices.createTenant(any(TenantRequest.class)))
         .thenReturn(CompletableFuture.completedFuture(null));
 
     // when
     migrationHandler.migrate();
 
     // then
-    final var tenantCapture = ArgumentCaptor.forClass(TenantDTO.class);
+    final var tenantCapture = ArgumentCaptor.forClass(TenantRequest.class);
     verify(tenantServices, times(2)).createTenant(tenantCapture.capture());
     final var capturedTenants = tenantCapture.getAllValues();
     assertThat(capturedTenants).hasSize(2);
@@ -98,7 +98,7 @@ public class OidcTenantMigrationHandlerTest {
     migrationHandler.migrate();
 
     // then
-    verify(tenantServices, times(0)).createTenant(any(TenantDTO.class));
+    verify(tenantServices, times(0)).createTenant(any(TenantRequest.class));
     verify(managementIdentityClient, times(1)).fetchTenants();
   }
 
@@ -107,7 +107,7 @@ public class OidcTenantMigrationHandlerTest {
     // given
     when(managementIdentityClient.fetchTenants())
         .thenReturn(List.of(new Tenant("tenant1", "Tenant 1"), new Tenant("tenant2", "Tenant 2")));
-    when(tenantServices.createTenant(any(TenantDTO.class)))
+    when(tenantServices.createTenant(any(TenantRequest.class)))
         .thenReturn(
             CompletableFuture.failedFuture(
                 ErrorMapper.mapError(
@@ -122,7 +122,7 @@ public class OidcTenantMigrationHandlerTest {
     migrationHandler.migrate();
 
     // then
-    verify(tenantServices, times(2)).createTenant(any(TenantDTO.class));
+    verify(tenantServices, times(2)).createTenant(any(TenantRequest.class));
     verify(tenantServices, times(0)).addMember(any(TenantMemberRequest.class));
   }
 
@@ -135,7 +135,7 @@ public class OidcTenantMigrationHandlerTest {
                 new Tenant("tenant1", "Tenant 1"),
                 new Tenant("tenant2", "Tenant 2"),
                 new Tenant("<default>", "Default Tenant")));
-    when(tenantServices.createTenant(any(TenantDTO.class)))
+    when(tenantServices.createTenant(any(TenantRequest.class)))
         .thenReturn(
             CompletableFuture.failedFuture(
                 ErrorMapper.mapError(
@@ -147,7 +147,7 @@ public class OidcTenantMigrationHandlerTest {
     migrationHandler.migrate();
 
     // then
-    verify(tenantServices, times(3)).createTenant(any(TenantDTO.class));
+    verify(tenantServices, times(3)).createTenant(any(TenantRequest.class));
     verify(tenantServices, times(0)).addMember(any(TenantMemberRequest.class));
   }
 }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/TenantFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/TenantFilterTransformer.java
@@ -79,7 +79,7 @@ public class TenantFilterTransformer extends IndexFilterTransformer<TenantFilter
   private SearchQuery buildCoreFilters(final TenantFilter filter) {
     return and(
         filter.key() == null ? null : term(KEY, filter.key()),
-        filter.tenantId() == null ? null : term(TENANT_ID, filter.tenantId()),
+        filter.tenantIds() == null ? null : stringTerms(TENANT_ID, filter.tenantIds()),
         filter.name() == null ? null : term(NAME, filter.name()),
         filter.joinParentId() == null
             ? term(TenantIndex.JOIN, IdentityJoinRelationshipType.TENANT.getType())

--- a/search/search-domain/src/main/java/io/camunda/search/filter/TenantFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/TenantFilter.java
@@ -7,15 +7,19 @@
  */
 package io.camunda.search.filter;
 
+import static io.camunda.util.CollectionUtil.addValuesToList;
+import static io.camunda.util.CollectionUtil.collectValues;
+
 import io.camunda.util.ObjectBuilder;
 import io.camunda.zeebe.protocol.record.value.EntityType;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 
 public record TenantFilter(
     Long key,
-    String tenantId,
+    List<String> tenantIds,
     String name,
     String joinParentId,
     EntityType entityType,
@@ -31,7 +35,7 @@ public record TenantFilter(
   public Builder toBuilder() {
     return new Builder()
         .key(key)
-        .tenantId(tenantId)
+        .tenantIds(tenantIds)
         .name(name)
         .joinParentId(joinParentId)
         .memberType(entityType)
@@ -43,7 +47,7 @@ public record TenantFilter(
   public static final class Builder implements ObjectBuilder<TenantFilter> {
 
     private Long key;
-    private String tenantId;
+    private List<String> tenantIds;
     private String name;
     private String joinParentId;
     private EntityType entityType;
@@ -56,8 +60,12 @@ public record TenantFilter(
       return this;
     }
 
-    public Builder tenantId(final String value) {
-      tenantId = value;
+    public Builder tenantId(final String value, final String... values) {
+      return tenantIds(collectValues(value, values));
+    }
+
+    public Builder tenantIds(final List<String> values) {
+      tenantIds = addValuesToList(tenantIds, values);
       return this;
     }
 
@@ -95,7 +103,7 @@ public record TenantFilter(
     public TenantFilter build() {
       return new TenantFilter(
           key,
-          tenantId,
+          tenantIds,
           name,
           joinParentId,
           entityType,

--- a/service/src/main/java/io/camunda/service/TenantServices.java
+++ b/service/src/main/java/io/camunda/service/TenantServices.java
@@ -25,7 +25,6 @@ import io.camunda.zeebe.gateway.impl.broker.request.tenant.BrokerTenantDeleteReq
 import io.camunda.zeebe.gateway.impl.broker.request.tenant.BrokerTenantUpdateRequest;
 import io.camunda.zeebe.protocol.impl.record.value.tenant.TenantRecord;
 import io.camunda.zeebe.protocol.record.value.EntityType;
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -72,7 +71,7 @@ public class TenantServices extends SearchQueryService<TenantServices, TenantQue
         brokerClient, securityContextProvider, tenantSearchClient, authentication);
   }
 
-  public CompletableFuture<TenantRecord> createTenant(final TenantDTO request) {
+  public CompletableFuture<TenantRecord> createTenant(final TenantRequest request) {
     return sendBrokerRequest(
         new BrokerTenantCreateRequest()
             .setTenantId(request.tenantId())
@@ -80,7 +79,7 @@ public class TenantServices extends SearchQueryService<TenantServices, TenantQue
             .setDescription(request.description()));
   }
 
-  public CompletableFuture<TenantRecord> updateTenant(final TenantDTO request) {
+  public CompletableFuture<TenantRecord> updateTenant(final TenantRequest request) {
     return sendBrokerRequest(
         new BrokerTenantUpdateRequest(request.tenantId())
             .setName(request.name())
@@ -155,12 +154,7 @@ public class TenantServices extends SearchQueryService<TenantServices, TenantQue
                 .getTenant(tenantId));
   }
 
-  public record TenantDTO(Long key, String tenantId, String name, String description)
-      implements Serializable {
-    public static TenantDTO fromEntity(final TenantEntity entity) {
-      return new TenantDTO(entity.key(), entity.tenantId(), entity.name(), entity.description());
-    }
-  }
+  public record TenantRequest(Long key, String tenantId, String name, String description) {}
 
   public record TenantMemberRequest(String tenantId, String entityId, EntityType entityType) {}
 }

--- a/service/src/test/java/io/camunda/service/TenantServiceTest.java
+++ b/service/src/test/java/io/camunda/service/TenantServiceTest.java
@@ -21,8 +21,8 @@ import io.camunda.search.filter.TenantFilter;
 import io.camunda.search.query.SearchQueryBuilders;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.auth.CamundaAuthentication;
-import io.camunda.service.TenantServices.TenantDTO;
 import io.camunda.service.TenantServices.TenantMemberRequest;
+import io.camunda.service.TenantServices.TenantRequest;
 import io.camunda.service.authorization.Authorizations;
 import io.camunda.service.exception.ServiceException;
 import io.camunda.service.exception.ServiceException.Status;
@@ -93,7 +93,7 @@ public class TenantServiceTest {
   public void shouldCreateTenant() {
     // given
     final var tenantDTO =
-        new TenantDTO(100L, "NewTenantName", "NewTenantId", "NewTenantDescription");
+        new TenantRequest(100L, "NewTenantName", "NewTenantId", "NewTenantDescription");
 
     // when
     services.createTenant(tenantDTO);
@@ -112,7 +112,7 @@ public class TenantServiceTest {
 
     // given
     final var tenantDTO =
-        new TenantDTO(tenantEntity.key(), tenantEntity.tenantId(), "UpdatedTenantId", null);
+        new TenantRequest(tenantEntity.key(), tenantEntity.tenantId(), "UpdatedTenantId", null);
 
     // when
     services.updateTenant(tenantDTO);
@@ -131,7 +131,7 @@ public class TenantServiceTest {
 
     // given
     final var tenantDTO =
-        new TenantDTO(
+        new TenantRequest(
             tenantEntity.key(), tenantEntity.tenantId(), "TenantName", "UpdatedTenantDescription");
 
     // when

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RequestMapper.java
@@ -63,8 +63,8 @@ import io.camunda.service.ResourceServices.ResourceDeletionRequest;
 import io.camunda.service.RoleServices.CreateRoleRequest;
 import io.camunda.service.RoleServices.RoleMemberRequest;
 import io.camunda.service.RoleServices.UpdateRoleRequest;
-import io.camunda.service.TenantServices.TenantDTO;
 import io.camunda.service.TenantServices.TenantMemberRequest;
+import io.camunda.service.TenantServices.TenantRequest;
 import io.camunda.service.UserServices.UserDTO;
 import io.camunda.zeebe.gateway.protocol.rest.AdHocSubProcessActivateActivitiesInstruction;
 import io.camunda.zeebe.gateway.protocol.rest.AuthorizationRequest;
@@ -829,24 +829,24 @@ public class RequestMapper {
                 tenantId));
   }
 
-  public static Either<ProblemDetail, TenantDTO> toTenantCreateDto(
+  public static Either<ProblemDetail, TenantRequest> toTenantCreateDto(
       final TenantCreateRequest tenantCreateRequest) {
     return getResult(
         TenantRequestValidator.validateTenantCreateRequest(tenantCreateRequest),
         () ->
-            new TenantDTO(
+            new TenantRequest(
                 null,
                 tenantCreateRequest.getTenantId(),
                 tenantCreateRequest.getName(),
                 tenantCreateRequest.getDescription()));
   }
 
-  public static Either<ProblemDetail, TenantDTO> toTenantUpdateDto(
+  public static Either<ProblemDetail, TenantRequest> toTenantUpdateDto(
       final String tenantId, final TenantUpdateRequest tenantUpdateRequest) {
     return getResult(
         TenantRequestValidator.validateTenantUpdateRequest(tenantUpdateRequest),
         () ->
-            new TenantDTO(
+            new TenantRequest(
                 null,
                 tenantId,
                 tenantUpdateRequest.getName(),

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantController.java
@@ -19,8 +19,8 @@ import io.camunda.service.GroupServices;
 import io.camunda.service.MappingRuleServices;
 import io.camunda.service.RoleServices;
 import io.camunda.service.TenantServices;
-import io.camunda.service.TenantServices.TenantDTO;
 import io.camunda.service.TenantServices.TenantMemberRequest;
+import io.camunda.service.TenantServices.TenantRequest;
 import io.camunda.service.UserServices;
 import io.camunda.zeebe.gateway.protocol.rest.GroupSearchQueryResult;
 import io.camunda.zeebe.gateway.protocol.rest.MappingRuleSearchQueryRequest;
@@ -266,12 +266,13 @@ public class TenantController {
             tenantQuery -> searchClientsInTenant(tenantId, tenantQuery));
   }
 
-  private CompletableFuture<ResponseEntity<Object>> createTenant(final TenantDTO tenantDTO) {
+  private CompletableFuture<ResponseEntity<Object>> createTenant(
+      final TenantRequest tenantRequest) {
     return RequestMapper.executeServiceMethod(
         () ->
             tenantServices
                 .withAuthentication(authenticationProvider.getCamundaAuthentication())
-                .createTenant(tenantDTO),
+                .createTenant(tenantRequest),
         ResponseMapper::toTenantCreateResponse);
   }
 
@@ -419,12 +420,13 @@ public class TenantController {
         .build();
   }
 
-  private CompletableFuture<ResponseEntity<Object>> updateTenant(final TenantDTO tenantDTO) {
+  private CompletableFuture<ResponseEntity<Object>> updateTenant(
+      final TenantRequest tenantRequest) {
     return RequestMapper.executeServiceMethod(
         () ->
             tenantServices
                 .withAuthentication(authenticationProvider.getCamundaAuthentication())
-                .updateTenant(tenantDTO),
+                .updateTenant(tenantRequest),
         ResponseMapper::toTenantUpdateResponse);
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantControllerTest.java
@@ -20,8 +20,8 @@ import io.camunda.service.GroupServices;
 import io.camunda.service.MappingRuleServices;
 import io.camunda.service.RoleServices;
 import io.camunda.service.TenantServices;
-import io.camunda.service.TenantServices.TenantDTO;
 import io.camunda.service.TenantServices.TenantMemberRequest;
+import io.camunda.service.TenantServices.TenantRequest;
 import io.camunda.service.UserServices;
 import io.camunda.service.exception.ErrorMapper;
 import io.camunda.zeebe.broker.client.api.dto.BrokerRejection;
@@ -81,7 +81,7 @@ public class TenantControllerTest {
       // given
       final var tenantName = "Test Tenant";
       final var tenantDescription = "Test description";
-      when(tenantServices.createTenant(new TenantDTO(null, id, tenantName, tenantDescription)))
+      when(tenantServices.createTenant(new TenantRequest(null, id, tenantName, tenantDescription)))
           .thenReturn(
               CompletableFuture.completedFuture(
                   new TenantRecord()
@@ -106,7 +106,7 @@ public class TenantControllerTest {
 
       // then
       verify(tenantServices, times(1))
-          .createTenant(new TenantDTO(null, id, tenantName, tenantDescription));
+          .createTenant(new TenantRequest(null, id, tenantName, tenantDescription));
     }
 
     @Test
@@ -116,7 +116,7 @@ public class TenantControllerTest {
       final var tenantId = "tenantId";
       final var tenantDescription = "Test description";
       when(tenantServices.createTenant(
-              new TenantDTO(null, tenantId, tenantName, tenantDescription)))
+              new TenantRequest(null, tenantId, tenantName, tenantDescription)))
           .thenReturn(
               CompletableFuture.completedFuture(
                   new TenantRecord()
@@ -152,7 +152,7 @@ public class TenantControllerTest {
 
       // then
       verify(tenantServices, times(1))
-          .createTenant(new TenantDTO(null, tenantId, tenantName, tenantDescription));
+          .createTenant(new TenantRequest(null, tenantId, tenantName, tenantDescription));
     }
 
     @Test
@@ -266,7 +266,7 @@ public class TenantControllerTest {
       final var tenantId = "tenant-test-id";
       final var tenantDescription = "Updated description";
       when(tenantServices.updateTenant(
-              new TenantDTO(null, tenantId, tenantName, tenantDescription)))
+              new TenantRequest(null, tenantId, tenantName, tenantDescription)))
           .thenReturn(
               CompletableFuture.completedFuture(
                   new TenantRecord()
@@ -298,7 +298,7 @@ public class TenantControllerTest {
 
       // then
       verify(tenantServices, times(1))
-          .updateTenant(new TenantDTO(null, tenantId, tenantName, tenantDescription));
+          .updateTenant(new TenantRequest(null, tenantId, tenantName, tenantDescription));
     }
 
     @Test
@@ -375,7 +375,7 @@ public class TenantControllerTest {
       final var tenantDescription = "My tenant description";
       final var path = "%s/%s".formatted(TENANT_BASE_URL, tenantId);
       when(tenantServices.updateTenant(
-              new TenantDTO(null, tenantId, tenantName, tenantDescription)))
+              new TenantRequest(null, tenantId, tenantName, tenantDescription)))
           .thenReturn(
               CompletableFuture.failedFuture(
                   ErrorMapper.mapBrokerRejection(
@@ -394,7 +394,7 @@ public class TenantControllerTest {
           .isNotFound();
 
       verify(tenantServices, times(1))
-          .updateTenant(new TenantDTO(null, tenantId, tenantName, tenantDescription));
+          .updateTenant(new TenantRequest(null, tenantId, tenantName, tenantDescription));
     }
 
     @Test


### PR DESCRIPTION
## Description

* Renames `TenantDTO` into `TenantRequest` to make clear that record is used to process a request to create or update a given tenant
* Stores only the `tenantIds` in the `AuthenticationContext`
* Resolves the actual tenants when fetching the current authenticated user `GET /v2/authentication/me`

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #36167 
