### PR TITLE
Set owner type on authorizations of default RPA role

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/IdentitySetupInitializer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/IdentitySetupInitializer.java
@@ -224,12 +224,14 @@ public final class IdentitySetupInitializer implements StreamProcessorLifecycleA
         .addAuthorization(
             new AuthorizationRecord()
                 .setOwnerId(rpaRoleId)
+                .setOwnerType(AuthorizationOwnerType.ROLE)
                 .setResourceType(AuthorizationResourceType.RESOURCE)
                 .setResourceId(WILDCARD_PERMISSION)
                 .setPermissionTypes(Set.of(PermissionType.READ)))
         .addAuthorization(
             new AuthorizationRecord()
                 .setOwnerId(rpaRoleId)
+                .setOwnerType(AuthorizationOwnerType.ROLE)
                 .setResourceType(AuthorizationResourceType.PROCESS_DEFINITION)
                 .setResourceId(WILDCARD_PERMISSION)
                 .setPermissionTypes(Set.of(PermissionType.UPDATE_PROCESS_INSTANCE)))

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/IdentitySetupInitializeDefaultsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/IdentitySetupInitializeDefaultsTest.java
@@ -261,4 +261,34 @@ public class IdentitySetupInitializeDefaultsTest {
                     .hasResourceType(AuthorizationResourceType.USAGE_METRIC)
                     .hasOnlyPermissionTypes(PermissionType.READ));
   }
+
+  @Test
+  public void shouldCreateConnectorsRoleByDefault() {
+    // then
+    assertThat(
+            RecordingExporter.records()
+                .limit(r -> r.getIntent() == IdentitySetupIntent.INITIALIZED)
+                .authorizationRecords()
+                .withOwnerId(DefaultRole.CONNECTORS.getId()))
+        .extracting(Record::getValue)
+        .describedAs("Expect all connectors role authorizations to be owned by the connectors role")
+        .allSatisfy(
+            auth ->
+                Assertions.assertThat(auth)
+                    .hasOwnerId(DefaultRole.CONNECTORS.getId())
+                    .hasOwnerType(AuthorizationOwnerType.ROLE))
+        .describedAs(
+            "Expect the connectors role authorizations to have specific resource permissions")
+        .satisfiesExactlyInAnyOrder(
+            auth ->
+                Assertions.assertThat(auth)
+                    .hasResourceType(AuthorizationResourceType.PROCESS_DEFINITION)
+                    .hasOnlyPermissionTypes(
+                        PermissionType.READ_PROCESS_DEFINITION,
+                        PermissionType.UPDATE_PROCESS_INSTANCE),
+            auth ->
+                Assertions.assertThat(auth)
+                    .hasResourceType(AuthorizationResourceType.MESSAGE)
+                    .hasOnlyPermissionTypes(PermissionType.CREATE));
+  }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/IdentitySetupInitializeDefaultsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/IdentitySetupInitializeDefaultsTest.java
@@ -169,4 +169,96 @@ public class IdentitySetupInitializeDefaultsTest {
                     .hasResourceType(AuthorizationResourceType.USAGE_METRIC)
                     .hasOnlyPermissionTypes(PermissionType.READ));
   }
