### PR TITLE
feat: retry batch operation initialization query on secondary db fail

### DIFF
--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -1425,6 +1425,18 @@
           # The default value is 1000, which is also the maximum supported by OracleDb.
           # queryInClauseSize: 1000
 
+          # Allows to configure the number of retries in case a query to the secondary database fails.
+          # The default value is 5, which means that in worst case the engine will query up to 6 times.
+          # queryRetryMax: 0
+
+          # Allows to configure the initial delay between retries in case a query to the secondary database fails.
+          # The default value is 1 second
+          # queryRetryInitialDelay: PT1S
+
+          # Allows to configure the factor by which the delay between retries is increased.
+          # The default value is 2, which means that the delay will be doubled after each retry.
+          # queryRetryBackoffFactor: 2.0
+
       # Allows to configure feature flags. These are used to test new features in dev and int environments prior
       # to rolling them out to production
       # features:

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -1339,6 +1339,18 @@
           # The default value is 1000, which is also the maximum supported by OracleDb.
           # queryInClauseSize: 1000
 
+          # Allows to configure the number of retries in case a query to the secondary database fails.
+          # The default value is 5, which means that in worst case the engine will query up to 6 times.
+          # queryRetryMax: 0
+
+          # Allows to configure the initial delay between retries in case a query to the secondary database fails.
+          # The default value is 1 second
+          # queryRetryInitialDelay: PT1S
+
+          # Allows to configure the factor by which the delay between retries is increased.
+          # The default value is 2, which means that the delay will be doubled after each retry.
+          # queryRetryBackoffFactor: 2.0
+
         # Allows to configure the maximum depth of child process instances that can be created.
         # The root process instance is considered depth `1`, and each called instance is considered
         # to be one level deeper. If a call activity attempts to create a child process instance

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
@@ -289,6 +289,28 @@ public final class SystemContext {
               config.getChunkSize()));
     }
 
