### PR TITLE
feat: add AppSwitcher to Identity

### DIFF
--- a/dist/src/main/java/io/camunda/identity/webapp/controllers/IdentityClientConfigController.java
+++ b/dist/src/main/java/io/camunda/identity/webapp/controllers/IdentityClientConfigController.java
@@ -27,6 +27,8 @@ public class IdentityClientConfigController {
   private static final String IS_OIDC = "isOidc";
   private static final String IS_CAMUNDA_GROUPS_ENABLED = "isCamundaGroupsEnabled";
   private static final String IS_TENANTS_API_ENABLED = "isTenantsApiEnabled";
+  private static final String ORGANIZATION_ID = "organizationId";
+  private static final String CLUSTER_ID = "clusterId";
   private static final String FALLBACK_CONFIG_JS = "window.clientConfig = {};";
   private static final String CONFIG_JS_TEMPLATE = "window.clientConfig = %s;";
 
@@ -50,11 +52,19 @@ public class IdentityClientConfigController {
   }
 
   private Map<String, String> createConfigMap(final SecurityConfiguration securityConfiguration) {
-    return Map.of(
-        IS_OIDC, String.valueOf(isOidcAuthentication(securityConfiguration)),
-        IS_CAMUNDA_GROUPS_ENABLED, String.valueOf(isCamundaGroupsEnabled(securityConfiguration)),
+    final var config = new java.util.HashMap<String, String>();
+    final var saasConfiguration = securityConfiguration.getSaas();
+
+    config.put(IS_OIDC, String.valueOf(isOidcAuthentication(securityConfiguration)));
+    config.put(
+        IS_CAMUNDA_GROUPS_ENABLED, String.valueOf(isCamundaGroupsEnabled(securityConfiguration)));
+    config.put(
         IS_TENANTS_API_ENABLED,
-            String.valueOf(securityConfiguration.getMultiTenancy().isApiEnabled()));
+        String.valueOf(securityConfiguration.getMultiTenancy().isApiEnabled()));
+    config.put(ORGANIZATION_ID, saasConfiguration.getOrganizationId());
+    config.put(CLUSTER_ID, saasConfiguration.getClusterId());
+
+    return config;
   }
 
   private boolean isOidcAuthentication(final SecurityConfiguration securityConfiguration) {

--- a/identity/client/.env
+++ b/identity/client/.env
@@ -1,1 +1,4 @@
 VITE_APP_VERSION=$npm_package_version
+VITE_DEV_ENV_URL=dev.ultrawombat.com
+VITE_INT_ENV_URL=ultrawombat.com
+VITE_PROD_ENV_URL=camunda.io

--- a/identity/client/package.json
+++ b/identity/client/package.json
@@ -18,7 +18,7 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@camunda/camunda-composite-components": "0.17.0",
+    "@camunda/camunda-composite-components": "0.20.2",
     "@carbon/elements": "^11.57.0",
     "@carbon/react": "1.78.2",
     "fuse.js": "7.1.0",

--- a/identity/client/src/components/global/AppRoot.tsx
+++ b/identity/client/src/components/global/AppRoot.tsx
@@ -18,6 +18,7 @@ import ForbiddenComponent from "src/pages/forbidden/ForbiddenPage";
 import LateLoading from "src/components/layout/LateLoading";
 import { addHandler, removeHandler } from "src/utility/api/request";
 import { activateSession } from "src/utility/auth";
+import { C3Provider } from "../layout/C3Provider";
 
 const GlobalStyle = createGlobalStyle`
   body {
@@ -127,8 +128,10 @@ const AppContent: FC<{ children?: ReactNode }> = ({ children }) => {
 const AppRoot: FC<{ children?: ReactNode }> = ({ children }) => (
   <AppRootWrapper>
     <ErrorBoundary>
-      <GlobalStyle />
-      <AppContent>{children}</AppContent>
+      <C3Provider>
+        <GlobalStyle />
+        <AppContent>{children}</AppContent>
+      </C3Provider>
     </ErrorBoundary>
   </AppRootWrapper>
 );

--- a/identity/client/src/components/layout/AppHeader.tsx
+++ b/identity/client/src/components/layout/AppHeader.tsx
@@ -14,15 +14,19 @@ import { checkLicense, License } from "src/utility/api/headers";
 import { getAuthentication } from "src/utility/api/authentication";
 import { ArrowRight } from "@carbon/react/icons";
 import { logout } from "src/utility/auth";
+import { useState } from "react";
+import { isSaaS } from "src/configuration";
 
 const AppHeader = ({ hideNavLinks = false }) => {
   const routes = useGlobalRoutes();
   const navigate = useNavigate();
   const { data: license } = useApi(checkLicense);
   const { data: camundaUser } = useApi(getAuthentication);
+  const [isAppBarOpen, setIsAppBarOpen] = useState(false);
 
   return (
     <C3Navigation
+      toggleAppbar={(isAppBarOpen) => setIsAppBarOpen(isAppBarOpen)}
       app={{
         name: "Identity",
         ariaLabel: "Identity",
@@ -31,8 +35,10 @@ const AppHeader = ({ hideNavLinks = false }) => {
         },
       }}
       appBar={{
-        isOpen: false,
-        elements: [],
+        ariaLabel: "App panel",
+        isOpen: isAppBarOpen,
+        elements: isSaaS ? undefined : [],
+        appTeaserRouteProps: isSaaS ? {} : undefined,
       }}
       navbar={{
         elements: hideNavLinks

--- a/identity/client/src/components/layout/C3Provider.tsx
+++ b/identity/client/src/components/layout/C3Provider.tsx
@@ -1,0 +1,57 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import { C3UserConfigurationProvider } from "@camunda/camunda-composite-components";
+import { useEffect } from "react";
+import { useApiCall } from "src/utility/api";
+import { getSaasUserToken } from "src/utility/api/authentication";
+import { getStage } from "src/utility/getStage";
+
+const STAGE = getStage(window.location.host);
+
+type Props = {
+  children: React.ReactNode;
+};
+
+const C3Provider: React.FC<Props> = ({ children }) => {
+  const [getToken, { data: token }] = useApiCall(getSaasUserToken);
+  const organizationId = window.clientConfig?.organizationId;
+  const clusterId = window.clientConfig?.clusterId;
+
+  useEffect(() => {
+    if (typeof organizationId === "string") {
+      void getToken();
+    }
+  }, [getToken]);
+
+  if (
+    !token ||
+    typeof organizationId !== "string" ||
+    typeof clusterId !== "string"
+  ) {
+    return children;
+  }
+
+  return (
+    <C3UserConfigurationProvider
+      activeOrganizationId={organizationId}
+      currentClusterUuid={clusterId}
+      userToken={token}
+      getNewUserToken={async () => {
+        const { data } = await getToken();
+        return data || "";
+      }}
+      currentApp="identity"
+      stage={STAGE === "unknown" ? "dev" : STAGE}
+    >
+      {children}
+    </C3UserConfigurationProvider>
+  );
+};
+
+export { C3Provider };

--- a/identity/client/src/utility/api/authentication/index.ts
+++ b/identity/client/src/utility/api/authentication/index.ts
@@ -35,3 +35,6 @@ export interface CamundaUser {
 
 export const getAuthentication: ApiDefinition<CamundaUser> = () =>
   apiGet("/authentication/me");
+
+export const getSaasUserToken: ApiDefinition<string> = () =>
+  apiGet("/authentication/me/token");

--- a/identity/client/src/utility/getStage.ts
+++ b/identity/client/src/utility/getStage.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+function getStage(host: string): "dev" | "int" | "prod" | "unknown" {
+  if (host.includes(import.meta.env.VITE_DEV_ENV_URL)) {
+    return "dev";
+  }
+
+  if (host.includes(import.meta.env.VITE_INT_ENV_URL)) {
+    return "int";
+  }
+
+  if (host.includes(import.meta.env.VITE_PROD_ENV_URL)) {
+    return "prod";
+  }
+
+  return "unknown";
+}
+
+export { getStage };

--- a/identity/client/yarn.lock
+++ b/identity/client/yarn.lock
@@ -542,9 +542,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@camunda/camunda-composite-components@npm:0.17.0":
-  version: 0.17.0
-  resolution: "@camunda/camunda-composite-components@npm:0.17.0"
+"@camunda/camunda-composite-components@npm:0.20.2":
+  version: 0.20.2
+  resolution: "@camunda/camunda-composite-components@npm:0.20.2"
   dependencies:
     jwt-decode: "npm:4.0.0"
     react-error-boundary: "npm:4.0.13"
@@ -552,10 +552,10 @@ __metadata:
   peerDependencies:
     "@carbon/react": 1.x
     event-source-polyfill: 1.0.x
-    react: 18.x
-    react-dom: 18.x
+    react: 18.x || 19.x
+    react-dom: 18.x || 19.x
     styled-components: 5.x || 6.x
-  checksum: 10c0/46be448b3849fe42ff0dc55b507cf4eba0eb6b11df1d85c6289e0ab8cb4156e2f42404f14763606f95db40faa961c0d0a490df551fc3bdde7422abd673a6b4ff
+  checksum: 10c0/e770377003d5f9f014d4dc77bafd58203c26fe544d51e7d63b941ef8f80326861cce6cc1950b2713383be53caac8a8b9ded22b512e31bd6bea0f394b7a6d842d
   languageName: node
   linkType: hard
 
@@ -3975,7 +3975,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "identity-frontend@workspace:."
   dependencies:
-    "@camunda/camunda-composite-components": "npm:0.17.0"
+    "@camunda/camunda-composite-components": "npm:0.20.2"
     "@carbon/elements": "npm:^11.57.0"
     "@carbon/react": "npm:1.78.2"
     "@types/carbon-components-react": "npm:^7.55.13"


### PR DESCRIPTION
## Description

This PR adds the appSwitcher to the Identity Webapp

More detailed setup instruction can be found here https://github.com/camunda/camunda/pull/36528#issuecomment-3167948976

<img width="718" height="421" alt="image" src="https://github.com/user-attachments/assets/49ecf495-525f-4d93-99cb-f5aa6e641e6a" />

Additionally, closes [this bug](https://github.com/camunda/camunda/issues/34475) by making `organizationId` available in the client config.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #33212
closes #34475 
