### PR TITLE
feat: add api rest filter properties to unified configuration

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/Api.java
+++ b/configuration/src/main/java/io/camunda/configuration/Api.java
@@ -15,6 +15,9 @@ public class Api {
   /** Configuration for grpc behavior */
   private Grpc grpc = new Grpc();
 
+  /** Configuration for rest behavior */
+  private Rest rest = new Rest();
+
   public LongPolling getLongPolling() {
     return longPolling;
   }
@@ -29,5 +32,13 @@ public class Api {
 
   public void setGrpc(final Grpc grpc) {
     this.grpc = grpc;
+  }
+
+  public Rest getRest() {
+    return rest;
+  }
+
+  public void setRest(final Rest rest) {
+    this.rest = rest;
   }
 }

--- a/configuration/src/main/java/io/camunda/configuration/Filter.java
+++ b/configuration/src/main/java/io/camunda/configuration/Filter.java
@@ -7,40 +7,15 @@
  */
 package io.camunda.configuration;
 
-import io.camunda.configuration.UnifiedConfigurationHelper.BackwardsCompatibilityMode;
-import java.util.Set;
+import io.camunda.zeebe.gateway.impl.configuration.FilterCfg;
 
 public class Filter extends BaseExternalCodeConfiguration {
-  private static final String PREFIX = "camunda.api.rest.filters.";
-  private static final String LEGACY_FILTER_PROPERTY = "zeebe.gateway.filters.";
 
-  @Override
-  public String getId(final int index) {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
-        PREFIX + index + ".id",
-        id,
-        String.class,
-        BackwardsCompatibilityMode.SUPPORTED,
-        Set.of(LEGACY_FILTER_PROPERTY + index + ".id"));
-  }
-
-  @Override
-  public String getJarPath(final int index) {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
-        PREFIX + index + ".jar-path",
-        jarPath,
-        String.class,
-        BackwardsCompatibilityMode.SUPPORTED,
-        Set.of(LEGACY_FILTER_PROPERTY + index + ".jarPath"));
-  }
-
-  @Override
-  public String getClassName(final int index) {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
-        PREFIX + index + ".class-name",
-        className,
-        String.class,
-        BackwardsCompatibilityMode.SUPPORTED,
-        Set.of(LEGACY_FILTER_PROPERTY + index + ".className"));
+  public FilterCfg toFilterCfg() {
+    final var filterCfg = new FilterCfg();
+    filterCfg.setId(getId());
+    filterCfg.setJarPath(getJarPath());
+    filterCfg.setClassName(getClassName());
+    return filterCfg;
   }
 }

--- a/configuration/src/main/java/io/camunda/configuration/Filter.java
+++ b/configuration/src/main/java/io/camunda/configuration/Filter.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import io.camunda.configuration.UnifiedConfigurationHelper.BackwardsCompatibilityMode;
+import java.util.Set;
+
+public class Filter extends BaseExternalCodeConfiguration {
+  private static final String PREFIX = "camunda.api.rest.filters.";
+  private static final String LEGACY_FILTER_PROPERTY = "zeebe.gateway.filters.";
+
+  @Override
+  public String getId(final int index) {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + index + ".id",
+        id,
+        String.class,
+        BackwardsCompatibilityMode.SUPPORTED,
+        Set.of(LEGACY_FILTER_PROPERTY + index + ".id"));
+  }
+
+  @Override
+  public String getJarPath(final int index) {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + index + ".jar-path",
+        jarPath,
+        String.class,
+        BackwardsCompatibilityMode.SUPPORTED,
+        Set.of(LEGACY_FILTER_PROPERTY + index + ".jarPath"));
+  }
+
+  @Override
+  public String getClassName(final int index) {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + index + ".class-name",
+        className,
+        String.class,
+        BackwardsCompatibilityMode.SUPPORTED,
+        Set.of(LEGACY_FILTER_PROPERTY + index + ".className"));
+  }
+}

