### PR TITLE
Add warning log message when basic auth is in use with link to troubleshooting guide

### DIFF
--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/Gateway.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/Gateway.java
@@ -413,7 +413,7 @@ public final class Gateway implements CloseableSilently {
     if (securityConfiguration.isApiProtected()) {
       final var handler =
           switch (securityConfiguration.getAuthentication().getMethod()) {
-            case BASIC -> new AuthenticationHandler.BasicAuth(userServices, passwordEncoder);
+            case BASIC -> basicAuth();
             case OIDC ->
                 new AuthenticationHandler.Oidc(
                     jwtDecoder, securityConfiguration.getAuthentication().getOidc());
@@ -421,6 +421,15 @@ public final class Gateway implements CloseableSilently {
       interceptors.add(new AuthenticationInterceptor(handler));
     }
     return ServerInterceptors.intercept(service, interceptors);
+  }
+
+  private AuthenticationHandler.BasicAuth basicAuth() {
+    LOG.atWarn()
+        .log(
+            "Basic Authentication only supports a very small number of API requests per second. Please refer to the documentation "
+                + "https://docs.camunda.io/docs/next/self-managed/operational-guides/troubleshooting/#basic-authentication-performance");
+
+    return new AuthenticationHandler.BasicAuth(userServices, passwordEncoder);
   }
 
   private static StatusException grpcStatusException(final int code, final String msg) {


### PR DESCRIPTION
## Description

This change will emit a warning log message at startup when basic authentication is in use, due to its low throughput. The log message includes a link to the troubleshooting guide

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

Relates #36392 
