### PR TITLE
Add support for scopeKey filter in Element Instance Search to Java Client

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/ElementInstanceFilter.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/ElementInstanceFilter.java
@@ -148,4 +148,12 @@ public interface ElementInstanceFilter extends SearchRequestFilter {
    * @return the updated filter
    */
   ElementInstanceFilter endDate(final Consumer<DateTimeProperty> endDate);
+
+  /**
+   * Filters element instances by the specified scope key.
+   *
+   * @param value the scope key of the element instance
+   * @return the updated filter
+   */
+  ElementInstanceFilter scopeKey(final long value);
 }

--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/ElementInstanceFilter.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/ElementInstanceFilter.java
@@ -155,5 +155,5 @@ public interface ElementInstanceFilter extends SearchRequestFilter {
    * @param value the scope key of the element instance
    * @return the updated filter
    */
-  ElementInstanceFilter scopeKey(final long value);
+  ElementInstanceFilter elementInstanceScopeKey(final long value);
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/ElementInstanceFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/ElementInstanceFilterImpl.java
@@ -143,6 +143,12 @@ public class ElementInstanceFilterImpl
   }
 
   @Override
+  public ElementInstanceFilter scopeKey(final long value) {
+    filter.setScopeKey(ParseUtil.keyToString(value));
+    return this;
+  }
+
+  @Override
   protected io.camunda.client.protocol.rest.ElementInstanceFilter getSearchRequestProperty() {
     return filter;
   }

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/ElementInstanceFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/ElementInstanceFilterImpl.java
@@ -143,8 +143,8 @@ public class ElementInstanceFilterImpl
   }
 
   @Override
-  public ElementInstanceFilter scopeKey(final long value) {
-    filter.setScopeKey(ParseUtil.keyToString(value));
+  public ElementInstanceFilter elementInstanceScopeKey(final long value) {
+    filter.setElementInstanceScopeKey(ParseUtil.keyToString(value));
     return this;
   }
 

--- a/clients/java/src/test/java/io/camunda/client/elementinstance/ElementInstanceTest.java
+++ b/clients/java/src/test/java/io/camunda/client/elementinstance/ElementInstanceTest.java
@@ -61,7 +61,8 @@ public class ElementInstanceTest extends ClientRestTest {
                     .incidentKey(4L)
                     .tenantId("<default>")
                     .startDate(b -> b.exists(true))
-                    .endDate(b -> b.exists(true)))
+                    .endDate(b -> b.exists(true))
+                    .scopeKey(4L))
         .send()
         .join();
     // then
@@ -82,6 +83,7 @@ public class ElementInstanceTest extends ClientRestTest {
     assertThat(filter.getEndDate()).isNotNull();
     assertThat(filter.getStartDate().get$Exists()).isTrue();
     assertThat(filter.getEndDate().get$Exists()).isTrue();
+    assertThat(filter.getScopeKey()).isEqualTo("4");
   }
 
   @Test

--- a/clients/java/src/test/java/io/camunda/client/elementinstance/ElementInstanceTest.java
+++ b/clients/java/src/test/java/io/camunda/client/elementinstance/ElementInstanceTest.java
@@ -62,7 +62,7 @@ public class ElementInstanceTest extends ClientRestTest {
                     .tenantId("<default>")
                     .startDate(b -> b.exists(true))
                     .endDate(b -> b.exists(true))
-                    .scopeKey(4L))
+                    .elementInstanceScopeKey(4L))
         .send()
         .join();
     // then
