### PR TITLE
feat: Create Jobs for for Ad-Hoc Sub-Processes

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobBehavior.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.engine.metrics.JobProcessingMetrics;
 import io.camunda.zeebe.engine.processing.bpmn.BpmnElementContext;
 import io.camunda.zeebe.engine.processing.common.ExpressionProcessor;
 import io.camunda.zeebe.engine.processing.common.Failure;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableAdHocSubProcess;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableJobWorkerElement;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutionListener;
 import io.camunda.zeebe.engine.processing.deployment.model.element.JobWorkerProperties;
@@ -315,6 +316,18 @@ public final class BpmnJobBehavior {
                     extractUserTaskHeaders(
                         taskRecordValue, changedAttributes, listener.getJobWorkerProperties())))
         .ifLeft(failure -> incidentBehavior.createIncident(failure, context));
+  }
+
+  public void createNewAdHocSubProcessJob(
+      final BpmnElementContext context,
+      final ExecutableAdHocSubProcess element,
+      final JobProperties jobProperties) {
+    writeJobCreatedEvent(
+        context,
+        jobProperties,
+        JobKind.AD_HOC_SUB_PROCESS,
+        JobListenerEventType.UNSPECIFIED,
+        element.getJobWorkerProperties().getTaskHeaders());
   }
 
   private Either<Failure, JobProperties> evaluateTaskListenerJobExpressions(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/AdHocSubProcessProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/AdHocSubProcessProcessor.java
@@ -22,11 +22,14 @@ import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnVariableMappingBehav
 import io.camunda.zeebe.engine.processing.common.ExpressionProcessor;
 import io.camunda.zeebe.engine.processing.common.Failure;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableAdHocSubProcess;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeAdHocImplementationType;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.ErrorType;
 import io.camunda.zeebe.util.Either;
 import java.util.Collections;
+import java.util.EnumMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 public class AdHocSubProcessProcessor
@@ -41,6 +44,13 @@ public class AdHocSubProcessProcessor
   private final ExpressionProcessor expressionProcessor;
   private final BpmnCompensationSubscriptionBehaviour compensationSubscriptionBehaviour;
   private final BpmnAdHocSubProcessBehavior adHocSubProcessBehavior;
+
+  private final EnumMap<ZeebeAdHocImplementationType, AdHocSubProcessBehavior>
+      adHocSubProcessBehaviors =
+          new EnumMap<>(
+              Map.ofEntries(
+                  Map.entry(ZeebeAdHocImplementationType.BPMN, new BpmnBehavior()),
+                  Map.entry(ZeebeAdHocImplementationType.JOB_WORKER, new JobWorkerBehavior())));
 
   public AdHocSubProcessProcessor(
       final BpmnBehaviors bpmnBehaviors,
@@ -290,5 +300,70 @@ public class AdHocSubProcessProcessor
       // all remaining child instances were terminated.
       stateTransitionBehavior.completeElement(adHocSubProcessContext);
     }
+  }
+
+  private interface AdHocSubProcessBehavior {
+
+    Either<Failure, ?> onActivation(
+        final ExecutableAdHocSubProcess element, final BpmnElementContext context);
+
+    Either<Failure, ?> beforeExecutionPathCompleted(
+        final ExecutableAdHocSubProcess adHocSubProcess,
+        final BpmnElementContext adHocSubProcessContext,
+        final BpmnElementContext childContext);
+
+    void afterExecutionPathCompleted(
+        final ExecutableAdHocSubProcess adHocSubProcess,
+        final BpmnElementContext adHocSubProcessContext,
+        final BpmnElementContext childContext,
+        final Boolean satisfiesCompletionCondition);
+  }
+
+  private final class BpmnBehavior implements AdHocSubProcessBehavior {
+
+    @Override
+    public Either<Failure, ?> onActivation(
+        final ExecutableAdHocSubProcess element, final BpmnElementContext context) {
+      return null;
+    }
+
+    @Override
+    public Either<Failure, ?> beforeExecutionPathCompleted(
+        final ExecutableAdHocSubProcess adHocSubProcess,
+        final BpmnElementContext adHocSubProcessContext,
+        final BpmnElementContext childContext) {
+      return null;
+    }
+
+    @Override
+    public void afterExecutionPathCompleted(
+        final ExecutableAdHocSubProcess adHocSubProcess,
+        final BpmnElementContext adHocSubProcessContext,
+        final BpmnElementContext childContext,
+        final Boolean satisfiesCompletionCondition) {}
+  }
+
+  private final class JobWorkerBehavior implements AdHocSubProcessBehavior {
+
+    @Override
+    public Either<Failure, ?> onActivation(
+        final ExecutableAdHocSubProcess element, final BpmnElementContext context) {
+      return null;
+    }
+
+    @Override
+    public Either<Failure, ?> beforeExecutionPathCompleted(
+        final ExecutableAdHocSubProcess adHocSubProcess,
+        final BpmnElementContext adHocSubProcessContext,
+        final BpmnElementContext childContext) {
+      return null;
+    }
+
+    @Override
+    public void afterExecutionPathCompleted(
+        final ExecutableAdHocSubProcess adHocSubProcess,
+        final BpmnElementContext adHocSubProcessContext,
+        final BpmnElementContext childContext,
+        final Boolean satisfiesCompletionCondition) {}
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/AdHocSubProcessProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/AdHocSubProcessProcessor.java
@@ -356,7 +356,14 @@ public class AdHocSubProcessProcessor
     @Override
     public Either<Failure, ?> finalizeActivation(
         final ExecutableAdHocSubProcess element, final BpmnElementContext context) {
-      return null;
+      return jobBehavior
+          .evaluateJobExpressions(element.getJobWorkerProperties(), context)
+          .flatMap(j -> eventSubscriptionBehavior.subscribeToEvents(element, context).map(ok -> j))
+          .thenDo(
+              jobProperties -> {
+                jobBehavior.createNewAdHocSubProcessJob(context, element, jobProperties);
+                stateTransitionBehavior.transitionToActivated(context, element.getEventType());
+              });
     }
 
     @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/AdHocSubProcessProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/AdHocSubProcessProcessor.java
@@ -112,7 +112,8 @@ public class AdHocSubProcessProcessor
   public TransitionOutcome onTerminate(
       final ExecutableAdHocSubProcess element, final BpmnElementContext terminating) {
 
-    if (element.hasExecutionListeners()) {
+    if (element.hasExecutionListeners()
+        || element.getImplementationType() == ZeebeAdHocImplementationType.JOB_WORKER) {
       jobBehavior.cancelJob(terminating);
     }
     eventSubscriptionBehavior.unsubscribeFromEvents(terminating);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/AdHocSubProcessProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/AdHocSubProcessProcessor.java
@@ -379,6 +379,17 @@ public class AdHocSubProcessProcessor
         final ExecutableAdHocSubProcess adHocSubProcess,
         final BpmnElementContext adHocSubProcessContext,
         final BpmnElementContext childContext,
-        final Boolean satisfiesCompletionCondition) {}
+        final Boolean satisfiesCompletionCondition) {
+      // There should only be 1 active Job for the ad-hoc sub-process. We should cancel any active
+      // job before creating the new one.
+      jobBehavior.cancelJob(adHocSubProcessContext);
+
+      jobBehavior
+          .evaluateJobExpressions(adHocSubProcess.getJobWorkerProperties(), adHocSubProcessContext)
+          .thenDo(
+              jobProperties ->
+                  jobBehavior.createNewAdHocSubProcessJob(
+                      adHocSubProcessContext, adHocSubProcess, jobProperties));
+    }
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/AdHocSubProcessProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/AdHocSubProcessProcessor.java
@@ -372,7 +372,7 @@ public class AdHocSubProcessProcessor
         final ExecutableAdHocSubProcess adHocSubProcess,
         final BpmnElementContext adHocSubProcessContext,
         final BpmnElementContext childContext) {
-      return null;
+      return SUCCESS;
     }
 
     @Override

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/JobBasedAdHocSubProcessTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/JobBasedAdHocSubProcessTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.bpmn.activity;
+
+import static io.camunda.zeebe.protocol.record.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.model.bpmn.builder.AdHocSubProcessBuilder;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeAdHocImplementationType;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.BpmnEventType;
+import io.camunda.zeebe.protocol.record.value.DeploymentRecordValue;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.function.Consumer;
+import org.assertj.core.api.Assertions;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestWatcher;
+
+public class JobBasedAdHocSubProcessTest {
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+  public static final String JOB_TYPE = "jobType";
+  private static final String PROCESS_ID = "process";
+  private static final String AHSP_ELEMENT_ID = "ad-hoc";
+  @Rule public final TestWatcher watcher = new RecordingExporterTestWatcher();
+
+  private BpmnModelInstance process(final Consumer<AdHocSubProcessBuilder> modifier) {
+    return Bpmn.createExecutableProcess(PROCESS_ID)
+        .startEvent()
+        .adHocSubProcess(AHSP_ELEMENT_ID, modifier)
+        .zeebeImplementation(ZeebeAdHocImplementationType.JOB_WORKER)
+        .zeebeJobType(JOB_TYPE)
+        .endEvent()
+        .done();
+  }
+
+  @Test
+  public void shouldDeployProcess() {
+    // given
+    final BpmnModelInstance process =
+        process(
+            adHocSubProcess -> {
+              adHocSubProcess.task("A1").task("A2");
+              adHocSubProcess.task("B");
+            });
+
+    // when
+    final Record<DeploymentRecordValue> deploymentEvent =
+        ENGINE.deployment().withXmlResource(process).deploy();
+
+    // then
+    assertThat(deploymentEvent).hasRecordType(RecordType.EVENT).hasIntent(DeploymentIntent.CREATED);
+  }
+
+  @Test
+  public void shouldActivateAdHocSubProcess() {
+    // given
+    final BpmnModelInstance process = process(adHocSubProcess -> adHocSubProcess.task("A"));
+
+    ENGINE.deployment().withXmlResource(process).deploy();
+
+    // when
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // then
+    Assertions.assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limit(AHSP_ELEMENT_ID, ProcessInstanceIntent.ELEMENT_ACTIVATED))
+        .extracting(r -> r.getValue().getBpmnElementType(), Record::getIntent)
+        .containsSequence(
+            tuple(BpmnElementType.AD_HOC_SUB_PROCESS, ProcessInstanceIntent.ACTIVATE_ELEMENT),
+            tuple(BpmnElementType.AD_HOC_SUB_PROCESS, ProcessInstanceIntent.ELEMENT_ACTIVATING),
+            tuple(BpmnElementType.AD_HOC_SUB_PROCESS, ProcessInstanceIntent.ELEMENT_ACTIVATED));
+
+    assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementId(AHSP_ELEMENT_ID)
+                .getFirst()
+                .getValue())
+        .hasElementId(AHSP_ELEMENT_ID)
+        .hasBpmnElementType(BpmnElementType.AD_HOC_SUB_PROCESS)
+        .hasBpmnEventType(BpmnEventType.UNSPECIFIED)
+        .hasFlowScopeKey(processInstanceKey);
+  }
+
+  @Test
+  public void shouldCreateJobOnActivation() {
+    // given
+    final BpmnModelInstance process =
+        process(
+            adHocSubProcess -> {
+              adHocSubProcess.task("A1");
+            });
+    ENGINE.deployment().withXmlResource(process).deploy();
+
+    // when
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // then
+    final var adHocSubProcess =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.AD_HOC_SUB_PROCESS)
+            .withElementId(AHSP_ELEMENT_ID)
+            .getFirst();
+
+    assertThat(
+            RecordingExporter.jobRecords(JobIntent.CREATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementId(AHSP_ELEMENT_ID)
+                .getFirst()
+                .getValue())
+        .hasType(JOB_TYPE)
+        .hasRetries(3)
+        .hasElementInstanceKey(adHocSubProcess.getKey())
+        .hasElementId(adHocSubProcess.getValue().getElementId())
+        .hasProcessDefinitionKey(adHocSubProcess.getValue().getProcessDefinitionKey())
+        .hasBpmnProcessId(adHocSubProcess.getValue().getBpmnProcessId())
+        .hasProcessDefinitionVersion(adHocSubProcess.getValue().getVersion());
+  }
+}


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR adds the creation of Jobs for the ad-hoc sub-process. 

Jobs are created upon activation of the AHSP. The Job Worker can determine which elements of the AHSP should get activated.
When a child completes a new job is recreated (any existing jobs are cancelled). This allows the Job Worker to react upon child completion by for example activating more elements, or completing the AHSP.

Upon termination the Job will get cancelled.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes https://github.com/camunda/ad-hoc-sub-process-phase-3/issues/7
