### PR TITLE
fix: change to skip group existence check

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/RolesByGroupIntegrationTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/RolesByGroupIntegrationTest.java
@@ -10,23 +10,14 @@ package io.camunda.it.client;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ProblemException;
-import io.camunda.client.protocol.rest.RoleResult;
+import io.camunda.client.api.search.response.Role;
+import io.camunda.client.api.search.response.SearchResponse;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.zeebe.test.util.Strings;
-import java.io.IOException;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
-import java.util.List;
 import java.util.UUID;
 import org.awaitility.Awaitility;
-import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -36,11 +27,6 @@ public class RolesByGroupIntegrationTest {
   private static CamundaClient camundaClient;
 
   private static final String EXISTING_ROLE_ID = Strings.newRandomValidIdentityId();
-
-  @AutoClose private static final HttpClient HTTP_CLIENT = HttpClient.newHttpClient();
-
-  private static final ObjectMapper OBJECT_MAPPER =
-      new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
   @BeforeAll
   static void setup() {
@@ -133,14 +119,7 @@ public class RolesByGroupIntegrationTest {
     // then
     Awaitility.await("Role was deleted and unassigned")
         .ignoreExceptionsInstanceOf(ProblemException.class)
-        .untilAsserted(
-            () ->
-                assertThat(
-                        searchRolesByGroupId(
-                                camundaClient.getConfiguration().getRestAddress().toString(),
-                                groupId)
-                            .items())
-                    .isEmpty());
+        .untilAsserted(() -> assertThat(searchRolesByGroupId(groupId).items()).isEmpty());
   }
 
   @Test
@@ -162,11 +141,7 @@ public class RolesByGroupIntegrationTest {
         .ignoreExceptionsInstanceOf(ProblemException.class)
         .untilAsserted(
             () ->
-                assertThat(
-                        searchRolesByGroupId(
-                                camundaClient.getConfiguration().getRestAddress().toString(),
-                                groupId)
-                            .items())
+                assertThat(searchRolesByGroupId(groupId).items())
                     .anyMatch(r -> EXISTING_ROLE_ID.equals(r.getRoleId())));
 
     // when
@@ -180,14 +155,7 @@ public class RolesByGroupIntegrationTest {
     // then
     Awaitility.await("Group is unassigned from the role")
         .ignoreExceptionsInstanceOf(ProblemException.class)
-        .untilAsserted(
-            () ->
-                assertThat(
-                        searchRolesByGroupId(
-                                camundaClient.getConfiguration().getRestAddress().toString(),
-                                groupId)
-                            .items())
-                    .isEmpty());
+        .untilAsserted(() -> assertThat(searchRolesByGroupId(groupId).items()).isEmpty());
   }
 
   @Test
@@ -383,11 +351,7 @@ public class RolesByGroupIntegrationTest {
         .ignoreExceptionsInstanceOf(ProblemException.class)
         .untilAsserted(
             () ->
-                assertThat(
-                        searchRolesByGroupId(
-                                camundaClient.getConfiguration().getRestAddress().toString(),
-                                groupId)
-                            .items())
+                assertThat(searchRolesByGroupId(groupId).items())
                     .anyMatch(r -> EXISTING_ROLE_ID.equals(r.getRoleId())));
 
     // when
@@ -401,14 +365,7 @@ public class RolesByGroupIntegrationTest {
     // then
     Awaitility.await("Group is unassigned from the role")
         .ignoreExceptionsInstanceOf(ProblemException.class)
-        .untilAsserted(
-            () ->
-                assertThat(
-                        searchRolesByGroupId(
-                                camundaClient.getConfiguration().getRestAddress().toString(),
-                                groupId)
-                            .items())
-                    .isEmpty());
+        .untilAsserted(() -> assertThat(searchRolesByGroupId(groupId).items()).isEmpty());
   }
 
   private static void createRole(
@@ -438,28 +395,11 @@ public class RolesByGroupIntegrationTest {
         .ignoreExceptionsInstanceOf(ProblemException.class)
         .untilAsserted(
             () ->
-                assertThat(
-                        searchRolesByGroupId(
-                                camundaClient.getConfiguration().getRestAddress().toString(),
-                                groupId)
-                            .items())
+                assertThat(searchRolesByGroupId(groupId).items())
                     .anyMatch(r -> roleId.equals(r.getRoleId())));
   }
 
-  // TODO once available, this test should use the client to make the request
-  private static RoleSearchResponse searchRolesByGroupId(
-      final String restAddress, final String groupId)
-      throws URISyntaxException, IOException, InterruptedException {
-    final HttpRequest request =
-        HttpRequest.newBuilder()
-            .uri(new URI("%s%s".formatted(restAddress, "v2/groups/" + groupId + "/roles/search")))
-            .POST(HttpRequest.BodyPublishers.ofString(""))
-            .build();
-
-    final HttpResponse<String> response =
-        HTTP_CLIENT.send(request, HttpResponse.BodyHandlers.ofString());
-    return OBJECT_MAPPER.readValue(response.body(), RoleSearchResponse.class);
+  private static SearchResponse<Role> searchRolesByGroupId(final String groupId) {
+    return camundaClient.newRolesByGroupSearchRequest(groupId).send().join();
   }
-
-  private record RoleSearchResponse(List<RoleResult> items) {}
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleAddEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleAddEntityProcessor.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.zeebe.engine.processing.identity;
 
-import io.camunda.zeebe.auth.Authorization;
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
 import io.camunda.zeebe.engine.processing.identity.AuthorizationCheckBehavior.AuthorizationRequest;
 import io.camunda.zeebe.engine.processing.streamprocessor.DistributedTypedRecordProcessor;
@@ -140,11 +139,8 @@ public class RoleAddEntityProcessor implements DistributedTypedRecordProcessor<R
       final EntityType entityType,
       final String entityId) {
     return switch (entityType) {
-      case USER, CLIENT ->
-          true; // With simple mapping rules, any username or client id can be assigned
-      case GROUP ->
-          authorizations.get(Authorization.USER_GROUPS_CLAIMS) != null
-              || groupState.get(entityId).isPresent();
+      case USER, CLIENT, GROUP ->
+          true; // With simple mapping rules, any username, client id or group can be assigned
       case MAPPING_RULE -> mappingRuleState.get(entityId).isPresent();
       default -> false;
     };

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleRemoveEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleRemoveEntityProcessor.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.zeebe.engine.processing.identity;
 
-import io.camunda.zeebe.auth.Authorization;
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
 import io.camunda.zeebe.engine.processing.identity.AuthorizationCheckBehavior.AuthorizationRequest;
 import io.camunda.zeebe.engine.processing.streamprocessor.DistributedTypedRecordProcessor;
@@ -145,11 +144,8 @@ public class RoleRemoveEntityProcessor implements DistributedTypedRecordProcesso
       final EntityType entityType,
       final String entityId) {
     return switch (entityType) {
-      case USER, CLIENT ->
-          true; // With simple mapping rules, any username or client id can be assigned
-      case GROUP ->
-          authorizations.get(Authorization.USER_GROUPS_CLAIMS) != null
-              || groupState.get(entityId).isPresent();
+      case USER, CLIENT, GROUP ->
+          true; // With simple mapping rules, any username, client id or group can be assigned
       case MAPPING_RULE -> mappingRuleState.get(entityId).isPresent();
       default -> false;
     };

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantAddEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantAddEntityProcessor.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.zeebe.engine.processing.tenant;
 
-import io.camunda.zeebe.auth.Authorization;
 import io.camunda.zeebe.engine.processing.Rejection;
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
 import io.camunda.zeebe.engine.processing.identity.AuthorizationCheckBehavior;
@@ -140,11 +139,8 @@ public class TenantAddEntityProcessor implements DistributedTypedRecordProcessor
       final EntityType entityType,
       final String entityId) {
     return switch (entityType) {
-      case USER, CLIENT ->
-          true; // With simple mapping rules, any username or client id can be assigned
-      case GROUP ->
-          authorizations.get(Authorization.USER_GROUPS_CLAIMS) != null
-              || groupState.get(entityId).isPresent();
+      case USER, CLIENT, GROUP ->
+          true; // With simple mapping rules, any username, client id or group can be assigned
       case MAPPING_RULE -> mappingRuleState.get(entityId).isPresent();
       case ROLE -> roleState.getRole(entityId).isPresent();
       default -> false;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantRemoveEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantRemoveEntityProcessor.java
@@ -7,7 +7,8 @@
  */
 package io.camunda.zeebe.engine.processing.tenant;
 
-import io.camunda.zeebe.auth.Authorization;
+import static io.camunda.zeebe.protocol.record.value.EntityType.MAPPING_RULE;
+
 import io.camunda.zeebe.engine.processing.Rejection;
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
 import io.camunda.zeebe.engine.processing.identity.AuthorizationCheckBehavior;
@@ -129,13 +130,7 @@ public class TenantRemoveEntityProcessor implements DistributedTypedRecordProces
       final Map<String, Object> authorizations,
       final EntityType entityType,
       final String entityId) {
-    return switch (entityType) {
-      case MAPPING_RULE -> mappingRuleState.get(entityId).isPresent();
-      case GROUP ->
-          authorizations.get(Authorization.USER_GROUPS_CLAIMS) != null
-              || groupState.get(entityId).isPresent();
-      default -> true;
-    };
+    return entityType != MAPPING_RULE || mappingRuleState.get(entityId).isPresent();
   }
 
   private void createEntityNotExistRejectCommand(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/role/RoleTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/role/RoleTest.java
@@ -267,28 +267,25 @@ public class RoleTest {
   }
 
   @Test
-  public void shouldRejectNonExistingGroupIfGroupsClaimDisabled() {
-    // given
-    final var roleId = UUID.randomUUID().toString();
-    final var roleRecord = engine.role().newRole(roleId).create();
-
-    // when
-    roleRecord.getValue();
-    final var entityId = "non-existing-entity";
-    final var notPresentUpdateRecord =
+  public void shouldAddNonExistingGroupIfGroupsClaimDisabled() {
+    final var groupId =
+        engine.group().newGroup("groupId").withName("Foo Bar").create().getValue().getGroupId();
+    final var roleId = Strings.newRandomValidIdentityId();
+    engine.role().newRole(roleId).create().getValue().getRoleKey();
+    final var updatedRole =
         engine
             .role()
             .addEntity(roleId)
-            .withEntityId(entityId)
+            .withEntityId(groupId)
             .withEntityType(EntityType.GROUP)
-            .expectRejection()
-            .add();
+            .add()
+            .getValue();
 
-    assertThat(notPresentUpdateRecord)
-        .hasRejectionType(RejectionType.NOT_FOUND)
-        .hasRejectionReason(
-            "Expected to add an entity with ID '%s' and type '%s' to role with ID '%s', but the entity doesn't exist."
-                .formatted(entityId, EntityType.GROUP, roleId));
+    assertThat(updatedRole)
+        .isNotNull()
+        .hasRoleId(roleId)
+        .hasEntityId(groupId)
+        .hasEntityType(EntityType.GROUP);
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/AddEntityTenantTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/AddEntityTenantTest.java
@@ -213,28 +213,32 @@ public class AddEntityTenantTest {
   }
 
   @Test
-  public void shouldRejectAddingNonExistingGroupToTenantIfGroupsClaimDisabled() {
+  public void shouldAddNonExistingGroupToTenantIfGroupsClaimDisabled() {
     // given
+    final var entityType = GROUP;
     final var groupId = Strings.newRandomValidIdentityId();
     final var tenantId = UUID.randomUUID().toString();
     engine.tenant().newTenant().withTenantId(tenantId).withName("Tenant 1").create().getValue();
 
-    // when
-    final var rejection =
+    // when add user entity to tenant
+    final var updatedTenant =
         engine
             .tenant()
             .addEntity(tenantId)
             .withEntityId(groupId)
-            .withEntityType(GROUP)
-            .expectRejection()
-            .add();
+            .withEntityType(entityType)
+            .add()
+            .getValue();
 
-    // then
-    assertThat(rejection)
-        .hasRejectionType(RejectionType.NOT_FOUND)
-        .hasRejectionReason(
-            "Expected to add group with ID '%s' to tenant with ID '%s', but the group doesn't exist."
-                .formatted(groupId, tenantId));
+    // then assert that the entity was added correctly
+    assertThat(updatedTenant)
+        .describedAs(
+            "Entity of type %s with ID %s should be correctly added to tenant with ID %s",
+            entityType, groupId, tenantId)
+        .isNotNull()
+        .hasTenantId(tenantId)
+        .hasEntityType(entityType)
+        .hasEntityId(groupId);
   }
 
   @Test

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/AssignGroupToTenantTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/AssignGroupToTenantTest.java
@@ -96,20 +96,19 @@ class AssignGroupToTenantTest {
     // given
     final String nonExistentGroupId = Strings.newRandomValidIdentityId();
 
-    // when / then
-    assertThatThrownBy(
-            () ->
-                client
-                    .newAssignGroupToTenantCommand()
-                    .groupId(nonExistentGroupId)
-                    .tenantId(tenantId)
-                    .send()
-                    .join())
-        .isInstanceOf(ProblemException.class)
-        .hasMessageContaining("Failed with code 404: 'Not Found'")
-        .hasMessageContaining(
-            "Expected to add group with ID '%s' to tenant with ID '%s', but the group doesn't exist."
-                .formatted(nonExistentGroupId, tenantId));
+    // when
+    client
+        .newAssignGroupToTenantCommand()
+        .groupId(nonExistentGroupId)
+        .tenantId(tenantId)
+        .send()
+        .join();
+
+    // then
+    ZeebeAssertHelper.assertEntityAssignedToTenant(
+        tenantId,
+        nonExistentGroupId,
+        tenant -> assertThat(tenant.getEntityType()).isEqualTo(EntityType.GROUP));
   }
 
   @Test


### PR DESCRIPTION
## Description

Since the migration app bypass the authentication layer the commands don't contain the group claim extracted from the token when BYOG functionality is enabled. In particular [this check](https://github.com/camunda/camunda/pull/33631/files#diff-9e5ebd48355f47e4d16dc960e898cafd6bb401aca1019ede103988f8259085e2R134-R136) is failing.

## Related issues

closes #36379 
