### PR TITLE
fix: rename internal groups to camunda groups

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/ConditionalOnCamundaGroupsEnabled.java
+++ b/authentication/src/main/java/io/camunda/authentication/ConditionalOnCamundaGroupsEnabled.java
@@ -20,4 +20,4 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 @Retention(RUNTIME)
 @Documented
 @ConditionalOnExpression("'${camunda.security.authentication.oidc.groupsClaim:}' == ''")
-public @interface ConditionalOnInternalGroupsEnabled {}
+public @interface ConditionalOnCamundaGroupsEnabled {}

--- a/dist/src/main/java/io/camunda/identity/webapp/controllers/IdentityClientConfigController.java
+++ b/dist/src/main/java/io/camunda/identity/webapp/controllers/IdentityClientConfigController.java
@@ -25,7 +25,7 @@ public class IdentityClientConfigController {
   private static final Logger LOG = LoggerFactory.getLogger(IdentityClientConfigController.class);
 
   private static final String VITE_IS_OIDC = "VITE_IS_OIDC";
-  private static final String VITE_INTERNAL_GROUPS_ENABLED = "VITE_INTERNAL_GROUPS_ENABLED";
+  private static final String VITE_CAMUNDA_GROUPS_ENABLED = "VITE_CAMUNDA_GROUPS_ENABLED";
   private static final String VITE_TENANTS_API_ENABLED = "VITE_TENANTS_API_ENABLED";
   private static final String FALLBACK_CONFIG_JS = "window.clientConfig = {};";
   private static final String CONFIG_JS_TEMPLATE = "window.clientConfig = %s;";
@@ -52,8 +52,7 @@ public class IdentityClientConfigController {
   private Map<String, String> createConfigMap(final SecurityConfiguration securityConfiguration) {
     return Map.of(
         VITE_IS_OIDC, String.valueOf(isOidcAuthentication(securityConfiguration)),
-        VITE_INTERNAL_GROUPS_ENABLED,
-            String.valueOf(isInternalGroupsEnabled(securityConfiguration)),
+        VITE_CAMUNDA_GROUPS_ENABLED, String.valueOf(isCamundaGroupsEnabled(securityConfiguration)),
         VITE_TENANTS_API_ENABLED,
             String.valueOf(securityConfiguration.getMultiTenancy().isApiEnabled()));
   }
@@ -62,10 +61,12 @@ public class IdentityClientConfigController {
     return AuthenticationMethod.OIDC.equals(securityConfiguration.getAuthentication().getMethod());
   }
 
-  private boolean isInternalGroupsEnabled(final SecurityConfiguration securityConfiguration) {
+  private boolean isCamundaGroupsEnabled(final SecurityConfiguration securityConfiguration) {
     final var authentication = securityConfiguration.getAuthentication();
     final var oidcConfig = authentication.getOidc();
-    return oidcConfig == null || oidcConfig.getGroupsClaim() == null;
+    return oidcConfig == null
+        || oidcConfig.getGroupsClaim() == null
+        || oidcConfig.getGroupsClaim().isEmpty();
   }
 
   @GetMapping(path = "/identity/config.js", produces = "text/javascript;charset=UTF-8")

--- a/dist/src/test/java/io/camunda/webapps/controllers/IdentityClientConfigControllerTest.java
+++ b/dist/src/test/java/io/camunda/webapps/controllers/IdentityClientConfigControllerTest.java
@@ -36,15 +36,16 @@ class IdentityClientConfigControllerParameterizedTest {
 
   @BeforeEach
   void setUp() {
-    // MockMvc will be setup for each test with specific controller configuration
+    // MockMvc will be setup for each test with a specific controller configuration
   }
 
   static Stream<Arguments> configurationProvider() {
     return Stream.of(
-        // AuthMethod, GroupsClaim, MultiTenancyEnabled, ExpectedIsOidc, ExpectedInternalGroups,
+        // AuthMethod, GroupsClaim, MultiTenancyEnabled, ExpectedIsOidc, ExpectedCamundaGroups,
         // ExpectedTenantsApi
         Arguments.of(AuthenticationMethod.OIDC, null, true, "true", "true", "true"),
         Arguments.of(AuthenticationMethod.OIDC, null, false, "true", "true", "false"),
+        Arguments.of(AuthenticationMethod.OIDC, "", false, "true", "true", "false"),
         Arguments.of(AuthenticationMethod.OIDC, "groups", true, "true", "false", "true"),
         Arguments.of(AuthenticationMethod.OIDC, "groups", false, "true", "false", "false"),
         Arguments.of(AuthenticationMethod.BASIC, null, true, "false", "true", "true"),
@@ -55,14 +56,14 @@ class IdentityClientConfigControllerParameterizedTest {
 
   @ParameterizedTest(
       name =
-          "AuthMethod={0}, GroupsClaim={1}, MultiTenancy={2} -> OIDC={3}, InternalGroups={4}, TenantsApi={5}")
+          "AuthMethod={0}, GroupsClaim={1}, MultiTenancy={2} -> OIDC={3}, CamundaGroups={4}, TenantsApi={5}")
   @MethodSource("configurationProvider")
   void shouldReturnCorrectClientConfigForAllPermutations(
       final AuthenticationMethod authMethod,
       final String groupsClaim,
       final boolean multiTenancyEnabled,
       final String expectedIsOidc,
-      final String expectedInternalGroups,
+      final String expectedCamundaGroups,
       final String expectedTenantsApi)
       throws Exception {
 
@@ -90,7 +91,7 @@ class IdentityClientConfigControllerParameterizedTest {
     // Assert all configuration values
     assertThat(configResponse)
         .containsEntry("VITE_IS_OIDC", expectedIsOidc)
-        .containsEntry("VITE_INTERNAL_GROUPS_ENABLED", expectedInternalGroups)
+        .containsEntry("VITE_CAMUNDA_GROUPS_ENABLED", expectedCamundaGroups)
         .containsEntry("VITE_TENANTS_API_ENABLED", expectedTenantsApi);
   }
 

--- a/security/security-core/src/main/java/io/camunda/security/auth/OidcGroupsLoader.java
+++ b/security/security-core/src/main/java/io/camunda/security/auth/OidcGroupsLoader.java
@@ -34,7 +34,7 @@ public class OidcGroupsLoader {
 
   public OidcGroupsLoader(final String groupsClaim) {
 
-    if (groupsClaim != null) {
+    if (groupsClaim != null && !groupsClaim.isEmpty()) {
       this.groupsClaim = sanitizeClaimPath(groupsClaim);
       try {
         JsonPath.compile(this.groupsClaim);

--- a/security/security-core/src/test/java/io/camunda/security/auth/OidcGroupsLoaderTest.java
+++ b/security/security-core/src/test/java/io/camunda/security/auth/OidcGroupsLoaderTest.java
@@ -34,6 +34,12 @@ final class OidcGroupsLoaderTest {
   }
 
   @Test
+  void shouldHandleEmptyRegexAsNull() {
+    final var loader = new OidcGroupsLoader("");
+    assertThat(loader.getGroupsClaim()).isNull();
+  }
+
+  @Test
   void shouldSanitizeInvalidRegex() {
     final var loader = new OidcGroupsLoader(".gg.ee...");
     assertThat(loader.getGroupsClaim()).isEqualTo("$['.gg.ee...']");

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupController.java
@@ -10,7 +10,7 @@ package io.camunda.zeebe.gateway.rest.controller.usermanagement;
 import static io.camunda.zeebe.gateway.rest.RestErrorMapper.mapErrorToResponse;
 import static io.camunda.zeebe.protocol.record.value.EntityType.GROUP;
 
-import io.camunda.authentication.ConditionalOnInternalGroupsEnabled;
+import io.camunda.authentication.ConditionalOnCamundaGroupsEnabled;
 import io.camunda.search.query.GroupQuery;
 import io.camunda.search.query.MappingRuleQuery;
 import io.camunda.search.query.RoleQuery;
@@ -52,7 +52,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 
 @CamundaRestController
 @RequestMapping("/v2/groups")
-@ConditionalOnInternalGroupsEnabled
+@ConditionalOnCamundaGroupsEnabled
 public class GroupController {
 
   private final GroupServices groupServices;

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupControllerTest.java
@@ -55,7 +55,7 @@ public class GroupControllerTest {
   @WebMvcTest(GroupController.class)
   @Import(ApiFiltersConfiguration.class)
   @TestPropertySource(properties = "camunda.security.authentication.oidc.groupsClaim=g1")
-  public class InternalGroupsDisabledTest extends RestControllerTest {
+  public class CamundaGroupsDisabledTest extends RestControllerTest {
 
     public static final String FORBIDDEN_MESSAGE =
         """
@@ -208,7 +208,7 @@ public class GroupControllerTest {
   @Nested
   @WebMvcTest(GroupController.class)
   @TestPropertySource(properties = "camunda.security.authentication.oidc.groupsClaim=")
-  public class InternalGroupsEnabledTest extends RestControllerTest {
+  public class CamundaGroupsEnabledTest extends RestControllerTest {
     @MockitoBean private GroupServices groupServices;
     @MockitoBean private UserServices userServices;
     @MockitoBean private RoleServices roleServices;


### PR DESCRIPTION
…sion as not set

## Description

We would like to rename the INTERNAL_GROUPS_ENABLED that's passed to the frontend and controls many things related to the UI of Group claims/"Bring your own groups" to CAMUNDA_GROUPS_ENABLED in order to avoid confusion, as the original name of this variable is ambiguous.

I've also added the checking for empty groupsClaim to be consistent in frontend and backend.

## Checklist

- [x] INTERNAL_GROUPS_ENABLED is renamed to CAMUNDA_GROUPS_ENABLED on the backend
- [x] Methods/Variables/Classes that named InternalGroup renamed to CamundaGroup

## Related issues

closes #35257 
