### PR TITLE
feat: add unified configuration for api long-polling

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/Api.java
+++ b/configuration/src/main/java/io/camunda/configuration/Api.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+public class Api {
+
+  /** Configuration for long-polling behavior */
+  private LongPolling longPolling = new LongPolling();
+
+  public LongPolling getLongPolling() {
+    return longPolling;
+  }
+
+  public void setLongPolling(final LongPolling longPolling) {
+    this.longPolling = longPolling;
+  }
+}

--- a/configuration/src/main/java/io/camunda/configuration/Camunda.java
+++ b/configuration/src/main/java/io/camunda/configuration/Camunda.java
@@ -21,6 +21,7 @@ public class Camunda {
   private Cluster cluster = new Cluster();
   private System system = new System();
   private Data data = new Data();
+  private Api api = new Api();
 
   public Cluster getCluster() {
     return cluster;
@@ -44,5 +45,13 @@ public class Camunda {
 
   public void setData(Data data) {
     this.data = data;
+  }
+
+  public Api getApi() {
+    return api;
+  }
+
+  public void setApi(final Api api) {
+    this.api = api;
   }
 }

--- a/configuration/src/main/java/io/camunda/configuration/LongPolling.java
+++ b/configuration/src/main/java/io/camunda/configuration/LongPolling.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import io.camunda.configuration.UnifiedConfigurationHelper.BackwardsCompatibilityMode;
+import io.camunda.zeebe.gateway.impl.configuration.ConfigurationDefaults;
+import java.util.Set;
+
+public class LongPolling {
+  private static final String PREFIX = "camunda.api.long-polling.";
+  private static final Set<String> LEGACY_ENABLED_PROPERTIES =
+      Set.of("zeebe.gateway.longPolling.enabled");
+  private static final Set<String> LEGACY_TIMEOUT_PROPERTIES =
+      Set.of("zeebe.gateway.longPolling.timeout");
+  private static final Set<String> LEGACY_PROBE_TIMEOUT_PROPERTIES =
+      Set.of("zeebe.gateway.longPolling.probeTimeout");
+  private static final Set<String> LEGACY_MIN_EMPTY_RESPONSES_PROPERTIES =
+      Set.of("zeebe.gateway.longPolling.minEmptyResponses");
+
+  /** Enables long polling for available jobs */
+  private boolean enabled = ConfigurationDefaults.DEFAULT_LONG_POLLING_ENABLED;
+
+  /** Set the timeout for long polling in milliseconds */
+  private long timeout = ConfigurationDefaults.DEFAULT_LONG_POLLING_TIMEOUT;
+
+  /** Set the probe timeout for long polling in milliseconds */
+  private long probeTimeout = ConfigurationDefaults.DEFAULT_PROBE_TIMEOUT;
+
+  /**
+   * Set the number of minimum empty responses, a minimum number of responses with jobCount of 0
+   * infers that no jobs are available
+   */
+  private int minEmptyResponses =
+      ConfigurationDefaults.DEFAULT_LONG_POLLING_EMPTY_RESPONSE_THRESHOLD;
+
+  public boolean isEnabled() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + "enabled",
+        enabled,
+        Boolean.class,
+        BackwardsCompatibilityMode.SUPPORTED,
+        LEGACY_ENABLED_PROPERTIES);
+  }
+
+  public void setEnabled(final boolean enabled) {
+    this.enabled = enabled;
+  }
+
+  public long getTimeout() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + "timeout",
+        timeout,
+        Long.class,
+        BackwardsCompatibilityMode.SUPPORTED,
+        LEGACY_TIMEOUT_PROPERTIES);
+  }
+
+  public void setTimeout(final long timeout) {
+    this.timeout = timeout;
+  }
+
+  public long getProbeTimeout() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + "probe-timeout",
+        probeTimeout,
+        Long.class,
+        BackwardsCompatibilityMode.SUPPORTED,
+        LEGACY_PROBE_TIMEOUT_PROPERTIES);
+  }
+
+  public void setProbeTimeout(final long probeTimeout) {
+    this.probeTimeout = probeTimeout;
+  }
+
+  public int getMinEmptyResponses() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + "min-empty-responses",
+        minEmptyResponses,
+        Integer.class,
+        BackwardsCompatibilityMode.SUPPORTED,
+        LEGACY_MIN_EMPTY_RESPONSES_PROPERTIES);
+  }
+
+  public void setMinEmptyResponses(final int minEmptyResponses) {
+    this.minEmptyResponses = minEmptyResponses;
+  }
+}

