### PR TITLE
deps: update awssdk for operate 8.5

### DIFF
--- a/operate/pom.xml
+++ b/operate/pom.xml
@@ -79,7 +79,7 @@
     <version.yarn>v1.22.10</version.yarn>
     <version.failsafe>2.4.4</version.failsafe>
     <version.log4j.testjar>2.19.0</version.log4j.testjar>
-    <version.awssdk>2.25.70</version.awssdk>
+    <version.awssdk>2.31.50</version.awssdk>
     <version.aws-java-sdk>1.12.788</version.aws-java-sdk>
     <version.jetbrains-annotations>24.1.0</version.jetbrains-annotations>
     <version.grpc>1.65.1</version.grpc>

--- a/operate/pom.xml
+++ b/operate/pom.xml
@@ -79,7 +79,7 @@
     <version.yarn>v1.22.10</version.yarn>
     <version.failsafe>2.4.4</version.failsafe>
     <version.log4j.testjar>2.19.0</version.log4j.testjar>
-    <version.awssdk>2.31.50</version.awssdk>
+    <version.awssdk>2.32.13</version.awssdk>
     <version.aws-java-sdk>1.12.788</version.aws-java-sdk>
     <version.jetbrains-annotations>24.1.0</version.jetbrains-annotations>
     <version.grpc>1.65.1</version.grpc>


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Upgrade the AWSSDK dependency to a more recent version. Older versions contain a segfault issue which is fixed in higher versions https://github.com/awslabs/aws-crt-java/releases/tag/v0.33.1

This PR upgrades the dependency to match what the monorepo is using on `main`

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes https://github.com/camunda/camunda/issues/36457
A similar issue was fixed in the past with https://github.com/camunda/camunda/pull/32777 and its incident https://camunda.slack.com/archives/C0903JS3X32
