### PR TITLE
fix: Identity authorization crud test

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/authorizations.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/authorizations.spec.ts
@@ -72,9 +72,7 @@ test.describe.serial('authorizations CRUD', () => {
       await identityHeader.logout();
 
       await loginPage.login(NEW_USER.username, NEW_USER.password);
-      await expect(page).toHaveURL(relativizePath(Paths.users()));
-      await expect(identityUsersPage.userCell('demo@example.com')).toBeHidden();
-      await expect(identityUsersPage.userCell(NEW_USER.email)).toBeVisible();
+      await expect(page).toHaveURL(relativizePath(Paths.forbidden('identity')));
     });
 
     await test.step(`Login as main user and create role and assign the new user to it`, async () => {


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
After the merge of this [PR](https://github.com/camunda/camunda/issues/36080) yesterday, newly created users no longer have access to apps by default unless explicit authorizations are granted. This has been confirmed as the expected behavior, so the test case has been updated accordingly to reflect the fix.

## Checklist
🧪 Successful test run [here](https://github.com/camunda/camunda/actions/runs/16617484720), Tests failed due to below issues:
[Variable Editing Spinner issue](https://github.com/camunda/camunda/issues/34148)
[API 401 Issue](https://github.com/camunda/camunda/issues/35443)
<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
