### PR TITLE
fix: declare use of bash when using pipe in GHA

### DIFF
--- a/.github/workflows/ci-operate.yml
+++ b/.github/workflows/ci-operate.yml
@@ -149,6 +149,7 @@ jobs:
           push: true
           distball: ${{ steps.build-zeebe.outputs.distball }}
       - name: Run Operate backup restore Tests
+        shell: bash
         run: ./mvnw -B -pl operate/qa/backup-restore-tests -DskipChecks -P -docker,-skipTests verify | tee "${BUILD_OUTPUT_FILE_PATH}"
       - name: Upload Test Report
         if: failure()

--- a/.github/workflows/ci-webapp-run-ut-reuseable.yml
+++ b/.github/workflows/ci-webapp-run-ut-reuseable.yml
@@ -49,6 +49,7 @@ jobs:
       - name: Create build output log file
         run: echo "BUILD_OUTPUT_FILE_PATH=$(mktemp)" >> "$GITHUB_ENV"
       - name: Maven Run Test
+        shell: bash
         # we use the verify goal here as flaky test extraction is bound to the post-integration-test
         # phase of Maven https://maven.apache.org/guides/introduction/introduction-to-the-lifecycle.html#default-lifecycle
         run: >

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -269,6 +269,7 @@ jobs:
         run: |
           bash .ci/scripts/ci/setup-general-ut.sh "${{ needs.setup-unit-tests.outputs.GENERAL_UT_DO_NOT_SKIP_MODULES}}" "${{ needs.setup-unit-tests.outputs.GENERAL_UT_EXTRA_SKIP_MODULES}}"
       - name: Maven Test Build
+        shell: bash
         # Modules in zeebe, operate, tasklist, and optimize are skipped as they have dedicated unit test jobs
         #
         # we use the verify goal here as flaky test extraction is bound to the post-integration-test
@@ -356,6 +357,7 @@ jobs:
       - name: Create build output log file
         run: echo "BUILD_OUTPUT_FILE_PATH=$(mktemp)" >> "$GITHUB_ENV"
       - name: Maven Run Test (Zeebe)
+        shell: bash
         # we use the verify goal here as flaky test extraction is bound to the post-integration-test
         # phase of Maven https://maven.apache.org/guides/introduction/introduction-to-the-lifecycle.html#default-lifecycle
         run: >
@@ -449,6 +451,7 @@ jobs:
       # -D test.integration.camunda.database.type=es
       #
       - name: Run integration test with externalized ES
+        shell: bash
         run: >
           ./mvnw -B -T 1 --no-snapshot-updates
           -D forkCount=4
@@ -547,6 +550,7 @@ jobs:
       # -D test.integration.camunda.database.type=os
       #
       - name: Run integration test with externalized OS
+        shell: bash
         run: >
           ./mvnw -B -T 1 --no-snapshot-updates
           -D forkCount=4
@@ -612,6 +616,7 @@ jobs:
       # -Dcamunda.it.database.type=rdbms
       #
       - name: Run integration test with InMemory H2
+        shell: bash
         timeout-minutes: 10
         run: >
           ./mvnw -B -T 2 --no-snapshot-updates
@@ -671,6 +676,7 @@ jobs:
         run: echo "BUILD_OUTPUT_FILE_PATH=$(mktemp)" >> "$GITHUB_ENV"
       # Run integration tests with RDBMS database
       - name: Maven Test Build
+        shell: bash
         run: >
           ./mvnw -B -T1C --no-snapshot-updates
           -D forkCount=1
@@ -837,6 +843,7 @@ jobs:
       - name: Create build output log file
         run: echo "BUILD_OUTPUT_FILE_PATH=$(mktemp)" >> "$GITHUB_ENV"
       - name: Maven Test Build
+        shell: bash
         run: >
           ./mvnw -B -T ${{ matrix.maven-build-threads }} --no-snapshot-updates
           -D forkCount=${{ matrix.maven-test-fork-count }}
@@ -947,6 +954,7 @@ jobs:
       - name: Create build output log file
         run: echo "BUILD_OUTPUT_FILE_PATH=$(mktemp)" >> "$GITHUB_ENV"
       - name: Run Docker tests
+        shell: bash
         # we use the verify goal here as flaky test extraction is bound to the post-integration-test
         # phase of Maven https://maven.apache.org/guides/introduction/introduction-to-the-lifecycle.html#default-lifecycle
         run: >

--- a/.github/workflows/tasklist-backup-restore-tests-reusable.yml
+++ b/.github/workflows/tasklist-backup-restore-tests-reusable.yml
@@ -47,6 +47,7 @@ jobs:
           push: true
           distball: ${{ steps.build-zeebe.outputs.distball }}
       - name: Run Tasklist backup restore Tests
+        shell: bash
         run: ./mvnw -B -pl tasklist/qa/backup-restore-tests -DskipChecks -DtasklistDatabase=${{ inputs.database }} -DskipTests=false verify | tee "${BUILD_OUTPUT_FILE_PATH}"
       - name: Upload Test Report
         if: failure()

--- a/.github/workflows/zeebe-aws-os-dispatch-tests.yml
+++ b/.github/workflows/zeebe-aws-os-dispatch-tests.yml
@@ -117,6 +117,7 @@ jobs:
       - name: Create build output log file
         run: echo "BUILD_OUTPUT_FILE_PATH=$(mktemp)" >> "$GITHUB_ENV"
       - name: Maven Test Build
+        shell: bash
         run: >
           ./mvnw -B -T ${{ matrix.maven-build-threads }} --no-snapshot-updates
           -D forkCount=${{ matrix.maven-test-fork-count }}

--- a/.github/workflows/zeebe-ci.yml
+++ b/.github/workflows/zeebe-ci.yml
@@ -74,6 +74,7 @@ jobs:
       - name: Create build output log file
         run: echo "BUILD_OUTPUT_FILE_PATH=$(mktemp)" >> "$GITHUB_ENV"
       - name: Run smoke test on ${{ matrix.arch }}
+        shell: bash
         env:
           # For non Linux runners there is no container available for testing, see build-zeebe-docker job
           EXCLUDED_TEST_GROUPS: ${{ runner.os != 'Linux' && 'container' }}
@@ -129,6 +130,7 @@ jobs:
       - name: Create build output log file
         run: echo "BUILD_OUTPUT_FILE_PATH=$(mktemp)" >> "$GITHUB_ENV"
       - name: Maven Test Build
+        shell: bash
         run: >
           ./mvnw -T1C -B --no-snapshot-updates
           -P parallel-tests,include-random-tests
@@ -183,6 +185,7 @@ jobs:
       - name: Create build output log file
         run: echo "BUILD_OUTPUT_FILE_PATH=$(mktemp)" >> "$GITHUB_ENV"
       - name: Maven Test Build
+        shell: bash
         run: >
           ./mvnw -B --no-snapshot-updates
           -P include-performance-tests
@@ -251,6 +254,7 @@ jobs:
       - name: Create build output log file
         run: echo "BUILD_OUTPUT_FILE_PATH=$(mktemp)" >> "$GITHUB_ENV"
       - name: Maven Test Build
+        shell: bash
         run: >
           ./mvnw -T1C -B --no-snapshot-updates
           -P include-strace-tests


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
`bash` needs to be explicitly declared to so that the `pipefail` option will be properly used and will fail the GHA on maven failure. Otherwise, without `pipefail`, the maven command can fail but the GHA job will show as succeeded

See, https://github.com/actions/runner-images/issues/4459

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes https://github.com/camunda/camunda/issues/36401
