### PR TITLE
fix: improve logging for opensearch error causes

### DIFF
--- a/operate/schema/src/main/java/io/camunda/operate/store/opensearch/client/sync/OpenSearchDocumentOperations.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/opensearch/client/sync/OpenSearchDocumentOperations.java
@@ -30,6 +30,7 @@ import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import org.opensearch.client.opensearch.OpenSearchClient;
+import org.opensearch.client.opensearch._types.ErrorCause;
 import org.opensearch.client.opensearch._types.Result;
 import org.opensearch.client.opensearch._types.ShardFailure;
 import org.opensearch.client.opensearch._types.aggregations.Aggregate;
@@ -96,7 +97,26 @@ public class OpenSearchDocumentOperations extends OpenSearchRetryOperation {
   private String formatShardFailure(final ShardFailure failure) {
     return String.format(
         "ShardFailure[index=%s, shard=%s, status=%s, node=%s, reason=%s]",
-        failure.index(), failure.shard(), failure.status(), failure.node(), failure.reason());
+        failure.index(),
+        failure.shard(),
+        failure.status(),
+        failure.node(),
+        formatErrorCause(failure.reason()));
+  }
+
+  private String formatErrorCause(final ErrorCause errorCause) {
+    if (errorCause == null) {
+      return "";
+    }
+    final StringBuilder details = new StringBuilder();
+    details.append("type=").append(errorCause.type());
+    if (errorCause.reason() != null) {
+      details.append(", reason=").append(errorCause.reason());
+    }
+    if (errorCause.causedBy() != null) {
+      details.append(", causedBy=[").append(formatErrorCause(errorCause.causedBy())).append("]");
+    }
+    return details.toString();
   }
 
   public <R> Map<String, Aggregate> unsafeScrollWith(

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/os/client/sync/OpenSearchDocumentOperations.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/os/client/sync/OpenSearchDocumentOperations.java
@@ -32,6 +32,7 @@ import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import org.opensearch.client.opensearch.OpenSearchClient;
+import org.opensearch.client.opensearch._types.ErrorCause;
 import org.opensearch.client.opensearch._types.OpenSearchException;
 import org.opensearch.client.opensearch._types.Script;
 import org.opensearch.client.opensearch._types.ShardFailure;
@@ -112,7 +113,26 @@ public class OpenSearchDocumentOperations extends OpenSearchRetryOperation {
   private String formatShardFailure(final ShardFailure failure) {
     return String.format(
         "ShardFailure[index=%s, shard=%s, status=%s, node=%s, reason=%s]",
-        failure.index(), failure.shard(), failure.status(), failure.node(), failure.reason());
+        failure.index(),
+        failure.shard(),
+        failure.status(),
+        failure.node(),
+        formatErrorCause(failure.reason()));
+  }
+
+  private String formatErrorCause(final ErrorCause errorCause) {
+    if (errorCause == null) {
+      return "";
+    }
+    final StringBuilder details = new StringBuilder();
+    details.append("type=").append(errorCause.type());
+    if (errorCause.reason() != null) {
+      details.append(", reason=").append(errorCause.reason());
+    }
+    if (errorCause.causedBy() != null) {
+      details.append(", causedBy=[").append(formatErrorCause(errorCause.causedBy())).append("]");
+    }
+    return details.toString();
   }
 
   public <R> Map<String, Aggregate> unsafeScrollWith(


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

`ErrorCause` has no `toString()` implementation, but can still provide valuable debugging information. This PR extracts the useful properties so we can still log error messages/causes

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
