### PR TITLE
feat: mark not found items as skipped

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/search/enums/BatchOperationItemState.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/enums/BatchOperationItemState.java
@@ -18,6 +18,7 @@ package io.camunda.client.api.search.enums;
 public enum BatchOperationItemState {
   ACTIVE,
   COMPLETED,
+  SKIPPED,
   FAILED,
   CANCELED,
   UNKNOWN_ENUM_VALUE;

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/BatchOperationWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/BatchOperationWriter.java
@@ -100,7 +100,8 @@ public class BatchOperationWriter {
               item.batchOperationKey(),
               "io.camunda.db.rdbms.sql.BatchOperationMapper.incrementFailedOperationsCount",
               item.batchOperationKey()));
-    } else if (item.state() == BatchOperationItemState.COMPLETED) {
+    } else if (item.state() == BatchOperationItemState.COMPLETED
+        || item.state() == BatchOperationItemState.SKIPPED) {
       executionQueue.executeInQueue(
           new QueueItem(
               ContextType.BATCH_OPERATION,

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/batchoperation/BatchOperationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/batchoperation/BatchOperationIT.java
@@ -289,6 +289,70 @@ public class BatchOperationIT {
   }
 
   @TestTemplate
+  public void shouldUpdateSkippedBatchItem(final CamundaRdbmsTestApplication testApplication) {
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+
+    // given
+    final RdbmsWriter writer = rdbmsService.createWriter(0);
+    final var batchOperation =
+        createAndSaveBatchOperation(
+            writer,
+            b ->
+                b.state(BatchOperationState.ACTIVE)
+                    .endDate(null)
+                    .operationsTotalCount(0)
+                    .operationsFailedCount(0));
+
+    final var items =
+        createAndSaveRandomBatchOperationItems(writer, batchOperation.batchOperationKey(), 2);
+
+    // when
+    writer
+        .getBatchOperationWriter()
+        .updateItem(
+            new BatchOperationItemDbModel(
+                batchOperation.batchOperationKey(),
+                items.getFirst().itemKey(),
+                items.getFirst().processInstanceKey(),
+                BatchOperationItemState.SKIPPED,
+                NOW,
+                null));
+    writer.flush();
+
+    // then
+    final var updatedBatchOperation = getBatchOperation(rdbmsService, batchOperation);
+
+    assertThat(updatedBatchOperation).isNotNull();
+    final BatchOperationEntity batchOperationEntity = updatedBatchOperation.items().getFirst();
+    assertThat(batchOperationEntity.endDate()).isNull();
+    assertThat(batchOperationEntity.operationsTotalCount()).isEqualTo(2);
+    assertThat(batchOperationEntity.operationsCompletedCount()).isEqualTo(1);
+    assertThat(batchOperationEntity.operationsFailedCount()).isEqualTo(0);
+    assertThat(batchOperationEntity.state()).isEqualTo(BatchOperationState.ACTIVE);
+
+    // and items have correct state
+    final var updatedItems =
+        getBatchOperationItems(rdbmsService, batchOperation.batchOperationKey()).items();
+    assertThat(updatedItems).isNotNull();
+    assertThat(updatedItems).hasSize(2);
+    final var firstItem =
+        updatedItems.stream()
+            .filter(i -> Objects.equals(i.itemKey(), items.getFirst().itemKey()))
+            .findFirst()
+            .orElseThrow();
+    assertThat(firstItem.state()).isEqualTo(BatchOperationItemState.SKIPPED);
+    assertThat(firstItem.processedDate())
+        .isCloseTo(NOW, new TemporalUnitWithinOffset(1, ChronoUnit.MILLIS));
+
+    final var lastItem =
+        updatedItems.stream()
+            .filter(i -> Objects.equals(i.itemKey(), items.getLast().itemKey()))
+            .findFirst()
+            .orElseThrow();
+    assertThat(lastItem.state()).isEqualTo(BatchOperationItemState.ACTIVE);
+  }
+
+  @TestTemplate
   public void shouldCancelBatchOperationAndActiveItems(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/BatchOperationItemEntityTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/BatchOperationItemEntityTransformer.java
@@ -71,6 +71,7 @@ public class BatchOperationItemEntityTransformer
       case SCHEDULED, LOCKED, SENT -> BatchOperationItemState.ACTIVE;
       case COMPLETED -> BatchOperationItemState.COMPLETED;
       case FAILED -> BatchOperationItemState.FAILED;
+      case SKIPPED -> BatchOperationItemState.SKIPPED;
     };
   }
 }

--- a/search/search-domain/src/main/java/io/camunda/search/entities/BatchOperationEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/BatchOperationEntity.java
@@ -72,6 +72,7 @@ public record BatchOperationEntity(
   public enum BatchOperationItemState {
     ACTIVE,
     COMPLETED,
+    SKIPPED,
     CANCELED,
     FAILED
   }

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/operation/OperationState.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/operation/OperationState.java
@@ -12,5 +12,6 @@ public enum OperationState {
   LOCKED,
   SENT,
   FAILED,
-  COMPLETED
+  COMPLETED,
+  SKIPPED
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/batchoperations/BatchOperationUpdateRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/batchoperations/BatchOperationUpdateRepository.java
@@ -58,7 +58,8 @@ public interface BatchOperationUpdateRepository extends AutoCloseable {
     }
 
     public long getCompletedOperationsCount() {
-      return stateCounts.getOrDefault(OperationState.COMPLETED.name(), 0L);
+      return stateCounts.getOrDefault(OperationState.COMPLETED.name(), 0L)
+          + stateCounts.getOrDefault(OperationState.SKIPPED.name(), 0L);
     }
 
     public long getFailedOperationsCount() {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/BatchOperationStatusHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/BatchOperationStatusHandlerTest.java
@@ -182,6 +182,23 @@ class BatchOperationStatusHandlerTest {
     }
 
     @Test
+    void shouldUpdateEntityOnNotFound() {
+      final var record =
+          ImmutableRecord.<T>builder()
+              .from(createFailureRecord())
+              .withRejectionType(RejectionType.NOT_FOUND)
+              .build();
+
+      final var entity = new OperationEntity();
+
+      handler.updateEntity(record, entity);
+
+      assertThat(entity.getState()).isEqualTo(OperationState.SKIPPED);
+      assertThat(entity.getErrorMessage()).isNull();
+      assertThat(entity.getCompletedDate()).isNull();
+    }
+
+    @Test
     void shouldFlushEntityFields() {
       final var entity = new OperationEntity();
       entity.setState(OperationState.COMPLETED);
@@ -269,7 +286,7 @@ class BatchOperationStatusHandlerTest {
       return factory.generateRecord(
           ValueType.PROCESS_INSTANCE_MODIFICATION,
           b ->
-              b.withRejectionType(RejectionType.NOT_FOUND)
+              b.withRejectionType(RejectionType.PROCESSING_ERROR)
                   .withIntent(ProcessInstanceModificationIntent.MODIFY)
                   .withBatchOperationReference(batchOperationKey));
     }
@@ -313,7 +330,7 @@ class BatchOperationStatusHandlerTest {
       return factory.generateRecord(
           ValueType.PROCESS_INSTANCE_MIGRATION,
           b ->
-              b.withRejectionType(RejectionType.NOT_FOUND)
+              b.withRejectionType(RejectionType.PROCESSING_ERROR)
                   .withIntent(ProcessInstanceMigrationIntent.MIGRATE)
                   .withBatchOperationReference(batchOperationKey));
     }
@@ -380,7 +397,7 @@ class BatchOperationStatusHandlerTest {
       return factory.generateRecord(
           ValueType.PROCESS_INSTANCE_MIGRATION,
           b ->
-              b.withRejectionType(RejectionType.NOT_FOUND)
+              b.withRejectionType(RejectionType.PROCESSING_ERROR)
                   .withValue(
                       ImmutableProcessInstanceRecordValue.builder()
                           .from(factory.generateObject(ProcessInstanceRecordValue.class))
@@ -429,7 +446,7 @@ class BatchOperationStatusHandlerTest {
       return factory.generateRecord(
           ValueType.INCIDENT,
           b ->
-              b.withRejectionType(RejectionType.NOT_FOUND)
+              b.withRejectionType(RejectionType.PROCESSING_ERROR)
                   .withIntent(IncidentIntent.RESOLVE)
                   .withBatchOperationReference(batchOperationKey));
     }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/batchoperations/BatchOperationUpdateRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/batchoperations/BatchOperationUpdateRepositoryIT.java
@@ -220,17 +220,18 @@ abstract class BatchOperationUpdateRepositoryIT {
       // given
       final var repository = createRepository();
       // 1, 2, 4, 5 - not finished batch operations, 3 - finished batch operation
-      createOperationEntity("111", "1", OperationState.COMPLETED);
-      createOperationEntity("222", "1", OperationState.FAILED);
-      createOperationEntity("333", "2", OperationState.COMPLETED);
-      createOperationEntity("444", "3", OperationState.COMPLETED);
-      createOperationEntity("555", "4", OperationState.LOCKED);
-      createOperationEntity("666", "5", OperationState.SENT);
+      createOperationEntity("111a", "1", OperationState.COMPLETED);
+      createOperationEntity("111b", "1", OperationState.FAILED);
+      createOperationEntity("222a", "2", OperationState.COMPLETED);
+      createOperationEntity("222b", "2", OperationState.SKIPPED);
+      createOperationEntity("333a", "3", OperationState.COMPLETED);
+      createOperationEntity("444a", "4", OperationState.LOCKED);
+      createOperationEntity("555a", "5", OperationState.SENT);
 
       final var expected =
           List.of(
               new OperationsAggData("1", Map.of("COMPLETED", 1L, "FAILED", 1L)),
-              new OperationsAggData("2", Map.of("COMPLETED", 1L)),
+              new OperationsAggData("2", Map.of("COMPLETED", 1L, "SKIPPED", 1L)),
               new OperationsAggData("4", Map.of("LOCKED", 1L)),
               new OperationsAggData("5", Map.of("SENT", 1L)));
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/batchoperations/BatchOperationUpdateRepositoryTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/batchoperations/BatchOperationUpdateRepositoryTest.java
@@ -20,11 +20,12 @@ public class BatchOperationUpdateRepositoryTest {
     // given
     final OperationsAggData data =
         new OperationsAggData(
-            "1", Map.of("SCHEDULED", 4L, "COMPLETED", 3L, "FAILED", 2L, "LOCKED", 1L));
+            "1",
+            Map.of("SCHEDULED", 3L, "COMPLETED", 3L, "SKIPPED", 1L, "FAILED", 2L, "LOCKED", 1L));
 
     // then
-    assertThat(data.getFinishedOperationsCount()).isEqualTo(5L);
-    assertThat(data.getCompletedOperationsCount()).isEqualTo(3L);
+    assertThat(data.getFinishedOperationsCount()).isEqualTo(6L);
+    assertThat(data.getCompletedOperationsCount()).isEqualTo(4L);
     assertThat(data.getFailedOperationsCount()).isEqualTo(2L);
     assertThat(data.getTotalOperationsCount()).isEqualTo(10L);
   }

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/RdbmsBatchOperationStatusExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/RdbmsBatchOperationStatusExportHandler.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.exporter.common.cache.ExporterEntityCache;
 import io.camunda.zeebe.exporter.common.cache.batchoperation.CachedBatchOperationEntity;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordValue;
+import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.util.DateUtil;
 import io.camunda.zeebe.util.VisibleForTesting;
 
@@ -55,24 +56,30 @@ public abstract class RdbmsBatchOperationStatusExportHandler<T extends RecordVal
   @Override
   public void export(final Record<T> record) {
     if (isCompleted(record)) {
-      batchOperationWriter.updateItem(
-          new BatchOperationItemDbModel(
-              String.valueOf(record.getBatchOperationReference()),
-              getItemKey(record),
-              getProcessInstanceKey(record),
-              BatchOperationItemState.COMPLETED,
-              DateUtil.toOffsetDateTime(record.getTimestamp()),
-              null));
+      updateItem(record, BatchOperationItemState.COMPLETED, null);
     } else if (isFailed(record)) {
-      batchOperationWriter.updateItem(
-          new BatchOperationItemDbModel(
-              String.valueOf(record.getBatchOperationReference()),
-              getItemKey(record),
-              getProcessInstanceKey(record),
-              BatchOperationItemState.FAILED,
-              DateUtil.toOffsetDateTime(record.getTimestamp()),
-              String.format(ERROR_MSG, record.getRejectionType(), record.getRejectionReason())));
+      if (record.getRejectionType() == RejectionType.NOT_FOUND) {
+        // If the item is not found, it means that the item was already removed from the engine
+        updateItem(record, BatchOperationItemState.SKIPPED, null);
+      } else {
+        updateItem(
+            record,
+            BatchOperationItemState.FAILED,
+            String.format(ERROR_MSG, record.getRejectionType(), record.getRejectionReason()));
+      }
     }
+  }
+
+  private void updateItem(
+      final Record<T> record, final BatchOperationItemState state, final String errorMessage) {
+    batchOperationWriter.updateItem(
+        new BatchOperationItemDbModel(
+            String.valueOf(record.getBatchOperationReference()),
+            getItemKey(record),
+            getProcessInstanceKey(record),
+            state,
+            DateUtil.toOffsetDateTime(record.getTimestamp()),
+            errorMessage));
   }
 
   /**

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/batchoperation/BatchOperationStatusHandlerTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/batchoperation/BatchOperationStatusHandlerTest.java
@@ -178,6 +178,24 @@ class BatchOperationStatusHandlerTest {
     }
 
     @Test
+    void shouldUpdateEntityAsSkippedOnNotFound() {
+      final var record =
+          ImmutableRecord.<T>builder()
+              .from(createFailureRecord())
+              .withRejectionType(RejectionType.NOT_FOUND)
+              .build();
+
+      handler.export(record);
+
+      final var itemCaptor = ArgumentCaptor.forClass(BatchOperationItemDbModel.class);
+      verify(batchOperationWriter).updateItem(itemCaptor.capture());
+
+      assertThat(itemCaptor.getValue().state()).isEqualTo(BatchOperationItemState.SKIPPED);
+      assertThat(itemCaptor.getValue().processedDate()).isNotNull();
+      assertThat(itemCaptor.getValue().errorMessage()).isNull();
+    }
+
+    @Test
     abstract void shouldExtractCorrectItemKey();
 
     @Test
@@ -228,7 +246,7 @@ class BatchOperationStatusHandlerTest {
       return factory.generateRecord(
           ValueType.PROCESS_INSTANCE_MODIFICATION,
           b ->
-              b.withRejectionType(RejectionType.NOT_FOUND)
+              b.withRejectionType(RejectionType.PROCESSING_ERROR)
                   .withIntent(ProcessInstanceModificationIntent.MODIFY)
                   .withBatchOperationReference(batchOperationKey));
     }
@@ -274,7 +292,7 @@ class BatchOperationStatusHandlerTest {
       return factory.generateRecord(
           ValueType.PROCESS_INSTANCE_MIGRATION,
           b ->
-              b.withRejectionType(RejectionType.NOT_FOUND)
+              b.withRejectionType(RejectionType.PROCESSING_ERROR)
                   .withIntent(ProcessInstanceMigrationIntent.MIGRATE)
                   .withBatchOperationReference(batchOperationKey));
     }
@@ -343,7 +361,7 @@ class BatchOperationStatusHandlerTest {
       return factory.generateRecord(
           ValueType.PROCESS_INSTANCE_MIGRATION,
           b ->
-              b.withRejectionType(RejectionType.NOT_FOUND)
+              b.withRejectionType(RejectionType.PROCESSING_ERROR)
                   .withValue(
                       ImmutableProcessInstanceRecordValue.builder()
                           .from(factory.generateObject(ProcessInstanceRecordValue.class))
@@ -392,7 +410,7 @@ class BatchOperationStatusHandlerTest {
       return factory.generateRecord(
           ValueType.INCIDENT,
           b ->
-              b.withRejectionType(RejectionType.NOT_FOUND)
+              b.withRejectionType(RejectionType.PROCESSING_ERROR)
                   .withIntent(IncidentIntent.RESOLVE)
                   .withBatchOperationReference(batchOperationKey));
     }

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -10790,6 +10790,7 @@ components:
           enum:
             - ACTIVE
             - COMPLETED
+            - SKIPPED
             - CANCELED
             - FAILED
         processedDate:


### PR DESCRIPTION
## Description

Sometimes it can happen, that a batch operation wants to process items where the items are not known anymore to the engine in time of processing. These items should be marked as SKIPPED instead of FAILED.

This PR solves this it by treating the rejectionType `NOT_FOUND` as `SKIPPED` in the exporters.

### Other investigated solution (but decided against)
- add a new `BatchOperationExecutionIntent.SKIPPED`
- directly check in the BatchOperationExecutor implementations if the item still exists. If no, we append a SKIPPED record and skip the whole execution

This had some drawbacks in complexity:
- this would need the actual `BatchOperationExecutor`s to know more deeply what the batch action will do and how. Currently most of these exectutors simply append the action command (e.g. ProcessInstanceIntent.CANCEL) without deeper knowledge what will happen
- currently the `BatchOperationExecutionRecord` only contains the itemKey of the handled operation item. When the `SKIPPED` record now should be able to create an `upsert` statement in the exporters, we also need the `processInstanceKey`. For this we would also need the `processInstanceKey` in the `PersistedBatchOperationChunk` in the RocksDb (only has a list of itemKeys). This then would at least double the amount of stored data and adds more complexity to a lot of locations

### Compatibility with Operate-API
- the new batch operations are never processed by Operates batch operation engine, so they would never read a SKIPPED
- in the `OperationRestService` the state is used directly by the `OperationState` enum without further conversion, so no change needed there. Still we need to inform the Operate-UI team about the new enum value.

## Related issues

closes #35457 
