### PR TITLE
deps: force systemd and perl to be upgraded to most recent version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,8 +31,8 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
     --mount=type=cache,target=/var/log/apt,sharing=locked \
     apt-get -qq update && \
-    apt-get install -yqq --no-install-recommends tini ca-certificates && \
-    apt-get upgrade -yqq --no-install-recommends
+    apt-get install -yqq --no-install-recommends tini ca-certificates systemd perl && \
+    apt-get upgrade -yqq --no-install-recommends systemd perl
 
 ### Build custom JRE using the base JDK image
 # hadolint ignore=DL3006

--- a/camunda.Dockerfile
+++ b/camunda.Dockerfile
@@ -31,8 +31,8 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
     --mount=type=cache,target=/var/log/apt,sharing=locked \
     apt-get -qq update && \
-    apt-get install -yqq --no-install-recommends tini ca-certificates && \
-    apt-get upgrade -yqq --no-install-recommends
+    apt-get install -yqq --no-install-recommends tini ca-certificates systemd perl && \
+    apt-get upgrade -yqq --no-install-recommends systemd perl
 
 ### Build custom JRE using the base JDK image
 # hadolint ignore=DL3006


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Fixes CVE-2025-4598 and CVE-2025-40909 by having the base image upgrading the vulnerable libraries `perl` and `systemd` to the latest version

The Dockerfiles for Tasklist, Optimize, and Operate do not need updating as those Dockerfiles uses alpine as the base image

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes https://github.com/camunda/camunda/issues/36463
