### PR TITLE
pg-revert-segments-manager-overlaps

### DIFF
--- a/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentsManager.java
+++ b/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentsManager.java
@@ -268,7 +268,14 @@ final class SegmentsManager implements AutoCloseable {
     if (lastSegment != null) {
       currentSegment = lastSegment;
     } else {
-      currentSegment = createInitialSegment();
+      final SegmentDescriptor descriptor =
+          SegmentDescriptor.builder()
+              .withId(FIRST_SEGMENT_ID)
+              .withIndex(INITIAL_INDEX)
+              .withMaxSegmentSize(maxSegmentSize)
+              .build();
+
+      currentSegment = createSegment(descriptor, INITIAL_ASQN);
 
       segments.put(1L, currentSegment);
       journalMetrics.incSegmentCount();
@@ -279,19 +286,23 @@ final class SegmentsManager implements AutoCloseable {
   void open() {
     final var openDurationTimer = journalMetrics.startJournalOpenDurationTimer();
     // Load existing log segments from disk.
-    loadSegments()
-        .forEach(
-            segment -> {
-              if (segments.put(segment.descriptor().index(), segment) == null) {
-                journalMetrics.incSegmentCount();
-              }
-            });
+    for (final Segment segment : loadSegments()) {
+      segments.put(segment.descriptor().index(), segment);
+      journalMetrics.incSegmentCount();
+    }
 
     // If a segment doesn't already exist, create an initial segment starting at index 1.
     if (!segments.isEmpty()) {
       currentSegment = segments.lastEntry().getValue();
     } else {
-      currentSegment = createInitialSegment();
+      final SegmentDescriptor descriptor =
+          SegmentDescriptor.builder()
+              .withId(FIRST_SEGMENT_ID)
+              .withIndex(INITIAL_INDEX)
+              .withMaxSegmentSize(maxSegmentSize)
+              .build();
+
+      currentSegment = createSegment(descriptor, INITIAL_ASQN);
 
       segments.put(1L, currentSegment);
       journalMetrics.incSegmentCount();
@@ -313,17 +324,6 @@ final class SegmentsManager implements AutoCloseable {
             .withMaxSegmentSize(maxSegmentSize)
             .build();
     nextSegment = CompletableFuture.supplyAsync(() -> createUninitializedSegment(descriptor));
-  }
-
-  private Segment createInitialSegment() {
-    final SegmentDescriptor descriptor =
-        SegmentDescriptor.builder()
-            .withId(FIRST_SEGMENT_ID)
-            .withIndex(INITIAL_INDEX)
-            .withMaxSegmentSize(maxSegmentSize)
-            .build();
-
-    return createSegment(descriptor, INITIAL_ASQN);
   }
 
   SortedMap<Long, Segment> getTailSegments(final long index) {
@@ -390,6 +390,7 @@ final class SegmentsManager implements AutoCloseable {
         if (handleSegmentCorruption(files, segments, i, lastFlushedIndex)) {
           return segments;
         }
+
         throw e;
       }
     }
@@ -398,7 +399,7 @@ final class SegmentsManager implements AutoCloseable {
   }
 
   private void checkForIndexGaps(final Segment prevSegment, final Segment segment) {
-    if (prevSegment.lastIndex() < segment.index() - 1) {
+    if (prevSegment.lastIndex() != segment.index() - 1) {
       throw new CorruptedJournalException(
           String.format(
               "Log segment %s is not aligned with previous segment %s (last index: %d).",
@@ -418,7 +419,7 @@ final class SegmentsManager implements AutoCloseable {
       long lastSegmentIndex = 0;
 
       if (!segments.isEmpty()) {
-        final Segment previousSegment = segments.getLast();
+        final Segment previousSegment = segments.get(segments.size() - 1);
         lastSegmentIndex = previousSegment.lastIndex();
       }
 

--- a/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentsManager.java
+++ b/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentsManager.java
@@ -282,12 +282,7 @@ final class SegmentsManager implements AutoCloseable {
     loadSegments()
         .forEach(
             segment -> {
-              final Segment replacedSegment = segments.put(segment.descriptor().index(), segment);
-              if (replacedSegment != null) {
-                // The previous segment can be safely deleted to free resources.
-                replacedSegment.close();
-                replacedSegment.delete();
-              } else {
+              if (segments.put(segment.descriptor().index(), segment) == null) {
                 journalMetrics.incSegmentCount();
               }
             });

--- a/zeebe/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentsManagerTest.java
+++ b/zeebe/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentsManagerTest.java
@@ -341,8 +341,6 @@ class SegmentsManagerTest {
     assertThat(segment.lastAsqn()).isEqualTo(thirdJournal.getLastSegment().lastAsqn());
     assertThat(segment.lastIndex()).isEqualTo(5);
     assertThat(segments.getFirstSegment()).isEqualTo(segments.getLastSegment());
-    assertThat(directory.resolve("data").resolve("journal-1.log")).doesNotExist();
-    assertThat(directory.resolve("data").resolve("journal-2.log")).doesNotExist();
   }
 
   @Test
@@ -402,9 +400,6 @@ class SegmentsManagerTest {
     assertThat(lastSegment.lastIndex()).isEqualTo(thirdJournal.getFirstSegment().lastIndex());
     assertThat(lastSegment.lastAsqn()).isEqualTo(thirdJournal.getFirstSegment().lastAsqn());
     assertThat(lastSegment.file().name()).isEqualTo("journal-3.log");
-    assertThat(directory.resolve("data").resolve("journal-1.log")).exists();
-    assertThat(directory.resolve("data").resolve("journal-2.log")).exists();
-    assertThat(directory.resolve("data").resolve("journal-3.log")).exists();
   }
 
   @Test
@@ -450,8 +445,6 @@ class SegmentsManagerTest {
     assertThat(lastSegment.lastIndex()).isEqualTo(secondaryJournal.getFirstSegment().lastIndex());
     assertThat(lastSegment.lastAsqn()).isEqualTo(secondaryJournal.getFirstSegment().lastAsqn());
     assertThat(lastSegment.file().name()).isEqualTo("journal-2.log");
-    assertThat(directory.resolve("data").resolve("journal-1.log")).exists();
-    assertThat(directory.resolve("data").resolve("journal-2.log")).exists();
   }
 
   private void appendJournalEntries(final SegmentedJournal journal, final int... asqns) {


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Revert handling of Overlaps in the SegmentsManager as the implementation is going another direction where no overlaps will be present on a continuous backup journal.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

reverts https://github.com/camunda/camunda/issues/35521
