### PR TITLE
feat: add cluster host to unified configuration

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/Cluster.java
+++ b/configuration/src/main/java/io/camunda/configuration/Cluster.java
@@ -22,6 +22,9 @@ public class Cluster {
   /** Configuration for the distributed metadata manager in the cluster. */
   private Metadata metadata = new Metadata();
 
+  /** Network configuration for cluster communication. */
+  private Network network = new Network();
+
   /**
    * Specifies the unique id of this broker node in a cluster. The id should be between 0 and number
    * of nodes in the cluster (exclusive).
@@ -46,6 +49,14 @@ public class Cluster {
 
   public void setMetadata(final Metadata metadata) {
     this.metadata = metadata;
+  }
+
+  public Network getNetwork() {
+    return network;
+  }
+
+  public void setNetwork(final Network network) {
+    this.network = network;
   }
 
   public int getNodeId() {

--- a/configuration/src/main/java/io/camunda/configuration/Network.java
+++ b/configuration/src/main/java/io/camunda/configuration/Network.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import static io.camunda.zeebe.gateway.impl.configuration.ConfigurationDefaults.DEFAULT_CLUSTER_HOST;
+
+import java.util.Map;
+import java.util.Set;
+
+/** Network configuration for cluster communication. */
+public class Network {
+
+  private static final String PREFIX = "camunda.cluster.network.";
+
+  private static final Map<String, String> LEGACY_GATEWAY_NETWORK_PROPERTIES =
+      Map.of("host", "zeebe.gateway.cluster.host");
+  private static final Map<String, String> LEGACY_BROKER_NETWORK_PROPERTIES =
+      Map.of("host", "zeebe.broker.network.host");
+
+  private Map<String, String> legacyPropertiesMap = LEGACY_BROKER_NETWORK_PROPERTIES;
+
+  /** The network host for internal cluster communication. */
+  private String host = DEFAULT_CLUSTER_HOST;
+
+  public String getHost() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + "host",
+        host,
+        String.class,
+        UnifiedConfigurationHelper.BackwardsCompatibilityMode.SUPPORTED,
+        Set.of(legacyPropertiesMap.get("host")));
+  }
+
+  public void setHost(final String host) {
+    this.host = host;
+  }
+
+  @Override
+  public Network clone() {
+    final Network copy = new Network();
+    copy.host = host;
+
+    return copy;
+  }
+
+  public Network withBrokerNetworkProperties() {
+    final var copy = clone();
+    copy.legacyPropertiesMap = LEGACY_BROKER_NETWORK_PROPERTIES;
+    return copy;
+  }
+
+  public Network withGatewayNetworkProperties() {
+    final var copy = clone();
+    copy.legacyPropertiesMap = LEGACY_GATEWAY_NETWORK_PROPERTIES;
+    return copy;
+  }
+}

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
@@ -67,6 +67,7 @@ public class BrokerBasedPropertiesOverride {
     override.getCluster().setClusterSize(cluster.getSize());
 
     populateFromClusterMetadata(override);
+    populateFromClusterNetwork(override);
     // Rest of camunda.cluster.* sections
   }
 
@@ -78,6 +79,13 @@ public class BrokerBasedPropertiesOverride {
     final var configManagerGossipConfig =
         new ClusterConfigurationGossiperConfig(syncDelay, syncTimeout, gossipFanout);
     override.getCluster().setConfigManager(new ConfigManagerCfg(configManagerGossipConfig));
+  }
+
+  private void populateFromClusterNetwork(final BrokerBasedProperties override) {
+    final var network =
+        unifiedConfiguration.getCamunda().getCluster().getNetwork().withBrokerNetworkProperties();
+
+    override.getNetwork().setHost(network.getHost());
   }
 
   private void populateFromSystem(final BrokerBasedProperties override) {

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/GatewayBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/GatewayBasedPropertiesOverride.java
@@ -40,6 +40,8 @@ public class GatewayBasedPropertiesOverride {
     final GatewayBasedProperties override = new GatewayBasedProperties();
     BeanUtils.copyProperties(legacyGatewayBasedProperties, override);
 
+    // from camunda.cluster.* sections
+    populateFromCluster(override);
     populateFromLongPolling(override);
 
     // TODO: Populate the bean using unifiedConfiguration
@@ -55,5 +57,17 @@ public class GatewayBasedPropertiesOverride {
     longPollingCfg.setTimeout(longPolling.getTimeout());
     longPollingCfg.setProbeTimeout(longPolling.getProbeTimeout());
     longPollingCfg.setMinEmptyResponses(longPolling.getMinEmptyResponses());
+  }
+
+  private void populateFromCluster(final GatewayBasedProperties override) {
+    populateFromClusterNetwork(override);
+    // Rest of camunda.cluster.* sections
+  }
+
+  private void populateFromClusterNetwork(final GatewayBasedProperties override) {
+    final var network =
+        unifiedConfiguration.getCamunda().getCluster().getNetwork().withGatewayNetworkProperties();
+
+    override.getCluster().setHost(network.getHost());
   }
 }

--- a/configuration/src/test/java/io/camunda/configuration/BrokerNetworkPropertiesTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/BrokerNetworkPropertiesTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import static io.camunda.zeebe.gateway.impl.configuration.ConfigurationDefaults.DEFAULT_CLUSTER_HOST;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.configuration.beanoverrides.BrokerBasedPropertiesOverride;
+import io.camunda.configuration.beans.BrokerBasedProperties;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+@SpringJUnitConfig({
+  UnifiedConfiguration.class,
+  BrokerBasedPropertiesOverride.class,
+  UnifiedConfigurationHelper.class
+})
+@ActiveProfiles("broker")
+public class BrokerNetworkPropertiesTest {
+
+  @Nested
+  @TestPropertySource(properties = {"camunda.cluster.network.host=127.0.0.1"})
+  class WithNetworkPropertiesSet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithNetworkPropertiesSet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldSetNetworkProperties() {
+      assertThat(brokerCfg.getNetwork().getHost()).isEqualTo("127.0.0.1");
+    }
+  }
+
+  @Nested
+  @TestPropertySource(properties = {"zeebe.broker.network.host=broker.host.com"})
+  class WithLegacyBrokerNetworkPropertiesSet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithLegacyBrokerNetworkPropertiesSet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldSetNetworkPropertiesFromLegacyBroker() {
+      assertThat(brokerCfg.getNetwork().getHost()).isEqualTo("broker.host.com");
+    }
+  }
+
+  @Nested
+  @TestPropertySource(properties = {"zeebe.gateway.cluster.host=gateway.host.com"})
+  class WithLegacyGatewayNetworkPropertiesSet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithLegacyGatewayNetworkPropertiesSet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldNotSetNetworkPropertiesFromLegacyGateway() {
+      assertThat(brokerCfg.getNetwork().getHost()).isEqualTo(DEFAULT_CLUSTER_HOST);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        // new unified properties
+        "camunda.cluster.network.host=unified.host.com",
+        // legacy broker properties
+        "zeebe.broker.network.host=legacy.broker.com",
+        // legacy gateway properties
+        "zeebe.gateway.cluster.host=legacy.gateway.com"
+      })
+  class WithNewAndLegacyNetworkPropertiesSet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithNewAndLegacyNetworkPropertiesSet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldPrioritizeNewNetworkProperties() {
+      assertThat(brokerCfg.getNetwork().getHost()).isEqualTo("unified.host.com");
+    }
+  }
+}