--- a/configuration/src/main/java/io/camunda/configuration/Grpc.java
+++ b/configuration/src/main/java/io/camunda/configuration/Grpc.java
@@ -106,8 +106,8 @@ public class Grpc {
     final Grpc copy = new Grpc();
     copy.address = address;
     copy.port = port;
-    copy.ssl = ssl.clone();
-    copy.interceptors = interceptors.stream().map(Interceptor::clone).toList();
+    copy.ssl = ssl;
+    copy.interceptors = interceptors;
     copy.managementThreads = managementThreads;
 
     return copy;

--- a/configuration/src/main/java/io/camunda/configuration/Interceptor.java
+++ b/configuration/src/main/java/io/camunda/configuration/Interceptor.java
@@ -18,14 +18,4 @@ public class Interceptor extends BaseExternalCodeConfiguration {
     interceptorCfg.setClassName(getClassName());
     return interceptorCfg;
   }
-
-  @Override
-  public Interceptor clone() {
-    final Interceptor copy = new Interceptor();
-    copy.setId(getId());
-    copy.setJarPath(getJarPath());
-    copy.setClassName(getClassName());
-
-    return copy;
-  }
 }

--- a/configuration/src/main/java/io/camunda/configuration/Rest.java
+++ b/configuration/src/main/java/io/camunda/configuration/Rest.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class Rest {
+
+  /** Sets the filters */
+  private List<Filter> filters = new ArrayList<>();
+
+  public List<Filter> getFilters() {
+    return filters;
+  }
+
+  public void setFilters(final List<Filter> filters) {
+    this.filters = filters;
+  }
+}

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/GatewayBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/GatewayBasedPropertiesOverride.java
@@ -7,21 +7,18 @@
  */
 package io.camunda.configuration.beanoverrides;
 
+import io.camunda.configuration.Filter;
 import io.camunda.configuration.Grpc;
 import io.camunda.configuration.Interceptor;
 import io.camunda.configuration.Ssl;
-import io.camunda.configuration.Filter;
 import io.camunda.configuration.UnifiedConfiguration;
 import io.camunda.configuration.beans.GatewayBasedProperties;
 import io.camunda.configuration.beans.LegacyGatewayBasedProperties;
+import io.camunda.zeebe.gateway.impl.configuration.FilterCfg;
 import io.camunda.zeebe.gateway.impl.configuration.InterceptorCfg;
 import io.camunda.zeebe.gateway.impl.configuration.NetworkCfg;
 import io.camunda.zeebe.gateway.impl.configuration.SecurityCfg;
 import io.camunda.zeebe.gateway.impl.configuration.ThreadsCfg;
