### PR TITLE
deps: revert linting to older version due to broken lint rule

### DIFF
--- a/operate/client/package-lock.json
+++ b/operate/client/package-lock.json
@@ -80,7 +80,7 @@
         "eslint-plugin-prettier": "5.5.1",
         "eslint-plugin-react-hooks": "5.2.0",
         "eslint-plugin-react-refresh": "0.4.20",
-        "eslint-plugin-testing-library": "7.6.3",
+        "eslint-plugin-testing-library": "7.5.3",
         "globals": "16.3.0",
         "jsdom": "26.1.0",
         "monaco-editor": "0.52.2",
@@ -6628,9 +6628,9 @@
       }
     },
     "node_modules/eslint-plugin-testing-library": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-testing-library/-/eslint-plugin-testing-library-7.6.3.tgz",
-      "integrity": "sha512-tI/epV/DD4+nJ51VGg7MWfqajMAW0+U+9dTLFrnqrJHoPO2TyGRU8ASrPNFPe2zzDT1qwznkCeeqMzViALgiig==",
+      "version": "7.5.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-testing-library/-/eslint-plugin-testing-library-7.5.3.tgz",
+      "integrity": "sha512-sZk5hIrx0p1ehvdS2qHefKwXHiEysiQN+FMGCzES6xRNUgwI3q4KdWMeAwpPDP9u0RDkNzJpebRUnNch1sJh+A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/operate/client/package.json
+++ b/operate/client/package.json
@@ -96,7 +96,7 @@
     "eslint-plugin-prettier": "5.5.1",
     "eslint-plugin-react-hooks": "5.2.0",
     "eslint-plugin-react-refresh": "0.4.20",
-    "eslint-plugin-testing-library": "7.6.3",
+    "eslint-plugin-testing-library": "7.5.3",
     "globals": "16.3.0",
     "jsdom": "26.1.0",
     "monaco-editor": "0.52.2",

--- a/tasklist/client/package-lock.json
+++ b/tasklist/client/package-lock.json
@@ -75,7 +75,7 @@
         "eslint-plugin-prettier": "5.5.0",
         "eslint-plugin-react-hooks": "5.2.0",
         "eslint-plugin-react-refresh": "0.4.20",
-        "eslint-plugin-testing-library": "7.6.3",
+        "eslint-plugin-testing-library": "7.5.3",
         "jsdom": "26.1.0",
         "monaco-editor": "0.52.2",
         "msw": "2.10.2",
@@ -620,9 +620,9 @@
       }
     },
     "node_modules/@carbon/colors": {
-      "version": "11.36.0",
-      "resolved": "https://registry.npmjs.org/@carbon/colors/-/colors-11.36.0.tgz",
-      "integrity": "sha512-qkTNnrJHESBUSTrftv/aiYw9sVdr41bHSYaOi2PoCIAXp4E+SLoqLhjhXR1yhK1Ep/mKesWNcp021fLYn7mHFQ==",
+      "version": "11.37.0",
+      "resolved": "https://registry.npmjs.org/@carbon/colors/-/colors-11.37.0.tgz",
+      "integrity": "sha512-PXZkIJ9AulEkiIFlI8fjaksi7tWuoPUKfChc5op55j6jP1zXTEfrb449SCKXOJM912MzY5EkaRGgNN09f6rM2Q==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -657,13 +657,13 @@
       }
     },
     "node_modules/@carbon/grid": {
-      "version": "11.39.0",
-      "resolved": "https://registry.npmjs.org/@carbon/grid/-/grid-11.39.0.tgz",
-      "integrity": "sha512-6zgkGQSyXYA59q0df01BqMwB+bvmjGs2NSt8ZOM0eMto46ca0UTLeFYOIv/qpAq42tUD//lOwzkogPIV2wIIGw==",
+      "version": "11.40.0",
+      "resolved": "https://registry.npmjs.org/@carbon/grid/-/grid-11.40.0.tgz",
+      "integrity": "sha512-WEQhlkSBjvhmC1yJTnDoNH7z1NVC6WuVzoORAY4ay7KJ71JfDLSU5lVbswj8YYQ9MfjECsTVwpTMJoAraZP0Hg==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@carbon/layout": "^11.37.0",
+        "@carbon/layout": "^11.38.0",
         "@ibm/telemetry-js": "^1.5.0"
       }
     },
