### PR TITLE
feat: improve `DropdownSearch` behavior

### DIFF
--- a/identity/client/package.json
+++ b/identity/client/package.json
@@ -22,6 +22,7 @@
     "@camunda/camunda-composite-components": "0.17.0",
     "@carbon/elements": "^11.57.0",
     "@carbon/react": "1.78.2",
+    "fuse.js": "7.1.0",
     "i18next": "25.3.0",
     "react": "18.3.1",
     "react-debounced": "1.1.2",

--- a/identity/client/src/pages/groups/detail/members/AssignMembersModal.tsx
+++ b/identity/client/src/pages/groups/detail/members/AssignMembersModal.tsx
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import { FC, useEffect, useState } from "react";
+import { FC, useCallback, useEffect, useState } from "react";
 import { Tag } from "@carbon/react";
 import { UseEntityModalCustomProps } from "src/components/modal";
 import { assignGroupMember } from "src/utility/api/membership";
@@ -35,21 +35,32 @@ const AssignMembersModal: FC<
   const [selectedUsers, setSelectedUsers] = useState<User[]>([]);
   const [loadingAssignUser, setLoadingAssignUser] = useState(false);
 
+  const [search, setSearch] = useState<Record<string, unknown>>({});
+
+  const handleSearchChange = (search: string) => {
+    if (search === "") {
+      setSearch({});
+      return;
+    }
+
+    setSearch({ filter: { username: { $like: `*${search}*` } } });
+  };
+
   const {
     data: userSearchResults,
     loading,
     reload,
     error,
-  } = useApi(searchUser);
+  } = useApi(searchUser, search);
 
   const [callAssignUser] = useApiCall(assignGroupMember);
 
-  const unassignedUsers =
-    userSearchResults?.items.filter(
-      ({ username }) =>
-        !assignedUsers.some((user) => user.username === username) &&
-        !selectedUsers.some((user) => user.username === username),
-    ) || [];
+  const unassignedFilter = useCallback(
+    ({ username }: User) =>
+      !assignedUsers.some((user) => user.username === username) &&
+      !selectedUsers.some((user) => user.username === username),
+    [assignedUsers, selectedUsers],
+  );
 
   const onSelectUser = (user: User) => {
     setSelectedUsers([...selectedUsers, user]);
@@ -132,11 +143,14 @@ const AssignMembersModal: FC<
       )}
       <DropdownSearch
         autoFocus
-        items={unassignedUsers}
+        items={userSearchResults?.items || []}
+        keyAttribute="username"
         itemTitle={({ username }) => username}
         itemSubTitle={({ email }) => email}
         placeholder={t("searchByNameOrEmail")}
         onSelect={onSelectUser}
+        onChange={handleSearchChange}
+        filter={unassignedFilter}
       />
       {!loading && error && (
         <TranslatedErrorInlineNotification

--- a/identity/client/src/pages/roles/detail/groups/AssignGroupsModal.tsx
+++ b/identity/client/src/pages/roles/detail/groups/AssignGroupsModal.tsx
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import { FC, useEffect, useState } from "react";
+import { FC, useCallback, useEffect, useState } from "react";
 import styled from "styled-components";
 import { Tag } from "@carbon/react";
 import { UseEntityModalCustomProps } from "src/components/modal";
@@ -33,22 +33,30 @@ const AssignGroupsModal: FC<
   const [loadingAssignGroup, setLoadingAssignGroup] = useState(false);
   const [currentInputValue, setCurrentInputValue] = useState("");
 
+  const [search, setSearch] = useState<Record<string, unknown>>({});
+  useEffect(() => {
+    if (currentInputValue === "") {
+      setSearch({});
+      return;
+    }
+    setSearch({ filter: { groupId: { $like: `*${currentInputValue}*` } } });
+  }, [currentInputValue]);
+
   const {
     data: groupSearchResults,
     loading,
     reload,
     error,
-  } = useApi(searchGroups);
+  } = useApi(searchGroups, search);
 
   const [callAssignGroup] = useApiCall(assignRoleGroup);
 
-  const unassignedGroups =
-    groupSearchResults?.items.filter(
-      ({ groupId }) =>
-        !assignedGroups.some((group) => group.groupId === groupId) &&
-        !selectedGroups.some((group) => group.groupId === groupId) &&
-        groupId.toLowerCase().includes(currentInputValue.toLowerCase()),
-    ) || [];
+  const unassignedFilter = useCallback(
+    ({ groupId }: Group) =>
+      !assignedGroups.some((group) => group.groupId === groupId) &&
+      !selectedGroups.some((group) => group.groupId === groupId),
+    [assignedGroups, selectedGroups],
+  );
 
   const handleDropdownChange = (value: string) => {
     setCurrentInputValue(value);
@@ -122,12 +130,13 @@ const AssignGroupsModal: FC<
       )}
       <DropdownSearch
         autoFocus
