### PR TITLE
fix: set Secure cookie flag only if the request is secure

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
@@ -327,7 +327,6 @@ public class WebSecurityConfig {
   public CookieCsrfTokenRepository cookieCsrfTokenRepository() {
     final CookieCsrfTokenRepository repository = new CookieCsrfTokenRepository();
     repository.setHeaderName(X_CSRF_TOKEN);
-    repository.setCookieCustomizer(cc -> cc.httpOnly(true).secure(true));
     repository.setCookieName(X_CSRF_TOKEN);
     return repository;
   }

--- a/authentication/src/test/java/io/camunda/authentication/config/AbstractWebSecurityConfigTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/AbstractWebSecurityConfigTest.java
@@ -44,6 +44,9 @@ import org.springframework.test.web.servlet.assertj.MvcTestResult;
 @ActiveProfiles("consolidated-auth")
 public class AbstractWebSecurityConfigTest {
 
+  protected static final String EXPECTED_CSRF_TOKEN_COOKIE_NAME = "X-CSRF-TOKEN";
+  protected static final String EXPECTED_CSRF_HEADER_NAME = "X-CSRF-TOKEN";
+
   /**
    * Wrapper around MockMvc that offers AssertJ-based assertions instead of Hamcrest matchers
    *

--- a/authentication/src/test/java/io/camunda/authentication/config/OidcWebSecurityConfigTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/OidcWebSecurityConfigTest.java
@@ -16,6 +16,7 @@ import io.camunda.authentication.config.controllers.OidcMockMvcTestHelper;
 import io.camunda.authentication.config.controllers.TestApiController;
 import io.camunda.authentication.config.controllers.WebSecurityConfigTestContext;
 import io.camunda.authentication.config.controllers.WebSecurityOidcTestContext;
+import jakarta.servlet.http.Cookie;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -173,5 +174,51 @@ public class OidcWebSecurityConfigTest extends AbstractWebSecurityConfigTest {
 
     // then
     assertThat(testResult).hasStatusOk();
+  }
+
+  @Test
+  public void shouldReturnCsrfTokenOnAuthenticatedGetRequest() {
+    // when
+    final MvcTestResult testResult =
+        mockMvcTester
+            .get()
+            .uri("https://localhost" + TestApiController.DUMMY_WEBAPP_ENDPOINT)
+            .with(OidcMockMvcTestHelper.oidcLogin(authorizedClientRepository))
+            .exchange();
+
+    // then
+    assertThat(testResult)
+        .hasStatusOk()
+        .containsHeader(EXPECTED_CSRF_HEADER_NAME)
+        .cookies()
+        .containsCookie(EXPECTED_CSRF_TOKEN_COOKIE_NAME);
+
+    final Cookie csrfCookie = testResult.getResponse().getCookie(EXPECTED_CSRF_TOKEN_COOKIE_NAME);
+
+    assertThat(csrfCookie.isHttpOnly()).isTrue();
+    assertThat(csrfCookie.getSecure()).isTrue();
+  }
+
+  @Test
+  public void shouldNotSetSecureFlagOnCsrfCookieWhenUsingHttp() {
+    // given
+    final String webappUrl =
+        "http://localhost" + TestApiController.DUMMY_WEBAPP_ENDPOINT; // note: http - not https
+
+    // when
+    final MvcTestResult testResult =
+        mockMvcTester
+            .get()
+            .uri(webappUrl)
+            .with(OidcMockMvcTestHelper.oidcLogin(authorizedClientRepository))
+            .exchange();
+
+    // then
+    assertThat(testResult).cookies().containsCookie(EXPECTED_CSRF_TOKEN_COOKIE_NAME);
+
+    final Cookie csrfCookie = testResult.getResponse().getCookie(EXPECTED_CSRF_TOKEN_COOKIE_NAME);
+
+    assertThat(csrfCookie.isHttpOnly()).isTrue();
+    assertThat(csrfCookie.getSecure()).isFalse();
   }
 }


### PR DESCRIPTION
- note that the fix is just removing an explicit configuration since the Spring default behavior is what we want

related to #36174