@@ -703,9 +703,9 @@
       }
     },
     "node_modules/@carbon/layout": {
-      "version": "11.37.0",
-      "resolved": "https://registry.npmjs.org/@carbon/layout/-/layout-11.37.0.tgz",
-      "integrity": "sha512-7quU4RzMu+AKMKLNkrdOVoissk5SS0XSg3S1PNLZ951njptTMddWF+uMvImLNvwtPKFL/gYi1hJ5Z+ThDmP3aw==",
+      "version": "11.38.0",
+      "resolved": "https://registry.npmjs.org/@carbon/layout/-/layout-11.38.0.tgz",
+      "integrity": "sha512-VoPPfpp/Bom6ZspW4wvXiWFvP9930nTCCfQ8ibKEMZEYxKfzdW6zedLfL/BaNcDD+GlnaPbOJ+la730n9Q6TTQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -713,9 +713,9 @@
       }
     },
     "node_modules/@carbon/motion": {
-      "version": "11.31.0",
-      "resolved": "https://registry.npmjs.org/@carbon/motion/-/motion-11.31.0.tgz",
-      "integrity": "sha512-lFP7latcNDQnzggpiQTXspbbF90+FkOaUiiRrp+Mqf2Of9KgLTN1Dld4m3LDd6FPvacxBlkCZmxjwvQi4CNQLg==",
+      "version": "11.32.0",
+      "resolved": "https://registry.npmjs.org/@carbon/motion/-/motion-11.32.0.tgz",
+      "integrity": "sha512-vv+zJg0Y08/z0WqYnDDPfMj1SvgHO9NDLxBHd8M1AQZ/5QQp9jjfLnhAD7a8JTwy5zRTuoFqI7t5UVQzJ9B5MQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -756,19 +756,19 @@
       }
     },
     "node_modules/@carbon/styles": {
-      "version": "1.86.0",
-      "resolved": "https://registry.npmjs.org/@carbon/styles/-/styles-1.86.0.tgz",
-      "integrity": "sha512-DpO5Z3iJ4NO5fdqF4GgzHFCeHypgchilKu4RshkogF+xRuTMcLx78E8eaRh17KgH/hO8RiI6DEZ0mY9PrdtbMQ==",
+      "version": "1.87.0",
+      "resolved": "https://registry.npmjs.org/@carbon/styles/-/styles-1.87.0.tgz",
+      "integrity": "sha512-3GxG8zhpdS0oOQ7Np0Z/FdEugk7PLbncGgQ7N0XNMd+xWJdOlfrzgy/9mxUc4LOuRWAUq3juTu2CwCKzSirMdQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@carbon/colors": "^11.36.0",
-        "@carbon/feature-flags": "^0.28.0",
-        "@carbon/grid": "^11.39.0",
-        "@carbon/layout": "^11.37.0",
-        "@carbon/motion": "^11.31.0",
-        "@carbon/themes": "^11.56.0",
-        "@carbon/type": "^11.43.0",
+        "@carbon/colors": "^11.37.0",
+        "@carbon/feature-flags": "^0.29.0",
+        "@carbon/grid": "^11.40.0",
+        "@carbon/layout": "^11.38.0",
+        "@carbon/motion": "^11.32.0",
+        "@carbon/themes": "^11.57.0",
+        "@carbon/type": "^11.44.0",
         "@ibm/plex": "6.0.0-next.6",
         "@ibm/plex-mono": "0.0.3-alpha.0",
         "@ibm/plex-sans": "0.0.3-alpha.0",
@@ -790,9 +790,9 @@
       }
     },
     "node_modules/@carbon/styles/node_modules/@carbon/feature-flags": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@carbon/feature-flags/-/feature-flags-0.28.0.tgz",
