### PR TITLE
Make naming in REST API schema consistent

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/CamundaClient.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClient.java
@@ -60,7 +60,6 @@ import io.camunda.client.api.command.EvaluateDecisionCommandStep1;
 import io.camunda.client.api.command.MigrateProcessInstanceCommandStep1;
 import io.camunda.client.api.command.ModifyProcessInstanceCommandStep1;
 import io.camunda.client.api.command.PublishMessageCommandStep1;
-import io.camunda.client.api.command.RemoveUserFromTenantCommandStep1;
 import io.camunda.client.api.command.ResolveIncidentCommandStep1;
 import io.camunda.client.api.command.ResumeBatchOperationStep1;
 import io.camunda.client.api.command.SetVariablesCommandStep1;
@@ -75,6 +74,7 @@ import io.camunda.client.api.command.UnassignRoleFromMappingRuleCommandStep1;
 import io.camunda.client.api.command.UnassignRoleFromTenantCommandStep1;
 import io.camunda.client.api.command.UnassignRoleFromUserCommandStep1;
 import io.camunda.client.api.command.UnassignUserFromGroupCommandStep1;
+import io.camunda.client.api.command.UnassignUserFromTenantCommandStep1;
 import io.camunda.client.api.command.UnassignUserTaskCommandStep1;
 import io.camunda.client.api.command.UpdateAuthorizationCommandStep1;
 import io.camunda.client.api.command.UpdateGroupCommandStep1;