-        items={unassignedGroups}
+        items={groupSearchResults?.items || []}
         itemTitle={({ groupId }) => groupId}
         itemSubTitle={({ name }) => name}
         placeholder={t("searchByGroupId")}
         onSelect={onSelectGroup}
         onChange={handleDropdownChange}
+        filter={unassignedFilter}
       />
       {!loading && error && (
         <TranslatedErrorInlineNotification

--- a/identity/client/src/pages/tenants/detail/mapping-rules/AssignMappingRulesModal.tsx
+++ b/identity/client/src/pages/tenants/detail/mapping-rules/AssignMappingRulesModal.tsx
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import { FC, useEffect, useState } from "react";
+import { FC, useCallback, useEffect, useState } from "react";
 import { Tag } from "@carbon/react";
 import { UseEntityModalCustomProps } from "src/components/modal";
 import useTranslate from "src/utility/localization";
@@ -35,25 +35,34 @@ const AssignMappingRulesModal: FC<
   const [loadingAssignMappingRule, setLoadingAssignMappingRule] =
     useState(false);
 
+  const [mappingRuleFilter, setMappingRuleFilter] = useState({});
+  const handleMappingRuleFilterChange = (search: string) => {
+    if (!search.trim()) {
+      setMappingRuleFilter({});
+      return;
+    }
+    setMappingRuleFilter({ filter: { name: search } });
+  };
+
   const {
     data: mappingRuleSearchResults,
     loading,
     reload,
     error,
-  } = useApi(searchMappingRule);
+  } = useApi(searchMappingRule, mappingRuleFilter);
 
   const [callAssignMappingRule] = useApiCall(assignTenantMappingRule);
 
-  const unassignedMappingRules =
-    mappingRuleSearchResults?.items.filter(
-      ({ mappingRuleId }) =>
-        !assignedMappingRules.some(
-          (mappingRule) => mappingRule.mappingRuleId === mappingRuleId,
-        ) &&
-        !selectedMappingRules.some(
-          (mappingRule) => mappingRule.mappingRuleId === mappingRuleId,
-        ),
-    ) || [];
+  const unassignedFilter = useCallback(
+    ({ mappingRuleId }: MappingRule) =>
+      !assignedMappingRules.some(
+        (mappingRule) => mappingRule.mappingRuleId === mappingRuleId,
+      ) &&
+      !selectedMappingRules.some(
+        (mappingRule) => mappingRule.mappingRuleId === mappingRuleId,
+      ),
+    [assignedMappingRules, selectedMappingRules],
+  );
 
   const onSelectMappingRule = (mappingRule: MappingRule) => {
     setSelectedMappingRules([...selectedMappingRules, mappingRule]);
@@ -132,11 +141,13 @@ const AssignMappingRulesModal: FC<
       )}
       <DropdownSearch
         autoFocus
-        items={unassignedMappingRules}
+        items={mappingRuleSearchResults?.items || []}
         itemTitle={({ mappingRuleId }) => mappingRuleId}
         itemSubTitle={({ name }) => name}
         placeholder={t("searchByMappingRuleId")}
         onSelect={onSelectMappingRule}
