### PR TITLE
refactor log4j2.xml + rdbms schema initialization too verbose

### DIFF
--- a/db/rdbms/README.md
+++ b/db/rdbms/README.md
@@ -1,0 +1,27 @@
+# Rdbms Module
+
+## Logging
+
+By default, we set all loggers that could log sensitive information (Records, SQLs, Queue Items) to INFO level.
+To enable debug logging for these loggers, it is not enough to enable logging for rdbms in log4j2.xml.
+
+They are set in application.properties, but you can override them via environment variables.
+
+For exported Records:
+
+```
+logging.level.io.camunda.exporter.rdbms.RdbmsExporter=TRACE
+```
+
+For executed SQLs + Parameters:
+
+```
+logging.level.io.camunda.db.rdbms.sql=DEBUG
+```
+
+For Execution Queue Items:
+
+```
+logging.level.io.camunda.db.rdbms.write.queue=TRACE
+```
+

--- a/dist/src/main/assembly.xml
+++ b/dist/src/main/assembly.xml
@@ -34,6 +34,12 @@
       <lineEnding>keep</lineEnding>
       <outputDirectory>/</outputDirectory>
     </file>
+    <file>
+      <source>${maven.multiModuleProjectDirectory}/dist/src/main/resources/log4j2.xml</source>
+      <filtered>true</filtered>
+      <lineEnding>keep</lineEnding>
+      <outputDirectory>/config</outputDirectory>
+    </file>
   </files>
 
 </assembly>

