### PR TITLE
feat: add camunda.data.backup.s3 properties to unified configuration

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/Backup.java
+++ b/configuration/src/main/java/io/camunda/configuration/Backup.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+public class Backup {
+  /** Configuration for backup store S3 */
+  private S3 s3 = new S3();
+
+  public S3 getS3() {
+    return s3;
+  }
+
+  public void setS3(final S3 s3) {
+    this.s3 = s3;
+  }
+}

--- a/configuration/src/main/java/io/camunda/configuration/Data.java
+++ b/configuration/src/main/java/io/camunda/configuration/Data.java
@@ -12,11 +12,22 @@ public class Data {
   /** This section allows to configure primary Zeebe's data storage. */
   private PrimaryStorage primaryStorage = new PrimaryStorage();
 
+  /** This section allows configuring a backup store. */
+  private Backup backup = new Backup();
+
   public PrimaryStorage getPrimaryStorage() {
     return primaryStorage;
   }
 
   public void setPrimaryStorage(final PrimaryStorage primaryStorage) {
     this.primaryStorage = primaryStorage;
+  }
+
+  public Backup getBackup() {
+    return backup;
+  }
+
+  public void setBackup(final Backup backup) {
+    this.backup = backup;
   }
 }

--- a/configuration/src/main/java/io/camunda/configuration/S3.java
+++ b/configuration/src/main/java/io/camunda/configuration/S3.java
@@ -1,0 +1,275 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import io.camunda.configuration.UnifiedConfigurationHelper.BackwardsCompatibilityMode;
+import java.time.Duration;
+import java.util.Set;
+
+public class S3 {
+  private static final String PREFIX = "camunda.data.backup.s3.";
+  private static final Set<String> LEGACY_BUCKETNAME_PROPERTIES =
+      Set.of("zeebe.broker.data.backup.s3.bucketName");
+  private static final Set<String> LEGACY_ENDPOINT_PROPERTIES =
+      Set.of("zeebe.broker.data.backup.s3.endpoint");
+  private static final Set<String> LEGACY_REGION_PROPERTIES =
+      Set.of("zeebe.broker.data.backup.s3.region");
+  private static final Set<String> LEGACY_ACCESS_KEY_PROPERTIES =
+      Set.of("zeebe.broker.data.backup.s3.accessKey");
+  private static final Set<String> LEGACY_SECRET_KEY_PROPERTIES =
+      Set.of("zeebe.broker.data.backup.s3.secretKey");
+  private static final Set<String> LEGACY_API_CALL_TIMEOUT_PROPERTIES =
+      Set.of("zeebe.broker.data.backup.s3.apiCallTimeout");
+  private static final Set<String> LEGACY_FORCE_PATH_STYLE_ACCESS_PROPERTIES =
+      Set.of("zeebe.broker.data.backup.s3.forcePathStyleAccess");
+  private static final Set<String> LEGACY_COMPRESSION_PROPERTIES =
+      Set.of("zeebe.broker.data.backup.s3.compression");
+  private static final Set<String> LEGACY_MAX_CONCURRENT_CONNECTIONS_PROPERTIES =
+      Set.of("zeebe.broker.data.backup.s3.maxConcurrentConnections");
+  private static final Set<String> LEGACY_CONNECTION_AQUISITION_TIMEOUT_PROPERTIES =
+      Set.of("zeebe.broker.data.backup.s3.connectionAcquisitionTimeout");
+  private static final Set<String> LEGACY_SUPPPORT_LEGACY_MD5_PROPERTIES =
+      Set.of("zeebe.broker.data.backup.s3.supportLegacyMd5");
+  private static final Set<String> LEGACY_BASEPATH_PROPERTIES =
+      Set.of("zeebe.broker.data.backup.s3.basePath");
+
+  /**
+   * Name of the bucket where the backup will be stored. The bucket must be already created. The
+   * bucket must not be shared with other zeebe clusters. bucketName must not be empty.
+   */
+  private String bucketName;
+
+  /**
+   * Configure URL endpoint for the store. If no endpoint is provided, it will be determined based
+   * on the configured region.
+   */
+  private String endpoint;
+
+  /**
+   * Configure AWS region. If no region is provided it will be determined as documented in <a
+   * href="https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/region-selection.html#automatically-determine-the-aws-region-from-the-environment">...</a>
+   */
+  private String region;
+
+  /**
+   * Configure access credentials. If either accessKey or secretKey is not provided, the credentials
+   * will be determined as documented in <a
+   * href="https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/credentials.html#credentials-chain">...</a>
+   */
+  private String accessKey;
+
+  /**
+   * Configure access credentials. If either accessKey or secretKey is not provided, the credentials
+   * will be determined as documented in <a
+   * href="https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/credentials.html#credentials-chain">...</a>
+   */
+  private String secretKey;
+
+  /**
+   * Configure a maximum duration for all S3 client API calls. Lower values will ensure that failed
+   * or slow API calls don't block other backups but may increase the risk that backups can't be
+   * stored if uploading parts of the backup takes longer than the configured timeout. See <a
+   * href="https://github.com/aws/aws-sdk-java-v2/blob/master/docs/BestPractices.md#utilize-timeout-configurations">...</a>
+   */
+  private Duration apiCallTimeout = Duration.ofSeconds(180);
+
+  /**
+   * When enabled, forces the s3 client to use path-style access. By default, the client will
+   * automatically choose between path-style and virtual-hosted-style. Should only be enabled if the
+   * s3 compatible storage cannot support virtual-hosted-style. See <a
+   * href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/access-bucket-intro.html">...</a>
+   */
+  private boolean forcePathStyleAccess = false;
+
+  /**
+   * When set to an algorithm such as 'zstd', enables compression of backup contents. When not set
+   * or set to 'none', backup content is not compressed. Enabling compression reduces the required
+   * storage space for backups in S3 but also increases the impact on CPU and disk utilization while
+   * taking a backup.
+   */
+  private String compression;
+
+  /** Enable s3 md5 plugin for legacy support */
+  private boolean supportLegacyMd5;
+
+  /**
+   * Maximum number of connections allowed in a connection pool. This is used to restrict the
+   * maximum number of concurrent uploads as to avoid connection timeouts when uploading backups
+   * with large/many files.
+   */
+  private int maxConcurrentConnections = 50;
+
+  /**
+   * Timeout for acquiring an already-established connection from a connection pool to a remote
+   * service.
+   */
+  private Duration connectionAcquisitionTimeout = Duration.ofSeconds(45);
+
+  /**
+   * When set, all objects in the bucket will use this prefix. Must be non-empty and not start or
+   * end with '/'. Useful for using the same bucket for multiple Zeebe clusters. In this case,
+   * basePath must be unique.
+   */
+  private String basePath;
+
+  public String getBucketName() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + "bucket-name",
+        bucketName,
+        String.class,
+        BackwardsCompatibilityMode.SUPPORTED,
+        LEGACY_BUCKETNAME_PROPERTIES);
+  }
+
+  public void setBucketName(final String bucketName) {
+    this.bucketName = bucketName;
+  }
+
+  public String getEndpoint() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + "endpoint",
+        endpoint,
+        String.class,
+        BackwardsCompatibilityMode.SUPPORTED,
+        LEGACY_ENDPOINT_PROPERTIES);
+  }
+
+  public void setEndpoint(final String endpoint) {
+    this.endpoint = endpoint;
+  }
+
+  public String getRegion() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + "region",
+        region,
+        String.class,
+        BackwardsCompatibilityMode.SUPPORTED,
+        LEGACY_REGION_PROPERTIES);
+  }
+
+  public void setRegion(final String region) {
+    this.region = region;
+  }
+
+  public String getAccessKey() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + "access-key",
+        accessKey,
+        String.class,
+        BackwardsCompatibilityMode.SUPPORTED,
+        LEGACY_ACCESS_KEY_PROPERTIES);
+  }
+
+  public void setAccessKey(final String accessKey) {
+    this.accessKey = accessKey;
+  }
+
+  public String getSecretKey() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + "secret-key",
+        secretKey,
+        String.class,
+        BackwardsCompatibilityMode.SUPPORTED,
+        LEGACY_SECRET_KEY_PROPERTIES);
+  }
+
+  public void setSecretKey(final String secretKey) {
+    this.secretKey = secretKey;
+  }
+
+  public Duration getApiCallTimeout() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + "api-call-timeout",
+        apiCallTimeout,
+        Duration.class,
+        BackwardsCompatibilityMode.SUPPORTED,
+        LEGACY_API_CALL_TIMEOUT_PROPERTIES);
+  }
+
+  public void setApiCallTimeout(final Duration apiCallTimeout) {
+    this.apiCallTimeout = apiCallTimeout;
+  }
+
+  public boolean isForcePathStyleAccess() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + "force-path-style-access",
+        forcePathStyleAccess,
+        Boolean.class,
+        BackwardsCompatibilityMode.SUPPORTED,
+        LEGACY_FORCE_PATH_STYLE_ACCESS_PROPERTIES);
+  }
+
+  public void setForcePathStyleAccess(final boolean forcePathStyleAccess) {
+    this.forcePathStyleAccess = forcePathStyleAccess;
+  }
+
+  public String getCompression() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + "compression",
+        compression,
+        String.class,
+        BackwardsCompatibilityMode.SUPPORTED,
+        LEGACY_COMPRESSION_PROPERTIES);
+  }
+
+  public void setCompression(final String compression) {
+    this.compression = compression;
+  }
+
+  public int getMaxConcurrentConnections() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + "max-concurrent-connections",
+        maxConcurrentConnections,
+        Integer.class,
+        BackwardsCompatibilityMode.SUPPORTED,
+        LEGACY_MAX_CONCURRENT_CONNECTIONS_PROPERTIES);
+  }
+
+  public void setMaxConcurrentConnections(final int maxConcurrentConnections) {
+    this.maxConcurrentConnections = maxConcurrentConnections;
+  }
+
+  public Duration getConnectionAcquisitionTimeout() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + "connection-acquisition-timeout",
+        connectionAcquisitionTimeout,
+        Duration.class,
+        BackwardsCompatibilityMode.SUPPORTED,
+        LEGACY_CONNECTION_AQUISITION_TIMEOUT_PROPERTIES);
+  }
+
+  public void setConnectionAcquisitionTimeout(final Duration connectionAcquisitionTimeout) {
+    this.connectionAcquisitionTimeout = connectionAcquisitionTimeout;
+  }
+
+  public boolean isSupportLegacyMd5() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + "support-legacy-md5",
+        supportLegacyMd5,
+        Boolean.class,
+        BackwardsCompatibilityMode.SUPPORTED,
+        LEGACY_SUPPPORT_LEGACY_MD5_PROPERTIES);
+  }
+
+  public void setSupportLegacyMd5(final boolean supportLegacyMd5) {
+    this.supportLegacyMd5 = supportLegacyMd5;
+  }
+
+  public String getBasePath() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + "base-path",
+        basePath,
+        String.class,
+        BackwardsCompatibilityMode.SUPPORTED,
+        LEGACY_BASEPATH_PROPERTIES);
+  }
+
+  public void setBasePath(final String basePath) {
+    this.basePath = basePath;
+  }
+}

