### PR TITLE
Fix Operate version in 8.6 CI smoke test

### DIFF
--- a/.github/workflows/optimize-deploy-artifacts.yml
+++ b/.github/workflows/optimize-deploy-artifacts.yml
@@ -84,6 +84,7 @@ jobs:
         ELASTIC_VERSION: ${{ steps.pom-info.outputs.x_elasticsearch_test_version }}
         ZEEBE_VERSION: ${{ steps.pom-info.outputs.x_zeebe_version }}
         IDENTITY_VERSION: ${{ steps.pom-info.outputs.x_identity_version }}
+        OPERATE_VERSION: ${{ steps.pom-info.outputs.x_zeebe_version }}
 
     - name: Wait for Optimize to start
       run: ./.github/optimize/scripts/wait-for.sh http://localhost:8090/ready


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
This PR fixes a CI failure when merging the release branch back into the stable 8.6 branch. The failure was caused by the Optimize Deployment Artifacts CI workflow, which runs a smoke test using an incorrect version of Operate — it defaulted to the latest version instead of the one aligned with the Zeebe version used for the release.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
