### PR TITLE
refactor: lowercase camunda exporter id in yaml templates

### DIFF
--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -1003,7 +1003,7 @@
       #
       # These setting can also be overridden using the environment variables "ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_..."
       #
-      # camundaExporter:
+      # camundaexporter:
         # className: io.camunda.exporter.CamundaExporter
         #
         # args:

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -917,7 +917,7 @@
       #
       # These setting can also be overridden using the environment variables "ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_..."
       #
-      # camundaExporter:
+      # camundaexporter:
         # className: io.camunda.exporter.CamundaExporter
         #
         # args:


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
lowercasing the id of camunda exporter in the yaml template examples, since using camelCase would create 2 camunda exporters if the env overrides ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_* are used

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

relates to https://github.com/camunda/camunda-platform-helm/issues/3897
