### PR TITLE
fix: supply a timeout for process migration

### DIFF
--- a/migration/migration-api/src/main/java/io/camunda/migration/api/MigrationTimeoutException.java
+++ b/migration/migration-api/src/main/java/io/camunda/migration/api/MigrationTimeoutException.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.migration.api;
+
+public class MigrationTimeoutException extends RuntimeException {
+  public MigrationTimeoutException(String message) {
+    super(message);
+  }
+}

--- a/migration/process-migration/src/main/java/io/camunda/migration/process/ProcessMigrator.java
+++ b/migration/process-migration/src/main/java/io/camunda/migration/process/ProcessMigrator.java
@@ -9,6 +9,7 @@ package io.camunda.migration.process;
 
 import co.elastic.clients.elasticsearch._types.ElasticsearchException;
 import io.camunda.migration.api.MigrationException;
+import io.camunda.migration.api.MigrationTimeoutException;
 import io.camunda.migration.api.Migrator;
 import io.camunda.migration.process.adapter.Adapter;
 import io.camunda.migration.process.adapter.es.ElasticsearchAdapter;
@@ -21,6 +22,7 @@ import io.camunda.webapps.schema.entities.ImportPositionEntity;
 import io.camunda.webapps.schema.entities.ProcessEntity;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.io.IOException;
