### PR TITLE
AHSP3 10 activate elements when job is completed

### DIFF
--- a/service/src/main/java/io/camunda/service/AdHocSubProcessActivityServices.java
+++ b/service/src/main/java/io/camunda/service/AdHocSubProcessActivityServices.java
@@ -52,7 +52,7 @@ public class AdHocSubProcessActivityServices extends ApiServices<AdHocSubProcess
   }
 
   public record AdHocSubProcessActivateActivitiesRequest(
-      String adHocSubProcessInstanceKey,
+      long adHocSubProcessInstanceKey,
       List<AdHocSubProcessActivateActivityReference> elements,
       boolean cancelRemainingInstances) {
     public record AdHocSubProcessActivateActivityReference(

--- a/service/src/test/java/io/camunda/service/AdHocSubProcessActivityServicesTest.java
+++ b/service/src/test/java/io/camunda/service/AdHocSubProcessActivityServicesTest.java
@@ -36,7 +36,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 public class AdHocSubProcessActivityServicesTest {
 
-  private static final String AD_HOC_SUB_PROCESS_INSTANCE_KEY = "123456";
+  private static final long AD_HOC_SUB_PROCESS_INSTANCE_KEY = 123456L;
   private static final String ELEMENT_ID = "activity1";
 
   private static final AdHocSubProcessActivateActivitiesRequest DEFAULT_ACTIVATION_REQUEST =

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/adhocsubprocess/AdHocSubProcessInstructionActivateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/adhocsubprocess/AdHocSubProcessInstructionActivateProcessor.java
@@ -168,11 +168,12 @@ public class AdHocSubProcessInstructionActivateProcessor
         adHocSubProcessElementInstance.getState());
 
     // activate the elements
-    for (final var elementValue : command.getValue().getActivateElements()) {
+    for (final var elementValue : command.getValue().activateElements()) {
       bpmnAdHocSubProcessBehavior.activateElement(
-          bpmnElementContext,
           adHocSubProcessElement,
-          adHocSubProcessElement.getAdHocActivitiesById().get(elementValue.getElementId()));
+          bpmnElementContext,
+          elementValue.getElementId(),
+          elementValue.getVariablesBuffer());
     }
 
     stateWriter.appendFollowUpEvent(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/adhocsubprocess/AdHocSubProcessInstructionActivateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/adhocsubprocess/AdHocSubProcessInstructionActivateProcessor.java
@@ -145,7 +145,7 @@ public class AdHocSubProcessInstructionActivateProcessor
             .map(AdHocSubProcessActivateElementInstruction::getElementId)
             .toList();
     final var activateElementsAreInProcess =
-        AdHocSubProcessUtils.validateActiveElementAreInProcess(
+        AdHocSubProcessUtils.validateActivateElementsExistInAdHocSubProcess(
             adHocSubProcessElementInstance.getKey(), adHocSubProcessElement, activateElements);
     if (activateElementsAreInProcess.isLeft()) {
       final var rejection = activateElementsAreInProcess.getLeft();

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/adhocsubprocess/AdHocSubProcessInstructionActivateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/adhocsubprocess/AdHocSubProcessInstructionActivateProcessor.java
@@ -70,8 +70,7 @@ public class AdHocSubProcessInstructionActivateProcessor
   @Override
   public void processRecord(final TypedRecord<AdHocSubProcessInstructionRecord> command) {
     final var adHocSubProcessElementInstance =
-        elementInstanceState.getInstance(
-            Long.parseLong(command.getValue().getAdHocSubProcessInstanceKey()));
+        elementInstanceState.getInstance(command.getValue().getAdHocSubProcessInstanceKey());
     if (adHocSubProcessElementInstance == null) {
       writeRejectionError(
           command,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/adhocsubprocess/AdHocSubProcessInstructionActivateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/adhocsubprocess/AdHocSubProcessInstructionActivateProcessor.java
@@ -44,8 +44,6 @@ public class AdHocSubProcessInstructionActivateProcessor
       "Expected to activate activities for ad-hoc sub-process with key '%s', but it is not active.";
   private static final String ERROR_MSG_AD_HOC_SUB_PROCESS_IS_NOT_ACTIVE =
       "Expected to activate activities for ad-hoc sub-process with key '%s', but it is not active.";
-  private static final String ERROR_MSG_ELEMENTS_NOT_FOUND =
-      "Expected to activate activities for ad-hoc sub-process with key '%s', but the given elements %s do not exist.";
 
   private final StateWriter stateWriter;
   private final TypedResponseWriter responseWriter;
@@ -136,28 +134,22 @@ public class AdHocSubProcessInstructionActivateProcessor
                 adHocSubProcessElementInstance.getValue().getProcessDefinitionKey(),
                 adHocSubProcessElementInstance.getValue().getTenantId())
             .getProcess();
-
     final var adHocSubProcessElement =
         (ExecutableAdHocSubProcess)
             adHocSubProcessDefinition.getElementById(
                 adHocSubProcessElementInstance.getValue().getElementId());
-    final var adHocActivitiesById = adHocSubProcessElement.getAdHocActivitiesById();
 
     // check that the given elements exist within the ad-hoc sub-process
-    final var elementsNotInAdHocSubProcess =
+    final var activateElements =
         command.getValue().activateElements().stream()
             .map(AdHocSubProcessActivateElementInstruction::getElementId)
-            .filter(elementId -> !adHocActivitiesById.containsKey(elementId))
             .toList();
-    if (!elementsNotInAdHocSubProcess.isEmpty()) {
-      writeRejectionError(
-          command,
-          RejectionType.NOT_FOUND,
-          String.format(
-              ERROR_MSG_ELEMENTS_NOT_FOUND,
-              command.getValue().getAdHocSubProcessInstanceKey(),
-              elementsNotInAdHocSubProcess));
-
+    final var activateElementsAreInProcess =
+        AdHocSubProcessUtils.validateActiveElementAreInProcess(
+            adHocSubProcessElementInstance.getKey(), adHocSubProcessElement, activateElements);
+    if (activateElementsAreInProcess.isLeft()) {
+      final var rejection = activateElementsAreInProcess.getLeft();
+      writeRejectionError(command, rejection.type(), rejection.reason());
       return;
     }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/adhocsubprocess/AdHocSubProcessUtils.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/adhocsubprocess/AdHocSubProcessUtils.java
@@ -16,6 +16,9 @@ import java.util.stream.Collectors;
 
 public class AdHocSubProcessUtils {
 
+  private static final String AHSP_ELEMENT_ACTIVATION_FAILED_NOT_FOUND =
+      "Failed to activate ad-hoc elements. No BPMN elements found with ids: %s.";
+
   public static Either<Failure, List<String>> validateActiveElementAreInProcess(
       final ExecutableAdHocSubProcess adHocSubProcess,
       final List<String> activateElementsCollection) {
@@ -33,8 +36,7 @@ public class AdHocSubProcessUtils {
           elementsNotFound.stream().map("'%s'"::formatted).collect(Collectors.joining(", "));
       return Either.left(
           new Failure(
-              "Failed to activate ad-hoc elements. No BPMN elements found with ids: %s."
-                  .formatted(elementIds),
+              AHSP_ELEMENT_ACTIVATION_FAILED_NOT_FOUND.formatted(elementIds),
               ErrorType.EXTRACT_VALUE_ERROR));
     }
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/adhocsubprocess/AdHocSubProcessUtils.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/adhocsubprocess/AdHocSubProcessUtils.java
@@ -7,19 +7,19 @@
  */
 package io.camunda.zeebe.engine.processing.adhocsubprocess;
 
-import io.camunda.zeebe.engine.processing.common.Failure;
+import io.camunda.zeebe.engine.processing.Rejection;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableAdHocSubProcess;
-import io.camunda.zeebe.protocol.record.value.ErrorType;
+import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.util.Either;
 import java.util.List;
-import java.util.stream.Collectors;
 
 public class AdHocSubProcessUtils {
 
-  private static final String AHSP_ELEMENT_ACTIVATION_FAILED_NOT_FOUND =
-      "Failed to activate ad-hoc elements. No BPMN elements found with ids: %s.";
+  private static final String ERROR_MSG_ELEMENTS_NOT_FOUND =
+      "Expected to activate activities for ad-hoc sub-process with key '%s', but the given elements %s do not exist.";
 
-  public static Either<Failure, List<String>> validateActiveElementAreInProcess(
+  public static Either<Rejection, List<String>> validateActiveElementAreInProcess(
+      final long adHocSubProcessKey,
       final ExecutableAdHocSubProcess adHocSubProcess,
       final List<String> activateElementsCollection) {
 
@@ -32,12 +32,10 @@ public class AdHocSubProcessUtils {
       return Either.right(activateElementsCollection);
 
     } else {
-      final String elementIds =
-          elementsNotFound.stream().map("'%s'"::formatted).collect(Collectors.joining(", "));
       return Either.left(
-          new Failure(
-              AHSP_ELEMENT_ACTIVATION_FAILED_NOT_FOUND.formatted(elementIds),
-              ErrorType.EXTRACT_VALUE_ERROR));
+          new Rejection(
+              RejectionType.NOT_FOUND,
+              ERROR_MSG_ELEMENTS_NOT_FOUND.formatted(adHocSubProcessKey, elementsNotFound)));
     }
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/adhocsubprocess/AdHocSubProcessUtils.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/adhocsubprocess/AdHocSubProcessUtils.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.adhocsubprocess;
+
+import io.camunda.zeebe.engine.processing.common.Failure;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableAdHocSubProcess;
+import io.camunda.zeebe.protocol.record.value.ErrorType;
+import io.camunda.zeebe.util.Either;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class AdHocSubProcessUtils {
+
+  public static Either<Failure, List<String>> validateActiveElementAreInProcess(
+      final ExecutableAdHocSubProcess adHocSubProcess,
+      final List<String> activateElementsCollection) {
+
+    final List<String> elementsNotFound =
+        activateElementsCollection.stream()
+            .filter(elementId -> !adHocSubProcess.getAdHocActivitiesById().containsKey(elementId))
+            .toList();
+
+    if (elementsNotFound.isEmpty()) {
+      return Either.right(activateElementsCollection);
+
+    } else {
+      final String elementIds =
+          elementsNotFound.stream().map("'%s'"::formatted).collect(Collectors.joining(", "));
+      return Either.left(
+          new Failure(
+              "Failed to activate ad-hoc elements. No BPMN elements found with ids: %s."
+                  .formatted(elementIds),
+              ErrorType.EXTRACT_VALUE_ERROR));
+    }
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/adhocsubprocess/AdHocSubProcessUtils.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/adhocsubprocess/AdHocSubProcessUtils.java
@@ -18,7 +18,7 @@ public class AdHocSubProcessUtils {
   private static final String ERROR_MSG_ELEMENTS_NOT_FOUND =
       "Expected to activate activities for ad-hoc sub-process with key '%s', but the given elements %s do not exist.";
 
-  public static Either<Rejection, List<String>> validateActiveElementAreInProcess(
+  public static Either<Rejection, List<String>> validateActivateElementsExistInAdHocSubProcess(
       final long adHocSubProcessKey,
       final ExecutableAdHocSubProcess adHocSubProcess,
       final List<String> activateElementsCollection) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnAdHocSubProcessBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnAdHocSubProcessBehavior.java
@@ -13,35 +13,66 @@ import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlo
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.processing.variable.VariableBehavior;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.BpmnEventType;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
+import org.agrona.DirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
 
 public final class BpmnAdHocSubProcessBehavior {
 
+  private static final DirectBuffer NO_VARIABLES = new UnsafeBuffer();
   private final KeyGenerator keyGenerator;
   private final StateWriter stateWriter;
   private final TypedCommandWriter commandWriter;
   private final BpmnStateBehavior stateBehavior;
+  private final VariableBehavior variableBehavior;
 
   public BpmnAdHocSubProcessBehavior(
       final KeyGenerator keyGenerator,
       final Writers writers,
-      final BpmnStateBehavior stateBehavior) {
+      final BpmnStateBehavior stateBehavior,
+      final VariableBehavior variableBehavior) {
     this.keyGenerator = keyGenerator;
     stateWriter = writers.state();
     commandWriter = writers.command();
     this.stateBehavior = stateBehavior;
+    this.variableBehavior = variableBehavior;
   }
 
   public void activateElement(
       final BpmnElementContext adHocSubProcessContext,
       final ExecutableAdHocSubProcess adHocSubProcess,
-      final ExecutableFlowNode elementToActivate) {
-    final var innerInstanceKey = createInnerInstance(adHocSubProcessContext, adHocSubProcess);
-    activateElement(adHocSubProcessContext, elementToActivate, innerInstanceKey);
+      final String elementToActivateId) {
+    activateElement(adHocSubProcess, adHocSubProcessContext, elementToActivateId, NO_VARIABLES);
+  }
+
+  public void activateElement(
+      final ExecutableAdHocSubProcess adHocSubProcess,
+      final BpmnElementContext context,
+      final String elementIdToActivate,
+      final DirectBuffer variablesBuffer) {
+
+    final long adHocSubProcessInnerInstanceKey = createInnerInstance(context, adHocSubProcess);
+
+    if (variablesBuffer != NO_VARIABLES && variablesBuffer.capacity() > 0) {
+      // set local variable in the scope of the inner instance
+      variableBehavior.mergeLocalDocument(
+          adHocSubProcessInnerInstanceKey,
+          context.getProcessDefinitionKey(),
+          context.getProcessInstanceKey(),
+          context.getBpmnProcessId(),
+          context.getTenantId(),
+          variablesBuffer);
+    }
+
+    final ExecutableFlowNode elementToActivate =
+        adHocSubProcess.getAdHocActivitiesById().get(elementIdToActivate);
+
+    activateElement(context, elementToActivate, adHocSubProcessInnerInstanceKey);
   }
 
   private long createInnerInstance(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
@@ -206,7 +206,8 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
         new JobUpdateBehaviour(processingState.getJobState(), clock, authCheckBehavior);
 
     adHocSubProcessBehavior =
-        new BpmnAdHocSubProcessBehavior(processingState.getKeyGenerator(), writers, stateBehavior);
+        new BpmnAdHocSubProcessBehavior(
+            processingState.getKeyGenerator(), writers, stateBehavior, variableBehavior);
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/AdHocSubProcessProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/AdHocSubProcessProcessor.java
@@ -184,7 +184,13 @@ public class AdHocSubProcessProcessor
           .flatMap(
               elements ->
                   AdHocSubProcessUtils.validateActiveElementAreInProcess(
-                      adHocSubProcess, elements));
+                          context.getElementInstanceKey(), adHocSubProcess, elements)
+                      .mapLeft(
+                          rejection ->
+                              new Failure(
+                                  rejection.reason(),
+                                  ErrorType.EXTRACT_VALUE_ERROR,
+                                  context.getElementInstanceKey())));
     }
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/AdHocSubProcessProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/AdHocSubProcessProcessor.java
@@ -183,7 +183,7 @@ public class AdHocSubProcessProcessor
                       ErrorType.EXTRACT_VALUE_ERROR))
           .flatMap(
               elements ->
-                  AdHocSubProcessUtils.validateActiveElementAreInProcess(
+                  AdHocSubProcessUtils.validateActivateElementsExistInAdHocSubProcess(
                           context.getElementInstanceKey(), adHocSubProcess, elements)
                       .mapLeft(
                           rejection ->

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/AdHocSubProcessProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/AdHocSubProcessProcessor.java
@@ -213,11 +213,9 @@ public class AdHocSubProcessProcessor
       final BpmnElementContext context,
       final List<String> elementsToActivate) {
 
-    elementsToActivate.stream()
-        .map(element.getAdHocActivitiesById()::get)
-        .forEach(
-            elementToActivate ->
-                adHocSubProcessBehavior.activateElement(context, element, elementToActivate));
+    elementsToActivate.forEach(
+        elementToActivate ->
+            adHocSubProcessBehavior.activateElement(context, element, elementToActivate));
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
@@ -224,10 +224,7 @@ public final class JobCompleteProcessor implements CommandProcessor<JobRecord> {
 
     final AdHocSubProcessInstructionRecord activationRecord =
         new AdHocSubProcessInstructionRecord()
-            .setAdHocSubProcessInstanceKey(
-                String.valueOf(
-                    jobRecord
-                        .getElementInstanceKey())); // TODO let's make the property a LongProperty
+            .setAdHocSubProcessInstanceKey(jobRecord.getElementInstanceKey());
 
     activateElements.stream()
         .map(JobResultActivateElement.class::cast)

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
@@ -88,6 +88,12 @@ public final class JobCompleteProcessor implements CommandProcessor<JobRecord> {
           (elementInstanceKey: '%d', processInstanceKey: '%d').
           """;
 
+  private static final String AHSP_JOB_NOT_ACTIVE =
+      """
+        Expected to complete ad-hoc sub-process job, but the ad-hoc sub-process instance is not active \
+        (job key '%d', type '%s', processInstanceKey '%d')
+      """;
+
   private static final Set<String> CORRECTABLE_PROPERTIES =
       Set.of(
           UserTaskRecord.ASSIGNEE,
@@ -290,9 +296,8 @@ public final class JobCompleteProcessor implements CommandProcessor<JobRecord> {
         return Either.left(
             new Rejection(
                 RejectionType.INVALID_STATE,
-                "Expected to complete ad-hoc sub-process job, but the ad-hoc sub-process instance is not active "
-                    + "(job key '%d', type '%s', processInstanceKey '%d')"
-                        .formatted(command.getKey(), job.getType(), job.getProcessInstanceKey())));
+                AHSP_JOB_NOT_ACTIVE.formatted(
+                    command.getKey(), job.getType(), job.getProcessInstanceKey())));
       }
     }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
@@ -222,7 +222,11 @@ public final class JobCompleteProcessor implements CommandProcessor<JobRecord> {
         jobRecord.getResult().getActivateElements();
 
     final AdHocSubProcessInstructionRecord activationRecord =
-        new AdHocSubProcessInstructionRecord();
+        new AdHocSubProcessInstructionRecord()
+            .setAdHocSubProcessInstanceKey(
+                String.valueOf(
+                    jobRecord
+                        .getElementInstanceKey())); // TODO let's make the property a LongProperty
 
     activateElements.stream()
         .map(JobResultActivateElement.class::cast)

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
@@ -261,7 +261,7 @@ public final class JobCompleteProcessor implements CommandProcessor<JobRecord> {
               .map(JobResultActivateElementValue::getElementId)
               .toList();
 
-      return AdHocSubProcessUtils.validateActiveElementAreInProcess(
+      return AdHocSubProcessUtils.validateActivateElementsExistInAdHocSubProcess(
               job.getElementInstanceKey(), executableAdHocSubProcess, elementsToBeActivated)
           .map(right -> job);
     }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
@@ -201,7 +201,7 @@ public final class JobCompleteProcessor implements CommandProcessor<JobRecord> {
               userTask.getUserTaskKey(), UserTaskIntent.COMPLETE_TASK_LISTENER, userTask);
         }
       }
-      case AD_HOC_SUB_PROCESS -> handleAdHocSubProcessJob(commandWriter, value, elementInstance);
+      case AD_HOC_SUB_PROCESS -> handleAdHocSubProcessJob(commandWriter, value);
       default -> {
         final long scopeKey = elementInstance.getValue().getFlowScopeKey();
         final ElementInstance scopeInstance = elementInstanceState.getInstance(scopeKey);
@@ -218,17 +218,7 @@ public final class JobCompleteProcessor implements CommandProcessor<JobRecord> {
   }
 
   private void handleAdHocSubProcessJob(
-      final TypedCommandWriter commandWriter,
-      final JobRecord jobRecord,
-      final ElementInstance adHocSubProcessInstance) {
-
-    // TODO: validate job command
-    // If the given ad-hoc sub-process instance is not active
-    //  If one of the given element IDs doesn't belong to an element inside the ad-hoc sub-process
-    // that can be activated
-    if (!adHocSubProcessInstance.isActive()) {
-      return; // reject command
-    }
+      final TypedCommandWriter commandWriter, final JobRecord jobRecord) {
 
     final List<JobResultActivateElementValue> activateElements =
         jobRecord.getResult().getActivateElements();
@@ -243,13 +233,12 @@ public final class JobCompleteProcessor implements CommandProcessor<JobRecord> {
     activateElements.stream()
         .map(JobResultActivateElement.class::cast)
         .forEach(
-            element -> {
-              activationRecord
-                  .activateElements()
-                  .add()
-                  .setElementId(element.getElementId())
-                  .setVariables(element.getVariablesBuffer());
-            });
+            element ->
+                activationRecord
+                    .activateElements()
+                    .add()
+                    .setElementId(element.getElementId())
+                    .setVariables(element.getVariablesBuffer()));
 
     commandWriter.appendFollowUpCommand(
         jobRecord.getElementInstanceKey(),

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
@@ -12,7 +12,6 @@ import io.camunda.zeebe.engine.metrics.JobProcessingMetrics;
 import io.camunda.zeebe.engine.processing.Rejection;
 import io.camunda.zeebe.engine.processing.adhocsubprocess.AdHocSubProcessUtils;
 import io.camunda.zeebe.engine.processing.common.EventHandle;
-import io.camunda.zeebe.engine.processing.common.Failure;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableAdHocSubProcess;
 import io.camunda.zeebe.engine.processing.identity.AuthorizationCheckBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.CommandProcessor;
@@ -262,16 +261,9 @@ public final class JobCompleteProcessor implements CommandProcessor<JobRecord> {
               .map(JobResultActivateElementValue::getElementId)
               .toList();
 
-      final Either<Failure, List<String>> validation =
-          AdHocSubProcessUtils.validateActiveElementAreInProcess(
-              executableAdHocSubProcess, elementsToBeActivated);
-
-      if (validation.isRight()) {
-        return Either.right(job);
-      } else {
-        return Either.left(
-            new Rejection(RejectionType.INVALID_ARGUMENT, validation.getLeft().getMessage()));
-      }
+      return AdHocSubProcessUtils.validateActiveElementAreInProcess(
+              job.getElementInstanceKey(), executableAdHocSubProcess, elementsToBeActivated)
+          .map(right -> job);
     }
     return Either.right(job);
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/adhocsubprocess/ActivateAdHocSubProcessActivityTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/adhocsubprocess/ActivateAdHocSubProcessActivityTest.java
@@ -67,7 +67,7 @@ public class ActivateAdHocSubProcessActivityTest {
   public void shouldActivateElement() {
     ENGINE
         .adHocSubProcessActivity()
-        .withAdHocSubProcessInstanceKey(String.valueOf(adHocSubProcessInstanceKey))
+        .withAdHocSubProcessInstanceKey(adHocSubProcessInstanceKey)
         .withElementIds("A")
         .activate();
 
@@ -88,7 +88,7 @@ public class ActivateAdHocSubProcessActivityTest {
   public void shouldSetElementTreePath() {
     ENGINE
         .adHocSubProcessActivity()
-        .withAdHocSubProcessInstanceKey(String.valueOf(adHocSubProcessInstanceKey))
+        .withAdHocSubProcessInstanceKey(adHocSubProcessInstanceKey)
         .withElementIds("A")
         .activate();
 
@@ -128,7 +128,7 @@ public class ActivateAdHocSubProcessActivityTest {
 
     ENGINE
         .adHocSubProcessActivity()
-        .withAdHocSubProcessInstanceKey(String.valueOf(adHocSubProcessInstanceKey))
+        .withAdHocSubProcessInstanceKey(adHocSubProcessInstanceKey)
         .withElementIds("A")
         .activate();
 
@@ -149,7 +149,7 @@ public class ActivateAdHocSubProcessActivityTest {
         .update();
     ENGINE
         .adHocSubProcessActivity()
-        .withAdHocSubProcessInstanceKey(String.valueOf(adHocSubProcessInstanceKey))
+        .withAdHocSubProcessInstanceKey(adHocSubProcessInstanceKey)
         .withElementIds("B")
         .activate();
 
@@ -168,13 +168,13 @@ public class ActivateAdHocSubProcessActivityTest {
   public void shouldConfirmActivationCommand() {
     ENGINE
         .adHocSubProcessActivity()
-        .withAdHocSubProcessInstanceKey(String.valueOf(adHocSubProcessInstanceKey))
+        .withAdHocSubProcessInstanceKey(adHocSubProcessInstanceKey)
         .withElementIds("A")
         .activate();
 
     assertThat(
             RecordingExporter.adHocSubProcessInstructionRecords()
-                .withAdHocSubProcessInstanceKey(String.valueOf(adHocSubProcessInstanceKey))
+                .withAdHocSubProcessInstanceKey(adHocSubProcessInstanceKey)
                 .limit(record -> record.getIntent() == AdHocSubProcessInstructionIntent.ACTIVATED))
         .extracting(
             r -> r.getValue().getActivateElements().getFirst().getElementId(), Record::getIntent)
@@ -185,7 +185,7 @@ public class ActivateAdHocSubProcessActivityTest {
   public void shouldActivateMultipleElements() {
     ENGINE
         .adHocSubProcessActivity()
-        .withAdHocSubProcessInstanceKey(String.valueOf(adHocSubProcessInstanceKey))
+        .withAdHocSubProcessInstanceKey(adHocSubProcessInstanceKey)
         .withElementIds("A")
         .withElementIds("B")
         .activate();
@@ -209,7 +209,7 @@ public class ActivateAdHocSubProcessActivityTest {
     final var rejection =
         ENGINE
             .adHocSubProcessActivity()
-            .withAdHocSubProcessInstanceKey(String.valueOf(adHocSubProcessInstanceKey))
+            .withAdHocSubProcessInstanceKey(adHocSubProcessInstanceKey)
             .withElementIds(nonExistingActivities.toArray(new String[0]))
             .expectRejection()
             .activate();
@@ -223,7 +223,7 @@ public class ActivateAdHocSubProcessActivityTest {
 
     assertThat(
             RecordingExporter.adHocSubProcessInstructionRecords()
-                .withAdHocSubProcessInstanceKey(String.valueOf(adHocSubProcessInstanceKey))
+                .withAdHocSubProcessInstanceKey(adHocSubProcessInstanceKey)
                 .limit(2))
         .extracting(Record::getRecordType, Record::getIntent)
         .contains(
@@ -234,7 +234,7 @@ public class ActivateAdHocSubProcessActivityTest {
 
   @Test
   public void shouldRejectCommandIfAdHocSubProcessInstanceDoesntExist() {
-    final var nonExistingAdHocSubProcessInstanceKey = "1";
+    final var nonExistingAdHocSubProcessInstanceKey = 1L;
 
     final var rejection =
         ENGINE
@@ -281,14 +281,14 @@ public class ActivateAdHocSubProcessActivityTest {
 
     ENGINE
         .adHocSubProcessActivity()
-        .withAdHocSubProcessInstanceKey(String.valueOf(faultyAdHocSubProcessInstanceKey))
+        .withAdHocSubProcessInstanceKey(faultyAdHocSubProcessInstanceKey)
         .withElementIds("A")
         .activate();
 
     final var rejection =
         ENGINE
             .adHocSubProcessActivity()
-            .withAdHocSubProcessInstanceKey(String.valueOf(faultyAdHocSubProcessInstanceKey))
+            .withAdHocSubProcessInstanceKey(faultyAdHocSubProcessInstanceKey)
             .withElementIds("A")
             .expectRejection()
             .activate();
@@ -306,7 +306,7 @@ public class ActivateAdHocSubProcessActivityTest {
     final var rejection =
         ENGINE
             .adHocSubProcessActivity()
-            .withAdHocSubProcessInstanceKey(String.valueOf(adHocSubProcessInstanceKey))
+            .withAdHocSubProcessInstanceKey(adHocSubProcessInstanceKey)
             .withElementIds("A")
             .withElementIds("A")
             .expectRejection()
@@ -322,7 +322,7 @@ public class ActivateAdHocSubProcessActivityTest {
 
     assertThat(
             RecordingExporter.adHocSubProcessInstructionRecords()
-                .withAdHocSubProcessInstanceKey(String.valueOf(adHocSubProcessInstanceKey))
+                .withAdHocSubProcessInstanceKey(adHocSubProcessInstanceKey)
                 .limit(2))
         .extracting(Record::getRecordType, Record::getIntent)
         .contains(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/JobBasedAdHocSubProcessTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/JobBasedAdHocSubProcessTest.java
@@ -310,17 +310,15 @@ public class JobBasedAdHocSubProcessTest {
   @Test
   public void shouldCreateIncidentOnJobFail() {
     // given
+    final var jobType = UUID.randomUUID().toString();
     final BpmnModelInstance process =
-        process(
-            adHocSubProcess -> {
-              adHocSubProcess.task("A1");
-            });
+        process(jobType, adHocSubProcess -> adHocSubProcess.task("A1"));
     ENGINE.deployment().withXmlResource(process).deploy();
     final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
 
     // when
     final var jobKey =
-        ENGINE.jobs().withType(JOB_TYPE).activate().getValue().getJobKeys().getFirst();
+        ENGINE.jobs().withType(jobType).activate().getValue().getJobKeys().getFirst();
     ENGINE
         .job()
         .withKey(jobKey)
@@ -343,7 +341,7 @@ public class JobBasedAdHocSubProcessTest {
                 .withElementId(AHSP_ELEMENT_ID)
                 .getFirst()
                 .getValue())
-        .hasType(JOB_TYPE)
+        .hasType(jobType)
         .hasElementInstanceKey(adHocSubProcess.getKey())
         .hasElementId(adHocSubProcess.getValue().getElementId())
         .hasProcessDefinitionKey(adHocSubProcess.getValue().getProcessDefinitionKey())
@@ -463,11 +461,7 @@ public class JobBasedAdHocSubProcessTest {
     // given
     final var jobType = UUID.randomUUID().toString();
     final BpmnModelInstance process =
-        process(
-            jobType,
-            adHocSubProcess -> {
-              adHocSubProcess.task("A");
-            });
+        process(jobType, adHocSubProcess -> adHocSubProcess.task("A"));
     ENGINE.deployment().withXmlResource(process).deploy();
     final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/JobBasedAdHocSubProcessTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/JobBasedAdHocSubProcessTest.java
@@ -473,8 +473,8 @@ public class JobBasedAdHocSubProcessTest {
             RecordingExporter.jobRecords(JobIntent.COMPLETE).onlyCommandRejections().getFirst())
         .extracting(Record::getRejectionType, Record::getRejectionReason)
         .containsOnly(
-            RejectionType.INVALID_ARGUMENT,
-            "Failed to activate ad-hoc elements. No BPMN elements found with ids: 'DoesntExist', 'NotThere'.");
+            RejectionType.NOT_FOUND,
+            "Expected to activate activities for ad-hoc sub-process with key '2251799813685256', but the given elements [DoesntExist, NotThere] do not exist.");
 
     Assertions.assertThat(
             RecordingExporter.records()

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/JobBasedAdHocSubProcessTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/JobBasedAdHocSubProcessTest.java
@@ -483,7 +483,12 @@ public class JobBasedAdHocSubProcessTest {
             "Failed to activate ad-hoc elements. No BPMN elements found with ids: 'DoesntExist', 'NotThere'.");
 
     Assertions.assertThat(
-            RecordingExporter.processInstanceRecords()
+            RecordingExporter.records()
+                .limit(
+                    r ->
+                        r.getIntent().equals(JobIntent.COMPLETE)
+                            && r.getRejectionType().equals(RejectionType.INVALID_ARGUMENT))
+                .processInstanceRecords()
                 .withProcessInstanceKey(processInstanceKey)
                 .limitByCount(
                     r ->

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/AdHocSubProcessIncidentTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/AdHocSubProcessIncidentTest.java
@@ -152,7 +152,7 @@ public class AdHocSubProcessIncidentTest {
         .hasElementId(AD_HOC_SUB_PROCESS_ELEMENT_ID)
         .hasErrorType(ErrorType.EXTRACT_VALUE_ERROR)
         .hasErrorMessage(
-            "Failed to activate ad-hoc elements. No BPMN elements found with ids: 'D', 'E'.");
+            "Expected to activate activities for ad-hoc sub-process with key '2251799813685257', but the given elements [D, E] do not exist.");
   }
 
   @Test
@@ -185,7 +185,7 @@ public class AdHocSubProcessIncidentTest {
         .hasElementId(AD_HOC_SUB_PROCESS_ELEMENT_ID)
         .hasErrorType(ErrorType.EXTRACT_VALUE_ERROR)
         .hasErrorMessage(
-            "Failed to activate ad-hoc elements. No BPMN elements found with ids: 'A2', 'A3'.");
+            "Expected to activate activities for ad-hoc sub-process with key '2251799813685266', but the given elements [A2, A3] do not exist.");
   }
 
   @Test
@@ -221,7 +221,7 @@ public class AdHocSubProcessIncidentTest {
         .hasElementId(AD_HOC_SUB_PROCESS_ELEMENT_ID)
         .hasErrorType(ErrorType.EXTRACT_VALUE_ERROR)
         .hasErrorMessage(
-            "Failed to activate ad-hoc elements. No BPMN elements found with ids: 'boundaryEvent'.");
+            "Expected to activate activities for ad-hoc sub-process with key '2251799813685275', but the given elements [boundaryEvent] do not exist.");
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/AdHocSubProcessActivityClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/AdHocSubProcessActivityClient.java
@@ -60,7 +60,7 @@ public class AdHocSubProcessActivityClient {
   }
 
   public AdHocSubProcessActivityClient withAdHocSubProcessInstanceKey(
-      final String adHocSubProcessInstanceKey) {
+      final long adHocSubProcessInstanceKey) {
     adHocSubProcessInstructionRecord.setAdHocSubProcessInstanceKey(adHocSubProcessInstanceKey);
     return this;
   }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RequestMapper.java
@@ -868,7 +868,7 @@ public class RequestMapper {
         validateAdHocSubProcessActivationRequest(request),
         () ->
             new AdHocSubProcessActivateActivitiesRequest(
-                adHocSubProcessInstanceKey,
+                Long.parseLong(adHocSubProcessInstanceKey),
                 request.getElements().stream()
                     .map(
                         element ->

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AdHocSubProcessActivityControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AdHocSubProcessActivityControllerTest.java
@@ -56,7 +56,7 @@ class AdHocSubProcessActivityControllerTest extends RestControllerTest {
   @Nested
   class ActivateActivities {
 
-    private static final String AD_HOC_SUBPROCESS_INSTANCE_KEY = "123456789";
+    private static final long AD_HOC_SUBPROCESS_INSTANCE_KEY = 123456789L;
 
     @ParameterizedTest
     @ValueSource(booleans = {true, false})

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerActivateAdHocSubProcessActivityRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerActivateAdHocSubProcessActivityRequest.java
@@ -24,7 +24,7 @@ public class BrokerActivateAdHocSubProcessActivityRequest
   }
 
   public BrokerActivateAdHocSubProcessActivityRequest setAdHocSubProcessInstanceKey(
-      final String adHocSubProcessInstanceKey) {
+      final long adHocSubProcessInstanceKey) {
     requestDto.setAdHocSubProcessInstanceKey(adHocSubProcessInstanceKey);
     return this;
   }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/adhocsubprocess/AdHocSubProcessActivateElementInstruction.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/adhocsubprocess/AdHocSubProcessActivateElementInstruction.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.protocol.impl.record.value.adhocsubprocess;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import io.camunda.zeebe.msgpack.property.DocumentProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
@@ -52,5 +53,10 @@ public final class AdHocSubProcessActivateElementInstruction extends ObjectValue
   public AdHocSubProcessActivateElementInstruction setVariables(final DirectBuffer variables) {
     this.variables.setValue(variables);
     return this;
+  }
+
+  @JsonIgnore
+  public DirectBuffer getVariablesBuffer() {
+    return variables.getValue();
   }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/adhocsubprocess/AdHocSubProcessInstructionRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/adhocsubprocess/AdHocSubProcessInstructionRecord.java
@@ -10,7 +10,9 @@ package io.camunda.zeebe.protocol.impl.record.value.adhocsubprocess;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.zeebe.msgpack.property.ArrayProperty;
 import io.camunda.zeebe.msgpack.property.BooleanProperty;
+import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
+import io.camunda.zeebe.msgpack.value.StringValue;
 import io.camunda.zeebe.msgpack.value.ValueArray;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.AdHocSubProcessInstructionRecordValue;
@@ -20,17 +22,21 @@ import java.util.List;
 
 public final class AdHocSubProcessInstructionRecord extends UnifiedRecordValue
     implements AdHocSubProcessInstructionRecordValue {
+  public static final StringValue AD_HOC_SUB_PROCESS_INSTANCE_KEY =
+      new StringValue("adHocSubProcessInstanceKey");
+  public static final StringValue ACTIVATE_ELEMENTS = new StringValue("activateElements");
+  public static final StringValue IS_CANCEL_REMAINING_INSTANCES =
+      new StringValue("isCancelRemainingInstances");
+  public static final StringValue TENANT_ID = new StringValue("tenantId");
 
-  private static final String DEFAULT_STRING = "";
-
-  private final StringProperty adHocSubProcessInstanceKey =
-      new StringProperty("adHocSubProcessInstanceKey", DEFAULT_STRING);
+  private final LongProperty adHocSubProcessInstanceKey =
+      new LongProperty(AD_HOC_SUB_PROCESS_INSTANCE_KEY, -1L);
   private final ArrayProperty<AdHocSubProcessActivateElementInstruction> activateElements =
-      new ArrayProperty<>("activateElements", AdHocSubProcessActivateElementInstruction::new);
+      new ArrayProperty<>(ACTIVATE_ELEMENTS, AdHocSubProcessActivateElementInstruction::new);
   private final BooleanProperty cancelRemainingInstances =
-      new BooleanProperty("isCancelRemainingInstances", false);
+      new BooleanProperty(IS_CANCEL_REMAINING_INSTANCES, false);
   private final StringProperty tenantId =
-      new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+      new StringProperty(TENANT_ID, TenantOwned.DEFAULT_TENANT_IDENTIFIER);
 
   public AdHocSubProcessInstructionRecord() {
     super(4);
@@ -41,12 +47,12 @@ public final class AdHocSubProcessInstructionRecord extends UnifiedRecordValue
   }
 
   @Override
-  public String getAdHocSubProcessInstanceKey() {
-    return BufferUtil.bufferAsString(adHocSubProcessInstanceKey.getValue());
+  public long getAdHocSubProcessInstanceKey() {
+    return adHocSubProcessInstanceKey.getValue();
   }
 
   public AdHocSubProcessInstructionRecord setAdHocSubProcessInstanceKey(
-      final String adHocSubProcessInstanceKey) {
+      final long adHocSubProcessInstanceKey) {
     this.adHocSubProcessInstanceKey.setValue(adHocSubProcessInstanceKey);
     return this;
   }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobResultActivateElement.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobResultActivateElement.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.protocol.impl.record.value.job;
 
 import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import io.camunda.zeebe.msgpack.UnpackedObject;
 import io.camunda.zeebe.msgpack.property.DocumentProperty;
@@ -57,5 +58,10 @@ public final class JobResultActivateElement extends UnpackedObject
   public JobResultActivateElement setVariables(final DirectBuffer variables) {
     variablesProp.setValue(variables);
     return this;
+  }
+
+  @JsonIgnore
+  public DirectBuffer getVariablesBuffer() {
+    return variablesProp.getValue();
   }
 }

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -2307,7 +2307,7 @@ final class JsonSerializableToJsonTest {
             () -> {
               final var adHocSubProcessInstructionRecord =
                   new AdHocSubProcessInstructionRecord()
-                      .setAdHocSubProcessInstanceKey("1234")
+                      .setAdHocSubProcessInstanceKey(1234L)
                       .setTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
 
               adHocSubProcessInstructionRecord.activateElements().add().setElementId("123");
@@ -2323,7 +2323,7 @@ final class JsonSerializableToJsonTest {
             },
         """
         {
-          "adHocSubProcessInstanceKey": "1234",
+          "adHocSubProcessInstanceKey": 1234,
           "tenantId": "<default>",
           "activateElements": [
             {
@@ -2350,7 +2350,7 @@ final class JsonSerializableToJsonTest {
         (Supplier<UnifiedRecordValue>) AdHocSubProcessInstructionRecord::new,
         """
         {
-          "adHocSubProcessInstanceKey": "",
+          "adHocSubProcessInstanceKey": -1,
           "tenantId": "<default>",
           "activateElements": [],
           "cancelRemainingInstances": false

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AdHocSubProcessInstructionRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AdHocSubProcessInstructionRecordValue.java
@@ -34,7 +34,7 @@ public interface AdHocSubProcessInstructionRecordValue extends RecordValue, Tena
   /**
    * @return the instance key of the ad-hoc sub-process to modify.
    */
-  String getAdHocSubProcessInstanceKey();
+  long getAdHocSubProcessInstanceKey();
 
   /**
    * @return the list of elements that should be activated.

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/AdHocSubProcessInstructionRecordStream.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/AdHocSubProcessInstructionRecordStream.java
@@ -28,15 +28,15 @@ public class AdHocSubProcessInstructionRecordStream
   }
 
   public AdHocSubProcessInstructionRecordStream withAdHocSubProcessInstanceKey(
-      final String adHocSubProcessInstanceKey) {
+      final long adHocSubProcessInstanceKey) {
     return valueFilter(
-        record -> record.getAdHocSubProcessInstanceKey().equals(adHocSubProcessInstanceKey));
+        record -> record.getAdHocSubProcessInstanceKey() == adHocSubProcessInstanceKey);
   }
 
   public AdHocSubProcessInstructionRecordStream limitToAdHocSubProcessInstanceCompleted() {
     return limit(
         r ->
             r.getIntent() == ProcessInstanceIntent.ELEMENT_COMPLETED
-                && r.getKey() == Long.parseLong(r.getValue().getAdHocSubProcessInstanceKey()));
+                && r.getKey() == r.getValue().getAdHocSubProcessInstanceKey());
   }
 }

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
@@ -803,8 +803,7 @@ public class CompactRecordLogger {
         .append(String.format("ACTIVATE elements %s", value.getActivateElements()))
         .append(
             String.format(
-                " in ad-hoc sub-process [%s]",
-                shortenKey(Long.parseLong(value.getAdHocSubProcessInstanceKey()))));
+                " in ad-hoc sub-process [%s]", shortenKey(value.getAdHocSubProcessInstanceKey())));
     return builder.toString();
   }
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
When a job is being completed, the elements inside an AHSP should be activated

- `AD_HOC_SUB_PROCESS` jobs have `ACTIVATE` commands written for them by `JobCompleteProcessor`
- Variables are created in the scope of the activated elements
- The job complete command is rejected if the passed in IDs do not match an element in the AHSP, or if the AHSP is not active
- A Utils class, `AdHocSubProcessUtils`, was created so that `AdHocSubProcessProcessor` and `AdHocSubProcessInstructionActivateProcessor` can share validation logic 

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes https://github.com/camunda/ad-hoc-sub-process-phase-3/issues/10
related https://github.com/camunda/ad-hoc-sub-process-phase-3/issues/34
