### PR TITLE
ci: increase helm upgarde timeout to 35m

### DIFF
--- a/.github/workflows/zeebe-benchmark.yml
+++ b/.github/workflows/zeebe-benchmark.yml
@@ -250,7 +250,7 @@ jobs:
           echo "chart-release=$(helm get metadata -o json --namespace ${{ inputs.name }} ${{ inputs.name }} | jq --raw-output .version)" >> "$GITHUB_OUTPUT"
       - name: Helm install
         run: >
-          helm upgrade --install ${{ inputs.name }} zeebe-benchmark/zeebe-benchmark --wait --timeout 20m0s
+          helm upgrade --install ${{ inputs.name }} zeebe-benchmark/zeebe-benchmark --wait --timeout 35m0s
           --namespace ${{ inputs.name }}
           --create-namespace
           --reuse-values


### PR DESCRIPTION
## Description

It seems not to be enough 20m to upgrade benchmark ecossystem.

<img width="1411" height="218" alt="image" src="https://github.com/user-attachments/assets/e8ad914f-7f36-41e3-8844-43985bae81ad" />

https://github.com/camunda/camunda/actions/runs/16581906696/job/46962241624
https://github.com/camunda/camunda/actions/runs/16581883024/job/46962562787

So I am proposing to increase a bit more the time.

related to this other implementation: https://github.com/camunda/camunda/pull/34231

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
