### PR TITLE
feat: Collect results in an output collection for AdHocSubProcess

### DIFF
--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractAdHocSubProcessBuilder.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractAdHocSubProcessBuilder.java
@@ -73,6 +73,18 @@ public class AbstractAdHocSubProcessBuilder<B extends AbstractAdHocSubProcessBui
     return myself;
   }
 
+  public B zeebeOutputCollection(final String outputCollection) {
+    final ZeebeAdHoc adHoc = getCreateSingleExtensionElement(ZeebeAdHoc.class);
+    adHoc.setOutputCollection(outputCollection);
+    return myself;
+  }
+
+  public B zeebeOutputElementExpression(final String outputElementExpression) {
+    final ZeebeAdHoc adHoc = getCreateSingleExtensionElement(ZeebeAdHoc.class);
+    adHoc.setOutputElement(asZeebeExpression(outputElementExpression));
+    return myself;
+  }
+
   @Override
   public B zeebeJobType(final String type) {
     return jobWorkerPropertiesBuilder.zeebeJobType(type);

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/impl/instance/zeebe/ZeebeAdHocImpl.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/impl/instance/zeebe/ZeebeAdHocImpl.java
@@ -27,6 +27,8 @@ import org.camunda.bpm.model.xml.type.attribute.Attribute;
 public class ZeebeAdHocImpl extends BpmnModelElementInstanceImpl implements ZeebeAdHoc {
 
   private static Attribute<String> activeElementsCollectionAttribute;
+  private static Attribute<String> outputCollectionAttribute;
+  private static Attribute<String> outputElementAttribute;
 
   public ZeebeAdHocImpl(final ModelTypeInstanceContext instanceContext) {
     super(instanceContext);
@@ -45,6 +47,18 @@ public class ZeebeAdHocImpl extends BpmnModelElementInstanceImpl implements Zeeb
             .namespace(BpmnModelConstants.ZEEBE_NS)
             .build();
 
+    outputCollectionAttribute =
+        typeBuilder
+            .stringAttribute(ZeebeConstants.ATTRIBUTE_OUTPUT_COLLECTION)
+            .namespace(BpmnModelConstants.ZEEBE_NS)
+            .build();
+
+    outputElementAttribute =
+        typeBuilder
+            .stringAttribute(ZeebeConstants.ATTRIBUTE_OUTPUT_ELEMENT)
+            .namespace(BpmnModelConstants.ZEEBE_NS)
+            .build();
+
     typeBuilder.build();
   }
 
@@ -56,5 +70,25 @@ public class ZeebeAdHocImpl extends BpmnModelElementInstanceImpl implements Zeeb
   @Override
   public void setActiveElementsCollection(final String activeElementsCollection) {
     activeElementsCollectionAttribute.setValue(this, activeElementsCollection);
+  }
+
+  @Override
+  public String getOutputCollection() {
+    return outputCollectionAttribute.getValue(this);
+  }
+
+  @Override
+  public void setOutputCollection(final String outputCollection) {
+    outputCollectionAttribute.setValue(this, outputCollection);
+  }
+
+  @Override
+  public String getOutputElement() {
+    return outputElementAttribute.getValue(this);
+  }
+
+  @Override
+  public void setOutputElement(final String outputElement) {
+    outputElementAttribute.setValue(this, outputElement);
   }
 }

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeAdHoc.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeAdHoc.java
@@ -34,18 +34,6 @@ public interface ZeebeAdHoc extends BpmnModelElementInstance {
   void setActiveElementsCollection(final String activateElements);
 
   /**
-   * @return the implementation type of the ad-hoc sub-process
-   */
-  ZeebeAdHocImplementationType getImplementationType();
-
-  /**
-   * Sets the implementation type of the ad-hoc sub-process.
-   *
-   * @param implementationType the implementation type
-   */
-  void setImplementationType(ZeebeAdHocImplementationType implementationType);
-
-  /**
    * @return the variable name of the output collection
    */
   String getOutputCollection();

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeAdHoc.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeAdHoc.java
@@ -32,4 +32,41 @@ public interface ZeebeAdHoc extends BpmnModelElementInstance {
    * @param activateElements the collection of element to be activated
    */
   void setActiveElementsCollection(final String activateElements);
+
+  /**
+   * @return the implementation type of the ad-hoc sub-process
+   */
+  ZeebeAdHocImplementationType getImplementationType();
+
+  /**
+   * Sets the implementation type of the ad-hoc sub-process.
+   *
+   * @param implementationType the implementation type
+   */
+  void setImplementationType(ZeebeAdHocImplementationType implementationType);
+
+  /**
+   * @return the variable name of the output collection
+   */
+  String getOutputCollection();
+
+  /**
+   * Sets the variable name of the output collection used to collect outputs of the element
+   * activation
+   *
+   * @param outputCollection the variable name of the output collection
+   */
+  void setOutputCollection(String outputCollection);
+
+  /**
+   * @return the output element expression
+   */
+  String getOutputElement();
+
+  /**
+   * Sets the output element expression.
+   *
+   * @param outputElement the output element expression
+   */
+  void setOutputElement(String outputElement);
 }

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/AdHocSubProcessValidator.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/AdHocSubProcessValidator.java
@@ -39,6 +39,7 @@ public final class AdHocSubProcessValidator implements ModelElementValidator<AdH
       final ValidationResultCollector validationResultCollector) {
     IdentifiableBpmnElementValidator.validate(adHocSubProcess, validationResultCollector);
     validateTaskDefinition(adHocSubProcess, validationResultCollector);
+    validationOutputCollectionAndOutputElement(adHocSubProcess, validationResultCollector);
 
     final Collection<FlowElement> flowElements = adHocSubProcess.getFlowElements();
 
@@ -94,6 +95,36 @@ public final class AdHocSubProcessValidator implements ModelElementValidator<AdH
                     "Must not define activeElementsCollection in combination with zeebe:taskDefinition.");
               }
             });
