### PR TITLE
Smoke test operate zebee version match

### DIFF
--- a/.github/workflows/optimize-release-optimize-c8-only.yml
+++ b/.github/workflows/optimize-release-optimize-c8-only.yml
@@ -199,6 +199,10 @@ jobs:
           git config --global user.name "github-actions[release]"
           git config --global user.email "github-actions[release]@users.noreply.github.com"
 
+      - name: Clean Release
+        run: |
+          mvn release:clean
+
       - name: Prepare release
         run: |
           ./mvnw -f optimize \

--- a/.github/workflows/optimize-release-optimize-c8-only.yml
+++ b/.github/workflows/optimize-release-optimize-c8-only.yml
@@ -340,6 +340,7 @@ jobs:
           ELASTIC_VERSION: ${{ steps.pom-info.outputs.x_elasticsearch_test_version }}
           ZEEBE_VERSION: ${{ steps.pom-info.outputs.x_zeebe_version }}
           IDENTITY_VERSION: ${{ steps.pom-info.outputs.x_identity_version }}
+          OPERATE_VERSION: ${{ steps.pom-info.outputs.x_zeebe_version }}
 
       - name: Wait for Optimize to start
         run: ./.github/optimize/scripts/wait-for.sh http://localhost:8090/ready

--- a/optimize-distro/pom.xml
+++ b/optimize-distro/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda.optimize</groupId>
     <artifactId>optimize-parent</artifactId>
-    <version>8.7.7-SNAPSHOT</version>
+    <version>8.7.6-SNAPSHOT</version>
     <relativePath>../optimize/pom.xml</relativePath>
   </parent>
 

--- a/optimize/backend/pom.xml
+++ b/optimize/backend/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda.optimize</groupId>
     <artifactId>optimize-parent</artifactId>
-    <version>8.7.7-SNAPSHOT</version>
+    <version>8.7.6-SNAPSHOT</version>
   </parent>
 
   <artifactId>optimize-backend</artifactId>

--- a/optimize/client/pom.xml
+++ b/optimize/client/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda.optimize</groupId>
     <artifactId>optimize-parent</artifactId>
-    <version>8.7.7-SNAPSHOT</version>
+    <version>8.7.6-SNAPSHOT</version>
   </parent>
 
   <artifactId>client</artifactId>

--- a/optimize/pom.xml
+++ b/optimize/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>io.camunda.optimize</groupId>
   <artifactId>optimize-parent</artifactId>
-  <version>8.7.7-SNAPSHOT</version>
+  <version>8.7.6-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Optimize Parent</name>
 

--- a/optimize/qa/pom.xml
+++ b/optimize/qa/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.camunda.optimize</groupId>
         <artifactId>optimize-parent</artifactId>
-        <version>8.7.7-SNAPSHOT</version>
+        <version>8.7.6-SNAPSHOT</version>
     </parent>
 
   <artifactId>optimize-qa</artifactId>

--- a/optimize/qa/schema-integrity-tests/pom.xml
+++ b/optimize/qa/schema-integrity-tests/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda.optimize</groupId>
     <artifactId>optimize-qa</artifactId>
-    <version>8.7.7-SNAPSHOT</version>
+    <version>8.7.6-SNAPSHOT</version>
   </parent>
 
   <artifactId>optimize-schema-integrity-tests</artifactId>

--- a/optimize/upgrade/pom.xml
+++ b/optimize/upgrade/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda.optimize</groupId>
     <artifactId>optimize-parent</artifactId>
-    <version>8.7.7-SNAPSHOT</version>
+    <version>8.7.6-SNAPSHOT</version>
   </parent>
 
   <artifactId>upgrade-optimize</artifactId>

--- a/optimize/util/optimize-commons/pom.xml
+++ b/optimize/util/optimize-commons/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda.optimize</groupId>
     <artifactId>util</artifactId>
-    <version>8.7.7-SNAPSHOT</version>
+    <version>8.7.6-SNAPSHOT</version>
   </parent>
 
   <artifactId>optimize-commons</artifactId>

--- a/optimize/util/pom.xml
+++ b/optimize/util/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.camunda.optimize</groupId>
         <artifactId>optimize-parent</artifactId>
-        <version>8.7.7-SNAPSHOT</version>
+        <version>8.7.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>util</artifactId>


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
This PR includes two small but important fixes to improve the reliability of the Optimize Release C8 CI workflow:
1. Ensure Operate version matches Zeebe version
The smoke test now uses the same version of Operate as Zeebe, rather than defaulting to the latest Operate version. This avoids compatibility issues observed in recent CI runs.
2. Add Maven clean step before release preparation
Adds an explicit mvn clean step before the release preparation phase to reduce the risk of residual build artifacts blocking re-runs.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
