### PR TITLE
Exclude authorizations from ES/OS exporters

### DIFF
--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/BulkIndexRequest.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/BulkIndexRequest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.exporter;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.core.JsonParser.Feature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.annotation.JsonAppend;
@@ -32,6 +33,7 @@ final class BulkIndexRequest implements ContentProducer {
 
   // The property of the ES record template to store the sequence of the record.
   private static final String RECORD_SEQUENCE_PROPERTY = "sequence";
+  private static final String RECORD_AUTHORIZATIONS_PROPERTY = "authorizations";
 
   private final List<BulkOperation> operations = new ArrayList<>();
 
@@ -135,5 +137,6 @@ final class BulkIndexRequest implements ContentProducer {
   record BulkOperation(BulkIndexAction metadata, byte[] source) {}
 
   @JsonAppend(attrs = {@JsonAppend.Attr(value = RECORD_SEQUENCE_PROPERTY)})
+  @JsonIgnoreProperties({RECORD_AUTHORIZATIONS_PROPERTY})
   private static final class RecordSequenceMixin {}
 }

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-template.json
@@ -36,9 +36,6 @@
         "rejectionReason": {
           "type": "text"
         },
-        "authorizations": {
-          "enabled": false
-        },
         "valueType": {
           "type": "keyword"
         },

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterIT.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterIT.java
@@ -75,7 +75,8 @@ final class ElasticsearchExporterIT {
 
   private final ElasticsearchExporterConfiguration config =
       new ElasticsearchExporterConfiguration();
-  private final ProtocolFactory factory = new ProtocolFactory();
+  // omit authorizations since they are removed from the records during serialization
+  private final ProtocolFactory factory = new ProtocolFactory(b -> b.withAuthorizations(Map.of()));
   private final ExporterTestController controller = new ExporterTestController();
   private final ElasticsearchExporter exporter = new ElasticsearchExporter();
   private final RecordIndexRouter indexRouter = new RecordIndexRouter(config.index);

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/FaultToleranceIT.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/FaultToleranceIT.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
 import io.camunda.zeebe.test.util.testcontainers.TestSearchContainers;
 import io.camunda.zeebe.util.VersionUtil;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.SocatContainer;
@@ -30,7 +31,8 @@ final class FaultToleranceIT {
 
   private final ElasticsearchExporterConfiguration config =
       new ElasticsearchExporterConfiguration();
-  private final ProtocolFactory factory = new ProtocolFactory();
+  // omit authorizations since they are removed from the records during serialization
+  private final ProtocolFactory factory = new ProtocolFactory(b -> b.withAuthorizations(Map.of()));
   private final ExporterTestController controller = new ExporterTestController();
   private final ElasticsearchExporter exporter = new ElasticsearchExporter();
   private final RecordIndexRouter indexRouter = new RecordIndexRouter(config.index);

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequest.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.exporter.opensearch;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.core.JsonParser.Feature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.annotation.JsonAppend;
@@ -32,6 +33,7 @@ final class BulkIndexRequest implements ContentProducer {
 
   // The property of the ES record template to store the sequence of the record.
   private static final String RECORD_SEQUENCE_PROPERTY = "sequence";
+  private static final String RECORD_AUTHORIZATIONS_PROPERTY = "authorizations";
 
   private final List<BulkOperation> operations = new ArrayList<>();
 
@@ -134,5 +136,6 @@ final class BulkIndexRequest implements ContentProducer {
   record BulkOperation(BulkIndexAction metadata, byte[] source) {}
 
   @JsonAppend(attrs = {@JsonAppend.Attr(value = RECORD_SEQUENCE_PROPERTY)})
+  @JsonIgnoreProperties({RECORD_AUTHORIZATIONS_PROPERTY})
   private static final class RecordSequenceMixin {}
 }

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-template.json
@@ -36,9 +36,6 @@
         "rejectionReason": {
           "type": "text"
         },
-        "authorizations": {
-          "enabled": false
-        },
         "valueType": {
           "type": "keyword"
         },

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequestTest.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequestTest.java
@@ -166,7 +166,7 @@ final class BulkIndexRequestTest {
 
     @Test
     void shouldWriteOperationsAsNDJson() throws IOException {
-      // given - use an empty authorization for comparison, since the bulk request
+      // given - use an empty authorization for comparison, since the bulk request will remove it
       final var records =
           recordFactory.generateRecords(b -> b.withAuthorizations(Map.of())).limit(2).toList();
       final var actions =

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequestTest.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequestTest.java
@@ -77,6 +77,7 @@ final class BulkIndexRequestTest {
     // The sequence property is not part of the record itself. It is added additionally in the
     // Opensearch exporter. We need to do the same in the test to get the correct memory usage.
     recordAsMap.put("sequence", recordSequence.sequence());
+    recordAsMap.remove("authorizations");
     return MAPPER.writeValueAsBytes(recordAsMap).length;
   }
 
@@ -148,8 +149,8 @@ final class BulkIndexRequestTest {
   final class SerializationTest {
     @Test
     void shouldIndexRecordSerialized() {
-      // given
-      final var record = recordFactory.generateRecord();
+      // given - use an empty authorization for comparison, since the bulk request
+      final var record = recordFactory.generateRecord(b -> b.withAuthorizations(Map.of()));
       final var action = new BulkIndexAction("index", "id", "routing");
 
       // when
@@ -165,8 +166,9 @@ final class BulkIndexRequestTest {
 
     @Test
     void shouldWriteOperationsAsNDJson() throws IOException {
-      // given
-      final var records = recordFactory.generateRecords().limit(2).toList();
+      // given - use an empty authorization for comparison, since the bulk request
+      final var records =
+          recordFactory.generateRecords(b -> b.withAuthorizations(Map.of())).limit(2).toList();
       final var actions =
           List.of(
               new BulkIndexAction("index", "id", "routing"),
@@ -221,6 +223,25 @@ final class BulkIndexRequestTest {
           .extracting(source -> source.get("sequence"))
           .describedAs("Expect that the records are serialized with the sequences")
           .containsExactly(recordSequences.get(0).sequence(), recordSequences.get(1).sequence());
+    }
+
+    @Test
+    void shouldIndexRecordWithoutAuthorizations() {
+      // given
+      final var records = recordFactory.generateRecords().limit(1).toList();
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.get(0), records.get(0), new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("authorizations"))
+          .describedAs("Expect that the records are NOT serialized with authorizations")
+          .containsExactly(new Object[] {null});
     }
 
     private Record<?> deserializeSource(final BulkOperation operation) {

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequestTest.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequestTest.java
@@ -149,7 +149,7 @@ final class BulkIndexRequestTest {
   final class SerializationTest {
     @Test
     void shouldIndexRecordSerialized() {
-      // given - use an empty authorization for comparison, since the bulk request
+      // given - use an empty authorization for comparison, since the bulk request will remove it
       final var record = recordFactory.generateRecord(b -> b.withAuthorizations(Map.of()));
       final var action = new BulkIndexAction("index", "id", "routing");
 

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/FaultToleranceIT.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/FaultToleranceIT.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
 import io.camunda.zeebe.test.util.testcontainers.TestSearchContainers;
 import io.camunda.zeebe.util.VersionUtil;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.opensearch.testcontainers.OpensearchContainer;
 import org.testcontainers.containers.Network;
@@ -29,7 +30,8 @@ import org.testcontainers.containers.SocatContainer;
 final class FaultToleranceIT {
 
   private final OpensearchExporterConfiguration config = new OpensearchExporterConfiguration();
-  private final ProtocolFactory factory = new ProtocolFactory();
+  // omit authorizations since they are removed from the records during serialization
+  private final ProtocolFactory factory = new ProtocolFactory(b -> b.withAuthorizations(Map.of()));
   private final ExporterTestController controller = new ExporterTestController();
   private final OpensearchExporter exporter = new OpensearchExporter();
   private final RecordIndexRouter indexRouter = new RecordIndexRouter(config.index);

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterIT.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterIT.java
@@ -71,7 +71,8 @@ final class OpensearchExporterIT {
           .withEnv("action.destructive_requires_name", "false");
 
   private final OpensearchExporterConfiguration config = new OpensearchExporterConfiguration();
-  private final ProtocolFactory factory = new ProtocolFactory();
+  // omit authorizations since they are removed from the records during serialization
+  private final ProtocolFactory factory = new ProtocolFactory(b -> b.withAuthorizations(Map.of()));
   private final ExporterTestController controller = new ExporterTestController();
   private final OpensearchExporter exporter = new OpensearchExporter();
   private final RecordIndexRouter indexRouter = new RecordIndexRouter(config.index);


### PR DESCRIPTION
## Description

This PR removes the authorizations from the exported `Record<?>` instances in the ES and OS exporters. Nothing was required for the `CamundaExporter` because we don't export raw records there.

## Related issues

closes #35178 
