### PR TITLE
feat: default to not controlling socket buffer size

### DIFF
--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -170,6 +170,16 @@
       # This setting can also be overridden using the environment variable ZEEBE_BROKER_NETWORK_MAXMESSAGESIZE.
       # maxMessageSize: 4MB
 
+      # Sets the size of the socket receive buffer (SO_RCVBUF), for example 1MB.
+      # When not set (the default), the operating system can determine the optimal size automatically.
+      # This setting can also be overridden using the environment variable ZEEBE_BROKER_NETWORK_SOCKETRECEIVEBUFFER.
+      # socketReceiveBuffer:
+
+      # Sets the size of the socket send buffer (SO_SNDBUF), for example 1MB.
+      # When not set (the default), the operating system can determine the optimal size automatically.
+      # This setting can also be overridden using the environment variable ZEEBE_BROKER_NETWORK_SOCKETSENDBUFFER.
+      # socketSendBuffer:
+
       # Connections that did not receive any message within the specified timeout will be closed.
       # This setting can also be overridden using the environment variable ZEEBE_BROKER_NETWORK_HEARTBEATTIMEOUT.
       # heartbeatTimeout: 15s

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -78,13 +78,15 @@
       # This setting can also be overridden using the environment variable ZEEBE_BROKER_NETWORK_MAXMESSAGESIZE.
       # maxMessageSize: 4MB
 
-      # Sets the size of the socket receive buffer (SO_RCVBUF).
+      # Sets the size of the socket receive buffer (SO_RCVBUF), for example 1MB.
+      # When not set (the default), the operating system can determine the optimal size automatically.
       # This setting can also be overridden using the environment variable ZEEBE_BROKER_NETWORK_SOCKETRECEIVEBUFFER.
-      # socketReceiveBuffer: 1MB
+      # socketReceiveBuffer:
 
-      # Sets the size of the socket send buffer (SO_SNDBUF).
+      # Sets the size of the socket send buffer (SO_SNDBUF), for example 1MB.
+      # When not set (the default), the operating system can determine the optimal size automatically.
       # This setting can also be overridden using the environment variable ZEEBE_BROKER_NETWORK_SOCKETSENDBUFFER.
-      # socketSendBuffer: 1MB
+      # socketSendBuffer:
 
       # Connections that did not receive any message within the specified timeout will be closed.
       # This setting can also be overridden using the environment variable ZEEBE_BROKER_NETWORK_HEARTBEATTIMEOUT.

--- a/dist/src/main/config/gateway.yaml.template
+++ b/dist/src/main/config/gateway.yaml.template
@@ -56,13 +56,15 @@
       # This setting can also be overridden using the environment variable ZEEBE_GATEWAY_NETWORK_MAXMESSAGESIZE.
       # maxMessageSize: 4MB
 
-      # Sets the size of the socket receive buffer (SO_RCVBUF).
+      # Sets the size of the socket receive buffer (SO_RCVBUF), for example 1MB.
+      # When not set (the default), the operating system can determine the optimal size automatically.
       # This setting can also be overridden using the environment variable ZEEBE_GATEWAY_NETWORK_SOCKETRECEIVEBUFFER.
-      # socketReceiveBuffer: 1MB
+      # socketReceiveBuffer:
 
-      # Sets the size of the socket send buffer (SO_SNDBUF).
+      # Sets the size of the socket send buffer (SO_SNDBUF), for example 1MB
+      # When not set (the default), the operating system can determine the optimal size automatically.
       # This setting can also be overridden using the environment variable ZEEBE_GATEWAY_NETWORK_SOCKETSENDBUFFER.
-      # socketSendBuffer: 1MB
+      # socketSendBuffer:
 
     # cluster:
       # Sets initial contact points (brokers), which the gateway should contact to

