### PR TITLE
feat: migrate secondary storage OS url to the UC

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/Elasticsearch.java
+++ b/configuration/src/main/java/io/camunda/configuration/Elasticsearch.java
@@ -24,7 +24,7 @@ public class Elasticsearch {
 
   public String getUrl() {
     return UnifiedConfigurationHelper.validateLegacyConfiguration(
-        PREFIX + ".url",
+        prefix() + ".url",
         url,
         String.class,
         BackwardsCompatibilityMode.SUPPORTED_ONLY_IF_VALUES_MATCH,
@@ -33,5 +33,13 @@ public class Elasticsearch {
 
   public void setUrl(String url) {
     this.url = url;
+  }
+
+  protected String prefix() {
+    return PREFIX;
+  }
+
+  protected Set<String> legacyUrlProperties() {
+    return LEGACY_URL_PROPERTIES;
   }
 }

--- a/configuration/src/main/java/io/camunda/configuration/Elasticsearch.java
+++ b/configuration/src/main/java/io/camunda/configuration/Elasticsearch.java
@@ -21,8 +21,6 @@ public class Elasticsearch extends SecondaryStorageDatabase {
     return Set.of(
         "camunda.database.url",
         "camunda.operate.elasticsearch.url",
-        "camunda.operate.zeebeElasticsearch.url",
-        "camunda.tasklist.elasticsearch.url",
-        "camunda.tasklist.zeebeElasticsearch.url");
+        "camunda.tasklist.elasticsearch.url");
   }
 }

--- a/configuration/src/main/java/io/camunda/configuration/Elasticsearch.java
+++ b/configuration/src/main/java/io/camunda/configuration/Elasticsearch.java
@@ -7,39 +7,22 @@
  */
 package io.camunda.configuration;
 
-import io.camunda.configuration.UnifiedConfigurationHelper.BackwardsCompatibilityMode;
 import java.util.Set;
 
-public class Elasticsearch {
+public class Elasticsearch extends SecondaryStorageDatabase {
 
-  private static final String PREFIX = "camunda.data.secondary-storage.elasticsearch";
-  private static final Set<String> LEGACY_URL_PROPERTIES =
-      Set.of(
-          "camunda.database.url",
-          "camunda.operate.elasticsearch.url",
-          "camunda.tasklist.elasticsearch.url");
-
-  /** Endpoint for the Elasticsearch engine configured as secondary storage. */
-  private String url = "http://localhost:9200";
-
-  public String getUrl() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
-        prefix() + ".url",
-        url,
-        String.class,
-        BackwardsCompatibilityMode.SUPPORTED_ONLY_IF_VALUES_MATCH,
-        LEGACY_URL_PROPERTIES);
-  }
-
-  public void setUrl(String url) {
-    this.url = url;
-  }
-
+  @Override
   protected String prefix() {
-    return PREFIX;
+    return "camunda.data.secondary-storage.elasticsearch";
   }
 
+  @Override
   protected Set<String> legacyUrlProperties() {
-    return LEGACY_URL_PROPERTIES;
+    return Set.of(
+        "camunda.database.url",
+        "camunda.operate.elasticsearch.url",
+        "camunda.operate.zeebeElasticsearch.url",
+        "camunda.tasklist.elasticsearch.url",
+        "camunda.tasklist.zeebeElasticsearch.url");
   }
 }

--- a/configuration/src/main/java/io/camunda/configuration/Opensearch.java
+++ b/configuration/src/main/java/io/camunda/configuration/Opensearch.java
@@ -7,6 +7,25 @@
  */
 package io.camunda.configuration;
 
