### PR TITLE
feat: configurable priority for index templates

### DIFF
--- a/schema-manager/src/main/java/io/camunda/search/schema/SchemaManager.java
+++ b/schema-manager/src/main/java/io/camunda/search/schema/SchemaManager.java
@@ -338,6 +338,7 @@ public class SchemaManager {
     final var settings = new IndexConfiguration();
     settings.setNumberOfShards(templateShards);
     settings.setNumberOfReplicas(templateReplicas);
+    settings.setTemplatePriority(config.index().getTemplatePriority());
 
     return settings;
   }

--- a/schema-manager/src/main/java/io/camunda/search/schema/config/IndexConfiguration.java
+++ b/schema-manager/src/main/java/io/camunda/search/schema/config/IndexConfiguration.java
@@ -16,6 +16,7 @@ public class IndexConfiguration {
 
   private Integer numberOfShards = 1;
   private Integer numberOfReplicas = 0;
+  private Integer templatePriority;
 
   private Map<String, Integer> replicasByIndexName = new HashMap<>();
   private Map<String, Integer> shardsByIndexName = new HashMap<>();
@@ -64,6 +65,14 @@ public class IndexConfiguration {
     this.shouldWaitForImporters = shouldWaitForImporters;
   }
 
+  public Integer getTemplatePriority() {
+    return templatePriority;
+  }
+
+  public void setTemplatePriority(final Integer templatePriority) {
+    this.templatePriority = templatePriority;
+  }
+
   @Override
   public String toString() {
     return "IndexConfiguration{"
@@ -71,6 +80,8 @@ public class IndexConfiguration {
         + numberOfShards
         + ", numberOfReplicas="
         + numberOfReplicas
+        + ", templatePriority="
+        + templatePriority
         + ", replicasByIndexName="
         + replicasByIndexName
         + ", shardsByIndexName="

--- a/schema-manager/src/main/java/io/camunda/search/schema/elasticsearch/ElasticsearchEngineClient.java
+++ b/schema-manager/src/main/java/io/camunda/search/schema/elasticsearch/ElasticsearchEngineClient.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.search.schema.elasticsearch;
 
+import static java.util.Optional.ofNullable;
+
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import co.elastic.clients.elasticsearch._types.AcknowledgedResponse;
 import co.elastic.clients.elasticsearch._types.Conflicts;
@@ -468,6 +470,7 @@ public class ElasticsearchEngineClient implements SearchEngineClient {
                   t.aliases(indexTemplateDescriptor.getAlias(), Alias.of(a -> a))
                       .mappings(templateFields.mappings())
                       .settings(templateFields.settings()))
+          .priority(ofNullable(settings.getTemplatePriority()).map(Long::valueOf).orElse(null))
           .composedOf(indexTemplateDescriptor.getComposedOf())
           .create(create)
           .build();
@@ -504,6 +507,8 @@ public class ElasticsearchEngineClient implements SearchEngineClient {
                   t.settings(updatedTemplateSettings)
                       .mappings(currentIndexTemplateState.mappings())
                       .aliases(currentIndexTemplateState.aliases()))
+          .priority(
+              ofNullable(currentSettings.getTemplatePriority()).map(Long::valueOf).orElse(null))
           .build();
 
     } catch (final IOException e) {

--- a/schema-manager/src/main/java/io/camunda/search/schema/opensearch/OpensearchEngineClient.java
+++ b/schema-manager/src/main/java/io/camunda/search/schema/opensearch/OpensearchEngineClient.java
@@ -490,6 +490,7 @@ public class OpensearchEngineClient implements SearchEngineClient {
                   t.aliases(indexTemplateDescriptor.getAlias(), a -> a)
                       .mappings(templateFields.mappings())
                       .settings(templateFields.settings()))
+          .priority(settings.getTemplatePriority())
           .composedOf(indexTemplateDescriptor.getComposedOf())
           .build();
     } catch (final IOException e) {
@@ -525,6 +526,7 @@ public class OpensearchEngineClient implements SearchEngineClient {
                   t.settings(updatedTemplateSettings)
                       .mappings(currentIndexTemplateState.mappings())
                       .aliases(currentIndexTemplateState.aliases()))
+          .priority(currentSettings.getTemplatePriority())
           .build();
 
     } catch (final IOException e) {


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
sets the index template priority from `camunda.database.index.template-priority` configuration.
@buccarel since the new unified configuration is still not in-place, can you confirm that it is fine to use this configuration for now?

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes https://github.com/camunda/camunda/issues/36086
