### PR TITLE
Include snyk skipped validation to trigger Slack notification

### DIFF
--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -729,7 +729,7 @@ jobs:
       needs.operate-docker.result == 'success' &&
       needs.tasklist-docker.result == 'success' &&
       needs.camunda-docker.result == 'success' &&
-      needs.snyk.result == 'success'
+      (needs.snyk.result == 'success' || needs.snyk.result == 'skipped')
       ) && inputs.dryRun == false }}
     timeout-minutes: 5
     permissions: {}  # GITHUB_TOKEN unused in this job


### PR DESCRIPTION
## Description
This PR fixes the notify-on-success Slack job would not run if the snyk job was skipped, even though the release was otherwise successful.

Problem Before:

- notify-on-success required all jobs to return success.
- If the snyk job was skipped (as happens for versions like -alpha, -rc, -SNAPSHOT), needs.snyk.result was "skipped" instead of "success".
- Result: No success Slack notification was sent for a successful release.

Change Implemented:

- notify-on-success now treats snyk: skipped as acceptable (same as success).
- notify-if-failed is unchanged:
- It still triggers if any job fails, including snyk.
- Skipped snyk does not count as a failure (same as before).

Example:
Scenario: release ✅, all other jobs ✅, snyk ⏭ (skipped)
Before: No notification sent.
After: Success notification sent.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
