### PR TITLE
Complete ad-hoc sub-process on job completion if completion condition is marked a fulfilled

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/BpmnProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/BpmnProcessors.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.engine.processing;
 import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.metrics.ProcessEngineMetrics;
 import io.camunda.zeebe.engine.processing.adhocsubprocess.AdHocSubProcessInstructionActivateProcessor;
+import io.camunda.zeebe.engine.processing.adhocsubprocess.AdHocSubProcessInstructionCompleteProcessor;
 import io.camunda.zeebe.engine.processing.bpmn.BpmnStreamProcessor;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
@@ -348,5 +349,9 @@ public final class BpmnProcessors {
         AdHocSubProcessInstructionIntent.ACTIVATE,
         new AdHocSubProcessInstructionActivateProcessor(
             writers, processingState, authCheckBehavior, bpmnBehaviors));
+    typedRecordProcessors.onCommand(
+        ValueType.AD_HOC_SUB_PROCESS_INSTRUCTION,
+        AdHocSubProcessInstructionIntent.COMPLETE,
+        new AdHocSubProcessInstructionCompleteProcessor(writers, processingState, bpmnBehaviors));
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/adhocsubprocess/AdHocSubProcessInstructionCompleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/adhocsubprocess/AdHocSubProcessInstructionCompleteProcessor.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.adhocsubprocess;
+
+import io.camunda.zeebe.engine.processing.bpmn.BpmnElementContext;
+import io.camunda.zeebe.engine.processing.bpmn.BpmnElementContextImpl;
+import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnAdHocSubProcessBehavior;
+import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
+import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
+import io.camunda.zeebe.engine.state.instance.ElementInstance;
+import io.camunda.zeebe.protocol.impl.record.value.adhocsubprocess.AdHocSubProcessInstructionRecord;
+import io.camunda.zeebe.protocol.record.intent.AdHocSubProcessInstructionIntent;
+import io.camunda.zeebe.stream.api.records.TypedRecord;
+
+public class AdHocSubProcessInstructionCompleteProcessor
+    implements TypedRecordProcessor<AdHocSubProcessInstructionRecord> {
+
+  private final StateWriter stateWriter;
+  private final TypedRejectionWriter rejectionWriter;
+  private final ElementInstanceState elementInstanceState;
+  private final BpmnAdHocSubProcessBehavior adHocSubProcessBehavior;
+
+  public AdHocSubProcessInstructionCompleteProcessor(
+      final Writers writers,
+      final ProcessingState processingState,
+      final BpmnBehaviors bpmnBehaviors) {
+    stateWriter = writers.state();
+    rejectionWriter = writers.rejection();
+    elementInstanceState = processingState.getElementInstanceState();
+    adHocSubProcessBehavior = bpmnBehaviors.adHocSubProcessBehavior();
+  }
+
+  @Override
+  public void processRecord(final TypedRecord<AdHocSubProcessInstructionRecord> record) {
+    final var recordValue = record.getValue();
+    final var ahspElementInstance =
+        elementInstanceState.getInstance(recordValue.getAdHocSubProcessInstanceKey());
+
+    adHocSubProcessBehavior.completionConditionFulfilled(
+        createBpmnElementContext(ahspElementInstance), recordValue.isCancelRemainingInstances());
+
+    stateWriter.appendFollowUpEvent(
+        recordValue.getAdHocSubProcessInstanceKey(),
+        AdHocSubProcessInstructionIntent.COMPLETED,
+        record.getValue());
+  }
+
+  private BpmnElementContext createBpmnElementContext(final ElementInstance elementInstance) {
+    final var context = new BpmnElementContextImpl();
+    context.init(elementInstance.getKey(), elementInstance.getValue(), elementInstance.getState());
+    return context;
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnAdHocSubProcessBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnAdHocSubProcessBehavior.java
@@ -142,7 +142,7 @@ public final class BpmnAdHocSubProcessBehavior {
     final var hasActiveSequenceFlows = adHocSubProcessInstance.getActiveSequenceFlows() > 0;
 
     if (cancelRemainingInstances) {
-      // terminate all remaining child instances & directly complete ad-hoc sub-process if there
+      // terminate all remaining child instances or directly complete ad-hoc sub-process if there
       // is no child activity left
       if (hasActiveChildInstances) {
         terminateChildInstances(adHocSubProcessContext);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnAdHocSubProcessBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnAdHocSubProcessBehavior.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.processing.variable.VariableBehavior;
 import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
+import io.camunda.zeebe.engine.state.instance.ElementInstance;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
@@ -128,6 +129,14 @@ public final class BpmnAdHocSubProcessBehavior {
   public void completionConditionFulfilled(
       final BpmnElementContext adHocSubProcessContext, final boolean cancelRemainingInstances) {
     final var adHocSubProcessInstance = stateBehavior.getElementInstance(adHocSubProcessContext);
+    completionConditionFulfilled(
+        adHocSubProcessContext, cancelRemainingInstances, adHocSubProcessInstance);
+  }
+
+  public void completionConditionFulfilled(
+      final BpmnElementContext adHocSubProcessContext,
+      final boolean cancelRemainingInstances,
+      final ElementInstance adHocSubProcessInstance) {
     final var hasActiveChildInstances =
         adHocSubProcessInstance.getNumberOfActiveElementInstances() > 0;
     final var hasActiveSequenceFlows = adHocSubProcessInstance.getActiveSequenceFlows() > 0;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
@@ -207,7 +207,11 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
 
     adHocSubProcessBehavior =
         new BpmnAdHocSubProcessBehavior(
-            processingState.getKeyGenerator(), writers, stateBehavior, variableBehavior);
+            processingState.getKeyGenerator(),
+            writers,
+            stateBehavior,
+            variableBehavior,
+            processingState);
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/AdHocSubProcessProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/AdHocSubProcessProcessor.java
@@ -317,21 +317,8 @@ public class AdHocSubProcessProcessor
       }
 
       if (satisfiesCompletionCondition) {
-        if (adHocSubProcess.isCancelRemainingInstances()) {
-          // terminate all remaining child instances & directly complete ad-hoc sub-process if there
-          // is no child activity left - otherwise see onChildTerminated
-          final boolean hasNoActiveChildren =
-              stateTransitionBehavior.terminateChildInstances(adHocSubProcessContext);
-          if (hasNoActiveChildren) {
-            stateTransitionBehavior.completeElement(adHocSubProcessContext);
-          }
-        } else {
-          // complete ad-hoc sub-process if possible, otherwise skip completion as the same block
-          // will be evaluated when the next activity is completed
-          if (stateBehavior.canBeCompleted(childContext)) {
-            stateTransitionBehavior.completeElement(adHocSubProcessContext);
-          }
-        }
+        adHocSubProcessBehavior.completionConditionFulfilled(
+            adHocSubProcessContext, adHocSubProcess.isCancelRemainingInstances());
       }
     }
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/AdHocSubProcessProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/AdHocSubProcessProcessor.java
@@ -358,7 +358,7 @@ public class AdHocSubProcessProcessor
 
       final var adHocSubProcessInstance =
           stateBehavior.getElementInstance(adHocSubProcessContext.getElementInstanceKey());
-      if (adHocSubProcessInstance.isCompletionConditionFulFilled()) {
+      if (adHocSubProcessInstance.isCompletionConditionFulfilled()) {
         adHocSubProcessBehavior.completionConditionFulfilled(
             adHocSubProcessContext,
             adHocSubProcess.isCancelRemainingInstances(),

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
@@ -224,7 +224,7 @@ public final class JobCompleteProcessor implements CommandProcessor<JobRecord> {
     final AdHocSubProcessInstructionRecord instructionRecord =
         new AdHocSubProcessInstructionRecord()
             .setAdHocSubProcessInstanceKey(jobRecord.getElementInstanceKey())
-            .setCompletionConditionFulFilled(jobResult.isCompletionConditionFulfilled());
+            .setCompletionConditionFulfilled(jobResult.isCompletionConditionFulfilled());
 
     if (!jobResult.getActivateElements().isEmpty()) {
       jobResult.getActivateElements().stream()

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
@@ -223,7 +223,8 @@ public final class JobCompleteProcessor implements CommandProcessor<JobRecord> {
 
     final AdHocSubProcessInstructionRecord instructionRecord =
         new AdHocSubProcessInstructionRecord()
-            .setAdHocSubProcessInstanceKey(jobRecord.getElementInstanceKey());
+            .setAdHocSubProcessInstanceKey(jobRecord.getElementInstanceKey())
+            .setCompletionConditionFulFilled(jobResult.isCompletionConditionFulfilled());
 
     if (!jobResult.getActivateElements().isEmpty()) {
       jobResult.getActivateElements().stream()

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
@@ -219,27 +219,35 @@ public final class JobCompleteProcessor implements CommandProcessor<JobRecord> {
   private void handleAdHocSubProcessJob(
       final TypedCommandWriter commandWriter, final JobRecord jobRecord) {
 
-    final List<JobResultActivateElementValue> activateElements =
-        jobRecord.getResult().getActivateElements();
+    final var jobResult = jobRecord.getResult();
 
-    final AdHocSubProcessInstructionRecord activationRecord =
+    final AdHocSubProcessInstructionRecord instructionRecord =
         new AdHocSubProcessInstructionRecord()
             .setAdHocSubProcessInstanceKey(jobRecord.getElementInstanceKey());
 
-    activateElements.stream()
-        .map(JobResultActivateElement.class::cast)
-        .forEach(
-            element ->
-                activationRecord
-                    .activateElements()
-                    .add()
-                    .setElementId(element.getElementId())
-                    .setVariables(element.getVariablesBuffer()));
+    if (!jobResult.getActivateElements().isEmpty()) {
+      jobResult.getActivateElements().stream()
+          .map(JobResultActivateElement.class::cast)
+          .forEach(
+              element ->
+                  instructionRecord
+                      .activateElements()
+                      .add()
+                      .setElementId(element.getElementId())
+                      .setVariables(element.getVariablesBuffer()));
 
-    commandWriter.appendFollowUpCommand(
-        jobRecord.getElementInstanceKey(),
-        AdHocSubProcessInstructionIntent.ACTIVATE,
-        activationRecord);
+      commandWriter.appendFollowUpCommand(
+          jobRecord.getElementInstanceKey(),
+          AdHocSubProcessInstructionIntent.ACTIVATE,
+          instructionRecord);
+    }
+
+    if (jobResult.isCompletionConditionFulfilled()) {
+      commandWriter.appendFollowUpCommand(
+          jobRecord.getElementInstanceKey(),
+          AdHocSubProcessInstructionIntent.COMPLETE,
+          instructionRecord);
+    }
   }
 
   private Either<Rejection, JobRecord> checkAdHocSubprocessActivationTargetsAreValid(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/AdHocSubProcessInstructionCompletedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/AdHocSubProcessInstructionCompletedApplier.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableElementInstanceState;
+import io.camunda.zeebe.protocol.impl.record.value.adhocsubprocess.AdHocSubProcessInstructionRecord;
+import io.camunda.zeebe.protocol.record.intent.AdHocSubProcessInstructionIntent;
+
+public class AdHocSubProcessInstructionCompletedApplier
+    implements TypedEventApplier<
+        AdHocSubProcessInstructionIntent, AdHocSubProcessInstructionRecord> {
+
+  private final MutableElementInstanceState elementInstanceState;
+
+  public AdHocSubProcessInstructionCompletedApplier(
+      final MutableElementInstanceState elementInstanceState) {
+    this.elementInstanceState = elementInstanceState;
+  }
+
+  @Override
+  public void applyState(final long key, final AdHocSubProcessInstructionRecord value) {
+    elementInstanceState.updateInstance(
+        value.getAdHocSubProcessInstanceKey(),
+        instance ->
+            instance.setCompletionConditionFulFilled(value.isCompletionConditionFulFilled()));
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/AdHocSubProcessInstructionCompletedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/AdHocSubProcessInstructionCompletedApplier.java
@@ -28,6 +28,6 @@ public class AdHocSubProcessInstructionCompletedApplier
     elementInstanceState.updateInstance(
         value.getAdHocSubProcessInstanceKey(),
         instance ->
-            instance.setCompletionConditionFulFilled(value.isCompletionConditionFulFilled()));
+            instance.setCompletionConditionFulfilled(value.isCompletionConditionFulfilled()));
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -131,7 +131,7 @@ public final class EventAppliers implements EventApplier {
     registerEscalationAppliers();
     registerResourceDeletionAppliers();
 
-    registerAdHocSubProcessInstructionAppliers();
+    registerAdHocSubProcessInstructionAppliers(state);
 
     registerUserAppliers(state);
     registerAuthorizationAppliers(state);
@@ -579,9 +579,11 @@ public final class EventAppliers implements EventApplier {
     register(ResourceDeletionIntent.DELETED, NOOP_EVENT_APPLIER);
   }
 
-  private void registerAdHocSubProcessInstructionAppliers() {
+  private void registerAdHocSubProcessInstructionAppliers(final MutableProcessingState state) {
     register(AdHocSubProcessInstructionIntent.ACTIVATED, NOOP_EVENT_APPLIER);
-    register(AdHocSubProcessInstructionIntent.COMPLETED, NOOP_EVENT_APPLIER);
+    register(
+        AdHocSubProcessInstructionIntent.COMPLETED,
+        new AdHocSubProcessInstructionCompletedApplier(state.getElementInstanceState()));
   }
 
   private void registerClockAppliers(final MutableProcessingState state) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -131,7 +131,7 @@ public final class EventAppliers implements EventApplier {
     registerEscalationAppliers();
     registerResourceDeletionAppliers();
 
-    registerAdHocSubProcessActivityActivationAppliers();
+    registerAdHocSubProcessInstructionAppliers();
 
     registerUserAppliers(state);
     registerAuthorizationAppliers(state);
@@ -579,8 +579,9 @@ public final class EventAppliers implements EventApplier {
     register(ResourceDeletionIntent.DELETED, NOOP_EVENT_APPLIER);
   }
 
-  private void registerAdHocSubProcessActivityActivationAppliers() {
+  private void registerAdHocSubProcessInstructionAppliers() {
     register(AdHocSubProcessInstructionIntent.ACTIVATED, NOOP_EVENT_APPLIER);
+    register(AdHocSubProcessInstructionIntent.COMPLETED, NOOP_EVENT_APPLIER);
   }
 
   private void registerClockAppliers(final MutableProcessingState state) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/ElementInstance.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/ElementInstance.java
@@ -50,8 +50,8 @@ public final class ElementInstance extends UnpackedObject implements DbValue {
       new StringValue("executionListenerIndex");
   private static final StringValue TASK_LISTENER_INDICES_RECORD =
       new StringValue("taskListenerIndicesRecord");
-  private static final StringValue COMPLETION_CONDITION_FUL_FILLED =
-      new StringValue("completionConditionFulFilled");
+  private static final StringValue COMPLETION_CONDITION_FULFILLED =
+      new StringValue("completionConditionFulfilled");
   private static final StringValue PROCESS_DEPTH = new StringValue("processDepth");
   private final LongProperty parentKeyProp = new LongProperty(PARENT_KEY, -1L);
   private final IntegerProperty childCountProp = new IntegerProperty(CHILD_COUNT, 0);
@@ -82,8 +82,8 @@ public final class ElementInstance extends UnpackedObject implements DbValue {
   private final ObjectProperty<TaskListenerIndicesRecord> taskListenerIndicesRecordProp =
       new ObjectProperty<>(TASK_LISTENER_INDICES_RECORD, new TaskListenerIndicesRecord());
   private final IntegerProperty processDepth = new IntegerProperty(PROCESS_DEPTH, 1);
-  private final BooleanProperty completionConditionFulFilledProp =
-      new BooleanProperty(COMPLETION_CONDITION_FUL_FILLED, false);
+  private final BooleanProperty completionConditionFulfilledProp =
+      new BooleanProperty(COMPLETION_CONDITION_FULFILLED, false);
 
   /**
    * Expresses the current depth of the process instance in the called process tree.
@@ -118,7 +118,7 @@ public final class ElementInstance extends UnpackedObject implements DbValue {
         .declareProperty(taskListenerIndicesRecordProp)
         .declareProperty(processDepth)
         .declareProperty(interruptedByRuntimeInstructionProp)
-        .declareProperty(completionConditionFulFilledProp);
+        .declareProperty(completionConditionFulfilledProp);
   }
 
   public ElementInstance(
@@ -368,11 +368,11 @@ public final class ElementInstance extends UnpackedObject implements DbValue {
     processDepth.setValue(depth);
   }
 
-  public boolean isCompletionConditionFulFilled() {
-    return completionConditionFulFilledProp.getValue();
+  public boolean isCompletionConditionFulfilled() {
+    return completionConditionFulfilledProp.getValue();
   }
 
-  public void setCompletionConditionFulFilled(final boolean fulfilled) {
-    completionConditionFulFilledProp.setValue(fulfilled);
+  public void setCompletionConditionFulfilled(final boolean fulfilled) {
+    completionConditionFulfilledProp.setValue(fulfilled);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/ElementInstance.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/ElementInstance.java
@@ -50,8 +50,9 @@ public final class ElementInstance extends UnpackedObject implements DbValue {
       new StringValue("executionListenerIndex");
   private static final StringValue TASK_LISTENER_INDICES_RECORD =
       new StringValue("taskListenerIndicesRecord");
+  private static final StringValue COMPLETION_CONDITION_FUL_FILLED =
+      new StringValue("completionConditionFulFilled");
   private static final StringValue PROCESS_DEPTH = new StringValue("processDepth");
-
   private final LongProperty parentKeyProp = new LongProperty(PARENT_KEY, -1L);
   private final IntegerProperty childCountProp = new IntegerProperty(CHILD_COUNT, 0);
   private final IntegerProperty childActivatedCountProp =
@@ -81,6 +82,8 @@ public final class ElementInstance extends UnpackedObject implements DbValue {
   private final ObjectProperty<TaskListenerIndicesRecord> taskListenerIndicesRecordProp =
       new ObjectProperty<>(TASK_LISTENER_INDICES_RECORD, new TaskListenerIndicesRecord());
   private final IntegerProperty processDepth = new IntegerProperty(PROCESS_DEPTH, 1);
+  private final BooleanProperty completionConditionFulFilledProp =
+      new BooleanProperty(COMPLETION_CONDITION_FUL_FILLED, false);
 
   /**
    * Expresses the current depth of the process instance in the called process tree.
@@ -97,7 +100,7 @@ public final class ElementInstance extends UnpackedObject implements DbValue {
    *     the property existed, will not have a correct depth.
    */
   public ElementInstance() {
-    super(17);
+    super(18);
     declareProperty(parentKeyProp)
         .declareProperty(childCountProp)
         .declareProperty(childActivatedCountProp)
@@ -114,7 +117,8 @@ public final class ElementInstance extends UnpackedObject implements DbValue {
         .declareProperty(executionListenerIndexProp)
         .declareProperty(taskListenerIndicesRecordProp)
         .declareProperty(processDepth)
-        .declareProperty(interruptedByRuntimeInstructionProp);
+        .declareProperty(interruptedByRuntimeInstructionProp)
+        .declareProperty(completionConditionFulFilledProp);
   }
 
   public ElementInstance(
@@ -362,5 +366,13 @@ public final class ElementInstance extends UnpackedObject implements DbValue {
 
   public void setProcessDepth(final int depth) {
     processDepth.setValue(depth);
+  }
+
+  public boolean isCompletionConditionFulFilled() {
+    return completionConditionFulFilledProp.getValue();
+  }
+
+  public void setCompletionConditionFulFilled(final boolean fulfilled) {
+    completionConditionFulFilledProp.setValue(fulfilled);
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/AdHocSubProcessInstructionCompletedApplierTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/AdHocSubProcessInstructionCompletedApplierTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.state.instance.ElementInstance;
+import io.camunda.zeebe.engine.state.mutable.MutableElementInstanceState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.util.ProcessingStateExtension;
+import io.camunda.zeebe.protocol.impl.record.value.adhocsubprocess.AdHocSubProcessInstructionRecord;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(ProcessingStateExtension.class)
+public class AdHocSubProcessInstructionCompletedApplierTest {
+  /** Injected by {@link ProcessingStateExtension} */
+  private MutableProcessingState processingState;
+
+  private MutableElementInstanceState elementInstanceState;
+  private AdHocSubProcessInstructionCompletedApplier applier;
+
+  @BeforeEach
+  public void setup() {
+    elementInstanceState = processingState.getElementInstanceState();
+    applier = new AdHocSubProcessInstructionCompletedApplier(elementInstanceState);
+  }
+
+  @Test
+  void shouldUpdateCompletionConditionFulfilled() {
+    // Given
+    final long adHocSubProcessInstanceKey = 1L;
+    final boolean completionConditionFulfilled = true;
+    elementInstanceState.createInstance(
+        new ElementInstance(
+            adHocSubProcessInstanceKey,
+            ProcessInstanceIntent.ELEMENT_ACTIVATED,
+            new ProcessInstanceRecord()));
+
+    // When
+    applier.applyState(
+        adHocSubProcessInstanceKey,
+        new AdHocSubProcessInstructionRecord()
+            .setAdHocSubProcessInstanceKey(adHocSubProcessInstanceKey)
+            .setCompletionConditionFulFilled(completionConditionFulfilled));
+
+    // Then
+    final var instance = elementInstanceState.getInstance(adHocSubProcessInstanceKey);
+    assertThat(instance.isCompletionConditionFulFilled()).isTrue();
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/AdHocSubProcessInstructionCompletedApplierTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/AdHocSubProcessInstructionCompletedApplierTest.java
@@ -50,10 +50,10 @@ public class AdHocSubProcessInstructionCompletedApplierTest {
         adHocSubProcessInstanceKey,
         new AdHocSubProcessInstructionRecord()
             .setAdHocSubProcessInstanceKey(adHocSubProcessInstanceKey)
-            .setCompletionConditionFulFilled(completionConditionFulfilled));
+            .setCompletionConditionFulfilled(completionConditionFulfilled));
 
     // Then
     final var instance = elementInstanceState.getInstance(adHocSubProcessInstanceKey);
-    assertThat(instance.isCompletionConditionFulFilled()).isTrue();
+    assertThat(instance.isCompletionConditionFulfilled()).isTrue();
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/RecordToWrite.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/RecordToWrite.java
@@ -187,10 +187,9 @@ public final class RecordToWrite implements LogAppendEntry {
   }
 
   public RecordToWrite adHocSubProcessInstruction(
+      final AdHocSubProcessInstructionIntent intent,
       final AdHocSubProcessInstructionRecordValue value) {
-    recordMetadata
-        .valueType(ValueType.AD_HOC_SUB_PROCESS_INSTRUCTION)
-        .intent(AdHocSubProcessInstructionIntent.ACTIVATE);
+    recordMetadata.valueType(ValueType.AD_HOC_SUB_PROCESS_INSTRUCTION).intent(intent);
     unifiedRecordValue = (AdHocSubProcessInstructionRecord) value;
     return this;
   }

--- a/zeebe/engine/src/test/resources/state/appliers/golden/AdHocSubProcessInstruction_COMPLETED_v1.golden
+++ b/zeebe/engine/src/test/resources/state/appliers/golden/AdHocSubProcessInstruction_COMPLETED_v1.golden
@@ -1,0 +1,33 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableElementInstanceState;
+import io.camunda.zeebe.protocol.impl.record.value.adhocsubprocess.AdHocSubProcessInstructionRecord;
+import io.camunda.zeebe.protocol.record.intent.AdHocSubProcessInstructionIntent;
+
+public class AdHocSubProcessInstructionCompletedApplier
+    implements TypedEventApplier<
+        AdHocSubProcessInstructionIntent, AdHocSubProcessInstructionRecord> {
+
+  private final MutableElementInstanceState elementInstanceState;
+
+  public AdHocSubProcessInstructionCompletedApplier(
+      final MutableElementInstanceState elementInstanceState) {
+    this.elementInstanceState = elementInstanceState;
+  }
+
+  @Override
+  public void applyState(final long key, final AdHocSubProcessInstructionRecord value) {
+    elementInstanceState.updateInstance(
+        value.getAdHocSubProcessInstanceKey(),
+        instance ->
+            instance.setCompletionConditionFulfilled(value.isCompletionConditionFulfilled()));
+  }
+}

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-ad-hoc-sub-process-instruction-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-ad-hoc-sub-process-instruction-template.json
@@ -39,6 +39,9 @@
             },
             "tenantId": {
               "type": "keyword"
+            },
+            "completionConditionFulfilled": {
+              "type": "boolean"
             }
           }
         }

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-ad-hoc-sub-process-instruction-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-ad-hoc-sub-process-instruction-template.json
@@ -39,6 +39,9 @@
             },
             "tenantId": {
               "type": "keyword"
+            },
+            "completionConditionFulfilled": {
+              "type": "boolean"
             }
           }
         }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/adhocsubprocess/AdHocSubProcessInstructionRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/adhocsubprocess/AdHocSubProcessInstructionRecord.java
@@ -22,12 +22,12 @@ import java.util.List;
 
 public final class AdHocSubProcessInstructionRecord extends UnifiedRecordValue
     implements AdHocSubProcessInstructionRecordValue {
-  public static final StringValue AD_HOC_SUB_PROCESS_INSTANCE_KEY =
+  private static final StringValue AD_HOC_SUB_PROCESS_INSTANCE_KEY =
       new StringValue("adHocSubProcessInstanceKey");
-  public static final StringValue ACTIVATE_ELEMENTS = new StringValue("activateElements");
-  public static final StringValue IS_CANCEL_REMAINING_INSTANCES =
+  private static final StringValue ACTIVATE_ELEMENTS = new StringValue("activateElements");
+  private static final StringValue IS_CANCEL_REMAINING_INSTANCES =
       new StringValue("isCancelRemainingInstances");
-  public static final StringValue TENANT_ID = new StringValue("tenantId");
+  private static final StringValue TENANT_ID = new StringValue("tenantId");
   private static final StringValue COMPLETION_CONDITION_FUL_FILLED =
       new StringValue("completionConditionFulFilled");
 

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/adhocsubprocess/AdHocSubProcessInstructionRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/adhocsubprocess/AdHocSubProcessInstructionRecord.java
@@ -28,6 +28,8 @@ public final class AdHocSubProcessInstructionRecord extends UnifiedRecordValue
   public static final StringValue IS_CANCEL_REMAINING_INSTANCES =
       new StringValue("isCancelRemainingInstances");
   public static final StringValue TENANT_ID = new StringValue("tenantId");
+  private static final StringValue COMPLETION_CONDITION_FUL_FILLED =
+      new StringValue("completionConditionFulFilled");
 
   private final LongProperty adHocSubProcessInstanceKey =
       new LongProperty(AD_HOC_SUB_PROCESS_INSTANCE_KEY, -1L);
@@ -37,13 +39,16 @@ public final class AdHocSubProcessInstructionRecord extends UnifiedRecordValue
       new BooleanProperty(IS_CANCEL_REMAINING_INSTANCES, false);
   private final StringProperty tenantId =
       new StringProperty(TENANT_ID, TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+  private final BooleanProperty completionConditionFulFilledProp =
+      new BooleanProperty(COMPLETION_CONDITION_FUL_FILLED, false);
 
   public AdHocSubProcessInstructionRecord() {
-    super(4);
+    super(5);
     declareProperty(adHocSubProcessInstanceKey)
         .declareProperty(activateElements)
         .declareProperty(cancelRemainingInstances)
-        .declareProperty(tenantId);
+        .declareProperty(tenantId)
+        .declareProperty(completionConditionFulFilledProp);
   }
 
   @Override
@@ -67,6 +72,16 @@ public final class AdHocSubProcessInstructionRecord extends UnifiedRecordValue
   @Override
   public boolean isCancelRemainingInstances() {
     return cancelRemainingInstances.getValue();
+  }
+
+  @Override
+  public boolean isCompletionConditionFulFilled() {
+    return completionConditionFulFilledProp.getValue();
+  }
+
+  public AdHocSubProcessInstructionRecord setCompletionConditionFulFilled(final boolean fulfilled) {
+    completionConditionFulFilledProp.setValue(fulfilled);
+    return this;
   }
 
   public AdHocSubProcessInstructionRecord cancelRemainingInstances(

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/adhocsubprocess/AdHocSubProcessInstructionRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/adhocsubprocess/AdHocSubProcessInstructionRecord.java
@@ -28,8 +28,8 @@ public final class AdHocSubProcessInstructionRecord extends UnifiedRecordValue
   private static final StringValue IS_CANCEL_REMAINING_INSTANCES =
       new StringValue("isCancelRemainingInstances");
   private static final StringValue TENANT_ID = new StringValue("tenantId");
-  private static final StringValue COMPLETION_CONDITION_FUL_FILLED =
-      new StringValue("completionConditionFulFilled");
+  private static final StringValue COMPLETION_CONDITION_FULFILLED =
+      new StringValue("completionConditionFulfilled");
 
   private final LongProperty adHocSubProcessInstanceKey =
       new LongProperty(AD_HOC_SUB_PROCESS_INSTANCE_KEY, -1L);
@@ -39,8 +39,8 @@ public final class AdHocSubProcessInstructionRecord extends UnifiedRecordValue
       new BooleanProperty(IS_CANCEL_REMAINING_INSTANCES, false);
   private final StringProperty tenantId =
       new StringProperty(TENANT_ID, TenantOwned.DEFAULT_TENANT_IDENTIFIER);
-  private final BooleanProperty completionConditionFulFilledProp =
-      new BooleanProperty(COMPLETION_CONDITION_FUL_FILLED, false);
+  private final BooleanProperty completionConditionFulfilledProp =
+      new BooleanProperty(COMPLETION_CONDITION_FULFILLED, false);
 
   public AdHocSubProcessInstructionRecord() {
     super(5);
@@ -48,7 +48,7 @@ public final class AdHocSubProcessInstructionRecord extends UnifiedRecordValue
         .declareProperty(activateElements)
         .declareProperty(cancelRemainingInstances)
         .declareProperty(tenantId)
-        .declareProperty(completionConditionFulFilledProp);
+        .declareProperty(completionConditionFulfilledProp);
   }
 
   @Override
@@ -75,12 +75,12 @@ public final class AdHocSubProcessInstructionRecord extends UnifiedRecordValue
   }
 
   @Override
-  public boolean isCompletionConditionFulFilled() {
-    return completionConditionFulFilledProp.getValue();
+  public boolean isCompletionConditionFulfilled() {
+    return completionConditionFulfilledProp.getValue();
   }
 
-  public AdHocSubProcessInstructionRecord setCompletionConditionFulFilled(final boolean fulfilled) {
-    completionConditionFulFilledProp.setValue(fulfilled);
+  public AdHocSubProcessInstructionRecord setCompletionConditionFulfilled(final boolean fulfilled) {
+    completionConditionFulfilledProp.setValue(fulfilled);
     return this;
   }
 

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -2308,7 +2308,8 @@ final class JsonSerializableToJsonTest {
               final var adHocSubProcessInstructionRecord =
                   new AdHocSubProcessInstructionRecord()
                       .setAdHocSubProcessInstanceKey(1234L)
-                      .setTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+                      .setTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER)
+                      .setCompletionConditionFulfilled(true);
 
               adHocSubProcessInstructionRecord.activateElements().add().setElementId("123");
               adHocSubProcessInstructionRecord
@@ -2337,7 +2338,8 @@ final class JsonSerializableToJsonTest {
               }
             }
           ],
-          "cancelRemainingInstances": true
+          "cancelRemainingInstances": true,
+          "completionConditionFulfilled": true
         }
         """
       },
@@ -2353,7 +2355,8 @@ final class JsonSerializableToJsonTest {
           "adHocSubProcessInstanceKey": -1,
           "tenantId": "<default>",
           "activateElements": [],
-          "cancelRemainingInstances": false
+          "cancelRemainingInstances": false,
+          "completionConditionFulfilled": false
         }
         """
       },

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/AdHocSubProcessInstructionIntent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/AdHocSubProcessInstructionIntent.java
@@ -17,7 +17,9 @@ package io.camunda.zeebe.protocol.record.intent;
 
 public enum AdHocSubProcessInstructionIntent implements Intent {
   ACTIVATE(0),
-  ACTIVATED(1);
+  ACTIVATED(1),
+  COMPLETE(2),
+  COMPLETED(3);
 
   private final short value;
 
@@ -38,6 +40,7 @@ public enum AdHocSubProcessInstructionIntent implements Intent {
   public boolean isEvent() {
     switch (this) {
       case ACTIVATED:
+      case COMPLETED:
         return true;
       default:
         return false;
@@ -50,6 +53,10 @@ public enum AdHocSubProcessInstructionIntent implements Intent {
         return ACTIVATE;
       case 1:
         return ACTIVATED;
+      case 2:
+        return COMPLETE;
+      case 3:
+        return COMPLETED;
       default:
         return Intent.UNKNOWN;
     }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AdHocSubProcessInstructionRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AdHocSubProcessInstructionRecordValue.java
@@ -43,6 +43,8 @@ public interface AdHocSubProcessInstructionRecordValue extends RecordValue, Tena
 
   boolean isCancelRemainingInstances();
 
+  boolean isCompletionConditionFulFilled();
+
   @Value.Immutable
   @ImmutableProtocol(
       builder = ImmutableAdHocSubProcessActivateElementInstructionValue.Builder.class)

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AdHocSubProcessInstructionRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AdHocSubProcessInstructionRecordValue.java
@@ -43,7 +43,7 @@ public interface AdHocSubProcessInstructionRecordValue extends RecordValue, Tena
 
   boolean isCancelRemainingInstances();
 
-  boolean isCompletionConditionFulFilled();
+  boolean isCompletionConditionFulfilled();
 
   @Value.Immutable
   @ImmutableProtocol(


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR start procesing the completion condition fulfilled flag of an AHSP job result. When this flag is set to true we will complete the AHSP upon job completion, or as soon as that last of it's children are completed. We will refrain from creating new jobs on child completion.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes https://github.com/camunda/ad-hoc-sub-process-phase-3/issues/11
