### PR TITLE
Cancel remaining instances on ad-hoc sub-process completion / element activation

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/adhocsubprocess/AdHocSubProcessInstructionActivateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/adhocsubprocess/AdHocSubProcessInstructionActivateProcessor.java
@@ -158,6 +158,10 @@ public class AdHocSubProcessInstructionActivateProcessor
         adHocSubProcessElementInstance.getValue(),
         adHocSubProcessElementInstance.getState());
 
+    if (command.getValue().isCancelRemainingInstances()) {
+      bpmnAdHocSubProcessBehavior.terminateChildInstances(bpmnElementContext);
+    }
+
     // activate the elements
     for (final var elementValue : command.getValue().activateElements()) {
       bpmnAdHocSubProcessBehavior.activateElement(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnAdHocSubProcessBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnAdHocSubProcessBehavior.java
@@ -178,7 +178,7 @@ public final class BpmnAdHocSubProcessBehavior {
     }
   }
 
-  private void terminateChildInstances(final BpmnElementContext adHocSubProcessContext) {
+  public void terminateChildInstances(final BpmnElementContext adHocSubProcessContext) {
     elementInstanceState
         .getChildren(adHocSubProcessContext.getElementInstanceKey())
         .forEach(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
@@ -230,7 +230,8 @@ public final class JobCompleteProcessor implements CommandProcessor<JobRecord> {
     final AdHocSubProcessInstructionRecord instructionRecord =
         new AdHocSubProcessInstructionRecord()
             .setAdHocSubProcessInstanceKey(jobRecord.getElementInstanceKey())
-            .setCompletionConditionFulfilled(jobResult.isCompletionConditionFulfilled());
+            .setCompletionConditionFulfilled(jobResult.isCompletionConditionFulfilled())
+            .setCancelRemainingInstances(jobResult.isCancelRemainingInstances());
 
     if (!jobResult.getActivateElements().isEmpty()) {
       jobResult.getActivateElements().stream()

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/JobBasedAdHocSubProcessTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/JobBasedAdHocSubProcessTest.java
@@ -625,7 +625,7 @@ public class JobBasedAdHocSubProcessTest {
 
     final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
 
-    completeJobWithActivateElements(jobType, false, activateElement("A"), activateElement("B"));
+    completeJob(jobType, false, false, activateElement("A"), activateElement("B"));
 
     // then
     final var ahsp =
@@ -653,7 +653,7 @@ public class JobBasedAdHocSubProcessTest {
 
     final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
 
-    completeJobWithActivateElements(jobType, false, activateElement("A"), activateElement("B"));
+    completeJob(jobType, false, false, activateElement("A"), activateElement("B"));
 
     // then
     final var innerInstanceKeys = getInnerInstanceKeysForOutputCollectionTest(processInstanceKey);
@@ -682,7 +682,7 @@ public class JobBasedAdHocSubProcessTest {
 
     final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
 
-    completeJobWithActivateElements(jobType, false, activateElement("A"), activateElement("B"));
+    completeJob(jobType, false, false, activateElement("A"), activateElement("B"));
 
     final var innerInstanceKeys = getInnerInstanceKeysForOutputCollectionTest(processInstanceKey);
 
@@ -726,7 +726,7 @@ public class JobBasedAdHocSubProcessTest {
 
     final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
 
-    completeJobWithActivateElements(jobType, false, activateElement("A"), activateElement("B"));
+    completeJob(jobType, false, false, activateElement("A"), activateElement("B"));
 
     final var ahsp =
         RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/JobBasedAdHocSubProcessTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/JobBasedAdHocSubProcessTest.java
@@ -168,7 +168,7 @@ public class JobBasedAdHocSubProcessTest {
     final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
 
     // when
-    completeJobWithActivateElements(jobType, false, false, activateElement("A1"));
+    completeJob(jobType, false, false, activateElement("A1"));
 
     // then
     final var adHocSubProcess =
@@ -205,8 +205,7 @@ public class JobBasedAdHocSubProcessTest {
     final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
 
     // when
-    completeJobWithActivateElements(
-        jobType, false, false, activateElement("A"), activateElement("B"));
+    completeJob(jobType, false, false, activateElement("A"), activateElement("B"));
 
     // then
     final var adHocSubProcess =
@@ -244,11 +243,10 @@ public class JobBasedAdHocSubProcessTest {
             });
     ENGINE.deployment().withXmlResource(process).deploy();
     final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
-    completeJobWithActivateElements(
-        jobType, false, false, activateElement("A"), activateElement("B"));
+    completeJob(jobType, false, false, activateElement("A"), activateElement("B"));
 
     // when
-    completeJobWithActivateElements(jobType, false, false, activateElement("C"));
+    completeJob(jobType, false, false, activateElement("C"));
 
     // then
     Assertions.assertThat(
@@ -385,8 +383,7 @@ public class JobBasedAdHocSubProcessTest {
     final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
 
     // when
-    completeJobWithActivateElements(
-        jobType, false, false, activateElement("A1"), activateElement("B"));
+    completeJob(jobType, false, false, activateElement("A1"), activateElement("B"));
 
     // then
     Assertions.assertThat(
@@ -428,7 +425,7 @@ public class JobBasedAdHocSubProcessTest {
     final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
 
     // then
-    completeJobWithActivateElements(
+    completeJob(
         jobType,
         false,
         false,
@@ -478,8 +475,7 @@ public class JobBasedAdHocSubProcessTest {
     final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
 
     // when
-    completeJobWithActivateElements(
-        jobType, false, false, activateElement("DoesntExist"), activateElement("NotThere"));
+    completeJob(jobType, false, false, activateElement("DoesntExist"), activateElement("NotThere"));
 
     final var ahspKey =
         RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATING)
@@ -517,7 +513,7 @@ public class JobBasedAdHocSubProcessTest {
     final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
 
     // when
-    completeJobWithActivateElements(jobType, true, false);
+    completeJob(jobType, true, false);
 
     // then
     Assertions.assertThat(
@@ -542,8 +538,7 @@ public class JobBasedAdHocSubProcessTest {
             });
     ENGINE.deployment().withXmlResource(process).deploy();
     final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
-    completeJobWithActivateElements(
-        jobType, false, false, activateElement("A"), activateElement("B"));
+    completeJob(jobType, false, false, activateElement("A"), activateElement("B"));
     Assertions.assertThat(
             RecordingExporter.processInstanceRecords(ELEMENT_COMPLETED)
                 .withProcessInstanceKey(processInstanceKey)
@@ -551,8 +546,7 @@ public class JobBasedAdHocSubProcessTest {
                 .exists())
         .describedAs("Element A is completed")
         .isTrue();
-    completeJobWithActivateElements(
-        jobType, true, false); // AHSP doesn't complete yet as B is still active
+    completeJob(jobType, true, false); // AHSP doesn't complete yet as B is still active
 
     // when
     final var userTaskKey =
@@ -787,11 +781,11 @@ public class JobBasedAdHocSubProcessTest {
             });
     ENGINE.deployment().withXmlResource(process).deploy();
     final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
-    completeJobWithActivateElements(
+    completeJob(
         jobType, false, false, activateElement("A"), activateElement("B"), activateElement("C"));
 
     // when
-    completeJobWithActivateElements(jobType, true, true);
+    completeJob(jobType, true, true);
 
     // then
     Assertions.assertThat(
@@ -823,11 +817,10 @@ public class JobBasedAdHocSubProcessTest {
             });
     ENGINE.deployment().withXmlResource(process).deploy();
     final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
-    completeJobWithActivateElements(
-        jobType, false, false, activateElement("A"), activateElement("B"));
+    completeJob(jobType, false, false, activateElement("A"), activateElement("B"));
 
     // when
-    completeJobWithActivateElements(jobType, false, true, activateElement("C"));
+    completeJob(jobType, false, true, activateElement("C"));
 
     // then
     Assertions.assertThat(
@@ -885,7 +878,7 @@ public class JobBasedAdHocSubProcessTest {
         .hasErrorMessage("The output collection has the wrong type. Expected ARRAY but was NIL.");
   }
 
-  private void completeJobWithActivateElements(
+  private void completeJob(
       final String jobType,
       final boolean completionConditionFulfilled,
       final boolean cancelRemainingInstances,

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerActivateAdHocSubProcessActivityRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerActivateAdHocSubProcessActivityRequest.java
@@ -42,7 +42,7 @@ public class BrokerActivateAdHocSubProcessActivityRequest
 
   public BrokerActivateAdHocSubProcessActivityRequest cancelRemainingInstances(
       final boolean cancelRemainingInstances) {
-    requestDto.cancelRemainingInstances(cancelRemainingInstances);
+    requestDto.setCancelRemainingInstances(cancelRemainingInstances);
     return this;
   }
 

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/adhocsubprocess/AdHocSubProcessInstructionRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/adhocsubprocess/AdHocSubProcessInstructionRecord.java
@@ -84,7 +84,7 @@ public final class AdHocSubProcessInstructionRecord extends UnifiedRecordValue
     return this;
   }
 
-  public AdHocSubProcessInstructionRecord cancelRemainingInstances(
+  public AdHocSubProcessInstructionRecord setCancelRemainingInstances(
       final boolean cancelRemainingInstances) {
     this.cancelRemainingInstances.setValue(cancelRemainingInstances);
     return this;

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/adhocsubprocess/AdHocSubProcessInstructionRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/adhocsubprocess/AdHocSubProcessInstructionRecord.java
@@ -25,8 +25,8 @@ public final class AdHocSubProcessInstructionRecord extends UnifiedRecordValue
   private static final StringValue AD_HOC_SUB_PROCESS_INSTANCE_KEY =
       new StringValue("adHocSubProcessInstanceKey");
   private static final StringValue ACTIVATE_ELEMENTS = new StringValue("activateElements");
-  private static final StringValue IS_CANCEL_REMAINING_INSTANCES =
-      new StringValue("isCancelRemainingInstances");
+  private static final StringValue CANCEL_REMAINING_INSTANCES =
+      new StringValue("cancelRemainingInstances");
   private static final StringValue TENANT_ID = new StringValue("tenantId");
   private static final StringValue COMPLETION_CONDITION_FULFILLED =
       new StringValue("completionConditionFulfilled");
@@ -36,7 +36,7 @@ public final class AdHocSubProcessInstructionRecord extends UnifiedRecordValue
   private final ArrayProperty<AdHocSubProcessActivateElementInstruction> activateElements =
       new ArrayProperty<>(ACTIVATE_ELEMENTS, AdHocSubProcessActivateElementInstruction::new);
   private final BooleanProperty cancelRemainingInstances =
-      new BooleanProperty(IS_CANCEL_REMAINING_INSTANCES, false);
+      new BooleanProperty(CANCEL_REMAINING_INSTANCES, false);
   private final StringProperty tenantId =
       new StringProperty(TENANT_ID, TenantOwned.DEFAULT_TENANT_IDENTIFIER);
   private final BooleanProperty completionConditionFulfilledProp =

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -2318,7 +2318,7 @@ final class JsonSerializableToJsonTest {
                   .setElementId("234")
                   .setVariables(VARIABLES_MSGPACK);
 
-              adHocSubProcessInstructionRecord.cancelRemainingInstances(true);
+              adHocSubProcessInstructionRecord.setCancelRemainingInstances(true);
 
               return adHocSubProcessInstructionRecord;
             },


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

With this PR we now correctly process the `cancelRemainingInstances` flag. When this flag is set any remaining active children of the ad-hoc sub-process are terminated.

If the completion condition is fulfilled we will first terminate the reamining instances, and complete the ad-hoc sub-process after.
If the completion condition is false, but there are new elements to activate, we will first terminate the active children and afterwards activate the new ones.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes https://github.com/camunda/ad-hoc-sub-process-phase-3/issues/15
