### PR TITLE
Include identity setup in recorded records stream

### DIFF
--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/IdentitySetupInitializeDefaultsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/IdentitySetupInitializeDefaultsTest.java
@@ -21,8 +21,12 @@ import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.DefaultRole;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher.ResetMode;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestWatcher;
 
 public class IdentitySetupInitializeDefaultsTest {
 
@@ -32,6 +36,10 @@ public class IdentitySetupInitializeDefaultsTest {
           .withResetRecordingExporterTestWatcherMode(
               ResetRecordingExporterTestWatcherMode.ONLY_BEFORE_AND_AFTER_ALL_TESTS)
           .withIdentitySetup(ResetRecordingExporterMode.NO_RESET_AFTER_IDENTITY_SETUP);
+
+  @Rule
+  public final TestWatcher testWatcher =
+      new RecordingExporterTestWatcher().withResetMode(ResetMode.NEVER);
 
   @Test
   public void shouldCreateAdminRoleByDefault() {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
@@ -85,6 +85,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -161,8 +162,10 @@ public final class EngineRule extends ExternalResource {
 
   @Override
   protected void before() {
-    if (resetRecordingExporterTestWatcherMode
-        == ResetRecordingExporterTestWatcherMode.ONLY_BEFORE_AND_AFTER_ALL_TESTS) {
+    if (EnumSet.of(
+            ResetRecordingExporterTestWatcherMode.ONLY_BEFORE_AND_AFTER_ALL_TESTS,
+            ResetRecordingExporterTestWatcherMode.BEFORE_ALL_TESTS_AND_AFTER_EACH_TEST)
+        .contains(resetRecordingExporterTestWatcherMode)) {
       RecordingExporter.reset();
     }
     start();
@@ -265,6 +268,10 @@ public final class EngineRule extends ExternalResource {
       }
       case BEFORE_EACH_TEST -> {
         recordingExporterTestWatcher.withResetMode(ResetMode.ON_STARTING);
+        yield this;
+      }
+      case BEFORE_ALL_TESTS_AND_AFTER_EACH_TEST -> {
+        recordingExporterTestWatcher.withResetMode(ResetMode.ON_FINISHED);
         yield this;
       }
     };
@@ -706,6 +713,7 @@ public final class EngineRule extends ExternalResource {
 
   public enum ResetRecordingExporterTestWatcherMode {
     ONLY_BEFORE_AND_AFTER_ALL_TESTS,
+    BEFORE_ALL_TESTS_AND_AFTER_EACH_TEST,
     BEFORE_EACH_TEST
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
@@ -109,7 +109,8 @@ public final class EngineRule extends ExternalResource {
   private final StreamProcessorRule environmentRule;
   private final RecordingExporterTestWatcher recordingExporterTestWatcher =
       new RecordingExporterTestWatcher();
-  private ResetRecordingExporterTestWatcherMode resetRecordingExporterTestWatcherMode;
+  private ResetRecordingExporterTestWatcherMode resetRecordingExporterTestWatcherMode =
+      ResetRecordingExporterTestWatcherMode.BEFORE_EACH_TEST;
   private final int partitionCount;
   private boolean awaitIdentitySetup = false;
   private ResetRecordingExporterMode awaitIdentitySetupResetMode =
@@ -202,6 +203,24 @@ public final class EngineRule extends ExternalResource {
 
   public EngineRule withIdentitySetup(
       final ResetRecordingExporterMode awaitIdentitySetupResetMode) {
+    if (awaitIdentitySetupResetMode == ResetRecordingExporterMode.NO_RESET_AFTER_IDENTITY_SETUP
+        && resetRecordingExporterTestWatcherMode
+            == ResetRecordingExporterTestWatcherMode.BEFORE_EACH_TEST) {
+      throw new IllegalStateException(
+          """
+          Expected to not reset RecordingExporter after identity setup, \
+          but the RecordingExporterTestWatcher is configured to reset before each test. \
+          This would mean that the identity setup is still not included in the recording exporter. \
+          If you want to include the identity setup in the recording exporter, please call \
+          .withResetRecordingExporterTestWatcherMode on the EngineRule to change the reset mode, \
+          and choose one of the following modes:
+          - ResetRecordingExporterTestWatcherMode.ONLY_BEFORE_AND_AFTER_ALL_TESTS
+          - ResetRecordingExporterTestWatcherMode.BEFORE_ALL_TESTS_AND_AFTER_EACH_TEST
+
+          Additionally, ensure that the RecordingExporterTestWatcher is not explicitly set up in the
+          test class.
+          """);
+    }
     this.awaitIdentitySetupResetMode = awaitIdentitySetupResetMode;
     return withIdentitySetup();
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
@@ -109,6 +109,7 @@ public final class EngineRule extends ExternalResource {
   private final StreamProcessorRule environmentRule;
   private final RecordingExporterTestWatcher recordingExporterTestWatcher =
       new RecordingExporterTestWatcher();
+  private ResetRecordingExporterTestWatcherMode resetRecordingExporterTestWatcherMode;
   private final int partitionCount;
   private boolean awaitIdentitySetup = false;
   private ResetRecordingExporterMode awaitIdentitySetupResetMode =
@@ -128,7 +129,6 @@ public final class EngineRule extends ExternalResource {
   private Consumer<EngineConfiguration> engineConfigModifier = cfg -> {};
   private SearchClientsProxy searchClientsProxy;
   private Optional<RoutingState> initialRoutingState = Optional.empty();
-  private ResetRecordingExporterTestWatcherMode resetRecordingExporterTestWatcherMode;
 
   private EngineRule(final int partitionCount) {
     this(partitionCount, null);


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Adds the ability use `NO_RESET_AFTER_IDENTITY_SETUP` for `EngineRule.withIdentitySetup` when the EngineRule is set up as `@Rule` rather than `@ClassRule`.

To use that mode, you needed to either use `ONLY_BEFORE_AND_AFTER_ALL_TESTS`, but that means you cannot have automatic resetting of the RecordingExporter in between test cases.

By introducing a new `BEFORE_ALL_TESTS_AND_AFTER_EACH_TEST` reset mode, you can now safely use `NO_RESET_AFTER_IDENTITY_SETUP` in cases where EngineRule is set up as `@Rule`.

**Example**

```java
  @Rule
  public final EngineRule engine =
      EngineRule.singlePartition()
          .withResetRecordingExporterTestWatcherMode(
              ResetRecordingExporterTestWatcherMode.BEFORE_ALL_TESTS_AND_AFTER_EACH_TEST)
          .withIdentitySetup(ResetRecordingExporterMode.NO_RESET_AFTER_IDENTITY_SETUP);
```

This PR does not apply this mode anywhere yet. It just enables its usage.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

relates to #36437 (uses the ability introduced by this PR)
relates to #36252 (added the ability for `NO_RESET_AFTER_IDENTITY_SETUP` for `@ClassRule`)
