### PR TITLE
Handle backpressure in the migration handlers

### DIFF
--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/IdentityMigrationProperties.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/IdentityMigrationProperties.java
@@ -30,6 +30,7 @@ public class IdentityMigrationProperties {
   private ConsoleProperties console = new ConsoleProperties();
   private ClusterProperties cluster = new ClusterProperties();
   private OidcProperties oidc = new OidcProperties();
+  private Integer backpressureDelay = 5000;
 
   public ManagementIdentityProperties getManagementIdentity() {
     return managementIdentity;
@@ -77,6 +78,14 @@ public class IdentityMigrationProperties {
 
   public void setOidc(final OidcProperties oidc) {
     this.oidc = oidc;
+  }
+
+  public Integer getBackpressureDelay() {
+    return backpressureDelay;
+  }
+
+  public void setBackpressureDelay(final Integer backpressureDelay) {
+    this.backpressureDelay = backpressureDelay;
   }
 
   public enum Mode {

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/saas/SaaSMigrationHandlerConfig.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/saas/SaaSMigrationHandlerConfig.java
@@ -9,6 +9,7 @@ package io.camunda.migration.identity.config.saas;
 
 import io.camunda.migration.identity.client.ConsoleClient;
 import io.camunda.migration.identity.client.ManagementIdentityClient;
+import io.camunda.migration.identity.config.IdentityMigrationProperties;
 import io.camunda.migration.identity.handler.saas.AuthorizationMigrationHandler;
 import io.camunda.migration.identity.handler.saas.ClientMigrationHandler;
 import io.camunda.migration.identity.handler.saas.GroupMigrationHandler;
@@ -29,25 +30,34 @@ public class SaaSMigrationHandlerConfig {
       final CamundaAuthentication authentication,
       final ConsoleClient consoleClient,
       final ManagementIdentityClient managementIdentityClient,
-      final GroupServices groupServices) {
+      final GroupServices groupServices,
+      final IdentityMigrationProperties migrationProperties) {
     return new GroupMigrationHandler(
-        authentication, consoleClient, managementIdentityClient, groupServices);
+        authentication,
+        consoleClient,
+        managementIdentityClient,
+        groupServices,
+        migrationProperties);
   }
 
   @Bean
   public StaticConsoleRoleMigrationHandler roleMigrationHandler(
       final CamundaAuthentication authentication,
       final RoleServices roleServices,
-      final ConsoleClient consoleClient) {
-    return new StaticConsoleRoleMigrationHandler(roleServices, authentication, consoleClient);
+      final ConsoleClient consoleClient,
+      final IdentityMigrationProperties migrationProperties) {
+    return new StaticConsoleRoleMigrationHandler(
+        roleServices, authentication, consoleClient, migrationProperties);
   }
 
   @Bean
   public StaticConsoleRoleAuthorizationMigrationHandler
       staticConsoleRoleAuthorizationMigrationHandler(
           final AuthorizationServices authorizationService,
-          final CamundaAuthentication authentication) {
-    return new StaticConsoleRoleAuthorizationMigrationHandler(authorizationService, authentication);
+          final CamundaAuthentication authentication,
+          final IdentityMigrationProperties migrationProperties) {
+    return new StaticConsoleRoleAuthorizationMigrationHandler(
+        authorizationService, authentication, migrationProperties);
   }
 
   @Bean
@@ -55,16 +65,23 @@ public class SaaSMigrationHandlerConfig {
       final CamundaAuthentication authentication,
       final AuthorizationServices authorizationService,
       final ConsoleClient consoleClient,
-      final ManagementIdentityClient managementIdentityClient) {
+      final ManagementIdentityClient managementIdentityClient,
+      final IdentityMigrationProperties migrationProperties) {
     return new AuthorizationMigrationHandler(
-        authentication, authorizationService, consoleClient, managementIdentityClient);
+        authentication,
+        authorizationService,
+        consoleClient,
+        managementIdentityClient,
+        migrationProperties);
   }
 
   @Bean
   public ClientMigrationHandler clientMigrationHandler(
       final ConsoleClient consoleClient,
       final AuthorizationServices authorizationServices,
-      final CamundaAuthentication servicesAuthentication) {
-    return new ClientMigrationHandler(consoleClient, authorizationServices, servicesAuthentication);
+      final CamundaAuthentication servicesAuthentication,
+      final IdentityMigrationProperties migrationProperties) {
+    return new ClientMigrationHandler(
+        consoleClient, authorizationServices, servicesAuthentication, migrationProperties);
   }
 }

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/sm/SMKeycloakMigrationHandlerConfig.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/sm/SMKeycloakMigrationHandlerConfig.java
@@ -49,9 +49,14 @@ public class SMKeycloakMigrationHandlerConfig {
       final ManagementIdentityClient managementIdentityClient,
       final GroupServices groupServices,
       final AuthorizationServices authorizationServices,
-      final CamundaAuthentication authentication) {
+      final CamundaAuthentication authentication,
+      final IdentityMigrationProperties migrationProperties) {
     return new GroupMigrationHandler(
-        managementIdentityClient, groupServices, authorizationServices, authentication);
+        managementIdentityClient,
+        groupServices,
+        authorizationServices,
+        authentication,
+        migrationProperties);
   }
 
   @Bean
@@ -59,8 +64,10 @@ public class SMKeycloakMigrationHandlerConfig {
   public UserRoleMigrationHandler userRoleMigrationHandler(
       final CamundaAuthentication authentication,
       final ManagementIdentityClient managementIdentityClient,
-      final RoleServices roleServices) {
-    return new UserRoleMigrationHandler(authentication, managementIdentityClient, roleServices);
+      final RoleServices roleServices,
+      final IdentityMigrationProperties migrationProperties) {
+    return new UserRoleMigrationHandler(
+        authentication, managementIdentityClient, roleServices, migrationProperties);
   }
 
   @Bean
@@ -79,9 +86,10 @@ public class SMKeycloakMigrationHandlerConfig {
   public AuthorizationMigrationHandler authorizationMigrationHandler(
       final CamundaAuthentication authentication,
       final AuthorizationServices authorizationService,
-      final ManagementIdentityClient managementIdentityClient) {
+      final ManagementIdentityClient managementIdentityClient,
+      final IdentityMigrationProperties migrationProperties) {
     return new AuthorizationMigrationHandler(
-        authentication, authorizationService, managementIdentityClient);
+        authentication, authorizationService, managementIdentityClient, migrationProperties);
   }
 
   @Bean
@@ -92,9 +100,6 @@ public class SMKeycloakMigrationHandlerConfig {
       final CamundaAuthentication camundaAuthentication,
       final IdentityMigrationProperties migrationProperties) {
     return new TenantMigrationHandler(
-        managementIdentityClient,
-        tenantService,
-        camundaAuthentication,
-        migrationProperties.getMode());
+        managementIdentityClient, tenantService, camundaAuthentication, migrationProperties);
   }
 }

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/sm/SMOidcMigrationHandlerConfig.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/sm/SMOidcMigrationHandlerConfig.java
@@ -49,10 +49,7 @@ public class SMOidcMigrationHandlerConfig {
       final CamundaAuthentication camundaAuthentication,
       final IdentityMigrationProperties migrationProperties) {
     return new TenantMigrationHandler(
-        managementIdentityClient,
-        tenantService,
-        camundaAuthentication,
-        migrationProperties.getMode());
+        managementIdentityClient, tenantService, camundaAuthentication, migrationProperties);
   }
 
   @Bean
@@ -62,12 +59,14 @@ public class SMOidcMigrationHandlerConfig {
       final MappingRuleServices mappingRuleServices,
       final RoleServices roleServices,
       final TenantServices tenantServices,
-      final CamundaAuthentication camundaAuthentication) {
+      final CamundaAuthentication camundaAuthentication,
+      final IdentityMigrationProperties migrationProperties) {
     return new MappingRuleMigrationHandler(
         managementIdentityClient,
         mappingRuleServices,
         roleServices,
         tenantServices,
-        camundaAuthentication);
+        camundaAuthentication,
+        migrationProperties);
   }
 }

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/handler/MigrationHandler.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/handler/MigrationHandler.java
@@ -7,16 +7,17 @@
  */
 package io.camunda.migration.identity.handler;
 
+import io.camunda.migration.api.MigrationException;
 import io.camunda.service.exception.ServiceException;
 import io.camunda.service.exception.ServiceException.Status;
 import java.util.List;
 import java.util.concurrent.CompletionException;
