### PR TITLE
Add authorization scope wrappers to authorization checks

### DIFF
--- a/authentication/src/test/java/io/camunda/authentication/service/BasicCamundaUserServiceTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/service/BasicCamundaUserServiceTest.java
@@ -9,6 +9,7 @@ package io.camunda.authentication.service;
 
 import static io.camunda.security.auth.Authorization.withAuthorization;
 import static io.camunda.service.authorization.Authorizations.COMPONENT_ACCESS_AUTHORIZATION;
+import static io.camunda.zeebe.protocol.record.value.AuthorizationScope.WILDCARD;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -145,7 +146,8 @@ public class BasicCamundaUserServiceTest {
     final var currentUser = basicCamundaUserService.getCurrentUser();
 
     // then
-    assertThat(currentUser.authorizedComponents()).containsExactlyInAnyOrder("*");
+    assertThat(currentUser.authorizedComponents())
+        .containsExactlyInAnyOrder(WILDCARD.getResourceId());
   }
 
   @Test

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -105,6 +105,11 @@
 
     <dependency>
       <groupId>io.camunda</groupId>
+      <artifactId>camunda-security-protocol</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
       <artifactId>camunda-exporter</artifactId>
       <exclusions>
         <exclusion>

--- a/dist/src/main/java/io/camunda/application/commons/security/CamundaSecurityConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/security/CamundaSecurityConfiguration.java
@@ -11,6 +11,7 @@ import io.camunda.application.commons.security.CamundaSecurityConfiguration.Camu
 import io.camunda.security.configuration.InitializationConfiguration;
 import io.camunda.security.configuration.MultiTenancyConfiguration;
 import io.camunda.security.configuration.SecurityConfiguration;
+import io.camunda.zeebe.protocol.record.value.AuthorizationScope;
 import io.camunda.zeebe.util.VisibleForTesting;
 import jakarta.annotation.PostConstruct;
 import java.util.regex.PatternSyntaxException;
