### PR TITLE
[Backport stable/8.7] feat: ad-hoc sub-process: allow intermediate catch events without outgoing sequence flows

### DIFF
--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/AdHocSubProcessValidator.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/AdHocSubProcessValidator.java
@@ -18,7 +18,6 @@ package io.camunda.zeebe.model.bpmn.validation.zeebe;
 import io.camunda.zeebe.model.bpmn.instance.AdHocSubProcess;
 import io.camunda.zeebe.model.bpmn.instance.EndEvent;
 import io.camunda.zeebe.model.bpmn.instance.FlowElement;
-import io.camunda.zeebe.model.bpmn.instance.IntermediateCatchEvent;
 import io.camunda.zeebe.model.bpmn.instance.StartEvent;
 import java.util.Collection;
 import org.camunda.bpm.model.xml.validation.ModelElementValidator;
@@ -48,11 +47,6 @@ public final class AdHocSubProcessValidator implements ModelElementValidator<AdH
     if (hasEndEvent(flowElements)) {
       validationResultCollector.addError(0, "Must not contain an end event.");
     }
-
-    if (hasSingleIntermediateCatchEvent(flowElements)) {
-      validationResultCollector.addError(
-          0, "Any intermediate catch event must have an outgoing sequence flow.");
-    }
   }
 
   private static boolean hasStartEvent(final Collection<FlowElement> flowElements) {
@@ -61,12 +55,5 @@ public final class AdHocSubProcessValidator implements ModelElementValidator<AdH
 
   private static boolean hasEndEvent(final Collection<FlowElement> flowElements) {
     return flowElements.stream().anyMatch(EndEvent.class::isInstance);
-  }
-
-  private static boolean hasSingleIntermediateCatchEvent(
-      final Collection<FlowElement> flowElements) {
-    return flowElements.stream()
-        .filter(IntermediateCatchEvent.class::isInstance)
-        .anyMatch(flowElement -> ((IntermediateCatchEvent) flowElement).getOutgoing().isEmpty());
   }
 }

--- a/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/AdhocSubprocessValidatorTest.java
+++ b/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/AdhocSubprocessValidatorTest.java
@@ -106,11 +106,7 @@ class AdhocSubprocessValidatorTest {
         process(adHocSubProcess -> adHocSubProcess.intermediateCatchEvent().signal("signal"));
 
     // when/then
-    ProcessValidationUtil.assertThatProcessHasViolations(
-        process,
-        expect(
-            AdHocSubProcess.class,
-            "Any intermediate catch event must have an outgoing sequence flow."));
+    ProcessValidationUtil.assertThatProcessIsValid(process);
   }
 
   @Test


### PR DESCRIPTION
# Description
Backport of #36135 to `stable/8.7`.

relates to camunda/ad-hoc-sub-process-phase-3#23 #31576