### PR TITLE
feat: new cpt configuration prefix with backwards compatibility

### DIFF
--- a/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/configuration/CamundaProcessTestRuntimeConfiguration.java
+++ b/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/configuration/CamundaProcessTestRuntimeConfiguration.java
@@ -27,7 +27,7 @@ import org.springframework.boot.context.properties.NestedConfigurationProperty;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-@ConfigurationProperties(prefix = "io.camunda.process.test")
+@ConfigurationProperties(prefix = "camunda.process-test")
 public class CamundaProcessTestRuntimeConfiguration {
 
   private String camundaDockerImageName =

--- a/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/configuration/LegacyCamundaProcessTestRuntimeConfiguration.java
+++ b/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/configuration/LegacyCamundaProcessTestRuntimeConfiguration.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.impl.configuration;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@ConfigurationProperties(prefix = "io.camunda.process.test")
+@Configuration
+@Deprecated
+public class LegacyCamundaProcessTestRuntimeConfiguration
+    extends CamundaProcessTestRuntimeConfiguration {}


### PR DESCRIPTION
## Description

Changed the CamundaProcessTestRuntimeConfiguration prefix from `io.camunda.process.test` to `camunda.process-test` and ensured backwards compatibility.

## Related issues

closes #35436
