### PR TITLE
Update golden file to match base image version in Dockerfile

### DIFF
--- a/optimize/docker/test/docker-labels.golden.json
+++ b/optimize/docker/test/docker-labels.golden.json
@@ -6,7 +6,7 @@
   "io.openshift.wants": "zeebe,elasticsearch,identity,keycloak,opensearch",
   "io.openshift.tags": "bpmn,optimization,camunda",
   "org.opencontainers.image.authors": "optimize@camunda.com",
-  "org.opencontainers.image.base.name": "docker.io/library/alpine:3.22.0",
+  "org.opencontainers.image.base.name": "docker.io/library/alpine:3.22.1",
   "org.opencontainers.image.base.digest": $BASEDIGEST,
   "org.opencontainers.image.created": $DATE,
   "org.opencontainers.image.description": "Provides business activity monitoring for workflows and uses BPMN-based analysis to uncover process bottlenecks",


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
The release build for Optimize 8.8.0-alpha7-rc1 was failing during the Docker image verification step. The issue was caused by a mismatch between the base image version specified in the Dockerfile and the expected version in the golden JSON file used for verification.

This PR updates the golden file to reflect the new base image version, resolving the mismatch and allowing the verification step to pass.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