+import java.util.function.Supplier;
 import org.apache.commons.lang3.NotImplementedException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public abstract class MigrationHandler<T> {
-  static final int SIZE = 100;
   protected final Logger logger = LoggerFactory.getLogger(getClass());
 
   protected boolean isConflictError(final Throwable e) {
@@ -28,6 +29,11 @@ public abstract class MigrationHandler<T> {
 
   protected boolean isNotImplementedError(final Throwable e) {
     return e instanceof final NotImplementedException exception;
+  }
+
+  protected static boolean isBackpressureError(final Throwable e) {
+    return (e instanceof final CompletionException ce && isBackpressureError(ce.getCause()))
+        || (e instanceof final ServiceException se && se.getStatus() == Status.RESOURCE_EXHAUSTED);
   }
 
   public void migrate() {
@@ -50,5 +56,27 @@ public abstract class MigrationHandler<T> {
 
   protected void logSummary() {
     logger.info("Completed {}", getName());
+  }
+
+  protected <T> void retryOnBackpressure(
+      final Supplier<T> operation, final String contextDescription) {
+
+    while (true) {
+      try {
+        operation.get();
+        return;
+      } catch (final Exception e) {
+        if (!isBackpressureError(e)) {
+          throw e;
+        }
+        logger.warn("Backpressure during {}. Retrying in 5 seconds...", contextDescription);
+        try {
+          Thread.sleep(5000);
+        } catch (final InterruptedException ie) {
+          Thread.currentThread().interrupt();
+          throw new MigrationException("Retry interrupted during backpressure handling.", ie);
+        }
+      }
+    }
   }
 }

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/handler/MigrationHandler.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/handler/MigrationHandler.java
@@ -20,6 +20,12 @@ import org.slf4j.LoggerFactory;
 public abstract class MigrationHandler<T> {
   protected final Logger logger = LoggerFactory.getLogger(getClass());
 
+  private final Integer backpressureDelay;
+
+  protected MigrationHandler(final Integer backpressureDelay) {
+    this.backpressureDelay = backpressureDelay;
+  }
+
   protected boolean isConflictError(final Throwable e) {
     return (e instanceof final CompletionException completionException
             && isConflictError(completionException.getCause()))
@@ -71,7 +77,7 @@ public abstract class MigrationHandler<T> {
         }
         logger.warn("Backpressure during {}. Retrying in 5 seconds...", contextDescription);
         try {
-          Thread.sleep(5000);
+          Thread.sleep(backpressureDelay);
         } catch (final InterruptedException ie) {
           Thread.currentThread().interrupt();
           throw new MigrationException("Retry interrupted during backpressure handling.", ie);

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/handler/MigrationHandler.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/handler/MigrationHandler.java
@@ -10,6 +10,7 @@ package io.camunda.migration.identity.handler;
 import io.camunda.migration.api.MigrationException;
 import io.camunda.service.exception.ServiceException;
 import io.camunda.service.exception.ServiceException.Status;
+import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.CompletionException;
 import java.util.function.Supplier;
@@ -75,9 +76,12 @@ public abstract class MigrationHandler<T> {
         if (!isBackpressureError(e)) {
           throw e;
         }
-        logger.warn("Backpressure during {}. Retrying in 5 seconds...", contextDescription);
+        logger.warn(
+            "Backpressure during {}. Retrying in {} seconds...",
+            contextDescription,
+            backpressureDelay);
         try {
-          Thread.sleep(backpressureDelay);
+          Thread.sleep(Duration.ofMillis(backpressureDelay));
         } catch (final InterruptedException ie) {
           Thread.currentThread().interrupt();
           throw new MigrationException("Retry interrupted during backpressure handling.", ie);

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/handler/saas/AuthorizationMigrationHandler.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/handler/saas/AuthorizationMigrationHandler.java
@@ -15,6 +15,7 @@ import static io.camunda.migration.identity.config.saas.StaticEntities.IDENTITY_
 import io.camunda.migration.identity.client.ConsoleClient;
 import io.camunda.migration.identity.client.ConsoleClient.Member;
 import io.camunda.migration.identity.client.ManagementIdentityClient;
+import io.camunda.migration.identity.config.IdentityMigrationProperties;
 import io.camunda.migration.identity.dto.Authorization;
 import io.camunda.migration.identity.handler.MigrationHandler;
 import io.camunda.security.auth.CamundaAuthentication;
@@ -43,7 +44,9 @@ public class AuthorizationMigrationHandler extends MigrationHandler<Authorizatio
       final CamundaAuthentication authentication,
       final AuthorizationServices authorizationService,
       final ConsoleClient consoleClient,
-      final ManagementIdentityClient managementIdentityClient) {
+      final ManagementIdentityClient managementIdentityClient,
+      final IdentityMigrationProperties migrationProperties) {
+    super(migrationProperties.getBackpressureDelay());
     this.consoleClient = consoleClient;
     this.managementIdentityClient = managementIdentityClient;
     this.authorizationService = authorizationService.withAuthentication(authentication);

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/handler/saas/AuthorizationMigrationHandler.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/handler/saas/AuthorizationMigrationHandler.java
@@ -84,7 +84,9 @@ public class AuthorizationMigrationHandler extends MigrationHandler<Authorizatio
                   convertResourceType(authorization.resourceType()),
                   convertPermissions(authorization.permissions(), authorization.resourceType()));
           try {
-            authorizationService.createAuthorization(request).join();
+            retryOnBackpressure(
+                () -> authorizationService.createAuthorization(request).join(),
+                "creating authorization for entity ID: " + authorization.entityId());
             createdAuthorizationsCount.incrementAndGet();
             logger.debug(
                 "Migrating authorization: {} to an Authorization with ownerId: {}",

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/handler/saas/ClientMigrationHandler.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/handler/saas/ClientMigrationHandler.java
@@ -76,7 +76,9 @@ public class ClientMigrationHandler extends MigrationHandler<Members> {
     }
     for (final CreateAuthorizationRequest request : combinedPermissions) {
       try {
-        authorizationServices.createAuthorization(request).join();
+        retryOnBackpressure(
+            () -> authorizationServices.createAuthorization(request).join(),
+            "creating client permission for client ID: " + clientId);
         createdAuthorizations.incrementAndGet();
         logger.debug(
             "Migrated client permission with owner ID: {} and resource type: {}",

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/handler/saas/ClientMigrationHandler.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/handler/saas/ClientMigrationHandler.java
@@ -17,6 +17,7 @@ import io.camunda.migration.identity.client.ConsoleClient;
 import io.camunda.migration.identity.client.ConsoleClient.Client;
 import io.camunda.migration.identity.client.ConsoleClient.Members;
 import io.camunda.migration.identity.client.ConsoleClient.Permission;
+import io.camunda.migration.identity.config.IdentityMigrationProperties;
 import io.camunda.migration.identity.handler.MigrationHandler;
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.AuthorizationServices;
@@ -38,7 +39,9 @@ public class ClientMigrationHandler extends MigrationHandler<Members> {
   public ClientMigrationHandler(
       final ConsoleClient consoleClient,
       final AuthorizationServices authorizationServices,
-      final CamundaAuthentication servicesAuthentication) {
+      final CamundaAuthentication servicesAuthentication,
+      final IdentityMigrationProperties migrationProperties) {
+    super(migrationProperties.getBackpressureDelay());
     this.consoleClient = consoleClient;
     this.authorizationServices = authorizationServices.withAuthentication(servicesAuthentication);
   }

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/handler/saas/GroupMigrationHandler.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/handler/saas/GroupMigrationHandler.java
@@ -66,7 +66,9 @@ public class GroupMigrationHandler extends MigrationHandler<Group> {
               "Migrating Group: {} to a Group with the identifier: {}.", group, normalizedGroupId);
           try {
             final var groupDTO = new GroupDTO(normalizedGroupId, group.name(), "");
-            groupServices.createGroup(groupDTO).join();
+            retryOnBackpressure(
+                () -> groupServices.createGroup(groupDTO).join(),
+                "create group with ID: " + group.id());
             createdGroupCount.incrementAndGet();
           } catch (final Exception e) {
             if (!isConflictError(e)) {
@@ -113,7 +115,9 @@ public class GroupMigrationHandler extends MigrationHandler<Group> {
                 userEmail,
                 targetGroupId);
             final var groupMember = new GroupMemberDTO(targetGroupId, userEmail, EntityType.USER);
-            groupServices.assignMember(groupMember).join();
+            retryOnBackpressure(
+                () -> groupServices.assignMember(groupMember).join(),
+                "assign user with ID: " + user.getId() + " to group with ID: " + targetGroupId);
             assignedUserCount.incrementAndGet();
           } catch (final Exception e) {
             if (!isConflictError(e)) {

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/handler/saas/GroupMigrationHandler.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/handler/saas/GroupMigrationHandler.java
@@ -13,6 +13,7 @@ import io.camunda.migration.api.MigrationException;
 import io.camunda.migration.identity.client.ConsoleClient;
 import io.camunda.migration.identity.client.ConsoleClient.Member;
 import io.camunda.migration.identity.client.ManagementIdentityClient;
+import io.camunda.migration.identity.config.IdentityMigrationProperties;
 import io.camunda.migration.identity.dto.Group;
 import io.camunda.migration.identity.handler.MigrationHandler;
 import io.camunda.security.auth.CamundaAuthentication;
@@ -41,7 +42,9 @@ public class GroupMigrationHandler extends MigrationHandler<Group> {
       final CamundaAuthentication authentication,
       final ConsoleClient consoleClient,
       final ManagementIdentityClient managementIdentityClient,
-      final GroupServices groupServices) {
+      final GroupServices groupServices,
+      final IdentityMigrationProperties migrationProperties) {
+    super(migrationProperties.getBackpressureDelay());
     this.consoleClient = consoleClient;
     this.managementIdentityClient = managementIdentityClient;
     this.groupServices = groupServices.withAuthentication(authentication);

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/handler/saas/StaticConsoleRoleAuthorizationMigrationHandler.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/handler/saas/StaticConsoleRoleAuthorizationMigrationHandler.java
@@ -10,6 +10,7 @@ package io.camunda.migration.identity.handler.saas;
 import static io.camunda.migration.identity.config.saas.StaticEntities.ROLE_PERMISSIONS;
 
 import io.camunda.migration.api.MigrationException;
+import io.camunda.migration.identity.config.IdentityMigrationProperties;
 import io.camunda.migration.identity.dto.NoopDTO;
 import io.camunda.migration.identity.handler.MigrationHandler;
 import io.camunda.security.auth.CamundaAuthentication;
@@ -27,7 +28,9 @@ public class StaticConsoleRoleAuthorizationMigrationHandler extends MigrationHan
 
   public StaticConsoleRoleAuthorizationMigrationHandler(
       final AuthorizationServices authorizationServices,
-      final CamundaAuthentication servicesAuthentication) {
+      final CamundaAuthentication servicesAuthentication,
+      final IdentityMigrationProperties migrationProperties) {
+    super(migrationProperties.getBackpressureDelay());
     this.authorizationServices = authorizationServices.withAuthentication(servicesAuthentication);
   }
 

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/handler/saas/StaticConsoleRoleAuthorizationMigrationHandler.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/handler/saas/StaticConsoleRoleAuthorizationMigrationHandler.java
@@ -44,7 +44,12 @@ public class StaticConsoleRoleAuthorizationMigrationHandler extends MigrationHan
     ROLE_PERMISSIONS.forEach(
         request -> {
           try {
-            authorizationServices.createAuthorization(request).join();
+            retryOnBackpressure(
+                () -> authorizationServices.createAuthorization(request).join(),
+                "migrating role permission with owner ID: "
+                    + request.ownerId()
+                    + " and resource type: "
+                    + request.resourceType());
             createdAuthorizations.incrementAndGet();
             logger.debug(
                 "Migrated role permission with owner ID: {} and resource type: {}",

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/handler/saas/StaticConsoleRoleMigrationHandler.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/handler/saas/StaticConsoleRoleMigrationHandler.java
@@ -11,6 +11,7 @@ import static io.camunda.migration.identity.config.saas.StaticEntities.ROLES;
 
 import io.camunda.migration.api.MigrationException;
 import io.camunda.migration.identity.client.ConsoleClient;
+import io.camunda.migration.identity.config.IdentityMigrationProperties;
 import io.camunda.migration.identity.dto.NoopDTO;
 import io.camunda.migration.identity.handler.MigrationHandler;
 import io.camunda.security.auth.CamundaAuthentication;
@@ -31,7 +32,9 @@ public class StaticConsoleRoleMigrationHandler extends MigrationHandler<NoopDTO>
   public StaticConsoleRoleMigrationHandler(
       final RoleServices roleServices,
       final CamundaAuthentication servicesAuthentication,
-      final ConsoleClient consoleClient) {
+      final ConsoleClient consoleClient,
+      final IdentityMigrationProperties migrationProperties) {
+    super(migrationProperties.getBackpressureDelay());
     this.roleServices = roleServices.withAuthentication(servicesAuthentication);
     this.consoleClient = consoleClient;
   }

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/handler/sm/AuthorizationMigrationHandler.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/handler/sm/AuthorizationMigrationHandler.java
@@ -75,7 +75,12 @@ public class AuthorizationMigrationHandler extends MigrationHandler<Authorizatio
                           convertPermissions(
                               authorization.permissions(), authorization.resourceType()));
                   try {
-                    authorizationService.createAuthorization(request).join();
+                    retryOnBackpressure(
+                        () -> authorizationService.createAuthorization(request).join(),
+                        "Failed to create authorization for entity with ID: "
+                            + authorization.entityId()
+                            + " and owner with ID: "
+                            + user.getEmail());
                     createdAuthorizationsCount.incrementAndGet();
                     logger.debug(
                         "Migrated authorization: {} to an Authorization with ownerId: {}",

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/handler/sm/AuthorizationMigrationHandler.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/handler/sm/AuthorizationMigrationHandler.java
@@ -14,6 +14,7 @@ import static io.camunda.migration.identity.config.saas.StaticEntities.IDENTITY_
 
 import io.camunda.identity.sdk.users.dto.User;
 import io.camunda.migration.identity.client.ManagementIdentityClient;
+import io.camunda.migration.identity.config.IdentityMigrationProperties;
 import io.camunda.migration.identity.dto.Authorization;
 import io.camunda.migration.identity.handler.MigrationHandler;
 import io.camunda.security.auth.CamundaAuthentication;
@@ -41,7 +42,9 @@ public class AuthorizationMigrationHandler extends MigrationHandler<Authorizatio
   public AuthorizationMigrationHandler(
       final CamundaAuthentication authentication,
       final AuthorizationServices authorizationService,
-      final ManagementIdentityClient managementIdentityClient) {
+      final ManagementIdentityClient managementIdentityClient,
+      final IdentityMigrationProperties migrationProperties) {
+    super(migrationProperties.getBackpressureDelay());
     this.managementIdentityClient = managementIdentityClient;
     this.authorizationService = authorizationService.withAuthentication(authentication);
   }

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/handler/sm/ClientMigrationHandler.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/handler/sm/ClientMigrationHandler.java
@@ -36,6 +36,7 @@ public class ClientMigrationHandler extends MigrationHandler<Client> {
       final ManagementIdentityClient managementIdentityClient,
       final AuthorizationServices authorizationService,
       final IdentityMigrationProperties migrationProperties) {
+    super(migrationProperties.getBackpressureDelay());
     this.managementIdentityClient = managementIdentityClient;
     this.authorizationService = authorizationService.withAuthentication(authentication);
     this.migrationProperties = migrationProperties;

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/handler/sm/ClientMigrationHandler.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/handler/sm/ClientMigrationHandler.java
@@ -101,7 +101,13 @@ public class ClientMigrationHandler extends MigrationHandler<Client> {
 
               for (final var request : combinedPermissions) {
                 try {
-                  authorizationService.createAuthorization(request).join();
+                  retryOnBackpressure(
+                      () -> authorizationService.createAuthorization(request).join(),
+                      "Failed to create authorization for client '"
+                          + clientId
+                          + "' with permissions '"
+                          + request.permissionTypes()
+                          + "'");
                   logger.debug(
                       "Authorization created for client '{}' with permissions '{}'.",
                       clientId,

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/handler/sm/GroupMigrationHandler.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/handler/sm/GroupMigrationHandler.java
@@ -16,6 +16,7 @@ import static io.camunda.migration.identity.config.saas.StaticEntities.IDENTITY_
 
 import io.camunda.migration.api.MigrationException;
 import io.camunda.migration.identity.client.ManagementIdentityClient;
+import io.camunda.migration.identity.config.IdentityMigrationProperties;
 import io.camunda.migration.identity.dto.Authorization;
 import io.camunda.migration.identity.dto.Group;
 import io.camunda.migration.identity.handler.MigrationHandler;
@@ -51,7 +52,9 @@ public class GroupMigrationHandler extends MigrationHandler<Group> {
       final ManagementIdentityClient managementIdentityClient,
       final GroupServices groupServices,
       final AuthorizationServices authorizationServices,
-      final CamundaAuthentication authentication) {
+      final CamundaAuthentication authentication,
+      final IdentityMigrationProperties migrationProperties) {
+    super(migrationProperties.getBackpressureDelay());
     this.managementIdentityClient = managementIdentityClient;
     this.groupServices = groupServices.withAuthentication(authentication);
     this.authorizationServices = authorizationServices.withAuthentication(authentication);

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/handler/sm/MappingRuleMigrationHandler.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/handler/sm/MappingRuleMigrationHandler.java
@@ -11,6 +11,7 @@ import static io.camunda.migration.identity.MigrationUtil.normalizeID;
 
 import io.camunda.migration.api.MigrationException;
 import io.camunda.migration.identity.client.ManagementIdentityClient;
+import io.camunda.migration.identity.config.IdentityMigrationProperties;
 import io.camunda.migration.identity.dto.MappingRule;
 import io.camunda.migration.identity.dto.Role;
 import io.camunda.migration.identity.dto.Tenant;
@@ -46,7 +47,9 @@ public class MappingRuleMigrationHandler extends MigrationHandler<MappingRule> {
       final MappingRuleServices mappingRuleServices,
       final RoleServices roleServices,
       final TenantServices tenantServices,
-      final CamundaAuthentication camundaAuthentication) {
+      final CamundaAuthentication camundaAuthentication,
+      final IdentityMigrationProperties migrationProperties) {
+    super(migrationProperties.getBackpressureDelay());
     this.managementIdentityClient = managementIdentityClient;
     this.mappingRuleServices = mappingRuleServices.withAuthentication(camundaAuthentication);
     this.roleServices = roleServices.withAuthentication(camundaAuthentication);

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/handler/sm/RoleMigrationHandler.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/handler/sm/RoleMigrationHandler.java
@@ -68,9 +68,10 @@ public class RoleMigrationHandler extends MigrationHandler<Role> {
           final var roleName = role.name();
           final var roleId = normalizeID(roleName);
           try {
-            roleServices
-                .createRole(new CreateRoleRequest(roleId, roleName, role.description()))
-                .join();
+            final var roleRequest = new CreateRoleRequest(roleId, roleName, role.description());
+            retryOnBackpressure(
+                () -> roleServices.createRole(roleRequest).join(),
+                "Failed to create role with ID " + roleId);
             createdRoleCount.incrementAndGet();
             logger.debug("Role '{}' with ID '{}' created successfully.", roleName, roleId);
           } catch (final Exception e) {
@@ -115,7 +116,13 @@ public class RoleMigrationHandler extends MigrationHandler<Role> {
 
     for (final var request : combinedPermissions) {
       try {
-        authorizationServices.createAuthorization(request).join();
+        retryOnBackpressure(
+            () -> authorizationServices.createAuthorization(request).join(),
+            "Failed to create authorization for role with ID '"
+                + roleId
+                + "' with permissions '"
+                + request.permissionTypes()
+                + "'");
         logger.debug(
             "Authorization created for role '{}' with permissions '{}'.",
             roleName,

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/handler/sm/RoleMigrationHandler.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/handler/sm/RoleMigrationHandler.java
@@ -41,6 +41,7 @@ public class RoleMigrationHandler extends MigrationHandler<Role> {
       final RoleServices roleServices,
       final AuthorizationServices authorizationServices,
       final IdentityMigrationProperties migrationProperties) {
+    super(migrationProperties.getBackpressureDelay());
     this.managementIdentityClient = managementIdentityClient;
     this.roleServices = roleServices.withAuthentication(authentication);
     this.authorizationServices = authorizationServices.withAuthentication(authentication);

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/handler/sm/TenantMigrationHandler.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/handler/sm/TenantMigrationHandler.java
@@ -13,6 +13,7 @@ import static io.camunda.migration.identity.MigrationUtil.normalizeID;
 import io.camunda.identity.sdk.users.dto.User;
 import io.camunda.migration.api.MigrationException;
 import io.camunda.migration.identity.client.ManagementIdentityClient;
+import io.camunda.migration.identity.config.IdentityMigrationProperties;
 import io.camunda.migration.identity.config.IdentityMigrationProperties.Mode;
 import io.camunda.migration.identity.dto.Client;
 import io.camunda.migration.identity.dto.Group;
@@ -47,10 +48,11 @@ public class TenantMigrationHandler extends MigrationHandler<Tenant> {
       final ManagementIdentityClient managementIdentityClient,
       final TenantServices tenantService,
       final CamundaAuthentication camundaAuthentication,
-      final Mode mode) {
+      final IdentityMigrationProperties migrationProperties) {
+    super(migrationProperties.getBackpressureDelay());
     this.managementIdentityClient = managementIdentityClient;
     this.tenantService = tenantService.withAuthentication(camundaAuthentication);
-    this.mode = mode;
+    mode = migrationProperties.getMode();
   }
 
   @Override

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/handler/sm/UserRoleMigrationHandler.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/handler/sm/UserRoleMigrationHandler.java
@@ -12,6 +12,7 @@ import static io.camunda.migration.identity.MigrationUtil.normalizeID;
 import io.camunda.identity.sdk.users.dto.User;
 import io.camunda.migration.api.MigrationException;
 import io.camunda.migration.identity.client.ManagementIdentityClient;
+import io.camunda.migration.identity.config.IdentityMigrationProperties;
 import io.camunda.migration.identity.handler.MigrationHandler;
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.RoleServices;
@@ -31,7 +32,9 @@ public class UserRoleMigrationHandler extends MigrationHandler<User> {
   public UserRoleMigrationHandler(
       final CamundaAuthentication authentication,
       final ManagementIdentityClient managementIdentityClient,
-      final RoleServices roleServices) {
+      final RoleServices roleServices,
+      final IdentityMigrationProperties migrationProperties) {
+    super(migrationProperties.getBackpressureDelay());
     this.managementIdentityClient = managementIdentityClient;
     this.roleServices = roleServices.withAuthentication(authentication);
   }

--- a/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/saas/AuthorizationMigrationHandlerTest.java
+++ b/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/saas/AuthorizationMigrationHandlerTest.java
@@ -17,6 +17,7 @@ import io.camunda.migration.identity.client.ConsoleClient;
 import io.camunda.migration.identity.client.ConsoleClient.Member;
 import io.camunda.migration.identity.client.ConsoleClient.Role;
 import io.camunda.migration.identity.client.ManagementIdentityClient;
+import io.camunda.migration.identity.config.IdentityMigrationProperties;
 import io.camunda.migration.identity.dto.Authorization;
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.AuthorizationServices;
@@ -55,12 +56,15 @@ final class AuthorizationMigrationHandlerTest {
     this.authorizationServices = authorizationServices;
     this.managementIdentityClient = managementIdentityClient;
     this.consoleClient = consoleClient;
+    final var migrationProperties = new IdentityMigrationProperties();
+    migrationProperties.setBackpressureDelay(100);
     migrationHandler =
         new AuthorizationMigrationHandler(
             CamundaAuthentication.none(),
             authorizationServices,
             consoleClient,
-            managementIdentityClient);
+            managementIdentityClient,
+            migrationProperties);
   }
 
   @Test

--- a/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/saas/AuthorizationMigrationHandlerTest.java
+++ b/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/saas/AuthorizationMigrationHandlerTest.java
@@ -21,7 +21,11 @@ import io.camunda.migration.identity.dto.Authorization;
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.AuthorizationServices;
 import io.camunda.service.AuthorizationServices.CreateAuthorizationRequest;
+import io.camunda.service.exception.ErrorMapper;
+import io.camunda.zeebe.broker.client.api.BrokerErrorException;
+import io.camunda.zeebe.broker.client.api.dto.BrokerError;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.AuthorizationRecord;
+import io.camunda.zeebe.protocol.record.ErrorCode;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
@@ -134,5 +138,54 @@ final class AuthorizationMigrationHandlerTest {
     assertThat(requests.get(2).resourceId(), Matchers.is("process"));
     assertThat(requests.get(2).resourceType(), Matchers.is(AuthorizationResourceType.UNSPECIFIED));
     assertThat(requests.get(2).permissionTypes(), Matchers.empty());
+  }
+
+  @Test
+  public void shouldRetryWithBackpressure() {
+    // given
+    when(authorizationServices.createAuthorization(any(CreateAuthorizationRequest.class)))
+        .thenReturn(
+            CompletableFuture.failedFuture(
+                ErrorMapper.mapError(
+                    new BrokerErrorException(
+                        new BrokerError(ErrorCode.RESOURCE_EXHAUSTED, "backpressure")))))
+        .thenReturn(CompletableFuture.completedFuture(new AuthorizationRecord()));
+    final var members =
+        new ConsoleClient.Members(
+            List.of(
+                new Member("user1", List.of(Role.DEVELOPER), "user1@email.com", "User One"),
+                new Member(
+                    "user2", List.of(Role.OPERATIONS_ENGINEER), "user2@email.com", "User Two"),
+                new Member("user3", List.of(Role.IGNORED), "user3@email.com", "User Three")),
+            List.of());
+    when(consoleClient.fetchMembers()).thenReturn(members);
+
+    when(managementIdentityClient.fetchAuthorizations())
+        .thenReturn(
+            List.of(
+                new Authorization(
+                    "user1",
+                    "USER",
+                    "process",
+                    "process-definition",
+                    Set.of("READ", "UPDATE_PROCESS_INSTANCE", "START_PROCESS_INSTANCE")),
+                new Authorization(
+                    "user2",
+                    "USER",
+                    "*",
+                    "decision-definition",
+                    Set.of("DELETE_PROCESS_INSTANCE", "READ", "DELETE")),
+                new Authorization(
+                    "user3",
+                    "NOT_VALID",
+                    "process",
+                    "not-valid",
+                    Set.of("UNKNOWN", "UPDATE_PROCESS_INSTANCE", "DELETE"))));
+
+    // when
+    migrationHandler.migrate();
+
+    // then
+    verify(authorizationServices, times(4)).createAuthorization(any());
   }
 }

--- a/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/saas/ClientMigrationHandlerTest.java
+++ b/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/saas/ClientMigrationHandlerTest.java
@@ -22,9 +22,12 @@ import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.AuthorizationServices;
 import io.camunda.service.AuthorizationServices.CreateAuthorizationRequest;
 import io.camunda.service.exception.ErrorMapper;
+import io.camunda.zeebe.broker.client.api.BrokerErrorException;
 import io.camunda.zeebe.broker.client.api.BrokerRejectionException;
+import io.camunda.zeebe.broker.client.api.dto.BrokerError;
 import io.camunda.zeebe.broker.client.api.dto.BrokerRejection;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.AuthorizationRecord;
+import io.camunda.zeebe.protocol.record.ErrorCode;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.AuthorizationIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
@@ -177,5 +180,30 @@ public class ClientMigrationHandlerTest {
 
     // then
     verify(authorizationServices, times(9)).createAuthorization(any());
+  }
+
+  @Test
+  public void shouldRetryWithBackpressure() {
+    // given
+    when(authorizationServices.createAuthorization(any(CreateAuthorizationRequest.class)))
+        .thenReturn(
+            CompletableFuture.failedFuture(
+                ErrorMapper.mapError(
+                    new BrokerErrorException(
+                        new BrokerError(ErrorCode.RESOURCE_EXHAUSTED, "backpressure")))))
+        .thenReturn(CompletableFuture.completedFuture(new AuthorizationRecord()));
+    final var members =
+        new Members(
+            List.of(),
+            List.of(
+                new Client("client", "client-id", List.of(Permission.ZEEBE, Permission.OPERATE)),
+                new Client("tasklist-client", "tasklist-client-id", List.of(Permission.TASKLIST))));
+    when(consoleClient.fetchMembers()).thenReturn(members);
+
+    // when
+    migrationHandler.migrate();
+
+    // then
+    verify(authorizationServices, times(10)).createAuthorization(any());
   }
 }

--- a/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/saas/ClientMigrationHandlerTest.java
+++ b/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/saas/ClientMigrationHandlerTest.java
@@ -18,6 +18,7 @@ import io.camunda.migration.identity.client.ConsoleClient;
 import io.camunda.migration.identity.client.ConsoleClient.Client;
 import io.camunda.migration.identity.client.ConsoleClient.Members;
 import io.camunda.migration.identity.client.ConsoleClient.Permission;
+import io.camunda.migration.identity.config.IdentityMigrationProperties;
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.AuthorizationServices;
 import io.camunda.service.AuthorizationServices.CreateAuthorizationRequest;
@@ -55,9 +56,14 @@ public class ClientMigrationHandlerTest {
       @Mock final ConsoleClient consoleClient) {
     this.authorizationServices = authorizationServices;
     this.consoleClient = consoleClient;
+    final var migrationProperties = new IdentityMigrationProperties();
+    migrationProperties.setBackpressureDelay(100);
     migrationHandler =
         new ClientMigrationHandler(
-            consoleClient, authorizationServices, CamundaAuthentication.none());
+            consoleClient,
+            authorizationServices,
+            CamundaAuthentication.none(),
+            migrationProperties);
   }
 
   @Test

--- a/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/saas/GroupMigrationHandlerTest.java
+++ b/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/saas/GroupMigrationHandlerTest.java
@@ -23,6 +23,7 @@ import io.camunda.migration.identity.client.ConsoleClient;
 import io.camunda.migration.identity.client.ConsoleClient.Member;
 import io.camunda.migration.identity.client.ConsoleClient.Members;
 import io.camunda.migration.identity.client.ManagementIdentityClient;
+import io.camunda.migration.identity.config.IdentityMigrationProperties;
 import io.camunda.migration.identity.dto.Group;
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.GroupServices;
@@ -63,9 +64,15 @@ public class GroupMigrationHandlerTest {
     this.consoleClient = consoleClient;
     this.managementIdentityClient = managementIdentityClient;
     this.groupService = groupService;
+    final var migrationProperties = new IdentityMigrationProperties();
+    migrationProperties.setBackpressureDelay(100);
     migrationHandler =
         new GroupMigrationHandler(
-            CamundaAuthentication.none(), consoleClient, managementIdentityClient, groupService);
+            CamundaAuthentication.none(),
+            consoleClient,
+            managementIdentityClient,
+            groupService,
+            migrationProperties);
   }
 
   @Test

--- a/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/saas/StaticConsoleRoleAuthorizationMigrationHandlerTest.java
+++ b/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/saas/StaticConsoleRoleAuthorizationMigrationHandlerTest.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.camunda.migration.identity.config.IdentityMigrationProperties;
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.AuthorizationServices;
 import io.camunda.service.AuthorizationServices.CreateAuthorizationRequest;
@@ -40,9 +41,11 @@ public class StaticConsoleRoleAuthorizationMigrationHandlerTest {
   public StaticConsoleRoleAuthorizationMigrationHandlerTest(
       @Mock(answer = Answers.RETURNS_SELF) final AuthorizationServices authorizationServices) {
     this.authorizationServices = authorizationServices;
+    final var migrationProperties = new IdentityMigrationProperties();
+    migrationProperties.setBackpressureDelay(100);
     migrationHandler =
         new StaticConsoleRoleAuthorizationMigrationHandler(
-            authorizationServices, CamundaAuthentication.none());
+            authorizationServices, CamundaAuthentication.none(), migrationProperties);
   }
 
   @Test

--- a/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/saas/StaticConsoleRoleMigrationHandlerTest.java
+++ b/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/saas/StaticConsoleRoleMigrationHandlerTest.java
@@ -18,6 +18,7 @@ import io.camunda.migration.identity.client.ConsoleClient;
 import io.camunda.migration.identity.client.ConsoleClient.Member;
 import io.camunda.migration.identity.client.ConsoleClient.Members;
 import io.camunda.migration.identity.client.ConsoleClient.Role;
+import io.camunda.migration.identity.config.IdentityMigrationProperties;
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.RoleServices;
 import io.camunda.service.RoleServices.CreateRoleRequest;
@@ -53,9 +54,11 @@ public class StaticConsoleRoleMigrationHandlerTest {
       @Mock(answer = Answers.RETURNS_SELF) final ConsoleClient consoleClient) {
     this.roleServices = roleServices;
     this.consoleClient = consoleClient;
+    final var migrationProperties = new IdentityMigrationProperties();
+    migrationProperties.setBackpressureDelay(100);
     migrationHandler =
         new StaticConsoleRoleMigrationHandler(
-            roleServices, CamundaAuthentication.none(), consoleClient);
+            roleServices, CamundaAuthentication.none(), consoleClient, migrationProperties);
   }
 
   @Test

--- a/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/saas/StaticConsoleRoleMigrationHandlerTest.java
+++ b/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/saas/StaticConsoleRoleMigrationHandlerTest.java
@@ -23,9 +23,12 @@ import io.camunda.service.RoleServices;
 import io.camunda.service.RoleServices.CreateRoleRequest;
 import io.camunda.service.RoleServices.RoleMemberRequest;
 import io.camunda.service.exception.ErrorMapper;
+import io.camunda.zeebe.broker.client.api.BrokerErrorException;
 import io.camunda.zeebe.broker.client.api.BrokerRejectionException;
+import io.camunda.zeebe.broker.client.api.dto.BrokerError;
 import io.camunda.zeebe.broker.client.api.dto.BrokerRejection;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.RoleRecord;
+import io.camunda.zeebe.protocol.record.ErrorCode;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.GroupIntent;
 import io.camunda.zeebe.protocol.record.value.EntityType;
@@ -140,5 +143,66 @@ public class StaticConsoleRoleMigrationHandlerTest {
     assertThat(requests.get(2).roleId()).isEqualTo("admin");
     assertThat(requests.get(2).entityId()).isEqualTo("user4@email.com");
     assertThat(requests.get(2).entityType()).isEqualTo(EntityType.USER);
+  }
+
+  @Test
+  public void shouldRetryWithBackpressureOnRoleCreation() {
+    // given
+    when(roleServices.createRole(any(CreateRoleRequest.class)))
+        .thenReturn(
+            CompletableFuture.failedFuture(
+                ErrorMapper.mapError(
+                    new BrokerErrorException(
+                        new BrokerError(ErrorCode.RESOURCE_EXHAUSTED, "backpressure")))))
+        .thenReturn(CompletableFuture.completedFuture(new RoleRecord()));
+    final var members =
+        new ConsoleClient.Members(
+            List.of(
+                new Member("user1", List.of(Role.DEVELOPER), "user1@email.com", "User One"),
+                new Member(
+                    "user2", List.of(Role.OPERATIONS_ENGINEER), "user2@email.com", "User Two"),
+                new Member("user3", List.of(Role.IGNORED), "user3@email.com", "User Three"),
+                new Member("user4", List.of(Role.OWNER), "user4@email.com", "User Four")),
+            List.of());
+    when(consoleClient.fetchMembers()).thenReturn(members);
+    when(roleServices.addMember(any())).thenReturn(CompletableFuture.completedFuture(null));
+
+    // when
+    migrationHandler.migrate();
+
+    // then
+    verify(roleServices, times(5)).createRole(any(CreateRoleRequest.class));
+    verify(roleServices, times(3)).addMember(any(RoleMemberRequest.class));
+  }
+
+  @Test
+  public void shouldRetryWithBackpressureOnRoleMembershipAssignation() {
+    // given
+    when(roleServices.createRole(any(CreateRoleRequest.class)))
+        .thenReturn(CompletableFuture.completedFuture(new RoleRecord()));
+    final var members =
+        new ConsoleClient.Members(
+            List.of(
+                new Member("user1", List.of(Role.DEVELOPER), "user1@email.com", "User One"),
+                new Member(
+                    "user2", List.of(Role.OPERATIONS_ENGINEER), "user2@email.com", "User Two"),
+                new Member("user3", List.of(Role.IGNORED), "user3@email.com", "User Three"),
+                new Member("user4", List.of(Role.OWNER), "user4@email.com", "User Four")),
+            List.of());
+    when(consoleClient.fetchMembers()).thenReturn(members);
+    when(roleServices.addMember(any()))
+        .thenReturn(
+            CompletableFuture.failedFuture(
+                ErrorMapper.mapError(
+                    new BrokerErrorException(
+                        new BrokerError(ErrorCode.RESOURCE_EXHAUSTED, "backpressure")))))
+        .thenReturn(CompletableFuture.completedFuture(null));
+
+    // when
+    migrationHandler.migrate();
+
+    // then
+    verify(roleServices, times(4)).createRole(any(CreateRoleRequest.class));
+    verify(roleServices, times(4)).addMember(any(RoleMemberRequest.class));
   }
 }

--- a/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/sm/AuthorizationMigrationHandlerTest.java
+++ b/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/sm/AuthorizationMigrationHandlerTest.java
@@ -16,6 +16,7 @@ import static org.mockito.Mockito.when;
 
 import io.camunda.identity.sdk.users.dto.User;
 import io.camunda.migration.identity.client.ManagementIdentityClient;
+import io.camunda.migration.identity.config.IdentityMigrationProperties;
 import io.camunda.migration.identity.dto.Authorization;
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.AuthorizationServices;
@@ -54,9 +55,14 @@ final class AuthorizationMigrationHandlerTest {
       @Mock final ManagementIdentityClient managementIdentityClient) {
     this.authorizationServices = authorizationServices;
     this.managementIdentityClient = managementIdentityClient;
+    final var migrationProperties = new IdentityMigrationProperties();
+    migrationProperties.setBackpressureDelay(100);
     migrationHandler =
         new AuthorizationMigrationHandler(
-            CamundaAuthentication.none(), authorizationServices, managementIdentityClient);
+            CamundaAuthentication.none(),
+            authorizationServices,
+            managementIdentityClient,
+            migrationProperties);
   }
 
   @Test

--- a/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/sm/AuthorizationMigrationHandlerTest.java
+++ b/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/sm/AuthorizationMigrationHandlerTest.java
@@ -22,9 +22,12 @@ import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.AuthorizationServices;
 import io.camunda.service.AuthorizationServices.CreateAuthorizationRequest;
 import io.camunda.service.exception.ErrorMapper;
+import io.camunda.zeebe.broker.client.api.BrokerErrorException;
 import io.camunda.zeebe.broker.client.api.BrokerRejectionException;
+import io.camunda.zeebe.broker.client.api.dto.BrokerError;
 import io.camunda.zeebe.broker.client.api.dto.BrokerRejection;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.AuthorizationRecord;
+import io.camunda.zeebe.protocol.record.ErrorCode;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.GroupIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
@@ -225,6 +228,46 @@ final class AuthorizationMigrationHandlerTest {
 
     // then
     verify(authorizationServices, times(2))
+        .createAuthorization(any(CreateAuthorizationRequest.class));
+  }
+
+  @Test
+  public void shouldRetryOnBackpressure() {
+    // given
+    when(authorizationServices.createAuthorization(any(CreateAuthorizationRequest.class)))
+        .thenReturn(
+            CompletableFuture.failedFuture(
+                ErrorMapper.mapError(
+                    new BrokerErrorException(
+                        new BrokerError(ErrorCode.RESOURCE_EXHAUSTED, "backpressure")))))
+        .thenReturn(CompletableFuture.completedFuture(new AuthorizationRecord()));
+    final var users1 = List.of(new User("user1", "username1", "name1", "email1"));
+    when(managementIdentityClient.fetchUsers(any(Integer.class)))
+        .thenReturn(users1)
+        .thenReturn(List.of());
+
+    when(managementIdentityClient.fetchUserAuthorizations(anyString()))
+        .thenReturn(
+            List.of(
+                new Authorization(
+                    "email1",
+                    "USER",
+                    "process",
+                    "process-definition",
+                    Set.of("READ", "UPDATE_PROCESS_INSTANCE", "START_PROCESS_INSTANCE")),
+                new Authorization(
+                    "email1",
+                    "USER",
+                    "*",
+                    "decision-definition",
+                    Set.of("DELETE_PROCESS_INSTANCE", "READ", "DELETE"))))
+        .thenReturn(List.of());
+
+    // when
+    migrationHandler.migrate();
+
+    // then
+    verify(authorizationServices, times(3))
         .createAuthorization(any(CreateAuthorizationRequest.class));
   }
 }

--- a/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/sm/ClientMigrationHandlerTest.java
+++ b/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/sm/ClientMigrationHandlerTest.java
@@ -27,9 +27,12 @@ import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.AuthorizationServices;
 import io.camunda.service.AuthorizationServices.CreateAuthorizationRequest;
 import io.camunda.service.exception.ErrorMapper;
+import io.camunda.zeebe.broker.client.api.BrokerErrorException;
 import io.camunda.zeebe.broker.client.api.BrokerRejectionException;
+import io.camunda.zeebe.broker.client.api.dto.BrokerError;
 import io.camunda.zeebe.broker.client.api.dto.BrokerRejection;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.AuthorizationRecord;
+import io.camunda.zeebe.protocol.record.ErrorCode;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.GroupIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
@@ -278,6 +281,38 @@ public class ClientMigrationHandlerTest {
 
     //
     verify(authorizationServices, times(16))
+        .createAuthorization(any(CreateAuthorizationRequest.class));
+  }
+
+  @Test
+  public void shouldRetryWithBackpressure() {
+    // given
+    when(authorizationServices.createAuthorization(any(CreateAuthorizationRequest.class)))
+        .thenReturn(
+            CompletableFuture.failedFuture(
+                ErrorMapper.mapError(
+                    new BrokerErrorException(
+                        new BrokerError(ErrorCode.RESOURCE_EXHAUSTED, "backpressure")))))
+        .thenReturn(CompletableFuture.completedFuture(new AuthorizationRecord()));
+    when(managementIdentityClient.fetchClients())
+        .thenReturn(
+            List.of(
+                new Client("client1", "ClientOne", CONFIDENTIAL),
+                new Client("client2", "ClientTwo", M2M)));
+    when(managementIdentityClient.fetchClientPermissions(anyString()))
+        .thenReturn(
+            List.of(
+                new Permission("write:*", "zeebe-api"), new Permission("write:*", "operate-api")))
+        .thenReturn(
+            List.of(
+                new Permission("read:*", "operate-api"),
+                new Permission("write:*", "tasklist-api")));
+
+    // when
+    migrationHandler.migrate();
+
+    // then
+    verify(authorizationServices, times(17))
         .createAuthorization(any(CreateAuthorizationRequest.class));
   }
 }

--- a/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/sm/ClientMigrationHandlerTest.java
+++ b/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/sm/ClientMigrationHandlerTest.java
@@ -57,12 +57,14 @@ public class ClientMigrationHandlerTest {
       @Mock(answer = Answers.RETURNS_SELF) final AuthorizationServices authorizationServices) {
     this.managementIdentityClient = managementIdentityClient;
     this.authorizationServices = authorizationServices;
+    final var migrationProperties = new IdentityMigrationProperties();
+    migrationProperties.setBackpressureDelay(100);
     migrationHandler =
         new ClientMigrationHandler(
             CamundaAuthentication.none(),
             managementIdentityClient,
             authorizationServices,
-            new IdentityMigrationProperties());
+            migrationProperties);
   }
 
   @Test

--- a/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/sm/GroupMigrationHandlerTest.java
+++ b/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/sm/GroupMigrationHandlerTest.java
@@ -16,6 +16,7 @@ import static org.mockito.Mockito.when;
 
 import io.camunda.identity.sdk.users.dto.User;
 import io.camunda.migration.identity.client.ManagementIdentityClient;
+import io.camunda.migration.identity.config.IdentityMigrationProperties;
 import io.camunda.migration.identity.dto.Authorization;
 import io.camunda.migration.identity.dto.Group;
 import io.camunda.migration.identity.dto.Role;
@@ -64,12 +65,15 @@ public class GroupMigrationHandlerTest {
     this.managementIdentityClient = managementIdentityClient;
     this.groupService = groupService;
     this.authorizationServices = authorizationServices;
+    final var migrationProperties = new IdentityMigrationProperties();
+    migrationProperties.setBackpressureDelay(100);
     migrationHandler =
         new GroupMigrationHandler(
             managementIdentityClient,
             groupService,
             authorizationServices,
-            CamundaAuthentication.none());
+            CamundaAuthentication.none(),
+            migrationProperties);
   }
 
   @Test

--- a/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/sm/KeycloakRoleMigrationHandlerTest.java
+++ b/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/sm/KeycloakRoleMigrationHandlerTest.java
@@ -60,13 +60,15 @@ public class KeycloakRoleMigrationHandlerTest {
     this.managementIdentityClient = managementIdentityClient;
     this.roleServices = roleServices;
     this.authorizationServices = authorizationServices;
+    final var migrationProperties = new IdentityMigrationProperties();
+    migrationProperties.setBackpressureDelay(100);
     roleMigrationHandler =
         new RoleMigrationHandler(
             CamundaAuthentication.none(),
             managementIdentityClient,
             roleServices,
             authorizationServices,
-            new IdentityMigrationProperties());
+            migrationProperties);
   }
 
   @Test

--- a/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/sm/KeycloakRoleMigrationHandlerTest.java
+++ b/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/sm/KeycloakRoleMigrationHandlerTest.java
@@ -24,10 +24,13 @@ import io.camunda.service.AuthorizationServices.CreateAuthorizationRequest;
 import io.camunda.service.RoleServices;
 import io.camunda.service.RoleServices.CreateRoleRequest;
 import io.camunda.service.exception.ErrorMapper;
+import io.camunda.zeebe.broker.client.api.BrokerErrorException;
 import io.camunda.zeebe.broker.client.api.BrokerRejectionException;
+import io.camunda.zeebe.broker.client.api.dto.BrokerError;
 import io.camunda.zeebe.broker.client.api.dto.BrokerRejection;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.AuthorizationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.RoleRecord;
+import io.camunda.zeebe.protocol.record.ErrorCode;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.AuthorizationIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
@@ -315,5 +318,69 @@ public class KeycloakRoleMigrationHandlerTest {
     // then
     verify(managementIdentityClient, times(2)).fetchPermissions(any());
     verify(authorizationServices, times(20)).createAuthorization(any());
+  }
+
+  @Test
+  public void shouldRetryWithBackpressureOnRoleCreation() {
+    // given
+    when(managementIdentityClient.fetchRoles())
+        .thenReturn(
+            List.of(
+                new Role("Role 1", "Description for Role 1"),
+                new Role("Role 2", "Description for Role 2")));
+    when(roleServices.createRole(any()))
+        .thenReturn(
+            CompletableFuture.failedFuture(
+                ErrorMapper.mapError(
+                    new BrokerErrorException(
+                        new BrokerError(ErrorCode.RESOURCE_EXHAUSTED, "backpressure")))))
+        .thenReturn(CompletableFuture.completedFuture(new RoleRecord()));
+
+    // when
+    roleMigrationHandler.migrate();
+
+    // then
+    verify(roleServices, Mockito.times(3)).createRole(any(CreateRoleRequest.class));
+  }
+
+  @Test
+  public void shouldRetryWithBackpressureOnRoleAuthorizationCreation() {
+    // given
+    when(managementIdentityClient.fetchRoles())
+        .thenReturn(
+            List.of(
+                new Role("Role 1", "Description for Role 1"),
+                new Role("Role 2", "Description for Role 2")));
+    when(roleServices.createRole(any()))
+        .thenReturn(CompletableFuture.completedFuture(new RoleRecord()));
+
+    when(managementIdentityClient.fetchPermissions(any()))
+        .thenReturn(
+            List.of(
+                new Permission("read", "camunda-identity-resource-server"),
+                new Permission("read:users", "camunda-identity-resource-server"),
+                new Permission("write", "camunda-identity-resource-server"),
+                new Permission("read:*", "operate-api"),
+                new Permission("write:*", "operate-api")))
+        .thenReturn(
+            List.of(
+                new Permission("read:*", "tasklist-api"),
+                new Permission("write:*", "tasklist-api"),
+                new Permission("write:*", "zeebe-api")));
+    when(authorizationServices.createAuthorization(any()))
+        .thenReturn(
+            CompletableFuture.failedFuture(
+                ErrorMapper.mapError(
+                    new BrokerErrorException(
+                        new BrokerError(ErrorCode.RESOURCE_EXHAUSTED, "backpressure")))))
+        .thenReturn(CompletableFuture.completedFuture(new AuthorizationRecord()));
+
+    // when
+    roleMigrationHandler.migrate();
+
+    // then
+    verify(roleServices, Mockito.times(2)).createRole(any(CreateRoleRequest.class));
+    verify(authorizationServices, Mockito.times(21))
+        .createAuthorization(any(CreateAuthorizationRequest.class));
   }
 }

--- a/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/sm/KeycloakTenantMigrationHandlerTest.java
+++ b/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/sm/KeycloakTenantMigrationHandlerTest.java
@@ -17,6 +17,7 @@ import static org.mockito.Mockito.when;
 
 import io.camunda.identity.sdk.users.dto.User;
 import io.camunda.migration.identity.client.ManagementIdentityClient;
+import io.camunda.migration.identity.config.IdentityMigrationProperties;
 import io.camunda.migration.identity.config.IdentityMigrationProperties.Mode;
 import io.camunda.migration.identity.dto.Client;
 import io.camunda.migration.identity.dto.Group;
@@ -53,9 +54,15 @@ public class KeycloakTenantMigrationHandlerTest {
       @Mock(answer = Answers.RETURNS_SELF) final TenantServices tenantServices) {
     this.managementIdentityClient = managementIdentityClient;
     this.tenantServices = tenantServices;
+    final var migrationProperties = new IdentityMigrationProperties();
+    migrationProperties.setMode(Mode.KEYCLOAK);
+    migrationProperties.setBackpressureDelay(100);
     migrationHandler =
         new TenantMigrationHandler(
-            managementIdentityClient, tenantServices, CamundaAuthentication.none(), Mode.KEYCLOAK);
+            managementIdentityClient,
+            tenantServices,
+            CamundaAuthentication.none(),
+            migrationProperties);
   }
 
   @Test

--- a/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/sm/KeycloakTenantMigrationHandlerTest.java
+++ b/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/sm/KeycloakTenantMigrationHandlerTest.java
@@ -27,8 +27,11 @@ import io.camunda.service.TenantServices;
 import io.camunda.service.TenantServices.TenantDTO;
 import io.camunda.service.TenantServices.TenantMemberRequest;
 import io.camunda.service.exception.ErrorMapper;
+import io.camunda.zeebe.broker.client.api.BrokerErrorException;
 import io.camunda.zeebe.broker.client.api.BrokerRejectionException;
+import io.camunda.zeebe.broker.client.api.dto.BrokerError;
 import io.camunda.zeebe.broker.client.api.dto.BrokerRejection;
+import io.camunda.zeebe.protocol.record.ErrorCode;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.GroupIntent;
 import io.camunda.zeebe.protocol.record.value.EntityType;
@@ -242,5 +245,109 @@ public class KeycloakTenantMigrationHandlerTest {
     // then
     verify(tenantServices, times(2)).createTenant(any(TenantDTO.class));
     verify(tenantServices, times(9)).addMember(any(TenantMemberRequest.class));
+  }
+
+  @Test
+  public void shouldRetryWithBackoffOnTenantCreation() {
+    // given
+    when(managementIdentityClient.fetchTenants())
+        .thenReturn(
+            List.of(
+                new Tenant("tenant1", "Tenant 1"),
+                new Tenant("tenant2", "Tenant 2"),
+                new Tenant("<default>", "Default Tenant")));
+    when(tenantServices.createTenant(any(TenantDTO.class)))
+        .thenReturn(
+            CompletableFuture.failedFuture(
+                ErrorMapper.mapError(
+                    new BrokerErrorException(
+                        new BrokerError(ErrorCode.RESOURCE_EXHAUSTED, "backpressure")))))
+        .thenReturn(CompletableFuture.completedFuture(null));
+    when(tenantServices.addMember(any(TenantMemberRequest.class)))
+        .thenReturn(CompletableFuture.completedFuture(null));
+    when(managementIdentityClient.fetchTenantUsers("tenant1"))
+        .thenReturn(
+            List.of(
+                new User("id", "username1", "name", "email"),
+                new User("id2", "username2", "name2", "email2")));
+    when(managementIdentityClient.fetchTenantUsers("tenant2"))
+        .thenReturn(
+            List.of(
+                new User("id3", "username3", "name3", "email3"),
+                new User("id4", "username4", "name4", "email4")));
+    when(managementIdentityClient.fetchTenantUsers("<default>"))
+        .thenReturn(List.of(new User("id4", "username4", "name4", "email4")));
+
+    when(managementIdentityClient.fetchTenantGroups("tenant1"))
+        .thenReturn(List.of(new Group("group1", "Group 1")));
+    when(managementIdentityClient.fetchTenantGroups("tenant2"))
+        .thenReturn(List.of(new Group("group2", "Group 2")));
+    when(managementIdentityClient.fetchTenantGroups("<default>"))
+        .thenReturn(List.of(new Group("group3", "Group 3")));
+    when(managementIdentityClient.fetchTenantClients("tenant1"))
+        .thenReturn(List.of(new Client("client1", "Client 1"), new Client("client2", "Client 2")));
+    when(managementIdentityClient.fetchTenantClients("tenant2"))
+        .thenReturn(List.of(new Client("client3", "Client 3")));
+    when(managementIdentityClient.fetchTenantClients("<default>"))
+        .thenReturn(List.of(new Client("client4", "Client 4")));
+
+    // when
+    migrationHandler.migrate();
+
+    // then
+    verify(tenantServices, times(3)).createTenant(any(TenantDTO.class));
+    verify(tenantServices, times(12)).addMember(any(TenantMemberRequest.class));
+  }
+
+  @Test
+  public void shouldRetryWithBackoffOnTenantMemberAssignation() {
+    // given
+    when(managementIdentityClient.fetchTenants())
+        .thenReturn(
+            List.of(
+                new Tenant("tenant1", "Tenant 1"),
+                new Tenant("tenant2", "Tenant 2"),
+                new Tenant("<default>", "Default Tenant")));
+    when(tenantServices.createTenant(any(TenantDTO.class)))
+        .thenReturn(CompletableFuture.completedFuture(null));
+    when(tenantServices.addMember(any(TenantMemberRequest.class)))
+        .thenReturn(
+            CompletableFuture.failedFuture(
+                ErrorMapper.mapError(
+                    new BrokerErrorException(
+                        new BrokerError(ErrorCode.RESOURCE_EXHAUSTED, "backpressure")))))
+        .thenReturn(CompletableFuture.completedFuture(null));
+    when(managementIdentityClient.fetchTenantUsers("tenant1"))
+        .thenReturn(
+            List.of(
+                new User("id", "username1", "name", "email"),
+                new User("id2", "username2", "name2", "email2")));
+    when(managementIdentityClient.fetchTenantUsers("tenant2"))
+        .thenReturn(
+            List.of(
+                new User("id3", "username3", "name3", "email3"),
+                new User("id4", "username4", "name4", "email4")));
+    when(managementIdentityClient.fetchTenantUsers("<default>"))
+        .thenReturn(List.of(new User("id4", "username4", "name4", "email4")));
+
+    when(managementIdentityClient.fetchTenantGroups("tenant1"))
+        .thenReturn(List.of(new Group("group1", "Group 1")));
+    when(managementIdentityClient.fetchTenantGroups("tenant2"))
+        .thenReturn(List.of(new Group("group2", "Group 2")));
+    when(managementIdentityClient.fetchTenantGroups("<default>"))
+        .thenReturn(List.of(new Group("group3", "Group 3")));
+    when(managementIdentityClient.fetchTenantClients("tenant1"))
+        .thenReturn(List.of(new Client("client1", "Client 1"), new Client("client2", "Client 2")));
+    when(managementIdentityClient.fetchTenantClients("tenant2"))
+        .thenReturn(List.of(new Client("client3", "Client 3")));
+    when(managementIdentityClient.fetchTenantClients("<default>"))
+        .thenReturn(List.of(new Client("client4", "Client 4")));
+
+    // when
+    migrationHandler.migrate();
+
+    // then
+    verify(tenantServices, times(2)).createTenant(any(TenantDTO.class));
+    verify(tenantServices, times(13)).addMember(any(TenantMemberRequest.class));
   }
 }

--- a/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/sm/MappingRuleMigrationHandlerTest.java
+++ b/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/sm/MappingRuleMigrationHandlerTest.java
@@ -27,8 +27,11 @@ import io.camunda.service.RoleServices.RoleMemberRequest;
 import io.camunda.service.TenantServices;
 import io.camunda.service.TenantServices.TenantMemberRequest;
 import io.camunda.service.exception.ErrorMapper;
+import io.camunda.zeebe.broker.client.api.BrokerErrorException;
 import io.camunda.zeebe.broker.client.api.BrokerRejectionException;
+import io.camunda.zeebe.broker.client.api.dto.BrokerError;
 import io.camunda.zeebe.broker.client.api.dto.BrokerRejection;
+import io.camunda.zeebe.protocol.record.ErrorCode;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.GroupIntent;
 import io.camunda.zeebe.protocol.record.intent.RoleIntent;
@@ -184,5 +187,110 @@ public class MappingRuleMigrationHandlerTest {
     verify(mappingRuleServices, times(1)).createMappingRule(any(MappingRuleDTO.class));
     verify(roleServices, times(2)).addMember(any(RoleMemberRequest.class));
     verify(tenantServices, times(2)).addMember(any(TenantMemberRequest.class));
+  }
+
+  @Test
+  public void shouldRetryWithBackpressureOnMappingCreation() {
+    // given
+    when(managementIdentityClient.fetchMappingRules())
+        .thenReturn(
+            List.of(
+                new MappingRule(
+                    "rule1",
+                    "claimName",
+                    "claimValue",
+                    Set.of(new Role("role1", "description1"), new Role("role2", "description2")),
+                    Set.of(
+                        new Tenant("tenant1", "tenantDescription1"),
+                        new Tenant("tenant2", "tenantDescription2")))));
+    when(mappingRuleServices.createMappingRule(any(MappingRuleDTO.class)))
+        .thenReturn(
+            CompletableFuture.failedFuture(
+                ErrorMapper.mapError(
+                    new BrokerErrorException(
+                        new BrokerError(ErrorCode.RESOURCE_EXHAUSTED, "backpressure")))))
+        .thenReturn(CompletableFuture.completedFuture(null));
+    when(roleServices.addMember(any(RoleMemberRequest.class)))
+        .thenReturn(CompletableFuture.completedFuture(null));
+    when(tenantServices.addMember(any(TenantMemberRequest.class)))
+        .thenReturn(CompletableFuture.completedFuture(null));
+
+    // when
+    mappingRuleMigrationHandler.migrate();
+
+    // then
+    verify(mappingRuleServices, times(2)).createMappingRule(any(MappingRuleDTO.class));
+    verify(roleServices, times(2)).addMember(any(RoleMemberRequest.class));
+    verify(tenantServices, times(2)).addMember(any(TenantMemberRequest.class));
+  }
+
+  @Test
+  public void shouldRetryWithBackpressureOnMappingRoleAssignation() {
+    // given
+    when(managementIdentityClient.fetchMappingRules())
+        .thenReturn(
+            List.of(
+                new MappingRule(
+                    "rule1",
+                    "claimName",
+                    "claimValue",
+                    Set.of(new Role("role1", "description1"), new Role("role2", "description2")),
+                    Set.of(
+                        new Tenant("tenant1", "tenantDescription1"),
+                        new Tenant("tenant2", "tenantDescription2")))));
+    when(mappingRuleServices.createMappingRule(any(MappingRuleDTO.class)))
+        .thenReturn(CompletableFuture.completedFuture(null));
+    when(roleServices.addMember(any(RoleMemberRequest.class)))
+        .thenReturn(
+            CompletableFuture.failedFuture(
+                ErrorMapper.mapError(
+                    new BrokerErrorException(
+                        new BrokerError(ErrorCode.RESOURCE_EXHAUSTED, "backpressure")))))
+        .thenReturn(CompletableFuture.completedFuture(null));
+    when(tenantServices.addMember(any(TenantMemberRequest.class)))
+        .thenReturn(CompletableFuture.completedFuture(null));
+
+    // when
+    mappingRuleMigrationHandler.migrate();
+
+    // then
+    verify(mappingRuleServices, times(1)).createMappingRule(any(MappingRuleDTO.class));
+    verify(roleServices, times(3)).addMember(any(RoleMemberRequest.class));
+    verify(tenantServices, times(2)).addMember(any(TenantMemberRequest.class));
+  }
+
+  @Test
+  public void shouldRetryWithBackpressureOnMappingTenantAssignation() {
+    // given
+    when(managementIdentityClient.fetchMappingRules())
+        .thenReturn(
+            List.of(
+                new MappingRule(
+                    "rule1",
+                    "claimName",
+                    "claimValue",
+                    Set.of(new Role("role1", "description1"), new Role("role2", "description2")),
+                    Set.of(
+                        new Tenant("tenant1", "tenantDescription1"),
+                        new Tenant("tenant2", "tenantDescription2")))));
+    when(mappingRuleServices.createMappingRule(any(MappingRuleDTO.class)))
+        .thenReturn(CompletableFuture.completedFuture(null));
+    when(roleServices.addMember(any(RoleMemberRequest.class)))
+        .thenReturn(CompletableFuture.completedFuture(null));
+    when(tenantServices.addMember(any(TenantMemberRequest.class)))
+        .thenReturn(
+            CompletableFuture.failedFuture(
+                ErrorMapper.mapError(
+                    new BrokerErrorException(
+                        new BrokerError(ErrorCode.RESOURCE_EXHAUSTED, "backpressure")))))
+        .thenReturn(CompletableFuture.completedFuture(null));
+
+    // when
+    mappingRuleMigrationHandler.migrate();
+
+    // then
+    verify(mappingRuleServices, times(1)).createMappingRule(any(MappingRuleDTO.class));
+    verify(roleServices, times(2)).addMember(any(RoleMemberRequest.class));
+    verify(tenantServices, times(3)).addMember(any(TenantMemberRequest.class));
   }
 }

--- a/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/sm/MappingRuleMigrationHandlerTest.java
+++ b/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/sm/MappingRuleMigrationHandlerTest.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.camunda.migration.identity.client.ManagementIdentityClient;
+import io.camunda.migration.identity.config.IdentityMigrationProperties;
 import io.camunda.migration.identity.dto.MappingRule;
 import io.camunda.migration.identity.dto.Role;
 import io.camunda.migration.identity.dto.Tenant;
@@ -61,13 +62,16 @@ public class MappingRuleMigrationHandlerTest {
     this.mappingRuleServices = mappingRuleServices;
     this.roleServices = roleServices;
     this.tenantServices = tenantServices;
+    final var migrationProperties = new IdentityMigrationProperties();
+    migrationProperties.setBackpressureDelay(100);
     mappingRuleMigrationHandler =
         new MappingRuleMigrationHandler(
             managementIdentityClient,
             mappingRuleServices,
             roleServices,
             tenantServices,
-            CamundaAuthentication.none());
+            CamundaAuthentication.none(),
+            migrationProperties);
   }
 
   @Test

--- a/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/sm/OidcRoleMigrationHandlerTest.java
+++ b/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/sm/OidcRoleMigrationHandlerTest.java
@@ -65,6 +65,7 @@ public class OidcRoleMigrationHandlerTest {
     final var audience = identityMigrationProperties.getOidc().getAudience();
     audience.setIdentity("identity");
     audience.setZeebe("zeebe");
+    identityMigrationProperties.setBackpressureDelay(100);
     roleMigrationHandler =
         new RoleMigrationHandler(
             CamundaAuthentication.none(),

--- a/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/sm/OidcRoleMigrationHandlerTest.java
+++ b/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/sm/OidcRoleMigrationHandlerTest.java
@@ -24,10 +24,13 @@ import io.camunda.service.AuthorizationServices.CreateAuthorizationRequest;
 import io.camunda.service.RoleServices;
 import io.camunda.service.RoleServices.CreateRoleRequest;
 import io.camunda.service.exception.ErrorMapper;
+import io.camunda.zeebe.broker.client.api.BrokerErrorException;
 import io.camunda.zeebe.broker.client.api.BrokerRejectionException;
+import io.camunda.zeebe.broker.client.api.dto.BrokerError;
 import io.camunda.zeebe.broker.client.api.dto.BrokerRejection;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.AuthorizationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.RoleRecord;
+import io.camunda.zeebe.protocol.record.ErrorCode;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.AuthorizationIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
@@ -319,5 +322,69 @@ public class OidcRoleMigrationHandlerTest {
     // then
     verify(managementIdentityClient, times(2)).fetchPermissions(any());
     verify(authorizationServices, times(20)).createAuthorization(any());
+  }
+
+  @Test
+  public void shouldRetryWithBackpressureOnRoleCreation() {
+    // given
+    when(managementIdentityClient.fetchRoles())
+        .thenReturn(
+            List.of(
+                new Role("Role 1", "Description for Role 1"),
+                new Role("Role 2", "Description for Role 2")));
+    when(roleServices.createRole(any()))
+        .thenReturn(
+            CompletableFuture.failedFuture(
+                ErrorMapper.mapError(
+                    new BrokerErrorException(
+                        new BrokerError(ErrorCode.RESOURCE_EXHAUSTED, "backpressure")))))
+        .thenReturn(CompletableFuture.completedFuture(new RoleRecord()));
+
+    // when
+    roleMigrationHandler.migrate();
+
+    // then
+    verify(roleServices, Mockito.times(3)).createRole(any(CreateRoleRequest.class));
+  }
+
+  @Test
+  public void shouldRetryWithBackpressureOnRoleAuthorizationCreation() {
+    // given
+    when(managementIdentityClient.fetchRoles())
+        .thenReturn(
+            List.of(
+                new Role("Role 1", "Description for Role 1"),
+                new Role("Role 2", "Description for Role 2")));
+    when(roleServices.createRole(any()))
+        .thenReturn(CompletableFuture.completedFuture(new RoleRecord()));
+
+    when(managementIdentityClient.fetchPermissions(any()))
+        .thenReturn(
+            List.of(
+                new Permission("read", "identity"),
+                new Permission("read:users", "identity"),
+                new Permission("write", "identity"),
+                new Permission("read:*", "operate-api"),
+                new Permission("write:*", "operate-api")))
+        .thenReturn(
+            List.of(
+                new Permission("read:*", "tasklist-api"),
+                new Permission("write:*", "tasklist-api"),
+                new Permission("write:*", "zeebe")));
+    when(authorizationServices.createAuthorization(any()))
+        .thenReturn(
+            CompletableFuture.failedFuture(
+                ErrorMapper.mapError(
+                    new BrokerErrorException(
+                        new BrokerError(ErrorCode.RESOURCE_EXHAUSTED, "backpressure")))))
+        .thenReturn(CompletableFuture.completedFuture(new AuthorizationRecord()));
+
+    // when
+    roleMigrationHandler.migrate();
+
+    // then
+    verify(roleServices, Mockito.times(2)).createRole(any(CreateRoleRequest.class));
+    verify(authorizationServices, Mockito.times(21))
+        .createAuthorization(any(CreateAuthorizationRequest.class));
   }
 }

--- a/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/sm/OidcTenantMigrationHandlerTest.java
+++ b/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/sm/OidcTenantMigrationHandlerTest.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.camunda.migration.identity.client.ManagementIdentityClient;
+import io.camunda.migration.identity.config.IdentityMigrationProperties;
 import io.camunda.migration.identity.config.IdentityMigrationProperties.Mode;
 import io.camunda.migration.identity.dto.Tenant;
 import io.camunda.security.auth.CamundaAuthentication;
@@ -47,9 +48,15 @@ public class OidcTenantMigrationHandlerTest {
       @Mock(answer = Answers.RETURNS_SELF) final TenantServices tenantServices) {
     this.managementIdentityClient = managementIdentityClient;
     this.tenantServices = tenantServices;
+    final var migrationProperties = new IdentityMigrationProperties();
+    migrationProperties.setMode(Mode.OIDC);
+    migrationProperties.setBackpressureDelay(100);
     migrationHandler =
         new TenantMigrationHandler(
-            managementIdentityClient, tenantServices, CamundaAuthentication.none(), Mode.OIDC);
+            managementIdentityClient,
+            tenantServices,
+            CamundaAuthentication.none(),
+            migrationProperties);
   }
 
   @Test

--- a/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/sm/UserRoleMigrationHandlerTest.java
+++ b/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/sm/UserRoleMigrationHandlerTest.java
@@ -22,8 +22,11 @@ import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.RoleServices;
 import io.camunda.service.RoleServices.RoleMemberRequest;
 import io.camunda.service.exception.ErrorMapper;
+import io.camunda.zeebe.broker.client.api.BrokerErrorException;
 import io.camunda.zeebe.broker.client.api.BrokerRejectionException;
+import io.camunda.zeebe.broker.client.api.dto.BrokerError;
 import io.camunda.zeebe.broker.client.api.dto.BrokerRejection;
+import io.camunda.zeebe.protocol.record.ErrorCode;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.RoleIntent;
 import java.util.List;
@@ -129,5 +132,39 @@ public class UserRoleMigrationHandlerTest {
 
     // then
     verify(roleServices, times(4)).addMember(any());
+  }
+
+  @Test
+  public void shouldRetryWithBackpressure() {
+    // given
+    when(managementIdentityClient.fetchUsers(any(Integer.class)))
+        .thenReturn(
+            List.of(
+                new User("user1", "username1", "name", "user1@email.com"),
+                new User("user2", "username2", "name", "user2@email.com")))
+        .thenReturn(List.of());
+    when(managementIdentityClient.fetchUserRoles(any()))
+        .thenReturn(
+            List.of(
+                new Role("Role 1", "Description for Role 1"),
+                new Role(
+                    "Role@Name#With$Special%Chars", "Description for Role with special chars")))
+        .thenReturn(
+            List.of(
+                new Role("Role 2", "Description for Role 2"),
+                new Role("Role 3", "Description for Role 3")));
+    when(roleServices.addMember(any()))
+        .thenReturn(
+            CompletableFuture.failedFuture(
+                ErrorMapper.mapError(
+                    new BrokerErrorException(
+                        new BrokerError(ErrorCode.RESOURCE_EXHAUSTED, "backpressure")))))
+        .thenReturn(CompletableFuture.completedFuture(null));
+
+    // when
+    userRoleMigrationHandler.migrate();
+
+    // then
+    verify(roleServices, times(5)).addMember(any(RoleMemberRequest.class));
   }
 }

--- a/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/sm/UserRoleMigrationHandlerTest.java
+++ b/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/sm/UserRoleMigrationHandlerTest.java
@@ -16,6 +16,7 @@ import static org.mockito.Mockito.when;
 
 import io.camunda.identity.sdk.users.dto.User;
 import io.camunda.migration.identity.client.ManagementIdentityClient;
+import io.camunda.migration.identity.config.IdentityMigrationProperties;
 import io.camunda.migration.identity.dto.Role;
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.RoleServices;
@@ -46,9 +47,14 @@ public class UserRoleMigrationHandlerTest {
       @Mock(answer = Answers.RETURNS_SELF) final RoleServices roleServices) {
     this.managementIdentityClient = managementIdentityClient;
     this.roleServices = roleServices;
+    final var migrationProperties = new IdentityMigrationProperties();
+    migrationProperties.setBackpressureDelay(100);
     userRoleMigrationHandler =
         new UserRoleMigrationHandler(
-            CamundaAuthentication.none(), managementIdentityClient, roleServices);
+            CamundaAuthentication.none(),
+            managementIdentityClient,
+            roleServices,
+            migrationProperties);
   }
 
   @Test


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

The migration handlers might face backpressure from the broker while migrating records into the OC. For this reason each handler should be able to deal with backpressure in order to continue with the migration after a configured delay (by default the delay is set to 5s).

## Related issues

closes #35446 