@@ -83,7 +83,7 @@ public class ElementInstanceTest extends ClientRestTest {
     assertThat(filter.getEndDate()).isNotNull();
     assertThat(filter.getStartDate().get$Exists()).isTrue();
     assertThat(filter.getEndDate().get$Exists()).isTrue();
-    assertThat(filter.getScopeKey()).isEqualTo("4");
+    assertThat(filter.getElementInstanceScopeKey()).isEqualTo("4");
   }
 
   @Test

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ElementInstanceSearchTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ElementInstanceSearchTest.java
@@ -723,7 +723,7 @@ public class ElementInstanceSearchTest {
     final var result =
         camundaClient
             .newElementInstanceSearchRequest()
-            .filter(f -> f.scopeKey(parentProcessInstanceKey))
+            .filter(f -> f.elementInstanceScopeKey(parentProcessInstanceKey))
             .send()
             .join();
 
@@ -752,7 +752,7 @@ public class ElementInstanceSearchTest {
     final var result =
         camundaClient
             .newElementInstanceSearchRequest()
-            .filter(f -> f.scopeKey(subProcessInstanceKey))
+            .filter(f -> f.elementInstanceScopeKey(subProcessInstanceKey))
             .send()
             .join();
 
@@ -783,7 +783,7 @@ public class ElementInstanceSearchTest {
     final var result =
         camundaClient
             .newElementInstanceSearchRequest()
-            .filter(f -> f.scopeKey(multiInstanceElementInstanceKey))
+            .filter(f -> f.elementInstanceScopeKey(multiInstanceElementInstanceKey))
             .send()
             .join();
 
@@ -812,7 +812,7 @@ public class ElementInstanceSearchTest {
     final var result =
         camundaClient
             .newElementInstanceSearchRequest()
-            .filter(f -> f.scopeKey(leafElementInstanceKey))
+            .filter(f -> f.elementInstanceScopeKey(leafElementInstanceKey))
             .send()
             .join();
 
@@ -829,7 +829,7 @@ public class ElementInstanceSearchTest {
     final var result =
         camundaClient
             .newElementInstanceSearchRequest()
-            .filter(f -> f.scopeKey(invalidElementInstanceKey))
+            .filter(f -> f.elementInstanceScopeKey(invalidElementInstanceKey))
             .send()
             .join();
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ElementInstanceSearchTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ElementInstanceSearchTest.java
@@ -58,7 +58,8 @@ public class ElementInstanceSearchTest {
             "manual_process.bpmn",
             "parent_process_v1.bpmn",
             "child_process_v1.bpmn",
-            "ad_hoc_sub_process.bpmn");
+            "ad_hoc_sub_process.bpmn",
+            "subprocess_with_multi_instance.bpmn");
     processes.forEach(
         process ->
             DEPLOYED_PROCESSES.addAll(
@@ -81,9 +82,10 @@ public class ElementInstanceSearchTest {
     PROCESS_INSTANCES.add(processInstanceWithIncident);
     PROCESS_INSTANCES.add(startProcessInstance(camundaClient, "parent_process_v1"));
     PROCESS_INSTANCES.add(startProcessInstance(camundaClient, "ad_hoc_sub_process"));
+    PROCESS_INSTANCES.add(startProcessInstance(camundaClient, "subprocess_with_multi_instance"));
 
-    waitForProcessInstancesToStart(camundaClient, 9);
-    waitForElementInstances(camundaClient, 26);
+    waitForProcessInstancesToStart(camundaClient, 10);
+    waitForElementInstances(camundaClient, 34);
     waitUntilElementInstanceHasIncidents(camundaClient, 2);
     waitUntilProcessInstanceHasIncidents(camundaClient, 2);
     // store element instances for querying
@@ -207,7 +209,7 @@ public class ElementInstanceSearchTest {
             .send()
             .join();
 
-    assertThat(resultAfter.items().size()).isEqualTo(24);
+    assertThat(resultAfter.items().size()).isEqualTo(32);
     final var keyAfter = resultAfter.items().getFirst().getElementInstanceKey();
     // apply searchBefore
     final var resultBefore =
@@ -518,7 +520,7 @@ public class ElementInstanceSearchTest {
             .join();
 
     // then
-    assertThat(result.items().size()).isEqualTo(20);
+    assertThat(result.items().size()).isEqualTo(28);
     assertThat(result.items().getFirst().getState()).isEqualTo(state);
   }
 
@@ -563,7 +565,7 @@ public class ElementInstanceSearchTest {
             .join();
 
     // then
-    assertThat(result.items().size()).isEqualTo(3);
+    assertThat(result.items().size()).isEqualTo(5);
     assertThat(result.items().getFirst().getType()).isEqualTo(type);
     assertThat(result.items().get(1).getType()).isEqualTo(type);
     assertThat(result.items().get(2).getType()).isEqualTo(type);
@@ -603,7 +605,7 @@ public class ElementInstanceSearchTest {
             .join();
 
     // then
-    assertThat(result.page().totalItems()).isEqualTo(26);
+    assertThat(result.page().totalItems()).isEqualTo(34);
     assertThat(result.items()).allMatch(f -> f.getTenantId().equals(tenantId));
   }
 
@@ -621,7 +623,7 @@ public class ElementInstanceSearchTest {
             .send()
             .join();
 
-    assertThat(resultAfter.items().size()).isEqualTo(24);
+    assertThat(resultAfter.items().size()).isEqualTo(32);
     final var keyAfter = resultAfter.items().getFirst().getElementInstanceKey();
     // apply searchBefore
     final var resultBefore =
@@ -703,5 +705,135 @@ public class ElementInstanceSearchTest {
 
     // then
     assertThat(result.items().size()).isEqualTo(2);
+  }
+
+  @Test
+  void shouldQueryElementInstancesByScopeKeyAsParentProcessInstanceKey() {
+    // given
+    final var parentProcessInstanceKey =
+        camundaClient
+            .newProcessInstanceSearchRequest()
+            .filter(f -> f.processDefinitionId("subprocess_with_multi_instance"))
+            .send()
+            .join()
+            .singleItem()
+            .getProcessInstanceKey();
+
+    // when
+    final var result =
+        camundaClient
+            .newElementInstanceSearchRequest()
+            .filter(f -> f.scopeKey(parentProcessInstanceKey))
+            .send()
+            .join();
+
+    // then
+    assertThat(result.items()).size().isEqualTo(3);
+    assertThat(result.items().stream().map(ElementInstance::getElementId))
+        .containsExactlyInAnyOrder("start_event", "sub_process", "end_event");
+  }
+
+  @Test
+  void shouldQueryElementInstancesByScopeKeyAsSubProcessInstanceKey() {
+    // given
+    final var subProcessInstanceKey =
+        camundaClient
+            .newElementInstanceSearchRequest()
+            .filter(
+                f ->
+                    f.processDefinitionId("subprocess_with_multi_instance")
+                        .elementId("sub_process"))
+            .send()
+            .join()
+            .singleItem()
+            .getElementInstanceKey();
+
+    // when
+    final var result =
+        camundaClient
+            .newElementInstanceSearchRequest()
+            .filter(f -> f.scopeKey(subProcessInstanceKey))
+            .send()
+            .join();
+
+    // then
+    assertThat(result.items()).size().isEqualTo(3);
+    assertThat(result.items().stream().map(ElementInstance::getElementId))
+        .containsExactlyInAnyOrder("sub_start_event", "bar_mi_task", "sub_end_event");
+  }
+
+  @Test
+  void shouldQueryElementInstancesByScopeKeyAsMultiInstanceElementInstanceKey() {
+    // given
+    final var multiInstanceElementInstanceKey =
+        camundaClient
+            .newElementInstanceSearchRequest()
+            .filter(
+                f ->
+                    f.processDefinitionId("subprocess_with_multi_instance")
+                        .elementId("bar_mi_task")
+                        .type(ElementInstanceType.MULTI_INSTANCE_BODY))
+            .send()
+            .join()
+            .items()
+            .getFirst()
+            .getElementInstanceKey();
+
+    // when
+    final var result =
+        camundaClient
+            .newElementInstanceSearchRequest()
+            .filter(f -> f.scopeKey(multiInstanceElementInstanceKey))
+            .send()
+            .join();
+
+    // then
+    assertThat(result.items()).size().isEqualTo(2);
+    assertThat(result.items().stream().map(ElementInstance::getElementId))
+        .containsExactlyInAnyOrder("bar_mi_task", "bar_mi_task");
+  }
+
+  @Test
+  void shouldQueryElementInstancesByScopeKeyAsLeafElementInstanceKey() {
+    // given
+    final var leafElementInstanceKey =
+        camundaClient
+            .newElementInstanceSearchRequest()
+            .filter(
+                f ->
+                    f.processDefinitionId("subprocess_with_multi_instance")
+                        .elementId("start_event"))
+            .send()
+            .join()
+            .singleItem()
+            .getElementInstanceKey();
+
+    // when
+    final var result =
+        camundaClient
+            .newElementInstanceSearchRequest()
+            .filter(f -> f.scopeKey(leafElementInstanceKey))
+            .send()
+            .join();
+
+    // then
+    assertThat(result.items()).isEmpty();
+  }
+
+  @Test
+  void shouldQueryElementInstancesByScopeKeyAsNonExistingElementInstanceKey() {
+    // given
+    final var invalidElementInstanceKey = 123456789L;
+
+    // when
+    final var result =
+        camundaClient
+            .newElementInstanceSearchRequest()
+            .filter(f -> f.scopeKey(invalidElementInstanceKey))
+            .send()
+            .join();
+
+    // then
+    assertThat(result.items()).isEmpty();
   }
 }

--- a/qa/acceptance-tests/src/test/resources/process/subprocess_with_multi_instance.bpmn
+++ b/qa/acceptance-tests/src/test/resources/process/subprocess_with_multi_instance.bpmn
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1pd9445" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.37.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.8.0">
+  <bpmn:process id="subprocess_with_multi_instance" name="Sub process with multi-instance" isExecutable="true">
+    <bpmn:extensionElements />
+    <bpmn:startEvent id="start_event" name="Start">
+      <bpmn:outgoing>Flow_05g5q9j</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:endEvent id="end_event" name="End">
+      <bpmn:incoming>Flow_1j3hu1c</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:subProcess id="sub_process" name="Sub Process">
+      <bpmn:incoming>Flow_05g5q9j</bpmn:incoming>
+      <bpmn:outgoing>Flow_1j3hu1c</bpmn:outgoing>
+      <bpmn:startEvent id="sub_start_event" name="Sub Start">
+        <bpmn:outgoing>Flow_1078jy8</bpmn:outgoing>
+      </bpmn:startEvent>
+      <bpmn:endEvent id="sub_end_event" name="Sub End">
+        <bpmn:incoming>Flow_19yqrdi</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:sequenceFlow id="Flow_19yqrdi" sourceRef="bar_mi_task" targetRef="sub_end_event" />
+      <bpmn:sequenceFlow id="Flow_1078jy8" sourceRef="sub_start_event" targetRef="bar_mi_task" />
+      <bpmn:scriptTask id="bar_mi_task" name="Bar MI">
+        <bpmn:extensionElements>
+          <zeebe:script expression="=&#34;bar&#34;" resultVariable="bar" />
+        </bpmn:extensionElements>
+        <bpmn:incoming>Flow_1078jy8</bpmn:incoming>
+        <bpmn:outgoing>Flow_19yqrdi</bpmn:outgoing>
+        <bpmn:multiInstanceLoopCharacteristics>
+          <bpmn:extensionElements>
+            <zeebe:loopCharacteristics inputCollection="=[1,2]" inputElement="" />
+          </bpmn:extensionElements>
+        </bpmn:multiInstanceLoopCharacteristics>
+      </bpmn:scriptTask>
+    </bpmn:subProcess>
+    <bpmn:sequenceFlow id="Flow_05g5q9j" sourceRef="start_event" targetRef="sub_process" />
+    <bpmn:sequenceFlow id="Flow_1j3hu1c" sourceRef="sub_process" targetRef="end_event" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="subprocess_with_multi_instance">
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="start_event">
+        <dc:Bounds x="172" y="152" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="178" y="195" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0fc7hpq_di" bpmnElement="end_event">
+        <dc:Bounds x="702" y="152" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="710" y="195" width="20" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_05hsc5e_di" bpmnElement="sub_process" isExpanded="true">
+        <dc:Bounds x="270" y="70" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0d1brs8_di" bpmnElement="sub_start_event">
+        <dc:Bounds x="310" y="152" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="305" y="195" width="46" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_14bwzaz_di" bpmnElement="bar_mi_task">
+        <dc:Bounds x="400" y="130" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0lxypdt_di" bpmnElement="sub_end_event">
+        <dc:Bounds x="552" y="152" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="549" y="195" width="43" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_19yqrdi_di" bpmnElement="Flow_19yqrdi">
+        <di:waypoint x="500" y="170" />
+        <di:waypoint x="552" y="170" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1078jy8_di" bpmnElement="Flow_1078jy8">
+        <di:waypoint x="346" y="170" />
+        <di:waypoint x="400" y="170" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_05g5q9j_di" bpmnElement="Flow_05g5q9j">
+        <di:waypoint x="208" y="170" />
+        <di:waypoint x="270" y="170" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1j3hu1c_di" bpmnElement="Flow_1j3hu1c">
+        <di:waypoint x="620" y="170" />
+        <di:waypoint x="702" y="170" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
This PR updates the Java Client to support the new scopeKey filter in the Element Instance Search endpoint.

- Adds scopeKey as an optional simple equality based filter parameter to the Element Instance Search endpoint.
- Enables users to retrieve immediate child element instances of a given scope key (e.g., a process instance key or an element instance key).

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #35666
