### PR TITLE
fix: Bump identity version to last released

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -64,7 +64,7 @@
     <version.httpclient5>5.5</version.httpclient5>
     <version.httpcore5>5.3.4</version.httpcore5>
     <version.httpcomponents>4.4.16</version.httpcomponents>
-    <version.identity>8.8.0-alpha3</version.identity>
+    <version.identity>8.8.0-alpha6</version.identity>
     <version.instancio>5.5.0</version.instancio>
     <version.surefire>3.5.3</version.surefire>
     <version.jackson>2.19.2</version.jackson>


### PR DESCRIPTION
## Description

Current workflow doesn't update identity version for alpha releases, so we ended up with RC with outdated identity version. This PR is to unblock current RC. Improvements will be added ASAP.
<img width="682" height="560" alt="image" src="https://github.com/user-attachments/assets/a0947c47-4a6c-4d59-8a78-a6e947b0566a" />

Thread:  https://camunda.slack.com/archives/C06UWQNCU7M/p1754055181322479?thread_ts=1753881283.661829&cid=C06UWQNCU7M

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
