### PR TITLE
fix: improve logging for failed shards in opensearch scrolling

### DIFF
--- a/operate/schema/src/main/java/io/camunda/operate/store/opensearch/client/sync/OpenSearchDocumentOperations.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/opensearch/client/sync/OpenSearchDocumentOperations.java
@@ -87,8 +87,9 @@ public class OpenSearchDocumentOperations extends OpenSearchRetryOperation {
     if (!response.shards().failures().isEmpty()) {
       throw new OpenSearchFailedShardsException(
           format(
-              "Shards failed executing request (request=%s, failed shards=%s)",
-              request, response.shards().failures().stream().map(ShardFailure::shard).toList()));
+              "Shards failed executing request (indices=%s, failed shards=%s)",
+              request.index(),
+              response.shards().failures().stream().map(ShardFailure::shard).toList()));
     }
   }
 

--- a/operate/schema/src/main/java/io/camunda/operate/store/opensearch/client/sync/OpenSearchDocumentOperations.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/opensearch/client/sync/OpenSearchDocumentOperations.java
@@ -31,6 +31,7 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import org.opensearch.client.opensearch.OpenSearchClient;
 import org.opensearch.client.opensearch._types.Result;
+import org.opensearch.client.opensearch._types.ShardFailure;
 import org.opensearch.client.opensearch._types.aggregations.Aggregate;
 import org.opensearch.client.opensearch._types.query_dsl.Query;
 import org.opensearch.client.opensearch.core.DeleteByQueryRequest;
@@ -87,7 +88,7 @@ public class OpenSearchDocumentOperations extends OpenSearchRetryOperation {
       throw new OpenSearchFailedShardsException(
           format(
               "Shards failed executing request (request=%s, failed shards=%s)",
-              request, response.shards().failures()));
+              request, response.shards().failures().stream().map(ShardFailure::shard).toList()));
     }
   }
 

--- a/operate/schema/src/main/java/io/camunda/operate/store/opensearch/client/sync/OpenSearchDocumentOperations.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/opensearch/client/sync/OpenSearchDocumentOperations.java
@@ -89,8 +89,14 @@ public class OpenSearchDocumentOperations extends OpenSearchRetryOperation {
           format(
               "Shards failed executing request (indices=%s, failed shards=%s)",
               request.index(),
-              response.shards().failures().stream().map(ShardFailure::shard).toList()));
+              response.shards().failures().stream().map(this::formatShardFailure).toList()));
     }
+  }
+
+  private String formatShardFailure(final ShardFailure failure) {
+    return String.format(
+        "ShardFailure[index=%s, shard=%s, status=%s, node=%s, reason=%s]",
+        failure.index(), failure.shard(), failure.status(), failure.node(), failure.reason());
   }
 
   public <R> Map<String, Aggregate> unsafeScrollWith(

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/os/client/sync/OpenSearchDocumentOperations.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/os/client/sync/OpenSearchDocumentOperations.java
@@ -34,6 +34,7 @@ import java.util.function.Function;
 import org.opensearch.client.opensearch.OpenSearchClient;
 import org.opensearch.client.opensearch._types.OpenSearchException;
 import org.opensearch.client.opensearch._types.Script;
+import org.opensearch.client.opensearch._types.ShardFailure;
 import org.opensearch.client.opensearch._types.aggregations.Aggregate;
 import org.opensearch.client.opensearch._types.query_dsl.Query;
 import org.opensearch.client.opensearch.core.BulkRequest;
@@ -103,7 +104,7 @@ public class OpenSearchDocumentOperations extends OpenSearchRetryOperation {
       throw new OptimizeRuntimeException(
           format(
               "Shards failed executing request (request=%s, failed shards=%s)",
-              request, response.shards().failures()));
+              request, response.shards().failures().stream().map(ShardFailure::shard).toList()));
     }
   }
 

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/os/client/sync/OpenSearchDocumentOperations.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/os/client/sync/OpenSearchDocumentOperations.java
@@ -103,8 +103,9 @@ public class OpenSearchDocumentOperations extends OpenSearchRetryOperation {
     if (!response.shards().failures().isEmpty()) {
       throw new OptimizeRuntimeException(
           format(
-              "Shards failed executing request (request=%s, failed shards=%s)",
-              request, response.shards().failures().stream().map(ShardFailure::shard).toList()));
+              "Shards failed executing request (indices=%s, failed shards=%s)",
+              request.index(),
+              response.shards().failures().stream().map(ShardFailure::shard).toList()));
     }
   }
 

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/os/client/sync/OpenSearchDocumentOperations.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/os/client/sync/OpenSearchDocumentOperations.java
@@ -105,8 +105,14 @@ public class OpenSearchDocumentOperations extends OpenSearchRetryOperation {
           format(
               "Shards failed executing request (indices=%s, failed shards=%s)",
               request.index(),
-              response.shards().failures().stream().map(ShardFailure::shard).toList()));
+              response.shards().failures().stream().map(this::formatShardFailure).toList()));
     }
+  }
+
+  private String formatShardFailure(final ShardFailure failure) {
+    return String.format(
+        "ShardFailure[index=%s, shard=%s, status=%s, node=%s, reason=%s]",
+        failure.index(), failure.shard(), failure.status(), failure.node(), failure.reason());
   }
 
   public <R> Map<String, Aggregate> unsafeScrollWith(


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

`ShardFailure` does not have a `toString()` method implemented, so we need to explicitly get the shard number when throwing the exception

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
