### PR TITLE
[Backport stable/8.6] ci: increase helm upgarde timeout to 35m

### DIFF
--- a/.github/workflows/zeebe-benchmark.yml
+++ b/.github/workflows/zeebe-benchmark.yml
@@ -297,7 +297,7 @@ jobs:
           echo "chart-release=$(helm get metadata -o json --namespace ${{ inputs.name }} ${{ inputs.name }} | jq --raw-output .version)" >> $GITHUB_OUTPUT
       - name: Helm install
         run: >
-          helm upgrade --install ${{ inputs.name }} zeebe-benchmark/zeebe-benchmark --wait --timeout 20m0s
+          helm upgrade --install ${{ inputs.name }} zeebe-benchmark/zeebe-benchmark --wait --timeout 35m0s
           --namespace ${{ inputs.name }}
           --create-namespace
           --reuse-values


### PR DESCRIPTION
# Description
Backport of #36177 to `stable/8.6`.

relates to 