--- a/dist/src/main/java/io/camunda/zeebe/broker/BrokerModuleConfiguration.java
+++ b/dist/src/main/java/io/camunda/zeebe/broker/BrokerModuleConfiguration.java
@@ -99,7 +99,7 @@ public class BrokerModuleConfiguration implements CloseableSilently {
   public ExporterRepository exporterRepository(
       @Autowired(required = false) final List<ExporterDescriptor> exporterDescriptors) {
     if (exporterDescriptors != null && !exporterDescriptors.isEmpty()) {
-      LOGGER.info("Create ExporterRepository with predefined exporter descriptors.");
+      LOGGER.debug("Create ExporterRepository with predefined exporter descriptors.");
       return new ExporterRepository(exporterDescriptors);
     } else {
       return new ExporterRepository();

--- a/dist/src/main/java/io/camunda/zeebe/broker/RdbmsExporterConfiguration.java
+++ b/dist/src/main/java/io/camunda/zeebe/broker/RdbmsExporterConfiguration.java
@@ -40,7 +40,7 @@ public class RdbmsExporterConfiguration {
   @Bean
   public ExporterDescriptor rdbmsExporterDescriptor(
       final RdbmsExporterFactory rdbmsExporterFactory, final ExporterCfg rdbmsExporterCfg) {
-    LOGGER.info("Provide ExporterDescriptor for RDBMS Exporter");
+    LOGGER.debug("Provide ExporterDescriptor for RDBMS Exporter");
     return new ExporterDescriptor(
         rdbmsExporterFactory.exporterId(),
         rdbmsExporterFactory,

--- a/dist/src/main/resources/application-rdbmsH2.yaml
+++ b/dist/src/main/resources/application-rdbmsH2.yaml
@@ -139,7 +139,3 @@ camunda:
       url: http://localhost:9200
       # Index prefix, configured in Zeebe Elasticsearch exporter
       prefix: zeebe-record
-logging:
-  level:
-    io:
-      camunda: DEBUG

--- a/dist/src/main/resources/application-rdbmsMariaDB.yaml
+++ b/dist/src/main/resources/application-rdbmsMariaDB.yaml
@@ -150,7 +150,3 @@ camunda:
       url: http://localhost:9200
       # Index prefix, configured in Zeebe Elasticsearch exporter
       prefix: zeebe-record
-logging:
-  level:
-    io:
-      camunda: DEBUG

--- a/dist/src/main/resources/application-rdbmsOracle.yaml
+++ b/dist/src/main/resources/application-rdbmsOracle.yaml
@@ -150,7 +150,3 @@ camunda:
       url: http://localhost:9200
       # Index prefix, configured in Zeebe Elasticsearch exporter
       prefix: zeebe-record
-logging:
-  level:
-    io:
-      camunda: DEBUG

--- a/dist/src/main/resources/application-rdbmsPostgres.yaml
+++ b/dist/src/main/resources/application-rdbmsPostgres.yaml
@@ -150,7 +150,3 @@ camunda:
       url: http://localhost:9200
       # Index prefix, configured in Zeebe Elasticsearch exporter
       prefix: zeebe-record
-logging:
-  level:
-    io:
-      camunda: DEBUG

--- a/dist/src/main/resources/application.properties
+++ b/dist/src/main/resources/application.properties
@@ -104,3 +104,9 @@ springdoc.swagger-ui.csrf.session-storage-key=X-CSRF-TOKEN
 springdoc.swagger-ui.csrf.use-session-storage=true
 
 camunda.security.multiTenancy.checksEnabled=${zeebe.broker.gateway.multiTenancy.enabled:false}
+
+# Those loggers log records / sql statements which could contain sensitive information on debug/trace.
+# Therefore, we set them to INFO by default, for the case that a customer enables debug logging for everything.
+logging.level.io.camunda.exporter.rdbms.RdbmsExporter=INFO
+logging.level.io.camunda.db.rdbms.sql=INFO
+logging.level.io.camunda.db.rdbms.write.queue=INFO

--- a/dist/src/main/resources/log4j2.xml
+++ b/dist/src/main/resources/log4j2.xml
@@ -40,10 +40,7 @@
       then avoid this altogether.
       -->
     <Select>
-      <EnvironmentArbiter propertyName="CAMUNDA_LOG_FILE_APPENDER_ENABLED" propertyValue="false">
-        <Null name="RollingFile" />
-      </EnvironmentArbiter>
-      <DefaultArbiter>
+      <EnvironmentArbiter propertyName="CAMUNDA_LOG_FILE_APPENDER_ENABLED" propertyValue="true" >
         <RollingFile name="RollingFile" fileName="${log.path}/zeebe.log"
           filePattern="${log.path}/zeebe-%d{yyyy-MM-dd}-%i.log.gz">
           <PatternLayout pattern="${log.pattern}" />
@@ -52,6 +49,9 @@
             <SizeBasedTriggeringPolicy size="250 MB"/>
           </Policies>
         </RollingFile>
+      </EnvironmentArbiter>
+      <DefaultArbiter>
+        <Null name="RollingFile" />
       </DefaultArbiter>
     </Select>
   </Appenders>
@@ -64,8 +64,8 @@
     <Logger name="org.springframework" level="INFO" />
 
     <Root level="WARN">
-      <!-- add to enable file logging -->
-      <!-- <AppenderRef ref="RollingFile" /> -->
+      <!-- This is just enabled if CAMUNDA_LOG_FILE_APPENDER_ENABLED is set to true! -->
+      <AppenderRef ref="RollingFile" />
 
       <!-- remove to disable console logging -->
       <AppenderRef ref="${env:ZEEBE_LOG_APPENDER:-${env:OPERATE_LOG_APPENDER:-${env:OPTIMIZE_LOG_APPENDER:-${env:TASKLIST_LOG_APPENDER:-Console}}}}"/>

--- a/dist/src/main/resources/log4j2.xml
+++ b/dist/src/main/resources/log4j2.xml
@@ -1,4 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+  ~ one or more contributor license agreements. See the NOTICE file distributed
+  ~ with this work for additional information regarding copyright ownership.
+  ~ Licensed under the Camunda License 1.0. You may not use this file
+  ~ except in compliance with the Camunda License 1.0.
+  -->
 <Configuration xmlns="https://logging.apache.org/xml/ns"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="
@@ -6,7 +13,7 @@
                    https://logging.apache.org/xml/ns/log4j-config-2.xsd" status="WARN" shutdownHook="disable">
   <Properties>
     <Property name="log.path" value="${sys:app.home}/logs" />
-    <Property name="log.pattern" value="[%d{yyyy-MM-dd HH:mm:ss.SSS}] [%t] %notEmpty{[%X] }%-5level%n\t%logger{36} - %msg%n" />
+    <Property name="log.pattern" value="%d{HH:mm:ss.SSS} [%t] %notEmpty{[%X] }%-5level\t%logger{1.1.1.*} - %msg%n" />
     <Property name="log.stackdriver.serviceName" value="${env:ZEEBE_LOG_STACKDRIVER_SERVICENAME:-${env:OPERATE_LOG_STACKDRIVER_SERVICENAME:-${env:OPTIMIZE_LOG_STACKDRIVER_SERVICENAME:-${env:TASKLIST_LOG_STACKDRIVER_SERVICENAME:-}}}}"/>
     <Property name="log.stackdriver.serviceVersion" value="${env:ZEEBE_LOG_STACKDRIVER_SERVICEVERSION:-${env:OPERATE_LOG_STACKDRIVER_SERVICEVERSION:-${env:OPTIMIZE_LOG_STACKDRIVER_SERVICEVERSION:-${env:TASKLIST_LOG_STACKDRIVER_SERVICEVERSION:-}}}}"/>
   </Properties>
@@ -57,7 +64,8 @@
     <Logger name="org.springframework" level="INFO" />
 
     <Root level="WARN">
-      <AppenderRef ref="RollingFile" />
+      <!-- add to enable file logging -->
+      <!-- <AppenderRef ref="RollingFile" /> -->
 
       <!-- remove to disable console logging -->
       <AppenderRef ref="${env:ZEEBE_LOG_APPENDER:-${env:OPERATE_LOG_APPENDER:-${env:OPTIMIZE_LOG_APPENDER:-${env:TASKLIST_LOG_APPENDER:-Console}}}}"/>

--- a/dist/src/main/resources/log4j2.xml
+++ b/dist/src/main/resources/log4j2.xml
@@ -13,7 +13,7 @@
                    https://logging.apache.org/xml/ns/log4j-config-2.xsd" status="WARN" shutdownHook="disable">
   <Properties>
     <Property name="log.path" value="${sys:app.home}/logs" />
-    <Property name="log.pattern" value="%d{HH:mm:ss.SSS} [%t] %notEmpty{[%X] }%-5level\t%logger{1.1.1.*} - %msg%n" />
+    <Property name="log.pattern" value="%d{HH:mm:ss.SSS} [%t] %notEmpty{[%X] }%-5level%logger{1.1.1.*} - %msg%n" />
     <Property name="log.stackdriver.serviceName" value="${env:ZEEBE_LOG_STACKDRIVER_SERVICENAME:-${env:OPERATE_LOG_STACKDRIVER_SERVICENAME:-${env:OPTIMIZE_LOG_STACKDRIVER_SERVICENAME:-${env:TASKLIST_LOG_STACKDRIVER_SERVICENAME:-}}}}"/>
     <Property name="log.stackdriver.serviceVersion" value="${env:ZEEBE_LOG_STACKDRIVER_SERVICEVERSION:-${env:OPERATE_LOG_STACKDRIVER_SERVICEVERSION:-${env:OPTIMIZE_LOG_STACKDRIVER_SERVICEVERSION:-${env:TASKLIST_LOG_STACKDRIVER_SERVICEVERSION:-}}}}"/>
   </Properties>

--- a/docs/observability/logging.md
+++ b/docs/observability/logging.md
@@ -32,9 +32,10 @@ Configuration of Log4j2 is done via a `log4j2.xml` file, located in a module's r
 i.e. `src/main/resources`.
 
 For the single C8 application, the configuration file is located in the `dist` folder (aka
-`camunda-zeebe` module), at [dist/src/config/log4j2.xml](../../dist/src/main/config/log4j2.xml). When
-looking at the assembled distribution artifact, you will find it at `config/log4j2.xml`. The
-application resolves it because we add the `config/` folder to the classpath at launch in all the
+`camunda-zeebe` module), at [dist/src/main/resources/log4j2.xml](../../dist/src/main/resources/log4j2.xml).
+When looking at the assembled distribution artifact, you will find it at `config/log4j2.xml`
+because we copy it when building the artifact.
+The application resolves it because we add the `config/` folder to the classpath at launch in all the
 shell scripts found in the distribution's `bin` folder.
 
 > [!Note]

--- a/docs/observability/logging.md
+++ b/docs/observability/logging.md
@@ -58,14 +58,16 @@ One notable exception is Spring, for which we set the log level to `INFO`. This 
 Spring as our application server, and information about its operation (e.g. the embedded Tomcat
 server starting, the security chain configuration, etc.) is relevant to the user.
 
-As for outputs, C8 will log both to standard out (aka console) and to file by default. Logging to
+As for outputs, C8 will log to standard out (aka console) by default. Logging to
 STDOUT is how most Kubernetes implementations - or in general, most cloud providers - capture and
-aggregate logs. The file output is then mostly for bare metal systems, where logs are expected to be
+aggregate logs.
+
+The file output is then mostly for bare metal systems, where logs are expected to be
 found on the server itself, and are periodically logged over, allowing the user to specify a
 retention window.
 
 > [!Note]
-> You can disable the file logging via `CAMUNDA_LOG_FILE_APPENDER_ENABLED=false` environment
+> You can enable the file logging via `CAMUNDA_LOG_FILE_APPENDER_ENABLED=true` environment
 > variable. This is done in the configuration file by using so-called
 > [Arbiters](https://logging.apache.org/log4j/2.x/manual/configuration.html#arbiters).
 


### PR DESCRIPTION
## Description

The PR adresess two topics around logging:

### Main log4j2.xml

- By moving the log4j2.xml from config to resources folder, it will now also be used during development as a default setting for logging.
  - In order to keep old behaviour, the file is copied to config folder when building the artefact
<img width="343" height="326" alt="Screenshot 2025-08-06 at 17 15 55" src="https://github.com/user-attachments/assets/0b308aea-4dd0-40de-bfe0-fbc8a9594770" />

- File logging is now disabled by default, as we don't need it in development or SaaS. The documentation has been updated to show how to enable file logging.
- In addition, the log pattern has been adjusted to achieve a leaner output and enable faster navigation.
  - Just time will be logged
  - Line break is removed
  - Logger name will be shortened: `io.atomix.cluster.messaging.impl.NettyUnicastService` it becomes _i.a.c.messaging.impl.NettyUnicastService_
- logging.md is updated

**Old logs:**

```
[2025-08-06 10:42:41.255] [main] INFO 
	io.camunda.application.StandaloneBroker - Starting StandaloneBroker v8.8.0-SNAPSHOT using Java 21.0.4 with PID 94586 (/Users/patrickschalk/workdir/intern/camunda/camunda/dist/target/classes started by patrickschalk in /Users/patrickschalk/workdir/intern/camunda/camunda)
[2025-08-06 10:42:41.258] [main] INFO 
	io.camunda.application.StandaloneBroker - The following 4 profiles are active: "broker", "standalone", "rdbmsH2", "insecure"
[2025-08-06 10:42:43.097] [main] INFO 
	org.springframework.boot.web.embedded.tomcat.TomcatWebServer - Tomcat initialized with port 8080 (http)
[2025-08-06 10:42:43.292] [main] WARN 
	io.camunda.configuration.UnifiedConfigurationHelper - The following legacy configuration properties should be removed in favor of 'camunda.system.io-thread-count': zeebe.broker.threads.ioThreadCount
[2025-08-06 10:42:43.627] [netty-messaging-event-nio-server-0] [{actor-scheduler=Broker-0}] INFO 
	io.atomix.cluster.messaging.impl.NettyMessagingService - Started messaging service bound to [0.0.0.0:26502], advertising 192.168.2.40:26502, and using plaintext
[2025-08-06 10:42:43.638] [netty-unicast-event-nio-client-0] [{actor-scheduler=Broker-0}] INFO 
	io.atomix.cluster.messaging.impl.NettyUnicastService - Started plaintext unicast service bound to 0.0.0.0:26502, advertising 192.168.2.40:26502
[2025-08-06 10:42:43.640] [atomix-cluster-0] INFO 
	io.atomix.cluster.protocol.swim - Started
```

**New logs:**

```
16:51:11.204 [main] INFO i.c.a.StandaloneBroker - Starting StandaloneBroker v8.8.0-SNAPSHOT using Java 21.0.4 with PID 10500 (/Users/patrickschalk/workdir/intern/camunda/camunda/dist/target/classes started by patrickschalk in /Users/patrickschalk/workdir/intern/camunda/camunda)
16:51:11.206 [main] INFO i.c.a.StandaloneBroker - The following 4 profiles are active: "broker", "standalone", "rdbmsH2", "insecure"
16:51:12.905 [main] INFO o.s.b.web.embedded.tomcat.TomcatWebServer - Tomcat initialized with port 8080 (http)
16:51:13.099 [main] WARN i.c.c.UnifiedConfigurationHelper - The following legacy configuration properties should be removed in favor of 'camunda.system.io-thread-count': zeebe.broker.threads.ioThreadCount
16:51:13.415 [netty-messaging-event-nio-server-0] [{actor-scheduler=Broker-0}] INFO i.a.c.messaging.impl.NettyMessagingService - Started messaging service bound to [0.0.0.0:26502], advertising 192.168.2.40:26502, and using plaintext
16:51:13.426 [netty-unicast-event-nio-client-0] [{actor-scheduler=Broker-0}] INFO i.a.c.messaging.impl.NettyUnicastService - Started plaintext unicast service bound to 0.0.0.0:26502, advertising 192.168.2.40:26502
16:51:13.428 [atomix-cluster-0] INFO i.a.c.protocol.swim - Started
```

### RDBMS reduce logging levels

- Set some log messages to debug which are not interesting for the user
- Also uses for liquibase the default and just log on warn level
- We now set some loggers which log sensitive data (Records, SQL Parameters, Queue Items) to info level via application.properties. With this, even when setting camunda log level to trace via log4j2.xml, they don't log anything. They have to be passed via environment variable in order to override the level. 

## Related issues

closes #35258
