### PR TITLE
fix: increase timeout value to avoid premature cancelation

### DIFF
--- a/.github/workflows/zeebe-aws-os-dispatch-tests.yml
+++ b/.github/workflows/zeebe-aws-os-dispatch-tests.yml
@@ -25,7 +25,7 @@ defaults:
 jobs:
   integration-tests:
     name: "[IT] ${{ matrix.name }}. OS ver.${{ matrix.os_version }}"
-    timeout-minutes: 15
+    timeout-minutes: 20
     runs-on: ${{ matrix.runs-on }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Description

fix: increase timeout value to avoid premature cancellation.

Some flows get periodic timeouts, like this one: https://github.com/camunda/camunda/actions/runs/16698606406/job/47325247238. This is probably due to poor resource performance at the AWS OS test instance.

This fix attempts to fix it.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

