### PR TITLE
[Backport release-8.8.0-alpha7] fix: include members ready check after restart on replication loop

### DIFF
--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RandomizedRaftTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RandomizedRaftTest.java
@@ -239,7 +239,8 @@ public class RandomizedRaftTest {
     int maxStepsToReplicateEntries = 2000;
     while (!(raftContexts.hasLeaderAtTheLatestTerm()
             && raftContexts.hasReplicatedAllEntries()
-            && raftContexts.hasCommittedAllEntries())
+            && raftContexts.hasCommittedAllEntries()
+            && raftContexts.allMembersAreReady())
         && maxStepsToReplicateEntries-- > 0) {
       raftContexts.runUntilDone();
       raftContexts.processAllMessage();


### PR DESCRIPTION
# Description
Backport of #36275 to `release-8.8.0-alpha7`.

relates to #34209