### PR TITLE
Add releaseVersion to mvn:perform and slack notification fix

### DIFF
--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -186,6 +186,7 @@ jobs:
 
           # shellcheck disable=SC2016
           ./mvnw release:perform -B \
+            -DreleaseVersion="${RELEASE_VERSION}" \
             -Dgpg.passphrase="${{ steps.secrets.outputs.MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE }}" \
             -DlocalCheckout="${{ inputs.dryRun }}" \
             -DskipQaBuild=true \


### PR DESCRIPTION
## Description

After bump of `camunda-release-parent` by https://github.com/camunda/camunda/commit/8eab13f720a2a09c2a84095c6f3e7fe8886afcde

it is required to have defined `releaseVersion` in the `mvn:perform` context, otherwise we end up producing artifacts as:
<img width="1056" height="169" alt="image" src="https://github.com/user-attachments/assets/1b082622-ea4b-42e6-9552-f6a02d55d67e" />

It was noted that `mvn: prepare` was successfull: https://github.com/camunda/camunda/actions/runs/16623251615/job/47032707548#step:10:903
but `mnv: perform` not
https://github.com/camunda/camunda/actions/runs/16623251615/job/47032707548#step:11:212

so this fix aims to provide the required context.

Also, it was verified that no slack message was sent once the release was done. So a fix for that was also introduced.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
