### PR TITLE
feat: enhance /usage-metrics with tu info

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/UsageMetricTUEntityMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/UsageMetricTUEntityMapper.java
@@ -18,15 +18,12 @@ import java.util.Optional;
 public class UsageMetricTUEntityMapper {
 
   public static UsageMetricTUStatisticsEntity toEntity(
-      final List<UsageMetricTUTenantStatisticsDbModel> dbModels) {
-
-    long totalTu = 0;
+      final List<UsageMetricTUTenantStatisticsDbModel> dbModels, final Long totalTu) {
 
     final var tenants = new HashMap<String, UsageMetricTUStatisticsEntityTenant>(dbModels.size());
 
     for (final UsageMetricTUTenantStatisticsDbModel dbModel : dbModels) {
       final long tenantTu = Optional.ofNullable(dbModel.tu()).orElse(0L);
-      totalTu += tenantTu;
       tenants.put(dbModel.tenantId(), new Builder().tu(tenantTu).build());
     }
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/UsageMetricTUEntityMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/UsageMetricTUEntityMapper.java
@@ -20,16 +20,16 @@ public class UsageMetricTUEntityMapper {
   public static UsageMetricTUStatisticsEntity toEntity(
       final List<UsageMetricTUTenantStatisticsDbModel> dbModels) {
 
-    long totalAtu = 0;
+    long totalTu = 0;
 
     final var tenants = new HashMap<String, UsageMetricTUStatisticsEntityTenant>(dbModels.size());
 
     for (final UsageMetricTUTenantStatisticsDbModel dbModel : dbModels) {
-      final long tenantAtu = Optional.ofNullable(dbModel.tu()).orElse(0L);
-      totalAtu += tenantAtu;
-      tenants.put(dbModel.tenantId(), new Builder().atu(tenantAtu).build());
+      final long tenantTu = Optional.ofNullable(dbModel.tu()).orElse(0L);
+      totalTu += tenantTu;
+      tenants.put(dbModel.tenantId(), new Builder().tu(tenantTu).build());
     }
 
-    return new UsageMetricTUStatisticsEntity(totalAtu, tenants);
+    return new UsageMetricTUStatisticsEntity(totalTu, tenants);
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/UsageMetricTUDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/UsageMetricTUDbReader.java
@@ -13,7 +13,7 @@ import io.camunda.db.rdbms.read.mapper.UsageMetricTUEntityMapper;
 import io.camunda.db.rdbms.sql.UsageMetricTUMapper;
 import io.camunda.search.clients.reader.UsageMetricsTUReader;
 import io.camunda.search.entities.UsageMetricTUStatisticsEntity;
-import io.camunda.search.query.UsageMetricsQuery;
+import io.camunda.search.query.UsageMetricsTUQuery;
 import io.camunda.security.reader.ResourceAccessChecks;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -27,17 +27,19 @@ public class UsageMetricTUDbReader implements UsageMetricsTUReader {
     this.usageMetricTUMapper = usageMetricTUMapper;
   }
 
+  @Override
   public UsageMetricTUStatisticsEntity usageMetricTUStatistics(
-      final UsageMetricsQuery query, final ResourceAccessChecks access) {
+      final UsageMetricsTUQuery query, final ResourceAccessChecks access) {
     LOG.trace("[RDBMS DB] Usage metrics assignees with {}", query);
     final var filter = query.filter();
 
+    final var tuStatistics = usageMetricTUMapper.usageMetricTUStatistics(filter);
+    final var totalTu = ofNullable(tuStatistics.tu()).orElse(0L);
     if (filter.withTenants()) {
       final var result = usageMetricTUMapper.usageMetricTUTenantsStatistics(filter);
-      return UsageMetricTUEntityMapper.toEntity(result);
+      return UsageMetricTUEntityMapper.toEntity(result, totalTu);
     } else {
-      final var result = usageMetricTUMapper.usageMetricTUStatistics(filter);
-      return new UsageMetricTUStatisticsEntity(ofNullable(result.tu()).orElse(0L), null);
+      return new UsageMetricTUStatisticsEntity(totalTu, null);
     }
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/UsageMetricTUDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/UsageMetricTUDbReader.java
@@ -11,13 +11,14 @@ import static java.util.Optional.ofNullable;
 
 import io.camunda.db.rdbms.read.mapper.UsageMetricTUEntityMapper;
 import io.camunda.db.rdbms.sql.UsageMetricTUMapper;
+import io.camunda.search.clients.reader.UsageMetricsTUReader;
 import io.camunda.search.entities.UsageMetricTUStatisticsEntity;
 import io.camunda.search.query.UsageMetricsQuery;
 import io.camunda.security.reader.ResourceAccessChecks;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class UsageMetricTUDbReader {
+public class UsageMetricTUDbReader implements UsageMetricsTUReader {
 
   private static final Logger LOG = LoggerFactory.getLogger(UsageMetricTUDbReader.class);
   private final UsageMetricTUMapper usageMetricTUMapper;

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/UsageMetricTUMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/UsageMetricTUMapper.java
@@ -10,15 +10,15 @@ package io.camunda.db.rdbms.sql;
 import io.camunda.db.rdbms.sql.HistoryCleanupMapper.CleanupHistoryDto;
 import io.camunda.db.rdbms.write.domain.UsageMetricTUDbModel.UsageMetricTUStatisticsDbModel;
 import io.camunda.db.rdbms.write.domain.UsageMetricTUDbModel.UsageMetricTUTenantStatisticsDbModel;
-import io.camunda.search.filter.UsageMetricsFilter;
+import io.camunda.search.filter.UsageMetricsTUFilter;
 import java.util.List;
 
 public interface UsageMetricTUMapper {
 
   List<UsageMetricTUTenantStatisticsDbModel> usageMetricTUTenantsStatistics(
-      final UsageMetricsFilter filter);
+      final UsageMetricsTUFilter filter);
 
-  UsageMetricTUStatisticsDbModel usageMetricTUStatistics(final UsageMetricsFilter filter);
+  UsageMetricTUStatisticsDbModel usageMetricTUStatistics(final UsageMetricsTUFilter filter);
 
   int cleanupMetrics(CleanupHistoryDto dto);
 }

--- a/dist/src/main/java/io/camunda/application/commons/search/SearchClientDatabaseConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/search/SearchClientDatabaseConfiguration.java
@@ -38,6 +38,7 @@ import io.camunda.search.clients.reader.SequenceFlowReader;
 import io.camunda.search.clients.reader.TenantMemberReader;
 import io.camunda.search.clients.reader.TenantReader;
 import io.camunda.search.clients.reader.UsageMetricsReader;
+import io.camunda.search.clients.reader.UsageMetricsTUReader;
 import io.camunda.search.clients.reader.UserReader;
 import io.camunda.search.clients.reader.UserTaskReader;
 import io.camunda.search.clients.reader.VariableReader;
@@ -125,6 +126,7 @@ public class SearchClientDatabaseConfiguration {
       final TenantReader tenantReader,
       final TenantMemberReader tenantMemberReader,
       final UsageMetricsReader usageMetricsReader,
+      final UsageMetricsTUReader usageMetricsTUReader,
       final UserReader userReader,
       final UserTaskReader userTaskReader,
       final VariableReader variableReader) {
@@ -153,6 +155,7 @@ public class SearchClientDatabaseConfiguration {
         tenantReader,
         tenantMemberReader,
         usageMetricsReader,
+        usageMetricsTUReader,
         userReader,
         userTaskReader,
         variableReader);

--- a/dist/src/main/java/io/camunda/application/commons/search/SearchClientReaderConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/search/SearchClientReaderConfiguration.java
@@ -76,10 +76,11 @@ import io.camunda.webapps.schema.descriptors.index.DecisionRequirementsIndex;
 import io.camunda.webapps.schema.descriptors.index.FormIndex;
 import io.camunda.webapps.schema.descriptors.index.GroupIndex;
 import io.camunda.webapps.schema.descriptors.index.MappingRuleIndex;
-import io.camunda.webapps.schema.descriptors.index.MetricIndex;
 import io.camunda.webapps.schema.descriptors.index.ProcessIndex;
 import io.camunda.webapps.schema.descriptors.index.RoleIndex;
 import io.camunda.webapps.schema.descriptors.index.TenantIndex;
+import io.camunda.webapps.schema.descriptors.index.UsageMetricIndex;
+import io.camunda.webapps.schema.descriptors.index.UsageMetricTUIndex;
 import io.camunda.webapps.schema.descriptors.index.UserIndex;
 import io.camunda.webapps.schema.descriptors.template.BatchOperationTemplate;
 import io.camunda.webapps.schema.descriptors.template.DecisionInstanceTemplate;
@@ -288,13 +289,13 @@ public class SearchClientReaderConfiguration {
   @Bean
   public UsageMetricsReader usageMetricsReader(
       final SearchClientBasedQueryExecutor executor, final IndexDescriptors descriptors) {
-    return new UsageMetricsDocumentReader(executor, descriptors.get(MetricIndex.class));
+    return new UsageMetricsDocumentReader(executor, descriptors.get(UsageMetricIndex.class));
   }
 
   @Bean
   public UsageMetricsTUReader usageMetricsTUReader(
       final SearchClientBasedQueryExecutor executor, final IndexDescriptors descriptors) {
-    return new UsageMetricsTUDocumentReader(executor, descriptors.get(MetricIndex.class));
+    return new UsageMetricsTUDocumentReader(executor, descriptors.get(UsageMetricTUIndex.class));
   }
 
   @Bean

--- a/search/search-client-elasticsearch/src/main/java/io/camunda/search/es/transformers/aggregator/SearchAggregationResultTransformer.java
+++ b/search/search-client-elasticsearch/src/main/java/io/camunda/search/es/transformers/aggregator/SearchAggregationResultTransformer.java
@@ -11,6 +11,7 @@ import co.elastic.clients.elasticsearch._types.FieldValue;
 import co.elastic.clients.elasticsearch._types.aggregations.Aggregate;
 import co.elastic.clients.elasticsearch._types.aggregations.CompositeAggregate;
 import co.elastic.clients.elasticsearch._types.aggregations.CompositeBucket;
+import co.elastic.clients.elasticsearch._types.aggregations.LongTermsAggregate;
 import co.elastic.clients.elasticsearch._types.aggregations.LongTermsBucket;
 import co.elastic.clients.elasticsearch._types.aggregations.MultiBucketAggregateBase;
 import co.elastic.clients.elasticsearch._types.aggregations.MultiBucketBase;
@@ -61,6 +62,10 @@ public class SearchAggregationResultTransformer<T>
         .docCount(aggregate.docCount())
         .aggregations(transformAggregation(aggregate.aggregations()))
         .build();
+  }
+
+  private AggregationResult transformLTermsBucketAggregate(final LongTermsAggregate aggregate) {
+    return new Builder().docCount((long) aggregate.buckets().array().size()).build();
   }
 
   private AggregationResult transformSingleMetricAggregate(
@@ -176,6 +181,7 @@ public class SearchAggregationResultTransformer<T>
             case Filter -> res = transformSingleBucketAggregate(aggregate.filter());
             case Filters -> res = transformMultiBucketAggregate(aggregate.filters());
             case Sterms -> res = transformMultiBucketAggregate(aggregate.sterms());
+            case Lterms -> res = transformLTermsBucketAggregate(aggregate.lterms());
             case Composite -> res = transformMultiBucketAggregate(aggregate.composite());
             case TopHits -> res = transformTopHitsAggregate(key, aggregate.topHits());
             case Sum -> res = transformSingleMetricAggregate(aggregate.sum());

--- a/search/search-client-opensearch/src/main/java/io/camunda/search/os/transformers/aggregator/SearchAggregationResultTransformer.java
+++ b/search/search-client-opensearch/src/main/java/io/camunda/search/os/transformers/aggregator/SearchAggregationResultTransformer.java
@@ -27,6 +27,7 @@ import org.opensearch.client.json.JsonData;
 import org.opensearch.client.opensearch._types.aggregations.Aggregate;
 import org.opensearch.client.opensearch._types.aggregations.CompositeAggregate;
 import org.opensearch.client.opensearch._types.aggregations.CompositeBucket;
+import org.opensearch.client.opensearch._types.aggregations.LongTermsAggregate;
 import org.opensearch.client.opensearch._types.aggregations.LongTermsBucket;
 import org.opensearch.client.opensearch._types.aggregations.MultiBucketAggregateBase;
 import org.opensearch.client.opensearch._types.aggregations.MultiBucketBase;
@@ -60,6 +61,10 @@ public class SearchAggregationResultTransformer<T>
         .docCount(aggregate.docCount())
         .aggregations(transformAggregation(aggregate.aggregations()))
         .build();
+  }
+
+  private AggregationResult transformLTermsBucketAggregate(final LongTermsAggregate aggregate) {
+    return new Builder().docCount((long) aggregate.buckets().array().size()).build();
   }
 
   private AggregationResult transformSingleMetricAggregate(
@@ -176,6 +181,7 @@ public class SearchAggregationResultTransformer<T>
             case Filter -> res = transformSingleBucketAggregate(aggregate.filter());
             case Filters -> res = transformMultiBucketAggregate(aggregate.filters());
             case Sterms -> res = transformMultiBucketAggregate(aggregate.sterms());
+            case Lterms -> res = transformLTermsBucketAggregate(aggregate.lterms());
             case Composite -> res = transformMultiBucketAggregate(aggregate.composite());
             case TopHits -> res = transformTopHitsAggregate(key, aggregate.topHits());
             case Sum -> res = transformSingleMetricAggregate(aggregate.sum());

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/UsageMetricsTUDocumentReader.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/UsageMetricsTUDocumentReader.java
@@ -7,9 +7,9 @@
  */
 package io.camunda.search.clients.reader;
 
+import io.camunda.search.aggregation.result.UsageMetricsTUAggregationResult;
 import io.camunda.search.clients.SearchClientBasedQueryExecutor;
-import io.camunda.search.entities.UsageMetricsTUEntity;
-import io.camunda.search.query.SearchQueryResult;
+import io.camunda.search.entities.UsageMetricTUStatisticsEntity;
 import io.camunda.search.query.UsageMetricsQuery;
 import io.camunda.security.reader.ResourceAccessChecks;
 import io.camunda.webapps.schema.descriptors.IndexDescriptor;
@@ -23,12 +23,10 @@ public class UsageMetricsTUDocumentReader extends DocumentBasedReader
   }
 
   @Override
-  public SearchQueryResult<UsageMetricsTUEntity> search(
+  public UsageMetricTUStatisticsEntity usageMetricTUStatistics(
       final UsageMetricsQuery query, final ResourceAccessChecks resourceAccessChecks) {
     return getSearchExecutor()
-        .search(
-            query,
-            io.camunda.webapps.schema.entities.metrics.UsageMetricsTUEntity.class,
-            resourceAccessChecks);
+        .aggregate(query, UsageMetricsTUAggregationResult.class, resourceAccessChecks)
+        .result();
   }
 }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/UsageMetricsTUDocumentReader.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/UsageMetricsTUDocumentReader.java
@@ -10,7 +10,7 @@ package io.camunda.search.clients.reader;
 import io.camunda.search.aggregation.result.UsageMetricsTUAggregationResult;
 import io.camunda.search.clients.SearchClientBasedQueryExecutor;
 import io.camunda.search.entities.UsageMetricTUStatisticsEntity;
-import io.camunda.search.query.UsageMetricsQuery;
+import io.camunda.search.query.UsageMetricsTUQuery;
 import io.camunda.security.reader.ResourceAccessChecks;
 import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 
@@ -24,7 +24,7 @@ public class UsageMetricsTUDocumentReader extends DocumentBasedReader
 
   @Override
   public UsageMetricTUStatisticsEntity usageMetricTUStatistics(
-      final UsageMetricsQuery query, final ResourceAccessChecks resourceAccessChecks) {
+      final UsageMetricsTUQuery query, final ResourceAccessChecks resourceAccessChecks) {
     return getSearchExecutor()
         .aggregate(query, UsageMetricsTUAggregationResult.class, resourceAccessChecks)
         .result();

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/ServiceTransformers.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/ServiceTransformers.java
@@ -17,6 +17,7 @@ import io.camunda.search.aggregation.result.ProcessDefinitionFlowNodeStatisticsA
 import io.camunda.search.aggregation.result.ProcessDefinitionLatestVersionAggregationResult;
 import io.camunda.search.aggregation.result.ProcessInstanceFlowNodeStatisticsAggregationResult;
 import io.camunda.search.aggregation.result.UsageMetricsAggregationResult;
+import io.camunda.search.aggregation.result.UsageMetricsTUAggregationResult;
 import io.camunda.search.clients.aggregator.SearchAggregator;
 import io.camunda.search.clients.core.AggregationResult;
 import io.camunda.search.clients.core.SearchQueryRequest;
@@ -31,6 +32,7 @@ import io.camunda.search.clients.transformers.aggregation.result.ProcessDefiniti
 import io.camunda.search.clients.transformers.aggregation.result.ProcessDefinitionLatestVersionAggregationResultTransformer;
 import io.camunda.search.clients.transformers.aggregation.result.ProcessInstanceFlowNodeStatisticsAggregationResultTransformer;
 import io.camunda.search.clients.transformers.aggregation.result.UsageMetricsAggregationResultTransformer;
+import io.camunda.search.clients.transformers.aggregation.result.UsageMetricsTUAggregationResultTransformer;
 import io.camunda.search.clients.transformers.entity.AuthorizationEntityTransformer;
 import io.camunda.search.clients.transformers.entity.BatchOperationEntityTransformer;
 import io.camunda.search.clients.transformers.entity.BatchOperationItemEntityTransformer;
@@ -480,5 +482,7 @@ public final class ServiceTransformers {
         new ProcessDefinitionLatestVersionAggregationResultTransformer());
     mappers.put(
         UsageMetricsAggregationResult.class, new UsageMetricsAggregationResultTransformer());
+    mappers.put(
+        UsageMetricsTUAggregationResult.class, new UsageMetricsTUAggregationResultTransformer());
   }
 }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/ServiceTransformers.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/ServiceTransformers.java
@@ -12,6 +12,7 @@ import io.camunda.search.aggregation.ProcessDefinitionFlowNodeStatisticsAggregat
 import io.camunda.search.aggregation.ProcessDefinitionLatestVersionAggregation;
 import io.camunda.search.aggregation.ProcessInstanceFlowNodeStatisticsAggregation;
 import io.camunda.search.aggregation.UsageMetricsAggregation;
+import io.camunda.search.aggregation.UsageMetricsTUAggregation;
 import io.camunda.search.aggregation.result.AggregationResultBase;
 import io.camunda.search.aggregation.result.ProcessDefinitionFlowNodeStatisticsAggregationResult;
 import io.camunda.search.aggregation.result.ProcessDefinitionLatestVersionAggregationResult;
@@ -27,6 +28,7 @@ import io.camunda.search.clients.transformers.aggregation.ProcessDefinitionFlowN
 import io.camunda.search.clients.transformers.aggregation.ProcessDefinitionLatestVersionAggregationTransformer;
 import io.camunda.search.clients.transformers.aggregation.ProcessInstanceFlowNodeStatisticsAggregationTransformer;
 import io.camunda.search.clients.transformers.aggregation.UsageMetricsAggregationTransformer;
+import io.camunda.search.clients.transformers.aggregation.UsageMetricsTUAggregationTransformer;
 import io.camunda.search.clients.transformers.aggregation.result.AggregationResultTransformer;
 import io.camunda.search.clients.transformers.aggregation.result.ProcessDefinitionFlowNodeStatisticsAggregationResultTransformer;
 import io.camunda.search.clients.transformers.aggregation.result.ProcessDefinitionLatestVersionAggregationResultTransformer;
@@ -80,6 +82,7 @@ import io.camunda.search.clients.transformers.filter.RoleFilterTransformer;
 import io.camunda.search.clients.transformers.filter.SequenceFlowFilterTransformer;
 import io.camunda.search.clients.transformers.filter.TenantFilterTransformer;
 import io.camunda.search.clients.transformers.filter.UsageMetricsFilterTransformer;
+import io.camunda.search.clients.transformers.filter.UsageMetricsTUFilterTransformer;
 import io.camunda.search.clients.transformers.filter.UserFilterTransformer;
 import io.camunda.search.clients.transformers.filter.UserTaskFilterTransformer;
 import io.camunda.search.clients.transformers.filter.VariableFilterTransformer;
@@ -133,6 +136,7 @@ import io.camunda.search.filter.RoleFilter;
 import io.camunda.search.filter.SequenceFlowFilter;
 import io.camunda.search.filter.TenantFilter;
 import io.camunda.search.filter.UsageMetricsFilter;
+import io.camunda.search.filter.UsageMetricsTUFilter;
 import io.camunda.search.filter.UserFilter;
 import io.camunda.search.filter.UserTaskFilter;
 import io.camunda.search.filter.VariableFilter;
@@ -159,6 +163,7 @@ import io.camunda.search.query.SequenceFlowQuery;
 import io.camunda.search.query.TenantQuery;
 import io.camunda.search.query.TypedSearchQuery;
 import io.camunda.search.query.UsageMetricsQuery;
+import io.camunda.search.query.UsageMetricsTUQuery;
 import io.camunda.search.query.UserQuery;
 import io.camunda.search.query.UserTaskQuery;
 import io.camunda.search.query.VariableQuery;
@@ -198,6 +203,7 @@ import io.camunda.webapps.schema.descriptors.index.ProcessIndex;
 import io.camunda.webapps.schema.descriptors.index.RoleIndex;
 import io.camunda.webapps.schema.descriptors.index.TenantIndex;
 import io.camunda.webapps.schema.descriptors.index.UsageMetricIndex;
+import io.camunda.webapps.schema.descriptors.index.UsageMetricTUIndex;
 import io.camunda.webapps.schema.descriptors.index.UserIndex;
 import io.camunda.webapps.schema.descriptors.template.BatchOperationTemplate;
 import io.camunda.webapps.schema.descriptors.template.DecisionInstanceTemplate;
@@ -321,6 +327,7 @@ public final class ServiceTransformers {
             UserQuery.class,
             VariableQuery.class,
             UsageMetricsQuery.class,
+            UsageMetricsTUQuery.class,
             SequenceFlowQuery.class,
             JobQuery.class,
             MessageSubscriptionQuery.class)
@@ -428,6 +435,9 @@ public final class ServiceTransformers {
         UsageMetricsFilter.class,
         new UsageMetricsFilterTransformer(indexDescriptors.get(UsageMetricIndex.class)));
     mappers.put(
+        UsageMetricsTUFilter.class,
+        new UsageMetricsTUFilterTransformer(indexDescriptors.get(UsageMetricTUIndex.class)));
+    mappers.put(
         ProcessDefinitionStatisticsFilter.class,
         new ProcessDefinitionStatisticsFilterTransformer(
             mappers, indexDescriptors.get(ListViewTemplate.class)));
@@ -469,6 +479,7 @@ public final class ServiceTransformers {
         ProcessDefinitionLatestVersionAggregation.class,
         new ProcessDefinitionLatestVersionAggregationTransformer());
     mappers.put(UsageMetricsAggregation.class, new UsageMetricsAggregationTransformer());
+    mappers.put(UsageMetricsTUAggregation.class, new UsageMetricsTUAggregationTransformer());
 
     // aggregation result
     mappers.put(

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/aggregation/UsageMetricsTUAggregationTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/aggregation/UsageMetricsTUAggregationTransformer.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.aggregation;
+
+import static io.camunda.search.aggregation.UsageMetricsTUAggregation.AGGREGATION_TERMS_ASSIGNEE_HASH;
+import static io.camunda.search.aggregation.UsageMetricsTUAggregation.AGGREGATION_TERMS_SIZE;
+import static io.camunda.search.aggregation.UsageMetricsTUAggregation.AGGREGATION_TERMS_TENANT_ID;
+import static io.camunda.search.clients.aggregator.SearchAggregatorBuilders.terms;
+
+import io.camunda.search.aggregation.UsageMetricsTUAggregation;
+import io.camunda.search.clients.aggregator.SearchAggregator;
+import io.camunda.search.clients.transformers.ServiceTransformers;
+import io.camunda.webapps.schema.descriptors.index.UsageMetricTUIndex;
+import io.camunda.zeebe.util.collection.Tuple;
+import java.util.List;
+
+public class UsageMetricsTUAggregationTransformer
+    implements AggregationTransformer<UsageMetricsTUAggregation> {
+
+  @Override
+  public List<SearchAggregator> apply(
+      final Tuple<UsageMetricsTUAggregation, ServiceTransformers> value) {
+
+    final var termsEventTypeAgg =
+        terms()
+            .name(AGGREGATION_TERMS_ASSIGNEE_HASH)
+            .field(UsageMetricTUIndex.ASSIGNEE_HASH)
+            .size(AGGREGATION_TERMS_SIZE)
+            .build();
+
+    final var termTenantAgg =
+        terms()
+            .name(AGGREGATION_TERMS_TENANT_ID)
+            .field(UsageMetricTUIndex.TENANT_ID)
+            .size(AGGREGATION_TERMS_SIZE)
+            .aggregations(termsEventTypeAgg)
+            .build();
+
+    final var filter = value.getLeft().filter();
+    return filter.withTenants()
+        ? List.of(termsEventTypeAgg, termTenantAgg)
+        : List.of(termsEventTypeAgg);
+  }
+}

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/aggregation/result/UsageMetricsTUAggregationResultTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/aggregation/result/UsageMetricsTUAggregationResultTransformer.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.aggregation.result;
+
+import io.camunda.search.aggregation.UsageMetricsAggregation;
+import io.camunda.search.aggregation.result.UsageMetricsTUAggregationResult;
+import io.camunda.search.clients.core.AggregationResult;
+import io.camunda.search.entities.UsageMetricTUStatisticsEntity;
+import io.camunda.search.entities.UsageMetricTUStatisticsEntity.UsageMetricTUStatisticsEntityTenant;
+import io.camunda.search.entities.UsageMetricTUStatisticsEntity.UsageMetricTUStatisticsEntityTenant.Builder;
+import io.camunda.webapps.schema.entities.metrics.UsageMetricsEventType;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+
+public class UsageMetricsTUAggregationResultTransformer
+    implements AggregationResultTransformer<UsageMetricsTUAggregationResult> {
+
+  private long extractMetricCount(
+      final AggregationResult eventTypes, final UsageMetricsEventType metricName) {
+    final var metric = eventTypes.aggregations().get(metricName.name());
+    if (metric != null) {
+      return metric
+          .aggregations()
+          .get(UsageMetricsAggregation.AGGREGATION_SUM_EVENT_TYPE)
+          .docCount();
+    }
+    return 0;
+  }
+
+  @Override
+  public UsageMetricsTUAggregationResult apply(final Map<String, AggregationResult> aggregations) {
+
+    final boolean withTenants =
+        !aggregations.containsKey(UsageMetricsAggregation.AGGREGATION_TERMS_EVENT_TYPE);
+    final UsageMetricTUStatisticsEntity res;
+
+    if (withTenants) {
+      final var tenantsAgg = aggregations.get(UsageMetricsAggregation.AGGREGATION_TERMS_TENANT_ID);
+
+      long totalTu = 0;
+      final var tenants =
+          new HashMap<String, UsageMetricTUStatisticsEntityTenant>(
+              tenantsAgg.aggregations().size());
+      for (final Entry<String, AggregationResult> entry : tenantsAgg.aggregations().entrySet()) {
+        final String tenantId = entry.getKey();
+        final AggregationResult tenantIdSet = entry.getValue();
+
+        final var eventTypesAgg =
+            tenantIdSet.aggregations().get(UsageMetricsAggregation.AGGREGATION_TERMS_EVENT_TYPE);
+        final long tenantTu = extractMetricCount(eventTypesAgg, UsageMetricsEventType.TU);
+        totalTu += tenantTu;
+        tenants.put(tenantId, new Builder().tu(tenantTu).build());
+      }
+      res = new UsageMetricTUStatisticsEntity(totalTu, tenants);
+    } else {
+      final var eventTypesAgg =
+          aggregations.get(UsageMetricsAggregation.AGGREGATION_TERMS_EVENT_TYPE);
+      final long totalTu = extractMetricCount(eventTypesAgg, UsageMetricsEventType.TU);
+
+      res = new UsageMetricTUStatisticsEntity(totalTu, null);
+    }
+
+    return new UsageMetricsTUAggregationResult(res);
+  }
+}

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/UsageMetricsTUFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/UsageMetricsTUFilterTransformer.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.filter;
+
+import static io.camunda.search.clients.query.SearchQueryBuilders.and;
+import static io.camunda.search.clients.query.SearchQueryBuilders.dateTimeOperations;
+import static io.camunda.search.clients.query.SearchQueryBuilders.matchAll;
+import static io.camunda.search.clients.query.SearchQueryBuilders.term;
+
+import io.camunda.search.clients.query.SearchQuery;
+import io.camunda.search.filter.Operation;
+import io.camunda.search.filter.UsageMetricsTUFilter;
+import io.camunda.security.auth.Authorization;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
+import io.camunda.webapps.schema.descriptors.index.UsageMetricTUIndex;
+import java.util.ArrayList;
+import java.util.List;
+
+public class UsageMetricsTUFilterTransformer extends IndexFilterTransformer<UsageMetricsTUFilter> {
+
+  public UsageMetricsTUFilterTransformer(final IndexDescriptor indexDescriptor) {
+    super(indexDescriptor);
+  }
+
+  @Override
+  public SearchQuery toSearchQuery(final UsageMetricsTUFilter filter) {
+    final var queries =
+        new ArrayList<>(
+            dateTimeOperations(
+                UsageMetricTUIndex.EVENT_TIME,
+                List.of(Operation.gte(filter.startTime()), Operation.lt(filter.endTime()))));
+
+    if (filter.tenantId() != null) {
+      queries.add(term(UsageMetricTUIndex.TENANT_ID, filter.tenantId()));
+    }
+
+    return and(queries);
+  }
+
+  @Override
+  protected SearchQuery toAuthorizationCheckSearchQuery(final Authorization<?> authorization) {
+    return matchAll();
+  }
+}

--- a/search/search-client-reader/src/main/java/io/camunda/search/clients/reader/SearchClientReaders.java
+++ b/search/search-client-reader/src/main/java/io/camunda/search/clients/reader/SearchClientReaders.java
@@ -32,6 +32,7 @@ public record SearchClientReaders(
     TenantReader tenantReader,
     TenantMemberReader tenantMemberReader,
     UsageMetricsReader usageMetricsReader,
+    UsageMetricsTUReader usageMetricsTUReader,
     UserReader userReader,
     UserTaskReader userTaskReader,
     VariableReader variableReader) {}

--- a/search/search-client-reader/src/main/java/io/camunda/search/clients/reader/UsageMetricsTUReader.java
+++ b/search/search-client-reader/src/main/java/io/camunda/search/clients/reader/UsageMetricsTUReader.java
@@ -8,11 +8,11 @@
 package io.camunda.search.clients.reader;
 
 import io.camunda.search.entities.UsageMetricTUStatisticsEntity;
-import io.camunda.search.query.UsageMetricsQuery;
+import io.camunda.search.query.UsageMetricsTUQuery;
 import io.camunda.security.reader.ResourceAccessChecks;
 
 public interface UsageMetricsTUReader extends SearchClientReader {
 
   UsageMetricTUStatisticsEntity usageMetricTUStatistics(
-      UsageMetricsQuery query, ResourceAccessChecks resourceAccessChecks);
+      UsageMetricsTUQuery query, ResourceAccessChecks resourceAccessChecks);
 }

--- a/search/search-client/src/main/java/io/camunda/search/clients/CamundaSearchClients.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/CamundaSearchClients.java
@@ -69,6 +69,7 @@ import io.camunda.search.query.SequenceFlowQuery;
 import io.camunda.search.query.TenantQuery;
 import io.camunda.search.query.TypedSearchQuery;
 import io.camunda.search.query.UsageMetricsQuery;
+import io.camunda.search.query.UsageMetricsTUQuery;
 import io.camunda.search.query.UserQuery;
 import io.camunda.search.query.UserTaskQuery;
 import io.camunda.search.query.VariableQuery;
@@ -350,7 +351,7 @@ public class CamundaSearchClients implements SearchClientsProxy {
   }
 
   @Override
-  public UsageMetricTUStatisticsEntity usageMetricTUStatistics(final UsageMetricsQuery query) {
+  public UsageMetricTUStatisticsEntity usageMetricTUStatistics(final UsageMetricsTUQuery query) {
     return doReadWithResourceAccessController(
         access -> readers.usageMetricsTUReader().usageMetricTUStatistics(query, access));
   }

--- a/search/search-client/src/main/java/io/camunda/search/clients/CamundaSearchClients.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/CamundaSearchClients.java
@@ -35,6 +35,7 @@ import io.camunda.search.entities.SequenceFlowEntity;
 import io.camunda.search.entities.TenantEntity;
 import io.camunda.search.entities.TenantMemberEntity;
 import io.camunda.search.entities.UsageMetricStatisticsEntity;
+import io.camunda.search.entities.UsageMetricTUStatisticsEntity;
 import io.camunda.search.entities.UserEntity;
 import io.camunda.search.entities.UserTaskEntity;
 import io.camunda.search.entities.VariableEntity;
@@ -346,6 +347,12 @@ public class CamundaSearchClients implements SearchClientsProxy {
   public UsageMetricStatisticsEntity usageMetricStatistics(final UsageMetricsQuery query) {
     return doReadWithResourceAccessController(
         access -> readers.usageMetricsReader().usageMetricStatistics(query, access));
+  }
+
+  @Override
+  public UsageMetricTUStatisticsEntity usageMetricTUStatistics(final UsageMetricsQuery query) {
+    return doReadWithResourceAccessController(
+        access -> readers.usageMetricsTUReader().usageMetricTUStatistics(query, access));
   }
 
   @Override

--- a/search/search-client/src/main/java/io/camunda/search/clients/UsageMetricsSearchClient.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/UsageMetricsSearchClient.java
@@ -10,6 +10,7 @@ package io.camunda.search.clients;
 import io.camunda.search.entities.UsageMetricStatisticsEntity;
 import io.camunda.search.entities.UsageMetricTUStatisticsEntity;
 import io.camunda.search.query.UsageMetricsQuery;
+import io.camunda.search.query.UsageMetricsTUQuery;
 import io.camunda.security.auth.SecurityContext;
 
 public interface UsageMetricsSearchClient {
@@ -18,5 +19,5 @@ public interface UsageMetricsSearchClient {
 
   UsageMetricStatisticsEntity usageMetricStatistics(final UsageMetricsQuery query);
 
-  UsageMetricTUStatisticsEntity usageMetricTUStatistics(final UsageMetricsQuery query);
+  UsageMetricTUStatisticsEntity usageMetricTUStatistics(final UsageMetricsTUQuery query);
 }

--- a/search/search-client/src/main/java/io/camunda/search/clients/UsageMetricsSearchClient.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/UsageMetricsSearchClient.java
@@ -8,6 +8,7 @@
 package io.camunda.search.clients;
 
 import io.camunda.search.entities.UsageMetricStatisticsEntity;
+import io.camunda.search.entities.UsageMetricTUStatisticsEntity;
 import io.camunda.search.query.UsageMetricsQuery;
 import io.camunda.security.auth.SecurityContext;
 
@@ -16,4 +17,6 @@ public interface UsageMetricsSearchClient {
   UsageMetricsSearchClient withSecurityContext(SecurityContext securityContext);
 
   UsageMetricStatisticsEntity usageMetricStatistics(final UsageMetricsQuery query);
+
+  UsageMetricTUStatisticsEntity usageMetricTUStatistics(final UsageMetricsQuery query);
 }

--- a/search/search-client/src/main/java/io/camunda/search/clients/impl/NoDBSearchClientsProxy.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/impl/NoDBSearchClientsProxy.java
@@ -31,6 +31,7 @@ import io.camunda.search.entities.SequenceFlowEntity;
 import io.camunda.search.entities.TenantEntity;
 import io.camunda.search.entities.TenantMemberEntity;
 import io.camunda.search.entities.UsageMetricStatisticsEntity;
+import io.camunda.search.entities.UsageMetricTUStatisticsEntity;
 import io.camunda.search.entities.UserEntity;
 import io.camunda.search.entities.UserTaskEntity;
 import io.camunda.search.entities.VariableEntity;
@@ -295,6 +296,11 @@ public class NoDBSearchClientsProxy implements SearchClientsProxy {
 
   @Override
   public UsageMetricStatisticsEntity usageMetricStatistics(final UsageMetricsQuery query) {
+    throw new NoSecondaryStorageException();
+  }
+
+  @Override
+  public UsageMetricTUStatisticsEntity usageMetricTUStatistics(final UsageMetricsQuery query) {
     throw new NoSecondaryStorageException();
   }
 

--- a/search/search-client/src/main/java/io/camunda/search/clients/impl/NoDBSearchClientsProxy.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/impl/NoDBSearchClientsProxy.java
@@ -57,6 +57,7 @@ import io.camunda.search.query.SearchQueryResult;
 import io.camunda.search.query.SequenceFlowQuery;
 import io.camunda.search.query.TenantQuery;
 import io.camunda.search.query.UsageMetricsQuery;
+import io.camunda.search.query.UsageMetricsTUQuery;
 import io.camunda.search.query.UserQuery;
 import io.camunda.search.query.UserTaskQuery;
 import io.camunda.search.query.VariableQuery;
@@ -300,7 +301,7 @@ public class NoDBSearchClientsProxy implements SearchClientsProxy {
   }
 
   @Override
-  public UsageMetricTUStatisticsEntity usageMetricTUStatistics(final UsageMetricsQuery query) {
+  public UsageMetricTUStatisticsEntity usageMetricTUStatistics(final UsageMetricsTUQuery query) {
     throw new NoSecondaryStorageException();
   }
 

--- a/search/search-client/src/main/java/io/camunda/search/clients/impl/NoopSearchClientsProxy.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/impl/NoopSearchClientsProxy.java
@@ -33,6 +33,7 @@ import io.camunda.search.entities.SequenceFlowEntity;
 import io.camunda.search.entities.TenantEntity;
 import io.camunda.search.entities.TenantMemberEntity;
 import io.camunda.search.entities.UsageMetricStatisticsEntity;
+import io.camunda.search.entities.UsageMetricTUStatisticsEntity;
 import io.camunda.search.entities.UserEntity;
 import io.camunda.search.entities.UserTaskEntity;
 import io.camunda.search.entities.VariableEntity;
@@ -298,6 +299,11 @@ public class NoopSearchClientsProxy implements SearchClientsProxy {
   @Override
   public UsageMetricStatisticsEntity usageMetricStatistics(final UsageMetricsQuery query) {
     return new UsageMetricStatisticsEntity(0, 0, 0, Map.of());
+  }
+
+  @Override
+  public UsageMetricTUStatisticsEntity usageMetricTUStatistics(final UsageMetricsQuery query) {
+    return new UsageMetricTUStatisticsEntity(0, Map.of());
   }
 
   @Override

--- a/search/search-client/src/main/java/io/camunda/search/clients/impl/NoopSearchClientsProxy.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/impl/NoopSearchClientsProxy.java
@@ -58,6 +58,7 @@ import io.camunda.search.query.SearchQueryResult;
 import io.camunda.search.query.SequenceFlowQuery;
 import io.camunda.search.query.TenantQuery;
 import io.camunda.search.query.UsageMetricsQuery;
+import io.camunda.search.query.UsageMetricsTUQuery;
 import io.camunda.search.query.UserQuery;
 import io.camunda.search.query.UserTaskQuery;
 import io.camunda.search.query.VariableQuery;
@@ -302,7 +303,7 @@ public class NoopSearchClientsProxy implements SearchClientsProxy {
   }
 
   @Override
-  public UsageMetricTUStatisticsEntity usageMetricTUStatistics(final UsageMetricsQuery query) {
+  public UsageMetricTUStatisticsEntity usageMetricTUStatistics(final UsageMetricsTUQuery query) {
     return new UsageMetricTUStatisticsEntity(0, Map.of());
   }
 

--- a/search/search-domain/src/main/java/io/camunda/search/aggregation/UsageMetricsTUAggregation.java
+++ b/search/search-domain/src/main/java/io/camunda/search/aggregation/UsageMetricsTUAggregation.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.aggregation;
+
+import io.camunda.search.filter.UsageMetricsTUFilter;
+
+public record UsageMetricsTUAggregation(UsageMetricsTUFilter filter) implements AggregationBase {
+
+  public static final int AGGREGATION_TERMS_SIZE = 10000;
+  public static final String AGGREGATION_TERMS_TENANT_ID = "termsTenantId";
+  public static final String AGGREGATION_TERMS_ASSIGNEE_HASH = "termsAssigneeHash";
+}

--- a/search/search-domain/src/main/java/io/camunda/search/aggregation/result/UsageMetricsTUAggregationResult.java
+++ b/search/search-domain/src/main/java/io/camunda/search/aggregation/result/UsageMetricsTUAggregationResult.java
@@ -5,14 +5,9 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.search.clients.reader;
+package io.camunda.search.aggregation.result;
 
 import io.camunda.search.entities.UsageMetricTUStatisticsEntity;
-import io.camunda.search.query.UsageMetricsQuery;
-import io.camunda.security.reader.ResourceAccessChecks;
 
-public interface UsageMetricsTUReader extends SearchClientReader {
-
-  UsageMetricTUStatisticsEntity usageMetricTUStatistics(
-      UsageMetricsQuery query, ResourceAccessChecks resourceAccessChecks);
-}
+public record UsageMetricsTUAggregationResult(UsageMetricTUStatisticsEntity result)
+    implements AggregationResultBase {}

--- a/search/search-domain/src/main/java/io/camunda/search/entities/UsageMetricTUStatisticsEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/UsageMetricTUStatisticsEntity.java
@@ -11,22 +11,22 @@ import io.camunda.util.ObjectBuilder;
 import java.util.Map;
 
 public record UsageMetricTUStatisticsEntity(
-    long totalAtu, Map<String, UsageMetricTUStatisticsEntityTenant> tenants) {
+    long totalTu, Map<String, UsageMetricTUStatisticsEntityTenant> tenants) {
 
-  public record UsageMetricTUStatisticsEntityTenant(long atu) {
+  public record UsageMetricTUStatisticsEntityTenant(long tu) {
 
     public static class Builder implements ObjectBuilder<UsageMetricTUStatisticsEntityTenant> {
 
-      private long atu = 0;
+      private long tu = 0;
 
-      public UsageMetricTUStatisticsEntityTenant.Builder atu(final long atu) {
-        this.atu = atu;
+      public UsageMetricTUStatisticsEntityTenant.Builder tu(final long tu) {
+        this.tu = tu;
         return this;
       }
 
       @Override
       public UsageMetricTUStatisticsEntityTenant build() {
-        return new UsageMetricTUStatisticsEntityTenant(atu);
+        return new UsageMetricTUStatisticsEntityTenant(tu);
       }
     }
   }

--- a/search/search-domain/src/main/java/io/camunda/search/filter/FilterBuilders.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/FilterBuilders.java
@@ -23,6 +23,15 @@ public final class FilterBuilders {
     return fn.apply(usageMetrics()).build();
   }
 
+  public static UsageMetricsTUFilter.Builder usageMetricsTU() {
+    return new UsageMetricsTUFilter.Builder();
+  }
+
+  public static UsageMetricsTUFilter usageMetricsTU(
+      final Function<UsageMetricsTUFilter.Builder, ObjectBuilder<UsageMetricsTUFilter>> fn) {
+    return fn.apply(usageMetricsTU()).build();
+  }
+
   public static ProcessDefinitionFilter.Builder processDefinition() {
     return new ProcessDefinitionFilter.Builder();
   }

--- a/search/search-domain/src/main/java/io/camunda/search/filter/UsageMetricsTUFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/UsageMetricsTUFilter.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.filter;
+
+import io.camunda.util.ObjectBuilder;
+import java.time.OffsetDateTime;
+
+public record UsageMetricsTUFilter(
+    OffsetDateTime startTime, OffsetDateTime endTime, String tenantId, boolean withTenants)
+    implements FilterBase {
+
+  public static final class Builder implements ObjectBuilder<UsageMetricsTUFilter> {
+    private OffsetDateTime startTime;
+    private OffsetDateTime endTime;
+    private String tenantId;
+    private boolean withTenants = false;
+
+    public Builder startTime(final OffsetDateTime value) {
+      startTime = value;
+      return this;
+    }
+
+    public Builder endTime(final OffsetDateTime value) {
+      endTime = value;
+      return this;
+    }
+
+    public Builder tenantId(final String value) {
+      tenantId = value;
+      return this;
+    }
+
+    public Builder withTenants(final boolean value) {
+      withTenants = value;
+      return this;
+    }
+
+    @Override
+    public UsageMetricsTUFilter build() {
+      return new UsageMetricsTUFilter(startTime, endTime, tenantId, withTenants);
+    }
+  }
+}

--- a/search/search-domain/src/main/java/io/camunda/search/query/UsageMetricsQueryMapper.java
+++ b/search/search-domain/src/main/java/io/camunda/search/query/UsageMetricsQueryMapper.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.query;
+
+import io.camunda.search.filter.UsageMetricsTUFilter;
+
+public class UsageMetricsQueryMapper {
+
+  public static UsageMetricsTUQuery mapToUsageMetricsTUQuery(final UsageMetricsQuery query) {
+    return new UsageMetricsTUQuery.Builder()
+        .filter(
+            new UsageMetricsTUFilter.Builder()
+                .startTime(query.filter().startTime())
+                .endTime(query.filter().endTime())
+                .tenantId(query.filter().tenantId())
+                .withTenants(query.filter().withTenants())
+                .build())
+        .build();
+  }
+}

--- a/search/search-domain/src/main/java/io/camunda/search/query/UsageMetricsTUQuery.java
+++ b/search/search-domain/src/main/java/io/camunda/search/query/UsageMetricsTUQuery.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.query;
+
+import io.camunda.search.aggregation.UsageMetricsTUAggregation;
+import io.camunda.search.filter.FilterBuilders;
+import io.camunda.search.filter.UsageMetricsTUFilter;
+import io.camunda.util.ObjectBuilder;
+import java.util.Objects;
+import java.util.function.Function;
+
+public record UsageMetricsTUQuery(UsageMetricsTUFilter filter)
+    implements TypedSearchAggregationQuery<UsageMetricsTUFilter, UsageMetricsTUAggregation> {
+
+  public static UsageMetricsTUQuery of(
+      final Function<Builder, ObjectBuilder<UsageMetricsTUQuery>> fn) {
+    return fn.apply(new Builder()).build();
+  }
+
+  @Override
+  public UsageMetricsTUAggregation aggregation() {
+    return new UsageMetricsTUAggregation(filter);
+  }
+
+  public static final class Builder implements ObjectBuilder<UsageMetricsTUQuery> {
+    private static final UsageMetricsTUFilter EMPTY_FILTER =
+        FilterBuilders.usageMetricsTU().build();
+
+    private UsageMetricsTUFilter filter;
+
+    public Builder filter(final UsageMetricsTUFilter value) {
+      filter = value;
+      return this;
+    }
+
+    public Builder filter(
+        final Function<UsageMetricsTUFilter.Builder, ObjectBuilder<UsageMetricsTUFilter>> fn) {
+      return filter(FilterBuilders.usageMetricsTU(fn));
+    }
+
+    @Override
+    public UsageMetricsTUQuery build() {
+      filter = Objects.requireNonNullElse(filter, EMPTY_FILTER);
+      return new UsageMetricsTUQuery(filter);
+    }
+  }
+}

--- a/service/src/main/java/io/camunda/service/UsageMetricsServices.java
+++ b/service/src/main/java/io/camunda/service/UsageMetricsServices.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.service;
 
+import static io.camunda.search.query.UsageMetricsQueryMapper.mapToUsageMetricsTUQuery;
+
 import io.camunda.search.clients.UsageMetricsSearchClient;
 import io.camunda.search.entities.UsageMetricStatisticsEntity;
 import io.camunda.search.entities.UsageMetricTUStatisticsEntity;
@@ -44,15 +46,13 @@ public final class UsageMetricsServices
     }
     validateStartAndEndTime(query);
     final UsageMetricsSearchClient authUsageMetricsSearchClient =
-        usageMetricsSearchClient
-            // TODO add proper authorization with https://github.com/camunda/camunda/issues/34708
-            .withSecurityContext(
+        usageMetricsSearchClient.withSecurityContext(
             securityContextProvider.provideSecurityContext(
                 authentication, Authorization.of(a -> a.usageMetric().read())));
     return SearchQueryResult.of(
         Tuple.of(
             authUsageMetricsSearchClient.usageMetricStatistics(query),
-            authUsageMetricsSearchClient.usageMetricTUStatistics(query)));
+            authUsageMetricsSearchClient.usageMetricTUStatistics(mapToUsageMetricsTUQuery(query))));
   }
 
   private void validateStartAndEndTime(final UsageMetricsQuery query) {

--- a/service/src/test/java/io/camunda/service/UsageMetricsServiceTest.java
+++ b/service/src/test/java/io/camunda/service/UsageMetricsServiceTest.java
@@ -14,11 +14,13 @@ import static org.mockito.Mockito.when;
 
 import io.camunda.search.clients.UsageMetricsSearchClient;
 import io.camunda.search.entities.UsageMetricStatisticsEntity;
+import io.camunda.search.entities.UsageMetricTUStatisticsEntity;
 import io.camunda.search.filter.UsageMetricsFilter;
 import io.camunda.search.query.SearchQueryBuilders;
 import io.camunda.search.query.UsageMetricsQuery;
 import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
+import io.camunda.zeebe.util.collection.Tuple;
 import java.time.OffsetDateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -42,6 +44,8 @@ public final class UsageMetricsServiceTest {
     // given
     when(client.usageMetricStatistics(any()))
         .thenReturn(new UsageMetricStatisticsEntity(16, 14, 2, null));
+    when(client.usageMetricTUStatistics(any()))
+        .thenReturn(new UsageMetricTUStatisticsEntity(16, null));
 
     final var startTime =
         OffsetDateTime.of(2021, 1, 1, 0, 0, 0, 0, OffsetDateTime.now().getOffset());
@@ -56,6 +60,9 @@ public final class UsageMetricsServiceTest {
 
     // then
     assertThat(searchQueryResult.items().getFirst())
-        .isEqualTo(new UsageMetricStatisticsEntity(16, 14, 2, null));
+        .isEqualTo(
+            Tuple.of(
+                new UsageMetricStatisticsEntity(16, 14, 2, null),
+                new UsageMetricTUStatisticsEntity(16, null)));
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UsageMetricHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UsageMetricHandlerTest.java
@@ -130,10 +130,7 @@ class UsageMetricHandlerTest {
                     .withKey(Long.parseLong(EVENT_KEY))
                     .withPartitionId(PARTITION_ID));
     final var usageMetricsBatch =
-        new UsageMetricsBatch(
-            EVENT_KEY,
-            composeUsageMetrics(now, UsageMetricsEventType.RPI, 11L, 22L),
-            new ArrayList<>());
+        new UsageMetricsBatch(EVENT_KEY, composeUsageMetrics(now, 11L, 22L), new ArrayList<>());
 
     // when
     underTest.updateEntity(record, usageMetricsBatch);
@@ -179,10 +176,7 @@ class UsageMetricHandlerTest {
                     .withKey(Long.parseLong(EVENT_KEY))
                     .withPartitionId(PARTITION_ID));
     final var usageMetricsBatch =
-        new UsageMetricsBatch(
-            EVENT_KEY,
-            composeUsageMetrics(now, UsageMetricsEventType.TU, 1L, 1L),
-            composeUsageMetricsTU(now));
+        new UsageMetricsBatch(EVENT_KEY, null, composeUsageMetricsTU(now));
 
     // when
     underTest.updateEntity(record, usageMetricsBatch);
@@ -191,19 +185,7 @@ class UsageMetricHandlerTest {
     final List<UsageMetricsEntity> variables = usageMetricsBatch.variables();
     final List<UsageMetricsTUEntity> tuVariables = usageMetricsBatch.tuVariables();
 
-    assertThat(variables)
-        .extracting(UsageMetricsEntity::getId)
-        .containsExactlyInAnyOrder(
-            String.format(ID_PATTERN, EVENT_KEY, TENANT_1),
-            String.format(ID_PATTERN, EVENT_KEY, TENANT_2),
-            String.format(ID_PATTERN, EVENT_KEY, TENANT_3));
-    assertThat(variables)
-        .extracting(UsageMetricsEntity::getEventTime)
-        .contains(DateUtil.toOffsetDateTime(now));
-    assertThat(variables).extracting(UsageMetricsEntity::getPartitionId).containsOnly(PARTITION_ID);
-    assertThat(variables)
-        .extracting(UsageMetricsEntity::getEventValue)
-        .containsExactlyInAnyOrder(1L, 1L, null);
+    assertThat(variables).isNull();
 
     assertThat(tuVariables)
         .extracting(UsageMetricsTUEntity::getId)
@@ -242,9 +224,7 @@ class UsageMetricHandlerTest {
                     .withPartitionId(PARTITION_ID));
     final var usageMetricsBatch =
         new UsageMetricsBatch(
-            EVENT_KEY,
-            composeUsageMetrics(now, UsageMetricsEventType.RPI, 11L, 22L),
-            composeUsageMetricsTU(now));
+            EVENT_KEY, composeUsageMetrics(now, 11L, 22L), composeUsageMetricsTU(now));
 
     // when
     underTest.updateEntity(record, usageMetricsBatch);
@@ -255,20 +235,19 @@ class UsageMetricHandlerTest {
 
     assertThat(variables)
         .extracting(UsageMetricsEntity::getEventType)
-        .contains(UsageMetricsEventType.RPI, UsageMetricsEventType.TU);
+        .containsOnly(UsageMetricsEventType.RPI);
     assertThat(variables)
         .extracting(UsageMetricsEntity::getId)
         .containsExactlyInAnyOrder(
             String.format(ID_PATTERN, EVENT_KEY, TENANT_1),
-            String.format(ID_PATTERN, EVENT_KEY, TENANT_2),
-            String.format(ID_PATTERN, EVENT_KEY, TENANT_3));
+            String.format(ID_PATTERN, EVENT_KEY, TENANT_2));
     assertThat(variables)
         .extracting(UsageMetricsEntity::getEventTime)
         .contains(DateUtil.toOffsetDateTime(now));
     assertThat(variables).extracting(UsageMetricsEntity::getPartitionId).containsOnly(PARTITION_ID);
     assertThat(variables)
         .extracting(UsageMetricsEntity::getEventValue)
-        .containsExactlyInAnyOrder(11L, 22L, null);
+        .containsExactlyInAnyOrder(11L, 22L);
 
     assertThat(tuVariables)
         .extracting(UsageMetricsTUEntity::getId)
@@ -304,9 +283,7 @@ class UsageMetricHandlerTest {
     final var now = OffsetDateTime.now().toEpochSecond();
     final var usageMetricsBatch =
         new UsageMetricsBatch(
-            EVENT_KEY,
-            composeUsageMetrics(now, UsageMetricsEventType.RPI, 11L, 22L),
-            composeUsageMetricsTU(now));
+            EVENT_KEY, composeUsageMetrics(now, 11L, 22L), composeUsageMetricsTU(now));
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when
@@ -320,19 +297,18 @@ class UsageMetricHandlerTest {
     verifyNoMoreInteractions(mockRequest);
   }
 
-  private ArrayList<UsageMetricsEntity> composeUsageMetrics(
-      final long now, final UsageMetricsEventType eventType, Long... eventValues) {
+  private ArrayList<UsageMetricsEntity> composeUsageMetrics(final long now, Long... eventValues) {
     return new ArrayList<>(
         List.of(
             new UsageMetricsEntity()
                 .setId(String.format(ID_PATTERN, EVENT_KEY, TENANT_1))
                 .setPartitionId(PARTITION_ID)
                 .setEventTime(DateUtil.toOffsetDateTime(now))
-                .setEventType(eventType)
+                .setEventType(UsageMetricsEventType.RPI)
                 .setEventValue(eventValues[0]),
             new UsageMetricsEntity()
                 .setId(String.format(ID_PATTERN, EVENT_KEY, TENANT_2))
-                .setEventType(eventType)
+                .setEventType(UsageMetricsEventType.RPI)
                 .setPartitionId(PARTITION_ID)
                 .setEventTime(DateUtil.toOffsetDateTime(now))
                 .setEventValue(eventValues[1])));

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/UsageMetricExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/UsageMetricExportHandler.java
@@ -78,18 +78,15 @@ public class UsageMetricExportHandler implements RdbmsExportHandler<UsageMetricR
                 usageMetricList.add(
                     new UsageMetricDbModel(
                         recordKey, startTime, key, eventType, val, partitionId)));
-    value
-        .getSetValues()
-        .forEach(
-            (key, valSet) -> {
-              usageMetricList.add(
-                  new UsageMetricDbModel(recordKey, startTime, key, eventType, null, partitionId));
-
-              valSet.forEach(
-                  val ->
-                      usageMetricTUList.add(
-                          new UsageMetricTUDbModel(recordKey, startTime, key, val, partitionId)));
-            });
+    value.getSetValues().entrySet().stream()
+        .flatMap(
+            entry ->
+                entry.getValue().stream()
+                    .map(
+                        val ->
+                            new UsageMetricTUDbModel(
+                                recordKey, startTime, entry.getKey(), val, partitionId)))
+        .forEach(usageMetricTUList::add);
 
     return new Tuple<>(usageMetricList, usageMetricTUList);
   }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
@@ -138,6 +138,7 @@ import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.util.collection.Tuple;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -165,7 +166,7 @@ public final class SearchQueryResponseMapper {
     if (withTenants) {
       final Map<String, UsageMetricStatisticsEntityTenant> tenants1 = statistics.tenants();
       final Map<String, UsageMetricTUStatisticsEntityTenant> tenants2 = tuStatistics.tenants();
-      final var allTenantKeys = new java.util.HashSet<>(tenants1.keySet());
+      final var allTenantKeys = new HashSet<>(tenants1.keySet());
       allTenantKeys.addAll(tenants2.keySet());
 
       final Map<String, UsageMetricsResponseItem> mergedTenants =

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
@@ -40,6 +40,9 @@ import io.camunda.search.entities.SequenceFlowEntity;
 import io.camunda.search.entities.TenantEntity;
 import io.camunda.search.entities.TenantMemberEntity;
 import io.camunda.search.entities.UsageMetricStatisticsEntity;
+import io.camunda.search.entities.UsageMetricStatisticsEntity.UsageMetricStatisticsEntityTenant;
+import io.camunda.search.entities.UsageMetricTUStatisticsEntity;
+import io.camunda.search.entities.UsageMetricTUStatisticsEntity.UsageMetricTUStatisticsEntityTenant;
 import io.camunda.search.entities.UserEntity;
 import io.camunda.search.entities.UserTaskEntity;
 import io.camunda.search.entities.VariableEntity;
@@ -133,10 +136,10 @@ import io.camunda.zeebe.gateway.protocol.rest.VariableSearchResult;
 import io.camunda.zeebe.gateway.rest.util.KeyUtil;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
+import io.camunda.zeebe.util.collection.Tuple;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 
@@ -145,28 +148,42 @@ public final class SearchQueryResponseMapper {
   private SearchQueryResponseMapper() {}
 
   public static UsageMetricsResponse toUsageMetricsResponse(
-      final SearchQueryResult<UsageMetricStatisticsEntity> result, final boolean withTenants) {
-
-    final var statistics = result.items().getFirst();
+      final SearchQueryResult<Tuple<UsageMetricStatisticsEntity, UsageMetricTUStatisticsEntity>>
+          result,
+      final boolean withTenants) {
+    final var tuple = result.items().getFirst();
+    final var statistics = tuple.getLeft();
+    final var tuStatistics = tuple.getRight();
 
     final var response =
         new UsageMetricsResponse()
-            .assignees(0L)
+            .assignees(tuStatistics.totalTu())
             .processInstances(statistics.totalRpi())
             .decisionInstances(statistics.totalEdi())
             .activeTenants(statistics.at());
 
-    if (withTenants && statistics.tenants() != null) {
-      response.tenants(
-          statistics.tenants().entrySet().stream()
+    if (withTenants) {
+      final Map<String, UsageMetricStatisticsEntityTenant> tenants1 = statistics.tenants();
+      final Map<String, UsageMetricTUStatisticsEntityTenant> tenants2 = tuStatistics.tenants();
+      final var allTenantKeys = new java.util.HashSet<>(tenants1.keySet());
+      allTenantKeys.addAll(tenants2.keySet());
+
+      final Map<String, UsageMetricsResponseItem> mergedTenants =
+          allTenantKeys.stream()
               .collect(
-                  toMap(
-                      Entry::getKey,
-                      e ->
-                          new UsageMetricsResponseItem()
-                              .processInstances(e.getValue().rpi())
-                              .decisionInstances(e.getValue().edi())
-                              .assignees(0L))));
+                  Collectors.toMap(
+                      key -> key,
+                      key -> {
+                        final UsageMetricStatisticsEntityTenant stats = tenants1.get(key);
+                        final UsageMetricTUStatisticsEntityTenant tuStats = tenants2.get(key);
+                        return new UsageMetricsResponseItem()
+                            .processInstances(stats != null ? stats.rpi() : 0L)
+                            .decisionInstances(stats != null ? stats.edi() : 0L)
+                            .assignees(tuStats != null ? tuStats.tu() : 0L);
+                      }));
+      if (!mergedTenants.isEmpty()) {
+        response.tenants(mergedTenants);
+      }
     }
 
     return response;


### PR DESCRIPTION
## Description

Enhance /v2/usage-metrics endpoint with total assigned tasks information and assigned tasks per tenant

- use UsageMetricsTUQuery, UsageMetricsTUFilter to search for usage metrics **TU**
- add different aggregation logic for TU
- align interfaces using UsageMetricsTUQuery and tests
- change rdbms totalTu retrieval logic --> unique total assignees and unique total assignees per tenant

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #31135
