### PR TITLE
fix: update exporter position when skipping records

### DIFF
--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporter.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporter.java
@@ -125,6 +125,10 @@ public class ElasticsearchExporter implements Exporter {
   public void export(final Record<?> record) {
 
     if (!shouldExportRecord(record)) {
+      // ignore the record but still update the last exported position
+      // so that we don't block compaction.
+      lastPosition = record.getPosition();
+      updateLastExportedPosition();
       return;
     }
     schemaManager.createSchema(record.getBrokerVersion());

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterTest.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterTest.java
@@ -326,6 +326,28 @@ final class ElasticsearchExporterTest {
     }
 
     @Test
+    void shouldUpdatePositionWhenSkippingDisabledRecordType() {
+      // given
+      TestSupport.setIndexingForValueType(config.index, ValueType.PROCESS_INSTANCE, false);
+      final var record =
+          ImmutableRecord.builder()
+              .withPosition(10L)
+              .withBrokerVersion(VersionUtil.getVersionLowerCase())
+              .withValueType(ValueType.PROCESS_INSTANCE)
+              .build();
+      exporter.configure(context);
+      exporter.open(controller);
+
+      // when
+      exporter.export(record);
+
+      // then
+      assertThat(controller.getPosition()).isEqualTo(10L);
+      verify(client, never()).index(any(), any());
+      verify(client, never()).flush();
+    }
+
+    @Test
     void shouldNotUpdatePositionOnFlushErrors() {
       // given
       final var record =


### PR DESCRIPTION
This is required so that the exporter position can always make progress and not block compaction when there's a long run of ignored records.