-import java.util.List;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import io.camunda.zeebe.gateway.impl.configuration.FilterCfg;
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/configuration/src/test/java/io/camunda/configuration/ApiRestBrokerFiltersTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/ApiRestBrokerFiltersTest.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.configuration.beanoverrides.BrokerBasedPropertiesOverride;
+import io.camunda.configuration.beans.BrokerBasedProperties;
+import io.camunda.zeebe.gateway.impl.configuration.FilterCfg;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+@SpringJUnitConfig({
+  UnifiedConfiguration.class,
+  BrokerBasedPropertiesOverride.class,
+  UnifiedConfigurationHelper.class
+})
+@ActiveProfiles("broker")
+public class ApiRestBrokerFiltersTest {
+
+  private FilterCfg createFilterCfg(final String id, final String jarPath, final String className) {
+    final var filterCfg = new FilterCfg();
+    filterCfg.setId(id);
+    filterCfg.setJarPath(jarPath);
+    filterCfg.setClassName(className);
+    return filterCfg;
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "camunda.api.rest.filters.0.id=0IdNew",
+        "camunda.api.rest.filters.0.jar-path=0JarPathNew",
+        "camunda.api.rest.filters.0.class-name=0ClassNameNew",
+        "camunda.api.rest.filters.1.id=1IdNew",
+        "camunda.api.rest.filters.1.jar-path=1JarPathNew",
+        "camunda.api.rest.filters.1.class-name=1ClassNameNew"
+      })
+  class WithOnlyUnifiedConfigSet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithOnlyUnifiedConfigSet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldSetFilters() {
+      final var expectedFilterCfg0 = createFilterCfg("0IdNew", "0JarPathNew", "0ClassNameNew");
+      final var expectedFilterCfg1 = createFilterCfg("1IdNew", "1JarPathNew", "1ClassNameNew");
+
+      assertThat(brokerCfg.getGateway().getFilters())
+          .hasSize(2)
+          .usingRecursiveFieldByFieldElementComparator()
+          .containsExactly(expectedFilterCfg0, expectedFilterCfg1);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "zeebe.gateway.filters.0.id=0IdLegacyGateway",
+        "zeebe.gateway.filters.0.jarPath=0JarPathLegacyGateway",
+        "zeebe.gateway.filters.0.className=0ClassNameLegacyGateway",
+        "zeebe.gateway.filters.1.id=1IdLegacyGateway",
+        "zeebe.gateway.filters.1.jarPath=1JarPathLegacyGateway",
+        "zeebe.gateway.filters.1.className=1ClassNameLegacyGateway"
+      })
+  class WithOnlyLegacyGatewayFiltersSet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithOnlyLegacyGatewayFiltersSet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldNotSetFiltersFromLegacyGatewaysFilters() {
+      assertThat(brokerCfg.getGateway().getFilters()).isEmpty();
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "zeebe.broker.gateway.filters.0.id=0IdLegacyBroker",
+        "zeebe.broker.gateway.filters.0.jarPath=0JarPathLegacyBroker",
+        "zeebe.broker.gateway.filters.0.className=0ClassNameLegacyBroker",
+        "zeebe.broker.gateway.filters.1.id=1IdLegacyBroker",
+        "zeebe.broker.gateway.filters.1.jarPath=1JarPathLegacyBroker",
+        "zeebe.broker.gateway.filters.1.className=1ClassNameLegacyBroker"
+      })
+  class WithOnlyLegacyBrokerFiltersSet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithOnlyLegacyBrokerFiltersSet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldSetFiltersFromLegacyBrokerFilters() {
+      final var expectedFilterCfg0 =
+          createFilterCfg("0IdLegacyBroker", "0JarPathLegacyBroker", "0ClassNameLegacyBroker");
+      final var expectedFilterCfg1 =
+          createFilterCfg("1IdLegacyBroker", "1JarPathLegacyBroker", "1ClassNameLegacyBroker");
+
+      assertThat(brokerCfg.getGateway().getFilters())
+          .hasSize(2)
+          .usingRecursiveFieldByFieldElementComparator()
+          .containsExactly(expectedFilterCfg0, expectedFilterCfg1);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        // new
+        "camunda.api.rest.filters.0.id=0IdNew",
+        "camunda.api.rest.filters.0.jar-path=0JarPathNew",
+        "camunda.api.rest.filters.0.class-name=0ClassNameNew",
+        "camunda.api.rest.filters.1.id=1IdNew",
+        "camunda.api.rest.filters.1.jar-path=1JarPathNew",
+        "camunda.api.rest.filters.1.class-name=1ClassNameNew",
+        // legacy gateway filters
+        "zeebe.gateway.filters.0.id=0IdLegacyGateway",
+        "zeebe.gateway.filters.0.jarPath=0JarPathLegacyGateway",
+        "zeebe.gateway.filters.0.className=0ClassNameLegacyGateway",
+        "zeebe.gateway.filters.1.id=1IdLegacyGateway",
+        "zeebe.gateway.filters.1.jarPath=1JarPathLegacyGateway",
+        "zeebe.gateway.filters.1.className=1ClassNameLegacyGateway",
+        // legacy broker filters
+        "zeebe.broker.gateway.filters.0.id=0IdLegacyBroker",
+        "zeebe.broker.gateway.filters.0.jarPath=0JarPathLegacyBroker",
+        "zeebe.broker.gateway.filters.0.className=0ClassNameLegacyBroker",
+        "zeebe.broker.gateway.filters.1.id=1IdLegacyBroker",
+        "zeebe.broker.gateway.filters.1.jarPath=1JarPathLegacyBroker",
+        "zeebe.broker.gateway.filters.1.className=1ClassNameLegacyBroker",
+      })
+  class WithNewAndLegacySet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithNewAndLegacySet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldSetFiltersFromNew() {
+      final var expectedFilterCfg0 = createFilterCfg("0IdNew", "0JarPathNew", "0ClassNameNew");
+      final var expectedFilterCfg1 = createFilterCfg("1IdNew", "1JarPathNew", "1ClassNameNew");
+
+      assertThat(brokerCfg.getGateway().getFilters())
+          .hasSize(2)
+          .usingRecursiveFieldByFieldElementComparator()
+          .containsExactly(expectedFilterCfg0, expectedFilterCfg1);
+    }
+  }
+}

