### PR TITLE
test: fix flaky backup restore tests

### DIFF
--- a/tasklist/qa/backup-restore-tests/src/test/java/io/camunda/tasklist/qa/backup/TasklistAPICaller.java
+++ b/tasklist/qa/backup-restore-tests/src/test/java/io/camunda/tasklist/qa/backup/TasklistAPICaller.java
@@ -70,7 +70,8 @@ public class TasklistAPICaller {
     final URI url = statefulRestTemplate.getURL("/v1/tasks/search");
     return Arrays.asList(
         statefulRestTemplate
-            .postForEntity(url, new TaskSearchRequest(), TaskSearchResponse[].class)
+            .postForEntity(
+                url, new TaskSearchRequest().setPageSize(10_000), TaskSearchResponse[].class)
             .getBody());
   }
 

--- a/tasklist/qa/backup-restore-tests/src/test/java/io/camunda/tasklist/qa/backup/generator/AbstractBackupRestoreDataGenerator.java
+++ b/tasklist/qa/backup-restore-tests/src/test/java/io/camunda/tasklist/qa/backup/generator/AbstractBackupRestoreDataGenerator.java
@@ -18,7 +18,6 @@ import io.camunda.tasklist.util.ThreadUtil;
 import io.camunda.tasklist.webapp.api.rest.v1.entities.SaveVariablesRequest;
 import io.camunda.tasklist.webapp.dto.VariableInputDTO;
 import io.camunda.webapps.schema.descriptors.template.DraftTaskVariableTemplate;
-import io.camunda.webapps.schema.descriptors.template.TaskTemplate;
 import io.camunda.webapps.schema.entities.usertask.TaskState;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
@@ -187,16 +186,15 @@ public abstract class AbstractBackupRestoreDataGenerator implements BackupRestor
 
   private void waitUntilAllDataAreImported() throws IOException {
     LOGGER.info("Wait till data is imported.");
-    long loadedProcessInstances = 0;
+    int loadedUserTasks = 0;
     int count = 0;
     final int maxWait = 101;
-    while (PROCESS_INSTANCE_COUNT > loadedProcessInstances && count < maxWait) {
+    while (PROCESS_INSTANCE_COUNT > loadedUserTasks && count < maxWait) {
       count++;
-      loadedProcessInstances = countEntitiesFor(TaskTemplate.INDEX_NAME);
+      loadedUserTasks = tasklistAPICaller.getAllTasks().size();
       LOGGER.info(
-          "Imported '{}' process instances of '{}'",
-          loadedProcessInstances,
-          PROCESS_INSTANCE_COUNT);
+          "Imported '{}' process instances of '{}'", loadedUserTasks, PROCESS_INSTANCE_COUNT);
+      assertThat(loadedUserTasks).isLessThanOrEqualTo(PROCESS_INSTANCE_COUNT);
       ThreadUtil.sleepFor(1000L);
     }
     if (count == maxWait) {


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
the test was checking in database if the number of documents in task index is equal or higher the expected number of PIs (we have one user task per PI)
however, in 8.8, we don't have only user task documents in task index, we do have also variables and other objects, so `waitUntilAllDataAreImported` completes even before the expected number of tasks is reached

here I fix it to check the actual number of tasks with an API call , instead of checking the number of documents in DB 

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes https://github.com/camunda/camunda/issues/36436
