### PR TITLE
test: add Identity OIDC flow tests

### DIFF
--- a/authentication/pom.xml
+++ b/authentication/pom.xml
@@ -227,6 +227,16 @@
       <artifactId>camunda-spring-utils</artifactId>
       <scope>compile</scope>
     </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.github.dasniko</groupId>
+      <artifactId>testcontainers-keycloak</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/authentication/src/test/java/io/camunda/authentication/OidcFlowTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/OidcFlowTest.java
@@ -1,0 +1,244 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication;
+
+import static io.camunda.authentication.config.controllers.TestApiController.*;
+import static io.camunda.authentication.config.controllers.TestApiController.DUMMY_UNPROTECTED_ENDPOINT;
+import static io.camunda.authentication.config.controllers.TestApiController.DUMMY_V2_API_ENDPOINT;
+import static java.net.http.HttpClient.newHttpClient;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dasniko.testcontainers.keycloak.KeycloakContainer;
+import io.camunda.authentication.config.WebSecurityConfig;
+import io.camunda.authentication.config.controllers.OidcFlowTestContext;
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureWebMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.assertj.MockMvcTester;
+import org.springframework.test.web.servlet.assertj.MvcTestResult;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@SuppressWarnings({"SpringBootApplicationProperties", "WrongPropertyKeyValueDelimiter"})
+@AutoConfigureMockMvc
+@AutoConfigureWebMvc
+@SpringBootTest(
+    classes = {
+      OidcFlowTestContext.class,
+      WebSecurityConfig.class,
+    },
+    properties = {
+      "camunda.security.authentication.unprotected-api=false",
+      "camunda.security.authentication.method=oidc",
+      "camunda.security.authentication.oidc.client-id=" + OidcFlowTest.CLIENT_ID,
+      "camunda.security.authentication.oidc.client-secret=" + OidcFlowTest.CLIENT_SECRET,
+      "camunda.security.authentication.oidc.redirect-uri=http://localhost/sso-callback",
+      // uncomment to debug the filter chain
+      //      "logging.level.org.springframework.security=TRACE",
+    })
+@ActiveProfiles("consolidated-auth")
+@Testcontainers
+class OidcFlowTest {
+
+  // client and user defined in camunda-identity-test-realm.json
+  static final String CLIENT_ID = "camunda-test";
+  static final String CLIENT_SECRET = "yI2oAlOzx2A9AXmiUO0fqT4qNb8l3HBP";
+  static final String REALM = "camunda-identity-test";
+  static final String TEST_USERNAME = "ccamundovski";
+  static final String TEST_PASSWORD = "apassword";
+
+  @Container
+  static KeycloakContainer keycloak =
+      new KeycloakContainer().withRealmImportFile("/camunda-identity-test-realm.json");
+
+  @Autowired MockMvcTester mockMvcTester;
+
+  @DynamicPropertySource
+  static void properties(final DynamicPropertyRegistry registry) {
+    registry.add(
+        "camunda.security.authentication.oidc.issuer-uri",
+        () -> keycloak.getAuthServerUrl() + "/realms/" + REALM);
+  }
+
+  @Nested
+  class ClientFlow {
+    @Test
+    public void shouldReturnUnauthorizedWhenClientUnauthenticated() {
+      // Given an unauthenticated client
+      // When the client accesses a protected API endpoint
+      final MvcTestResult result =
+          mockMvcTester.get().uri("/api/dummy").accept(MediaType.APPLICATION_JSON).exchange();
+
+      // Then the client receives the http response code 401
+      assertThat(result).hasStatus(HttpStatus.UNAUTHORIZED);
+    }
+
+    @Test
+    public void shouldDenyAccessWithInvalidClientCredentialsToken() {
+      // Given an invalid token
+      final String invalidToken = "invalid-token";
+      final MvcTestResult result =
+          mockMvcTester
+              .get()
+              .uri(DUMMY_V2_API_ENDPOINT)
+              .accept(MediaType.APPLICATION_JSON)
+              .header("Authorization", "Bearer " + invalidToken)
+              .exchange();
+      assertThat(result).hasStatus(HttpStatus.UNAUTHORIZED);
+    }
+
+    @Test
+    public void shouldObtainTokenWithClientCredentialsAndAccessProtectedApi() throws Exception {
+      // Given valid client credentials
+      final String accessToken = getClientAccessToken();
+
+      // When using the token to access a protected endpoint
+      final MvcTestResult apiResult =
+          mockMvcTester
+              .get()
+              .uri(DUMMY_V2_API_ENDPOINT)
+              .accept(MediaType.APPLICATION_JSON)
+              .header("Authorization", "Bearer " + accessToken)
+              .exchange();
+      // Then access is granted
+      assertThat(apiResult).hasStatus(HttpStatus.OK).hasBodyTextEqualTo(DEFAULT_RESPONSE);
+    }
+
+    private static String getClientAccessToken() throws IOException, InterruptedException {
+      final String tokenEndpoint =
+          keycloak.getAuthServerUrl() + "/realms/" + REALM + "/protocol/openid-connect/token";
+      final String requestBody =
+          "grant_type=client_credentials&client_id="
+              + CLIENT_ID
+              + "&client_secret="
+              + CLIENT_SECRET;
+      final HttpResponse<String> response;
+      try (final HttpClient httpClient = newHttpClient()) {
+        final HttpRequest request =
+            HttpRequest.newBuilder()
+                .uri(URI.create(tokenEndpoint))
+                .header("Content-Type", "application/x-www-form-urlencoded")
+                .POST(HttpRequest.BodyPublishers.ofString(requestBody))
+                .build();
+
+        response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+      }
+      return new ObjectMapper().readTree(response.body()).get("access_token").asText();
+    }
+  }
+
+  @Nested
+  class UserFlow {
+    @Test
+    public void shouldAllowUnauthenticatedRequestsToUnprotectedApi() {
+      final MvcTestResult result =
+          mockMvcTester
+              .get()
+              .uri(DUMMY_UNPROTECTED_ENDPOINT)
+              .accept(MediaType.TEXT_HTML)
+              .exchange();
+      assertThat(result).hasStatus(HttpStatus.OK);
+    }
+
+    @Test
+    public void shouldRedirectWhenUserUnauthenticated() {
+      // Given an unauthenticated user
+      // When the user accesses a protected webapp endpoint...
+      // (The Accept header is essential here - Spring filters use text/html to match the request to
+      // a redirection flow, rather than just returning 401)
+      final MvcTestResult result =
+          mockMvcTester.get().uri("/").accept(MediaType.TEXT_HTML).exchange();
+
+      // Then the user is redirected to the OIDC authorization endpoint
+      assertThat(result)
+          .hasStatus(HttpStatus.FOUND)
+          .hasHeader("Location", "http://localhost/oauth2/authorization/oidc");
+    }
+
+    @Test
+    public void shouldRedirectToOidcProviderWhenLocalAuthorizationEndpointIsRequested() {
+      // When a user requests Spring's local authorization endpoint
+      final MvcTestResult result =
+          mockMvcTester
+              .get()
+              .uri("/oauth2/authorization/oidc")
+              .accept(MediaType.TEXT_HTML)
+              .exchange();
+
+      // Then the response should be a redirect to the OIDC provider's authentication endpoint
+      assertThat(result).hasStatus(HttpStatus.FOUND).containsHeader("Location");
+      final var locationHeader = result.getResponse().getHeader("Location");
+      assertThat(locationHeader)
+          .startsWith(
+              keycloak.getAuthServerUrl() + "/realms/" + REALM + "/protocol/openid-connect/auth")
+          .contains("client_id=" + CLIENT_ID)
+          .contains("response_type=code")
+          .contains("scope=openid%20profile");
+    }
+
+    @Test
+    public void shouldAllowAccessToProtectedWebEndpointWithValidUserToken() throws Exception {
+      // Given valid user credentials
+      final String accessToken = getUserAccessToken();
+
+      // When using the token to access a protected web endpoint
+      final MvcTestResult result =
+          mockMvcTester
+              .get()
+              .uri(DUMMY_WEBAPP_ENDPOINT)
+              .accept(MediaType.TEXT_HTML)
+              .header("Authorization", "Bearer " + accessToken)
+              .exchange();
+
+      // Then access is granted
+      assertThat(result).hasStatus(HttpStatus.OK).hasBodyTextEqualTo(DEFAULT_RESPONSE);
+    }
+
+    private String getUserAccessToken() throws IOException, InterruptedException {
+      final String tokenEndpoint =
+          keycloak.getAuthServerUrl() + "/realms/" + REALM + "/protocol/openid-connect/token";
+      final String requestBody =
+          "grant_type=password&client_id="
+              + CLIENT_ID
+              + "&client_secret="
+              + CLIENT_SECRET
+              + "&username="
+              + TEST_USERNAME
+              + "&password="
+              + TEST_PASSWORD;
+      final HttpResponse<String> response;
+      try (final HttpClient httpClient = newHttpClient()) {
+        final HttpRequest request =
+            HttpRequest.newBuilder()
+                .uri(URI.create(tokenEndpoint))
+                .header("Content-Type", "application/x-www-form-urlencoded")
+                .POST(HttpRequest.BodyPublishers.ofString(requestBody))
+                .build();
+
+        response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+      }
+      return new ObjectMapper().readTree(response.body()).get("access_token").asText();
+    }
+  }
+}

