### PR TITLE
Support basic authentication for the benchmark applications

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/CredentialsProvider.java
+++ b/clients/java/src/main/java/io/camunda/client/CredentialsProvider.java
@@ -15,6 +15,7 @@
  */
 package io.camunda.client;
 
+import io.camunda.client.impl.basicauth.BasicAuthCredentialsProviderBuilder;
 import io.camunda.client.impl.oauth.OAuthCredentialsProvider;
 import io.camunda.client.impl.oauth.OAuthCredentialsProviderBuilder;
 import io.grpc.Metadata;
@@ -46,6 +47,13 @@ public interface CredentialsProvider {
    */
   static OAuthCredentialsProviderBuilder newCredentialsProviderBuilder() {
     return new OAuthCredentialsProviderBuilder();
+  }
+
+  /**
+   * @return a builder to configure authentication use basic auth
+   */
+  static BasicAuthCredentialsProviderBuilder newBasicAuthCredentialsProviderBuilder() {
+    return new BasicAuthCredentialsProviderBuilder();
   }
 
   /**

--- a/zeebe/benchmarks/project/src/main/java/io/camunda/zeebe/config/AppCfg.java
+++ b/zeebe/benchmarks/project/src/main/java/io/camunda/zeebe/config/AppCfg.java
@@ -24,6 +24,7 @@ public class AppCfg {
   private int monitoringPort;
   private StarterCfg starter;
   private WorkerCfg worker;
+  private AuthCfg auth;
 
   public String getBrokerUrl() {
     return brokerUrl;
@@ -79,5 +80,13 @@ public class AppCfg {
 
   public void setMonitoringPort(final int monitoringPort) {
     this.monitoringPort = monitoringPort;
+  }
+
+  public AuthCfg getAuth() {
+    return auth;
+  }
+
+  public void setAuth(final AuthCfg auth) {
+    this.auth = auth;
   }
 }

--- a/zeebe/benchmarks/project/src/main/java/io/camunda/zeebe/config/AuthCfg.java
+++ b/zeebe/benchmarks/project/src/main/java/io/camunda/zeebe/config/AuthCfg.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.config;
+
+public final class AuthCfg {
+  private AuthType type = AuthType.NONE;
+  private BasicCfg basic = new BasicCfg();
+
+  public AuthType getType() {
+    return type;
+  }
+
+  public void setType(final AuthType type) {
+    this.type = type;
+  }
+
+  public BasicCfg getBasic() {
+    return basic;
+  }
+
+  public void setBasic(final BasicCfg basic) {
+    this.basic = basic;
+  }
+
+  public enum AuthType {
+    NONE,
+    BASIC
+  }
+
+  public static final class BasicCfg {
+    private String username;
+    private String password;
+
+    public String getUsername() {
+      return username;
+    }
+
+    public void setUsername(final String username) {
+      this.username = username;
+    }
+
+    public String getPassword() {
+      return password;
+    }
+
+    public void setPassword(final String password) {
+      this.password = password;
+    }
+  }
+}

--- a/zeebe/benchmarks/project/src/main/resources/application.conf
+++ b/zeebe/benchmarks/project/src/main/resources/application.conf
@@ -6,6 +6,14 @@ app {
   preferRest = false
   monitoringPort = 9600
 
+  auth {
+    type = "NONE" # NONE, BASIC
+    basic {
+      username = "demo"
+      password = "demo"
+    }
+  }
+
   starter {
     processId = "benchmark"
     rate = 300

--- a/zeebe/benchmarks/project/src/test/java/io/camunda/zeebe/config/ConfigTest.java
+++ b/zeebe/benchmarks/project/src/test/java/io/camunda/zeebe/config/ConfigTest.java
@@ -35,6 +35,11 @@ public class ConfigTest {
     assertThat(appCfg.isTls()).isFalse();
     assertThat(appCfg.getMonitoringPort()).isEqualTo(9600);
 
+    // authentication
+    final var authCfg = appCfg.getAuth();
+    assertThat(authCfg).isNotNull();
+    assertThat(authCfg.getType()).isEqualTo(AuthCfg.AuthType.NONE);
+
     // starter
     final var starterCfg = appCfg.getStarter();
     assertThat(starterCfg).isNotNull();
@@ -83,6 +88,13 @@ public class ConfigTest {
     assertThat(appCfg.isPreferRest()).isTrue();
     assertThat(appCfg.isTls()).isFalse();
     assertThat(appCfg.getMonitoringPort()).isEqualTo(9600);
+
+    // authentication
+    final var authCfg = appCfg.getAuth();
+    assertThat(authCfg).isNotNull();
+    assertThat(authCfg.getType()).isEqualTo(AuthCfg.AuthType.BASIC);
+    assertThat(authCfg.getBasic().getUsername()).isEqualTo("benchmark-user");
+    assertThat(authCfg.getBasic().getPassword()).isEqualTo("benchmark-password");
 
     // starter
     final var starterCfg = appCfg.getStarter();

--- a/zeebe/benchmarks/project/src/test/java/io/camunda/zeebe/config/ConfigTest.java
+++ b/zeebe/benchmarks/project/src/test/java/io/camunda/zeebe/config/ConfigTest.java
@@ -31,7 +31,7 @@ public class ConfigTest {
     // then
     assertThat(appCfg.getBrokerUrl()).isEqualTo("http://localhost:26500");
     assertThat(appCfg.getBrokerRestUrl()).isEqualTo("http://localhost:8080");
-    assertThat(appCfg.isPreferRest()).isEqualTo(false);
+    assertThat(appCfg.isPreferRest()).isFalse();
     assertThat(appCfg.isTls()).isFalse();
     assertThat(appCfg.getMonitoringPort()).isEqualTo(9600);
 
@@ -48,7 +48,7 @@ public class ConfigTest {
     assertThat(starterCfg.getPayloadPath()).isEqualTo("bpmn/big_payload.json");
     assertThat(starterCfg.isWithResults()).isFalse();
     assertThat(starterCfg.getWithResultsTimeout()).hasSeconds(60);
-    assertThat(starterCfg.getDurationLimit()).isEqualTo(0);
+    assertThat(starterCfg.getDurationLimit()).isZero();
     assertThat(starterCfg.getMsgName()).isEqualTo("msg");
     assertThat(starterCfg.isStartViaMessage()).isFalse();
 
@@ -80,7 +80,7 @@ public class ConfigTest {
     // then
     assertThat(appCfg.getBrokerUrl()).isEqualTo("http://localhost:26500");
     assertThat(appCfg.getBrokerRestUrl()).isEqualTo("http://localhost:8081");
-    assertThat(appCfg.isPreferRest()).isEqualTo(true);
+    assertThat(appCfg.isPreferRest()).isTrue();
     assertThat(appCfg.isTls()).isFalse();
     assertThat(appCfg.getMonitoringPort()).isEqualTo(9600);
 
@@ -102,7 +102,7 @@ public class ConfigTest {
     assertThat(starterCfg.getPayloadPath()).isEqualTo("bpmn/realistic/realisticPayload.json");
     assertThat(starterCfg.isWithResults()).isFalse();
     assertThat(starterCfg.getWithResultsTimeout()).hasSeconds(60);
-    assertThat(starterCfg.getDurationLimit()).isEqualTo(0);
+    assertThat(starterCfg.getDurationLimit()).isZero();
     assertThat(starterCfg.getMsgName()).isEqualTo("msg");
     assertThat(starterCfg.isStartViaMessage()).isFalse();
 

--- a/zeebe/benchmarks/project/src/test/resources/different-application.conf
+++ b/zeebe/benchmarks/project/src/test/resources/different-application.conf
@@ -6,6 +6,14 @@ app {
   monitoringPort = 9600
   preferRest = true
 
+  auth {
+    type = "BASIC" # NONE, BASIC
+    basic {
+      username = "benchmark-user"
+      password = "benchmark-password"
+    }
+  }
+
   starter {
     processId = "benchmark"
     rate = 300


### PR DESCRIPTION
## Description

This PR allows configuring the benchmark application to connect to an orchestration cluster configured for basic auth.

To use, you can use the properties:

```
-Dapp.auth.type=BASIC -Dapp.auth.basic.username=USERNAME -Dapp.auth.basic.password=PASSWORD
```

Or via environment variables:

```
CONFIG_FORCE_app_auth_type=BASIC
CONFIG_FORCE_app_auth_basic_username=demo
CONFIG_FORCE_app_auth_basic_password=demo
```

Or via the `CamundaClient` environment variable overrides:

```
CAMUNDA_BASIC_AUTH_USERNAME=demo
CAMUNDA_BASIC_AUTH_PASSWORD=password
```

This will simplify integration into our own benchmarks in the future when setting up things against basic auth, and sets the foundation to add support for OIDC.

In case the topology fails with a unauthenticated or permission denied error, I opted for a fail fast behavior, since there is likely no point in retrying. In a Kubernetes world, this will mean a crash loop, which is fine. For other errors, we still retry as we did before.
