### PR TITLE
fix: skip tests for tenants and improve waitforitem utility to fix authorizations tests

### DIFF
--- a/identity/client/e2e/tests/authorizations.spec.ts
+++ b/identity/client/e2e/tests/authorizations.spec.ts
@@ -48,7 +48,7 @@ const NEW_APPLICATION_AUTHORIZATION = {
 };
 
 test.describe.serial("authorizations CRUD", () => {
-  test.skip("create user authorization", async ({
+  test("create user authorization", async ({
     page,
     usersPage,
     rolesPage,
@@ -94,7 +94,7 @@ test.describe.serial("authorizations CRUD", () => {
     await expect(page).toHaveURL(relativizePath(Paths.forbidden()));
   });
 
-  test.skip("create application authorization", async ({
+  test("create application authorization", async ({
     usersPage,
     authorizationsPage,
     header,
@@ -111,7 +111,7 @@ test.describe.serial("authorizations CRUD", () => {
     ).toBeVisible();
   });
 
-  test.skip("delete an authorization", async ({
+  test("delete an authorization", async ({
     page,
     header,
     loginPage,

--- a/identity/client/e2e/tests/tenants.spec.ts
+++ b/identity/client/e2e/tests/tenants.spec.ts
@@ -27,8 +27,10 @@ test.beforeEach(async ({ loginPage, tenantsPage }) => {
   await loginPage.login(LOGIN_CREDENTIALS);
 });
 
-test.describe.serial("tenants CRUD", () => {
-  test.skip("creates a tenant", async ({ page, tenantsPage }) => {
+// this is skipped as it is not currently possible to run e2e tests in isTenantsApiEnabled mode.
+// TODO: renable when https://github.com/camunda/camunda/issues/36092 is implemented
+test.describe.skip("tenants CRUD", () => {
+  test("creates a tenant", async ({ page, tenantsPage }) => {
     await expect(
       tenantsPage.tenantsList.getByRole("cell", { name: NEW_TENANT.name }),
     ).not.toBeVisible();
@@ -48,7 +50,7 @@ test.describe.serial("tenants CRUD", () => {
     await waitForItemInList(page, item);
   });
 
-  test.skip("assign a user", async ({ page, tenantsPage }) => {
+  test("assign a user", async ({ page, tenantsPage }) => {
     await tenantsPage.openTenantDetails(NEW_TENANT.tenantId).click();
 
     await tenantsPage.assignUserButton.click();
@@ -69,7 +71,7 @@ test.describe.serial("tenants CRUD", () => {
     });
   });
 
-  test.skip("remove a user", async ({ page, tenantsPage }) => {
+  test("remove a user", async ({ page, tenantsPage }) => {
     await tenantsPage.openTenantDetails(NEW_TENANT.tenantId).click();
     await tenantsPage.removeUserButton(USER.name).click();
     await expect(tenantsPage.removeUserModal).toBeVisible();
@@ -87,7 +89,7 @@ test.describe.serial("tenants CRUD", () => {
     });
   });
 
-  test.skip("deletes a tenant", async ({ page, tenantsPage }) => {
+  test("deletes a tenant", async ({ page, tenantsPage }) => {
     await expect(
       tenantsPage.tenantsList.getByRole("cell", { name: NEW_TENANT.name }),
     ).toBeVisible();

--- a/identity/client/e2e/utils/waitForItemInList.ts
+++ b/identity/client/e2e/utils/waitForItemInList.ts
@@ -35,13 +35,17 @@ export const waitForItemInList = async (
 
       if (emptyStateLocator) {
         await Promise.race([
-          page.getByRole("cell").filter({ hasText: /.+/ }).first().waitFor(),
+          page
+            .getByRole("cell")
+            .filter({ hasText: /.+/, hasNot: page.locator("div") })
+            .first()
+            .waitFor(),
           emptyStateLocator?.waitFor(),
         ]);
       } else {
         await page
           .getByRole("cell")
-          .filter({ hasText: /.+/ })
+          .filter({ hasText: /.+/, hasNot: page.locator("div") })
           .first()
           .waitFor();
       }


### PR DESCRIPTION
## Description

- Skips entire tenants test suite as well as adding comment with link to issue that addresses that
- Add one more specificity layer to `waitForItem` util function in order to decrease flakiness
- Unskip authorizations tests

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #36183
