### PR TITLE
35977 truncate batch operation error message

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/BatchOperationMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/BatchOperationMapper.java
@@ -74,6 +74,10 @@ public interface BatchOperationMapper {
 
     public BatchOperationErrorDto truncateErrorMessage(
         final int sizeLimit, final Integer byteLimit) {
+      if (message == null) {
+        return this;
+      }
+
       final var truncatedValue = TruncateUtil.truncateValue(message, sizeLimit, byteLimit);
 
       if (truncatedValue.length() < message.length()) {

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/BatchOperationMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/BatchOperationMapper.java
@@ -11,11 +11,14 @@ import io.camunda.db.rdbms.read.domain.BatchOperationDbQuery;
 import io.camunda.db.rdbms.read.domain.BatchOperationItemDbQuery;
 import io.camunda.db.rdbms.write.domain.BatchOperationDbModel;
 import io.camunda.db.rdbms.write.domain.BatchOperationItemDbModel;
+import io.camunda.db.rdbms.write.util.TruncateUtil;
 import io.camunda.search.entities.BatchOperationEntity;
 import io.camunda.search.entities.BatchOperationEntity.BatchOperationItemEntity;
 import io.camunda.search.entities.BatchOperationEntity.BatchOperationState;
 import java.time.OffsetDateTime;
 import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public interface BatchOperationMapper {
 
@@ -66,5 +69,21 @@ public interface BatchOperationMapper {
 
   record BatchOperationErrorsDto(String batchOperationKey, List<BatchOperationErrorDto> errors) {}
 
-  record BatchOperationErrorDto(Integer partitionId, String type, String message) {}
+  record BatchOperationErrorDto(Integer partitionId, String type, String message) {
+    public static final Logger LOG = LoggerFactory.getLogger(BatchOperationErrorDto.class);
+
+    public BatchOperationErrorDto truncateErrorMessage(
+        final int sizeLimit, final Integer byteLimit) {
+      final var truncatedValue = TruncateUtil.truncateValue(message, sizeLimit, byteLimit);
+
+      if (truncatedValue.length() < message.length()) {
+        LOG.warn(
+            "Truncated error message for batch operation partition {}, original message was: {}",
+            partitionId,
+            message);
+      }
+
+      return new BatchOperationErrorDto(partitionId, type, truncatedValue);
+    }
+  }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriter.java
@@ -114,7 +114,9 @@ public class RdbmsWriter {
     userTaskWriter = new UserTaskWriter(executionQueue, userTaskMapper);
     formWriter = new FormWriter(executionQueue);
     mappingRuleWriter = new MappingRuleWriter(executionQueue);
-    batchOperationWriter = new BatchOperationWriter(batchOperationReader, executionQueue, config);
+    batchOperationWriter =
+        new BatchOperationWriter(
+            batchOperationReader, executionQueue, config, vendorDatabaseProperties);
     jobWriter = new JobWriter(executionQueue, jobMapper, vendorDatabaseProperties);
     sequenceFlowWriter = new SequenceFlowWriter(executionQueue, sequenceFlowMapper);
     usageMetricWriter = new UsageMetricWriter(executionQueue, usageMetricMapper);

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/BatchOperationItemDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/BatchOperationItemDbModel.java
@@ -26,9 +26,13 @@ public record BatchOperationItemDbModel(
 
   public BatchOperationItemDbModel truncateErrorMessage(
       final int sizeLimit, final Integer byteLimit) {
+    if (errorMessage == null) {
+      return this;
+    }
+
     final var truncatedValue = TruncateUtil.truncateValue(errorMessage, sizeLimit, byteLimit);
 
-    if (truncatedValue.length() < errorMessage.length()) {
+    if (truncatedValue != null && truncatedValue.length() < errorMessage.length()) {
       LOG.warn(
           "Truncated error message for batchOperation {} item {}, original message was: {}",
           batchOperationKey,

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/BatchOperationItemDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/BatchOperationItemDbModel.java
@@ -7,8 +7,12 @@
  */
 package io.camunda.db.rdbms.write.domain;
 
+import static org.slf4j.LoggerFactory.getLogger;
+
+import io.camunda.db.rdbms.write.util.TruncateUtil;
 import io.camunda.search.entities.BatchOperationEntity;
 import java.time.OffsetDateTime;
+import org.slf4j.Logger;
 
 public record BatchOperationItemDbModel(
     String batchOperationKey,
@@ -16,4 +20,23 @@ public record BatchOperationItemDbModel(
     long processInstanceKey,
     BatchOperationEntity.BatchOperationItemState state,
     OffsetDateTime processedDate,
-    String errorMessage) {}
+    String errorMessage) {
+
+  private static final Logger LOG = getLogger(BatchOperationItemDbModel.class);
+
+  public BatchOperationItemDbModel truncateErrorMessage(
+      final int sizeLimit, final Integer byteLimit) {
+    final var truncatedValue = TruncateUtil.truncateValue(errorMessage, sizeLimit, byteLimit);
+
+    if (truncatedValue.length() < errorMessage.length()) {
+      LOG.warn(
+          "Truncated error message for batchOperation {} item {}, original message was: {}",
+          batchOperationKey,
+          itemKey,
+          errorMessage);
+    }
+
+    return new BatchOperationItemDbModel(
+        batchOperationKey, itemKey, processInstanceKey, state, processedDate, truncatedValue);
+  }
+}

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/mapper/BatchOperationEntityMapperTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/mapper/BatchOperationEntityMapperTest.java
@@ -9,6 +9,7 @@ package io.camunda.db.rdbms.read.mapper;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.db.rdbms.sql.BatchOperationMapper.BatchOperationErrorDto;
 import io.camunda.db.rdbms.write.domain.BatchOperationDbModel;
 import java.time.OffsetDateTime;
 import java.util.List;
@@ -67,5 +68,23 @@ class BatchOperationEntityMapperTest {
     assertThat(errorEntity.partitionId()).isEqualTo(42);
     assertThat(errorEntity.type()).isEqualTo("SOME_ERROR");
     assertThat(errorEntity.message()).isEqualTo("trace");
+  }
+
+  @Test
+  void shouldTruncateBatchOperationErrorMessageWithLargeValue() {
+    final var truncatedMessage =
+        new BatchOperationErrorDto(1, "errorType", "errorMessage").truncateErrorMessage(10, null);
+
+    assertThat(truncatedMessage.message().length()).isEqualTo(10);
+    assertThat(truncatedMessage.message()).isEqualTo("errorMessa");
+  }
+
+  @Test
+  void shouldTruncateBatchOperationErrorMessageWithLargeBytes() {
+    final var truncatedMessage =
+        new BatchOperationErrorDto(1, "errorType", "ääääääääää").truncateErrorMessage(50, 5);
+
+    assertThat(truncatedMessage.message().length()).isEqualTo(2);
+    assertThat(truncatedMessage.message()).isEqualTo("ää");
   }
 }

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/write/domain/BatchOperationItemDbModelTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/write/domain/BatchOperationItemDbModelTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.write.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.search.entities.BatchOperationEntity.BatchOperationItemState;
+import org.junit.jupiter.api.Test;
+
+class BatchOperationItemDbModelTest {
+
+  @Test
+  void shouldTruncateErrorMessage() {
+    final BatchOperationItemDbModel truncatedMessage =
+        new BatchOperationItemDbModel(
+                "batchId", 123L, 456L, BatchOperationItemState.ACTIVE, null, "errorMessage")
+            .truncateErrorMessage(10, null);
+
+    assertThat(truncatedMessage.errorMessage().length()).isEqualTo(10);
+    assertThat(truncatedMessage.errorMessage()).isEqualTo("errorMessa");
+  }
+
+  @Test
+  void shouldTruncateErrorMessageBytes() {
+    final BatchOperationItemDbModel truncatedMessage =
+        new BatchOperationItemDbModel(
+                "batchId", 123L, 456L, BatchOperationItemState.ACTIVE, null, "ääääääääää")
+            .truncateErrorMessage(50, 5);
+
+    assertThat(truncatedMessage.errorMessage().length()).isEqualTo(2);
+    assertThat(truncatedMessage.errorMessage()).isEqualTo("ää");
+  }
+}

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/write/service/BatchOperationWriterTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/write/service/BatchOperationWriterTest.java
@@ -9,6 +9,7 @@ package io.camunda.db.rdbms.write.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.db.rdbms.config.VendorDatabaseProperties;
 import io.camunda.db.rdbms.sql.BatchOperationMapper.BatchOperationItemsDto;
 import io.camunda.db.rdbms.write.RdbmsWriterConfig;
 import io.camunda.db.rdbms.write.domain.BatchOperationItemDbModel;
@@ -24,11 +25,14 @@ import org.mockito.Mockito;
 class BatchOperationWriterTest {
 
   private final ExecutionQueue executionQueue = Mockito.mock(ExecutionQueue.class);
+  private final VendorDatabaseProperties vendorDatabaseProperties =
+      Mockito.mock(VendorDatabaseProperties.class);
   private final BatchOperationWriter batchOperationWriter =
       new BatchOperationWriter(
           null,
           executionQueue,
-          RdbmsWriterConfig.builder().batchOperationItemInsertBlockSize(10).build());
+          RdbmsWriterConfig.builder().batchOperationItemInsertBlockSize(10).build(),
+          vendorDatabaseProperties);
 
   @Test
   void testSplitCorrectly() {


### PR DESCRIPTION
## Description

Error messages in BatchOperation and BatchOperationItem must be truncated to comply with vendor specific restrictions.

## Related issues

closes #35977 
