### PR TITLE
[Backport stable/8.6] fix: include members ready check after restart on replication loop

### DIFF
--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RandomizedRaftTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RandomizedRaftTest.java
@@ -234,7 +234,8 @@ public class RandomizedRaftTest {
     int maxStepsToReplicateEntries = 2000;
     while (!(raftContexts.hasLeaderAtTheLatestTerm()
             && raftContexts.hasReplicatedAllEntries()
-            && raftContexts.hasCommittedAllEntries())
+            && raftContexts.hasCommittedAllEntries()
+            && raftContexts.allMembersAreReady())
         && maxStepsToReplicateEntries-- > 0) {
       raftContexts.runUntilDone();
       raftContexts.processAllMessage();


### PR DESCRIPTION
# Description
Backport of #36275 to `stable/8.6`.

relates to #34209