### PR TITLE
fix: only wait for the topologyReadinessCheck and brokerReadyCheck when starting camundaContainer

### DIFF
--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/containers/CamundaContainer.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/containers/CamundaContainer.java
@@ -36,7 +36,6 @@ import java.time.Duration;
 import java.util.UUID;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
-import org.testcontainers.containers.wait.strategy.HostPortWaitStrategy;
 import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
 import org.testcontainers.containers.wait.strategy.WaitAllStrategy;
 import org.testcontainers.containers.wait.strategy.WaitAllStrategy.Mode;
@@ -149,7 +148,6 @@ public class CamundaContainer extends GenericContainer<CamundaContainer> {
 
   private WaitAllStrategy newDefaultWaitStrategy() {
     return new WaitAllStrategy(Mode.WITH_OUTER_TIMEOUT)
-        .withStrategy(new HostPortWaitStrategy())
         .withStrategy(newDefaultBrokerReadyCheck())
         .withStrategy(newDefaultTopologyReadyCheck())
         .withStartupTimeout(DEFAULT_STARTUP_TIMEOUT);


### PR DESCRIPTION
## Description

Adding a bad exposedPort causes the camundaContainer to fail on startup. We should limit the wait strategy to check only the management and the REST API port.

## Related issues

closes #35424
