### PR TITLE
ci: add release branch patterns to license scanning

### DIFF
--- a/.github/workflows/check-licenses.yml
+++ b/.github/workflows/check-licenses.yml
@@ -10,6 +10,8 @@ on:
     branches:
     - main
     - stable/*
+    - release/*
+    - release-*
     tags:
     - '*'
   pull_request:


### PR DESCRIPTION
## Description

As discussed with @maxdanilov, this PR adds `release/*`, and `release-*` branch patterns to `check-licenses.yml` workflow, to ensures license scanning runs on all release-related branches.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).
