### PR TITLE
[Backport stable/8.6] test: fix legacy operate migration ci

### DIFF
--- a/operate/qa/util/pom.xml
+++ b/operate/qa/util/pom.xml
@@ -38,6 +38,11 @@
     </dependency>
 
     <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-util</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-context</artifactId>
     </dependency>

--- a/operate/qa/util/src/main/java/io/camunda/operate/qa/util/TestContainerUtil.java
+++ b/operate/qa/util/src/main/java/io/camunda/operate/qa/util/TestContainerUtil.java
@@ -12,6 +12,7 @@ import static org.testcontainers.images.PullPolicy.alwaysPull;
 
 import io.camunda.operate.exceptions.OperateRuntimeException;
 import io.camunda.operate.util.RetryOperation;
+import io.camunda.zeebe.util.SemanticVersion;
 import io.zeebe.containers.ZeebeContainer;
 import io.zeebe.containers.ZeebePort;
 import jakarta.annotation.PreDestroy;
@@ -24,6 +25,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -489,6 +491,20 @@ public class TestContainerUtil {
       final long startTime = System.currentTimeMillis();
       Testcontainers.exposeHostPorts(ELS_PORT);
       broker = new ZeebeContainer(DockerImageName.parse("camunda/zeebe:" + version));
+      final var exposedPorts =
+          new ArrayList<>(
+              List.of(
+                  ZeebePort.GATEWAY_GRPC.getPort(),
+                  ZeebePort.COMMAND.getPort(),
+                  ZeebePort.INTERNAL.getPort(),
+                  ZeebePort.MONITORING.getPort()));
+      // Expose REST port only for versions >= 8.5.0
+      if (SemanticVersion.parse(version)
+          .map(v -> v.compareTo(SemanticVersion.parse("8.5.0").get()) >= 0)
+          .orElse(true)) {
+        exposedPorts.add(ZeebePort.GATEWAY_REST.getPort());
+      }
+      broker.setExposedPorts(exposedPorts);
       if (testContext.getNetwork() != null) {
         broker.withNetwork(testContext.getNetwork());
       }


### PR DESCRIPTION
# Description
Backport of #36267 to `stable/8.6`.

relates to 