### PR TITLE
[Backport stable/8.7] Downgrade surefire version to 3.5.2 to allow running ArchUnit tests in the CI

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -155,7 +155,23 @@
       "description": "Automerge all updates with green CI.",
       "matchPackagePatterns": ["*"],
       "automerge": true,
+<<<<<<< HEAD
       "addLabels": ["automerge"]
+=======
+      "addLabels": [
+        "automerge"
+      ]
+    },
+    {
+      "description": "Skip maven-surefire-plugin updates, as 3.5.3 version has a bug preventing ArchUnit tests from running. https://issues.apache.org/jira/browse/SUREFIRE-2298",
+      "matchManagers": [
+        "maven"
+      ],
+      "matchPackageNames": [
+        "org.apache.maven.plugins:maven-surefire-plugin"
+      ],
+      "enabled": false
+>>>>>>> 6d184e28 (ci: downgrade surefire version to 3.5.2 to allow running ArchUnit tests in the CI)
     }
   ],
   "dockerfile": {

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -216,9 +216,15 @@
     <plugin.version.revapi>0.15.1</plugin.version.revapi>
     <plugin.version.shade>3.6.0</plugin.version.shade>
     <plugin.version.sonar>3.9.1.2184</plugin.version.sonar>
+<<<<<<< HEAD
     <plugin.version.spotbugs>4.8.6.6</plugin.version.spotbugs>
     <plugin.version.surefire>3.5.2</plugin.version.surefire>
     <plugin.version.versions>2.17.1</plugin.version.versions>
+=======
+    <plugin.version.spotbugs>4.9.3.2</plugin.version.spotbugs>
+    <plugin.version.surefire>3.5.2</plugin.version.surefire>
+    <plugin.version.versions>2.18.0</plugin.version.versions>
+>>>>>>> 6d184e28 (ci: downgrade surefire version to 3.5.2 to allow running ArchUnit tests in the CI)
     <plugin.version.frontend-maven>1.15.1</plugin.version.frontend-maven>
     <plugin.version.maven-source>3.3.1</plugin.version.maven-source>
 


### PR DESCRIPTION
# Description
Backport of #36115 to `stable/8.7`.

relates to TNG/ArchUnit#1442