--- a/configuration/src/main/java/io/camunda/configuration/beans/GatewayBasedProperties.java
+++ b/configuration/src/main/java/io/camunda/configuration/beans/GatewayBasedProperties.java
@@ -8,7 +8,6 @@
 package io.camunda.configuration.beans;
 
 import io.camunda.zeebe.gateway.impl.configuration.GatewayCfg;
-import org.springframework.boot.context.properties.ConfigurationProperties;
 
 // NOTE: This class has been moved away from dist. The reason for this is that as, for now,
 //  we're storing the unified configuration objects and beans in the configuration module,
@@ -21,5 +20,4 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 //  such refactoring happens, we can bring back GatewayBasedProperties within dist, as there will
 //  be no more circular dependency issues.
 
-@ConfigurationProperties("zeebe.gateway")
 public class GatewayBasedProperties extends GatewayCfg {}

--- a/configuration/src/main/java/io/camunda/configuration/beans/LegacyGatewayBasedProperties.java
+++ b/configuration/src/main/java/io/camunda/configuration/beans/LegacyGatewayBasedProperties.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration.beans;
+
+import io.camunda.zeebe.gateway.impl.configuration.GatewayCfg;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties("zeebe.gateway")
+public class LegacyGatewayBasedProperties extends GatewayCfg {}

--- a/configuration/src/test/java/io/camunda/configuration/ApiLongPollingTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/ApiLongPollingTest.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.configuration.beanoverrides.GatewayBasedPropertiesOverride;
+import io.camunda.configuration.beans.GatewayBasedProperties;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+@SpringJUnitConfig({
+  UnifiedConfiguration.class,
+  GatewayBasedPropertiesOverride.class,
+  UnifiedConfigurationHelper.class
+})
+public class ApiLongPollingTest {
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "camunda.api.long-polling.enabled=true",
+        "camunda.api.long-polling.timeout=20000",
+        "camunda.api.long-polling.probe-timeout=30000",
+        "camunda.api.long-polling.min-empty-responses=5"
+      })
+  class WithOnlyUnifiedConfigSet {
+    final GatewayBasedProperties gatewayCfg;
+
+    WithOnlyUnifiedConfigSet(@Autowired final GatewayBasedProperties gatewayCfg) {
+      this.gatewayCfg = gatewayCfg;
+    }
+
+    @Test
+    void shouldSetEnabled() {
+      assertThat(gatewayCfg.getLongPolling().isEnabled()).isTrue();
+    }
+
+    @Test
+    void shouldSetTimeout() {
+      assertThat(gatewayCfg.getLongPolling().getTimeout()).isEqualTo(20000);
+    }
+
+    @Test
+    void shouldSetProbeTimeout() {
+      assertThat(gatewayCfg.getLongPolling().getProbeTimeout()).isEqualTo(30000);
+    }
+
+    @Test
+    void shouldSetMinEmptyResponses() {
+      assertThat(gatewayCfg.getLongPolling().getMinEmptyResponses()).isEqualTo(5);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "zeebe.gateway.longPolling.enabled=false",
+        "zeebe.gateway.longPolling.timeout=2",
+        "zeebe.gateway.longPolling.probeTimeout=3",
+        "zeebe.gateway.longPolling.minEmptyResponses=4"
+      })
+  class WithOnlyLegacySet {
+    final GatewayBasedProperties gatewayCfg;
+
+    WithOnlyLegacySet(@Autowired final GatewayBasedProperties gatewayCfg) {
+      this.gatewayCfg = gatewayCfg;
+    }
+
+    @Test
+    void shouldSetEnabled() {
+      assertThat(gatewayCfg.getLongPolling().isEnabled()).isFalse();
+    }
+
+    @Test
+    void shouldSetTimeout() {
+      assertThat(gatewayCfg.getLongPolling().getTimeout()).isEqualTo(2);
+    }
+
+    @Test
+    void shouldSetProbeTimeout() {
+      assertThat(gatewayCfg.getLongPolling().getProbeTimeout()).isEqualTo(3);
+    }
+
+    @Test
+    void shouldSetMinEmptyResponses() {
+      assertThat(gatewayCfg.getLongPolling().getMinEmptyResponses()).isEqualTo(4);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        // new
+        "camunda.api.long-polling.enabled=true",
+        "camunda.api.long-polling.timeout=20000",
+        "camunda.api.long-polling.probe-timeout=30000",
+        "camunda.api.long-polling.min-empty-responses=5",
+        // legacy
+        "zeebe.gateway.longPolling.enabled=false",
+        "zeebe.gateway.longPolling.timeout=2",
+        "zeebe.gateway.longPolling.probeTimeout=3",
+        "zeebe.gateway.longPolling.minEmptyResponses=4"
+      })
+  class WithNewAndLegacySet {
+    final GatewayBasedProperties gatewayCfg;
+
+    WithNewAndLegacySet(@Autowired final GatewayBasedProperties gatewayCfg) {
+      this.gatewayCfg = gatewayCfg;
+    }
+
+    @Test
+    void shouldSetEnabledFromNew() {
+      assertThat(gatewayCfg.getLongPolling().isEnabled()).isTrue();
+    }
+
+    @Test
+    void shouldSetTimeoutFromNew() {
+      assertThat(gatewayCfg.getLongPolling().getTimeout()).isEqualTo(20000);
+    }
+
+    @Test
+    void shouldSetProbeTimeoutFromNew() {
+      assertThat(gatewayCfg.getLongPolling().getProbeTimeout()).isEqualTo(30000);
+    }
+
+    @Test
+    void shouldSetMinEmptyResponseFromNew() {
+      assertThat(gatewayCfg.getLongPolling().getMinEmptyResponses()).isEqualTo(5);
+    }
+  }
+}

