### PR TITLE
ci: perform mvn release:clean before release:prepare

### DIFF
--- a/.github/workflows/optimize-release-optimize-c8-only.yml
+++ b/.github/workflows/optimize-release-optimize-c8-only.yml
@@ -199,6 +199,10 @@ jobs:
           git config --global user.name "github-actions[release]"
           git config --global user.email "github-actions[release]@users.noreply.github.com"
 
+      - name: Clean Release
+        run: |
+          mvn release:clean
+
       - name: Prepare release
         run: |
           ./mvnw -f optimize \


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
wip

inspiration from https://stackoverflow.com/questions/20213557/maven-release-plugin-tag-already-exists-for-nonexistant-tag

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
