### PR TITLE
fix: catch Throwable to ensure all possible errors are caught in JobRunnableFactory

### DIFF
--- a/testing/camunda-process-test-java/pom.xml
+++ b/testing/camunda-process-test-java/pom.xml
@@ -140,6 +140,16 @@
       <artifactId>log4j-core</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
+      <scope>test</scope>
+    </dependency>
 
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>

--- a/testing/camunda-process-test-java/pom.xml
+++ b/testing/camunda-process-test-java/pom.xml
@@ -140,16 +140,6 @@
       <artifactId>log4j-core</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-core-test</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-api</artifactId>
-      <scope>test</scope>
-    </dependency>
 
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/mock/JobWorkerMockBuilderImpl.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/mock/JobWorkerMockBuilderImpl.java
@@ -31,7 +31,7 @@ public class JobWorkerMockBuilderImpl implements JobWorkerMockBuilder {
   private final CamundaClient client;
 
   /**
-   * Constructs a `JobWorkerMock` instance.
+   * Constructs a `JobWorkerMockBuilder` instance.
    *
    * @param jobType the job type to mock, matching the `zeebeJobType` in the BPMN model.
    * @param client the Camunda client used to create the mock worker.

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/mock/JobWorkerMockImpl.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/mock/JobWorkerMockImpl.java
@@ -21,6 +21,10 @@ import io.camunda.client.api.worker.JobHandler;
 import io.camunda.process.test.api.mock.JobWorkerMockBuilder.JobWorkerMock;
 import java.util.ArrayList;
 import java.util.List;
+import io.camunda.process.test.api.mock.JobWorkerMock;
+import java.io.PrintStream;
+import java.util.HashMap;
+import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -28,10 +32,28 @@ public class JobWorkerMockImpl implements JobWorkerMock {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(JobWorkerMockImpl.class);
 
+  private final String jobType;
+  private final CamundaClient client;
+  private final PrintStream printStream;
   private final List<ActivatedJob> activatedJobs = new ArrayList<>();
 
+  /**
+   * Constructs a `JobWorkerMock` instance.
+   *
+   * @param jobType the job type to mock, matching the `zeebeJobType` in the BPMN model.
+   * @param client the Camunda client used to create the mock worker.
+   */
+  public JobWorkerMockImpl(final String jobType, final CamundaClient client) {
+
+    this(jobType, client, System.err);
+  }
+
   public JobWorkerMockImpl(
-      final String jobType, final CamundaClient camundaClient, final JobHandler jobHandler) {
+      final String jobType, final CamundaClient client, final PrintStream printStream, final JobHandler jobHandler) {
+    this.jobType = jobType;
+    this.client = client;
+    this.printStream = printStream;
+  }
 
     final JobHandler loggingJobHandler =
         (jobClient, job) -> {
@@ -45,6 +67,32 @@ public class JobWorkerMockImpl implements JobWorkerMock {
         };
 
     camundaClient.newWorker().jobType(jobType).handler(loggingJobHandler).open();
+  }
+
+  @Override
+  public void withHandler(final JobHandler jobHandler) {
+    final JobHandler loggingJobHandler =
+        (client, job) -> {
+          LOGGER.debug(
+              "Mock: Pass job to custom handler [job-type: '{}', job-key: '{}']",
+              jobType,
+              job.getKey());
+
+          jobHandler.handle(client, job);
+        };
+
+    final JobHandler safeLoggingJobHandler =
+        (client, job) -> {
+          try {
+            loggingJobHandler.handle(client, job);
+          } catch (final AssertionError e) {
+            LOGGER.error("JobWorkerMock has a failed assertion and will be terminated.", e);
+
+            client.newFailCommand(job.getKey()).retries(0).send().join();
+          }
+        };
+
+    client.newWorker().jobType(jobType).handler(safeLoggingJobHandler).open();
   }
 
   @Override

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/mock/JobWorkerMockImpl.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/mock/JobWorkerMockImpl.java
@@ -21,10 +21,6 @@ import io.camunda.client.api.worker.JobHandler;
 import io.camunda.process.test.api.mock.JobWorkerMockBuilder.JobWorkerMock;
 import java.util.ArrayList;
 import java.util.List;
-import io.camunda.process.test.api.mock.JobWorkerMock;
-import java.io.PrintStream;
-import java.util.HashMap;
-import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -32,28 +28,10 @@ public class JobWorkerMockImpl implements JobWorkerMock {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(JobWorkerMockImpl.class);
 
-  private final String jobType;
-  private final CamundaClient client;
-  private final PrintStream printStream;
   private final List<ActivatedJob> activatedJobs = new ArrayList<>();
 
-  /**
-   * Constructs a `JobWorkerMock` instance.
-   *
-   * @param jobType the job type to mock, matching the `zeebeJobType` in the BPMN model.
-   * @param client the Camunda client used to create the mock worker.
-   */
-  public JobWorkerMockImpl(final String jobType, final CamundaClient client) {
-
-    this(jobType, client, System.err);
-  }
-
   public JobWorkerMockImpl(
-      final String jobType, final CamundaClient client, final PrintStream printStream, final JobHandler jobHandler) {
-    this.jobType = jobType;
-    this.client = client;
-    this.printStream = printStream;
-  }
+      final String jobType, final CamundaClient camundaClient, final JobHandler jobHandler) {
 
     final JobHandler loggingJobHandler =
         (jobClient, job) -> {
@@ -66,33 +44,23 @@ public class JobWorkerMockImpl implements JobWorkerMock {
           jobHandler.handle(jobClient, job);
         };
 
-    camundaClient.newWorker().jobType(jobType).handler(loggingJobHandler).open();
-  }
-
-  @Override
-  public void withHandler(final JobHandler jobHandler) {
-    final JobHandler loggingJobHandler =
-        (client, job) -> {
-          LOGGER.debug(
-              "Mock: Pass job to custom handler [job-type: '{}', job-key: '{}']",
-              jobType,
-              job.getKey());
-
-          jobHandler.handle(client, job);
-        };
-
     final JobHandler safeLoggingJobHandler =
         (client, job) -> {
           try {
             loggingJobHandler.handle(client, job);
           } catch (final AssertionError e) {
-            LOGGER.error("JobWorkerMock has a failed assertion and will be terminated.", e);
+            final String failureMessage =
+                String.format(
+                    "JobWorkerMock [job-type: %s, job-key: %s] has failed assertions and will be terminated.",
+                    jobType, job.getKey());
+            System.err.println(failureMessage);
+            e.printStackTrace();
 
             client.newFailCommand(job.getKey()).retries(0).send().join();
           }
         };
 
-    client.newWorker().jobType(jobType).handler(safeLoggingJobHandler).open();
+    camundaClient.newWorker().jobType(jobType).handler(safeLoggingJobHandler).open();
   }
 
   @Override

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/extensions/CamundaProcessTestContextIT.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/extensions/CamundaProcessTestContextIT.java
@@ -19,8 +19,8 @@ import static io.camunda.process.test.api.CamundaAssert.assertThatDecision;
 import static io.camunda.process.test.api.CamundaAssert.assertThatProcessInstance;
 import static io.camunda.process.test.api.CamundaAssert.assertThatUserTask;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Fail.fail;
 import static org.assertj.core.api.Assertions.entry;
+import static org.assertj.core.api.Fail.fail;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.response.DeploymentEvent;
@@ -32,7 +32,6 @@ import io.camunda.process.test.api.assertions.DecisionSelectors;
 import io.camunda.process.test.api.assertions.UserTaskSelectors;
 import io.camunda.process.test.api.mock.JobWorkerMockBuilder.JobWorkerMock;
 import io.camunda.process.test.impl.assertions.util.AssertionJsonMapper;
-import io.camunda.process.test.impl.mock.JobWorkerMockImpl;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import java.io.ByteArrayInputStream;
@@ -41,10 +40,6 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.apache.logging.log4j.core.LogEvent;
-import org.apache.logging.log4j.core.Logger;
-import org.apache.logging.log4j.core.LoggerContext;
-import org.apache.logging.log4j.core.test.appender.ListAppender;
 import org.assertj.core.api.Assertions;
 import org.camunda.bpm.model.dmn.Dmn;
 import org.camunda.bpm.model.dmn.DmnModelInstance;
@@ -190,13 +185,6 @@ public class CamundaProcessTestContextIT {
   @Test
   void shouldMockJobWorkerWithAssertionError() {
     // Given
-    final LoggerContext loggerContext = LoggerContext.getContext(false);
-    final Logger logger = ((Logger) loggerContext.getLogger(JobWorkerMockImpl.class));
-    final ListAppender appender = new ListAppender("List");
-    appender.start();
-    ((Logger) loggerContext.getLogger(JobWorkerMockImpl.class)).addAppender(appender);
-    loggerContext.getConfiguration().addLoggerAppender(logger, appender);
-
     processTestContext
         .mockJobWorker("test")
         .withHandler(
@@ -214,12 +202,6 @@ public class CamundaProcessTestContextIT {
 
     // Then the process instance should still be active since the jobWorker failed
     assertThatProcessInstance(processInstanceEvent).isActive();
-    assertThat(appender.getEvents()).hasSize(1);
-
-    final LogEvent event = appender.getEvents().get(0);
-    assertThat(event.getMessage().getFormattedMessage())
-        .contains("JobWorkerMock has a failed assertion and will be terminated");
-    assertThat(event.getThrown()).isInstanceOf(AssertionError.class);
   }
 
   @Test


### PR DESCRIPTION
## Description

The JobRunnableFactory catches Exceptions, but certain errors, such as AssertionErrors used in MockJobWorkers, aren't caught. This fix changes the behavior to catch all Throwables.

## Related issues

closes #35381
