### PR TITLE
Allow configuring benchmark application for OAuth

### DIFF
--- a/zeebe/benchmarks/project/src/main/java/io/camunda/zeebe/config/AuthCfg.java
+++ b/zeebe/benchmarks/project/src/main/java/io/camunda/zeebe/config/AuthCfg.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.config;
 public final class AuthCfg {
   private AuthType type = AuthType.NONE;
   private BasicCfg basic = new BasicCfg();
+  private OAuthConfig oauth = new OAuthConfig();
 
   public AuthType getType() {
     return type;
@@ -27,9 +28,18 @@ public final class AuthCfg {
     this.basic = basic;
   }
 
+  public OAuthConfig getOauth() {
+    return oauth;
+  }
+
+  public void setOauth(final OAuthConfig oauth) {
+    this.oauth = oauth;
+  }
+
   public enum AuthType {
     NONE,
-    BASIC
+    BASIC,
+    OAUTH
   }
 
   public static final class BasicCfg {
@@ -50,6 +60,45 @@ public final class AuthCfg {
 
     public void setPassword(final String password) {
       this.password = password;
+    }
+  }
+
+  public static final class OAuthConfig {
+    private String clientId;
+    private String clientSecret;
+    private String audience;
+    private String authzUrl;
+
+    public String getClientId() {
+      return clientId;
+    }
+
+    public void setClientId(final String clientId) {
+      this.clientId = clientId;
+    }
+
+    public String getClientSecret() {
+      return clientSecret;
+    }
+
+    public void setClientSecret(final String clientSecret) {
+      this.clientSecret = clientSecret;
+    }
+
+    public String getAudience() {
+      return audience;
+    }
+
+    public void setAudience(final String audience) {
+      this.audience = audience;
+    }
+
+    public String getAuthzUrl() {
+      return authzUrl;
+    }
+
+    public void setAuthzUrl(final String authzUrl) {
+      this.authzUrl = authzUrl;
     }
   }
 }

--- a/zeebe/benchmarks/project/src/main/resources/application.conf
+++ b/zeebe/benchmarks/project/src/main/resources/application.conf
@@ -12,6 +12,13 @@ app {
       username = "demo"
       password = "demo"
     }
+
+    oauth {
+      audience = "${brokerUrl}"
+      clientId = "client-id"
+      clientSecret = ""
+      authzUrl = "http://localhost:8080/auth/realms/demo/protocol/openid-connect/auth"
+    }
   }
 
   starter {

--- a/zeebe/benchmarks/project/src/test/java/io/camunda/zeebe/config/ConfigTest.java
+++ b/zeebe/benchmarks/project/src/test/java/io/camunda/zeebe/config/ConfigTest.java
@@ -96,6 +96,11 @@ public class ConfigTest {
     assertThat(authCfg.getBasic().getUsername()).isEqualTo("benchmark-user");
     assertThat(authCfg.getBasic().getPassword()).isEqualTo("benchmark-password");
 
+    assertThat(authCfg.getOauth().getAudience()).isEqualTo("zeebe");
+    assertThat(authCfg.getOauth().getClientId()).isEqualTo("benchmark-client");
+    assertThat(authCfg.getOauth().getClientSecret()).isEqualTo("benchmark-secret");
+    assertThat(authCfg.getOauth().getAuthzUrl()).isEqualTo("http://localhost:9090/auth");
+
     // starter
     final var starterCfg = appCfg.getStarter();
     assertThat(starterCfg).isNotNull();

--- a/zeebe/benchmarks/project/src/test/resources/different-application.conf
+++ b/zeebe/benchmarks/project/src/test/resources/different-application.conf
@@ -12,6 +12,13 @@ app {
       username = "benchmark-user"
       password = "benchmark-password"
     }
+
+    oauth {
+      audience = "zeebe"
+      clientId = "benchmark-client"
+      clientSecret = "benchmark-secret"
+      authzUrl = "http://localhost:9090/auth"
+    }
   }
 
   starter {


### PR DESCRIPTION
## Description

This PR adds the ability to configure the benchmark apps (both starter and worker) with OAuth credentials.

I only added a few properties, as there are so many possible properties. That said, all of them are configurable via the standard `CamundaClient` environment variables overrides.

Based on #36344, so please review and merge this first.