### PR TITLE
feat: unified config: temporarily support fallback for elasticsearch URL

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/Elasticsearch.java
+++ b/configuration/src/main/java/io/camunda/configuration/Elasticsearch.java
@@ -29,7 +29,7 @@ public class Elasticsearch {
         PREFIX + ".url",
         url,
         String.class,
-        BackwardsCompatibilityMode.SUPPORTED_ONLY_IF_VALUES_MATCH,
+        BackwardsCompatibilityMode.SUPPORTED,
         LEGACY_URL_PROPERTIES);
   }
 

--- a/configuration/src/test/java/io/camunda/configuration/SecondaryStorageFailureWithLegacySchemaTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/SecondaryStorageFailureWithLegacySchemaTest.java
@@ -89,6 +89,7 @@ public class SecondaryStorageFailureWithLegacySchemaTest {
         });
   }
 
+  @Disabled
   @Test
   void testTasklistshouldFailWhenUsingLegacyDatabasePropertiesDontMatchNewProperties() {
     tasklistRunnerWithMismatchingConfigs.run(


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
This temporary change allows existing deployments and tests not to fail while we change their configs everywhere.
This change was supposed to be delivered together with commit b41c0061cd9ccdfa03cc9b82ec18942f467c51d1 but was forgotten.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
