### PR TITLE
feat: uc: add primary storage handling

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/Camunda.java
+++ b/configuration/src/main/java/io/camunda/configuration/Camunda.java
@@ -20,6 +20,7 @@ public class Camunda {
 
   private Cluster cluster = new Cluster();
   private System system = new System();
+  private Data data = new Data();
   private Api api = new Api();
 
   public Cluster getCluster() {
@@ -44,5 +45,13 @@ public class Camunda {
 
   public void setApi(final Api api) {
     this.api = api;
+  }
+
+  public Data getData() {
+    return data;
+  }
+
+  public void setData(final Data data) {
+    this.data = data;
   }
 }

--- a/configuration/src/main/java/io/camunda/configuration/Data.java
+++ b/configuration/src/main/java/io/camunda/configuration/Data.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+public class Data {
+
+  /** This section allows to configure primary Zeebe's data storage. */
+  private PrimaryStorage primaryStorage = new PrimaryStorage();
+
+  public PrimaryStorage getPrimaryStorage() {
+    return primaryStorage;
+  }
+
+  public void setPrimaryStorage(final PrimaryStorage primaryStorage) {
+    this.primaryStorage = primaryStorage;
+  }
+}

--- a/configuration/src/main/java/io/camunda/configuration/Disk.java
+++ b/configuration/src/main/java/io/camunda/configuration/Disk.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import io.camunda.configuration.UnifiedConfigurationHelper.BackwardsCompatibilityMode;
+import java.time.Duration;
+import java.util.Set;
+
+public class Disk {
+
+  private static final String PREFIX = "camunda.data.primary-storage.disk.";
+
+  private static final Set<String> LEGACY_ENABLE_MONITORING_PROPERTIES =
+      Set.of("zeebe.broker.data.disk.enableMonitoring");
+  private static final Set<String> LEGACY_MONITORING_INTERVAL_PROPERTIES =
+      Set.of("zeebe.broker.data.disk.monitoringInterval");
+
+  /**
+   * Configure disk monitoring to prevent getting into a non-recoverable state due to out of disk
+   * space. When monitoring is enabled, the broker rejects commands and pause replication when the
+   * required freeSpace is not available.
+   */
+  private boolean monitoringEnabled = true;
+
+  /** Sets the interval at which the disk usage is monitored */
+  private Duration monitoringInterval = Duration.ofSeconds(1);
+
+  private FreeSpace freeSpace = new FreeSpace();
+
+  public FreeSpace getFreeSpace() {
+    return freeSpace;
+  }
+
+  public void setFreeSpace(final FreeSpace freeSpace) {
+    this.freeSpace = freeSpace;
+  }
+
+  public boolean isMonitoringEnabled() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + "monitoring-enabled",
+        monitoringEnabled,
+        Boolean.class,
+        BackwardsCompatibilityMode.SUPPORTED,
+        LEGACY_ENABLE_MONITORING_PROPERTIES);
+  }
+
+  public void setMonitoringEnabled(final boolean monitoringEnabled) {
+    this.monitoringEnabled = monitoringEnabled;
+  }
+
+  public Duration getMonitoringInterval() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + "monitoring-interval",
+        monitoringInterval,
+        Duration.class,
+        BackwardsCompatibilityMode.SUPPORTED,
+        LEGACY_MONITORING_INTERVAL_PROPERTIES);
+  }
+
+  public void setMonitoringInterval(final Duration monitoringInterval) {
+    this.monitoringInterval = monitoringInterval;
+  }
+}

