### PR TITLE
fix: include members ready check after restart on replication loop

### DIFF
--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RandomizedRaftTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RandomizedRaftTest.java
@@ -239,7 +239,8 @@ public class RandomizedRaftTest {
     int maxStepsToReplicateEntries = 2000;
     while (!(raftContexts.hasLeaderAtTheLatestTerm()
             && raftContexts.hasReplicatedAllEntries()
-            && raftContexts.hasCommittedAllEntries())
+            && raftContexts.hasCommittedAllEntries()
+            && raftContexts.allMembersAreReady())
         && maxStepsToReplicateEntries-- > 0) {
       raftContexts.runUntilDone();
       raftContexts.processAllMessage();


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Include the membersReady check for the liveness checks during wait loop for replicating steps.

During investigation alongside @deepthidevaki we found that the flake is most probably caused because the raftContext is being restarted quick enough that the cluster does not detect the actual node being restarted on some occasions. In case the unnoticed restarting node was a previous leader does cause the restart of the leader to happen silently without affecting the state of the cluster leaving all nodes in the `ACTIVE` state rather than the `READY` the check is looking for.

I attach the runs for the failed & successful run of this scenario, after the 3 final operations (restarts) occur in the members. 


<details><summary>Successful Run Log</summary>
<p>

10:55:46.208 [raft-server-1 ] INFO  io.atomix.raft.RandomizedRaftTest - Restart member on 0
10:55:46.208 [raft-server-1 0] DEBUG io.atomix.raft.impl.RaftContext - Closing RaftContext: term=17, commitIdx=2, lastFlushedIdx=3
10:55:46.208 [raft-server-1 0] DEBUG io.camunda.zeebe.journal.file.SegmentsManager - Closing segment: Segment{id=1, index=1}
10:55:46.208 [raft-server-1 0] DEBUG io.atomix.raft.impl.RaftContext - Raft context closed
10:55:46.208 [raft-server-1 ] DEBUG io.camunda.zeebe.snapshots.impl.FileBasedSnapshotStoreImpl - Closing snapshot store /tmp/1180496286099004907/0/snapshots/snapshots
10:55:46.211 [raft-server-1 ] DEBUG io.camunda.zeebe.snapshots.impl.FileBasedSnapshotStoreImpl - Deleting snapshots other than 1-6-1-1-0-42f6f453
10:55:46.211 [raft-server-1 ] DEBUG io.atomix.raft.impl.RaftContext - Priority election is enabled with target priority 3 and node priority 1
10:55:46.212 [raft-server-1 ] DEBUG io.camunda.zeebe.journal.file.SegmentsManager - Found segment file: atomix-1.log
10:55:46.213 [raft-server-1 ] TRACE io.atomix.raft.storage.system.MetaStore - Skip storing same last flushed commit index 2
10:55:46.213 [raft-server-1 ] DEBUG io.atomix.raft.impl.RaftContext - Server started with term=17, lastVotedFor=null, lastFlushedIndex=3, commitIndex=2
10:55:46.213 [raft-server-1 ] INFO  io.atomix.raft.RandomizedRaftTest - Restart member on 1
10:55:46.213 [raft-server-1 1] DEBUG io.atomix.raft.impl.RaftContext - Closing RaftContext: term=17, commitIdx=2, lastFlushedIdx=3
10:55:46.214 [raft-server-1 1] TRACE io.atomix.raft.storage.system.MetaStore - Store last flushed index 3 and commitIndex 2
10:55:46.214 [raft-server-1 1] DEBUG io.camunda.zeebe.journal.file.SegmentsManager - Closing segment: Segment{id=1, index=1}
10:55:46.214 [raft-server-1 1] DEBUG io.atomix.raft.impl.RaftContext - Raft context closed
10:55:46.214 [raft-server-1 ] DEBUG io.camunda.zeebe.snapshots.impl.FileBasedSnapshotStoreImpl - Closing snapshot store /tmp/1180496286099004907/1/snapshots/snapshots
10:55:46.217 [raft-server-1 ] DEBUG io.camunda.zeebe.snapshots.impl.FileBasedSnapshotStoreImpl - Deleting snapshots other than 1-6-1-1-1-7cc9e261
10:55:46.218 [raft-server-1 ] DEBUG io.atomix.raft.impl.RaftContext - Priority election is enabled with target priority 3 and node priority 2
10:55:46.219 [raft-server-1 ] DEBUG io.camunda.zeebe.journal.file.SegmentsManager - Found segment file: atomix-1.log
10:55:46.219 [raft-server-1 ] TRACE io.atomix.raft.storage.system.MetaStore - Skip storing same last flushed commit index 2
10:55:46.219 [raft-server-1 ] DEBUG io.atomix.raft.impl.RaftContext - Server started with term=17, lastVotedFor=1, lastFlushedIndex=3, commitIndex=2
10:55:46.219 [raft-server-1 ] INFO  io.atomix.raft.RandomizedRaftTest - Restart member on 2
10:55:46.219 [raft-server-1 2] DEBUG io.atomix.raft.impl.RaftContext - Closing RaftContext: term=17, commitIdx=2, lastFlushedIdx=2
10:55:46.219 [raft-server-1 2] DEBUG io.camunda.zeebe.journal.file.SegmentsManager - Closing segment: Segment{id=1, index=1}
10:55:46.219 [raft-server-1 2] DEBUG io.atomix.raft.impl.RaftContext - Raft context closed
10:55:46.219 [raft-server-1 ] DEBUG io.camunda.zeebe.snapshots.impl.FileBasedSnapshotStoreImpl - Closing snapshot store /tmp/1180496286099004907/2/snapshots/snapshots
10:55:46.223 [raft-server-1 ] DEBUG io.camunda.zeebe.snapshots.impl.FileBasedSnapshotStoreImpl - Deleting snapshots other than 1-6-1-1-2-87e10c35
10:55:46.223 [raft-server-1 ] DEBUG io.atomix.raft.impl.RaftContext - Priority election is enabled with target priority 3 and node priority 3
10:55:46.223 [raft-server-1 ] DEBUG io.camunda.zeebe.journal.file.SegmentsManager - Found segment file: atomix-1.log
10:55:46.224 [raft-server-1 ] TRACE io.atomix.raft.storage.system.MetaStore - Skip storing same last flushed commit index 2
10:55:46.224 [raft-server-1 ] DEBUG io.atomix.raft.impl.RaftContext - Server started with term=17, lastVotedFor=1, lastFlushedIndex=2, commitIndex=2
10:55:46.224 [raft-server-1 1] INFO  io.atomix.raft.impl.RaftContext - Transitioning to FOLLOWER: term=17, lastFlushedIdx=3, commitIdx=2
10:55:46.225 [raft-server-1 2] INFO  io.atomix.raft.impl.RaftContext - Transitioning to FOLLOWER: term=17, lastFlushedIdx=2, commitIdx=2
10:55:46.225 [raft-server-1 0] INFO  io.atomix.raft.impl.RaftContext - Transitioning to FOLLOWER: term=17, lastFlushedIdx=3, commitIdx=2
10:55:46.225 [raft-server-1 1] DEBUG io.atomix.raft.roles.FollowerRole - Node priority 2 < target priority 3. Not triggering election.
10:55:46.225 [raft-server-1 2] TRACE io.atomix.raft.roles.FollowerRole - Node triggering an election
10:55:46.225 [raft-server-1 2] INFO  io.atomix.raft.roles.FollowerRole - No heartbeat from a known leader since 1ms
10:55:46.225 [raft-server-1 2] INFO  io.atomix.raft.roles.FollowerRole - Sending poll requests to all active members: [DefaultRaftMember{id=1, type=ACTIVE, updated=2025-07-31T07:55:46.120Z}, DefaultRaftMember{id=0, type=ACTIVE, updated=2025-07-31T07:55:46.120Z}]
10:55:46.225 [raft-server-1 2] DEBUG io.atomix.raft.roles.FollowerRole - Polling DefaultRaftMember{id=1, type=ACTIVE, updated=2025-07-31T07:55:46.120Z} for next term 18
10:55:46.225 [raft-server-1 2] DEBUG io.atomix.raft.roles.FollowerRole - Polling DefaultRaftMember{id=0, type=ACTIVE, updated=2025-07-31T07:55:46.120Z} for next term 18
10:55:46.225 [raft-server-1 0] DEBUG io.atomix.raft.roles.FollowerRole - Node priority 1 < target priority 3. Not triggering election.
10:55:46.225 [raft-server-1 1] TRACE io.atomix.raft.roles.FollowerRole - Received PollRequest{term=17, candidate=2, lastLogIndex=2, lastLogTerm=9}
10:55:46.225 [raft-server-1 1] DEBUG io.atomix.raft.roles.FollowerRole - Rejected PollRequest{term=17, candidate=2, lastLogIndex=2, lastLogTerm=9}: candidate's last log entry (9) is at a lower term than the local log (17)
10:55:46.225 [raft-server-1 1] TRACE io.atomix.raft.roles.FollowerRole - Sending PollResponse{status=OK, term=17, accepted=false}
10:55:46.225 [raft-server-1 0] TRACE io.atomix.raft.roles.FollowerRole - Received PollRequest{term=17, candidate=2, lastLogIndex=2, lastLogTerm=9}
10:55:46.225 [raft-server-1 0] DEBUG io.atomix.raft.roles.FollowerRole - Rejected PollRequest{term=17, candidate=2, lastLogIndex=2, lastLogTerm=9}: candidate's last log entry (9) is at a lower term than the local log (17)
10:55:46.225 [raft-server-1 0] TRACE io.atomix.raft.roles.FollowerRole - Sending PollResponse{status=OK, term=17, accepted=false}
10:55:46.225 [raft-server-1 2] DEBUG io.atomix.raft.roles.FollowerRole - Received rejected poll from DefaultRaftMember{id=1, type=ACTIVE, updated=2025-07-31T07:55:46.120Z}
10:55:46.225 [raft-server-1 2] DEBUG io.atomix.raft.roles.FollowerRole - Received rejected poll from DefaultRaftMember{id=0, type=ACTIVE, updated=2025-07-31T07:55:46.120Z}
10:55:46.225 [raft-server-1 1] TRACE io.atomix.raft.roles.FollowerRole - Node triggering an election
10:55:46.225 [raft-server-1 1] INFO  io.atomix.raft.roles.FollowerRole - No heartbeat from a known leader since 6ms
10:55:46.225 [raft-server-1 1] INFO  io.atomix.raft.roles.FollowerRole - Sending poll requests to all active members: [DefaultRaftMember{id=2, type=ACTIVE, updated=2025-07-31T07:55:46.119Z}, DefaultRaftMember{id=0, type=ACTIVE, updated=2025-07-31T07:55:46.119Z}]
10:55:46.225 [raft-server-1 1] DEBUG io.atomix.raft.roles.FollowerRole - Polling DefaultRaftMember{id=2, type=ACTIVE, updated=2025-07-31T07:55:46.119Z} for next term 18
10:55:46.225 [raft-server-1 1] DEBUG io.atomix.raft.roles.FollowerRole - Polling DefaultRaftMember{id=0, type=ACTIVE, updated=2025-07-31T07:55:46.119Z} for next term 18
10:55:46.225 [raft-server-1 0] DEBUG io.atomix.raft.roles.FollowerRole - Node priority 1 < target priority 2. Not triggering election.
10:55:46.225 [raft-server-1 2] TRACE io.atomix.raft.roles.FollowerRole - Received PollRequest{term=17, candidate=1, lastLogIndex=3, lastLogTerm=17}
10:55:46.225 [raft-server-1 2] INFO  io.atomix.raft.roles.FollowerRole - Accepted PollRequest{term=17, candidate=1, lastLogIndex=3, lastLogTerm=17}: candidate's log is up-to-date
10:55:46.225 [raft-server-1 2] TRACE io.atomix.raft.roles.FollowerRole - Sending PollResponse{status=OK, term=17, accepted=true}
10:55:46.225 [raft-server-1 2] TRACE io.atomix.raft.roles.FollowerRole - Node triggering an election
10:55:46.225 [raft-server-1 2] INFO  io.atomix.raft.roles.FollowerRole - No heartbeat from a known leader since 1ms
10:55:46.225 [raft-server-1 2] INFO  io.atomix.raft.roles.FollowerRole - Sending poll requests to all active members: [DefaultRaftMember{id=1, type=ACTIVE, updated=2025-07-31T07:55:46.120Z}, DefaultRaftMember{id=0, type=ACTIVE, updated=2025-07-31T07:55:46.120Z}]
10:55:46.225 [raft-server-1 2] DEBUG io.atomix.raft.roles.FollowerRole - Polling DefaultRaftMember{id=1, type=ACTIVE, updated=2025-07-31T07:55:46.120Z} for next term 18
10:55:46.225 [raft-server-1 2] DEBUG io.atomix.raft.roles.FollowerRole - Polling DefaultRaftMember{id=0, type=ACTIVE, updated=2025-07-31T07:55:46.120Z} for next term 18
10:55:46.225 [raft-server-1 0] TRACE io.atomix.raft.roles.FollowerRole - Received PollRequest{term=17, candidate=1, lastLogIndex=3, lastLogTerm=17}
10:55:46.225 [raft-server-1 0] INFO  io.atomix.raft.roles.FollowerRole - Accepted PollRequest{term=17, candidate=1, lastLogIndex=3, lastLogTerm=17}: candidate's log is up-to-date
10:55:46.225 [raft-server-1 0] TRACE io.atomix.raft.roles.FollowerRole - Sending PollResponse{status=OK, term=17, accepted=true}
10:55:46.225 [raft-server-1 1] DEBUG io.atomix.raft.roles.FollowerRole - Received accepted poll from DefaultRaftMember{id=2, type=ACTIVE, updated=2025-07-31T07:55:46.119Z}
10:55:46.225 [raft-server-1 1] INFO  io.atomix.raft.impl.RaftContext - Transitioning to CANDIDATE: term=17, lastFlushedIdx=3, commitIdx=2
10:55:46.225 [raft-server-1 1] INFO  io.atomix.raft.roles.CandidateRole - Starting election
10:55:46.225 [raft-server-1 1] TRACE io.atomix.raft.storage.system.MetaStore - Store term 18
10:55:46.225 [raft-server-1 1] TRACE io.atomix.raft.storage.system.MetaStore - Store vote null
10:55:46.225 [raft-server-1 1] DEBUG io.atomix.raft.impl.RaftContext - Set term 18
10:55:46.225 [raft-server-1 1] TRACE io.atomix.raft.storage.system.MetaStore - Store vote 1
10:55:46.225 [raft-server-1 1] DEBUG io.atomix.raft.impl.RaftContext - Voted for 1
10:55:46.225 [raft-server-1 1] DEBUG io.atomix.raft.roles.CandidateRole - Requesting votes for term 18
10:55:46.225 [raft-server-1 1] DEBUG io.atomix.raft.roles.CandidateRole - Requesting vote from DefaultRaftMember{id=2, type=ACTIVE, updated=2025-07-31T07:55:46.119Z} for term 18
10:55:46.226 [raft-server-1 1] DEBUG io.atomix.raft.roles.CandidateRole - Requesting vote from DefaultRaftMember{id=0, type=ACTIVE, updated=2025-07-31T07:55:46.119Z} for term 18
10:55:46.226 [raft-server-1 1] TRACE io.atomix.raft.roles.CandidateRole - Received PollRequest{term=17, candidate=2, lastLogIndex=2, lastLogTerm=9}
10:55:46.226 [raft-server-1 1] DEBUG io.atomix.raft.roles.CandidateRole - Rejected PollRequest{term=17, candidate=2, lastLogIndex=2, lastLogTerm=9}: candidate's term is less than the current term
10:55:46.226 [raft-server-1 1] TRACE io.atomix.raft.roles.CandidateRole - Sending PollResponse{status=OK, term=18, accepted=false}
10:55:46.226 [raft-server-1 0] TRACE io.atomix.raft.roles.FollowerRole - Received PollRequest{term=17, candidate=2, lastLogIndex=2, lastLogTerm=9}
10:55:46.226 [raft-server-1 0] DEBUG io.atomix.raft.roles.FollowerRole - Rejected PollRequest{term=17, candidate=2, lastLogIndex=2, lastLogTerm=9}: candidate's last log entry (9) is at a lower term than the local log (17)
10:55:46.226 [raft-server-1 0] TRACE io.atomix.raft.roles.FollowerRole - Sending PollResponse{status=OK, term=17, accepted=false}
10:55:46.226 [raft-server-1 2] TRACE io.atomix.raft.roles.FollowerRole - Received VoteRequest{term=18, candidate=1, lastLogIndex=3, lastLogTerm=17}
10:55:46.226 [raft-server-1 2] TRACE io.atomix.raft.storage.system.MetaStore - Store term 18
10:55:46.226 [raft-server-1 2] TRACE io.atomix.raft.storage.system.MetaStore - Store vote null
10:55:46.226 [raft-server-1 2] DEBUG io.atomix.raft.impl.RaftContext - Set term 18
10:55:46.226 [raft-server-1 2] INFO  io.atomix.raft.roles.FollowerRole - Accepted VoteRequest{term=18, candidate=1, lastLogIndex=3, lastLogTerm=17}: candidate's log is up-to-date
10:55:46.226 [raft-server-1 2] TRACE io.atomix.raft.storage.system.MetaStore - Store vote 1
10:55:46.226 [raft-server-1 2] DEBUG io.atomix.raft.impl.RaftContext - Voted for 1
10:55:46.226 [raft-server-1 2] TRACE io.atomix.raft.roles.FollowerRole - Sending VoteResponse{status=OK, term=18, voted=true}
10:55:46.226 [raft-server-1 2] DEBUG io.atomix.raft.roles.FollowerRole - Received rejected poll from DefaultRaftMember{id=1, type=ACTIVE, updated=2025-07-31T07:55:46.120Z}
10:55:46.226 [raft-server-1 2] DEBUG io.atomix.raft.roles.FollowerRole - Received rejected poll from DefaultRaftMember{id=0, type=ACTIVE, updated=2025-07-31T07:55:46.120Z}
10:55:46.226 [raft-server-1 0] TRACE io.atomix.raft.roles.FollowerRole - Received VoteRequest{term=18, candidate=1, lastLogIndex=3, lastLogTerm=17}
10:55:46.226 [raft-server-1 0] TRACE io.atomix.raft.storage.system.MetaStore - Store term 18
10:55:46.226 [raft-server-1 0] TRACE io.atomix.raft.storage.system.MetaStore - Store vote null
10:55:46.226 [raft-server-1 0] DEBUG io.atomix.raft.impl.RaftContext - Set term 18
10:55:46.226 [raft-server-1 0] INFO  io.atomix.raft.roles.FollowerRole - Accepted VoteRequest{term=18, candidate=1, lastLogIndex=3, lastLogTerm=17}: candidate's log is up-to-date
10:55:46.226 [raft-server-1 0] TRACE io.atomix.raft.storage.system.MetaStore - Store vote 1
10:55:46.226 [raft-server-1 0] DEBUG io.atomix.raft.impl.RaftContext - Voted for 1
10:55:46.226 [raft-server-1 0] TRACE io.atomix.raft.roles.FollowerRole - Sending VoteResponse{status=OK, term=18, voted=true}
10:55:46.226 [raft-server-1 1] DEBUG io.atomix.raft.roles.CandidateRole - Received successful vote from DefaultRaftMember{id=2, type=ACTIVE, updated=2025-07-31T07:55:46.119Z}
10:55:46.226 [raft-server-1 1] INFO  io.atomix.raft.impl.RaftContext - Transitioning to LEADER: term=18, lastFlushedIdx=3, commitIdx=2
10:55:46.226 [raft-server-1 1] DEBUG io.atomix.raft.roles.CandidateRole - Cancelling election
10:55:46.226 [raft-server-1 1] INFO  io.atomix.raft.impl.RaftContext - Found leader 1
10:55:46.226 [raft-server-1 1] TRACE io.atomix.raft.impl.RaftContext - Set leader 1
10:55:46.226 [raft-server-1 1] TRACE io.atomix.raft.roles.LeaderRole - Appended IndexedRaftLogEntryImpl[index=4, term=18, entry=InitialEntry[], record=PersistedJournalRecord[metadata=RecordMetadata[checksum=3758297753, length=45], record=RecordData[index=4, asqn=-1, data=UnsafeBuffer{addressOffset=140158271119664, capacity=17, byteArray=null, byteBuffer=java.nio.DirectByteBuffer[pos=321 lim=10240 cap=10240]}], serializedRecord=UnsafeBuffer{addressOffset=140158271119636, capacity=45, byteArray=null, byteBuffer=java.nio.DirectByteBuffer[pos=321 lim=10240 cap=10240]}]]
10:55:46.226 [raft-server-1 1] DEBUG io.atomix.raft.roles.LeaderAppender - Configuring 0 : ConfigureRequest{term=18, leader='1', index=0, timestamp=1753948546119, newMembers=[DefaultRaftMember{id=2, type=ACTIVE, updated=2025-07-31T07:55:46.119Z}, DefaultRaftMember{id=1, type=ACTIVE, updated=2025-07-31T07:55:46.119Z}, DefaultRaftMember{id=0, type=ACTIVE, updated=2025-07-31T07:55:46.119Z}], oldMembers=[]}
10:55:46.226 [raft-server-1 1] TRACE io.atomix.raft.roles.LeaderAppender - Sending ConfigureRequest{term=18, leader='1', index=0, timestamp=1753948546119, newMembers=[DefaultRaftMember{id=2, type=ACTIVE, updated=2025-07-31T07:55:46.119Z}, DefaultRaftMember{id=1, type=ACTIVE, updated=2025-07-31T07:55:46.119Z}, DefaultRaftMember{id=0, type=ACTIVE, updated=2025-07-31T07:55:46.119Z}], oldMembers=[]} to 0
10:55:46.226 [raft-server-1 1] DEBUG io.atomix.raft.roles.LeaderAppender - Configuring 2 : ConfigureRequest{term=18, leader='1', index=0, timestamp=1753948546119, newMembers=[DefaultRaftMember{id=2, type=ACTIVE, updated=2025-07-31T07:55:46.119Z}, DefaultRaftMember{id=1, type=ACTIVE, updated=2025-07-31T07:55:46.119Z}, DefaultRaftMember{id=0, type=ACTIVE, updated=2025-07-31T07:55:46.119Z}], oldMembers=[]}
10:55:46.226 [raft-server-1 1] TRACE io.atomix.raft.roles.LeaderAppender - Sending ConfigureRequest{term=18, leader='1', index=0, timestamp=1753948546119, newMembers=[DefaultRaftMember{id=2, type=ACTIVE, updated=2025-07-31T07:55:46.119Z}, DefaultRaftMember{id=1, type=ACTIVE, updated=2025-07-31T07:55:46.119Z}, DefaultRaftMember{id=0, type=ACTIVE, updated=2025-07-31T07:55:46.119Z}], oldMembers=[]} to 2
10:55:46.226 [raft-server-1 1] TRACE io.atomix.raft.roles.LeaderRole - Starting append timer on fix rate of PT0.25S
10:55:46.226 [raft-server-1 1] TRACE io.atomix.raft.roles.LeaderAppender - Sending VersionedAppendRequest{version=2, term=18, leader=1, prevLogIndex=3, prevLogTerm=17, entries=0, commitIndex=2} to 0
10:55:46.226 [raft-server-1 1] TRACE io.atomix.raft.roles.LeaderAppender - Sending VersionedAppendRequest{version=2, term=18, leader=1, prevLogIndex=3, prevLogTerm=17, entries=0, commitIndex=2} to 2
10:55:46.226 [raft-server-1 2] TRACE io.atomix.raft.roles.FollowerRole - Received ConfigureRequest{term=18, leader='1', index=0, timestamp=1753948546119, newMembers=[DefaultRaftMember{id=2, type=ACTIVE, updated=2025-07-31T07:55:46.119Z}, DefaultRaftMember{id=1, type=ACTIVE, updated=2025-07-31T07:55:46.119Z}, DefaultRaftMember{id=0, type=ACTIVE, updated=2025-07-31T07:55:46.119Z}], oldMembers=[]}
10:55:46.226 [raft-server-1 2] INFO  io.atomix.raft.impl.RaftContext - Found leader 1
10:55:46.226 [raft-server-1 2] TRACE io.atomix.raft.impl.RaftContext - Set leader 1
10:55:46.226 [raft-server-1 2] TRACE io.atomix.raft.roles.FollowerRole - Sending ConfigureResponse{status=OK}
10:55:46.226 [raft-server-1 2] TRACE io.atomix.raft.roles.FollowerRole - Received InternalAppendRequest[term=18, leader=1, prevLogIndex=3, prevLogTerm=17, commitIndex=2, entries=[]]
10:55:46.226 [raft-server-1 2] DEBUG io.atomix.raft.roles.FollowerRole - Rejected InternalAppendRequest[term=18, leader=1, prevLogIndex=3, prevLogTerm=17, commitIndex=2, entries=[]]: Previous index (3) is greater than the local log's last index (2)
10:55:46.226 [raft-server-1 2] TRACE io.atomix.raft.roles.FollowerRole - Sending AppendResponse{status=OK, term=18, succeeded=false, lastLogIndex=2, lastSnapshotIndex=1, configurationIndex=0}
10:55:46.226 [raft-server-1 0] TRACE io.atomix.raft.roles.FollowerRole - Received ConfigureRequest{term=18, leader='1', index=0, timestamp=1753948546119, newMembers=[DefaultRaftMember{id=2, type=ACTIVE, updated=2025-07-31T07:55:46.119Z}, DefaultRaftMember{id=1, type=ACTIVE, updated=2025-07-31T07:55:46.119Z}, DefaultRaftMember{id=0, type=ACTIVE, updated=2025-07-31T07:55:46.119Z}], oldMembers=[]}
10:55:46.226 [raft-server-1 0] INFO  io.atomix.raft.impl.RaftContext - Found leader 1
10:55:46.227 [raft-server-1 0] TRACE io.atomix.raft.impl.RaftContext - Set leader 1
10:55:46.227 [raft-server-1 0] TRACE io.atomix.raft.roles.FollowerRole - Sending ConfigureResponse{status=OK}
10:55:46.227 [raft-server-1 0] TRACE io.atomix.raft.roles.FollowerRole - Received InternalAppendRequest[term=18, leader=1, prevLogIndex=3, prevLogTerm=17, commitIndex=2, entries=[]]
10:55:46.227 [raft-server-1 0] INFO  io.atomix.raft.impl.RaftContext - Setting firstCommitIndex to 2. RaftServer is ready only after it has committed events up to this index
10:55:46.227 [raft-server-1 0] INFO  io.atomix.raft.impl.RaftContext - Commit index is 2. RaftServer is ready
10:55:46.227 [raft-server-1 0] TRACE io.atomix.raft.roles.FollowerRole - Sending AppendResponse{status=OK, term=18, succeeded=true, lastLogIndex=3, lastSnapshotIndex=1, configurationIndex=0}
10:55:46.227 [raft-server-1 1] TRACE io.atomix.raft.roles.LeaderAppender - Received ConfigureResponse{status=OK} from 2
10:55:46.227 [raft-server-1 1] TRACE io.atomix.raft.roles.LeaderAppender - Received AppendResponse{status=OK, term=18, succeeded=false, lastLogIndex=2, lastSnapshotIndex=1, configurationIndex=0} from 2
10:55:46.227 [raft-server-1 1] TRACE io.atomix.raft.roles.LeaderAppender - Reset next index for RaftMemberContext{member=2, term=18, configIndex=0, snapshotIndex=0, nextSnapshotIndex=0, nextSnapshotChunk=null, matchIndex=0, heartbeatTime=1753948546226, appending=0, appendSucceeded=false, configuring=false, installing=false, failures=0} to 3
10:55:46.227 [raft-server-1 1] TRACE io.atomix.raft.roles.LeaderAppender - Reset snapshot index for RaftMemberContext{member=2, term=18, configIndex=0, snapshotIndex=1, nextSnapshotIndex=0, nextSnapshotChunk=null, matchIndex=0, heartbeatTime=1753948546226, appending=0, appendSucceeded=false, configuring=false, installing=false, failures=0} to 1
10:55:46.227 [raft-server-1 1] TRACE io.atomix.raft.roles.LeaderAppender - Sending VersionedAppendRequest{version=2, term=18, leader=1, prevLogIndex=2, prevLogTerm=9, entries=2, commitIndex=2} to 2
10:55:46.227 [raft-server-1 1] TRACE io.atomix.raft.roles.LeaderAppender - Received ConfigureResponse{status=OK} from 0
10:55:46.227 [raft-server-1 1] TRACE io.atomix.raft.roles.LeaderAppender - Received AppendResponse{status=OK, term=18, succeeded=true, lastLogIndex=3, lastSnapshotIndex=1, configurationIndex=0} from 0
10:55:46.227 [raft-server-1 1] TRACE io.atomix.raft.roles.LeaderAppender - Sending VersionedAppendRequest{version=2, term=18, leader=1, prevLogIndex=3, prevLogTerm=17, entries=1, commitIndex=2} to 0
10:55:46.227 [raft-server-1 2] TRACE io.atomix.raft.roles.FollowerRole - Received InternalAppendRequest[term=18, leader=1, prevLogIndex=2, prevLogTerm=9, commitIndex=2, entries=[ReplicatableJournalRecord{term=17, index=3, checksum=240035644, serializedJournalRecord={rawToString=[B@418b3215, length=45, hashCode=-748712521}}, ReplicatableJournalRecord{term=18, index=4, checksum=3758297753, serializedJournalRecord={rawToString=[B@58fb9020, length=45, hashCode=2068566073}}]]
10:55:46.227 [raft-server-1 2] TRACE io.atomix.raft.roles.FollowerRole - Appended IndexedRaftLogEntryImpl[index=3, term=17, entry=InitialEntry[], record=PersistedJournalRecord[metadata=RecordMetadata[checksum=240035644, length=45], record=RecordData[index=3, asqn=-1, data=UnsafeBuffer{addressOffset=140158128013550, capacity=17, byteArray=null, byteBuffer=java.nio.DirectByteBuffer[pos=255 lim=10240 cap=10240]}], serializedRecord=UnsafeBuffer{addressOffset=140158128013522, capacity=45, byteArray=null, byteBuffer=java.nio.DirectByteBuffer[pos=255 lim=10240 cap=10240]}]]
10:55:46.227 [raft-server-1 2] TRACE io.atomix.raft.roles.FollowerRole - Appended IndexedRaftLogEntryImpl[index=4, term=18, entry=InitialEntry[], record=PersistedJournalRecord[metadata=RecordMetadata[checksum=3758297753, length=45], record=RecordData[index=4, asqn=-1, data=UnsafeBuffer{addressOffset=140158128013616, capacity=17, byteArray=null, byteBuffer=java.nio.DirectByteBuffer[pos=321 lim=10240 cap=10240]}], serializedRecord=UnsafeBuffer{addressOffset=140158128013588, capacity=45, byteArray=null, byteBuffer=java.nio.DirectByteBuffer[pos=321 lim=10240 cap=10240]}]]
10:55:46.227 [raft-server-1 2] INFO  io.atomix.raft.impl.RaftContext - Setting firstCommitIndex to 2. RaftServer is ready only after it has committed events up to this index
10:55:46.227 [raft-server-1 2] INFO  io.atomix.raft.impl.RaftContext - Commit index is 2. RaftServer is ready
10:55:46.227 [raft-server-1 2] TRACE io.atomix.raft.storage.system.MetaStore - Store last flushed index 4 and commitIndex 2
10:55:46.227 [raft-server-1 2] TRACE io.atomix.raft.roles.FollowerRole - Sending AppendResponse{status=OK, term=18, succeeded=true, lastLogIndex=4, lastSnapshotIndex=1, configurationIndex=0}
10:55:46.227 [raft-server-1 0] TRACE io.atomix.raft.roles.FollowerRole - Received InternalAppendRequest[term=18, leader=1, prevLogIndex=3, prevLogTerm=17, commitIndex=2, entries=[ReplicatableJournalRecord{term=18, index=4, checksum=3758297753, serializedJournalRecord={rawToString=[B@19ed779e, length=45, hashCode=2068566073}}]]
10:55:46.227 [raft-server-1 0] TRACE io.atomix.raft.roles.FollowerRole - Appended IndexedRaftLogEntryImpl[index=4, term=18, entry=InitialEntry[], record=PersistedJournalRecord[metadata=RecordMetadata[checksum=3758297753, length=45], record=RecordData[index=4, asqn=-1, data=UnsafeBuffer{addressOffset=140158338863408, capacity=17, byteArray=null, byteBuffer=java.nio.DirectByteBuffer[pos=321 lim=10240 cap=10240]}], serializedRecord=UnsafeBuffer{addressOffset=140158338863380, capacity=45, byteArray=null, byteBuffer=java.nio.DirectByteBuffer[pos=321 lim=10240 cap=10240]}]]
10:55:46.227 [raft-server-1 0] TRACE io.atomix.raft.storage.system.MetaStore - Store last flushed index 4 and commitIndex 2
10:55:46.227 [raft-server-1 0] TRACE io.atomix.raft.roles.FollowerRole - Sending AppendResponse{status=OK, term=18, succeeded=true, lastLogIndex=4, lastSnapshotIndex=1, configurationIndex=0}
10:55:46.227 [raft-server-1 1] TRACE io.atomix.raft.roles.LeaderAppender - Received AppendResponse{status=OK, term=18, succeeded=true, lastLogIndex=4, lastSnapshotIndex=1, configurationIndex=0} from 2
10:55:46.227 [raft-server-1 1] TRACE io.atomix.raft.roles.LeaderAppender - Committed entries up to 4
10:55:46.227 [raft-server-1 1] TRACE io.atomix.raft.storage.system.MetaStore - Store last flushed index 4 and commitIndex 2
10:55:46.228 [raft-server-1 1] INFO  io.atomix.raft.impl.RaftContext - Commit index is 4. RaftServer is ready
10:55:46.228 [raft-server-1 1] TRACE io.atomix.raft.roles.LeaderAppender - Sending VersionedAppendRequest{version=2, term=18, leader=1, prevLogIndex=4, prevLogTerm=18, entries=0, commitIndex=4} to 2
10:55:46.228 [raft-server-1 1] TRACE io.atomix.raft.roles.LeaderAppender - Received AppendResponse{status=OK, term=18, succeeded=true, lastLogIndex=4, lastSnapshotIndex=1, configurationIndex=0} from 0
10:55:46.228 [raft-server-1 1] TRACE io.atomix.raft.roles.LeaderAppender - Sending VersionedAppendRequest{version=2, term=18, leader=1, prevLogIndex=4, prevLogTerm=18, entries=0, commitIndex=4} to 0
10:55:46.228 [raft-server-1 2] TRACE io.atomix.raft.roles.FollowerRole - Received InternalAppendRequest[term=18, leader=1, prevLogIndex=4, prevLogTerm=18, commitIndex=4, entries=[]]
10:55:46.228 [raft-server-1 2] TRACE io.atomix.raft.roles.FollowerRole - Committed entries up to index 4
10:55:46.228 [raft-server-1 2] TRACE io.atomix.raft.roles.FollowerRole - Sending AppendResponse{status=OK, term=18, succeeded=true, lastLogIndex=4, lastSnapshotIndex=1, configurationIndex=0}
10:55:46.228 [raft-server-1 0] TRACE io.atomix.raft.roles.FollowerRole - Received InternalAppendRequest[term=18, leader=1, prevLogIndex=4, prevLogTerm=18, commitIndex=4, entries=[]]
10:55:46.228 [raft-server-1 0] TRACE io.atomix.raft.roles.FollowerRole - Committed entries up to index 4
10:55:46.228 [raft-server-1 0] TRACE io.atomix.raft.roles.FollowerRole - Sending AppendResponse{status=OK, term=18, succeeded=true, lastLogIndex=4, lastSnapshotIndex=1, configurationIndex=0}
10:55:46.228 [raft-server-1 ] INFO  TEST - Checking if all members are ready 1-partition-1 - READY [DefaultRaftMember{id=2, type=ACTIVE, updated=2025-07-31T07:55:46.119Z}, DefaultRaftMember{id=1, type=ACTIVE, updated=2025-07-31T07:55:46.119Z}, DefaultRaftMember{id=0, type=ACTIVE, updated=2025-07-31T07:55:46.119Z}]
10:55:46.228 [raft-server-1 ] INFO  TEST - Checking if all members are ready 2-partition-1 - READY [DefaultRaftMember{id=2, type=ACTIVE, updated=2025-07-31T07:55:46.120Z}, DefaultRaftMember{id=1, type=ACTIVE, updated=2025-07-31T07:55:46.120Z}, DefaultRaftMember{id=0, type=ACTIVE, updated=2025-07-31T07:55:46.120Z}]
10:55:46.228 [raft-server-1 ] INFO  TEST - Checking if all members are ready 0-partition-1 - READY [DefaultRaftMember{id=2, type=ACTIVE, updated=2025-07-31T07:55:46.116Z}, DefaultRaftMember{id=1, type=ACTIVE, updated=2025-07-31T07:55:46.116Z}, DefaultRaftMember{id=0, type=ACTIVE, updated=2025-07-31T07:55:46.116Z}]
10:55:46.229 [raft-server-1 ] DEBUG io.camunda.zeebe.snapshots.impl.FileBasedSnapshotStoreImpl - Closing snapshot store /tmp/1180496286099004907/1/snapshots/snapshots
10:55:46.229 [raft-server-1 ] DEBUG io.camunda.zeebe.snapshots.impl.FileBasedSnapshotStoreImpl - Closing snapshot store /tmp/1180496286099004907/2/snapshots/snapshots
10:55:46.229 [raft-server-1 ] DEBUG io.camunda.zeebe.snapshots.impl.FileBasedSnapshotStoreImpl - Closing snapshot store /tmp/1180496286099004907/0/snapshots/snapshots
10:55:46.229 [raft-server-1 ] DEBUG io.atomix.raft.impl.RaftContext - Closing RaftContext: term=18, commitIdx=4, lastFlushedIdx=4
10:55:46.229 [raft-server-1 ] DEBUG io.camunda.zeebe.journal.file.SegmentsManager - Closing segment: Segment{id=1, index=1}
10:55:46.229 [raft-server-1 ] DEBUG io.atomix.raft.impl.RaftContext - Raft context closed
10:55:46.229 [raft-server-1 ] DEBUG io.atomix.raft.impl.RaftContext - Closing RaftContext: term=18, commitIdx=4, lastFlushedIdx=4
10:55:46.229 [raft-server-1 ] DEBUG io.camunda.zeebe.journal.file.SegmentsManager - Closing segment: Segment{id=1, index=1}
10:55:46.229 [raft-server-1 ] DEBUG io.atomix.raft.impl.RaftContext - Raft context closed
10:55:46.229 [raft-server-1 ] DEBUG io.atomix.raft.impl.RaftContext - Closing RaftContext: term=18, commitIdx=4, lastFlushedIdx=4
10:55:46.229 [raft-server-1 ] DEBUG io.camunda.zeebe.journal.file.SegmentsManager - Closing segment: Segment{id=1, index=1}
10:55:46.229 [raft-server-1 ] DEBUG io.atomix.raft.impl.RaftContext - Raft context closed

</p>
</details> 

<details><summary>Failed Run Log</summary>
<p>

12:55:57.609 [raft-server-1 ] INFO  io.atomix.raft.RandomizedRaftTest - Restart member on 0
12:55:57.609 [raft-server-1 0] DEBUG io.atomix.raft.impl.RaftContext - Closing RaftContext: term=18, commitIdx=2, lastFlushedIdx=2
12:55:57.609 [raft-server-1 0] DEBUG io.camunda.zeebe.journal.file.SegmentsManager - Closing segment: Segment{id=1, index=1}
12:55:57.609 [raft-server-1 0] DEBUG io.atomix.raft.impl.RaftContext - Raft context closed
12:55:57.609 [raft-server-1 ] DEBUG io.camunda.zeebe.snapshots.impl.FileBasedSnapshotStoreImpl - Closing snapshot store /tmp/7538211368358465635/0/snapshots/snapshots
12:55:57.612 [raft-server-1 ] DEBUG io.camunda.zeebe.snapshots.impl.FileBasedSnapshotStoreImpl - Deleting snapshots other than 1-10-1-1-0-318da350
12:55:57.613 [raft-server-1 ] DEBUG io.atomix.raft.impl.RaftContext - Priority election is enabled with target priority 3 and node priority 1
12:55:57.613 [raft-server-1 ] DEBUG io.camunda.zeebe.journal.file.SegmentsManager - Found segment file: atomix-1.log
12:55:57.614 [raft-server-1 ] TRACE io.atomix.raft.storage.system.MetaStore - Skip storing same last flushed commit index 2
12:55:57.614 [raft-server-1 ] DEBUG io.atomix.raft.impl.RaftContext - Server started with term=18, lastVotedFor=2, lastFlushedIndex=2, commitIndex=2
12:55:57.614 [raft-server-1 ] INFO  io.atomix.raft.RandomizedRaftTest - Restart member on 1
12:55:57.614 [raft-server-1 1] DEBUG io.atomix.raft.impl.RaftContext - Closing RaftContext: term=18, commitIdx=2, lastFlushedIdx=2
12:55:57.614 [raft-server-1 1] DEBUG io.camunda.zeebe.journal.file.SegmentsManager - Closing segment: Segment{id=1, index=1}
12:55:57.614 [raft-server-1 1] DEBUG io.atomix.raft.impl.RaftContext - Raft context closed
12:55:57.614 [raft-server-1 ] DEBUG io.camunda.zeebe.snapshots.impl.FileBasedSnapshotStoreImpl - Closing snapshot store /tmp/7538211368358465635/1/snapshots/snapshots
12:55:57.616 [raft-server-1 ] DEBUG io.camunda.zeebe.snapshots.impl.FileBasedSnapshotStoreImpl - Deleting snapshots other than 1-10-1-1-1-54c0c0a9
12:55:57.617 [raft-server-1 ] DEBUG io.atomix.raft.impl.RaftContext - Priority election is enabled with target priority 3 and node priority 2
12:55:57.617 [raft-server-1 ] DEBUG io.camunda.zeebe.journal.file.SegmentsManager - Found segment file: atomix-1.log
12:55:57.617 [raft-server-1 ] TRACE io.atomix.raft.storage.system.MetaStore - Skip storing same last flushed commit index 2
12:55:57.617 [raft-server-1 ] DEBUG io.atomix.raft.impl.RaftContext - Server started with term=18, lastVotedFor=null, lastFlushedIndex=2, commitIndex=2
12:55:57.617 [raft-server-1 ] INFO  io.atomix.raft.RandomizedRaftTest - Restart member on 2
12:55:57.617 [raft-server-1 2] TRACE io.atomix.raft.roles.LeaderAppender - Received AppendResponse{status=OK, term=18, succeeded=true, lastLogIndex=2, lastSnapshotIndex=1, configurationIndex=0} from 0
12:55:57.617 [raft-server-1 2] TRACE io.atomix.raft.roles.LeaderAppender - Sending VersionedAppendRequest{version=2, term=18, leader=2, prevLogIndex=2, prevLogTerm=18, entries=0, commitIndex=2} to 0
12:55:57.617 [raft-server-1 2] DEBUG io.atomix.raft.impl.RaftContext - Closing RaftContext: term=18, commitIdx=2, lastFlushedIdx=2
12:55:57.617 [raft-server-1 2] DEBUG io.camunda.zeebe.journal.file.SegmentsManager - Closing segment: Segment{id=1, index=1}
12:55:57.617 [raft-server-1 2] DEBUG io.atomix.raft.impl.RaftContext - Raft context closed
12:55:57.617 [raft-server-1 ] DEBUG io.camunda.zeebe.snapshots.impl.FileBasedSnapshotStoreImpl - Closing snapshot store /tmp/7538211368358465635/2/snapshots/snapshots
12:55:57.619 [raft-server-1 ] DEBUG io.camunda.zeebe.snapshots.impl.FileBasedSnapshotStoreImpl - Deleting snapshots other than 1-10-1-1-2-aa6590d2
12:55:57.620 [raft-server-1 ] DEBUG io.atomix.raft.impl.RaftContext - Priority election is enabled with target priority 3 and node priority 3
12:55:57.620 [raft-server-1 ] DEBUG io.camunda.zeebe.journal.file.SegmentsManager - Found segment file: atomix-1.log
12:55:57.620 [raft-server-1 ] TRACE io.atomix.raft.storage.system.MetaStore - Skip storing same last flushed commit index 2
12:55:57.620 [raft-server-1 ] DEBUG io.atomix.raft.impl.RaftContext - Server started with term=18, lastVotedFor=2, lastFlushedIndex=2, commitIndex=2
12:55:57.620 [raft-server-1 1] INFO  io.atomix.raft.impl.RaftContext - Transitioning to FOLLOWER: term=18, lastFlushedIdx=2, commitIdx=2
12:55:57.620 [raft-server-1 2] INFO  io.atomix.raft.impl.RaftContext - Transitioning to FOLLOWER: term=18, lastFlushedIdx=2, commitIdx=2
12:55:57.621 [raft-server-1 0] INFO  io.atomix.raft.impl.RaftContext - Transitioning to FOLLOWER: term=18, lastFlushedIdx=2, commitIdx=2
12:55:57.621 [raft-server-1 0] TRACE io.atomix.raft.roles.FollowerRole - Received InternalAppendRequest[term=18, leader=2, prevLogIndex=2, prevLogTerm=18, commitIndex=2, entries=[]]
12:55:57.621 [raft-server-1 0] INFO  io.atomix.raft.impl.RaftContext - Found leader 2
12:55:57.621 [raft-server-1 0] TRACE io.atomix.raft.impl.RaftContext - Set leader 2
12:55:57.621 [raft-server-1 0] INFO  io.atomix.raft.impl.RaftContext - Setting firstCommitIndex to 2. RaftServer is ready only after it has committed events up to this index
12:55:57.621 [raft-server-1 0] INFO  io.atomix.raft.impl.RaftContext - Commit index is 2. RaftServer is ready
12:55:57.621 [raft-server-1 0] TRACE io.atomix.raft.roles.FollowerRole - Sending AppendResponse{status=OK, term=18, succeeded=true, lastLogIndex=2, lastSnapshotIndex=1, configurationIndex=0}
12:55:57.621 [raft-server-1 ] INFO  TEST - Checking if all members are ready 1-partition-1 - ACTIVE [DefaultRaftMember{id=1, type=ACTIVE, updated=2025-07-31T09:55:57.522Z}, DefaultRaftMember{id=2, type=ACTIVE, updated=2025-07-31T09:55:57.522Z}, DefaultRaftMember{id=0, type=ACTIVE, updated=2025-07-31T09:55:57.522Z}]
12:55:57.638 [raft-server-1 ] DEBUG io.camunda.zeebe.snapshots.impl.FileBasedSnapshotStoreImpl - Closing snapshot store /tmp/7538211368358465635/1/snapshots/snapshots
12:55:57.638 [raft-server-1 ] DEBUG io.camunda.zeebe.snapshots.impl.FileBasedSnapshotStoreImpl - Closing snapshot store /tmp/7538211368358465635/2/snapshots/snapshots
12:55:57.638 [raft-server-1 ] DEBUG io.camunda.zeebe.snapshots.impl.FileBasedSnapshotStoreImpl - Closing snapshot store /tmp/7538211368358465635/0/snapshots/snapshots
12:55:57.638 [raft-server-1 ] DEBUG io.atomix.raft.impl.RaftContext - Closing RaftContext: term=18, commitIdx=2, lastFlushedIdx=2
12:55:57.638 [raft-server-1 ] DEBUG io.camunda.zeebe.journal.file.SegmentsManager - Closing segment: Segment{id=1, index=1}
12:55:57.638 [raft-server-1 ] DEBUG io.atomix.raft.impl.RaftContext - Raft context closed
12:55:57.638 [raft-server-1 ] DEBUG io.atomix.raft.impl.RaftContext - Closing RaftContext: term=18, commitIdx=2, lastFlushedIdx=2
12:55:57.638 [raft-server-1 ] DEBUG io.camunda.zeebe.journal.file.SegmentsManager - Closing segment: Segment{id=1, index=1}
12:55:57.638 [raft-server-1 ] DEBUG io.atomix.raft.impl.RaftContext - Raft context closed
12:55:57.638 [raft-server-1 ] DEBUG io.atomix.raft.impl.RaftContext - Closing RaftContext: term=18, commitIdx=2, lastFlushedIdx=2
12:55:57.638 [raft-server-1 ] DEBUG io.camunda.zeebe.journal.file.SegmentsManager - Closing segment: Segment{id=1, index=1}
12:55:57.638 [raft-server-1 ] DEBUG io.atomix.raft.impl.RaftContext - Raft context closed

</p>
</details> 

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #34209
