### PR TITLE
[Backport stable/8.5] fix: set a project id for gcs backup store tests

### DIFF
--- a/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/GcsBackupConfig.java
+++ b/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/GcsBackupConfig.java
@@ -11,9 +11,11 @@ import static java.util.Objects.requireNonNull;
 
 import io.camunda.zeebe.backup.gcs.GcsBackupStoreException.ConfigurationException;
 import io.camunda.zeebe.backup.gcs.GcsConnectionConfig.Authentication.Auto;
+import io.camunda.zeebe.backup.gcs.GcsConnectionConfig.Authentication.None;
 
 public record GcsBackupConfig(String bucketName, String basePath, GcsConnectionConfig connection) {
-  public GcsBackupConfig(String bucketName, String basePath, GcsConnectionConfig connection) {
+  public GcsBackupConfig(
+      final String bucketName, final String basePath, final GcsConnectionConfig connection) {
     this.bucketName = requireBucketName(bucketName);
     this.basePath = sanitizeBasePath(basePath);
     this.connection = requireNonNull(connection);
@@ -68,18 +70,19 @@ public record GcsBackupConfig(String bucketName, String basePath, GcsConnectionC
       return this;
     }
 
-    public Builder withHost(String host) {
+    public Builder withHost(final String host) {
       this.host = host;
       return this;
     }
 
     public Builder withoutAuthentication() {
-      this.auth = new GcsConnectionConfig.Authentication.None();
+      // This is only used for testing, so we can make up a project id for it.
+      auth = new None("tmp");
       return this;
     }
 
     public Builder withAutoAuthentication() {
-      this.auth = new Auto();
+      auth = new Auto();
       return this;
     }
 

--- a/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/GcsBackupStore.java
+++ b/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/GcsBackupStore.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.backup.common.BackupImpl;
 import io.camunda.zeebe.backup.common.BackupStatusImpl;
 import io.camunda.zeebe.backup.common.Manifest;
 import io.camunda.zeebe.backup.gcs.GcsBackupStoreException.ConfigurationException;
+import io.camunda.zeebe.backup.gcs.GcsConnectionConfig.Authentication.None;
 import java.nio.file.Path;
 import java.util.Collection;
 import java.util.Optional;
@@ -163,11 +164,17 @@ public final class GcsBackupStore implements BackupStore {
   }
 
   public static Storage buildClient(final GcsBackupConfig config) {
-    return StorageOptions.newBuilder()
-        .setHost(config.connection().host())
-        .setCredentials(config.connection().auth().credentials())
-        .build()
-        .getService();
+    final var builder =
+        StorageOptions.newBuilder()
+            .setHost(config.connection().host())
+            .setCredentials(config.connection().auth().credentials());
+
+    // Without authentication, we need to set the project ID explicitly
+    if (config.connection().auth() instanceof None(final String projectId)) {
+      builder.setProjectId(projectId);
+    }
+
+    return builder.build().getService();
   }
 
   public static void validateConfig(final GcsBackupConfig config) {


### PR DESCRIPTION
# Description
Backport of #36409 to `stable/8.5`.

relates to #35204