### PR TITLE
fix: Revert use of virtual threads for gRPC executor due to ES issue

### DIFF
--- a/dist/src/main/config/gateway.yaml.template
+++ b/dist/src/main/config/gateway.yaml.template
@@ -219,6 +219,21 @@
       # Sets the number of threads the gateway will use to communicate with the broker cluster
       # This setting can also be overridden using the environment variable ZEEBE_GATEWAY_THREADS_MANAGEMENTTHREADS.
       # managementThreads: 1
+      #
+      # A separate thread pool is used to run the gRPC business logic. The thread pool is elastic
+      # (meaning it will start/stop threads dynamically), but will always keep a minimum number of
+      # threads, and only start up to a maximum number of threads. By default, this range is from
+      # 1 thread per core, up to 2 threads per core.
+      #
+      # Sets the minimum number of threads in the gRPC thread pool. Only accepts static values;
+      # defaults to the number of cores available.
+      # This setting can also be overridden using the environment variable ZEEBE_GATEWAY_THREADS_GRPCMINTHREADS.
+      # grpcMinThreads:
+      #
+      # Sets the maximum number of threads in the gRPC thread pool. Only accepts static values;
+      # defaults to twice the number of cores available.
+      # This setting can also be overridden using the environment variable ZEEBE_GATEWAY_THREADS_GRPCMAXTHREADS.
+      # grpcMaxThreads:
 
     # security:
       # Enables TLS authentication between clients and the gateway

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/configuration/ThreadsCfg.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/configuration/ThreadsCfg.java
@@ -14,6 +14,8 @@ import java.util.Objects;
 public final class ThreadsCfg {
 
   private int managementThreads = DEFAULT_MANAGEMENT_THREADS;
+  private int grpcMinThreads = Runtime.getRuntime().availableProcessors();
+  private int grpcMaxThreads = 2 * Runtime.getRuntime().availableProcessors();
 
   public int getManagementThreads() {
     return managementThreads;
@@ -24,9 +26,25 @@ public final class ThreadsCfg {
     return this;
   }
 
+  public int getGrpcMinThreads() {
+    return grpcMinThreads;
+  }
+
+  public void setGrpcMinThreads(final int grpcMinThreads) {
+    this.grpcMinThreads = grpcMinThreads;
+  }
+
+  public int getGrpcMaxThreads() {
+    return grpcMaxThreads;
+  }
+
+  public void setGrpcMaxThreads(final int grpcMaxThreads) {
+    this.grpcMaxThreads = grpcMaxThreads;
+  }
+
   @Override
   public int hashCode() {
-    return Objects.hash(managementThreads);
+    return Objects.hash(managementThreads, grpcMinThreads, grpcMaxThreads);
   }
 
   @Override
@@ -38,11 +56,20 @@ public final class ThreadsCfg {
       return false;
     }
     final ThreadsCfg that = (ThreadsCfg) o;
-    return managementThreads == that.managementThreads;
+    return managementThreads == that.managementThreads
+        && grpcMinThreads == that.grpcMinThreads
+        && grpcMaxThreads == that.grpcMaxThreads;
   }
 
   @Override
   public String toString() {
-    return "ThreadsCfg{" + "managementThreads=" + managementThreads + '}';
+    return "ThreadsCfg{"
+        + "managementThreads="
+        + managementThreads
+        + ", grpcMinThreads="
+        + grpcMinThreads
+        + ", grpcMaxThreads="
+        + grpcMaxThreads
+        + '}';
   }
 }


### PR DESCRIPTION
Reverts:
 * f1cec07d44a6682fb7bc37d70952abd255c1017c
 * 5d82be2bc31c5482ba6a5115345569be23eddbb0
 * 116093e03f4e9f83c2c72a0b508bb9d4272485d5

## Description

This PR reverts the change made to the gRPC configuration which assigned a virtual thread executor
to run requests. The ES client does not support the use of virtual threads at this time, and this causes
a deadlock issue. This brings back the original ForkJoinPool, re-exposing configuration for the
thread pool. 

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