--- a/configuration/src/test/java/io/camunda/configuration/GatewayNetworkPropertiesTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/GatewayNetworkPropertiesTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import static io.camunda.zeebe.gateway.impl.configuration.ConfigurationDefaults.DEFAULT_CLUSTER_HOST;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.configuration.beanoverrides.GatewayBasedPropertiesOverride;
+import io.camunda.configuration.beans.GatewayBasedProperties;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+@SpringJUnitConfig({
+  UnifiedConfiguration.class,
+  GatewayBasedPropertiesOverride.class,
+  UnifiedConfigurationHelper.class
+})
+@ActiveProfiles("gateway")
+public class GatewayNetworkPropertiesTest {
+
+  @Nested
+  @TestPropertySource(properties = {"camunda.cluster.network.host=127.0.0.1"})
+  class WithNetworkPropertiesSet {
+    final GatewayBasedProperties gatewayCfg;
+
+    WithNetworkPropertiesSet(@Autowired final GatewayBasedProperties gatewayCfg) {
+      this.gatewayCfg = gatewayCfg;
+    }
+
+    @Test
+    void shouldSetNetworkProperties() {
+      assertThat(gatewayCfg.getCluster().getHost()).isEqualTo("127.0.0.1");
+    }
+  }
+
+  @Nested
+  @TestPropertySource(properties = {"zeebe.broker.network.host=broker.host.com"})
+  class WithLegacyBrokerNetworkPropertiesSet {
+    final GatewayBasedProperties gatewayCfg;
+
+    WithLegacyBrokerNetworkPropertiesSet(@Autowired final GatewayBasedProperties gatewayCfg) {
+      this.gatewayCfg = gatewayCfg;
+    }
+
+    @Test
+    void shouldNotSetNetworkPropertiesFromLegacyBroker() {
+      assertThat(gatewayCfg.getCluster().getHost()).isEqualTo(DEFAULT_CLUSTER_HOST);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(properties = {"zeebe.gateway.cluster.host=gateway.host.com"})
+  class WithLegacyGatewayNetworkPropertiesSet {
+    final GatewayBasedProperties gatewayCfg;
+
+    WithLegacyGatewayNetworkPropertiesSet(@Autowired final GatewayBasedProperties gatewayCfg) {
+      this.gatewayCfg = gatewayCfg;
+    }
+
+    @Test
+    void shouldSetNetworkPropertiesFromLegacyGateway() {
+      assertThat(gatewayCfg.getCluster().getHost()).isEqualTo("gateway.host.com");
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        // new unified properties
+        "camunda.cluster.network.host=unified.host.com",
+        // legacy broker properties
+        "zeebe.broker.network.host=legacy.broker.com",
+        // legacy gateway properties
+        "zeebe.gateway.cluster.host=legacy.gateway.com",
+      })
+  class WithNewAndLegacyNetworkPropertiesSet {
+    final GatewayBasedProperties gatewayCfg;
+
+    WithNewAndLegacyNetworkPropertiesSet(@Autowired final GatewayBasedProperties gatewayCfg) {
+      this.gatewayCfg = gatewayCfg;
+    }
+
+    @Test
+    void shouldPrioritizeNewNetworkProperties() {
+      assertThat(gatewayCfg.getCluster().getHost()).isEqualTo("unified.host.com");
+    }
+  }
+}


### PR DESCRIPTION
## Description

This PR adds the network host to unified configuration. The legacy property is chosen based on if it is a gateway or broker, thus we can keep backwards compatibility with the existing deployments. 

The other properties in `camunda.cluster` can follow similar approach to choose between gateway or legacy broker properties.

## Checklist

- [x] The legacy properties and the backwards compatibility strategy are updated in [schema doc](https://docs.google.com/spreadsheets/d/1R4epsy6DWemA8_76cUE6zOGUFbrXCXlM2reXnKFuz7Y/edit?gid=818158292#gid=818158292) 
- [x] The new property fields are documented in the code
## Related issues

related to #34906 
