### PR TITLE
[Backport stable/8.6] Downgrade surefire version to 3.5.2 to allow running ArchUnit tests in the CI

### DIFF
--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -456,6 +456,11 @@
       <artifactId>java-jwt</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.opensearch.client</groupId>
+      <artifactId>opensearch-java</artifactId>
+    </dependency>
+
     <!-- /end -->
 
     <dependency>
@@ -660,6 +665,7 @@
             <ignoredNonTestScopedDependency>com.fasterxml.jackson.core:jackson-databind</ignoredNonTestScopedDependency>
             <ignoredNonTestScopedDependency>org.apache.httpcomponents.client5:httpclient5</ignoredNonTestScopedDependency>
             <ignoredNonTestScopedDependency>org.apache.httpcomponents.core5:httpcore5</ignoredNonTestScopedDependency>
+            <ignoredNonTestScopedDependency>org.opensearch.client:opensearch-java</ignoredNonTestScopedDependency>
           </ignoredNonTestScopedDependencies>
           <!-- dependencies only packaged but not explicitly used -->
           <usedDependencies>

--- a/dist/src/test/java/io/camunda/operate/OperateQualifiedBeansArchTest.java
+++ b/dist/src/test/java/io/camunda/operate/OperateQualifiedBeansArchTest.java
@@ -5,7 +5,7 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.it.operate;
+package io.camunda.operate;
 
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.fields;
 
@@ -27,7 +27,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 @AnalyzeClasses(
     packages = "io.camunda.operate",
     importOptions = ImportOption.DoNotIncludeTests.class)
-public class OperateQualifiedBeansArchIT {
+public class OperateQualifiedBeansArchTest {
 
   private static final String OPERATE_OBJECT_MAPPER_QUALIFIER = "operateObjectMapper";
 

--- a/dist/src/test/java/io/camunda/tasklist/TasklistQualifiedBeansArchTest.java
+++ b/dist/src/test/java/io/camunda/tasklist/TasklistQualifiedBeansArchTest.java
@@ -5,7 +5,7 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.it.tasklist;
+package io.camunda.tasklist;
 
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.fields;
 
@@ -27,7 +27,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 @AnalyzeClasses(
     packages = "io.camunda.tasklist",
     importOptions = ImportOption.DoNotIncludeTests.class)
-public class TasklistQualifiedBeansArchIT {
+public class TasklistQualifiedBeansArchTest {
 
   private static final String TASKLIST_OS_ASYNC_CLIENT_QUALIFIER = "tasklistOsAsyncClient";
 

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -217,7 +217,7 @@
     <plugin.version.shade>3.6.0</plugin.version.shade>
     <plugin.version.sonar>3.9.1.2184</plugin.version.sonar>
     <plugin.version.spotbugs>4.8.6.6</plugin.version.spotbugs>
-    <plugin.version.surefire>3.5.3</plugin.version.surefire>
+    <plugin.version.surefire>3.5.2</plugin.version.surefire>
     <plugin.version.versions>2.17.1</plugin.version.versions>
     <plugin.version.frontend-maven>1.15.1</plugin.version.frontend-maven>
     <plugin.version.maven-source>3.3.1</plugin.version.maven-source>

--- a/qa/integration-tests/pom.xml
+++ b/qa/integration-tests/pom.xml
@@ -234,26 +234,6 @@
       <artifactId>zeebe-test-container</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.opensearch.client</groupId>
-      <artifactId>opensearch-java</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.tngtech.archunit</groupId>
-      <artifactId>archunit</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.tngtech.archunit</groupId>
-      <artifactId>archunit-junit5-api</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.tngtech.archunit</groupId>
-      <artifactId>archunit-junit5-engine</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
# Description
Backport of #36115 to `stable/8.6`.

relates to TNG/ArchUnit#1442