### PR TITLE
ci: Adding  access token to issue labeler

### DIFF
--- a/.github/workflows/opened_issue_labeler.yml
+++ b/.github/workflows/opened_issue_labeler.yml
@@ -16,4 +16,5 @@ jobs:
     - uses: github/issue-labeler@v3.4
       with:
         configuration-path: .github/opened_issue_labeler.yml
+        github-token: ${{ secrets.GH_PROJECT_AUTOMATION_TOKEN }}
         enable-versioned-regex: 0

--- a/.github/workflows/opened_issue_labeler.yml
+++ b/.github/workflows/opened_issue_labeler.yml
@@ -16,5 +16,5 @@ jobs:
     - uses: github/issue-labeler@v3.4
       with:
         configuration-path: .github/opened_issue_labeler.yml
-        github-token: ${{ secrets.GH_PROJECT_AUTOMATION_TOKEN }}
         enable-versioned-regex: 0
+        repo-token: ${{ secrets.GH_PROJECT_AUTOMATION_TOKEN }}


### PR DESCRIPTION
## Description

Currently, the automated project allocation (add-to-projects.yml) does not work, since the labels added automatically by this script do not trigger the project allocation script. By adding this PAT token to the script, the hope is that the labels added by this script would now trigger it.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
