### PR TITLE
feat: allow for disabling the archiver

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/config/ExporterConfiguration.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/config/ExporterConfiguration.java
@@ -176,6 +176,15 @@ public class ExporterConfiguration {
     private int maxDelayBetweenRuns = 60000;
     private RetentionConfiguration retention = new RetentionConfiguration();
     private boolean trackArchivalMetricsForProcessInstance = true;
+    private boolean archiverEnabled = true;
+
+    public boolean isArchiverEnabled() {
+      return archiverEnabled;
+    }
+
+    public void setArchiverEnabled(final boolean archiverEnabled) {
+      this.archiverEnabled = archiverEnabled;
+    }
 
     public String getElsRolloverDateFormat() {
       return elsRolloverDateFormat;

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManagerFactory.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManagerFactory.java
@@ -122,8 +122,10 @@ public final class BackgroundTaskManagerFactory {
       if (partitionId == START_PARTITION_ID) {
         tasks.add(buildBatchOperationArchiverJob());
         tasks.add(new ApplyRolloverPeriodJob(archiverRepository));
-        tasks.add(buildBatchOperationUpdateTask());
       }
+    }
+    if (partitionId == START_PARTITION_ID) {
+      tasks.add(buildBatchOperationUpdateTask());
     }
     executor.setCorePoolSize(tasks.size());
     return tasks;


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR adds a flag to disable the archiver being part of the exporter.

There should be some tests in place to assert that the implementation does not break anywhere during execution.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