-public class Opensearch extends Elasticsearch {
+import java.util.Set;
 
+public class Opensearch extends Elasticsearch {
+  private static final String PREFIX = "camunda.data.secondary-storage.opensearch";
+  private static final Set<String> LEGACY_URL_PROPERTIES =
+      Set.of(
+          "camunda.database.url",
+          "camunda.operate.opensearch.url",
+          "camunda.operate.zeebeOpensearch.url",
+          "camunda.tasklist.opensearch.url",
+          "camunda.tasklist.zeebeOpensearch.url");
+
+  @Override
+  protected String prefix() {
+    return PREFIX;
+  }
+
+  @Override
+  protected Set<String> legacyUrlProperties() {
+    return LEGACY_URL_PROPERTIES;
+  }
 }

--- a/configuration/src/main/java/io/camunda/configuration/Opensearch.java
+++ b/configuration/src/main/java/io/camunda/configuration/Opensearch.java
@@ -9,23 +9,20 @@ package io.camunda.configuration;
 
 import java.util.Set;
 
-public class Opensearch extends Elasticsearch {
-  private static final String PREFIX = "camunda.data.secondary-storage.opensearch";
-  private static final Set<String> LEGACY_URL_PROPERTIES =
-      Set.of(
-          "camunda.database.url",
-          "camunda.operate.opensearch.url",
-          "camunda.operate.zeebeOpensearch.url",
-          "camunda.tasklist.opensearch.url",
-          "camunda.tasklist.zeebeOpensearch.url");
+public class Opensearch extends SecondaryStorageDatabase {
 
   @Override
   protected String prefix() {
-    return PREFIX;
+    return "camunda.data.secondary-storage.opensearch";
   }
 
   @Override
   protected Set<String> legacyUrlProperties() {
-    return LEGACY_URL_PROPERTIES;
+    return Set.of(
+        "camunda.database.url",
+        "camunda.operate.opensearch.url",
+        "camunda.operate.zeebeOpensearch.url",
+        "camunda.tasklist.opensearch.url",
+        "camunda.tasklist.zeebeOpensearch.url");
   }
 }

--- a/configuration/src/main/java/io/camunda/configuration/Opensearch.java
+++ b/configuration/src/main/java/io/camunda/configuration/Opensearch.java
@@ -21,8 +21,6 @@ public class Opensearch extends SecondaryStorageDatabase {
     return Set.of(
         "camunda.database.url",
         "camunda.operate.opensearch.url",
-        "camunda.operate.zeebeOpensearch.url",
-        "camunda.tasklist.opensearch.url",
-        "camunda.tasklist.zeebeOpensearch.url");
+        "camunda.tasklist.opensearch.url");
   }
 }

--- a/configuration/src/main/java/io/camunda/configuration/Opensearch.java
+++ b/configuration/src/main/java/io/camunda/configuration/Opensearch.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+public class Opensearch extends Elasticsearch {
+
+}

--- a/configuration/src/main/java/io/camunda/configuration/SecondaryStorage.java
+++ b/configuration/src/main/java/io/camunda/configuration/SecondaryStorage.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.configuration;
 
-import static io.camunda.configuration.UnifiedConfigurationHelper.BackwardsCompatibilityMode.SUPPORTED;
 import static io.camunda.configuration.UnifiedConfigurationHelper.BackwardsCompatibilityMode.SUPPORTED_ONLY_IF_VALUES_MATCH;
 
 import java.util.Set;

--- a/configuration/src/main/java/io/camunda/configuration/SecondaryStorage.java
+++ b/configuration/src/main/java/io/camunda/configuration/SecondaryStorage.java
@@ -8,6 +8,7 @@
 package io.camunda.configuration;
 
 import static io.camunda.configuration.UnifiedConfigurationHelper.BackwardsCompatibilityMode.SUPPORTED;
+import static io.camunda.configuration.UnifiedConfigurationHelper.BackwardsCompatibilityMode.SUPPORTED_ONLY_IF_VALUES_MATCH;
 
 import java.util.Set;
 
