### PR TITLE
Add scopeKey filter support to Element Instance Search (RDBMS)

### DIFF
--- a/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.8.0.xml
+++ b/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.8.0.xml
@@ -116,6 +116,7 @@
       </column>
       <column name="FLOW_NODE_ID" type="VARCHAR(255)"/>
       <column name="FLOW_NODE_NAME" type="VARCHAR(255)"/>
+      <column name="FLOW_NODE_SCOPE_KEY" type="BIGINT" />
       <column name="PROCESS_INSTANCE_KEY" type="BIGINT" />
       <column name="PROCESS_DEFINITION_ID" type="VARCHAR(255)"/>
       <column name="PROCESS_DEFINITION_KEY" type="BIGINT" />

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/FlowNodeInstanceDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/FlowNodeInstanceDbModel.java
@@ -18,6 +18,7 @@ public record FlowNodeInstanceDbModel(
     Long processInstanceKey,
     Long processDefinitionKey,
     String processDefinitionId,
+    Long flowNodeScopeKey,
     OffsetDateTime startDate,
     OffsetDateTime endDate,
     String flowNodeId,
@@ -44,6 +45,7 @@ public record FlowNodeInstanceDbModel(
                 .processInstanceKey(processInstanceKey())
                 .processDefinitionKey(processDefinitionKey)
                 .processDefinitionId(processDefinitionId)
+                .flowNodeScopeKey(flowNodeScopeKey)
                 .startDate(startDate)
                 .endDate(endDate)
                 .flowNodeId(flowNodeId)
@@ -67,6 +69,7 @@ public record FlowNodeInstanceDbModel(
     private Long processInstanceKey;
     private Long processDefinitionKey;
     private String processDefinitionId;
+    private Long flowNodeScopeKey;
     private OffsetDateTime startDate;
     private OffsetDateTime endDate;
     private String flowNodeId;
@@ -97,6 +100,11 @@ public record FlowNodeInstanceDbModel(
 
     public FlowNodeInstanceDbModelBuilder processDefinitionKey(final Long processDefinitionKey) {
       this.processDefinitionKey = processDefinitionKey;
+      return this;
+    }
+
+    public FlowNodeInstanceDbModelBuilder flowNodeScopeKey(final Long flowNodeScopeKey) {
+      this.flowNodeScopeKey = flowNodeScopeKey;
       return this;
     }
 
@@ -182,6 +190,7 @@ public record FlowNodeInstanceDbModel(
           processInstanceKey,
           processDefinitionKey,
           processDefinitionId,
+          flowNodeScopeKey,
           startDate,
           endDate,
           flowNodeId,

--- a/db/rdbms/src/main/resources/mapper/FlowNodeInstanceMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/FlowNodeInstanceMapper.xml
@@ -22,6 +22,7 @@
     SELECT * FROM (
     SELECT
     FLOW_NODE_INSTANCE_KEY,
+    FLOW_NODE_SCOPE_KEY,
     FLOW_NODE_ID,
     FLOW_NODE_NAME,
     PROCESS_INSTANCE_KEY,
@@ -85,6 +86,10 @@
       AND FLOW_NODE_NAME IN
       <foreach collection="filter.flowNodeNames" item="value" open="(" separator=", " close=")">#{value}</foreach>
     </if>
+    <if test="filter.flowNodeScopeKeys != null and !filter.flowNodeScopeKeys.isEmpty()">
+      AND FLOW_NODE_SCOPE_KEY IN
+      <foreach collection="filter.flowNodeScopeKeys" item="value" open="(" separator=", " close=")">#{value}</foreach>
+    </if>
     <if test="filter.incidentKeys != null and !filter.incidentKeys.isEmpty()">
       AND INCIDENT_KEY IN
       <foreach collection="filter.incidentKeys" item="value" open="(" separator=", " close=")">#{value}</foreach>
@@ -128,6 +133,7 @@
       <arg column="PROCESS_INSTANCE_KEY" javaType="java.lang.Long"/>
       <arg column="PROCESS_DEFINITION_KEY" javaType="java.lang.Long"/>
       <arg column="PROCESS_DEFINITION_ID" javaType="java.lang.String"/>
+      <arg column="FLOW_NODE_SCOPE_KEY" javaType="java.lang.Long"/>
       <arg column="START_DATE" javaType="java.time.OffsetDateTime"/>
       <arg column="END_DATE" javaType="java.time.OffsetDateTime"/>
       <arg column="FLOW_NODE_ID" javaType="java.lang.String"/>
@@ -145,11 +151,11 @@
   </resultMap>
 
   <insert id="insert" parameterType="io.camunda.db.rdbms.write.domain.FlowNodeInstanceDbModel">
-    INSERT INTO ${prefix}FLOW_NODE_INSTANCE (FLOW_NODE_INSTANCE_KEY, FLOW_NODE_ID, FLOW_NODE_NAME, PROCESS_INSTANCE_KEY,
+    INSERT INTO ${prefix}FLOW_NODE_INSTANCE (FLOW_NODE_INSTANCE_KEY, FLOW_NODE_ID, FLOW_NODE_NAME, FLOW_NODE_SCOPE_KEY, PROCESS_INSTANCE_KEY,
                                     PROCESS_DEFINITION_ID, PROCESS_DEFINITION_KEY, TYPE, STATE,
                                              START_DATE, END_DATE, TENANT_ID, TREE_PATH,
                                              INCIDENT_KEY, NUM_SUBPROCESS_INCIDENTS, PARTITION_ID, HISTORY_CLEANUP_DATE)
-    VALUES (#{flowNodeInstanceKey}, #{flowNodeId}, #{flowNodeName}, #{processInstanceKey}, #{processDefinitionId},
+    VALUES (#{flowNodeInstanceKey}, #{flowNodeId}, #{flowNodeName}, #{flowNodeScopeKey}, #{processInstanceKey}, #{processDefinitionId},
             #{processDefinitionKey}, #{type}, #{state},
             #{startDate, jdbcType=TIMESTAMP}, #{endDate, jdbcType=TIMESTAMP}, #{tenantId},
             #{treePath}, #{incidentKey}, #{numSubprocessIncidents}, #{partitionId}, #{historyCleanupDate, jdbcType=TIMESTAMP})
@@ -159,6 +165,7 @@
     UPDATE FLOW_NODE_INSTANCE
     SET FLOW_NODE_ID             = #{flowNodeId},
         FLOW_NODE_NAME           = #{flowNodeName},
+        FLOW_NODE_SCOPE_KEY      = #{flowNodeScopeKey},
         PROCESS_INSTANCE_KEY     = #{processInstanceKey},
         PROCESS_DEFINITION_ID    = #{processDefinitionId},
         PROCESS_DEFINITION_KEY   = #{processDefinitionKey},

--- a/db/rdbms/src/main/resources/mapper/FlowNodeInstanceMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/FlowNodeInstanceMapper.xml
@@ -86,9 +86,9 @@
       AND FLOW_NODE_NAME IN
       <foreach collection="filter.flowNodeNames" item="value" open="(" separator=", " close=")">#{value}</foreach>
     </if>
-    <if test="filter.flowNodeScopeKeys != null and !filter.flowNodeScopeKeys.isEmpty()">
+    <if test="filter.elementInstanceScopeKeys != null and !filter.elementInstanceScopeKeys.isEmpty()">
       AND FLOW_NODE_SCOPE_KEY IN
-      <foreach collection="filter.flowNodeScopeKeys" item="value" open="(" separator=", " close=")">#{value}</foreach>
+      <foreach collection="filter.elementInstanceScopeKeys" item="value" open="(" separator=", " close=")">#{value}</foreach>
     </if>
     <if test="filter.incidentKeys != null and !filter.incidentKeys.isEmpty()">
       AND INCIDENT_KEY IN

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/mapper/FlowNodeInstanceEntityMapperTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/mapper/FlowNodeInstanceEntityMapperTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.read.mapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.db.rdbms.write.domain.FlowNodeInstanceDbModel;
+import io.camunda.db.rdbms.write.domain.FlowNodeInstanceDbModel.FlowNodeInstanceDbModelBuilder;
+import io.camunda.search.entities.FlowNodeInstanceEntity;
+import io.camunda.search.entities.FlowNodeInstanceEntity.FlowNodeState;
+import io.camunda.search.entities.FlowNodeInstanceEntity.FlowNodeType;
+import java.time.OffsetDateTime;
+import java.time.temporal.ChronoUnit;
+import org.assertj.core.data.TemporalUnitWithinOffset;
+import org.junit.jupiter.api.Test;
+
+public class FlowNodeInstanceEntityMapperTest {
+
+  @Test
+  public void testToEntity() {
+    // Given
+    final FlowNodeInstanceDbModel flowNodeInstanceDbModel =
+        new FlowNodeInstanceDbModelBuilder()
+            .flowNodeInstanceKey(1L)
+            .processInstanceKey(2L)
+            .processDefinitionKey(3L)
+            .processDefinitionId("processDefinitionId")
+            .flowNodeScopeKey(4L)
+            .startDate(OffsetDateTime.now())
+            .endDate(OffsetDateTime.now().plusDays(1))
+            .flowNodeId("flowNodeId")
+            .flowNodeName("flowNodeName")
+            .treePath("element1/element2/element3")
+            .type(FlowNodeType.CALL_ACTIVITY)
+            .state(FlowNodeState.ACTIVE)
+            .incidentKey(5L)
+            .numSubprocessIncidents(6L)
+            .hasIncident(true)
+            .tenantId("tenantId")
+            .partitionId(7)
+            .historyCleanupDate(OffsetDateTime.now().plusDays(1))
+            .build();
+
+    // When
+    final FlowNodeInstanceEntity entity =
+        FlowNodeInstanceEntityMapper.toEntity(flowNodeInstanceDbModel);
+
+    // Then
+    assertThat(entity)
+        .usingRecursiveComparison()
+        .ignoringFields("startDate", "endDate", "level")
+        .isEqualTo(flowNodeInstanceDbModel);
+
+    assertThat(entity.startDate())
+        .isCloseTo(
+            flowNodeInstanceDbModel.startDate(),
+            new TemporalUnitWithinOffset(1, ChronoUnit.MILLIS));
+    assertThat(entity.endDate())
+        .isCloseTo(
+            flowNodeInstanceDbModel.endDate(), new TemporalUnitWithinOffset(1, ChronoUnit.MILLIS));
+  }
+
+  @Test
+  public void testToEntityWithNullValues() {
+    // Given
+    final FlowNodeInstanceDbModel flowNodeInstanceDbModel =
+        new FlowNodeInstanceDbModelBuilder()
+            .flowNodeInstanceKey(1L)
+            .processInstanceKey(2L)
+            .processDefinitionKey(3L)
+            .processDefinitionId(null)
+            .flowNodeScopeKey(4L)
+            .startDate(null)
+            .endDate(null)
+            .flowNodeId(null)
+            .flowNodeName(null)
+            .treePath(null)
+            .type(FlowNodeType.CALL_ACTIVITY)
+            .state(FlowNodeState.ACTIVE)
+            .incidentKey(5L)
+            .numSubprocessIncidents(null)
+            .hasIncident(true)
+            .tenantId(null)
+            .partitionId(0)
+            .historyCleanupDate(null)
+            .build();
+
+    // When
+    final FlowNodeInstanceEntity entity =
+        FlowNodeInstanceEntityMapper.toEntity(flowNodeInstanceDbModel);
+
+    // Then
+    assertThat(entity.flowNodeInstanceKey()).isNotNull();
+    assertThat(entity.processInstanceKey()).isNotNull();
+    assertThat(entity.processDefinitionKey()).isNotNull();
+    assertThat(entity.processDefinitionId()).isNull();
+    assertThat(entity.startDate()).isNull();
+    assertThat(entity.endDate()).isNull();
+    assertThat(entity.flowNodeId()).isNull();
+    assertThat(entity.flowNodeName()).isNull();
+    assertThat(entity.treePath()).isNull();
+    assertThat(entity.type()).isNotNull();
+    assertThat(entity.state()).isNotNull();
+    assertThat(entity.incidentKey()).isNotNull();
+    assertThat(entity.hasIncident()).isNotNull();
+    assertThat(entity.tenantId()).isNull();
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/elementinstance/ElementInstanceIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/elementinstance/ElementInstanceIT.java
@@ -169,6 +169,7 @@ public class ElementInstanceIT {
                     .processInstanceKeys(instance.processInstanceKey())
                     .processDefinitionIds(instance.processDefinitionId())
                     .processDefinitionKeys(instance.processDefinitionKey())
+                    .flowNodeScopeKeys(instance.flowNodeScopeKey())
                     .flowNodeIds(instance.flowNodeId())
                     .types(instance.type())
                     .states(instance.state().name())

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/elementinstance/ElementInstanceIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/elementinstance/ElementInstanceIT.java
@@ -169,7 +169,7 @@ public class ElementInstanceIT {
                     .processInstanceKeys(instance.processInstanceKey())
                     .processDefinitionIds(instance.processDefinitionId())
                     .processDefinitionKeys(instance.processDefinitionKey())
-                    .flowNodeScopeKeys(instance.flowNodeScopeKey())
+                    .elementInstanceScopeKeys(instance.flowNodeScopeKey())
                     .flowNodeIds(instance.flowNodeId())
                     .types(instance.type())
                     .states(instance.state().name())

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/elementinstance/ElementInstanceSpecificFilterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/elementinstance/ElementInstanceSpecificFilterIT.java
@@ -96,7 +96,7 @@ public class ElementInstanceSpecificFilterIT {
         FlowNodeInstanceFilter.of(b -> b.processInstanceKeys(123L)),
         FlowNodeInstanceFilter.of(b -> b.processDefinitionKeys(124L)),
         FlowNodeInstanceFilter.of(b -> b.processDefinitionIds("unique-process-124")),
-        FlowNodeInstanceFilter.of(b -> b.flowNodeScopeKeys(124L)),
+        FlowNodeInstanceFilter.of(b -> b.elementInstanceScopeKeys(124L)),
         FlowNodeInstanceFilter.of(b -> b.states(FlowNodeState.ACTIVE.name())),
         FlowNodeInstanceFilter.of(b -> b.types(FlowNodeType.SERVICE_TASK)),
         FlowNodeInstanceFilter.of(b -> b.tenantIds("unique-tenant-1")),

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/elementinstance/ElementInstanceSpecificFilterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/elementinstance/ElementInstanceSpecificFilterIT.java
@@ -70,6 +70,7 @@ public class ElementInstanceSpecificFilterIT {
                     .processInstanceKey(123L)
                     .processDefinitionId("unique-process-124")
                     .processDefinitionKey(124L)
+                    .flowNodeScopeKey(124L)
                     .state(FlowNodeState.ACTIVE)
                     .type(FlowNodeType.SERVICE_TASK)
                     .tenantId("unique-tenant-1")
@@ -95,6 +96,7 @@ public class ElementInstanceSpecificFilterIT {
         FlowNodeInstanceFilter.of(b -> b.processInstanceKeys(123L)),
         FlowNodeInstanceFilter.of(b -> b.processDefinitionKeys(124L)),
         FlowNodeInstanceFilter.of(b -> b.processDefinitionIds("unique-process-124")),
+        FlowNodeInstanceFilter.of(b -> b.flowNodeScopeKeys(124L)),
         FlowNodeInstanceFilter.of(b -> b.states(FlowNodeState.ACTIVE.name())),
         FlowNodeInstanceFilter.of(b -> b.types(FlowNodeType.SERVICE_TASK)),
         FlowNodeInstanceFilter.of(b -> b.tenantIds("unique-tenant-1")),

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/ElementInstanceFixtures.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/ElementInstanceFixtures.java
@@ -30,6 +30,7 @@ public final class ElementInstanceFixtures extends CommonFixtures {
             .processDefinitionKey(nextKey())
             .processDefinitionId("process-" + generateRandomString(20))
             .flowNodeId("element-" + generateRandomString(20))
+            .flowNodeScopeKey(nextKey())
             .startDate(NOW.plus(RANDOM.nextInt(), ChronoUnit.MILLIS))
             .endDate(NOW.plus(RANDOM.nextInt(), ChronoUnit.MILLIS))
             .treePath(nextStringId())

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/FlowNodeExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/FlowNodeExportHandler.java
@@ -93,6 +93,7 @@ public class FlowNodeExportHandler implements RdbmsExportHandler<ProcessInstance
                     processCache, processDefinitionKey, value.getElementId())
                 .orElse(null))
         .processInstanceKey(value.getProcessInstanceKey())
+        .flowNodeScopeKey(value.getFlowScopeKey())
         .processDefinitionKey(value.getProcessDefinitionKey())
         .processDefinitionId(value.getBpmnProcessId())
         .tenantId(value.getTenantId())


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
This PR adds support for filtering by scopeKey in the Element Instance Search endpoint when using the RDBMS data layer.

- Implements scopeKey filter logic specifically for the relational database backend.
- Complements the existing document-based implementation (Elasticsearch/OpenSearch).
- Enables retrieving immediate child element instances of a given scope (process or element) for RDBMS clients.


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #35665
