### PR TITLE
feat: add the batch operation to history cleanup service in rdbms

### DIFF
--- a/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.8.0.xml
+++ b/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.8.0.xml
@@ -486,6 +486,7 @@
       <column name="OPERATIONS_TOTAL_COUNT" type="INT"/>
       <column name="OPERATIONS_FAILED_COUNT" type="INT"/>
       <column name="OPERATIONS_COMPLETED_COUNT" type="INT"/>
+      <column name="HISTORY_CLEANUP_DATE" type="TIMESTAMP WITH TIME ZONE(3)" />
     </createTable>
 
     <createTable tableName="${prefix}BATCH_OPERATION_ITEM">

--- a/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.8.0.xml
+++ b/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.8.0.xml
@@ -506,6 +506,7 @@
       <column name="PROCESSED_DATE" type="TIMESTAMP WITH TIME ZONE(3)"/>
       <column name="ERROR_MESSAGE" type="VARCHAR(4000)"/>
       <column name="STATE" type="VARCHAR(20)" defaultValue="ACTIVE"/>
+      <column name="HISTORY_CLEANUP_DATE" type="TIMESTAMP WITH TIME ZONE(3)" />
     </createTable>
 
     <createTable tableName="${prefix}BATCH_OPERATION_ERROR">

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/BatchOperationMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/BatchOperationMapper.java
@@ -20,7 +20,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public interface BatchOperationMapper {
+public interface BatchOperationMapper extends HistoryCleanupMapper {
 
   void insert(BatchOperationDbModel batchOperationDbModel);
 
@@ -45,6 +45,16 @@ public interface BatchOperationMapper {
   Long countItems(BatchOperationItemDbQuery query);
 
   List<BatchOperationItemEntity> searchItems(BatchOperationItemDbQuery query);
+
+  int updateHistoryCleanupDate(UpdateHistoryCleanupDateDto dto);
+
+  int cleanupHistory(CleanupBatchOperationHistoryDto dto);
+
+  int cleanupItemHistory(CleanupBatchOperationHistoryDto dto);
+
+  record CleanupBatchOperationHistoryDto(OffsetDateTime cleanupDate, int limit) {}
+
+  record UpdateHistoryCleanupDateDto(String batchOperationKey, OffsetDateTime historyCleanupDate) {}
 
   record BatchOperationUpdateDto(
       String batchOperationKey, BatchOperationState state, OffsetDateTime endDate) {}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriter.java
@@ -9,6 +9,7 @@ package io.camunda.db.rdbms.write;
 
 import io.camunda.db.rdbms.config.VendorDatabaseProperties;
 import io.camunda.db.rdbms.read.service.BatchOperationDbReader;
+import io.camunda.db.rdbms.sql.BatchOperationMapper;
 import io.camunda.db.rdbms.sql.DecisionInstanceMapper;
 import io.camunda.db.rdbms.sql.FlowNodeInstanceMapper;
 import io.camunda.db.rdbms.sql.IncidentMapper;
@@ -92,7 +93,8 @@ public class RdbmsWriter {
       final JobMapper jobMapper,
       final SequenceFlowMapper sequenceFlowMapper,
       final UsageMetricMapper usageMetricMapper,
-      final UsageMetricTUMapper usageMetricTUMapper) {
+      final UsageMetricTUMapper usageMetricTUMapper,
+      final BatchOperationMapper batchOperationMapper) {
     this.executionQueue = executionQueue;
     this.exporterPositionService = exporterPositionService;
     rdbmsPurger = new RdbmsPurger(purgeMapper, vendorDatabaseProperties);
@@ -116,7 +118,11 @@ public class RdbmsWriter {
     mappingRuleWriter = new MappingRuleWriter(executionQueue);
     batchOperationWriter =
         new BatchOperationWriter(
-            batchOperationReader, executionQueue, config, vendorDatabaseProperties);
+            batchOperationReader,
+            executionQueue,
+            batchOperationMapper,
+            config,
+            vendorDatabaseProperties);
     jobWriter = new JobWriter(executionQueue, jobMapper, vendorDatabaseProperties);
     sequenceFlowWriter = new SequenceFlowWriter(executionQueue, sequenceFlowMapper);
     usageMetricWriter = new UsageMetricWriter(executionQueue, usageMetricMapper);
@@ -133,6 +139,7 @@ public class RdbmsWriter {
             decisionInstanceWriter,
             jobWriter,
             sequenceFlowWriter,
+            batchOperationWriter,
             metrics);
   }
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriterConfig.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriterConfig.java
@@ -14,10 +14,10 @@ public record RdbmsWriterConfig(
     int partitionId,
     int queueSize,
     Duration defaultHistoryTTL,
-    Duration cancelProcessInstanceHistoryTTL,
-    Duration migrateProcessInstanceHistoryTTL,
-    Duration modifyProcessInstanceHistoryTTL,
-    Duration resolveIncidentHistoryTTL,
+    Duration batchOperationCancelProcessInstanceHistoryTTL,
+    Duration batchOperationMigrateProcessInstanceHistoryTTL,
+    Duration batchOperationModifyProcessInstanceHistoryTTL,
+    Duration batchOperationResolveIncidentHistoryTTL,
     Duration minHistoryCleanupInterval,
     Duration maxHistoryCleanupInterval,
     int historyCleanupBatchSize,
@@ -50,10 +50,13 @@ public record RdbmsWriterConfig(
     private int partitionId;
     private int queueSize = DEFAULT_QUEUE_SIZE;
     private Duration defaultHistoryTTL = DEFAULT_HISTORY_TTL;
-    private Duration cancelProcessInstanceHistoryTTL = DEFAULT_BATCH_OPERATION_HISTORY_TTL;
-    private Duration migrateProcessInstanceHistoryTTL = DEFAULT_BATCH_OPERATION_HISTORY_TTL;
-    private Duration modifyProcessInstanceHistoryTTL = DEFAULT_BATCH_OPERATION_HISTORY_TTL;
-    private Duration resolveIncidentHistoryTTL = DEFAULT_BATCH_OPERATION_HISTORY_TTL;
+    private Duration batchOperationCancelProcessInstanceHistoryTTL =
+        DEFAULT_BATCH_OPERATION_HISTORY_TTL;
+    private Duration batchOperationMigrateProcessInstanceHistoryTTL =
+        DEFAULT_BATCH_OPERATION_HISTORY_TTL;
+    private Duration batchOperationModifyProcessInstanceHistoryTTL =
+        DEFAULT_BATCH_OPERATION_HISTORY_TTL;
+    private Duration batchOperationResolveIncidentHistoryTTL = DEFAULT_BATCH_OPERATION_HISTORY_TTL;
     private Duration minHistoryCleanupInterval = DEFAULT_MIN_HISTORY_CLEANUP_INTERVAL;
     private Duration maxHistoryCleanupInterval = DEFAULT_MAX_HISTORY_CLEANUP_INTERVAL;
     private int historyCleanupBatchSize = DEFAULT_HISTORY_CLEANUP_BATCH_SIZE;
@@ -76,24 +79,30 @@ public record RdbmsWriterConfig(
       return this;
     }
 
-    public Builder cancelProcessInstanceHistoryTTL(final Duration cancelProcessInstanceHistoryTTL) {
-      this.cancelProcessInstanceHistoryTTL = cancelProcessInstanceHistoryTTL;
+    public Builder batchOperationCancelProcessInstanceHistoryTTL(
+        final Duration batchOperationCancelProcessInstanceHistoryTTL) {
+      this.batchOperationCancelProcessInstanceHistoryTTL =
+          batchOperationCancelProcessInstanceHistoryTTL;
       return this;
     }
 
-    public Builder migrateProcessInstanceHistoryTTL(
-        final Duration migrateProcessInstanceHistoryTTL) {
-      this.migrateProcessInstanceHistoryTTL = migrateProcessInstanceHistoryTTL;
+    public Builder batchOperationMigrateProcessInstanceHistoryTTL(
+        final Duration batchOperationMigrateProcessInstanceHistoryTTL) {
+      this.batchOperationMigrateProcessInstanceHistoryTTL =
+          batchOperationMigrateProcessInstanceHistoryTTL;
       return this;
     }
 
-    public Builder modifyProcessInstanceHistoryTTL(final Duration modifyProcessInstanceHistoryTTL) {
-      this.modifyProcessInstanceHistoryTTL = modifyProcessInstanceHistoryTTL;
+    public Builder batchOperationModifyProcessInstanceHistoryTTL(
+        final Duration batchOperationModifyProcessInstanceHistoryTTL) {
+      this.batchOperationModifyProcessInstanceHistoryTTL =
+          batchOperationModifyProcessInstanceHistoryTTL;
       return this;
     }
 
-    public Builder resolveIncidentHistoryTTL(final Duration resolveIncidentHistoryTTL) {
-      this.resolveIncidentHistoryTTL = resolveIncidentHistoryTTL;
+    public Builder batchOperationResolveIncidentHistoryTTL(
+        final Duration batchOperationResolveIncidentHistoryTTL) {
+      this.batchOperationResolveIncidentHistoryTTL = batchOperationResolveIncidentHistoryTTL;
       return this;
     }
 
@@ -129,10 +138,10 @@ public record RdbmsWriterConfig(
           partitionId,
           queueSize,
           defaultHistoryTTL,
-          cancelProcessInstanceHistoryTTL,
-          migrateProcessInstanceHistoryTTL,
-          modifyProcessInstanceHistoryTTL,
-          resolveIncidentHistoryTTL,
+          batchOperationCancelProcessInstanceHistoryTTL,
+          batchOperationMigrateProcessInstanceHistoryTTL,
+          batchOperationModifyProcessInstanceHistoryTTL,
+          batchOperationResolveIncidentHistoryTTL,
           minHistoryCleanupInterval,
           maxHistoryCleanupInterval,
           historyCleanupBatchSize,

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriterConfig.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriterConfig.java
@@ -13,14 +13,6 @@ import java.time.Duration;
 public record RdbmsWriterConfig(
     int partitionId,
     int queueSize,
-    Duration defaultHistoryTTL,
-    Duration batchOperationCancelProcessInstanceHistoryTTL,
-    Duration batchOperationMigrateProcessInstanceHistoryTTL,
-    Duration batchOperationModifyProcessInstanceHistoryTTL,
-    Duration batchOperationResolveIncidentHistoryTTL,
-    Duration minHistoryCleanupInterval,
-    Duration maxHistoryCleanupInterval,
-    int historyCleanupBatchSize,
     /*
      * The number of batch operation items to insert in a single insert statement.
      */
@@ -30,14 +22,10 @@ public record RdbmsWriterConfig(
      * <code>false</code>, the batch operation items will be exported only when they have been
      * processed and are completed or failed.
      */
-    boolean exportBatchOperationItemsOnCreation) {
+    boolean exportBatchOperationItemsOnCreation,
+    HistoryConfig historyConfig) {
 
   public static final int DEFAULT_QUEUE_SIZE = 1000;
-  public static final Duration DEFAULT_HISTORY_TTL = Duration.ofDays(30);
-  public static final Duration DEFAULT_BATCH_OPERATION_HISTORY_TTL = Duration.ofDays(5);
-  public static final Duration DEFAULT_MIN_HISTORY_CLEANUP_INTERVAL = Duration.ofMinutes(1);
-  public static final Duration DEFAULT_MAX_HISTORY_CLEANUP_INTERVAL = Duration.ofMinutes(60);
-  public static final int DEFAULT_HISTORY_CLEANUP_BATCH_SIZE = 1000;
   public static final int DEFAULT_BATCH_OPERATION_ITEM_INSERT_BLOCK_SIZE = 10000;
   public static final boolean DEFAULT_EXPORT_BATCH_OPERATION_ITEMS_ON_CREATION = true;
 
@@ -49,20 +37,10 @@ public record RdbmsWriterConfig(
 
     private int partitionId;
     private int queueSize = DEFAULT_QUEUE_SIZE;
-    private Duration defaultHistoryTTL = DEFAULT_HISTORY_TTL;
-    private Duration batchOperationCancelProcessInstanceHistoryTTL =
-        DEFAULT_BATCH_OPERATION_HISTORY_TTL;
-    private Duration batchOperationMigrateProcessInstanceHistoryTTL =
-        DEFAULT_BATCH_OPERATION_HISTORY_TTL;
-    private Duration batchOperationModifyProcessInstanceHistoryTTL =
-        DEFAULT_BATCH_OPERATION_HISTORY_TTL;
-    private Duration batchOperationResolveIncidentHistoryTTL = DEFAULT_BATCH_OPERATION_HISTORY_TTL;
-    private Duration minHistoryCleanupInterval = DEFAULT_MIN_HISTORY_CLEANUP_INTERVAL;
-    private Duration maxHistoryCleanupInterval = DEFAULT_MAX_HISTORY_CLEANUP_INTERVAL;
-    private int historyCleanupBatchSize = DEFAULT_HISTORY_CLEANUP_BATCH_SIZE;
     private int batchOperationItemInsertBlockSize = DEFAULT_BATCH_OPERATION_ITEM_INSERT_BLOCK_SIZE;
     private boolean exportBatchOperationItemsOnCreation =
         DEFAULT_EXPORT_BATCH_OPERATION_ITEMS_ON_CREATION;
+    private HistoryConfig historyConfig = new HistoryConfig.Builder().build();
 
     public Builder partitionId(final int partitionId) {
       this.partitionId = partitionId;
@@ -71,53 +49,6 @@ public record RdbmsWriterConfig(
 
     public Builder queueSize(final int queueSize) {
       this.queueSize = queueSize;
-      return this;
-    }
-
-    public Builder defaultHistoryTTL(final Duration defaultHistoryTTL) {
-      this.defaultHistoryTTL = defaultHistoryTTL;
-      return this;
-    }
-
-    public Builder batchOperationCancelProcessInstanceHistoryTTL(
-        final Duration batchOperationCancelProcessInstanceHistoryTTL) {
-      this.batchOperationCancelProcessInstanceHistoryTTL =
-          batchOperationCancelProcessInstanceHistoryTTL;
-      return this;
-    }
-
-    public Builder batchOperationMigrateProcessInstanceHistoryTTL(
-        final Duration batchOperationMigrateProcessInstanceHistoryTTL) {
-      this.batchOperationMigrateProcessInstanceHistoryTTL =
-          batchOperationMigrateProcessInstanceHistoryTTL;
-      return this;
-    }
-
-    public Builder batchOperationModifyProcessInstanceHistoryTTL(
-        final Duration batchOperationModifyProcessInstanceHistoryTTL) {
-      this.batchOperationModifyProcessInstanceHistoryTTL =
-          batchOperationModifyProcessInstanceHistoryTTL;
-      return this;
-    }
-
-    public Builder batchOperationResolveIncidentHistoryTTL(
-        final Duration batchOperationResolveIncidentHistoryTTL) {
-      this.batchOperationResolveIncidentHistoryTTL = batchOperationResolveIncidentHistoryTTL;
-      return this;
-    }
-
-    public Builder minHistoryCleanupInterval(final Duration minHistoryCleanupInterval) {
-      this.minHistoryCleanupInterval = minHistoryCleanupInterval;
-      return this;
-    }
-
-    public Builder maxHistoryCleanupInterval(final Duration maxHistoryCleanupInterval) {
-      this.maxHistoryCleanupInterval = maxHistoryCleanupInterval;
-      return this;
-    }
-
-    public Builder historyCleanupBatchSize(final int historyCleanupBatchSize) {
-      this.historyCleanupBatchSize = historyCleanupBatchSize;
       return this;
     }
 
@@ -132,21 +63,118 @@ public record RdbmsWriterConfig(
       return this;
     }
 
+    public Builder historyConfig(final HistoryConfig historyConfig) {
+      this.historyConfig = historyConfig;
+      return this;
+    }
+
     @Override
     public RdbmsWriterConfig build() {
       return new RdbmsWriterConfig(
           partitionId,
           queueSize,
-          defaultHistoryTTL,
-          batchOperationCancelProcessInstanceHistoryTTL,
-          batchOperationMigrateProcessInstanceHistoryTTL,
-          batchOperationModifyProcessInstanceHistoryTTL,
-          batchOperationResolveIncidentHistoryTTL,
-          minHistoryCleanupInterval,
-          maxHistoryCleanupInterval,
-          historyCleanupBatchSize,
           batchOperationItemInsertBlockSize,
-          exportBatchOperationItemsOnCreation);
+          exportBatchOperationItemsOnCreation,
+          historyConfig);
+    }
+  }
+
+  public record HistoryConfig(
+      Duration defaultHistoryTTL,
+      Duration batchOperationCancelProcessInstanceHistoryTTL,
+      Duration batchOperationMigrateProcessInstanceHistoryTTL,
+      Duration batchOperationModifyProcessInstanceHistoryTTL,
+      Duration batchOperationResolveIncidentHistoryTTL,
+      Duration minHistoryCleanupInterval,
+      Duration maxHistoryCleanupInterval,
+      int historyCleanupBatchSize) {
+
+    public static final Duration DEFAULT_HISTORY_TTL = Duration.ofDays(30);
+    public static final Duration DEFAULT_BATCH_OPERATION_HISTORY_TTL = Duration.ofDays(5);
+    public static final Duration DEFAULT_MIN_HISTORY_CLEANUP_INTERVAL = Duration.ofMinutes(1);
+    public static final Duration DEFAULT_MAX_HISTORY_CLEANUP_INTERVAL = Duration.ofMinutes(60);
+    public static final int DEFAULT_HISTORY_CLEANUP_BATCH_SIZE = 1000;
+
+    public static RdbmsWriterConfig.Builder builder() {
+      return new RdbmsWriterConfig.Builder();
+    }
+
+    public static class Builder implements ObjectBuilder<HistoryConfig> {
+
+      private Duration defaultHistoryTTL = DEFAULT_HISTORY_TTL;
+      private Duration batchOperationCancelProcessInstanceHistoryTTL =
+          DEFAULT_BATCH_OPERATION_HISTORY_TTL;
+      private Duration batchOperationMigrateProcessInstanceHistoryTTL =
+          DEFAULT_BATCH_OPERATION_HISTORY_TTL;
+      private Duration batchOperationModifyProcessInstanceHistoryTTL =
+          DEFAULT_BATCH_OPERATION_HISTORY_TTL;
+      private Duration batchOperationResolveIncidentHistoryTTL =
+          DEFAULT_BATCH_OPERATION_HISTORY_TTL;
+      private Duration minHistoryCleanupInterval = DEFAULT_MIN_HISTORY_CLEANUP_INTERVAL;
+      private Duration maxHistoryCleanupInterval = DEFAULT_MAX_HISTORY_CLEANUP_INTERVAL;
+      private int historyCleanupBatchSize = DEFAULT_HISTORY_CLEANUP_BATCH_SIZE;
+
+      public HistoryConfig.Builder defaultHistoryTTL(final Duration defaultHistoryTTL) {
+        this.defaultHistoryTTL = defaultHistoryTTL;
+        return this;
+      }
+
+      public HistoryConfig.Builder batchOperationCancelProcessInstanceHistoryTTL(
+          final Duration batchOperationCancelProcessInstanceHistoryTTL) {
+        this.batchOperationCancelProcessInstanceHistoryTTL =
+            batchOperationCancelProcessInstanceHistoryTTL;
+        return this;
+      }
+
+      public HistoryConfig.Builder batchOperationMigrateProcessInstanceHistoryTTL(
+          final Duration batchOperationMigrateProcessInstanceHistoryTTL) {
+        this.batchOperationMigrateProcessInstanceHistoryTTL =
+            batchOperationMigrateProcessInstanceHistoryTTL;
+        return this;
+      }
+
+      public HistoryConfig.Builder batchOperationModifyProcessInstanceHistoryTTL(
+          final Duration batchOperationModifyProcessInstanceHistoryTTL) {
+        this.batchOperationModifyProcessInstanceHistoryTTL =
+            batchOperationModifyProcessInstanceHistoryTTL;
+        return this;
+      }
+
+      public HistoryConfig.Builder batchOperationResolveIncidentHistoryTTL(
+          final Duration batchOperationResolveIncidentHistoryTTL) {
+        this.batchOperationResolveIncidentHistoryTTL = batchOperationResolveIncidentHistoryTTL;
+        return this;
+      }
+
+      public HistoryConfig.Builder minHistoryCleanupInterval(
+          final Duration minHistoryCleanupInterval) {
+        this.minHistoryCleanupInterval = minHistoryCleanupInterval;
+        return this;
+      }
+
+      public HistoryConfig.Builder maxHistoryCleanupInterval(
+          final Duration maxHistoryCleanupInterval) {
+        this.maxHistoryCleanupInterval = maxHistoryCleanupInterval;
+        return this;
+      }
+
+      public HistoryConfig.Builder historyCleanupBatchSize(final int historyCleanupBatchSize) {
+        this.historyCleanupBatchSize = historyCleanupBatchSize;
+        return this;
+      }
+
+      @Override
+      public HistoryConfig build() {
+        return new HistoryConfig(
+            defaultHistoryTTL,
+            batchOperationCancelProcessInstanceHistoryTTL,
+            batchOperationMigrateProcessInstanceHistoryTTL,
+            batchOperationModifyProcessInstanceHistoryTTL,
+            batchOperationResolveIncidentHistoryTTL,
+            minHistoryCleanupInterval,
+            maxHistoryCleanupInterval,
+            historyCleanupBatchSize);
+      }
     }
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriterConfig.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriterConfig.java
@@ -23,7 +23,7 @@ public record RdbmsWriterConfig(
      * processed and are completed or failed.
      */
     boolean exportBatchOperationItemsOnCreation,
-    HistoryConfig historyConfig) {
+    HistoryConfig history) {
 
   public static final int DEFAULT_QUEUE_SIZE = 1000;
   public static final int DEFAULT_BATCH_OPERATION_ITEM_INSERT_BLOCK_SIZE = 10000;
@@ -40,7 +40,7 @@ public record RdbmsWriterConfig(
     private int batchOperationItemInsertBlockSize = DEFAULT_BATCH_OPERATION_ITEM_INSERT_BLOCK_SIZE;
     private boolean exportBatchOperationItemsOnCreation =
         DEFAULT_EXPORT_BATCH_OPERATION_ITEMS_ON_CREATION;
-    private HistoryConfig historyConfig = new HistoryConfig.Builder().build();
+    private HistoryConfig history = new HistoryConfig.Builder().build();
 
     public Builder partitionId(final int partitionId) {
       this.partitionId = partitionId;
@@ -63,8 +63,8 @@ public record RdbmsWriterConfig(
       return this;
     }
 
-    public Builder historyConfig(final HistoryConfig historyConfig) {
-      this.historyConfig = historyConfig;
+    public Builder history(final HistoryConfig history) {
+      this.history = history;
       return this;
     }
 
@@ -75,7 +75,7 @@ public record RdbmsWriterConfig(
           queueSize,
           batchOperationItemInsertBlockSize,
           exportBatchOperationItemsOnCreation,
-          historyConfig);
+          history);
     }
   }
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriterConfig.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriterConfig.java
@@ -14,6 +14,10 @@ public record RdbmsWriterConfig(
     int partitionId,
     int queueSize,
     Duration defaultHistoryTTL,
+    Duration cancelProcessInstanceHistoryTTL,
+    Duration migrateProcessInstanceHistoryTTL,
+    Duration modifyProcessInstanceHistoryTTL,
+    Duration resolveIncidentHistoryTTL,
     Duration minHistoryCleanupInterval,
     Duration maxHistoryCleanupInterval,
     int historyCleanupBatchSize,
@@ -30,6 +34,7 @@ public record RdbmsWriterConfig(
 
   public static final int DEFAULT_QUEUE_SIZE = 1000;
   public static final Duration DEFAULT_HISTORY_TTL = Duration.ofDays(30);
+  public static final Duration DEFAULT_BATCH_OPERATION_HISTORY_TTL = Duration.ofDays(5);
   public static final Duration DEFAULT_MIN_HISTORY_CLEANUP_INTERVAL = Duration.ofMinutes(1);
   public static final Duration DEFAULT_MAX_HISTORY_CLEANUP_INTERVAL = Duration.ofMinutes(60);
   public static final int DEFAULT_HISTORY_CLEANUP_BATCH_SIZE = 1000;
@@ -45,6 +50,10 @@ public record RdbmsWriterConfig(
     private int partitionId;
     private int queueSize = DEFAULT_QUEUE_SIZE;
     private Duration defaultHistoryTTL = DEFAULT_HISTORY_TTL;
+    private Duration cancelProcessInstanceHistoryTTL = DEFAULT_BATCH_OPERATION_HISTORY_TTL;
+    private Duration migrateProcessInstanceHistoryTTL = DEFAULT_BATCH_OPERATION_HISTORY_TTL;
+    private Duration modifyProcessInstanceHistoryTTL = DEFAULT_BATCH_OPERATION_HISTORY_TTL;
+    private Duration resolveIncidentHistoryTTL = DEFAULT_BATCH_OPERATION_HISTORY_TTL;
     private Duration minHistoryCleanupInterval = DEFAULT_MIN_HISTORY_CLEANUP_INTERVAL;
     private Duration maxHistoryCleanupInterval = DEFAULT_MAX_HISTORY_CLEANUP_INTERVAL;
     private int historyCleanupBatchSize = DEFAULT_HISTORY_CLEANUP_BATCH_SIZE;
@@ -64,6 +73,27 @@ public record RdbmsWriterConfig(
 
     public Builder defaultHistoryTTL(final Duration defaultHistoryTTL) {
       this.defaultHistoryTTL = defaultHistoryTTL;
+      return this;
+    }
+
+    public Builder cancelProcessInstanceHistoryTTL(final Duration cancelProcessInstanceHistoryTTL) {
+      this.cancelProcessInstanceHistoryTTL = cancelProcessInstanceHistoryTTL;
+      return this;
+    }
+
+    public Builder migrateProcessInstanceHistoryTTL(
+        final Duration migrateProcessInstanceHistoryTTL) {
+      this.migrateProcessInstanceHistoryTTL = migrateProcessInstanceHistoryTTL;
+      return this;
+    }
+
+    public Builder modifyProcessInstanceHistoryTTL(final Duration modifyProcessInstanceHistoryTTL) {
+      this.modifyProcessInstanceHistoryTTL = modifyProcessInstanceHistoryTTL;
+      return this;
+    }
+
+    public Builder resolveIncidentHistoryTTL(final Duration resolveIncidentHistoryTTL) {
+      this.resolveIncidentHistoryTTL = resolveIncidentHistoryTTL;
       return this;
     }
 
@@ -99,6 +129,10 @@ public record RdbmsWriterConfig(
           partitionId,
           queueSize,
           defaultHistoryTTL,
+          cancelProcessInstanceHistoryTTL,
+          migrateProcessInstanceHistoryTTL,
+          modifyProcessInstanceHistoryTTL,
+          resolveIncidentHistoryTTL,
           minHistoryCleanupInterval,
           maxHistoryCleanupInterval,
           historyCleanupBatchSize,

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriterFactory.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriterFactory.java
@@ -9,6 +9,7 @@ package io.camunda.db.rdbms.write;
 
 import io.camunda.db.rdbms.config.VendorDatabaseProperties;
 import io.camunda.db.rdbms.read.service.BatchOperationDbReader;
+import io.camunda.db.rdbms.sql.BatchOperationMapper;
 import io.camunda.db.rdbms.sql.DecisionInstanceMapper;
 import io.camunda.db.rdbms.sql.ExporterPositionMapper;
 import io.camunda.db.rdbms.sql.FlowNodeInstanceMapper;
@@ -43,6 +44,7 @@ public class RdbmsWriterFactory {
   private final SequenceFlowMapper sequenceFlowMapper;
   private final UsageMetricMapper usageMetricMapper;
   private final UsageMetricTUMapper usageMetricTUMapper;
+  private final BatchOperationMapper batchOperationMapper;
 
   public RdbmsWriterFactory(
       final SqlSessionFactory sqlSessionFactory,
@@ -60,7 +62,8 @@ public class RdbmsWriterFactory {
       final JobMapper jobMapper,
       final SequenceFlowMapper sequenceFlowMapper,
       final UsageMetricMapper usageMetricMapper,
-      final UsageMetricTUMapper usageMetricTUMapper) {
+      final UsageMetricTUMapper usageMetricTUMapper,
+      final BatchOperationMapper batchOperationMapper) {
     this.sqlSessionFactory = sqlSessionFactory;
     this.exporterPositionMapper = exporterPositionMapper;
     this.vendorDatabaseProperties = vendorDatabaseProperties;
@@ -77,6 +80,7 @@ public class RdbmsWriterFactory {
     this.sequenceFlowMapper = sequenceFlowMapper;
     this.usageMetricMapper = usageMetricMapper;
     this.usageMetricTUMapper = usageMetricTUMapper;
+    this.batchOperationMapper = batchOperationMapper;
   }
 
   public RdbmsWriter createWriter(final RdbmsWriterConfig config) {
@@ -100,6 +104,7 @@ public class RdbmsWriterFactory {
         jobMapper,
         sequenceFlowMapper,
         usageMetricMapper,
-        usageMetricTUMapper);
+        usageMetricTUMapper,
+        batchOperationMapper);
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/HistoryCleanupService.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/HistoryCleanupService.java
@@ -58,19 +58,21 @@ public class HistoryCleanupService {
       final BatchOperationWriter batchOperationWriter,
       final RdbmsWriterMetrics metrics) {
     LOG.info(
-        "Creating HistoryCleanupService with default history ttl {}", config.defaultHistoryTTL());
+        "Creating HistoryCleanupService with default history ttl {}",
+        config.historyConfig().defaultHistoryTTL());
 
-    defaultHistoryTTL = config.defaultHistoryTTL();
+    defaultHistoryTTL = config.historyConfig().defaultHistoryTTL();
     batchOperationCancelProcessInstanceHistoryTTL =
-        config.batchOperationCancelProcessInstanceHistoryTTL();
+        config.historyConfig().batchOperationCancelProcessInstanceHistoryTTL();
     batchOperationMigrateProcessInstanceHistoryTTL =
-        config.batchOperationMigrateProcessInstanceHistoryTTL();
+        config.historyConfig().batchOperationMigrateProcessInstanceHistoryTTL();
     batchOperationModifyProcessInstanceHistoryTTL =
-        config.batchOperationModifyProcessInstanceHistoryTTL();
-    batchOperationResolveIncidentHistoryTTL = config.batchOperationResolveIncidentHistoryTTL();
-    minCleanupInterval = config.minHistoryCleanupInterval();
-    maxCleanupInterval = config.maxHistoryCleanupInterval();
-    cleanupBatchSize = config.historyCleanupBatchSize();
+        config.historyConfig().batchOperationModifyProcessInstanceHistoryTTL();
+    batchOperationResolveIncidentHistoryTTL =
+        config.historyConfig().batchOperationResolveIncidentHistoryTTL();
+    minCleanupInterval = config.historyConfig().minHistoryCleanupInterval();
+    maxCleanupInterval = config.historyConfig().maxHistoryCleanupInterval();
+    cleanupBatchSize = config.historyConfig().historyCleanupBatchSize();
     this.processInstanceWriter = processInstanceWriter;
     this.incidentWriter = incidentWriter;
     this.flowNodeInstanceWriter = flowNodeInstanceWriter;

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/HistoryCleanupService.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/HistoryCleanupService.java
@@ -23,10 +23,10 @@ public class HistoryCleanupService {
   private static final Logger LOG = LoggerFactory.getLogger(HistoryCleanupService.class);
 
   private final Duration defaultHistoryTTL;
-  private final Duration cancelProcessInstanceHistoryTTL;
-  private final Duration migrateProcessInstanceHistoryTTL;
-  private final Duration modifyProcessInstanceHistoryTTL;
-  private final Duration resolveIncidentHistoryTTL;
+  private final Duration batchOperationCancelProcessInstanceHistoryTTL;
+  private final Duration batchOperationMigrateProcessInstanceHistoryTTL;
+  private final Duration batchOperationModifyProcessInstanceHistoryTTL;
+  private final Duration batchOperationResolveIncidentHistoryTTL;
   private final Duration minCleanupInterval;
   private final Duration maxCleanupInterval;
   private final int cleanupBatchSize;
@@ -61,10 +61,13 @@ public class HistoryCleanupService {
         "Creating HistoryCleanupService with default history ttl {}", config.defaultHistoryTTL());
 
     defaultHistoryTTL = config.defaultHistoryTTL();
-    cancelProcessInstanceHistoryTTL = config.cancelProcessInstanceHistoryTTL();
-    migrateProcessInstanceHistoryTTL = config.migrateProcessInstanceHistoryTTL();
-    modifyProcessInstanceHistoryTTL = config.modifyProcessInstanceHistoryTTL();
-    resolveIncidentHistoryTTL = config.resolveIncidentHistoryTTL();
+    batchOperationCancelProcessInstanceHistoryTTL =
+        config.batchOperationCancelProcessInstanceHistoryTTL();
+    batchOperationMigrateProcessInstanceHistoryTTL =
+        config.batchOperationMigrateProcessInstanceHistoryTTL();
+    batchOperationModifyProcessInstanceHistoryTTL =
+        config.batchOperationModifyProcessInstanceHistoryTTL();
+    batchOperationResolveIncidentHistoryTTL = config.batchOperationResolveIncidentHistoryTTL();
     minCleanupInterval = config.minHistoryCleanupInterval();
     maxCleanupInterval = config.maxHistoryCleanupInterval();
     cleanupBatchSize = config.historyCleanupBatchSize();
@@ -116,10 +119,10 @@ public class HistoryCleanupService {
   @VisibleForTesting
   public Duration resolveBatchOperationTTL(final BatchOperationType type) {
     return switch (type) {
-      case CANCEL_PROCESS_INSTANCE -> cancelProcessInstanceHistoryTTL;
-      case MIGRATE_PROCESS_INSTANCE -> migrateProcessInstanceHistoryTTL;
-      case MODIFY_PROCESS_INSTANCE -> modifyProcessInstanceHistoryTTL;
-      case RESOLVE_INCIDENT -> resolveIncidentHistoryTTL;
+      case CANCEL_PROCESS_INSTANCE -> batchOperationCancelProcessInstanceHistoryTTL;
+      case MIGRATE_PROCESS_INSTANCE -> batchOperationMigrateProcessInstanceHistoryTTL;
+      case MODIFY_PROCESS_INSTANCE -> batchOperationModifyProcessInstanceHistoryTTL;
+      case RESOLVE_INCIDENT -> batchOperationResolveIncidentHistoryTTL;
       default -> defaultHistoryTTL;
     };
   }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/HistoryCleanupService.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/HistoryCleanupService.java
@@ -59,20 +59,20 @@ public class HistoryCleanupService {
       final RdbmsWriterMetrics metrics) {
     LOG.info(
         "Creating HistoryCleanupService with default history ttl {}",
-        config.historyConfig().defaultHistoryTTL());
+        config.history().defaultHistoryTTL());
 
-    defaultHistoryTTL = config.historyConfig().defaultHistoryTTL();
+    defaultHistoryTTL = config.history().defaultHistoryTTL();
     batchOperationCancelProcessInstanceHistoryTTL =
-        config.historyConfig().batchOperationCancelProcessInstanceHistoryTTL();
+        config.history().batchOperationCancelProcessInstanceHistoryTTL();
     batchOperationMigrateProcessInstanceHistoryTTL =
-        config.historyConfig().batchOperationMigrateProcessInstanceHistoryTTL();
+        config.history().batchOperationMigrateProcessInstanceHistoryTTL();
     batchOperationModifyProcessInstanceHistoryTTL =
-        config.historyConfig().batchOperationModifyProcessInstanceHistoryTTL();
+        config.history().batchOperationModifyProcessInstanceHistoryTTL();
     batchOperationResolveIncidentHistoryTTL =
-        config.historyConfig().batchOperationResolveIncidentHistoryTTL();
-    minCleanupInterval = config.historyConfig().minHistoryCleanupInterval();
-    maxCleanupInterval = config.historyConfig().maxHistoryCleanupInterval();
-    cleanupBatchSize = config.historyConfig().historyCleanupBatchSize();
+        config.history().batchOperationResolveIncidentHistoryTTL();
+    minCleanupInterval = config.history().minHistoryCleanupInterval();
+    maxCleanupInterval = config.history().maxHistoryCleanupInterval();
+    cleanupBatchSize = config.history().historyCleanupBatchSize();
     this.processInstanceWriter = processInstanceWriter;
     this.incidentWriter = incidentWriter;
     this.flowNodeInstanceWriter = flowNodeInstanceWriter;

--- a/db/rdbms/src/main/resources/mapper/BatchOperationMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/BatchOperationMapper.xml
@@ -349,17 +349,17 @@
   </sql>
   <sql id="historyCleanup" databaseId="oracle">
     DELETE
-    FROM ${prefix} ${tableName}
+    FROM ${prefix}${tableName}
     WHERE rowid IN (SELECT rowid
-                    FROM ${prefix} ${tableName}
+                    FROM ${prefix}${tableName}
                     WHERE HISTORY_CLEANUP_DATE &lt; #{cleanupDate}
                       AND ROWNUM &lt;= #{limit})
   </sql>
   <sql id="historyCleanup" databaseId="postgresql">
     DELETE
-    FROM ${prefix} ${tableName}
+    FROM ${prefix}${tableName}
     WHERE ctid IN (SELECT ctid
-                   FROM ${prefix} ${tableName}
+                   FROM ${prefix}${tableName}
                    WHERE HISTORY_CLEANUP_DATE &lt; #{cleanupDate}
       LIMIT #{limit})
   </sql>

--- a/db/rdbms/src/main/resources/mapper/BatchOperationMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/BatchOperationMapper.xml
@@ -319,4 +319,49 @@
     </if>
   </sql>
 
+  <update id="updateHistoryCleanupDate">
+    UPDATE ${prefix}BATCH_OPERATION
+    SET HISTORY_CLEANUP_DATE = #{historyCleanupDate, jdbcType=TIMESTAMP}
+    WHERE BATCH_OPERATION_KEY = #{batchOperationKey}
+  </update>
+
+  <update id="updateItemHistoryCleanupDate">
+    UPDATE ${prefix}BATCH_OPERATION_ITEM
+    SET HISTORY_CLEANUP_DATE = #{historyCleanupDate, jdbcType=TIMESTAMP}
+    WHERE BATCH_OPERATION_KEY = #{batchOperationKey}
+  </update>
+
+  <delete id="cleanupHistory">
+    <bind name="tableName" value="'BATCH_OPERATION'"/>
+    <include refid="historyCleanup"/>
+  </delete>
+
+  <delete id="cleanupItemHistory">
+    <bind name="tableName" value="'BATCH_OPERATION_ITEM'"/>
+    <include refid="historyCleanup"/>
+  </delete>
+
+  <sql id="historyCleanup">
+    DELETE
+    FROM ${prefix}${tableName}
+    WHERE HISTORY_CLEANUP_DATE &lt; #{cleanupDate}
+      LIMIT #{limit}
+  </sql>
+  <sql id="historyCleanup" databaseId="oracle">
+    DELETE
+    FROM ${prefix} ${tableName}
+    WHERE rowid IN (SELECT rowid
+                    FROM ${prefix} ${tableName}
+                    WHERE HISTORY_CLEANUP_DATE &lt; #{cleanupDate}
+                      AND ROWNUM &lt;= #{limit})
+  </sql>
+  <sql id="historyCleanup" databaseId="postgresql">
+    DELETE
+    FROM ${prefix} ${tableName}
+    WHERE ctid IN (SELECT ctid
+                   FROM ${prefix} ${tableName}
+                   WHERE HISTORY_CLEANUP_DATE &lt; #{cleanupDate}
+      LIMIT #{limit})
+  </sql>
+
 </mapper>

--- a/db/rdbms/src/main/resources/mapper/Commons.xml
+++ b/db/rdbms/src/main/resources/mapper/Commons.xml
@@ -176,18 +176,18 @@
   </sql>
   <sql id="historyCleanup" databaseId="oracle">
     DELETE
-    FROM ${prefix} ${tableName}
+    FROM ${prefix}${tableName}
     WHERE rowid IN (SELECT rowid
-                    FROM ${prefix} ${tableName}
+                    FROM ${prefix}${tableName}
                     WHERE PARTITION_ID = #{partitionId}
                       AND HISTORY_CLEANUP_DATE &lt; #{cleanupDate}
                       AND ROWNUM &lt;= #{limit})
   </sql>
   <sql id="historyCleanup" databaseId="postgresql">
     DELETE
-    FROM ${prefix} ${tableName}
+    FROM ${prefix}${tableName}
     WHERE ctid IN (SELECT ctid
-                   FROM ${prefix} ${tableName}
+                   FROM ${prefix}${tableName}
                    WHERE PARTITION_ID = #{partitionId}
                      AND HISTORY_CLEANUP_DATE &lt; #{cleanupDate}
                    LIMIT #{limit})

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/write/service/BatchOperationWriterTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/write/service/BatchOperationWriterTest.java
@@ -10,6 +10,7 @@ package io.camunda.db.rdbms.write.service;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.db.rdbms.config.VendorDatabaseProperties;
+import io.camunda.db.rdbms.sql.BatchOperationMapper;
 import io.camunda.db.rdbms.sql.BatchOperationMapper.BatchOperationItemsDto;
 import io.camunda.db.rdbms.write.RdbmsWriterConfig;
 import io.camunda.db.rdbms.write.domain.BatchOperationItemDbModel;
@@ -27,10 +28,13 @@ class BatchOperationWriterTest {
   private final ExecutionQueue executionQueue = Mockito.mock(ExecutionQueue.class);
   private final VendorDatabaseProperties vendorDatabaseProperties =
       Mockito.mock(VendorDatabaseProperties.class);
+  private final BatchOperationMapper batchOperationMapper =
+      Mockito.mock(BatchOperationMapper.class);
   private final BatchOperationWriter batchOperationWriter =
       new BatchOperationWriter(
           null,
           executionQueue,
+          batchOperationMapper,
           RdbmsWriterConfig.builder().batchOperationItemInsertBlockSize(10).build(),
           vendorDatabaseProperties);
 

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/write/service/HistoryCleanupServiceTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/write/service/HistoryCleanupServiceTest.java
@@ -66,14 +66,19 @@ class HistoryCleanupServiceTest {
     when(batchOperationWriter.cleanupItemHistory(any(), anyInt())).thenReturn(0);
     when(batchOperationWriter.cleanupHistory(any(), anyInt())).thenReturn(0);
 
-    when(config.defaultHistoryTTL()).thenReturn(Duration.ofDays(90));
-    when(config.batchOperationCancelProcessInstanceHistoryTTL()).thenReturn(Duration.ofDays(2));
-    when(config.batchOperationMigrateProcessInstanceHistoryTTL()).thenReturn(Duration.ofDays(3));
-    when(config.batchOperationModifyProcessInstanceHistoryTTL()).thenReturn(Duration.ofDays(4));
-    when(config.batchOperationResolveIncidentHistoryTTL()).thenReturn(Duration.ofDays(5));
-    when(config.minHistoryCleanupInterval()).thenReturn(Duration.ofHours(1));
-    when(config.maxHistoryCleanupInterval()).thenReturn(Duration.ofDays(1));
-    when(config.historyCleanupBatchSize()).thenReturn(100);
+    final var historyConfig = mock(RdbmsWriterConfig.HistoryConfig.class);
+    when(config.historyConfig()).thenReturn(historyConfig);
+    when(historyConfig.defaultHistoryTTL()).thenReturn(Duration.ofDays(90));
+    when(historyConfig.batchOperationCancelProcessInstanceHistoryTTL())
+        .thenReturn(Duration.ofDays(2));
+    when(historyConfig.batchOperationMigrateProcessInstanceHistoryTTL())
+        .thenReturn(Duration.ofDays(3));
+    when(historyConfig.batchOperationModifyProcessInstanceHistoryTTL())
+        .thenReturn(Duration.ofDays(4));
+    when(historyConfig.batchOperationResolveIncidentHistoryTTL()).thenReturn(Duration.ofDays(5));
+    when(historyConfig.minHistoryCleanupInterval()).thenReturn(Duration.ofHours(1));
+    when(historyConfig.maxHistoryCleanupInterval()).thenReturn(Duration.ofDays(1));
+    when(historyConfig.historyCleanupBatchSize()).thenReturn(100);
 
     historyCleanupService =
         new HistoryCleanupService(

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/write/service/HistoryCleanupServiceTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/write/service/HistoryCleanupServiceTest.java
@@ -67,10 +67,10 @@ class HistoryCleanupServiceTest {
     when(batchOperationWriter.cleanupHistory(any(), anyInt())).thenReturn(0);
 
     when(config.defaultHistoryTTL()).thenReturn(Duration.ofDays(90));
-    when(config.cancelProcessInstanceHistoryTTL()).thenReturn(Duration.ofDays(2));
-    when(config.migrateProcessInstanceHistoryTTL()).thenReturn(Duration.ofDays(3));
-    when(config.modifyProcessInstanceHistoryTTL()).thenReturn(Duration.ofDays(4));
-    when(config.resolveIncidentHistoryTTL()).thenReturn(Duration.ofDays(5));
+    when(config.batchOperationCancelProcessInstanceHistoryTTL()).thenReturn(Duration.ofDays(2));
+    when(config.batchOperationMigrateProcessInstanceHistoryTTL()).thenReturn(Duration.ofDays(3));
+    when(config.batchOperationModifyProcessInstanceHistoryTTL()).thenReturn(Duration.ofDays(4));
+    when(config.batchOperationResolveIncidentHistoryTTL()).thenReturn(Duration.ofDays(5));
     when(config.minHistoryCleanupInterval()).thenReturn(Duration.ofHours(1));
     when(config.maxHistoryCleanupInterval()).thenReturn(Duration.ofDays(1));
     when(config.historyCleanupBatchSize()).thenReturn(100);

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/write/service/HistoryCleanupServiceTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/write/service/HistoryCleanupServiceTest.java
@@ -16,6 +16,7 @@ import static org.mockito.Mockito.when;
 
 import io.camunda.db.rdbms.write.RdbmsWriterConfig;
 import io.camunda.db.rdbms.write.RdbmsWriterMetrics;
+import io.camunda.search.entities.BatchOperationType;
 import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.util.Map;
@@ -37,6 +38,7 @@ class HistoryCleanupServiceTest {
   private DecisionInstanceWriter decisionInstanceWriter;
   private JobWriter jobWriter;
   private SequenceFlowWriter sequenceFlowWriter;
+  private BatchOperationWriter batchOperationWriter;
 
   private HistoryCleanupService historyCleanupService;
 
@@ -51,6 +53,7 @@ class HistoryCleanupServiceTest {
     decisionInstanceWriter = mock(DecisionInstanceWriter.class);
     jobWriter = mock(JobWriter.class);
     sequenceFlowWriter = mock(SequenceFlowWriter.class);
+    batchOperationWriter = mock(BatchOperationWriter.class);
 
     when(processInstanceWriter.cleanupHistory(anyInt(), any(), anyInt())).thenReturn(0);
     when(flowNodeInstanceWriter.cleanupHistory(anyInt(), any(), anyInt())).thenReturn(0);
@@ -60,8 +63,14 @@ class HistoryCleanupServiceTest {
     when(decisionInstanceWriter.cleanupHistory(anyInt(), any(), anyInt())).thenReturn(0);
     when(jobWriter.cleanupHistory(anyInt(), any(), anyInt())).thenReturn(0);
     when(sequenceFlowWriter.cleanupHistory(anyInt(), any(), anyInt())).thenReturn(0);
+    when(batchOperationWriter.cleanupItemHistory(any(), anyInt())).thenReturn(0);
+    when(batchOperationWriter.cleanupHistory(any(), anyInt())).thenReturn(0);
 
-    when(config.defaultHistoryTTL()).thenReturn(Duration.ofDays(30));
+    when(config.defaultHistoryTTL()).thenReturn(Duration.ofDays(90));
+    when(config.cancelProcessInstanceHistoryTTL()).thenReturn(Duration.ofDays(2));
+    when(config.migrateProcessInstanceHistoryTTL()).thenReturn(Duration.ofDays(3));
+    when(config.modifyProcessInstanceHistoryTTL()).thenReturn(Duration.ofDays(4));
+    when(config.resolveIncidentHistoryTTL()).thenReturn(Duration.ofDays(5));
     when(config.minHistoryCleanupInterval()).thenReturn(Duration.ofHours(1));
     when(config.maxHistoryCleanupInterval()).thenReturn(Duration.ofDays(1));
     when(config.historyCleanupBatchSize()).thenReturn(100);
@@ -77,6 +86,7 @@ class HistoryCleanupServiceTest {
             decisionInstanceWriter,
             jobWriter,
             sequenceFlowWriter,
+            batchOperationWriter,
             mock(RdbmsWriterMetrics.class, Mockito.RETURNS_DEEP_STUBS));
   }
 
@@ -91,6 +101,8 @@ class HistoryCleanupServiceTest {
     when(decisionInstanceWriter.cleanupHistory(anyInt(), any(), anyInt())).thenReturn(1);
     when(jobWriter.cleanupHistory(anyInt(), any(), anyInt())).thenReturn(1);
     when(sequenceFlowWriter.cleanupHistory(anyInt(), any(), anyInt())).thenReturn(1);
+    when(batchOperationWriter.cleanupItemHistory(any(), anyInt())).thenReturn(1);
+    when(batchOperationWriter.cleanupHistory(any(), anyInt())).thenReturn(1);
 
     // when
     final Duration nextCleanupInterval =
@@ -106,6 +118,8 @@ class HistoryCleanupServiceTest {
     verify(decisionInstanceWriter).cleanupHistory(PARTITION_ID, CLEANUP_DATE, 100);
     verify(jobWriter).cleanupHistory(PARTITION_ID, CLEANUP_DATE, 100);
     verify(sequenceFlowWriter).cleanupHistory(PARTITION_ID, CLEANUP_DATE, 100);
+    verify(batchOperationWriter).cleanupItemHistory(CLEANUP_DATE, 100);
+    verify(batchOperationWriter).cleanupHistory(CLEANUP_DATE, 100);
   }
 
   @Test
@@ -120,7 +134,8 @@ class HistoryCleanupServiceTest {
             "variable", 0,
             "decisionInstance", 0,
             "job", 0,
-            "sequenceFlow", 0);
+            "sequenceFlow", 0,
+            "batchOperation", 0);
 
     // when
     final Duration nextDuration =
@@ -143,7 +158,9 @@ class HistoryCleanupServiceTest {
             "variable", 100,
             "decisionInstance", 100,
             "job", 100,
-            "sequenceFlow", 100);
+            "sequenceFlow", 100,
+            "batchOperationItem", 100,
+            "batchOperation", 100);
 
     // when
     final Duration nextDuration =
@@ -166,7 +183,8 @@ class HistoryCleanupServiceTest {
             "variable", 50,
             "decisionInstance", 50,
             "job", 50,
-            "sequenceFlow", 50);
+            "sequenceFlow", 50,
+            "batchOperation", 50);
 
     // when
     final Duration nextDuration =
@@ -175,5 +193,26 @@ class HistoryCleanupServiceTest {
     // then
     assertThat(nextDuration)
         .isEqualTo(Duration.ofHours(4)); // assuming minCleanupInterval is 1 hour
+  }
+
+  @Test
+  void testResolveBatchOperationTTL() {
+    assertThat(
+            historyCleanupService.resolveBatchOperationTTL(
+                BatchOperationType.CANCEL_PROCESS_INSTANCE))
+        .isEqualTo(Duration.ofDays(2));
+    assertThat(
+            historyCleanupService.resolveBatchOperationTTL(
+                BatchOperationType.MIGRATE_PROCESS_INSTANCE))
+        .isEqualTo(Duration.ofDays(3));
+    assertThat(
+            historyCleanupService.resolveBatchOperationTTL(
+                BatchOperationType.MODIFY_PROCESS_INSTANCE))
+        .isEqualTo(Duration.ofDays(4));
+    assertThat(historyCleanupService.resolveBatchOperationTTL(BatchOperationType.RESOLVE_INCIDENT))
+        .isEqualTo(Duration.ofDays(5));
+
+    assertThat(historyCleanupService.resolveBatchOperationTTL(BatchOperationType.ADD_VARIABLE))
+        .isEqualTo(Duration.ofDays(90)); // default history TTL
   }
 }

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/write/service/HistoryCleanupServiceTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/write/service/HistoryCleanupServiceTest.java
@@ -67,7 +67,7 @@ class HistoryCleanupServiceTest {
     when(batchOperationWriter.cleanupHistory(any(), anyInt())).thenReturn(0);
 
     final var historyConfig = mock(RdbmsWriterConfig.HistoryConfig.class);
-    when(config.historyConfig()).thenReturn(historyConfig);
+    when(config.history()).thenReturn(historyConfig);
     when(historyConfig.defaultHistoryTTL()).thenReturn(Duration.ofDays(90));
     when(historyConfig.batchOperationCancelProcessInstanceHistoryTTL())
         .thenReturn(Duration.ofDays(2));

--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -1061,6 +1061,30 @@
         #   batchOperationCache:
         #     maxCacheSize: 10000
 
+      # RDBMS Exporter ----------
+      # An example configuration for the rdbms exporter:
+      #
+      # These setting can also be overridden using the environment variables "ZEEBE_BROKER_EXPORTERS_RDBMS_..."
+      #
+      # rdbms:
+        # The class name is not import, since spring is used to create the instance.
+        # Just the name of the exporter itself MUST be rdbms.
+        # className: RdbmsExporter
+        #
+        # args:
+        #   flushInterval: PT0.5S
+        #   maxQueueSize: 1000
+        #   cleanupBatchSize: 1000
+        #   defaultHistoryTTL: PT1M
+        #   defaultBatchOperationHistoryTTL: PT7D
+        #   cancelProcessInstanceHistoryTTL: PT1D
+        #   migrateProcessInstanceHistoryTTL: PT10D
+        #   modifyProcessInstanceHistoryTTL: PT7D
+        #   resolveIncidentHistoryTTL: PT5D
+        #   minHistoryCleanupInterval: PT1S
+        #   maxHistoryCleanupInterval: PT1H
+        #   historyCleanupBatchSize: 1000
+
     # processing:
       # Sets the maximum number of commands that processed within one batch.
       # The processor will process until no more follow up commands are created by the initial command

--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -1074,16 +1074,20 @@
         # args:
         #   flushInterval: PT0.5S
         #   maxQueueSize: 1000
-        #   cleanupBatchSize: 1000
-        #   defaultHistoryTTL: PT1M
-        #   defaultBatchOperationHistoryTTL: PT7D
-        #   batchOperationCancelProcessInstanceHistoryTTL: PT1D
-        #   batchOperationMigrateProcessInstanceHistoryTTL: PT10D
-        #   batchOperationModifyProcessInstanceHistoryTTL: PT7D
-        #   batchOperationResolveIncidentHistoryTTL: PT5D
-        #   minHistoryCleanupInterval: PT1S
-        #   maxHistoryCleanupInterval: PT1H
-        #   historyCleanupBatchSize: 1000
+        #   history:
+        #     defaultHistoryTTL: PT1M
+        #     defaultBatchOperationHistoryTTL: PT7D
+        #     batchOperationCancelProcessInstanceHistoryTTL: PT1D
+        #     batchOperationMigrateProcessInstanceHistoryTTL: PT10D
+        #     batchOperationModifyProcessInstanceHistoryTTL: PT7D
+        #     batchOperationResolveIncidentHistoryTTL: PT5D
+        #     minHistoryCleanupInterval: PT1S
+        #     maxHistoryCleanupInterval: PT1H
+        #     historyCleanupBatchSize: 1000
+        #   processCache:
+        #     maxSize: 10000
+        #   batchOperationCache_
+        #     maxSize: 10000
 
     # processing:
       # Sets the maximum number of commands that processed within one batch.

--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -1077,10 +1077,10 @@
         #   cleanupBatchSize: 1000
         #   defaultHistoryTTL: PT1M
         #   defaultBatchOperationHistoryTTL: PT7D
-        #   cancelProcessInstanceHistoryTTL: PT1D
-        #   migrateProcessInstanceHistoryTTL: PT10D
-        #   modifyProcessInstanceHistoryTTL: PT7D
-        #   resolveIncidentHistoryTTL: PT5D
+        #   batchOperationCancelProcessInstanceHistoryTTL: PT1D
+        #   batchOperationMigrateProcessInstanceHistoryTTL: PT10D
+        #   batchOperationModifyProcessInstanceHistoryTTL: PT7D
+        #   batchOperationResolveIncidentHistoryTTL: PT5D
         #   minHistoryCleanupInterval: PT1S
         #   maxHistoryCleanupInterval: PT1H
         #   historyCleanupBatchSize: 1000

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -991,10 +991,10 @@
         #   cleanupBatchSize: 1000
         #   defaultHistoryTTL: PT1M
         #   defaultBatchOperationHistoryTTL: PT7D
-        #   cancelProcessInstanceHistoryTTL: PT1D
-        #   migrateProcessInstanceHistoryTTL: PT10D
-        #   modifyProcessInstanceHistoryTTL: PT7D
-        #   resolveIncidentHistoryTTL: PT5D
+        #   batchOperationCancelProcessInstanceHistoryTTL: PT1D
+        #   batchOperationMigrateProcessInstanceHistoryTTL: PT10D
+        #   batchOperationModifyProcessInstanceHistoryTTL: PT7D
+        #   batchOperationResolveIncidentHistoryTTL: PT5D
         #   minHistoryCleanupInterval: PT1S
         #   maxHistoryCleanupInterval: PT1H
         #   historyCleanupBatchSize: 1000

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -988,16 +988,20 @@
         # args:
         #   flushInterval: PT0.5S
         #   maxQueueSize: 1000
-        #   cleanupBatchSize: 1000
-        #   defaultHistoryTTL: PT1M
-        #   defaultBatchOperationHistoryTTL: PT7D
-        #   batchOperationCancelProcessInstanceHistoryTTL: PT1D
-        #   batchOperationMigrateProcessInstanceHistoryTTL: PT10D
-        #   batchOperationModifyProcessInstanceHistoryTTL: PT7D
-        #   batchOperationResolveIncidentHistoryTTL: PT5D
-        #   minHistoryCleanupInterval: PT1S
-        #   maxHistoryCleanupInterval: PT1H
-        #   historyCleanupBatchSize: 1000
+        #   history:
+        #     defaultHistoryTTL: PT1M
+        #     defaultBatchOperationHistoryTTL: PT7D
+        #     batchOperationCancelProcessInstanceHistoryTTL: PT1D
+        #     batchOperationMigrateProcessInstanceHistoryTTL: PT10D
+        #     batchOperationModifyProcessInstanceHistoryTTL: PT7D
+        #     batchOperationResolveIncidentHistoryTTL: PT5D
+        #     minHistoryCleanupInterval: PT1S
+        #     maxHistoryCleanupInterval: PT1H
+        #     historyCleanupBatchSize: 1000
+        #   processCache:
+        #     maxSize: 10000
+        #   batchOperationCache_
+        #     maxSize: 10000
 
     # processing:
       # Sets the maximum number of commands that processed within one batch.

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -975,6 +975,30 @@
         #   batchOperationCache:
         #     maxCacheSize: 10000
 
+      # RDBMS Exporter ----------
+      # An example configuration for the rdbms exporter:
+      #
+      # These setting can also be overridden using the environment variables "ZEEBE_BROKER_EXPORTERS_RDBMS_..."
+      #
+      # rdbms:
+        # The class name is not import, since spring is used to create the instance.
+        # Just the name of the exporter itself MUST be rdbms.
+        # className: RdbmsExporter
+        #
+        # args:
+        #   flushInterval: PT0.5S
+        #   maxQueueSize: 1000
+        #   cleanupBatchSize: 1000
+        #   defaultHistoryTTL: PT1M
+        #   defaultBatchOperationHistoryTTL: PT7D
+        #   cancelProcessInstanceHistoryTTL: PT1D
+        #   migrateProcessInstanceHistoryTTL: PT10D
+        #   modifyProcessInstanceHistoryTTL: PT7D
+        #   resolveIncidentHistoryTTL: PT5D
+        #   minHistoryCleanupInterval: PT1S
+        #   maxHistoryCleanupInterval: PT1H
+        #   historyCleanupBatchSize: 1000
+
     # processing:
       # Sets the maximum number of commands that processed within one batch.
       # The processor will process until no more follow up commands are created by the initial command

--- a/dist/src/main/java/io/camunda/application/commons/rdbms/RdbmsConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/rdbms/RdbmsConfiguration.java
@@ -247,7 +247,8 @@ public class RdbmsConfiguration {
       final JobMapper jobMapper,
       final SequenceFlowMapper sequenceFlowMapper,
       final UsageMetricMapper usageMetricMapper,
-      final UsageMetricTUMapper usageMetricTUMapper) {
+      final UsageMetricTUMapper usageMetricTUMapper,
+      final BatchOperationMapper batchOperationMapper) {
     return new RdbmsWriterFactory(
         sqlSessionFactory,
         exporterPositionMapper,
@@ -264,7 +265,8 @@ public class RdbmsConfiguration {
         jobMapper,
         sequenceFlowMapper,
         usageMetricMapper,
-        usageMetricTUMapper);
+        usageMetricTUMapper,
+        batchOperationMapper);
   }
 
   @Bean

--- a/dist/src/main/resources/application-rdbmsMariaDB.yaml
+++ b/dist/src/main/resources/application-rdbmsMariaDB.yaml
@@ -80,10 +80,10 @@ zeebe:
           cleanupBatchSize: 1000
           defaultHistoryTTL: PT1M
           defaultBatchOperationHistoryTTL: PT7D
-          cancelProcessInstanceHistoryTTL: PT1D
-          migrateProcessInstanceHistoryTTL: PT10D
-          modifyProcessInstanceHistoryTTL: PT7D
-          resolveIncidentHistoryTTL: PT5D
+          batchOperationCancelProcessInstanceHistoryTTL: PT1D
+          batchOperationMigrateProcessInstanceHistoryTTL: PT10D
+          batchOperationModifyProcessInstanceHistoryTTL: PT7D
+          batchOperationResolveIncidentHistoryTTL: PT5D
           minHistoryCleanupInterval: PT1S
           maxHistoryCleanupInterval: PT1H
           historyCleanupBatchSize: 1000

--- a/dist/src/main/resources/application-rdbmsMariaDB.yaml
+++ b/dist/src/main/resources/application-rdbmsMariaDB.yaml
@@ -74,6 +74,19 @@ zeebe:
       rdbms:
         # Classname doesn't matter, since this exporter is present via spring bean
         className: RdbmsExporter
+        args:
+          flushInterval: PT0.5S
+          maxQueueSize: 1000
+          cleanupBatchSize: 1000
+          defaultHistoryTTL: PT1M
+          defaultBatchOperationHistoryTTL: PT7D
+          cancelProcessInstanceHistoryTTL: PT1D
+          migrateProcessInstanceHistoryTTL: PT10D
+          modifyProcessInstanceHistoryTTL: PT7D
+          resolveIncidentHistoryTTL: PT5D
+          minHistoryCleanupInterval: PT1S
+          maxHistoryCleanupInterval: PT1H
+          historyCleanupBatchSize: 1000
       #elasticsearch:
       #  className: io.camunda.zeebe.exporter.ElasticsearchExporter
       #  args:

--- a/dist/src/main/resources/application-rdbmsMariaDB.yaml
+++ b/dist/src/main/resources/application-rdbmsMariaDB.yaml
@@ -76,17 +76,17 @@ zeebe:
         className: RdbmsExporter
         args:
           flushInterval: PT0.5S
-          maxQueueSize: 1000
-          cleanupBatchSize: 1000
-          defaultHistoryTTL: PT1M
-          defaultBatchOperationHistoryTTL: PT7D
-          batchOperationCancelProcessInstanceHistoryTTL: PT1D
-          batchOperationMigrateProcessInstanceHistoryTTL: PT10D
-          batchOperationModifyProcessInstanceHistoryTTL: PT7D
-          batchOperationResolveIncidentHistoryTTL: PT5D
-          minHistoryCleanupInterval: PT1S
-          maxHistoryCleanupInterval: PT1H
-          historyCleanupBatchSize: 1000
+          queueSize: 1000
+          history:
+            defaultHistoryTTL: PT1M
+            defaultBatchOperationHistoryTTL: PT7D
+            batchOperationCancelProcessInstanceHistoryTTL: PT1D
+            batchOperationMigrateProcessInstanceHistoryTTL: PT10D
+            batchOperationModifyProcessInstanceHistoryTTL: PT7D
+            batchOperationResolveIncidentHistoryTTL: PT5D
+            minHistoryCleanupInterval: PT1S
+            maxHistoryCleanupInterval: PT1H
+            historyCleanupBatchSize: 1000
       #elasticsearch:
       #  className: io.camunda.zeebe.exporter.ElasticsearchExporter
       #  args:

--- a/dist/src/main/resources/application-rdbmsOracle.yaml
+++ b/dist/src/main/resources/application-rdbmsOracle.yaml
@@ -77,16 +77,16 @@ zeebe:
         args:
           flushInterval: PT0.5S
           maxQueueSize: 1000
-          cleanupBatchSize: 1000
-          defaultHistoryTTL: PT1M
-          defaultBatchOperationHistoryTTL: PT7D
-          batchOperationCancelProcessInstanceHistoryTTL: PT1D
-          batchOperationMigrateProcessInstanceHistoryTTL: PT10D
-          batchOperationModifyProcessInstanceHistoryTTL: PT7D
-          batchOperationResolveIncidentHistoryTTL: PT5D
-          minHistoryCleanupInterval: PT1S
-          maxHistoryCleanupInterval: PT1H
-          historyCleanupBatchSize: 1000
+          history:
+            defaultHistoryTTL: PT1M
+            defaultBatchOperationHistoryTTL: PT7D
+            batchOperationCancelProcessInstanceHistoryTTL: PT1D
+            batchOperationMigrateProcessInstanceHistoryTTL: PT10D
+            batchOperationModifyProcessInstanceHistoryTTL: PT7D
+            batchOperationResolveIncidentHistoryTTL: PT5D
+            minHistoryCleanupInterval: PT1S
+            maxHistoryCleanupInterval: PT1H
+            historyCleanupBatchSize: 1000
       #elasticsearch:
       #  className: io.camunda.zeebe.exporter.ElasticsearchExporter
       #  args:

--- a/dist/src/main/resources/application-rdbmsOracle.yaml
+++ b/dist/src/main/resources/application-rdbmsOracle.yaml
@@ -80,10 +80,10 @@ zeebe:
           cleanupBatchSize: 1000
           defaultHistoryTTL: PT1M
           defaultBatchOperationHistoryTTL: PT7D
-          cancelProcessInstanceHistoryTTL: PT1D
-          migrateProcessInstanceHistoryTTL: PT10D
-          modifyProcessInstanceHistoryTTL: PT7D
-          resolveIncidentHistoryTTL: PT5D
+          batchOperationCancelProcessInstanceHistoryTTL: PT1D
+          batchOperationMigrateProcessInstanceHistoryTTL: PT10D
+          batchOperationModifyProcessInstanceHistoryTTL: PT7D
+          batchOperationResolveIncidentHistoryTTL: PT5D
           minHistoryCleanupInterval: PT1S
           maxHistoryCleanupInterval: PT1H
           historyCleanupBatchSize: 1000

--- a/dist/src/main/resources/application-rdbmsOracle.yaml
+++ b/dist/src/main/resources/application-rdbmsOracle.yaml
@@ -74,6 +74,19 @@ zeebe:
       rdbms:
         # Classname doesn't matter, since this exporter is present via spring bean
         className: RdbmsExporter
+        args:
+          flushInterval: PT0.5S
+          maxQueueSize: 1000
+          cleanupBatchSize: 1000
+          defaultHistoryTTL: PT1M
+          defaultBatchOperationHistoryTTL: PT7D
+          cancelProcessInstanceHistoryTTL: PT1D
+          migrateProcessInstanceHistoryTTL: PT10D
+          modifyProcessInstanceHistoryTTL: PT7D
+          resolveIncidentHistoryTTL: PT5D
+          minHistoryCleanupInterval: PT1S
+          maxHistoryCleanupInterval: PT1H
+          historyCleanupBatchSize: 1000
       #elasticsearch:
       #  className: io.camunda.zeebe.exporter.ElasticsearchExporter
       #  args:

--- a/dist/src/main/resources/application-rdbmsPostgres.yaml
+++ b/dist/src/main/resources/application-rdbmsPostgres.yaml
@@ -77,16 +77,16 @@ zeebe:
         args:
           flushInterval: PT0.5S
           queueSize: 1000
-          cleanupBatchSize: 1000
-          defaultHistoryTTL: PT1M
-          defaultBatchOperationHistoryTTL: PT7D
-          batchOperationCancelProcessInstanceHistoryTTL: PT1D
-          batchOperationMigrateProcessInstanceHistoryTTL: PT10D
-          batchOperationModifyProcessInstanceHistoryTTL: PT7D
-          batchOperationResolveIncidentHistoryTTL: PT5D
-          minHistoryCleanupInterval: PT1S
-          maxHistoryCleanupInterval: PT1H
-          historyCleanupBatchSize: 1000
+          history:
+            defaultHistoryTTL: PT1M
+            defaultBatchOperationHistoryTTL: PT7D
+            batchOperationCancelProcessInstanceHistoryTTL: PT1D
+            batchOperationMigrateProcessInstanceHistoryTTL: PT10D
+            batchOperationModifyProcessInstanceHistoryTTL: PT7D
+            batchOperationResolveIncidentHistoryTTL: PT5D
+            minHistoryCleanupInterval: PT1S
+            maxHistoryCleanupInterval: PT1H
+            historyCleanupBatchSize: 1000
       #elasticsearch:
       #  className: io.camunda.zeebe.exporter.ElasticsearchExporter
       #  args:

--- a/dist/src/main/resources/application-rdbmsPostgres.yaml
+++ b/dist/src/main/resources/application-rdbmsPostgres.yaml
@@ -80,10 +80,10 @@ zeebe:
           cleanupBatchSize: 1000
           defaultHistoryTTL: PT1M
           defaultBatchOperationHistoryTTL: PT7D
-          cancelProcessInstanceHistoryTTL: PT1D
-          migrateProcessInstanceHistoryTTL: PT10D
-          modifyProcessInstanceHistoryTTL: PT7D
-          resolveIncidentHistoryTTL: PT5D
+          batchOperationCancelProcessInstanceHistoryTTL: PT1D
+          batchOperationMigrateProcessInstanceHistoryTTL: PT10D
+          batchOperationModifyProcessInstanceHistoryTTL: PT7D
+          batchOperationResolveIncidentHistoryTTL: PT5D
           minHistoryCleanupInterval: PT1S
           maxHistoryCleanupInterval: PT1H
           historyCleanupBatchSize: 1000

--- a/dist/src/main/resources/application-rdbmsPostgres.yaml
+++ b/dist/src/main/resources/application-rdbmsPostgres.yaml
@@ -79,6 +79,11 @@ zeebe:
           queueSize: 1000
           cleanupBatchSize: 1000
           defaultHistoryTTL: PT1M
+          defaultBatchOperationHistoryTTL: PT7D
+          cancelProcessInstanceHistoryTTL: PT1D
+          migrateProcessInstanceHistoryTTL: PT10D
+          modifyProcessInstanceHistoryTTL: PT7D
+          resolveIncidentHistoryTTL: PT5D
           minHistoryCleanupInterval: PT1S
           maxHistoryCleanupInterval: PT1H
           historyCleanupBatchSize: 1000

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/HistoryCleanupIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/HistoryCleanupIT.java
@@ -14,6 +14,7 @@ import io.camunda.application.commons.rdbms.RdbmsConfiguration;
 import io.camunda.db.rdbms.RdbmsService;
 import io.camunda.db.rdbms.write.RdbmsWriter;
 import io.camunda.db.rdbms.write.service.HistoryCleanupService;
+import io.camunda.it.rdbms.db.fixtures.BatchOperationFixtures;
 import io.camunda.it.rdbms.db.fixtures.DecisionInstanceFixtures;
 import io.camunda.it.rdbms.db.fixtures.ElementInstanceFixtures;
 import io.camunda.it.rdbms.db.fixtures.IncidentFixtures;
@@ -21,6 +22,7 @@ import io.camunda.it.rdbms.db.fixtures.ProcessInstanceFixtures;
 import io.camunda.it.rdbms.db.fixtures.UserTaskFixtures;
 import io.camunda.it.rdbms.db.fixtures.VariableFixtures;
 import io.camunda.it.rdbms.db.util.RdbmsTestConfiguration;
+import io.camunda.search.entities.BatchOperationType;
 import java.time.OffsetDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.HashMap;
@@ -45,7 +47,7 @@ import org.springframework.test.context.TestPropertySource;
     properties = {"spring.liquibase.enabled=false", "camunda.data.secondary-storage.type=rdbms"})
 public class HistoryCleanupIT {
 
-  private static final List<String> TABLE_NAMES =
+  private static final List<String> PROCESS_RELATED_TABLE_NAMES =
       List.of(
           "VARIABLE",
           "FLOW_NODE_INSTANCE",
@@ -69,7 +71,7 @@ public class HistoryCleanupIT {
   }
 
   @Test
-  public void shouldUpdateHistoryCleanupDate() {
+  public void shouldUpdateHistoryCleanupDateForProcess() {
     // GIVEN
     final Long processInstanceKey = createRandomProcessWithCleanupRelevantData();
 
@@ -80,7 +82,7 @@ public class HistoryCleanupIT {
 
     // THEN
     final var expectedDate = now.plus(historyCleanupService.getHistoryCleanupInterval());
-    getHistoryCleanupDates(processInstanceKey)
+    getProcessRelatedHistoryCleanupDates(processInstanceKey)
         .forEach(
             (tableName, historyCleanupDate) -> {
               historyCleanupDate.forEach(
@@ -99,10 +101,35 @@ public class HistoryCleanupIT {
             });
   }
 
+  @Test
+  public void shouldUpdateHistoryCleanupDateForBatchOperation() {
+    // GIVEN
+    final var batchOperation =
+        BatchOperationFixtures.createAndSaveBatchOperation(rdbmsWriter, b -> b);
+    final var batchOperationKey = batchOperation.batchOperationKey();
+    final BatchOperationType batchOperationType = batchOperation.operationType();
+
+    BatchOperationFixtures.createAndSaveRandomBatchOperationItems(
+        rdbmsWriter, batchOperationKey, 5);
+
+    // WHEN we schedule history cleanup
+    final OffsetDateTime now = OffsetDateTime.now();
+    historyCleanupService.scheduleBatchOperationForHistoryCleanup(
+        batchOperationKey, batchOperationType, now);
+    rdbmsWriter.flush();
+
+    // THEN
+    final var expectedDate =
+        now.plus(historyCleanupService.resolveBatchOperationTTL(batchOperationType));
+    assertThat(getBatchOperationHistoryCleanupDate(batchOperationKey))
+        .describedAs("should update the history cleanup date for batch operation")
+        .isNotNull()
+        .isCloseTo(expectedDate, within(10, ChronoUnit.MILLIS));
+  }
+
   private Long createRandomProcessWithCleanupRelevantData() {
     final Long processInstanceKey =
-        ProcessInstanceFixtures.createAndSaveRandomProcessInstance(
-                rdbmsService.createWriter(0), b -> b)
+        ProcessInstanceFixtures.createAndSaveRandomProcessInstance(rdbmsWriter, b -> b)
             .processInstanceKey();
 
     ElementInstanceFixtures.createAndSaveRandomElementInstances(
@@ -123,10 +150,11 @@ public class HistoryCleanupIT {
     return processInstanceKey;
   }
 
-  private Map<String, List<Object>> getHistoryCleanupDates(final Long processInstanceKey) {
+  private Map<String, List<Object>> getProcessRelatedHistoryCleanupDates(
+      final Long processInstanceKey) {
     final Map<String, List<Object>> historyCleanupDatesMap = new HashMap<>();
 
-    TABLE_NAMES.forEach(
+    PROCESS_RELATED_TABLE_NAMES.forEach(
         tableName -> {
           final List<Object> historyCleanupDates =
               jdbcTemplate
@@ -142,5 +170,14 @@ public class HistoryCleanupIT {
         });
 
     return historyCleanupDatesMap;
+  }
+
+  private OffsetDateTime getBatchOperationHistoryCleanupDate(final String batchOperationKey) {
+    return jdbcTemplate.queryForObject(
+        "SELECT HISTORY_CLEANUP_DATE FROM BATCH_OPERATION "
+            + "WHERE BATCH_OPERATION_KEY = '"
+            + batchOperationKey
+            + "'",
+        OffsetDateTime.class);
   }
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/batchoperation/BatchOperationHistoryCleanupIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/batchoperation/BatchOperationHistoryCleanupIT.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.rdbms.db.batchoperation;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import io.camunda.db.rdbms.write.RdbmsWriterConfig;
+import io.camunda.it.rdbms.db.fixtures.BatchOperationFixtures;
+import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
+import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.search.entities.BatchOperationType;
+import io.camunda.search.query.BatchOperationItemQuery;
+import java.time.OffsetDateTime;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@Tag("rdbms")
+@ExtendWith(CamundaRdbmsInvocationContextProviderExtension.class)
+public class BatchOperationHistoryCleanupIT {
+
+  @TestTemplate
+  public void shouldCleanupBatchOperations(final CamundaRdbmsTestApplication testApplication) {
+    // GIVEN
+    final var rdbmsService = testApplication.getRdbmsService();
+    final var rdbmsWriter = rdbmsService.createWriter(0);
+    final var historyCleanupService = rdbmsWriter.getHistoryCleanupService();
+    final var batchOperationReader = rdbmsService.getBatchOperationReader();
+    final var batchOperationItemReader = rdbmsService.getBatchOperationItemReader();
+
+    final var batchOperation =
+        BatchOperationFixtures.createAndSaveBatchOperation(rdbmsWriter, b -> b);
+    final var batchOperationKey = batchOperation.batchOperationKey();
+    final BatchOperationType batchOperationType = batchOperation.operationType();
+
+    BatchOperationFixtures.createAndSaveRandomBatchOperationItems(
+        rdbmsWriter, batchOperationKey, 5);
+
+    // AND we schedule history cleanup
+    final OffsetDateTime now = OffsetDateTime.now();
+    historyCleanupService.scheduleBatchOperationForHistoryCleanup(
+        batchOperationKey, batchOperationType, now);
+    rdbmsWriter.flush();
+
+    // WHEN we do the history cleanup (partition doesn't matter here)
+    final OffsetDateTime cleanupDate =
+        now.plus(RdbmsWriterConfig.DEFAULT_BATCH_OPERATION_HISTORY_TTL).plusSeconds(1);
+    historyCleanupService.cleanupHistory(0, cleanupDate);
+
+    // THEN
+    assertThat(batchOperationReader.exists(batchOperationKey)).isFalse();
+    final var query =
+        BatchOperationItemQuery.of(b -> b.filter(f -> f.batchOperationKeys(batchOperationKey)));
+    assertThat(batchOperationItemReader.search(query).total()).isEqualTo(0);
+  }
+
+  @TestTemplate
+  public void shouldNOTCleanupBatchOperations(final CamundaRdbmsTestApplication testApplication) {
+    // GIVEN
+    final var rdbmsService = testApplication.getRdbmsService();
+    final var rdbmsWriter = rdbmsService.createWriter(0);
+    final var historyCleanupService = rdbmsWriter.getHistoryCleanupService();
+    final var batchOperationReader = rdbmsService.getBatchOperationReader();
+    final var batchOperationItemReader = rdbmsService.getBatchOperationItemReader();
+
+    final var batchOperation =
+        BatchOperationFixtures.createAndSaveBatchOperation(rdbmsWriter, b -> b);
+    final var batchOperationKey = batchOperation.batchOperationKey();
+    final BatchOperationType batchOperationType = batchOperation.operationType();
+
+    BatchOperationFixtures.createAndSaveRandomBatchOperationItems(
+        rdbmsWriter, batchOperationKey, 5);
+
+    // AND we schedule history cleanup
+    final OffsetDateTime now = OffsetDateTime.now();
+    historyCleanupService.scheduleBatchOperationForHistoryCleanup(
+        batchOperationKey, batchOperationType, now);
+    rdbmsWriter.flush();
+
+    // WHEN we do the history cleanup too early (partition doesn't matter here)
+    historyCleanupService.cleanupHistory(0, now);
+
+    // THEN
+    assertThat(batchOperationReader.exists(batchOperationKey)).isTrue();
+    final var query =
+        BatchOperationItemQuery.of(b -> b.filter(f -> f.batchOperationKeys(batchOperationKey)));
+    assertThat(batchOperationItemReader.search(query).total()).isEqualTo(5);
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/batchoperation/BatchOperationHistoryCleanupIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/batchoperation/BatchOperationHistoryCleanupIT.java
@@ -49,7 +49,8 @@ public class BatchOperationHistoryCleanupIT {
 
     // WHEN we do the history cleanup (partition doesn't matter here)
     final OffsetDateTime cleanupDate =
-        now.plus(RdbmsWriterConfig.DEFAULT_BATCH_OPERATION_HISTORY_TTL).plusSeconds(1);
+        now.plus(RdbmsWriterConfig.HistoryConfig.DEFAULT_BATCH_OPERATION_HISTORY_TTL)
+            .plusSeconds(1);
     historyCleanupService.cleanupHistory(0, cleanupDate);
 
     // THEN

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/MultiDbConfigurator.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/MultiDbConfigurator.java
@@ -267,6 +267,9 @@ public class MultiDbConfigurator {
     testApplication.withProperty(
         "zeebe.broker.exporters.rdbms.args.defaultHistoryTTL", retentionEnabled ? "PT1S" : "PT1H");
     testApplication.withProperty(
+        "zeebe.broker.exporters.rdbms.args.defaultBatchOperationHistoryTTL",
+        retentionEnabled ? "PT1S" : "PT1H");
+    testApplication.withProperty(
         "zeebe.broker.exporters.rdbms.args.minHistoryCleanupInterval",
         retentionEnabled ? "PT1S" : "PT1H");
     testApplication.withProperty(

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/MultiDbConfigurator.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/MultiDbConfigurator.java
@@ -265,15 +265,16 @@ public class MultiDbConfigurator {
     testApplication.withProperty("spring.datasource.password", "");
     testApplication.withProperty("zeebe.broker.exporters.rdbms.args.flushInterval", "PT0S");
     testApplication.withProperty(
-        "zeebe.broker.exporters.rdbms.args.defaultHistoryTTL", retentionEnabled ? "PT1S" : "PT1H");
-    testApplication.withProperty(
-        "zeebe.broker.exporters.rdbms.args.defaultBatchOperationHistoryTTL",
+        "zeebe.broker.exporters.rdbms.args.history.defaultHistoryTTL",
         retentionEnabled ? "PT1S" : "PT1H");
     testApplication.withProperty(
-        "zeebe.broker.exporters.rdbms.args.minHistoryCleanupInterval",
+        "zeebe.broker.exporters.rdbms.args.history.defaultBatchOperationHistoryTTL",
         retentionEnabled ? "PT1S" : "PT1H");
     testApplication.withProperty(
-        "zeebe.broker.exporters.rdbms.args.maxHistoryCleanupInterval",
+        "zeebe.broker.exporters.rdbms.args.history.minHistoryCleanupInterval",
+        retentionEnabled ? "PT1S" : "PT1H");
+    testApplication.withProperty(
+        "zeebe.broker.exporters.rdbms.args.history.maxHistoryCleanupInterval",
         retentionEnabled ? "PT5S" : "PT2H");
     testApplication.withExporter(
         "rdbms",

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/ExporterConfiguration.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/ExporterConfiguration.java
@@ -26,13 +26,13 @@ public class ExporterConfiguration {
   private Duration defaultBatchOperationHistoryTTL =
       RdbmsWriterConfig.DEFAULT_BATCH_OPERATION_HISTORY_TTL;
   // specific history TTLs for batch operations
-  private Duration cancelProcessInstanceHistoryTTL =
+  private Duration batchOperationCancelProcessInstanceHistoryTTL =
       RdbmsWriterConfig.DEFAULT_BATCH_OPERATION_HISTORY_TTL;
-  private Duration migrateProcessInstanceHistoryTTL =
+  private Duration batchOperationMigrateProcessInstanceHistoryTTL =
       RdbmsWriterConfig.DEFAULT_BATCH_OPERATION_HISTORY_TTL;
-  private Duration modifyProcessInstanceHistoryTTL =
+  private Duration batchOperationModifyProcessInstanceHistoryTTL =
       RdbmsWriterConfig.DEFAULT_BATCH_OPERATION_HISTORY_TTL;
-  private Duration resolveIncidentHistoryTTL =
+  private Duration batchOperationResolveIncidentHistoryTTL =
       RdbmsWriterConfig.DEFAULT_BATCH_OPERATION_HISTORY_TTL;
   private Duration minHistoryCleanupInterval =
       RdbmsWriterConfig.DEFAULT_MIN_HISTORY_CLEANUP_INTERVAL;
@@ -83,35 +83,41 @@ public class ExporterConfiguration {
   }
 
   public Duration getCancelProcessInstanceHistoryTTL() {
-    return cancelProcessInstanceHistoryTTL;
+    return batchOperationCancelProcessInstanceHistoryTTL;
   }
 
-  public void setCancelProcessInstanceHistoryTTL(final Duration cancelProcessInstanceHistoryTTL) {
-    this.cancelProcessInstanceHistoryTTL = cancelProcessInstanceHistoryTTL;
+  public void setCancelProcessInstanceHistoryTTL(
+      final Duration batchOperationCancelProcessInstanceHistoryTTL) {
+    this.batchOperationCancelProcessInstanceHistoryTTL =
+        batchOperationCancelProcessInstanceHistoryTTL;
   }
 
   public Duration getMigrateProcessInstanceHistoryTTL() {
-    return migrateProcessInstanceHistoryTTL;
+    return batchOperationMigrateProcessInstanceHistoryTTL;
   }
 
-  public void setMigrateProcessInstanceHistoryTTL(final Duration migrateProcessInstanceHistoryTTL) {
-    this.migrateProcessInstanceHistoryTTL = migrateProcessInstanceHistoryTTL;
+  public void setMigrateProcessInstanceHistoryTTL(
+      final Duration batchOperationMigrateProcessInstanceHistoryTTL) {
+    this.batchOperationMigrateProcessInstanceHistoryTTL =
+        batchOperationMigrateProcessInstanceHistoryTTL;
   }
 
   public Duration getModifyProcessInstanceHistoryTTL() {
-    return modifyProcessInstanceHistoryTTL;
+    return batchOperationModifyProcessInstanceHistoryTTL;
   }
 
-  public void setModifyProcessInstanceHistoryTTL(final Duration modifyProcessInstanceHistoryTTL) {
-    this.modifyProcessInstanceHistoryTTL = modifyProcessInstanceHistoryTTL;
+  public void setModifyProcessInstanceHistoryTTL(
+      final Duration batchOperationModifyProcessInstanceHistoryTTL) {
+    this.batchOperationModifyProcessInstanceHistoryTTL =
+        batchOperationModifyProcessInstanceHistoryTTL;
   }
 
   public Duration getResolveIncidentHistoryTTL() {
-    return resolveIncidentHistoryTTL;
+    return batchOperationResolveIncidentHistoryTTL;
   }
 
-  public void setResolveIncidentHistoryTTL(final Duration resolveIncidentHistoryTTL) {
-    this.resolveIncidentHistoryTTL = resolveIncidentHistoryTTL;
+  public void setResolveIncidentHistoryTTL(final Duration batchOperationResolveIncidentHistoryTTL) {
+    this.batchOperationResolveIncidentHistoryTTL = batchOperationResolveIncidentHistoryTTL;
   }
 
   public Duration getMinHistoryCleanupInterval() {
@@ -187,12 +193,19 @@ public class ExporterConfiguration {
     checkPositiveDuration(
         defaultBatchOperationHistoryTTL, "defaultBatchOperationHistoryTTL", errors);
     checkPositiveDuration(
-        cancelProcessInstanceHistoryTTL, "cancelProcessInstanceHistoryTTL", errors);
+        batchOperationCancelProcessInstanceHistoryTTL,
+        "batchOperationCancelProcessInstanceHistoryTTL",
+        errors);
     checkPositiveDuration(
-        migrateProcessInstanceHistoryTTL, "migrateProcessInstanceHistoryTTL", errors);
+        batchOperationMigrateProcessInstanceHistoryTTL,
+        "batchOperationMigrateProcessInstanceHistoryTTL",
+        errors);
     checkPositiveDuration(
-        modifyProcessInstanceHistoryTTL, "modifyProcessInstanceHistoryTTL", errors);
-    checkPositiveDuration(resolveIncidentHistoryTTL, "resolveIncidentHistoryTTL", errors);
+        batchOperationModifyProcessInstanceHistoryTTL,
+        "batchOperationModifyProcessInstanceHistoryTTL",
+        errors);
+    checkPositiveDuration(
+        batchOperationResolveIncidentHistoryTTL, "batchOperationResolveIncidentHistoryTTL", errors);
     checkPositiveDuration(minHistoryCleanupInterval, "minHistoryCleanupInterval", errors);
     checkPositiveDuration(maxHistoryCleanupInterval, "maxHistoryCleanupInterval", errors);
 
@@ -241,10 +254,13 @@ public class ExporterConfiguration {
         .partitionId(partitionId)
         .queueSize(queueSize)
         .defaultHistoryTTL(defaultHistoryTTL)
-        .cancelProcessInstanceHistoryTTL(cancelProcessInstanceHistoryTTL)
-        .migrateProcessInstanceHistoryTTL(migrateProcessInstanceHistoryTTL)
-        .modifyProcessInstanceHistoryTTL(modifyProcessInstanceHistoryTTL)
-        .resolveIncidentHistoryTTL(resolveIncidentHistoryTTL)
+        .batchOperationCancelProcessInstanceHistoryTTL(
+            batchOperationCancelProcessInstanceHistoryTTL)
+        .batchOperationMigrateProcessInstanceHistoryTTL(
+            batchOperationMigrateProcessInstanceHistoryTTL)
+        .batchOperationModifyProcessInstanceHistoryTTL(
+            batchOperationModifyProcessInstanceHistoryTTL)
+        .batchOperationResolveIncidentHistoryTTL(batchOperationResolveIncidentHistoryTTL)
         .minHistoryCleanupInterval(minHistoryCleanupInterval)
         .maxHistoryCleanupInterval(maxHistoryCleanupInterval)
         .historyCleanupBatchSize(historyCleanupBatchSize)

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/ExporterConfiguration.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/ExporterConfiguration.java
@@ -8,6 +8,7 @@
 package io.camunda.exporter.rdbms;
 
 import io.camunda.db.rdbms.write.RdbmsWriterConfig;
+import io.camunda.db.rdbms.write.RdbmsWriterConfig.HistoryConfig;
 import io.camunda.zeebe.exporter.api.ExporterException;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -21,24 +22,7 @@ public class ExporterConfiguration {
   private Duration flushInterval = DEFAULT_FLUSH_INTERVAL;
   private int queueSize = RdbmsWriterConfig.DEFAULT_QUEUE_SIZE;
 
-  // history cleanup configuration
-  private Duration defaultHistoryTTL = RdbmsWriterConfig.DEFAULT_HISTORY_TTL;
-  private Duration defaultBatchOperationHistoryTTL =
-      RdbmsWriterConfig.DEFAULT_BATCH_OPERATION_HISTORY_TTL;
-  // specific history TTLs for batch operations
-  private Duration batchOperationCancelProcessInstanceHistoryTTL =
-      RdbmsWriterConfig.DEFAULT_BATCH_OPERATION_HISTORY_TTL;
-  private Duration batchOperationMigrateProcessInstanceHistoryTTL =
-      RdbmsWriterConfig.DEFAULT_BATCH_OPERATION_HISTORY_TTL;
-  private Duration batchOperationModifyProcessInstanceHistoryTTL =
-      RdbmsWriterConfig.DEFAULT_BATCH_OPERATION_HISTORY_TTL;
-  private Duration batchOperationResolveIncidentHistoryTTL =
-      RdbmsWriterConfig.DEFAULT_BATCH_OPERATION_HISTORY_TTL;
-  private Duration minHistoryCleanupInterval =
-      RdbmsWriterConfig.DEFAULT_MIN_HISTORY_CLEANUP_INTERVAL;
-  private Duration maxHistoryCleanupInterval =
-      RdbmsWriterConfig.DEFAULT_MAX_HISTORY_CLEANUP_INTERVAL;
-  private int historyCleanupBatchSize = DEFAULT_CLEANUP_BATCH_SIZE;
+  private HistoryConfiguration history = new HistoryConfiguration();
 
   // batch operation configuration
   private boolean exportBatchOperationItemsOnCreation =
@@ -66,84 +50,6 @@ public class ExporterConfiguration {
     this.queueSize = queueSize;
   }
 
-  public Duration getDefaultHistoryTTL() {
-    return defaultHistoryTTL;
-  }
-
-  public void setDefaultHistoryTTL(final Duration defaultHistoryTTL) {
-    this.defaultHistoryTTL = defaultHistoryTTL;
-  }
-
-  public Duration getDefaultBatchOperationHistoryTTL() {
-    return defaultBatchOperationHistoryTTL;
-  }
-
-  public void setDefaultBatchOperationHistoryTTL(final Duration defaultBatchOperationHistoryTTL) {
-    this.defaultBatchOperationHistoryTTL = defaultBatchOperationHistoryTTL;
-  }
-
-  public Duration getCancelProcessInstanceHistoryTTL() {
-    return batchOperationCancelProcessInstanceHistoryTTL;
-  }
-
-  public void setCancelProcessInstanceHistoryTTL(
-      final Duration batchOperationCancelProcessInstanceHistoryTTL) {
-    this.batchOperationCancelProcessInstanceHistoryTTL =
-        batchOperationCancelProcessInstanceHistoryTTL;
-  }
-
-  public Duration getMigrateProcessInstanceHistoryTTL() {
-    return batchOperationMigrateProcessInstanceHistoryTTL;
-  }
-
-  public void setMigrateProcessInstanceHistoryTTL(
-      final Duration batchOperationMigrateProcessInstanceHistoryTTL) {
-    this.batchOperationMigrateProcessInstanceHistoryTTL =
-        batchOperationMigrateProcessInstanceHistoryTTL;
-  }
-
-  public Duration getModifyProcessInstanceHistoryTTL() {
-    return batchOperationModifyProcessInstanceHistoryTTL;
-  }
-
-  public void setModifyProcessInstanceHistoryTTL(
-      final Duration batchOperationModifyProcessInstanceHistoryTTL) {
-    this.batchOperationModifyProcessInstanceHistoryTTL =
-        batchOperationModifyProcessInstanceHistoryTTL;
-  }
-
-  public Duration getResolveIncidentHistoryTTL() {
-    return batchOperationResolveIncidentHistoryTTL;
-  }
-
-  public void setResolveIncidentHistoryTTL(final Duration batchOperationResolveIncidentHistoryTTL) {
-    this.batchOperationResolveIncidentHistoryTTL = batchOperationResolveIncidentHistoryTTL;
-  }
-
-  public Duration getMinHistoryCleanupInterval() {
-    return minHistoryCleanupInterval;
-  }
-
-  public void setMinHistoryCleanupInterval(final Duration minHistoryCleanupInterval) {
-    this.minHistoryCleanupInterval = minHistoryCleanupInterval;
-  }
-
-  public Duration getMaxHistoryCleanupInterval() {
-    return maxHistoryCleanupInterval;
-  }
-
-  public void setMaxHistoryCleanupInterval(final Duration maxHistoryCleanupInterval) {
-    this.maxHistoryCleanupInterval = maxHistoryCleanupInterval;
-  }
-
-  public int getHistoryCleanupBatchSize() {
-    return historyCleanupBatchSize;
-  }
-
-  public void setHistoryCleanupBatchSize(final int historyCleanupBatchSize) {
-    this.historyCleanupBatchSize = historyCleanupBatchSize;
-  }
-
   public boolean isExportBatchOperationItemsOnCreation() {
     return exportBatchOperationItemsOnCreation;
   }
@@ -159,6 +65,14 @@ public class ExporterConfiguration {
 
   public void setBatchOperationItemInsertBlockSize(final int batchOperationItemInsertBlockSize) {
     this.batchOperationItemInsertBlockSize = batchOperationItemInsertBlockSize;
+  }
+
+  public HistoryConfiguration getHistory() {
+    return history;
+  }
+
+  public void setHistory(final HistoryConfiguration history) {
+    this.history = history;
   }
 
   public CacheConfiguration getProcessCache() {
@@ -178,7 +92,8 @@ public class ExporterConfiguration {
   }
 
   public void validate() {
-    final List<String> errors = new ArrayList<>();
+
+    final List<String> errors = new ArrayList<>(history.validate());
 
     if (flushInterval.isNegative()) {
       errors.add(
@@ -187,40 +102,6 @@ public class ExporterConfiguration {
 
     if (queueSize < 0) {
       errors.add(String.format("queueSize must be greater or equal 0 but was %d", queueSize));
-    }
-
-    checkPositiveDuration(defaultHistoryTTL, "defaultHistoryTTL", errors);
-    checkPositiveDuration(
-        defaultBatchOperationHistoryTTL, "defaultBatchOperationHistoryTTL", errors);
-    checkPositiveDuration(
-        batchOperationCancelProcessInstanceHistoryTTL,
-        "batchOperationCancelProcessInstanceHistoryTTL",
-        errors);
-    checkPositiveDuration(
-        batchOperationMigrateProcessInstanceHistoryTTL,
-        "batchOperationMigrateProcessInstanceHistoryTTL",
-        errors);
-    checkPositiveDuration(
-        batchOperationModifyProcessInstanceHistoryTTL,
-        "batchOperationModifyProcessInstanceHistoryTTL",
-        errors);
-    checkPositiveDuration(
-        batchOperationResolveIncidentHistoryTTL, "batchOperationResolveIncidentHistoryTTL", errors);
-    checkPositiveDuration(minHistoryCleanupInterval, "minHistoryCleanupInterval", errors);
-    checkPositiveDuration(maxHistoryCleanupInterval, "maxHistoryCleanupInterval", errors);
-
-    if (maxHistoryCleanupInterval.compareTo(minHistoryCleanupInterval) <= 0) {
-      errors.add(
-          String.format(
-              "maxHistoryCleanupInterval must be greater than minHistoryCleanupInterval but max was %s and min was %s",
-              maxHistoryCleanupInterval, minHistoryCleanupInterval));
-    }
-
-    if (historyCleanupBatchSize < 1) {
-      errors.add(
-          String.format(
-              "historyCleanupBatchSize must be greater than 0 but was %d",
-              historyCleanupBatchSize));
     }
 
     if (batchOperationItemInsertBlockSize < 1) {
@@ -250,26 +131,32 @@ public class ExporterConfiguration {
   }
 
   public RdbmsWriterConfig createRdbmsWriterConfig(final int partitionId) {
+    final var historyConfig =
+        new HistoryConfig.Builder()
+            .defaultHistoryTTL(history.getDefaultHistoryTTL())
+            .batchOperationCancelProcessInstanceHistoryTTL(
+                history.getBatchOperationCancelProcessInstanceHistoryTTL())
+            .batchOperationMigrateProcessInstanceHistoryTTL(
+                history.getBatchOperationMigrateProcessInstanceHistoryTTL())
+            .batchOperationModifyProcessInstanceHistoryTTL(
+                history.getBatchOperationModifyProcessInstanceHistoryTTL())
+            .batchOperationResolveIncidentHistoryTTL(
+                history.getBatchOperationResolveIncidentHistoryTTL())
+            .minHistoryCleanupInterval(history.getMinHistoryCleanupInterval())
+            .maxHistoryCleanupInterval(history.getMaxHistoryCleanupInterval())
+            .historyCleanupBatchSize(history.getHistoryCleanupBatchSize())
+            .build();
+
     return new RdbmsWriterConfig.Builder()
         .partitionId(partitionId)
         .queueSize(queueSize)
-        .defaultHistoryTTL(defaultHistoryTTL)
-        .batchOperationCancelProcessInstanceHistoryTTL(
-            batchOperationCancelProcessInstanceHistoryTTL)
-        .batchOperationMigrateProcessInstanceHistoryTTL(
-            batchOperationMigrateProcessInstanceHistoryTTL)
-        .batchOperationModifyProcessInstanceHistoryTTL(
-            batchOperationModifyProcessInstanceHistoryTTL)
-        .batchOperationResolveIncidentHistoryTTL(batchOperationResolveIncidentHistoryTTL)
-        .minHistoryCleanupInterval(minHistoryCleanupInterval)
-        .maxHistoryCleanupInterval(maxHistoryCleanupInterval)
-        .historyCleanupBatchSize(historyCleanupBatchSize)
         .batchOperationItemInsertBlockSize(batchOperationItemInsertBlockSize)
         .exportBatchOperationItemsOnCreation(exportBatchOperationItemsOnCreation)
+        .historyConfig(historyConfig)
         .build();
   }
 
-  private void checkPositiveDuration(
+  private static void checkPositiveDuration(
       final Duration duration, final String name, final List<String> errors) {
     if (duration.isNegative() || duration.isZero()) {
       errors.add(String.format("%s must be a positive duration but was %s", name, duration));
@@ -285,6 +172,148 @@ public class ExporterConfiguration {
 
     public void setMaxSize(final int maxSize) {
       this.maxSize = maxSize;
+    }
+  }
+
+  public static class HistoryConfiguration {
+    // history cleanup configuration
+    private Duration defaultHistoryTTL = RdbmsWriterConfig.HistoryConfig.DEFAULT_HISTORY_TTL;
+    private Duration defaultBatchOperationHistoryTTL =
+        RdbmsWriterConfig.HistoryConfig.DEFAULT_BATCH_OPERATION_HISTORY_TTL;
+    // specific history TTLs for batch operations
+    private Duration batchOperationCancelProcessInstanceHistoryTTL =
+        RdbmsWriterConfig.HistoryConfig.DEFAULT_BATCH_OPERATION_HISTORY_TTL;
+    private Duration batchOperationMigrateProcessInstanceHistoryTTL =
+        RdbmsWriterConfig.HistoryConfig.DEFAULT_BATCH_OPERATION_HISTORY_TTL;
+    private Duration batchOperationModifyProcessInstanceHistoryTTL =
+        RdbmsWriterConfig.HistoryConfig.DEFAULT_BATCH_OPERATION_HISTORY_TTL;
+    private Duration batchOperationResolveIncidentHistoryTTL =
+        RdbmsWriterConfig.HistoryConfig.DEFAULT_BATCH_OPERATION_HISTORY_TTL;
+    private Duration minHistoryCleanupInterval =
+        RdbmsWriterConfig.HistoryConfig.DEFAULT_MIN_HISTORY_CLEANUP_INTERVAL;
+    private Duration maxHistoryCleanupInterval =
+        RdbmsWriterConfig.HistoryConfig.DEFAULT_MAX_HISTORY_CLEANUP_INTERVAL;
+    private int historyCleanupBatchSize = DEFAULT_CLEANUP_BATCH_SIZE;
+
+    public Duration getDefaultHistoryTTL() {
+      return defaultHistoryTTL;
+    }
+
+    public void setDefaultHistoryTTL(final Duration defaultHistoryTTL) {
+      this.defaultHistoryTTL = defaultHistoryTTL;
+    }
+
+    public Duration getDefaultBatchOperationHistoryTTL() {
+      return defaultBatchOperationHistoryTTL;
+    }
+
+    public void setDefaultBatchOperationHistoryTTL(final Duration defaultBatchOperationHistoryTTL) {
+      this.defaultBatchOperationHistoryTTL = defaultBatchOperationHistoryTTL;
+    }
+
+    public Duration getBatchOperationCancelProcessInstanceHistoryTTL() {
+      return batchOperationCancelProcessInstanceHistoryTTL;
+    }
+
+    public void setBatchOperationCancelProcessInstanceHistoryTTL(
+        final Duration batchOperationCancelProcessInstanceHistoryTTL) {
+      this.batchOperationCancelProcessInstanceHistoryTTL =
+          batchOperationCancelProcessInstanceHistoryTTL;
+    }
+
+    public Duration getBatchOperationMigrateProcessInstanceHistoryTTL() {
+      return batchOperationMigrateProcessInstanceHistoryTTL;
+    }
+
+    public void setBatchOperationMigrateProcessInstanceHistoryTTL(
+        final Duration batchOperationMigrateProcessInstanceHistoryTTL) {
+      this.batchOperationMigrateProcessInstanceHistoryTTL =
+          batchOperationMigrateProcessInstanceHistoryTTL;
+    }
+
+    public Duration getBatchOperationModifyProcessInstanceHistoryTTL() {
+      return batchOperationModifyProcessInstanceHistoryTTL;
+    }
+
+    public void setBatchOperationModifyProcessInstanceHistoryTTL(
+        final Duration batchOperationModifyProcessInstanceHistoryTTL) {
+      this.batchOperationModifyProcessInstanceHistoryTTL =
+          batchOperationModifyProcessInstanceHistoryTTL;
+    }
+
+    public Duration getBatchOperationResolveIncidentHistoryTTL() {
+      return batchOperationResolveIncidentHistoryTTL;
+    }
+
+    public void setBatchOperationResolveIncidentHistoryTTL(
+        final Duration batchOperationResolveIncidentHistoryTTL) {
+      this.batchOperationResolveIncidentHistoryTTL = batchOperationResolveIncidentHistoryTTL;
+    }
+
+    public Duration getMinHistoryCleanupInterval() {
+      return minHistoryCleanupInterval;
+    }
+
+    public void setMinHistoryCleanupInterval(final Duration minHistoryCleanupInterval) {
+      this.minHistoryCleanupInterval = minHistoryCleanupInterval;
+    }
+
+    public Duration getMaxHistoryCleanupInterval() {
+      return maxHistoryCleanupInterval;
+    }
+
+    public void setMaxHistoryCleanupInterval(final Duration maxHistoryCleanupInterval) {
+      this.maxHistoryCleanupInterval = maxHistoryCleanupInterval;
+    }
+
+    public int getHistoryCleanupBatchSize() {
+      return historyCleanupBatchSize;
+    }
+
+    public void setHistoryCleanupBatchSize(final int historyCleanupBatchSize) {
+      this.historyCleanupBatchSize = historyCleanupBatchSize;
+    }
+
+    public List<String> validate() {
+      final List<String> errors = new ArrayList<>();
+
+      checkPositiveDuration(defaultHistoryTTL, "defaultHistoryTTL", errors);
+      checkPositiveDuration(
+          defaultBatchOperationHistoryTTL, "defaultBatchOperationHistoryTTL", errors);
+      checkPositiveDuration(
+          batchOperationCancelProcessInstanceHistoryTTL,
+          "batchOperationCancelProcessInstanceHistoryTTL",
+          errors);
+      checkPositiveDuration(
+          batchOperationMigrateProcessInstanceHistoryTTL,
+          "batchOperationMigrateProcessInstanceHistoryTTL",
+          errors);
+      checkPositiveDuration(
+          batchOperationModifyProcessInstanceHistoryTTL,
+          "batchOperationModifyProcessInstanceHistoryTTL",
+          errors);
+      checkPositiveDuration(
+          batchOperationResolveIncidentHistoryTTL,
+          "batchOperationResolveIncidentHistoryTTL",
+          errors);
+      checkPositiveDuration(minHistoryCleanupInterval, "minHistoryCleanupInterval", errors);
+      checkPositiveDuration(maxHistoryCleanupInterval, "maxHistoryCleanupInterval", errors);
+
+      if (maxHistoryCleanupInterval.compareTo(minHistoryCleanupInterval) <= 0) {
+        errors.add(
+            String.format(
+                "maxHistoryCleanupInterval must be greater than minHistoryCleanupInterval but max was %s and min was %s",
+                maxHistoryCleanupInterval, minHistoryCleanupInterval));
+      }
+
+      if (historyCleanupBatchSize < 1) {
+        errors.add(
+            String.format(
+                "historyCleanupBatchSize must be greater than 0 but was %d",
+                historyCleanupBatchSize));
+      }
+
+      return errors;
     }
   }
 }

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/ExporterConfiguration.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/ExporterConfiguration.java
@@ -23,6 +23,17 @@ public class ExporterConfiguration {
 
   // history cleanup configuration
   private Duration defaultHistoryTTL = RdbmsWriterConfig.DEFAULT_HISTORY_TTL;
+  private Duration defaultBatchOperationHistoryTTL =
+      RdbmsWriterConfig.DEFAULT_BATCH_OPERATION_HISTORY_TTL;
+  // specific history TTLs for batch operations
+  private Duration cancelProcessInstanceHistoryTTL =
+      RdbmsWriterConfig.DEFAULT_BATCH_OPERATION_HISTORY_TTL;
+  private Duration migrateProcessInstanceHistoryTTL =
+      RdbmsWriterConfig.DEFAULT_BATCH_OPERATION_HISTORY_TTL;
+  private Duration modifyProcessInstanceHistoryTTL =
+      RdbmsWriterConfig.DEFAULT_BATCH_OPERATION_HISTORY_TTL;
+  private Duration resolveIncidentHistoryTTL =
+      RdbmsWriterConfig.DEFAULT_BATCH_OPERATION_HISTORY_TTL;
   private Duration minHistoryCleanupInterval =
       RdbmsWriterConfig.DEFAULT_MIN_HISTORY_CLEANUP_INTERVAL;
   private Duration maxHistoryCleanupInterval =
@@ -61,6 +72,47 @@ public class ExporterConfiguration {
 
   public void setDefaultHistoryTTL(final Duration defaultHistoryTTL) {
     this.defaultHistoryTTL = defaultHistoryTTL;
+  }
+
+  public Duration getDefaultBatchOperationHistoryTTL() {
+    return defaultBatchOperationHistoryTTL;
+  }
+
+  public void setDefaultBatchOperationHistoryTTL(
+      final Duration defaultBatchOperationHistoryTTL) {
+    this.defaultBatchOperationHistoryTTL = defaultBatchOperationHistoryTTL;
+  }
+
+  public Duration getCancelProcessInstanceHistoryTTL() {
+    return cancelProcessInstanceHistoryTTL;
+  }
+
+  public void setCancelProcessInstanceHistoryTTL(final Duration cancelProcessInstanceHistoryTTL) {
+    this.cancelProcessInstanceHistoryTTL = cancelProcessInstanceHistoryTTL;
+  }
+
+  public Duration getMigrateProcessInstanceHistoryTTL() {
+    return migrateProcessInstanceHistoryTTL;
+  }
+
+  public void setMigrateProcessInstanceHistoryTTL(final Duration migrateProcessInstanceHistoryTTL) {
+    this.migrateProcessInstanceHistoryTTL = migrateProcessInstanceHistoryTTL;
+  }
+
+  public Duration getModifyProcessInstanceHistoryTTL() {
+    return modifyProcessInstanceHistoryTTL;
+  }
+
+  public void setModifyProcessInstanceHistoryTTL(final Duration modifyProcessInstanceHistoryTTL) {
+    this.modifyProcessInstanceHistoryTTL = modifyProcessInstanceHistoryTTL;
+  }
+
+  public Duration getResolveIncidentHistoryTTL() {
+    return resolveIncidentHistoryTTL;
+  }
+
+  public void setResolveIncidentHistoryTTL(final Duration resolveIncidentHistoryTTL) {
+    this.resolveIncidentHistoryTTL = resolveIncidentHistoryTTL;
   }
 
   public Duration getMinHistoryCleanupInterval() {
@@ -132,25 +184,18 @@ public class ExporterConfiguration {
       errors.add(String.format("queueSize must be greater or equal 0 but was %d", queueSize));
     }
 
-    if (defaultHistoryTTL.isNegative() || defaultHistoryTTL.isZero()) {
-      errors.add(
-          String.format(
-              "defaultHistoryTTL must be a positive duration but was %s", defaultHistoryTTL));
-    }
-
-    if (minHistoryCleanupInterval.isNegative() || minHistoryCleanupInterval.isZero()) {
-      errors.add(
-          String.format(
-              "minHistoryCleanupInterval must be a positive duration but was %s",
-              minHistoryCleanupInterval));
-    }
-
-    if (maxHistoryCleanupInterval.isNegative() || maxHistoryCleanupInterval.isZero()) {
-      errors.add(
-          String.format(
-              "maxHistoryCleanupInterval must be a positive duration but was %s",
-              maxHistoryCleanupInterval));
-    }
+    checkPositiveDuration(defaultHistoryTTL, "defaultHistoryTTL", errors);
+    checkPositiveDuration(
+        defaultBatchOperationHistoryTTL, "defaultBatchOperationHistoryTTL", errors);
+    checkPositiveDuration(
+        cancelProcessInstanceHistoryTTL, "cancelProcessInstanceHistoryTTL", errors);
+    checkPositiveDuration(
+        migrateProcessInstanceHistoryTTL, "migrateProcessInstanceHistoryTTL", errors);
+    checkPositiveDuration(
+        modifyProcessInstanceHistoryTTL, "modifyProcessInstanceHistoryTTL", errors);
+    checkPositiveDuration(resolveIncidentHistoryTTL, "resolveIncidentHistoryTTL", errors);
+    checkPositiveDuration(minHistoryCleanupInterval, "minHistoryCleanupInterval", errors);
+    checkPositiveDuration(maxHistoryCleanupInterval, "maxHistoryCleanupInterval", errors);
 
     if (maxHistoryCleanupInterval.compareTo(minHistoryCleanupInterval) <= 0) {
       errors.add(
@@ -192,17 +237,28 @@ public class ExporterConfiguration {
     }
   }
 
-  public RdbmsWriterConfig createRdbmsWriterConfig(int partitionId) {
+  public RdbmsWriterConfig createRdbmsWriterConfig(final int partitionId) {
     return new RdbmsWriterConfig.Builder()
         .partitionId(partitionId)
         .queueSize(queueSize)
         .defaultHistoryTTL(defaultHistoryTTL)
+        .cancelProcessInstanceHistoryTTL(cancelProcessInstanceHistoryTTL)
+        .migrateProcessInstanceHistoryTTL(migrateProcessInstanceHistoryTTL)
+        .modifyProcessInstanceHistoryTTL(modifyProcessInstanceHistoryTTL)
+        .resolveIncidentHistoryTTL(resolveIncidentHistoryTTL)
         .minHistoryCleanupInterval(minHistoryCleanupInterval)
         .maxHistoryCleanupInterval(maxHistoryCleanupInterval)
         .historyCleanupBatchSize(historyCleanupBatchSize)
         .batchOperationItemInsertBlockSize(batchOperationItemInsertBlockSize)
         .exportBatchOperationItemsOnCreation(exportBatchOperationItemsOnCreation)
         .build();
+  }
+
+  private void checkPositiveDuration(
+      final Duration duration, final String name, final List<String> errors) {
+    if (duration.isNegative() || duration.isZero()) {
+      errors.add(String.format("%s must be a positive duration but was %s", name, duration));
+    }
   }
 
   public static class CacheConfiguration {

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/ExporterConfiguration.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/ExporterConfiguration.java
@@ -78,8 +78,7 @@ public class ExporterConfiguration {
     return defaultBatchOperationHistoryTTL;
   }
 
-  public void setDefaultBatchOperationHistoryTTL(
-      final Duration defaultBatchOperationHistoryTTL) {
+  public void setDefaultBatchOperationHistoryTTL(final Duration defaultBatchOperationHistoryTTL) {
     this.defaultBatchOperationHistoryTTL = defaultBatchOperationHistoryTTL;
   }
 

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/ExporterConfiguration.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/ExporterConfiguration.java
@@ -152,7 +152,7 @@ public class ExporterConfiguration {
         .queueSize(queueSize)
         .batchOperationItemInsertBlockSize(batchOperationItemInsertBlockSize)
         .exportBatchOperationItemsOnCreation(exportBatchOperationItemsOnCreation)
-        .historyConfig(historyConfig)
+        .history(historyConfig)
         .build();
   }
 

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporterWrapper.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporterWrapper.java
@@ -193,7 +193,10 @@ public class RdbmsExporterWrapper implements Exporter {
         new BatchOperationChunkExportHandler(rdbmsWriter.getBatchOperationWriter()));
     builder.withHandler(
         ValueType.BATCH_OPERATION_LIFECYCLE_MANAGEMENT,
-        new BatchOperationLifecycleManagementExportHandler(rdbmsWriter.getBatchOperationWriter()));
+        new BatchOperationLifecycleManagementExportHandler(
+            rdbmsWriter.getBatchOperationWriter(),
+            rdbmsWriter.getHistoryCleanupService(),
+            batchOperationCache));
 
     // Handlers per batch operation to track status
     builder.withHandler(

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/ExporterConfigurationTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/ExporterConfigurationTest.java
@@ -28,22 +28,37 @@ class ExporterConfigurationTest {
 
   @Test
   public void shouldFailWithAllErrors() {
+    final ExporterConfiguration.HistoryConfiguration historyConfiguration =
+        new ExporterConfiguration.HistoryConfiguration();
+    historyConfiguration.setDefaultHistoryTTL(Duration.ofMillis(-1000));
+    historyConfiguration.setDefaultBatchOperationHistoryTTL(Duration.ofMillis(-1000));
+    historyConfiguration.setMinHistoryCleanupInterval(Duration.ofMillis(-1000));
+    historyConfiguration.setMaxHistoryCleanupInterval(Duration.ofMillis(-2000));
+    historyConfiguration.setHistoryCleanupBatchSize(-1000);
+    historyConfiguration.setBatchOperationCancelProcessInstanceHistoryTTL(Duration.ofMillis(-1000));
+    historyConfiguration.setBatchOperationMigrateProcessInstanceHistoryTTL(
+        Duration.ofMillis(-1000));
+    historyConfiguration.setBatchOperationModifyProcessInstanceHistoryTTL(Duration.ofMillis(-1000));
+    historyConfiguration.setBatchOperationResolveIncidentHistoryTTL(Duration.ofMillis(-1000));
+
     final ExporterConfiguration configuration = new ExporterConfiguration();
     configuration.setFlushInterval(Duration.ofMillis(-1000));
     configuration.setQueueSize(-1000);
-    configuration.setDefaultHistoryTTL(Duration.ofMillis(-1000));
-    configuration.setMinHistoryCleanupInterval(Duration.ofMillis(-1000));
-    configuration.setMaxHistoryCleanupInterval(Duration.ofMillis(-2000));
-    configuration.setHistoryCleanupBatchSize(-1000);
     configuration.setBatchOperationItemInsertBlockSize(-1000);
     configuration.getBatchOperationCache().setMaxSize(-1000);
     configuration.getProcessCache().setMaxSize(-1000);
+    configuration.setHistory(historyConfiguration);
 
     // when
     assertThatThrownBy(configuration::validate)
         .hasMessageContaining("flushInterval must be")
         .hasMessageContaining("queueSize must be")
         .hasMessageContaining("defaultHistoryTTL must be")
+        .hasMessageContaining("defaultBatchOperationHistoryTTL must be")
+        .hasMessageContaining("batchOperationCancelProcessInstanceHistoryTTL must be")
+        .hasMessageContaining("batchOperationMigrateProcessInstanceHistoryTTL must be")
+        .hasMessageContaining("batchOperationModifyProcessInstanceHistoryTTL must be")
+        .hasMessageContaining("batchOperationResolveIncidentHistoryTTL must be")
         .hasMessageContaining("minHistoryCleanupInterval must be")
         .hasMessageContaining("maxHistoryCleanupInterval must be a positive duration")
         .hasMessageContaining(
@@ -73,24 +88,88 @@ class ExporterConfigurationTest {
 
   @Test
   public void shouldFailWithNegativeDefaultHistoryTTL() {
+    final ExporterConfiguration.HistoryConfiguration historyConfiguration =
+        new ExporterConfiguration.HistoryConfiguration();
     final ExporterConfiguration configuration = new ExporterConfiguration();
-    configuration.setDefaultHistoryTTL(Duration.ofMillis(-1000));
+    configuration.setHistory(historyConfiguration);
+
+    historyConfiguration.setDefaultHistoryTTL(Duration.ofMillis(-1000));
 
     assertThatThrownBy(configuration::validate).hasMessageContaining("defaultHistoryTTL must be");
   }
 
   @Test
   public void shouldFailWithDefaultHistoryTTL() {
+    final ExporterConfiguration.HistoryConfiguration historyConfiguration =
+        new ExporterConfiguration.HistoryConfiguration();
     final ExporterConfiguration configuration = new ExporterConfiguration();
-    configuration.setDefaultHistoryTTL(Duration.ZERO);
+    configuration.setHistory(historyConfiguration);
+
+    historyConfiguration.setDefaultHistoryTTL(Duration.ZERO);
 
     assertThatThrownBy(configuration::validate).hasMessageContaining("defaultHistoryTTL must be");
   }
 
   @Test
-  public void shouldFailWithNegativeMinHistoryCleanupInterval() {
+  public void shouldFailWithBatchOperationCancelProcessInstanceHistoryTTL() {
+    final ExporterConfiguration.HistoryConfiguration historyConfiguration =
+        new ExporterConfiguration.HistoryConfiguration();
     final ExporterConfiguration configuration = new ExporterConfiguration();
-    configuration.setMinHistoryCleanupInterval(Duration.ofMillis(-1000));
+    configuration.setHistory(historyConfiguration);
+
+    historyConfiguration.setBatchOperationCancelProcessInstanceHistoryTTL(Duration.ZERO);
+
+    assertThatThrownBy(configuration::validate)
+        .hasMessageContaining("batchOperationCancelProcessInstanceHistoryTTL must be");
+  }
+
+  @Test
+  public void shouldFailWithBatchOperationMigrateProcessInstanceHistoryTTL() {
+    final ExporterConfiguration.HistoryConfiguration historyConfiguration =
+        new ExporterConfiguration.HistoryConfiguration();
+    final ExporterConfiguration configuration = new ExporterConfiguration();
+    configuration.setHistory(historyConfiguration);
+
+    historyConfiguration.setBatchOperationMigrateProcessInstanceHistoryTTL(Duration.ZERO);
+
+    assertThatThrownBy(configuration::validate)
+        .hasMessageContaining("batchOperationMigrateProcessInstanceHistoryTTL must be");
+  }
+
+  @Test
+  public void shouldFailWithBatchOperationModifyProcessInstanceHistoryTTL() {
+    final ExporterConfiguration.HistoryConfiguration historyConfiguration =
+        new ExporterConfiguration.HistoryConfiguration();
+    final ExporterConfiguration configuration = new ExporterConfiguration();
+    configuration.setHistory(historyConfiguration);
+
+    historyConfiguration.setBatchOperationModifyProcessInstanceHistoryTTL(Duration.ZERO);
+
+    assertThatThrownBy(configuration::validate)
+        .hasMessageContaining("batchOperationModifyProcessInstanceHistoryTTL must be");
+  }
+
+  @Test
+  public void shouldFailWithBatchOperationResolveIncidentHistoryTTL() {
+    final ExporterConfiguration.HistoryConfiguration historyConfiguration =
+        new ExporterConfiguration.HistoryConfiguration();
+    final ExporterConfiguration configuration = new ExporterConfiguration();
+    configuration.setHistory(historyConfiguration);
+
+    historyConfiguration.setBatchOperationResolveIncidentHistoryTTL(Duration.ZERO);
+
+    assertThatThrownBy(configuration::validate)
+        .hasMessageContaining("batchOperationResolveIncidentHistoryTTL must be");
+  }
+
+  @Test
+  public void shouldFailWithNegativeMinHistoryCleanupInterval() {
+    final ExporterConfiguration.HistoryConfiguration historyConfiguration =
+        new ExporterConfiguration.HistoryConfiguration();
+    final ExporterConfiguration configuration = new ExporterConfiguration();
+    configuration.setHistory(historyConfiguration);
+
+    historyConfiguration.setMinHistoryCleanupInterval(Duration.ofMillis(-1000));
 
     assertThatThrownBy(configuration::validate)
         .hasMessageContaining("minHistoryCleanupInterval must be");
@@ -98,8 +177,12 @@ class ExporterConfigurationTest {
 
   @Test
   public void shouldFailWithZeroMinHistoryCleanupInterval() {
+    final ExporterConfiguration.HistoryConfiguration historyConfiguration =
+        new ExporterConfiguration.HistoryConfiguration();
     final ExporterConfiguration configuration = new ExporterConfiguration();
-    configuration.setMinHistoryCleanupInterval(Duration.ZERO);
+    configuration.setHistory(historyConfiguration);
+
+    historyConfiguration.setMinHistoryCleanupInterval(Duration.ZERO);
 
     assertThatThrownBy(configuration::validate)
         .hasMessageContaining("minHistoryCleanupInterval must be");
@@ -107,8 +190,12 @@ class ExporterConfigurationTest {
 
   @Test
   public void shouldFailWithNegativeMaxHistoryCleanupInterval() {
+    final ExporterConfiguration.HistoryConfiguration historyConfiguration =
+        new ExporterConfiguration.HistoryConfiguration();
     final ExporterConfiguration configuration = new ExporterConfiguration();
-    configuration.setMaxHistoryCleanupInterval(Duration.ofMillis(-1000));
+    configuration.setHistory(historyConfiguration);
+
+    historyConfiguration.setMaxHistoryCleanupInterval(Duration.ofMillis(-1000));
 
     assertThatThrownBy(configuration::validate)
         .hasMessageContaining("maxHistoryCleanupInterval must be a positive duration");
@@ -116,8 +203,12 @@ class ExporterConfigurationTest {
 
   @Test
   public void shouldFailWithZeroMaxHistoryCleanupInterval() {
+    final ExporterConfiguration.HistoryConfiguration historyConfiguration =
+        new ExporterConfiguration.HistoryConfiguration();
     final ExporterConfiguration configuration = new ExporterConfiguration();
-    configuration.setMaxHistoryCleanupInterval(Duration.ZERO);
+    configuration.setHistory(historyConfiguration);
+
+    historyConfiguration.setMaxHistoryCleanupInterval(Duration.ZERO);
 
     assertThatThrownBy(configuration::validate)
         .hasMessageContaining("maxHistoryCleanupInterval must be a positive duration");
@@ -125,9 +216,13 @@ class ExporterConfigurationTest {
 
   @Test
   public void shouldFailWithMaxHistoryCleanupIntervalLesserThanMin() {
+    final ExporterConfiguration.HistoryConfiguration historyConfiguration =
+        new ExporterConfiguration.HistoryConfiguration();
     final ExporterConfiguration configuration = new ExporterConfiguration();
-    configuration.setMaxHistoryCleanupInterval(Duration.ofSeconds(1));
-    configuration.setMinHistoryCleanupInterval(Duration.ofSeconds(2));
+    configuration.setHistory(historyConfiguration);
+
+    historyConfiguration.setMaxHistoryCleanupInterval(Duration.ofSeconds(1));
+    historyConfiguration.setMinHistoryCleanupInterval(Duration.ofSeconds(2));
 
     assertThatThrownBy(configuration::validate)
         .hasMessageContaining(
@@ -136,8 +231,12 @@ class ExporterConfigurationTest {
 
   @Test
   public void shouldFailWithNegativeHistoryCleanupBatchSize() {
+    final ExporterConfiguration.HistoryConfiguration historyConfiguration =
+        new ExporterConfiguration.HistoryConfiguration();
     final ExporterConfiguration configuration = new ExporterConfiguration();
-    configuration.setHistoryCleanupBatchSize(-1);
+    configuration.setHistory(historyConfiguration);
+
+    historyConfiguration.setHistoryCleanupBatchSize(-1);
 
     assertThatThrownBy(configuration::validate)
         .hasMessageContaining("historyCleanupBatchSize must be");
@@ -145,8 +244,12 @@ class ExporterConfigurationTest {
 
   @Test
   public void shouldFailWithZeroHistoryCleanupBatchSize() {
+    final ExporterConfiguration.HistoryConfiguration historyConfiguration =
+        new ExporterConfiguration.HistoryConfiguration();
     final ExporterConfiguration configuration = new ExporterConfiguration();
-    configuration.setHistoryCleanupBatchSize(0);
+    configuration.setHistory(historyConfiguration);
+
+    historyConfiguration.setHistoryCleanupBatchSize(0);
 
     assertThatThrownBy(configuration::validate)
         .hasMessageContaining("historyCleanupBatchSize must be");

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneBroker.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneBroker.java
@@ -337,6 +337,7 @@ public final class TestStandaloneBroker extends TestSpringApplication<TestStanda
     withProperty("logging.level.org.mybatis", "DEBUG");
     withProperty("zeebe.broker.exporters.rdbms.args.flushInterval", "PT0S");
     withProperty("zeebe.broker.exporters.rdbms.args.defaultHistoryTTL", "PT2S");
+    withProperty("zeebe.broker.exporters.rdbms.args.defaultBatchOperationHistoryTTL", "PT2S");
     withProperty("zeebe.broker.exporters.rdbms.args.minHistoryCleanupInterval", "PT2S");
     withProperty("zeebe.broker.exporters.rdbms.args.maxHistoryCleanupInterval", "PT5S");
     withExporter("rdbms", cfg -> cfg.setClassName("-"));

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneBroker.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneBroker.java
@@ -336,10 +336,11 @@ public final class TestStandaloneBroker extends TestSpringApplication<TestStanda
     withProperty("logging.level.io.camunda.db.rdbms", "DEBUG");
     withProperty("logging.level.org.mybatis", "DEBUG");
     withProperty("zeebe.broker.exporters.rdbms.args.flushInterval", "PT0S");
-    withProperty("zeebe.broker.exporters.rdbms.args.defaultHistoryTTL", "PT2S");
-    withProperty("zeebe.broker.exporters.rdbms.args.defaultBatchOperationHistoryTTL", "PT2S");
-    withProperty("zeebe.broker.exporters.rdbms.args.minHistoryCleanupInterval", "PT2S");
-    withProperty("zeebe.broker.exporters.rdbms.args.maxHistoryCleanupInterval", "PT5S");
+    withProperty("zeebe.broker.exporters.rdbms.args.history.defaultHistoryTTL", "PT2S");
+    withProperty(
+        "zeebe.broker.exporters.rdbms.args.history.defaultBatchOperationHistoryTTL", "PT2S");
+    withProperty("zeebe.broker.exporters.rdbms.args.history.minHistoryCleanupInterval", "PT2S");
+    withProperty("zeebe.broker.exporters.rdbms.args.history.maxHistoryCleanupInterval", "PT5S");
     withExporter("rdbms", cfg -> cfg.setClassName("-"));
     return this;
   }


### PR DESCRIPTION
## Description

Adds batch operation history cleanup functionality to the RDBMS exporter, implementing TTL-based cleanup for different batch operation types.

- Adds a new `scheduleBatchOperationForHistoryCleanup` method to track when batch operations should be cleaned up
- Configures specific TTL values for different batch operation types (cancel, migrate, modify, resolve incident)
- Integrates batch operation cleanup into the existing history cleanup service
- Batch Operations and Items get cleaned separately, since it could be that the items table is really really big

## Related issues

closes #35023
