### PR TITLE
Fix broken ad-hoc sub-process incident tests

### DIFF
--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/JobBasedAdHocSubProcessTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/JobBasedAdHocSubProcessTest.java
@@ -469,12 +469,19 @@ public class JobBasedAdHocSubProcessTest {
     completeJobWithActivateElements(
         jobType, activateElement("DoesntExist"), activateElement("NotThere"));
 
+    final var ahspKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATING)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementId(AHSP_ELEMENT_ID)
+            .getFirst()
+            .getKey();
     Assertions.assertThat(
             RecordingExporter.jobRecords(JobIntent.COMPLETE).onlyCommandRejections().getFirst())
         .extracting(Record::getRejectionType, Record::getRejectionReason)
         .containsOnly(
             RejectionType.NOT_FOUND,
-            "Expected to activate activities for ad-hoc sub-process with key '2251799813685256', but the given elements [DoesntExist, NotThere] do not exist.");
+            "Expected to activate activities for ad-hoc sub-process with key '%d', but the given elements [DoesntExist, NotThere] do not exist."
+                .formatted(ahspKey));
 
     Assertions.assertThat(
             RecordingExporter.records()

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/AdHocSubProcessIncidentTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/AdHocSubProcessIncidentTest.java
@@ -144,6 +144,12 @@ public class AdHocSubProcessIncidentTest {
             .create();
 
     // then
+    final var ahspKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATING)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementId(AD_HOC_SUB_PROCESS_ELEMENT_ID)
+            .getFirst()
+            .getKey();
     Assertions.assertThat(
             RecordingExporter.incidentRecords(IncidentIntent.CREATED)
                 .withProcessInstanceKey(processInstanceKey)
@@ -152,7 +158,8 @@ public class AdHocSubProcessIncidentTest {
         .hasElementId(AD_HOC_SUB_PROCESS_ELEMENT_ID)
         .hasErrorType(ErrorType.EXTRACT_VALUE_ERROR)
         .hasErrorMessage(
-            "Expected to activate activities for ad-hoc sub-process with key '2251799813685257', but the given elements [D, E] do not exist.");
+            "Expected to activate activities for ad-hoc sub-process with key '%s', but the given elements [D, E] do not exist."
+                .formatted(ahspKey));
   }
 
   @Test
@@ -177,6 +184,12 @@ public class AdHocSubProcessIncidentTest {
             .create();
 
     // then
+    final var ahspKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATING)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementId(AD_HOC_SUB_PROCESS_ELEMENT_ID)
+            .getFirst()
+            .getKey();
     Assertions.assertThat(
             RecordingExporter.incidentRecords(IncidentIntent.CREATED)
                 .withProcessInstanceKey(processInstanceKey)
@@ -185,7 +198,8 @@ public class AdHocSubProcessIncidentTest {
         .hasElementId(AD_HOC_SUB_PROCESS_ELEMENT_ID)
         .hasErrorType(ErrorType.EXTRACT_VALUE_ERROR)
         .hasErrorMessage(
-            "Expected to activate activities for ad-hoc sub-process with key '2251799813685266', but the given elements [A2, A3] do not exist.");
+            "Expected to activate activities for ad-hoc sub-process with key '%d', but the given elements [A2, A3] do not exist."
+                .formatted(ahspKey));
   }
 
   @Test
@@ -213,6 +227,12 @@ public class AdHocSubProcessIncidentTest {
             .create();
 
     // then
+    final var ahspKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATING)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementId(AD_HOC_SUB_PROCESS_ELEMENT_ID)
+            .getFirst()
+            .getKey();
     Assertions.assertThat(
             RecordingExporter.incidentRecords(IncidentIntent.CREATED)
                 .withProcessInstanceKey(processInstanceKey)
@@ -221,7 +241,8 @@ public class AdHocSubProcessIncidentTest {
         .hasElementId(AD_HOC_SUB_PROCESS_ELEMENT_ID)
         .hasErrorType(ErrorType.EXTRACT_VALUE_ERROR)
         .hasErrorMessage(
-            "Expected to activate activities for ad-hoc sub-process with key '2251799813685275', but the given elements [boundaryEvent] do not exist.");
+            "Expected to activate activities for ad-hoc sub-process with key '%d', but the given elements [boundaryEvent] do not exist."
+                .formatted(ahspKey));
   }
 
   @Test


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Removed hardcoded keys in test assertions

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes N/A