+        onChange={handleMappingRuleFilterChange}
+        filter={unassignedFilter}
       />
       {!loading && error && (
         <TranslatedErrorInlineNotification

--- a/identity/client/src/pages/tenants/detail/members/AssignMembersModal.tsx
+++ b/identity/client/src/pages/tenants/detail/members/AssignMembersModal.tsx
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import { FC, useEffect, useState } from "react";
+import { FC, useCallback, useEffect, useState } from "react";
 import { Tag } from "@carbon/react";
 import { UseEntityModalCustomProps } from "src/components/modal";
 import { assignTenantMember } from "src/utility/api/membership";
@@ -33,21 +33,30 @@ const AssignMembersModal: FC<
   const [selectedUsers, setSelectedUsers] = useState<User[]>([]);
   const [loadingAssignUser, setLoadingAssignUser] = useState(false);
 
+  const [search, setSearch] = useState<Record<string, unknown>>({});
+  const handleSearchChange = (search: string) => {
+    if (search === "") {
+      setSearch({});
+      return;
+    }
+    setSearch({ filter: { username: { $like: `*${search}*` } } });
+  };
+
   const {
     data: userSearchResults,
     loading,
     reload,
     error,
-  } = useApi(searchUser);
+  } = useApi(searchUser, search);
 
   const [callAssignUser] = useApiCall(assignTenantMember);
 
-  const unassignedUsers =
-    userSearchResults?.items.filter(
-      ({ username }) =>
-        !assignedUsers.some((user) => user.username === username) &&
-        !selectedUsers.some((user) => user.username === username),
-    ) || [];
+  const unassignedFilter = useCallback(
+    ({ username }: User) =>
+      !assignedUsers.some((user) => user.username === username) &&
+      !selectedUsers.some((user) => user.username === username),
+    [assignedUsers, selectedUsers],
+  );
 
   const onSelectUser = (user: User) => {
     setSelectedUsers([...selectedUsers, user]);
@@ -117,11 +126,13 @@ const AssignMembersModal: FC<
       )}
       <DropdownSearch
         autoFocus
-        items={unassignedUsers}
+        items={userSearchResults?.items || []}
         itemTitle={({ username }) => username}
         itemSubTitle={({ email }) => email}
         placeholder={t("searchByNameOrEmail")}
         onSelect={onSelectUser}
+        onChange={handleSearchChange}
+        filter={unassignedFilter}
       />
       {!loading && error && (
         <TranslatedErrorInlineNotification

--- a/identity/client/src/pages/tenants/detail/roles/AssignRolesModal.tsx
+++ b/identity/client/src/pages/tenants/detail/roles/AssignRolesModal.tsx
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import { FC, useEffect, useState } from "react";
+import { FC, useCallback, useEffect, useState } from "react";
 import { Tag } from "@carbon/react";
 import { UseEntityModalCustomProps } from "src/components/modal";
 import useTranslate from "src/utility/localization";
@@ -32,21 +32,30 @@ const AssignRolesModal: FC<
   const [selectedRoles, setSelectedRoles] = useState<Role[]>([]);
   const [loadingAssignRole, setLoadingAssignRole] = useState(false);
 
+  const [search, setSearch] = useState<Record<string, unknown>>({});
+  const handleSearchChange = (search: string) => {
+    if (search === "") {
+      setSearch({});
+      return;
+    }
+    setSearch({ filter: { name: search } });
+  };
+
   const {
     data: roleSearchResults,
     loading,
     reload,
     error,
-  } = useApi(searchRoles);
+  } = useApi(searchRoles, search);
 
   const [callAssignRole] = useApiCall(assignTenantRole);
 
-  const unassignedRoles =
-    roleSearchResults?.items.filter(
-      ({ roleId }) =>
-        !assignedRoles.some((role) => role.roleId === roleId) &&
-        !selectedRoles.some((role) => role.roleId === roleId),
-    ) || [];
+  const unassignedFilter = useCallback(
+    ({ roleId }: Role) =>
+      !assignedRoles.some((role) => role.roleId === roleId) &&
+      !selectedRoles.some((role) => role.roleId === roleId),
+    [assignedRoles, selectedRoles],
+  );
 
   const onSelectRole = (role: Role) => {
     setSelectedRoles([...selectedRoles, role]);
@@ -116,11 +125,13 @@ const AssignRolesModal: FC<
       )}
       <DropdownSearch
         autoFocus
