### PR TITLE
feat: configurable priority for Tasklist and Operate index templates

### DIFF
--- a/operate/common/src/main/java/io/camunda/operate/property/OperateElasticsearchProperties.java
+++ b/operate/common/src/main/java/io/camunda/operate/property/OperateElasticsearchProperties.java
@@ -17,6 +17,7 @@ public class OperateElasticsearchProperties extends ElasticsearchProperties {
   private static final String DEFAULT_REFRESH_INTERVAL = "1s";
 
   private String indexPrefix = DEFAULT_INDEX_PREFIX;
+  private Integer indexTemplatePriority;
   private int numberOfShards = DEFAULT_NUMBER_OF_SHARDS;
   private Map<String, Integer> numberOfShardsForIndices = Map.of();
   private int numberOfReplicas = DEFAULT_NUMBER_OF_REPLICAS;
@@ -81,5 +82,13 @@ public class OperateElasticsearchProperties extends ElasticsearchProperties {
 
   public int getNumberOfShards(final String indexName) {
     return numberOfShardsForIndices.getOrDefault(indexName, numberOfShards);
+  }
+
+  public Integer getIndexTemplatePriority() {
+    return indexTemplatePriority;
+  }
+
+  public void setIndexTemplatePriority(final Integer indexTemplatePriority) {
+    this.indexTemplatePriority = indexTemplatePriority;
   }
 }

--- a/operate/common/src/main/java/io/camunda/operate/property/OperateOpensearchProperties.java
+++ b/operate/common/src/main/java/io/camunda/operate/property/OperateOpensearchProperties.java
@@ -17,6 +17,7 @@ public class OperateOpensearchProperties extends OpensearchProperties {
   private static final String DEFAULT_REFRESH_INTERVAL = "1s";
 
   private String indexPrefix = DEFAULT_INDEX_PREFIX;
+  private Integer indexTemplatePriority;
   private int numberOfShards = DEFAULT_NUMBER_OF_SHARDS;
   private Map<String, Integer> numberOfShardsForIndices = Map.of();
   private int numberOfReplicas = DEFAULT_NUMBER_OF_REPLICAS;
@@ -81,5 +82,13 @@ public class OperateOpensearchProperties extends OpensearchProperties {
 
   public int getNumberOfShards(final String indexName) {
     return numberOfShardsForIndices.getOrDefault(indexName, numberOfShards);
+  }
+
+  public Integer getIndexTemplatePriority() {
+    return indexTemplatePriority;
+  }
+
+  public void setIndexTemplatePriority(final Integer indexTemplatePriority) {
+    this.indexTemplatePriority = indexTemplatePriority;
   }
 }

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/elasticsearch/SchemaCreationIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/elasticsearch/SchemaCreationIT.java
@@ -22,6 +22,7 @@ import io.camunda.operate.schema.indices.ProcessIndex;
 import io.camunda.operate.schema.migration.ProcessorStep;
 import io.camunda.operate.schema.templates.EventTemplate;
 import io.camunda.operate.schema.templates.ListViewTemplate;
+import io.camunda.operate.schema.templates.TemplateDescriptor;
 import io.camunda.operate.util.j5templates.OperateSearchAbstractIT;
 import io.camunda.operate.util.searchrepository.TestSearchRepository;
 import java.io.IOException;
@@ -54,6 +55,8 @@ public class SchemaCreationIT extends OperateSearchAbstractIT {
         operateProperties
             .getElasticsearch()
             .setNumberOfReplicasForIndices(numberOfReplicasForIndices);
+        operateProperties.getOpensearch().setIndexTemplatePriority(100);
+        operateProperties.getElasticsearch().setIndexTemplatePriority(100);
       };
 
   @Autowired private EventTemplate eventTemplate;
@@ -61,6 +64,7 @@ public class SchemaCreationIT extends OperateSearchAbstractIT {
   @Autowired private ProcessIndex processIndex;
   @Autowired private DecisionIndex decisionIndex;
   @Autowired private List<IndexDescriptor> indexDescriptors;
+  @Autowired private List<TemplateDescriptor> templateDescriptors;
   @Autowired private IndicesCheck indicesCheck;
   @Autowired private OperateProperties operateProperties;
 
@@ -153,6 +157,15 @@ public class SchemaCreationIT extends OperateSearchAbstractIT {
     for (final IndexDescriptor indexDescriptor : strictMappingIndices) {
       assertThatIndexHasDynamicMappingOf(
           indexDescriptor, TestSearchRepository.DynamicMappingType.Strict);
+    }
+  }
+
+  @Test
+  void testIndexTemplatePriority() {
+    for (final var templateDescriptor : templateDescriptors) {
+      assertThat(
+              testSearchRepository.getIndexTemplatePriority(templateDescriptor.getTemplateName()))
+          .isEqualTo(100L);
     }
   }
 

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/schema/util/SchemaTestHelper.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/schema/util/SchemaTestHelper.java
@@ -10,7 +10,6 @@ package io.camunda.operate.schema.util;
 import io.camunda.operate.schema.IndexMapping;
 import io.camunda.operate.schema.indices.IndexDescriptor;
 import io.camunda.operate.schema.templates.TemplateDescriptor;
-import java.util.Map;
 
 public interface SchemaTestHelper {
 
@@ -22,7 +21,9 @@ public interface SchemaTestHelper {
 
   void setReadOnly(String indexName, boolean readOnly);
 
-  Map<String, String> getComponentTemplateSettings(String componentTemplateName);
+  IndexSettings getComponentTemplateSettings(String componentTemplateName);
 
-  Map<String, String> getIndexTemplateSettings(String indexTemplateName);
+  IndexSettings getIndexTemplateSettings(String indexTemplateName);
+
+  record IndexSettings(String numberOfShards, String numberOfReplicas, Long priority) {}
 }

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/schema/util/elasticsearch/ElasticsearchSchemaTestHelper.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/schema/util/elasticsearch/ElasticsearchSchemaTestHelper.java
@@ -139,7 +139,7 @@ public class ElasticsearchSchemaTestHelper implements SchemaTestHelper {
   }
 
   @Override
-  public Map<String, String> getComponentTemplateSettings(final String componentTemplateName) {
+  public IndexSettings getComponentTemplateSettings(final String componentTemplateName) {
     final Settings settings;
     try {
       settings =
@@ -154,15 +154,12 @@ public class ElasticsearchSchemaTestHelper implements SchemaTestHelper {
     } catch (final IOException e) {
       throw new OperateRuntimeException(e);
     }
-    return Map.of(
-        NUMBERS_OF_REPLICA,
-        settings.get(NUMBERS_OF_REPLICA),
-        NUMBERS_OF_SHARDS,
-        settings.get(NUMBERS_OF_SHARDS));
+    return new IndexSettings(
+        settings.get(NUMBERS_OF_SHARDS), settings.get(NUMBERS_OF_REPLICA), null);
   }
 
   @Override
-  public Map<String, String> getIndexTemplateSettings(final String indexTemplateName) {
+  public IndexSettings getIndexTemplateSettings(final String indexTemplateName) {
     final ComposableIndexTemplate indexTemplate;
     try {
       indexTemplate =
@@ -176,10 +173,9 @@ public class ElasticsearchSchemaTestHelper implements SchemaTestHelper {
       throw new OperateRuntimeException(e);
     }
     final Settings settings = indexTemplate.template().settings();
-    return Map.of(
-        NUMBERS_OF_REPLICA,
+    return new IndexSettings(
+        settings.get(NUMBERS_OF_SHARDS),
         settings.get(NUMBERS_OF_REPLICA),
-        NUMBERS_OF_SHARDS,
-        settings.get(NUMBERS_OF_SHARDS));
+        indexTemplate.priority());
   }
 }

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/searchrepository/TestElasticSearchRepository.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/searchrepository/TestElasticSearchRepository.java
@@ -46,6 +46,7 @@ import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestHighLevelClient;
 import org.elasticsearch.client.indexlifecycle.GetLifecyclePolicyRequest;
 import org.elasticsearch.client.indices.CreateIndexRequest;
+import org.elasticsearch.client.indices.GetComposableIndexTemplateRequest;
 import org.elasticsearch.client.indices.GetIndexRequest;
 import org.elasticsearch.index.query.ConstantScoreQueryBuilder;
 import org.elasticsearch.index.query.IdsQueryBuilder;
@@ -390,6 +391,21 @@ public class TestElasticSearchRepository implements TestSearchRepository {
         throw ex;
       }
       return Optional.empty();
+    }
+  }
+
+  @Override
+  public Long getIndexTemplatePriority(final String templateName) {
+    try {
+      final var request = new GetComposableIndexTemplateRequest(templateName);
+      final var response = esClient.indices().getIndexTemplate(request, RequestOptions.DEFAULT);
+      final var templates = response.getIndexTemplates();
+      if (templates.isEmpty()) {
+        throw new IllegalStateException(templateName + " index template not found");
+      }
+      return templates.get(templateName).priority();
+    } catch (final IOException e) {
+      throw new RuntimeException(e);
     }
   }
 

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/searchrepository/TestOpenSearchRepository.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/searchrepository/TestOpenSearchRepository.java
@@ -47,6 +47,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import org.opensearch.client.opensearch.OpenSearchClient;
 import org.opensearch.client.opensearch._types.OpenSearchException;
 import org.opensearch.client.opensearch._types.mapping.DynamicMapping;
 import org.opensearch.client.opensearch._types.query_dsl.Query;
@@ -63,6 +64,8 @@ public class TestOpenSearchRepository implements TestSearchRepository {
   @Autowired private ZeebeRichOpenSearchClient zeebeRichOpenSearchClient;
 
   @Autowired private ObjectMapper objectMapper;
+
+  @Autowired private OpenSearchClient openSearchClient;
 
   @Override
   public boolean isConnected() {
@@ -391,6 +394,20 @@ public class TestOpenSearchRepository implements TestSearchRepository {
         throw ex;
       }
       return Optional.empty();
+    }
+  }
+
+  @Override
+  public Long getIndexTemplatePriority(final String templateName) {
+    try {
+      final var response =
+          openSearchClient.indices().getIndexTemplate(req -> req.name(templateName));
+      if (response.indexTemplates().isEmpty()) {
+        throw new IllegalStateException(templateName + " index template not found");
+      }
+      return response.indexTemplates().get(0).indexTemplate().priority();
+    } catch (final Exception e) {
+      throw new RuntimeException(e);
     }
   }
 }

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/searchrepository/TestSearchRepository.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/searchrepository/TestSearchRepository.java
@@ -85,6 +85,8 @@ public interface TestSearchRepository {
       String indexName, String idFieldName, List<Long> ids, boolean ignoreAbsentIndex)
       throws IOException;
 
+  Long getIndexTemplatePriority(String templateName);
+
   record IndexSettings(Integer shards, Integer replicas) {}
 
   enum DynamicMappingType {

--- a/operate/schema/src/main/java/io/camunda/operate/schema/elasticsearch/ElasticsearchSchemaManager.java
+++ b/operate/schema/src/main/java/io/camunda/operate/schema/elasticsearch/ElasticsearchSchemaManager.java
@@ -8,6 +8,7 @@
 package io.camunda.operate.schema.elasticsearch;
 
 import static io.camunda.operate.store.elasticsearch.RetryElasticsearchClient.NUMBERS_OF_SHARDS;
+import static java.util.Optional.ofNullable;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -433,6 +434,10 @@ public class ElasticsearchSchemaManager implements SchemaManager {
             .indexPatterns(List.of(templateDescriptor.getIndexPattern()))
             .template(template)
             .componentTemplates(List.of(componentTemplateName()))
+            .priority(
+                ofNullable(operateProperties.getElasticsearch().getIndexTemplatePriority())
+                    .map(Long::valueOf)
+                    .orElse(null))
             .build();
     final PutComposableIndexTemplateRequest request =
         new PutComposableIndexTemplateRequest()

--- a/operate/schema/src/main/java/io/camunda/operate/schema/opensearch/OpensearchSchemaManager.java
+++ b/operate/schema/src/main/java/io/camunda/operate/schema/opensearch/OpensearchSchemaManager.java
@@ -548,6 +548,7 @@ public class OpensearchSchemaManager implements SchemaManager {
               .indexPatterns(templateDescriptor.getIndexPattern())
               .template(template)
               .composedOf(componentTemplateName())
+              .priority(operateProperties.getOpensearch().getIndexTemplatePriority())
               .build();
       return request;
     } catch (final Exception ex) {

--- a/tasklist/common/src/main/java/io/camunda/tasklist/property/TasklistElasticsearchProperties.java
+++ b/tasklist/common/src/main/java/io/camunda/tasklist/property/TasklistElasticsearchProperties.java
@@ -16,6 +16,7 @@ public class TasklistElasticsearchProperties extends ElasticsearchProperties {
   private static final int DEFAULT_NUMBER_OF_REPLICAS = 0;
   private static final String DEFAULT_REFRESH_INTERVAL = "1s";
   private String indexPrefix = DEFAULT_INDEX_PREFIX;
+  private Integer indexTemplatePriority;
   private int numberOfShards = DEFAULT_NUMBER_OF_SHARDS;
   private int numberOfReplicas = DEFAULT_NUMBER_OF_REPLICAS;
   private Map<String, Integer> numberOfShardsPerIndex = Map.of();
@@ -81,5 +82,13 @@ public class TasklistElasticsearchProperties extends ElasticsearchProperties {
 
   public int getNumberOfReplicas(final String indexName) {
     return numberOfReplicasPerIndices.getOrDefault(indexName, numberOfReplicas);
+  }
+
+  public Integer getIndexTemplatePriority() {
+    return indexTemplatePriority;
+  }
+
+  public void setIndexTemplatePriority(final Integer indexTemplatePriority) {
+    this.indexTemplatePriority = indexTemplatePriority;
   }
 }

--- a/tasklist/common/src/main/java/io/camunda/tasklist/property/TasklistOpenSearchProperties.java
+++ b/tasklist/common/src/main/java/io/camunda/tasklist/property/TasklistOpenSearchProperties.java
@@ -16,6 +16,7 @@ public class TasklistOpenSearchProperties extends OpenSearchProperties {
   private static final int DEFAULT_NUMBER_OF_REPLICAS = 0;
   private static final String DEFAULT_REFRESH_INTERVAL = "1s";
   private String indexPrefix = DEFAULT_INDEX_PREFIX;
+  private Integer indexTemplatePriority;
   private int numberOfShards = DEFAULT_NUMBER_OF_SHARDS;
   private int numberOfReplicas = DEFAULT_NUMBER_OF_REPLICAS;
   private Map<String, Integer> numberOfShardsPerIndex = Map.of();
@@ -81,5 +82,13 @@ public class TasklistOpenSearchProperties extends OpenSearchProperties {
 
   public int getNumberOfReplicas(final String indexName) {
     return numberOfReplicasPerIndex.getOrDefault(indexName, numberOfReplicas);
+  }
+
+  public Integer getIndexTemplatePriority() {
+    return indexTemplatePriority;
+  }
+
+  public void setIndexTemplatePriority(final Integer indexTemplatePriority) {
+    this.indexTemplatePriority = indexTemplatePriority;
   }
 }

--- a/tasklist/els-schema/pom.xml
+++ b/tasklist/els-schema/pom.xml
@@ -181,6 +181,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.junit.platform</groupId>
+      <artifactId>junit-platform-commons</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-test</artifactId>
       <scope>test</scope>

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/schema/manager/ElasticsearchSchemaManager.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/schema/manager/ElasticsearchSchemaManager.java
@@ -34,6 +34,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -199,15 +200,23 @@ public class ElasticsearchSchemaManager implements SchemaManager {
               tasklistProperties
                   .getElasticsearch()
                   .getNumberOfReplicas(templateDescriptor.getIndexName()));
+      final var expectedPriority =
+          ofNullable(tasklistProperties.getElasticsearch().getIndexTemplatePriority())
+              .map(Long::valueOf)
+              .orElse(null);
       final var actualShards = indexTemplate.template().settings().get(NUMBERS_OF_SHARDS);
       final var actualReplicas = indexTemplate.template().settings().get(NUMBERS_OF_REPLICA);
+      final var actualPriority = indexTemplate.priority();
 
-      if (!expectedShards.equals(actualShards) || !expectedReplicas.equals(actualReplicas)) {
+      if (!expectedShards.equals(actualShards)
+          || !expectedReplicas.equals(actualReplicas)
+          || !Objects.equals(expectedPriority, actualPriority)) {
         LOGGER.info(
-            "Updating index template {} to shards={}, replicas={}",
+            "Updating index template {} to shards={}, replicas={}, priority={}",
             templateDescriptor.getTemplateName(),
             expectedShards,
-            expectedReplicas);
+            expectedReplicas,
+            expectedPriority);
         putIndexTemplate(prepareComposableTemplateRequest(templateDescriptor, null), true);
       }
     }

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/schema/manager/ElasticsearchSchemaManager.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/schema/manager/ElasticsearchSchemaManager.java
@@ -11,6 +11,7 @@ import static io.camunda.tasklist.es.RetryElasticsearchClient.DEFAULT_SHARDS;
 import static io.camunda.tasklist.es.RetryElasticsearchClient.NO_REPLICA;
 import static io.camunda.tasklist.es.RetryElasticsearchClient.NUMBERS_OF_REPLICA;
 import static io.camunda.tasklist.es.RetryElasticsearchClient.NUMBERS_OF_SHARDS;
+import static java.util.Optional.ofNullable;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -25,6 +26,7 @@ import io.camunda.tasklist.schema.indices.AbstractIndexDescriptor;
 import io.camunda.tasklist.schema.indices.IndexDescriptor;
 import io.camunda.tasklist.schema.templates.TemplateDescriptor;
 import io.camunda.tasklist.util.ElasticsearchJSONUtil;
+import io.camunda.zeebe.util.VisibleForTesting;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
@@ -321,7 +323,8 @@ public class ElasticsearchSchemaManager implements SchemaManager {
         indexDescriptor.getFullQualifiedName());
   }
 
-  private void createTemplate(final TemplateDescriptor templateDescriptor) {
+  @VisibleForTesting
+  void createTemplate(final TemplateDescriptor templateDescriptor) {
     createTemplate(templateDescriptor, null);
   }
 
@@ -367,6 +370,10 @@ public class ElasticsearchSchemaManager implements SchemaManager {
             .indexPatterns(List.of(templateDescriptor.getIndexPattern()))
             .template(template)
             .componentTemplates(List.of(getComponentTemplateName()))
+            .priority(
+                ofNullable(tasklistProperties.getElasticsearch().getIndexTemplatePriority())
+                    .map(Long::valueOf)
+                    .orElse(null))
             .build();
     final PutComposableIndexTemplateRequest request =
         new PutComposableIndexTemplateRequest()

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/schema/manager/OpenSearchSchemaManager.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/schema/manager/OpenSearchSchemaManager.java
@@ -311,6 +311,7 @@ public class OpenSearchSchemaManager implements SchemaManager {
             .template(getTemplateFrom(templateDescriptor))
             .name(templateDescriptor.getTemplateName())
             .composedOf(List.of(getComponentTemplateName()))
+            .priority(tasklistProperties.getOpenSearch().getIndexTemplatePriority())
             .build(),
         overwrite);
   }

--- a/tasklist/els-schema/src/test/java/io/camunda/tasklist/schema/manager/ElasticsearchSchemaManagerTest.java
+++ b/tasklist/els-schema/src/test/java/io/camunda/tasklist/schema/manager/ElasticsearchSchemaManagerTest.java
@@ -10,7 +10,7 @@ package io.camunda.tasklist.schema.manager;
 import static io.camunda.tasklist.property.TasklistProperties.ELASTIC_SEARCH;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.platform.commons.util.ReflectionUtils.tryToReadFieldValue;
-import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -64,7 +64,7 @@ class ElasticsearchSchemaManagerTest {
 
     // then
     final var requestCaptor = ArgumentCaptor.forClass(PutComposableIndexTemplateRequest.class);
-    verify(retryElasticsearchClient).createTemplate(requestCaptor.capture(), isNull());
+    verify(retryElasticsearchClient).createTemplate(requestCaptor.capture(), eq(false));
     final ComposableIndexTemplate indexTemplate =
         (ComposableIndexTemplate)
             tryToReadFieldValue(

--- a/tasklist/els-schema/src/test/java/io/camunda/tasklist/schema/manager/ElasticsearchSchemaManagerTest.java
+++ b/tasklist/els-schema/src/test/java/io/camunda/tasklist/schema/manager/ElasticsearchSchemaManagerTest.java
@@ -51,7 +51,7 @@ class ElasticsearchSchemaManagerTest {
   }
 
   @ParameterizedTest
-  @ValueSource(ints = {100})
+  @ValueSource(ints = {0, 100, Integer.MAX_VALUE})
   @NullSource
   void shouldSetIndexTemplatePriority(final Integer priority) throws Exception {
     // given

--- a/tasklist/els-schema/src/test/java/io/camunda/tasklist/schema/manager/ElasticsearchSchemaManagerTest.java
+++ b/tasklist/els-schema/src/test/java/io/camunda/tasklist/schema/manager/ElasticsearchSchemaManagerTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.tasklist.schema.manager;
+
+import static io.camunda.tasklist.property.TasklistProperties.ELASTIC_SEARCH;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.platform.commons.util.ReflectionUtils.tryToReadFieldValue;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.tasklist.es.RetryElasticsearchClient;
+import io.camunda.tasklist.property.TasklistElasticsearchProperties;
+import io.camunda.tasklist.property.TasklistProperties;
+import io.camunda.tasklist.schema.templates.TaskTemplate;
+import org.elasticsearch.client.indices.PutComposableIndexTemplateRequest;
+import org.elasticsearch.cluster.metadata.ComposableIndexTemplate;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ElasticsearchSchemaManagerTest {
+
+  @InjectMocks private ElasticsearchSchemaManager elasticsearchSchemaManager;
+
+  @Mock private TasklistProperties tasklistProperties;
+
+  @Mock private RetryElasticsearchClient retryElasticsearchClient;
+
+  @Spy @InjectMocks private TaskTemplate taskTemplate = new TaskTemplate();
+
+  @BeforeEach
+  public void setUp() {
+    when(tasklistProperties.getElasticsearch())
+        .thenReturn(mock(TasklistElasticsearchProperties.class));
+    when(tasklistProperties.getDatabase()).thenReturn(ELASTIC_SEARCH);
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {100})
+  @NullSource
+  void shouldSetIndexTemplatePriority(final Integer priority) throws Exception {
+    // given
+    final var elasticsearchProperties = mock(TasklistElasticsearchProperties.class);
+    when(tasklistProperties.getElasticsearch()).thenReturn(elasticsearchProperties);
+    when(elasticsearchProperties.getIndexTemplatePriority()).thenReturn(priority);
+
+    // when
+    elasticsearchSchemaManager.createTemplate(taskTemplate);
+
+    // then
+    final var requestCaptor = ArgumentCaptor.forClass(PutComposableIndexTemplateRequest.class);
+    verify(retryElasticsearchClient).createTemplate(requestCaptor.capture(), isNull());
+    final ComposableIndexTemplate indexTemplate =
+        (ComposableIndexTemplate)
+            tryToReadFieldValue(
+                    PutComposableIndexTemplateRequest.class,
+                    "indexTemplate",
+                    requestCaptor.getValue())
+                .get();
+    final var expectedPriority = priority != null ? Long.valueOf(priority) : null;
+    assertThat(indexTemplate.priority()).isEqualTo(expectedPriority);
+  }
+}

--- a/tasklist/els-schema/src/test/java/io/camunda/tasklist/schema/manager/OpenSearchSchemaManagerTest.java
+++ b/tasklist/els-schema/src/test/java/io/camunda/tasklist/schema/manager/OpenSearchSchemaManagerTest.java
@@ -9,7 +9,8 @@ package io.camunda.tasklist.schema.manager;
 
 import static io.camunda.tasklist.property.TasklistProperties.OPEN_SEARCH;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -24,6 +25,9 @@ import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Answers;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
@@ -34,6 +38,7 @@ import org.opensearch.client.json.jackson.JacksonJsonpMapper;
 import org.opensearch.client.opensearch.OpenSearchClient;
 import org.opensearch.client.opensearch._types.mapping.TypeMapping;
 import org.opensearch.client.opensearch.indices.CreateIndexRequest;
+import org.opensearch.client.opensearch.indices.PutIndexTemplateRequest;
 
 @ExtendWith(MockitoExtension.class)
 class OpenSearchSchemaManagerTest {
@@ -41,6 +46,8 @@ class OpenSearchSchemaManagerTest {
   @InjectMocks private OpenSearchSchemaManager openSearchSchemaManager;
 
   @Mock private TasklistProperties tasklistProperties;
+
+  @Mock private TasklistOpenSearchProperties openSearchProperties;
 
   @Mock private RetryOpenSearchClient retryOpenSearchClient;
 
@@ -53,7 +60,7 @@ class OpenSearchSchemaManagerTest {
 
   @BeforeEach
   public void setUp() {
-    when(tasklistProperties.getOpenSearch()).thenReturn(mock(TasklistOpenSearchProperties.class));
+    when(tasklistProperties.getOpenSearch()).thenReturn(openSearchProperties);
     when(tasklistProperties.getDatabase()).thenReturn(OPEN_SEARCH);
     when(openSearchClient._transport().jsonpMapper()).thenReturn(new JacksonJsonpMapper());
   }
@@ -79,6 +86,23 @@ class OpenSearchSchemaManagerTest {
     assertThat(request.settings().numberOfReplicas()).isEqualTo("2");
     assertThat(request.aliases().keySet().iterator().next()).isEqualTo("prefix-task-8.5.0_alias");
     validateMappings(request.mappings(), taskTemplate.getSchemaClasspathFilename());
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {100})
+  @NullSource
+  void shouldSetIndexTemplatePriority(final Integer priority) {
+    // given
+    when(openSearchProperties.getIndexTemplatePriority()).thenReturn(priority);
+
+    // when
+    openSearchSchemaManager.createTemplate(taskTemplate);
+
+    // then
+    final var requestCaptor = ArgumentCaptor.forClass(PutIndexTemplateRequest.class);
+    verify(retryOpenSearchClient).createTemplate(requestCaptor.capture(), eq(false));
+    final var request = requestCaptor.getValue();
+    assertThat(request.priority()).isEqualTo(priority);
   }
 
   private void validateMappings(final TypeMapping mapping, final String fileName)

--- a/tasklist/els-schema/src/test/java/io/camunda/tasklist/schema/manager/OpenSearchSchemaManagerTest.java
+++ b/tasklist/els-schema/src/test/java/io/camunda/tasklist/schema/manager/OpenSearchSchemaManagerTest.java
@@ -9,7 +9,6 @@ package io.camunda.tasklist.schema.manager;
 
 import static io.camunda.tasklist.property.TasklistProperties.OPEN_SEARCH;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;

--- a/tasklist/els-schema/src/test/java/io/camunda/tasklist/schema/manager/OpenSearchSchemaManagerTest.java
+++ b/tasklist/els-schema/src/test/java/io/camunda/tasklist/schema/manager/OpenSearchSchemaManagerTest.java
@@ -88,7 +88,7 @@ class OpenSearchSchemaManagerTest {
   }
 
   @ParameterizedTest
-  @ValueSource(ints = {100})
+  @ValueSource(ints = {0, 100, Integer.MAX_VALUE})
   @NullSource
   void shouldSetIndexTemplatePriority(final Integer priority) {
     // given


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Adds a new property in Operate and Tasklist exporters configurations
- `camunda.operate.elasticsearch.index-template-priority`
- `camunda.operate.opensearch.index-template-priority`
- `camunda.tasklist.elasticsearch.index-template-priority`
- `camunda.tasklist.opensearch.index-template-priority`

This configuration is set in Operate and Tasklist index templates priority setting, and it defaults to null (implicitly zero in ES and OS) when the configuration is not provided.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #36085 
