### PR TITLE
[Backport stable/8.7] fix: improve logging for failed shards in opensearch scrolling

### DIFF
--- a/operate/schema/src/main/java/io/camunda/operate/store/opensearch/client/sync/OpenSearchDocumentOperations.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/opensearch/client/sync/OpenSearchDocumentOperations.java
@@ -87,8 +87,9 @@ public class OpenSearchDocumentOperations extends OpenSearchRetryOperation {
     if (!response.shards().failures().isEmpty()) {
       throw new OpenSearchFailedShardsException(
           format(
-              "Shards failed executing request (request=%s, failed shards=%s)",
-              request, response.shards().failures().stream().map(ShardFailure::shard).toList()));
+              "Shards failed executing request (indices=%s, failed shards=%s)",
+              request.index(),
+              response.shards().failures().stream().map(ShardFailure::shard).toList()));
     }
   }
 

--- a/operate/schema/src/main/java/io/camunda/operate/store/opensearch/client/sync/OpenSearchDocumentOperations.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/opensearch/client/sync/OpenSearchDocumentOperations.java
@@ -31,6 +31,7 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import org.opensearch.client.opensearch.OpenSearchClient;
 import org.opensearch.client.opensearch._types.Result;
+import org.opensearch.client.opensearch._types.ShardFailure;
 import org.opensearch.client.opensearch._types.aggregations.Aggregate;
 import org.opensearch.client.opensearch._types.query_dsl.Query;
 import org.opensearch.client.opensearch.core.DeleteByQueryRequest;
@@ -87,7 +88,7 @@ public class OpenSearchDocumentOperations extends OpenSearchRetryOperation {
       throw new OpenSearchFailedShardsException(
           format(
               "Shards failed executing request (request=%s, failed shards=%s)",
-              request, response.shards().failures()));
+              request, response.shards().failures().stream().map(ShardFailure::shard).toList()));
     }
   }
 

--- a/operate/schema/src/main/java/io/camunda/operate/store/opensearch/client/sync/OpenSearchDocumentOperations.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/opensearch/client/sync/OpenSearchDocumentOperations.java
@@ -89,8 +89,14 @@ public class OpenSearchDocumentOperations extends OpenSearchRetryOperation {
           format(
               "Shards failed executing request (indices=%s, failed shards=%s)",
               request.index(),
-              response.shards().failures().stream().map(ShardFailure::shard).toList()));
+              response.shards().failures().stream().map(this::formatShardFailure).toList()));
     }
+  }
+
+  private String formatShardFailure(final ShardFailure failure) {
+    return String.format(
+        "ShardFailure[index=%s, shard=%s, status=%s, node=%s, reason=%s]",
+        failure.index(), failure.shard(), failure.status(), failure.node(), failure.reason());
   }
 
   public <R> Map<String, Aggregate> unsafeScrollWith(


### PR DESCRIPTION
# Description
Backport of #36239 to `stable/8.7`.

relates to 