--- a/configuration/src/test/java/io/camunda/configuration/ApiRestGatewayFiltersTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/ApiRestGatewayFiltersTest.java
@@ -23,7 +23,7 @@ import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
   GatewayBasedPropertiesOverride.class,
   UnifiedConfigurationHelper.class
 })
-public class ApiRestTest {
+public class ApiRestGatewayFiltersTest {
 
   private FilterCfg createFilterCfg(final String id, final String jarPath, final String className) {
     final var filterCfg = new FilterCfg();
@@ -51,7 +51,7 @@ public class ApiRestTest {
     }
 
     @Test
-    void shouldContainFilters() {
+    void shouldSetFilters() {
       final var expectedFilterCfg0 = createFilterCfg("0IdNew", "0JarPathNew", "0ClassNameNew");
       final var expectedFilterCfg1 = createFilterCfg("1IdNew", "1JarPathNew", "1ClassNameNew");
 
@@ -65,26 +65,49 @@ public class ApiRestTest {
   @Nested
   @TestPropertySource(
       properties = {
-        "zeebe.gateway.filters.0.id=0IdLegacy",
-        "zeebe.gateway.filters.0.jarPath=0JarPathLegacy",
-        "zeebe.gateway.filters.0.className=0ClassNameLegacy",
-        "zeebe.gateway.filters.1.id=1IdLegacy",
-        "zeebe.gateway.filters.1.jarPath=1JarPathLegacy",
-        "zeebe.gateway.filters.1.className=1ClassNameLegacy"
+        "zeebe.broker.gateway.filters.0.id=0IdLegacyBroker",
+        "zeebe.broker.gateway.filters.0.jarPath=0JarPathLegacyBroker",
+        "zeebe.broker.gateway.filters.0.className=0ClassNameLegacyBroker",
+        "zeebe.broker.gateway.filters.1.id=1IdLegacyBroker",
+        "zeebe.broker.gateway.filters.1.jarPath=1JarPathLegacyBroker",
+        "zeebe.broker.gateway.filters.1.className=1ClassNameLegacyBroker"
       })
-  class WithOnlyLegacySet {
+  class WithOnlyLegacyBrokerFiltersSet {
     final GatewayBasedProperties gatewayCfg;
 
-    WithOnlyLegacySet(@Autowired final GatewayBasedProperties gatewayCfg) {
+    WithOnlyLegacyBrokerFiltersSet(@Autowired final GatewayBasedProperties gatewayCfg) {
       this.gatewayCfg = gatewayCfg;
     }
 
     @Test
-    void shouldContainFilters() {
+    void shouldNotSetFiltersFromLegacyBrokerFilters() {
+      assertThat(gatewayCfg.getInterceptors()).isEmpty();
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "zeebe.gateway.filters.0.id=0IdLegacyGateway",
+        "zeebe.gateway.filters.0.jarPath=0JarPathLegacyGateway",
+        "zeebe.gateway.filters.0.className=0ClassNameLegacyGateway",
+        "zeebe.gateway.filters.1.id=1IdLegacyGateway",
+        "zeebe.gateway.filters.1.jarPath=1JarPathLegacyGateway",
+        "zeebe.gateway.filters.1.className=1ClassNameLegacyGateway"
+      })
+  class WithOnlyLegacyGatewayFiltersSet {
+    final GatewayBasedProperties gatewayCfg;
+
+    WithOnlyLegacyGatewayFiltersSet(@Autowired final GatewayBasedProperties gatewayCfg) {
+      this.gatewayCfg = gatewayCfg;
+    }
+
+    @Test
+    void shouldSetFiltersFromLegacyGatewayFilters() {
       final var expectedFilterCfg0 =
-          createFilterCfg("0IdLegacy", "0JarPathLegacy", "0ClassNameLegacy");
+          createFilterCfg("0IdLegacyGateway", "0JarPathLegacyGateway", "0ClassNameLegacyGateway");
       final var expectedFilterCfg1 =
-          createFilterCfg("1IdLegacy", "1JarPathLegacy", "1ClassNameLegacy");
+          createFilterCfg("1IdLegacyGateway", "1JarPathLegacyGateway", "1ClassNameLegacyGateway");
 
       assertThat(gatewayCfg.getFilters())
           .hasSize(2)
@@ -103,13 +126,20 @@ public class ApiRestTest {
         "camunda.api.rest.filters.1.id=1IdNew",
         "camunda.api.rest.filters.1.jar-path=1JarPathNew",
         "camunda.api.rest.filters.1.class-name=1ClassNameNew",
-        // legacy
-        "zeebe.gateway.filters.0.id=0IdLegacy",
-        "zeebe.gateway.filters.0.jarPath=0JarPathLegacy",
-        "zeebe.gateway.filters.0.className=0ClassNameLegacy",
-        "zeebe.gateway.filters.1.id=1IdLegacy",
-        "zeebe.gateway.filters.1.jarPath=1JarPathLegacy",
-        "zeebe.gateway.filters.1.className=1ClassNameLegacy"
+        // legacy broker filters
+        "zeebe.broker.gateway.filters.0.id=0IdLegacyBroker",
+        "zeebe.broker.gateway.filters.0.jarPath=0JarPathLegacyBroker",
+        "zeebe.broker.gateway.filters.0.className=0ClassNameLegacyBroker",
+        "zeebe.broker.gateway.filters.1.id=1IdLegacyBroker",
+        "zeebe.broker.gateway.filters.1.jarPath=1JarPathLegacyBroker",
+        "zeebe.broker.gateway.filters.1.className=1ClassNameLegacyBroker",
+        // legacy gateway filters
+        "zeebe.gateway.filters.0.id=0IdLegacyGateway",
+        "zeebe.gateway.filters.0.jarPath=0JarPathLegacyGateway",
+        "zeebe.gateway.filters.0.className=0ClassNameLegacyGateway",
+        "zeebe.gateway.filters.1.id=1IdLegacyGateway",
+        "zeebe.gateway.filters.1.jarPath=1JarPathLegacyGateway",
+        "zeebe.gateway.filters.1.className=1ClassNameLegacyGateway"
       })
   class WithNewAndLegacySet {
     final GatewayBasedProperties gatewayCfg;
@@ -119,7 +149,7 @@ public class ApiRestTest {
     }
 
     @Test
-    void shouldContainFiltersFromNew() {
+    void shouldSetFiltersFromNew() {
       final var expectedFilterCfg0 = createFilterCfg("0IdNew", "0JarPathNew", "0ClassNameNew");
       final var expectedFilterCfg1 = createFilterCfg("1IdNew", "1JarPathNew", "1ClassNameNew");
 

--- a/configuration/src/test/java/io/camunda/configuration/ApiRestTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/ApiRestTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.configuration.beanoverrides.GatewayBasedPropertiesOverride;
+import io.camunda.configuration.beans.GatewayBasedProperties;
+import io.camunda.zeebe.gateway.impl.configuration.FilterCfg;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+@SpringJUnitConfig({
+  UnifiedConfiguration.class,
+  GatewayBasedPropertiesOverride.class,
+  UnifiedConfigurationHelper.class
+})
+public class ApiRestTest {
+
+  private FilterCfg createFilterCfg(final String id, final String jarPath, final String className) {
+    final var filterCfg = new FilterCfg();
+    filterCfg.setId(id);
+    filterCfg.setJarPath(jarPath);
+    filterCfg.setClassName(className);
+    return filterCfg;
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "camunda.api.rest.filters.0.id=0IdNew",
+        "camunda.api.rest.filters.0.jar-path=0JarPathNew",
+        "camunda.api.rest.filters.0.class-name=0ClassNameNew",
+        "camunda.api.rest.filters.1.id=1IdNew",
+        "camunda.api.rest.filters.1.jar-path=1JarPathNew",
+        "camunda.api.rest.filters.1.class-name=1ClassNameNew"
+      })
+  class WithOnlyUnifiedConfigSet {
+    final GatewayBasedProperties gatewayCfg;
+
+    WithOnlyUnifiedConfigSet(@Autowired final GatewayBasedProperties gatewayCfg) {
+      this.gatewayCfg = gatewayCfg;
+    }
+
+    @Test
+    void shouldContainFilters() {
+      final var expectedFilterCfg0 = createFilterCfg("0IdNew", "0JarPathNew", "0ClassNameNew");
+      final var expectedFilterCfg1 = createFilterCfg("1IdNew", "1JarPathNew", "1ClassNameNew");
+
+      assertThat(gatewayCfg.getFilters())
+          .hasSize(2)
+          .usingRecursiveFieldByFieldElementComparator()
+          .containsExactly(expectedFilterCfg0, expectedFilterCfg1);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "zeebe.gateway.filters.0.id=0IdLegacy",
+        "zeebe.gateway.filters.0.jarPath=0JarPathLegacy",
+        "zeebe.gateway.filters.0.className=0ClassNameLegacy",
+        "zeebe.gateway.filters.1.id=1IdLegacy",
+        "zeebe.gateway.filters.1.jarPath=1JarPathLegacy",
+        "zeebe.gateway.filters.1.className=1ClassNameLegacy"
+      })
+  class WithOnlyLegacySet {
+    final GatewayBasedProperties gatewayCfg;
+
+    WithOnlyLegacySet(@Autowired final GatewayBasedProperties gatewayCfg) {
+      this.gatewayCfg = gatewayCfg;
+    }
+
+    @Test
+    void shouldContainFilters() {
+      final var expectedFilterCfg0 =
+          createFilterCfg("0IdLegacy", "0JarPathLegacy", "0ClassNameLegacy");
+      final var expectedFilterCfg1 =
+          createFilterCfg("1IdLegacy", "1JarPathLegacy", "1ClassNameLegacy");
+
+      assertThat(gatewayCfg.getFilters())
+          .hasSize(2)
+          .usingRecursiveFieldByFieldElementComparator()
+          .containsExactly(expectedFilterCfg0, expectedFilterCfg1);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        // new
+        "camunda.api.rest.filters.0.id=0IdNew",
+        "camunda.api.rest.filters.0.jar-path=0JarPathNew",
+        "camunda.api.rest.filters.0.class-name=0ClassNameNew",
+        "camunda.api.rest.filters.1.id=1IdNew",
+        "camunda.api.rest.filters.1.jar-path=1JarPathNew",
+        "camunda.api.rest.filters.1.class-name=1ClassNameNew",
+        // legacy
+        "zeebe.gateway.filters.0.id=0IdLegacy",
+        "zeebe.gateway.filters.0.jarPath=0JarPathLegacy",
+        "zeebe.gateway.filters.0.className=0ClassNameLegacy",
+        "zeebe.gateway.filters.1.id=1IdLegacy",
+        "zeebe.gateway.filters.1.jarPath=1JarPathLegacy",
+        "zeebe.gateway.filters.1.className=1ClassNameLegacy"
+      })
+  class WithNewAndLegacySet {
+    final GatewayBasedProperties gatewayCfg;
+
+    WithNewAndLegacySet(@Autowired final GatewayBasedProperties gatewayCfg) {
+      this.gatewayCfg = gatewayCfg;
+    }
+
+    @Test
+    void shouldContainFiltersFromNew() {
+      final var expectedFilterCfg0 = createFilterCfg("0IdNew", "0JarPathNew", "0ClassNameNew");
+      final var expectedFilterCfg1 = createFilterCfg("1IdNew", "1JarPathNew", "1ClassNameNew");
+
+      assertThat(gatewayCfg.getFilters())
+          .hasSize(2)
+          .usingRecursiveFieldByFieldElementComparator()
+          .containsExactly(expectedFilterCfg0, expectedFilterCfg1);
+    }
+  }
+}


### PR DESCRIPTION
This PR adds the properties from section camunda.api.grpc in unified config.

The legacy properties are:

zeebe.gateway.filters.[x].id
zeebe.gateway.filters.[x].jarPath
zeebe.gateway.filters.[x].className

zeebe.broker.gateway.filters.[x].id
zeebe.broker.gateway.filters.[x].jarPath
zeebe.broker.gateway.filters.[x].className

The new properties are:

camunda.api.rest.filters.[x].id
camunda.api.rest.filters.[x].jar-path
camunda.api.rest.filters.[x].class-name

Backwards compatibility is supported for these properties. That means, if legacy is set and new property is not set, legacy value will be used.
## Checklist

- [ ] The legacy properties and the backwards compatibility strategy are updated in [schema doc](https://docs.google.com/spreadsheets/d/1R4epsy6DWemA8_76cUE6zOGUFbrXCXlM2reXnKFuz7Y/edit?gid=818158292#gid=818158292)
- [ ] The new property fields are documented in the code
## Related issues

related to #34911 