--- a/authentication/src/test/java/io/camunda/authentication/config/controllers/OidcFlowTestContext.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/controllers/OidcFlowTestContext.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.config.controllers;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.authentication.handler.AuthFailureHandler;
+import io.camunda.authentication.service.MembershipService;
+import io.camunda.authentication.service.NoDBMembershipService;
+import io.camunda.search.clients.auth.DisabledResourceAccessProvider;
+import io.camunda.security.auth.CamundaAuthentication;
+import io.camunda.security.auth.CamundaAuthenticationProvider;
+import io.camunda.security.configuration.SecurityConfiguration;
+import io.camunda.security.reader.ResourceAccessProvider;
+import java.util.List;
+import java.util.Map;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OidcFlowTestContext {
+
+  @Bean
+  public TestApiController createTestController() {
+    return new TestApiController();
+  }
+
+  @Bean
+  public CamundaAuthenticationProvider createCamundaAuthenticationProvider() {
+    return () ->
+        new CamundaAuthentication(
+            "dummyUsername", "dummyClientId", List.of(), List.of(), List.of(), List.of(), Map.of());
+  }
+
+  @Bean
+  public ResourceAccessProvider createResourceAccessProvider() {
+    return new DisabledResourceAccessProvider();
+  }
+
+  @Bean
+  public AuthFailureHandler createFailureHandler() {
+    return new AuthFailureHandler(new ObjectMapper());
+  }
+
+  /**
+   * So that camunda.security properties can be used in tests; must be prefixed with
+   * 'camunda.security' because this prefix is hardcoded in AuthenticationProperties.
+   */
+  @SuppressWarnings("ConfigurationProperties")
+  @Bean
+  @ConfigurationProperties("camunda.security")
+  public SecurityConfiguration createSecurityConfiguration() {
+    return new SecurityConfiguration();
+  }
+
+  @Bean
+  public MembershipService createMembershipService(
+      final SecurityConfiguration securityConfiguration) {
+    return new NoDBMembershipService(securityConfiguration);
+  }
+}