@@ -2128,7 +2128,7 @@ public interface CamundaClient extends AutoCloseable, JobClient {
   AssignUserToTenantCommandStep1 newAssignUserToTenantCommand();
 
   /**
-   * Command to remove a user from a tenant.
+   * Command to unassign a user from a tenant.
    *
    * <p>Example usage:
    *
@@ -2140,12 +2140,12 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    *   .send();
    * </pre>
    *
-   * <p>This command sends an HTTP DELETE request to remove the specified user from the given
+   * <p>This command sends an HTTP DELETE request to unassign the specified user from the given
    * tenant.
    *
-   * @return a builder for the remove user from tenant command
+   * @return a builder for the unassign user from tenant command
    */
-  RemoveUserFromTenantCommandStep1 newUnassignUserFromTenantCommand();
+  UnassignUserFromTenantCommandStep1 newUnassignUserFromTenantCommand();
 
   /**
    * Command to assign a group to a tenant.

--- a/clients/java/src/main/java/io/camunda/client/api/command/UnassignUserFromTenantCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/UnassignUserFromTenantCommandStep1.java
@@ -15,20 +15,20 @@
  */
 package io.camunda.client.api.command;
 
-import io.camunda.client.api.response.RemoveUserFromTenantResponse;
+import io.camunda.client.api.response.UnassignUserFromTenantResponse;
 
-/** Command to remove a user from a tenant. */
-public interface RemoveUserFromTenantCommandStep1 {
+/** Command to unassign a user from a tenant. */
+public interface UnassignUserFromTenantCommandStep1 {
 
   /**
-   * Sets the username for the removal of assignment.
+   * Sets the username for unassignment.
    *
    * @return the builder for this command.
    */
-  RemoveUserFromTenantCommandStep2 username(String username);
+  UnassignUserFromTenantCommandStep2 username(String username);
 
-  interface RemoveUserFromTenantCommandStep2
-      extends FinalCommandStep<RemoveUserFromTenantResponse> {
+  interface UnassignUserFromTenantCommandStep2
+      extends FinalCommandStep<UnassignUserFromTenantResponse> {
 
     /**
      * Sets the tenant ID.
@@ -37,6 +37,6 @@ public interface RemoveUserFromTenantCommandStep1 {
      * @return the builder for this command. Call {@link #send()} to complete the command and send
      *     it to the broker.
      */
-    RemoveUserFromTenantCommandStep2 tenantId(String tenantId);
+    UnassignUserFromTenantCommandStep2 tenantId(String tenantId);
   }
 }

--- a/clients/java/src/main/java/io/camunda/client/api/response/UnassignUserFromTenantResponse.java
+++ b/clients/java/src/main/java/io/camunda/client/api/response/UnassignUserFromTenantResponse.java
@@ -15,4 +15,4 @@
  */
 package io.camunda.client.api.response;
 
-public interface RemoveUserFromTenantResponse {}
+public interface UnassignUserFromTenantResponse {}

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
@@ -69,7 +69,6 @@ import io.camunda.client.api.command.FailJobCommandStep1;
 import io.camunda.client.api.command.MigrateProcessInstanceCommandStep1;
 import io.camunda.client.api.command.ModifyProcessInstanceCommandStep1;
 import io.camunda.client.api.command.PublishMessageCommandStep1;
-import io.camunda.client.api.command.RemoveUserFromTenantCommandStep1;
 import io.camunda.client.api.command.ResolveIncidentCommandStep1;
 import io.camunda.client.api.command.ResumeBatchOperationStep1;
 import io.camunda.client.api.command.SetVariablesCommandStep1;
@@ -86,6 +85,7 @@ import io.camunda.client.api.command.UnassignRoleFromMappingRuleCommandStep1;
 import io.camunda.client.api.command.UnassignRoleFromTenantCommandStep1;
 import io.camunda.client.api.command.UnassignRoleFromUserCommandStep1;
 import io.camunda.client.api.command.UnassignUserFromGroupCommandStep1;
+import io.camunda.client.api.command.UnassignUserFromTenantCommandStep1;
 import io.camunda.client.api.command.UnassignUserTaskCommandStep1;
 import io.camunda.client.api.command.UpdateAuthorizationCommandStep1;
 import io.camunda.client.api.command.UpdateGroupCommandStep1;
@@ -205,7 +205,6 @@ import io.camunda.client.impl.command.JobUpdateTimeoutCommandImpl;
 import io.camunda.client.impl.command.MigrateProcessInstanceCommandImpl;
 import io.camunda.client.impl.command.ModifyProcessInstanceCommandImpl;
 import io.camunda.client.impl.command.PublishMessageCommandImpl;
-import io.camunda.client.impl.command.RemoveUserFromTenantCommandImpl;
 import io.camunda.client.impl.command.ResolveIncidentCommandImpl;
 import io.camunda.client.impl.command.ResumeBatchOperationCommandImpl;
 import io.camunda.client.impl.command.SetVariablesCommandImpl;
@@ -221,6 +220,7 @@ import io.camunda.client.impl.command.UnassignRoleFromMappingRuleCommandImpl;
 import io.camunda.client.impl.command.UnassignRoleFromTenantCommandImpl;
 import io.camunda.client.impl.command.UnassignRoleFromUserCommandImpl;
 import io.camunda.client.impl.command.UnassignUserFromGroupCommandImpl;
+import io.camunda.client.impl.command.UnassignUserFromTenantCommandImpl;
 import io.camunda.client.impl.command.UnassignUserTaskCommandImpl;
 import io.camunda.client.impl.command.UpdateAuthorizationCommandImpl;
 import io.camunda.client.impl.command.UpdateGroupCommandImpl;
@@ -1155,8 +1155,8 @@ public final class CamundaClientImpl implements CamundaClient {
   }
 
   @Override
-  public RemoveUserFromTenantCommandStep1 newUnassignUserFromTenantCommand() {
-    return new RemoveUserFromTenantCommandImpl(httpClient);
+  public UnassignUserFromTenantCommandStep1 newUnassignUserFromTenantCommand() {
+    return new UnassignUserFromTenantCommandImpl(httpClient);
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/client/impl/command/UnassignUserFromTenantCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/UnassignUserFromTenantCommandImpl.java
@@ -17,50 +17,50 @@ package io.camunda.client.impl.command;
 
 import io.camunda.client.api.CamundaFuture;
 import io.camunda.client.api.command.FinalCommandStep;
-import io.camunda.client.api.command.RemoveUserFromTenantCommandStep1;
-import io.camunda.client.api.command.RemoveUserFromTenantCommandStep1.RemoveUserFromTenantCommandStep2;
-import io.camunda.client.api.response.RemoveUserFromTenantResponse;
+import io.camunda.client.api.command.UnassignUserFromTenantCommandStep1;
+import io.camunda.client.api.command.UnassignUserFromTenantCommandStep1.UnassignUserFromTenantCommandStep2;
+import io.camunda.client.api.response.UnassignUserFromTenantResponse;
 import io.camunda.client.impl.http.HttpCamundaFuture;
 import io.camunda.client.impl.http.HttpClient;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import org.apache.hc.client5.http.config.RequestConfig;
 
-public final class RemoveUserFromTenantCommandImpl
-    implements RemoveUserFromTenantCommandStep1, RemoveUserFromTenantCommandStep2 {
+public final class UnassignUserFromTenantCommandImpl
+    implements UnassignUserFromTenantCommandStep1, UnassignUserFromTenantCommandStep2 {
 
   private String tenantId;
   private String username;
   private final HttpClient httpClient;
   private final RequestConfig.Builder httpRequestConfig;
 
-  public RemoveUserFromTenantCommandImpl(final HttpClient httpClient) {
+  public UnassignUserFromTenantCommandImpl(final HttpClient httpClient) {
     this.httpClient = httpClient;
     httpRequestConfig = httpClient.newRequestConfig();
   }
 
   @Override
-  public RemoveUserFromTenantCommandStep2 username(final String username) {
+  public UnassignUserFromTenantCommandStep2 username(final String username) {
     this.username = username;
     return this;
   }
 
   @Override
-  public RemoveUserFromTenantCommandStep2 tenantId(final String tenantId) {
+  public UnassignUserFromTenantCommandStep2 tenantId(final String tenantId) {
     this.tenantId = tenantId;
     return this;
   }
 
   @Override
-  public FinalCommandStep<RemoveUserFromTenantResponse> requestTimeout(
+  public FinalCommandStep<UnassignUserFromTenantResponse> requestTimeout(
       final Duration requestTimeout) {
     httpRequestConfig.setResponseTimeout(requestTimeout.toMillis(), TimeUnit.MILLISECONDS);
     return this;
   }
 
   @Override
-  public CamundaFuture<RemoveUserFromTenantResponse> send() {
-    final HttpCamundaFuture<RemoveUserFromTenantResponse> result = new HttpCamundaFuture<>();
+  public CamundaFuture<UnassignUserFromTenantResponse> send() {
+    final HttpCamundaFuture<UnassignUserFromTenantResponse> result = new HttpCamundaFuture<>();
     final String endpoint = String.format("/tenants/%s/users/%s", tenantId, username);
     httpClient.delete(endpoint, null, httpRequestConfig.build(), result);
     return result;

--- a/clients/java/src/test/java/io/camunda/client/tenant/UnassignUserFromTenantTest.java
+++ b/clients/java/src/test/java/io/camunda/client/tenant/UnassignUserFromTenantTest.java
@@ -26,13 +26,13 @@ import io.camunda.client.util.ClientRestTest;
 import io.camunda.client.util.RestGatewayService;
 import org.junit.jupiter.api.Test;
 
-public class RemoveUserFromTenantTest extends ClientRestTest {
+public class UnassignUserFromTenantTest extends ClientRestTest {
 
   private static final String TENANT_ID = "tenant-id";
   private static final String USERNAME = "username";
 
   @Test
-  void shouldRemoveUserFromTenant() {
+  void shouldUnassignUserFromTenant() {
     // when
     client.newUnassignUserFromTenantCommand().username(USERNAME).tenantId(TENANT_ID).send().join();
 

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -3803,10 +3803,11 @@ paths:
     put:
       tags:
         - Group
-      operationId: addUserToGroup
+      operationId: assignUserToGroup
       summary: Assign a user to a group
       description: |
-        Assigns a user to a group.
+        Assigns a user to a group, making the user a member of the group.
+        Group members inherit the group authorizations, roles, and tenant assignments.
       parameters:
         - name: groupId
           in: path
@@ -3850,6 +3851,7 @@ paths:
       summary: Unassign a user from a group
       description: |
         Unassigns a user from a group.
+        The user is removed as a group member, with associated authorizations, roles, and tenant assignments no longer applied.
       parameters:
         - name: groupId
           in: path
@@ -3884,10 +3886,11 @@ paths:
     put:
       tags:
         - Group
-      operationId: addClientToGroup
+      operationId: assignClientToGroup
       summary: Assign a client to a group
       description: |
-        Assigns a client to a group.
+        Assigns a client to a group, making it a member of the group.
+        Members of the group inherit the group authorizations, roles, and tenant assignments.
       parameters:
         - name: groupId
           in: path
@@ -3931,6 +3934,7 @@ paths:
       summary: Unassign a client from a group
       description: |
         Unassigns a client from a group.
+        The client is removed as a group member, with associated authorizations, roles, and tenant assignments no longer applied.
       parameters:
         - name: groupId
           in: path

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -3037,10 +3037,11 @@ paths:
     put:
       tags:
         - Role
-      operationId: addRoleToUser
+      operationId: assignRoleToUser
       summary: Assign a role to a user
       description: |
-        Assigns a role to a user.
+        Assigns the specified role to the user.
+        The user will inherit the authorizations associated with this role.
       parameters:
         - name: roleId
           in: path
@@ -3080,10 +3081,11 @@ paths:
     delete:
       tags:
         - Role
-      operationId: removeUserFromRole
+      operationId: unassignRoleFromUser
       summary: Unassign a user from a role
       description: |
         Unassigns a user from a role.
+        The user will no longer inherit the authorizations associated with this role.
       parameters:
         - name: roleId
           in: path
@@ -3118,10 +3120,11 @@ paths:
     put:
       tags:
         - Role
-      operationId: addRoleToClient
+      operationId: assignRoleToClient
       summary: Assign a role to a client
       description: |
-        Assigns a role to a client.
+        Assigns the specified role to the client.
+        The client will inherit the authorizations associated with this role.
       parameters:
         - name: roleId
           in: path
@@ -3161,10 +3164,11 @@ paths:
     delete:
       tags:
         - Role
-      operationId: removeRoleFromClient
+      operationId: unassignRoleFromClient
       summary: Unassign a role from a client
       description: |
-        Unassigns a role from a client.
+        Unassigns the specified role from the client.
+        The client will no longer inherit the authorizations associated with this role.
       parameters:
         - name: roleId
           in: path
@@ -3232,10 +3236,11 @@ paths:
     put:
       tags:
         - Role
-      operationId: addRoleToGroup
+      operationId: assignRoleToGroup
       summary: Assign a role to a group
       description: |
-        Assigns a role to a group.
+        Assigns the specified role to the group.
+        Every member of the group (user or client) will inherit the authorizations associated with this role.
       parameters:
         - name: roleId
           in: path
@@ -3275,10 +3280,11 @@ paths:
     delete:
       tags:
         - Role
-      operationId: removeRoleFromGroup
+      operationId: unassignRoleFromGroup
       summary: Unassign a role from a group
       description: |
-        Unassigns a role from a group.
+        Unassigns the specified role from the group.
+        All group members (user or client) no longer inherit the authorizations associated with this role.
       parameters:
         - name: roleId
           in: path
@@ -3355,7 +3361,7 @@ paths:
     put:
       tags:
         - Role
-      operationId: addRoleToMappingRule
+      operationId: assignRoleToMappingRule
       summary: Assign a role to a mapping rule
       description: |
         Assigns a role to a mapping rule.
@@ -3398,7 +3404,7 @@ paths:
     delete:
       tags:
         - Role
-      operationId: removeRoleFromMappingRule
+      operationId: unassignRoleFromMappingRule
       summary: Unassign a role from a mapping rule
       description: |
         Unassigns a role from a mapping rule.

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -3098,9 +3098,9 @@ paths:
       tags:
         - Role
       operationId: unassignRoleFromUser
-      summary: Unassign a user from a role
+      summary: Unassign a role from a user
       description: |
-        Unassigns a user from a role.
+        Unassigns a role from a user.
         The user will no longer inherit the authorizations associated with this role.
       parameters:
         - name: roleId
@@ -3117,7 +3117,7 @@ paths:
             type: string
       responses:
         "204":
-          description: The user was unassigned successfully from the role.
+          description: The role was unassigned successfully from the user.
         "400":
           $ref: "#/components/responses/InvalidData"
         "403":

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -526,7 +526,9 @@ paths:
         - Tenant
       operationId: assignUserToTenant
       summary: Assign a user to a tenant
-      description: Assign a single user to a specified tenant.
+      description: |
+        Assign a user to the specified tenant.
+        The user can then access tenant data and perform authorized actions.
       parameters:
         - name: tenantId
           in: path
@@ -560,9 +562,11 @@ paths:
     delete:
       tags:
         - Tenant
-      operationId: removeUserFromTenant
-      summary: Remove a user from a tenant
-      description: Removes a single user from a specified tenant without deleting the user.
+      operationId: unassignUserFromTenant
+      summary: Unassign a user from a tenant
+      description: |
+        Unassigns the user from the specified tenant.
+        The user can no longer access tenant data.
       parameters:
         - name: tenantId
           in: path
@@ -578,7 +582,7 @@ paths:
             type: string
       responses:
         "204":
-          description: The user was successfully removed from the tenant.
+          description: The user was successfully unassigned from the tenant.
         "400":
           $ref: "#/components/responses/InvalidData"
         "403":
@@ -708,7 +712,9 @@ paths:
         - Tenant
       operationId: assignClientToTenant
       summary: Assign a client to a tenant
-      description: Assign a client to a specified tenant.
+      description: |
+        Assign the client to the specified tenant.
+        The client can then access tenant data and perform authorized actions.
       parameters:
         - name: tenantId
           in: path
@@ -742,9 +748,11 @@ paths:
     delete:
       tags:
         - Tenant
-      operationId: removeClientFromTenant
-      summary: Remove a client from a tenant
-      description: Removes a single client from a specified tenant.
+      operationId: unassignClientFromTenant
+      summary: Unassign a client from a tenant
+      description: |
+        Unassigns the client from the specified tenant.
+        The client can no longer access tenant data.
       parameters:
         - name: tenantId
           in: path
@@ -760,7 +768,7 @@ paths:
             type: string
       responses:
         "204":
-          description: The client was successfully removed from the tenant.
+          description: The client was successfully unassigned from the tenant.
         "400":
           $ref: "#/components/responses/InvalidData"
         "403":
@@ -816,9 +824,9 @@ paths:
     delete:
       tags:
         - Tenant
-      operationId: removeMappingRuleFromTenant
-      summary: Remove a mapping rule from a tenant
-      description: Removes a single mapping rule from a specified tenant without deleting the rule.
+      operationId: unassignMappingRuleFromTenant
+      summary: Unassign a mapping rule from a tenant
+      description: Unassigns a single mapping rule from a specified tenant without deleting the rule.
       parameters:
         - name: tenantId
           in: path
@@ -834,7 +842,7 @@ paths:
             type: string
       responses:
         "204":
-          description: The mapping rule was successfully removed from the tenant.
+          description: The mapping rule was successfully unassigned from the tenant.
         "400":
           $ref: "#/components/responses/InvalidData"
         "403":
@@ -883,7 +891,9 @@ paths:
         - Tenant
       operationId: assignGroupToTenant
       summary: Assign a group to a tenant
-      description: Assign a single group to a specified tenant.
+      description: |
+        Assigns a group to a specified tenant.
+        Group members (users, clients) can then access tenant data and perform authorized actions.
       parameters:
         - name: tenantId
           in: path
@@ -918,9 +928,11 @@ paths:
     delete:
       tags:
         - Tenant
-      operationId: removeGroupFromTenant
-      summary: Remove a group from a tenant
-      description: Removes a single group from a specified tenant without deleting the group.
+      operationId: unassignGroupFromTenant
+      summary: Unassign a group from a tenant
+      description: |
+        Unassigns a group from a specified tenant.
+        Members of the group (users, clients) will no longer have access to the tenant's data - except they are assigned directly to the tenant.
       parameters:
         - name: tenantId
           in: path
@@ -936,7 +948,7 @@ paths:
             type: string
       responses:
         "204":
-          description: The group was successfully removed from the tenant.
+          description: The group was successfully unassigned from the tenant.
         "400":
           $ref: "#/components/responses/InvalidData"
         "403":
@@ -958,7 +970,9 @@ paths:
         - Tenant
       operationId: assignRoleToTenant
       summary: Assign a role to a tenant
-      description: Assign a single role to a specified tenant.
+      description: |
+        Assigns a role to a specified tenant.
+        Users, Clients or Groups, that have the role assigned, will get access to the tenant's data and can perform actions according to their authorizations.
       parameters:
         - name: tenantId
           in: path
@@ -992,9 +1006,11 @@ paths:
     delete:
       tags:
         - Tenant
-      operationId: removeRoleFromTenant
-      summary: Remove a role from a tenant
-      description: Removes a single role from a specified tenant without deleting the role.
+      operationId: unassignRoleFromTenant
+      summary: Unassign a role from a tenant
+      description: |
+        Unassigns a role from a specified tenant.
+        Users, Clients or Groups, that have the role assigned, will no longer have access to the tenant's data - except they are assigned directly to the tenant.
       parameters:
         - name: tenantId
           in: path
@@ -1010,7 +1026,7 @@ paths:
             type: string
       responses:
         "204":
-          description: The role was successfully removed from the tenant.
+          description: The role was successfully unassigned from the tenant.
         "400":
           $ref: "#/components/responses/InvalidData"
         "403":

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantController.java
@@ -119,7 +119,7 @@ public class TenantController {
   }
 
   @CamundaPutMapping(path = "/{tenantId}/users/{username}")
-  public CompletableFuture<ResponseEntity<Object>> assignUsersToTenant(
+  public CompletableFuture<ResponseEntity<Object>> assignUserToTenant(
       @PathVariable final String tenantId, @PathVariable final String username) {
     return RequestMapper.toTenantMemberRequest(tenantId, username, EntityType.USER)
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::addMemberToTenant);
@@ -175,14 +175,14 @@ public class TenantController {
   }
 
   @CamundaDeleteMapping(path = "/{tenantId}/users/{username}")
-  public CompletableFuture<ResponseEntity<Object>> removeUserFromTenant(
+  public CompletableFuture<ResponseEntity<Object>> unassignUserFromTenant(
       @PathVariable final String tenantId, @PathVariable final String username) {
     return RequestMapper.toTenantMemberRequest(tenantId, username, EntityType.USER)
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::removeMemberFromTenant);
   }
 
   @CamundaDeleteMapping(path = "/{tenantId}/clients/{clientId}")
-  public CompletableFuture<ResponseEntity<Object>> removeClientFromTenant(
+  public CompletableFuture<ResponseEntity<Object>> unassignClientFromTenant(
       @PathVariable final String tenantId, @PathVariable final String clientId) {
     return RequestMapper.toTenantMemberRequest(tenantId, clientId, EntityType.CLIENT)
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::removeMemberFromTenant);
@@ -200,21 +200,21 @@ public class TenantController {
   }
 
   @CamundaDeleteMapping(path = "/{tenantId}/mapping-rules/{mappingRuleId}")
-  public CompletableFuture<ResponseEntity<Object>> removeMappingRuleFromTenant(
+  public CompletableFuture<ResponseEntity<Object>> unassignMappingRuleFromTenant(
       @PathVariable final String tenantId, @PathVariable final String mappingRuleId) {
     return RequestMapper.toTenantMemberRequest(tenantId, mappingRuleId, EntityType.MAPPING_RULE)
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::removeMemberFromTenant);
   }
 
   @CamundaDeleteMapping(path = "/{tenantId}/groups/{groupId}")
-  public CompletableFuture<ResponseEntity<Object>> removeGroupFromTenant(
+  public CompletableFuture<ResponseEntity<Object>> unassignGroupFromTenant(
       @PathVariable final String tenantId, @PathVariable final String groupId) {
     return RequestMapper.toTenantMemberRequest(tenantId, groupId, EntityType.GROUP)
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::removeMemberFromTenant);
   }
 
   @CamundaDeleteMapping(path = "/{tenantId}/roles/{roleId}")
-  public CompletableFuture<ResponseEntity<Object>> removeRoleFromTenant(
+  public CompletableFuture<ResponseEntity<Object>> unassignRoleFromTenant(
       @PathVariable final String tenantId, @PathVariable final String roleId) {
     return RequestMapper.toTenantMemberRequest(tenantId, roleId, EntityType.ROLE)
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::removeMemberFromTenant);

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupController.java
@@ -95,27 +95,21 @@ public class GroupController {
                 .deleteGroup(groupId));
   }
 
-  @CamundaPutMapping(
-      path = "/{groupId}/users/{username}",
-      consumes = {})
+  @CamundaPutMapping(path = "/{groupId}/users/{username}")
   public CompletableFuture<ResponseEntity<Object>> assignUserToGroup(
       @PathVariable final String groupId, @PathVariable final String username) {
     return RequestMapper.toGroupMemberRequest(groupId, username, EntityType.USER)
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::assignMember);
   }
 
-  @CamundaPutMapping(
-      path = "/{groupId}/clients/{clientId}",
-      consumes = {})
+  @CamundaPutMapping(path = "/{groupId}/clients/{clientId}")
   public CompletableFuture<ResponseEntity<Object>> assignClientToGroup(
       @PathVariable final String groupId, @PathVariable final String clientId) {
     return RequestMapper.toGroupMemberRequest(groupId, clientId, EntityType.CLIENT)
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::assignMember);
   }
 
-  @CamundaPutMapping(
-      path = "/{groupId}/mapping-rules/{mappingRuleId}",
-      consumes = {})
+  @CamundaPutMapping(path = "/{groupId}/mapping-rules/{mappingRuleId}")
   public CompletableFuture<ResponseEntity<Object>> assignMappingRuleToGroup(
       @PathVariable final String groupId, @PathVariable final String mappingRuleId) {
     return RequestMapper.toGroupMemberRequest(groupId, mappingRuleId, EntityType.MAPPING_RULE)
@@ -136,9 +130,7 @@ public class GroupController {
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::unassignMember);
   }
 
-  @CamundaDeleteMapping(
-      path = "/{groupId}/mapping-rules/{mappingRuleId}",
-      consumes = {})
+  @CamundaDeleteMapping(path = "/{groupId}/mapping-rules/{mappingRuleId}")
   public CompletableFuture<ResponseEntity<Object>> unassignMappingRuleFromGroup(
       @PathVariable final String groupId, @PathVariable final String mappingRuleId) {
     return RequestMapper.toGroupMemberRequest(groupId, mappingRuleId, EntityType.MAPPING_RULE)

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleController.java
@@ -53,9 +53,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 @RequestMapping("/v2/roles")
 public class RoleController {
   private final RoleServices roleServices;
-  private final UserServices userServices;
   private final MappingRuleServices mappingServices;
-  private final GroupServices groupServices;
   private final CamundaAuthenticationProvider authenticationProvider;
 
   public RoleController(
@@ -65,9 +63,7 @@ public class RoleController {
       final GroupServices groupServices,
       final CamundaAuthenticationProvider authenticationProvider) {
     this.roleServices = roleServices;
-    this.userServices = userServices;
     this.mappingServices = mappingServices;
-    this.groupServices = groupServices;
     this.authenticationProvider = authenticationProvider;
   }
 

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleController.java
@@ -236,28 +236,22 @@ public class RoleController {
         .build();
   }
 
-  @CamundaPutMapping(
-      path = "/{roleId}/users/{username}",
-      consumes = {})
-  public CompletableFuture<ResponseEntity<Object>> addRoleToUser(
+  @CamundaPutMapping(path = "/{roleId}/users/{username}")
+  public CompletableFuture<ResponseEntity<Object>> assignRoleToUser(
       @PathVariable final String roleId, @PathVariable final String username) {
     return RequestMapper.toRoleMemberRequest(roleId, username, EntityType.USER)
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::addMemberToRole);
   }
 
-  @CamundaPutMapping(
-      path = "/{roleId}/clients/{clientId}",
-      consumes = {})
-  public CompletableFuture<ResponseEntity<Object>> addRoleToClient(
+  @CamundaPutMapping(path = "/{roleId}/clients/{clientId}")
+  public CompletableFuture<ResponseEntity<Object>> assignRoleToClient(
       @PathVariable final String roleId, @PathVariable final String clientId) {
     return RequestMapper.toRoleMemberRequest(roleId, clientId, EntityType.CLIENT)
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::addMemberToRole);
   }
 
-  @CamundaPutMapping(
-      path = "/{roleId}/groups/{groupId}",
-      consumes = {})
-  public CompletableFuture<ResponseEntity<Object>> addRoleToGroup(
+  @CamundaPutMapping(path = "/{roleId}/groups/{groupId}")
+  public CompletableFuture<ResponseEntity<Object>> assignRoleToGroup(
       @PathVariable final String roleId, @PathVariable final String groupId) {
     return RequestMapper.toRoleMemberRequest(roleId, groupId, EntityType.GROUP)
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::addMemberToRole);
@@ -272,38 +266,36 @@ public class RoleController {
                 .addMember(request));
   }
 
-  @CamundaPutMapping(
-      path = "/{roleId}/mapping-rules/{mappingRuleId}",
-      consumes = {})
-  public CompletableFuture<ResponseEntity<Object>> addRoleToMappingRule(
+  @CamundaPutMapping(path = "/{roleId}/mapping-rules/{mappingRuleId}")
+  public CompletableFuture<ResponseEntity<Object>> assignRoleToMappingRule(
       @PathVariable final String roleId, @PathVariable final String mappingRuleId) {
     return RequestMapper.toRoleMemberRequest(roleId, mappingRuleId, EntityType.MAPPING_RULE)
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::addMemberToRole);
   }
 
   @CamundaDeleteMapping(path = "/{roleId}/mapping-rules/{mappingRuleId}")
-  public CompletableFuture<ResponseEntity<Object>> removeRoleFromMappingRule(
+  public CompletableFuture<ResponseEntity<Object>> unassignRoleFromMappingRule(
       @PathVariable final String roleId, @PathVariable final String mappingRuleId) {
     return RequestMapper.toRoleMemberRequest(roleId, mappingRuleId, EntityType.MAPPING_RULE)
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::removeMemberFromRole);
   }
 
   @CamundaDeleteMapping(path = "/{roleId}/users/{username}")
-  public CompletableFuture<ResponseEntity<Object>> removeRoleFromUser(
+  public CompletableFuture<ResponseEntity<Object>> unassignRoleFromUser(
       @PathVariable final String roleId, @PathVariable final String username) {
     return RequestMapper.toRoleMemberRequest(roleId, username, EntityType.USER)
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::removeMemberFromRole);
   }
 
   @CamundaDeleteMapping(path = "/{roleId}/clients/{clientId}")
-  public CompletableFuture<ResponseEntity<Object>> removeRoleFromClient(
+  public CompletableFuture<ResponseEntity<Object>> unassignRoleFromClient(
       @PathVariable final String roleId, @PathVariable final String clientId) {
     return RequestMapper.toRoleMemberRequest(roleId, clientId, EntityType.CLIENT)
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::removeMemberFromRole);
   }
 
   @CamundaDeleteMapping(path = "/{roleId}/groups/{groupId}")
-  public CompletableFuture<ResponseEntity<Object>> removeRoleFromGroup(
+  public CompletableFuture<ResponseEntity<Object>> unassignRoleFromGroup(
       @PathVariable final String roleId, @PathVariable final String groupId) {
     return RequestMapper.toRoleMemberRequest(roleId, groupId, EntityType.GROUP)
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::removeMemberFromRole);

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleControllerTest.java
@@ -465,7 +465,7 @@ public class RoleControllerTest extends RestControllerTest {
   }
 
   @Test
-  void shouldReturnErrorForAddingMissingMappingToRole() {
+  void shouldReturnErrorForAssigningMissingMappingToRole() {
     // given
     final var roleId = Strings.newRandomValidIdentityId();
     final var mappingRuleId = Strings.newRandomValidIdentityId();
@@ -495,7 +495,7 @@ public class RoleControllerTest extends RestControllerTest {
   }
 
   @Test
-  void shouldReturnErrorForAddingMappingToMissingRole() {
+  void shouldReturnErrorForAssigningMappingToMissingRole() {
     // given
     final var roleId = Strings.newRandomValidIdentityId();
     final var mappingRuleId = Strings.newRandomValidIdentityId();
@@ -522,7 +522,7 @@ public class RoleControllerTest extends RestControllerTest {
   }
 
   @Test
-  void shouldReturnErrorForProvidingInvalidMappingIdWhenAddingToRole() {
+  void shouldReturnErrorForProvidingInvalidMappingIdWhenAssigningToRole() {
     // given
     final var roleId = Strings.newRandomValidIdentityId();
     final var mappingRuleId = "mappingRuleId!";
@@ -553,7 +553,7 @@ public class RoleControllerTest extends RestControllerTest {
   }
 
   @Test
-  void shouldReturnErrorForProvidingInvalidRoleIdWhenAddingMappingToRole() {
+  void shouldReturnErrorForProvidingInvalidRoleIdWhenAssigningMappingToRole() {
     // given
     final String roleId = "roleId!";
     final String mappingRuleId = Strings.newRandomValidIdentityId();
@@ -606,7 +606,7 @@ public class RoleControllerTest extends RestControllerTest {
   }
 
   @Test
-  void shouldReturnErrorForRemovingMissingMappingFromRole() {
+  void shouldReturnErrorForUnassigningMissingMappingFromRole() {
     // given
     final var roleId = Strings.newRandomValidIdentityId();
     final var mappingRuleId = Strings.newRandomValidIdentityId();
@@ -636,7 +636,7 @@ public class RoleControllerTest extends RestControllerTest {
   }
 
   @Test
-  void shouldReturnErrorForRemovingMappingFromMissingRole() {
+  void shouldReturnErrorForUnassigningMappingFromMissingRole() {
     // given
     final var roleId = Strings.newRandomValidIdentityId();
     final var mappingRuleId = Strings.newRandomValidIdentityId();
@@ -663,7 +663,7 @@ public class RoleControllerTest extends RestControllerTest {
   }
 
   @Test
-  void shouldReturnErrorForAddingMissingUserToRole() {
+  void shouldReturnErrorForAssigningMissingUserToRole() {
     // given
     final var roleId = "roleId";
     final var username = "username";
@@ -690,7 +690,7 @@ public class RoleControllerTest extends RestControllerTest {
   }
 
   @Test
-  void shouldReturnErrorForAddingUserToMissingRole() {
+  void shouldReturnErrorForAssigningUserToMissingRole() {
     // given
     final String roleId = "roleId";
     final String username = "username";
@@ -717,7 +717,7 @@ public class RoleControllerTest extends RestControllerTest {
   }
 
   @Test
-  void shouldReturnErrorForProvidingInvalidUsernameWhenAddingToRole() {
+  void shouldReturnErrorForProvidingInvalidUsernameWhenAssigningToRole() {
     // given
     final String roleId = "roleId";
     final String username = "username!";
@@ -748,7 +748,7 @@ public class RoleControllerTest extends RestControllerTest {
   }
 
   @Test
-  void shouldReturnErrorForProvidingInvalidRoleIdWhenAddingToRole() {
+  void shouldReturnErrorForProvidingInvalidRoleIdWhenAssigningToRole() {
     // given
     final String roleId = "roleId!";
     final String username = "username";
@@ -801,7 +801,7 @@ public class RoleControllerTest extends RestControllerTest {
   }
 
   @Test
-  void shouldReturnErrorForRemovingMissingUserFromRole() {
+  void shouldReturnErrorForUnassigningMissingUserFromRole() {
     // given
     final var roleId = "roleId";
     final var username = "username";
@@ -828,7 +828,7 @@ public class RoleControllerTest extends RestControllerTest {
   }
 
   @Test
-  void shouldReturnErrorForRemovingUserFromMissingRole() {
+  void shouldReturnErrorForUnassigningUserFromMissingRole() {
     // given
     final String roleId = "roleId";
     final String username = "username";
@@ -855,7 +855,7 @@ public class RoleControllerTest extends RestControllerTest {
   }
 
   @Test
-  void shouldReturnErrorForProvidingInvalidUsernameWhenRemovingFromRole() {
+  void shouldReturnErrorForProvidingInvalidUsernameWhenUnassigningFromRole() {
     // given
     final String roleId = "roleId";
     final String username = "username!";
@@ -885,7 +885,7 @@ public class RoleControllerTest extends RestControllerTest {
   }
 
   @Test
-  void shouldReturnErrorForProvidingInvalidRoleIdWhenRemovingFromRole() {
+  void shouldReturnErrorForProvidingInvalidRoleIdWhenUnassigningFromRole() {
     // given
     final String roleId = "roleId!";
     final String username = "username";
@@ -937,7 +937,7 @@ public class RoleControllerTest extends RestControllerTest {
   }
 
   @Test
-  void shouldReturnErrorForAddingMissingGroupToRole() {
+  void shouldReturnErrorForAssigningMissingGroupToRole() {
     // given
     final var roleId = "roleId";
     final var groupId = "groupId";
@@ -964,7 +964,7 @@ public class RoleControllerTest extends RestControllerTest {
   }
 
   @Test
-  void shouldReturnErrorForAddingGroupToMissingRole() {
+  void shouldReturnErrorForAssigningGroupToMissingRole() {
     // given
     final String roleId = "roleId";
     final String groupId = "groupId";
@@ -991,7 +991,7 @@ public class RoleControllerTest extends RestControllerTest {
   }
 
   @Test
-  void shouldReturnErrorForProvidingInvalidGroupIdWhenAddingToRole() {
+  void shouldReturnErrorForProvidingInvalidGroupIdWhenAssigningToRole() {
     // given
     final String roleId = "roleId";
     final String groupId = "groupId!";
@@ -1022,7 +1022,7 @@ public class RoleControllerTest extends RestControllerTest {
   }
 
   @Test
-  void shouldReturnErrorForProvidingInvalidRoleIdWhenAddingGroupToRole() {
+  void shouldReturnErrorForProvidingInvalidRoleIdWhenAssigningGroupToRole() {
     // given
     final String roleId = "roleId!";
     final String groupId = "groupId";
@@ -1075,7 +1075,7 @@ public class RoleControllerTest extends RestControllerTest {
   }
 
   @Test
-  void shouldReturnErrorForRemovingMissingGroupFromRole() {
+  void shouldReturnErrorForUnassigningMissingGroupFromRole() {
     // given
     final var roleId = "roleId";
     final var groupId = "groupId";
@@ -1105,7 +1105,7 @@ public class RoleControllerTest extends RestControllerTest {
   }
 
   @Test
-  void shouldReturnErrorForRemovingGroupFromMissingRole() {
+  void shouldReturnErrorForUnassigningGroupFromMissingRole() {
     // given
     final String roleId = "roleId";
     final String groupId = "groupId";
@@ -1132,7 +1132,7 @@ public class RoleControllerTest extends RestControllerTest {
   }
 
   @Test
-  void shouldReturnErrorForProvidingInvalidGroupIdWhenRemovingFromRole() {
+  void shouldReturnErrorForProvidingInvalidGroupIdWhenUnassigningFromRole() {
     // given
     final String roleId = "roleId";
     final String groupId = "groupId!";
@@ -1162,7 +1162,7 @@ public class RoleControllerTest extends RestControllerTest {
   }
 
   @Test
-  void shouldReturnErrorForProvidingInvalidRoleIdWhenRemovingGroupFromRole() {
+  void shouldReturnErrorForProvidingInvalidRoleIdWhenUnassigningGroupFromRole() {
     // given
     final String roleId = "roleId!";
     final String groupId = "groupId";

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/UnassignUserFromTenantTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/UnassignUserFromTenantTest.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 @ZeebeIntegration
-class RemoveUserFromTenantTest {
+class UnassignUserFromTenantTest {
 
   private static final String TENANT_ID = "tenantId";
   private static final String USERNAME = "username";
@@ -57,7 +57,7 @@ class RemoveUserFromTenantTest {
   }
 
   @Test
-  void shouldRemoveUserFromTenant() {
+  void shouldUnassignUserFromTenant() {
     // When
     client.newUnassignUserFromTenantCommand().username(USERNAME).tenantId(TENANT_ID).send().join();
 


### PR DESCRIPTION
## Description

As a team, we have agreed on a pattern of `assign`/`unassign` for client methods:

- example: `newAssignRoleToTenantCommand`, `newUnassignRoleFromTenantCommand`

But we also have `RemoveUserFromTenantCommandStep1` for `newUnassignUserFromTenantCommand` . Remove is used in one place only, so it has to be fixed.


Next, in the REST API backend we use:

- assign (example: `assignRoleToTenant`)
- add (example: `addUserToRole`)
- unassign (example: `unassignMappingFromGroup`)
- remove (example: `removeGroupFromRole`)

In rest-api docs we also have inconsistencies:

-  for example: `operationId`: `addUserToGroup` but `summary`: `Assign a user to a group`
This has also to be in line of what we've agreed as a team.


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #35312