--- a/dist/src/main/java/io/camunda/application/commons/configuration/GatewayBasedConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/configuration/GatewayBasedConfiguration.java
@@ -149,9 +149,13 @@ public final class GatewayBasedConfiguration {
         new MessagingConfig()
             .setCompressionAlgorithm(cluster.getMessageCompression())
             .setInterfaces(Collections.singletonList(cluster.getHost()))
-            .setPort(cluster.getPort())
-            .setSocketSendBuffer((int) cluster.getSocketSendBuffer().toBytes())
-            .setSocketReceiveBuffer((int) cluster.getSocketReceiveBuffer().toBytes());
+            .setPort(cluster.getPort());
+    if (cluster.getSocketSendBuffer() != null) {
+      messaging.setSocketSendBuffer((int) cluster.getSocketSendBuffer().toBytes());
+    }
+    if (cluster.getSocketReceiveBuffer() != null) {
+      messaging.setSocketReceiveBuffer((int) cluster.getSocketReceiveBuffer().toBytes());
+    }
 
     final var security = cluster.getSecurity();
     if (security.isEnabled()) {

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/MessagingConfig.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/MessagingConfig.java
@@ -24,6 +24,7 @@ import java.util.List;
 
 /** Messaging configuration. */
 public class MessagingConfig implements Config {
+  public static final int AUTO_SOCKET_SIZE = -11;
   private final int connectionPoolSize = 8;
   private List<String> interfaces = new ArrayList<>();
   private Integer port;
@@ -35,8 +36,8 @@ public class MessagingConfig implements Config {
   private CompressionAlgorithm compressionAlgorithm = CompressionAlgorithm.NONE;
   private File keyStore;
   private String keyStorePassword;
-  private int socketSendBuffer = -1;
-  private int socketReceiveBuffer = -1;
+  private int socketSendBuffer = AUTO_SOCKET_SIZE;
+  private int socketReceiveBuffer = AUTO_SOCKET_SIZE;
   private Duration heartbeatTimeout = Duration.ofSeconds(15);
   private Duration heartbeatInterval = Duration.ofSeconds(5);
 

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/MessagingConfig.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/MessagingConfig.java
@@ -25,7 +25,6 @@ import java.util.List;
 /** Messaging configuration. */
 public class MessagingConfig implements Config {
   public static final int AUTO_SOCKET_SIZE = -11;
-  private final int connectionPoolSize = 8;
   private List<String> interfaces = new ArrayList<>();
   private Integer port;
   private Duration shutdownQuietPeriod = Duration.ofMillis(20);
@@ -79,15 +78,6 @@ public class MessagingConfig implements Config {
   public MessagingConfig setPort(final Integer port) {
     this.port = port;
     return this;
-  }
-
-  /**
-   * Returns the connection pool size.
-   *
-   * @return the connection pool size
-   */
-  public int getConnectionPoolSize() {
-    return connectionPoolSize;
   }
 
   /**

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/MessagingConfig.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/MessagingConfig.java
@@ -35,8 +35,8 @@ public class MessagingConfig implements Config {
   private CompressionAlgorithm compressionAlgorithm = CompressionAlgorithm.NONE;
   private File keyStore;
   private String keyStorePassword;
-  private int socketSendBuffer = 1024 * 1024;
-  private int socketReceiveBuffer = 1024 * 1024;
+  private int socketSendBuffer = -1;
+  private int socketReceiveBuffer = -1;
   private Duration heartbeatTimeout = Duration.ofSeconds(15);
   private Duration heartbeatInterval = Duration.ofSeconds(5);
 
@@ -255,7 +255,7 @@ public class MessagingConfig implements Config {
   }
 
   /**
-   * @return the configured size in bytes for SO_SNDBUF
+   * @return the configured size in bytes for SO_SNDBUF or `-1` if not configured.
    */
   public int getSocketSendBuffer() {
     return socketSendBuffer;
@@ -273,7 +273,7 @@ public class MessagingConfig implements Config {
   }
 
   /**
-   * @return the configured size in bytes for SO_RCVBUF
+   * @return the configured size in bytes for SO_RCVBUF or `-1` if not configured.
    */
   public int getSocketReceiveBuffer() {
     return socketReceiveBuffer;

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/ChannelPool.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/ChannelPool.java
@@ -35,7 +35,7 @@ class ChannelPool {
   private final Map<Tuple<Address, InetAddress>, Map<String, CompletableFuture<Channel>>> channels =
       Maps.newConcurrentMap();
 
-  ChannelPool(final Function<Address, CompletableFuture<Channel>> factory, final int size) {
+  ChannelPool(final Function<Address, CompletableFuture<Channel>> factory) {
     this.factory = factory;
   }
 

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
@@ -819,8 +819,12 @@ public final class NettyMessagingService implements ManagedMessagingService {
     bootstrap.option(
         ChannelOption.WRITE_BUFFER_WATER_MARK,
         new WriteBufferWaterMark(10 * 32 * 1024, 10 * 64 * 1024));
-    bootstrap.option(ChannelOption.SO_RCVBUF, config.getSocketReceiveBuffer());
-    bootstrap.option(ChannelOption.SO_SNDBUF, config.getSocketSendBuffer());
+    if (config.getSocketReceiveBuffer() > 0) {
+      bootstrap.option(ChannelOption.SO_RCVBUF, config.getSocketReceiveBuffer());
+    }
+    if (config.getSocketSendBuffer() > 0) {
+      bootstrap.option(ChannelOption.SO_SNDBUF, config.getSocketSendBuffer());
+    }
     bootstrap.option(ChannelOption.SO_KEEPALIVE, true);
     bootstrap.option(ChannelOption.TCP_NODELAY, true);
     bootstrap.option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 1000);
@@ -877,8 +881,12 @@ public final class NettyMessagingService implements ManagedMessagingService {
     b.option(ChannelOption.SO_BACKLOG, 128);
     b.childOption(
         ChannelOption.WRITE_BUFFER_WATER_MARK, new WriteBufferWaterMark(8 * 1024, 32 * 1024));
-    b.childOption(ChannelOption.SO_RCVBUF, config.getSocketReceiveBuffer());
-    b.childOption(ChannelOption.SO_SNDBUF, config.getSocketSendBuffer());
+    if (config.getSocketReceiveBuffer() > 0) {
+      b.option(ChannelOption.SO_RCVBUF, config.getSocketReceiveBuffer());
+    }
+    if (config.getSocketSendBuffer() > 0) {
+      b.option(ChannelOption.SO_SNDBUF, config.getSocketSendBuffer());
+    }
     b.childOption(ChannelOption.SO_KEEPALIVE, true);
     b.childOption(ChannelOption.TCP_NODELAY, true);
     b.childOption(ChannelOption.ALLOCATOR, PooledByteBufAllocator.DEFAULT);

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
@@ -177,7 +177,7 @@ public final class NettyMessagingService implements ManagedMessagingService {
     this.protocolVersion = protocolVersion;
     this.config = verifyHeartbeatConfig(config);
     // pool of client connections
-    channelPool = new ChannelPool(this::openChannel, config.getConnectionPoolSize());
+    channelPool = new ChannelPool(this::openChannel);
     this.actorSchedulerName = actorSchedulerName;
     messagingMetrics = new MessagingMetricsImpl(registry);
     this.registry = registry;

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
@@ -819,10 +819,10 @@ public final class NettyMessagingService implements ManagedMessagingService {
     bootstrap.option(
         ChannelOption.WRITE_BUFFER_WATER_MARK,
         new WriteBufferWaterMark(10 * 32 * 1024, 10 * 64 * 1024));
-    if (config.getSocketReceiveBuffer() > 0) {
+    if (config.getSocketReceiveBuffer() != MessagingConfig.AUTO_SOCKET_SIZE) {
       bootstrap.option(ChannelOption.SO_RCVBUF, config.getSocketReceiveBuffer());
     }
-    if (config.getSocketSendBuffer() > 0) {
+    if (config.getSocketSendBuffer() != MessagingConfig.AUTO_SOCKET_SIZE) {
       bootstrap.option(ChannelOption.SO_SNDBUF, config.getSocketSendBuffer());
     }
     bootstrap.option(ChannelOption.SO_KEEPALIVE, true);

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/cluster/messaging/impl/ChannelPoolTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/cluster/messaging/impl/ChannelPoolTest.java
@@ -27,7 +27,7 @@ class ChannelPoolTest {
         when(channel.isActive()).thenReturn(true);
         return CompletableFuture.completedFuture(channel);
       };
-  private final ChannelPool channelPool = new ChannelPool(factory, 8);
+  private final ChannelPool channelPool = new ChannelPool(factory);
 
   @Test
   void shouldNotUseOldChannelWhenIPChanged() throws UnknownHostException {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/clustering/ClusterConfigFactory.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/clustering/ClusterConfigFactory.java
@@ -80,10 +80,15 @@ public final class ClusterConfigFactory {
             .setCompressionAlgorithm(cluster.getMessageCompression())
             .setInterfaces(Collections.singletonList(network.getInternalApi().getHost()))
             .setPort(network.getInternalApi().getPort())
-            .setSocketReceiveBuffer((int) network.getSocketReceiveBuffer().toBytes())
-            .setSocketSendBuffer((int) network.getSocketSendBuffer().toBytes())
             .setHeartbeatTimeout(network.getHeartbeatTimeout())
             .setHeartbeatInterval(network.getHeartbeatInterval());
+
+    if (network.getSocketSendBuffer() != null) {
+      messaging.setSocketSendBuffer((int) network.getSocketSendBuffer().toBytes());
+    }
+    if (network.getSocketReceiveBuffer() != null) {
+      messaging.setSocketReceiveBuffer((int) network.getSocketReceiveBuffer().toBytes());
+    }
 
     if (network.getSecurity().isEnabled()) {
       final var security = network.getSecurity();

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/NetworkCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/NetworkCfg.java
@@ -21,16 +21,14 @@ public final class NetworkCfg implements ConfigurationEntry {
   private static final String DEFAULT_HOST = "0.0.0.0";
   private static final String DEFAULT_ADVERTISED_HOST =
       Address.defaultAdvertisedHost().getHostAddress();
-  private static final DataSize DEFAULT_BROKER_SOCKET_SEND_BUFFER = DataSize.ofMegabytes(1);
-  private static final DataSize DEFAULT_BROKER_SOCKET_RECEIVE_BUFFER = DataSize.ofMegabytes(1);
 
   // leave host and advertised host to null, so we can distinguish if they are set explicitly or not
   private String host = null;
   private String advertisedHost = null;
   private int portOffset = 0;
   private DataSize maxMessageSize = DEFAULT_MAX_MESSAGE_SIZE;
-  private DataSize socketSendBuffer = DEFAULT_BROKER_SOCKET_SEND_BUFFER;
-  private DataSize socketReceiveBuffer = DEFAULT_BROKER_SOCKET_RECEIVE_BUFFER;
+  private DataSize socketSendBuffer = null;
+  private DataSize socketReceiveBuffer = null;
   private Duration heartbeatTimeout = Duration.ofSeconds(15);
   private Duration heartbeatInterval = Duration.ofSeconds(5);
 

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/BrokerCfgTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/BrokerCfgTest.java
@@ -555,7 +555,7 @@ public final class BrokerCfgTest {
     final BrokerCfg cfg = TestConfigReader.readConfig("cluster-cfg", environment);
 
     // then
-    assertThat(cfg.getNetwork().getSocketSendBuffer().toKilobytes()).isEqualTo(1024);
+    assertThat(cfg.getNetwork().getSocketSendBuffer()).isNull();
   }
 
   @Test
@@ -578,7 +578,7 @@ public final class BrokerCfgTest {
     final BrokerCfg cfg = TestConfigReader.readConfig("cluster-cfg", environment);
 
     // then
-    assertThat(cfg.getNetwork().getSocketReceiveBuffer().toKilobytes()).isEqualTo(1024);
+    assertThat(cfg.getNetwork().getSocketReceiveBuffer()).isNull();
   }
 
   @Test

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/configuration/ClusterCfg.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/configuration/ClusterCfg.java
@@ -14,8 +14,6 @@ import static io.camunda.zeebe.gateway.impl.configuration.ConfigurationDefaults.
 import static io.camunda.zeebe.gateway.impl.configuration.ConfigurationDefaults.DEFAULT_CLUSTER_PORT;
 import static io.camunda.zeebe.gateway.impl.configuration.ConfigurationDefaults.DEFAULT_CONTACT_POINT_HOST;
 import static io.camunda.zeebe.gateway.impl.configuration.ConfigurationDefaults.DEFAULT_CONTACT_POINT_PORT;
-import static io.camunda.zeebe.gateway.impl.configuration.ConfigurationDefaults.DEFAULT_GATEWAY_SOCKET_RECEIVE_BUFFER;
-import static io.camunda.zeebe.gateway.impl.configuration.ConfigurationDefaults.DEFAULT_GATEWAY_SOCKET_SEND_BUFFER;
 import static io.camunda.zeebe.gateway.impl.configuration.ConfigurationDefaults.DEFAULT_REQUEST_TIMEOUT;
 import static io.camunda.zeebe.util.StringUtil.LIST_SANITIZER;
 
@@ -46,8 +44,8 @@ public final class ClusterCfg {
   private SecurityCfg security = new SecurityCfg();
   private CompressionAlgorithm messageCompression = CompressionAlgorithm.NONE;
   private ConfigManagerCfg configManager = ConfigManagerCfg.defaultConfig();
-  private DataSize socketSendBuffer = DEFAULT_GATEWAY_SOCKET_SEND_BUFFER;
-  private DataSize socketReceiveBuffer = DEFAULT_GATEWAY_SOCKET_RECEIVE_BUFFER;
+  private DataSize socketSendBuffer = null;
+  private DataSize socketReceiveBuffer = null;
 
   public String getMemberId() {
     return memberId;

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/configuration/ConfigurationDefaults.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/configuration/ConfigurationDefaults.java
@@ -8,7 +8,6 @@
 package io.camunda.zeebe.gateway.impl.configuration;
 
 import java.time.Duration;
-import org.springframework.util.unit.DataSize;
 
 public final class ConfigurationDefaults {
 
@@ -18,8 +17,6 @@ public final class ConfigurationDefaults {
   public static final String DEFAULT_CONTACT_POINT_HOST = "127.0.0.1";
   public static final int DEFAULT_CONTACT_POINT_PORT = 26502;
 
-  public static final DataSize DEFAULT_GATEWAY_SOCKET_SEND_BUFFER = DataSize.ofMegabytes(1);
-  public static final DataSize DEFAULT_GATEWAY_SOCKET_RECEIVE_BUFFER = DataSize.ofMegabytes(1);
   public static final String DEFAULT_MAX_MESSAGE_SIZE = "4M";
   public static final int DEFAULT_MAX_MESSAGE_COUNT = 16;
   public static final Duration DEFAULT_REQUEST_TIMEOUT = Duration.ofSeconds(15);


### PR DESCRIPTION
Removes the previous default to 1MB for both send and receive buffers. Unless explicitly configured, we let the OS tune buffer size.

closes #35810