+  }
+
+  private static void validationOutputCollectionAndOutputElement(
+      final AdHocSubProcess adHocSubProcess,
+      final ValidationResultCollector validationResultCollector) {
+
+    final ExtensionElements extensionElements = adHocSubProcess.getExtensionElements();
+    if (extensionElements == null) {
+      return;
+    }
+
+    extensionElements
+        .getChildElementsByType(ZeebeAdHoc.class)
+        .forEach(
+            adhoc -> {
+              final boolean outputElementEmpty = nullOrEmpty(adhoc.getOutputElement());
+              final boolean outputCollectionEmpty = nullOrEmpty(adhoc.getOutputCollection());
+
+              if (outputElementEmpty != outputCollectionEmpty) {
+                validationResultCollector.addError(
+                    0,
+                    String.format(
+                        "OutputElement and OutputCollection must both be set, or neither of them set. outputElement:%s and outputCollection:%s.",
+                        adhoc.getOutputElement(), adhoc.getOutputCollection()));
+              }
+            });
+  }
+
+  private static boolean nullOrEmpty(final String str) {
+    return str == null || str.isEmpty();
   }
 
   private static boolean hasStartEvent(final Collection<FlowElement> flowElements) {

--- a/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/builder/AdHocSubProcessBuilderTest.java
+++ b/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/builder/AdHocSubProcessBuilderTest.java
@@ -256,7 +256,7 @@ class AdHocSubProcessBuilderTest {
   @Test
   void shouldSetOutputCollectionAndElement() {
     // given
-    final String outputExpression = "result";
+    final String outputElementExpression = "result";
     final String outputCollection = "results";
 
     final BpmnModelInstance process =
@@ -264,7 +264,7 @@ class AdHocSubProcessBuilderTest {
             .startEvent()
             .adHocSubProcess("ad-hoc", adHocSubProcess -> adHocSubProcess.task("A"))
             .zeebeOutputCollection(outputCollection)
-            .zeebeOutputElementExpression(outputExpression)
+            .zeebeOutputElementExpression(outputElementExpression)
             .endEvent()
             .done();
 
@@ -278,13 +278,7 @@ class AdHocSubProcessBuilderTest {
     assertThat(extensionElements.getChildElementsByType(ZeebeAdHoc.class))
         .hasSize(1)
         .first()
-        .extracting(ZeebeAdHoc::getOutputElement)
-        .isEqualTo("=" + outputExpression);
-
-    assertThat(extensionElements.getChildElementsByType(ZeebeAdHoc.class))
-        .hasSize(1)
-        .first()
-        .extracting(ZeebeAdHoc::getOutputCollection)
-        .isEqualTo(outputCollection);
+        .extracting(ZeebeAdHoc::getOutputElement, ZeebeAdHoc::getOutputCollection)
+        .containsExactly("=" + outputElementExpression, outputCollection);
   }
 }

--- a/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/builder/AdHocSubProcessBuilderTest.java
+++ b/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/builder/AdHocSubProcessBuilderTest.java
@@ -252,4 +252,39 @@ class AdHocSubProcessBuilderTest {
                     .containsExactly(
                         tuple("headerKey1", "headerValue1"), tuple("headerKey2", "headerValue2")));
   }
+
+  @Test
+  void shouldSetOutputCollectionAndElement() {
+    // given
+    final String outputExpression = "result";
+    final String outputCollection = "results";
+
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .adHocSubProcess("ad-hoc", adHocSubProcess -> adHocSubProcess.task("A"))
+            .zeebeOutputCollection(outputCollection)
+            .zeebeOutputElementExpression(outputExpression)
+            .endEvent()
+            .done();
+
+    // when/then
+    final ModelElementInstance adHocSubProcess = process.getModelElementById("ad-hoc");
+
+    final ExtensionElements extensionElements =
+        (ExtensionElements) adHocSubProcess.getUniqueChildElementByType(ExtensionElements.class);
+    assertThat(extensionElements).isNotNull();
+
+    assertThat(extensionElements.getChildElementsByType(ZeebeAdHoc.class))
+        .hasSize(1)
+        .first()
+        .extracting(ZeebeAdHoc::getOutputElement)
+        .isEqualTo("=" + outputExpression);
+
+    assertThat(extensionElements.getChildElementsByType(ZeebeAdHoc.class))
+        .hasSize(1)
+        .first()
+        .extracting(ZeebeAdHoc::getOutputCollection)
+        .isEqualTo(outputCollection);
+  }
 }

--- a/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/AdHocSubProcessValidatorTest.java
+++ b/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/AdHocSubProcessValidatorTest.java
@@ -233,4 +233,58 @@ class AdHocSubProcessValidatorTest {
         .endEvent()
         .done();
   }
+
+  @Test
+  void withMissingOutputElement() {
+    // when
+    final BpmnModelInstance outputElementDoesntExist =
+        process(adHocSubProcess -> adHocSubProcess.zeebeOutputCollection("collection").task("A"));
+
+    // then
+    ProcessValidationUtil.assertThatProcessHasViolations(
+        outputElementDoesntExist,
+        expect(
+            AdHocSubProcess.class,
+            "OutputElement and OutputCollection must both be set, or neither of them set. outputElement:null and outputCollection:collection."));
+  }
+
+  @Test
+  void withMissingOutputCollection() {
+    // when
+    final BpmnModelInstance outputCollectionDoesntExist =
+        process(
+            adHocSubProcess -> adHocSubProcess.zeebeOutputElementExpression("element").task("A"));
+
+    // then
+    ProcessValidationUtil.assertThatProcessHasViolations(
+        outputCollectionDoesntExist,
+        expect(
+            AdHocSubProcess.class,
+            "OutputElement and OutputCollection must both be set, or neither of them set. outputElement:=element and outputCollection:null."));
+  }
+
+  @Test
+  void withOutputElementAndCollection() {
+    // when
+    final BpmnModelInstance bothOutputElementOrOutputCollectionExist =
+        process(
+            adHocSubProcess ->
+                adHocSubProcess
+                    .zeebeOutputElementExpression("element")
+                    .zeebeOutputCollection("collection")
+                    .task("A"));
+
+    // then
+    ProcessValidationUtil.assertThatProcessIsValid(bothOutputElementOrOutputCollectionExist);
+  }
+
+  @Test
+  void withNeitherOutputElementOrCollection() {
+    // when
+    final BpmnModelInstance neitherOutputElementOrOutputCollectionExist =
+        process(adHocSubProcess -> adHocSubProcess.task("A"));
+
+    // then
+    ProcessValidationUtil.assertThatProcessIsValid(neitherOutputElementOrOutputCollectionExist);
+  }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/AdHocSubProcessOutputCollectionBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/AdHocSubProcessOutputCollectionBehavior.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.bpmn.behavior;
+
+import io.camunda.zeebe.engine.processing.common.Failure;
+import io.camunda.zeebe.msgpack.spec.MsgPackReader;
+import io.camunda.zeebe.msgpack.spec.MsgPackType;
+import io.camunda.zeebe.msgpack.spec.MsgPackWriter;
+import io.camunda.zeebe.util.Either;
+import org.agrona.DirectBuffer;
+import org.agrona.ExpandableArrayBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
+
+public class AdHocSubProcessOutputCollectionBehavior {
+  private final MsgPackReader outputCollectionReader = new MsgPackReader();
+  private final MsgPackWriter outputCollectionWriter = new MsgPackWriter();
+  private final ExpandableArrayBuffer outputCollectionBuffer = new ExpandableArrayBuffer();
+  private final DirectBuffer updatedOutputCollectionBuffer = new UnsafeBuffer(0, 0);
+
+  public Either<Failure, DirectBuffer> appendToOutputCollection(
+      final DirectBuffer outputCollection, final DirectBuffer newValue) {
+
+    // read output collection
+    outputCollectionReader.wrap(outputCollection, 0, outputCollection.capacity());
+    final var token = outputCollectionReader.readToken();
+    if (token.getType() != MsgPackType.ARRAY) {
+      return Either.left(
+          new Failure(
+              "The output collection has the wrong type. Expected %s but was %s."
+                  .formatted(MsgPackType.ARRAY, token.getType())));
+    }
+    final int currentSize = token.getSize();
+    final int valuesOffset = outputCollectionReader.getOffset();
+
+    // write updated output collection
+    outputCollectionWriter.wrap(outputCollectionBuffer, 0);
+    outputCollectionWriter.writeArrayHeader(currentSize + 1);
+    // add current values
+    outputCollectionWriter.writeRaw(
+        outputCollection, valuesOffset, outputCollection.capacity() - valuesOffset);
+    // add new value
+    outputCollectionWriter.writeRaw(newValue);
+
+    final var length = outputCollectionWriter.getOffset();
+    updatedOutputCollectionBuffer.wrap(outputCollectionBuffer, 0, length);
+
+    return Either.right(updatedOutputCollectionBuffer);
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnAdHocSubProcessBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnAdHocSubProcessBehavior.java
@@ -65,8 +65,7 @@ public final class BpmnAdHocSubProcessBehavior {
       final String elementIdToActivate,
       final DirectBuffer variablesBuffer) {
 
-    final long adHocSubProcessInnerInstanceKey =
-        createInnerInstance(context, adHocSubProcess, variablesBuffer.capacity());
+    final long adHocSubProcessInnerInstanceKey = createInnerInstance(context, adHocSubProcess);
 
     if (variablesBuffer != NO_VARIABLES && variablesBuffer.capacity() > 0) {
       // set local variable in the scope of the inner instance
@@ -87,8 +86,7 @@ public final class BpmnAdHocSubProcessBehavior {
 
   private long createInnerInstance(
       final BpmnElementContext adHocSubProcessContext,
-      final ExecutableAdHocSubProcess adHocSubProcess,
-      final int variablesBufferSize) {
+      final ExecutableAdHocSubProcess adHocSubProcess) {
     final var adHocSubProcessElementInstanceKey = adHocSubProcessContext.getElementInstanceKey();
 
     final var innerInstanceKey = keyGenerator.nextKey();
@@ -127,7 +125,7 @@ public final class BpmnAdHocSubProcessBehavior {
                     variableName,
                     new UnsafeBuffer(MsgPackHelper.NIL),
                     0,
-                    variablesBufferSize));
+                    MsgPackHelper.NIL.length));
 
     return innerInstanceKey;
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnAdHocSubProcessBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnAdHocSubProcessBehavior.java
@@ -120,7 +120,7 @@ public final class BpmnAdHocSubProcessBehavior {
                     innerInstanceKey,
                     innerInstanceRecord.getProcessDefinitionKey(),
                     innerInstanceRecord.getProcessInstanceKey(),
-                    BufferUtil.wrapString(innerInstanceRecord.getBpmnProcessId()),
+                    innerInstanceRecord.getBpmnProcessIdBuffer(),
                     innerInstanceRecord.getTenantId(),
                     variableName,
                     new UnsafeBuffer(MsgPackHelper.NIL),

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/AdHocSubProcessProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/AdHocSubProcessProcessor.java
@@ -62,7 +62,8 @@ public class AdHocSubProcessProcessor
               Map.ofEntries(
                   Map.entry(ZeebeAdHocImplementationType.BPMN, new BpmnBehavior()),
                   Map.entry(ZeebeAdHocImplementationType.JOB_WORKER, new JobWorkerBehavior())));
-  private final AdHocSubProcessOutputCollectionBehavior adHocSubProcessOutputCollectionBehavior = new AdHocSubProcessOutputCollectionBehavior();
+  private final AdHocSubProcessOutputCollectionBehavior adHocSubProcessOutputCollectionBehavior =
+      new AdHocSubProcessOutputCollectionBehavior();
 
   public AdHocSubProcessProcessor(
       final BpmnBehaviors bpmnBehaviors,
@@ -288,7 +289,15 @@ public class AdHocSubProcessProcessor
       final BpmnElementContext adHocSubProcessContext,
       final BpmnElementContext childContext) {
 
-    final Expression outputElementExpression = adHocSubProcess.getOutputElement().orElseThrow();
+    final var outputElementOptional = adHocSubProcess.getOutputElement();
+    if (outputElementOptional.isEmpty()) {
+      return Either.left(
+          new Failure(
+              "Expected an expression for the output element of the ad-hoc sub-process, but none was provided.",
+              ErrorType.EXTRACT_VALUE_ERROR));
+    }
+
+    final Expression outputElementExpression = outputElementOptional.get();
     return expressionProcessor
         .evaluateAnyExpression(outputElementExpression, childContext.getElementInstanceKey())
         .flatMap(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/AdHocSubProcessProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/AdHocSubProcessProcessor.java
@@ -332,7 +332,7 @@ public class AdHocSubProcessProcessor
       if (token.getType() != MsgPackType.ARRAY) {
         return Either.left(
             new Failure(
-                "The output collection has the wrong type. Expect %s but was %s."
+                "The output collection has the wrong type. Expected %s but was %s."
                     .formatted(MsgPackType.ARRAY, token.getType())));
       }
       final int currentSize = token.getSize();

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/AdHocSubProcessProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/AdHocSubProcessProcessor.java
@@ -291,24 +291,14 @@ public class AdHocSubProcessProcessor
     final Expression outputElementExpression = adHocSubProcess.getOutputElement().orElseThrow();
     return expressionProcessor
         .evaluateAnyExpression(outputElementExpression, childContext.getElementInstanceKey())
-        .mapLeft(
-            failure -> {
-              incidentBehavior.createIncident(failure, adHocSubProcessContext);
-              return new Failure(failure.getMessage(), ErrorType.EXTRACT_VALUE_ERROR);
-            })
         .flatMap(
             outputElementValue -> {
               final DirectBuffer outputCollectionValue =
                   stateBehavior.getLocalVariable(
                       adHocSubProcessContext, outputCollectionVariableName);
 
-              return outputCollectionUpdater
-                  .appendToOutputCollection(outputCollectionValue, outputElementValue)
-                  .mapLeft(
-                      failure -> {
-                        incidentBehavior.createIncident(failure, adHocSubProcessContext);
-                        return new Failure(failure.getMessage(), ErrorType.EXTRACT_VALUE_ERROR);
-                      });
+              return outputCollectionUpdater.appendToOutputCollection(
+                  outputCollectionValue, outputElementValue);
             })
         .thenDo(
             updatedCollection ->

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/AdHocSubProcessProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/AdHocSubProcessProcessor.java
@@ -62,7 +62,7 @@ public class AdHocSubProcessProcessor
               Map.ofEntries(
                   Map.entry(ZeebeAdHocImplementationType.BPMN, new BpmnBehavior()),
                   Map.entry(ZeebeAdHocImplementationType.JOB_WORKER, new JobWorkerBehavior())));
-  private final OutputCollectionUpdater outputCollectionUpdater = new OutputCollectionUpdater();
+  private final AdHocSubProcessOutputCollectionBehavior adHocSubProcessOutputCollectionBehavior = new AdHocSubProcessOutputCollectionBehavior();
 
   public AdHocSubProcessProcessor(
       final BpmnBehaviors bpmnBehaviors,
@@ -297,7 +297,7 @@ public class AdHocSubProcessProcessor
                   stateBehavior.getLocalVariable(
                       adHocSubProcessContext, outputCollectionVariableName);
 
-              return outputCollectionUpdater.appendToOutputCollection(
+              return adHocSubProcessOutputCollectionBehavior.appendToOutputCollection(
                   outputCollectionValue, outputElementValue);
             })
         .thenDo(
@@ -306,7 +306,7 @@ public class AdHocSubProcessProcessor
                     adHocSubProcessContext, outputCollectionVariableName, updatedCollection));
   }
 
-  private static final class OutputCollectionUpdater {
+  private static final class AdHocSubProcessOutputCollectionBehavior {
 
     private final MsgPackReader outputCollectionReader = new MsgPackReader();
     private final MsgPackWriter outputCollectionWriter = new MsgPackWriter();

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableAdHocSubProcess.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableAdHocSubProcess.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeAdHocImplementationType;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import org.agrona.DirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
 
@@ -26,6 +27,9 @@ public class ExecutableAdHocSubProcess extends ExecutableFlowElementContainer
   private boolean cancelRemainingInstances;
   private ZeebeAdHocImplementationType implementationType;
   private JobWorkerProperties jobWorkerProperties;
+
+  private Optional<DirectBuffer> outputCollection = Optional.empty();
+  private Optional<Expression> outputElement = Optional.empty();
 
   private final Map<String, ExecutableFlowNode> adHocActivitiesById = new HashMap<>();
   private final DirectBuffer adHocActivitiesMetadata = new UnsafeBuffer();
@@ -96,5 +100,21 @@ public class ExecutableAdHocSubProcess extends ExecutableFlowElementContainer
 
   public void setAdHocActivitiesMetadata(final DirectBuffer activitiesMetadata) {
     adHocActivitiesMetadata.wrap(activitiesMetadata);
+  }
+
+  public Optional<DirectBuffer> getOutputCollection() {
+    return outputCollection;
+  }
+
+  public void setOutputCollection(final DirectBuffer outputCollection) {
+    this.outputCollection = Optional.of(outputCollection);
+  }
+
+  public Optional<Expression> getOutputElement() {
+    return outputElement;
+  }
+
+  public void setOutputElement(final Expression outputElement) {
+    this.outputElement = Optional.of(outputElement);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/AdHocSubProcessTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/AdHocSubProcessTransformer.java
@@ -72,6 +72,7 @@ public final class AdHocSubProcessTransformer implements ModelElementTransformer
     setInnerInstance(executableAdHocSubProcess, childElements, process);
     setJobWorkerProperties(executableAdHocSubProcess, context, element);
     setAdHocActivitiesMetadata(executableAdHocSubProcess);
+    setOutputCollectionAndElement(executableAdHocSubProcess, element, context);
   }
 
   private static void setActiveElementsCollection(
@@ -200,6 +201,23 @@ public final class AdHocSubProcessTransformer implements ModelElementTransformer
         parameter.type(),
         parameter.schema(),
         parameter.options());
+  }
+
+  private void setOutputCollectionAndElement(
+      final ExecutableAdHocSubProcess executableAdHocSubProcess,
+      final AdHocSubProcess element,
+      final TransformContext context) {
+    Optional.ofNullable(element.getSingleExtensionElement(ZeebeAdHoc.class))
+        .map(ZeebeAdHoc::getOutputCollection)
+        .filter(e -> !e.isEmpty())
+        .map(BufferUtil::wrapString)
+        .ifPresent(executableAdHocSubProcess::setOutputCollection);
+
+    Optional.ofNullable(element.getSingleExtensionElement(ZeebeAdHoc.class))
+        .map(ZeebeAdHoc::getOutputElement)
+        .filter(e -> !e.isEmpty())
+        .map(e -> context.getExpressionLanguage().parseExpression(e))
+        .ifPresent(executableAdHocSubProcess::setOutputElement);
   }
 
   /**

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeRuntimeValidators.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeRuntimeValidators.java
@@ -207,6 +207,8 @@ public final class ZeebeRuntimeValidators {
             .hasValidExpression(
                 ZeebeAdHoc::getActiveElementsCollection,
                 expression -> expression.isOptional().isNonStatic())
+            .hasValidExpression(
+                ZeebeAdHoc::getOutputElement, expression -> expression.isNonStatic().isOptional())
             .build(expressionLanguage));
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/AdHocSubProcessTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/AdHocSubProcessTest.java
@@ -1025,9 +1025,7 @@ public final class AdHocSubProcessTest {
   @Test
   public void shouldCreateOutputCollectionInAHSPScope() {
     // given
-    final BpmnModelInstance process = createOutputCollectionBPMN();
-
-    ENGINE.deployment().withXmlResource(process).deploy();
+    createOutputCollectionProcessAndDeploy();
 
     final long processInstanceKey = getProcessInstanceKeyForOutputCollectionTest();
 
@@ -1052,9 +1050,7 @@ public final class AdHocSubProcessTest {
   @Test
   public void shouldCreateOutputElementsInInnerInstanceScope() {
     // given
-    final BpmnModelInstance process = createOutputCollectionBPMN();
-
-    ENGINE.deployment().withXmlResource(process).deploy();
+    createOutputCollectionProcessAndDeploy();
 
     final long processInstanceKey = getProcessInstanceKeyForOutputCollectionTest();
 
@@ -1094,25 +1090,25 @@ public final class AdHocSubProcessTest {
         .create();
   }
 
-  private BpmnModelInstance createOutputCollectionBPMN() {
-    return process(
-        adHocSubProcess -> {
-          adHocSubProcess
-              .zeebeActiveElementsCollectionExpression("activateElements")
-              .zeebeOutputCollection("results")
-              .zeebeOutputElementExpression("result");
-          adHocSubProcess.serviceTask("A", t -> t.zeebeJobType("A"));
-          adHocSubProcess.serviceTask("B", t -> t.zeebeJobType("B"));
-          adHocSubProcess.task("C");
-        });
+  private void createOutputCollectionProcessAndDeploy() {
+    final var process =
+        process(
+            adHocSubProcess -> {
+              adHocSubProcess
+                  .zeebeActiveElementsCollectionExpression("activateElements")
+                  .zeebeOutputCollection("results")
+                  .zeebeOutputElementExpression("result");
+              adHocSubProcess.serviceTask("A", t -> t.zeebeJobType("A"));
+              adHocSubProcess.serviceTask("B", t -> t.zeebeJobType("B"));
+              adHocSubProcess.task("C");
+            });
+    ENGINE.deployment().withXmlResource(process).deploy();
   }
 
   @Test
   public void shouldUpdateOutputElementsInInnerInstanceScope() {
     // given
-    final BpmnModelInstance process = createOutputCollectionBPMN();
-
-    ENGINE.deployment().withXmlResource(process).deploy();
+    createOutputCollectionProcessAndDeploy();
 
     final long processInstanceKey = getProcessInstanceKeyForOutputCollectionTest();
 
@@ -1153,9 +1149,7 @@ public final class AdHocSubProcessTest {
   @Test
   public void shouldAppendOutputCollection() {
     // given
-    final BpmnModelInstance process = createOutputCollectionBPMN();
-
-    ENGINE.deployment().withXmlResource(process).deploy();
+    createOutputCollectionProcessAndDeploy();
 
     final long processInstanceKey = getProcessInstanceKeyForOutputCollectionTest();
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/AdHocSubProcessTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/AdHocSubProcessTest.java
@@ -1073,38 +1073,6 @@ public final class AdHocSubProcessTest {
             tuple("result", "null", innerInstanceKeys.get(1)));
   }
 
-  private List<Long> getInnerInstanceKeysForOutputCollectionTest(final long processInstanceKey) {
-    return RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
-        .withProcessInstanceKey(processInstanceKey)
-        .withElementType(BpmnElementType.AD_HOC_SUB_PROCESS_INNER_INSTANCE)
-        .limit(2)
-        .map(Record::getKey)
-        .toList();
-  }
-
-  private long getProcessInstanceKeyForOutputCollectionTest() {
-    return ENGINE
-        .processInstance()
-        .ofBpmnProcessId(PROCESS_ID)
-        .withVariable("activateElements", List.of("A", "B"))
-        .create();
-  }
-
-  private void createOutputCollectionProcessAndDeploy() {
-    final var process =
-        process(
-            adHocSubProcess -> {
-              adHocSubProcess
-                  .zeebeActiveElementsCollectionExpression("activateElements")
-                  .zeebeOutputCollection("results")
-                  .zeebeOutputElementExpression("result");
-              adHocSubProcess.serviceTask("A", t -> t.zeebeJobType("A"));
-              adHocSubProcess.serviceTask("B", t -> t.zeebeJobType("B"));
-              adHocSubProcess.task("C");
-            });
-    ENGINE.deployment().withXmlResource(process).deploy();
-  }
-
   @Test
   public void shouldUpdateOutputElementsInInnerInstanceScope() {
     // given
@@ -1195,5 +1163,37 @@ public final class AdHocSubProcessTest {
     return r ->
         r.getIntent() == SignalIntent.BROADCASTED
             && ((SignalRecord) r.getValue()).getSignalName().equals(signalName);
+  }
+
+  private List<Long> getInnerInstanceKeysForOutputCollectionTest(final long processInstanceKey) {
+    return RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementType(BpmnElementType.AD_HOC_SUB_PROCESS_INNER_INSTANCE)
+        .limit(2)
+        .map(Record::getKey)
+        .toList();
+  }
+
+  private long getProcessInstanceKeyForOutputCollectionTest() {
+    return ENGINE
+        .processInstance()
+        .ofBpmnProcessId(PROCESS_ID)
+        .withVariable("activateElements", List.of("A", "B"))
+        .create();
+  }
+
+  private void createOutputCollectionProcessAndDeploy() {
+    final var process =
+        process(
+            adHocSubProcess -> {
+              adHocSubProcess
+                  .zeebeActiveElementsCollectionExpression("activateElements")
+                  .zeebeOutputCollection("results")
+                  .zeebeOutputElementExpression("result");
+              adHocSubProcess.serviceTask("A", t -> t.zeebeJobType("A"));
+              adHocSubProcess.serviceTask("B", t -> t.zeebeJobType("B"));
+              adHocSubProcess.task("C");
+            });
+    ENGINE.deployment().withXmlResource(process).deploy();
   }
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Create output collection for AHSP (Ad Hoc Sub Process) and Output Element

- The two properties were added to `ZeebeAdHocImpl/ZeebeAdHoc`, and `ExecutableAdHocSubProcess`
- Added processing and seeting for the new fields to `AbstractAdHocSubProcessBuilder`, `AdHocSubProcessTransformer`, and `AdHocSubProcessProcessor`
- Validation for the fiews added to `AdHocSubProcessValidator` and `ZeebeRuntimeValidators`
- Tests added to `AdHocSubProcessBuilderTest`, `AdHocSubProcessValidatorTest`, and `AdHocSubProcessTest`

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes https://github.com/camunda/ad-hoc-sub-process-phase-3/issues/14