--- a/configuration/src/main/java/io/camunda/configuration/FreeSpace.java
+++ b/configuration/src/main/java/io/camunda/configuration/FreeSpace.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import io.camunda.configuration.UnifiedConfigurationHelper.BackwardsCompatibilityMode;
+import java.util.Set;
+import org.springframework.util.unit.DataSize;
+
+public class FreeSpace {
+  private static final String PREFIX = "camunda.data.primary-storage.disk.free-space.";
+
+  private static final Set<String> LEGACY_PROCESSING_PROPERTIES =
+      Set.of("zeebe.broker.data.disk.freeSpace.processing");
+  private static final Set<String> LEGACY_REPLICATION_PROPERTIES =
+      Set.of("zeebe.broker.data.disk.freeSpace.replication");
+
+  /**
+   * When the free space available is less than this value, this broker rejects all client commands
+   * and pause processing.
+   */
+  private DataSize processing = DataSize.ofGigabytes(2);
+
+  /**
+   * When the free space available is less than this value, broker stops receiving replicated
+   * events. This value must be less than `...free-space.processing`. It is recommended to configure
+   * free space large enough for at least one log segment and one snapshot. This is because a
+   * partition needs enough space to take a new snapshot to be able to compact the log segments to
+   * make disk space available again.
+   */
+  private DataSize replication = DataSize.ofGigabytes(1);
+
+  public DataSize getProcessing() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + "processing",
+        processing,
+        DataSize.class,
+        BackwardsCompatibilityMode.SUPPORTED,
+        LEGACY_PROCESSING_PROPERTIES);
+  }
+
+  public void setProcessing(final DataSize processing) {
+    this.processing = processing;
+  }
+
+  public DataSize getReplication() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + "replication",
+        replication,
+        DataSize.class,
+        BackwardsCompatibilityMode.SUPPORTED,
+        LEGACY_REPLICATION_PROPERTIES);
+  }
+
+  public void setReplication(final DataSize replication) {
+    this.replication = replication;
+  }
+}

--- a/configuration/src/main/java/io/camunda/configuration/LogStream.java
+++ b/configuration/src/main/java/io/camunda/configuration/LogStream.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import io.camunda.configuration.UnifiedConfigurationHelper.BackwardsCompatibilityMode;
+import java.util.Set;
+import org.springframework.util.unit.DataSize;
+
+public class LogStream {
+  private static final String PREFIX = "camunda.data.primary-storage.log-stream.";
+
+  private static final Set<String> LEGACY_INDEX_DENSITY_PROPERTIES =
+      Set.of("zeebe.broker.data.logIndexDensity");
+  private static final Set<String> LEGACY_SEGMENT_SIZE_PROPERTIES =
+      Set.of("zeebe.broker.data.logSegmentSize");
+
+  /**
+   * The density of the log index, which determines how frequently index entries are created in the
+   * log. This value specifies the number of log entries between each index entry. A lower value
+   * increases the number of index entries (improving lookup speed but using more memory), while a
+   * higher value reduces the number of index entries (saving memory but potentially slowing
+   * lookups).
+   *
+   * <p>Valid values: any positive integer (recommended range: 1-1000). Default: 100.
+   */
+  private int logIndexDensity = 100;
+
+  /** The size of data log segment files. */
+  private DataSize logSegmentSize = DataSize.ofMegabytes(128);
+
+  public int getLogIndexDensity() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + "log-index-density",
+        logIndexDensity,
+        Integer.class,
+        BackwardsCompatibilityMode.SUPPORTED,
+        LEGACY_INDEX_DENSITY_PROPERTIES);
+  }
+
+  public void setLogIndexDensity(final int logIndexDensity) {
+    this.logIndexDensity = logIndexDensity;
+  }
+
+  public DataSize getLogSegmentSize() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + "log-segment-size",
+        logSegmentSize,
+        DataSize.class,
+        BackwardsCompatibilityMode.SUPPORTED,
+        LEGACY_SEGMENT_SIZE_PROPERTIES);
+  }
+
+  public void setLogSegmentSize(final DataSize logSegmentSize) {
+    this.logSegmentSize = logSegmentSize;
+  }
+}

