### PR TITLE
Add authorization checks where missing to Operate internal API endpoints

### DIFF
--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/elasticsearch/DecisionListQueryIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/elasticsearch/DecisionListQueryIT.java
@@ -38,6 +38,7 @@ import java.util.Comparator;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.jetbrains.annotations.NotNull;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -55,6 +56,12 @@ public class DecisionListQueryIT extends OperateAbstractIT {
   @Autowired private DecisionDataUtil testDataUtil;
 
   @MockitoBean private PermissionsService permissionsService;
+
+  @Before
+  public void setup() {
+    when(permissionsService.getDecisionsWithPermission(PermissionType.READ_DECISION_INSTANCE))
+        .thenReturn(PermissionsService.ResourcesAllowed.wildcard());
+  }
 
   @Test
   public void testVariousQueries() throws Exception {
@@ -599,7 +606,6 @@ public class DecisionListQueryIT extends OperateAbstractIT {
     createData();
 
     // when
-    when(permissionsService.permissionsEnabled()).thenReturn(true);
     when(permissionsService.getDecisionsWithPermission(PermissionType.READ_DECISION_INSTANCE))
         .thenReturn(PermissionsService.ResourcesAllowed.withIds(Set.of()));
 
@@ -623,7 +629,6 @@ public class DecisionListQueryIT extends OperateAbstractIT {
     createData();
 
     // when
-    when(permissionsService.permissionsEnabled()).thenReturn(true);
     when(permissionsService.getDecisionsWithPermission(PermissionType.READ_DECISION_INSTANCE))
         .thenReturn(PermissionsService.ResourcesAllowed.withIds(Set.of(decisionId)));
 

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/elasticsearch/FlowNodeStatisticsIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/elasticsearch/FlowNodeStatisticsIT.java
@@ -35,6 +35,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
@@ -51,6 +52,12 @@ public class FlowNodeStatisticsIT extends OperateAbstractIT {
   private static final Long PROCESS_KEY_OTHER_PROCESS = 27L;
   @Rule public SearchTestRule searchTestRule = new SearchTestRule();
   @MockitoBean private PermissionsService permissionsService;
+
+  @Before
+  public void setup() {
+    when(permissionsService.getProcessesWithPermission(PermissionType.READ_PROCESS_INSTANCE))
+        .thenReturn(PermissionsService.ResourcesAllowed.wildcard());
+  }
 
   @Test
   public void testOneProcessStatistics() throws Exception {
@@ -165,7 +172,6 @@ public class FlowNodeStatisticsIT extends OperateAbstractIT {
     final ListViewQueryDto queryRequest = createGetAllProcessInstancesQuery(processDefinitionKey);
 
     // when
-    when(permissionsService.permissionsEnabled()).thenReturn(true);
     when(permissionsService.getProcessesWithPermission(PermissionType.READ_PROCESS_INSTANCE))
         .thenReturn(PermissionsService.ResourcesAllowed.withIds(Set.of()));
 
@@ -195,7 +201,6 @@ public class FlowNodeStatisticsIT extends OperateAbstractIT {
     final ListViewRequestDto queryRequest = createGetAllProcessInstancesRequest();
 
     // when
-    when(permissionsService.permissionsEnabled()).thenReturn(true);
     when(permissionsService.getProcessesWithPermission(PermissionType.READ_PROCESS_INSTANCE))
         .thenReturn(PermissionsService.ResourcesAllowed.withIds(Set.of()));
 

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/elasticsearch/IncidentStatisticsIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/elasticsearch/IncidentStatisticsIT.java
@@ -38,6 +38,7 @@ import java.util.Objects;
 import java.util.Random;
 import java.util.Set;
 import java.util.stream.Collectors;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
@@ -63,13 +64,17 @@ public class IncidentStatisticsIT extends OperateAbstractIT {
   private final String tenantId1 = "tenant1";
   private final String tenantId2 = "tenant2";
 
-  @Test
-  public void testAbsentProcessDoesntThrowExceptions() throws Exception {
-    final List<ExporterEntity> entities = new ArrayList<>();
+  @Before
+  public void setup() {
     when(permissionsService.getProcessesWithPermission(PermissionType.READ_PROCESS_INSTANCE))
         .thenReturn(PermissionsService.ResourcesAllowed.wildcard());
     when(permissionsService.getProcessesWithPermission(PermissionType.READ_PROCESS_DEFINITION))
         .thenReturn(PermissionsService.ResourcesAllowed.wildcard());
+  }
+
+  @Test
+  public void testAbsentProcessDoesntThrowExceptions() throws Exception {
+    final List<ExporterEntity> entities = new ArrayList<>();
 
     // Create a processInstance that has no matching process
     final Long processDefinitionKey = 0L;
@@ -87,10 +92,6 @@ public class IncidentStatisticsIT extends OperateAbstractIT {
   @Test
   public void testIncidentStatisticsByError() throws Exception {
     createData();
-    when(permissionsService.getProcessesWithPermission(PermissionType.READ_PROCESS_DEFINITION))
-        .thenReturn(PermissionsService.ResourcesAllowed.wildcard());
-    when(permissionsService.getProcessesWithPermission(PermissionType.READ_PROCESS_INSTANCE))
-        .thenReturn(PermissionsService.ResourcesAllowed.wildcard());
 
     final List<IncidentsByErrorMsgStatisticsDto> response = requestIncidentsByError();
     assertThat(response).hasSize(2);
@@ -142,8 +143,6 @@ public class IncidentStatisticsIT extends OperateAbstractIT {
   @Test
   public void testProcessAndIncidentStatistics() throws Exception {
     createData();
-    when(permissionsService.getProcessesWithPermission(PermissionType.READ_PROCESS_DEFINITION))
-        .thenReturn(PermissionsService.ResourcesAllowed.wildcard());
 
     final List<IncidentsByProcessGroupStatisticsDto> processGroups = requestIncidentsByProcess();
 
@@ -156,8 +155,6 @@ public class IncidentStatisticsIT extends OperateAbstractIT {
   @Test
   public void testProcessWithoutInstancesIsSortedByVersionAscending() throws Exception {
     createNoInstancesProcessData(3);
-    when(permissionsService.getProcessesWithPermission(PermissionType.READ_PROCESS_DEFINITION))
-        .thenReturn(PermissionsService.ResourcesAllowed.wildcard());
 
     final List<IncidentsByProcessGroupStatisticsDto> processGroups = requestIncidentsByProcess();
 
@@ -179,8 +176,6 @@ public class IncidentStatisticsIT extends OperateAbstractIT {
     createData();
 
     // when
-    when(permissionsService.getProcessesWithPermission(PermissionType.READ_PROCESS_DEFINITION))
-        .thenReturn(PermissionsService.ResourcesAllowed.wildcard());
 
     // then
     final List<IncidentsByProcessGroupStatisticsDto> response = requestIncidentsByProcess();
@@ -224,13 +219,7 @@ public class IncidentStatisticsIT extends OperateAbstractIT {
     // given
     createData();
 
-    // when
-    when(permissionsService.getProcessesWithPermission(PermissionType.READ_PROCESS_INSTANCE))
-        .thenReturn(PermissionsService.ResourcesAllowed.wildcard());
-    when(permissionsService.getProcessesWithPermission(PermissionType.READ_PROCESS_DEFINITION))
-        .thenReturn(PermissionsService.ResourcesAllowed.wildcard());
-
-    // then
+    // when - then
     final List<IncidentsByErrorMsgStatisticsDto> response = requestIncidentsByError();
 
     assertThat(response).hasSize(2);

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/elasticsearch/IncidentStatisticsIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/elasticsearch/IncidentStatisticsIT.java
@@ -66,6 +66,10 @@ public class IncidentStatisticsIT extends OperateAbstractIT {
   @Test
   public void testAbsentProcessDoesntThrowExceptions() throws Exception {
     final List<ExporterEntity> entities = new ArrayList<>();
+    when(permissionsService.getProcessesWithPermission(PermissionType.READ_PROCESS_INSTANCE))
+        .thenReturn(PermissionsService.ResourcesAllowed.wildcard());
+    when(permissionsService.getProcessesWithPermission(PermissionType.READ_PROCESS_DEFINITION))
+        .thenReturn(PermissionsService.ResourcesAllowed.wildcard());
 
     // Create a processInstance that has no matching process
     final Long processDefinitionKey = 0L;
@@ -83,6 +87,10 @@ public class IncidentStatisticsIT extends OperateAbstractIT {
   @Test
   public void testIncidentStatisticsByError() throws Exception {
     createData();
+    when(permissionsService.getProcessesWithPermission(PermissionType.READ_PROCESS_DEFINITION))
+        .thenReturn(PermissionsService.ResourcesAllowed.wildcard());
+    when(permissionsService.getProcessesWithPermission(PermissionType.READ_PROCESS_INSTANCE))
+        .thenReturn(PermissionsService.ResourcesAllowed.wildcard());
 
     final List<IncidentsByErrorMsgStatisticsDto> response = requestIncidentsByError();
     assertThat(response).hasSize(2);
@@ -134,6 +142,8 @@ public class IncidentStatisticsIT extends OperateAbstractIT {
   @Test
   public void testProcessAndIncidentStatistics() throws Exception {
     createData();
+    when(permissionsService.getProcessesWithPermission(PermissionType.READ_PROCESS_DEFINITION))
+        .thenReturn(PermissionsService.ResourcesAllowed.wildcard());
 
     final List<IncidentsByProcessGroupStatisticsDto> processGroups = requestIncidentsByProcess();
 
@@ -146,6 +156,8 @@ public class IncidentStatisticsIT extends OperateAbstractIT {
   @Test
   public void testProcessWithoutInstancesIsSortedByVersionAscending() throws Exception {
     createNoInstancesProcessData(3);
+    when(permissionsService.getProcessesWithPermission(PermissionType.READ_PROCESS_DEFINITION))
+        .thenReturn(PermissionsService.ResourcesAllowed.wildcard());
 
     final List<IncidentsByProcessGroupStatisticsDto> processGroups = requestIncidentsByProcess();
 
@@ -167,7 +179,6 @@ public class IncidentStatisticsIT extends OperateAbstractIT {
     createData();
 
     // when
-    when(permissionsService.permissionsEnabled()).thenReturn(true);
     when(permissionsService.getProcessesWithPermission(PermissionType.READ_PROCESS_DEFINITION))
         .thenReturn(PermissionsService.ResourcesAllowed.wildcard());
 
@@ -214,8 +225,9 @@ public class IncidentStatisticsIT extends OperateAbstractIT {
     createData();
 
     // when
-    when(permissionsService.permissionsEnabled()).thenReturn(true);
     when(permissionsService.getProcessesWithPermission(PermissionType.READ_PROCESS_INSTANCE))
+        .thenReturn(PermissionsService.ResourcesAllowed.wildcard());
+    when(permissionsService.getProcessesWithPermission(PermissionType.READ_PROCESS_DEFINITION))
         .thenReturn(PermissionsService.ResourcesAllowed.wildcard());
 
     // then
@@ -228,7 +240,6 @@ public class IncidentStatisticsIT extends OperateAbstractIT {
             .filter(x -> Objects.equals(x.getErrorMessage(), TestUtil.ERROR_MSG))
             .findFirst()
             .orElseThrow();
-    // TODO: Check
     assertThat(incidentsByError1.getInstancesWithErrorCount()).isEqualTo(3);
     assertThat(incidentsByError1.getProcesses()).hasSize(2);
     assertThat(incidentsByError1.getIncidentErrorHashCode())
@@ -261,8 +272,9 @@ public class IncidentStatisticsIT extends OperateAbstractIT {
     createData();
 
     // when
-    when(permissionsService.permissionsEnabled()).thenReturn(true);
     when(permissionsService.getProcessesWithPermission(PermissionType.READ_PROCESS_INSTANCE))
+        .thenReturn(PermissionsService.ResourcesAllowed.withIds(Set.of()));
+    when(permissionsService.getProcessesWithPermission(PermissionType.READ_PROCESS_DEFINITION))
         .thenReturn(PermissionsService.ResourcesAllowed.withIds(Set.of()));
 
     // then
@@ -278,8 +290,9 @@ public class IncidentStatisticsIT extends OperateAbstractIT {
     createData();
 
     // when
-    when(permissionsService.permissionsEnabled()).thenReturn(true);
     when(permissionsService.getProcessesWithPermission(PermissionType.READ_PROCESS_INSTANCE))
+        .thenReturn(PermissionsService.ResourcesAllowed.withIds(Set.of(DEMO_BPMN_PROCESS_ID)));
+    when(permissionsService.getProcessesWithPermission(PermissionType.READ_PROCESS_DEFINITION))
         .thenReturn(PermissionsService.ResourcesAllowed.withIds(Set.of(DEMO_BPMN_PROCESS_ID)));
 
     // then
@@ -324,8 +337,9 @@ public class IncidentStatisticsIT extends OperateAbstractIT {
     createData();
 
     // when
-    when(permissionsService.permissionsEnabled()).thenReturn(true);
     when(permissionsService.getProcessesWithPermission(PermissionType.READ_PROCESS_INSTANCE))
+        .thenReturn(PermissionsService.ResourcesAllowed.withIds(Set.of(ORDER_BPMN_PROCESS_ID)));
+    when(permissionsService.getProcessesWithPermission(PermissionType.READ_PROCESS_DEFINITION))
         .thenReturn(PermissionsService.ResourcesAllowed.withIds(Set.of(ORDER_BPMN_PROCESS_ID)));
 
     // then
@@ -338,7 +352,6 @@ public class IncidentStatisticsIT extends OperateAbstractIT {
             .filter(x -> Objects.equals(x.getErrorMessage(), TestUtil.ERROR_MSG))
             .findFirst()
             .orElseThrow();
-    // TODO: Check
     assertThat(incidentsByError1.getInstancesWithErrorCount()).isEqualTo(1);
     assertThat(incidentsByError1.getProcesses()).hasSize(1);
     assertThat(incidentsByError1.getIncidentErrorHashCode())

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/elasticsearch/ListViewReaderIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/elasticsearch/ListViewReaderIT.java
@@ -31,8 +31,8 @@ import io.camunda.zeebe.protocol.record.value.PermissionType;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
@@ -173,9 +173,10 @@ public class ListViewReaderIT extends OperateSearchAbstractIT {
     searchContainerManager.refreshIndices("*list-view*");
   }
 
-  @Override
-  protected void runAdditionalBeforeEachSetup() throws Exception {
-    Mockito.reset(permissionsService);
+  @BeforeEach
+  public void setup() {
+    when(permissionsService.getProcessesWithPermission(PermissionType.READ_PROCESS_INSTANCE))
+        .thenReturn(PermissionsService.ResourcesAllowed.wildcard());
   }
 
   @Test
@@ -438,7 +439,6 @@ public class ListViewReaderIT extends OperateSearchAbstractIT {
 
   @Test
   public void testQueryProcessInstancesWithPermissions() {
-    when(permissionsService.permissionsEnabled()).thenReturn(true);
     when(permissionsService.getProcessesWithPermission(PermissionType.READ_PROCESS_INSTANCE))
         .thenReturn(
             PermissionsService.ResourcesAllowed.withIds(Set.of(activeProcess.getBpmnProcessId())));

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/it/ListenerReaderIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/it/ListenerReaderIT.java
@@ -8,11 +8,14 @@
 package io.camunda.operate.it;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.camunda.operate.util.j5templates.MockMvcManager;
 import io.camunda.operate.util.j5templates.OperateSearchAbstractIT;
+import io.camunda.operate.webapp.elasticsearch.reader.ProcessInstanceReader;
 import io.camunda.operate.webapp.rest.ProcessInstanceRestService;
 import io.camunda.operate.webapp.rest.dto.ListenerDto;
 import io.camunda.operate.webapp.rest.dto.ListenerRequestDto;
@@ -24,18 +27,21 @@ import io.camunda.webapps.schema.entities.JobEntity;
 import io.camunda.webapps.schema.entities.listener.ListenerEventType;
 import io.camunda.webapps.schema.entities.listener.ListenerState;
 import io.camunda.webapps.schema.entities.listener.ListenerType;
+import io.camunda.webapps.schema.entities.listview.ProcessInstanceForListViewEntity;
 import java.io.IOException;
 import java.time.OffsetDateTime;
 import java.util.List;
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MvcResult;
 
 public class ListenerReaderIT extends OperateSearchAbstractIT {
 
   @Autowired MockMvcManager mockMvcManager;
   @Autowired JobTemplate jobTemplate;
+  @MockitoBean ProcessInstanceReader mockProcessInstanceReader;
   @Autowired private CamundaAuthenticationProvider camundaAuthenticationProvider;
   private String jobIndexName;
   private final ObjectMapper objectMapper = new ObjectMapper();
@@ -50,6 +56,8 @@ public class ListenerReaderIT extends OperateSearchAbstractIT {
 
   @Test
   public void testListenerReaderFlowNodeId() throws Exception {
+    when(mockProcessInstanceReader.getProcessInstanceByKey(any()))
+        .thenReturn(new ProcessInstanceForListViewEntity().setBpmnProcessId("genericid"));
     final ListenerRequestDto request =
         new ListenerRequestDto().setPageSize(20).setFlowNodeId("test_task");
     final ListenerResponseDto response = postListenerRequest("111", request);
@@ -97,6 +105,8 @@ public class ListenerReaderIT extends OperateSearchAbstractIT {
 
   @Test
   public void testListenerReaderFlowNodeInstanceId() throws Exception {
+    when(mockProcessInstanceReader.getProcessInstanceByKey(any()))
+        .thenReturn(new ProcessInstanceForListViewEntity().setBpmnProcessId("genericid"));
     final ListenerRequestDto request =
         new ListenerRequestDto().setPageSize(20).setFlowNodeInstanceId(1L);
     final ListenerResponseDto response = postListenerRequest("111", request);
@@ -130,6 +140,8 @@ public class ListenerReaderIT extends OperateSearchAbstractIT {
 
   @Test
   public void testListenerReaderPaging() throws Exception {
+    when(mockProcessInstanceReader.getProcessInstanceByKey(any()))
+        .thenReturn(new ProcessInstanceForListViewEntity().setBpmnProcessId("genericid"));
     final ListenerRequestDto request1 =
         new ListenerRequestDto().setPageSize(3).setFlowNodeId("test_task");
     final ListenerResponseDto response1 = postListenerRequest("111", request1);
@@ -178,6 +190,8 @@ public class ListenerReaderIT extends OperateSearchAbstractIT {
 
   @Test
   public void testListenerReaderWithTypeFilters() throws Exception {
+    when(mockProcessInstanceReader.getProcessInstanceByKey(any()))
+        .thenReturn(new ProcessInstanceForListViewEntity().setBpmnProcessId("genericid"));
     // request only Execution Listeners
     final ListenerRequestDto elRequest =
         new ListenerRequestDto()

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/it/OperationReaderIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/it/OperationReaderIT.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.operate.it;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.operate.util.j5templates.OperateSearchAbstractIT;
+import io.camunda.operate.webapp.reader.OperationReader;
+import io.camunda.operate.webapp.rest.dto.OperationDto;
+import io.camunda.security.auth.CamundaAuthenticationProvider;
+import io.camunda.webapps.schema.descriptors.template.BatchOperationTemplate;
+import io.camunda.webapps.schema.descriptors.template.OperationTemplate;
+import io.camunda.webapps.schema.entities.operation.OperationEntity;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class OperationReaderIT extends OperateSearchAbstractIT {
+
+  private static final String BATCH_OPERATION_ID = "123";
+  private static final String ENTITY_KEY_1 = "1";
+  private static final String ENTITY_KEY_2 = "2";
+  private static final String ENTITY_KEY_3 = "3";
+  @Autowired OperationReader operationReader;
+  @Autowired private OperationTemplate operationTemplate;
+  @Autowired private BatchOperationTemplate batchOperationTemplate;
+  @Autowired private DateTimeFormatter dateTimeFormatter;
+  @Autowired private CamundaAuthenticationProvider camundaAuthenticationProvider;
+
+  @Override
+  protected void runAdditionalBeforeAllSetup() throws Exception {
+    final OperationEntity oe1 =
+        new OperationEntity()
+            .setBatchOperationId(BATCH_OPERATION_ID)
+            .setUsername(DEFAULT_USER)
+            .setId(ENTITY_KEY_1);
+    final OperationEntity oe2 =
+        new OperationEntity()
+            .setBatchOperationId(BATCH_OPERATION_ID)
+            .setUsername(DEFAULT_USER)
+            .setId(ENTITY_KEY_2);
+    final OperationEntity oe3 =
+        new OperationEntity()
+            .setBatchOperationId(BATCH_OPERATION_ID)
+            .setUsername("otheruser")
+            .setId(ENTITY_KEY_3);
+
+    testSearchRepository.createOrUpdateDocumentFromObject(
+        operationTemplate.getFullQualifiedName(), ENTITY_KEY_1, oe1);
+    testSearchRepository.createOrUpdateDocumentFromObject(
+        operationTemplate.getFullQualifiedName(), ENTITY_KEY_2, oe2);
+    testSearchRepository.createOrUpdateDocumentFromObject(
+        operationTemplate.getFullQualifiedName(), ENTITY_KEY_3, oe3);
+    searchContainerManager.refreshIndices("*operate*");
+  }
+
+  @Test
+  public void onlyReturnOperationsStartedByUser() {
+    final List<OperationDto> result =
+        operationReader.getOperationsByBatchOperationId(BATCH_OPERATION_ID);
+    assertThat(result)
+        .hasSize(2)
+        .extracting(OperationDto::getId)
+        .containsExactlyInAnyOrder(ENTITY_KEY_1, ENTITY_KEY_2);
+  }
+}

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/it/ProcessInstanceReaderIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/it/ProcessInstanceReaderIT.java
@@ -9,11 +9,14 @@ package io.camunda.operate.it;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
+import static org.mockito.Mockito.when;
 
 import io.camunda.operate.store.NotFoundException;
 import io.camunda.operate.util.j5templates.OperateSearchAbstractIT;
 import io.camunda.operate.webapp.elasticsearch.reader.ProcessInstanceReader;
+import io.camunda.operate.webapp.rest.dto.ProcessInstanceCoreStatisticsDto;
 import io.camunda.operate.webapp.rest.dto.listview.ListViewProcessInstanceDto;
+import io.camunda.operate.webapp.security.permission.PermissionsService;
 import io.camunda.security.auth.CamundaAuthenticationProvider;
 import io.camunda.webapps.schema.descriptors.template.ListViewTemplate;
 import io.camunda.webapps.schema.descriptors.template.OperationTemplate;
@@ -22,10 +25,13 @@ import io.camunda.webapps.schema.entities.listview.ProcessInstanceForListViewEnt
 import io.camunda.webapps.schema.entities.listview.ProcessInstanceState;
 import io.camunda.webapps.schema.entities.operation.OperationEntity;
 import io.camunda.webapps.schema.entities.operation.OperationState;
+import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import java.time.OffsetDateTime;
+import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 public class ProcessInstanceReaderIT extends OperateSearchAbstractIT {
 
@@ -37,18 +43,22 @@ public class ProcessInstanceReaderIT extends OperateSearchAbstractIT {
 
   @Autowired private CamundaAuthenticationProvider camundaAuthenticationProvider;
 
+  @MockitoBean private PermissionsService permissionsService;
+
   private ProcessInstanceForListViewEntity processInstanceData;
+  private ProcessInstanceForListViewEntity processInstanceData2;
   private OperationEntity operationData;
 
   @Override
   protected void runAdditionalBeforeAllSetup() throws Exception {
-    final Long processInstanceKey = 2251799813685251L;
+    final Long processInstanceKey1 = 2251799813685251L;
+    final Long processInstanceKey2 = 2251799813685252L;
     final String indexName = listViewTemplate.getFullQualifiedName();
 
     processInstanceData =
         new ProcessInstanceForListViewEntity()
             .setId("2251799813685251")
-            .setKey(processInstanceKey)
+            .setKey(processInstanceKey1)
             .setPartitionId(1)
             .setProcessDefinitionKey(2251799813685249L)
             .setProcessName("Demo process")
@@ -59,11 +69,29 @@ public class ProcessInstanceReaderIT extends OperateSearchAbstractIT {
             .setTreePath("PI_2251799813685251")
             .setIncident(true)
             .setTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER)
-            .setProcessInstanceKey(processInstanceKey)
+            .setProcessInstanceKey(processInstanceKey1)
+            .setJoinRelation(new ListViewJoinRelation("processInstance"));
+    processInstanceData2 =
+        new ProcessInstanceForListViewEntity()
+            .setId("2251799813685252")
+            .setKey(processInstanceKey2)
+            .setPartitionId(1)
+            .setProcessDefinitionKey(2251799813685242L)
+            .setProcessName("Demo process 2")
+            .setProcessVersion(1)
+            .setBpmnProcessId("demoProcess2")
+            .setStartDate(OffsetDateTime.now())
+            .setState(ProcessInstanceState.ACTIVE)
+            .setTreePath("PI_2251799813685252")
+            .setIncident(false)
+            .setTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER)
+            .setProcessInstanceKey(processInstanceKey2)
             .setJoinRelation(new ListViewJoinRelation("processInstance"));
 
     testSearchRepository.createOrUpdateDocumentFromObject(
-        indexName, String.valueOf(processInstanceKey), processInstanceData);
+        indexName, String.valueOf(processInstanceKey1), processInstanceData);
+    testSearchRepository.createOrUpdateDocumentFromObject(
+        indexName, String.valueOf(processInstanceKey2), processInstanceData2);
 
     operationData = new OperationEntity();
     operationData.setProcessInstanceKey(processInstanceData.getProcessInstanceKey());
@@ -108,5 +136,44 @@ public class ProcessInstanceReaderIT extends OperateSearchAbstractIT {
   public void testGetProcessInstanceWithOperationsWithInvalidKey() {
     assertThatExceptionOfType(NotFoundException.class)
         .isThrownBy(() -> processInstanceReader.getProcessInstanceWithOperationsByKey(1L));
+  }
+
+  @Test
+  public void testGetCoreStatisticsWithWildcardPermissions() {
+    // given
+    when(permissionsService.permissionsEnabled()).thenReturn(true);
+    when(permissionsService.getProcessesWithPermission(PermissionType.READ_PROCESS_INSTANCE))
+        .thenReturn(PermissionsService.ResourcesAllowed.wildcard());
+    // when
+    final ProcessInstanceCoreStatisticsDto result = processInstanceReader.getCoreStatistics();
+    assertThat(result.getRunning()).isEqualTo(2);
+    assertThat(result.getWithIncidents()).isOne();
+    assertThat(result.getActive()).isOne();
+  }
+
+  @Test
+  public void testGetCoreStatisticsWithSomePermissions() {
+    // given
+    when(permissionsService.permissionsEnabled()).thenReturn(true);
+    when(permissionsService.getProcessesWithPermission(PermissionType.READ_PROCESS_INSTANCE))
+        .thenReturn(
+            PermissionsService.ResourcesAllowed.withIds(
+                Set.of(processInstanceData.getBpmnProcessId())));
+    // when
+    final ProcessInstanceCoreStatisticsDto result = processInstanceReader.getCoreStatistics();
+    assertThat(result.getRunning()).isOne();
+    assertThat(result.getWithIncidents()).isOne();
+  }
+
+  @Test
+  public void testGetCoreStatisticsWithNoPermission() {
+    // given
+    when(permissionsService.permissionsEnabled()).thenReturn(true);
+    when(permissionsService.getProcessesWithPermission(PermissionType.READ_PROCESS_INSTANCE))
+        .thenReturn(PermissionsService.ResourcesAllowed.withIds(Set.of()));
+    // when
+    final ProcessInstanceCoreStatisticsDto result = processInstanceReader.getCoreStatistics();
+    assertThat(result.getRunning()).isZero();
+    assertThat(result.getWithIncidents()).isZero();
   }
 }

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/rest/DecisionInstanceRestServiceIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/rest/DecisionInstanceRestServiceIT.java
@@ -128,7 +128,9 @@ public class DecisionInstanceRestServiceIT extends OperateAbstractIT {
     // when
     when(decisionInstanceReader.getDecisionInstance(decisionInstanceId))
         .thenReturn(new DecisionInstanceDto().setDecisionId(bpmnDecisionId));
-    when(permissionsService.permissionsEnabled()).thenReturn(false);
+    when(permissionsService.hasPermissionForDecision(
+            bpmnDecisionId, PermissionType.READ_DECISION_INSTANCE))
+        .thenReturn(true);
     final MvcResult mvcResult = getRequest(getDecisionInstanceByIdUrl(decisionInstanceId));
     // then
     final DecisionInstanceDto result =

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/rest/DecisionRestServiceIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/rest/DecisionRestServiceIT.java
@@ -88,7 +88,7 @@ public class DecisionRestServiceIT extends OperateAbstractIT {
         .thenReturn(new DecisionDefinitionEntity().setDecisionId(decisionId));
     when(permissionsService.permissionsEnabled()).thenReturn(true);
     when(permissionsService.hasPermissionForDecision(
-            decisionId, PermissionType.READ_DECISION_INSTANCE))
+            decisionId, PermissionType.READ_DECISION_DEFINITION))
         .thenReturn(true);
     final MvcResult mvcResult = getRequest(getDecisionXmlByIdUrl(decisionDefinitionKey.toString()));
     // then

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/rest/ProcessInstanceRestServiceIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/rest/ProcessInstanceRestServiceIT.java
@@ -16,15 +16,34 @@ import io.camunda.operate.property.OperateProperties;
 import io.camunda.operate.qa.util.DependencyInjectionTestExecutionListener;
 import io.camunda.operate.util.TestApplication;
 import io.camunda.operate.util.j5templates.MockMvcManager;
+import io.camunda.operate.webapp.elasticsearch.reader.ProcessInstanceReader;
 import io.camunda.operate.webapp.rest.ProcessInstanceRestService;
 import io.camunda.operate.webapp.rest.dto.ListenerRequestDto;
+import io.camunda.operate.webapp.rest.dto.VariableRequestDto;
+import io.camunda.operate.webapp.rest.dto.metadata.FlowNodeMetadataRequestDto;
+import io.camunda.operate.webapp.rest.dto.operation.CreateOperationRequestDto;
+import io.camunda.operate.webapp.rest.dto.operation.ModifyProcessInstanceRequestDto;
+import io.camunda.operate.webapp.rest.dto.operation.ModifyProcessInstanceRequestDto.Modification;
+import io.camunda.operate.webapp.rest.dto.operation.ModifyProcessInstanceRequestDto.Modification.Type;
+import io.camunda.operate.webapp.rest.exception.NotAuthorizedException;
+import io.camunda.operate.webapp.security.permission.PermissionsService;
 import io.camunda.webapps.schema.entities.listener.ListenerType;
+import io.camunda.webapps.schema.entities.listview.ProcessInstanceForListViewEntity;
+import io.camunda.webapps.schema.entities.operation.OperationType;
+import io.camunda.zeebe.protocol.record.value.PermissionType;
 import jakarta.validation.ConstraintViolationException;
+import java.util.List;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.TestExecutionListeners;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.test.web.servlet.MvcResult;
 
@@ -35,8 +54,7 @@ import org.springframework.test.web.servlet.MvcResult;
       OperateProperties.PREFIX + ".archiver.rolloverEnabled = false",
       OperateProperties.PREFIX + ".zeebe.compatibility.enabled = true",
       "spring.mvc.pathmatch.matching-strategy=ANT_PATH_MATCHER",
-      OperateProperties.PREFIX + ".multiTenancy.enabled = false",
-      "camunda.security.authorizations.enabled=false"
+      OperateProperties.PREFIX + ".multiTenancy.enabled = false"
     })
 @WebAppConfiguration
 @TestExecutionListeners(
@@ -45,10 +63,12 @@ import org.springframework.test.web.servlet.MvcResult;
 @WithMockUser(DEFAULT_USER)
 public class ProcessInstanceRestServiceIT {
   @Autowired MockMvcManager mockMvcManager;
+  @MockitoBean PermissionsService mockPermissionsService;
+  @MockitoBean ProcessInstanceReader mockProcessInstanceReader;
 
   @Test
   public void testGetInstanceByIdWithInvalidId() throws Exception {
-    final String url = ProcessInstanceRestService.PROCESS_INSTANCE_URL + "/4503599627535750:";
+    final var url = ProcessInstanceRestService.PROCESS_INSTANCE_URL + "/4503599627535750:";
     final MvcResult mvcResult =
         mockMvcManager.getRequestShouldFailWithException(url, ConstraintViolationException.class);
 
@@ -57,8 +77,7 @@ public class ProcessInstanceRestServiceIT {
 
   @Test
   public void testGetIncidentsByIdWithInvalidId() throws Exception {
-    final String url =
-        ProcessInstanceRestService.PROCESS_INSTANCE_URL + "/not-valid-id-123/incidents";
+    final var url = ProcessInstanceRestService.PROCESS_INSTANCE_URL + "/not-valid-id-123/incidents";
     final MvcResult mvcResult =
         mockMvcManager.getRequestShouldFailWithException(url, ConstraintViolationException.class);
     assertThat(mvcResult.getResolvedException().getMessage()).contains("Specified ID is not valid");
@@ -66,8 +85,7 @@ public class ProcessInstanceRestServiceIT {
 
   @Test
   public void testGetVariablesByIdWithInvalidId() throws Exception {
-    final String url =
-        ProcessInstanceRestService.PROCESS_INSTANCE_URL + "/not-valid-id-123/variables";
+    final var url = ProcessInstanceRestService.PROCESS_INSTANCE_URL + "/not-valid-id-123/variables";
     final MvcResult mvcResult =
         mockMvcManager.postRequestShouldFailWithException(url, ConstraintViolationException.class);
     assertThat(mvcResult.getResolvedException().getMessage()).contains("Specified ID is not valid");
@@ -75,7 +93,7 @@ public class ProcessInstanceRestServiceIT {
 
   @Test
   public void testGetFlowNodeStatesByIdWithInvalidId() throws Exception {
-    final String url =
+    final var url =
         ProcessInstanceRestService.PROCESS_INSTANCE_URL + "/not-valid-id-123/flow-node-states";
     final MvcResult mvcResult =
         mockMvcManager.getRequestShouldFailWithException(url, ConstraintViolationException.class);
@@ -84,7 +102,7 @@ public class ProcessInstanceRestServiceIT {
 
   @Test
   public void testGetFlowNodeMetadataByIdWithInvalidId() throws Exception {
-    final String url =
+    final var url =
         ProcessInstanceRestService.PROCESS_INSTANCE_URL + "/not-valid-id-123/flow-node-metadata";
     final MvcResult mvcResult =
         mockMvcManager.postRequestShouldFailWithException(url, ConstraintViolationException.class);
@@ -93,8 +111,7 @@ public class ProcessInstanceRestServiceIT {
 
   @Test
   public void testGetListenersWithInvalidId() throws Exception {
-    final String url =
-        ProcessInstanceRestService.PROCESS_INSTANCE_URL + "/not-valid-id-123/listeners";
+    final var url = ProcessInstanceRestService.PROCESS_INSTANCE_URL + "/not-valid-id-123/listeners";
     final MvcResult mvcResult =
         mockMvcManager.postRequestShouldFailWithException(url, ConstraintViolationException.class);
     assertThat(mvcResult.getResolvedException().getMessage()).contains("Specified ID is not valid");
@@ -102,7 +119,7 @@ public class ProcessInstanceRestServiceIT {
 
   @Test
   public void testListenersRequestWithFlowNodeIdAndFlowNodeInstanceIdInvalid() throws Exception {
-    final String url = ProcessInstanceRestService.PROCESS_INSTANCE_URL + "/1/listeners";
+    final var url = ProcessInstanceRestService.PROCESS_INSTANCE_URL + "/1/listeners";
     final ListenerRequestDto request =
         new ListenerRequestDto()
             .setPageSize(20)
@@ -115,7 +132,7 @@ public class ProcessInstanceRestServiceIT {
 
   @Test
   public void testListenersRequestWithListenerFilterInvalid() throws Exception {
-    final String url = ProcessInstanceRestService.PROCESS_INSTANCE_URL + "/1/listeners";
+    final var url = ProcessInstanceRestService.PROCESS_INSTANCE_URL + "/1/listeners";
     final ListenerRequestDto request =
         new ListenerRequestDto()
             .setPageSize(20)
@@ -130,5 +147,130 @@ public class ProcessInstanceRestServiceIT {
                 + ", "
                 + ListenerType.TASK_LISTENER
                 + "]");
+  }
+
+  @Test
+  public void testPostUnsupportedOperationDeleteDecisionRequest() throws Exception {
+    // given
+    final var url = ProcessInstanceRestService.PROCESS_INSTANCE_URL + "/1/operation";
+    final CreateOperationRequestDto request =
+        new CreateOperationRequestDto().setOperationType(OperationType.DELETE_DECISION_DEFINITION);
+
+    // when - then
+    final MvcResult mvcResult = mockMvcManager.postRequest(url, request, 400);
+    assertThat(mvcResult.getResolvedException().getMessage())
+        .contains(
+            "Operation type '%s' is not supported by this endpoint."
+                .formatted(OperationType.DELETE_DECISION_DEFINITION));
+  }
+
+  @Test
+  public void testPostUnsupportedOperationDeleteProcessRequest() throws Exception {
+    // given
+    final var url = ProcessInstanceRestService.PROCESS_INSTANCE_URL + "/1/operation";
+    final CreateOperationRequestDto request =
+        new CreateOperationRequestDto().setOperationType(OperationType.DELETE_PROCESS_DEFINITION);
+
+    // when - then
+    final MvcResult mvcResult = mockMvcManager.postRequest(url, request, 400);
+    assertThat(mvcResult.getResolvedException().getMessage())
+        .contains(
+            "Operation type '%s' is not supported by this endpoint."
+                .formatted(OperationType.DELETE_PROCESS_DEFINITION));
+  }
+
+  @ParameterizedTest
+  @MethodSource("noPermissionPostParameters")
+  public void testPostWithNoPermission(
+      final String urlFragment, final Object requestObject, final PermissionType permissionType)
+      throws Exception {
+    // given
+    Mockito.when(mockProcessInstanceReader.getProcessInstanceByKey(1L))
+        .thenReturn(new ProcessInstanceForListViewEntity().setBpmnProcessId("p1"));
+    Mockito.when(mockPermissionsService.hasPermissionForProcess("p1", permissionType))
+        .thenReturn(false);
+    final var url = ProcessInstanceRestService.PROCESS_INSTANCE_URL + urlFragment;
+
+    // when - then
+    final MvcResult mvcResult = mockMvcManager.postRequest(url, requestObject, 403);
+    assertThat(mvcResult.getResolvedException().getMessage())
+        .contains("No %s permission for process instance".formatted(permissionType));
+  }
+
+  @ParameterizedTest
+  @MethodSource("noPermissionGetParameters")
+  public void testGetWithNoPermission(final String urlFragment) throws Exception {
+    Mockito.when(mockProcessInstanceReader.getProcessInstanceByKey(1L))
+        .thenReturn(new ProcessInstanceForListViewEntity().setBpmnProcessId("p1"));
+    Mockito.when(
+            mockPermissionsService.hasPermissionForProcess(
+                "p1", PermissionType.READ_PROCESS_INSTANCE))
+        .thenReturn(false);
+    final var url = ProcessInstanceRestService.PROCESS_INSTANCE_URL + urlFragment;
+    final MvcResult mvcResult =
+        mockMvcManager.getRequestShouldFailWithException(url, NotAuthorizedException.class);
+    assertThat(mvcResult.getResolvedException().getMessage())
+        .contains(
+            "No %s permission for process instance"
+                .formatted(PermissionType.READ_PROCESS_INSTANCE));
+  }
+
+  private static Stream<Arguments> noPermissionGetParameters() {
+    return Stream.of(
+        Arguments.of("/1"),
+        Arguments.of("/1/incidents"),
+        Arguments.of("/1/sequence-flows"),
+        Arguments.of("/1/variables/1"),
+        Arguments.of("/1/variables/1"),
+        Arguments.of("/1/flow-node-states"),
+        Arguments.of("/1/statistics"));
+  }
+
+  private static Stream<Arguments> noPermissionPostParameters() {
+    return Stream.of(
+        Arguments.of(
+            "/1/operation",
+            new CreateOperationRequestDto().setOperationType(OperationType.DELETE_PROCESS_INSTANCE),
+            PermissionType.DELETE_PROCESS_INSTANCE),
+        Arguments.of(
+            "/1/operation",
+            new CreateOperationRequestDto().setOperationType(OperationType.CANCEL_PROCESS_INSTANCE),
+            PermissionType.CANCEL_PROCESS_INSTANCE),
+        Arguments.of(
+            "/1/operation",
+            new CreateOperationRequestDto().setOperationType(OperationType.RESOLVE_INCIDENT),
+            PermissionType.UPDATE_PROCESS_INSTANCE),
+        Arguments.of(
+            "/1/operation",
+            new CreateOperationRequestDto().setOperationType(OperationType.ADD_VARIABLE),
+            PermissionType.UPDATE_PROCESS_INSTANCE),
+        Arguments.of(
+            "/1/operation",
+            new CreateOperationRequestDto().setOperationType(OperationType.UPDATE_VARIABLE),
+            PermissionType.UPDATE_PROCESS_INSTANCE),
+        Arguments.of(
+            "/1/operation",
+            new CreateOperationRequestDto()
+                .setOperationType(OperationType.MIGRATE_PROCESS_INSTANCE),
+            PermissionType.UPDATE_PROCESS_INSTANCE),
+        Arguments.of(
+            "/1/modify",
+            new ModifyProcessInstanceRequestDto()
+                .setModifications(
+                    List.of(
+                        new Modification().setModification(Type.ADD_TOKEN).setToFlowNodeId("fid"))),
+            PermissionType.MODIFY_PROCESS_INSTANCE),
+        Arguments.of(
+            "/1/variables",
+            new VariableRequestDto().setScopeId("scope"),
+            PermissionType.READ_PROCESS_INSTANCE),
+        Arguments.of(
+            "/1/listeners",
+            new ListenerRequestDto().setPageSize(5).setFlowNodeId("fid"),
+            PermissionType.READ_PROCESS_INSTANCE),
+        Arguments.of(
+            "/1/flow-node-metadata",
+            new FlowNodeMetadataRequestDto().setFlowNodeId("fid"),
+            PermissionType.READ_PROCESS_INSTANCE));
   }
 }

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/elasticsearch/QueryHelper.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/elasticsearch/QueryHelper.java
@@ -104,7 +104,6 @@ public class QueryHelper {
         createVariablesInQuery(query),
         createBatchOperationIdQuery(query),
         createParentInstanceIdQuery(query),
-        // TODO Elasticsearch changes
         createTenantIdQuery(query),
         createReadPermissionQuery());
   }

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/elasticsearch/QueryHelper.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/elasticsearch/QueryHelper.java
@@ -109,14 +109,8 @@ public class QueryHelper {
   }
 
   private QueryBuilder createReadPermissionQuery() {
-    if (!permissionsService.permissionsEnabled()) {
-      return null;
-    }
     final var allowed =
         permissionsService.getProcessesWithPermission(PermissionType.READ_PROCESS_INSTANCE);
-    if (allowed == null) {
-      return null;
-    }
     return allowed.isAll()
         ? QueryBuilders.matchAllQuery()
         : termsQuery(ListViewTemplate.BPMN_PROCESS_ID, allowed.getIds());

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/elasticsearch/reader/DecisionInstanceReader.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/elasticsearch/reader/DecisionInstanceReader.java
@@ -335,14 +335,8 @@ public class DecisionInstanceReader extends AbstractReader
   }
 
   private QueryBuilder createReadPermissionQuery() {
-    if (!permissionsService.permissionsEnabled()) {
-      return null;
-    }
     final var allowed =
         permissionsService.getDecisionsWithPermission(PermissionType.READ_DECISION_INSTANCE);
-    if (allowed == null) {
-      return null;
-    }
     return allowed.isAll()
         ? QueryBuilders.matchAllQuery()
         : QueryBuilders.termsQuery(DecisionIndex.DECISION_ID, allowed.getIds());

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/elasticsearch/reader/DecisionInstanceReader.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/elasticsearch/reader/DecisionInstanceReader.java
@@ -320,7 +320,6 @@ public class DecisionInstanceReader extends AbstractReader
             createProcessInstanceIdQuery(query),
             createEvaluationDateQuery(query),
             createReadPermissionQuery(),
-            // TODO Elasticsearch changes
             createTenantIdQuery(query));
     if (queryBuilder == null) {
       queryBuilder = matchAllQuery();

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/elasticsearch/reader/IncidentStatisticsReader.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/elasticsearch/reader/IncidentStatisticsReader.java
@@ -116,13 +116,10 @@ public class IncidentStatisticsReader extends AbstractReader
                         cardinality(UNIQ_PROCESS_INSTANCES)
                             .field(IncidentTemplate.PROCESS_INSTANCE_KEY)));
 
-    var query = ACTIVE_INCIDENT_QUERY;
-    if (permissionsService.permissionsEnabled()) {
-      query =
-          joinWithAnd(
-              ACTIVE_INCIDENT_QUERY,
-              createQueryForProcessesByPermission(PermissionType.READ_PROCESS_INSTANCE));
-    }
+    final var query =
+        joinWithAnd(
+            ACTIVE_INCIDENT_QUERY,
+            createQueryForProcessesByPermission(PermissionType.READ_PROCESS_INSTANCE));
 
     final SearchRequest searchRequest =
         ElasticsearchUtil.createSearchRequest(incidentTemplate, ONLY_RUNTIME)
@@ -283,9 +280,6 @@ public class IncidentStatisticsReader extends AbstractReader
   private QueryBuilder createQueryForProcessesByPermission(final PermissionType permission) {
     final PermissionsService.ResourcesAllowed allowed =
         permissionsService.getProcessesWithPermission(permission);
-    if (allowed == null) {
-      return null;
-    }
     return allowed.isAll()
         ? QueryBuilders.matchAllQuery()
         : QueryBuilders.termsQuery(ListViewTemplate.BPMN_PROCESS_ID, allowed.getIds());

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/elasticsearch/reader/OperationReader.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/elasticsearch/reader/OperationReader.java
@@ -312,7 +312,8 @@ public class OperationReader extends AbstractReader
 
   @Override
   public List<OperationDto> getOperationsByBatchOperationId(final String batchOperationId) {
-    final TermQueryBuilder operationIdQ = termQuery(BATCH_OPERATION_ID, batchOperationId);
+    final QueryBuilder operationIdQ =
+        joinWithAnd(termQuery(BATCH_OPERATION_ID, batchOperationId), createUsernameQuery());
     final SearchRequest searchRequest =
         ElasticsearchUtil.createSearchRequest(operationTemplate, ALL)
             .source(new SearchSourceBuilder().query(operationIdQ));

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/elasticsearch/reader/ProcessInstanceReader.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/elasticsearch/reader/ProcessInstanceReader.java
@@ -93,15 +93,9 @@ public class ProcessInstanceReader {
 
   public ProcessInstanceCoreStatisticsDto getCoreStatistics() {
     final Map<String, Long> statistics;
-    if (permissionsService.permissionsEnabled()) {
-      final PermissionsService.ResourcesAllowed allowed =
-          permissionsService.getProcessesWithPermission(PermissionType.READ_PROCESS_INSTANCE);
-      statistics =
-          processStore.getCoreStatistics(
-              (allowed == null || allowed.isAll()) ? null : allowed.getIds());
-    } else {
-      statistics = processStore.getCoreStatistics(null);
-    }
+    final PermissionsService.ResourcesAllowed allowed =
+        permissionsService.getProcessesWithPermission(PermissionType.READ_PROCESS_INSTANCE);
+    statistics = processStore.getCoreStatistics(allowed.isAll() ? null : allowed.getIds());
     final Long runningCount = statistics.get("running");
     final Long incidentCount = statistics.get("incidents");
     final ProcessInstanceCoreStatisticsDto processInstanceCoreStatisticsDto =

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/opensearch/OpenSearchQueryHelper.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/opensearch/OpenSearchQueryHelper.java
@@ -333,14 +333,8 @@ public class OpenSearchQueryHelper {
   }
 
   private Query readPermissionQuery() {
-    if (!permissionsService.permissionsEnabled()) {
-      return null;
-    }
     final var allowed =
         permissionsService.getProcessesWithPermission(PermissionType.READ_PROCESS_INSTANCE);
-    if (allowed == null) {
-      return null;
-    }
     return allowed.isAll()
         ? matchAll()
         : stringTerms(ListViewTemplate.BPMN_PROCESS_ID, allowed.getIds());

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/opensearch/OpenSearchQueryHelper.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/opensearch/OpenSearchQueryHelper.java
@@ -90,9 +90,7 @@ public class OpenSearchQueryHelper {
         batchOperationIdQuery(query),
         parentInstanceIdQuery(query),
         tenantIdQuery(query),
-        readPermissionQuery()
-        // TODO filter by tenants assigned to current user #4858
-        );
+        readPermissionQuery());
   }
 
   private Query runningFinishedQuery(

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/opensearch/reader/OpensearchDecisionInstanceReader.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/opensearch/reader/OpensearchDecisionInstanceReader.java
@@ -240,14 +240,8 @@ public class OpensearchDecisionInstanceReader implements DecisionInstanceReader 
   }
 
   private Query createReadPermissionQuery() {
-    if (!permissionsService.permissionsEnabled()) {
-      return null;
-    }
     final var allowed =
         permissionsService.getDecisionsWithPermission(PermissionType.READ_DECISION_INSTANCE);
-    if (allowed == null) {
-      return null;
-    }
     return allowed.isAll() ? matchAll() : stringTerms(DecisionIndex.DECISION_ID, allowed.getIds());
   }
 

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/opensearch/reader/OpensearchDecisionReader.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/opensearch/reader/OpensearchDecisionReader.java
@@ -171,19 +171,15 @@ public class OpensearchDecisionReader implements DecisionReader {
   }
 
   private Query buildQuery(final String tenantId) {
-    Query decisionIdQuery = null;
-    if (permissionsService.permissionsEnabled()) {
-      final var allowed =
-          permissionsService.getDecisionsWithPermission(PermissionType.READ_DECISION_DEFINITION);
-      if (allowed != null && !allowed.isAll()) {
-        decisionIdQuery = stringTerms(DecisionIndex.DECISION_ID, allowed.getIds());
-      }
-    }
+    final var allowed =
+        permissionsService.getDecisionsWithPermission(PermissionType.READ_DECISION_DEFINITION);
+    final Query decisionIdQuery =
+        allowed.isAll() ? matchAll() : stringTerms(DecisionIndex.DECISION_ID, allowed.getIds());
+
     Query tenantIdQuery = null;
     if (securityConfiguration.getMultiTenancy().isChecksEnabled()) {
       tenantIdQuery = tenantId != null ? term(DecisionIndex.TENANT_ID, tenantId) : null;
     }
-    final var query = and(decisionIdQuery, tenantIdQuery);
-    return query == null ? matchAll() : query;
+    return and(decisionIdQuery, tenantIdQuery);
   }
 }

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/opensearch/reader/OpensearchIncidentStatisticsReader.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/opensearch/reader/OpensearchIncidentStatisticsReader.java
@@ -94,11 +94,9 @@ public class OpensearchIncidentStatisticsReader implements IncidentStatisticsRea
             ProcessIndex.VERSION);
 
     final Query query =
-        (!permissionsService.permissionsEnabled())
-            ? ACTIVE_INCIDENT_QUERY
-            : and(
-                ACTIVE_INCIDENT_QUERY,
-                createQueryForProcessesByPermission(PermissionType.READ_PROCESS_INSTANCE));
+        and(
+            ACTIVE_INCIDENT_QUERY,
+            createQueryForProcessesByPermission(PermissionType.READ_PROCESS_INSTANCE));
 
     final var uniqueProcessInstances =
         cardinalityAggregation(IncidentTemplate.PROCESS_INSTANCE_KEY);
@@ -244,9 +242,6 @@ public class OpensearchIncidentStatisticsReader implements IncidentStatisticsRea
   private Query createQueryForProcessesByPermission(final PermissionType permission) {
     final PermissionsService.ResourcesAllowed allowed =
         permissionsService.getProcessesWithPermission(permission);
-    if (allowed == null) {
-      return null;
-    }
     return allowed.isAll()
         ? matchAll()
         : stringTerms(ListViewTemplate.BPMN_PROCESS_ID, allowed.getIds());

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/opensearch/reader/OpensearchOperationReader.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/opensearch/reader/OpensearchOperationReader.java
@@ -214,7 +214,7 @@ public class OpensearchOperationReader extends OpensearchAbstractReader implemen
   public List<OperationDto> getOperationsByBatchOperationId(final String batchOperationId) {
     final var searchRequestBuilder =
         searchRequestBuilder(operationTemplate, ALL)
-            .query(term(BATCH_OPERATION_ID, batchOperationId));
+            .query(and(term(BATCH_OPERATION_ID, batchOperationId), usernameQuery()));
 
     final List<OperationEntity> operationEntities =
         richOpenSearchClient.doc().scrollValues(searchRequestBuilder, OperationEntity.class);

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/reader/ProcessReader.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/reader/ProcessReader.java
@@ -87,12 +87,8 @@ public class ProcessReader {
   }
 
   private Set<String> getAllowedProcessIdsOrNullForAll() {
-    if (!permissionsService.permissionsEnabled()) {
-      return null;
-    }
-
     final PermissionsService.ResourcesAllowed allowed =
         permissionsService.getProcessesWithPermission(PermissionType.READ_PROCESS_DEFINITION);
-    return allowed == null || allowed.isAll() ? null : allowed.getIds();
+    return allowed.isAll() ? null : allowed.getIds();
   }
 }

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/DecisionInstanceRestService.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/DecisionInstanceRestService.java
@@ -72,7 +72,7 @@ public class DecisionInstanceRestService extends InternalAPIErrorController {
     final Map<String, List<DRDDataEntryDto>> result =
         decisionInstanceReader.getDecisionInstanceDRDData(decisionInstanceId);
     if (result.isEmpty()) {
-      throw new NotFoundException("Decision instance nor found: " + decisionInstanceId);
+      throw new NotFoundException("Decision instance not found: " + decisionInstanceId);
     }
     return result;
   }

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/DecisionInstanceRestService.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/DecisionInstanceRestService.java
@@ -84,9 +84,8 @@ public class DecisionInstanceRestService extends InternalAPIErrorController {
   }
 
   private void checkIdentityReadPermission(final DecisionInstanceDto decisionInstance) {
-    if (permissionsService.permissionsEnabled()
-        && !permissionsService.hasPermissionForDecision(
-            decisionInstance.getDecisionId(), PermissionType.READ_DECISION_INSTANCE)) {
+    if (!permissionsService.hasPermissionForDecision(
+        decisionInstance.getDecisionId(), PermissionType.READ_DECISION_INSTANCE)) {
       throw new NotAuthorizedException(
           String.format(
               "No read permission for decision instance %s", decisionInstance.getDecisionId()));

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/DecisionRestService.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/DecisionRestService.java
@@ -75,7 +75,7 @@ public class DecisionRestService extends InternalAPIErrorController {
   private void checkIdentityReadPermission(final Long decisionDefinitionKey) {
     final String decisionId = decisionReader.getDecision(decisionDefinitionKey).getDecisionId();
     if (!permissionsService.hasPermissionForDecision(
-        decisionId, PermissionType.READ_DECISION_INSTANCE)) {
+        decisionId, PermissionType.READ_DECISION_DEFINITION)) {
       throw new NotAuthorizedException(
           String.format("No read permission for decision %s", decisionId));
     }

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/DecisionRestService.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/DecisionRestService.java
@@ -73,23 +73,19 @@ public class DecisionRestService extends InternalAPIErrorController {
   }
 
   private void checkIdentityReadPermission(final Long decisionDefinitionKey) {
-    if (permissionsService.permissionsEnabled()) {
-      final String decisionId = decisionReader.getDecision(decisionDefinitionKey).getDecisionId();
-      if (!permissionsService.hasPermissionForDecision(
-          decisionId, PermissionType.READ_DECISION_INSTANCE)) {
-        throw new NotAuthorizedException(
-            String.format("No read permission for decision %s", decisionId));
-      }
+    final String decisionId = decisionReader.getDecision(decisionDefinitionKey).getDecisionId();
+    if (!permissionsService.hasPermissionForDecision(
+        decisionId, PermissionType.READ_DECISION_INSTANCE)) {
+      throw new NotAuthorizedException(
+          String.format("No read permission for decision %s", decisionId));
     }
   }
 
   private void checkIdentityDeletePermission(final String decisionId) {
-    if (permissionsService.permissionsEnabled()) {
-      if (!permissionsService.hasPermissionForDecision(
-          decisionId, PermissionType.DELETE_DECISION_INSTANCE)) {
-        throw new NotAuthorizedException(
-            String.format("No delete permission for decision %s", decisionId));
-      }
+    if (!permissionsService.hasPermissionForDecision(
+        decisionId, PermissionType.DELETE_DECISION_INSTANCE)) {
+      throw new NotAuthorizedException(
+          String.format("No delete permission for decision %s", decisionId));
     }
   }
 }

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/FlowNodeInstanceRestService.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/FlowNodeInstanceRestService.java
@@ -80,10 +80,9 @@ public class FlowNodeInstanceRestService extends InternalAPIErrorController {
   }
 
   private void checkIdentityReadPermission(final Long processInstanceKey) {
-    if (permissionsService.permissionsEnabled()
-        && !permissionsService.hasPermissionForProcess(
-            processInstanceReader.getProcessInstanceByKey(processInstanceKey).getBpmnProcessId(),
-            PermissionType.READ_PROCESS_INSTANCE)) {
+    if (!permissionsService.hasPermissionForProcess(
+        processInstanceReader.getProcessInstanceByKey(processInstanceKey).getBpmnProcessId(),
+        PermissionType.READ_PROCESS_INSTANCE)) {
       throw new NotAuthorizedException(
           String.format("No read permission for process instance %s", processInstanceKey));
     }

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/ProcessInstanceRestService.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/ProcessInstanceRestService.java
@@ -265,10 +265,9 @@ public class ProcessInstanceRestService extends InternalAPIErrorController {
 
   private void checkIdentityPermission(
       final Long processInstanceKey, final PermissionType permission) {
-    if (permissionsService.permissionsEnabled()
-        && !permissionsService.hasPermissionForProcess(
-            processInstanceReader.getProcessInstanceByKey(processInstanceKey).getBpmnProcessId(),
-            permission)) {
+    if (!permissionsService.hasPermissionForProcess(
+        processInstanceReader.getProcessInstanceByKey(processInstanceKey).getBpmnProcessId(),
+        permission)) {
       throw new NotAuthorizedException(
           String.format(
               "No %s permission for process instance %s", permission, processInstanceKey));

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/ProcessRestService.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/ProcessRestService.java
@@ -84,17 +84,15 @@ public class ProcessRestService extends InternalAPIErrorController {
 
   private void checkReadPermission(
       final String bpmnProcessId, final PermissionType permissionType) {
-    if (permissionsService.permissionsEnabled()
-        && !permissionsService.hasPermissionForProcess(bpmnProcessId, permissionType)) {
+    if (!permissionsService.hasPermissionForProcess(bpmnProcessId, permissionType)) {
       throw new NotAuthorizedException(
           String.format("No read permission for process %s", bpmnProcessId));
     }
   }
 
   private void checkDeletePermission(final Long processDefinitionKey) {
-    if (permissionsService.permissionsEnabled()
-        && !permissionsService.hasPermissionForResource(
-            processDefinitionKey, PermissionType.DELETE_PROCESS)) {
+    if (!permissionsService.hasPermissionForResource(
+        processDefinitionKey, PermissionType.DELETE_PROCESS)) {
       throw new NotAuthorizedException(
           String.format("No delete permission for process definition %s", processDefinitionKey));
     }

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/dto/ProcessGroupDto.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/dto/ProcessGroupDto.java
@@ -13,7 +13,6 @@ import io.camunda.webapps.schema.entities.ProcessEntity;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.ArrayList;
 import java.util.Comparator;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -51,10 +50,7 @@ public class ProcessGroupDto {
               groupDto.setTenantId(process0.getTenantId());
               groupDto.setName(process0.getName());
               groupDto.setPermissions(
-                  (!permissionsService.permissionsEnabled())
-                      ? new HashSet<>()
-                      : permissionsService.getProcessDefinitionPermissions(
-                          process0.getBpmnProcessId()));
+                  permissionsService.getProcessDefinitionPermissions(process0.getBpmnProcessId()));
               groupDto.setProcesses(DtoCreator.create(group, ProcessDto.class));
               groups.add(groupDto);
             });

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/dto/dmn/DecisionGroupDto.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/dto/dmn/DecisionGroupDto.java
@@ -46,10 +46,7 @@ public class DecisionGroupDto {
               groupDto.setTenantId(decision0.getTenantId());
               groupDto.setName(decision0.getName());
               groupDto.setPermissions(
-                  (!permissionsService.permissionsEnabled())
-                      ? new HashSet<>()
-                      : permissionsService.getDecisionDefinitionPermissions(
-                          decision0.getDecisionId()));
+                  permissionsService.getDecisionDefinitionPermissions(decision0.getDecisionId()));
               groupDto.setDecisions(DtoCreator.create(group, DecisionDto.class));
               groups.add(groupDto);
             });

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/dto/listview/ListViewProcessInstanceDto.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/dto/listview/ListViewProcessInstanceDto.java
@@ -124,10 +124,8 @@ public class ListViewProcessInstanceDto {
     }
     processInstance.setCallHierarchy(callHierarchy);
     processInstance.setPermissions(
-        (!permissionsService.permissionsEnabled())
-            ? new HashSet<>()
-            : permissionsService.getProcessDefinitionPermissions(
-                processInstanceEntity.getBpmnProcessId()));
+        permissionsService.getProcessDefinitionPermissions(
+            processInstanceEntity.getBpmnProcessId()));
     return processInstance;
   }
 

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/dto/operation/CreateOperationRequestDto.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/dto/operation/CreateOperationRequestDto.java
@@ -27,7 +27,7 @@ public class CreateOperationRequestDto {
 
   public CreateOperationRequestDto() {}
 
-  public CreateOperationRequestDto(OperationType operationType) {
+  public CreateOperationRequestDto(final OperationType operationType) {
     this.operationType = operationType;
   }
 
@@ -35,7 +35,7 @@ public class CreateOperationRequestDto {
     return operationType;
   }
 
-  public CreateOperationRequestDto setOperationType(OperationType operationType) {
+  public CreateOperationRequestDto setOperationType(final OperationType operationType) {
     this.operationType = operationType;
     return this;
   }
@@ -44,40 +44,45 @@ public class CreateOperationRequestDto {
     return name;
   }
 
-  public void setName(String name) {
+  public CreateOperationRequestDto setName(final String name) {
     this.name = name;
+    return this;
   }
 
   public String getIncidentId() {
     return incidentId;
   }
 
-  public void setIncidentId(String incidentId) {
+  public CreateOperationRequestDto setIncidentId(final String incidentId) {
     this.incidentId = incidentId;
+    return this;
   }
 
   public String getVariableScopeId() {
     return variableScopeId;
   }
 
-  public void setVariableScopeId(String variableScopeId) {
+  public CreateOperationRequestDto setVariableScopeId(final String variableScopeId) {
     this.variableScopeId = variableScopeId;
+    return this;
   }
 
   public String getVariableName() {
     return variableName;
   }
 
-  public void setVariableName(String variableName) {
+  public CreateOperationRequestDto setVariableName(final String variableName) {
     this.variableName = variableName;
+    return this;
   }
 
   public String getVariableValue() {
     return variableValue;
   }
 
-  public void setVariableValue(String variableValue) {
+  public CreateOperationRequestDto setVariableValue(final String variableValue) {
     this.variableValue = variableValue;
+    return this;
   }
 
   @Override
@@ -92,7 +97,7 @@ public class CreateOperationRequestDto {
   }
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(final Object o) {
     if (this == o) {
       return true;
     }

--- a/operate/webapp/src/test/java/io/camunda/operate/webapp/rest/ProcessInstanceRestServiceTest.java
+++ b/operate/webapp/src/test/java/io/camunda/operate/webapp/rest/ProcessInstanceRestServiceTest.java
@@ -73,7 +73,6 @@ public class ProcessInstanceRestServiceTest {
             flowNodeStatisticsReader,
             sequenceFlowStore);
 
-    when(permissionsService.permissionsEnabled()).thenReturn(true);
     when(permissionsService.hasPermissionForProcess(any(), any(PermissionType.class)))
         .thenReturn(true);
   }

--- a/operate/webapp/src/test/java/io/camunda/operate/webapp/rest/ProcessInstanceRestServiceTest.java
+++ b/operate/webapp/src/test/java/io/camunda/operate/webapp/rest/ProcessInstanceRestServiceTest.java
@@ -275,7 +275,7 @@ public class ProcessInstanceRestServiceTest {
     when(processInstanceReader.getProcessInstanceByKey(Long.valueOf(processInstanceId)))
         .thenReturn(new ProcessInstanceForListViewEntity().setBpmnProcessId(bpmnProcessId));
     when(permissionsService.hasPermissionForProcess(
-            bpmnProcessId, PermissionType.UPDATE_PROCESS_INSTANCE))
+            bpmnProcessId, PermissionType.CANCEL_PROCESS_INSTANCE))
         .thenReturn(false);
 
     final NotAuthorizedException exception =
@@ -289,7 +289,7 @@ public class ProcessInstanceRestServiceTest {
             .actual();
 
     assertThat(exception.getMessage())
-        .contains("No UPDATE_PROCESS_INSTANCE permission for process instance");
+        .contains("No CANCEL_PROCESS_INSTANCE permission for process instance");
   }
 
   @Test

--- a/operate/webapp/src/test/java/io/camunda/operate/webapp/rest/ProcessReaderTest.java
+++ b/operate/webapp/src/test/java/io/camunda/operate/webapp/rest/ProcessReaderTest.java
@@ -50,7 +50,6 @@ public class ProcessReaderTest {
   @Test
   public void testGetProcess() {
     final ProcessReader underTest = new ProcessReader(mockProcessStore, mockPermissionsService);
-
     when(mockProcessStore.getProcessByKey(1L)).thenReturn(new ProcessEntity());
 
     final var response = underTest.getProcess(1L);
@@ -63,11 +62,12 @@ public class ProcessReaderTest {
   @Test
   public void testGetProcessesGroupedWithDisabledPermissions() {
 
-    when(mockPermissionsService.permissionsEnabled()).thenReturn(false);
     final ProcessReader underTest = new ProcessReader(mockProcessStore, mockPermissionsService);
 
     final String tenantId = "tenantId";
     when(mockProcessStore.getProcessesGrouped(tenantId, null)).thenReturn(new HashMap<>());
+    when(mockPermissionsService.getProcessesWithPermission(PermissionType.READ_PROCESS_DEFINITION))
+        .thenReturn(PermissionsService.ResourcesAllowed.wildcard());
 
     final ProcessRequestDto requestDto = new ProcessRequestDto();
     requestDto.setTenantId(tenantId);
@@ -75,14 +75,12 @@ public class ProcessReaderTest {
     final var response = underTest.getProcessesGrouped(requestDto);
 
     assertThat(response).isNotNull();
-    verify(mockPermissionsService, times(1)).permissionsEnabled();
     verify(mockProcessStore, times(1)).getProcessesGrouped(tenantId, null);
   }
 
   @Test
   public void testGetProcessesGroupedWithNoPermissions() {
 
-    when(mockPermissionsService.permissionsEnabled()).thenReturn(true);
     when(mockPermissionsService.getProcessesWithPermission(PermissionType.READ_PROCESS_DEFINITION))
         .thenReturn(ResourcesAllowed.withIds(Set.of()));
 
@@ -104,7 +102,6 @@ public class ProcessReaderTest {
   @Test
   public void testGetProcessesGroupedWithAllPermissions() {
 
-    when(mockPermissionsService.permissionsEnabled()).thenReturn(true);
     when(mockPermissionsService.getProcessesWithPermission(PermissionType.READ_PROCESS_DEFINITION))
         .thenReturn(ResourcesAllowed.wildcard());
 
@@ -126,7 +123,6 @@ public class ProcessReaderTest {
   @Test
   public void testGetProcessesGroupedWithSomePermissions() {
 
-    when(mockPermissionsService.permissionsEnabled()).thenReturn(true);
     final Set<String> allowedProcessIds = Set.of("p1, p2");
     when(mockPermissionsService.getProcessesWithPermission(PermissionType.READ_PROCESS_DEFINITION))
         .thenReturn(ResourcesAllowed.withIds(allowedProcessIds));

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/operate/OperateInternalApiPermissionsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/operate/OperateInternalApiPermissionsIT.java
@@ -34,7 +34,7 @@ import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 @MultiDbTest
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms")
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
-public class OperatePermissionsIT {
+public class OperateInternalApiPermissionsIT {
 
   @MultiDbTestApplication
   static final TestCamundaApplication STANDALONE_CAMUNDA =

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/operate/OperateMultiTenancyIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/operate/OperateMultiTenancyIT.java
@@ -8,6 +8,7 @@
 package io.camunda.it.operate;
 
 import static io.camunda.it.util.TestHelper.deployResourceForTenant;
+import static io.camunda.it.util.TestHelper.waitForProcessesToBeDeployed;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 import static org.springframework.http.HttpStatus.OK;
@@ -20,9 +21,7 @@ import io.camunda.qa.util.cluster.TestCamundaApplication;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.qa.util.multidb.MultiDbTestApplication;
 import io.camunda.security.configuration.InitializationConfiguration;
-import java.time.Duration;
 import java.util.List;
-import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
@@ -121,16 +120,5 @@ public class OperateMultiTenancyIT {
     for (final var username : usernames) {
       client.newAssignUserToTenantCommand().username(username).tenantId(tenantId).send().join();
     }
-  }
-
-  private static void waitForProcessesToBeDeployed(
-      final CamundaClient camundaClient, final int expectedProcessDefinitions) {
-    Awaitility.await("Should processes be exported")
-        .atMost(Duration.ofSeconds(15))
-        .ignoreExceptions() // Ignore exceptions and continue retrying
-        .untilAsserted(
-            () ->
-                assertThat(camundaClient.newProcessDefinitionSearchRequest().send().join().items())
-                    .hasSize(expectedProcessDefinitions));
   }
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/operate/OperateV1ApiPermissionsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/operate/OperateV1ApiPermissionsIT.java
@@ -16,6 +16,7 @@ import static io.camunda.client.api.search.enums.PermissionType.READ_PROCESS_INS
 import static io.camunda.client.api.search.enums.ResourceType.DECISION_DEFINITION;
 import static io.camunda.client.api.search.enums.ResourceType.DECISION_REQUIREMENTS_DEFINITION;
 import static io.camunda.client.api.search.enums.ResourceType.PROCESS_DEFINITION;
+import static io.camunda.it.util.TestHelper.deployDefaultTestDecisionProcessInstance;
 import static io.camunda.it.util.TestHelper.deployResource;
 import static io.camunda.it.util.TestHelper.startDefaultTestDecisionProcessInstance;
 import static io.camunda.it.util.TestHelper.startProcessInstance;
@@ -29,6 +30,7 @@ import static org.awaitility.Awaitility.await;
 
 import io.camunda.application.Profile;
 import io.camunda.client.CamundaClient;
+import io.camunda.client.api.response.Decision;
 import io.camunda.qa.util.auth.GroupDefinition;
 import io.camunda.qa.util.auth.Membership;
 import io.camunda.qa.util.auth.Permissions;
@@ -212,15 +214,12 @@ public class OperateV1ApiPermissionsIT {
         adminClient.newIncidentSearchRequest().send().join().items().getFirst().getIncidentKey();
 
     // DMN
-    startDefaultTestDecisionProcessInstance(adminClient, "decision_model.dmn");
-    decisionDefinitionKey =
-        adminClient
-            .newDecisionDefinitionSearchRequest()
-            .send()
-            .join()
-            .items()
-            .getFirst()
-            .getDecisionKey();
+    final Decision decision =
+        deployDefaultTestDecisionProcessInstance(adminClient, "decision_model.dmn");
+    startDefaultTestDecisionProcessInstance(
+        adminClient, decision.getDmnDecisionId(), "dmn_process");
+    decisionDefinitionKey = decision.getDecisionKey();
+    decisionRequirementsKey = decision.getDecisionRequirementsKey();
     decisionInstanceId =
         adminClient
             .newDecisionInstanceSearchRequest()
@@ -229,14 +228,6 @@ public class OperateV1ApiPermissionsIT {
             .items()
             .getFirst()
             .getDecisionInstanceId();
-    decisionRequirementsKey =
-        adminClient
-            .newDecisionRequirementsSearchRequest()
-            .send()
-            .join()
-            .items()
-            .getFirst()
-            .getDecisionRequirementsKey();
   }
 
   @ParameterizedTest

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/operate/OperateV1ApiPermissionsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/operate/OperateV1ApiPermissionsIT.java
@@ -17,9 +17,8 @@ import static io.camunda.client.api.search.enums.ResourceType.DECISION_DEFINITIO
 import static io.camunda.client.api.search.enums.ResourceType.DECISION_REQUIREMENTS_DEFINITION;
 import static io.camunda.client.api.search.enums.ResourceType.PROCESS_DEFINITION;
 import static io.camunda.it.util.TestHelper.deployResource;
+import static io.camunda.it.util.TestHelper.startDefaultTestDecisionProcessInstance;
 import static io.camunda.it.util.TestHelper.startProcessInstance;
-import static io.camunda.it.util.TestHelper.waitForDecisionToBeEvaluated;
-import static io.camunda.it.util.TestHelper.waitForDecisionsToBeDeployed;
 import static io.camunda.it.util.TestHelper.waitForElementInstances;
 import static io.camunda.it.util.TestHelper.waitForProcessInstanceToBeTerminated;
 import static io.camunda.it.util.TestHelper.waitForProcessInstancesToStart;
@@ -213,30 +212,7 @@ public class OperateV1ApiPermissionsIT {
         adminClient.newIncidentSearchRequest().send().join().items().getFirst().getIncidentKey();
 
     // DMN
-    final var decisionDeployment =
-        adminClient
-            .newDeployResourceCommand()
-            .addResourceFromClasspath(String.format("decisions/%s", "decision_model.dmn"))
-            .send()
-            .join()
-            .getDecisions()
-            .getFirst();
-    waitForDecisionsToBeDeployed(adminClient, 1, 1);
-    final String dmnDecisionId = decisionDeployment.getDmnDecisionId();
-    deployResource(
-            adminClient,
-            Bpmn.createExecutableProcess("dmn_process")
-                .startEvent()
-                .businessRuleTask("dmn_task")
-                .zeebeCalledDecisionId(dmnDecisionId)
-                .zeebeResultVariable("{\"output1\": \"B\"}")
-                .endEvent()
-                .done(),
-            "dmn_process.bpmn")
-        .getProcesses()
-        .getFirst();
-    startProcessInstance(adminClient, "dmn_process").getProcessInstanceKey();
-    waitForDecisionToBeEvaluated(adminClient, 1);
+    startDefaultTestDecisionProcessInstance(adminClient, "decision_model.dmn");
     decisionDefinitionKey =
         adminClient
             .newDecisionDefinitionSearchRequest()
@@ -269,7 +245,7 @@ public class OperateV1ApiPermissionsIT {
       final String user, final String endpoint, final int expectedStatus, final String key)
       throws Exception {
     try (final var client = STANDALONE_CAMUNDA.newOperateClient(user, user)) {
-      final int statusCode = client.getRequest(endpoint, key).statusCode();
+      final int statusCode = client.sendGetRequest(endpoint, key).statusCode();
       assertThat(statusCode).isEqualTo(expectedStatus);
     }
   }
@@ -279,7 +255,7 @@ public class OperateV1ApiPermissionsIT {
   void shouldEvaluateSearchRequest(
       final String user, final String endpoint, final int expectedStatus) throws Exception {
     try (final var client = STANDALONE_CAMUNDA.newOperateClient(user, user)) {
-      final int statusCode = client.searchRequest(endpoint, "{}").statusCode();
+      final int statusCode = client.sendV1SearchRequest(endpoint, "{}").statusCode();
       assertThat(statusCode).isEqualTo(expectedStatus);
     }
   }
@@ -299,7 +275,7 @@ public class OperateV1ApiPermissionsIT {
 
     try (final var client = STANDALONE_CAMUNDA.newOperateClient(user, user)) {
       final int statusCode =
-          client.deleteRequest("v1/process-instances", processInstanceToDeleteKey).statusCode();
+          client.sendDeleteRequest("v1/process-instances", processInstanceToDeleteKey).statusCode();
       assertThat(statusCode).isEqualTo(expectedStatus);
     }
   }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/operate/compatibility/CompatibilityModeOperateZeebeAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/operate/compatibility/CompatibilityModeOperateZeebeAuthorizationIT.java
@@ -144,6 +144,16 @@ public class CompatibilityModeOperateZeebeAuthorizationIT {
                   ResourceType.PROCESS_DEFINITION,
                   PermissionType.UPDATE_PROCESS_INSTANCE,
                   List.of(
+                      PROCESS_WITH_INCIDENT, PROCESS_WITH_VARIABLE, PROCESS_WITH_SERVICE_TASKS)),
+              new Permissions(
+                  ResourceType.PROCESS_DEFINITION,
+                  PermissionType.MODIFY_PROCESS_INSTANCE,
+                  List.of(
+                      PROCESS_WITH_INCIDENT, PROCESS_WITH_VARIABLE, PROCESS_WITH_SERVICE_TASKS)),
+              new Permissions(
+                  ResourceType.PROCESS_DEFINITION,
+                  PermissionType.CANCEL_PROCESS_INSTANCE,
+                  List.of(
                       PROCESS_WITH_INCIDENT, PROCESS_WITH_VARIABLE, PROCESS_WITH_SERVICE_TASKS))));
 
   private static long processDefinitionForDeletionKey;

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/operate/compatibility/NoCompatibilityModeOperateZeebeAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/operate/compatibility/NoCompatibilityModeOperateZeebeAuthorizationIT.java
@@ -144,6 +144,16 @@ public class NoCompatibilityModeOperateZeebeAuthorizationIT {
                   ResourceType.PROCESS_DEFINITION,
                   PermissionType.UPDATE_PROCESS_INSTANCE,
                   List.of(
+                      PROCESS_WITH_INCIDENT, PROCESS_WITH_VARIABLE, PROCESS_WITH_SERVICE_TASKS)),
+              new Permissions(
+                  ResourceType.PROCESS_DEFINITION,
+                  PermissionType.CANCEL_PROCESS_INSTANCE,
+                  List.of(
+                      PROCESS_WITH_INCIDENT, PROCESS_WITH_VARIABLE, PROCESS_WITH_SERVICE_TASKS)),
+              new Permissions(
+                  ResourceType.PROCESS_DEFINITION,
+                  PermissionType.MODIFY_PROCESS_INSTANCE,
+                  List.of(
                       PROCESS_WITH_INCIDENT, PROCESS_WITH_VARIABLE, PROCESS_WITH_SERVICE_TASKS))));
 
   private static long processDefinitionForDeletionKey;

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/util/TestHelper.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/util/TestHelper.java
@@ -14,6 +14,7 @@ import static org.awaitility.Awaitility.await;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.CreateProcessInstanceCommandStep1;
 import io.camunda.client.api.command.ProblemException;
+import io.camunda.client.api.response.Decision;
 import io.camunda.client.api.response.DeploymentEvent;
 import io.camunda.client.api.response.Process;
 import io.camunda.client.api.response.ProcessInstanceEvent;
@@ -21,12 +22,17 @@ import io.camunda.client.api.search.enums.BatchOperationState;
 import io.camunda.client.api.search.enums.IncidentState;
 import io.camunda.client.api.search.enums.ProcessInstanceState;
 import io.camunda.client.api.search.enums.UserTaskState;
+import io.camunda.client.api.search.filter.DecisionDefinitionFilter;
+import io.camunda.client.api.search.filter.DecisionRequirementsFilter;
 import io.camunda.client.api.search.filter.ElementInstanceFilter;
 import io.camunda.client.api.search.filter.IncidentFilter;
 import io.camunda.client.api.search.filter.ProcessDefinitionFilter;
 import io.camunda.client.api.search.filter.ProcessInstanceFilter;
 import io.camunda.client.api.search.response.ProcessInstance;
 import io.camunda.client.api.search.response.SearchResponse;
+import io.camunda.client.impl.search.filter.DecisionDefinitionFilterImpl;
+import io.camunda.client.impl.search.filter.DecisionRequirementsFilterImpl;
+import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import java.time.Duration;
 import java.util.Comparator;
@@ -617,10 +623,54 @@ public final class TestHelper {
             });
   }
 
+  public static Decision startDefaultTestDecisionProcessInstance(
+      final CamundaClient camundaClient, final String dmnResource) {
+    final var decisionDeployment =
+        camundaClient
+            .newDeployResourceCommand()
+            .addResourceFromClasspath(String.format("decisions/%s", dmnResource))
+            .send()
+            .join()
+            .getDecisions()
+            .getFirst();
+    waitForDecisionsToBeDeployed(
+        camundaClient,
+        decisionDeployment.getDecisionKey(),
+        decisionDeployment.getDecisionRequirementsKey(),
+        1,
+        1);
+    deployResource(
+            camundaClient,
+            Bpmn.createExecutableProcess("dmn_process")
+                .startEvent()
+                .businessRuleTask("dmn_task")
+                .zeebeCalledDecisionId(decisionDeployment.getDmnDecisionId())
+                .zeebeResultVariable("{\"output1\": \"B\"}")
+                .endEvent()
+                .done(),
+            "dmn_process.bpmn")
+        .getProcesses()
+        .getFirst();
+    final long processInstanceKey =
+        startProcessInstance(camundaClient, "dmn_process").getProcessInstanceKey();
+    waitForDecisionToBeEvaluated(camundaClient, processInstanceKey, 1);
+    return decisionDeployment;
+  }
+
   public static void waitForDecisionsToBeDeployed(
       final CamundaClient camundaClient,
+      final long decisionKey,
+      final long decisionRequirementsKey,
       final int expectedDecisionDefinitions,
       final int expectedDecisionRequirements) {
+    final DecisionDefinitionFilter decisionDefinitionFilter =
+        decisionKey != -1
+            ? new DecisionDefinitionFilterImpl().decisionDefinitionKey(decisionKey)
+            : new DecisionDefinitionFilterImpl();
+    final DecisionRequirementsFilter decisionRequirementsFilter =
+        decisionRequirementsKey != -1
+            ? new DecisionRequirementsFilterImpl().decisionRequirementsKey(decisionRequirementsKey)
+            : new DecisionRequirementsFilterImpl();
     Awaitility.await("should receive data from ES")
         .atMost(TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptions() // Ignore exceptions and continue retrying
@@ -629,6 +679,7 @@ public final class TestHelper {
               assertThat(
                       camundaClient
                           .newDecisionDefinitionSearchRequest()
+                          .filter(decisionDefinitionFilter)
                           .send()
                           .join()
                           .items()
@@ -637,6 +688,7 @@ public final class TestHelper {
               assertThat(
                       camundaClient
                           .newDecisionRequirementsSearchRequest()
+                          .filter(decisionRequirementsFilter)
                           .send()
                           .join()
                           .items()
@@ -645,14 +697,29 @@ public final class TestHelper {
             });
   }
 
+  public static void waitForDecisionsToBeDeployed(
+      final CamundaClient camundaClient,
+      final int expectedDecisionDefinitions,
+      final int expectedDecisionRequirements) {
+    waitForDecisionsToBeDeployed(
+        camundaClient, -1, -1, expectedDecisionDefinitions, expectedDecisionRequirements);
+  }
+
   public static void waitForDecisionToBeEvaluated(
-      final CamundaClient camundaClient, final int expectedDecisionInstances) {
+      final CamundaClient camundaClient,
+      final long processInstanceKey,
+      final int expectedDecisionInstances) {
     Awaitility.await("should deploy decision definitions and wait for import")
         .atMost(Duration.ofSeconds(15))
         .ignoreExceptions() // Ignore exceptions and continue retrying
         .untilAsserted(
             () -> {
-              final var result = camundaClient.newDecisionInstanceSearchRequest().send().join();
+              final var result =
+                  camundaClient
+                      .newDecisionInstanceSearchRequest()
+                      .filter(f -> f.processInstanceKey(processInstanceKey))
+                      .send()
+                      .join();
               assertThat(result.items()).hasSize(expectedDecisionInstances);
             });
   }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/util/TestHelper.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/util/TestHelper.java
@@ -623,7 +623,7 @@ public final class TestHelper {
             });
   }
 
-  public static Decision startDefaultTestDecisionProcessInstance(
+  public static Decision deployDefaultTestDecisionProcessInstance(
       final CamundaClient camundaClient, final String dmnResource) {
     final var decisionDeployment =
         camundaClient
@@ -639,22 +639,28 @@ public final class TestHelper {
         decisionDeployment.getDecisionRequirementsKey(),
         1,
         1);
-    deployResource(
-            camundaClient,
-            Bpmn.createExecutableProcess("dmn_process")
-                .startEvent()
-                .businessRuleTask("dmn_task")
-                .zeebeCalledDecisionId(decisionDeployment.getDmnDecisionId())
-                .zeebeResultVariable("{\"output1\": \"B\"}")
-                .endEvent()
-                .done(),
-            "dmn_process.bpmn")
-        .getProcesses()
-        .getFirst();
-    final long processInstanceKey =
-        startProcessInstance(camundaClient, "dmn_process").getProcessInstanceKey();
-    waitForDecisionToBeEvaluated(camundaClient, processInstanceKey, 1);
     return decisionDeployment;
+  }
+
+  public static Process startDefaultTestDecisionProcessInstance(
+      final CamundaClient camundaClient, final String dmnDecisionId, final String bpmnProcessId) {
+    final var deployment =
+        deployResource(
+                camundaClient,
+                Bpmn.createExecutableProcess(bpmnProcessId)
+                    .startEvent()
+                    .businessRuleTask("dmn_task")
+                    .zeebeCalledDecisionId(dmnDecisionId)
+                    .zeebeResultVariable("{\"output1\": \"B\"}")
+                    .endEvent()
+                    .done(),
+                "dmn_process.bpmn")
+            .getProcesses()
+            .getFirst();
+    final long processInstanceKey =
+        startProcessInstance(camundaClient, bpmnProcessId).getProcessInstanceKey();
+    waitForDecisionToBeEvaluated(camundaClient, processInstanceKey, 1);
+    return deployment;
   }
 
   public static void waitForDecisionsToBeDeployed(

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/util/TestHelper.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/util/TestHelper.java
@@ -867,6 +867,22 @@ public final class TestHelper {
             });
   }
 
+  public static void waitUntilJobExistsForProcessInstance(
+      final CamundaClient camundaClient, final long processInstanceKey) {
+    await("should wait until the process instance has an active job.")
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .untilAsserted(
+            () -> {
+              final var result =
+                  camundaClient
+                      .newJobSearchRequest()
+                      .filter(f -> f.processInstanceKey(processInstanceKey))
+                      .send()
+                      .join();
+              assertThat(result.items()).hasSize(1);
+            });
+  }
+
   public static void waitUntilExactUsersExist(
       final CamundaClient camundaClient, final String... usernames) {
     await("should wait until the expected users are in the secondary storage.")

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/util/TestHelper.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/util/TestHelper.java
@@ -893,6 +893,23 @@ public final class TestHelper {
             });
   }
 
+  public static void waitUntilAuthorizationVisible(
+      final CamundaClient camundaClient, final String owner, final String resource) {
+    Awaitility.await("should wait until authorization is visible")
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .ignoreExceptions() // Ignore exceptions and continue retrying
+        .untilAsserted(
+            () -> {
+              final var result =
+                  camundaClient
+                      .newAuthorizationSearchRequest()
+                      .filter(f -> f.ownerId(owner).resourceIds(resource))
+                      .send()
+                      .join();
+              assertThat(result.items().size()).isOne();
+            });
+  }
+
   public static <T, U extends Comparable<U>> void assertSorted(
       final SearchResponse<T> resultAsc,
       final SearchResponse<T> resultDesc,

--- a/qa/util/src/main/java/io/camunda/qa/util/cluster/TestRestOperateClient.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/cluster/TestRestOperateClient.java
@@ -220,11 +220,25 @@ public class TestRestOperateClient implements AutoCloseable {
     return httpClient.send(httpRequest, BodyHandlers.ofString());
   }
 
-  public HttpResponse<String> deleteRequest(final String endpointUri, final long key)
+  public HttpResponse sendInternalSearchRequest(final String endpointUri, final String request)
+      throws URISyntaxException, IOException, InterruptedException {
+    final HttpRequest httpRequest =
+        addAuthHeader(createBuilder(endpoint + endpointUri))
+            .POST(HttpRequest.BodyPublishers.ofString(request))
+            .header("Content-Type", "application/json")
+            .build();
+    return httpClient.send(httpRequest, BodyHandlers.ofString());
+  }
+
+  public HttpResponse<String> sendDeleteRequest(final String endpointUri, final long key)
       throws URISyntaxException, IOException, InterruptedException {
     final String url = endpoint + endpointUri + "/" + key;
     final HttpRequest request = addAuthHeader(createBuilder(url)).DELETE().build();
     return httpClient.send(request, BodyHandlers.ofString());
+  }
+
+  public static String toJsonString(final Object request) throws JsonProcessingException {
+    return OBJECT_MAPPER.writeValueAsString(request);
   }
 
   private Either<Exception, HttpResponse<String>> createProcessInstanceOperationRequest(
@@ -301,7 +315,7 @@ public class TestRestOperateClient implements AutoCloseable {
     }
   }
 
-  private <T> Either<Exception, T> mapResult(
+  public <T> Either<Exception, T> mapResult(
       final HttpResponse<String> response, final Class<T> tClass) {
     if (response.statusCode() != 200) {
       return Either.left(

--- a/qa/util/src/main/java/io/camunda/qa/util/cluster/TestRestOperateClient.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/cluster/TestRestOperateClient.java
@@ -197,19 +197,19 @@ public class TestRestOperateClient implements AutoCloseable {
         processInstanceKey, new CreateOperationRequestDto(OperationType.RESOLVE_INCIDENT));
   }
 
-  public HttpResponse<String> getRequest(final String endpointUriFormat, final String key)
+  public HttpResponse<String> sendGetRequest(final String endpointUriFormat, final String key)
       throws URISyntaxException, IOException, InterruptedException {
     final String url = endpoint + endpointUriFormat.formatted(key);
     final HttpRequest request = addAuthHeader(createBuilder(url)).GET().build();
     return httpClient.send(request, BodyHandlers.ofString());
   }
 
-  public HttpResponse<String> getRequest(final String endpointUriFormat, final long key)
+  public HttpResponse<String> sendGetRequest(final String endpointUriFormat, final long key)
       throws URISyntaxException, IOException, InterruptedException {
-    return getRequest(endpointUriFormat, String.valueOf(key));
+    return sendGetRequest(endpointUriFormat, String.valueOf(key));
   }
 
-  public HttpResponse<String> searchRequest(final String endpointUri, final String request)
+  public HttpResponse<String> sendV1SearchRequest(final String endpointUri, final String request)
       throws URISyntaxException, IOException, InterruptedException {
     final String url = endpoint + endpointUri + "/search";
     final HttpRequest httpRequest =


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Checked all internal Operate endpoints for permission checks and ensured test coverage for all of them.

- Fixed some old code leftovers related to the PermissionsService: removed unnecessary `permissionsEnabled` checks and wrong null checks for methods that can't return null
- Added permission checks where they were missing (full evaluation in the [parent ticket comments](https://github.com/camunda/camunda/issues/32409#issuecomment-3150219324))
- Added tests for permission checks where they were missing (full evaluation in [this issue comment](https://github.com/camunda/camunda/issues/36426#issuecomment-3162756304))
- Added permission checks (and tests) for the new process instance permissions (see https://github.com/camunda/camunda/issues/36149)
- refactored DecisionInstanceReaderIT to be an actual IT for the reader and not the API (I couldn't use this test the way I wanted to in the end), but I figured I'll still leave this change in since the naming bothered me

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes https://github.com/camunda/camunda/issues/36426
