### PR TITLE
[CPT] feat: Align log level of debug statement

### DIFF
--- a/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/api/CamundaProcessTestExecutionListener.java
+++ b/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/api/CamundaProcessTestExecutionListener.java
@@ -217,9 +217,9 @@ public class CamundaProcessTestExecutionListener implements TestExecutionListene
 
   private void resetRuntimeClock() {
     try {
-      LOG.info("Resetting the time");
+      LOG.debug("Resetting the time");
       camundaManagementClient.resetTime();
-      LOG.info("Time reset");
+      LOG.debug("Time reset");
     } catch (final Throwable t) {
       LOG.warn(
           "Failed to reset the time, skipping. Check the runtime for details. "


### PR DESCRIPTION
## Description

Reduce the log level of the time reset statement from `INFO` to `DEBUG` to align the implementations and to reduce the noise.

## Related issues

