### PR TITLE
feat: add camunda.data.backup.gcs properties to unified configuration

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/Backup.java
+++ b/configuration/src/main/java/io/camunda/configuration/Backup.java
@@ -8,8 +8,11 @@
 package io.camunda.configuration;
 
 public class Backup {
-  /** Configuration for backup store S3 */
+  /** Configuration for backup store AWS S3 */
   private S3 s3 = new S3();
+
+  /** Configuration for backup store GCS */
+  private Gcs gcs = new Gcs();
 
   public S3 getS3() {
     return s3;
@@ -17,5 +20,13 @@ public class Backup {
 
   public void setS3(final S3 s3) {
     this.s3 = s3;
+  }
+
+  public Gcs getGcs() {
+    return gcs;
+  }
+
+  public void setGcs(final Gcs gcs) {
+    this.gcs = gcs;
   }
 }

--- a/configuration/src/main/java/io/camunda/configuration/Gcs.java
+++ b/configuration/src/main/java/io/camunda/configuration/Gcs.java
@@ -11,7 +11,7 @@ import io.camunda.configuration.UnifiedConfigurationHelper.BackwardsCompatibilit
 import java.util.Set;
 
 public class Gcs {
-  private static final String PREFIX = "camunda.data.backup.gcs.";
+  private static final String PREFIX = "camunda.data.backup.gcs";
   private static final Set<String> LEGACY_BUCKETNAME_PROPERTIES =
       Set.of("zeebe.broker.data.backup.gcs.bucketName");
   private static final Set<String> LEGACY_BASEPATH_PROPERTIES =
@@ -52,7 +52,7 @@ public class Gcs {
 
   public String getBucketName() {
     return UnifiedConfigurationHelper.validateLegacyConfiguration(
-        PREFIX + "bucket-name",
+        PREFIX + ".bucket-name",
         bucketName,
         String.class,
         BackwardsCompatibilityMode.SUPPORTED,
@@ -65,7 +65,7 @@ public class Gcs {
 
   public String getBasePath() {
     return UnifiedConfigurationHelper.validateLegacyConfiguration(
-        PREFIX + "base-path",
+        PREFIX + ".base-path",
         basePath,
         String.class,
         BackwardsCompatibilityMode.SUPPORTED,
@@ -78,7 +78,7 @@ public class Gcs {
 
   public String getHost() {
     return UnifiedConfigurationHelper.validateLegacyConfiguration(
-        PREFIX + "host",
+        PREFIX + ".host",
         host,
         String.class,
         BackwardsCompatibilityMode.SUPPORTED,
@@ -91,7 +91,7 @@ public class Gcs {
 
   public GcsBackupStoreAuth getAuth() {
     return UnifiedConfigurationHelper.validateLegacyConfiguration(
-        PREFIX + "auth",
+        PREFIX + ".auth",
         auth,
         GcsBackupStoreAuth.class,
         BackwardsCompatibilityMode.SUPPORTED,

--- a/configuration/src/main/java/io/camunda/configuration/Gcs.java
+++ b/configuration/src/main/java/io/camunda/configuration/Gcs.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import io.camunda.configuration.UnifiedConfigurationHelper.BackwardsCompatibilityMode;
+import java.util.Set;
+
+public class Gcs {
+  private static final String PREFIX = "camunda.data.backup.gcs.";
+  private static final Set<String> LEGACY_BUCKETNAME_PROPERTIES =
+      Set.of("zeebe.broker.data.backup.gcs.bucketName");
+  private static final Set<String> LEGACY_BASEPATH_PROPERTIES =
+      Set.of("zeebe.broker.data.backup.gcs.basePath");
+  private static final Set<String> LEGACY_HOST_PROPERTIES =
+      Set.of("zeebe.broker.data.backup.gcs.host");
+  private static final Set<String> LEGACY_AUTH_PROPERTIES =
+      Set.of("zeebe.broker.data.backup.gcs.auth");
+
+  /**
+   * Name of the bucket where the backup will be stored. The bucket must already exist. The bucket
+   * must not be shared with other Zeebe clusters unless basePath is also set.
+   */
+  private String bucketName;
+
+  /**
+   * When set, all blobs in the bucket will use this prefix. Useful for using the same bucket for
+   * multiple Zeebe clusters. In this case, basePath must be unique. Should not start or end with
+   * '/' character. Must be non-empty and not consist of only '/' characters.
+   */
+  private String basePath;
+
+  /**
+   * When set, this overrides the host that the GCS client connects to. # By default, this is not
+   * set because the client can automatically discover the correct host to # connect to.
+   */
+  private String host;
+
+  /**
+   * Configures which authentication method is used for connecting to GCS. Can be either 'auto' or
+   * 'none'. Choosing 'auto' means that the GCS client uses application default credentials which
+   * automatically discovers appropriate credentials from the runtime environment: <a
+   * href="https://cloud.google.com/docs/authentication/application-default-credentials">...</a>
+   * Choosing 'none' means that no authentication is attempted which is only applicable for testing
+   * with emulated GCS.
+   */
+  private GcsBackupStoreAuth auth = GcsBackupStoreAuth.AUTO;
+
+  public String getBucketName() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + "bucket-name",
+        bucketName,
+        String.class,
+        BackwardsCompatibilityMode.SUPPORTED,
+        LEGACY_BUCKETNAME_PROPERTIES);
+  }
+
+  public void setBucketName(final String bucketName) {
+    this.bucketName = bucketName;
+  }
+
+  public String getBasePath() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + "base-path",
+        basePath,
+        String.class,
+        BackwardsCompatibilityMode.SUPPORTED,
+        LEGACY_BASEPATH_PROPERTIES);
+  }
+
+  public void setBasePath(final String basePath) {
+    this.basePath = basePath;
+  }
+
+  public String getHost() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + "host",
+        host,
+        String.class,
+        BackwardsCompatibilityMode.SUPPORTED,
+        LEGACY_HOST_PROPERTIES);
+  }
+
+  public void setHost(final String host) {
+    this.host = host;
+  }
+
+  public GcsBackupStoreAuth getAuth() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + "auth",
+        auth,
+        GcsBackupStoreAuth.class,
+        BackwardsCompatibilityMode.SUPPORTED,
+        LEGACY_AUTH_PROPERTIES);
+  }
+
+  public void setAuth(final GcsBackupStoreAuth auth) {
+    this.auth = auth;
+  }
+
+  public enum GcsBackupStoreAuth {
+    NONE,
+    AUTO
+  }
+}

--- a/configuration/src/main/java/io/camunda/configuration/UnifiedConfigurationHelper.java
+++ b/configuration/src/main/java/io/camunda/configuration/UnifiedConfigurationHelper.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.configuration;
 
+import io.camunda.configuration.Gcs.GcsBackupStoreAuth;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
@@ -214,6 +215,7 @@ public class UnifiedConfigurationHelper {
       case "Duration" -> (T) DurationStyle.detectAndParse(strValue);
       case "Long" -> (T) Long.valueOf(strValue);
       case "DataSize" -> (T) DataSize.parse(strValue);
+      case "GcsBackupStoreAuth" -> (T) GcsBackupStoreAuth.valueOf(strValue.toUpperCase());
       default -> throw new IllegalArgumentException("Unsupported type: " + type);
     };
   }

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.configuration.beanoverrides;
 
+import io.camunda.configuration.Gcs;
 import io.camunda.configuration.S3;
 import io.camunda.configuration.UnifiedConfiguration;
 import io.camunda.configuration.beans.BrokerBasedProperties;
@@ -14,6 +15,8 @@ import io.camunda.configuration.beans.LegacyBrokerBasedProperties;
 import io.camunda.zeebe.broker.system.configuration.ConfigManagerCfg;
 import io.camunda.zeebe.broker.system.configuration.RaftCfg.FlushConfig;
 import io.camunda.zeebe.broker.system.configuration.ThreadsCfg;
+import io.camunda.zeebe.broker.system.configuration.backup.GcsBackupStoreConfig;
+import io.camunda.zeebe.broker.system.configuration.backup.GcsBackupStoreConfig.GcsBackupStoreAuth;
 import io.camunda.zeebe.broker.system.configuration.backup.S3BackupStoreConfig;
 import io.camunda.zeebe.dynamic.config.gossip.ClusterConfigurationGossiperConfig;
 import org.springframework.beans.BeanUtils;
@@ -124,6 +127,7 @@ public class BrokerBasedPropertiesOverride {
 
   private void populateFromBackup(final BrokerBasedProperties override) {
     populateFromS3(override);
+    populateFromGcs(override);
   }
 
   private void populateFromS3(final BrokerBasedProperties override) {
@@ -160,5 +164,16 @@ public class BrokerBasedPropertiesOverride {
         .setReplication(unifiedDiskConfig.getFreeSpace().getReplication());
     brokerDiskConfig.setEnableMonitoring(unifiedDiskConfig.isMonitoringEnabled());
     brokerDiskConfig.setMonitoringInterval(unifiedDiskConfig.getMonitoringInterval());
+  }
+
+  private void populateFromGcs(final BrokerBasedProperties override) {
+    final Gcs gcs = unifiedConfiguration.getCamunda().getData().getBackup().getGcs();
+    final GcsBackupStoreConfig gcsBackupStoreConfig = override.getData().getBackup().getGcs();
+    gcsBackupStoreConfig.setBucketName(gcs.getBucketName());
+    gcsBackupStoreConfig.setBasePath(gcs.getBasePath());
+    gcsBackupStoreConfig.setHost(gcs.getHost());
+    gcsBackupStoreConfig.setAuth(GcsBackupStoreAuth.valueOf(gcs.getAuth().name()));
+
+    override.getData().getBackup().setGcs(gcsBackupStoreConfig);
   }
 }

--- a/configuration/src/test/java/io/camunda/configuration/DataBackupGcsTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/DataBackupGcsTest.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.configuration.beanoverrides.BrokerBasedPropertiesOverride;
+import io.camunda.configuration.beans.BrokerBasedProperties;
+import io.camunda.zeebe.broker.system.configuration.backup.GcsBackupStoreConfig.GcsBackupStoreAuth;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+@SpringJUnitConfig({
+  UnifiedConfiguration.class,
+  BrokerBasedPropertiesOverride.class,
+  UnifiedConfigurationHelper.class
+})
+@ActiveProfiles("broker")
+public class DataBackupGcsTest {
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "camunda.data.backup.gcs.bucket-name=bucketNameNew",
+        "camunda.data.backup.gcs.base-path=basePathNew",
+        "camunda.data.backup.gcs.host=hostNew",
+        "camunda.data.backup.gcs.auth=none",
+      })
+  class WithOnlyUnifiedConfigSet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithOnlyUnifiedConfigSet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldSetBucketName() {
+      assertThat(brokerCfg.getData().getBackup().getGcs().getBucketName())
+          .isEqualTo("bucketNameNew");
+    }
+
+    @Test
+    void shouldSetBasePath() {
+      assertThat(brokerCfg.getData().getBackup().getGcs().getBasePath()).isEqualTo("basePathNew");
+    }
+
+    @Test
+    void shouldSetHost() {
+      assertThat(brokerCfg.getData().getBackup().getGcs().getHost()).isEqualTo("hostNew");
+    }
+
+    @Test
+    void shouldSetAuth() {
+      assertThat(brokerCfg.getData().getBackup().getGcs().getAuth())
+          .isEqualTo(GcsBackupStoreAuth.NONE);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "zeebe.broker.data.backup.gcs.bucketName=bucketNameLegacy",
+        "zeebe.broker.data.backup.gcs.basePath=basePathLegacy",
+        "zeebe.broker.data.backup.gcs.host=hostLegacy",
+        "zeebe.broker.data.backup.gcs.auth=none",
+      })
+  class WithOnlyLegacySet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithOnlyLegacySet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldSetBucketName() {
+      assertThat(brokerCfg.getData().getBackup().getGcs().getBucketName())
+          .isEqualTo("bucketNameLegacy");
+    }
+
+    @Test
+    void shouldSetBasePath() {
+      assertThat(brokerCfg.getData().getBackup().getGcs().getBasePath())
+          .isEqualTo("basePathLegacy");
+    }
+
+    @Test
+    void shouldSetHost() {
+      assertThat(brokerCfg.getData().getBackup().getGcs().getHost()).isEqualTo("hostLegacy");
+    }
+
+    @Test
+    void shouldSetAuth() {
+      assertThat(brokerCfg.getData().getBackup().getGcs().getAuth())
+          .isEqualTo(GcsBackupStoreAuth.NONE);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        // new
+        "camunda.data.backup.gcs.bucket-name=bucketNameNew",
+        "camunda.data.backup.gcs.base-path=basePathNew",
+        "camunda.data.backup.gcs.host=hostNew",
+        "camunda.data.backup.gcs.auth=none",
+        // legacy
+        "zeebe.broker.data.backup.gcs.bucketName=bucketNameLegacy",
+        "zeebe.broker.data.backup.gcs.basePath=basePathLegacy",
+        "zeebe.broker.data.backup.gcs.host=hostLegacy",
+        "zeebe.broker.data.backup.gcs.auth=auto",
+      })
+  class WithNewAndLegacySet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithNewAndLegacySet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldSetBucketNameFromNew() {
+      assertThat(brokerCfg.getData().getBackup().getGcs().getBucketName())
+          .isEqualTo("bucketNameNew");
+    }
+
+    @Test
+    void shouldSetBasePathFromNew() {
+      assertThat(brokerCfg.getData().getBackup().getGcs().getBasePath()).isEqualTo("basePathNew");
+    }
+
+    @Test
+    void shouldSetHostFromNew() {
+      assertThat(brokerCfg.getData().getBackup().getGcs().getHost()).isEqualTo("hostNew");
+    }
+
+    @Test
+    void shouldSetAuthFromNew() {
+      assertThat(brokerCfg.getData().getBackup().getGcs().getAuth())
+          .isEqualTo(GcsBackupStoreAuth.NONE);
+    }
+  }
+}


### PR DESCRIPTION
## Description

This PR adds the properties from section camunda.data.backup.gcs in unified config.

The legacy properties are:

zeebe.broker.data.backup.gcs.bucketName
zeebe.broker.data.backup.gcs.basePath
zeebe.broker.data.backup.gcs.host
zeebe.broker.data.backup.gcs.auth

The new properties are:

camunda.data.backup.gcs.bucket-name
camunda.data.backup.gcs.base-path
camunda.data.backup.gcs.host
camunda.data.backup.gcs.auth

Backwards compatibility is supported for these properties. That means, if legacy is set and new property is not set, legacy value will be used.
## Checklist

- [ ] The legacy properties and the backwards compatibility strategy are updated in [schema doc](https://docs.google.com/spreadsheets/d/1R4epsy6DWemA8_76cUE6zOGUFbrXCXlM2reXnKFuz7Y/edit?gid=818158292#gid=818158292)
- [ ] The new property fields are documented in the code
## Related issues

related to #34908 
