### PR TITLE
feat: Enable configurable priority for zeebe-record Index templates

### DIFF
--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -896,6 +896,7 @@
         #
         #     numberOfShards: 3
         #     numberOfReplicas: 0
+        #     templatePriority: 100
         #
         #     command: false
         #     event: true
@@ -978,6 +979,7 @@
         #
         #     numberOfShards: 3
         #     numberOfReplicas: 0
+        #     templatePriority: 100
         #
         #     command: false
         #     event: true

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -749,6 +749,7 @@
         #
         #     numberOfShards: 3
         #     numberOfReplicas: 0
+        #     templatePriority: 100
         #
         #     command: false
         #     event: true
@@ -831,6 +832,7 @@
         #
         #     numberOfShards: 3
         #     numberOfReplicas: 0
+        #     templatePriority: 100
         #
         #     command: false
         #     event: true

--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporter.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporter.java
@@ -164,6 +164,12 @@ public class ElasticsearchExporter implements Exporter {
               "Elasticsearch numberOfReplicas must be >= 0. Current value: %d", numberOfReplicas));
     }
 
+    final int priority = configuration.index.getPriority();
+    if (priority < 0) {
+      throw new ExporterException(
+          "Elasticsearch priority must be >= 0. Current value: %d".formatted(priority));
+    }
+
     final String minimumAge = configuration.retention.getMinimumAge();
     if (minimumAge != null && !CHECKER_MIN_AGE.test(minimumAge)) {
       throw new ExporterException(

--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporter.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporter.java
@@ -164,10 +164,11 @@ public class ElasticsearchExporter implements Exporter {
               "Elasticsearch numberOfReplicas must be >= 0. Current value: %d", numberOfReplicas));
     }
 
-    final int priority = configuration.index.getPriority();
+    final int priority = configuration.index.getTemplatePriority();
     if (priority < 0) {
       throw new ExporterException(
-          "Elasticsearch priority must be >= 0. Current value: %d".formatted(priority));
+          "Elasticsearch index template priority must be >= 0. Current value: %d"
+              .formatted(priority));
     }
 
     final String minimumAge = configuration.retention.getMinimumAge();