-        items={unassignedRoles}
+        items={roleSearchResults?.items || []}
         itemTitle={({ roleId }) => roleId}
         itemSubTitle={({ name }) => name}
         placeholder={t("searchByRoleId")}
         onSelect={onSelectRole}
+        onChange={handleSearchChange}
+        filter={unassignedFilter}
       />
       {!loading && error && (
         <TranslatedErrorInlineNotification

--- a/identity/client/src/utility/api/mapping-rules/index.ts
+++ b/identity/client/src/utility/api/mapping-rules/index.ts
@@ -23,9 +23,19 @@ export type MappingRule = {
   claimValue: string;
 };
 
-export const searchMappingRule: ApiDefinition<SearchResponse<MappingRule>> = (
-  params,
-) => apiPost(`${MAPPING_RULES_ENDPOINT}/search`, params);
+type MappingRuleSearchParams = {
+  filter?: {
+    name?: string;
+    claimName?: string;
+    claimValue?: string;
+    mappingRuleId?: string;
+  };
+};
+
+export const searchMappingRule: ApiDefinition<
+  SearchResponse<MappingRule>,
+  MappingRuleSearchParams | undefined
+> = (params) => apiPost(`${MAPPING_RULES_ENDPOINT}/search`, params);
 
 export const createMappingRule: ApiDefinition<undefined, MappingRule> = (
   mappingRule,

--- a/identity/client/src/utility/api/roles/index.ts
+++ b/identity/client/src/utility/api/roles/index.ts
@@ -28,7 +28,7 @@ export type Role = {
 
 export const searchRoles: ApiDefinition<
   SearchResponse<Role>,
-  PageSearchParams | undefined
+  PageSearchParams | Record<string, unknown> | undefined
 > = (params) => apiPost(`${ROLES_ENDPOINT}/search`, params);
 
 type GetRoleParams = {

--- a/identity/client/yarn.lock
+++ b/identity/client/yarn.lock
@@ -3783,6 +3783,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fuse.js@npm:7.1.0":
+  version: 7.1.0
+  resolution: "fuse.js@npm:7.1.0"
+  checksum: 10c0/c0d1b1d192a4bdf3eade897453ddd28aff96b70bf3e49161a45880f9845ebaee97265595db633776700a5bcf8942223c752754a848d70c508c3c9fd997faad1e
+  languageName: node
+  linkType: hard
+
 "gauge@npm:^3.0.0":
   version: 3.0.2
   resolution: "gauge@npm:3.0.2"
@@ -4041,6 +4048,7 @@ __metadata:
     eslint-plugin-react-hooks: "npm:5.2.0"
     eslint-plugin-react-refresh: "npm:0.4.19"
     event-source-polyfill: "npm:1.0.31"
+    fuse.js: "npm:7.1.0"
     i18next: "npm:25.3.0"
     license-checker: "npm:25.0.1"
     prettier: "npm:3.6.2"


### PR DESCRIPTION
## Description

This PR improves the UX of the Dropdown search component.

 - Apply fuzzy search to items. This introduces a dependency to Fuse.js
 - Additionally query the backend for the current search, dynamically expanding the list of available options
   - Users only benefit from suggestions if the item is within the first 100 entries.
   - If the item falls beyond that range, the user must know and enter the exact value to find and add it.


[screencap-2025-07-30-15-10-01.webm](https://github.com/user-attachments/assets/1446b1c9-4cad-49dc-93f8-c62407f3d309)

## Related issues

closes #35256 