--- a/configuration/src/main/java/io/camunda/configuration/S3.java
+++ b/configuration/src/main/java/io/camunda/configuration/S3.java
@@ -12,7 +12,7 @@ import java.time.Duration;
 import java.util.Set;
 
 public class S3 {
-  private static final String PREFIX = "camunda.data.backup.s3.";
+  private static final String PREFIX = "camunda.data.backup.s3";
   private static final Set<String> LEGACY_BUCKETNAME_PROPERTIES =
       Set.of("zeebe.broker.data.backup.s3.bucketName");
   private static final Set<String> LEGACY_ENDPOINT_PROPERTIES =
@@ -119,7 +119,7 @@ public class S3 {
 
   public String getBucketName() {
     return UnifiedConfigurationHelper.validateLegacyConfiguration(
-        PREFIX + "bucket-name",
+        PREFIX + ".bucket-name",
         bucketName,
         String.class,
         BackwardsCompatibilityMode.SUPPORTED,
@@ -132,7 +132,7 @@ public class S3 {
 
   public String getEndpoint() {
     return UnifiedConfigurationHelper.validateLegacyConfiguration(
-        PREFIX + "endpoint",
+        PREFIX + ".endpoint",
         endpoint,
         String.class,
         BackwardsCompatibilityMode.SUPPORTED,
@@ -145,7 +145,7 @@ public class S3 {
 
   public String getRegion() {
     return UnifiedConfigurationHelper.validateLegacyConfiguration(
-        PREFIX + "region",
+        PREFIX + ".region",
         region,
         String.class,
         BackwardsCompatibilityMode.SUPPORTED,
@@ -158,7 +158,7 @@ public class S3 {
 
   public String getAccessKey() {
     return UnifiedConfigurationHelper.validateLegacyConfiguration(
-        PREFIX + "access-key",
+        PREFIX + ".access-key",
         accessKey,
         String.class,
         BackwardsCompatibilityMode.SUPPORTED,
@@ -171,7 +171,7 @@ public class S3 {
 
   public String getSecretKey() {
     return UnifiedConfigurationHelper.validateLegacyConfiguration(
-        PREFIX + "secret-key",
+        PREFIX + ".secret-key",
         secretKey,
         String.class,
         BackwardsCompatibilityMode.SUPPORTED,
@@ -184,7 +184,7 @@ public class S3 {
 
   public Duration getApiCallTimeout() {
     return UnifiedConfigurationHelper.validateLegacyConfiguration(
-        PREFIX + "api-call-timeout",
+        PREFIX + ".api-call-timeout",
         apiCallTimeout,
         Duration.class,
         BackwardsCompatibilityMode.SUPPORTED,
@@ -197,7 +197,7 @@ public class S3 {
 
   public boolean isForcePathStyleAccess() {
     return UnifiedConfigurationHelper.validateLegacyConfiguration(
-        PREFIX + "force-path-style-access",
+        PREFIX + ".force-path-style-access",
         forcePathStyleAccess,
         Boolean.class,
         BackwardsCompatibilityMode.SUPPORTED,
@@ -210,7 +210,7 @@ public class S3 {
 
   public String getCompression() {
     return UnifiedConfigurationHelper.validateLegacyConfiguration(
-        PREFIX + "compression",
+        PREFIX + ".compression",
         compression,
         String.class,
         BackwardsCompatibilityMode.SUPPORTED,
@@ -223,7 +223,7 @@ public class S3 {
 
   public int getMaxConcurrentConnections() {
     return UnifiedConfigurationHelper.validateLegacyConfiguration(
-        PREFIX + "max-concurrent-connections",
+        PREFIX + ".max-concurrent-connections",
         maxConcurrentConnections,
         Integer.class,
         BackwardsCompatibilityMode.SUPPORTED,
@@ -236,7 +236,7 @@ public class S3 {
 
   public Duration getConnectionAcquisitionTimeout() {
     return UnifiedConfigurationHelper.validateLegacyConfiguration(
-        PREFIX + "connection-acquisition-timeout",
+        PREFIX + ".connection-acquisition-timeout",
         connectionAcquisitionTimeout,
         Duration.class,
         BackwardsCompatibilityMode.SUPPORTED,
@@ -249,7 +249,7 @@ public class S3 {
 
   public boolean isSupportLegacyMd5() {
     return UnifiedConfigurationHelper.validateLegacyConfiguration(
-        PREFIX + "support-legacy-md5",
+        PREFIX + ".support-legacy-md5",
         supportLegacyMd5,
         Boolean.class,
         BackwardsCompatibilityMode.SUPPORTED,
@@ -262,7 +262,7 @@ public class S3 {
 
   public String getBasePath() {
     return UnifiedConfigurationHelper.validateLegacyConfiguration(
-        PREFIX + "base-path",
+        PREFIX + ".base-path",
         basePath,
         String.class,
         BackwardsCompatibilityMode.SUPPORTED,

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
@@ -7,11 +7,13 @@
  */
 package io.camunda.configuration.beanoverrides;
 
+import io.camunda.configuration.S3;
 import io.camunda.configuration.UnifiedConfiguration;
 import io.camunda.configuration.beans.BrokerBasedProperties;
 import io.camunda.configuration.beans.LegacyBrokerBasedProperties;
 import io.camunda.zeebe.broker.system.configuration.ConfigManagerCfg;
 import io.camunda.zeebe.broker.system.configuration.ThreadsCfg;
+import io.camunda.zeebe.broker.system.configuration.backup.S3BackupStoreConfig;
 import io.camunda.zeebe.dynamic.config.gossip.ClusterConfigurationGossiperConfig;
 import org.springframework.beans.BeanUtils;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -54,6 +56,8 @@ public class BrokerBasedPropertiesOverride {
 
     // TODO: Populate the bean from rest of camunda.* sections
     // populateFromData(override);
+    // from camunda.data.* sections
+    populateFromData(override);
 
     return override;
   }
@@ -99,6 +103,33 @@ public class BrokerBasedPropertiesOverride {
     final var enableVersionCheck =
         unifiedConfiguration.getCamunda().getSystem().getUpgrade().getEnableVersionCheck();
     override.getExperimental().setVersionCheckRestrictionEnabled(enableVersionCheck);
+  }
+
+  private void populateFromData(final BrokerBasedProperties override) {
+    populateFromBackup(override);
+  }
+
+  private void populateFromBackup(final BrokerBasedProperties override) {
+    populateFromS3(override);
+  }
+
+  private void populateFromS3(final BrokerBasedProperties override) {
+    final S3 s3 = unifiedConfiguration.getCamunda().getData().getBackup().getS3();
+    final S3BackupStoreConfig s3BackupStoreConfig = override.getData().getBackup().getS3();
+    s3BackupStoreConfig.setBucketName(s3.getBucketName());
+    s3BackupStoreConfig.setEndpoint(s3.getEndpoint());
+    s3BackupStoreConfig.setRegion(s3.getRegion());
+    s3BackupStoreConfig.setAccessKey(s3.getAccessKey());
+    s3BackupStoreConfig.setSecretKey(s3.getSecretKey());
+    s3BackupStoreConfig.setApiCallTimeout(s3.getApiCallTimeout());
+    s3BackupStoreConfig.setForcePathStyleAccess(s3.isForcePathStyleAccess());
+    s3BackupStoreConfig.setCompression(s3.getCompression());
+    s3BackupStoreConfig.setMaxConcurrentConnections(s3.getMaxConcurrentConnections());
+    s3BackupStoreConfig.setConnectionAcquisitionTimeout(s3.getConnectionAcquisitionTimeout());
+    s3BackupStoreConfig.setBasePath(s3.getBasePath());
+    s3BackupStoreConfig.setSupportLegacyMd5(s3.isSupportLegacyMd5());
+
+    override.getData().getBackup().setS3(s3BackupStoreConfig);
   }
 
   private void populateFromPrimaryStorage(final BrokerBasedProperties override) {

--- a/configuration/src/test/java/io/camunda/configuration/DataBackupS3Test.java
+++ b/configuration/src/test/java/io/camunda/configuration/DataBackupS3Test.java
@@ -1,0 +1,311 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.configuration.beanoverrides.BrokerBasedPropertiesOverride;
+import io.camunda.configuration.beans.BrokerBasedProperties;
+import java.time.Duration;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+@SpringJUnitConfig({
+  UnifiedConfiguration.class,
+  BrokerBasedPropertiesOverride.class,
+  UnifiedConfigurationHelper.class
+})
+@ActiveProfiles("broker")
+public class DataBackupS3Test {
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "camunda.data.backup.s3.bucket-name=bucketNameNew",
+        "camunda.data.backup.s3.endpoint=endpointNew",
+        "camunda.data.backup.s3.region=regionNew",
+        "camunda.data.backup.s3.access-key=accessKeyNew",
+        "camunda.data.backup.s3.secret-key=secretKeyNew",
+        "camunda.data.backup.s3.api-call-timeout=360s",
+        "camunda.data.backup.s3.force-path-style-access=true",
+        "camunda.data.backup.s3.compression=compressionNew",
+        "camunda.data.backup.s3.max-concurrent-connections=100",
+        "camunda.data.backup.s3.connection-acquisition-timeout=90s",
+        "camunda.data.backup.s3.base-path=basePathNew",
+        "camunda.data.backup.s3.support-legacy-md5=true",
+      })
+  class WithOnlyUnifiedConfigSet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithOnlyUnifiedConfigSet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldSetBucketName() {
+      assertThat(brokerCfg.getData().getBackup().getS3().getBucketName())
+          .isEqualTo("bucketNameNew");
+    }
+
+    @Test
+    void shouldSetEndpoint() {
+      assertThat(brokerCfg.getData().getBackup().getS3().getEndpoint()).isEqualTo("endpointNew");
+    }
+
+    @Test
+    void shouldSetRegion() {
+      assertThat(brokerCfg.getData().getBackup().getS3().getRegion()).isEqualTo("regionNew");
+    }
+
+    @Test
+    void shouldSetAccessKey() {
+      assertThat(brokerCfg.getData().getBackup().getS3().getAccessKey()).isEqualTo("accessKeyNew");
+    }
+
+    @Test
+    void shouldSetSecretKey() {
+      assertThat(brokerCfg.getData().getBackup().getS3().getSecretKey()).isEqualTo("secretKeyNew");
+    }
+
+    @Test
+    void shouldSetApiCallTimeout() {
+      assertThat(brokerCfg.getData().getBackup().getS3().getApiCallTimeout())
+          .isEqualTo(Duration.ofSeconds(360));
+    }
+
+    @Test
+    void shouldSetForcePathStyleAccess() {
+      assertThat(brokerCfg.getData().getBackup().getS3().isForcePathStyleAccess()).isTrue();
+    }
+
+    @Test
+    void shouldSetCompression() {
+      assertThat(brokerCfg.getData().getBackup().getS3().getCompression())
+          .isEqualTo("compressionNew");
+    }
+
+    @Test
+    void shouldSetMaxConcurrentConnection() {
+      assertThat(brokerCfg.getData().getBackup().getS3().getMaxConcurrentConnections())
+          .isEqualTo(100);
+    }
+
+    @Test
+    void shouldSetConnectionAcquisitionTimeout() {
+      assertThat(brokerCfg.getData().getBackup().getS3().getConnectionAcquisitionTimeout())
+          .isEqualTo(Duration.ofSeconds(90));
+    }
+
+    @Test
+    void shouldSetBasePath() {
+      assertThat(brokerCfg.getData().getBackup().getS3().getBasePath()).isEqualTo("basePathNew");
+    }
+
+    @Test
+    void shouldSetSupportLegacyMd5() {
+      assertThat(brokerCfg.getData().getBackup().getS3().isSupportLegacyMd5()).isTrue();
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "zeebe.broker.data.backup.s3.bucketName=bucketNameLegacy",
+        "zeebe.broker.data.backup.s3.endpoint=endpointLegacy",
+        "zeebe.broker.data.backup.s3.region=regionLegacy",
+        "zeebe.broker.data.backup.s3.accessKey=accessKeyLegacy",
+        "zeebe.broker.data.backup.s3.secretKey=secretKeyLegacy",
+        "zeebe.broker.data.backup.s3.apiCallTimeout=360s",
+        "zeebe.broker.data.backup.s3.forcePathStyleAccess=true",
+        "zeebe.broker.data.backup.s3.compression=compressionLegacy",
+        "zeebe.broker.data.backup.s3.maxConcurrentConnections=100",
+        "zeebe.broker.data.backup.s3.connectionAcquisitionTimeout=90s",
+        "zeebe.broker.data.backup.s3.basePath=basePathLegacy",
+        "zeebe.broker.data.backup.s3.supportLegacyMd5=true",
+      })
+  class WithOnlyLegacySet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithOnlyLegacySet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldSetBucketName() {
+      assertThat(brokerCfg.getData().getBackup().getS3().getBucketName())
+          .isEqualTo("bucketNameLegacy");
+    }
+
+    @Test
+    void shouldSetEndpoint() {
+      assertThat(brokerCfg.getData().getBackup().getS3().getEndpoint()).isEqualTo("endpointLegacy");
+    }
+
+    @Test
+    void shouldSetRegion() {
+      assertThat(brokerCfg.getData().getBackup().getS3().getRegion()).isEqualTo("regionLegacy");
+    }
+
+    @Test
+    void shouldSetAccessKey() {
+      assertThat(brokerCfg.getData().getBackup().getS3().getAccessKey())
+          .isEqualTo("accessKeyLegacy");
+    }
+
+    @Test
+    void shouldSetSecretKey() {
+      assertThat(brokerCfg.getData().getBackup().getS3().getSecretKey())
+          .isEqualTo("secretKeyLegacy");
+    }
+
+    @Test
+    void shouldSetApiCallTimeout() {
+      assertThat(brokerCfg.getData().getBackup().getS3().getApiCallTimeout())
+          .isEqualTo(Duration.ofSeconds(360));
+    }
+
+    @Test
+    void shouldSetForcePathStyleAccess() {
+      assertThat(brokerCfg.getData().getBackup().getS3().isForcePathStyleAccess()).isTrue();
+    }
+
+    @Test
+    void shouldSetCompression() {
+      assertThat(brokerCfg.getData().getBackup().getS3().getCompression())
+          .isEqualTo("compressionLegacy");
+    }
+
+    @Test
+    void shouldSetMaxConcurrentConnection() {
+      assertThat(brokerCfg.getData().getBackup().getS3().getMaxConcurrentConnections())
+          .isEqualTo(100);
+    }
+
+    @Test
+    void shouldSetConnectionAcquisitionTimeout() {
+      assertThat(brokerCfg.getData().getBackup().getS3().getConnectionAcquisitionTimeout())
+          .isEqualTo(Duration.ofSeconds(90));
+    }
+
+    @Test
+    void shouldSetBasePath() {
+      assertThat(brokerCfg.getData().getBackup().getS3().getBasePath()).isEqualTo("basePathLegacy");
+    }
+
+    @Test
+    void shouldSetSupportLegacyMd5() {
+      assertThat(brokerCfg.getData().getBackup().getS3().isSupportLegacyMd5()).isTrue();
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        // new
+        "camunda.data.backup.s3.bucket-name=bucketNameNew",
+        "camunda.data.backup.s3.endpoint=endpointNew",
+        "camunda.data.backup.s3.region=regionNew",
+        "camunda.data.backup.s3.access-key=accessKeyNew",
+        "camunda.data.backup.s3.secret-key=secretKeyNew",
+        "camunda.data.backup.s3.api-call-timeout=360s",
+        "camunda.data.backup.s3.force-path-style-access=true",
+        "camunda.data.backup.s3.compression=compressionNew",
+        "camunda.data.backup.s3.max-concurrent-connections=100",
+        "camunda.data.backup.s3.connection-acquisition-timeout=90s",
+        "camunda.data.backup.s3.base-path=basePathNew",
+        "camunda.data.backup.s3.support-legacy-md5=true",
+        // legacy
+        "zeebe.broker.data.backup.s3.bucketName=bucketNameLegacy",
+        "zeebe.broker.data.backup.s3.endpoint=endpointLegacy",
+        "zeebe.broker.data.backup.s3.region=regionLegacy",
+        "zeebe.broker.data.backup.s3.accessKey=accessKeyLegacy",
+        "zeebe.broker.data.backup.s3.secretKey=secretKeyLegacy",
+        "zeebe.broker.data.backup.s3.apiCallTimeout=720s",
+        "zeebe.broker.data.backup.s3.forcePathStyleAccess=false",
+        "zeebe.broker.data.backup.s3.compression=compressionLegacy",
+        "zeebe.broker.data.backup.s3.maxConcurrentConnections=200",
+        "zeebe.broker.data.backup.s3.connectionAcquisitionTimeout=180s",
+        "zeebe.broker.data.backup.s3.basePath=basePathLegacy",
+        "zeebe.broker.data.backup.s3.supportLegacyMd5=false",
+      })
+  class WithNewAndLegacySet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithNewAndLegacySet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldSetBucketNameFromNew() {
+      assertThat(brokerCfg.getData().getBackup().getS3().getBucketName())
+          .isEqualTo("bucketNameNew");
+    }
+
+    @Test
+    void shouldSetEndpointFromNew() {
+      assertThat(brokerCfg.getData().getBackup().getS3().getEndpoint()).isEqualTo("endpointNew");
+    }
+
+    @Test
+    void shouldSetRegionFromNew() {
+      assertThat(brokerCfg.getData().getBackup().getS3().getRegion()).isEqualTo("regionNew");
+    }
+
+    @Test
+    void shouldSetAccessKeyFromNew() {
+      assertThat(brokerCfg.getData().getBackup().getS3().getAccessKey()).isEqualTo("accessKeyNew");
+    }
+
+    @Test
+    void shouldSetSecretKeyFromNew() {
+      assertThat(brokerCfg.getData().getBackup().getS3().getSecretKey()).isEqualTo("secretKeyNew");
+    }
+
+    @Test
+    void shouldSetApiCallTimeoutFromNew() {
+      assertThat(brokerCfg.getData().getBackup().getS3().getApiCallTimeout())
+          .isEqualTo(Duration.ofSeconds(360));
+    }
+
+    @Test
+    void shouldSetForcePathStyleAccessFromNew() {
+      assertThat(brokerCfg.getData().getBackup().getS3().isForcePathStyleAccess()).isTrue();
+    }
+
+    @Test
+    void shouldSetCompressionFromNew() {
+      assertThat(brokerCfg.getData().getBackup().getS3().getCompression())
+          .isEqualTo("compressionNew");
+    }
+
+    @Test
+    void shouldSetMaxConcurrentConnectionFromNew() {
+      assertThat(brokerCfg.getData().getBackup().getS3().getMaxConcurrentConnections())
+          .isEqualTo(100);
+    }
+
+    @Test
+    void shouldSetConnectionAcquisitionTimeoutFromNew() {
+      assertThat(brokerCfg.getData().getBackup().getS3().getConnectionAcquisitionTimeout())
+          .isEqualTo(Duration.ofSeconds(90));
+    }
+
+    @Test
+    void shouldSetBasePathFromNew() {
+      assertThat(brokerCfg.getData().getBackup().getS3().getBasePath()).isEqualTo("basePathNew");
+    }
+
+    @Test
+    void shouldSetSupportLegacyMd5FromNew() {
+      assertThat(brokerCfg.getData().getBackup().getS3().isSupportLegacyMd5()).isTrue();
+    }
+  }
+}


### PR DESCRIPTION
## Description

This PR adds the properties from section camunda.data.backup.s3 in unified config.

The legacy properties are:

zeebe.broker.data.backup.s3.bucketName
zeebe.broker.data.backup.s3.endpoint
zeebe.broker.data.backup.s3.region
zeebe.broker.data.backup.s3.accessKey
zeebe.broker.data.backup.s3.secretKey
zeebe.broker.data.backup.s3.apiCallTimeout
zeebe.broker.data.backup.s3.forcePathStyleAccess
zeebe.broker.data.backup.s3.compression
zeebe.broker.data.backup.s3.maxConcurrentConnections
zeebe.broker.data.backup.s3.connectionAcquisitionTimeout
zeebe.broker.data.backup.s3.basePath
zeebe.broker.data.backup.s3.supportLegacyMd5

The new properties are:

camunda.data.backup.s3.bucket-name
camunda.data.backup.s3.endpoint
camunda.data.backup.s3.region
camunda.data.backup.s3.access-key
camunda.data.backup.s3.secret-key
camunda.data.backup.s3.api-call-timeout
camunda.data.backup.s3.force-path-style-access
camunda.data.backup.s3.compression
camunda.data.backup.s3.max-concurrent-connections
camunda.data.backup.s3.connection-acquisition-timeout
camunda.data.backup.s3.base-path
camunda.data.backup.s3.support-legacy-md5

Backwards compatibility is supported for these properties. That means, if legacy is set and new property is not set, legacy value will be used.
## Checklist

- [x] The legacy properties and the backwards compatibility strategy are updated in [schema doc](https://docs.google.com/spreadsheets/d/1R4epsy6DWemA8_76cUE6zOGUFbrXCXlM2reXnKFuz7Y/edit?gid=818158292#gid=818158292)
- [x] The new property fields are documented in the code
## Related issues

related to #34912 