@@ -70,8 +71,7 @@ public class CamundaSecurityConfiguration {
     final var idRegex = initializationCfg.getIdentifierRegex();
     try {
       final var idPattern = initializationCfg.getIdentifierPattern();
-      // TODO: use AuthorizationScope.WILDCARD_CHAR from #36158
-      if (idPattern != null && idPattern.matcher("*").matches()) {
+      if (idPattern != null && idPattern.matcher(AuthorizationScope.WILDCARD_CHAR).matches()) {
         throw new IllegalStateException(
             "The configured identifier pattern (%s=%s) allows the asterisk ('*') which is a reserved character. Please use a different pattern."
                 .formatted("camunda.security.initialization.identifierRegex", idRegex));

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/security/permission/PermissionsService.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/security/permission/PermissionsService.java
@@ -15,6 +15,7 @@ import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.security.impl.AuthorizationChecker;
 import io.camunda.security.reader.ResourceAccessProvider;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationScope;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
@@ -114,11 +115,14 @@ public class PermissionsService {
 
   public void verifyWildcardResourcePermission(
       final AuthorizationResourceType resourceType, final PermissionType permissionType) {
-    if (!hasPermissionForResourceType(Authorization.WILDCARD, resourceType, permissionType)) {
+    if (!hasPermissionForResourceType(
+        AuthorizationScope.WILDCARD_CHAR, resourceType, permissionType)) {
       throw new ForbiddenException(
           "%s:%s:%s permissions required to access this resource."
               .formatted(
-                  resourceType.toString(), Authorization.WILDCARD, permissionType.toString()));
+                  resourceType.toString(),
+                  AuthorizationScope.WILDCARD_CHAR,
+                  permissionType.toString()));
     }
   }
 

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/auth/DefaultResourceAccessProvider.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/auth/DefaultResourceAccessProvider.java
@@ -42,13 +42,16 @@ public class DefaultResourceAccessProvider implements ResourceAccessProvider {
     if (resourceIds.contains(WILDCARD)) {
       // no authorization check required, user can access
       // the respective resources.
-      return ResourceAccess.wildcard(resultingAuthorization.resourceId(WILDCARD).build());
+      return ResourceAccess.wildcard(
+          resultingAuthorization.resourceId(WILDCARD.getResourceId()).build());
     }
 
     if (resourceIds.isEmpty()) {
       return ResourceAccess.denied(resultingAuthorization.build());
     }
 
+    final var resourceIds =
+        authorizationScopes.stream().map(AuthorizationScope::getResourceId).distinct().toList();
     final var authorizationWithResolvedResourceIds =
         resultingAuthorization.resourceIds(resourceIds).build();
     return ResourceAccess.allowed(authorizationWithResolvedResourceIds);

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/auth/DisabledResourceAccessProvider.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/auth/DisabledResourceAccessProvider.java
@@ -7,8 +7,8 @@
  */
 package io.camunda.search.clients.auth;
 
-import static io.camunda.security.auth.Authorization.WILDCARD;
 import static io.camunda.security.auth.Authorization.withAuthorization;
+import static io.camunda.zeebe.protocol.record.value.AuthorizationScope.WILDCARD;
 
 import io.camunda.security.auth.Authorization;
 import io.camunda.security.auth.CamundaAuthentication;
@@ -20,7 +20,8 @@ public class DisabledResourceAccessProvider implements ResourceAccessProvider {
   @Override
   public <T> ResourceAccess resolveResourceAccess(
       final CamundaAuthentication authentication, final Authorization<T> requiredAuthorization) {
-    return ResourceAccess.wildcard(withAuthorization(requiredAuthorization, WILDCARD));
+    return ResourceAccess.wildcard(
+        withAuthorization(requiredAuthorization, WILDCARD.getResourceId()));
   }
 
   @Override
@@ -28,7 +29,8 @@ public class DisabledResourceAccessProvider implements ResourceAccessProvider {
       final CamundaAuthentication authentication,
       final Authorization<T> requiredAuthorization,
       final T resource) {
-    return ResourceAccess.wildcard(withAuthorization(requiredAuthorization, WILDCARD));
+    return ResourceAccess.wildcard(
+        withAuthorization(requiredAuthorization, WILDCARD.getResourceId()));
   }
 
   @Override
@@ -36,6 +38,7 @@ public class DisabledResourceAccessProvider implements ResourceAccessProvider {
       final CamundaAuthentication authentication,
       final Authorization<T> requiredAuthorization,
       final String resourceId) {
-    return ResourceAccess.wildcard(withAuthorization(requiredAuthorization, WILDCARD));
+    return ResourceAccess.wildcard(
+        withAuthorization(requiredAuthorization, WILDCARD.getResourceId()));
   }
 }

--- a/security/security-core/src/main/java/io/camunda/security/auth/Authorization.java
+++ b/security/security-core/src/main/java/io/camunda/security/auth/Authorization.java
@@ -44,8 +44,6 @@ public record Authorization<T>(
     @JsonProperty("resource_ids") List<String> resourceIds,
     @JsonIgnore Function<T, String> resourceIdSupplier) {
 
-  public static final String WILDCARD = "*";
-
   public static <T> Authorization<T> withAuthorization(
       final Authorization<T> authorization, final String resourceId) {
     return of(

--- a/security/security-protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AuthorizationScope.java
+++ b/security/security-protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AuthorizationScope.java
@@ -11,7 +11,7 @@ import java.util.Objects;
 
 public class AuthorizationScope {
 
-  private static final String WILDCARD_CHAR = "*";
+  public static final String WILDCARD_CHAR = "*";
   public static final AuthorizationScope WILDCARD =
       new AuthorizationScope(AuthorizationResourceMatcher.ANY, WILDCARD_CHAR);
 

--- a/security/security-protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AuthorizationScope.java
+++ b/security/security-protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AuthorizationScope.java
@@ -11,7 +11,9 @@ import java.util.Objects;
 
 public class AuthorizationScope {
 
-  public static final String WILDCARD = "*";
+  private static final String WILDCARD_CHAR = "*";
+  public static final AuthorizationScope WILDCARD =
+      new AuthorizationScope(AuthorizationResourceMatcher.ANY, WILDCARD_CHAR);
 
   private AuthorizationResourceMatcher matcher;
   private String resourceId;
@@ -55,17 +57,20 @@ public class AuthorizationScope {
     return false;
   }
 
-  public static AuthorizationScope wildcard() {
-    return new AuthorizationScope(AuthorizationResourceMatcher.ANY, null);
-  }
-
-  public static AuthorizationScope id(final String resourceId) {
+  public static AuthorizationScope id(final String resourceId) throws IllegalArgumentException {
+    if (WILDCARD_CHAR.equals(resourceId)) {
+      final String errorMsg =
+          String.format(
+              "Resource ID cannot be the wildcard character '%s'. For declaring WILDCARD access, please use the AuthorizationScope.WILDCARD constant.",
+              WILDCARD_CHAR);
+      throw new IllegalArgumentException(errorMsg);
+    }
     return new AuthorizationScope(AuthorizationResourceMatcher.ID, resourceId);
   }
 
   public static AuthorizationScope of(final String resourceId) {
-    if (WILDCARD.equals(resourceId)) {
-      return wildcard();
+    if (WILDCARD_CHAR.equals(resourceId)) {
+      return WILDCARD;
     }
 
     return id(resourceId);

--- a/security/security-protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AuthorizationScope.java
+++ b/security/security-protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AuthorizationScope.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.protocol.record.value;
+
+import java.util.Objects;
+
+public class AuthorizationScope {
+
+  public static final String WILDCARD = "*";
+
+  private AuthorizationResourceMatcher matcher;
+  private String resourceId;
+
+  public AuthorizationScope() {}
+
+  public AuthorizationScope(final AuthorizationResourceMatcher matcher, final String resourceId) {
+    this.matcher = matcher;
+    this.resourceId = resourceId;
+  }
+
+  public AuthorizationResourceMatcher getMatcher() {
+    return matcher;
+  }
+
+  public AuthorizationScope setMatcher(final AuthorizationResourceMatcher matcher) {
+    this.matcher = matcher;
+    return this;
+  }
+
+  public String getResourceId() {
+    return resourceId;
+  }
+
+  public AuthorizationScope setResourceId(final String resourceId) {
+    this.resourceId = resourceId;
+    return this;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(matcher, resourceId);
+  }
+
+  @Override
+  public boolean equals(final Object obj) {
+    if (obj instanceof AuthorizationScope) {
+      final AuthorizationScope other = (AuthorizationScope) obj;
+      return matcher.equals(other.matcher) && resourceId.equals(other.resourceId);
+    }
+    return false;
+  }
+
+  public static AuthorizationScope wildcard() {
+    return new AuthorizationScope(AuthorizationResourceMatcher.ANY, null);
+  }
+
+  public static AuthorizationScope id(final String resourceId) {
+    return new AuthorizationScope(AuthorizationResourceMatcher.ID, resourceId);
+  }
+
+  public static AuthorizationScope of(final String resourceId) {
+    if (WILDCARD.equals(resourceId)) {
+      return wildcard();
+    }
+
+    return id(resourceId);
+  }
+}

--- a/security/security-services/src/main/java/io/camunda/security/impl/AuthorizationChecker.java
+++ b/security/security-services/src/main/java/io/camunda/security/impl/AuthorizationChecker.java
@@ -97,7 +97,10 @@ public class AuthorizationChecker {
                                   f.ownerTypeToOwnerIds(ownerIds)
                                       .resourceType(resourceType.name())
                                       .permissionTypes(permissionType)
-                                      .resourceIds(List.of(WILDCARD, resourceId)))
+                                      .resourceIds(
+                                          List.of(
+                                              AuthorizationScope.WILDCARD.getResourceId(),
+                                              authorizationScope.getResourceId())))
                           .page(p -> p.size(1)));
           return authorizationReader.search(query, ResourceAccessChecks.disabled()).total() > 0;
         },
@@ -127,7 +130,10 @@ public class AuthorizationChecker {
                               f ->
                                   f.ownerTypeToOwnerIds(ownerIds)
                                       .resourceType(resourceType.name())
-                                      .resourceIds(List.of(WILDCARD, resourceId)))
+                                      .resourceIds(
+                                          List.of(
+                                              AuthorizationScope.WILDCARD.getResourceId(),
+                                              resourceId)))
                           .unlimited());
           final var authorizationEntities =
               authorizationReader.search(query, ResourceAccessChecks.disabled()).items();

--- a/security/security-services/src/test/java/io/camunda/security/impl/AuthorizationCheckerTest.java
+++ b/security/security-services/src/test/java/io/camunda/security/impl/AuthorizationCheckerTest.java
@@ -16,6 +16,7 @@ import io.camunda.search.clients.reader.AuthorizationReader;
 import io.camunda.security.auth.Authorization;
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.security.auth.SecurityContext;
+import io.camunda.zeebe.protocol.record.value.AuthorizationScope;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -40,7 +41,7 @@ public class AuthorizationCheckerTest {
     when(securityContext.authorization()).thenReturn(authorization);
 
     // when
-    final var result = authorizationChecker.retrieveAuthorizedResourceIds(securityContext);
+    final var result = authorizationChecker.retrieveAuthorizedAuthorizationScopes(securityContext);
 
     // then
     assertThat(result).isEmpty();
@@ -62,6 +63,7 @@ public class AuthorizationCheckerTest {
   @Test
   public void notAuthorizedWhenOwnerIdsIsEmpty() {
     // given
+    final var authScope = AuthorizationScope.id("foo");
     final var authentication = mock(CamundaAuthentication.class);
     final var authorization = mock(Authorization.class);
     final var securityContext = mock(SecurityContext.class);
@@ -69,7 +71,7 @@ public class AuthorizationCheckerTest {
     when(securityContext.authorization()).thenReturn(authorization);
 
     // when
-    final var result = authorizationChecker.isAuthorized("foo", securityContext);
+    final var result = authorizationChecker.isAuthorized(authScope, securityContext);
 
     // then
     assertThat(result).isFalse();

--- a/service/src/main/java/io/camunda/service/AuthorizationServices.java
+++ b/service/src/main/java/io/camunda/service/AuthorizationServices.java
@@ -25,6 +25,7 @@ import io.camunda.zeebe.protocol.record.intent.AuthorizationIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationScope;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -105,8 +106,7 @@ public class AuthorizationServices
   }
 
   private AuthorizationResourceMatcher getResourceMatcher(final String resourceId) {
-    // TODO: use WILDCARD constant or find another place to set the matcher
-    return "*".equals(resourceId)
+    return AuthorizationScope.WILDCARD.getResourceId().equals(resourceId)
         ? AuthorizationResourceMatcher.ANY
         : AuthorizationResourceMatcher.ID;
   }

--- a/service/src/main/java/io/camunda/service/DocumentServices.java
+++ b/service/src/main/java/io/camunda/service/DocumentServices.java
@@ -26,6 +26,7 @@ import io.camunda.service.exception.ServiceException;
 import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationScope;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.util.Either;
 import java.io.InputStream;
@@ -263,7 +264,7 @@ public class DocumentServices extends ApiServices<DocumentServices> {
 
     return authorizationChecker
         .collectPermissionTypes(
-            Authorization.WILDCARD, AuthorizationResourceType.DOCUMENT, authentication)
+            AuthorizationScope.WILDCARD_CHAR, AuthorizationResourceType.DOCUMENT, authentication)
         .contains(permission);
   }
 

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/AuthorizationEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/AuthorizationEntity.java
@@ -51,11 +51,11 @@ public class AuthorizationEntity extends AbstractExporterEntity<AuthorizationEnt
     return this;
   }
 
-  public short getResourceMatcher() {
+  public Short getResourceMatcher() {
     return resourceMatcher;
   }
 
-  public AuthorizationEntity setResourceMatcher(final short resourceMatcher) {
+  public AuthorizationEntity setResourceMatcher(final Short resourceMatcher) {
     this.resourceMatcher = resourceMatcher;
     return this;
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationCheckBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationCheckBehavior.java
@@ -49,7 +49,6 @@ public final class AuthorizationCheckBehavior {
       "Expected to %s with key '%s', but no %s was found";
   public static final String NOT_FOUND_FOR_TENANT_ERROR_MESSAGE =
       "Expected to perform operation '%s' on resource '%s', but no resource was found for tenant '%s'";
-  public static final String WILDCARD_PERMISSION = "*";
   private final AuthorizationState authorizationState;
   private final MappingRuleState mappingRuleState;
   private final MembershipState membershipState;
@@ -307,7 +306,7 @@ public final class AuthorizationCheckBehavior {
   public Set<AuthorizationScope> getAllAuthorizedResourceIdentifiers(
       final AuthorizationRequest request) {
     if (!authorizationsEnabled || isAuthorizedAnonymousUser(request.getCommand())) {
-      return Set.of(AuthorizationScope.wildcard());
+      return Set.of(AuthorizationScope.WILDCARD);
     }
 
     final var authorizedResourceIds = new HashSet<AuthorizationScope>();
@@ -510,7 +509,7 @@ public final class AuthorizationCheckBehavior {
       this.resourceType = resourceType;
       this.permissionType = permissionType;
       authorizationScopes = new HashSet<>();
-      authorizationScopes.add(AuthorizationScope.wildcard());
+      authorizationScopes.add(AuthorizationScope.WILDCARD);
       this.tenantId = tenantId;
       this.isNewResource = isNewResource;
       this.isTenantOwnedResource = isTenantOwnedResource;
@@ -581,7 +580,7 @@ public final class AuthorizationCheckBehavior {
     public String getForbiddenErrorMessage() {
       final var resourceIdsContainsOnlyWildcard =
           authorizationScopes.size() == 1
-              && authorizationScopes.contains(AuthorizationScope.wildcard());
+              && authorizationScopes.contains(AuthorizationScope.WILDCARD);
       return resourceIdsContainsOnlyWildcard
           ? FORBIDDEN_ERROR_MESSAGE.formatted(permissionType, resourceType)
           : FORBIDDEN_ERROR_MESSAGE_WITH_RESOURCE.formatted(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationDeleteProcessor.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.engine.state.distribution.DistributionQueue;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.AuthorizationRecord;
 import io.camunda.zeebe.protocol.record.intent.AuthorizationIntent;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
@@ -85,7 +86,10 @@ public class AuthorizationDeleteProcessor
   private void writeEventAndDistribute(
       final TypedRecord<AuthorizationRecord> command, final long authorizationKey) {
     final long key = keyGenerator.nextKey();
-    command.getValue().setAuthorizationKey(authorizationKey);
+    command
+        .getValue()
+        .setAuthorizationKey(authorizationKey)
+        .setResourceMatcher(AuthorizationResourceMatcher.UNSPECIFIED);
     stateWriter.appendFollowUpEvent(
         authorizationKey, AuthorizationIntent.DELETED, command.getValue());
     distributionBehavior

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupDeleteProcessor.java
@@ -26,6 +26,7 @@ import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.AuthorizationIntent;
 import io.camunda.zeebe.protocol.record.intent.GroupIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
@@ -144,7 +145,10 @@ public class GroupDeleteProcessor implements DistributedTypedRecordProcessor<Gro
 
     authorizationKeysForGroup.forEach(
         authorizationKey -> {
-          final var authorization = new AuthorizationRecord().setAuthorizationKey(authorizationKey);
+          final var authorization =
+              new AuthorizationRecord()
+                  .setAuthorizationKey(authorizationKey)
+                  .setResourceMatcher(AuthorizationResourceMatcher.UNSPECIFIED);
           stateWriter.appendFollowUpEvent(
               authorizationKey, AuthorizationIntent.DELETED, authorization);
         });

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/MappingRuleDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/MappingRuleDeleteProcessor.java
@@ -36,6 +36,7 @@ import io.camunda.zeebe.protocol.record.intent.MappingRuleIntent;
 import io.camunda.zeebe.protocol.record.intent.RoleIntent;
 import io.camunda.zeebe.protocol.record.intent.TenantIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.EntityType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
@@ -182,7 +183,10 @@ public class MappingRuleDeleteProcessor
 
     authorizationKeysForMappingRule.forEach(
         authorizationKey -> {
-          final var authorization = new AuthorizationRecord().setAuthorizationKey(authorizationKey);
+          final var authorization =
+              new AuthorizationRecord()
+                  .setAuthorizationKey(authorizationKey)
+                  .setResourceMatcher(AuthorizationResourceMatcher.UNSPECIFIED);
           stateWriter.appendFollowUpEvent(
               authorizationKey, AuthorizationIntent.DELETED, authorization);
         });

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/PermissionsBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/PermissionsBehavior.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.protocol.impl.record.value.authorization.AuthorizationRe
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationScope;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.util.Either;
@@ -71,17 +72,17 @@ public class PermissionsBehavior {
   public Either<Rejection, AuthorizationRecord> permissionsAlreadyExist(
       final AuthorizationRecord record) {
     for (final PermissionType permission : record.getPermissionTypes()) {
-      final var addedResourceId = record.getResourceId();
-      final var currentResourceIds =
-          authCheckBehavior.getDirectAuthorizedResourceIdentifiers(
+      final var addedAuthorizationScope = AuthorizationScope.of(record.getResourceId());
+      final var currentAuthorizationScopes =
+          authCheckBehavior.getDirectAuthorizedAuthorizationScopes(
               record.getOwnerType(), record.getOwnerId(), record.getResourceType(), permission);
 
-      if (currentResourceIds.contains(addedResourceId)) {
+      if (currentAuthorizationScopes.contains(addedAuthorizationScope)) {
         return Either.left(
             new Rejection(
                 RejectionType.ALREADY_EXISTS,
                 PERMISSIONS_ALREADY_EXISTS_MESSAGE.formatted(
-                    record.getOwnerId(), addedResourceId)));
+                    record.getOwnerId(), addedAuthorizationScope)));
       }
     }
     return Either.right(record);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/PermissionsBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/PermissionsBehavior.java
@@ -82,7 +82,7 @@ public class PermissionsBehavior {
             new Rejection(
                 RejectionType.ALREADY_EXISTS,
                 PERMISSIONS_ALREADY_EXISTS_MESSAGE.formatted(
-                    record.getOwnerId(), addedAuthorizationScope)));
+                    record.getOwnerId(), addedAuthorizationScope.getResourceId())));
       }
     }
     return Either.right(record);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleDeleteProcessor.java
@@ -26,6 +26,7 @@ import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.AuthorizationIntent;
 import io.camunda.zeebe.protocol.record.intent.RoleIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
@@ -143,7 +144,10 @@ public class RoleDeleteProcessor implements DistributedTypedRecordProcessor<Role
 
     authorizationKeysForRole.forEach(
         authorizationKey -> {
-          final var authorization = new AuthorizationRecord().setAuthorizationKey(authorizationKey);
+          final var authorization =
+              new AuthorizationRecord()
+                  .setAuthorizationKey(authorizationKey)
+                  .setResourceMatcher(AuthorizationResourceMatcher.UNSPECIFIED);
           stateWriter.appendFollowUpEvent(
               authorizationKey, AuthorizationIntent.DELETED, authorization);
         });

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchCollector.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchCollector.java
@@ -155,7 +155,7 @@ final class JobBatchCollector {
 
   private boolean isAuthorizedForJob(
       final JobRecord jobRecord, final Set<AuthorizationScope> authorizedProcessIds) {
-    return authorizedProcessIds.contains(AuthorizationScope.wildcard())
+    return authorizedProcessIds.contains(AuthorizationScope.WILDCARD)
         || authorizedProcessIds.contains(jobRecord.getBpmnProcessId());
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchCollector.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchCollector.java
@@ -7,8 +7,6 @@
  */
 package io.camunda.zeebe.engine.processing.job;
 
-import static io.camunda.zeebe.engine.processing.identity.AuthorizationCheckBehavior.WILDCARD_PERMISSION;
-
 import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.processing.identity.AuthorizationCheckBehavior;
 import io.camunda.zeebe.engine.processing.identity.AuthorizationCheckBehavior.AuthorizationRequest;
@@ -21,6 +19,7 @@ import io.camunda.zeebe.msgpack.value.ValueArray;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobBatchRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationScope;
 import io.camunda.zeebe.protocol.record.value.JobKind;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
@@ -155,8 +154,8 @@ final class JobBatchCollector {
   }
 
   private boolean isAuthorizedForJob(
-      final JobRecord jobRecord, final Set<String> authorizedProcessIds) {
-    return authorizedProcessIds.contains(WILDCARD_PERMISSION)
+      final JobRecord jobRecord, final Set<AuthorizationScope> authorizedProcessIds) {
+    return authorizedProcessIds.contains(AuthorizationScope.wildcard())
         || authorizedProcessIds.contains(jobRecord.getBpmnProcessId());
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchCollector.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchCollector.java
@@ -95,7 +95,7 @@ final class JobBatchCollector {
     // the tenant check is performed earlier in the JobBatchActivateProcessor, so we can skip it
     // here and only check if the requester has the correct permissions to access the jobs
     final var authorizedProcessIds =
-        authCheckBehavior.getAllAuthorizedResourceIdentifiers(
+        authCheckBehavior.getAllAuthorizedScopes(
             new AuthorizationRequest(
                 record,
                 AuthorizationResourceType.PROCESS_DEFINITION,
@@ -156,7 +156,7 @@ final class JobBatchCollector {
   private boolean isAuthorizedForJob(
       final JobRecord jobRecord, final Set<AuthorizationScope> authorizedProcessIds) {
     return authorizedProcessIds.contains(AuthorizationScope.WILDCARD)
-        || authorizedProcessIds.contains(jobRecord.getBpmnProcessId());
+        || authorizedProcessIds.contains(AuthorizationScope.id(jobRecord.getBpmnProcessId()));
   }
 
   private void appendJobToBatch(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantDeleteProcessor.java
@@ -29,6 +29,7 @@ import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.AuthorizationIntent;
 import io.camunda.zeebe.protocol.record.intent.TenantIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
@@ -168,7 +169,10 @@ public class TenantDeleteProcessor implements DistributedTypedRecordProcessor<Te
 
     authorizationKeysForGroup.forEach(
         authorizationKey -> {
-          final var authorization = new AuthorizationRecord().setAuthorizationKey(authorizationKey);
+          final var authorization =
+              new AuthorizationRecord()
+                  .setAuthorizationKey(authorizationKey)
+                  .setResourceMatcher(AuthorizationResourceMatcher.UNSPECIFIED);
           stateWriter.appendFollowUpEvent(
               authorizationKey, AuthorizationIntent.DELETED, authorization);
         });

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/IdentitySetupInitializer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/IdentitySetupInitializer.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.user;
 
-import static io.camunda.zeebe.engine.processing.identity.AuthorizationCheckBehavior.WILDCARD_PERMISSION;
+import static io.camunda.zeebe.protocol.record.value.AuthorizationScope.WILDCARD;
 
 import io.camunda.security.configuration.InitializationConfiguration;
 import io.camunda.security.configuration.SecurityConfiguration;
@@ -21,7 +21,6 @@ import io.camunda.zeebe.protocol.impl.record.value.tenant.TenantRecord;
 import io.camunda.zeebe.protocol.impl.record.value.user.UserRecord;
 import io.camunda.zeebe.protocol.record.intent.IdentitySetupIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
-import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.DefaultRole;
 import io.camunda.zeebe.protocol.record.value.EntityType;
@@ -162,8 +161,8 @@ public final class IdentitySetupInitializer implements StreamProcessorLifecycleA
               .setOwnerType(AuthorizationOwnerType.ROLE)
               .setOwnerId(readOnlyAdminRoleId)
               .setResourceType(resourceType)
-              .setResourceMatcher(AuthorizationResourceMatcher.ANY)
-              .setResourceId(WILDCARD_PERMISSION)
+              .setResourceMatcher(WILDCARD.getMatcher())
+              .setResourceId(WILDCARD.getResourceId())
               .setPermissionTypes(readBasedPermissions));
     }
   }
@@ -182,8 +181,8 @@ public final class IdentitySetupInitializer implements StreamProcessorLifecycleA
               .setOwnerType(AuthorizationOwnerType.ROLE)
               .setOwnerId(adminRoleId)
               .setResourceType(resourceType)
-              .setResourceMatcher(AuthorizationResourceMatcher.ANY)
-              .setResourceId(WILDCARD_PERMISSION)
+              .setResourceMatcher(WILDCARD.getMatcher())
+              .setResourceId(WILDCARD.getResourceId())
               .setPermissionTypes(resourceType.getSupportedPermissionTypes()));
     }
     setupRecord.addTenantMember(
@@ -201,8 +200,8 @@ public final class IdentitySetupInitializer implements StreamProcessorLifecycleA
             .setOwnerType(AuthorizationOwnerType.ROLE)
             .setOwnerId(connectorsRoleId)
             .setResourceType(AuthorizationResourceType.PROCESS_DEFINITION)
-            .setResourceMatcher(AuthorizationResourceMatcher.ANY)
-            .setResourceId(WILDCARD_PERMISSION)
+            .setResourceMatcher(WILDCARD.getMatcher())
+            .setResourceId(WILDCARD.getResourceId())
             .setPermissionTypes(
                 Set.of(
                     PermissionType.READ_PROCESS_DEFINITION,
@@ -212,8 +211,8 @@ public final class IdentitySetupInitializer implements StreamProcessorLifecycleA
             .setOwnerType(AuthorizationOwnerType.ROLE)
             .setOwnerId(connectorsRoleId)
             .setResourceType(AuthorizationResourceType.MESSAGE)
-            .setResourceMatcher(AuthorizationResourceMatcher.ANY)
-            .setResourceId(WILDCARD_PERMISSION)
+            .setResourceMatcher(WILDCARD.getMatcher())
+            .setResourceId(WILDCARD.getResourceId())
             .setPermissionTypes(Set.of(PermissionType.CREATE)));
     setupRecord.addTenantMember(
         new TenantRecord()
@@ -231,16 +230,16 @@ public final class IdentitySetupInitializer implements StreamProcessorLifecycleA
                 .setOwnerId(rpaRoleId)
                 .setOwnerType(AuthorizationOwnerType.ROLE)
                 .setResourceType(AuthorizationResourceType.RESOURCE)
-                .setResourceMatcher(AuthorizationResourceMatcher.ANY)
-                .setResourceId(WILDCARD_PERMISSION)
+                .setResourceMatcher(WILDCARD.getMatcher())
+                .setResourceId(WILDCARD.getResourceId())
                 .setPermissionTypes(Set.of(PermissionType.READ)))
         .addAuthorization(
             new AuthorizationRecord()
                 .setOwnerId(rpaRoleId)
                 .setOwnerType(AuthorizationOwnerType.ROLE)
                 .setResourceType(AuthorizationResourceType.PROCESS_DEFINITION)
-                .setResourceMatcher(AuthorizationResourceMatcher.ANY)
-                .setResourceId(WILDCARD_PERMISSION)
+                .setResourceMatcher(WILDCARD.getMatcher())
+                .setResourceId(WILDCARD.getResourceId())
                 .setPermissionTypes(Set.of(PermissionType.UPDATE_PROCESS_INSTANCE)))
         .addTenantMember(
             new TenantRecord()

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserDeleteProcessor.java
@@ -37,6 +37,7 @@ import io.camunda.zeebe.protocol.record.intent.RoleIntent;
 import io.camunda.zeebe.protocol.record.intent.TenantIntent;
 import io.camunda.zeebe.protocol.record.intent.UserIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.EntityType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
@@ -183,7 +184,10 @@ public class UserDeleteProcessor implements DistributedTypedRecordProcessor<User
 
     authorizationKeysForGroup.forEach(
         authorizationKey -> {
-          final var authorization = new AuthorizationRecord().setAuthorizationKey(authorizationKey);
+          final var authorization =
+              new AuthorizationRecord()
+                  .setAuthorizationKey(authorizationKey)
+                  .setResourceMatcher(AuthorizationResourceMatcher.UNSPECIFIED);
           stateWriter.appendFollowUpEvent(
               authorizationKey, AuthorizationIntent.DELETED, authorization);
         });

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/DbAuthorizationState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/DbAuthorizationState.java
@@ -97,7 +97,10 @@ public class DbAuthorizationState implements MutableAuthorizationState {
         .getPermissionTypes()
         .forEach(
             permissionType -> {
-              permissions.addAuthorizationScope(permissionType, authorization.getResourceId());
+              permissions.addAuthorizationScope(
+                  permissionType,
+                  new AuthorizationScope(
+                      authorization.getResourceMatcher(), authorization.getResourceId()));
             });
     permissionsColumnFamily.upsert(ownerTypeOwnerIdAndResourceType, permissions);
 
@@ -134,7 +137,10 @@ public class DbAuthorizationState implements MutableAuthorizationState {
                   persistedAuthorization.getOwnerId(),
                   persistedAuthorization.getResourceType(),
                   permissionType,
-                  Set.of(persistedAuthorization.getResourceId()));
+                  Set.of(
+                      new AuthorizationScope(
+                          persistedAuthorization.getResourceMatcher(),
+                          persistedAuthorization.getResourceId())));
             });
 
     // delete the old authorization record
@@ -157,7 +163,7 @@ public class DbAuthorizationState implements MutableAuthorizationState {
   }
 
   @Override
-  public Set<AuthorizationScope> getResourceIdentifiers(
+  public Set<AuthorizationScope> getAuthorizationScopes(
       final AuthorizationOwnerType ownerType,
       final String ownerId,
       final AuthorizationResourceType resourceType,
@@ -189,7 +195,7 @@ public class DbAuthorizationState implements MutableAuthorizationState {
       final String ownerId,
       final AuthorizationResourceType resourceType,
       final PermissionType permissionType,
-      final Set<String> resourceIds) {
+      final Set<AuthorizationScope> resourceIds) {
     this.ownerType.wrapString(ownerType.name());
     this.ownerId.wrapString(ownerId);
     this.resourceType.wrapString(resourceType.name());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/DbAuthorizationState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/DbAuthorizationState.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.protocol.ZbColumnFamilies;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.AuthorizationRecord;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationScope;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import java.util.Collections;
 import java.util.Optional;
@@ -96,7 +97,7 @@ public class DbAuthorizationState implements MutableAuthorizationState {
         .getPermissionTypes()
         .forEach(
             permissionType -> {
-              permissions.addResourceIdentifier(permissionType, authorization.getResourceId());
+              permissions.addAuthorizationScope(permissionType, authorization.getResourceId());
             });
     permissionsColumnFamily.upsert(ownerTypeOwnerIdAndResourceType, permissions);
 
@@ -156,7 +157,7 @@ public class DbAuthorizationState implements MutableAuthorizationState {
   }
 
   @Override
-  public Set<String> getResourceIdentifiers(
+  public Set<AuthorizationScope> getResourceIdentifiers(
       final AuthorizationOwnerType ownerType,
       final String ownerId,
       final AuthorizationResourceType resourceType,
@@ -194,7 +195,7 @@ public class DbAuthorizationState implements MutableAuthorizationState {
     this.resourceType.wrapString(resourceType.name());
 
     final var permissions = permissionsColumnFamily.get(ownerTypeOwnerIdAndResourceType);
-    permissions.removeResourceIdentifiers(permissionType, resourceIds);
+    permissions.removeAuthorizationScopes(permissionType, resourceIds);
 
     if (permissions.isEmpty()) {
       permissionsColumnFamily.deleteExisting(ownerTypeOwnerIdAndResourceType);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/Permissions.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/Permissions.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.db.DbValue;
 import io.camunda.zeebe.msgpack.UnpackedObject;
 import io.camunda.zeebe.msgpack.property.DocumentProperty;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
+import io.camunda.zeebe.protocol.record.value.AuthorizationScope;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.HashSet;
@@ -26,40 +27,31 @@ public class Permissions extends UnpackedObject implements DbValue {
     declareProperty(permissions);
   }
 
-  public Map<PermissionType, Set<String>> getPermissions() {
+  public Map<PermissionType, Set<AuthorizationScope>> getPermissions() {
     return MsgPackConverter.convertToPermissionMap(permissions.getValue());
   }
 
-  public void setPermissions(final Map<PermissionType, Set<String>> permissions) {
+  public void setPermissions(final Map<PermissionType, Set<AuthorizationScope>> permissions) {
     this.permissions.setValue(BufferUtil.wrapArray(MsgPackConverter.convertToMsgPack(permissions)));
   }
 
-  public void removeResourceIdentifiers(
-      final PermissionType permissionType, final Set<String> resourceIds) {
+  public void removeAuthorizationScopes(
+      final PermissionType permissionType, final Set<AuthorizationScope> authorizationScopes) {
     final var permissions = getPermissions();
-    final var resourceIdentifiers = permissions.get(permissionType);
-    resourceIdentifiers.removeAll(resourceIds);
+    final var totalAuthorizationScopes = permissions.get(permissionType);
+    totalAuthorizationScopes.removeAll(authorizationScopes);
 
-    if (resourceIdentifiers.isEmpty()) {
+    if (totalAuthorizationScopes.isEmpty()) {
       permissions.remove(permissionType);
     }
 
     setPermissions(permissions);
   }
 
-  public void addResourceIdentifiers(
-      final PermissionType permissionType, final Set<String> resourceIdentifiers) {
+  public void addAuthorizationScope(
+      final PermissionType permissionType, final AuthorizationScope authorizationScope) {
     final var permissions = getPermissions();
-    permissions
-        .computeIfAbsent(permissionType, ignored -> new HashSet<>())
-        .addAll(resourceIdentifiers);
-    setPermissions(permissions);
-  }
-
-  public void addResourceIdentifier(
-      final PermissionType permissionType, final String resourceIdentifier) {
-    final var permissions = getPermissions();
-    permissions.computeIfAbsent(permissionType, ignored -> new HashSet<>()).add(resourceIdentifier);
+    permissions.computeIfAbsent(permissionType, ignored -> new HashSet<>()).add(authorizationScope);
     setPermissions(permissions);
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/PersistedAuthorization.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/PersistedAuthorization.java
@@ -33,10 +33,7 @@ public class PersistedAuthorization extends UnpackedObject implements DbValue {
   private final EnumProperty<AuthorizationOwnerType> ownerTypeProp =
       new EnumProperty<>("ownerType", AuthorizationOwnerType.class);
   private final EnumProperty<AuthorizationResourceMatcher> resourceMatcherProp =
-      new EnumProperty<>(
-          "resourceMatcher",
-          AuthorizationResourceMatcher.class,
-          AuthorizationResourceMatcher.UNSPECIFIED);
+      new EnumProperty<>("resourceMatcher", AuthorizationResourceMatcher.class);
   private final StringProperty resourceIdProp = new StringProperty("resourceId");
   private final EnumProperty<AuthorizationResourceType> resourceTypeProp =
       new EnumProperty<>("resourceType", AuthorizationResourceType.class);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/AuthorizationState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/AuthorizationState.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.engine.state.immutable;
 import io.camunda.zeebe.engine.state.authorization.PersistedAuthorization;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationScope;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import java.util.Optional;
 import java.util.Set;
@@ -17,7 +18,7 @@ import java.util.Set;
 public interface AuthorizationState {
   Optional<PersistedAuthorization> get(final long authorizationKey);
 
-  Set<String> getResourceIdentifiers(
+  Set<AuthorizationScope> getAuthorizationScopes(
       final AuthorizationOwnerType ownerType,
       final String ownerId,
       AuthorizationResourceType resourceType,

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AnonymousAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AnonymousAuthorizationTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.authorization;
 
+import static io.camunda.zeebe.protocol.record.value.AuthorizationScope.WILDCARD;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 
@@ -19,7 +20,6 @@ import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
-import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.EntityType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
@@ -74,8 +74,8 @@ public class AnonymousAuthorizationTest {
         .newAuthorization()
         .withPermissions(PermissionType.CREATE)
         .withResourceType(AuthorizationResourceType.RESOURCE)
-        .withResourceMatcher(AuthorizationResourceMatcher.ANY)
-        .withResourceId("*")
+        .withResourceMatcher(WILDCARD.getMatcher())
+        .withResourceId(WILDCARD.getResourceId())
         .withOwnerId(user.getUsername())
         .withOwnerType(AuthorizationOwnerType.USER)
         .create();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCheckBehaviorGroupsClaimsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCheckBehaviorGroupsClaimsTest.java
@@ -99,7 +99,8 @@ final class AuthorizationCheckBehaviorGroupsClaimsTest {
 
     // when
     final var request =
-        new AuthorizationRequest(command, resourceType, permissionType).addResourceId(resourceId);
+        new AuthorizationRequest(command, resourceType, permissionType)
+            .addAuthorizationScope(resourceId);
     final var authorized = authorizationCheckBehavior.isAuthorized(request);
 
     // then
@@ -126,8 +127,7 @@ final class AuthorizationCheckBehaviorGroupsClaimsTest {
 
     // when
     final var request = new AuthorizationRequest(command, resourceType, permissionType);
-    final var resourceIdentifiers =
-        authorizationCheckBehavior.getAllAuthorizedResourceIdentifiers(request);
+    final var resourceIdentifiers = authorizationCheckBehavior.getAllAuthorizedScopes(request);
 
     // then
     assertThat(resourceIdentifiers).containsExactlyInAnyOrder(resourceId1, resourceId2);
@@ -149,9 +149,9 @@ final class AuthorizationCheckBehaviorGroupsClaimsTest {
 
     // when
     final var request =
-        new AuthorizationRequest(command, resourceType, permissionType).addResourceId(resourceId);
-    final var authorizations =
-        authorizationCheckBehavior.getAllAuthorizedResourceIdentifiers(request);
+        new AuthorizationRequest(command, resourceType, permissionType)
+            .addAuthorizationScope(resourceId);
+    final var authorizations = authorizationCheckBehavior.getAllAuthorizedScopes(request);
 
     // then
     assertThat(authorizations).containsExactlyInAnyOrder(resourceId);
@@ -173,7 +173,8 @@ final class AuthorizationCheckBehaviorGroupsClaimsTest {
 
     // when
     final var request =
-        new AuthorizationRequest(command, resourceType, permissionType).addResourceId(resourceId);
+        new AuthorizationRequest(command, resourceType, permissionType)
+            .addAuthorizationScope(resourceId);
     final var authorized = authorizationCheckBehavior.isAuthorized(request);
 
     // then
@@ -196,7 +197,7 @@ final class AuthorizationCheckBehaviorGroupsClaimsTest {
     // when
     final var request =
         new AuthorizationRequest(command, resourceType, permissionType, tenantId)
-            .addResourceId(resourceId);
+            .addAuthorizationScope(resourceId);
     final var authorized = authorizationCheckBehavior.isAuthorized(request);
 
     // then

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCheckBehaviorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCheckBehaviorTest.java
@@ -100,7 +100,8 @@ final class AuthorizationCheckBehaviorTest {
 
     // when
     final var request =
-        new AuthorizationRequest(command, resourceType, permissionType).addResourceId(resourceId);
+        new AuthorizationRequest(command, resourceType, permissionType)
+            .addAuthorizationScope(resourceId);
     final var authorized = authorizationCheckBehavior.isAuthorized(request);
 
     // then
@@ -144,8 +145,7 @@ final class AuthorizationCheckBehaviorTest {
 
     // when
     final var request = new AuthorizationRequest(command, resourceType, permissionType);
-    final var resourceIdentifiers =
-        authorizationCheckBehavior.getAllAuthorizedResourceIdentifiers(request);
+    final var resourceIdentifiers = authorizationCheckBehavior.getAllAuthorizedScopes(request);
 
     // then
     assertThat(resourceIdentifiers).containsExactlyInAnyOrder(resourceId1, resourceId2);
@@ -161,8 +161,7 @@ final class AuthorizationCheckBehaviorTest {
 
     // when
     final var request = new AuthorizationRequest(command, resourceType, permissionType);
-    final var resourceIdentifiers =
-        authorizationCheckBehavior.getAllAuthorizedResourceIdentifiers(request);
+    final var resourceIdentifiers = authorizationCheckBehavior.getAllAuthorizedScopes(request);
 
     // then
     assertThat(resourceIdentifiers).isEmpty();
@@ -182,7 +181,8 @@ final class AuthorizationCheckBehaviorTest {
 
     // when
     final var request =
-        new AuthorizationRequest(command, resourceType, permissionType).addResourceId(resourceId);
+        new AuthorizationRequest(command, resourceType, permissionType)
+            .addAuthorizationScope(resourceId);
     final var authorized = authorizationCheckBehavior.isAuthorized(request);
 
     // then
@@ -209,8 +209,7 @@ final class AuthorizationCheckBehaviorTest {
 
     // when
     final var request = new AuthorizationRequest(command, resourceType, permissionType);
-    final var resourceIdentifiers =
-        authorizationCheckBehavior.getAllAuthorizedResourceIdentifiers(request);
+    final var resourceIdentifiers = authorizationCheckBehavior.getAllAuthorizedScopes(request);
 
     // then
     assertThat(resourceIdentifiers).containsExactlyInAnyOrder(resourceId1, resourceId2);
@@ -230,7 +229,8 @@ final class AuthorizationCheckBehaviorTest {
 
     // when
     final var request =
-        new AuthorizationRequest(command, resourceType, permissionType).addResourceId(resourceId);
+        new AuthorizationRequest(command, resourceType, permissionType)
+            .addAuthorizationScope(resourceId);
     final var authorized = authorizationCheckBehavior.isAuthorized(request);
 
     // then
@@ -258,8 +258,7 @@ final class AuthorizationCheckBehaviorTest {
 
     // when
     final var request = new AuthorizationRequest(command, resourceType, permissionType);
-    final var resourceIdentifiers =
-        authorizationCheckBehavior.getAllAuthorizedResourceIdentifiers(request);
+    final var resourceIdentifiers = authorizationCheckBehavior.getAllAuthorizedScopes(request);
 
     // then
     assertThat(resourceIdentifiers).containsExactlyInAnyOrder(resourceId1, resourceId2);
@@ -278,7 +277,8 @@ final class AuthorizationCheckBehaviorTest {
 
     // when
     final var request =
-        new AuthorizationRequest(command, resourceType, permissionType).addResourceId(resourceId);
+        new AuthorizationRequest(command, resourceType, permissionType)
+            .addAuthorizationScope(resourceId);
     final var authorized = authorizationCheckBehavior.isAuthorized(request);
 
     // then
@@ -304,7 +304,8 @@ final class AuthorizationCheckBehaviorTest {
 
     // when
     final var request =
-        new AuthorizationRequest(command, resourceType, permissionType).addResourceId(resourceId);
+        new AuthorizationRequest(command, resourceType, permissionType)
+            .addAuthorizationScope(resourceId);
     final var authorized = authorizationCheckBehavior.isAuthorized(request);
 
     // then
@@ -327,7 +328,8 @@ final class AuthorizationCheckBehaviorTest {
 
     // when
     final var request =
-        new AuthorizationRequest(command, resourceType, permissionType).addResourceId(resourceId);
+        new AuthorizationRequest(command, resourceType, permissionType)
+            .addAuthorizationScope(resourceId);
     final var authorized = authorizationCheckBehavior.isAuthorized(request);
 
     // then
@@ -352,7 +354,8 @@ final class AuthorizationCheckBehaviorTest {
 
     // when
     final var request =
-        new AuthorizationRequest(command, resourceType, permissionType).addResourceId(resourceId);
+        new AuthorizationRequest(command, resourceType, permissionType)
+            .addAuthorizationScope(resourceId);
     final var authorized = authorizationCheckBehavior.isAuthorized(request);
 
     // then
@@ -417,12 +420,12 @@ final class AuthorizationCheckBehaviorTest {
     EitherAssert.assertThat(
             authorizationCheckBehavior.isAuthorized(
                 new AuthorizationRequest(command, resourceType, permissionType)
-                    .addResourceId(firstResourceId)))
+                    .addAuthorizationScope(firstResourceId)))
         .isRight();
     EitherAssert.assertThat(
             authorizationCheckBehavior.isAuthorized(
                 new AuthorizationRequest(command, resourceType, permissionType)
-                    .addResourceId(secondResourceId)))
+                    .addAuthorizationScope(secondResourceId)))
         .isRight();
   }
 
@@ -464,12 +467,12 @@ final class AuthorizationCheckBehaviorTest {
     EitherAssert.assertThat(
             authorizationCheckBehavior.isAuthorized(
                 new AuthorizationRequest(command, resourceType, permissionType)
-                    .addResourceId(firstResourceId)))
+                    .addAuthorizationScope(firstResourceId)))
         .isRight();
     EitherAssert.assertThat(
             authorizationCheckBehavior.isAuthorized(
                 new AuthorizationRequest(command, resourceType, permissionType)
-                    .addResourceId(secondResourceId)))
+                    .addAuthorizationScope(secondResourceId)))
         .isRight();
   }
 
@@ -492,9 +495,9 @@ final class AuthorizationCheckBehaviorTest {
 
     // when
     final var request =
-        new AuthorizationRequest(command, resourceType, permissionType).addResourceId(resourceId);
-    final var authorizations =
-        authorizationCheckBehavior.getAllAuthorizedResourceIdentifiers(request);
+        new AuthorizationRequest(command, resourceType, permissionType)
+            .addAuthorizationScope(resourceId);
+    final var authorizations = authorizationCheckBehavior.getAllAuthorizedScopes(request);
 
     // then
     assertThat(authorizations).containsExactlyInAnyOrder(resourceId);
@@ -522,9 +525,9 @@ final class AuthorizationCheckBehaviorTest {
 
     // when
     final var request =
-        new AuthorizationRequest(command, resourceType, permissionType).addResourceId(resourceId);
-    final var authorizations =
-        authorizationCheckBehavior.getAllAuthorizedResourceIdentifiers(request);
+        new AuthorizationRequest(command, resourceType, permissionType)
+            .addAuthorizationScope(resourceId);
+    final var authorizations = authorizationCheckBehavior.getAllAuthorizedScopes(request);
 
     // then
     assertThat(authorizations).containsExactlyInAnyOrder(resourceId);
@@ -547,9 +550,9 @@ final class AuthorizationCheckBehaviorTest {
 
     // when
     final var request =
-        new AuthorizationRequest(command, resourceType, permissionType).addResourceId(resourceId);
-    final var authorizations =
-        authorizationCheckBehavior.getAllAuthorizedResourceIdentifiers(request);
+        new AuthorizationRequest(command, resourceType, permissionType)
+            .addAuthorizationScope(resourceId);
+    final var authorizations = authorizationCheckBehavior.getAllAuthorizedScopes(request);
 
     // then
     assertThat(authorizations).containsExactlyInAnyOrder(resourceId);
@@ -572,9 +575,9 @@ final class AuthorizationCheckBehaviorTest {
 
     // when
     final var request =
-        new AuthorizationRequest(command, resourceType, permissionType).addResourceId(resourceId);
-    final var authorizations =
-        authorizationCheckBehavior.getAllAuthorizedResourceIdentifiers(request);
+        new AuthorizationRequest(command, resourceType, permissionType)
+            .addAuthorizationScope(resourceId);
+    final var authorizations = authorizationCheckBehavior.getAllAuthorizedScopes(request);
 
     // then
     assertThat(authorizations).containsExactlyInAnyOrder(resourceId);
@@ -596,7 +599,8 @@ final class AuthorizationCheckBehaviorTest {
 
     // when
     final var request =
-        new AuthorizationRequest(command, resourceType, permissionType).addResourceId(resourceId);
+        new AuthorizationRequest(command, resourceType, permissionType)
+            .addAuthorizationScope(resourceId);
     final var authorized = authorizationCheckBehavior.isAuthorized(request);
 
     // then
@@ -619,11 +623,12 @@ final class AuthorizationCheckBehaviorTest {
 
     // when
     final var request =
-        new AuthorizationRequest(command, resourceType, permissionType).addResourceId(resourceId);
+        new AuthorizationRequest(command, resourceType, permissionType)
+            .addAuthorizationScope(resourceId);
     final var allAuthorizedResourceIdentifiers =
-        authorizationCheckBehavior.getAllAuthorizedResourceIdentifiers(request);
+        authorizationCheckBehavior.getAllAuthorizedScopes(request);
     final var directAuthorizedResourceIdentifiers =
-        authorizationCheckBehavior.getDirectAuthorizedResourceIdentifiers(
+        authorizationCheckBehavior.getDirectAuthorizedAuthorizationScopes(
             AuthorizationOwnerType.USER, user.getUsername(), resourceType, permissionType);
 
     // then
@@ -650,7 +655,8 @@ final class AuthorizationCheckBehaviorTest {
 
     // when
     final var request =
-        new AuthorizationRequest(command, resourceType, permissionType).addResourceId(resourceId);
+        new AuthorizationRequest(command, resourceType, permissionType)
+            .addAuthorizationScope(resourceId);
     final var authorized = authorizationCheckBehavior.isAuthorized(request);
 
     // then
@@ -676,11 +682,12 @@ final class AuthorizationCheckBehaviorTest {
 
     // when
     final var request =
-        new AuthorizationRequest(command, resourceType, permissionType).addResourceId(resourceId);
+        new AuthorizationRequest(command, resourceType, permissionType)
+            .addAuthorizationScope(resourceId);
     final var allAuthorizedResourceIdentifiers =
-        authorizationCheckBehavior.getAllAuthorizedResourceIdentifiers(request);
+        authorizationCheckBehavior.getAllAuthorizedScopes(request);
     final var directAuthorizedResourceIdentifiers =
-        authorizationCheckBehavior.getDirectAuthorizedResourceIdentifiers(
+        authorizationCheckBehavior.getDirectAuthorizedAuthorizationScopes(
             AuthorizationOwnerType.MAPPING_RULE,
             mappingRule.getMappingRuleId(),
             resourceType,
@@ -704,7 +711,8 @@ final class AuthorizationCheckBehaviorTest {
 
     // when
     final var request =
-        new AuthorizationRequest(command, resourceType, permissionType).addResourceId(resourceId);
+        new AuthorizationRequest(command, resourceType, permissionType)
+            .addAuthorizationScope(resourceId);
     final var authorized = authorizationCheckBehavior.isAuthorized(request);
 
     // then
@@ -722,7 +730,8 @@ final class AuthorizationCheckBehaviorTest {
 
     // when
     final var request =
-        new AuthorizationRequest(command, resourceType, permissionType).addResourceId(resourceId);
+        new AuthorizationRequest(command, resourceType, permissionType)
+            .addAuthorizationScope(resourceId);
     final var authorized = authorizationCheckBehavior.isAuthorized(request);
 
     // then
@@ -748,8 +757,7 @@ final class AuthorizationCheckBehaviorTest {
 
     // when
     final var request = new AuthorizationRequest(command, resourceType, permissionType);
-    final var resourceIdentifiers =
-        authorizationCheckBehavior.getAllAuthorizedResourceIdentifiers(request);
+    final var resourceIdentifiers = authorizationCheckBehavior.getAllAuthorizedScopes(request);
 
     // then
     assertThat(resourceIdentifiers).containsExactlyInAnyOrder(resourceId1, resourceId2);
@@ -765,8 +773,7 @@ final class AuthorizationCheckBehaviorTest {
 
     // when
     final var request = new AuthorizationRequest(command, resourceType, permissionType);
-    final var resourceIdentifiers =
-        authorizationCheckBehavior.getAllAuthorizedResourceIdentifiers(request);
+    final var resourceIdentifiers = authorizationCheckBehavior.getAllAuthorizedScopes(request);
 
     // then
     assertThat(resourceIdentifiers).isEmpty();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCheckBehaviorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCheckBehaviorTest.java
@@ -34,8 +34,8 @@ import io.camunda.zeebe.protocol.impl.record.value.authorization.RoleRecord;
 import io.camunda.zeebe.protocol.impl.record.value.group.GroupRecord;
 import io.camunda.zeebe.protocol.impl.record.value.user.UserRecord;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
-import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationScope;
 import io.camunda.zeebe.protocol.record.value.EntityType;
 import io.camunda.zeebe.protocol.record.value.MappingRuleRecordValue;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
@@ -93,7 +93,7 @@ final class AuthorizationCheckBehaviorTest {
     final var user = createUser();
     final var resourceType = AuthorizationResourceType.RESOURCE;
     final var permissionType = PermissionType.CREATE;
-    final var resourceId = UUID.randomUUID().toString();
+    final var resourceId = AuthorizationScope.of(UUID.randomUUID().toString());
     addPermission(
         user.getUsername(), AuthorizationOwnerType.USER, resourceType, permissionType, resourceId);
     final var command = mockCommand(user.getUsername());
@@ -131,8 +131,8 @@ final class AuthorizationCheckBehaviorTest {
     final var user = createUser();
     final var resourceType = AuthorizationResourceType.RESOURCE;
     final var permissionType = PermissionType.CREATE;
-    final var resourceId1 = UUID.randomUUID().toString();
-    final var resourceId2 = UUID.randomUUID().toString();
+    final var resourceId1 = AuthorizationScope.of(UUID.randomUUID().toString());
+    final var resourceId2 = AuthorizationScope.of(UUID.randomUUID().toString());
     addPermission(
         user.getUsername(),
         AuthorizationOwnerType.USER,
@@ -175,7 +175,7 @@ final class AuthorizationCheckBehaviorTest {
     final var role = createRoleAndAssignEntity(user.getUsername(), EntityType.USER);
     final var resourceType = AuthorizationResourceType.RESOURCE;
     final var permissionType = PermissionType.CREATE;
-    final var resourceId = UUID.randomUUID().toString();
+    final var resourceId = AuthorizationScope.of(UUID.randomUUID().toString());
     addPermission(
         role.getRoleId(), AuthorizationOwnerType.ROLE, resourceType, permissionType, resourceId);
     final var command = mockCommand(user.getUsername());
@@ -196,8 +196,8 @@ final class AuthorizationCheckBehaviorTest {
     final var role = createRoleAndAssignEntity(user.getUsername(), EntityType.USER);
     final var resourceType = AuthorizationResourceType.RESOURCE;
     final var permissionType = PermissionType.CREATE;
-    final var resourceId1 = UUID.randomUUID().toString();
-    final var resourceId2 = UUID.randomUUID().toString();
+    final var resourceId1 = AuthorizationScope.of(UUID.randomUUID().toString());
+    final var resourceId2 = AuthorizationScope.of(UUID.randomUUID().toString());
     addPermission(
         role.getRoleId(),
         AuthorizationOwnerType.ROLE,
@@ -223,7 +223,7 @@ final class AuthorizationCheckBehaviorTest {
     final var group = createGroupAndAssignEntity(user.getUsername(), EntityType.USER);
     final var resourceType = AuthorizationResourceType.RESOURCE;
     final var permissionType = PermissionType.CREATE;
-    final var resourceId = UUID.randomUUID().toString();
+    final var resourceId = AuthorizationScope.of(UUID.randomUUID().toString());
     addPermission(
         group.getGroupId(), AuthorizationOwnerType.GROUP, resourceType, permissionType, resourceId);
     final var command = mockCommand(user.getUsername());
@@ -245,8 +245,8 @@ final class AuthorizationCheckBehaviorTest {
     final var groupId = group.getGroupId();
     final var resourceType = AuthorizationResourceType.RESOURCE;
     final var permissionType = PermissionType.CREATE;
-    final var resourceId1 = UUID.randomUUID().toString();
-    final var resourceId2 = UUID.randomUUID().toString();
+    final var resourceId1 = AuthorizationScope.of(UUID.randomUUID().toString());
+    final var resourceId2 = AuthorizationScope.of(UUID.randomUUID().toString());
     addPermission(
         groupId,
         AuthorizationOwnerType.GROUP,
@@ -271,7 +271,7 @@ final class AuthorizationCheckBehaviorTest {
     final var user = createUser();
     final var resourceType = AuthorizationResourceType.RESOURCE;
     final var permissionType = PermissionType.CREATE;
-    final var resourceId = UUID.randomUUID().toString();
+    final var resourceId = AuthorizationScope.of(UUID.randomUUID().toString());
     addPermission(
         user.getUsername(), AuthorizationOwnerType.USER, resourceType, permissionType, resourceId);
     final var command = mockCommandWithAnonymousUser();
@@ -293,7 +293,7 @@ final class AuthorizationCheckBehaviorTest {
     final var mappingRule = createMappingRule(claimName, claimValue);
     final var resourceType = AuthorizationResourceType.RESOURCE;
     final var permissionType = PermissionType.CREATE;
-    final var resourceId = UUID.randomUUID().toString();
+    final var resourceId = AuthorizationScope.of(UUID.randomUUID().toString());
     addPermission(
         mappingRule.getMappingRuleId(),
         AuthorizationOwnerType.MAPPING_RULE,
@@ -320,7 +320,7 @@ final class AuthorizationCheckBehaviorTest {
     final var group = createGroupAndAssignEntity(mappingRuleId, EntityType.MAPPING_RULE);
     final var resourceType = AuthorizationResourceType.RESOURCE;
     final var permissionType = PermissionType.CREATE;
-    final var resourceId = UUID.randomUUID().toString();
+    final var resourceId = AuthorizationScope.of(UUID.randomUUID().toString());
     addPermission(
         group.getGroupId(), AuthorizationOwnerType.GROUP, resourceType, permissionType, resourceId);
     final var command = mockCommandWithMappingRule(claimName, claimValue);
@@ -344,7 +344,7 @@ final class AuthorizationCheckBehaviorTest {
         createRoleAndAssignEntity(mappingRule.getMappingRuleId(), EntityType.MAPPING_RULE);
     final var resourceType = AuthorizationResourceType.RESOURCE;
     final var permissionType = PermissionType.CREATE;
-    final var resourceId = UUID.randomUUID().toString();
+    final var resourceId = AuthorizationScope.of(UUID.randomUUID().toString());
     addPermission(
         role.getRoleId(), AuthorizationOwnerType.ROLE, resourceType, permissionType, resourceId);
 
@@ -389,8 +389,8 @@ final class AuthorizationCheckBehaviorTest {
 
     final var resourceType = AuthorizationResourceType.RESOURCE;
     final var permissionType = PermissionType.CREATE;
-    final var firstResourceId = UUID.randomUUID().toString();
-    final var secondResourceId = UUID.randomUUID().toString();
+    final var firstResourceId = AuthorizationScope.of(UUID.randomUUID().toString());
+    final var secondResourceId = AuthorizationScope.of(UUID.randomUUID().toString());
     addPermission(
         firstMapping.getMappingRuleId(),
         AuthorizationOwnerType.MAPPING_RULE,
@@ -437,8 +437,8 @@ final class AuthorizationCheckBehaviorTest {
 
     final var resourceType = AuthorizationResourceType.RESOURCE;
     final var permissionType = PermissionType.CREATE;
-    final var firstResourceId = UUID.randomUUID().toString();
-    final var secondResourceId = UUID.randomUUID().toString();
+    final var firstResourceId = AuthorizationScope.of(UUID.randomUUID().toString());
+    final var secondResourceId = AuthorizationScope.of(UUID.randomUUID().toString());
     addPermission(
         firstMapping.getMappingRuleId(),
         AuthorizationOwnerType.MAPPING_RULE,
@@ -481,7 +481,7 @@ final class AuthorizationCheckBehaviorTest {
     final var mappingRule = createMappingRule(claimName, claimValue);
     final var resourceType = AuthorizationResourceType.RESOURCE;
     final var permissionType = PermissionType.CREATE;
-    final var resourceId = UUID.randomUUID().toString();
+    final var resourceId = AuthorizationScope.of(UUID.randomUUID().toString());
     addPermission(
         mappingRule.getMappingRuleId(),
         AuthorizationOwnerType.MAPPING_RULE,
@@ -508,7 +508,7 @@ final class AuthorizationCheckBehaviorTest {
     final var mappingRule = createMappingRule(claimName, claimValue);
     final var resourceType = AuthorizationResourceType.RESOURCE;
     final var permissionType = PermissionType.CREATE;
-    final var resourceId = UUID.randomUUID().toString();
+    final var resourceId = AuthorizationScope.of(UUID.randomUUID().toString());
     addPermission(
         mappingRule.getMappingRuleId(),
         AuthorizationOwnerType.MAPPING_RULE,
@@ -540,7 +540,7 @@ final class AuthorizationCheckBehaviorTest {
         createRoleAndAssignEntity(mappingRule.getMappingRuleId(), EntityType.MAPPING_RULE);
     final var resourceType = AuthorizationResourceType.RESOURCE;
     final var permissionType = PermissionType.CREATE;
-    final var resourceId = UUID.randomUUID().toString();
+    final var resourceId = AuthorizationScope.of(UUID.randomUUID().toString());
     addPermission(
         role.getRoleId(), AuthorizationOwnerType.ROLE, resourceType, permissionType, resourceId);
     final var command = mockCommandWithMappingRule(claimName, claimValue);
@@ -565,7 +565,7 @@ final class AuthorizationCheckBehaviorTest {
         createGroupAndAssignEntity(mappingRule.getMappingRuleId(), EntityType.MAPPING_RULE);
     final var resourceType = AuthorizationResourceType.RESOURCE;
     final var permissionType = PermissionType.CREATE;
-    final var resourceId = UUID.randomUUID().toString();
+    final var resourceId = AuthorizationScope.of(UUID.randomUUID().toString());
     addPermission(
         group.getGroupId(), AuthorizationOwnerType.GROUP, resourceType, permissionType, resourceId);
     final var command = mockCommandWithMappingRule(claimName, claimValue);
@@ -589,7 +589,7 @@ final class AuthorizationCheckBehaviorTest {
 
     final var resourceType = AuthorizationResourceType.RESOURCE;
     final var permissionType = PermissionType.CREATE;
-    final var resourceId = UUID.randomUUID().toString();
+    final var resourceId = AuthorizationScope.of(UUID.randomUUID().toString());
     addPermission(
         role.getRoleId(), AuthorizationOwnerType.ROLE, resourceType, permissionType, resourceId);
     final var command = mockCommand(user.getUsername());
@@ -612,7 +612,7 @@ final class AuthorizationCheckBehaviorTest {
 
     final var resourceType = AuthorizationResourceType.RESOURCE;
     final var permissionType = PermissionType.CREATE;
-    final var resourceId = UUID.randomUUID().toString();
+    final var resourceId = AuthorizationScope.of(UUID.randomUUID().toString());
     addPermission(
         role.getRoleId(), AuthorizationOwnerType.ROLE, resourceType, permissionType, resourceId);
     final var command = mockCommand(user.getUsername());
@@ -642,7 +642,7 @@ final class AuthorizationCheckBehaviorTest {
 
     final var resourceType = AuthorizationResourceType.RESOURCE;
     final var permissionType = PermissionType.CREATE;
-    final var resourceId = UUID.randomUUID().toString();
+    final var resourceId = AuthorizationScope.of(UUID.randomUUID().toString());
     addPermission(
         role.getRoleId(), AuthorizationOwnerType.ROLE, resourceType, permissionType, resourceId);
     final var command =
@@ -668,7 +668,7 @@ final class AuthorizationCheckBehaviorTest {
 
     final var resourceType = AuthorizationResourceType.RESOURCE;
     final var permissionType = PermissionType.CREATE;
-    final var resourceId = UUID.randomUUID().toString();
+    final var resourceId = AuthorizationScope.of(UUID.randomUUID().toString());
     addPermission(
         role.getRoleId(), AuthorizationOwnerType.ROLE, resourceType, permissionType, resourceId);
     final var command =
@@ -697,7 +697,7 @@ final class AuthorizationCheckBehaviorTest {
     final var clientId = createClientId();
     final var resourceType = AuthorizationResourceType.RESOURCE;
     final var permissionType = PermissionType.CREATE;
-    final var resourceId = UUID.randomUUID().toString();
+    final var resourceId = AuthorizationScope.of(UUID.randomUUID().toString());
     addPermission(
         clientId, AuthorizationOwnerType.CLIENT, resourceType, permissionType, resourceId);
     final var command = mockCommandWithClientId(clientId);
@@ -717,7 +717,7 @@ final class AuthorizationCheckBehaviorTest {
     final var clientId = createClientId();
     final var resourceType = AuthorizationResourceType.RESOURCE;
     final var permissionType = PermissionType.DELETE;
-    final var resourceId = UUID.randomUUID().toString();
+    final var resourceId = AuthorizationScope.of(UUID.randomUUID().toString());
     final var command = mockCommandWithClientId(clientId);
 
     // when
@@ -735,8 +735,8 @@ final class AuthorizationCheckBehaviorTest {
     final var clientId = createClientId();
     final var resourceType = AuthorizationResourceType.RESOURCE;
     final var permissionType = PermissionType.CREATE;
-    final var resourceId1 = UUID.randomUUID().toString();
-    final var resourceId2 = UUID.randomUUID().toString();
+    final var resourceId1 = AuthorizationScope.of(UUID.randomUUID().toString());
+    final var resourceId2 = AuthorizationScope.of(UUID.randomUUID().toString());
     addPermission(
         clientId,
         AuthorizationOwnerType.CLIENT,
@@ -839,20 +839,16 @@ final class AuthorizationCheckBehaviorTest {
       final AuthorizationOwnerType ownerType,
       final AuthorizationResourceType resourceType,
       final PermissionType permissionType,
-      final String... resourceIds) {
-    for (final String resourceId : resourceIds) {
+      final AuthorizationScope... authorizationScopes) {
+    for (final AuthorizationScope authorizationScope : authorizationScopes) {
       final var authorizationKey = random.nextLong();
-      final var resourceMatcher =
-          "*".equals(resourceId)
-              ? AuthorizationResourceMatcher.ANY
-              : AuthorizationResourceMatcher.ID;
       final var authorization =
           new AuthorizationRecord()
               .setAuthorizationKey(authorizationKey)
               .setOwnerId(ownerId)
               .setOwnerType(ownerType)
-              .setResourceMatcher(resourceMatcher)
-              .setResourceId(resourceId)
+              .setResourceMatcher(authorizationScope.getMatcher())
+              .setResourceId(authorizationScope.getResourceId())
               .setResourceType(resourceType)
               .setPermissionTypes(Set.of(permissionType));
       authorizationCreatedApplier.applyState(authorizationKey, authorization);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCreateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCreateAuthorizationTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.authorization;
 
+import static io.camunda.zeebe.protocol.record.value.AuthorizationScope.WILDCARD;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.security.configuration.ConfiguredUser;
@@ -15,7 +16,6 @@ import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.AuthorizationIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
-import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.protocol.record.value.UserRecordValue;
@@ -63,8 +63,8 @@ public class AuthorizationCreateAuthorizationTest {
         .withOwnerId(user.getUsername())
         .withOwnerType(AuthorizationOwnerType.USER)
         .withResourceType(AuthorizationResourceType.RESOURCE)
-        .withResourceMatcher(AuthorizationResourceMatcher.ANY)
-        .withResourceId("*")
+        .withResourceMatcher(WILDCARD.getMatcher())
+        .withResourceId(WILDCARD.getResourceId())
         .withPermissions(PermissionType.CREATE)
         .create(DEFAULT_USER.getUsername());
 
@@ -89,8 +89,8 @@ public class AuthorizationCreateAuthorizationTest {
         .withOwnerId(user.getUsername())
         .withOwnerType(AuthorizationOwnerType.USER)
         .withResourceType(AuthorizationResourceType.RESOURCE)
-        .withResourceMatcher(AuthorizationResourceMatcher.ANY)
-        .withResourceId("*")
+        .withResourceMatcher(WILDCARD.getMatcher())
+        .withResourceId(WILDCARD.getResourceId())
         .withPermissions(PermissionType.CREATE)
         .create(user.getUsername());
 
@@ -115,8 +115,8 @@ public class AuthorizationCreateAuthorizationTest {
             .withOwnerId(user.getUsername())
             .withOwnerType(AuthorizationOwnerType.USER)
             .withResourceType(AuthorizationResourceType.RESOURCE)
-            .withResourceMatcher(AuthorizationResourceMatcher.ANY)
-            .withResourceId("*")
+            .withResourceMatcher(WILDCARD.getMatcher())
+            .withResourceId(WILDCARD.getResourceId())
             .withPermissions(PermissionType.CREATE)
             .expectRejection()
             .create(user.getUsername());
@@ -149,8 +149,8 @@ public class AuthorizationCreateAuthorizationTest {
         .withOwnerId(user.getUsername())
         .withOwnerType(AuthorizationOwnerType.USER)
         .withResourceType(authorization)
-        .withResourceMatcher(AuthorizationResourceMatcher.ANY)
-        .withResourceId("*")
+        .withResourceMatcher(WILDCARD.getMatcher())
+        .withResourceId(WILDCARD.getResourceId())
         .withPermissions(permissionType)
         .create(DEFAULT_USER.getUsername());
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationDeleteAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationDeleteAuthorizationTest.java
@@ -15,7 +15,9 @@ import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.AuthorizationIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationScope;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.protocol.record.value.UserRecordValue;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
@@ -129,12 +131,17 @@ public class AuthorizationDeleteAuthorizationTest {
       final AuthorizationResourceType authorization,
       final PermissionType permissionType,
       final String resourceId) {
+    final var resourceMatcher =
+        AuthorizationScope.WILDCARD_CHAR.equals(resourceId)
+            ? AuthorizationResourceMatcher.ANY
+            : AuthorizationResourceMatcher.ID;
     return engine
         .authorization()
         .newAuthorization()
         .withOwnerId(user.getUsername())
         .withOwnerType(AuthorizationOwnerType.USER)
         .withResourceType(authorization)
+        .withResourceMatcher(resourceMatcher)
         .withResourceId(resourceId)
         .withPermissions(permissionType)
         .create(DEFAULT_USER.getUsername())

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationUpdateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationUpdateAuthorizationTest.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.AuthorizationIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.protocol.record.value.UserRecordValue;
@@ -73,6 +74,7 @@ public class AuthorizationUpdateAuthorizationTest {
     engine
         .authorization()
         .updateAuthorization(authorizationKey)
+        .withResourceMatcher(AuthorizationResourceMatcher.UNSPECIFIED)
         .withPermissions(PermissionType.DELETE_FORM)
         .update(DEFAULT_USER.getUsername());
 
@@ -108,6 +110,7 @@ public class AuthorizationUpdateAuthorizationTest {
         .authorization()
         .updateAuthorization(authorizationKey)
         .withPermissions(PermissionType.DELETE_FORM)
+        .withResourceMatcher(AuthorizationResourceMatcher.UNSPECIFIED)
         .update(user.getUsername());
 
     // then
@@ -142,6 +145,7 @@ public class AuthorizationUpdateAuthorizationTest {
             .authorization()
             .updateAuthorization(authorizationKey)
             .withPermissions(PermissionType.DELETE_FORM)
+            .withResourceMatcher(AuthorizationResourceMatcher.UNSPECIFIED)
             .expectRejection()
             .update(user.getUsername());
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationUpdateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationUpdateAuthorizationTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.authorization;
 
+import static io.camunda.zeebe.protocol.record.value.AuthorizationScope.WILDCARD;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.security.configuration.ConfiguredUser;
@@ -15,7 +16,6 @@ import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.AuthorizationIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
-import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.protocol.record.value.UserRecordValue;
@@ -62,8 +62,8 @@ public class AuthorizationUpdateAuthorizationTest {
             .withOwnerId(user.getUsername())
             .withOwnerType(AuthorizationOwnerType.USER)
             .withResourceType(AuthorizationResourceType.RESOURCE)
-            .withResourceMatcher(AuthorizationResourceMatcher.ANY)
-            .withResourceId("*")
+            .withResourceMatcher(WILDCARD.getMatcher())
+            .withResourceId(WILDCARD.getResourceId())
             .withPermissions(PermissionType.CREATE)
             .create(DEFAULT_USER.getUsername())
             .getValue()
@@ -96,8 +96,8 @@ public class AuthorizationUpdateAuthorizationTest {
             .withOwnerId(user.getUsername())
             .withOwnerType(AuthorizationOwnerType.USER)
             .withResourceType(AuthorizationResourceType.RESOURCE)
-            .withResourceMatcher(AuthorizationResourceMatcher.ANY)
-            .withResourceId("*")
+            .withResourceMatcher(WILDCARD.getMatcher())
+            .withResourceId(WILDCARD.getResourceId())
             .withPermissions(PermissionType.CREATE)
             .create(DEFAULT_USER.getUsername())
             .getValue()
@@ -129,8 +129,8 @@ public class AuthorizationUpdateAuthorizationTest {
             .withOwnerId(user.getUsername())
             .withOwnerType(AuthorizationOwnerType.USER)
             .withResourceType(AuthorizationResourceType.RESOURCE)
-            .withResourceMatcher(AuthorizationResourceMatcher.ANY)
-            .withResourceId("*")
+            .withResourceMatcher(WILDCARD.getMatcher())
+            .withResourceId(WILDCARD.getResourceId())
             .withPermissions(PermissionType.CREATE)
             .create(DEFAULT_USER.getUsername())
             .getValue()
@@ -173,8 +173,8 @@ public class AuthorizationUpdateAuthorizationTest {
         .withOwnerId(user.getUsername())
         .withOwnerType(AuthorizationOwnerType.USER)
         .withResourceType(authorization)
-        .withResourceMatcher(AuthorizationResourceMatcher.ANY)
-        .withResourceId("*")
+        .withResourceMatcher(WILDCARD.getMatcher())
+        .withResourceId(WILDCARD.getResourceId())
         .withPermissions(permissionType)
         .create(DEFAULT_USER.getUsername());
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/IdentitySetupInitializeDefaultsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/IdentitySetupInitializeDefaultsTest.java
@@ -7,9 +7,9 @@
  */
 package io.camunda.zeebe.engine.processing.authorization;
 
+import static io.camunda.zeebe.protocol.record.value.AuthorizationScope.WILDCARD;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.camunda.zeebe.engine.processing.identity.AuthorizationCheckBehavior;
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.engine.util.EngineRule.ResetRecordingExporterMode;
 import io.camunda.zeebe.engine.util.EngineRule.ResetRecordingExporterTestWatcherMode;
@@ -57,10 +57,7 @@ public class IdentitySetupInitializeDefaultsTest {
                     .hasOwnerId(DefaultRole.ADMIN.getId())
                     .hasOwnerType(AuthorizationOwnerType.ROLE))
         .describedAs("Expect all admin role authorizations to have the wildcard resource ID")
-        .allSatisfy(
-            auth ->
-                Assertions.assertThat(auth)
-                    .hasResourceId(AuthorizationCheckBehavior.WILDCARD_PERMISSION))
+        .allSatisfy(auth -> Assertions.assertThat(auth).hasResourceId(WILDCARD.getResourceId()))
         .describedAs("Expect the admin role authorizations to have specific resource permissions")
         .satisfiesExactlyInAnyOrder(
             auth ->
@@ -203,10 +200,7 @@ public class IdentitySetupInitializeDefaultsTest {
                     .hasOwnerType(AuthorizationOwnerType.ROLE))
         .describedAs(
             "Expect all readonly-admin role authorizations to have the wildcard resource ID")
-        .allSatisfy(
-            auth ->
-                Assertions.assertThat(auth)
-                    .hasResourceId(AuthorizationCheckBehavior.WILDCARD_PERMISSION))
+        .allSatisfy(auth -> Assertions.assertThat(auth).hasResourceId(WILDCARD.getResourceId()))
         .describedAs(
             "Expect the readonly-admin role authorizations to have specific read permissions only")
         .satisfiesExactlyInAnyOrder(
@@ -327,10 +321,7 @@ public class IdentitySetupInitializeDefaultsTest {
                     .hasOwnerId(DefaultRole.RPA.getId())
                     .hasOwnerType(AuthorizationOwnerType.ROLE))
         .describedAs("Expect all RPA role authorizations to have the wildcard resource ID")
-        .allSatisfy(
-            auth ->
-                Assertions.assertThat(auth)
-                    .hasResourceId(AuthorizationCheckBehavior.WILDCARD_PERMISSION))
+        .allSatisfy(auth -> Assertions.assertThat(auth).hasResourceId(WILDCARD.getResourceId()))
         .describedAs("Expect the RPA role authorizations to have specific resource permissions")
         .satisfiesExactlyInAnyOrder(
             auth ->

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/UpdateAuthorizationMultipartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/UpdateAuthorizationMultipartitionTest.java
@@ -55,7 +55,11 @@ public class UpdateAuthorizationMultipartitionTest {
             .getValue()
             .getAuthorizationKey();
 
-    engine.authorization().updateAuthorization(key).update();
+    engine
+        .authorization()
+        .updateAuthorization(key)
+        .withResourceMatcher(AuthorizationResourceMatcher.UNSPECIFIED)
+        .update();
 
     RecordingExporter.commandDistributionRecords(CommandDistributionIntent.FINISHED)
         .withDistributionIntent(AuthorizationIntent.CREATE)
@@ -125,7 +129,11 @@ public class UpdateAuthorizationMultipartitionTest {
             .getValue()
             .getAuthorizationKey();
 
-    engine.authorization().updateAuthorization(key).update();
+    engine
+        .authorization()
+        .updateAuthorization(key)
+        .withResourceMatcher(AuthorizationResourceMatcher.UNSPECIFIED)
+        .update();
 
     // then
     assertThat(
@@ -156,7 +164,11 @@ public class UpdateAuthorizationMultipartitionTest {
             .getValue()
             .getAuthorizationKey();
 
-    engine.authorization().updateAuthorization(key).update();
+    engine
+        .authorization()
+        .updateAuthorization(key)
+        .withResourceMatcher(AuthorizationResourceMatcher.UNSPECIFIED)
+        .update();
 
     // Increase time to trigger a redistribution
     engine.increaseTime(Duration.ofMinutes(1));

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/UpdateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/UpdateAuthorizationTest.java
@@ -81,7 +81,12 @@ public class UpdateAuthorizationTest {
   @Test
   public void shouldRejectTheCommandIfAuthorizationDoesNotExist() {
     final var userNotFoundRejection =
-        engine.authorization().updateAuthorization(1L).expectRejection().update();
+        engine
+            .authorization()
+            .updateAuthorization(1L)
+            .withResourceMatcher(AuthorizationResourceMatcher.UNSPECIFIED)
+            .expectRejection()
+            .update();
 
     Assertions.assertThat(userNotFoundRejection)
         .hasRejectionType(RejectionType.NOT_FOUND)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/AbstractBatchOperationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/AbstractBatchOperationTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.batchoperation;
 
+import static io.camunda.zeebe.protocol.record.value.AuthorizationScope.WILDCARD;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
@@ -26,7 +27,6 @@ import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperation
 import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationProcessInstanceModificationPlan;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceMigrationMappingInstruction;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
-import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.BatchOperationType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
@@ -327,8 +327,8 @@ abstract class AbstractBatchOperationTest {
         .withOwnerId(user.getUsername())
         .withOwnerType(AuthorizationOwnerType.USER)
         .withResourceType(AuthorizationResourceType.BATCH)
-        .withResourceMatcher(AuthorizationResourceMatcher.ANY)
-        .withResourceId("*")
+        .withResourceMatcher(WILDCARD.getMatcher())
+        .withResourceId(WILDCARD.getResourceId())
         .create(DEFAULT_USER.getUsername());
   }
 
@@ -341,8 +341,8 @@ abstract class AbstractBatchOperationTest {
         .withOwnerId(user.getUsername())
         .withOwnerType(AuthorizationOwnerType.USER)
         .withResourceType(AuthorizationResourceType.PROCESS_DEFINITION)
-        .withResourceMatcher(AuthorizationResourceMatcher.ANY)
-        .withResourceId("*")
+        .withResourceMatcher(WILDCARD.getMatcher())
+        .withResourceId(WILDCARD.getResourceId())
         .create(DEFAULT_USER.getUsername());
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/JobWorkerElementMultiTenantTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/JobWorkerElementMultiTenantTest.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.EntityType;
@@ -100,6 +101,7 @@ public class JobWorkerElementMultiTenantTest {
         .authorization()
         .newAuthorization()
         .withPermissions(PermissionType.UPDATE_PROCESS_INSTANCE)
+        .withResourceMatcher(AuthorizationResourceMatcher.ID)
         .withResourceId(PROCESS_ID)
         .withResourceType(AuthorizationResourceType.PROCESS_DEFINITION)
         .withOwnerId(username)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/clock/ClockPinAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/clock/ClockPinAuthorizationTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.clock;
 
+import static io.camunda.zeebe.protocol.record.value.AuthorizationScope.WILDCARD;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.security.configuration.ConfiguredUser;
@@ -15,7 +16,6 @@ import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.ClockIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
-import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.protocol.record.value.UserRecordValue;
@@ -119,8 +119,8 @@ public class ClockPinAuthorizationTest {
         .withOwnerId(user.getUsername())
         .withOwnerType(AuthorizationOwnerType.USER)
         .withResourceType(authorization)
-        .withResourceMatcher(AuthorizationResourceMatcher.ANY)
-        .withResourceId("*")
+        .withResourceMatcher(WILDCARD.getMatcher())
+        .withResourceId(WILDCARD.getResourceId())
         .create(DEFAULT_USER.getUsername());
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateAuthorizationTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.deployment;
 
+import static io.camunda.zeebe.protocol.record.value.AuthorizationScope.WILDCARD;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.security.configuration.ConfiguredUser;
@@ -16,7 +17,6 @@ import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
-import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.protocol.record.value.UserRecordValue;
@@ -139,8 +139,8 @@ public class DeploymentCreateAuthorizationTest {
         .withOwnerId(user.getUsername())
         .withOwnerType(AuthorizationOwnerType.USER)
         .withResourceType(authorization)
-        .withResourceMatcher(AuthorizationResourceMatcher.ANY)
-        .withResourceId("*")
+        .withResourceMatcher(WILDCARD.getMatcher())
+        .withResourceId(WILDCARD.getResourceId())
         .create(DEFAULT_USER.getUsername());
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/MultiTenantDeploymentCreateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/MultiTenantDeploymentCreateAuthorizationTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.deployment;
 
+import static io.camunda.zeebe.protocol.record.value.AuthorizationScope.WILDCARD;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.security.configuration.ConfiguredUser;
@@ -16,7 +17,6 @@ import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
-import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.EntityType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
@@ -149,8 +149,8 @@ public class MultiTenantDeploymentCreateAuthorizationTest {
         .withOwnerId(user.getUsername())
         .withOwnerType(AuthorizationOwnerType.USER)
         .withResourceType(authorization)
-        .withResourceMatcher(AuthorizationResourceMatcher.ANY)
-        .withResourceId("*")
+        .withResourceMatcher(WILDCARD.getMatcher())
+        .withResourceId(WILDCARD.getResourceId())
         .create(DEFAULT_USER.getUsername());
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionIdempotencyTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionIdempotencyTest.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.engine.processing.distribution;
 
 import static io.camunda.zeebe.engine.processing.processinstance.migration.MigrationTestUtil.extractProcessDefinitionKeyByProcessId;
+import static io.camunda.zeebe.protocol.record.value.AuthorizationScope.WILDCARD;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
@@ -75,7 +76,6 @@ import io.camunda.zeebe.protocol.record.intent.SignalIntent;
 import io.camunda.zeebe.protocol.record.intent.TenantIntent;
 import io.camunda.zeebe.protocol.record.intent.UserIntent;
 import io.camunda.zeebe.protocol.record.intent.scaling.ScaleIntent;
-import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.BatchOperationCreationRecordValue;
 import io.camunda.zeebe.protocol.record.value.BatchOperationLifecycleManagementRecordValue;
@@ -180,8 +180,8 @@ public class CommandDistributionIdempotencyTest {
                       .authorization()
                       .newAuthorization()
                       .withOwnerId(user.getValue().getUsername())
-                      .withResourceMatcher(AuthorizationResourceMatcher.ANY)
-                      .withResourceId("*")
+                      .withResourceMatcher(WILDCARD.getMatcher())
+                      .withResourceId(WILDCARD.getResourceId())
                       .withResourceType(AuthorizationResourceType.USER)
                       .withPermissions(PermissionType.READ)
                       .create();
@@ -200,8 +200,8 @@ public class CommandDistributionIdempotencyTest {
                           .authorization()
                           .newAuthorization()
                           .withOwnerId(user.getValue().getUsername())
-                          .withResourceMatcher(AuthorizationResourceMatcher.ANY)
-                          .withResourceId("*")
+                          .withResourceMatcher(WILDCARD.getMatcher())
+                          .withResourceId(WILDCARD.getResourceId())
                           .withResourceType(AuthorizationResourceType.USER)
                           .withPermissions(PermissionType.READ)
                           .create()
@@ -224,8 +224,8 @@ public class CommandDistributionIdempotencyTest {
                           .authorization()
                           .newAuthorization()
                           .withOwnerId(user.getValue().getUsername())
-                          .withResourceMatcher(AuthorizationResourceMatcher.ANY)
-                          .withResourceId("*")
+                          .withResourceMatcher(WILDCARD.getMatcher())
+                          .withResourceId(WILDCARD.getResourceId())
                           .withResourceType(AuthorizationResourceType.USER)
                           .withPermissions(PermissionType.READ)
                           .create()

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionIdempotencyTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionIdempotencyTest.java
@@ -76,6 +76,7 @@ import io.camunda.zeebe.protocol.record.intent.SignalIntent;
 import io.camunda.zeebe.protocol.record.intent.TenantIntent;
 import io.camunda.zeebe.protocol.record.intent.UserIntent;
 import io.camunda.zeebe.protocol.record.intent.scaling.ScaleIntent;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.BatchOperationCreationRecordValue;
 import io.camunda.zeebe.protocol.record.value.BatchOperationLifecycleManagementRecordValue;
@@ -232,7 +233,11 @@ public class CommandDistributionIdempotencyTest {
                           .getValue()
                           .getAuthorizationKey();
 
-                  return ENGINE.authorization().updateAuthorization(key).update();
+                  return ENGINE
+                      .authorization()
+                      .updateAuthorization(key)
+                      .withResourceMatcher(AuthorizationResourceMatcher.UNSPECIFIED)
+                      .update();
                 }),
             AuthorizationUpdateProcessor.class
           },

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/dmn/DecisionEvaluationEvaluateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/dmn/DecisionEvaluationEvaluateAuthorizationTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.dmn;
 
+import static io.camunda.zeebe.protocol.record.value.AuthorizationScope.WILDCARD;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.security.configuration.ConfiguredUser;
@@ -14,7 +15,6 @@ import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
-import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.protocol.record.value.UserRecordValue;
@@ -135,8 +135,8 @@ public class DecisionEvaluationEvaluateAuthorizationTest {
         .withOwnerType(AuthorizationOwnerType.USER)
         .withResourceType(authorization)
         .withPermissions(permissionType)
-        .withResourceMatcher(AuthorizationResourceMatcher.ANY)
-        .withResourceId("*")
+        .withResourceMatcher(WILDCARD.getMatcher())
+        .withResourceId(WILDCARD.getResourceId())
         .create(DEFAULT_USER.getUsername());
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/IncidentResolveAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/IncidentResolveAuthorizationTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.incident;
 
+import static io.camunda.zeebe.protocol.record.value.AuthorizationScope.WILDCARD;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.security.configuration.ConfiguredUser;
@@ -16,7 +17,6 @@ import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
-import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.protocol.record.value.UserRecordValue;
@@ -148,8 +148,8 @@ public class IncidentResolveAuthorizationTest {
         .withOwnerId(user.getUsername())
         .withOwnerType(AuthorizationOwnerType.USER)
         .withResourceType(authorization)
-        .withResourceMatcher(AuthorizationResourceMatcher.ANY)
-        .withResourceId("*")
+        .withResourceMatcher(WILDCARD.getMatcher())
+        .withResourceId(WILDCARD.getResourceId())
         .create(DEFAULT_USER.getUsername());
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/FailJobTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/FailJobTest.java
@@ -25,6 +25,7 @@ import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.JobBatchIntent;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.EntityType;
 import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
@@ -78,6 +79,7 @@ public final class FailJobTest {
         .authorization()
         .newAuthorization()
         .withPermissions(PermissionType.UPDATE_PROCESS_INSTANCE)
+        .withResourceMatcher(AuthorizationResourceMatcher.ID)
         .withResourceId(PROCESS_ID)
         .withResourceType(AuthorizationResourceType.PROCESS_DEFINITION)
         .withOwnerId(username)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobBatchActivateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobBatchActivateAuthorizationTest.java
@@ -14,7 +14,9 @@ import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationScope;
 import io.camunda.zeebe.protocol.record.value.JobRecordValue;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.protocol.record.value.UserRecordValue;
@@ -157,6 +159,10 @@ public class JobBatchActivateAuthorizationTest {
       final PermissionType permissionType,
       final String... resourceIds) {
     for (final String resourceId : resourceIds) {
+      final var resourceMatcher =
+          AuthorizationScope.WILDCARD_CHAR.equals(resourceId)
+              ? AuthorizationResourceMatcher.ANY
+              : AuthorizationResourceMatcher.ID;
       engine
           .authorization()
           .newAuthorization()
@@ -164,6 +170,7 @@ public class JobBatchActivateAuthorizationTest {
           .withOwnerId(user.getUsername())
           .withOwnerType(AuthorizationOwnerType.USER)
           .withResourceType(authorization)
+          .withResourceMatcher(resourceMatcher)
           .withResourceId(resourceId)
           .create(DEFAULT_USER.getUsername());
     }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobCompleteAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobCompleteAuthorizationTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.job;
 
+import static io.camunda.zeebe.protocol.record.value.AuthorizationScope.WILDCARD;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.security.configuration.ConfiguredUser;
@@ -16,7 +17,6 @@ import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
-import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.protocol.record.value.UserRecordValue;
@@ -137,8 +137,8 @@ public class JobCompleteAuthorizationTest {
         .withOwnerId(user.getUsername())
         .withOwnerType(AuthorizationOwnerType.USER)
         .withResourceType(authorization)
-        .withResourceMatcher(AuthorizationResourceMatcher.ANY)
-        .withResourceId("*")
+        .withResourceMatcher(WILDCARD.getMatcher())
+        .withResourceId(WILDCARD.getResourceId())
         .create(DEFAULT_USER.getUsername());
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobFailAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobFailAuthorizationTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.job;
 
+import static io.camunda.zeebe.protocol.record.value.AuthorizationScope.WILDCARD;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.security.configuration.ConfiguredUser;
@@ -16,7 +17,6 @@ import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
-import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.protocol.record.value.UserRecordValue;
@@ -136,8 +136,8 @@ public class JobFailAuthorizationTest {
         .withOwnerId(user.getUsername())
         .withOwnerType(AuthorizationOwnerType.USER)
         .withResourceType(authorization)
-        .withResourceMatcher(AuthorizationResourceMatcher.ANY)
-        .withResourceId("*")
+        .withResourceMatcher(WILDCARD.getMatcher())
+        .withResourceId(WILDCARD.getResourceId())
         .create(DEFAULT_USER.getUsername());
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobThrowErrorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobThrowErrorTest.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.VariableIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.EntityType;
 import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
@@ -68,6 +69,7 @@ public final class JobThrowErrorTest {
         .newAuthorization()
         .withPermissions(PermissionType.UPDATE_PROCESS_INSTANCE)
         .withResourceType(AuthorizationResourceType.PROCESS_DEFINITION)
+        .withResourceMatcher(AuthorizationResourceMatcher.ID)
         .withResourceId(PROCESS_ID)
         .withOwnerId(username)
         .withOwnerType(AuthorizationOwnerType.USER)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobUpdateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobUpdateAuthorizationTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.job;
 
+import static io.camunda.zeebe.protocol.record.value.AuthorizationScope.WILDCARD;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.security.configuration.ConfiguredUser;
@@ -16,7 +17,6 @@ import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
-import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.protocol.record.value.UserRecordValue;
@@ -144,8 +144,8 @@ public class JobUpdateAuthorizationTest {
         .withOwnerId(user.getUsername())
         .withOwnerType(AuthorizationOwnerType.USER)
         .withResourceType(authorization)
-        .withResourceMatcher(AuthorizationResourceMatcher.ANY)
-        .withResourceId("*")
+        .withResourceMatcher(WILDCARD.getMatcher())
+        .withResourceId(WILDCARD.getResourceId())
         .create(DEFAULT_USER.getUsername());
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobUpdateRetriesTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobUpdateRetriesTest.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.EntityType;
 import io.camunda.zeebe.protocol.record.value.JobBatchRecordValue;
@@ -59,6 +60,7 @@ public final class JobUpdateRetriesTest {
         .authorization()
         .newAuthorization()
         .withPermissions(PermissionType.UPDATE_PROCESS_INSTANCE)
+        .withResourceMatcher(AuthorizationResourceMatcher.ID)
         .withResourceId(PROCESS_ID)
         .withResourceType(AuthorizationResourceType.PROCESS_DEFINITION)
         .withOwnerId(username)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobUpdateTimeoutTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobUpdateTimeoutTest.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.EntityType;
 import io.camunda.zeebe.protocol.record.value.JobRecordValue;
@@ -67,6 +68,7 @@ public class JobUpdateTimeoutTest {
         .authorization()
         .newAuthorization()
         .withPermissions(PermissionType.UPDATE_PROCESS_INSTANCE)
+        .withResourceMatcher(AuthorizationResourceMatcher.ID)
         .withResourceId(PROCESS_ID)
         .withResourceType(AuthorizationResourceType.PROCESS_DEFINITION)
         .withOwnerId(username)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/MultiTenantJobOperationsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/MultiTenantJobOperationsTest.java
@@ -22,6 +22,7 @@ import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.EntityType;
 import io.camunda.zeebe.protocol.record.value.ErrorType;
@@ -92,6 +93,7 @@ public class MultiTenantJobOperationsTest {
         .authorization()
         .newAuthorization()
         .withPermissions(PermissionType.UPDATE_PROCESS_INSTANCE)
+        .withResourceMatcher(AuthorizationResourceMatcher.ID)
         .withResourceId(PROCESS_ID)
         .withResourceType(AuthorizationResourceType.PROCESS_DEFINITION)
         .withOwnerId(username)
@@ -102,6 +104,7 @@ public class MultiTenantJobOperationsTest {
         .authorization()
         .newAuthorization()
         .withPermissions(PermissionType.UPDATE_PROCESS_INSTANCE)
+        .withResourceMatcher(AuthorizationResourceMatcher.ID)
         .withResourceId(BOUNDARY_PROCESS_ID)
         .withResourceType(AuthorizationResourceType.PROCESS_DEFINITION)
         .withOwnerId(username)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/mappingrule/MappingRuleCreateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/mappingrule/MappingRuleCreateAuthorizationTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.mappingrule;
 
+import static io.camunda.zeebe.protocol.record.value.AuthorizationScope.WILDCARD;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.security.configuration.ConfiguredUser;
@@ -15,7 +16,6 @@ import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.MappingRuleIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
-import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.protocol.record.value.UserRecordValue;
@@ -154,8 +154,8 @@ public class MappingRuleCreateAuthorizationTest {
         .withOwnerId(user.getUsername())
         .withOwnerType(AuthorizationOwnerType.USER)
         .withResourceType(authorization)
-        .withResourceMatcher(AuthorizationResourceMatcher.ANY)
-        .withResourceId("*")
+        .withResourceMatcher(WILDCARD.getMatcher())
+        .withResourceId(WILDCARD.getResourceId())
         .create(DEFAULT_USER.getUsername());
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/mappingrule/MappingRuleUpdateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/mappingrule/MappingRuleUpdateAuthorizationTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.mappingrule;
 
+import static io.camunda.zeebe.protocol.record.value.AuthorizationScope.WILDCARD;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.security.configuration.ConfiguredUser;
@@ -15,7 +16,6 @@ import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.MappingRuleIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
-import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.protocol.record.value.UserRecordValue;
@@ -185,8 +185,8 @@ public class MappingRuleUpdateAuthorizationTest {
         .withOwnerId(user.getUsername())
         .withOwnerType(AuthorizationOwnerType.USER)
         .withResourceType(authorization)
-        .withResourceMatcher(AuthorizationResourceMatcher.ANY)
-        .withResourceId("*")
+        .withResourceMatcher(WILDCARD.getMatcher())
+        .withResourceId(WILDCARD.getResourceId())
         .create(DEFAULT_USER.getUsername());
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageCorrelationCorrelateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageCorrelationCorrelateAuthorizationTest.java
@@ -16,7 +16,9 @@ import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.MessageCorrelationIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationScope;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.protocol.record.value.UserRecordValue;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
@@ -277,6 +279,10 @@ public class MessageCorrelationCorrelateAuthorizationTest {
       final AuthorizationResourceType authorization,
       final PermissionType permissionType,
       final String resourceId) {
+    final var resourceMatcher =
+        AuthorizationScope.WILDCARD_CHAR.equals(resourceId)
+            ? AuthorizationResourceMatcher.ANY
+            : AuthorizationResourceMatcher.ID;
     engine
         .authorization()
         .newAuthorization()
@@ -284,6 +290,7 @@ public class MessageCorrelationCorrelateAuthorizationTest {
         .withOwnerId(user.getUsername())
         .withOwnerType(AuthorizationOwnerType.USER)
         .withResourceType(authorization)
+        .withResourceMatcher(resourceMatcher)
         .withResourceId(resourceId)
         .create(DEFAULT_USER.getUsername());
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessagePublishAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessagePublishAuthorizationTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.message;
 
+import static io.camunda.zeebe.protocol.record.value.AuthorizationScope.WILDCARD;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.security.configuration.ConfiguredUser;
@@ -16,7 +17,6 @@ import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.MessageIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
-import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.protocol.record.value.UserRecordValue;
@@ -168,8 +168,8 @@ public class MessagePublishAuthorizationTest {
         .withOwnerId(user.getUsername())
         .withOwnerType(AuthorizationOwnerType.USER)
         .withResourceType(authorization)
-        .withResourceMatcher(AuthorizationResourceMatcher.ANY)
-        .withResourceId("*")
+        .withResourceMatcher(WILDCARD.getMatcher())
+        .withResourceId(WILDCARD.getResourceId())
         .create(DEFAULT_USER.getUsername());
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCancelAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCancelAuthorizationTest.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.protocol.record.value.UserRecordValue;
@@ -88,6 +89,7 @@ public class ProcessInstanceCancelAuthorizationTest {
         user,
         AuthorizationResourceType.PROCESS_DEFINITION,
         PermissionType.CANCEL_PROCESS_INSTANCE,
+        AuthorizationResourceMatcher.ID,
         PROCESS_ID);
 
     // when
@@ -138,6 +140,7 @@ public class ProcessInstanceCancelAuthorizationTest {
       final UserRecordValue user,
       final AuthorizationResourceType authorization,
       final PermissionType permissionType,
+      final AuthorizationResourceMatcher matcher,
       final String resourceId) {
     engine
         .authorization()
@@ -146,6 +149,7 @@ public class ProcessInstanceCancelAuthorizationTest {
         .withOwnerId(user.getUsername())
         .withOwnerType(AuthorizationOwnerType.USER)
         .withResourceType(authorization)
+        .withResourceMatcher(matcher)
         .withResourceId(resourceId)
         .create(DEFAULT_USER.getUsername());
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreateAuthorizationTest.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.protocol.record.value.UserRecordValue;
@@ -102,6 +103,7 @@ public class ProcessInstanceCreateAuthorizationTest {
         user,
         AuthorizationResourceType.PROCESS_DEFINITION,
         PermissionType.CREATE_PROCESS_INSTANCE,
+        AuthorizationResourceMatcher.ID,
         PROCESS_ID);
 
     // when
@@ -124,6 +126,7 @@ public class ProcessInstanceCreateAuthorizationTest {
         user,
         AuthorizationResourceType.PROCESS_DEFINITION,
         PermissionType.CREATE_PROCESS_INSTANCE,
+        AuthorizationResourceMatcher.ID,
         PROCESS_ID);
 
     // when
@@ -200,6 +203,7 @@ public class ProcessInstanceCreateAuthorizationTest {
       final UserRecordValue user,
       final AuthorizationResourceType authorization,
       final PermissionType permissionType,
+      final AuthorizationResourceMatcher matcher,
       final String resourceId) {
     engine
         .authorization()
@@ -208,6 +212,7 @@ public class ProcessInstanceCreateAuthorizationTest {
         .withOwnerId(user.getUsername())
         .withOwnerType(AuthorizationOwnerType.USER)
         .withResourceType(authorization)
+        .withResourceMatcher(matcher)
         .withResourceId(resourceId)
         .create(DEFAULT_USER.getUsername());
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationModifyAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationModifyAuthorizationTest.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceModificationIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.protocol.record.value.UserRecordValue;
@@ -104,6 +105,7 @@ public class ProcessInstanceModificationModifyAuthorizationTest {
         user,
         AuthorizationResourceType.PROCESS_DEFINITION,
         PermissionType.MODIFY_PROCESS_INSTANCE,
+        AuthorizationResourceMatcher.ID,
         PROCESS_ID);
 
     // when
@@ -165,6 +167,7 @@ public class ProcessInstanceModificationModifyAuthorizationTest {
       final UserRecordValue user,
       final AuthorizationResourceType authorization,
       final PermissionType permissionType,
+      final AuthorizationResourceMatcher matcher,
       final String resourceId) {
     engine
         .authorization()
@@ -173,6 +176,7 @@ public class ProcessInstanceModificationModifyAuthorizationTest {
         .withOwnerId(user.getUsername())
         .withOwnerType(AuthorizationOwnerType.USER)
         .withResourceType(authorization)
+        .withResourceMatcher(matcher)
         .withResourceId(resourceId)
         .create(DEFAULT_USER.getUsername());
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/ProcessInstanceMigrationMigrateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/ProcessInstanceMigrationMigrateAuthorizationTest.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceMigrationIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.protocol.record.value.UserRecordValue;
@@ -118,6 +119,7 @@ public class ProcessInstanceMigrationMigrateAuthorizationTest {
         user,
         AuthorizationResourceType.PROCESS_DEFINITION,
         PermissionType.UPDATE_PROCESS_INSTANCE,
+        AuthorizationResourceMatcher.ID,
         PROCESS_ID);
 
     // when
@@ -178,6 +180,7 @@ public class ProcessInstanceMigrationMigrateAuthorizationTest {
       final UserRecordValue user,
       final AuthorizationResourceType authorization,
       final PermissionType permissionType,
+      final AuthorizationResourceMatcher matcher,
       final String resourceId) {
     engine
         .authorization()
@@ -186,6 +189,7 @@ public class ProcessInstanceMigrationMigrateAuthorizationTest {
         .withOwnerId(user.getUsername())
         .withOwnerType(AuthorizationOwnerType.USER)
         .withResourceType(authorization)
+        .withResourceMatcher(matcher)
         .withResourceId(resourceId)
         .create(DEFAULT_USER.getUsername());
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionAuthorizationTest.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.ResourceDeletionIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.protocol.record.value.UserRecordValue;
@@ -77,7 +78,11 @@ public class ResourceDeletionAuthorizationTest {
     final var processDefinitionKey = deployProcessDefinition(processId);
     final var user = createUser();
     addPermissionsToUser(
-        user, AuthorizationResourceType.RESOURCE, PermissionType.DELETE_PROCESS, processId);
+        user,
+        AuthorizationResourceType.RESOURCE,
+        PermissionType.DELETE_PROCESS,
+        AuthorizationResourceMatcher.ID,
+        processId);
 
     // when
     engine.resourceDeletion().withResourceKey(processDefinitionKey).delete(user.getUsername());
@@ -138,7 +143,11 @@ public class ResourceDeletionAuthorizationTest {
     final var drdKey = deployDrd();
     final var user = createUser();
     addPermissionsToUser(
-        user, AuthorizationResourceType.RESOURCE, PermissionType.DELETE_DRD, drdId);
+        user,
+        AuthorizationResourceType.RESOURCE,
+        PermissionType.DELETE_DRD,
+        AuthorizationResourceMatcher.ID,
+        drdId);
 
     // when
     engine.resourceDeletion().withResourceKey(drdKey).delete(user.getUsername());
@@ -195,7 +204,11 @@ public class ResourceDeletionAuthorizationTest {
     final var formKey = deployForm();
     final var user = createUser();
     addPermissionsToUser(
-        user, AuthorizationResourceType.RESOURCE, PermissionType.DELETE_FORM, formId);
+        user,
+        AuthorizationResourceType.RESOURCE,
+        PermissionType.DELETE_FORM,
+        AuthorizationResourceMatcher.ID,
+        formId);
 
     // when
     engine.resourceDeletion().withResourceKey(formKey).delete(user.getUsername());
@@ -252,7 +265,11 @@ public class ResourceDeletionAuthorizationTest {
     final var resourceKey = deployResource();
     final var user = createUser();
     addPermissionsToUser(
-        user, AuthorizationResourceType.RESOURCE, PermissionType.DELETE_RESOURCE, resourceId);
+        user,
+        AuthorizationResourceType.RESOURCE,
+        PermissionType.DELETE_RESOURCE,
+        AuthorizationResourceMatcher.ID,
+        resourceId);
 
     // when
     engine.resourceDeletion().withResourceKey(resourceKey).delete(user.getUsername());
@@ -305,6 +322,7 @@ public class ResourceDeletionAuthorizationTest {
       final UserRecordValue user,
       final AuthorizationResourceType authorization,
       final PermissionType permissionType,
+      final AuthorizationResourceMatcher matcher,
       final String resourceId) {
     engine
         .authorization()
@@ -313,6 +331,7 @@ public class ResourceDeletionAuthorizationTest {
         .withOwnerId(user.getUsername())
         .withOwnerType(AuthorizationOwnerType.USER)
         .withResourceType(authorization)
+        .withResourceMatcher(matcher)
         .withResourceId(resourceId)
         .create(DEFAULT_USER.getUsername());
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/ResourceFetchAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/ResourceFetchAuthorizationTest.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.ResourceIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.protocol.record.value.UserRecordValue;
@@ -75,6 +76,7 @@ public class ResourceFetchAuthorizationTest {
         user,
         AuthorizationResourceType.RESOURCE,
         PermissionType.READ,
+        AuthorizationResourceMatcher.ID,
         resourceMetadata.getResourceId());
 
     // when
@@ -133,6 +135,7 @@ public class ResourceFetchAuthorizationTest {
       final UserRecordValue user,
       final AuthorizationResourceType authorization,
       final PermissionType permissionType,
+      final AuthorizationResourceMatcher matcher,
       final String resourceId) {
     engine
         .authorization()
@@ -141,6 +144,7 @@ public class ResourceFetchAuthorizationTest {
         .withOwnerId(user.getUsername())
         .withOwnerType(AuthorizationOwnerType.USER)
         .withResourceType(authorization)
+        .withResourceMatcher(matcher)
         .withResourceId(resourceId)
         .create(DEFAULT_USER.getUsername());
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/role/RoleCreateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/role/RoleCreateAuthorizationTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.role;
 
+import static io.camunda.zeebe.protocol.record.value.AuthorizationScope.WILDCARD;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.security.configuration.ConfiguredUser;
@@ -15,7 +16,6 @@ import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.RoleIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
-import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.protocol.record.value.UserRecordValue;
@@ -117,8 +117,8 @@ public class RoleCreateAuthorizationTest {
         .withOwnerId(user.getUsername())
         .withOwnerType(AuthorizationOwnerType.USER)
         .withResourceType(authorization)
-        .withResourceMatcher(AuthorizationResourceMatcher.ANY)
-        .withResourceId("*")
+        .withResourceMatcher(WILDCARD.getMatcher())
+        .withResourceId(WILDCARD.getResourceId())
         .create(DEFAULT_USER.getUsername());
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/signal/SignalBroadcastAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/signal/SignalBroadcastAuthorizationTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.signal;
 
+import static io.camunda.zeebe.protocol.record.value.AuthorizationScope.WILDCARD;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.security.configuration.ConfiguredUser;
@@ -16,7 +17,6 @@ import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.SignalIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
-import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.protocol.record.value.UserRecordValue;
@@ -169,8 +169,8 @@ public class SignalBroadcastAuthorizationTest {
         .withOwnerId(user.getUsername())
         .withOwnerType(AuthorizationOwnerType.USER)
         .withResourceType(authorization)
-        .withResourceMatcher(AuthorizationResourceMatcher.ANY)
-        .withResourceId("*")
+        .withResourceMatcher(WILDCARD.getMatcher())
+        .withResourceId(WILDCARD.getResourceId())
         .create(DEFAULT_USER.getUsername());
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/DeleteTenantAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/DeleteTenantAuthorizationTest.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.TenantIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.EntityType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
@@ -74,7 +75,12 @@ public class DeleteTenantAuthorizationTest {
     final var user = createUser();
     final var tenantId = UUID.randomUUID().toString();
     createTenant(tenantId);
-    addPermissionsToUser(user, AuthorizationResourceType.TENANT, PermissionType.DELETE, tenantId);
+    addPermissionsToUser(
+        user,
+        AuthorizationResourceType.TENANT,
+        PermissionType.DELETE,
+        AuthorizationResourceMatcher.ID,
+        tenantId);
     assignUserToTenant(user.getUsername(), tenantId);
 
     // when
@@ -123,6 +129,7 @@ public class DeleteTenantAuthorizationTest {
       final UserRecordValue user,
       final AuthorizationResourceType authorization,
       final PermissionType permissionType,
+      final AuthorizationResourceMatcher resourceMatcher,
       final String resourceId) {
     engine
         .authorization()
@@ -131,6 +138,7 @@ public class DeleteTenantAuthorizationTest {
         .withOwnerId(user.getUsername())
         .withOwnerType(AuthorizationOwnerType.USER)
         .withResourceType(authorization)
+        .withResourceMatcher(resourceMatcher)
         .withResourceId(resourceId)
         .create(DEFAULT_USER.getUsername());
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/user/CreateInitialAdminUserAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/user/CreateInitialAdminUserAuthorizationTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.user;
 
+import static io.camunda.zeebe.protocol.record.value.AuthorizationScope.WILDCARD;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.security.configuration.ConfiguredUser;
@@ -16,7 +17,6 @@ import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.RoleIntent;
 import io.camunda.zeebe.protocol.record.intent.UserIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
-import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.EntityType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
@@ -71,8 +71,8 @@ public class CreateInitialAdminUserAuthorizationTest {
         .withOwnerType(AuthorizationOwnerType.ROLE)
         .withResourceType(AuthorizationResourceType.AUTHORIZATION)
         .withPermissions(PermissionType.CREATE)
-        .withResourceMatcher(AuthorizationResourceMatcher.ANY)
-        .withResourceId("*")
+        .withResourceMatcher(WILDCARD.getMatcher())
+        .withResourceId(WILDCARD.getResourceId())
         .create(DEFAULT_USER.getUsername());
     engine
         .authorization()
@@ -81,8 +81,8 @@ public class CreateInitialAdminUserAuthorizationTest {
         .withOwnerType(AuthorizationOwnerType.ROLE)
         .withResourceType(AuthorizationResourceType.USER)
         .withPermissions(PermissionType.CREATE)
-        .withResourceMatcher(AuthorizationResourceMatcher.ANY)
-        .withResourceId("*")
+        .withResourceMatcher(WILDCARD.getMatcher())
+        .withResourceId(WILDCARD.getResourceId())
         .create(DEFAULT_USER.getUsername());
     engine
         .authorization()
@@ -91,8 +91,8 @@ public class CreateInitialAdminUserAuthorizationTest {
         .withOwnerType(AuthorizationOwnerType.ROLE)
         .withResourceType(AuthorizationResourceType.ROLE)
         .withPermissions(PermissionType.UPDATE)
-        .withResourceMatcher(AuthorizationResourceMatcher.ANY)
-        .withResourceId("*")
+        .withResourceMatcher(WILDCARD.getMatcher())
+        .withResourceId(WILDCARD.getResourceId())
         .create(DEFAULT_USER.getUsername());
     engine
         .role()
@@ -205,8 +205,8 @@ public class CreateInitialAdminUserAuthorizationTest {
         .withOwnerId(user.getUsername())
         .withOwnerType(AuthorizationOwnerType.USER)
         .withResourceType(authorization)
-        .withResourceMatcher(AuthorizationResourceMatcher.ANY)
-        .withResourceId("*")
+        .withResourceMatcher(WILDCARD.getMatcher())
+        .withResourceId(WILDCARD.getResourceId())
         .create(DEFAULT_USER.getUsername());
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/user/UserCreateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/user/UserCreateAuthorizationTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.user;
 
+import static io.camunda.zeebe.protocol.record.value.AuthorizationScope.WILDCARD;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.security.configuration.ConfiguredUser;
@@ -15,7 +16,6 @@ import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.UserIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
-import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.protocol.record.value.UserRecordValue;
@@ -128,8 +128,8 @@ public class UserCreateAuthorizationTest {
         .withOwnerId(user.getUsername())
         .withOwnerType(AuthorizationOwnerType.USER)
         .withResourceType(authorization)
-        .withResourceMatcher(AuthorizationResourceMatcher.ANY)
-        .withResourceId("*")
+        .withResourceMatcher(WILDCARD.getMatcher())
+        .withResourceId(WILDCARD.getResourceId())
         .create(DEFAULT_USER.getUsername());
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/MultiTenantUserTaskOperationsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/MultiTenantUserTaskOperationsTest.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.EntityType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
@@ -81,6 +82,7 @@ public class MultiTenantUserTaskOperationsTest {
         .authorization()
         .newAuthorization()
         .withPermissions(PermissionType.UPDATE_USER_TASK)
+        .withResourceMatcher(AuthorizationResourceMatcher.ID)
         .withResourceId(PROCESS_ID)
         .withResourceType(AuthorizationResourceType.PROCESS_DEFINITION)
         .withOwnerId(username)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/UserTaskAssignAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/UserTaskAssignAuthorizationTest.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.protocol.record.value.UserRecordValue;
@@ -97,6 +98,7 @@ public class UserTaskAssignAuthorizationTest {
         user,
         AuthorizationResourceType.PROCESS_DEFINITION,
         PermissionType.UPDATE_USER_TASK,
+        AuthorizationResourceMatcher.ID,
         PROCESS_ID);
 
     // when
@@ -152,6 +154,7 @@ public class UserTaskAssignAuthorizationTest {
       final UserRecordValue user,
       final AuthorizationResourceType authorization,
       final PermissionType permissionType,
+      final AuthorizationResourceMatcher matcher,
       final String resourceId) {
     engine
         .authorization()
@@ -160,6 +163,7 @@ public class UserTaskAssignAuthorizationTest {
         .withOwnerId(user.getUsername())
         .withOwnerType(AuthorizationOwnerType.USER)
         .withResourceType(authorization)
+        .withResourceMatcher(matcher)
         .withResourceId(resourceId)
         .create(DEFAULT_USER.getUsername());
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/UserTaskClaimAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/UserTaskClaimAuthorizationTest.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.protocol.record.value.UserRecordValue;
@@ -98,6 +99,7 @@ public class UserTaskClaimAuthorizationTest {
         user,
         AuthorizationResourceType.PROCESS_DEFINITION,
         PermissionType.UPDATE_USER_TASK,
+        AuthorizationResourceMatcher.ID,
         PROCESS_ID);
 
     // when
@@ -153,6 +155,7 @@ public class UserTaskClaimAuthorizationTest {
       final UserRecordValue user,
       final AuthorizationResourceType authorization,
       final PermissionType permissionType,
+      final AuthorizationResourceMatcher matcher,
       final String resourceId) {
     engine
         .authorization()
@@ -161,6 +164,7 @@ public class UserTaskClaimAuthorizationTest {
         .withOwnerId(user.getUsername())
         .withOwnerType(AuthorizationOwnerType.USER)
         .withResourceType(authorization)
+        .withResourceMatcher(matcher)
         .withResourceId(resourceId)
         .create(DEFAULT_USER.getUsername());
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/UserTaskCompleteAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/UserTaskCompleteAuthorizationTest.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.protocol.record.value.UserRecordValue;
@@ -98,6 +99,7 @@ public class UserTaskCompleteAuthorizationTest {
         user,
         AuthorizationResourceType.PROCESS_DEFINITION,
         PermissionType.UPDATE_USER_TASK,
+        AuthorizationResourceMatcher.ID,
         PROCESS_ID);
 
     // when
@@ -153,6 +155,7 @@ public class UserTaskCompleteAuthorizationTest {
       final UserRecordValue user,
       final AuthorizationResourceType authorization,
       final PermissionType permissionType,
+      final AuthorizationResourceMatcher matcher,
       final String resourceId) {
     engine
         .authorization()
@@ -161,6 +164,7 @@ public class UserTaskCompleteAuthorizationTest {
         .withOwnerId(user.getUsername())
         .withOwnerType(AuthorizationOwnerType.USER)
         .withResourceType(authorization)
+        .withResourceMatcher(matcher)
         .withResourceId(resourceId)
         .create(DEFAULT_USER.getUsername());
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/UserTaskUpdateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/UserTaskUpdateAuthorizationTest.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.protocol.record.value.UserRecordValue;
@@ -94,6 +95,7 @@ public class UserTaskUpdateAuthorizationTest {
         user,
         AuthorizationResourceType.PROCESS_DEFINITION,
         PermissionType.UPDATE_USER_TASK,
+        AuthorizationResourceMatcher.ID,
         PROCESS_ID);
 
     // when
@@ -144,6 +146,7 @@ public class UserTaskUpdateAuthorizationTest {
       final UserRecordValue user,
       final AuthorizationResourceType authorization,
       final PermissionType permissionType,
+      final AuthorizationResourceMatcher matcher,
       final String resourceId) {
     engine
         .authorization()
@@ -152,6 +155,7 @@ public class UserTaskUpdateAuthorizationTest {
         .withOwnerId(user.getUsername())
         .withOwnerType(AuthorizationOwnerType.USER)
         .withResourceType(authorization)
+        .withResourceMatcher(matcher)
         .withResourceId(resourceId)
         .create(DEFAULT_USER.getUsername());
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/VariableDocumentUpdateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/VariableDocumentUpdateAuthorizationTest.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.VariableDocumentIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.protocol.record.value.UserRecordValue;
@@ -96,6 +97,7 @@ public class VariableDocumentUpdateAuthorizationTest {
         user,
         AuthorizationResourceType.PROCESS_DEFINITION,
         PermissionType.UPDATE_PROCESS_INSTANCE,
+        AuthorizationResourceMatcher.ID,
         PROCESS_ID);
 
     // when
@@ -151,6 +153,7 @@ public class VariableDocumentUpdateAuthorizationTest {
       final UserRecordValue user,
       final AuthorizationResourceType authorization,
       final PermissionType permissionType,
+      final AuthorizationResourceMatcher matcher,
       final String resourceId) {
     engine
         .authorization()
@@ -159,6 +162,7 @@ public class VariableDocumentUpdateAuthorizationTest {
         .withOwnerId(user.getUsername())
         .withOwnerType(AuthorizationOwnerType.USER)
         .withResourceType(authorization)
+        .withResourceMatcher(matcher)
         .withResourceId(resourceId)
         .create(DEFAULT_USER.getUsername());
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/TenantAppliersTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/TenantAppliersTest.java
@@ -143,7 +143,7 @@ public class TenantAppliersTest {
     // then
     assertThat(tenantState.getTenantById(tenantId)).isEmpty();
     final var resourceIdentifiers =
-        authorizationState.getResourceIdentifiers(
+        authorizationState.getAuthorizationScopes(
             AuthorizationOwnerType.TENANT,
             tenantId,
             AuthorizationResourceType.TENANT,

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/UserDeletedApplierTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/UserDeletedApplierTest.java
@@ -61,8 +61,8 @@ public class UserDeletedApplierTest {
         1L,
         new AuthorizationRecord()
             .setAuthorizationKey(1L)
-            .setResourceMatcher(authScope1.matcher())
-            .setResourceId(authScope1.resourceId())
+            .setResourceMatcher(authScope1.getMatcher())
+            .setResourceId(authScope1.getResourceId())
             .setResourceType(PROCESS_DEFINITION)
             .setOwnerId(userRecord.getUsername())
             .setOwnerType(AuthorizationOwnerType.USER)
@@ -71,8 +71,8 @@ public class UserDeletedApplierTest {
         2L,
         new AuthorizationRecord()
             .setAuthorizationKey(2L)
-            .setResourceMatcher(authScope2.matcher())
-            .setResourceId(authScope2.resourceId())
+            .setResourceMatcher(authScope2.getMatcher())
+            .setResourceId(authScope2.getResourceId())
             .setResourceType(PROCESS_DEFINITION)
             .setOwnerId(userRecord.getUsername())
             .setOwnerType(AuthorizationOwnerType.USER)
@@ -81,8 +81,8 @@ public class UserDeletedApplierTest {
         3L,
         new AuthorizationRecord()
             .setAuthorizationKey(3L)
-            .setResourceMatcher(authScope3.matcher())
-            .setResourceId(authScope3.resourceId())
+            .setResourceMatcher(authScope3.getMatcher())
+            .setResourceId(authScope3.getResourceId())
             .setResourceType(DECISION_DEFINITION)
             .setOwnerId(userRecord.getUsername())
             .setOwnerType(AuthorizationOwnerType.USER)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/authorization/AuthorizationStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/authorization/AuthorizationStateTest.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.engine.state.authorization;
 
 import static io.camunda.zeebe.protocol.record.Assertions.assertThat;
+import static io.camunda.zeebe.protocol.record.value.AuthorizationScope.WILDCARD;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.engine.state.mutable.MutableAuthorizationState;
@@ -190,7 +191,7 @@ public class AuthorizationStateTest {
             .setAuthorizationKey(authorizationKey)
             .setOwnerId(ownerId)
             .setOwnerType(ownerType)
-            .setResourceMatcher(AuthorizationResourceMatcher.ANY)
+            .setResourceMatcher(WILDCARD.getMatcher())
             .setResourceId("*")
             .setResourceType(resourceType)
             .setPermissionTypes(Set.of(PermissionType.READ, PermissionType.ACCESS));
@@ -203,8 +204,8 @@ public class AuthorizationStateTest {
     assertThat(authorization.getAuthorizationKey()).isEqualTo(authorizationKey);
     assertThat(authorization.getOwnerId()).isEqualTo(ownerId);
     assertThat(authorization.getOwnerType()).isEqualTo(ownerType);
-    assertThat(authorization.getResourceMatcher()).isEqualTo(AuthorizationResourceMatcher.ANY);
-    assertThat(authorization.getResourceId()).isEqualTo("*");
+    assertThat(authorization.getResourceMatcher()).isEqualTo(WILDCARD.getMatcher());
+    assertThat(authorization.getResourceId()).isEqualTo(WILDCARD.getResourceId());
     assertThat(authorization.getResourceType()).isEqualTo(resourceType);
     assertThat(authorization.getPermissionTypes())
         .containsExactlyInAnyOrderElementsOf(Set.of(PermissionType.READ, PermissionType.ACCESS));
@@ -212,12 +213,12 @@ public class AuthorizationStateTest {
     final var authorizationScopes =
         authorizationState.getAuthorizationScopes(
             ownerType, ownerId, resourceType, PermissionType.READ);
-    assertThat(authorizationScopes).containsExactly(AuthorizationScope.wildcard());
+    assertThat(authorizationScopes).containsExactly(WILDCARD);
 
     final var anotherAuthorizationScopes =
         authorizationState.getAuthorizationScopes(
             ownerType, ownerId, resourceType, PermissionType.ACCESS);
-    assertThat(anotherAuthorizationScopes).containsExactly(AuthorizationScope.wildcard());
+    assertThat(anotherAuthorizationScopes).containsExactly(WILDCARD);
 
     final var anotherAuthorizationScopes2 =
         authorizationState.getAuthorizationScopes(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/authorization/AuthorizationStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/authorization/AuthorizationStateTest.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.protocol.impl.record.value.authorization.AuthorizationRe
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationScope;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
@@ -39,7 +40,7 @@ public class AuthorizationStateTest {
   void shouldReturnEmptyListIfNoAuthorizationForOwnerAndResourceExists() {
     // when
     final var persistedAuth =
-        authorizationState.getResourceIdentifiers(
+        authorizationState.getAuthorizationScopes(
             AuthorizationOwnerType.USER,
             "test",
             AuthorizationResourceType.RESOURCE,
@@ -82,9 +83,9 @@ public class AuthorizationStateTest {
     assertThat(authorization.getResourceType()).isEqualTo(resourceType);
     assertThat(authorization.getPermissionTypes()).containsExactlyInAnyOrderElementsOf(permissions);
     final var resourceIdentifiers =
-        authorizationState.getResourceIdentifiers(
+        authorizationState.getAuthorizationScopes(
             ownerType, ownerId, resourceType, PermissionType.CREATE);
-    assertThat(resourceIdentifiers).containsExactly("resourceId");
+    assertThat(resourceIdentifiers).containsExactly(AuthorizationScope.id("resourceId"));
 
     final var keys = authorizationState.getAuthorizationKeysForOwner(ownerType, ownerId);
     assertThat(keys).containsExactly(authorizationKey);
@@ -136,25 +137,26 @@ public class AuthorizationStateTest {
     assertThat(authorization.getPermissionTypes())
         .containsExactlyInAnyOrderElementsOf(Set.of(PermissionType.READ, PermissionType.ACCESS));
 
-    final var resourceIdentifiers =
-        authorizationState.getResourceIdentifiers(
+    final var authorizationScopes =
+        authorizationState.getAuthorizationScopes(
             ownerType, ownerId, resourceType, PermissionType.READ);
-    assertThat(resourceIdentifiers).containsExactly("anotherResourceId");
+    assertThat(authorizationScopes).containsExactly(AuthorizationScope.id("anotherResourceId"));
 
-    final var anotherResourceIdentifiers =
-        authorizationState.getResourceIdentifiers(
+    final var anotherAuthorizationScopes =
+        authorizationState.getAuthorizationScopes(
             ownerType, ownerId, resourceType, PermissionType.ACCESS);
-    assertThat(anotherResourceIdentifiers).containsExactly("anotherResourceId");
+    assertThat(anotherAuthorizationScopes)
+        .containsExactly(AuthorizationScope.id("anotherResourceId"));
 
-    final var anotherResourceIdentifiers2 =
-        authorizationState.getResourceIdentifiers(
+    final var anotherAuthorizationScopes2 =
+        authorizationState.getAuthorizationScopes(
             ownerType, ownerId, resourceType, PermissionType.CREATE);
-    assertThat(anotherResourceIdentifiers2).isEmpty();
+    assertThat(anotherAuthorizationScopes2).isEmpty();
 
-    final var anotherResourceIdentifiers3 =
-        authorizationState.getResourceIdentifiers(
+    final var anotherAuthorizationScopes3 =
+        authorizationState.getAuthorizationScopes(
             ownerType, ownerId, resourceType, PermissionType.DELETE);
-    assertThat(anotherResourceIdentifiers3).isEmpty();
+    assertThat(anotherAuthorizationScopes3).isEmpty();
 
     final var keys = authorizationState.getAuthorizationKeysForOwner(ownerType, ownerId);
     assertThat(keys).containsExactly(authorizationKey);
@@ -207,25 +209,25 @@ public class AuthorizationStateTest {
     assertThat(authorization.getPermissionTypes())
         .containsExactlyInAnyOrderElementsOf(Set.of(PermissionType.READ, PermissionType.ACCESS));
 
-    final var resourceIdentifiers =
-        authorizationState.getResourceIdentifiers(
+    final var authorizationScopes =
+        authorizationState.getAuthorizationScopes(
             ownerType, ownerId, resourceType, PermissionType.READ);
-    assertThat(resourceIdentifiers).containsExactly("*");
+    assertThat(authorizationScopes).containsExactly(AuthorizationScope.wildcard());
 
-    final var anotherResourceIdentifiers =
-        authorizationState.getResourceIdentifiers(
+    final var anotherAuthorizationScopes =
+        authorizationState.getAuthorizationScopes(
             ownerType, ownerId, resourceType, PermissionType.ACCESS);
-    assertThat(anotherResourceIdentifiers).containsExactly("*");
+    assertThat(anotherAuthorizationScopes).containsExactly(AuthorizationScope.wildcard());
 
-    final var anotherResourceIdentifiers2 =
-        authorizationState.getResourceIdentifiers(
+    final var anotherAuthorizationScopes2 =
+        authorizationState.getAuthorizationScopes(
             ownerType, ownerId, resourceType, PermissionType.CREATE);
-    assertThat(anotherResourceIdentifiers2).isEmpty();
+    assertThat(anotherAuthorizationScopes2).isEmpty();
 
-    final var anotherResourceIdentifiers3 =
-        authorizationState.getResourceIdentifiers(
+    final var anotherAuthorizationScopes3 =
+        authorizationState.getAuthorizationScopes(
             ownerType, ownerId, resourceType, PermissionType.DELETE);
-    assertThat(anotherResourceIdentifiers3).isEmpty();
+    assertThat(anotherAuthorizationScopes3).isEmpty();
 
     final var keys = authorizationState.getAuthorizationKeysForOwner(ownerType, ownerId);
     assertThat(keys).containsExactly(authorizationKey);
@@ -275,25 +277,26 @@ public class AuthorizationStateTest {
     assertThat(authorization.getResourceType()).isEqualTo(resourceType);
     assertThat(authorization.getPermissionTypes()).containsExactlyInAnyOrderElementsOf(permissions);
 
-    final var resourceIdentifiers =
-        authorizationState.getResourceIdentifiers(
+    final var authorizationScopes =
+        authorizationState.getAuthorizationScopes(
             ownerType, "anotherOwnerId", resourceType, PermissionType.CREATE);
-    assertThat(resourceIdentifiers).containsExactly("anotherResourceId");
+    assertThat(authorizationScopes).containsExactly(AuthorizationScope.id("anotherResourceId"));
 
-    final var anotherResourceIdentifiers =
-        authorizationState.getResourceIdentifiers(
+    final var anotherAuthorizationScopes =
+        authorizationState.getAuthorizationScopes(
             ownerType, "anotherOwnerId", resourceType, PermissionType.DELETE);
-    assertThat(anotherResourceIdentifiers).containsExactly("anotherResourceId");
+    assertThat(anotherAuthorizationScopes)
+        .containsExactly(AuthorizationScope.id("anotherResourceId"));
 
-    final var anotherResourceIdentifiers2 =
-        authorizationState.getResourceIdentifiers(
+    final var anotherAuthorizationScopes2 =
+        authorizationState.getAuthorizationScopes(
             ownerType, ownerId, resourceType, PermissionType.CREATE);
-    assertThat(anotherResourceIdentifiers2).isEmpty();
+    assertThat(anotherAuthorizationScopes2).isEmpty();
 
-    final var anotherResourceIdentifiers3 =
-        authorizationState.getResourceIdentifiers(
+    final var anotherAuthorizationScopes3 =
+        authorizationState.getAuthorizationScopes(
             ownerType, ownerId, resourceType, PermissionType.DELETE);
-    assertThat(anotherResourceIdentifiers3).isEmpty();
+    assertThat(anotherAuthorizationScopes3).isEmpty();
 
     final var keysByOwner = authorizationState.getAuthorizationKeysForOwner(ownerType, ownerId);
     assertThat(keysByOwner).isEmpty();
@@ -347,31 +350,31 @@ public class AuthorizationStateTest {
         .isEqualTo(AuthorizationResourceType.PROCESS_DEFINITION);
     assertThat(authorization.getPermissionTypes()).containsExactlyInAnyOrderElementsOf(permissions);
 
-    final var resourceIdentifiers =
-        authorizationState.getResourceIdentifiers(
+    final var authorizationScopes =
+        authorizationState.getAuthorizationScopes(
             ownerType,
             ownerId,
             AuthorizationResourceType.PROCESS_DEFINITION,
             PermissionType.CREATE);
-    assertThat(resourceIdentifiers).containsExactly("resourceId");
+    assertThat(authorizationScopes).containsExactly(AuthorizationScope.id("resourceId"));
 
-    final var anotherResourceIdentifiers =
-        authorizationState.getResourceIdentifiers(
+    final var anotherAuthorizationScopes =
+        authorizationState.getAuthorizationScopes(
             ownerType,
             ownerId,
             AuthorizationResourceType.PROCESS_DEFINITION,
             PermissionType.DELETE);
-    assertThat(anotherResourceIdentifiers).containsExactly("resourceId");
+    assertThat(anotherAuthorizationScopes).containsExactly(AuthorizationScope.id("resourceId"));
 
-    final var anotherResourceIdentifiers2 =
-        authorizationState.getResourceIdentifiers(
+    final var anotherAuthorizationScopes2 =
+        authorizationState.getAuthorizationScopes(
             ownerType, ownerId, AuthorizationResourceType.RESOURCE, PermissionType.CREATE);
-    assertThat(anotherResourceIdentifiers2).isEmpty();
+    assertThat(anotherAuthorizationScopes2).isEmpty();
 
-    final var anotherResourceIdentifiers3 =
-        authorizationState.getResourceIdentifiers(
+    final var anotherAuthorizationScopes3 =
+        authorizationState.getAuthorizationScopes(
             ownerType, ownerId, AuthorizationResourceType.RESOURCE, PermissionType.DELETE);
-    assertThat(anotherResourceIdentifiers3).isEmpty();
+    assertThat(anotherAuthorizationScopes3).isEmpty();
 
     final var keys = authorizationState.getAuthorizationKeysForOwner(ownerType, ownerId);
     assertThat(keys).containsExactly(authorizationKey);
@@ -435,23 +438,23 @@ public class AuthorizationStateTest {
     assertThat(authorization.getPermissionTypes())
         .containsExactlyInAnyOrderElementsOf(Set.of(PermissionType.READ_PROCESS_DEFINITION));
 
-    final var resourceIdentifiers =
-        authorizationState.getResourceIdentifiers(
+    final var authorizationScopes =
+        authorizationState.getAuthorizationScopes(
             ownerType,
             ownerId,
             AuthorizationResourceType.PROCESS_DEFINITION,
             PermissionType.READ_PROCESS_DEFINITION);
-    assertThat(resourceIdentifiers).containsExactly("resourceId");
+    assertThat(authorizationScopes).containsExactly(AuthorizationScope.id("resourceId"));
 
-    final var anotherResourceIdentifiers =
-        authorizationState.getResourceIdentifiers(
+    final var anotherAuthorizationScopes =
+        authorizationState.getAuthorizationScopes(
             ownerType, ownerId, AuthorizationResourceType.RESOURCE, PermissionType.CREATE);
-    assertThat(anotherResourceIdentifiers).containsExactly("resourceId2");
+    assertThat(anotherAuthorizationScopes).containsExactly(AuthorizationScope.id("resourceId2"));
 
-    final var anotherResourceIdentifiers2 =
-        authorizationState.getResourceIdentifiers(
+    final var anotherAuthorizationScopes2 =
+        authorizationState.getAuthorizationScopes(
             ownerType, ownerId, AuthorizationResourceType.RESOURCE, PermissionType.DELETE);
-    assertThat(anotherResourceIdentifiers2).containsExactly("resourceId2");
+    assertThat(anotherAuthorizationScopes2).containsExactly(AuthorizationScope.id("resourceId2"));
 
     final var keys = authorizationState.getAuthorizationKeysForOwner(ownerType, ownerId);
     assertThat(keys).containsExactly(1L, 2L);
@@ -484,15 +487,15 @@ public class AuthorizationStateTest {
     // then
     assertThat(authorizationState.get(authorizationKey)).isEmpty();
 
-    final var resourceIdentifiers =
-        authorizationState.getResourceIdentifiers(
+    final var authorizationScopes =
+        authorizationState.getAuthorizationScopes(
             ownerType, ownerId, resourceType, PermissionType.CREATE);
-    assertThat(resourceIdentifiers).isEmpty();
+    assertThat(authorizationScopes).isEmpty();
 
-    final var resourceIdentifiers2 =
-        authorizationState.getResourceIdentifiers(
+    final var authorizationScopes2 =
+        authorizationState.getAuthorizationScopes(
             ownerType, ownerId, resourceType, PermissionType.DELETE);
-    assertThat(resourceIdentifiers2).isEmpty();
+    assertThat(authorizationScopes2).isEmpty();
 
     final var keys = authorizationState.getAuthorizationKeysForOwner(ownerType, ownerId);
     assertThat(keys).isEmpty();
@@ -542,25 +545,25 @@ public class AuthorizationStateTest {
     // then
     assertThat(authorizationState.get(authorizationKey1)).isEmpty();
 
-    final var resourceIdentifiers1 =
-        authorizationState.getResourceIdentifiers(
+    final var authorizationScopes1 =
+        authorizationState.getAuthorizationScopes(
             ownerType1, ownerId1, resourceType1, PermissionType.CREATE);
-    assertThat(resourceIdentifiers1).isEmpty();
+    assertThat(authorizationScopes1).isEmpty();
 
-    final var resourceIdentifiers2 =
-        authorizationState.getResourceIdentifiers(
+    final var authorizationScopes2 =
+        authorizationState.getAuthorizationScopes(
             ownerType1, ownerId1, resourceType1, PermissionType.DELETE);
-    assertThat(resourceIdentifiers2).isEmpty();
+    assertThat(authorizationScopes2).isEmpty();
 
-    final var resourceIdentifiers3 =
-        authorizationState.getResourceIdentifiers(
+    final var authorizationScopes3 =
+        authorizationState.getAuthorizationScopes(
             ownerType2, ownerId2, resourceType2, PermissionType.CREATE);
-    assertThat(resourceIdentifiers3).containsExactly(resourceId2);
+    assertThat(authorizationScopes3).containsExactly(AuthorizationScope.id(resourceId2));
 
-    final var resourceIdentifiers4 =
-        authorizationState.getResourceIdentifiers(
+    final var authorizationScopes4 =
+        authorizationState.getAuthorizationScopes(
             ownerType2, ownerId2, resourceType2, PermissionType.DELETE);
-    assertThat(resourceIdentifiers4).containsExactly(resourceId2);
+    assertThat(authorizationScopes4).containsExactly(AuthorizationScope.id(resourceId2));
 
     final var keys1 = authorizationState.getAuthorizationKeysForOwner(ownerType1, ownerId1);
     assertThat(keys1).isEmpty();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/AuthorizationClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/AuthorizationClient.java
@@ -140,7 +140,10 @@ public final class AuthorizationClient {
 
     public AuthorizationDeleteClient(final CommandWriter writer, final long authorizationKey) {
       this.writer = writer;
-      authorizationDeletionRecord = new AuthorizationRecord().setAuthorizationKey(authorizationKey);
+      authorizationDeletionRecord =
+          new AuthorizationRecord()
+              .setAuthorizationKey(authorizationKey)
+              .setResourceMatcher(AuthorizationResourceMatcher.UNSPECIFIED);
     }
 
     public AuthorizationDeleteClient expectRejection() {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/AuthorizationCreatedUpdatedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/AuthorizationCreatedUpdatedHandlerTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.exporter.handlers;
 
+import static io.camunda.zeebe.protocol.record.value.AuthorizationScope.WILDCARD;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -98,8 +99,8 @@ public class AuthorizationCreatedUpdatedHandlerTest {
             .withAuthorizationKey(456L)
             .withOwnerId("foo")
             .withOwnerType(AuthorizationOwnerType.USER)
-            .withResourceMatcher(AuthorizationResourceMatcher.ANY)
-            .withResourceId("*")
+            .withResourceMatcher(WILDCARD.getMatcher())
+            .withResourceId(WILDCARD.getResourceId())
             .withPermissionTypes(List.of(PermissionType.CREATE, PermissionType.DELETE))
             .build();
 

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.gateway.rest;
 
 import static io.camunda.zeebe.gateway.rest.ResponseMapper.formatDate;
+import static io.camunda.zeebe.protocol.record.value.AuthorizationScope.WILDCARD;
 import static java.util.Optional.ofNullable;
 import static java.util.stream.Collectors.toMap;
 
@@ -134,7 +135,6 @@ import io.camunda.zeebe.gateway.protocol.rest.VariableResult;
 import io.camunda.zeebe.gateway.protocol.rest.VariableSearchQueryResult;
 import io.camunda.zeebe.gateway.protocol.rest.VariableSearchResult;
 import io.camunda.zeebe.gateway.rest.util.KeyUtil;
-import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.util.collection.Tuple;
 import java.util.Collections;
@@ -1090,9 +1090,8 @@ public final class SearchQueryResponseMapper {
   }
 
   public static AuthorizationResult toAuthorization(final AuthorizationEntity authorization) {
-    // TODO: handle with WILDCARD constant
     final var resourceId =
-        (AuthorizationResourceMatcher.ANY.value() == authorization.resourceMatcher())
+        (WILDCARD.getMatcher().value() == authorization.resourceMatcher())
             ? "*"
             : authorization.resourceId();
     return new AuthorizationResult()

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerAuthorizationDeleteRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerAuthorizationDeleteRequest.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.broker.client.api.dto.BrokerExecuteCommand;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.AuthorizationRecord;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.AuthorizationIntent;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.util.buffer.BufferWriter;
 import org.agrona.DirectBuffer;
 
@@ -21,6 +22,7 @@ public class BrokerAuthorizationDeleteRequest extends BrokerExecuteCommand<Autho
     super(ValueType.AUTHORIZATION, AuthorizationIntent.DELETE);
     request.setKey(authorizationKey);
     requestDto.setAuthorizationKey(authorizationKey);
+    requestDto.setResourceMatcher(AuthorizationResourceMatcher.UNSPECIFIED);
   }
 
   @Override

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/MsgPackConverter.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/MsgPackConverter.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.MappingJsonFactory;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.camunda.zeebe.protocol.record.JsonSerializable;
+import io.camunda.zeebe.protocol.record.value.AuthorizationScope;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.io.ByteArrayInputStream;
@@ -57,7 +58,7 @@ public final class MsgPackConverter {
       new TypeReference<>() {};
   private static final TypeReference<HashMap<String, Set<Long>>> SET_LONG_MAP_TYPE_REFERENCE =
       new TypeReference<>() {};
-  private static final TypeReference<HashMap<PermissionType, Set<String>>>
+  private static final TypeReference<HashMap<PermissionType, Set<AuthorizationScope>>>
       PERMISSION_MAP_TYPE_REFERENCE = new TypeReference<>() {};
 
   /*
@@ -190,7 +191,8 @@ public final class MsgPackConverter {
     return convertToMap(SET_LONG_MAP_TYPE_REFERENCE, buffer);
   }
 
-  public static Map<PermissionType, Set<String>> convertToPermissionMap(final DirectBuffer buffer) {
+  public static Map<PermissionType, Set<AuthorizationScope>> convertToPermissionMap(
+      final DirectBuffer buffer) {
     return convertToMap(PERMISSION_MAP_TYPE_REFERENCE, buffer);
   }
 

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/authorization/AuthorizationRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/authorization/AuthorizationRecord.java
@@ -42,10 +42,7 @@ public final class AuthorizationRecord extends UnifiedRecordValue
       new EnumProperty<>(
           OWNER_TYPE_KEY, AuthorizationOwnerType.class, AuthorizationOwnerType.UNSPECIFIED);
   private final EnumProperty<AuthorizationResourceMatcher> resourceMatcherProp =
-      new EnumProperty<>(
-          RESOURCE_MATCHER,
-          AuthorizationResourceMatcher.class,
-          AuthorizationResourceMatcher.UNSPECIFIED);
+      new EnumProperty<>(RESOURCE_MATCHER, AuthorizationResourceMatcher.class);
   private final StringProperty resourceIdProp = new StringProperty(RESOURCE_ID_KEY, "");
   private final EnumProperty<AuthorizationResourceType> resourceTypeProp =
       new EnumProperty<>(

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/AuthorizationScopeTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/AuthorizationScopeTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.protocol.impl;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
+import io.camunda.zeebe.protocol.record.value.AuthorizationScope;
+import org.junit.jupiter.api.Test;
+
+public class AuthorizationScopeTest {
+
+  @Test
+  public void shouldProvideWildcardScope() {
+    // given
+    final var wildcardScope = AuthorizationScope.WILDCARD;
+
+    // then
+    assertThat(wildcardScope.getMatcher()).isEqualTo(AuthorizationResourceMatcher.ANY);
+    assertThat(wildcardScope.getResourceId()).isEqualTo(AuthorizationScope.WILDCARD_CHAR);
+  }
+
+  @Test
+  public void shouldDetectWildcardId() {
+    // given
+    final var wildcardId = AuthorizationScope.WILDCARD_CHAR;
+
+    // when
+    final var wildcardScope = AuthorizationScope.of(wildcardId);
+
+    // then
+    assertThat(wildcardScope.getMatcher()).isEqualTo(AuthorizationResourceMatcher.ANY);
+    assertThat(wildcardScope.getResourceId()).isEqualTo(AuthorizationScope.WILDCARD_CHAR);
+  }
+
+  @Test
+  public void shouldProvideIdScope() {
+    // given
+    final var resourceId = "resource-id";
+
+    // when
+    final var idScope = AuthorizationScope.id(resourceId);
+
+    // then
+    assertThat(idScope.getMatcher()).isEqualTo(AuthorizationResourceMatcher.ID);
+    assertThat(idScope.getResourceId()).isEqualTo(resourceId);
+  }
+
+  @Test
+  public void shouldDetectIdScope() {
+    // given
+    final var resourceId = "resource-id";
+
+    // when
+    final var idScope = AuthorizationScope.of(resourceId);
+
+    // then
+    assertThat(idScope.getMatcher()).isEqualTo(AuthorizationResourceMatcher.ID);
+    assertThat(idScope.getResourceId()).isEqualTo(resourceId);
+  }
+
+  @Test
+  public void shouldThrowErrorForInvalidId() {
+    // given
+    final var invalidResourceId = AuthorizationScope.WILDCARD_CHAR;
+
+    // when / then
+    assertThatThrownBy(() -> AuthorizationScope.id(invalidResourceId))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining(
+            ("Resource ID cannot be the wildcard character '%s'. For declaring WILDCARD access, please use the AuthorizationScope.WILDCARD constant.")
+                .formatted(invalidResourceId));
+  }
+}

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -2882,7 +2882,10 @@ final class JsonSerializableToJsonTest {
       /////////////////////////////////////////////////////////////////////////////////////////////
       {
         "Empty AuthorizationRecord",
-        (Supplier<AuthorizationRecord>) AuthorizationRecord::new,
+        (Supplier<AuthorizationRecord>)
+            () ->
+                new AuthorizationRecord()
+                    .setResourceMatcher(AuthorizationResourceMatcher.UNSPECIFIED),
         """
         {
           "authorizationKey": -1,


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Adds an `AuthorizationScope` wrapper class to the `security-protocol` module. The class is used in the workflow engine and search layer to wrap resource IDs. This enables the platform to perform more secure authorization checks agains provided resource IDs.

ℹ️ Note: Commit [0f2e50e](https://github.com/camunda/camunda/pull/36290/commits/0f2e50e33fb456aaff64cd0d80b7b31e19096ec2) makes the new `AuthorizationRecord#resourceMatcher` property required, to ensure that the `matcher` is always set and avoid any NPEs when the data is read from secondary storage.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #36158
closes #36343
related to #29453 
