### PR TITLE
[Backport release-8.8.0-alpha7] fix: initialize routing info when desired key is not present

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/routing/DbRoutingState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/routing/DbRoutingState.java
@@ -73,7 +73,10 @@ public final class DbRoutingState implements MutableRoutingState {
   @Override
   public boolean isInitialized() {
     key.wrapString(CURRENT_KEY);
-    return columnFamily.exists(key);
+    final var currentPartitionExists = columnFamily.exists(key);
+    key.wrapString(DESIRED_KEY);
+    final var desiredPartitionExists = columnFamily.exists(key);
+    return currentPartitionExists && desiredPartitionExists;
   }
 
   @Override
@@ -97,7 +100,7 @@ public final class DbRoutingState implements MutableRoutingState {
     currentRoutingInfo.reset();
     currentRoutingInfo.setPartitions(partitions);
     currentRoutingInfo.setMessageCorrelation(new MessageCorrelation.HashMod(partitionCount));
-    columnFamily.insert(key, currentRoutingInfo);
+    columnFamily.upsert(key, currentRoutingInfo);
     setDesiredPartitions(partitions, 0L);
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/routing/PersistedRoutingInfo.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/routing/PersistedRoutingInfo.java
@@ -20,7 +20,7 @@ import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
 
-final class PersistedRoutingInfo extends UnpackedObject implements DbValue {
+public final class PersistedRoutingInfo extends UnpackedObject implements DbValue {
   private final ArrayProperty<IntegerValue> partitions =
       new ArrayProperty<>("partitions", IntegerValue::new);
   private final EnumProperty<MessageCorrelationStrategy> messageCorrelationStrategy =

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/migration/DbMigratorImplTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/migration/DbMigratorImplTest.java
@@ -7,11 +7,14 @@
  */
 package io.camunda.zeebe.engine.state.migration;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -19,10 +22,22 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.camunda.zeebe.db.ColumnFamily;
+import io.camunda.zeebe.db.TransactionContext;
+import io.camunda.zeebe.db.ZeebeDb;
+import io.camunda.zeebe.db.impl.DbInt;
+import io.camunda.zeebe.db.impl.DbLong;
+import io.camunda.zeebe.db.impl.DbString;
+import io.camunda.zeebe.engine.state.immutable.RoutingState.MessageCorrelation.HashMod;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.state.routing.DbRoutingState;
+import io.camunda.zeebe.engine.state.routing.PersistedRoutingInfo;
+import io.camunda.zeebe.protocol.ZbColumnFamilies;
 import io.camunda.zeebe.stream.impl.ClusterContextImpl;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Answers;
@@ -274,5 +289,84 @@ public class DbMigratorImplTest {
     verify(migration, atLeastOnce()).isInitialization();
     verify(migration).runMigration(any());
     verify(mockProcessingState.getMigrationState()).setMigratedByVersion(eq(CURRENT_VERSION));
+  }
+
+  @Test
+  void shouldRunRoutingInfoInitializationWhenDesiredIsNotSet() {
+    // given
+    context = new MigrationTaskContextImpl(new ClusterContextImpl(3), mockProcessingState);
+    final PersistedRoutingInfo persistedRoutingInfo = new PersistedRoutingInfo();
+    persistedRoutingInfo.setMessageCorrelation(new HashMod(3));
+    persistedRoutingInfo.setPartitions(new TreeSet<>(Set.of(1, 2, 3)));
+
+    final var zeebeDb = mock(ZeebeDb.class);
+    final var txContext = mock(TransactionContext.class);
+    final ColumnFamily<DbString, PersistedRoutingInfo> routingColumnFamily =
+        mock(ColumnFamily.class);
+    final ColumnFamily<DbInt, DbLong> scalingStartedAtColumnFamily = mock(ColumnFamily.class);
+
+    // mock column family creation
+    when(zeebeDb.createColumnFamily(eq(ZbColumnFamilies.ROUTING), eq(txContext), any(), any()))
+        .thenReturn(routingColumnFamily);
+    when(zeebeDb.createColumnFamily(
+            eq(ZbColumnFamilies.SCALING_STARTED_AT), eq(txContext), any(), any()))
+        .thenReturn(scalingStartedAtColumnFamily);
+
+    when(routingColumnFamily.exists(argThat(d -> d != null && d.toString().equals("CURRENT"))))
+        .thenReturn(true);
+    when(routingColumnFamily.exists(argThat(d -> d != null && d.toString().equals("DESIRED"))))
+        .thenReturn(false);
+    when(routingColumnFamily.get(argThat(d -> d != null && d.toString().equals("CURRENT"))))
+        .thenReturn(persistedRoutingInfo);
+
+    final var routingState = new DbRoutingState(zeebeDb, txContext);
+    when(mockProcessingState.getRoutingState()).thenReturn(routingState);
+
+    final var migration = new RoutingInfoInitializationMigration();
+
+    // then the migration needs to run
+    assertThat(migration.needsToRun(context)).isTrue();
+
+    // DbString is being mutated, argument captors cannot be used to snapshot the value of the key
+    // thus we use a list to snapshot the keys during invocation time to verify that both have been
+    // updated
+    final List<String> argSnapshot = new ArrayList<>();
+    doAnswer(
+            invocation -> {
+              final DbString key = invocation.getArgument(0);
+              argSnapshot.add(key.toString());
+              return null;
+            })
+        .when(routingColumnFamily)
+        .upsert(any(DbString.class), argThat(r -> r.getPartitions().containsAll(Set.of(1, 2, 3))));
+
+    // when
+    migrations.add(migration);
+    migration.runMigration(context);
+
+    // then
+    assertThat(routingState.currentPartitions()).containsExactlyInAnyOrder(1, 2, 3);
+    assertThat(argSnapshot).containsExactly("CURRENT", "DESIRED");
+  }
+
+  @Test
+  void shouldNotRunRoutingInfoInitializationWhenBothAreSet() {
+    // given
+    context = new MigrationTaskContextImpl(new ClusterContextImpl(3), mockProcessingState);
+    final var zeebeDb = mock(ZeebeDb.class);
+    final var txContext = mock(TransactionContext.class);
+
+    // mock column families
+    final ColumnFamily<DbString, ?> routingColumnFamily = mock(ColumnFamily.class);
+    when(zeebeDb.createColumnFamily(eq(ZbColumnFamilies.ROUTING), eq(txContext), any(), any()))
+        .thenReturn(routingColumnFamily);
+    when(routingColumnFamily.exists(any())).thenReturn(true);
+
+    final var routingState = new DbRoutingState(zeebeDb, txContext);
+
+    when(mockProcessingState.getRoutingState()).thenReturn(routingState);
+
+    final var migration = new RoutingInfoInitializationMigration();
+    assertThat(migration.needsToRun(context)).isFalse();
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/migration/RoutingInfoInitializationMigrationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/migration/RoutingInfoInitializationMigrationTest.java
@@ -8,13 +8,34 @@
 package io.camunda.zeebe.engine.state.migration;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import io.camunda.zeebe.db.ColumnFamily;
+import io.camunda.zeebe.db.TransactionContext;
+import io.camunda.zeebe.db.ZeebeDb;
+import io.camunda.zeebe.db.impl.DbInt;
+import io.camunda.zeebe.db.impl.DbLong;
+import io.camunda.zeebe.db.impl.DbString;
 import io.camunda.zeebe.engine.state.immutable.RoutingState.MessageCorrelation;
+import io.camunda.zeebe.engine.state.immutable.RoutingState.MessageCorrelation.HashMod;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.state.routing.DbRoutingState;
+import io.camunda.zeebe.engine.state.routing.PersistedRoutingInfo;
 import io.camunda.zeebe.engine.util.ProcessingStateExtension;
+import io.camunda.zeebe.protocol.ZbColumnFamilies;
 import io.camunda.zeebe.stream.impl.ClusterContextImpl;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
 
 @ExtendWith(ProcessingStateExtension.class)
 final class RoutingInfoInitializationMigrationTest {
@@ -76,5 +97,87 @@ final class RoutingInfoInitializationMigrationTest {
 
     // when/then
     assertThat(migration.isInitialization()).isTrue();
+  }
+
+  @Test
+  void shouldRunRoutingInfoInitializationWhenDesiredIsNotSet() {
+    // given
+    final var mockProcessingState = mock(MutableProcessingState.class, Answers.RETURNS_DEEP_STUBS);
+    final var context =
+        new MigrationTaskContextImpl(new ClusterContextImpl(3), mockProcessingState);
+    final PersistedRoutingInfo persistedRoutingInfo = new PersistedRoutingInfo();
+    persistedRoutingInfo.setMessageCorrelation(new HashMod(3));
+    persistedRoutingInfo.setPartitions(new TreeSet<>(Set.of(1, 2, 3)));
+
+    final var zeebeDb = mock(ZeebeDb.class);
+    final var txContext = mock(TransactionContext.class);
+    final ColumnFamily<DbString, PersistedRoutingInfo> routingColumnFamily =
+        mock(ColumnFamily.class);
+    final ColumnFamily<DbInt, DbLong> scalingStartedAtColumnFamily = mock(ColumnFamily.class);
+
+    // mock column family creation
+    when(zeebeDb.createColumnFamily(eq(ZbColumnFamilies.ROUTING), eq(txContext), any(), any()))
+        .thenReturn(routingColumnFamily);
+    when(zeebeDb.createColumnFamily(
+            eq(ZbColumnFamilies.SCALING_STARTED_AT), eq(txContext), any(), any()))
+        .thenReturn(scalingStartedAtColumnFamily);
+
+    when(routingColumnFamily.exists(argThat(d -> d != null && d.toString().equals("CURRENT"))))
+        .thenReturn(true);
+    when(routingColumnFamily.exists(argThat(d -> d != null && d.toString().equals("DESIRED"))))
+        .thenReturn(false);
+    when(routingColumnFamily.get(argThat(d -> d != null && d.toString().equals("CURRENT"))))
+        .thenReturn(persistedRoutingInfo);
+
+    final var routingState = new DbRoutingState(zeebeDb, txContext);
+    when(mockProcessingState.getRoutingState()).thenReturn(routingState);
+
+    final var migration = new RoutingInfoInitializationMigration();
+
+    // then the migration needs to run
+    assertThat(migration.needsToRun(context)).isTrue();
+
+    // DbString is being mutated, argument captors cannot be used to snapshot the value of the key
+    // thus we use a list to snapshot the keys during invocation time to verify that both have been
+    // updated
+    final List<String> argSnapshot = new ArrayList<>();
+    doAnswer(
+            invocation -> {
+              final DbString key = invocation.getArgument(0);
+              argSnapshot.add(key.toString());
+              return null;
+            })
+        .when(routingColumnFamily)
+        .upsert(any(DbString.class), argThat(r -> r.getPartitions().containsAll(Set.of(1, 2, 3))));
+
+    // when
+    migration.runMigration(context);
+
+    // then
+    assertThat(routingState.currentPartitions()).containsExactlyInAnyOrder(1, 2, 3);
+    assertThat(argSnapshot).containsExactly("CURRENT", "DESIRED");
+  }
+
+  @Test
+  void shouldNotRunRoutingInfoInitializationWhenBothAreSet() {
+    // given
+    final var mockProcessingState = mock(MutableProcessingState.class, Answers.RETURNS_DEEP_STUBS);
+    final var context =
+        new MigrationTaskContextImpl(new ClusterContextImpl(3), mockProcessingState);
+    final var zeebeDb = mock(ZeebeDb.class);
+    final var txContext = mock(TransactionContext.class);
+
+    // mock column families
+    final ColumnFamily<DbString, ?> routingColumnFamily = mock(ColumnFamily.class);
+    when(zeebeDb.createColumnFamily(eq(ZbColumnFamilies.ROUTING), eq(txContext), any(), any()))
+        .thenReturn(routingColumnFamily);
+    when(routingColumnFamily.exists(any())).thenReturn(true);
+
+    final var routingState = new DbRoutingState(zeebeDb, txContext);
+
+    when(mockProcessingState.getRoutingState()).thenReturn(routingState);
+
+    final var migration = new RoutingInfoInitializationMigration();
+    assertThat(migration.needsToRun(context)).isFalse();
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/migration/RoutingInfoInitializationMigrationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/migration/RoutingInfoInitializationMigrationTest.java
@@ -66,6 +66,7 @@ final class RoutingInfoInitializationMigrationTest {
     assertThat(updatedRoutingState.currentPartitions()).containsExactlyInAnyOrder(1, 2, 3);
     assertThat(updatedRoutingState.messageCorrelation())
         .isEqualTo(new MessageCorrelation.HashMod(3));
+    assertThat(updatedRoutingState.desiredPartitions()).containsExactlyInAnyOrder(1, 2, 3);
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/routing/DbRoutingStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/routing/DbRoutingStateTest.java
@@ -39,9 +39,10 @@ final class DbRoutingStateTest {
     // then
     assertThat(routingState.isInitialized()).isTrue();
     assertThat(routingState.currentPartitions()).containsExactlyInAnyOrder(1, 2, 3);
+    assertThat(routingState.desiredPartitions()).containsExactlyInAnyOrder(1, 2, 3);
     assertThat(routingState.messageCorrelation())
         .isEqualTo(new RoutingState.MessageCorrelation.HashMod(3));
-    assertThat(routingState.scalingStartedAt(3)).isEqualTo(0);
+    assertThat(routingState.scalingStartedAt(3)).isZero();
   }
 
   @Test


### PR DESCRIPTION
# Description
Backport of #36216 to `release-8.8.0-alpha7`.

relates to #36219