### PR TITLE
fix: skip exporting not initialized usage metric bucket

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/metrics/UsageMetricsExportProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/metrics/UsageMetricsExportProcessor.java
@@ -51,7 +51,7 @@ public class UsageMetricsExportProcessor implements TypedRecordProcessor<UsageMe
             .setResetTime(usageMetricRecord.getTimestamp());
 
     final var bucket = usageMetricState.getActiveBucket();
-    if (bucket == null) {
+    if (bucket == null || !bucket.isInitialized()) {
       appendFollowUpEvent(eventRecord);
       return;
     }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UsageMetricsExportedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UsageMetricsExportedApplier.java
@@ -31,7 +31,7 @@ public class UsageMetricsExportedApplier
     final var activeBucket = usageMetricState.getActiveBucket();
 
     // uninitialized bucket created on-demand
-    if (activeBucket != null && activeBucket.getFromTime() == -1) {
+    if (activeBucket != null && !activeBucket.isInitialized()) {
       LOG.debug("Update active bucket time {}", record.getResetTime());
       usageMetricState.updateActiveBucketTime(record.getResetTime());
     }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/metrics/PersistedUsageMetrics.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/metrics/PersistedUsageMetrics.java
@@ -35,6 +35,10 @@ public class PersistedUsageMetrics extends UnpackedObject implements DbValue {
         .declareProperty(tenantTUMapProp);
   }
 
+  public boolean isInitialized() {
+    return fromTimeProp.getValue() != -1L && toTimeProp.getValue() != -1L;
+  }
+
   public long getFromTime() {
     return fromTimeProp.getValue();
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/metrics/PersistedUsageMetrics.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/metrics/PersistedUsageMetrics.java
@@ -20,8 +20,10 @@ import org.agrona.DirectBuffer;
 
 public class PersistedUsageMetrics extends UnpackedObject implements DbValue {
 
-  private final LongProperty fromTimeProp = new LongProperty("fromTime", -1L);
-  private final LongProperty toTimeProp = new LongProperty("toTime", -1L);
+  public static final int TIME_NOT_SET = -1;
+
+  private final LongProperty fromTimeProp = new LongProperty("fromTime", TIME_NOT_SET);
+  private final LongProperty toTimeProp = new LongProperty("toTime", TIME_NOT_SET);
   private final DocumentProperty tenantRPIMapProp = new DocumentProperty("tenantRPI");
   private final DocumentProperty tenantEDIMapProp = new DocumentProperty("tenantEDI");
   private final DocumentProperty tenantTUMapProp = new DocumentProperty("tenantTU");
@@ -36,7 +38,7 @@ public class PersistedUsageMetrics extends UnpackedObject implements DbValue {
   }
 
   public boolean isInitialized() {
-    return fromTimeProp.getValue() != -1L && toTimeProp.getValue() != -1L;
+    return fromTimeProp.getValue() != TIME_NOT_SET && toTimeProp.getValue() != TIME_NOT_SET;
   }
 
   public long getFromTime() {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/metrics/UsageMetricsExportProcessorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/metrics/UsageMetricsExportProcessorTest.java
@@ -85,6 +85,30 @@ class UsageMetricsExportProcessorTest {
   }
 
   @Test
+  void shouldAppendExportedNoneEventWhenBucketNotInitialized() {
+    // given
+    when(state.getActiveBucket())
+        .thenReturn(new PersistedUsageMetrics().setTenantRPIMap(Map.of(TENANT_1, 10L)));
+
+    // when
+    processor.processRecord(record);
+
+    // then
+    verify(state).getActiveBucket();
+    verify(stateWriter)
+        .appendFollowUpEvent(
+            eq(1L), eq(UsageMetricIntent.EXPORTED), recordArgumentCaptor.capture());
+    final var actual = recordArgumentCaptor.getValue();
+    assertThat(actual.getIntervalType()).isEqualTo(IntervalType.ACTIVE);
+    assertThat(actual.getEventType()).isEqualTo(EventType.NONE);
+    assertThat(actual.getResetTime()).isEqualTo(2);
+    assertThat(actual.getStartTime()).isEqualTo(-1);
+    assertThat(actual.getEndTime()).isEqualTo(-1);
+    assertThat(actual.getCounterValues()).isEmpty();
+    assertThat(actual.getSetValues()).isEmpty();
+  }
+
+  @Test
   void shouldAppendExportedEventRPI() {
     // given
     when(state.getActiveBucket())

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/metrics/UsageMetricsExportProcessorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/metrics/UsageMetricsExportProcessorTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.metrics;
 
+import static io.camunda.zeebe.engine.state.metrics.PersistedUsageMetrics.TIME_NOT_SET;
 import static io.camunda.zeebe.util.HashUtil.getStringHashValue;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -78,8 +79,8 @@ class UsageMetricsExportProcessorTest {
     assertThat(actual.getIntervalType()).isEqualTo(IntervalType.ACTIVE);
     assertThat(actual.getEventType()).isEqualTo(EventType.NONE);
     assertThat(actual.getResetTime()).isEqualTo(2);
-    assertThat(actual.getStartTime()).isEqualTo(-1);
-    assertThat(actual.getEndTime()).isEqualTo(-1);
+    assertThat(actual.getStartTime()).isEqualTo(TIME_NOT_SET);
+    assertThat(actual.getEndTime()).isEqualTo(TIME_NOT_SET);
     assertThat(actual.getCounterValues()).isEmpty();
     assertThat(actual.getSetValues()).isEmpty();
   }
@@ -102,8 +103,8 @@ class UsageMetricsExportProcessorTest {
     assertThat(actual.getIntervalType()).isEqualTo(IntervalType.ACTIVE);
     assertThat(actual.getEventType()).isEqualTo(EventType.NONE);
     assertThat(actual.getResetTime()).isEqualTo(2);
-    assertThat(actual.getStartTime()).isEqualTo(-1);
-    assertThat(actual.getEndTime()).isEqualTo(-1);
+    assertThat(actual.getStartTime()).isEqualTo(TIME_NOT_SET);
+    assertThat(actual.getEndTime()).isEqualTo(TIME_NOT_SET);
     assertThat(actual.getCounterValues()).isEmpty();
     assertThat(actual.getSetValues()).isEmpty();
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/UsageMetricsExportedApplierTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/UsageMetricsExportedApplierTest.java
@@ -58,6 +58,25 @@ class UsageMetricsExportedApplierTest {
   }
 
   @Test
+  void shouldUpdateActiveBucketTimeWhenNotInitialized() {
+    // given
+    usageMetricState.recordRPIMetric("tenant1");
+    assertThat(usageMetricState.getActiveBucket().getFromTime()).isEqualTo(-1);
+    assertThat(usageMetricState.getActiveBucket().getToTime()).isEqualTo(-1);
+    assertThat(usageMetricState.getActiveBucket().getTenantRPIMap())
+        .containsExactlyInAnyOrderEntriesOf(Map.of("tenant1", 1L));
+
+    // when
+    usageMetricsExportedApplier.applyState(1L, new UsageMetricRecord().setResetTime(2L));
+
+    // then
+    assertThat(usageMetricState.getActiveBucket().getFromTime()).isEqualTo(2L);
+    assertThat(usageMetricState.getActiveBucket().getToTime()).isEqualTo(300002L);
+    assertThat(usageMetricState.getActiveBucket().getTenantRPIMap())
+        .containsExactlyInAnyOrderEntriesOf(Map.of("tenant1", 1L));
+  }
+
+  @Test
   void shouldResetActiveBucketRPI() {
     // given
     usageMetricState.resetActiveBucket(1L);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/UsageMetricsExportedApplierTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/UsageMetricsExportedApplierTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.state.appliers;
 
+import static io.camunda.zeebe.engine.state.metrics.PersistedUsageMetrics.TIME_NOT_SET;
 import static io.camunda.zeebe.util.HashUtil.getStringHashValue;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -61,8 +62,8 @@ class UsageMetricsExportedApplierTest {
   void shouldUpdateActiveBucketTimeWhenNotInitialized() {
     // given
     usageMetricState.recordRPIMetric("tenant1");
-    assertThat(usageMetricState.getActiveBucket().getFromTime()).isEqualTo(-1);
-    assertThat(usageMetricState.getActiveBucket().getToTime()).isEqualTo(-1);
+    assertThat(usageMetricState.getActiveBucket().getFromTime()).isEqualTo(TIME_NOT_SET);
+    assertThat(usageMetricState.getActiveBucket().getToTime()).isEqualTo(TIME_NOT_SET);
     assertThat(usageMetricState.getActiveBucket().getTenantRPIMap())
         .containsExactlyInAnyOrderEntriesOf(Map.of("tenant1", 1L));
 

--- a/zeebe/engine/src/test/resources/state/appliers/golden/UsageMetric_EXPORTED_v1.golden
+++ b/zeebe/engine/src/test/resources/state/appliers/golden/UsageMetric_EXPORTED_v1.golden
@@ -31,7 +31,7 @@ public class UsageMetricsExportedApplier
     final var activeBucket = usageMetricState.getActiveBucket();
 
     // uninitialized bucket created on-demand
-    if (activeBucket != null && activeBucket.getFromTime() == -1) {
+    if (activeBucket != null && !activeBucket.isInitialized()) {
       LOG.debug("Update active bucket time {}", record.getResetTime());
       usageMetricState.updateActiveBucketTime(record.getResetTime());
     }


### PR DESCRIPTION
## Description

- Skip exporting not initialized usage metric bucket

## Related issues

closes https://github.com/camunda/camunda/issues/36484
