### PR TITLE
refactor: cached batch operation should not use webapp schema

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/BatchOperationDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/BatchOperationDbModel.java
@@ -8,6 +8,7 @@
 package io.camunda.db.rdbms.write.domain;
 
 import io.camunda.search.entities.BatchOperationEntity.BatchOperationState;
+import io.camunda.search.entities.BatchOperationType;
 import io.camunda.util.ObjectBuilder;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
@@ -18,7 +19,7 @@ public class BatchOperationDbModel implements Copyable<BatchOperationDbModel> {
 
   private String batchOperationKey;
   private BatchOperationState state;
-  private String operationType;
+  private BatchOperationType operationType;
   private OffsetDateTime startDate;
   private OffsetDateTime endDate;
   private Integer operationsTotalCount;
@@ -29,7 +30,7 @@ public class BatchOperationDbModel implements Copyable<BatchOperationDbModel> {
   public BatchOperationDbModel(
       final String batchOperationKey,
       final BatchOperationState state,
-      final String operationType,
+      final BatchOperationType operationType,
       final OffsetDateTime startDate,
       final OffsetDateTime endDate,
       final Integer operationsTotalCount,
@@ -48,7 +49,7 @@ public class BatchOperationDbModel implements Copyable<BatchOperationDbModel> {
   public BatchOperationDbModel(
       final String batchOperationKey,
       final BatchOperationState state,
-      final String operationType,
+      final BatchOperationType operationType,
       final OffsetDateTime startDate,
       final OffsetDateTime endDate,
       final Integer operationsTotalCount,
@@ -91,11 +92,11 @@ public class BatchOperationDbModel implements Copyable<BatchOperationDbModel> {
     this.state = state;
   }
 
-  public String operationType() {
+  public BatchOperationType operationType() {
     return operationType;
   }
 
-  public void operationType(final String operationType) {
+  public void operationType(final BatchOperationType operationType) {
     this.operationType = operationType;
   }
 
@@ -163,7 +164,7 @@ public class BatchOperationDbModel implements Copyable<BatchOperationDbModel> {
   public static class Builder implements ObjectBuilder<BatchOperationDbModel> {
     private String batchOperationKey;
     private BatchOperationState state;
-    private String operationType;
+    private BatchOperationType operationType;
     private OffsetDateTime startDate;
     private OffsetDateTime endDate;
     private Integer operationsTotalCount = 0;
@@ -188,7 +189,7 @@ public class BatchOperationDbModel implements Copyable<BatchOperationDbModel> {
       return this;
     }
 
-    public Builder operationType(final String operationType) {
+    public Builder operationType(final BatchOperationType operationType) {
       this.operationType = operationType;
       return this;
     }

--- a/db/rdbms/src/main/resources/mapper/BatchOperationMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/BatchOperationMapper.xml
@@ -11,7 +11,7 @@
       <idArg column="BATCH_OPERATION_KEY" javaType="java.lang.String"/>
       <arg column="STATE"
         javaType="io.camunda.search.entities.BatchOperationEntity$BatchOperationState"/>
-      <arg column="OPERATION_TYPE" javaType="java.lang.String"/>
+      <arg column="OPERATION_TYPE" javaType="io.camunda.search.entities.BatchOperationType"/>
       <arg column="START_DATE" javaType="java.time.OffsetDateTime"/>
       <arg column="END_DATE" javaType="java.time.OffsetDateTime"/>
       <arg column="OPERATIONS_TOTAL_COUNT" javaType="int"/>

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/mapper/BatchOperationEntityMapperTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/mapper/BatchOperationEntityMapperTest.java
@@ -10,6 +10,7 @@ package io.camunda.db.rdbms.read.mapper;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.db.rdbms.write.domain.BatchOperationDbModel;
+import io.camunda.search.entities.BatchOperationType;
 import java.time.OffsetDateTime;
 import java.util.List;
 import org.junit.jupiter.api.Test;
@@ -27,7 +28,7 @@ class BatchOperationEntityMapperTest {
         new BatchOperationDbModel.Builder()
             .batchOperationKey("id-1")
             .state(io.camunda.search.entities.BatchOperationEntity.BatchOperationState.ACTIVE)
-            .operationType("TYPE")
+            .operationType(BatchOperationType.CANCEL_PROCESS_INSTANCE)
             .startDate(OffsetDateTime.parse("2024-07-01T10:00:00Z"))
             .endDate(null)
             .operationsTotalCount(10)
@@ -41,7 +42,7 @@ class BatchOperationEntityMapperTest {
     assertThat(entity.batchOperationKey()).isEqualTo("id-1");
     assertThat(entity.state())
         .isEqualTo(io.camunda.search.entities.BatchOperationEntity.BatchOperationState.ACTIVE);
-    assertThat(entity.operationType()).isEqualTo("TYPE");
+    assertThat(entity.operationType()).isEqualTo(BatchOperationType.CANCEL_PROCESS_INSTANCE);
     assertThat(entity.startDate()).isEqualTo(OffsetDateTime.parse("2024-07-01T10:00:00Z"));
     assertThat(entity.endDate()).isNull();
     assertThat(entity.operationsTotalCount()).isEqualTo(10);

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/batchoperation/BatchOperationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/batchoperation/BatchOperationIT.java
@@ -14,8 +14,8 @@ import static io.camunda.it.rdbms.db.fixtures.BatchOperationFixtures.createSaveR
 import static io.camunda.it.rdbms.db.fixtures.BatchOperationFixtures.insertBatchOperationsItems;
 import static io.camunda.it.rdbms.db.fixtures.CommonFixtures.NOW;
 import static io.camunda.it.rdbms.db.fixtures.CommonFixtures.nextKey;
-import static io.camunda.it.rdbms.db.fixtures.CommonFixtures.nextStringId;
 import static io.camunda.it.rdbms.db.fixtures.CommonFixtures.nextStringKey;
+import static io.camunda.it.rdbms.db.fixtures.CommonFixtures.randomEnum;
 import static io.camunda.util.FilterUtil.mapDefaultToOperation;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -31,6 +31,7 @@ import io.camunda.search.entities.BatchOperationEntity;
 import io.camunda.search.entities.BatchOperationEntity.BatchOperationItemEntity;
 import io.camunda.search.entities.BatchOperationEntity.BatchOperationItemState;
 import io.camunda.search.entities.BatchOperationEntity.BatchOperationState;
+import io.camunda.search.entities.BatchOperationType;
 import io.camunda.search.filter.BatchOperationFilter;
 import io.camunda.search.filter.BatchOperationItemFilter;
 import io.camunda.search.page.SearchQueryPage;
@@ -496,7 +497,7 @@ public class BatchOperationIT {
             .search(
                 new BatchOperationQuery(
                     new BatchOperationFilter.Builder()
-                        .operationTypes(batchOperation.operationType())
+                        .operationTypes(batchOperation.operationType().name())
                         .build(),
                     BatchOperationSort.of(b -> b),
                     SearchQueryPage.of(b -> b.from(0).size(10))));
@@ -557,7 +558,7 @@ public class BatchOperationIT {
                 new BatchOperationQuery(
                     new BatchOperationFilter.Builder()
                         .batchOperationKeys(batchOperation.batchOperationKey())
-                        .operationTypes(batchOperation.operationType())
+                        .operationTypes(batchOperation.operationType().name())
                         .states(batchOperation.state().name())
                         .build(),
                     BatchOperationSort.of(b -> b),
@@ -574,7 +575,7 @@ public class BatchOperationIT {
   public void shouldFindAllBatchOperationsPaged(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
 
-    final String operationType = nextStringId();
+    final BatchOperationType operationType = randomEnum(BatchOperationType.class);
     createAndSaveRandomBatchOperations(
         rdbmsService.createWriter(0), b -> b.operationType(operationType));
 
@@ -583,7 +584,7 @@ public class BatchOperationIT {
             .getBatchOperationReader()
             .search(
                 new BatchOperationQuery(
-                    new BatchOperationFilter.Builder().operationTypes(operationType).build(),
+                    new BatchOperationFilter.Builder().operationTypes(operationType.name()).build(),
                     BatchOperationSort.of(b -> b),
                     SearchQueryPage.of(b -> b.from(0).size(5))));
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/BatchOperationFixtures.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/BatchOperationFixtures.java
@@ -8,7 +8,6 @@
 package io.camunda.it.rdbms.db.fixtures;
 
 import static io.camunda.it.rdbms.db.fixtures.CommonFixtures.NOW;
-import static io.camunda.it.rdbms.db.fixtures.CommonFixtures.RANDOM;
 import static io.camunda.it.rdbms.db.fixtures.CommonFixtures.randomEnum;
 
 import io.camunda.db.rdbms.write.RdbmsWriter;
@@ -17,6 +16,7 @@ import io.camunda.db.rdbms.write.domain.BatchOperationDbModel.Builder;
 import io.camunda.db.rdbms.write.domain.BatchOperationItemDbModel;
 import io.camunda.search.entities.BatchOperationEntity.BatchOperationItemState;
 import io.camunda.search.entities.BatchOperationEntity.BatchOperationState;
+import io.camunda.search.entities.BatchOperationType;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Set;
@@ -35,7 +35,7 @@ public final class BatchOperationFixtures {
         new Builder()
             .batchOperationKey(key)
             .state(randomEnum(BatchOperationState.class))
-            .operationType("some-operation" + RANDOM.nextInt(1000))
+            .operationType(BatchOperationType.CANCEL_PROCESS_INSTANCE)
             .startDate(OffsetDateTime.now())
             .endDate(OffsetDateTime.now().plusSeconds(1))
             .operationsTotalCount(0)

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/BatchOperationEntityTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/BatchOperationEntityTransformer.java
@@ -11,6 +11,7 @@ import io.camunda.search.clients.transformers.ServiceTransformer;
 import io.camunda.search.entities.BatchOperationEntity;
 import io.camunda.search.entities.BatchOperationEntity.BatchOperationErrorEntity;
 import io.camunda.search.entities.BatchOperationEntity.BatchOperationState;
+import io.camunda.search.entities.BatchOperationType;
 import java.util.Collections;
 import org.apache.commons.lang3.StringUtils;
 
@@ -45,7 +46,7 @@ public class BatchOperationEntityTransformer
     return new BatchOperationEntity(
         source.getId(),
         BatchOperationState.valueOf(source.getState().name()),
-        source.getType().name(),
+        BatchOperationType.valueOf(source.getType().name()),
         source.getStartDate(),
         source.getEndDate(),
         source.getOperationsTotalCount(),
@@ -65,7 +66,7 @@ public class BatchOperationEntityTransformer
     return new BatchOperationEntity(
         source.getId(),
         BatchOperationState.INCOMPLETED,
-        source.getType() != null ? source.getType().name() : null,
+        source.getType() != null ? BatchOperationType.valueOf(source.getType().name()) : null,
         source.getStartDate(),
         source.getEndDate(),
         source.getOperationsTotalCount(),

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/entity/BatchOperationEntityTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/entity/BatchOperationEntityTransformerTest.java
@@ -9,6 +9,7 @@ package io.camunda.search.clients.transformers.entity;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.search.entities.BatchOperationType;
 import io.camunda.webapps.schema.entities.operation.BatchOperationEntity;
 import io.camunda.webapps.schema.entities.operation.BatchOperationEntity.BatchOperationState;
 import io.camunda.webapps.schema.entities.operation.BatchOperationErrorEntity;
@@ -37,8 +38,7 @@ class BatchOperationEntityTransformerTest {
     assertThat(searchEntity).isNotNull();
     assertThat(searchEntity.batchOperationKey()).isEqualTo("1");
     assertThat(searchEntity.state().name()).isEqualTo(BatchOperationState.ACTIVE.name());
-    assertThat(searchEntity.operationType())
-        .isEqualTo(OperationType.CANCEL_PROCESS_INSTANCE.name());
+    assertThat(searchEntity.operationType()).isEqualTo(BatchOperationType.CANCEL_PROCESS_INSTANCE);
     assertThat(searchEntity.operationsTotalCount()).isEqualTo(42);
     assertThat(searchEntity.operationsFailedCount()).isEqualTo(1);
     assertThat(searchEntity.operationsCompletedCount()).isEqualTo(41);
@@ -70,8 +70,7 @@ class BatchOperationEntityTransformerTest {
     assertThat(searchEntity).isNotNull();
     assertThat(searchEntity.batchOperationKey()).isEqualTo("1");
     assertThat(searchEntity.state().name()).isEqualTo(BatchOperationState.ACTIVE.name());
-    assertThat(searchEntity.operationType())
-        .isEqualTo(OperationType.CANCEL_PROCESS_INSTANCE.name());
+    assertThat(searchEntity.operationType()).isEqualTo(BatchOperationType.CANCEL_PROCESS_INSTANCE);
     assertThat(searchEntity.operationsTotalCount()).isEqualTo(42);
     assertThat(searchEntity.operationsFailedCount()).isEqualTo(1);
     assertThat(searchEntity.operationsCompletedCount()).isEqualTo(41);
@@ -99,8 +98,7 @@ class BatchOperationEntityTransformerTest {
     assertThat(searchEntity).isNotNull();
     assertThat(searchEntity.batchOperationKey()).isEqualTo(uuid);
     assertThat(searchEntity.state().name()).isEqualTo(BatchOperationState.INCOMPLETED.name());
-    assertThat(searchEntity.operationType())
-        .isEqualTo(OperationType.CANCEL_PROCESS_INSTANCE.name());
+    assertThat(searchEntity.operationType()).isEqualTo(BatchOperationType.CANCEL_PROCESS_INSTANCE);
     assertThat(searchEntity.operationsTotalCount()).isEqualTo(42);
     assertThat(searchEntity.operationsFailedCount()).isEqualTo(0);
     assertThat(searchEntity.operationsCompletedCount()).isEqualTo(41);

--- a/search/search-domain/src/main/java/io/camunda/search/entities/BatchOperationEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/BatchOperationEntity.java
@@ -18,7 +18,7 @@ public record BatchOperationEntity(
     // Engine BatchOperation Key is a Long
     String batchOperationKey,
     BatchOperationState state,
-    String operationType,
+    BatchOperationType operationType,
     OffsetDateTime startDate,
     OffsetDateTime endDate,
     Integer operationsTotalCount,

--- a/search/search-domain/src/main/java/io/camunda/search/entities/BatchOperationType.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/BatchOperationType.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.entities;
+
+public enum BatchOperationType {
+  RESOLVE_INCIDENT,
+  CANCEL_PROCESS_INSTANCE,
+  DELETE_PROCESS_INSTANCE,
+  ADD_VARIABLE,
+  UPDATE_VARIABLE,
+  MODIFY_PROCESS_INSTANCE,
+  DELETE_DECISION_DEFINITION,
+  DELETE_PROCESS_DEFINITION,
+  MIGRATE_PROCESS_INSTANCE
+}

--- a/zeebe/exporter-common/pom.xml
+++ b/zeebe/exporter-common/pom.xml
@@ -36,11 +36,6 @@
       <artifactId>caffeine</artifactId>
     </dependency>
 
-    <dependency>
-      <groupId>io.camunda</groupId>
-      <artifactId>webapps-schema</artifactId>
-    </dependency>
-
     <!-- testing -->
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/cache/batchoperation/CachedBatchOperationEntity.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/cache/batchoperation/CachedBatchOperationEntity.java
@@ -7,6 +7,6 @@
  */
 package io.camunda.zeebe.exporter.common.cache.batchoperation;
 
-import io.camunda.webapps.schema.entities.operation.OperationType;
+import io.camunda.search.entities.BatchOperationType;
 
-public record CachedBatchOperationEntity(String batchOperationKey, OperationType type) {}
+public record CachedBatchOperationEntity(String batchOperationKey, BatchOperationType type) {}

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/utils/ProcessCacheUtil.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/utils/ProcessCacheUtil.java
@@ -8,8 +8,6 @@
 package io.camunda.zeebe.exporter.common.utils;
 
 import io.camunda.search.entities.ProcessDefinitionEntity;
-import io.camunda.webapps.schema.entities.ProcessEntity;
-import io.camunda.webapps.schema.entities.ProcessFlowNodeEntity;
 import io.camunda.zeebe.exporter.common.cache.ExporterEntityCache;
 import io.camunda.zeebe.exporter.common.cache.process.CachedProcessEntity;
 import io.camunda.zeebe.exporter.common.cache.process.ProcessDiagramData;
@@ -69,16 +67,6 @@ public final class ProcessCacheUtil {
     return processCache.getAll(processDefinitionKeys).values().stream()
         .map(CachedProcessEntity::callElementIds)
         .toList();
-  }
-
-  /**
-   * Returns relevant data from process diagram
-   *
-   * @param processEntity
-   * @return ProcessDiagramData
-   */
-  public static ProcessDiagramData extractProcessDiagramData(final ProcessEntity processEntity) {
-    return extractProcessDiagramData(processEntity.getBpmnXml(), processEntity.getBpmnProcessId());
   }
 
   /**
@@ -144,14 +132,5 @@ public final class ProcessCacheUtil {
   public static Map<String, String> getFlowNodesMap(Collection<FlowNode> flowNodes) {
     return flowNodes.stream()
         .collect(HashMap::new, (map, fn) -> map.put(fn.getId(), fn.getName()), HashMap::putAll);
-  }
-
-  public static Map<String, String> getFlowNodesMap(List<ProcessFlowNodeEntity> flowNodes) {
-    final Map<String, String> flowNodesMap = new HashMap<>();
-    for (ProcessFlowNodeEntity flowNode : flowNodes) {
-      flowNodesMap.put(flowNode.getId(), flowNode.getName());
-    }
-
-    return flowNodesMap;
   }
 }

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/utils/ProcessCacheUtilTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/utils/ProcessCacheUtilTest.java
@@ -9,7 +9,6 @@ package io.camunda.zeebe.exporter.common.utils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.camunda.webapps.schema.entities.ProcessEntity;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.model.bpmn.instance.CallActivity;
@@ -23,11 +22,10 @@ public class ProcessCacheUtilTest {
     // given
     final String processId = "testProcessId";
     final var model = buildModel(processId, List.of("C_Activity", "A_Activity", "D_Activity"));
-    final var process =
-        new ProcessEntity().setBpmnXml(Bpmn.convertToString(model)).setBpmnProcessId(processId);
+    final var bpmnXml = Bpmn.convertToString(model);
     // when
     final var callActivities =
-        ProcessCacheUtil.extractProcessDiagramData(process).callActivityIds();
+        ProcessCacheUtil.extractProcessDiagramData(bpmnXml, processId).callActivityIds();
     // then
     assertThat(callActivities).containsExactly("A_Activity", "C_Activity", "D_Activity");
   }

--- a/zeebe/exporters/camunda-exporter/pom.xml
+++ b/zeebe/exporters/camunda-exporter/pom.xml
@@ -42,6 +42,11 @@
 
     <dependency>
       <groupId>io.camunda</groupId>
+      <artifactId>camunda-search-domain</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
       <artifactId>camunda-security-protocol</artifactId>
     </dependency>
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/cache/batchoperation/ElasticSearchBatchOperationCacheLoader.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/cache/batchoperation/ElasticSearchBatchOperationCacheLoader.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.exporter.cache.batchoperation;
 
+import static io.camunda.exporter.utils.ExporterUtil.map;
+
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import co.elastic.clients.elasticsearch._types.query_dsl.QueryBuilders;
 import co.elastic.clients.elasticsearch.core.search.SourceConfigBuilders;
@@ -51,7 +53,7 @@ public class ElasticSearchBatchOperationCacheLoader
             BatchOperationEntity.class);
     if (response.hits() != null && !response.hits().hits().isEmpty()) {
       final var entity = response.hits().hits().getFirst().source();
-      return new CachedBatchOperationEntity(entity.getId(), entity.getType());
+      return new CachedBatchOperationEntity(entity.getId(), map(entity.getType()));
     } else {
       LOG.debug("BatchOperation '{}' not found in Elasticsearch", batchOperationKey);
       return null;

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/cache/batchoperation/OpenSearchBatchOperationCacheLoader.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/cache/batchoperation/OpenSearchBatchOperationCacheLoader.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.exporter.cache.batchoperation;
 
+import static io.camunda.exporter.utils.ExporterUtil.map;
+
 import com.github.benmanes.caffeine.cache.CacheLoader;
 import io.camunda.webapps.schema.descriptors.template.BatchOperationTemplate;
 import io.camunda.webapps.schema.entities.operation.BatchOperationEntity;
@@ -50,7 +52,7 @@ public class OpenSearchBatchOperationCacheLoader
             BatchOperationEntity.class);
     if (response.hits() != null && !response.hits().hits().isEmpty()) {
       final var entity = response.hits().hits().getFirst().source();
-      return new CachedBatchOperationEntity(entity.getId(), entity.getType());
+      return new CachedBatchOperationEntity(entity.getId(), map(entity.getType()));
     } else {
       LOG.debug("BatchOperation '{}' not found in OpenSearch", batchOperationKey);
       return null;

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/cache/process/ElasticSearchProcessCacheLoader.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/cache/process/ElasticSearchProcessCacheLoader.java
@@ -37,7 +37,9 @@ public class ElasticSearchProcessCacheLoader implements CacheLoader<Long, Cached
             ProcessEntity.class);
     if (response.found()) {
       final var processEntity = response.source();
-      final var processDiagramData = ProcessCacheUtil.extractProcessDiagramData(processEntity);
+      final var processDiagramData =
+          ProcessCacheUtil.extractProcessDiagramData(
+              processEntity.getBpmnXml(), processEntity.getBpmnProcessId());
       return new CachedProcessEntity(
           processEntity.getName(),
           processEntity.getVersionTag(),

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/cache/process/OpenSearchProcessCacheLoader.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/cache/process/OpenSearchProcessCacheLoader.java
@@ -36,7 +36,9 @@ public class OpenSearchProcessCacheLoader implements CacheLoader<Long, CachedPro
             ProcessEntity.class);
     if (response.found()) {
       final var processEntity = response.source();
-      final var processDiagramData = ProcessCacheUtil.extractProcessDiagramData(processEntity);
+      final var processDiagramData =
+          ProcessCacheUtil.extractProcessDiagramData(
+              processEntity.getBpmnXml(), processEntity.getBpmnProcessId());
       return new CachedProcessEntity(
           processEntity.getName(),
           processEntity.getVersionTag(),

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ProcessHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ProcessHandler.java
@@ -20,7 +20,9 @@ import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
 import io.camunda.zeebe.protocol.record.value.deployment.Process;
 import io.camunda.zeebe.util.modelreader.ProcessModelReader;
 import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class ProcessHandler implements ExportHandler<ProcessEntity, Process> {
 
@@ -90,7 +92,7 @@ public class ProcessHandler implements ExportHandler<ProcessEntity, Process> {
             entity.getVersionTag(),
             Integer.toString(entity.getVersion()),
             entity.getCallActivityIds(),
-            ProcessCacheUtil.getFlowNodesMap(entity.getFlowNodes()));
+            getFlowNodesMap(entity.getFlowNodes()));
     processCache.put(process.getProcessDefinitionKey(), cachedProcessEntity);
   }
 
@@ -126,5 +128,14 @@ public class ProcessHandler implements ExportHandler<ProcessEntity, Process> {
                         entity.setIsFormEmbedded(!ExporterUtil.isEmpty(formLink.formKey()));
                       });
             });
+  }
+
+  private static Map<String, String> getFlowNodesMap(final List<ProcessFlowNodeEntity> flowNodes) {
+    final Map<String, String> flowNodesMap = new HashMap<>();
+    for (final ProcessFlowNodeEntity flowNode : flowNodes) {
+      flowNodesMap.put(flowNode.getId(), flowNode.getName());
+    }
+
+    return flowNodesMap;
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/AbstractOperationHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/AbstractOperationHandler.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.exporter.handlers.batchoperation;
 
+import static io.camunda.exporter.utils.ExporterUtil.map;
+
 import io.camunda.exporter.handlers.ExportHandler;
 import io.camunda.webapps.schema.entities.ExporterEntity;
 import io.camunda.webapps.schema.entities.operation.OperationType;
@@ -74,7 +76,7 @@ public abstract class AbstractOperationHandler<T extends ExporterEntity<T>, R ex
     return cachedEntity
         .filter(
             cachedBatchOperationEntity ->
-                cachedBatchOperationEntity.type() == relevantOperationType)
+                map(cachedBatchOperationEntity.type()) == relevantOperationType)
         .isPresent();
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/BatchOperationCreatedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/BatchOperationCreatedHandler.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.exporter.handlers.batchoperation;
 
+import static io.camunda.exporter.utils.ExporterUtil.map;
+
 import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.exporter.handlers.ExportHandler;
 import io.camunda.exporter.store.BatchRequest;
@@ -76,7 +78,7 @@ public class BatchOperationCreatedHandler
 
     // update local cache so that the batch operation info is available immediately to operation
     // status handlers
-    final var cachedEntity = new CachedBatchOperationEntity(entity.getId(), entity.getType());
+    final var cachedEntity = new CachedBatchOperationEntity(entity.getId(), map(entity.getType()));
     batchOperationCache.put(cachedEntity.batchOperationKey(), cachedEntity);
   }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/utils/ExporterUtil.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/utils/ExporterUtil.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.exporter.utils;
 
+import io.camunda.search.entities.BatchOperationType;
+import io.camunda.webapps.schema.entities.operation.OperationType;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import java.time.Instant;
 import java.time.OffsetDateTime;
@@ -81,5 +83,13 @@ public final class ExporterUtil {
     }
 
     return null;
+  }
+
+  public static BatchOperationType map(final OperationType operationType) {
+    return BatchOperationType.valueOf(operationType.name());
+  }
+
+  public static OperationType map(final BatchOperationType operationType) {
+    return OperationType.valueOf(operationType.name());
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/cache/BatchOperationCacheIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/cache/BatchOperationCacheIT.java
@@ -15,6 +15,7 @@ import static org.assertj.core.api.Assertions.assertThatException;
 import io.camunda.exporter.DefaultExporterResourceProvider;
 import io.camunda.exporter.cache.batchoperation.ElasticSearchBatchOperationCacheLoader;
 import io.camunda.exporter.cache.batchoperation.OpenSearchBatchOperationCacheLoader;
+import io.camunda.search.entities.BatchOperationType;
 import io.camunda.search.schema.config.IndexConfiguration;
 import io.camunda.search.schema.elasticsearch.ElasticsearchEngineClient;
 import io.camunda.search.schema.opensearch.OpensearchEngineClient;
@@ -91,7 +92,7 @@ class BatchOperationCacheIT {
 
     // then
     final var expectedCachedBatchOperationEntity =
-        new CachedBatchOperationEntity("3", OperationType.RESOLVE_INCIDENT);
+        new CachedBatchOperationEntity("3", BatchOperationType.RESOLVE_INCIDENT);
     assertThat(batchOperation).isPresent().get().isEqualTo(expectedCachedBatchOperationEntity);
   }
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/BatchOperationStatusHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/BatchOperationStatusHandlerTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.exporter.handlers.batchoperation;
 
+import static io.camunda.exporter.utils.ExporterUtil.map;
 import static io.camunda.zeebe.protocol.record.RecordMetadataDecoder.batchOperationReferenceNullValue;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
@@ -63,7 +64,7 @@ class BatchOperationStatusHandlerTest {
           .thenReturn(
               Optional.of(
                   new CachedBatchOperationEntity(
-                      String.valueOf(batchOperationKey), handler.getRelevantOperationType())));
+                      String.valueOf(batchOperationKey), map(handler.getRelevantOperationType()))));
     }
 
     @Test
@@ -97,7 +98,7 @@ class BatchOperationStatusHandlerTest {
           .thenReturn(
               Optional.of(
                   new CachedBatchOperationEntity(
-                      String.valueOf(batchOperationKey), otherOperationType)));
+                      String.valueOf(batchOperationKey), map(otherOperationType))));
 
       final var record =
           ImmutableRecord.<T>builder()
@@ -139,7 +140,7 @@ class BatchOperationStatusHandlerTest {
           .thenReturn(
               Optional.of(
                   new CachedBatchOperationEntity(
-                      String.valueOf(batchOperationKey), otherOperationType)));
+                      String.valueOf(batchOperationKey), map(otherOperationType))));
 
       final var record =
           ImmutableRecord.<T>builder()

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/listview/AbstractProcessInstanceFromOperationItemHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/listview/AbstractProcessInstanceFromOperationItemHandlerTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.exporter.handlers.batchoperation.listview;
 
+import static io.camunda.exporter.utils.ExporterUtil.map;
 import static io.camunda.zeebe.protocol.record.RecordMetadataDecoder.batchOperationReferenceNullValue;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -53,7 +54,7 @@ public abstract class AbstractProcessInstanceFromOperationItemHandlerTest<
             Optional.of(
                 new CachedBatchOperationEntity(
                     String.valueOf(record.getBatchOperationReference()),
-                    underTest.getRelevantOperationType())));
+                    map(underTest.getRelevantOperationType()))));
 
     assertThat(underTest.handlesRecord(record)).isTrue();
   }
@@ -67,7 +68,7 @@ public abstract class AbstractProcessInstanceFromOperationItemHandlerTest<
             Optional.of(
                 new CachedBatchOperationEntity(
                     String.valueOf(record.getBatchOperationReference()),
-                    underTest.getRelevantOperationType())));
+                    map(underTest.getRelevantOperationType()))));
 
     assertThat(underTest.handlesRecord(record)).isTrue();
   }
@@ -85,7 +86,7 @@ public abstract class AbstractProcessInstanceFromOperationItemHandlerTest<
             Optional.of(
                 new CachedBatchOperationEntity(
                     String.valueOf(record.getBatchOperationReference()),
-                    underTest.getRelevantOperationType())));
+                    map(underTest.getRelevantOperationType()))));
     // When
     final boolean result = underTest.handlesRecord(record);
 
@@ -107,7 +108,8 @@ public abstract class AbstractProcessInstanceFromOperationItemHandlerTest<
         .thenReturn(
             Optional.of(
                 new CachedBatchOperationEntity(
-                    String.valueOf(record.getBatchOperationReference()), irrelevantOperationType)));
+                    String.valueOf(record.getBatchOperationReference()),
+                    map(irrelevantOperationType))));
 
     // When
     final boolean result = underTest.handlesRecord(record);

--- a/zeebe/exporters/rdbms-exporter/pom.xml
+++ b/zeebe/exporters/rdbms-exporter/pom.xml
@@ -40,11 +40,6 @@
 
     <dependency>
       <groupId>io.camunda</groupId>
-      <artifactId>webapps-schema</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>io.camunda</groupId>
       <artifactId>zeebe-protocol</artifactId>
     </dependency>
 

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/cache/RdbmsBatchOperationCacheLoader.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/cache/RdbmsBatchOperationCacheLoader.java
@@ -9,7 +9,7 @@ package io.camunda.exporter.rdbms.cache;
 
 import com.github.benmanes.caffeine.cache.CacheLoader;
 import io.camunda.db.rdbms.read.service.BatchOperationDbReader;
-import io.camunda.webapps.schema.entities.operation.OperationType;
+import io.camunda.search.entities.BatchOperationType;
 import io.camunda.zeebe.exporter.common.cache.batchoperation.CachedBatchOperationEntity;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
@@ -32,7 +32,7 @@ public class RdbmsBatchOperationCacheLoader
       final var batchOperationEntity = response.get();
       return new CachedBatchOperationEntity(
           batchOperationEntity.batchOperationKey(),
-          OperationType.valueOf(batchOperationEntity.operationType()));
+          BatchOperationType.valueOf(batchOperationEntity.operationType()));
     }
     LOG.debug("BatchOperation '{}' not found in RDBMS", key);
     return null;

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/cache/RdbmsBatchOperationCacheLoader.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/cache/RdbmsBatchOperationCacheLoader.java
@@ -9,7 +9,6 @@ package io.camunda.exporter.rdbms.cache;
 
 import com.github.benmanes.caffeine.cache.CacheLoader;
 import io.camunda.db.rdbms.read.service.BatchOperationDbReader;
-import io.camunda.search.entities.BatchOperationType;
 import io.camunda.zeebe.exporter.common.cache.batchoperation.CachedBatchOperationEntity;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
@@ -31,8 +30,7 @@ public class RdbmsBatchOperationCacheLoader
     if (response.isPresent()) {
       final var batchOperationEntity = response.get();
       return new CachedBatchOperationEntity(
-          batchOperationEntity.batchOperationKey(),
-          BatchOperationType.valueOf(batchOperationEntity.operationType()));
+          batchOperationEntity.batchOperationKey(), batchOperationEntity.operationType());
     }
     LOG.debug("BatchOperation '{}' not found in RDBMS", key);
     return null;

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/BatchOperationCreatedExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/BatchOperationCreatedExportHandler.java
@@ -11,7 +11,7 @@ import io.camunda.db.rdbms.write.domain.BatchOperationDbModel;
 import io.camunda.db.rdbms.write.service.BatchOperationWriter;
 import io.camunda.exporter.rdbms.RdbmsExportHandler;
 import io.camunda.search.entities.BatchOperationEntity.BatchOperationState;
-import io.camunda.webapps.schema.entities.operation.OperationType;
+import io.camunda.search.entities.BatchOperationType;
 import io.camunda.zeebe.exporter.common.cache.ExporterEntityCache;
 import io.camunda.zeebe.exporter.common.cache.batchoperation.CachedBatchOperationEntity;
 import io.camunda.zeebe.protocol.record.Record;
@@ -50,7 +50,7 @@ public class BatchOperationCreatedExportHandler
         String.valueOf(record.getKey()),
         new CachedBatchOperationEntity(
             String.valueOf(record.getValue().getBatchOperationKey()),
-            OperationType.valueOf(record.getValue().getBatchOperationType().name())));
+            BatchOperationType.valueOf(record.getValue().getBatchOperationType().name())));
   }
 
   private BatchOperationDbModel map(final Record<BatchOperationCreationRecordValue> record) {

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/BatchOperationCreatedExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/BatchOperationCreatedExportHandler.java
@@ -59,7 +59,7 @@ public class BatchOperationCreatedExportHandler
     return new BatchOperationDbModel.Builder()
         .batchOperationKey(batchOperationKey)
         .state(BatchOperationState.ACTIVE)
-        .operationType(value.getBatchOperationType().name())
+        .operationType(BatchOperationType.valueOf(value.getBatchOperationType().name()))
         .startDate(DateUtil.toOffsetDateTime(record.getTimestamp()))
         .build();
   }

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/IncidentBatchOperationExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/IncidentBatchOperationExportHandler.java
@@ -8,7 +8,7 @@
 package io.camunda.exporter.rdbms.handlers.batchoperation;
 
 import io.camunda.db.rdbms.write.service.BatchOperationWriter;
-import io.camunda.webapps.schema.entities.operation.OperationType;
+import io.camunda.search.entities.BatchOperationType;
 import io.camunda.zeebe.exporter.common.cache.ExporterEntityCache;
 import io.camunda.zeebe.exporter.common.cache.batchoperation.CachedBatchOperationEntity;
 import io.camunda.zeebe.protocol.record.Record;
@@ -26,7 +26,7 @@ public class IncidentBatchOperationExportHandler
   public IncidentBatchOperationExportHandler(
       final BatchOperationWriter batchOperationWriter,
       final ExporterEntityCache<String, CachedBatchOperationEntity> batchOperationCache) {
-    super(batchOperationWriter, batchOperationCache, OperationType.RESOLVE_INCIDENT);
+    super(batchOperationWriter, batchOperationCache, BatchOperationType.RESOLVE_INCIDENT);
   }
 
   @Override

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/ProcessInstanceCancellationBatchOperationExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/ProcessInstanceCancellationBatchOperationExportHandler.java
@@ -8,7 +8,7 @@
 package io.camunda.exporter.rdbms.handlers.batchoperation;
 
 import io.camunda.db.rdbms.write.service.BatchOperationWriter;
-import io.camunda.webapps.schema.entities.operation.OperationType;
+import io.camunda.search.entities.BatchOperationType;
 import io.camunda.zeebe.exporter.common.cache.ExporterEntityCache;
 import io.camunda.zeebe.exporter.common.cache.batchoperation.CachedBatchOperationEntity;
 import io.camunda.zeebe.protocol.record.Record;
@@ -28,7 +28,7 @@ public class ProcessInstanceCancellationBatchOperationExportHandler
   public ProcessInstanceCancellationBatchOperationExportHandler(
       final BatchOperationWriter batchOperationWriter,
       final ExporterEntityCache<String, CachedBatchOperationEntity> batchOperationCache) {
-    super(batchOperationWriter, batchOperationCache, OperationType.CANCEL_PROCESS_INSTANCE);
+    super(batchOperationWriter, batchOperationCache, BatchOperationType.CANCEL_PROCESS_INSTANCE);
   }
 
   @Override

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/ProcessInstanceMigrationBatchOperationExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/ProcessInstanceMigrationBatchOperationExportHandler.java
@@ -8,7 +8,7 @@
 package io.camunda.exporter.rdbms.handlers.batchoperation;
 
 import io.camunda.db.rdbms.write.service.BatchOperationWriter;
-import io.camunda.webapps.schema.entities.operation.OperationType;
+import io.camunda.search.entities.BatchOperationType;
 import io.camunda.zeebe.exporter.common.cache.ExporterEntityCache;
 import io.camunda.zeebe.exporter.common.cache.batchoperation.CachedBatchOperationEntity;
 import io.camunda.zeebe.protocol.record.Record;
@@ -27,7 +27,7 @@ public class ProcessInstanceMigrationBatchOperationExportHandler
   public ProcessInstanceMigrationBatchOperationExportHandler(
       final BatchOperationWriter batchOperationWriter,
       final ExporterEntityCache<String, CachedBatchOperationEntity> batchOperationCache) {
-    super(batchOperationWriter, batchOperationCache, OperationType.MIGRATE_PROCESS_INSTANCE);
+    super(batchOperationWriter, batchOperationCache, BatchOperationType.MIGRATE_PROCESS_INSTANCE);
   }
 
   @Override

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/ProcessInstanceModificationBatchOperationExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/ProcessInstanceModificationBatchOperationExportHandler.java
@@ -8,7 +8,7 @@
 package io.camunda.exporter.rdbms.handlers.batchoperation;
 
 import io.camunda.db.rdbms.write.service.BatchOperationWriter;
-import io.camunda.webapps.schema.entities.operation.OperationType;
+import io.camunda.search.entities.BatchOperationType;
 import io.camunda.zeebe.exporter.common.cache.ExporterEntityCache;
 import io.camunda.zeebe.exporter.common.cache.batchoperation.CachedBatchOperationEntity;
 import io.camunda.zeebe.protocol.record.Record;
@@ -27,7 +27,7 @@ public class ProcessInstanceModificationBatchOperationExportHandler
   public ProcessInstanceModificationBatchOperationExportHandler(
       final BatchOperationWriter batchOperationWriter,
       final ExporterEntityCache<String, CachedBatchOperationEntity> batchOperationCache) {
-    super(batchOperationWriter, batchOperationCache, OperationType.MODIFY_PROCESS_INSTANCE);
+    super(batchOperationWriter, batchOperationCache, BatchOperationType.MODIFY_PROCESS_INSTANCE);
   }
 
   @Override

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/RdbmsBatchOperationStatusExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/RdbmsBatchOperationStatusExportHandler.java
@@ -13,7 +13,7 @@ import io.camunda.db.rdbms.write.domain.BatchOperationItemDbModel;
 import io.camunda.db.rdbms.write.service.BatchOperationWriter;
 import io.camunda.exporter.rdbms.RdbmsExportHandler;
 import io.camunda.search.entities.BatchOperationEntity.BatchOperationItemState;
-import io.camunda.webapps.schema.entities.operation.OperationType;
+import io.camunda.search.entities.BatchOperationType;
 import io.camunda.zeebe.exporter.common.cache.ExporterEntityCache;
 import io.camunda.zeebe.exporter.common.cache.batchoperation.CachedBatchOperationEntity;
 import io.camunda.zeebe.protocol.record.Record;
@@ -32,14 +32,14 @@ import io.camunda.zeebe.util.VisibleForTesting;
 public abstract class RdbmsBatchOperationStatusExportHandler<T extends RecordValue>
     implements RdbmsExportHandler<T> {
   public static final String ERROR_MSG = "%s: %s";
-  @VisibleForTesting final OperationType relevantOperationType;
+  @VisibleForTesting final BatchOperationType relevantOperationType;
   private final BatchOperationWriter batchOperationWriter;
   private final ExporterEntityCache<String, CachedBatchOperationEntity> batchOperationCache;
 
   public RdbmsBatchOperationStatusExportHandler(
       final BatchOperationWriter batchOperationWriter,
       final ExporterEntityCache<String, CachedBatchOperationEntity> batchOperationCache,
-      final OperationType relevantOperationType) {
+      final BatchOperationType relevantOperationType) {
     this.batchOperationWriter = batchOperationWriter;
     this.batchOperationCache = batchOperationCache;
     this.relevantOperationType = relevantOperationType;

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/batchoperation/BatchOperationStatusHandlerTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/batchoperation/BatchOperationStatusHandlerTest.java
@@ -15,7 +15,7 @@ import static org.mockito.Mockito.mock;
 import io.camunda.db.rdbms.write.domain.BatchOperationItemDbModel;
 import io.camunda.db.rdbms.write.service.BatchOperationWriter;
 import io.camunda.search.entities.BatchOperationEntity.BatchOperationItemState;
-import io.camunda.webapps.schema.entities.operation.OperationType;
+import io.camunda.search.entities.BatchOperationType;
 import io.camunda.zeebe.exporter.common.cache.ExporterEntityCache;
 import io.camunda.zeebe.exporter.common.cache.batchoperation.CachedBatchOperationEntity;
 import io.camunda.zeebe.protocol.record.ImmutableRecord;
@@ -87,7 +87,7 @@ class BatchOperationStatusHandlerTest {
     void shouldNotHandleSuccessRecordWhenNotRelevantType() {
       Mockito.reset(batchOperationCache);
       final var otherOperationType =
-          Arrays.stream(OperationType.values())
+          Arrays.stream(BatchOperationType.values())
               .filter(t -> !t.equals(handler.relevantOperationType))
               .findAny()
               .get();
@@ -129,7 +129,7 @@ class BatchOperationStatusHandlerTest {
     void shouldNotHandleFailureRecordWhenNotRelevantType() {
       Mockito.reset(batchOperationCache);
       final var otherOperationType =
-          Arrays.stream(OperationType.values())
+          Arrays.stream(BatchOperationType.values())
               .filter(t -> !t.equals(handler.relevantOperationType))
               .findAny()
               .get();

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
@@ -567,7 +567,7 @@ public final class SearchQueryResponseMapper {
     return new BatchOperationResponse()
         .batchOperationKey(entity.batchOperationKey())
         .state(BatchOperationResponse.StateEnum.fromValue(entity.state().name()))
-        .batchOperationType(BatchOperationTypeEnum.fromValue(entity.operationType()))
+        .batchOperationType(BatchOperationTypeEnum.fromValue(entity.operationType().name()))
         .startDate(formatDate(entity.startDate()))
         .endDate(formatDate(entity.endDate()))
         .operationsTotalCount(entity.operationsTotalCount())

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/BatchOperationControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/BatchOperationControllerTest.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.when;
 import io.camunda.search.entities.BatchOperationEntity;
 import io.camunda.search.entities.BatchOperationEntity.BatchOperationErrorEntity;
 import io.camunda.search.entities.BatchOperationEntity.BatchOperationState;
+import io.camunda.search.entities.BatchOperationType;
 import io.camunda.search.filter.Operation;
 import io.camunda.search.query.BatchOperationQuery;
 import io.camunda.search.query.SearchQueryResult;
@@ -272,7 +273,7 @@ class BatchOperationControllerTest extends RestControllerTest {
     return new BatchOperationEntity(
         batchOperationKey,
         BatchOperationState.COMPLETED,
-        "CANCEL_PROCESS_INSTANCE",
+        BatchOperationType.CANCEL_PROCESS_INSTANCE,
         OffsetDateTime.parse("2025-03-18T10:57:44+01:00"),
         OffsetDateTime.parse("2025-03-18T10:57:45+01:00"),
         10,
@@ -286,7 +287,7 @@ class BatchOperationControllerTest extends RestControllerTest {
     return new BatchOperationEntity(
         batchOperationKey,
         BatchOperationState.PARTIALLY_COMPLETED,
-        "CANCEL_PROCESS_INSTANCE",
+        BatchOperationType.CANCEL_PROCESS_INSTANCE,
         OffsetDateTime.parse("2025-03-18T10:57:44+01:00"),
         OffsetDateTime.parse("2025-03-18T10:57:45+01:00"),
         10,


### PR DESCRIPTION
## Description

This PR refactors the batch operation system to remove dependency on the webapp schema module from the RDBMS module by introducing a new BatchOperationType enum in the search-domain module. This change reduces coupling between modules and standardizes the operation type representation across the codebase.

* Introduces BatchOperationType enum in search-domain module to replace webapp schema OperationType
* Updates CachedBatchOperationEntity and related classes to use the new enum type

# Related issue

#35023