--- a/dist/src/main/java/io/camunda/application/StandaloneGateway.java
+++ b/dist/src/main/java/io/camunda/application/StandaloneGateway.java
@@ -11,6 +11,7 @@ import io.camunda.application.commons.CommonsModuleConfiguration;
 import io.camunda.application.initializers.HealthConfigurationInitializer;
 import io.camunda.configuration.UnifiedConfiguration;
 import io.camunda.configuration.UnifiedConfigurationHelper;
+import io.camunda.configuration.beanoverrides.GatewayBasedPropertiesOverride;
 import io.camunda.zeebe.gateway.GatewayModuleConfiguration;
 import org.springframework.boot.SpringBootConfiguration;
 
@@ -28,7 +29,8 @@ public class StandaloneGateway {
                 CommonsModuleConfiguration.class,
                 GatewayModuleConfiguration.class,
                 UnifiedConfiguration.class,
-                UnifiedConfigurationHelper.class)
+                UnifiedConfigurationHelper.class,
+                GatewayBasedPropertiesOverride.class)
             .profiles(Profile.GATEWAY.getId(), Profile.STANDALONE.getId())
             .initializers(new HealthConfigurationInitializer())
             .build(args);

--- a/dist/src/main/java/io/camunda/application/StandaloneOperate.java
+++ b/dist/src/main/java/io/camunda/application/StandaloneOperate.java
@@ -13,6 +13,7 @@ import io.camunda.application.initializers.WebappsConfigurationInitializer;
 import io.camunda.application.listeners.ApplicationErrorListener;
 import io.camunda.configuration.UnifiedConfiguration;
 import io.camunda.configuration.UnifiedConfigurationHelper;
+import io.camunda.configuration.beanoverrides.GatewayBasedPropertiesOverride;
 import io.camunda.configuration.beanoverrides.OperatePropertiesOverride;
 import io.camunda.operate.OperateModuleConfiguration;
 import io.camunda.webapps.WebappsModuleConfiguration;