--- a/configuration/src/main/java/io/camunda/configuration/PrimaryStorage.java
+++ b/configuration/src/main/java/io/camunda/configuration/PrimaryStorage.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import io.camunda.configuration.UnifiedConfigurationHelper.BackwardsCompatibilityMode;
+import java.util.Set;
+
+public class PrimaryStorage {
+
+  private static final String PREFIX = "camunda.data.primary-storage.";
+
+  private static final Set<String> LEGACY_DIRECTORY_PROPERTIES =
+      Set.of("zeebe.broker.data.directory");
+  private static final Set<String> LEGACY_RUNTIME_DIRECTORY_PROPERTIES =
+      Set.of("zeebe.broker.data.runtimeDirectory");
+
+  /** Specify the directory in which data is stored. */
+  private String directory = "data";
+
+  /**
+   * Specify the directory in which runtime is stored. By default, runtime is stored in `directory`
+   * for data. If `runtime-directory` is configured, then the configured directory will be used. It
+   * will have a subdirectory for each partition to store its runtime. There is no need to store
+   * runtime in a persistent storage. This configuration allows to split runtime to another disk to
+   * optimize for performance and disk usage. Note: If runtime is another disk than the data
+   * directory, files need to be copied to data directory while taking snapshot. This may impact
+   * disk i/o or performance during snapshotting.
+   */
+  private String runtimeDirectory;
+
+  private Disk disk = new Disk();
+  private LogStream logStream = new LogStream();
+
+  public String getDirectory() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + "directory",
+        directory,
+        String.class,
+        BackwardsCompatibilityMode.SUPPORTED,
+        LEGACY_DIRECTORY_PROPERTIES);
+  }
+
+  public void setDirectory(final String directory) {
+    this.directory = directory;
+  }
+
+  public String getRuntimeDirectory() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + "runtime-directory",
+        runtimeDirectory,
+        String.class,
+        BackwardsCompatibilityMode.SUPPORTED,
+        LEGACY_RUNTIME_DIRECTORY_PROPERTIES);
+  }
+
+  public void setRuntimeDirectory(final String runtimeDirectory) {
+    this.runtimeDirectory = runtimeDirectory;
+  }
+
+  public Disk getDisk() {
+    return disk;
+  }
+
+  public void setDisk(final Disk disk) {
+    this.disk = disk;
+  }
+
+  public LogStream getLogStream() {
+    return logStream;
+  }
+
+  public void setLogStream(final LogStream logStream) {
+    this.logStream = logStream;
+  }
+}

--- a/configuration/src/main/java/io/camunda/configuration/UnifiedConfigurationHelper.java
+++ b/configuration/src/main/java/io/camunda/configuration/UnifiedConfigurationHelper.java
@@ -16,6 +16,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.convert.DurationStyle;
 import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Component;
+import org.springframework.util.unit.DataSize;
 
 @Component("unifiedConfigurationHelper")
 public class UnifiedConfigurationHelper {
@@ -212,6 +213,7 @@ public class UnifiedConfigurationHelper {
       case "Boolean" -> (T) Boolean.valueOf(strValue);
       case "Duration" -> (T) DurationStyle.detectAndParse(strValue);
       case "Long" -> (T) Long.valueOf(strValue);
+      case "DataSize" -> (T) DataSize.parse(strValue);
       default -> throw new IllegalArgumentException("Unsupported type: " + type);
     };
   }

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
@@ -50,6 +50,8 @@ public class BrokerBasedPropertiesOverride {
     // with zeebe.broker.*
     populateFromSystem(override);
 
+    populateFromPrimaryStorage(override);
+
     // TODO: Populate the bean from rest of camunda.* sections
     // populateFromData(override);
 
@@ -89,5 +91,22 @@ public class BrokerBasedPropertiesOverride {
     final var enableVersionCheck =
         unifiedConfiguration.getCamunda().getSystem().getUpgrade().getEnableVersionCheck();
     override.getExperimental().setVersionCheckRestrictionEnabled(enableVersionCheck);
+  }
+
+  private void populateFromPrimaryStorage(final BrokerBasedProperties override) {
+    final var primaryStorage = unifiedConfiguration.getCamunda().getData().getPrimaryStorage();
+    final var data = override.getData();
+    data.setDirectory(primaryStorage.getDirectory());
+    data.setRuntimeDirectory(primaryStorage.getRuntimeDirectory());
+    data.setLogIndexDensity(primaryStorage.getLogStream().getLogIndexDensity());
+    data.setLogSegmentSize(primaryStorage.getLogStream().getLogSegmentSize());
+    final var brokerDiskConfig = data.getDisk();
+    final var unifiedDiskConfig = primaryStorage.getDisk();
+    brokerDiskConfig.getFreeSpace().setProcessing(unifiedDiskConfig.getFreeSpace().getProcessing());
+    brokerDiskConfig
+        .getFreeSpace()
+        .setReplication(unifiedDiskConfig.getFreeSpace().getReplication());
+    brokerDiskConfig.setEnableMonitoring(unifiedDiskConfig.isMonitoringEnabled());
+    brokerDiskConfig.setMonitoringInterval(unifiedDiskConfig.getMonitoringInterval());
   }
 }

