### PR TITLE
feat: add raft properties to unified config

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/Cluster.java
+++ b/configuration/src/main/java/io/camunda/configuration/Cluster.java
@@ -44,6 +44,9 @@ public class Cluster {
   /** The number of nodes in the cluster. */
   private int size = 1;
 
+  /** Configuration for the Raft protocol in the cluster. */
+  private Raft raft = new Raft();
+
   public Metadata getMetadata() {
     return metadata;
   }
@@ -110,5 +113,13 @@ public class Cluster {
 
   public void setSize(final int size) {
     this.size = size;
+  }
+
+  public Raft getRaft() {
+    return raft;
+  }
+
+  public void setRaft(final Raft raft) {
+    this.raft = raft;
   }
 }

--- a/configuration/src/main/java/io/camunda/configuration/Raft.java
+++ b/configuration/src/main/java/io/camunda/configuration/Raft.java
@@ -16,7 +16,7 @@ import java.util.Set;
  * Raft algorithm parameters including timing, elections, and log flushing.
  */
 public class Raft {
-  private static final String PREFIX = "camunda.cluster.raft.";
+  private static final String PREFIX = "camunda.cluster.raft";
 
   private static final String LEGACY_HEARTBEAT_INTERVAL = "zeebe.broker.cluster.heartbeatInterval";
   private static final String LEGACY_ELECTION_TIMEOUT = "zeebe.broker.cluster.electionTimeout";
@@ -75,7 +75,7 @@ public class Raft {
 
   public Duration getHeartbeatInterval() {
     return UnifiedConfigurationHelper.validateLegacyConfiguration(
-        PREFIX + "heartbeat-interval",
+        PREFIX + ".heartbeat-interval",
         heartbeatInterval,
         Duration.class,
         UnifiedConfigurationHelper.BackwardsCompatibilityMode.SUPPORTED,
@@ -88,7 +88,7 @@ public class Raft {
 
   public Duration getElectionTimeout() {
     return UnifiedConfigurationHelper.validateLegacyConfiguration(
-        PREFIX + "election-timeout",
+        PREFIX + ".election-timeout",
         electionTimeout,
         Duration.class,
         UnifiedConfigurationHelper.BackwardsCompatibilityMode.SUPPORTED,
@@ -101,7 +101,7 @@ public class Raft {
 
   public boolean isPriorityElectionEnabled() {
     return UnifiedConfigurationHelper.validateLegacyConfiguration(
-        PREFIX + "priority-election-enabled",
+        PREFIX + ".priority-election-enabled",
         priorityElectionEnabled,
         Boolean.class,
         UnifiedConfigurationHelper.BackwardsCompatibilityMode.SUPPORTED,
@@ -114,7 +114,7 @@ public class Raft {
 
   public boolean isFlushEnabled() {
     return UnifiedConfigurationHelper.validateLegacyConfiguration(
-        PREFIX + "flush-enabled",
+        PREFIX + ".flush-enabled",
         flushEnabled,
         Boolean.class,
         UnifiedConfigurationHelper.BackwardsCompatibilityMode.SUPPORTED,
@@ -127,7 +127,7 @@ public class Raft {
 
   public Duration getFlushDelay() {
     return UnifiedConfigurationHelper.validateLegacyConfiguration(
-        PREFIX + "flush-delay",
+        PREFIX + ".flush-delay",
         flushDelay,
         Duration.class,
         UnifiedConfigurationHelper.BackwardsCompatibilityMode.SUPPORTED,

--- a/configuration/src/main/java/io/camunda/configuration/Raft.java
+++ b/configuration/src/main/java/io/camunda/configuration/Raft.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+package io.camunda.configuration;
+
+import java.time.Duration;
+import java.util.Set;
+
+/**
+ * Configuration for the Raft consensus protocol in the cluster. This class provides settings for
+ * Raft algorithm parameters including timing, elections, and log flushing.
+ */
+public class Raft {
+  private static final String PREFIX = "camunda.cluster.raft.";
+
+  private static final String LEGACY_HEARTBEAT_INTERVAL = "zeebe.broker.cluster.heartbeatInterval";
+  private static final String LEGACY_ELECTION_TIMEOUT = "zeebe.broker.cluster.electionTimeout";
+  private static final String LEGACY_PRIORITY_ELECTION_ENABLED =
+      "zeebe.broker.cluster.raft.enablePriorityElection";
+  private static final String LEGACY_FLUSH_ENABLED = "zeebe.broker.cluster.raft.flush.enabled";
+  private static final String LEGACY_FLUSH_DELAY = "zeebe.broker.cluster.raft.flush.delay";
+
+  /**
+   * The heartbeat interval for Raft. The leader sends a heartbeat to a follower every
+   * heartbeatInterval. This is an advanced setting.
+   */
+  private Duration heartbeatInterval = Duration.ofMillis(250);
+
+  /**
+   * The election timeout for Raft. If a follower does not receive a heartbeat from the leader
+   * within an election timeout, it can start a new leader election. electionTimeout should be
+   * greater than configured heartbeatInterval. When the electionTimeout is large, there will be
+   * delay in detecting a leader failure. When the electionTimeout is small, it can lead to false
+   * positives when detecting leader failures and thus leading to unnecessary leader changes. If the
+   * network latency between the nodes is high, it is recommended to have a higher election timeout.
+   * This is an advanced setting.
+   */
+  private Duration electionTimeout = Duration.ofMillis(2500);
+
+  /**
+   * When this flag is enabled, the leader election algorithm attempts to elect the leaders based on
+   * a pre-defined priority. As a result, it tries to distribute the leaders uniformly across the
+   * brokers. Note that it is only a best-effort strategy. It is not guaranteed to be a strictly
+   * uniform distribution.
+   */
+  private boolean priorityElectionEnabled = true;
+
+  /**
+   * If false, explicit flushing of the Raft log is disabled, and flushing only occurs right before
+   * a snapshot is taken. You should only disable explicit flushing if you are willing to accept
+   * potential data loss at the expense of performance. Before disabling it, try the delayed
+   * options, which provide a trade-off between safety and performance.
+   *
+   * <p>By default, for a given partition, data is flushed on every leader commit, and every
+   * follower append. This is to ensure consistency across all replicas. Disabling this can cause
+   * inconsistencies, and at worst, data corruption or data loss scenarios.
+   */
+  private boolean flushEnabled = true;
+
+  /**
+   * If the delay is > 0, then flush requests are delayed by at least the given period. It is
+   * recommended that you find the smallest delay here with which you achieve your performance
+   * goals. It's also likely that anything above 30s is not useful, as this is the typical default
+   * flush interval for the Linux OS.
+   *
+   * <p>The default behavior is optimized for safety, and flushing occurs on every leader commit and
+   * follower append in a synchronous fashion.
+   */
+  private Duration flushDelay = Duration.ZERO;
+
+  public Duration getHeartbeatInterval() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + "heartbeat-interval",
+        heartbeatInterval,
+        Duration.class,
+        UnifiedConfigurationHelper.BackwardsCompatibilityMode.SUPPORTED,
+        Set.of(LEGACY_HEARTBEAT_INTERVAL));
+  }
+
+  public void setHeartbeatInterval(final Duration heartbeatInterval) {
+    this.heartbeatInterval = heartbeatInterval;
+  }
+
+  public Duration getElectionTimeout() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + "election-timeout",
+        electionTimeout,
+        Duration.class,
+        UnifiedConfigurationHelper.BackwardsCompatibilityMode.SUPPORTED,
+        Set.of(LEGACY_ELECTION_TIMEOUT));
+  }
+
+  public void setElectionTimeout(final Duration electionTimeout) {
+    this.electionTimeout = electionTimeout;
+  }
+
+  public boolean isPriorityElectionEnabled() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + "priority-election-enabled",
+        priorityElectionEnabled,
+        Boolean.class,
+        UnifiedConfigurationHelper.BackwardsCompatibilityMode.SUPPORTED,
+        Set.of(LEGACY_PRIORITY_ELECTION_ENABLED));
+  }
+
+  public void setPriorityElectionEnabled(final boolean priorityElectionEnabled) {
+    this.priorityElectionEnabled = priorityElectionEnabled;
+  }
+
+  public boolean isFlushEnabled() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + "flush-enabled",
+        flushEnabled,
+        Boolean.class,
+        UnifiedConfigurationHelper.BackwardsCompatibilityMode.SUPPORTED,
+        Set.of(LEGACY_FLUSH_ENABLED));
+  }
+
+  public void setFlushEnabled(final boolean flushEnabled) {
+    this.flushEnabled = flushEnabled;
+  }
+
+  public Duration getFlushDelay() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + "flush-delay",
+        flushDelay,
+        Duration.class,
+        UnifiedConfigurationHelper.BackwardsCompatibilityMode.SUPPORTED,
+        Set.of(LEGACY_FLUSH_DELAY));
+  }
+
+  public void setFlushDelay(final Duration flushDelay) {
+    this.flushDelay = flushDelay;
+  }
+}

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
@@ -11,6 +11,7 @@ import io.camunda.configuration.UnifiedConfiguration;
 import io.camunda.configuration.beans.BrokerBasedProperties;
 import io.camunda.configuration.beans.LegacyBrokerBasedProperties;
 import io.camunda.zeebe.broker.system.configuration.ConfigManagerCfg;
+import io.camunda.zeebe.broker.system.configuration.RaftCfg.FlushConfig;
 import io.camunda.zeebe.broker.system.configuration.ThreadsCfg;
 import io.camunda.zeebe.dynamic.config.gossip.ClusterConfigurationGossiperConfig;
 import org.springframework.beans.BeanUtils;
@@ -66,9 +67,21 @@ public class BrokerBasedPropertiesOverride {
     override.getCluster().setReplicationFactor(cluster.getReplicationFactor());
     override.getCluster().setClusterSize(cluster.getSize());
 
+    populateFromRaftProperties(override);
     populateFromClusterMetadata(override);
     populateFromClusterNetwork(override);
     // Rest of camunda.cluster.* sections
+  }
+
+  private void populateFromRaftProperties(final BrokerBasedProperties override) {
+    final var raft = unifiedConfiguration.getCamunda().getCluster().getRaft();
+    override.getCluster().setHeartbeatInterval(raft.getHeartbeatInterval());
+    override.getCluster().setElectionTimeout(raft.getElectionTimeout());
+    override.getCluster().getRaft().setEnablePriorityElection(raft.isPriorityElectionEnabled());
+
+    // Set flush configuration
+    final var flushConfig = new FlushConfig(raft.isFlushEnabled(), raft.getFlushDelay());
+    override.getCluster().getRaft().setFlush(flushConfig);
   }
 
   private void populateFromClusterMetadata(final BrokerBasedProperties override) {

--- a/configuration/src/test/java/io/camunda/configuration/ClusterRaftTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/ClusterRaftTest.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.configuration.beanoverrides.BrokerBasedPropertiesOverride;
+import io.camunda.configuration.beans.BrokerBasedProperties;
+import java.time.Duration;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+@SpringJUnitConfig({
+  UnifiedConfiguration.class,
+  BrokerBasedPropertiesOverride.class,
+  UnifiedConfigurationHelper.class
+})
+@ActiveProfiles("broker")
+public class ClusterRaftTest {
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "camunda.cluster.raft.heartbeat-interval=1s",
+        "camunda.cluster.raft.election-timeout=10s",
+        "camunda.cluster.raft.priority-election-enabled=false",
+        "camunda.cluster.raft.flush-enabled=false",
+        "camunda.cluster.raft.flush-delay=5s"
+      })
+  class WithOnlyUnifiedConfigSet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithOnlyUnifiedConfigSet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldSetHeartbeatInterval() {
+      assertThat(brokerCfg.getCluster().getHeartbeatInterval()).isEqualTo(Duration.ofSeconds(1));
+    }
+
+    @Test
+    void shouldSetElectionTimeout() {
+      assertThat(brokerCfg.getCluster().getElectionTimeout()).isEqualTo(Duration.ofSeconds(10));
+    }
+
+    @Test
+    void shouldSetPriorityElectionEnabled() {
+      assertThat(brokerCfg.getCluster().getRaft().isEnablePriorityElection()).isFalse();
+    }
+
+    @Test
+    void shouldSetFlushEnabled() {
+      assertThat(brokerCfg.getCluster().getRaft().getFlush().enabled()).isFalse();
+    }
+
+    @Test
+    void shouldSetFlushDelay() {
+      assertThat(brokerCfg.getCluster().getRaft().getFlush().delayTime())
+          .isEqualTo(Duration.ofSeconds(5));
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "zeebe.broker.cluster.heartbeatInterval=2s",
+        "zeebe.broker.cluster.electionTimeout=20s",
+        "zeebe.broker.cluster.raft.enablePriorityElection=false",
+        "zeebe.broker.cluster.raft.flush.enabled=false",
+        "zeebe.broker.cluster.raft.flush.delay=10s"
+      })
+  class WithOnlyLegacySet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithOnlyLegacySet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldSetHeartbeatIntervalFromLegacy() {
+      assertThat(brokerCfg.getCluster().getHeartbeatInterval()).isEqualTo(Duration.ofSeconds(2));
+    }
+
+    @Test
+    void shouldSetElectionTimeoutFromLegacy() {
+      assertThat(brokerCfg.getCluster().getElectionTimeout()).isEqualTo(Duration.ofSeconds(20));
+    }
+
+    @Test
+    void shouldSetPriorityElectionEnabledFromLegacy() {
+      assertThat(brokerCfg.getCluster().getRaft().isEnablePriorityElection()).isFalse();
+    }
+
+    @Test
+    void shouldSetFlushEnabledFromLegacy() {
+      assertThat(brokerCfg.getCluster().getRaft().getFlush().enabled()).isFalse();
+    }
+
+    @Test
+    void shouldSetFlushDelayFromLegacy() {
+      assertThat(brokerCfg.getCluster().getRaft().getFlush().delayTime())
+          .isEqualTo(Duration.ofSeconds(10));
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        // new
+        "camunda.cluster.raft.heartbeat-interval=3s",
+        "camunda.cluster.raft.election-timeout=30s",
+        "camunda.cluster.raft.priority-election-enabled=true",
+        "camunda.cluster.raft.flush-enabled=true",
+        "camunda.cluster.raft.flush-delay=15s",
+        // legacy
+        "zeebe.broker.cluster.heartbeatInterval=99s",
+        "zeebe.broker.cluster.electionTimeout=99s",
+        "zeebe.broker.cluster.raft.enablePriorityElection=false",
+        "zeebe.broker.cluster.raft.flush.enabled=false",
+        "zeebe.broker.cluster.raft.flush.delay=99s"
+      })
+  class WithNewAndLegacySet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithNewAndLegacySet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldSetHeartbeatIntervalFromNew() {
+      assertThat(brokerCfg.getCluster().getHeartbeatInterval()).isEqualTo(Duration.ofSeconds(3));
+    }
+
+    @Test
+    void shouldSetElectionTimeoutFromNew() {
+      assertThat(brokerCfg.getCluster().getElectionTimeout()).isEqualTo(Duration.ofSeconds(30));
+    }
+
+    @Test
+    void shouldSetPriorityElectionEnabledFromNew() {
+      assertThat(brokerCfg.getCluster().getRaft().isEnablePriorityElection()).isTrue();
+    }
+
+    @Test
+    void shouldSetFlushEnabledFromNew() {
+      assertThat(brokerCfg.getCluster().getRaft().getFlush().enabled()).isTrue();
+    }
+
+    @Test
+    void shouldSetFlushDelayFromNew() {
+      assertThat(brokerCfg.getCluster().getRaft().getFlush().delayTime())
+          .isEqualTo(Duration.ofSeconds(15));
+    }
+  }
+}


### PR DESCRIPTION
## Description

Add raft properties
* hearbeat-interval
* election-timeout
* flush-enabled
* flush-disabled
* priority-election-enabled

to unified configuration. The properties are backwards compatible with the legacy properties from `zeebe.broker.cluster.*`

## Checklist

- [x] The legacy properties and the backwards compatibility strategy are updated in [schema doc](https://docs.google.com/spreadsheets/d/1R4epsy6DWemA8_76cUE6zOGUFbrXCXlM2reXnKFuz7Y/edit?gid=818158292#gid=818158292) 
- [x] The new property fields are documented in the code

## Related issues

related to #34906 