@@ -46,6 +47,7 @@ public class StandaloneOperate {
                 UnifiedConfiguration.class,
                 UnifiedConfigurationHelper.class,
                 OperatePropertiesOverride.class,
+                GatewayBasedPropertiesOverride.class,
                 // ---
                 CommonsModuleConfiguration.class,
                 OperateModuleConfiguration.class,

--- a/dist/src/main/java/io/camunda/application/StandaloneTasklist.java
+++ b/dist/src/main/java/io/camunda/application/StandaloneTasklist.java
@@ -13,6 +13,7 @@ import io.camunda.application.initializers.WebappsConfigurationInitializer;
 import io.camunda.application.listeners.ApplicationErrorListener;
 import io.camunda.configuration.UnifiedConfiguration;
 import io.camunda.configuration.UnifiedConfigurationHelper;
+import io.camunda.configuration.beanoverrides.GatewayBasedPropertiesOverride;
 import io.camunda.configuration.beanoverrides.TasklistPropertiesOverride;
 import io.camunda.tasklist.TasklistModuleConfiguration;
 import io.camunda.webapps.WebappsModuleConfiguration;
@@ -41,6 +42,7 @@ public class StandaloneTasklist {
                 UnifiedConfiguration.class,
                 UnifiedConfigurationHelper.class,
                 TasklistPropertiesOverride.class,
+                GatewayBasedPropertiesOverride.class,
                 // ---
                 CommonsModuleConfiguration.class,
                 TasklistModuleConfiguration.class,

--- a/dist/src/main/java/io/camunda/application/commons/configuration/GatewayBasedConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/configuration/GatewayBasedConfiguration.java
@@ -33,14 +33,12 @@ import java.util.List;
 import java.util.stream.Collectors;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.context.LifecycleProperties;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 import org.springframework.web.filter.CompositeFilter;
 
 @Configuration(proxyBeanMethods = false)
-@EnableConfigurationProperties(GatewayBasedProperties.class)
 @Profile("!broker")
 public final class GatewayBasedConfiguration {
 

--- a/dist/src/test/java/io/camunda/application/commons/security/CamundaSecurityConfigurationTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/security/CamundaSecurityConfigurationTest.java
@@ -12,6 +12,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import io.camunda.application.commons.CommonsModuleConfiguration;
 import io.camunda.configuration.UnifiedConfiguration;
 import io.camunda.configuration.UnifiedConfigurationHelper;
+import io.camunda.configuration.beanoverrides.GatewayBasedPropertiesOverride;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.BeanCreationException;
 import org.springframework.boot.SpringApplication;
@@ -30,8 +31,9 @@ public class CamundaSecurityConfigurationTest {
               final SpringApplication app =
                   new SpringApplication(
                       CommonsModuleConfiguration.class,
+                      UnifiedConfiguration.class,
                       UnifiedConfigurationHelper.class,
-                      UnifiedConfiguration.class);
+                      GatewayBasedPropertiesOverride.class);
               app.run();
             })
         .isInstanceOf(BeanCreationException.class)

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/TestApplication.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/TestApplication.java
@@ -9,6 +9,7 @@ package io.camunda.operate.util;
 
 import io.camunda.configuration.UnifiedConfiguration;
 import io.camunda.configuration.UnifiedConfigurationHelper;
+import io.camunda.configuration.beanoverrides.GatewayBasedPropertiesOverride;
 import io.camunda.configuration.beanoverrides.OperatePropertiesOverride;
 import io.camunda.operate.OperateModuleConfiguration;
 import io.camunda.webapps.WebappsModuleConfiguration;
@@ -35,7 +36,8 @@ import org.springframework.context.annotation.Import;
   WebappsModuleConfiguration.class,
   OperatePropertiesOverride.class,
   UnifiedConfiguration.class,
-  UnifiedConfigurationHelper.class
+  UnifiedConfigurationHelper.class,
+  GatewayBasedPropertiesOverride.class
 })
 public class TestApplication {
 

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/apps/modules/ModulesTestApplication.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/apps/modules/ModulesTestApplication.java
@@ -7,6 +7,9 @@
  */
 package io.camunda.operate.util.apps.modules;
 
+import io.camunda.configuration.UnifiedConfiguration;
+import io.camunda.configuration.UnifiedConfigurationHelper;
+import io.camunda.configuration.beanoverrides.GatewayBasedPropertiesOverride;
 import io.camunda.configuration.beanoverrides.OperatePropertiesOverride;
 import io.camunda.operate.OperateModuleConfiguration;
 import io.camunda.operate.util.TestApplication;
@@ -44,6 +47,9 @@ import org.springframework.context.annotation.Import;
 @Import({
   WebappsModuleConfiguration.class,
   OperatePropertiesOverride.class,
+  UnifiedConfiguration.class,
+  UnifiedConfigurationHelper.class,
+  GatewayBasedPropertiesOverride.class,
 })
 public class ModulesTestApplication {
 

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TestApplication.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TestApplication.java
@@ -10,6 +10,7 @@ package io.camunda.tasklist.util;
 import io.camunda.application.commons.CommonsModuleConfiguration;
 import io.camunda.configuration.UnifiedConfiguration;
 import io.camunda.configuration.UnifiedConfigurationHelper;
+import io.camunda.configuration.beanoverrides.GatewayBasedPropertiesOverride;
 import io.camunda.configuration.beanoverrides.TasklistPropertiesOverride;
 import io.camunda.tasklist.TasklistModuleConfiguration;
 import io.camunda.tasklist.data.DataGenerator;
@@ -43,7 +44,8 @@ import org.springframework.context.annotation.Profile;
   CommonsModuleConfiguration.class,
   TasklistPropertiesOverride.class,
   UnifiedConfiguration.class,
-  UnifiedConfigurationHelper.class
+  UnifiedConfigurationHelper.class,
+  GatewayBasedPropertiesOverride.class
 })
 public class TestApplication {
 

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/apps/modules/ModulesTestApplication.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/apps/modules/ModulesTestApplication.java
@@ -9,6 +9,7 @@ package io.camunda.tasklist.util.apps.modules;
 
 import io.camunda.configuration.UnifiedConfiguration;
 import io.camunda.configuration.UnifiedConfigurationHelper;
+import io.camunda.configuration.beanoverrides.GatewayBasedPropertiesOverride;
 import io.camunda.configuration.beanoverrides.TasklistPropertiesOverride;
 import io.camunda.tasklist.TasklistModuleConfiguration;
 import io.camunda.tasklist.data.DataGenerator;
@@ -61,7 +62,8 @@ import org.springframework.context.annotation.Profile;
   WebappManagementModuleConfiguration.class,
   TasklistPropertiesOverride.class,
   UnifiedConfiguration.class,
-  UnifiedConfigurationHelper.class
+  UnifiedConfigurationHelper.class,
+  GatewayBasedPropertiesOverride.class,
 })
 public class ModulesTestApplication {
 

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneGateway.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneGateway.java
@@ -15,7 +15,6 @@ import io.camunda.configuration.UnifiedConfiguration;
 import io.camunda.configuration.UnifiedConfigurationHelper;
 import io.camunda.configuration.beanoverrides.ActorClockControlledPropertiesOverride;
 import io.camunda.configuration.beanoverrides.BrokerBasedPropertiesOverride;
-import io.camunda.configuration.beanoverrides.GatewayBasedPropertiesOverride;
 import io.camunda.configuration.beanoverrides.IdleStrategyPropertiesOverride;
 import io.camunda.configuration.beanoverrides.OperatePropertiesOverride;
 import io.camunda.configuration.beanoverrides.TasklistPropertiesOverride;
@@ -39,7 +38,6 @@ public final class TestStandaloneGateway extends TestSpringApplication<TestStand
         UnifiedConfigurationHelper.class,
         TasklistPropertiesOverride.class,
         OperatePropertiesOverride.class,
-        GatewayBasedPropertiesOverride.class,
         BrokerBasedPropertiesOverride.class,
         ActorClockControlledPropertiesOverride.class,
         IdleStrategyPropertiesOverride.class);


### PR DESCRIPTION
## Description

This PR adds the properties from section camunda.api.long-polling in unified config.

The legacy properties are:

zeebe.gateway.longPolling.enabled
zeebe.gateway.longPolling.timeout
zeebe.gateway.longPolling.probeTimeout
zeebe.gateway.longPolling.minEmptyResponses

The new properties are:

camunda.api.long-polling.enabled
camunda.api.long-polling.timeout
camunda.api.long-polling.probe-timeout
camunda.api.long-polling.min-empty-responses

Backwards compatibility is supported for these properties. That means, if legacy is set and new property is not set, legacy value will be used.

## Checklist

- [x] The legacy properties and the backwards compatibility strategy are updated in [schema doc](https://docs.google.com/spreadsheets/d/1R4epsy6DWemA8_76cUE6zOGUFbrXCXlM2reXnKFuz7Y/edit?gid=818158292#gid=818158292)
- [x] The new property fields are documented in the code