### PR TITLE
Bump zeebe and identity versions for release 8.7.7

### DIFF
--- a/optimize/backend/pom.xml
+++ b/optimize/backend/pom.xml
@@ -147,6 +147,10 @@
           <groupId>org.apache.logging.log4j</groupId>
           <artifactId>log4j-slf4j2-impl</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.apache.tomcat.embed</groupId>
+          <artifactId>tomcat-embed-core</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
 

--- a/optimize/pom.xml
+++ b/optimize/pom.xml
@@ -14,8 +14,8 @@
     <camunda.maven.artifacts.version>7.22.0</camunda.maven.artifacts.version>
 
     <!-- We use this version to compile but run IT against containers with zeebe.docker.version -->
-    <zeebe.version>8.7.9</zeebe.version>
-    <identity.version>8.7.4</identity.version>
+    <zeebe.version>8.7.10</zeebe.version>
+    <identity.version>8.7.5</identity.version>
     <!-- We use this for the Zeebe test container version only -->
     <zeebe.docker.version>${zeebe.version}</zeebe.docker.version>
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
This PR updates the Zeebe and Identity versions used in Optimize. It also includes a compatibility fix for Identity 8.7.5, addressing a known issue that caused Optimize to break when used with this version.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
