### PR TITLE
Prevent finished instances operations

### DIFF
--- a/operate/client/src/App/Dashboard/InstancesByProcess/index.test.tsx
+++ b/operate/client/src/App/Dashboard/InstancesByProcess/index.test.tsx
@@ -323,7 +323,6 @@ describe('InstancesByProcess', () => {
     ).toBeInTheDocument();
 
     expect(
-      // eslint-disable-next-line testing-library/no-node-access
       screen.getByRole('button', {name: 'Go to Modeler'}).closest('a'),
     ).toHaveAttribute('href', 'https://link-to-modeler');
   });

--- a/operate/client/src/App/ProcessInstance/FlowNodeInstancesTree/tests/multiInstanceSubprocess.test.tsx
+++ b/operate/client/src/App/ProcessInstance/FlowNodeInstancesTree/tests/multiInstanceSubprocess.test.tsx
@@ -161,7 +161,6 @@ describe('FlowNodeInstancesTree - Multi Instance Subprocess', () => {
     const withinMultiInstanceFlowNode = within(
       screen.getByTestId(
         `tree-node-${
-          // eslint-disable-next-line testing-library/no-node-access
           flowNodeInstances.level1Poll[processInstanceId]!.children[1]!.id
         }`,
       ),

--- a/operate/client/src/App/ProcessInstance/FlowNodeInstancesTree/v2/multiInstanceSubprocess.test.tsx
+++ b/operate/client/src/App/ProcessInstance/FlowNodeInstancesTree/v2/multiInstanceSubprocess.test.tsx
@@ -181,7 +181,6 @@ describe('FlowNodeInstancesTree - Multi Instance Subprocess', () => {
     const withinMultiInstanceFlowNode = within(
       screen.getByTestId(
         `tree-node-${
-          // eslint-disable-next-line testing-library/no-node-access
           flowNodeInstances.level1Poll[processInstanceId]!.children[1]!.id
         }`,
       ),

--- a/operate/client/src/App/Processes/ListView/InstancesTable/Toolbar/index.tsx
+++ b/operate/client/src/App/Processes/ListView/InstancesTable/Toolbar/index.tsx
@@ -118,7 +118,7 @@ const Toolbar: React.FC<Props> = observer(({selectedInstancesCount}) => {
               batchModificationStore.state.isEnabled
                 ? 'Not available in batch modification mode'
                 : !processInstancesSelectionStore.hasSelectedRunningInstances
-                  ? 'No active or incident process instances selected to cancel'
+                  ? 'No running process instances selected. Please select at least one active or incident process instance to cancel.'
                   : undefined
             }
           >
@@ -135,7 +135,7 @@ const Toolbar: React.FC<Props> = observer(({selectedInstancesCount}) => {
               batchModificationStore.state.isEnabled
                 ? 'Not available in batch modification mode'
                 : !processInstancesSelectionStore.hasSelectedRunningInstances
-                  ? 'No active or incident process instances selected to retry'
+                  ? 'No running process instances selected. Please select at least one active or incident process instance to retry.'
                   : undefined
             }
           >

--- a/operate/client/src/App/Processes/ListView/InstancesTable/Toolbar/index.tsx
+++ b/operate/client/src/App/Processes/ListView/InstancesTable/Toolbar/index.tsx
@@ -63,10 +63,10 @@ const Toolbar: React.FC<Props> = observer(({selectedInstancesCount}) => {
     const runningInstancesCount =
       processInstancesSelectionStore.checkedRunningProcessInstanceIds.length;
 
-    const operationMessage = `About to ${ACTION_NAMES[modalMode]} ${pluralSuffix(
-      runningInstancesCount,
+    const operationMessage = `${pluralSuffix(
+      selectedInstancesCount,
       'Instance',
-    )}.`;
+    )} selected for ${ACTION_NAMES[modalMode]} operation.`;
 
     const messages = [operationMessage];
 

--- a/operate/client/src/App/Processes/ListView/InstancesTable/Toolbar/index.tsx
+++ b/operate/client/src/App/Processes/ListView/InstancesTable/Toolbar/index.tsx
@@ -55,17 +55,33 @@ const Toolbar: React.FC<Props> = observer(({selectedInstancesCount}) => {
     processInstancesSelectionStore.reset();
   };
 
-  const getBodyText = () =>
-    modalMode === null
-      ? ''
-      : `About to ${ACTION_NAMES[modalMode]} ${pluralSuffix(
-          selectedInstancesCount,
-          'Instance',
-        )}.${
-          modalMode === 'CANCEL_PROCESS_INSTANCE'
-            ? ' In case there are called instances, these will be canceled too.'
-            : ''
-        } `;
+  const getBodyText = () => {
+    if (modalMode === null) {
+      return '';
+    }
+
+    const runningInstancesCount =
+      processInstancesSelectionStore.checkedRunningProcessInstanceIds.length;
+
+    const operationMessage = `About to ${ACTION_NAMES[modalMode]} ${pluralSuffix(
+      runningInstancesCount,
+      'Instance',
+    )}.`;
+
+    const messages = [operationMessage];
+
+    if (modalMode === 'CANCEL_PROCESS_INSTANCE') {
+      messages.push(
+        'In case there are called instances, these will be canceled too.',
+      );
+    }
+
+    if (selectedInstancesCount > runningInstancesCount) {
+      messages.push('Finished instances in your selection will be ignored.');
+    }
+
+    return messages.join(' ');
+  };
 
   if (selectedInstancesCount === 0) {
     return null;
@@ -94,11 +110,16 @@ const Toolbar: React.FC<Props> = observer(({selectedInstancesCount}) => {
           <TableBatchAction
             renderIcon={Error}
             onClick={() => setModalMode('CANCEL_PROCESS_INSTANCE')}
-            disabled={batchModificationStore.state.isEnabled}
+            disabled={
+              batchModificationStore.state.isEnabled ||
+              !processInstancesSelectionStore.hasSelectedRunningInstances
+            }
             title={
               batchModificationStore.state.isEnabled
                 ? 'Not available in batch modification mode'
-                : undefined
+                : !processInstancesSelectionStore.hasSelectedRunningInstances
+                  ? 'No active or incident process instances selected to cancel'
+                  : undefined
             }
           >
             Cancel
@@ -106,11 +127,16 @@ const Toolbar: React.FC<Props> = observer(({selectedInstancesCount}) => {
           <TableBatchAction
             renderIcon={RetryFailed}
             onClick={() => setModalMode('RESOLVE_INCIDENT')}
-            disabled={batchModificationStore.state.isEnabled}
+            disabled={
+              batchModificationStore.state.isEnabled ||
+              !processInstancesSelectionStore.hasSelectedRunningInstances
+            }
             title={
               batchModificationStore.state.isEnabled
                 ? 'Not available in batch modification mode'
-                : undefined
+                : !processInstancesSelectionStore.hasSelectedRunningInstances
+                  ? 'No active or incident process instances selected to retry'
+                  : undefined
             }
           >
             Retry

--- a/operate/client/src/App/Processes/ListView/InstancesTable/useOperationApply/index.setup.ts
+++ b/operate/client/src/App/Processes/ListView/InstancesTable/useOperationApply/index.setup.ts
@@ -45,7 +45,7 @@ const mockData = {
       operationType: 'RESOLVE_INCIDENT',
       query: {
         ...baseQuery,
-        ids: ['1'],
+        ids: ['2251799813685594'],
         excludeIds: [],
       },
     },
@@ -69,7 +69,7 @@ const mockData = {
       operationType: 'RESOLVE_INCIDENT',
       query: {
         ...baseQuery,
-        ids: ['1'],
+        ids: ['2251799813685594'],
         excludeIds: [],
         processIds: ['demoProcess1'],
       },

--- a/operate/client/src/App/Processes/ListView/InstancesTable/useOperationApply/index.test.tsx
+++ b/operate/client/src/App/Processes/ListView/InstancesTable/useOperationApply/index.test.tsx
@@ -117,7 +117,7 @@ describe('useOperationApply', () => {
     processInstancesStore.fetchProcessInstancesFromFilters();
     vi.stubGlobal('location', {
       ...window.location,
-      search: '?active=true&running=true&incidents=true&ids=1',
+      search: '?active=true&running=true&incidents=true&ids=2251799813685594',
     });
 
     mockApplyBatchOperation().withSuccess(mockOperationCreated);
@@ -126,7 +126,7 @@ describe('useOperationApply', () => {
       expect(processInstancesStore.state.status).toBe('fetched'),
     );
 
-    processInstancesSelectionStore.selectProcessInstance('1');
+    processInstancesSelectionStore.selectProcessInstance('2251799813685594');
 
     expect(operationsStore.state.operations).toEqual([]);
     renderUseOperationApply();
@@ -137,6 +137,8 @@ describe('useOperationApply', () => {
     expect(applyBatchOperationSpy).toHaveBeenCalledWith({
       operationType: expectedBody.operationType,
       query: expectedBody.query,
+      migrationPlan: undefined,
+      modifications: undefined,
     });
   });
 
@@ -188,7 +190,7 @@ describe('useOperationApply', () => {
     vi.stubGlobal('location', {
       ...window.location,
       search:
-        '?active=true&running=true&incidents=true&process=demoProcess&version=1&ids=1',
+        '?active=true&running=true&incidents=true&process=demoProcess&version=1&ids=2251799813685594',
     });
     await processesStore.fetchProcesses();
 
@@ -198,7 +200,7 @@ describe('useOperationApply', () => {
       expect(processInstancesStore.state.status).toBe('fetched'),
     );
 
-    processInstancesSelectionStore.selectProcessInstance('1');
+    processInstancesSelectionStore.selectProcessInstance('2251799813685594');
 
     expect(operationsStore.state.operations).toEqual([]);
     // @ts-expect-error ts-migrate(2554) FIXME: Expected 0 arguments, but got 1.
@@ -210,6 +212,8 @@ describe('useOperationApply', () => {
     expect(applyBatchOperationSpy).toHaveBeenCalledWith({
       operationType: expectedBody.operationType,
       query: expectedBody.query,
+      migrationPlan: undefined,
+      modifications: undefined,
     });
   });
 
@@ -272,7 +276,7 @@ describe('useOperationApply', () => {
   });
 
   it.skip('should poll the selected instances', async () => {
-    const {expectedBody, ...context} = mockData.setProcessFilterSelectOne;
+    const {...context} = mockData.setProcessFilterSelectOne;
     processInstancesSelectionStore.selectProcessInstance('2251799813685594');
 
     vi.useFakeTimers({shouldAdvanceTime: true});

--- a/operate/client/src/App/Processes/ListView/InstancesTable/useOperationApply/index.ts
+++ b/operate/client/src/App/Processes/ListView/InstancesTable/useOperationApply/index.ts
@@ -22,8 +22,12 @@ type ApplyBatchOperationParams = {
 };
 
 function useOperationApply() {
-  const {selectedProcessInstanceIds, excludedProcessInstanceIds, reset} =
-    processInstancesSelectionStore;
+  const {
+    selectedProcessInstanceIds,
+    excludedProcessInstanceIds,
+    checkedRunningProcessInstanceIds,
+    reset,
+  } = processInstancesSelectionStore;
 
   return {
     applyBatchOperation: ({
@@ -34,16 +38,22 @@ function useOperationApply() {
       const query = getProcessInstancesRequestFilters();
       const filterIds = query.ids || [];
 
-      // if ids are selected, ignore ids from filter
-      // if no ids are selected, apply ids from filter
+      const shouldFilterToRunningInstances =
+        operationType === 'CANCEL_PROCESS_INSTANCE' ||
+        operationType === 'RESOLVE_INCIDENT';
+
       const ids: string[] =
         selectedProcessInstanceIds.length > 0
-          ? selectedProcessInstanceIds
+          ? shouldFilterToRunningInstances
+            ? checkedRunningProcessInstanceIds
+            : selectedProcessInstanceIds
           : filterIds;
 
       if (selectedProcessInstanceIds.length > 0) {
         processInstancesStore.markProcessInstancesWithActiveOperations({
-          ids: selectedProcessInstanceIds,
+          ids: shouldFilterToRunningInstances
+            ? checkedRunningProcessInstanceIds
+            : selectedProcessInstanceIds,
           operationType,
         });
       } else {

--- a/operate/client/src/modules/stores/flowNodeInstance/tests/index.test.ts
+++ b/operate/client/src/modules/stores/flowNodeInstance/tests/index.test.ts
@@ -101,9 +101,7 @@ describe('stores/flowNodeInstance', () => {
         [PROCESS_INSTANCE_ID]: {
           ...mockFlowNodeInstances.level1[PROCESS_INSTANCE_ID],
           children: [
-            // eslint-disable-next-line testing-library/no-node-access
             ...mockFlowNodeInstances.level1[PROCESS_INSTANCE_ID]!.children,
-            // eslint-disable-next-line testing-library/no-node-access
             ...mockFlowNodeInstances.level1Next[PROCESS_INSTANCE_ID]!.children,
           ],
         },
@@ -141,9 +139,7 @@ describe('stores/flowNodeInstance', () => {
         [PROCESS_INSTANCE_ID]: {
           ...mockFlowNodeInstances.level1[PROCESS_INSTANCE_ID],
           children: [
-            // eslint-disable-next-line testing-library/no-node-access
             ...mockFlowNodeInstances.level1Prev[PROCESS_INSTANCE_ID]!.children,
-            // eslint-disable-next-line testing-library/no-node-access
             ...mockFlowNodeInstances.level1[PROCESS_INSTANCE_ID]!.children,
           ],
         },

--- a/operate/client/src/modules/stores/processInstancesSelection.ts
+++ b/operate/client/src/modules/stores/processInstancesSelection.ts
@@ -165,6 +165,28 @@ class ProcessInstancesSelection {
     );
   }
 
+  get checkedRunningProcessInstanceIds() {
+    const {selectionMode, selectedProcessInstanceIds} = this.state;
+    const runningInstances =
+      processInstancesStore.state.processInstances.filter((instance) =>
+        ['ACTIVE', 'INCIDENT'].includes(instance.state),
+      );
+
+    if (selectionMode === 'INCLUDE') {
+      return selectedProcessInstanceIds.filter((id) =>
+        runningInstances.some((instance) => instance.id === id),
+      );
+    }
+
+    const allRunningInstanceIds = runningInstances.map(
+      (instance) => instance.id,
+    );
+
+    return allRunningInstanceIds.filter(
+      (id) => !selectedProcessInstanceIds.includes(id),
+    );
+  }
+
   get checkedProcessInstanceIds() {
     const {selectionMode, selectedProcessInstanceIds} = this.state;
 

--- a/operate/client/src/modules/testUtils/dateTimeRange.ts
+++ b/operate/client/src/modules/testUtils/dateTimeRange.ts
@@ -29,9 +29,7 @@ const pickDateTimeRange = async ({
   toTime?: string;
 }) => {
   expect(screen.getByTestId('date-range-modal')).toHaveClass('is-visible');
-  // eslint-disable-next-line testing-library/no-node-access
   const monthName = document.querySelector('.cur-month')?.textContent;
-  // eslint-disable-next-line testing-library/no-node-access
   const year = document.querySelector<HTMLInputElement>('.cur-year')?.value;
   const month = new Date(`${monthName} 01, ${year}`).getMonth() + 1;
 

--- a/operate/client/src/modules/testUtils/selectComboBoxOption.ts
+++ b/operate/client/src/modules/testUtils/selectComboBoxOption.ts
@@ -87,7 +87,6 @@ const clearComboBox = async ({
   user: UserEvent;
   fieldName: string;
 }) => {
-  // eslint-disable-next-line testing-library/no-node-access
   const parentElement = screen.getByLabelText(fieldName).parentElement;
 
   await waitFor(() => expect(parentElement).toBeInTheDocument());


### PR DESCRIPTION
## Description

- Prevents finished instances to allow operations like Canceling and Retrying (disabled buttons on batch modifications);
- Handles a selection of mixed running and finished instances to only perform the desired operations on running instances;
- Adds disclaimer that finished process instances will be ignored for the purposes of the selected operation on the Apply Operation modal.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #32971