-      "integrity": "sha512-NBjGPKBPA4lCK/s9CFhKeVhxuFiTvjfr3159RowcYAw9xMIvAgfRnTig1lp1W1XzBbPkLf6jnQqpy8h31YPYTA==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@carbon/feature-flags/-/feature-flags-0.29.0.tgz",
+      "integrity": "sha512-UFvD/6P/He8cq8onqMoSqeL4Nu4Alur8wPrZbD5HgkSMS8Ro2dKnebtn2Vy3EFgzTWSCYL7z70jJZvuoKtaPZg==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -800,28 +800,28 @@
       }
     },
     "node_modules/@carbon/themes": {
-      "version": "11.56.0",
-      "resolved": "https://registry.npmjs.org/@carbon/themes/-/themes-11.56.0.tgz",
-      "integrity": "sha512-AAsDPy8okiks6sGYcM2SNSCKu2PC0ccjy3aS5MnfNruZdKzdl9Ao0y94j2G/b1vv10QYMLi/2DFrPb1HxFkgqA==",
+      "version": "11.57.0",
+      "resolved": "https://registry.npmjs.org/@carbon/themes/-/themes-11.57.0.tgz",
+      "integrity": "sha512-1GpMP/DWtvoUq3XmOnybS80RLNi0NW7Xo4JrTkQrSZHBhHZjEhQK1z5bRYGS+g7Gq4sbNwRfGKYTP1H3266k4Q==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@carbon/colors": "^11.36.0",
-        "@carbon/layout": "^11.37.0",
-        "@carbon/type": "^11.43.0",
+        "@carbon/colors": "^11.37.0",
+        "@carbon/layout": "^11.38.0",
+        "@carbon/type": "^11.44.0",
         "@ibm/telemetry-js": "^1.5.0",
         "color": "^4.0.0"
       }
     },
     "node_modules/@carbon/type": {
-      "version": "11.43.0",
-      "resolved": "https://registry.npmjs.org/@carbon/type/-/type-11.43.0.tgz",
-      "integrity": "sha512-miT4mYa7n/+JnuRsZLmi8WYI0Pyeuj7VM3jid4lK+oS3o9p8Cm6U5/bMiv5cZk6ZsTZCqRHSNq+uuc4jwGi4eA==",
+      "version": "11.44.0",
+      "resolved": "https://registry.npmjs.org/@carbon/type/-/type-11.44.0.tgz",
+      "integrity": "sha512-zaR7mR23LjQ5MOT/pesv5wIw6WVnoeiBWrTmXOe9v9K3wFgKxY2c3GPxBqWBI/HLNKLhPPqzpJEU87G5WIiY0A==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@carbon/grid": "^11.39.0",
-        "@carbon/layout": "^11.37.0",
+        "@carbon/grid": "^11.40.0",
+        "@carbon/layout": "^11.38.0",
         "@ibm/telemetry-js": "^1.5.0"
       }
     },
@@ -6263,9 +6263,9 @@
       }
     },
     "node_modules/eslint-plugin-testing-library": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-testing-library/-/eslint-plugin-testing-library-7.6.3.tgz",
-      "integrity": "sha512-tI/epV/DD4+nJ51VGg7MWfqajMAW0+U+9dTLFrnqrJHoPO2TyGRU8ASrPNFPe2zzDT1qwznkCeeqMzViALgiig==",
+      "version": "7.5.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-testing-library/-/eslint-plugin-testing-library-7.5.3.tgz",
+      "integrity": "sha512-sZk5hIrx0p1ehvdS2qHefKwXHiEysiQN+FMGCzES6xRNUgwI3q4KdWMeAwpPDP9u0RDkNzJpebRUnNch1sJh+A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/tasklist/client/package.json
+++ b/tasklist/client/package.json
@@ -96,7 +96,7 @@
     "eslint-plugin-prettier": "5.5.0",
     "eslint-plugin-react-hooks": "5.2.0",
     "eslint-plugin-react-refresh": "0.4.20",
-    "eslint-plugin-testing-library": "7.6.3",
+    "eslint-plugin-testing-library": "7.5.3",
     "jsdom": "26.1.0",
     "monaco-editor": "0.52.2",
     "msw": "2.10.2",


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

The ESLint plugin was broken. There's a fix for it but it's not released yet: https://github.com/testing-library/eslint-plugin-testing-library/pull/1048

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