+    if (config.getQueryRetryMax() < 0) {
+      errors.add(
+          String.format(
+              "experimental.engine.batchOperation.queryRetryMax must be greater than or equal to 0, but was %s",
+              config.getQueryRetryMax()));
+    }
+
+    if (config.getQueryRetryInitialDelay().isNegative()
+        || config.getQueryRetryInitialDelay().isZero()) {
+      errors.add(
+          String.format(
+              "experimental.engine.batchOperation.queryRetryInitialDelay must be positive, but was %s",
+              config.getQueryRetryInitialDelay()));
+    }
+
+    if (config.getQueryRetryBackoffFactor() < 1.0) {
+      errors.add(
+          String.format(
+              "experimental.engine.batchOperation.queryRetryBackoffFactor must be greater than or equal to 1.0, but was %s",
+              config.getQueryRetryBackoffFactor()));
+    }
+
     if (!errors.isEmpty()) {
       throw new InvalidConfigurationException(
           "Invalid BatchOperations configuration: " + String.join(", ", errors), null);

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/BatchOperationCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/BatchOperationCfg.java
@@ -26,6 +26,12 @@ public class BatchOperationCfg implements ConfigurationEntry {
   private int queryPageSize = EngineConfiguration.DEFAULT_BATCH_OPERATION_QUERY_PAGE_SIZE;
   private int queryInClauseSize = EngineConfiguration.DEFAULT_BATCH_OPERATION_QUERY_IN_CLAUSE_SIZE;
 
+  private int queryRetryMax = EngineConfiguration.DEFAULT_BATCH_OPERATION_QUERY_RETRY_MAX;
+  private Duration queryRetryInitialDelay =
+      EngineConfiguration.DEFAULT_BATCH_OPERATION_QUERY_RETRY_INITIAL_DELAY;
+  private double queryRetryBackoffFactor =
+      EngineConfiguration.DEFAULT_BATCH_OPERATION_QUERY_RETRY_BACKOFF_FACTOR;
+
   public Duration getSchedulerInterval() {
     return schedulerInterval;
   }
@@ -66,6 +72,30 @@ public class BatchOperationCfg implements ConfigurationEntry {
     this.queryInClauseSize = queryInClauseSize;
   }
 
+  public int getQueryRetryMax() {
+    return queryRetryMax;
+  }
+
+  public void setQueryRetryMax(final int queryRetryMax) {
+    this.queryRetryMax = queryRetryMax;
+  }
+
+  public Duration getQueryRetryInitialDelay() {
+    return queryRetryInitialDelay;
+  }
+
+  public void setQueryRetryInitialDelay(final Duration queryRetryInitialDelay) {
+    this.queryRetryInitialDelay = queryRetryInitialDelay;
+  }
+
+  public double getQueryRetryBackoffFactor() {
+    return queryRetryBackoffFactor;
+  }
+
+  public void setQueryRetryBackoffFactor(final double queryRetryBackoffFactor) {
+    this.queryRetryBackoffFactor = queryRetryBackoffFactor;
+  }
+
   @Override
   public String toString() {
     return "BatchOperationCfg{"
@@ -79,6 +109,12 @@ public class BatchOperationCfg implements ConfigurationEntry {
         + queryPageSize
         + ", queryInClauseSize="
         + queryInClauseSize
+        + ", queryRetryMax="
+        + queryRetryMax
+        + ", queryRetryInitialDelay="
+        + queryRetryInitialDelay
+        + ", queryRetryBackoffFactor="
+        + queryRetryBackoffFactor
         + '}';
   }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/EngineCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/EngineCfg.java
@@ -135,6 +135,9 @@ public final class EngineCfg implements ConfigurationEntry {
         .setBatchOperationDbChunkSize(batchOperations.getDbChunkSize())
         .setBatchOperationQueryPageSize(batchOperations.getQueryPageSize())
         .setBatchOperationQueryInClauseSize(batchOperations.getQueryInClauseSize())
+        .setBatchOperationQueryRetryMax(batchOperations.getQueryRetryMax())
+        .setBatchOperationQueryRetryInitialDelay(batchOperations.getQueryRetryInitialDelay())
+        .setBatchOperationQueryRetryBackoffFactor(batchOperations.getQueryRetryBackoffFactor())
         .setUsageMetricsExportInterval(usageMetrics.getExportInterval())
         .setCommandDistributionPaused(distribution.isPauseCommandDistribution())
         .setMaxProcessDepth(getMaxProcessDepth());

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/SystemContextTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/SystemContextTest.java
@@ -532,4 +532,47 @@ final class SystemContextTest {
         .hasMessageContaining(
             "experimental.engine.batchOperation.queryInClauseSize must be greater than 0");
   }
+
+  @Test
+  void shouldThrowExceptionIfBatchOperationQueryRetryMaxIsInvalid() {
+    // given
+    final BrokerCfg brokerCfg = new BrokerCfg();
+    brokerCfg.getExperimental().getEngine().getBatchOperations().setQueryRetryMax(-1);
+
+    // when - then
+    assertThatCode(() -> initSystemContext(brokerCfg))
+        .isInstanceOf(InvalidConfigurationException.class)
+        .hasMessageContaining(
+            "experimental.engine.batchOperation.queryRetryMax must be greater than or equal to 0");
+  }
+
+  @Test
+  void shouldThrowExceptionIfBatchOperationQueryRetryBackoffFactorInvalid() {
+    // given
+    final BrokerCfg brokerCfg = new BrokerCfg();
+    brokerCfg.getExperimental().getEngine().getBatchOperations().setQueryRetryBackoffFactor(0.3);
+
+    // when - then
+    assertThatCode(() -> initSystemContext(brokerCfg))
+        .isInstanceOf(InvalidConfigurationException.class)
+        .hasMessageContaining(
+            "experimental.engine.batchOperation.queryRetryBackoffFactor must be greater than or equal to 1.0");
+  }
+
+  @Test
+  void shouldThrowExceptionIfBatchOperationQueryRetryInitialDelayIsInvalid() {
+    // given
+    final BrokerCfg brokerCfg = new BrokerCfg();
+    brokerCfg
+        .getExperimental()
+        .getEngine()
+        .getBatchOperations()
+        .setQueryRetryInitialDelay(Duration.ofMillis(-1000));
+
+    // when - then
+    assertThatCode(() -> initSystemContext(brokerCfg))
+        .isInstanceOf(InvalidConfigurationException.class)
+        .hasMessageContaining(
+            "experimental.engine.batchOperation.queryRetryInitialDelay must be positive");
+  }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/EngineConfiguration.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/EngineConfiguration.java
@@ -40,6 +40,10 @@ public final class EngineConfiguration {
   public static final int DEFAULT_BATCH_OPERATION_QUERY_PAGE_SIZE = 10000;
   // Oracle can only have 1000 elements in `IN` clause
   public static final int DEFAULT_BATCH_OPERATION_QUERY_IN_CLAUSE_SIZE = 1000;
+  public static final int DEFAULT_BATCH_OPERATION_QUERY_RETRY_MAX = 0;
+  public static final Duration DEFAULT_BATCH_OPERATION_QUERY_RETRY_INITIAL_DELAY =
+      Duration.ofSeconds(1);
+  public static final double DEFAULT_BATCH_OPERATION_QUERY_RETRY_BACKOFF_FACTOR = 2.0;
   public static final boolean DEFAULT_COMMAND_DISTRIBUTION_PAUSED = false;
 
   private int messagesTtlCheckerBatchLimit = DEFAULT_MESSAGES_TTL_CHECKER_BATCH_LIMIT;
@@ -63,6 +67,11 @@ public final class EngineConfiguration {
   private int batchOperationDbChunkSize = DEFAULT_BATCH_OPERATION_DB_CHUNK_SIZE;
   private int batchOperationQueryPageSize = DEFAULT_BATCH_OPERATION_QUERY_PAGE_SIZE;
   private int batchOperationQueryInClauseSize = DEFAULT_BATCH_OPERATION_QUERY_IN_CLAUSE_SIZE;
+  private int batchOperationQueryRetryMax = DEFAULT_BATCH_OPERATION_QUERY_RETRY_MAX;
+  private Duration batchOperationQueryRetryInitialDelay =
+      DEFAULT_BATCH_OPERATION_QUERY_RETRY_INITIAL_DELAY;
+  private double batchOperationQueryRetryBackoffFactor =
+      DEFAULT_BATCH_OPERATION_QUERY_RETRY_BACKOFF_FACTOR;
 
   private Duration usageMetricsExportInterval = DEFAULT_USAGE_METRICS_EXPORT_INTERVAL;
 
@@ -215,6 +224,35 @@ public final class EngineConfiguration {
   public EngineConfiguration setBatchOperationQueryInClauseSize(
       final int batchOperationQueryInClauseSize) {
     this.batchOperationQueryInClauseSize = batchOperationQueryInClauseSize;
+    return this;
+  }
+
+  public int getBatchOperationQueryRetryMax() {
+    return batchOperationQueryRetryMax;
+  }
+
+  public EngineConfiguration setBatchOperationQueryRetryMax(final int batchOperationQueryRetryMax) {
+    this.batchOperationQueryRetryMax = batchOperationQueryRetryMax;
+    return this;
+  }
+
+  public Duration getBatchOperationQueryRetryInitialDelay() {
+    return batchOperationQueryRetryInitialDelay;
+  }
+
+  public EngineConfiguration setBatchOperationQueryRetryInitialDelay(
+      final Duration batchOperationQueryRetryInitialDelay) {
+    this.batchOperationQueryRetryInitialDelay = batchOperationQueryRetryInitialDelay;
+    return this;
+  }
+
+  public double getBatchOperationQueryRetryBackoffFactor() {
+    return batchOperationQueryRetryBackoffFactor;
+  }
+
+  public EngineConfiguration setBatchOperationQueryRetryBackoffFactor(
+      final double batchOperationQueryRetryBackoffFactor) {
+    this.batchOperationQueryRetryBackoffFactor = batchOperationQueryRetryBackoffFactor;
     return this;
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/itemprovider/IncidentItemProvider.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/itemprovider/IncidentItemProvider.java
@@ -18,6 +18,7 @@ import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.security.auth.SecurityContext;
 import io.camunda.util.FilterUtil;
 import io.camunda.zeebe.engine.metrics.BatchOperationMetrics;
+import io.camunda.zeebe.engine.processing.batchoperation.itemprovider.retry.RetryingQueryExecutor;
 import io.camunda.zeebe.util.VisibleForTesting;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
@@ -28,6 +29,7 @@ import java.util.stream.Collectors;
 public class IncidentItemProvider implements ItemProvider {
 
   private final SearchClientsProxy searchClientsProxy;
+  private final RetryingQueryExecutor retryingQueryExecutor;
   private final ProcessInstanceFilter filter;
   private final ProcessInstanceItemProvider processInstanceItemProvider;
   private final SecurityContext securityContext;
@@ -35,14 +37,17 @@ public class IncidentItemProvider implements ItemProvider {
 
   public IncidentItemProvider(
       final SearchClientsProxy searchClientsProxy,
+      final RetryingQueryExecutor retryingQueryExecutor,
       final BatchOperationMetrics metrics,
       final ProcessInstanceFilter filter,
       final CamundaAuthentication authentication) {
     this.searchClientsProxy = searchClientsProxy;
+    this.retryingQueryExecutor = retryingQueryExecutor;
     this.metrics = metrics;
     this.filter = filter;
     processInstanceItemProvider =
-        new ProcessInstanceItemProvider(searchClientsProxy, metrics, filter, authentication);
+        new ProcessInstanceItemProvider(
+            searchClientsProxy, retryingQueryExecutor, metrics, filter, authentication);
     securityContext =
         createSecurityContext(
             authentication, Authorization.of(a -> a.processDefinition().readProcessInstance()));

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/itemprovider/ItemProviderFactory.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/itemprovider/ItemProviderFactory.java
@@ -13,19 +13,23 @@ import io.camunda.search.filter.Operation;
 import io.camunda.search.filter.ProcessInstanceFilter;
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.zeebe.engine.metrics.BatchOperationMetrics;
+import io.camunda.zeebe.engine.processing.batchoperation.itemprovider.retry.RetryingQueryExecutor;
 import io.camunda.zeebe.engine.state.batchoperation.PersistedBatchOperation;
 
 public class ItemProviderFactory {
 
   private final SearchClientsProxy searchClientsProxy;
+  private final RetryingQueryExecutor retryingQueryExecutor;
   private final BatchOperationMetrics metrics;
   private final int partitionId;
 
   public ItemProviderFactory(
       final SearchClientsProxy searchClientsProxy,
+      final RetryingQueryExecutor retryingQueryExecutor,
       final BatchOperationMetrics metrics,
       final int partitionId) {
     this.searchClientsProxy = searchClientsProxy;
+    this.retryingQueryExecutor = retryingQueryExecutor;
     this.metrics = metrics;
     this.partitionId = partitionId;
   }
@@ -55,6 +59,7 @@ public class ItemProviderFactory {
       final ProcessInstanceFilter filter, final CamundaAuthentication authentication) {
     return new ProcessInstanceItemProvider(
         searchClientsProxy,
+        retryingQueryExecutor,
         metrics,
         filter.toBuilder()
             .partitionId(partitionId)
@@ -68,6 +73,7 @@ public class ItemProviderFactory {
       final ProcessInstanceFilter filter, final CamundaAuthentication authentication) {
     return new ProcessInstanceItemProvider(
         searchClientsProxy,
+        retryingQueryExecutor,
         metrics,
         filter.toBuilder()
             .partitionId(partitionId)
@@ -80,6 +86,7 @@ public class ItemProviderFactory {
       final ProcessInstanceFilter filter, final CamundaAuthentication authentication) {
     return new ProcessInstanceItemProvider(
         searchClientsProxy,
+        retryingQueryExecutor,
         metrics,
         filter.toBuilder()
             .partitionId(partitionId)
@@ -92,6 +99,7 @@ public class ItemProviderFactory {
       final ProcessInstanceFilter filter, final CamundaAuthentication authentication) {
     return new IncidentItemProvider(
         searchClientsProxy,
+        retryingQueryExecutor,
         metrics,
         filter.toBuilder()
             .partitionId(partitionId)

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/itemprovider/retry/ExponentialBackoffRetryingQueryExecutor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/itemprovider/retry/ExponentialBackoffRetryingQueryExecutor.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.batchoperation.itemprovider.retry;
+
+import java.time.Duration;
+import java.util.concurrent.Callable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * An implementation of {@link RetryingQueryExecutor} that retries operations with an exponential
+ * backoff strategy.
+ */
+public class ExponentialBackoffRetryingQueryExecutor implements RetryingQueryExecutor {
+  private static final Logger LOG =
+      LoggerFactory.getLogger(ExponentialBackoffRetryingQueryExecutor.class);
+
+  private final int maxRetries;
+  private final Duration initialRetryDelay;
+  private final double backoffFactor;
+
+  /**
+   * Constructor for ExponentialBackoffRetryingQueryExecutor.
+   *
+   * @param maxRetries the maximum number of retries to attempt after the first attempt failed
+   * @param initialRetryDelay the initial delay before the first retry
+   * @param backoffFactor the factor by which the retry delay increases after each attempt
+   */
+  public ExponentialBackoffRetryingQueryExecutor(
+      final int maxRetries, final Duration initialRetryDelay, final double backoffFactor) {
+    this.maxRetries = maxRetries;
+    this.initialRetryDelay = initialRetryDelay;
+    this.backoffFactor = backoffFactor;
+  }
+
+  @Override
+  public <V> V runRetryable(final Callable<V> retryableOperation) {
+    int numAttempts = maxRetries + 1; // + 1 for the initial attempt
+    Duration retryDelay = initialRetryDelay;
+
+    try {
+      while (numAttempts > 0) {
+        try {
+          return retryableOperation.call();
+        } catch (final Exception e) {
+          if (--numAttempts == 0) {
+            throw new RuntimeException("Max retries reached", e);
+          }
+          LOG.warn(
+              "Retryable operation failed, retries left: {}, retrying in {} ms. Error: {}",
+              numAttempts,
+              retryDelay.toMillis(),
+              e.getLocalizedMessage());
+
+          Thread.sleep(retryDelay.toMillis());
+          retryDelay = retryDelay.multipliedBy((long) backoffFactor);
+        }
+      }
+    } catch (final InterruptedException e) {
+      Thread.currentThread().interrupt(); // Restore interrupted status
+      throw new RuntimeException("Retryable operation was interrupted", e);
+    }
+
+    throw new RuntimeException("Unexpected state: should not reach here");
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/itemprovider/retry/ExponentialBackoffRetryingQueryExecutor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/itemprovider/retry/ExponentialBackoffRetryingQueryExecutor.java
@@ -48,7 +48,7 @@ public class ExponentialBackoffRetryingQueryExecutor implements RetryingQueryExe
         try {
           return retryableOperation.call();
         } catch (final Exception e) {
-          if (--numAttempts == 0) {
+          if (shouldFailImmediately(e) || --numAttempts == 0) {
             throw new RuntimeException("Max retries reached", e);
           }
           LOG.warn(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/itemprovider/retry/RetryingQueryExecutor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/itemprovider/retry/RetryingQueryExecutor.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.batchoperation.itemprovider.retry;
+
+import java.util.concurrent.Callable;
+
+/**
+ * An interface for executing retryable queries with a retry mechanism. Implementations should
+ * handle the logic for retrying operations that may fail.
+ */
+public interface RetryingQueryExecutor {
+
+  /**
+   * Executes a retryable operation, retrying it if it fails.
+   *
+   * @param retryableOperation the operation to execute, which may throw an exception
+   * @param <V> the type of the result returned by the operation
+   * @return the result of the operation if successful
+   * @throws RuntimeException if the operation fails after all retries
+   */
+  <V> V runRetryable(Callable<V> retryableOperation);
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/itemprovider/retry/RetryingQueryExecutor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/itemprovider/retry/RetryingQueryExecutor.java
@@ -42,4 +42,16 @@ public interface RetryingQueryExecutor {
     return exception instanceof CamundaSearchException
         && FAIL_IMMEDIATELY_REASONS.contains(((CamundaSearchException) exception).getReason());
   }
+
+  class RetryAttemptsExceededException extends RuntimeException {
+    public RetryAttemptsExceededException(final String message, final Throwable cause) {
+      super(message, cause);
+    }
+  }
+
+  class ExecutorInterruptedException extends RuntimeException {
+    public ExecutorInterruptedException(final String message, final Throwable cause) {
+      super(message, cause);
+    }
+  }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/AbstractBatchOperationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/AbstractBatchOperationTest.java
@@ -33,6 +33,7 @@ import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.protocol.record.value.UserRecordValue;
 import io.camunda.zeebe.test.util.BrokerClassRuleHelper;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -73,7 +74,11 @@ abstract class AbstractBatchOperationTest {
                   cfg.getInitialization()
                       .getDefaultRoles()
                       .put("admin", Map.of("users", List.of(DEFAULT_USER.getUsername()))))
-          .withEngineConfig(cfg -> cfg.setBatchOperationQueryPageSize(DEFAULT_QUERY_PAGE_SIZE))
+          .withEngineConfig(
+              cfg ->
+                  cfg.setBatchOperationQueryPageSize(DEFAULT_QUERY_PAGE_SIZE)
+                      .setBatchOperationQueryRetryMax(2)
+                      .setBatchOperationQueryRetryInitialDelay(Duration.ofMillis(100)))
           .withSearchClientsProxy(searchClientsProxy);
 
   @Before

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/itemprovider/IncidentItemProviderTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/itemprovider/IncidentItemProviderTest.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -130,6 +131,9 @@ class IncidentItemProviderTest {
             new Item(51, 5),
             new Item(52, 5));
     assertThat(resultPage.isLastPage()).isFalse();
+
+    // 1 for procesInstances, 3 for incidents
+    verify(retryingQueryExecutor, times(4)).runRetryable(any());
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/itemprovider/ItemProviderFactoryTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/itemprovider/ItemProviderFactoryTest.java
@@ -14,6 +14,7 @@ import io.camunda.search.clients.SearchClientsProxy;
 import io.camunda.search.filter.Operation;
 import io.camunda.search.filter.ProcessInstanceFilter;
 import io.camunda.zeebe.engine.metrics.BatchOperationMetrics;
+import io.camunda.zeebe.engine.processing.batchoperation.itemprovider.retry.RetryingQueryExecutor;
 import io.camunda.zeebe.engine.state.batchoperation.PersistedBatchOperation;
 import io.camunda.zeebe.protocol.record.value.BatchOperationType;
 import org.junit.jupiter.api.Test;
@@ -22,8 +23,9 @@ class ItemProviderFactoryTest {
 
   private final SearchClientsProxy searchClientsProxy = mock(SearchClientsProxy.class);
   private final BatchOperationMetrics metrics = mock(BatchOperationMetrics.class);
+  private final RetryingQueryExecutor retryingQueryExecutor = mock(RetryingQueryExecutor.class);
   private final ItemProviderFactory factory =
-      new ItemProviderFactory(searchClientsProxy, metrics, 1);
+      new ItemProviderFactory(searchClientsProxy, retryingQueryExecutor, metrics, 1);
 
   @Test
   void shouldSetFiltersForCancelProcessInstance() {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/itemprovider/retry/ExponentialBackoffRetryingQueryExecutorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/itemprovider/retry/ExponentialBackoffRetryingQueryExecutorTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.batchoperation.itemprovider.retry;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+import java.time.Duration;
+import java.util.concurrent.Callable;
+import org.junit.jupiter.api.Test;
+
+class ExponentialBackoffRetryingQueryExecutorTest {
+
+  final int maxRetries = 2;
+  final Duration initialRetryDelay = Duration.ofMillis(50);
+  final double backoffFactor = 2.0;
+
+  @Test
+  public void shouldReturnOnFirstTry() throws Exception {
+    final var retryStrategy =
+        new ExponentialBackoffRetryingQueryExecutor(maxRetries, initialRetryDelay, backoffFactor);
+
+    final var callableResult = "result";
+    final Callable<String> callable = mock(Callable.class);
+    when(callable.call()).thenReturn(callableResult);
+
+    final var result = retryStrategy.runRetryable(callable);
+
+    verify(callable, times(1)).call();
+    assertThat(result).isEqualTo(callableResult);
+  }
+
+  @Test
+  public void shouldReturnOnFirstTryWithNoRetries() throws Exception {
+    final var retryStrategy =
+        new ExponentialBackoffRetryingQueryExecutor(0, initialRetryDelay, backoffFactor);
+
+    final var callableResult = "result";
+    final Callable<String> callable = mock(Callable.class);
+    when(callable.call()).thenReturn(callableResult);
+
+    final var result = retryStrategy.runRetryable(callable);
+
+    verify(callable, times(1)).call();
+    assertThat(result).isEqualTo(callableResult);
+  }
+
+  @Test
+  public void shouldDoTwoRetries() throws Exception {
+    final var retryStrategy =
+        new ExponentialBackoffRetryingQueryExecutor(maxRetries, initialRetryDelay, backoffFactor);
+
+    final var callableResult = "result";
+    final Callable<String> callable = mock(Callable.class);
+    when(callable.call()).thenThrow(new Exception("error 1")).thenReturn(callableResult);
+
+    final var result = retryStrategy.runRetryable(callable);
+
+    verify(callable, times(2)).call();
+    assertThat(result).isEqualTo(callableResult);
+  }
+
+  @Test
+  public void shouldThrowException() throws Exception {
+    final var retryStrategy =
+        new ExponentialBackoffRetryingQueryExecutor(maxRetries, initialRetryDelay, backoffFactor);
+
+    final Callable<String> callable = mock(Callable.class);
+    when(callable.call())
+        .thenThrow(new Exception("error 1"))
+        .thenThrow(new Exception("error 2"))
+        .thenThrow(new Exception("error 3"));
+
+    final long startTime = System.currentTimeMillis();
+    assertThatThrownBy(() -> retryStrategy.runRetryable(callable)).cause().hasMessage("error 3");
+    final long endTime = System.currentTimeMillis();
+
+    verify(callable, times(3)).call();
+
+    // The total delay should be at least the sum of the delays for 3 retries:
+    // 50ms + 100ms = 150ms
+    assertThat(endTime - startTime).isGreaterThan(150);
+  }
+}


### PR DESCRIPTION
## Description

Adds a retry strategy with exponential backoff for batch operation initialization in case the query to the secondary database fails.

Note: I replaced the BatchOperationInitialization golden record because so far we have never released a production version.

## Related issues

closes #31222 