### PR TITLE
[Backport release-8.8.0-alpha7] fix: Bump identity version to last released

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -64,7 +64,7 @@
     <version.httpclient5>5.5</version.httpclient5>
     <version.httpcore5>5.3.4</version.httpcore5>
     <version.httpcomponents>4.4.16</version.httpcomponents>
-    <version.identity>8.8.0-alpha3</version.identity>
+    <version.identity>8.8.0-alpha6</version.identity>
     <version.instancio>5.5.0</version.instancio>
     <version.surefire>3.5.3</version.surefire>
     <version.jackson>2.19.2</version.jackson>


### PR DESCRIPTION
# Description
Backport of #36339 to `release-8.8.0-alpha7`.

relates to 