+
+  @Test
+  public void shouldCreateReadOnlyAdminRoleByDefault() {
+    // then
+    assertThat(
+            RecordingExporter.records()
+                .limit(r -> r.getIntent() == IdentitySetupIntent.INITIALIZED)
+                .authorizationRecords()
+                .withOwnerId("readonly-admin"))
+        .extracting(Record::getValue)
+        .describedAs(
+            "Expect all readonly-admin role authorizations to be owned by the readonly-admin role")
+        .allSatisfy(
+            auth ->
+                Assertions.assertThat(auth)
+                    .hasOwnerId("readonly-admin")
+                    .hasOwnerType(AuthorizationOwnerType.ROLE))
+        .describedAs(
+            "Expect all readonly-admin role authorizations to have the wildcard resource ID")
+        .allSatisfy(
+            auth ->
+                Assertions.assertThat(auth)
+                    .hasResourceId(AuthorizationCheckBehavior.WILDCARD_PERMISSION))
+        .describedAs(
+            "Expect the readonly-admin role authorizations to have specific read permissions only")
+        .satisfiesExactlyInAnyOrder(
+            auth ->
+                Assertions.assertThat(auth)
+                    .hasResourceType(AuthorizationResourceType.AUTHORIZATION)
+                    .hasOnlyPermissionTypes(PermissionType.READ),
+            auth ->
+                Assertions.assertThat(auth)
+                    .hasResourceType(AuthorizationResourceType.MAPPING_RULE)
+                    .hasOnlyPermissionTypes(PermissionType.READ),
+            auth ->
+                Assertions.assertThat(auth)
+                    .hasResourceType(AuthorizationResourceType.MESSAGE)
+                    .hasOnlyPermissionTypes(PermissionType.READ),
+            auth ->
+                Assertions.assertThat(auth)
+                    .hasResourceType(AuthorizationResourceType.APPLICATION)
+                    .hasOnlyPermissionTypes(PermissionType.ACCESS),
+            auth ->
+                Assertions.assertThat(auth)
+                    .hasResourceType(AuthorizationResourceType.SYSTEM)
+                    .hasOnlyPermissionTypes(PermissionType.READ),
+            auth ->
+                Assertions.assertThat(auth)
+                    .hasResourceType(AuthorizationResourceType.TENANT)
+                    .hasOnlyPermissionTypes(PermissionType.READ),
+            auth ->
+                Assertions.assertThat(auth)
+                    .hasResourceType(AuthorizationResourceType.RESOURCE)
+                    .hasOnlyPermissionTypes(PermissionType.READ),
+            auth ->
+                Assertions.assertThat(auth)
+                    .hasResourceType(AuthorizationResourceType.PROCESS_DEFINITION)
+                    .hasOnlyPermissionTypes(
+                        PermissionType.READ_PROCESS_DEFINITION,
+                        PermissionType.READ_PROCESS_INSTANCE,
+                        PermissionType.READ_USER_TASK),
+            auth ->
+                Assertions.assertThat(auth)
+                    .hasResourceType(AuthorizationResourceType.DECISION_REQUIREMENTS_DEFINITION)
+                    .hasOnlyPermissionTypes(PermissionType.READ),
+            auth ->
+                Assertions.assertThat(auth)
+                    .hasResourceType(AuthorizationResourceType.DECISION_DEFINITION)
+                    .hasOnlyPermissionTypes(
+                        PermissionType.READ_DECISION_DEFINITION,
+                        PermissionType.READ_DECISION_INSTANCE),
+            auth ->
+                Assertions.assertThat(auth)
+                    .hasResourceType(AuthorizationResourceType.GROUP)
+                    .hasOnlyPermissionTypes(PermissionType.READ),
+            auth ->
+                Assertions.assertThat(auth)
+                    .hasResourceType(AuthorizationResourceType.USER)
+                    .hasOnlyPermissionTypes(PermissionType.READ),
+            auth ->
+                Assertions.assertThat(auth)
+                    .hasResourceType(AuthorizationResourceType.ROLE)
+                    .hasOnlyPermissionTypes(PermissionType.READ),
+            auth ->
+                Assertions.assertThat(auth)
+                    .hasResourceType(AuthorizationResourceType.BATCH)
+                    .hasOnlyPermissionTypes(PermissionType.READ),
+            auth ->
+                Assertions.assertThat(auth)
+                    .hasResourceType(AuthorizationResourceType.USAGE_METRIC)
+                    .hasOnlyPermissionTypes(PermissionType.READ));
+  }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/IdentitySetupInitializeDefaultsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/IdentitySetupInitializeDefaultsTest.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.authorization;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.processing.identity.AuthorizationCheckBehavior;
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.engine.util.EngineRule.ResetRecordingExporterMode;
+import io.camunda.zeebe.engine.util.EngineRule.ResetRecordingExporterTestWatcherMode;
+import io.camunda.zeebe.protocol.record.Assertions;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.IdentitySetupIntent;
+import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
+import io.camunda.zeebe.protocol.record.value.DefaultRole;
+import io.camunda.zeebe.protocol.record.value.PermissionType;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+public class IdentitySetupInitializeDefaultsTest {
+
+  @ClassRule
+  public static final EngineRule ENGINE =
+      EngineRule.singlePartition()
+          .withResetRecordingExporterTestWatcherMode(
+              ResetRecordingExporterTestWatcherMode.ONLY_BEFORE_AND_AFTER_ALL_TESTS)
+          .withIdentitySetup(ResetRecordingExporterMode.NO_RESET_AFTER_IDENTITY_SETUP);
+
+  @Test
+  public void shouldCreateAdminRoleByDefault() {
+    // then
+    assertThat(
+            RecordingExporter.records()
+                .limit(r -> r.getIntent() == IdentitySetupIntent.INITIALIZED)
+                .authorizationRecords()
+                .withOwnerId(DefaultRole.ADMIN.getId()))
+        .extracting(Record::getValue)
+        .describedAs("Expect all admin role authorizations to be owned by the admin role")
+        .allSatisfy(
+            auth ->
+                Assertions.assertThat(auth)
+                    .hasOwnerId(DefaultRole.ADMIN.getId())
+                    .hasOwnerType(AuthorizationOwnerType.ROLE))
+        .describedAs("Expect all admin role authorizations to have the wildcard resource ID")
+        .allSatisfy(
+            auth ->
+                Assertions.assertThat(auth)
+                    .hasResourceId(AuthorizationCheckBehavior.WILDCARD_PERMISSION))
+        .describedAs("Expect the admin role authorizations to have specific resource permissions")
+        .satisfiesExactlyInAnyOrder(
+            auth ->
+                Assertions.assertThat(auth)
+                    .hasResourceType(AuthorizationResourceType.AUTHORIZATION)
+                    .hasOnlyPermissionTypes(
+                        PermissionType.CREATE,
+                        PermissionType.READ,
+                        PermissionType.UPDATE,
+                        PermissionType.DELETE),
+            auth ->
+                Assertions.assertThat(auth)
+                    .hasResourceType(AuthorizationResourceType.MAPPING_RULE)
+                    .hasOnlyPermissionTypes(
+                        PermissionType.CREATE,
+                        PermissionType.READ,
+                        PermissionType.UPDATE,
+                        PermissionType.DELETE),
+            auth ->
+                Assertions.assertThat(auth)
+                    .hasResourceType(AuthorizationResourceType.MESSAGE)
+                    .hasOnlyPermissionTypes(PermissionType.CREATE, PermissionType.READ),
+            auth ->
+                Assertions.assertThat(auth)
+                    .hasResourceType(AuthorizationResourceType.APPLICATION)
+                    .hasOnlyPermissionTypes(PermissionType.ACCESS),
+            auth ->
+                Assertions.assertThat(auth)
+                    .hasResourceType(AuthorizationResourceType.SYSTEM)
+                    .hasOnlyPermissionTypes(PermissionType.READ, PermissionType.UPDATE),
+            auth ->
+                Assertions.assertThat(auth)
+                    .hasResourceType(AuthorizationResourceType.TENANT)
+                    .hasOnlyPermissionTypes(
+                        PermissionType.CREATE,
+                        PermissionType.READ,
+                        PermissionType.UPDATE,
+                        PermissionType.DELETE),
+            auth ->
+                Assertions.assertThat(auth)
+                    .hasResourceType(AuthorizationResourceType.RESOURCE)
+                    .hasOnlyPermissionTypes(
+                        PermissionType.READ,
+                        PermissionType.CREATE,
+                        PermissionType.DELETE_FORM,
+                        PermissionType.DELETE_PROCESS,
+                        PermissionType.DELETE_DRD,
+                        PermissionType.DELETE_RESOURCE),
+            auth ->
+                Assertions.assertThat(auth)
+                    .hasResourceType(AuthorizationResourceType.PROCESS_DEFINITION)
+                    .hasOnlyPermissionTypes(
+                        PermissionType.READ_PROCESS_DEFINITION,
+                        PermissionType.READ_PROCESS_INSTANCE,
+                        PermissionType.READ_USER_TASK,
+                        PermissionType.UPDATE_PROCESS_INSTANCE,
+                        PermissionType.UPDATE_USER_TASK,
+                        PermissionType.CREATE_PROCESS_INSTANCE,
+                        PermissionType.DELETE_PROCESS_INSTANCE),
+            auth ->
+                Assertions.assertThat(auth)
+                    .hasResourceType(AuthorizationResourceType.DECISION_REQUIREMENTS_DEFINITION)
+                    .hasOnlyPermissionTypes(
+                        PermissionType.READ, PermissionType.UPDATE, PermissionType.DELETE),
+            auth ->
+                Assertions.assertThat(auth)
+                    .hasResourceType(AuthorizationResourceType.DECISION_DEFINITION)
+                    .hasOnlyPermissionTypes(
+                        PermissionType.READ_DECISION_DEFINITION,
+                        PermissionType.READ_DECISION_INSTANCE,
+                        PermissionType.CREATE_DECISION_INSTANCE,
+                        PermissionType.DELETE_DECISION_INSTANCE),
+            auth ->
+                Assertions.assertThat(auth)
+                    .hasResourceType(AuthorizationResourceType.GROUP)
+                    .hasOnlyPermissionTypes(
+                        PermissionType.CREATE,
+                        PermissionType.READ,
+                        PermissionType.UPDATE,
+                        PermissionType.DELETE),
+            auth ->
+                Assertions.assertThat(auth)
+                    .hasResourceType(AuthorizationResourceType.USER)
+                    .hasOnlyPermissionTypes(
+                        PermissionType.CREATE,
+                        PermissionType.READ,
+                        PermissionType.UPDATE,
+                        PermissionType.DELETE),
+            auth ->
+                Assertions.assertThat(auth)
+                    .hasResourceType(AuthorizationResourceType.ROLE)
+                    .hasOnlyPermissionTypes(
+                        PermissionType.CREATE,
+                        PermissionType.READ,
+                        PermissionType.UPDATE,
+                        PermissionType.DELETE),
+            auth ->
+                Assertions.assertThat(auth)
+                    .hasResourceType(AuthorizationResourceType.BATCH)
+                    .hasOnlyPermissionTypes(
+                        PermissionType.CREATE,
+                        PermissionType.CREATE_BATCH_OPERATION_CANCEL_PROCESS_INSTANCE,
+                        PermissionType.CREATE_BATCH_OPERATION_DELETE_PROCESS_INSTANCE,
+                        PermissionType.CREATE_BATCH_OPERATION_MIGRATE_PROCESS_INSTANCE,
+                        PermissionType.CREATE_BATCH_OPERATION_MODIFY_PROCESS_INSTANCE,
+                        PermissionType.CREATE_BATCH_OPERATION_RESOLVE_INCIDENT,
+                        PermissionType.CREATE_BATCH_OPERATION_DELETE_DECISION_INSTANCE,
+                        PermissionType.CREATE_BATCH_OPERATION_DELETE_DECISION_DEFINITION,
+                        PermissionType.CREATE_BATCH_OPERATION_DELETE_PROCESS_DEFINITION,
+                        PermissionType.UPDATE,
+                        PermissionType.READ),
+            auth ->
+                Assertions.assertThat(auth)
+                    .hasResourceType(AuthorizationResourceType.USAGE_METRIC)
+                    .hasOnlyPermissionTypes(PermissionType.READ));
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/IdentitySetupInitializeDefaultsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/IdentitySetupInitializeDefaultsTest.java
@@ -291,4 +291,36 @@ public class IdentitySetupInitializeDefaultsTest {
                     .hasResourceType(AuthorizationResourceType.MESSAGE)
                     .hasOnlyPermissionTypes(PermissionType.CREATE));
   }
+
+  @Test
+  public void shouldCreateRpaRoleByDefault() {
+    // then
+    assertThat(
+            RecordingExporter.records()
+                .limit(r -> r.getIntent() == IdentitySetupIntent.INITIALIZED)
+                .authorizationRecords()
+                .withOwnerId(DefaultRole.RPA.getId()))
+        .extracting(Record::getValue)
+        .describedAs("Expect all RPA role authorizations to be owned by the RPA role")
+        .allSatisfy(
+            auth ->
+                Assertions.assertThat(auth)
+                    .hasOwnerId(DefaultRole.RPA.getId())
+                    .hasOwnerType(AuthorizationOwnerType.ROLE))
+        .describedAs("Expect all RPA role authorizations to have the wildcard resource ID")
+        .allSatisfy(
+            auth ->
+                Assertions.assertThat(auth)
+                    .hasResourceId(AuthorizationCheckBehavior.WILDCARD_PERMISSION))
+        .describedAs("Expect the RPA role authorizations to have specific resource permissions")
+        .satisfiesExactlyInAnyOrder(
+            auth ->
+                Assertions.assertThat(auth)
+                    .hasResourceType(AuthorizationResourceType.RESOURCE)
+                    .hasOnlyPermissionTypes(PermissionType.READ),
+            auth ->
+                Assertions.assertThat(auth)
+                    .hasResourceType(AuthorizationResourceType.PROCESS_DEFINITION)
+                    .hasOnlyPermissionTypes(PermissionType.UPDATE_PROCESS_INSTANCE));
+  }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
@@ -257,13 +257,17 @@ public final class EngineRule extends ExternalResource {
   public EngineRule withResetRecordingExporterTestWatcherMode(
       final ResetRecordingExporterTestWatcherMode resetMode) {
     resetRecordingExporterTestWatcherMode = resetMode;
-    switch (resetMode) {
-      case ONLY_BEFORE_AND_AFTER_ALL_TESTS ->
-          // so, never on individual tests
-          recordingExporterTestWatcher.withResetMode(ResetMode.NEVER);
-      case BEFORE_EACH_TEST -> recordingExporterTestWatcher.withResetMode(ResetMode.ON_STARTING);
-    }
-    return this;
+    return switch (resetMode) {
+      case ONLY_BEFORE_AND_AFTER_ALL_TESTS -> {
+        // so, never on individual tests
+        recordingExporterTestWatcher.withResetMode(ResetMode.NEVER);
+        yield this;
+      }
+      case BEFORE_EACH_TEST -> {
+        recordingExporterTestWatcher.withResetMode(ResetMode.ON_STARTING);
+        yield this;
+      }
+    };
   }
 
   private void startProcessors(final StreamProcessorMode mode, final boolean awaitOpening) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
@@ -110,6 +110,8 @@ public final class EngineRule extends ExternalResource {
       new RecordingExporterTestWatcher();
   private final int partitionCount;
   private boolean awaitIdentitySetup = false;
+  private ResetRecordingExporterMode awaitIdentitySetupResetMode =
+      ResetRecordingExporterMode.AFTER_IDENTITY_SETUP;
   private boolean initializeRoutingState = true;
 
   private Consumer<TypedRecord> onProcessedCallback = record -> {};
@@ -193,6 +195,12 @@ public final class EngineRule extends ExternalResource {
     awaitIdentitySetup = true;
     withFeatureFlags(ff -> ff.setEnableIdentitySetup(true));
     return this;
+  }
+
+  public EngineRule withIdentitySetup(
+      final ResetRecordingExporterMode awaitIdentitySetupResetMode) {
+    this.awaitIdentitySetupResetMode = awaitIdentitySetupResetMode;
+    return withIdentitySetup();
   }
 
   public EngineRule withJobStreamer(final JobStreamer jobStreamer) {
@@ -606,7 +614,10 @@ public final class EngineRule extends ExternalResource {
           .await();
     }
 
-    RecordingExporter.reset();
+    if (awaitIdentitySetupResetMode == ResetRecordingExporterMode.AFTER_IDENTITY_SETUP) {
+      // reset the RecordingExporter to avoid that the identity setup is included in the test
+      RecordingExporter.reset();
+    }
   }
 
   public void awaitProcessingOf(final Record<?> record) {
@@ -692,5 +703,10 @@ public final class EngineRule extends ExternalResource {
   public enum ResetRecordingExporterTestWatcherMode {
     ONLY_BEFORE_AND_AFTER_ALL_TESTS,
     BEFORE_EACH_TEST
+  }
+
+  public enum ResetRecordingExporterMode {
+    AFTER_IDENTITY_SETUP,
+    NO_RESET_AFTER_IDENTITY_SETUP
   }
 }

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordingExporterTestWatcher.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordingExporterTestWatcher.java
@@ -15,6 +15,7 @@ import org.slf4j.LoggerFactory;
 public final class RecordingExporterTestWatcher extends TestWatcher {
 
   public static final Logger LOG = LoggerFactory.getLogger("io.camunda.zeebe.test.records");
+  private ResetMode resetMode = ResetMode.ON_STARTING;
 
   @Override
   protected void failed(final Throwable e, final Description description) {
@@ -23,6 +24,26 @@ public final class RecordingExporterTestWatcher extends TestWatcher {
 
   @Override
   protected void starting(final Description description) {
-    RecordingExporter.reset();
+    if (resetMode == ResetMode.ON_STARTING) {
+      RecordingExporter.reset();
+    }
+  }
+
+  @Override
+  protected void finished(final Description description) {
+    if (resetMode == ResetMode.ON_FINISHED) {
+      RecordingExporter.reset();
+    }
+  }
+
+  public RecordingExporterTestWatcher withResetMode(final ResetMode resetMode) {
+    this.resetMode = resetMode;
+    return this;
+  }
+
+  public enum ResetMode {
+    ON_STARTING,
+    ON_FINISHED,
+    NEVER
   }
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

The [default RPA role](https://docs.camunda.io/docs/next/components/concepts/access-control/authorizations/#default-roles)'s authorizations did not have an owner type specified. This would be displayed as Unspecified. By specifying the owner type as Role, we align it to the authorizations of other default roles.

This PR also adds extensive test cases for the authorizations of the other default roles:
- `admin`
- `readonly-admin`
- `connectors`
- `rpa` (where the bug was)

The tests do not cover the entire default identity setup, which would also include users, mapping rules, the default tenant, tenant membership, and role membership.

> [!NOTE]
> To support the new tests, EngineRule tests now allows more control over when (or whether) the recording exporter is reset. The specific test resets only before and after all tests, it does not reset in between tests nor does it reset after awaiting the identity setup.
>
> Initially, I explored to control this directly from the test class, but that resulted in a lot more code. The current solution does not impact other tests, but still allows for the needed control.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #34144