+import java.time.Instant;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
@@ -45,6 +47,7 @@ public class ProcessMigrator implements Migrator {
   private ScheduledFuture<?> countdownTask;
   private final ScheduledExecutorService scheduler;
   private final MetricRegistry metricRegistry;
+  private final Instant timeout;
 
   public ProcessMigrator(
       final ProcessMigrationProperties properties,
@@ -57,6 +60,7 @@ public class ProcessMigrator implements Migrator {
             : new OpensearchAdapter(properties, connect);
     scheduler = Executors.newScheduledThreadPool(1);
     metricRegistry = new MetricRegistry(meterRegistry);
+    timeout = Instant.now().plus(properties.getTimeout());
   }
 
   @Override
@@ -95,9 +99,19 @@ public class ProcessMigrator implements Migrator {
     return null;
   }
 
-  private boolean shouldContinue(final List<ProcessEntity> processes) {
+  private boolean shouldContinue(final List<ProcessEntity> processes)
+      throws MigrationTimeoutException {
     if (!processes.isEmpty()) {
       return true;
+    }
+    if (Instant.now().isAfter(timeout)) {
+      if (countdownTask != null && !countdownTask.isDone()) {
+        LOG.info("Process Migration has timed out but countdown is in progress");
+        return true;
+      } else {
+        throw new MigrationTimeoutException(
+            "Process Migration timed out after " + properties.getTimeout());
+      }
     }
     return countdownTask == null || !countdownTask.isDone();
   }
@@ -192,6 +206,9 @@ public class ProcessMigrator implements Migrator {
     } else if (exception.getCause() instanceof final OpenSearchException ex) {
       return ex.error().reason() != null
           && !MigrationUtil.MIGRATION_REPOSITORY_NOT_EXISTS.matcher(ex.error().reason()).find();
+    } else if (exception instanceof MigrationTimeoutException) {
+      LOG.warn("Process Migration timed out after running for {}", properties.getTimeout());
+      return true;
     }
     return true;
   }

--- a/migration/process-migration/src/main/java/io/camunda/migration/process/ProcessMigrator.java
+++ b/migration/process-migration/src/main/java/io/camunda/migration/process/ProcessMigrator.java
@@ -108,6 +108,8 @@ public class ProcessMigrator implements Migrator {
       if (countdownTask != null && !countdownTask.isDone()) {
         LOG.info("Process Migration has timed out but countdown is in progress");
         return true;
+      } else if (countdownTask != null && countdownTask.isDone()) {
+        return false;
       } else {
         throw new MigrationTimeoutException(
             "Process Migration timed out after " + properties.getTimeout());

--- a/migration/process-migration/src/main/java/io/camunda/migration/process/config/ProcessMigrationProperties.java
+++ b/migration/process-migration/src/main/java/io/camunda/migration/process/config/ProcessMigrationProperties.java
@@ -16,6 +16,7 @@ public class ProcessMigrationProperties {
 
   private int batchSize = 20;
   private Duration importerFinishedTimeout = Duration.ofMinutes(1);
+  private Duration timeout = Duration.ofHours(2);
   private ProcessMigrationRetryConfiguration retry = new ProcessMigrationRetryConfiguration();
 
   public int getBatchSize() {
@@ -40,6 +41,14 @@ public class ProcessMigrationProperties {
 
   public void setRetry(final ProcessMigrationRetryConfiguration retry) {
     this.retry = retry;
+  }
+
+  public Duration getTimeout() {
+    return timeout;
+  }
+
+  public void setTimeout(final Duration timeout) {
+    this.timeout = timeout;
   }
 
   public static class ProcessMigrationRetryConfiguration extends RetryConfiguration {

--- a/migration/process-migration/src/test/java/io/camunda/migration/process/it/AdapterTest.java
+++ b/migration/process-migration/src/test/java/io/camunda/migration/process/it/AdapterTest.java
@@ -133,6 +133,7 @@ public abstract class AdapterTest {
   @AfterEach
   public void cleanUp() throws IOException {
     properties.setBatchSize(5);
+    properties.setTimeout(Duration.ofMinutes(10));
     if (isElasticsearch) {
       esMigrator = new ProcessMigrator(properties, ES_CONFIGURATION, meterRegistry);
       esClient.deleteByQuery(

--- a/migration/process-migration/src/test/java/io/camunda/migration/process/it/ProcessMigratorIT.java
+++ b/migration/process-migration/src/test/java/io/camunda/migration/process/it/ProcessMigratorIT.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 
 import io.camunda.migration.api.MigrationException;
+import io.camunda.migration.api.MigrationTimeoutException;
 import io.camunda.migration.process.ProcessMigrator;
 import io.camunda.migration.process.TestData;
 import io.camunda.migration.process.adapter.Adapter;
@@ -422,5 +423,72 @@ public class ProcessMigratorIT extends AdapterTest {
     } else {
       OS_CONFIGURATION.setIndexPrefix(null);
     }
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  public void shouldTimeoutMigration(final boolean isElasticsearch) throws IOException {
+    // given
+    this.isElasticsearch = isElasticsearch;
+    properties.setTimeout(Duration.ofSeconds(5));
+
+    final var migrator =
+        new ProcessMigrator(
+            properties, isElasticsearch ? ES_CONFIGURATION : OS_CONFIGURATION, meterRegistry);
+    writeImportPositionToIndex(TestData.notCompletedImportPosition(1));
+
+    // when - then
+    final var maxTimeout =
+        properties.getTimeout().getSeconds()
+            + properties.getRetry().getMinRetryDelay().getSeconds()
+            + 1;
+    Awaitility.await()
+        .atLeast(properties.getTimeout().getSeconds() - 1, TimeUnit.SECONDS)
+        .atMost(maxTimeout, TimeUnit.SECONDS)
+        .untilAsserted(
+            () ->
+                assertThatExceptionOfType(MigrationException.class)
+                    .isThrownBy(migrator::call)
+                    .withCauseInstanceOf(MigrationTimeoutException.class)
+                    .withMessageContaining("Process Migration timed out"));
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  public void shouldTimeoutAfterMigratingDataWithoutImportersCompleted(
+      final boolean isElasticsearch) throws IOException {
+    // given
+    this.isElasticsearch = isElasticsearch;
+    properties.setTimeout(Duration.ofSeconds(1));
+
+    final var migrator =
+        new ProcessMigrator(
+            properties, isElasticsearch ? ES_CONFIGURATION : OS_CONFIGURATION, meterRegistry);
+    writeImportPositionToIndex(TestData.notCompletedImportPosition(1));
+
+    for (int i = 1; i < 10; i++) {
+      writeProcessToIndex(TestData.processEntityWithPublicFormId((long) i));
+    }
+    awaitRecordsArePresent(ProcessEntity.class, processIndex.getFullQualifiedName(), 9);
+
+    // when -  then
+    Awaitility.await()
+        .untilAsserted(
+            () ->
+                assertThatExceptionOfType(MigrationException.class)
+                    .isThrownBy(migrator::call)
+                    .withCauseInstanceOf(MigrationTimeoutException.class)
+                    .withMessageContaining("Process Migration timed out"));
+    refreshIndices();
+
+    // and
+    final var records = readRecords(ProcessEntity.class, processIndex.getFullQualifiedName());
+
+    assertProcessorStepContentIsStored("9");
+    assertThat(records).hasSize(9);
+    assertThat(records.stream().noneMatch(r -> r.getIsPublic().equals(Boolean.FALSE))).isTrue();
+    assertThat(records.stream().noneMatch(r -> r.getFormId() == null)).isTrue();
+    assertThat(records.stream().allMatch(r -> r.getFormKey() == null)).isTrue();
+    assertThat(records.stream().noneMatch(ProcessEntity::getIsFormEmbedded)).isTrue();
   }
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Provide a force timeout for the process migration. This timeout will not trigger the termination if there are still Process Definitions being migrated. Rather, it's used to determine whether there is possible idling in the cluster and terminate without waiting for the 8.7 Importers to be completed.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #36176
