### PR TITLE
deps: revert update to identity version

### DIFF
--- a/optimize/pom.xml
+++ b/optimize/pom.xml
@@ -15,7 +15,7 @@
 
     <!-- We use this version to compile but run IT against containers with zeebe.docker.version -->
     <zeebe.version>8.7.9</zeebe.version>
-    <identity.version>8.7.5</identity.version>
+    <identity.version>8.7.4</identity.version>
     <!-- We use this for the Zeebe test container version only -->
     <zeebe.docker.version>${zeebe.version}</zeebe.docker.version>
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
This pull request reverts the Identity dependency version that was previously updated for the upcoming Optimize 8.7 release.

#### Context:
After the update, we discovered that the new Identity version introduces an error that causes the Optimize CI build to fail. As this is blocking the release process, we are reverting the change to restore a stable build state and allow the 8.7 release to proceed.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
