### PR TITLE
fix: added requiired UC bean to Identity migration

### DIFF
--- a/dist/src/main/java/io/camunda/application/StandaloneIdentityMigration.java
+++ b/dist/src/main/java/io/camunda/application/StandaloneIdentityMigration.java
@@ -8,6 +8,8 @@
 package io.camunda.application;
 
 import io.camunda.application.commons.migration.BlockingMigrationsRunner;
+import io.camunda.configuration.UnifiedConfiguration;
+import io.camunda.configuration.UnifiedConfigurationHelper;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.ExitCodeGenerator;
 import org.springframework.boot.SpringApplication;
@@ -38,7 +40,11 @@ public class StandaloneIdentityMigration implements CommandLineRunner, ExitCodeG
         new SpringApplicationBuilder()
             .logStartupInfo(true)
             .web(WebApplicationType.NONE)
-            .sources(StandaloneIdentityMigration.class, BlockingMigrationsRunner.class)
+            .sources(
+                StandaloneIdentityMigration.class,
+                BlockingMigrationsRunner.class,
+                UnifiedConfigurationHelper.class,
+                UnifiedConfiguration.class)
             .profiles(Profile.IDENTITY_MIGRATION.getId())
             .addCommandLineProperties(true)
             .build(args);


### PR DESCRIPTION
## Description

Context: Identity Migration application won't start due to Unified Config classes missing during Spring context loading. Identity engineers approached us via direct communication: https://camunda.slack.com/archives/C08E56YUUMS/p1754549783716559.

This PR adds required UC config classes.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

Inquiry without an issue.