--- a/authentication/src/test/java/io/camunda/authentication/config/controllers/WebSecurityConfigTestContext.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/controllers/WebSecurityConfigTestContext.java
@@ -98,6 +98,7 @@ public class WebSecurityConfigTestContext {
    * So that camunda.security properties can be used in tests; must be prefixed with
    * 'camunda.security' because this prefix is hardcoded in AuthenticationProperties.
    */
+  @SuppressWarnings("ConfigurationProperties")
   @Bean
   @ConfigurationProperties("camunda.security")
   public SecurityConfiguration createSecurityConfiguration() {

--- a/authentication/src/test/resources/camunda-identity-test-realm.json
+++ b/authentication/src/test/resources/camunda-identity-test-realm.json
@@ -1,0 +1,2077 @@
+{
+  "id" : "b3d2880f-a1e6-46b5-b1e1-3eaa99979e40",
+  "realm" : "camunda-identity-test",
+  "notBefore" : 0,
+  "defaultSignatureAlgorithm" : "RS256",
+  "revokeRefreshToken" : false,
+  "refreshTokenMaxReuse" : 0,
+  "accessTokenLifespan" : 300,
+  "accessTokenLifespanForImplicitFlow" : 900,
+  "ssoSessionIdleTimeout" : 1800,
+  "ssoSessionMaxLifespan" : 36000,
+  "ssoSessionIdleTimeoutRememberMe" : 0,
+  "ssoSessionMaxLifespanRememberMe" : 0,
+  "offlineSessionIdleTimeout" : 2592000,
+  "offlineSessionMaxLifespanEnabled" : false,
+  "offlineSessionMaxLifespan" : 5184000,
+  "clientSessionIdleTimeout" : 0,
+  "clientSessionMaxLifespan" : 0,
+  "clientOfflineSessionIdleTimeout" : 0,
+  "clientOfflineSessionMaxLifespan" : 0,
+  "accessCodeLifespan" : 60,
+  "accessCodeLifespanUserAction" : 300,
+  "accessCodeLifespanLogin" : 1800,
+  "actionTokenGeneratedByAdminLifespan" : 43200,
+  "actionTokenGeneratedByUserLifespan" : 300,
+  "oauth2DeviceCodeLifespan" : 600,
+  "oauth2DevicePollingInterval" : 5,
+  "enabled" : true,
+  "sslRequired" : "external",
+  "registrationAllowed" : false,
+  "registrationEmailAsUsername" : false,
+  "rememberMe" : false,
+  "verifyEmail" : false,
+  "loginWithEmailAllowed" : true,
+  "duplicateEmailsAllowed" : false,
+  "resetPasswordAllowed" : false,
+  "editUsernameAllowed" : false,
+  "bruteForceProtected" : false,
+  "permanentLockout" : false,
+  "maxTemporaryLockouts" : 0,
+  "bruteForceStrategy" : "MULTIPLE",
+  "maxFailureWaitSeconds" : 900,
+  "minimumQuickLoginWaitSeconds" : 60,
+  "waitIncrementSeconds" : 60,
+  "quickLoginCheckMilliSeconds" : 1000,
+  "maxDeltaTimeSeconds" : 43200,
+  "failureFactor" : 30,
+  "roles" : {
+    "realm" : [ {
+      "id" : "d5fabde9-9bfc-41cf-b4d0-9157d10f2030",
+      "name" : "uma_authorization",
+      "description" : "${role_uma_authorization}",
+      "composite" : false,
+      "clientRole" : false,
+      "containerId" : "b3d2880f-a1e6-46b5-b1e1-3eaa99979e40",
+      "attributes" : { }
+    }, {
+      "id" : "36a86ae3-1f05-4db7-be16-2df1afb4aa8f",
+      "name" : "default-roles-camunda-identity-test",
+      "description" : "${role_default-roles}",
+      "composite" : true,
+      "composites" : {
+        "realm" : [ "offline_access", "uma_authorization" ],
+        "client" : {
+          "account" : [ "view-profile", "manage-account" ]
+        }
+      },
+      "clientRole" : false,
+      "containerId" : "b3d2880f-a1e6-46b5-b1e1-3eaa99979e40",
+      "attributes" : { }
+    }, {
+      "id" : "59a88345-8d9c-43f8-8fd3-38a015c9b659",
+      "name" : "offline_access",
+      "description" : "${role_offline-access}",
+      "composite" : false,
+      "clientRole" : false,
+      "containerId" : "b3d2880f-a1e6-46b5-b1e1-3eaa99979e40",
+      "attributes" : { }
+    } ],
+    "client" : {
+      "realm-management" : [ {
+        "id" : "8cacb419-9f5b-49e7-bd25-3c0a171f6452",
+        "name" : "create-client",
+        "description" : "${role_create-client}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "414ad2e9-1e37-46bb-847a-1abacbdd6312",
+        "attributes" : { }
+      }, {
+        "id" : "2dd3fc2e-bf23-4f1c-a3f2-8bb27e387165",
+        "name" : "realm-admin",
+        "description" : "${role_realm-admin}",
+        "composite" : true,
+        "composites" : {
+          "client" : {
+            "realm-management" : [ "create-client", "view-events", "manage-users", "query-clients", "manage-identity-providers", "impersonation", "view-identity-providers", "view-authorization", "view-users", "query-realms", "manage-events", "manage-clients", "query-groups", "manage-realm", "view-realm", "view-clients", "query-users", "manage-authorization" ]
+          }
+        },
+        "clientRole" : true,
+        "containerId" : "414ad2e9-1e37-46bb-847a-1abacbdd6312",
+        "attributes" : { }
+      }, {
+        "id" : "6aaed19d-544f-42fd-8305-ab4358c8b6eb",
+        "name" : "view-events",
+        "description" : "${role_view-events}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "414ad2e9-1e37-46bb-847a-1abacbdd6312",
+        "attributes" : { }
+      }, {
+        "id" : "4c74be80-6a8d-4de3-bf5c-de58d41c4f49",
+        "name" : "manage-users",
+        "description" : "${role_manage-users}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "414ad2e9-1e37-46bb-847a-1abacbdd6312",
+        "attributes" : { }
+      }, {
+        "id" : "d9a2a260-e28e-4e9e-970b-eb0b692c39e2",
+        "name" : "query-clients",
+        "description" : "${role_query-clients}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "414ad2e9-1e37-46bb-847a-1abacbdd6312",
+        "attributes" : { }
+      }, {
+        "id" : "4591e337-1a8d-4ae6-8fdf-0c778c81fc32",
+        "name" : "impersonation",
+        "description" : "${role_impersonation}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "414ad2e9-1e37-46bb-847a-1abacbdd6312",
+        "attributes" : { }
+      }, {
+        "id" : "513120b3-c14e-4e3c-9a8c-4895b2a1f8c2",
+        "name" : "manage-identity-providers",
+        "description" : "${role_manage-identity-providers}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "414ad2e9-1e37-46bb-847a-1abacbdd6312",
+        "attributes" : { }
+      }, {
+        "id" : "a39d1e60-b223-4c5f-abb4-0227f9b74dbf",
+        "name" : "view-identity-providers",
+        "description" : "${role_view-identity-providers}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "414ad2e9-1e37-46bb-847a-1abacbdd6312",
+        "attributes" : { }
+      }, {
+        "id" : "b3da7b3f-ed8e-4613-8a7c-a4661af3fa27",
+        "name" : "view-authorization",
+        "description" : "${role_view-authorization}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "414ad2e9-1e37-46bb-847a-1abacbdd6312",
+        "attributes" : { }
+      }, {
+        "id" : "fb72b204-f56a-4750-92cb-6af2c391067a",
+        "name" : "view-users",
+        "description" : "${role_view-users}",
+        "composite" : true,
+        "composites" : {
+          "client" : {
+            "realm-management" : [ "query-groups", "query-users" ]
+          }
+        },
+        "clientRole" : true,
+        "containerId" : "414ad2e9-1e37-46bb-847a-1abacbdd6312",
+        "attributes" : { }
+      }, {
+        "id" : "dba6fab3-1a1d-4eea-8f73-b6803f20b959",
+        "name" : "query-realms",
+        "description" : "${role_query-realms}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "414ad2e9-1e37-46bb-847a-1abacbdd6312",
+        "attributes" : { }
+      }, {
+        "id" : "03682853-822e-44c7-98ce-b3ca3c0d19dc",
+        "name" : "manage-events",
+        "description" : "${role_manage-events}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "414ad2e9-1e37-46bb-847a-1abacbdd6312",
+        "attributes" : { }
+      }, {
+        "id" : "ebbcb048-72f6-4857-9478-5a80357e5515",
+        "name" : "manage-clients",
+        "description" : "${role_manage-clients}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "414ad2e9-1e37-46bb-847a-1abacbdd6312",
+        "attributes" : { }
+      }, {
+        "id" : "089caa3f-1a96-4385-80cc-c56a2ad00f61",
+        "name" : "query-groups",
+        "description" : "${role_query-groups}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "414ad2e9-1e37-46bb-847a-1abacbdd6312",
+        "attributes" : { }
+      }, {
+        "id" : "92c9ede2-ca93-42b7-a9c8-e97f49ece3fe",
+        "name" : "manage-realm",
+        "description" : "${role_manage-realm}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "414ad2e9-1e37-46bb-847a-1abacbdd6312",
+        "attributes" : { }
+      }, {
+        "id" : "d3822530-5f2b-4186-9d0a-9e4e7693fdad",
+        "name" : "view-clients",
+        "description" : "${role_view-clients}",
+        "composite" : true,
+        "composites" : {
+          "client" : {
+            "realm-management" : [ "query-clients" ]
+          }
+        },
+        "clientRole" : true,
+        "containerId" : "414ad2e9-1e37-46bb-847a-1abacbdd6312",
+        "attributes" : { }
+      }, {
+        "id" : "599ba3d5-944c-4507-9524-902f1107c6cf",
+        "name" : "view-realm",
+        "description" : "${role_view-realm}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "414ad2e9-1e37-46bb-847a-1abacbdd6312",
+        "attributes" : { }
+      }, {
+        "id" : "73597e34-98ca-4494-8ce8-11c4a7d39134",
+        "name" : "query-users",
+        "description" : "${role_query-users}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "414ad2e9-1e37-46bb-847a-1abacbdd6312",
+        "attributes" : { }
+      }, {
+        "id" : "9bc2c558-6780-4153-819b-84a23edb6cef",
+        "name" : "manage-authorization",
+        "description" : "${role_manage-authorization}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "414ad2e9-1e37-46bb-847a-1abacbdd6312",
+        "attributes" : { }
+      } ],
+      "security-admin-console" : [ ],
+      "camunda-test" : [ ],
+      "admin-cli" : [ ],
+      "account-console" : [ ],
+      "broker" : [ {
+        "id" : "a0b4b907-0a05-4dee-a22f-500044ea9354",
+        "name" : "read-token",
+        "description" : "${role_read-token}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "4381b770-1ed8-45d9-9b45-55b9e10340d0",
+        "attributes" : { }
+      } ],
+      "account" : [ {
+        "id" : "917f0d72-339e-4579-9213-d94c82bdc148",
+        "name" : "manage-account-links",
+        "description" : "${role_manage-account-links}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "4f80b02c-5d37-4607-8bfa-2c5c47252357",
+        "attributes" : { }
+      }, {
+        "id" : "44e9daad-24a1-4796-aa12-268d1e0536e5",
+        "name" : "view-applications",
+        "description" : "${role_view-applications}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "4f80b02c-5d37-4607-8bfa-2c5c47252357",
+        "attributes" : { }
+      }, {
+        "id" : "db9fe9ba-22c7-415c-aeab-5b0c9f7b9d00",
+        "name" : "view-groups",
+        "description" : "${role_view-groups}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "4f80b02c-5d37-4607-8bfa-2c5c47252357",
+        "attributes" : { }
+      }, {
+        "id" : "264a30e6-8845-49d1-b1c3-17b9428e5577",
+        "name" : "delete-account",
+        "description" : "${role_delete-account}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "4f80b02c-5d37-4607-8bfa-2c5c47252357",
+        "attributes" : { }
+      }, {
+        "id" : "bc44789c-36cb-44a8-8548-a11025cedbb3",
+        "name" : "view-profile",
+        "description" : "${role_view-profile}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "4f80b02c-5d37-4607-8bfa-2c5c47252357",
+        "attributes" : { }
+      }, {
+        "id" : "e2b4ac0b-e803-431f-905e-0382e367a33b",
+        "name" : "manage-consent",
+        "description" : "${role_manage-consent}",
+        "composite" : true,
+        "composites" : {
+          "client" : {
+            "account" : [ "view-consent" ]
+          }
+        },
+        "clientRole" : true,
+        "containerId" : "4f80b02c-5d37-4607-8bfa-2c5c47252357",
+        "attributes" : { }
+      }, {
+        "id" : "6efca0b0-b6fb-4c31-8e84-7b71196d963a",
+        "name" : "manage-account",
+        "description" : "${role_manage-account}",
+        "composite" : true,
+        "composites" : {
+          "client" : {
+            "account" : [ "manage-account-links" ]
+          }
+        },
+        "clientRole" : true,
+        "containerId" : "4f80b02c-5d37-4607-8bfa-2c5c47252357",
+        "attributes" : { }
+      }, {
+        "id" : "52bae05a-0077-448c-bf3b-c77dba3a669e",
+        "name" : "view-consent",
+        "description" : "${role_view-consent}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "4f80b02c-5d37-4607-8bfa-2c5c47252357",
+        "attributes" : { }
+      } ]
+    }
+  },
+  "groups" : [ ],
+  "defaultRole" : {
+    "id" : "36a86ae3-1f05-4db7-be16-2df1afb4aa8f",
+    "name" : "default-roles-camunda-identity-test",
+    "description" : "${role_default-roles}",
+    "composite" : true,
+    "clientRole" : false,
+    "containerId" : "b3d2880f-a1e6-46b5-b1e1-3eaa99979e40"
+  },
+  "requiredCredentials" : [ "password" ],
+  "otpPolicyType" : "totp",
+  "otpPolicyAlgorithm" : "HmacSHA1",
+  "otpPolicyInitialCounter" : 0,
+  "otpPolicyDigits" : 6,
+  "otpPolicyLookAheadWindow" : 1,
+  "otpPolicyPeriod" : 30,
+  "otpPolicyCodeReusable" : false,
+  "otpSupportedApplications" : [ "totpAppFreeOTPName", "totpAppGoogleName", "totpAppMicrosoftAuthenticatorName" ],
+  "localizationTexts" : { },
+  "webAuthnPolicyRpEntityName" : "keycloak",
+  "webAuthnPolicySignatureAlgorithms" : [ "ES256", "RS256" ],
+  "webAuthnPolicyRpId" : "",
+  "webAuthnPolicyAttestationConveyancePreference" : "not specified",
+  "webAuthnPolicyAuthenticatorAttachment" : "not specified",
+  "webAuthnPolicyRequireResidentKey" : "not specified",
+  "webAuthnPolicyUserVerificationRequirement" : "not specified",
+  "webAuthnPolicyCreateTimeout" : 0,
+  "webAuthnPolicyAvoidSameAuthenticatorRegister" : false,
+  "webAuthnPolicyAcceptableAaguids" : [ ],
+  "webAuthnPolicyExtraOrigins" : [ ],
+  "webAuthnPolicyPasswordlessRpEntityName" : "keycloak",
+  "webAuthnPolicyPasswordlessSignatureAlgorithms" : [ "ES256", "RS256" ],
+  "webAuthnPolicyPasswordlessRpId" : "",
+  "webAuthnPolicyPasswordlessAttestationConveyancePreference" : "not specified",
+  "webAuthnPolicyPasswordlessAuthenticatorAttachment" : "not specified",
+  "webAuthnPolicyPasswordlessRequireResidentKey" : "not specified",
+  "webAuthnPolicyPasswordlessUserVerificationRequirement" : "not specified",
+  "webAuthnPolicyPasswordlessCreateTimeout" : 0,
+  "webAuthnPolicyPasswordlessAvoidSameAuthenticatorRegister" : false,
+  "webAuthnPolicyPasswordlessAcceptableAaguids" : [ ],
+  "webAuthnPolicyPasswordlessExtraOrigins" : [ ],
+  "users" : [ {
+    "id" : "ea63716a-2d23-496a-b2e7-1637f18e7a7e",
+    "username" : "ccamundovski",
+    "firstName" : "Camundus",
+    "lastName" : "Camundovski",
+    "email" : "c.c@camunda.example.com",
+    "emailVerified" : true,
+    "createdTimestamp" : 1754855595223,
+    "enabled" : true,
+    "totp" : false,
+    "credentials" : [ {
+      "id" : "8a973346-757e-4a88-a246-59d63fd7c24d",
+      "type" : "password",
+      "userLabel" : "My password",
+      "createdDate" : 1754855625490,
+      "secretData" : "{\"value\":\"JjhHIYv6RKa0qNFhQcdoVBYqgLqyi6piw0hyBoYlGic=\",\"salt\":\"7YRBMGI6rUp7OoID1sKwoQ==\",\"additionalParameters\":{}}",
+      "credentialData" : "{\"hashIterations\":5,\"algorithm\":\"argon2\",\"additionalParameters\":{\"hashLength\":[\"32\"],\"memory\":[\"7168\"],\"type\":[\"id\"],\"version\":[\"1.3\"],\"parallelism\":[\"1\"]}}"
+    } ],
+    "disableableCredentialTypes" : [ ],
+    "requiredActions" : [ ],
+    "realmRoles" : [ "default-roles-camunda-identity-test" ],
+    "notBefore" : 0,
+    "groups" : [ ]
+  }, {
+    "id" : "d6d5bece-39c3-48f4-b0a0-b20fe03433a2",
+    "username" : "service-account-camunda-test",
+    "emailVerified" : false,
+    "createdTimestamp" : 1754503670922,
+    "enabled" : true,
+    "totp" : false,
+    "serviceAccountClientId" : "camunda-test",
+    "credentials" : [ ],
+    "disableableCredentialTypes" : [ ],
+    "requiredActions" : [ ],
+    "realmRoles" : [ "default-roles-camunda-identity-test" ],
+    "notBefore" : 0,
+    "groups" : [ ]
+  } ],
+  "scopeMappings" : [ {
+    "clientScope" : "offline_access",
+    "roles" : [ "offline_access" ]
+  } ],
+  "clients" : [ {
+    "id" : "4f80b02c-5d37-4607-8bfa-2c5c47252357",
+    "clientId" : "account",
+    "name" : "${client_account}",
+    "rootUrl" : "${authBaseUrl}",
+    "baseUrl" : "/realms/camunda-identity-test/account/",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "redirectUris" : [ "/realms/camunda-identity-test/account/*" ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : false,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : true,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "realm_client" : "false",
+      "post.logout.redirect.uris" : "+"
+    },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : false,
+    "nodeReRegistrationTimeout" : 0,
+    "defaultClientScopes" : [ "web-origins", "acr", "profile", "roles", "basic", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "organization", "offline_access", "microprofile-jwt" ]
+  }, {
+    "id" : "a655ee3f-3b0f-4fde-b6cf-f1e70d9a7d61",
+    "clientId" : "account-console",
+    "name" : "${client_account-console}",
+    "rootUrl" : "${authBaseUrl}",
+    "baseUrl" : "/realms/camunda-identity-test/account/",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "redirectUris" : [ "/realms/camunda-identity-test/account/*" ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : false,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : true,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "realm_client" : "false",
+      "post.logout.redirect.uris" : "+",
+      "pkce.code.challenge.method" : "S256"
+    },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : false,
+    "nodeReRegistrationTimeout" : 0,
+    "protocolMappers" : [ {
+      "id" : "8257eda8-a739-4611-9a1e-b83a4850dc7a",
+      "name" : "audience resolve",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-audience-resolve-mapper",
+      "consentRequired" : false,
+      "config" : { }
+    } ],
+    "defaultClientScopes" : [ "web-origins", "acr", "profile", "roles", "basic", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "organization", "offline_access", "microprofile-jwt" ]
+  }, {
+    "id" : "86b61e87-7649-4a95-9190-4bb12fa51e5b",
+    "clientId" : "admin-cli",
+    "name" : "${client_admin-cli}",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "redirectUris" : [ ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "standardFlowEnabled" : false,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : true,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : true,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "realm_client" : "false",
+      "client.use.lightweight.access.token.enabled" : "true"
+    },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : true,
+    "nodeReRegistrationTimeout" : 0,
+    "defaultClientScopes" : [ "web-origins", "acr", "profile", "roles", "basic", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "organization", "offline_access", "microprofile-jwt" ]
+  }, {
+    "id" : "4381b770-1ed8-45d9-9b45-55b9e10340d0",
+    "clientId" : "broker",
+    "name" : "${client_broker}",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "redirectUris" : [ ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : true,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : false,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : false,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "realm_client" : "true"
+    },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : false,
+    "nodeReRegistrationTimeout" : 0,
+    "defaultClientScopes" : [ "web-origins", "acr", "profile", "roles", "basic", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "organization", "offline_access", "microprofile-jwt" ]
+  }, {
+    "id" : "d83dfbc8-70a1-41ab-9735-065857a8d35d",
+    "clientId" : "camunda-test",
+    "name" : "",
+    "description" : "",
+    "rootUrl" : "",
+    "adminUrl" : "",
+    "baseUrl" : "",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "secret" : "yI2oAlOzx2A9AXmiUO0fqT4qNb8l3HBP",
+    "redirectUris" : [ "/*" ],
+    "webOrigins" : [ "/*" ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "standardFlowEnabled" : false,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : true,
+    "serviceAccountsEnabled" : true,
+    "publicClient" : false,
+    "frontchannelLogout" : true,
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "client.secret.creation.time" : "1754503670",
+      "client.introspection.response.allow.jwt.claim.enabled" : "false",
+      "frontchannel.logout.session.required" : "true",
+      "oauth2.device.authorization.grant.enabled" : "false",
+      "backchannel.logout.revoke.offline.tokens" : "false",
+      "use.refresh.tokens" : "true",
+      "realm_client" : "false",
+      "oidc.ciba.grant.enabled" : "false",
+      "client.use.lightweight.access.token.enabled" : "false",
+      "backchannel.logout.session.required" : "true",
+      "client_credentials.use_refresh_token" : "false",
+      "acr.loa.map" : "{}",
+      "require.pushed.authorization.requests" : "false",
+      "tls.client.certificate.bound.access.tokens" : "false",
+      "display.on.consent.screen" : "false",
+      "token.response.type.bearer.lower-case" : "false"
+    },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : true,
+    "nodeReRegistrationTimeout" : -1,
+    "defaultClientScopes" : [ "web-origins", "service_account", "acr", "profile", "roles", "basic", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "organization", "offline_access", "microprofile-jwt" ]
+  }, {
+    "id" : "414ad2e9-1e37-46bb-847a-1abacbdd6312",
+    "clientId" : "realm-management",
+    "name" : "${client_realm-management}",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "redirectUris" : [ ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : true,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : false,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : false,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "realm_client" : "true"
+    },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : false,
+    "nodeReRegistrationTimeout" : 0,
+    "defaultClientScopes" : [ "web-origins", "acr", "profile", "roles", "basic", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "organization", "offline_access", "microprofile-jwt" ]
+  }, {
+    "id" : "e3098f12-ccbb-4c85-bda7-1431b674d93a",
+    "clientId" : "security-admin-console",
+    "name" : "${client_security-admin-console}",
+    "rootUrl" : "${authAdminUrl}",
+    "baseUrl" : "/admin/camunda-identity-test/console/",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "redirectUris" : [ "/admin/camunda-identity-test/console/*" ],
+    "webOrigins" : [ "+" ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : false,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : true,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "realm_client" : "false",
+      "client.use.lightweight.access.token.enabled" : "true",
+      "post.logout.redirect.uris" : "+",
+      "pkce.code.challenge.method" : "S256"
+    },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : true,
+    "nodeReRegistrationTimeout" : 0,
+    "protocolMappers" : [ {
+      "id" : "d72aa3f6-c951-4fd2-98a0-03dadcbb6095",
+      "name" : "locale",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "locale",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "locale",
+        "jsonType.label" : "String"
+      }
+    } ],
+    "defaultClientScopes" : [ "web-origins", "acr", "profile", "roles", "basic", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "organization", "offline_access", "microprofile-jwt" ]
+  } ],
+  "clientScopes" : [ {
+    "id" : "3652d185-76f8-4084-83b5-35aefb1e884b",
+    "name" : "organization",
+    "description" : "Additional claims about the organization a subject belongs to",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "true",
+      "consent.screen.text" : "${organizationScopeConsentText}",
+      "display.on.consent.screen" : "true"
+    },
+    "protocolMappers" : [ {
+      "id" : "0fe6bcae-1dbc-4841-8fab-ff7d7035ccd2",
+      "name" : "organization",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-organization-membership-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "id.token.claim" : "true",
+        "introspection.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "organization",
+        "jsonType.label" : "String",
+        "multivalued" : "true"
+      }
+    } ]
+  }, {
+    "id" : "e82f3c84-3c07-43cd-8158-d9ce02272218",
+    "name" : "profile",
+    "description" : "OpenID Connect built-in scope: profile",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "true",
+      "consent.screen.text" : "${profileScopeConsentText}",
+      "display.on.consent.screen" : "true"
+    },
+    "protocolMappers" : [ {
+      "id" : "c70e92b7-78a9-4fa2-b29c-2912681d3693",
+      "name" : "locale",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "locale",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "locale",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "903f33f7-6309-4e50-aab2-81ccfac5a471",
+      "name" : "zoneinfo",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "zoneinfo",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "zoneinfo",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "39fc6901-6044-43d9-88e4-4418c3f573a9",
+      "name" : "picture",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "picture",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "picture",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "d37897bd-fc15-40ca-9686-77f99fd964fe",
+      "name" : "given name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "firstName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "given_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "673df5d3-29da-4edf-89a2-229f4b03607b",
+      "name" : "username",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "username",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "preferred_username",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "3615ee39-dc10-4018-aa7d-5c16ccdae44c",
+      "name" : "profile",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "profile",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "profile",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "95a2f488-9077-4d78-be15-6e86f908cb8a",
+      "name" : "nickname",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "nickname",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "nickname",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "5254637b-6e3a-4267-8c9e-7a8453001045",
+      "name" : "full name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-full-name-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "id.token.claim" : "true",
+        "introspection.token.claim" : "true",
+        "access.token.claim" : "true",
+        "userinfo.token.claim" : "true"
+      }
+    }, {
+      "id" : "dc8b4f40-6d88-4dcc-9c9c-9ef3b8a9ee48",
+      "name" : "website",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "website",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "website",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "1bf6f3eb-53f0-4674-b4be-1816b7d1e6c8",
+      "name" : "family name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "lastName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "family_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "a9ffa7ec-d784-48d0-ae17-c0725fa901e9",
+      "name" : "gender",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "gender",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "gender",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "9183037f-bdc3-422c-94e1-cc9336815500",
+      "name" : "middle name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "middleName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "middle_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "690f4891-3b45-4ec7-a194-5829d7e9e26a",
+      "name" : "updated at",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "updatedAt",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "updated_at",
+        "jsonType.label" : "long"
+      }
+    }, {
+      "id" : "ab978bf2-4270-4131-a901-0545927f54e1",
+      "name" : "birthdate",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "birthdate",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "birthdate",
+        "jsonType.label" : "String"
+      }
+    } ]
+  }, {
+    "id" : "66581de3-2c53-44e6-9ebb-282748ab2544",
+    "name" : "saml_organization",
+    "description" : "Organization Membership",
+    "protocol" : "saml",
+    "attributes" : {
+      "display.on.consent.screen" : "false"
+    },
+    "protocolMappers" : [ {
+      "id" : "9509cc67-d46e-47f8-b20d-d376ad270d2c",
+      "name" : "organization",
+      "protocol" : "saml",
+      "protocolMapper" : "saml-organization-membership-mapper",
+      "consentRequired" : false,
+      "config" : { }
+    } ]
+  }, {
+    "id" : "6ffea049-995c-4aec-872a-ff09a646495d",
+    "name" : "acr",
+    "description" : "OpenID Connect scope for add acr (authentication context class reference) to the token",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "false",
+      "display.on.consent.screen" : "false"
+    },
+    "protocolMappers" : [ {
+      "id" : "a6c2f8c2-44bf-42a1-a732-36eb254522b9",
+      "name" : "acr loa level",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-acr-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "id.token.claim" : "true",
+        "introspection.token.claim" : "true",
+        "access.token.claim" : "true"
+      }
+    } ]
+  }, {
+    "id" : "5bb0ae3b-f0cc-4229-b3de-806bde019848",
+    "name" : "basic",
+    "description" : "OpenID Connect scope for add all basic claims to the token",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "false",
+      "display.on.consent.screen" : "false"
+    },
+    "protocolMappers" : [ {
+      "id" : "2f8e5d2b-9ae6-43a8-b77c-183e8c7dd982",
+      "name" : "sub",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-sub-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "access.token.claim" : "true"
+      }
+    }, {
+      "id" : "7d803930-eeb0-4ec9-bd25-66ee25473a61",
+      "name" : "auth_time",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usersessionmodel-note-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "user.session.note" : "AUTH_TIME",
+        "id.token.claim" : "true",
+        "introspection.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "auth_time",
+        "jsonType.label" : "long"
+      }
+    } ]
+  }, {
+    "id" : "35896a3a-b8a7-4f4b-94a6-72a7a6438e5d",
+    "name" : "service_account",
+    "description" : "Specific scope for a client enabled for service accounts",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "false",
+      "display.on.consent.screen" : "false"
+    },
+    "protocolMappers" : [ {
+      "id" : "42ee0b7f-c266-4816-a537-f1b72244d354",
+      "name" : "Client Host",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usersessionmodel-note-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "user.session.note" : "clientHost",
+        "id.token.claim" : "true",
+        "introspection.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "clientHost",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "2c43f4c4-06e2-4ddd-8d20-933a3dcd1edc",
+      "name" : "Client IP Address",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usersessionmodel-note-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "user.session.note" : "clientAddress",
+        "id.token.claim" : "true",
+        "introspection.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "clientAddress",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "fa36d00b-98f5-4fcd-bf18-ef6fc7206fa6",
+      "name" : "Client ID",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usersessionmodel-note-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "user.session.note" : "client_id",
+        "id.token.claim" : "true",
+        "introspection.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "client_id",
+        "jsonType.label" : "String"
+      }
+    } ]
+  }, {
+    "id" : "5b7e48e2-4236-4e76-83c2-369c950f2a93",
+    "name" : "web-origins",
+    "description" : "OpenID Connect scope for add allowed web origins to the access token",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "false",
+      "consent.screen.text" : "",
+      "display.on.consent.screen" : "false"
+    },
+    "protocolMappers" : [ {
+      "id" : "1f383f61-f3ba-47c8-8bc1-3d5dced54249",
+      "name" : "allowed web origins",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-allowed-origins-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "access.token.claim" : "true"
+      }
+    } ]
+  }, {
+    "id" : "90ed29ce-4a5e-41bd-bd39-650bfc0346b4",
+    "name" : "role_list",
+    "description" : "SAML role list",
+    "protocol" : "saml",
+    "attributes" : {
+      "consent.screen.text" : "${samlRoleListScopeConsentText}",
+      "display.on.consent.screen" : "true"
+    },
+    "protocolMappers" : [ {
+      "id" : "a51c3ec3-521e-491e-8a44-3c52ddc268ec",
+      "name" : "role list",
+      "protocol" : "saml",
+      "protocolMapper" : "saml-role-list-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "single" : "false",
+        "attribute.nameformat" : "Basic",
+        "attribute.name" : "Role"
+      }
+    } ]
+  }, {
+    "id" : "9790ed0c-2e55-4dbd-b19a-06a028c10eab",
+    "name" : "email",
+    "description" : "OpenID Connect built-in scope: email",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "true",
+      "consent.screen.text" : "${emailScopeConsentText}",
+      "display.on.consent.screen" : "true"
+    },
+    "protocolMappers" : [ {
+      "id" : "668f331a-d28e-424c-9b9c-1987c420f429",
+      "name" : "email",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "email",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "email",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "553b495d-8685-46a2-938e-3c3f5ed9975c",
+      "name" : "email verified",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "emailVerified",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "email_verified",
+        "jsonType.label" : "boolean"
+      }
+    } ]
+  }, {
+    "id" : "0b8e6714-3bef-4be0-adf4-81fb4dce88fe",
+    "name" : "phone",
+    "description" : "OpenID Connect built-in scope: phone",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "true",
+      "consent.screen.text" : "${phoneScopeConsentText}",
+      "display.on.consent.screen" : "true"
+    },
+    "protocolMappers" : [ {
+      "id" : "e9e17169-ebbd-4c9e-a292-effa728531a5",
+      "name" : "phone number",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "phoneNumber",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "phone_number",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "ac3299a3-b106-4fca-bfa3-d71b5428afc6",
+      "name" : "phone number verified",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "phoneNumberVerified",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "phone_number_verified",
+        "jsonType.label" : "boolean"
+      }
+    } ]
+  }, {
+    "id" : "409f1945-8b66-48bc-be78-74dfc9df2df9",
+    "name" : "offline_access",
+    "description" : "OpenID Connect built-in scope: offline_access",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "consent.screen.text" : "${offlineAccessScopeConsentText}",
+      "display.on.consent.screen" : "true"
+    }
+  }, {
+    "id" : "1dcee4c9-37c3-490b-b3a9-25a1a7aa5a2d",
+    "name" : "roles",
+    "description" : "OpenID Connect scope for add user roles to the access token",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "false",
+      "consent.screen.text" : "${rolesScopeConsentText}",
+      "display.on.consent.screen" : "true"
+    },
+    "protocolMappers" : [ {
+      "id" : "78f67290-81fc-4a2c-bd74-91074d28cf29",
+      "name" : "client roles",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-client-role-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "user.attribute" : "foo",
+        "introspection.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "resource_access.${client_id}.roles",
+        "jsonType.label" : "String",
+        "multivalued" : "true"
+      }
+    }, {
+      "id" : "6f2944bf-5ba2-453c-a724-de3545d872ad",
+      "name" : "realm roles",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-realm-role-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "user.attribute" : "foo",
+        "introspection.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "realm_access.roles",
+        "jsonType.label" : "String",
+        "multivalued" : "true"
+      }
+    }, {
+      "id" : "5ef368df-3f54-4c40-8dd6-6fb66cf5469e",
+      "name" : "audience resolve",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-audience-resolve-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "access.token.claim" : "true"
+      }
+    } ]
+  }, {
+    "id" : "855aaed6-c2a0-42a5-b04e-32971fec29e9",
+    "name" : "address",
+    "description" : "OpenID Connect built-in scope: address",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "true",
+      "consent.screen.text" : "${addressScopeConsentText}",
+      "display.on.consent.screen" : "true"
+    },
+    "protocolMappers" : [ {
+      "id" : "85c8f2d3-96a5-4571-9701-3b8dba3a9a30",
+      "name" : "address",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-address-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "user.attribute.formatted" : "formatted",
+        "user.attribute.country" : "country",
+        "introspection.token.claim" : "true",
+        "user.attribute.postal_code" : "postal_code",
+        "userinfo.token.claim" : "true",
+        "user.attribute.street" : "street",
+        "id.token.claim" : "true",
+        "user.attribute.region" : "region",
+        "access.token.claim" : "true",
+        "user.attribute.locality" : "locality"
+      }
+    } ]
+  }, {
+    "id" : "5402fe17-7d67-47f7-a74c-fc02a31b67b0",
+    "name" : "microprofile-jwt",
+    "description" : "Microprofile - JWT built-in scope",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "true",
+      "display.on.consent.screen" : "false"
+    },
+    "protocolMappers" : [ {
+      "id" : "e1b7098a-9386-4a5c-a87d-2ddcef27ec5a",
+      "name" : "upn",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "username",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "upn",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "69d51eda-faa4-480f-a5ce-66eb9c4c2dfe",
+      "name" : "groups",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-realm-role-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "multivalued" : "true",
+        "user.attribute" : "foo",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "groups",
+        "jsonType.label" : "String"
+      }
+    } ]
+  } ],
+  "defaultDefaultClientScopes" : [ "role_list", "saml_organization", "profile", "email", "roles", "web-origins", "acr", "basic" ],
+  "defaultOptionalClientScopes" : [ "offline_access", "address", "phone", "microprofile-jwt", "organization" ],
+  "browserSecurityHeaders" : {
+    "contentSecurityPolicyReportOnly" : "",
+    "xContentTypeOptions" : "nosniff",
+    "referrerPolicy" : "no-referrer",
+    "xRobotsTag" : "none",
+    "xFrameOptions" : "SAMEORIGIN",
+    "contentSecurityPolicy" : "frame-src 'self'; frame-ancestors 'self'; object-src 'none';",
+    "xXSSProtection" : "1; mode=block",
+    "strictTransportSecurity" : "max-age=31536000; includeSubDomains"
+  },
+  "smtpServer" : { },
+  "eventsEnabled" : false,
+  "eventsListeners" : [ "jboss-logging" ],
+  "enabledEventTypes" : [ ],
+  "adminEventsEnabled" : false,
+  "adminEventsDetailsEnabled" : false,
+  "identityProviders" : [ ],
+  "identityProviderMappers" : [ ],
+  "components" : {
+    "org.keycloak.services.clientregistration.policy.ClientRegistrationPolicy" : [ {
+      "id" : "3b084453-1053-4010-aa54-f2208269633d",
+      "name" : "Consent Required",
+      "providerId" : "consent-required",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : { }
+    }, {
+      "id" : "f4463882-6a4d-456e-9eb8-eef6f746e816",
+      "name" : "Max Clients Limit",
+      "providerId" : "max-clients",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : {
+        "max-clients" : [ "200" ]
+      }
+    }, {
+      "id" : "f41c9561-2d97-4224-a527-24d3dc7c819d",
+      "name" : "Trusted Hosts",
+      "providerId" : "trusted-hosts",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : {
+        "host-sending-registration-request-must-match" : [ "true" ],
+        "client-uris-must-match" : [ "true" ]
+      }
+    }, {
+      "id" : "d8e4e016-43d9-4c5d-ac1a-dc704d228074",
+      "name" : "Allowed Protocol Mapper Types",
+      "providerId" : "allowed-protocol-mappers",
+      "subType" : "authenticated",
+      "subComponents" : { },
+      "config" : {
+        "allowed-protocol-mapper-types" : [ "oidc-usermodel-property-mapper", "oidc-address-mapper", "saml-role-list-mapper", "oidc-usermodel-attribute-mapper", "saml-user-attribute-mapper", "oidc-full-name-mapper", "saml-user-property-mapper", "oidc-sha256-pairwise-sub-mapper" ]
+      }
+    }, {
+      "id" : "3f7c881e-c22a-45d3-aab3-181ee38c6bf9",
+      "name" : "Allowed Client Scopes",
+      "providerId" : "allowed-client-templates",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : {
+        "allow-default-scopes" : [ "true" ]
+      }
+    }, {
+      "id" : "3caafa01-7fd6-4582-8b41-3cdc845930d1",
+      "name" : "Allowed Client Scopes",
+      "providerId" : "allowed-client-templates",
+      "subType" : "authenticated",
+      "subComponents" : { },
+      "config" : {
+        "allow-default-scopes" : [ "true" ]
+      }
+    }, {
+      "id" : "f0ef32c9-e3a8-4cdf-91b5-028df5f2932f",
+      "name" : "Allowed Protocol Mapper Types",
+      "providerId" : "allowed-protocol-mappers",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : {
+        "allowed-protocol-mapper-types" : [ "saml-user-property-mapper", "oidc-usermodel-attribute-mapper", "oidc-full-name-mapper", "oidc-address-mapper", "oidc-sha256-pairwise-sub-mapper", "oidc-usermodel-property-mapper", "saml-role-list-mapper", "saml-user-attribute-mapper" ]
+      }
+    }, {
+      "id" : "0f31257d-07a8-4fde-84fb-8b4bf44f0dcf",
+      "name" : "Full Scope Disabled",
+      "providerId" : "scope",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : { }
+    } ],
+    "org.keycloak.keys.KeyProvider" : [ {
+      "id" : "a60e56ce-b939-4b0f-94b4-c62aaba55dcf",
+      "name" : "rsa-enc-generated",
+      "providerId" : "rsa-enc-generated",
+      "subComponents" : { },
+      "config" : {
+        "privateKey" : [ "MIIEowIBAAKCAQEAj2uFWRD5lTzX8B/u6ogZU7XOTzv2UIkfy/Bvos4dibUYURp+7T6725Tcldv7+XZgTt1l/wao48XUoTCcr+WOkGE1Iswdu57AN0fnmzuw2bA7HzECltUQp9DdfWy0ht8fsfs60HX1dw34r5wWrl6MkmI91IUGiro0/7OR1/tO4WEPuoFY26aXaQWSjbF24vhg8dXzj1aUpRF1/u+orOEmr/5nkwYdLF6UjqElrn/JrkyyVRU3vbirFEjB7bxngu280GE1yMJaj7622+BxYljVp0TejA8nKsyfX+U7x22mmUIg6WAwyn9KJNMIHvZrCGMkDuej0hTpDOLMW+2GzDNRzQIDAQABAoIBAACLEiUIF6toP5xUZxSDRNTYlQ9+GwEFbIoYFr1ZQrRhz3b5G0G2wrFKzr4hBNX3atceq9POvyZ38OcmvBR2aU2gvMgQ1N0cfuInUIQkcBdUew84NIJAAtatOWUbp26WF6niBAwIzJJIFBANL/RJr4GzG2EIyrMzMWZ1cJzai3xL6JxKVTo5UHYUTEyftcqr1oo/cEI4YmCdaviYkfwLoKXx661ErXJ8F8zOWmGRoJXhfegb7nck9be6MZ2cIQxx/fumwN85rIHFSCvv7Z68zrVhTwXH/GP7GKAMsdP9L3IQ9YPVDpufFPZGUhPyViqNpdte9L3XNWxFAneeQCHeKCECgYEAyPxOYJzZB3ph6YZY9sYtU1O/+NGoGrMfJ183xgFpAGwZ+oW/6zHV9bnF3S/D29vRmZbT8mKmXg8BgPZQuS/C9kjno+Pl6j/pP4lYnVttJTIhJYyazCMImQtzGCABFY44mg5YbG4SRQHa9eIp0o1Q4HLAV0N669uXA7+SmAmH130CgYEAtq1p4BX8sc5YfA7+d5VuWMqpf/P/8MAkRcliYULt7udQUKGU5wHJlRm3b3UyIp41REbLyJdEXRRXiKte7q7BEbhjPXesJns/9IceAg14KvIOgqZMoLtVK3oGNm2kCRPwgHtzQFkUPvVg7xv2qlEO0tviIISlVBHa3XKms2/GlJECgYEAs1TM6k+JJq8AJkoFn0r8rlkP9Ye8ovYoWg0PytD/S60pEOu+brEs4/A6qD0yWT4uKwj1XFTBdTOWd+dP56zCHNa4OPfj8bvM9zAprV4iaQntoX9vr62iwkwBCgmkbgNUZcFfDIC6NHCPWs3N21zUSTCahkJjr4djm6iXuKjoWFECgYADv8FZgPoDqCl2ulQMnjt6hQY/gwFwrnDQIdbsChSZ/5NNZFOK/iVl8vYpymzx+u867H0IK9qSUnWNb37uRRXfSDp5K3iT/ZmNaix6fE5IC1my4rjV36Ja1xFDkrJ4ITmhWWc/HdTlieGoZpmEW0+DklGsuywtcoRcYRr8ucGIkQKBgB6rsQd3r0TqGTLe6b2BI2xLgiWXqsmf2pFztGBTgGrhbpIjB1IWYhHoUanG5mIdJFDeHVV72NH+jcnoteUyqJQ3lNDY8sfiXfO7sD2+V6Gu0UaGiSlsGkHZrmLZ9CL0zWa3KPtZ1XFPTup8KP91k1VwiK3PZbkqUzEzzPaLHLDg" ],
+        "keyUse" : [ "ENC" ],
+        "certificate" : [ "MIICuTCCAaECBgGYgIsA6DANBgkqhkiG9w0BAQsFADAgMR4wHAYDVQQDDBVjYW11bmRhLWlkZW50aXR5LXRlc3QwHhcNMjUwODA2MTc1OTEwWhcNMzUwODA2MTgwMDUwWjAgMR4wHAYDVQQDDBVjYW11bmRhLWlkZW50aXR5LXRlc3QwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCPa4VZEPmVPNfwH+7qiBlTtc5PO/ZQiR/L8G+izh2JtRhRGn7tPrvblNyV2/v5dmBO3WX/BqjjxdShMJyv5Y6QYTUizB27nsA3R+ebO7DZsDsfMQKW1RCn0N19bLSG3x+x+zrQdfV3DfivnBauXoySYj3UhQaKujT/s5HX+07hYQ+6gVjbppdpBZKNsXbi+GDx1fOPVpSlEXX+76is4Sav/meTBh0sXpSOoSWuf8muTLJVFTe9uKsUSMHtvGeC7bzQYTXIwlqPvrbb4HFiWNWnRN6MDycqzJ9f5TvHbaaZQiDpYDDKf0ok0wge9msIYyQO56PSFOkM4sxb7YbMM1HNAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAHSA7i2zvpDHF2GZisvT2JYqKuM04ug4eQAKU0BrFrA4ML0HyLyGRbo6OE0pLLkKxCiYJ1YSy10QEjKSF3f80L8mxhQHW+Dclrk1xOGlvQp4aXgJWSlVTWJ/t+0MBG7yc6iCVL9bHPEohu6MXUqehOTTaVJ6MBEs1nsEjYdDZIWQIGogYTm9elR41H5q6vz1M64LQH2lL9TASlxMF85rNS1kQ5nw6lkxc20APUIiwxONzRSwjHdC1dcJvlU5A4+UGKB8/c5OJHKtjVtMXVnsttbQnkvHj5Tddr3TQIvkjdBOxxKfXEkad3D2+zsnHS53mA2xuhOXKLcIassDBXnWUJA=" ],
+        "priority" : [ "100" ],
+        "algorithm" : [ "RSA-OAEP" ]
+      }
+    }, {
+      "id" : "42898dfd-126f-430e-a283-31df15c58edb",
+      "name" : "aes-generated",
+      "providerId" : "aes-generated",
+      "subComponents" : { },
+      "config" : {
+        "kid" : [ "1960c3b7-d254-4510-8a2f-70fd280d7208" ],
+        "secret" : [ "yBQWJ7SDCaXgUZJvIV1bKg" ],
+        "priority" : [ "100" ]
+      }
+    }, {
+      "id" : "7887c35c-6ec4-4013-9a73-59556cb17ecc",
+      "name" : "rsa-generated",
+      "providerId" : "rsa-generated",
+      "subComponents" : { },
+      "config" : {
+        "privateKey" : [ "MIIEpAIBAAKCAQEAoCxgLo+b2LMTs7hXQz9zk92Di+dRgQRog9wuIbPWdd2T9tT60ZPrnH8UOfebdZbHh38fo4PBIz3v8NGbLz2f4oxzX7i+OZuionIoMDAuXA+Ra0ENEDJqd4/0W9Ag7kESe4IrctE1gQrsHyRdlJ8tC96Dvm3AnkLHPfXVwveiP7N9+kZJWXHMLWzW0KlSm57lLaGMU5xKtZFD9K0reWJTilzgJDxm8Cxp0rzFhDby8Dmw+SbS0pF30xVHkU3393Rc5+bnaEWauMrPQ8YQzcWYujI4/vKFUFGbnlpKk3mZgZw+NYo+TTmXnrRUG+7gcRNyDmn88aLZi+iXsv4/sGc2HwIDAQABAoIBACxQmrvHF8M4qHbMxbfhUkTSwJZwhWhAo/n3bPv+GZO6njloa4yYdFN0BVCUZPp/oOyoC0TeKw1pEX17QIgtcJLpcPJG1rpxiOmQ0/WhHvJxjDY0ZTzZ9gLmXSEZ0EKa1lY9iW/W2gq9zt4+3XVFJN1nzuNc0jH3H9DQtzed89HTky97XSauZ2Bxm7pBdKEY5v5xyveHM/8ktj9b+wGS+pRta7JGgFvxOBfEUOkW53oqyD+prcz6P1Vmhbz6YB4Qfagc0Hf11JwfGEVVWK4ptyOUStc1V7bChvIlevVefSDyVCP/+DhNp8i1jOvHrwhtlrLjXU5YjAry26gFJIr7AUECgYEAzwISXzxOqt1+7JWz88HE9grHh3GMGLXT2YZ1i86jbtHVBVRl9wyoMntWXIPOWJxNSq0JwZG7Uzk+yvZXRtbmAnlLTCWtGOlznT/rjH09nmCcf9/2a0iquffHHyBRUEbSz+NKPNBaSGItb82pG8FstAwj48bXUTkwuiaxusW3cfcCgYEAxhS+NlNqbb0jOYXTyKYK1wfYeW2jYAybLCNM4ZuGpHYA4NvkZ9W2359JX2GMOvu8Beq5T/WOE6nZt8xDtT5du4DtX6sZF42qJrbMmHuk3+bHnNWQpT0aENqjea8ACnAM2K/TvZnuKUCEjaebZpj/BkoxiexOzXSP5qgER7JGUxkCgYEAxTdfE3ZcKDLvaixRjghsQlAQufw2kZAhLdsI/9I1KC4muXYn0o8vazDQHUHBg/AdPujOI6lYgzhFl43LpoS0C2VNlFVMrTA0Ynr0SRtEai/2yWkw1hMb/CKQhRn//fALhd0v6/JAITfPu/V+iB/mFT5/rtDQb+SBhMe6iYs2cw8CgYEAkK5EBTBGk6NL4E800uEdF9UeNAt2AskSalnaZQuRe/zJRXS3z3QVoB8bm7SHlembe4LoGlRUk15DrXFgnzjPhA5206MIr+CEwMRSiqn9UqGheZewkFEiAd+A+ndtgzI23+sFsP6HK9B5QXKEGptz4yc8Ke7V3FHgbeyZO7kmjrkCgYBAxGyQeBGqmGGxhqKEdjZsBoXuICT3RT1CU33XHwgrCD35Dqc2KbuETsuMMkF928TZBlWsgoQKEYm3leY7SOyiFW1edVK5oE78kd3XuExVj9sIPxzVewxkPs9mlw4TzLcC95bxiNA8fVPE/L7EpxwAxSi7NdFtSBYZvpcPpbSLRw==" ],
+        "keyUse" : [ "SIG" ],
+        "certificate" : [ "MIICuTCCAaECBgGYgIsAwjANBgkqhkiG9w0BAQsFADAgMR4wHAYDVQQDDBVjYW11bmRhLWlkZW50aXR5LXRlc3QwHhcNMjUwODA2MTc1OTEwWhcNMzUwODA2MTgwMDUwWjAgMR4wHAYDVQQDDBVjYW11bmRhLWlkZW50aXR5LXRlc3QwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCgLGAuj5vYsxOzuFdDP3OT3YOL51GBBGiD3C4hs9Z13ZP21PrRk+ucfxQ595t1lseHfx+jg8EjPe/w0ZsvPZ/ijHNfuL45m6KicigwMC5cD5FrQQ0QMmp3j/Rb0CDuQRJ7gity0TWBCuwfJF2Uny0L3oO+bcCeQsc99dXC96I/s336RklZccwtbNbQqVKbnuUtoYxTnEq1kUP0rSt5YlOKXOAkPGbwLGnSvMWENvLwObD5JtLSkXfTFUeRTff3dFzn5udoRZq4ys9DxhDNxZi6Mjj+8oVQUZueWkqTeZmBnD41ij5NOZeetFQb7uBxE3IOafzxotmL6Jey/j+wZzYfAgMBAAEwDQYJKoZIhvcNAQELBQADggEBADpx3+OA403dEV4cY3sEo/objdyg7zv3c7UfvkbOL2T6PHQVWhDrKobGP55FNOcDfnVOBCxxgLlAEAEjNlPcH0VBm0sRRj4CoOVndHhzFNrgajfxmE3HuksXol8As5BEhLxDX8sBgZmATAmQvUTGsVwE3B/xcpa9ZrpFw5BVKmXy+fuXP2K+LoX7OXoAGPqOHVnbNJxr1tBja8TnxAhffSWuTfAU+hvirtVmZuSk6fC+gq1Bl2X0OZfrAibeUpnhxlODh9B+DeMpnwmUQ5c0uM4CcY4WKE9pskfoeBg+CfHDP7lOZPlLp15R7cQwSNyd7i2rf6vrndrJjdpav3WrcLU=" ],
+        "priority" : [ "100" ]
+      }
+    }, {
+      "id" : "f07640ae-3451-4ae2-b638-cb2ad0bd6485",
+      "name" : "hmac-generated-hs512",
+      "providerId" : "hmac-generated",
+      "subComponents" : { },
+      "config" : {
+        "kid" : [ "a65c10ae-a227-4d6b-9265-00b36d5bfd8a" ],
+        "secret" : [ "S13WbC8VVI7jcWaW10XMeycMVLBNhwozpkEz3pTBoA6WhHgBLwnLzUFCN1jOtmPDxYLrw54GXXMGjvoWFuj2qLNW1y7C6iL5GLJ_kyGmeUbAIl8gn8cVRP39vsmhNs8PcdduOvfAItCRx-KmhU_pPBRWj3LbvadGjJNWKQ4hDv4" ],
+        "priority" : [ "100" ],
+        "algorithm" : [ "HS512" ]
+      }
+    } ]
+  },
+  "internationalizationEnabled" : false,
+  "supportedLocales" : [ ],
+  "authenticationFlows" : [ {
+    "id" : "4e834390-bbe8-439d-834a-f67e096a32ae",
+    "alias" : "Account verification options",
+    "description" : "Method with which to verity the existing account",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "idp-email-verification",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 20,
+      "autheticatorFlow" : true,
+      "flowAlias" : "Verify Existing Account by Re-authentication",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "c38ced19-6f2a-4051-8ab3-5e53a0434bf7",
+    "alias" : "Browser - Conditional OTP",
+    "description" : "Flow to determine if the OTP is required for the authentication",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "conditional-user-configured",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "auth-otp-form",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "445f8e01-3fe0-4fbb-ab56-239a036d9449",
+    "alias" : "Browser - Conditional Organization",
+    "description" : "Flow to determine if the organization identity-first login is to be used",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "conditional-user-configured",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "organization",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "dc43646a-4023-4ecd-a87a-13b9831515fd",
+    "alias" : "Direct Grant - Conditional OTP",
+    "description" : "Flow to determine if the OTP is required for the authentication",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "conditional-user-configured",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "direct-grant-validate-otp",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "e1e347c5-0705-4112-b749-8665181b8961",
+    "alias" : "First Broker Login - Conditional Organization",
+    "description" : "Flow to determine if the authenticator that adds organization members is to be used",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "conditional-user-configured",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "idp-add-organization-member",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "655ff557-7725-4322-ac6f-f367c999fc66",
+    "alias" : "First broker login - Conditional OTP",
+    "description" : "Flow to determine if the OTP is required for the authentication",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "conditional-user-configured",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "auth-otp-form",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "a9c5bb54-9c20-44bc-b3b1-8bacc9d76c58",
+    "alias" : "Handle Existing Account",
+    "description" : "Handle what to do if there is existing account with same email/username like authenticated identity provider",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "idp-confirm-link",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : true,
+      "flowAlias" : "Account verification options",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "d6eae695-c184-4d4c-b106-55d982c6ba58",
+    "alias" : "Organization",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticatorFlow" : true,
+      "requirement" : "CONDITIONAL",
+      "priority" : 10,
+      "autheticatorFlow" : true,
+      "flowAlias" : "Browser - Conditional Organization",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "864f657e-bc3c-4b83-a22d-466f4a83b5b4",
+    "alias" : "Reset - Conditional OTP",
+    "description" : "Flow to determine if the OTP should be reset or not. Set to REQUIRED to force.",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "conditional-user-configured",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "reset-otp",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "ce3d7c0c-4db6-48bb-8be0-275942146af0",
+    "alias" : "User creation or linking",
+    "description" : "Flow for the existing/non-existing user alternatives",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticatorConfig" : "create unique user config",
+      "authenticator" : "idp-create-user-if-unique",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 20,
+      "autheticatorFlow" : true,
+      "flowAlias" : "Handle Existing Account",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "b355286e-c2e6-42a3-993b-24ddfeb50269",
+    "alias" : "Verify Existing Account by Re-authentication",
+    "description" : "Reauthentication of existing account",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "idp-username-password-form",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "CONDITIONAL",
+      "priority" : 20,
+      "autheticatorFlow" : true,
+      "flowAlias" : "First broker login - Conditional OTP",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "f4e65f0a-026b-40bb-95f7-fe47bc7f28f7",
+    "alias" : "browser",
+    "description" : "Browser based authentication",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "auth-cookie",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "auth-spnego",
+      "authenticatorFlow" : false,
+      "requirement" : "DISABLED",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "identity-provider-redirector",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 25,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 26,
+      "autheticatorFlow" : true,
+      "flowAlias" : "Organization",
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 30,
+      "autheticatorFlow" : true,
+      "flowAlias" : "forms",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "a2a935c8-db76-4c77-8356-0a7432259363",
+    "alias" : "clients",
+    "description" : "Base authentication for clients",
+    "providerId" : "client-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "client-secret",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "client-jwt",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "client-secret-jwt",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 30,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "client-x509",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 40,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "95202d5a-f47e-4d6f-957e-1448b0d82320",
+    "alias" : "direct grant",
+    "description" : "OpenID Connect Resource Owner Grant",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "direct-grant-validate-username",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "direct-grant-validate-password",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "CONDITIONAL",
+      "priority" : 30,
+      "autheticatorFlow" : true,
+      "flowAlias" : "Direct Grant - Conditional OTP",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "f08ded89-69ca-45d3-80dd-55f7b848ebfe",
+    "alias" : "docker auth",
+    "description" : "Used by Docker clients to authenticate against the IDP",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "docker-http-basic-authenticator",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "6200362c-9300-420e-9483-a41735ceafcc",
+    "alias" : "first broker login",
+    "description" : "Actions taken after first broker login with identity provider account, which is not yet linked to any Keycloak account",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticatorConfig" : "review profile config",
+      "authenticator" : "idp-review-profile",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : true,
+      "flowAlias" : "User creation or linking",
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "CONDITIONAL",
+      "priority" : 50,
+      "autheticatorFlow" : true,
+      "flowAlias" : "First Broker Login - Conditional Organization",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "57d0d688-8a0d-4c0d-804c-02316683a6b2",
+    "alias" : "forms",
+    "description" : "Username, password, otp and other auth forms.",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "auth-username-password-form",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "CONDITIONAL",
+      "priority" : 20,
+      "autheticatorFlow" : true,
+      "flowAlias" : "Browser - Conditional OTP",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "63e7278d-fbdd-408e-9668-82492d20107b",
+    "alias" : "registration",
+    "description" : "Registration flow",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "registration-page-form",
+      "authenticatorFlow" : true,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : true,
+      "flowAlias" : "registration form",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "66240490-351b-4141-bd4d-a21aae644ca0",
+    "alias" : "registration form",
+    "description" : "Registration form",
+    "providerId" : "form-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "registration-user-creation",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "registration-password-action",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 50,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "registration-recaptcha-action",
+      "authenticatorFlow" : false,
+      "requirement" : "DISABLED",
+      "priority" : 60,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "registration-terms-and-conditions",
+      "authenticatorFlow" : false,
+      "requirement" : "DISABLED",
+      "priority" : 70,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "62e50103-1ab0-49fd-bc45-b8558853e0b9",
+    "alias" : "reset credentials",
+    "description" : "Reset credentials for a user if they forgot their password or something",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "reset-credentials-choose-user",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "reset-credential-email",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "reset-password",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 30,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "CONDITIONAL",
+      "priority" : 40,
+      "autheticatorFlow" : true,
+      "flowAlias" : "Reset - Conditional OTP",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "21eab71f-e47a-4339-9089-4fca72da6244",
+    "alias" : "saml ecp",
+    "description" : "SAML ECP Profile Authentication Flow",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "http-basic-authenticator",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  } ],
+  "authenticatorConfig" : [ {
+    "id" : "349dc9b7-6fb6-423b-ac15-d54995c4a43f",
+    "alias" : "create unique user config",
+    "config" : {
+      "require.password.update.after.registration" : "false"
+    }
+  }, {
+    "id" : "0a4b44ed-f1ac-4025-b82d-ea1dedfac011",
+    "alias" : "review profile config",
+    "config" : {
+      "update.profile.on.first.login" : "missing"
+    }
+  } ],
+  "requiredActions" : [ {
+    "alias" : "CONFIGURE_TOTP",
+    "name" : "Configure OTP",
+    "providerId" : "CONFIGURE_TOTP",
+    "enabled" : true,
+    "defaultAction" : false,
+    "priority" : 10,
+    "config" : { }
+  }, {
+    "alias" : "TERMS_AND_CONDITIONS",
+    "name" : "Terms and Conditions",
+    "providerId" : "TERMS_AND_CONDITIONS",
+    "enabled" : false,
+    "defaultAction" : false,
+    "priority" : 20,
+    "config" : { }
+  }, {
+    "alias" : "UPDATE_PASSWORD",
+    "name" : "Update Password",
+    "providerId" : "UPDATE_PASSWORD",
+    "enabled" : true,
+    "defaultAction" : false,
+    "priority" : 30,
+    "config" : { }
+  }, {
+    "alias" : "UPDATE_PROFILE",
+    "name" : "Update Profile",
+    "providerId" : "UPDATE_PROFILE",
+    "enabled" : true,
+    "defaultAction" : false,
+    "priority" : 40,
+    "config" : { }
+  }, {
+    "alias" : "VERIFY_EMAIL",
+    "name" : "Verify Email",
+    "providerId" : "VERIFY_EMAIL",
+    "enabled" : true,
+    "defaultAction" : false,
+    "priority" : 50,
+    "config" : { }
+  }, {
+    "alias" : "delete_account",
+    "name" : "Delete Account",
+    "providerId" : "delete_account",
+    "enabled" : false,
+    "defaultAction" : false,
+    "priority" : 60,
+    "config" : { }
+  }, {
+    "alias" : "webauthn-register",
+    "name" : "Webauthn Register",
+    "providerId" : "webauthn-register",
+    "enabled" : true,
+    "defaultAction" : false,
+    "priority" : 70,
+    "config" : { }
+  }, {
+    "alias" : "webauthn-register-passwordless",
+    "name" : "Webauthn Register Passwordless",
+    "providerId" : "webauthn-register-passwordless",
+    "enabled" : true,
+    "defaultAction" : false,
+    "priority" : 80,
+    "config" : { }
+  }, {
+    "alias" : "VERIFY_PROFILE",
+    "name" : "Verify Profile",
+    "providerId" : "VERIFY_PROFILE",
+    "enabled" : true,
+    "defaultAction" : false,
+    "priority" : 90,
+    "config" : { }
+  }, {
+    "alias" : "delete_credential",
+    "name" : "Delete Credential",
+    "providerId" : "delete_credential",
+    "enabled" : true,
+    "defaultAction" : false,
+    "priority" : 100,
+    "config" : { }
+  }, {
+    "alias" : "update_user_locale",
+    "name" : "Update User Locale",
+    "providerId" : "update_user_locale",
+    "enabled" : true,
+    "defaultAction" : false,
+    "priority" : 1000,
+    "config" : { }
+  } ],
+  "browserFlow" : "browser",
+  "registrationFlow" : "registration",
+  "directGrantFlow" : "direct grant",
+  "resetCredentialsFlow" : "reset credentials",
+  "clientAuthenticationFlow" : "clients",
+  "dockerAuthenticationFlow" : "docker auth",
+  "firstBrokerLoginFlow" : "first broker login",
+  "attributes" : {
+    "cibaBackchannelTokenDeliveryMode" : "poll",
+    "cibaExpiresIn" : "120",
+    "cibaAuthRequestedUserHint" : "login_hint",
+    "oauth2DeviceCodeLifespan" : "600",
+    "oauth2DevicePollingInterval" : "5",
+    "parRequestUriLifespan" : "60",
+    "cibaInterval" : "5",
+    "realmReusableOtpCode" : "false"
+  },
+  "keycloakVersion" : "26.1.0",
+  "userManagedAccessAllowed" : false,
+  "organizationsEnabled" : false,
+  "verifiableCredentialsEnabled" : false,
+  "adminPermissionsEnabled" : false,
+  "clientProfiles" : {
+    "profiles" : [ ]
+  },
+  "clientPolicies" : {
+    "policies" : [ ]
+  }
+}


### PR DESCRIPTION
## Description

This PR adds integration tests for client and end-user OIDC flows.
The tests cover responses to unauthenticated requests, invalid credentials obtaining valid tokens via Keycloak, and accessing protected resources with valid tokens.

Keycloak is not in the center of the tests, rather it's used as a generic IDP with the aim of validating the expected behavior of the Identity module, with the emphasis on the behavior configured in `WebSecurityConfig`.
The tests can be extended with further edge cases with minimal cost, as the Keycloak container is reused.
The local runtime of the `OidcFlowTest` test class is  around 10 seconds due to container startup, while CI duration has been observed at around 30 seconds (as part of a separate thread, so not extending the whole runtime by that much).

<!-- Describe the goal and purpose of this PR. -->

## Related issues

closes #31998
