### PR TITLE
fix: support for AWS LegacyMd5Plugin

### DIFF
--- a/zeebe/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupConfig.java
+++ b/zeebe/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupConfig.java
@@ -50,7 +50,8 @@ public record S3BackupConfig(
     Optional<String> compressionAlgorithm,
     Optional<String> basePath,
     Integer maxConcurrentConnections,
-    Duration connectionAcquisitionTimeout) {
+    Duration connectionAcquisitionTimeout,
+    boolean supportLegacyMd5) {
 
   public S3BackupConfig {
     if (bucketName == null || bucketName.isEmpty()) {
@@ -93,6 +94,7 @@ public record S3BackupConfig(
     private String compressionAlgorithm;
     private Credentials credentials;
     private String basePath;
+    private boolean supportLegacyMd5 = false;
 
     /** Default from `SdkHttpConfigurationOption.MAX_CONNECTIONS` */
     private Integer maxConcurrentConnections = 50;
@@ -150,6 +152,11 @@ public record S3BackupConfig(
       return this;
     }
 
+    public Builder withSupportLegacyMd5(final boolean useMd5LegacyPlugin) {
+      supportLegacyMd5 = useMd5LegacyPlugin;
+      return this;
+    }
+
     public S3BackupConfig build() {
       return new S3BackupConfig(
           bucketName,
@@ -161,7 +168,8 @@ public record S3BackupConfig(
           Optional.ofNullable(compressionAlgorithm),
           Optional.ofNullable(basePath),
           maxConcurrentConnections,
-          connectionAcquisitionTimeout);
+          connectionAcquisitionTimeout,
+          supportLegacyMd5);
     }
   }
 

--- a/zeebe/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupStore.java
+++ b/zeebe/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupStore.java
@@ -51,6 +51,7 @@ import software.amazon.awssdk.core.async.SdkPublisher;
 import software.amazon.awssdk.core.retry.RetryMode;
 import software.amazon.awssdk.http.nio.netty.NettyNioAsyncHttpClient;
 import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.LegacyMd5Plugin;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
 import software.amazon.awssdk.services.s3.model.ObjectIdentifier;
@@ -396,6 +397,12 @@ public final class S3BackupStore implements BackupStore {
 
     // Enable auto-tuning of various parameters based on the environment
     builder.defaultsMode(DefaultsMode.AUTO);
+
+    // Enable legacy MD5 plugin if configured, as it is required for compatibility with S3
+    // compatible storage systems that expect MD5 checksums in the request.
+    if (config.supportLegacyMd5()) {
+      builder.addPlugin(LegacyMd5Plugin.create());
+    }
 
     builder.httpClient(
         NettyNioAsyncHttpClient.builder()

--- a/zeebe/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/MinioLegacyMd5IT.java
+++ b/zeebe/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/MinioLegacyMd5IT.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.backup.s3;
+
+import io.camunda.zeebe.backup.s3.S3BackupConfig.Builder;
+import java.nio.file.NoSuchFileException;
+import java.time.Duration;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
+
+@Testcontainers
+public class MinioLegacyMd5IT implements S3BackupStoreTests {
+  public static final String ACCESS_KEY = "letmein";
+  public static final String SECRET_KEY = "letmein1234";
+  public static final int DEFAULT_PORT = 9000;
+  // Deliberately using an old MinIO image to verify AWS legacy MD5 support
+  private static final String LEGACY_MINIO_IMAGE = "minio/minio:RELEASE.2023-11-20T22-40-07Z";
+  private static final Logger LOG = LoggerFactory.getLogger(MinioLegacyMd5IT.class);
+  private static final String BUCKET_NAME = RandomStringUtils.randomAlphabetic(10).toLowerCase();
+
+  @SuppressWarnings("resource")
+  @Container
+  private static final GenericContainer<?> S3 =
+      new GenericContainer<>(DockerImageName.parse(LEGACY_MINIO_IMAGE))
+          .withCommand("server /data")
+          .withExposedPorts(DEFAULT_PORT)
+          .withEnv("MINIO_ACCESS_KEY", ACCESS_KEY)
+          .withEnv("MINIO_SECRET_KEY", SECRET_KEY)
+          .withEnv("MINIO_DOMAIN", "localhost")
+          .waitingFor(
+              new HttpWaitStrategy()
+                  .forPath("/minio/health/ready")
+                  .forPort(DEFAULT_PORT)
+                  .withStartupTimeout(Duration.ofMinutes(1)));
+
+  private S3AsyncClient client;
+  private S3BackupStore store;
+  private S3BackupConfig config;
+
+  @BeforeAll
+  static void setupBucket() {
+    final var config =
+        new Builder()
+            .withBucketName(BUCKET_NAME)
+            .withEndpoint("http://%s:%d".formatted(S3.getHost(), S3.getMappedPort(DEFAULT_PORT)))
+            .withRegion(Region.US_EAST_1.id())
+            .withCredentials(ACCESS_KEY, SECRET_KEY)
+            .forcePathStyleAccess(true)
+            .build();
+    try (final var client = S3BackupStore.buildClient(config)) {
+      client.createBucket(CreateBucketRequest.builder().bucket(config.bucketName()).build()).join();
+    }
+  }
+
+  @BeforeEach
+  void setup(final TestInfo testInfo) {
+    final String basePath = RandomStringUtils.randomAlphabetic(10).toLowerCase();
+    config =
+        new Builder()
+            .withBucketName(BUCKET_NAME)
+            .withBasePath(basePath)
+            .withEndpoint("http://%s:%d".formatted(S3.getHost(), S3.getMappedPort(DEFAULT_PORT)))
+            .withRegion(Region.US_EAST_1.id())
+            .withCredentials(ACCESS_KEY, SECRET_KEY)
+            .forcePathStyleAccess(true)
+            .withSupportLegacyMd5(true)
+            .build();
+    client = S3BackupStore.buildClient(config);
+    store = new S3BackupStore(config, client);
+
+    LOG.info("{} is running with base path {}", testInfo.getDisplayName(), basePath);
+  }
+
+  @AfterEach
+  void tearDown() {
+    store.closeAsync();
+  }
+
+  @Override
+  public S3AsyncClient getClient() {
+    return client;
+  }
+
+  @Override
+  public S3BackupConfig getConfig() {
+    return config;
+  }
+
+  @Override
+  public S3BackupStore getStore() {
+    return store;
+  }
+
+  @Override
+  public Class<? extends Exception> getFileNotFoundExceptionClass() {
+    return NoSuchFileException.class;
+  }
+}

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/backup/S3BackupStoreConfig.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/backup/S3BackupStoreConfig.java
@@ -23,6 +23,7 @@ public class S3BackupStoreConfig implements ConfigurationEntry {
   private Duration apiCallTimeout = Duration.ofSeconds(180);
   private boolean forcePathStyleAccess = false;
   private String compression;
+  private boolean supportLegacyMd5;
 
   /** Default from `SdkHttpConfigurationOption.MAX_CONNECTIONS` */
   private int maxConcurrentConnections = 50;
@@ -124,6 +125,14 @@ public class S3BackupStoreConfig implements ConfigurationEntry {
     this.connectionAcquisitionTimeout = connectionAcquisitionTimeout;
   }
 
+  public boolean isSupportLegacyMd5() {
+    return supportLegacyMd5;
+  }
+
+  public void setSupportLegacyMd5(final boolean supportLegacyMd5) {
+    this.supportLegacyMd5 = supportLegacyMd5;
+  }
+
   public static S3BackupConfig toStoreConfig(final S3BackupStoreConfig config) {
     final var builder =
         new Builder()
@@ -135,7 +144,8 @@ public class S3BackupStoreConfig implements ConfigurationEntry {
             .withCompressionAlgorithm(config.getCompression())
             .withBasePath(config.getBasePath())
             .withMaxConcurrentConnections(config.getMaxConcurrentConnections())
-            .withConnectionAcquisitionTimeout(config.getConnectionAcquisitionTimeout());
+            .withConnectionAcquisitionTimeout(config.getConnectionAcquisitionTimeout())
+            .withSupportLegacyMd5(config.isSupportLegacyMd5());
     if (config.getAccessKey() != null && config.getSecretKey() != null) {
       builder.withCredentials(config.getAccessKey(), config.getSecretKey());
     }
@@ -171,37 +181,18 @@ public class S3BackupStoreConfig implements ConfigurationEntry {
 
     final S3BackupStoreConfig that = (S3BackupStoreConfig) o;
 
-    if (forcePathStyleAccess != that.forcePathStyleAccess) {
-      return false;
-    }
-    if (!Objects.equals(compression, that.compression)) {
-      return false;
-    }
-    if (!Objects.equals(bucketName, that.bucketName)) {
-      return false;
-    }
-    if (!Objects.equals(endpoint, that.endpoint)) {
-      return false;
-    }
-    if (!Objects.equals(region, that.region)) {
-      return false;
-    }
-    if (!Objects.equals(accessKey, that.accessKey)) {
-      return false;
-    }
-    if (!Objects.equals(secretKey, that.secretKey)) {
-      return false;
-    }
-    if (!Objects.equals(basePath, that.basePath)) {
-      return false;
-    }
-    if (maxConcurrentConnections != that.maxConcurrentConnections) {
-      return false;
-    }
-    if (!Objects.equals(connectionAcquisitionTimeout, that.connectionAcquisitionTimeout)) {
-      return false;
-    }
-    return Objects.equals(apiCallTimeout, that.apiCallTimeout);
+    return forcePathStyleAccess == that.forcePathStyleAccess
+        && maxConcurrentConnections == that.maxConcurrentConnections
+        && Objects.equals(bucketName, that.bucketName)
+        && Objects.equals(endpoint, that.endpoint)
+        && Objects.equals(region, that.region)
+        && Objects.equals(accessKey, that.accessKey)
+        && Objects.equals(secretKey, that.secretKey)
+        && Objects.equals(apiCallTimeout, that.apiCallTimeout)
+        && Objects.equals(compression, that.compression)
+        && Objects.equals(basePath, that.basePath)
+        && Objects.equals(connectionAcquisitionTimeout, that.connectionAcquisitionTimeout)
+        && supportLegacyMd5 == that.supportLegacyMd5;
   }
 
   @Override
@@ -234,6 +225,8 @@ public class S3BackupStoreConfig implements ConfigurationEntry {
         + maxConcurrentConnections
         + ", connectionAcquisitionTimeout="
         + connectionAcquisitionTimeout
+        + ", supportLegacyMd5="
+        + supportLegacyMd5
         + '}';
   }
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Conditionally enable the AWS provided `LegacyMd5Plugin` to extend compatibility support for our backups with S3-compatible object storages. Ref. https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/s3-checksums.html

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #35953
