### PR TITLE
feat: new cpt configuration prefix with backwards compatibility

### DIFF
--- a/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/configuration/CamundaProcessTestAutoConfiguration.java
+++ b/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/configuration/CamundaProcessTestAutoConfiguration.java
@@ -26,8 +26,9 @@ import org.springframework.context.annotation.Bean;
 @ImportAutoConfiguration({
   CamundaProcessTestProxyConfiguration.class,
   CamundaProcessTestDefaultConfiguration.class,
+  LegacyCamundaProcessTestRuntimeConfiguration.class,
+  CamundaProcessTestRuntimeConfiguration.class,
   CamundaAutoConfiguration.class,
-  CamundaProcessTestRuntimeConfiguration.class
 })
 @AutoConfigureBefore(CamundaAutoConfiguration.class)
 public class CamundaProcessTestAutoConfiguration {

--- a/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/configuration/LegacyCamundaProcessTestRuntimeConfiguration.java
+++ b/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/configuration/LegacyCamundaProcessTestRuntimeConfiguration.java
@@ -20,16 +20,14 @@ import io.camunda.process.test.impl.runtime.CamundaProcessTestRuntimeDefaults;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import org.springframework.beans.BeanUtils;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Primary;
 
 @Configuration
-@ConfigurationProperties(prefix = "camunda.process-test")
-public class CamundaProcessTestRuntimeConfiguration {
+@ConfigurationProperties(prefix = "io.camunda.process.test")
+@Deprecated
+public class LegacyCamundaProcessTestRuntimeConfiguration {
 
   private String camundaDockerImageName =
       CamundaProcessTestRuntimeDefaults.CAMUNDA_DOCKER_IMAGE_NAME;
@@ -50,66 +48,20 @@ public class CamundaProcessTestRuntimeConfiguration {
 
   @NestedConfigurationProperty private RemoteConfiguration remote = new RemoteConfiguration();
 
-  @Bean
-  @Primary
-  public CamundaProcessTestRuntimeConfiguration runtimeConfiguration(
-      final LegacyCamundaProcessTestRuntimeConfiguration legacyConfiguration) {
-    final CamundaProcessTestRuntimeConfiguration mergedConfig =
-        new CamundaProcessTestRuntimeConfiguration();
-
-    BeanUtils.copyProperties(legacyConfiguration, mergedConfig);
-
-    return mergedConfig;
-  }
-
-  /**
-   * Gets the Camunda docker image version.
-   *
-   * @return the camunda docker image version
-   * @deprecated use getCamundaDockerImageVersion
-   * @since 8.8.0
-   */
-  @Deprecated
-  public String getCamundaVersion() {
-    return getCamundaDockerImageVersion();
-  }
-
-  /**
-   * Sets the Camunda docker image version.
-   *
-   * @param camundaDockerImageVersion the Camunda docker image version to set
-   * @deprecated use setCamundaDockerImageVersion
-   * @since 8.8.0
-   */
-  @Deprecated
-  public void setCamundaVersion(final String camundaDockerImageVersion) {
-    this.camundaDockerImageVersion = camundaDockerImageVersion;
-  }
-
-  /**
-   * Gets the Camunda docker image version.
-   *
-   * @return the camunda docker image version
-   */
-  public String getCamundaDockerImageVersion() {
-    return camundaDockerImageVersion;
-  }
-
-  /**
-   * Sets the Camunda docker image version.
-   *
-   * @param camundaDockerImageVersion the Camunda docker image version to set
-   */
-  public void setCamundaDockerImageVersion(final String camundaDockerImageVersion) {
-    this.camundaDockerImageVersion = camundaDockerImageVersion;
-  }
-
   public String getCamundaDockerImageName() {
     return camundaDockerImageName;
   }
 
   public void setCamundaDockerImageName(final String camundaDockerImageName) {
     this.camundaDockerImageName = camundaDockerImageName;
+  }
+
+  public String getCamundaDockerImageVersion() {
+    return camundaDockerImageVersion;
+  }
+
+  public void setCamundaDockerImageVersion(final String camundaDockerImageVersion) {
+    this.camundaDockerImageVersion = camundaDockerImageVersion;
   }
 
   public Map<String, String> getCamundaEnvVars() {

--- a/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/configuration/RemoteConfiguration.java
+++ b/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/configuration/RemoteConfiguration.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.impl.configuration;
+
+import io.camunda.process.test.impl.runtime.CamundaProcessTestRuntimeDefaults;
+import io.camunda.spring.client.properties.CamundaClientProperties;
+import java.net.URI;
+import java.util.Objects;
+import org.springframework.boot.context.properties.NestedConfigurationProperty;
+
+public class RemoteConfiguration {
+
+  @NestedConfigurationProperty
+  private CamundaClientProperties client = new CamundaClientProperties();
+
+  private URI camundaMonitoringApiAddress =
+      CamundaProcessTestRuntimeDefaults.LOCAL_CAMUNDA_MONITORING_API_ADDRESS;
+
+  private URI connectorsRestApiAddress =
+      CamundaProcessTestRuntimeDefaults.LOCAL_CONNECTORS_REST_API_ADDRESS;
+
+  public CamundaClientProperties getClient() {
+    return client;
+  }
+
+  public void setClient(final CamundaClientProperties client) {
+    this.client = client;
+  }
+
+  public URI getCamundaMonitoringApiAddress() {
+    return camundaMonitoringApiAddress;
+  }
+
+  public void setCamundaMonitoringApiAddress(final URI camundaMonitoringApiAddress) {
+    this.camundaMonitoringApiAddress = camundaMonitoringApiAddress;
+  }
+
+  public URI getConnectorsRestApiAddress() {
+    return connectorsRestApiAddress;
+  }
+
+  public void setConnectorsRestApiAddress(final URI connectorsRestApiAddress) {
+    this.connectorsRestApiAddress = connectorsRestApiAddress;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final RemoteConfiguration that = (RemoteConfiguration) o;
+    return Objects.equals(camundaMonitoringApiAddress, that.camundaMonitoringApiAddress)
+        && Objects.equals(connectorsRestApiAddress, that.connectorsRestApiAddress);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(camundaMonitoringApiAddress, connectorsRestApiAddress);
+  }
+}

--- a/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/api/CamundaProcessTestRuntimeConfigurationIT.java
+++ b/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/api/CamundaProcessTestRuntimeConfigurationIT.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.process.test.impl.configuration.CamundaProcessTestAutoConfiguration;
+import io.camunda.process.test.impl.configuration.CamundaProcessTestRuntimeConfiguration;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+
+@SpringBootTest(
+    classes = {LegacyCamundaProcessTestRuntimeConfigurationIT.class},
+    properties = {
+      "camunda.process-test.connectors-enabled=true",
+      "camunda.process-test.camunda-docker-image-version=8.8.0-new",
+      "camunda.process-test.camunda-docker-image-name=camunda/camunda-new",
+      "io.camunda.process.test.camunda-docker-image-name=camunda/camunda-legacy",
+    })
+@Import({CamundaProcessTestAutoConfiguration.class})
+public class CamundaProcessTestRuntimeConfigurationIT {
+
+  @Autowired private CamundaProcessTestRuntimeConfiguration configuration;
+
+  @Test
+  public void shouldReadConfigurationWithNewPrefix() {
+    assertThat(configuration.isConnectorsEnabled()).isTrue();
+    assertThat(configuration.getCamundaDockerImageVersion()).isEqualTo("8.8.0-new");
+    assertThat(configuration.getCamundaDockerImageName()).isEqualTo("camunda/camunda-new");
+  }
+}

--- a/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/api/CamundaSpringProcessTestClockResetIT.java
+++ b/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/api/CamundaSpringProcessTestClockResetIT.java
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
-@SpringBootTest(classes = {CamundaSpringProcessTestListenerIT.class})
+@SpringBootTest(classes = {CamundaSpringProcessTestClockResetIT.class})
 @CamundaSpringProcessTest
 public class CamundaSpringProcessTestClockResetIT {
 

--- a/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/api/LegacyCamundaProcessTestRuntimeConfigurationIT.java
+++ b/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/api/LegacyCamundaProcessTestRuntimeConfigurationIT.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.process.test.impl.configuration.CamundaProcessTestAutoConfiguration;
+import io.camunda.process.test.impl.configuration.CamundaProcessTestRuntimeConfiguration;
+import io.camunda.process.test.impl.configuration.LegacyCamundaProcessTestRuntimeConfiguration;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+
+@SpringBootTest(
+    classes = {
+      LegacyCamundaProcessTestRuntimeConfiguration.class,
+      CamundaProcessTestAutoConfiguration.class,
+      LegacyCamundaProcessTestRuntimeConfigurationIT.class,
+    },
+    properties = {
+      "io.camunda.process.test.connectors-enabled=true",
+      "io.camunda.process.test.camunda-docker-image-version=8.8.0-legacy",
+      "io.camunda.process.test.camunda-docker-image-name=camunda/camunda-legacy"
+    })
+@Import({CamundaProcessTestAutoConfiguration.class})
+public class LegacyCamundaProcessTestRuntimeConfigurationIT {
+
+  @Autowired private CamundaProcessTestRuntimeConfiguration runtimeConfiguration;
+
+  @Test
+  public void usesLegacyConfiguration() {
+    assertThat(runtimeConfiguration.isConnectorsEnabled()).isTrue();
+    assertThat(runtimeConfiguration.getCamundaDockerImageVersion()).isEqualTo("8.8.0-legacy");
+    assertThat(runtimeConfiguration.getCamundaDockerImageName())
+        .isEqualTo("camunda/camunda-legacy");
+  }
+}

--- a/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/impl/CamundaSpringProcessTestRuntimeBuilderTest.java
+++ b/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/impl/CamundaSpringProcessTestRuntimeBuilderTest.java
@@ -25,7 +25,7 @@ import io.camunda.client.impl.oauth.OAuthCredentialsProvider;
 import io.camunda.process.test.api.CamundaClientBuilderFactory;
 import io.camunda.process.test.api.CamundaProcessTestRuntimeMode;
 import io.camunda.process.test.impl.configuration.CamundaProcessTestRuntimeConfiguration;
-import io.camunda.process.test.impl.configuration.CamundaProcessTestRuntimeConfiguration.RemoteConfiguration;
+import io.camunda.process.test.impl.configuration.RemoteConfiguration;
 import io.camunda.process.test.impl.runtime.CamundaProcessTestContainerRuntime;
 import io.camunda.process.test.impl.runtime.CamundaProcessTestRemoteRuntime;
 import io.camunda.process.test.impl.runtime.CamundaProcessTestRuntime;


### PR DESCRIPTION
## Description

Changed the CPT configuration prefix from "io.camunda.process.test" to "camunda.process-test" and ensured that the legacy configuration is still usable.

## Related issues

closes #35436