--- a/configuration/src/test/java/io/camunda/configuration/PrimaryStoragePropertiesTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/PrimaryStoragePropertiesTest.java
@@ -1,0 +1,229 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.configuration.beanoverrides.BrokerBasedPropertiesOverride;
+import io.camunda.configuration.beans.BrokerBasedProperties;
+import java.time.Duration;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+import org.springframework.util.unit.DataSize;
+
+@SpringJUnitConfig({
+  UnifiedConfiguration.class,
+  BrokerBasedPropertiesOverride.class,
+  UnifiedConfigurationHelper.class
+})
+@ActiveProfiles("broker")
+public class PrimaryStoragePropertiesTest {
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "camunda.data.primary-storage.directory=/custom/data",
+        "camunda.data.primary-storage.runtime-directory=/custom/runtime",
+        "camunda.data.primary-storage.disk.monitoring-enabled=false",
+        "camunda.data.primary-storage.disk.monitoring-interval=30s",
+        "camunda.data.primary-storage.disk.free-space.processing=5GB",
+        "camunda.data.primary-storage.disk.free-space.replication=3GB",
+        "camunda.data.primary-storage.log-stream.log-index-density=200",
+        "camunda.data.primary-storage.log-stream.log-segment-size=256MB"
+      })
+  class WithOnlyUnifiedConfigSet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithOnlyUnifiedConfigSet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldSetDirectory() {
+      assertThat(brokerCfg.getData().getDirectory()).isEqualTo("/custom/data");
+    }
+
+    @Test
+    void shouldSetRuntimeDirectory() {
+      assertThat(brokerCfg.getData().getRuntimeDirectory()).isEqualTo("/custom/runtime");
+    }
+
+    @Test
+    void shouldSetDiskEnableMonitoring() {
+      assertThat(brokerCfg.getData().getDisk().isEnableMonitoring()).isFalse();
+    }
+
+    @Test
+    void shouldSetDiskMonitoringInterval() {
+      assertThat(brokerCfg.getData().getDisk().getMonitoringInterval())
+          .isEqualTo(Duration.ofSeconds(30));
+    }
+
+    @Test
+    void shouldSetDiskFreeSpaceProcessing() {
+      assertThat(brokerCfg.getData().getDisk().getFreeSpace().getProcessing())
+          .isEqualTo(DataSize.ofGigabytes(5));
+    }
+
+    @Test
+    void shouldSetDiskFreeSpaceReplication() {
+      assertThat(brokerCfg.getData().getDisk().getFreeSpace().getReplication())
+          .isEqualTo(DataSize.ofGigabytes(3));
+    }
+
+    @Test
+    void shouldSetLogIndexDensity() {
+      assertThat(brokerCfg.getData().getLogIndexDensity()).isEqualTo(200);
+    }
+
+    @Test
+    void shouldSetLogSegmentSize() {
+      assertThat(brokerCfg.getData().getLogSegmentSize()).isEqualTo(DataSize.ofMegabytes(256));
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "zeebe.broker.data.directory=/legacy/data",
+        "zeebe.broker.data.runtimeDirectory=/legacy/runtime",
+        "zeebe.broker.data.disk.enableMonitoring=true",
+        "zeebe.broker.data.disk.monitoringInterval=5s",
+        "zeebe.broker.data.disk.freeSpace.processing=4GB",
+        "zeebe.broker.data.disk.freeSpace.replication=2GB",
+        "zeebe.broker.data.logIndexDensity=150",
+        "zeebe.broker.data.logSegmentSize=64MB"
+      })
+  class WithOnlyLegacySet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithOnlyLegacySet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldSetDirectory() {
+      assertThat(brokerCfg.getData().getDirectory()).isEqualTo("/legacy/data");
+    }
+
+    @Test
+    void shouldSetRuntimeDirectory() {
+      assertThat(brokerCfg.getData().getRuntimeDirectory()).isEqualTo("/legacy/runtime");
+    }
+
+    @Test
+    void shouldSetDiskEnableMonitoring() {
+      assertThat(brokerCfg.getData().getDisk().isEnableMonitoring()).isTrue();
+    }
+
+    @Test
+    void shouldSetDiskMonitoringInterval() {
+      assertThat(brokerCfg.getData().getDisk().getMonitoringInterval())
+          .isEqualTo(Duration.ofSeconds(5));
+    }
+
+    @Test
+    void shouldSetDiskFreeSpaceProcessing() {
+      assertThat(brokerCfg.getData().getDisk().getFreeSpace().getProcessing())
+          .isEqualTo(DataSize.ofGigabytes(4));
+    }
+
+    @Test
+    void shouldSetDiskFreeSpaceReplication() {
+      assertThat(brokerCfg.getData().getDisk().getFreeSpace().getReplication())
+          .isEqualTo(DataSize.ofGigabytes(2));
+    }
+
+    @Test
+    void shouldSetLogIndexDensity() {
+      assertThat(brokerCfg.getData().getLogIndexDensity()).isEqualTo(150);
+    }
+
+    @Test
+    void shouldSetLogSegmentSize() {
+      assertThat(brokerCfg.getData().getLogSegmentSize()).isEqualTo(DataSize.ofMegabytes(64));
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        // new properties
+        "camunda.data.primary-storage.directory=/unified/data",
+        "camunda.data.primary-storage.runtime-directory=/unified/runtime",
+        "camunda.data.primary-storage.disk.monitoring-enabled=false",
+        "camunda.data.primary-storage.disk.monitoring-interval=10s",
+        "camunda.data.primary-storage.disk.free-space.processing=8GB",
+        "camunda.data.primary-storage.disk.free-space.replication=4GB",
+        "camunda.data.primary-storage.log-stream.log-index-density=300",
+        "camunda.data.primary-storage.log-stream.log-segment-size=512MB",
+        // legacy properties (should be ignored when new ones are present)
+        "zeebe.broker.data.directory=/legacy/ignored",
+        "zeebe.broker.data.runtimeDirectory=/legacy/ignored",
+        "zeebe.broker.data.disk.enableMonitoring=true",
+        "zeebe.broker.data.disk.monitoringInterval=60s",
+        "zeebe.broker.data.disk.freeSpace.processing=1GB",
+        "zeebe.broker.data.disk.freeSpace.replication=512MB",
+        "zeebe.broker.data.logIndexDensity=50",
+        "zeebe.broker.data.logSegmentSize=32MB"
+      })
+  class WithNewAndLegacySet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithNewAndLegacySet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldSetDirectoryFromNew() {
+      assertThat(brokerCfg.getData().getDirectory()).isEqualTo("/unified/data");
+    }
+
+    @Test
+    void shouldSetRuntimeDirectoryFromNew() {
+      assertThat(brokerCfg.getData().getRuntimeDirectory()).isEqualTo("/unified/runtime");
+    }
+
+    @Test
+    void shouldSetDiskEnableMonitoringFromNew() {
+      assertThat(brokerCfg.getData().getDisk().isEnableMonitoring()).isFalse();
+    }
+
+    @Test
+    void shouldSetDiskMonitoringIntervalFromNew() {
+      assertThat(brokerCfg.getData().getDisk().getMonitoringInterval())
+          .isEqualTo(Duration.ofSeconds(10));
+    }
+
+    @Test
+    void shouldSetDiskFreeSpaceProcessingFromNew() {
+      assertThat(brokerCfg.getData().getDisk().getFreeSpace().getProcessing())
+          .isEqualTo(DataSize.ofGigabytes(8));
+    }
+
+    @Test
+    void shouldSetDiskFreeSpaceReplicationFromNew() {
+      assertThat(brokerCfg.getData().getDisk().getFreeSpace().getReplication())
+          .isEqualTo(DataSize.ofGigabytes(4));
+    }
+
+    @Test
+    void shouldSetLogIndexDensityFromNew() {
+      assertThat(brokerCfg.getData().getLogIndexDensity()).isEqualTo(300);
+    }
+
+    @Test
+    void shouldSetLogSegmentSizeFromNew() {
+      assertThat(brokerCfg.getData().getLogSegmentSize()).isEqualTo(DataSize.ofMegabytes(512));
+    }
+  }
+}


### PR DESCRIPTION
## Description

feat: uc: add primary storage handling

note for reviewer: originally, the `LogStream` was proposed to be mapped as `logstream`. I remapped it to `log-stream` but happy to discuss.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #36430