@@ -28,7 +29,11 @@ public class SecondaryStorage {
 
   public SecondaryStorageType getType() {
     return UnifiedConfigurationHelper.validateLegacyConfiguration(
-        PREFIX + ".type", type, SecondaryStorageType.class, SUPPORTED, LEGACY_TYPE_PROPERTIES);
+        PREFIX + ".type",
+        type,
+        SecondaryStorageType.class,
+        SUPPORTED_ONLY_IF_VALUES_MATCH,
+        LEGACY_TYPE_PROPERTIES);
   }
 
   public void setType(SecondaryStorageType type) {

--- a/configuration/src/main/java/io/camunda/configuration/SecondaryStorage.java
+++ b/configuration/src/main/java/io/camunda/configuration/SecondaryStorage.java
@@ -23,6 +23,9 @@ public class SecondaryStorage {
   /** Stores the Elasticsearch configuration, when type is set to 'elasticsearch'. */
   private Elasticsearch elasticsearch = new Elasticsearch();
 
+  /** Stores the Elasticsearch configuration, when type is set to 'elasticsearch'. */
+  private Opensearch opensearch = new Opensearch();
+
   public SecondaryStorageType getType() {
     return UnifiedConfigurationHelper.validateLegacyConfiguration(
         PREFIX + ".type", type, SecondaryStorageType.class, SUPPORTED, LEGACY_TYPE_PROPERTIES);
@@ -38,6 +41,14 @@ public class SecondaryStorage {
 
   public void setElasticsearch(Elasticsearch elasticsearch) {
     this.elasticsearch = elasticsearch;
+  }
+
+  public Opensearch getOpensearch() {
+    return opensearch;
+  }
+
+  public void setOpensearch(Opensearch opensearch) {
+    this.opensearch = opensearch;
   }
 
   public enum SecondaryStorageType {

--- a/configuration/src/main/java/io/camunda/configuration/SecondaryStorageDatabase.java
+++ b/configuration/src/main/java/io/camunda/configuration/SecondaryStorageDatabase.java
@@ -20,7 +20,7 @@ public abstract class SecondaryStorageDatabase {
         prefix() + ".url",
         url,
         String.class,
-        BackwardsCompatibilityMode.SUPPORTED,
+        BackwardsCompatibilityMode.SUPPORTED_ONLY_IF_VALUES_MATCH,
         legacyUrlProperties());
   }
 

--- a/configuration/src/main/java/io/camunda/configuration/SecondaryStorageDatabase.java
+++ b/configuration/src/main/java/io/camunda/configuration/SecondaryStorageDatabase.java
@@ -29,5 +29,6 @@ public abstract class SecondaryStorageDatabase {
   }
 
   protected abstract String prefix();
+
   protected abstract Set<String> legacyUrlProperties();
 }

--- a/configuration/src/main/java/io/camunda/configuration/SecondaryStorageDatabase.java
+++ b/configuration/src/main/java/io/camunda/configuration/SecondaryStorageDatabase.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import io.camunda.configuration.UnifiedConfigurationHelper.BackwardsCompatibilityMode;
+import java.util.Set;
+
+public abstract class SecondaryStorageDatabase {
+
+  /** Endpoint for the database configured as secondary storage. */
+  private String url = "http://localhost:9200";
+
+  public String getUrl() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        prefix() + ".url",
+        url,
+        String.class,
+        BackwardsCompatibilityMode.SUPPORTED,
+        legacyUrlProperties());
+  }
+
+  public void setUrl(String url) {
+    this.url = url;
+  }
+
+  protected abstract String prefix();
+  protected abstract Set<String> legacyUrlProperties();
+}

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/OperatePropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/OperatePropertiesOverride.java
@@ -50,6 +50,7 @@ public class OperatePropertiesOverride {
       override.getElasticsearch().setUrl(database.getElasticsearch().getUrl());
     } else if (SecondaryStorageType.opensearch == database.getType()) {
       override.setDatabase(DatabaseType.Opensearch);
+      override.getOpensearch().setUrl(database.getOpensearch().getUrl());
     }
 
     // TODO: Populate the rest of the bean using unifiedConfiguration

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/TasklistPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/TasklistPropertiesOverride.java
@@ -50,6 +50,7 @@ public class TasklistPropertiesOverride {
       override.getElasticsearch().setUrl(database.getElasticsearch().getUrl());
     } else if (SecondaryStorageType.opensearch == database.getType()) {
       override.setDatabase("opensearch");
+      override.getOpenSearch().setUrl(database.getOpensearch().getUrl());
     }
 
     // TODO: Populate the rest of the bean using unifiedConfiguration

--- a/configuration/src/test/java/io/camunda/configuration/SecondaryStorageFailureWithLegacySchemaTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/SecondaryStorageFailureWithLegacySchemaTest.java
@@ -11,7 +11,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.configuration.beanoverrides.OperatePropertiesOverride;
 import io.camunda.configuration.beanoverrides.TasklistPropertiesOverride;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 
@@ -59,7 +58,6 @@ public class SecondaryStorageFailureWithLegacySchemaTest {
               "camunda.tasklist.elasticsearch.url=http://legacy-mismatching-url:4321",
               "camunda.operate.elasticsearch.url=http://legacy-mismatching-url:4321");
 
-  @Disabled
   @Test
   void testOperateshouldFailWhenUsingLegacyDatabaseProperties() {
     operateRunner.run(
@@ -68,12 +66,11 @@ public class SecondaryStorageFailureWithLegacySchemaTest {
           assertThat(context.getStartupFailure())
               .hasRootCauseInstanceOf(UnifiedConfigurationException.class)
               .rootCause()
-              .hasMessageContaining("Ambiguous legacy configuration")
-              .hasMessageNotContaining("conflicts");
+              .hasMessageContaining("Ambiguous configuration")
+              .hasMessageContaining("conflicts");
         });
   }
 
-  @Disabled
   @Test
   void testTasklistshouldFailWhenUsingLegacyDatabaseProperties() {
     tasklistRunner.run(
@@ -82,8 +79,8 @@ public class SecondaryStorageFailureWithLegacySchemaTest {
           assertThat(context.getStartupFailure())
               .hasRootCauseInstanceOf(UnifiedConfigurationException.class)
               .rootCause()
-              .hasMessageContaining("Ambiguous legacy configuration")
-              .hasMessageNotContaining("conflicts");
+              .hasMessageContaining("Ambiguous configuration")
+              .hasMessageContaining("conflicts");
         });
   }
 

--- a/configuration/src/test/java/io/camunda/configuration/SecondaryStorageFailureWithLegacySchemaTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/SecondaryStorageFailureWithLegacySchemaTest.java
@@ -56,8 +56,6 @@ public class SecondaryStorageFailureWithLegacySchemaTest {
               // url
               "camunda.data.secondary-storage.elasticsearch.url=http://new-mismatching-url:4321",
               "camunda.database.url=http://legacy-mismatching-url:4321",
-              "camunda.operate.zeebeElasticsearch.url=http://legacy-mismatching-url:4321",
-              "camunda.tasklist.zeebeElasticsearch.url=http://legacy-mismatching-url:4321",
               "camunda.tasklist.elasticsearch.url=http://legacy-mismatching-url:4321",
               "camunda.operate.elasticsearch.url=http://legacy-mismatching-url:4321");
 

--- a/configuration/src/test/java/io/camunda/configuration/SecondaryStorageTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/SecondaryStorageTest.java
@@ -73,8 +73,6 @@ public class SecondaryStorageTest {
         // url
         "camunda.data.secondary-storage.elasticsearch.url=http://matching-url:4321",
         "camunda.database.url=http://matching-url:4321",
-        "camunda.operate.zeebeElasticsearch.url=http://matching-url:4321",
-        "camunda.tasklist.zeebeElasticsearch.url=http://matching-url:4321",
         "camunda.tasklist.elasticsearch.url=http://matching-url:4321",
         "camunda.operate.elasticsearch.url=http://matching-url:4321"
       })

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/MultiDbConfigurator.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/MultiDbConfigurator.java
@@ -63,29 +63,29 @@ public class MultiDbConfigurator {
     final Map<String, Object> elasticsearchProperties = new HashMap<>();
 
     /* Tasklist */
-    elasticsearchProperties.put("camunda.tasklist.elasticsearch.url", elasticsearchUrl);
-    elasticsearchProperties.put("camunda.tasklist.zeebeElasticsearch.url", elasticsearchUrl);
     elasticsearchProperties.put("camunda.tasklist.elasticsearch.indexPrefix", indexPrefix);
     elasticsearchProperties.put("camunda.tasklist.zeebeElasticsearch.prefix", zeebeIndexPrefix());
 
     /* Operate */
-    elasticsearchProperties.put("camunda.operate.elasticsearch.url", elasticsearchUrl);
-    elasticsearchProperties.put("camunda.operate.zeebeElasticsearch.url", elasticsearchUrl);
     elasticsearchProperties.put("camunda.operate.elasticsearch.indexPrefix", indexPrefix);
     elasticsearchProperties.put("camunda.operate.zeebeElasticsearch.prefix", zeebeIndexPrefix());
 
-    /* Camunda */
-    // type
+    // db type
     elasticsearchProperties.put(PROPERTY_CAMUNDA_DATABASE_TYPE, DB_TYPE_ELASTICSEARCH);
     elasticsearchProperties.put(
         UNIFIED_CONFIG_PROPERTY_CAMUNDA_DATABASE_TYPE, DB_TYPE_ELASTICSEARCH);
     elasticsearchProperties.put("camunda.operate.database", DB_TYPE_ELASTICSEARCH);
     elasticsearchProperties.put("camunda.tasklist.database", DB_TYPE_ELASTICSEARCH);
     // url
-    elasticsearchProperties.put("camunda.database.url", elasticsearchUrl);
     elasticsearchProperties.put(
         "camunda.data.secondary-storage.elasticsearch.url", elasticsearchUrl);
-    // ---
+    elasticsearchProperties.put("camunda.database.url", elasticsearchUrl);
+    elasticsearchProperties.put("camunda.tasklist.elasticsearch.url", elasticsearchUrl);
+    elasticsearchProperties.put("camunda.tasklist.zeebeElasticsearch.url", elasticsearchUrl);
+    elasticsearchProperties.put("camunda.operate.elasticsearch.url", elasticsearchUrl);
+    elasticsearchProperties.put("camunda.operate.zeebeElasticsearch.url", elasticsearchUrl);
+
+    /* Camunda */
     elasticsearchProperties.put("camunda.database.indexPrefix", indexPrefix);
     elasticsearchProperties.put(
         "camunda.database.retention.enabled", Boolean.toString(retentionEnabled));
@@ -175,28 +175,30 @@ public class MultiDbConfigurator {
     final Map<String, Object> opensearchProperties = new HashMap<>();
 
     /* Tasklist */
-    opensearchProperties.put("camunda.tasklist.opensearch.url", opensearchUrl);
-    opensearchProperties.put("camunda.tasklist.zeebeOpensearch.url", opensearchUrl);
     opensearchProperties.put("camunda.tasklist.opensearch.indexPrefix", indexPrefix);
     opensearchProperties.put("camunda.tasklist.zeebeOpensearch.prefix", zeebeIndexPrefix());
     opensearchProperties.put("camunda.tasklist.opensearch.username", userName);
     opensearchProperties.put("camunda.tasklist.opensearch.password", userPassword);
 
     /* Operate */
-    opensearchProperties.put("camunda.operate.opensearch.url", opensearchUrl);
-    opensearchProperties.put("camunda.operate.zeebeOpensearch.url", opensearchUrl);
     opensearchProperties.put("camunda.operate.opensearch.indexPrefix", indexPrefix);
     opensearchProperties.put("camunda.operate.zeebeOpensearch.prefix", zeebeIndexPrefix());
     opensearchProperties.put("camunda.operate.opensearch.username", userName);
     opensearchProperties.put("camunda.operate.opensearch.password", userPassword);
 
-    /* Camunda */
+    // db url
+    opensearchProperties.put("camunda.data.secondary-storage.opensearch.url", opensearchUrl);
+    opensearchProperties.put("camunda.tasklist.opensearch.url", opensearchUrl);
+    opensearchProperties.put("camunda.tasklist.zeebeOpensearch.url", opensearchUrl);
+    opensearchProperties.put("camunda.operate.opensearch.url", opensearchUrl);
+    opensearchProperties.put("camunda.operate.zeebeOpensearch.url", opensearchUrl);
     // db type
     opensearchProperties.put(UNIFIED_CONFIG_PROPERTY_CAMUNDA_DATABASE_TYPE, DB_TYPE_OPENSEARCH);
     opensearchProperties.put(PROPERTY_CAMUNDA_DATABASE_TYPE, DB_TYPE_OPENSEARCH);
     opensearchProperties.put("camunda.operate.database", DB_TYPE_OPENSEARCH);
     opensearchProperties.put("camunda.tasklist.database", DB_TYPE_OPENSEARCH);
-    // ---
+
+    /* Camunda */
     opensearchProperties.put("camunda.database.indexPrefix", indexPrefix);
     opensearchProperties.put("camunda.database.username", userName);
     opensearchProperties.put("camunda.database.password", userPassword);


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
This PRs migrates the following properties to the Unified Configuration system:

`camunda.database.url` -> `camunda.data.secondary-storage.opensearch.url`

This PR is restricting the scope of the URL property to opensearch only.
The exporters are not yet covered, with the reason of having smaller PRs.

The URL could also be set with other legacy keys, but now they will be configured with the new one:
- `camunda.operate.opensearch.url`
- `camunda.operate.zeebeOpensearch.url`
- `camunda.tasklist.opensearch.url`
- `camunda.tasklist.zeebeOpensearch.url`

Backwards compatibility is generally temporarily supported, so that current deployments and tests do not fail.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