--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
@@ -161,6 +161,8 @@ public class ElasticsearchExporterConfiguration {
   }
 
   public static class IndexConfiguration {
+
+    private static final int DEFAULT_INDEX_TEMPLATE_PRIORITY = 20;
     // prefix for index and templates
     public String prefix = "zeebe-record";
 
@@ -224,6 +226,7 @@ public class ElasticsearchExporterConfiguration {
     // index settings
     private Integer numberOfShards = null;
     private Integer numberOfReplicas = null;
+    private int priority = DEFAULT_INDEX_TEMPLATE_PRIORITY;
 
     public Integer getNumberOfShards() {
       return numberOfShards;
@@ -239,6 +242,14 @@ public class ElasticsearchExporterConfiguration {
 
     public void setNumberOfReplicas(final Integer numberOfReplicas) {
       this.numberOfReplicas = numberOfReplicas;
+    }
+
+    public int getPriority() {
+      return priority;
+    }
+
+    public void setPriority(final int priority) {
+      this.priority = priority;
     }
 
     @Override

--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
@@ -226,7 +226,7 @@ public class ElasticsearchExporterConfiguration {
     // index settings
     private Integer numberOfShards = null;
     private Integer numberOfReplicas = null;
-    private int priority = DEFAULT_INDEX_TEMPLATE_PRIORITY;
+    private int templatePriority = DEFAULT_INDEX_TEMPLATE_PRIORITY;
 
     public Integer getNumberOfShards() {
       return numberOfShards;
@@ -244,12 +244,12 @@ public class ElasticsearchExporterConfiguration {
       this.numberOfReplicas = numberOfReplicas;
     }
 
-    public int getPriority() {
-      return priority;
+    public int getTemplatePriority() {
+      return templatePriority;
     }
 
-    public void setPriority(final int priority) {
-      this.priority = priority;
+    public void setTemplatePriority(final int templatePriority) {
+      this.templatePriority = templatePriority;
     }
 
     @Override

--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/TemplateReader.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/TemplateReader.java
@@ -57,7 +57,7 @@ final class TemplateReader {
               aliases.clear();
               aliases.put(aliasName, Collections.emptyMap());
             })
-        .withPriority(Long.valueOf(config.index.getPriority()))
+        .withPriority(Long.valueOf(config.index.getTemplatePriority()))
         .build();
   }
 

--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/TemplateReader.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/TemplateReader.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.exporter;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.zeebe.exporter.dto.Template;
+import io.camunda.zeebe.exporter.dto.Template.MutableCopyBuilder;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.util.VersionUtil;
 import java.io.IOException;
@@ -46,12 +47,18 @@ final class TemplateReader {
     final Template template = readTemplate(findResourceForTemplate(valueType));
 
     // update prefix in template in case it was changed in configuration
-    template.composedOf().set(0, config.index.prefix + "-" + VersionUtil.getVersionLowerCase());
-    template.patterns().set(0, searchPattern);
-    template.template().aliases().clear();
-    template.template().aliases().put(aliasName, Collections.emptyMap());
-
-    return template;
+    return MutableCopyBuilder.copyOf(template)
+        .updateComposedOf(
+            composedOf ->
+                composedOf.set(0, config.index.prefix + "-" + VersionUtil.getVersionLowerCase()))
+        .updatePatterns(patterns -> patterns.set(0, searchPattern))
+        .updateAliases(
+            aliases -> {
+              aliases.clear();
+              aliases.put(aliasName, Collections.emptyMap());
+            })
+        .withPriority(Long.valueOf(config.index.getPriority()))
+        .build();
   }
 
   private String findResourceForTemplate(final ValueType valueType) {

--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/dto/Template.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/dto/Template.java
@@ -7,11 +7,16 @@
  */
 package io.camunda.zeebe.exporter.dto;
 
+import static java.util.Optional.ofNullable;
+
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Consumer;
 
 /**
  * Index template representation. You can read more about index templates <a
@@ -27,5 +32,61 @@ public record Template(
 
   @JsonInclude(Include.NON_EMPTY)
   public record TemplateProperty(
-      Map<String, Object> aliases, Map<String, Object> settings, Map<String, Object> mappings) {}
+      Map<String, Object> aliases, Map<String, Object> settings, Map<String, Object> mappings) {
+    public static TemplateProperty mutableCopyOf(final TemplateProperty templateProperty) {
+      if (templateProperty == null) {
+        return new TemplateProperty(new HashMap<>(), new HashMap<>(), new HashMap<>());
+      }
+      return new TemplateProperty(
+          ofNullable(templateProperty.aliases).map(HashMap::new).orElseGet(HashMap::new),
+          ofNullable(templateProperty.settings).map(HashMap::new).orElseGet(HashMap::new),
+          ofNullable(templateProperty.mappings).map(HashMap::new).orElseGet(HashMap::new));
+    }
+  }
+
+  public static final class MutableCopyBuilder {
+    private List<String> patterns;
+    private List<String> composedOf;
+    private TemplateProperty template;
+    private Long priority;
+    private Long version;
+
+    private MutableCopyBuilder() {}
+
+    public static MutableCopyBuilder copyOf(final Template template) {
+      final MutableCopyBuilder builder = new MutableCopyBuilder();
+      builder.patterns =
+          ofNullable(template.patterns).map(ArrayList::new).orElseGet(ArrayList::new);
+      builder.composedOf =
+          ofNullable(template.composedOf).map(ArrayList::new).orElseGet(ArrayList::new);
+      builder.template = TemplateProperty.mutableCopyOf(template.template);
+      builder.priority = template.priority;
+      builder.version = template.version;
+      return builder;
+    }
+
+    public MutableCopyBuilder updatePatterns(final Consumer<List<String>> patternsConsumer) {
+      patternsConsumer.accept(patterns);
+      return this;
+    }
+
+    public MutableCopyBuilder updateComposedOf(final Consumer<List<String>> composedOfConsumer) {
+      composedOfConsumer.accept(composedOf);
+      return this;
+    }
+
+    public MutableCopyBuilder updateAliases(final Consumer<Map<String, Object>> aliasesConsumer) {
+      aliasesConsumer.accept(template.aliases);
+      return this;
+    }
+
+    public MutableCopyBuilder withPriority(final Long priority) {
+      this.priority = priority;
+      return this;
+    }
+
+    public Template build() {
+      return new Template(patterns, composedOf, template, priority, version);
+    }
+  }
 }

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterIT.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterIT.java
@@ -36,6 +36,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Consumer;
 import org.agrona.CloseHelper;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterAll;
@@ -361,8 +362,52 @@ final class ElasticsearchExporterIT {
       assertThat(document.index().contains(oldRecord.getBrokerVersion())).isTrue();
     }
 
+    @Test
+    void shouldSetIndexTemplatePriorityFromConfiguration() {
+      // given
+      final int priority = 100;
+      configureExporter(config -> config.index.setPriority(priority));
+      final var record = generateRecord(ValueType.JOB);
+
+      // when
+      export(record);
+
+      // then
+      final var template = testClient.getIndexTemplate(ValueType.JOB);
+      assertThat(template)
+          .as("should have created index template for value type %s", ValueType.JOB)
+          .isPresent()
+          .get()
+          .extracting(wrapper -> wrapper.template().priority())
+          .isEqualTo((long) priority);
+    }
+
+    @Test
+    void shouldSetIndexTemplateWithDefaultPriorityWhenNotSetInConfiguration() {
+      // given
+      configureExporter(config -> {});
+      final var record = generateRecord(ValueType.JOB);
+
+      // when
+      export(record);
+
+      // then
+      final var template = testClient.getIndexTemplate(ValueType.JOB);
+      assertThat(template)
+          .as("should have created index template for value type %s", ValueType.JOB)
+          .isPresent()
+          .get()
+          .extracting(wrapper -> wrapper.template().priority())
+          .isEqualTo(20L); // default priority is 20
+    }
+
     private void configureExporter(final boolean retentionEnabled) {
-      config.retention.setEnabled(retentionEnabled);
+      configureExporter(config -> config.retention.setEnabled(retentionEnabled));
+    }
+
+    private void configureExporter(
+        final Consumer<ElasticsearchExporterConfiguration> configurator) {
+      configurator.accept(config);
       exporter.configure(exporterTestContext);
     }
 

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterIT.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterIT.java
@@ -366,7 +366,7 @@ final class ElasticsearchExporterIT {
     void shouldSetIndexTemplatePriorityFromConfiguration() {
       // given
       final int priority = 100;
-      configureExporter(config -> config.index.setPriority(priority));
+      configureExporter(config -> config.index.setTemplatePriority(priority));
       final var record = generateRecord(ValueType.JOB);
 
       // when

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterTest.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterTest.java
@@ -376,6 +376,15 @@ final class ElasticsearchExporterTest {
       // when - then
       assertThatCode(() -> exporter.configure(context)).isInstanceOf(ExporterException.class);
     }
+
+    @Test
+    void shouldForbidNegativePriority() {
+      // given
+      config.index.setPriority(-1);
+
+      // when - then
+      assertThatCode(() -> exporter.configure(context)).isInstanceOf(ExporterException.class);
+    }
   }
 
   @Nested

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterTest.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterTest.java
@@ -383,7 +383,9 @@ final class ElasticsearchExporterTest {
       config.index.setTemplatePriority(-1);
 
       // when - then
-      assertThatCode(() -> exporter.configure(context)).isInstanceOf(ExporterException.class);
+      assertThatCode(() -> exporter.configure(context))
+          .isInstanceOf(ExporterException.class)
+          .hasMessage("Elasticsearch index template priority must be >= 0. Current value: -1");
     }
   }
 

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterTest.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterTest.java
@@ -380,7 +380,7 @@ final class ElasticsearchExporterTest {
     @Test
     void shouldForbidNegativePriority() {
       // given
-      config.index.setPriority(-1);
+      config.index.setTemplatePriority(-1);
 
       // when - then
       assertThatCode(() -> exporter.configure(context)).isInstanceOf(ExporterException.class);

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporter.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporter.java
@@ -153,6 +153,12 @@ public class OpensearchExporter implements Exporter {
           String.format(
               "Opensearch numberOfReplicas must be >= 0. Current value: %d", numberOfReplicas));
     }
+
+    final int priority = configuration.index.getPriority();
+    if (priority < 0) {
+      throw new ExporterException(
+          "Opensearch index priority must be >= 0. Current value: %d".formatted(priority));
+    }
   }
 
   // TODO: remove this and instead allow client to be inject-able for testing

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporter.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporter.java
@@ -157,7 +157,7 @@ public class OpensearchExporter implements Exporter {
     final int priority = configuration.index.getPriority();
     if (priority < 0) {
       throw new ExporterException(
-          "Opensearch index priority must be >= 0. Current value: %d".formatted(priority));
+          "Opensearch index template priority must be >= 0. Current value: %d".formatted(priority));
     }
   }
 

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterConfiguration.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterConfiguration.java
@@ -160,6 +160,8 @@ public class OpensearchExporterConfiguration {
   }
 
   public static class IndexConfiguration {
+
+    public static final int DEFAULT_INDEX_TEMPLATE_PRIORITY = 20;
     // prefix for index and templates
     public String prefix = "zeebe-record";
 
@@ -214,6 +216,7 @@ public class OpensearchExporterConfiguration {
     // index settings
     private Integer numberOfShards = null;
     private Integer numberOfReplicas = null;
+    private int priority = DEFAULT_INDEX_TEMPLATE_PRIORITY;
 
     public Integer getNumberOfShards() {
       return numberOfShards;
@@ -229,6 +232,14 @@ public class OpensearchExporterConfiguration {
 
     public void setNumberOfReplicas(final Integer numberOfReplicas) {
       this.numberOfReplicas = numberOfReplicas;
+    }
+
+    public int getPriority() {
+      return priority;
+    }
+
+    public void setPriority(final int priority) {
+      this.priority = priority;
     }
 
     @Override

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/TemplateReader.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/TemplateReader.java
@@ -46,13 +46,18 @@ final class TemplateReader {
     final Template template = readTemplate(findResourceForTemplate(valueType));
 
     // update prefix in template in case it was changed in configuration
-    template.composedOf().set(0, config.prefix + "-" + VersionUtil.getVersionLowerCase());
-
-    template.patterns().set(0, searchPattern);
-    template.template().aliases().clear();
-    template.template().aliases().put(aliasName, Collections.emptyMap());
-
-    return template;
+    return Template.MutableCopyBuilder.copyOf(template)
+        .updateComposedOf(
+            composedOf ->
+                composedOf.set(0, config.prefix + "-" + VersionUtil.getVersionLowerCase()))
+        .updatePatterns(patterns -> patterns.set(0, searchPattern))
+        .updateAliases(
+            aliases -> {
+              aliases.clear();
+              aliases.put(aliasName, Collections.emptyMap());
+            })
+        .withPriority(Long.valueOf(config.getPriority()))
+        .build();
   }
 
   private String findResourceForTemplate(final ValueType valueType) {

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/dto/Template.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/dto/Template.java
@@ -7,11 +7,16 @@
  */
 package io.camunda.zeebe.exporter.opensearch.dto;
 
+import static java.util.Optional.ofNullable;
+
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Consumer;
 
 /**
  * Index template representation. You can read more about index templates <a
@@ -27,5 +32,61 @@ public record Template(
 
   @JsonInclude(Include.NON_EMPTY)
   public record TemplateProperty(
-      Map<String, Object> aliases, Map<String, Object> settings, Map<String, Object> mappings) {}
+      Map<String, Object> aliases, Map<String, Object> settings, Map<String, Object> mappings) {
+    public static TemplateProperty mutableCopyOf(final TemplateProperty templateProperty) {
+      if (templateProperty == null) {
+        return new TemplateProperty(new HashMap<>(), new HashMap<>(), new HashMap<>());
+      }
+      return new TemplateProperty(
+          ofNullable(templateProperty.aliases).map(HashMap::new).orElseGet(HashMap::new),
+          ofNullable(templateProperty.settings).map(HashMap::new).orElseGet(HashMap::new),
+          ofNullable(templateProperty.mappings).map(HashMap::new).orElseGet(HashMap::new));
+    }
+  }
+
+  public static final class MutableCopyBuilder {
+    private List<String> patterns;
+    private List<String> composedOf;
+    private TemplateProperty template;
+    private Long priority;
+    private Long version;
+
+    private MutableCopyBuilder() {}
+
+    public static MutableCopyBuilder copyOf(final Template template) {
+      final MutableCopyBuilder builder = new MutableCopyBuilder();
+      builder.patterns =
+          ofNullable(template.patterns).map(ArrayList::new).orElseGet(ArrayList::new);
+      builder.composedOf =
+          ofNullable(template.composedOf).map(ArrayList::new).orElseGet(ArrayList::new);
+      builder.template = TemplateProperty.mutableCopyOf(template.template);
+      builder.priority = template.priority;
+      builder.version = template.version;
+      return builder;
+    }
+
+    public MutableCopyBuilder updatePatterns(final Consumer<List<String>> patternsConsumer) {
+      patternsConsumer.accept(patterns);
+      return this;
+    }
+
+    public MutableCopyBuilder updateComposedOf(final Consumer<List<String>> composedOfConsumer) {
+      composedOfConsumer.accept(composedOf);
+      return this;
+    }
+
+    public MutableCopyBuilder updateAliases(final Consumer<Map<String, Object>> aliasesConsumer) {
+      aliasesConsumer.accept(template.aliases);
+      return this;
+    }
+
+    public MutableCopyBuilder withPriority(final Long priority) {
+      this.priority = priority;
+      return this;
+    }
+
+    public Template build() {
+      return new Template(patterns, composedOf, template, priority, version);
+    }
+  }
 }

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterTest.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterTest.java
@@ -402,6 +402,15 @@ final class OpensearchExporterTest {
       // when - then
       assertThatCode(() -> exporter.configure(context)).isInstanceOf(ExporterException.class);
     }
+
+    @Test
+    void shouldForbidNegativePriority() {
+      // given
+      config.index.setPriority(-1);
+
+      // when - then
+      assertThatCode(() -> exporter.configure(context)).isInstanceOf(ExporterException.class);
+    }
   }
 
   @Nested

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterTest.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterTest.java
@@ -409,7 +409,9 @@ final class OpensearchExporterTest {
       config.index.setPriority(-1);
 
       // when - then
-      assertThatCode(() -> exporter.configure(context)).isInstanceOf(ExporterException.class);
+      assertThatCode(() -> exporter.configure(context))
+          .isInstanceOf(ExporterException.class)
+          .hasMessage("Opensearch index template priority must be >= 0. Current value: -1");
     }
   }
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Adds a new property in Elasticsearch and Opensearch exporters configuration
- `zeebe.broker.exporters.elasticsearch.args.index.template-priority`
- `zeebe.broker.exporters.opensearch.args.index.template-priority`

This configuration is set in zeebe records index templates priority setting, and it defaults to 20 when the configuration is not provided. 20 being the hardcoded value that was part of the existing index templates.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #36084 
