### PR TITLE
refactor: unified config: distribute the legacy properties dict across classes

### DIFF
--- a/configuration/pom.xml
+++ b/configuration/pom.xml
@@ -62,6 +62,18 @@
     </dependency>
 
     <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
@@ -76,18 +88,5 @@
       <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>
     </dependency>
-
-    <dependency>
-      <groupId>org.assertj</groupId>
-      <artifactId>assertj-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.springframework</groupId>
-      <artifactId>spring-test</artifactId>
-      <scope>test</scope>
-    </dependency>
-
   </dependencies>
 </project>

--- a/configuration/src/main/java/io/camunda/configuration/Metadata.java
+++ b/configuration/src/main/java/io/camunda/configuration/Metadata.java
@@ -7,12 +7,20 @@
  */
 package io.camunda.configuration;
 
-import io.camunda.configuration.UnifiedConfigurationHelper.BackwardsCompatibilityMode;
+import static io.camunda.configuration.UnifiedConfigurationHelper.BackwardsCompatibilityMode.SUPPORTED;
+
 import io.camunda.zeebe.dynamic.config.gossip.ClusterConfigurationGossiperConfig;
 import java.time.Duration;
+import java.util.Set;
 
 public class Metadata {
   private static final String PREFIX = "camunda.cluster.metadata.";
+  private static final Set<String> LEGACY_SYNC_DELAY_PROPERTIES =
+      Set.of("zeebe.broker.cluster.configManager.gossip.syncDelay");
+  private static final Set<String> LEGACY_SYNC_REQUEST_TIMEOUT_PROPERTIES =
+      Set.of("zeebe.broker.cluster.configManager.gossip.syncRequestTimeout");
+  private static final Set<String> LEGACY_GOSSIP_FANOUT_PROPERTIES =
+      Set.of("zeebe.broker.cluster.configManager.gossip.gossipFanout");
 
   /**
    * The delay between two sync requests in the ClusterConfigurationManager. A sync request is sent
@@ -29,7 +37,7 @@ public class Metadata {
 
   public Duration getSyncDelay() {
     return UnifiedConfigurationHelper.validateLegacyConfiguration(
-        PREFIX + "sync-delay", syncDelay, Duration.class, BackwardsCompatibilityMode.SUPPORTED);
+        PREFIX + "sync-delay", syncDelay, Duration.class, SUPPORTED, LEGACY_SYNC_DELAY_PROPERTIES);
   }
 
   public void setSyncDelay(final Duration syncDelay) {
@@ -41,7 +49,8 @@ public class Metadata {
         PREFIX + "sync-request-timeout",
         syncRequestTimeout,
         Duration.class,
-        BackwardsCompatibilityMode.SUPPORTED);
+        SUPPORTED,
+        LEGACY_SYNC_REQUEST_TIMEOUT_PROPERTIES);
   }
 
   public void setSyncRequestTimeout(final Duration syncRequestTimeout) {
@@ -53,7 +62,8 @@ public class Metadata {
         PREFIX + "gossip-fanout",
         gossipFanout,
         Integer.class,
-        BackwardsCompatibilityMode.SUPPORTED);
+        SUPPORTED,
+        LEGACY_GOSSIP_FANOUT_PROPERTIES);
   }
 
   public void setGossipFanout(final Integer gossipFanout) {


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
This PR scatters the dictionary that keeps the legacy config breadcrumbs corresponding to the new keys distributed across multiple classes, instead of accumulating it into one single place. This is in favor of code modularity and maintainability.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
