### PR TITLE
[Backport release-8.8.0-alpha7] fix: update os exporter position when skipping records

### DIFF
--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporter.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporter.java
@@ -126,9 +126,9 @@ public class ElasticsearchExporter implements Exporter {
 
     if (!shouldExportRecord(record)) {
       // ignore the record but still update the last exported position
-      // so that we don't block compaction.
+      // so that we don't block compaction. Don't update the controller yet, this needs to be done
+      // on the next flush.
       lastPosition = record.getPosition();
-      updateLastExportedPosition();
       return;
     }
     schemaManager.createSchema(record.getBrokerVersion());

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporter.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporter.java
@@ -110,6 +110,10 @@ public class OpensearchExporter implements Exporter {
   public void export(final Record<?> record) {
 
     if (!shouldExportRecord(record)) {
+      // ignore the record but still update the last exported position
+      // so that we don't block compaction.
+      lastPosition = record.getPosition();
+      updateLastExportedPosition();
       return;
     }
 

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporter.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporter.java
@@ -111,9 +111,9 @@ public class OpensearchExporter implements Exporter {
 
     if (!shouldExportRecord(record)) {
       // ignore the record but still update the last exported position
-      // so that we don't block compaction.
+      // so that we don't block compaction. Don't update the controller yet, this needs to be done
+      // on the next flush.
       lastPosition = record.getPosition();
-      updateLastExportedPosition();
       return;
     }
 

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterTest.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterTest.java
@@ -385,7 +385,7 @@ final class OpensearchExporterTest {
     }
 
     @Test
-    void shouldUpdatePositionWhenSkippingDisabledValueType() {
+    void shouldNotUpdatePositionWhenSkippingDisabledValueType() {
       // given
       TestSupport.setIndexingForValueType(config.index, ValueType.PROCESS_INSTANCE, false);
       final var record =
@@ -401,9 +401,31 @@ final class OpensearchExporterTest {
       exporter.export(record);
 
       // then
-      assertThat(controller.getPosition()).isEqualTo(10L);
+      assertThat(controller.getPosition()).isEqualTo(-1);
       verify(client, never()).index(any(), any());
       verify(client, never()).flush();
+    }
+
+    @Test
+    void shouldUpdatePositionWhenSkippingDisabledValueTypeAndFlushingAfterwards() {
+      // given
+      TestSupport.setIndexingForValueType(config.index, ValueType.PROCESS_INSTANCE, false);
+      final var record =
+          ImmutableRecord.builder()
+              .withPosition(10L)
+              .withBrokerVersion(VersionUtil.getVersionLowerCase())
+              .withValueType(ValueType.PROCESS_INSTANCE)
+              .build();
+      exporter.configure(context);
+      exporter.open(controller);
+      exporter.export(record);
+
+      // when
+      when(client.shouldFlush()).thenReturn(true);
+      controller.runScheduledTasks(Duration.ofSeconds(10));
+
+      // then
+      assertThat(controller.getPosition()).isEqualTo(10L);
     }
 
     @Test

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterTest.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterTest.java
@@ -385,6 +385,28 @@ final class OpensearchExporterTest {
     }
 
     @Test
+    void shouldUpdatePositionWhenSkippingDisabledValueType() {
+      // given
+      TestSupport.setIndexingForValueType(config.index, ValueType.PROCESS_INSTANCE, false);
+      final var record =
+          ImmutableRecord.builder()
+              .withPosition(10L)
+              .withBrokerVersion(VersionUtil.getVersionLowerCase())
+              .withValueType(ValueType.PROCESS_INSTANCE)
+              .build();
+      exporter.configure(context);
+      exporter.open(controller);
+
+      // when
+      exporter.export(record);
+
+      // then
+      assertThat(controller.getPosition()).isEqualTo(10L);
+      verify(client, never()).index(any(), any());
+      verify(client, never()).flush();
+    }
+
+    @Test
     void shouldNotUpdatePositionOnFlushErrors() {
       // given
       final var record =


### PR DESCRIPTION
# Description
Backport of #36289 to `release-8.8.0-alpha7`.

relates to 