### PR TITLE
ci: rely on outer timeout for opensearch integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -587,7 +587,6 @@ jobs:
       # -D test.integration.camunda.database.type=os
       #
       - name: Run integration test with externalized OS
-        timeout-minutes: 10
         run: >
           ./mvnw -B -T 1 --no-snapshot-updates
           -D forkCount=4


### PR DESCRIPTION
The tests are approaching 10 minutes runtime under normal circumstances, leading to unnecessary timeouts. Since the surrounding job already defines a timeout of 15 minutes, we can simply remove the extra timeout on the step. This gives us a bit more freedom.