### PR TITLE
fix bo legacy status mapping

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/search/enums/BatchOperationState.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/enums/BatchOperationState.java
@@ -22,6 +22,5 @@ public enum BatchOperationState {
   COMPLETED,
   PARTIALLY_COMPLETED,
   CANCELED,
-  INCOMPLETED,
   UNKNOWN_ENUM_VALUE;
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/operate/OperateProcessInstanceAddVariableIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/operate/OperateProcessInstanceAddVariableIT.java
@@ -18,6 +18,7 @@ import static io.camunda.client.api.search.enums.ResourceType.PROCESS_DEFINITION
 import static io.camunda.client.api.search.enums.ResourceType.RESOURCE;
 import static io.camunda.it.util.TestHelper.deployProcessAndWaitForIt;
 import static io.camunda.it.util.TestHelper.startScopedProcessInstance;
+import static io.camunda.it.util.TestHelper.waitForBatchOperationCompleted;
 import static io.camunda.it.util.TestHelper.waitForBatchOperationWithCorrectTotalCount;
 import static io.camunda.it.util.TestHelper.waitForScopedProcessInstancesToStart;
 import static io.camunda.it.util.TestHelper.waitUntilProcessInstanceHasVariable;
@@ -113,6 +114,7 @@ public class OperateProcessInstanceAddVariableIT {
 
     waitForBatchOperationWithCorrectTotalCount(client, batchOperationId, 1);
     waitUntilProcessInstanceHasVariable(client, processInstanceKey, "foo", "\"bar\"");
+    waitForBatchOperationCompleted(client, batchOperationId, 1, 0);
   }
 
   private List<Long> createProcessInstances(

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/operate/OperateProcessInstanceCancellationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/operate/OperateProcessInstanceCancellationIT.java
@@ -18,6 +18,7 @@ import static io.camunda.client.api.search.enums.ResourceType.PROCESS_DEFINITION
 import static io.camunda.client.api.search.enums.ResourceType.RESOURCE;
 import static io.camunda.it.util.TestHelper.deployProcessAndWaitForIt;
 import static io.camunda.it.util.TestHelper.startScopedProcessInstance;
+import static io.camunda.it.util.TestHelper.waitForBatchOperationCompleted;
 import static io.camunda.it.util.TestHelper.waitForBatchOperationWithCorrectTotalCount;
 import static io.camunda.it.util.TestHelper.waitForProcessInstanceToBeTerminated;
 import static io.camunda.it.util.TestHelper.waitForScopedProcessInstancesToStart;
@@ -119,6 +120,7 @@ public class OperateProcessInstanceCancellationIT {
 
     waitForBatchOperationWithCorrectTotalCount(
         client, batchOperationId.get(), processInstanceCount);
+    waitForBatchOperationCompleted(client, batchOperationId.get(), processInstanceCount, 0);
 
     for (final Long key : processInstanceKeys) {
       waitForProcessInstanceToBeTerminated(client, key);

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/BatchOperationEntityTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/BatchOperationEntityTransformer.java
@@ -65,7 +65,9 @@ public class BatchOperationEntityTransformer
       final io.camunda.webapps.schema.entities.operation.BatchOperationEntity source) {
     return new BatchOperationEntity(
         source.getId(),
-        BatchOperationState.INCOMPLETED,
+        source.getState() != null
+            ? BatchOperationState.valueOf(source.getState().name())
+            : interpolateLegacyState(source),
         source.getType() != null ? BatchOperationType.valueOf(source.getType().name()) : null,
         source.getStartDate(),
         source.getEndDate(),
@@ -73,5 +75,16 @@ public class BatchOperationEntityTransformer
         0,
         source.getOperationsFinishedCount(),
         Collections.emptyList());
+  }
+
+  private BatchOperationState interpolateLegacyState(
+      final io.camunda.webapps.schema.entities.operation.BatchOperationEntity entity) {
+    if (entity.getEndDate() != null) {
+      return BatchOperationState.COMPLETED;
+    } else if (entity.getOperationsFinishedCount() == 0) {
+      return BatchOperationState.CREATED;
+    } else {
+      return BatchOperationState.ACTIVE;
+    }
   }
 }

--- a/search/search-domain/src/main/java/io/camunda/search/entities/BatchOperationEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/BatchOperationEntity.java
@@ -65,8 +65,7 @@ public record BatchOperationEntity(
     SUSPENDED,
     COMPLETED,
     PARTIALLY_COMPLETED,
-    CANCELED,
-    INCOMPLETED // This is just used for running legacy batch operations
+    CANCELED
   }
 
   public enum BatchOperationItemState {

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/operation/BatchOperationEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/operation/BatchOperationEntity.java
@@ -274,7 +274,6 @@ public class BatchOperationEntity extends AbstractExporterEntity<BatchOperationE
     SUSPENDED,
     COMPLETED,
     PARTIALLY_COMPLETED,
-    CANCELED,
-    INCOMPLETED
+    CANCELED
   }
 }

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -10617,7 +10617,6 @@ components:
         - COMPLETED
         - PARTIALLY_COMPLETED
         - CANCELED
-        - INCOMPLETED
     BatchOperationItemSearchQuerySortRequest:
       type: object
       properties:
@@ -10735,7 +10734,6 @@ components:
             - COMPLETED
             - PARTIALLY_COMPLETED
             - CANCELED
-            - INCOMPLETED
         batchOperationType:
           $ref: "#/components/schemas/BatchOperationTypeEnum"
         startDate:


### PR DESCRIPTION
## Description

So far the state of legacy batch operations is always mapped to INCOMPLETED because back then it was assumed, that the Operate batch operation engine will be switched off with 8.8.
Since this is not the case anymore (or at least not sure), we try to interpolate the state property based on `endDate` and `finishedCount` properties.

## Related issues

closes #36378 