### PR TITLE
Migrate camunda/camunda image to use minimus JRE image

### DIFF
--- a/.ci/docker/test/camunda-docker-labels.golden.json
+++ b/.ci/docker/test/camunda-docker-labels.golden.json
@@ -12,11 +12,13 @@
   "org.opencontainers.image.description": "Camunda platform: the universal process orchestrator",
   "org.opencontainers.image.documentation": "https://docs.camunda.io/docs/self-managed/about-self-managed/",
   "org.opencontainers.image.licenses": "(Apache-2.0 AND LicenseRef-Camunda-License-1.0)",
-  "org.opencontainers.image.ref.name": "ubuntu:noble",
+  "org.opencontainers.image.ref.name": "reg.mini.dev/openjre:21-dev",
   "org.opencontainers.image.revision": $REVISION,
   "org.opencontainers.image.source": "https://github.com/camunda/camunda",
   "org.opencontainers.image.title": "Camunda Platform",
   "org.opencontainers.image.url": "https://camunda.com/platform/",
   "org.opencontainers.image.vendor": "Camunda Services GmbH",
-  "org.opencontainers.image.version": $VERSION
+  "org.opencontainers.image.version": $VERSION,
+  "io.minimus.images.galleryURL": "https://images.minimus.io/gallery/images/openjre",
+  "io.minimus.images.line": "21"
 }

--- a/.ci/docker/test/camunda-docker-labels.golden.json
+++ b/.ci/docker/test/camunda-docker-labels.golden.json
@@ -12,7 +12,7 @@
   "org.opencontainers.image.description": "Camunda platform: the universal process orchestrator",
   "org.opencontainers.image.documentation": "https://docs.camunda.io/docs/self-managed/about-self-managed/",
   "org.opencontainers.image.licenses": "(Apache-2.0 AND LicenseRef-Camunda-License-1.0)",
-  "org.opencontainers.image.ref.name": "reg.mini.dev/openjre:21.0.8-dev",
+  "org.opencontainers.image.ref.name": "reg.mini.dev/openjre:21-dev",
   "org.opencontainers.image.revision": $REVISION,
   "org.opencontainers.image.source": "https://github.com/camunda/camunda",
   "org.opencontainers.image.title": "Camunda Platform",

--- a/.ci/docker/test/camunda-docker-labels.golden.json
+++ b/.ci/docker/test/camunda-docker-labels.golden.json
@@ -12,7 +12,7 @@
   "org.opencontainers.image.description": "Camunda platform: the universal process orchestrator",
   "org.opencontainers.image.documentation": "https://docs.camunda.io/docs/self-managed/about-self-managed/",
   "org.opencontainers.image.licenses": "(Apache-2.0 AND LicenseRef-Camunda-License-1.0)",
-  "org.opencontainers.image.ref.name": "reg.mini.dev/openjre:21-dev",
+  "org.opencontainers.image.ref.name": "reg.mini.dev/openjre:21.0.8-dev",
   "org.opencontainers.image.revision": $REVISION,
   "org.opencontainers.image.source": "https://github.com/camunda/camunda",
   "org.opencontainers.image.title": "Camunda Platform",

--- a/.github/actions/setup-build/action.yml
+++ b/.github/actions/setup-build/action.yml
@@ -31,6 +31,12 @@ inputs:
       Harbor login is automatically disabled for fork PRs.
     required: false
     default: "false"
+  minimus:
+    description: |
+      If enabled, logs into Minimus with a CI account.
+      Minimus login is automatically disabled for fork PRs.
+    required: false
+    default: "false"
   java-distribution:
     description: Java distribution to use
     required: false
@@ -150,6 +156,7 @@ runs:
         secret/data/github.com/organizations/camunda NEXUS_USR | ci-account-username;
         ${{ steps.checks.outputs.dockerhub-vault-path }} REGISTRY_HUB_DOCKER_COM_PSW${{ inputs.dockerhub-readonly == 'true' && '_READ_ONLY' || ''}} | dockerhub-token;
         ${{ steps.checks.outputs.dockerhub-vault-path }} REGISTRY_HUB_DOCKER_COM_USR | dockerhub-username;
+        secret/data/products/camunda/ci/github-actions POC_MINIMUS_PSW | minimus-token
   - name: Setup Java
     uses: actions/setup-java@v4
     with:
@@ -253,3 +260,13 @@ runs:
       registry: registry.camunda.cloud
       username: ${{ steps.secrets.outputs.ci-account-username }}
       password: ${{ steps.secrets.outputs.ci-account-password }}
+  - name: Logs on to Minimus
+    # Minimus login is disabled for fork PRs
+    if: >-
+      steps.is-fork.outputs.is-fork != 'true' &&
+      inputs.minimus == 'true'
+    uses: docker/login-action@v3
+    with:
+      registry: reg.mini.dev
+      username: minimus
+      password: ${{ steps.secrets.outputs.minimus-token }}

--- a/.github/actions/setup-build/action.yml
+++ b/.github/actions/setup-build/action.yml
@@ -156,7 +156,7 @@ runs:
         secret/data/github.com/organizations/camunda NEXUS_USR | ci-account-username;
         ${{ steps.checks.outputs.dockerhub-vault-path }} REGISTRY_HUB_DOCKER_COM_PSW${{ inputs.dockerhub-readonly == 'true' && '_READ_ONLY' || ''}} | dockerhub-token;
         ${{ steps.checks.outputs.dockerhub-vault-path }} REGISTRY_HUB_DOCKER_COM_USR | dockerhub-username;
-        secret/data/products/camunda/ci/github-actions POC_MINIMUS_PSW | minimus-token
+        secret/data/products/camunda/ci/github-actions REGISTRY_MINIMUS_PSW | minimus-token
   - name: Setup Java
     uses: actions/setup-java@v4
     with:

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -37,6 +37,12 @@
   },
   "hostRules": [
     {
+      "hostType": "docker",
+      "matchHost": "https://reg.mini.dev",
+      "username": "minimus",
+      "password": "{{ secrets.INFRA_MINIMUS_REGISTRY_TOKEN }}"
+    },
+    {
       "timeout": 10000
     }
   ],
@@ -170,7 +176,7 @@
       "enabled": false
     },
     {
-      "description": "Digest updates cover all use cases since they are used as base, so we disable other types.",
+      "description": "Digest + patch updates cover all use cases since they are used as base, so we disable other types.",
       "matchManagers": [
         "dockerfile"
       ],
@@ -180,8 +186,7 @@
       ],
       "matchUpdateTypes": [
         "major",
-        "minor",
-        "patch"
+        "minor"
       ],
       "enabled": false
     },

--- a/.github/workflows/camunda-platform-docker-deploy-saas-image.yml
+++ b/.github/workflows/camunda-platform-docker-deploy-saas-image.yml
@@ -59,6 +59,7 @@ jobs:
           vault-address: ${{ secrets.VAULT_ADDR }}
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+          minimus: true
       - id: image-tag
         name: Calculate image tag
         shell: bash

--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -675,7 +675,7 @@ jobs:
           secrets: |
             secret/data/products/camunda/ci/github-actions REGISTRY_HUB_DOCKER_COM_USR;
             secret/data/products/camunda/ci/github-actions REGISTRY_HUB_DOCKER_COM_PSW;
-            secret/data/products/camunda/ci/github-actions POC_MINIMUS_PSW | minimus-token
+            secret/data/products/camunda/ci/github-actions REGISTRY_MINIMUS_PSW | minimus-token
       - name: Login to DockerHub
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -696,6 +696,7 @@ jobs:
           distball: camunda-zeebe-${{ inputs.releaseVersion }}.tar.gz
           platforms: ${{ env.PLATFORMS }}
           dockerfile: camunda.Dockerfile
+          minimus: true
       - name: Verify Camunda Docker image
         uses: ./.github/actions/verify-platform-docker
         with:

--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -675,11 +675,18 @@ jobs:
           secrets: |
             secret/data/products/camunda/ci/github-actions REGISTRY_HUB_DOCKER_COM_USR;
             secret/data/products/camunda/ci/github-actions REGISTRY_HUB_DOCKER_COM_PSW;
+            secret/data/products/camunda/ci/github-actions POC_MINIMUS_PSW | minimus-token
       - name: Login to DockerHub
         uses: docker/login-action@v3
         with:
           username: ${{ steps.secrets.outputs.REGISTRY_HUB_DOCKER_COM_USR }}
           password: ${{ steps.secrets.outputs.REGISTRY_HUB_DOCKER_COM_PSW }}
+      - name: Logs on to Minimus
+        uses: docker/login-action@v3
+        with:
+          registry: reg.mini.dev
+          username: minimus
+          password: ${{ steps.secrets.outputs.minimus-token }}
       - name: Download Release Artifacts
         uses: actions/download-artifact@v4
         with:
@@ -696,7 +703,6 @@ jobs:
           distball: camunda-zeebe-${{ inputs.releaseVersion }}.tar.gz
           platforms: ${{ env.PLATFORMS }}
           dockerfile: camunda.Dockerfile
-          minimus: true
       - name: Verify Camunda Docker image
         uses: ./.github/actions/verify-platform-docker
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -844,6 +844,7 @@ jobs:
           vault-address: ${{ secrets.VAULT_ADDR }}
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+          minimus: true
       - uses: ./.github/actions/build-zeebe
         id: build-zeebe
         with:
@@ -1030,6 +1031,7 @@ jobs:
           vault-address: ${{ secrets.VAULT_ADDR }}
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+          minimus: true
       - uses: ./.github/actions/build-zeebe
         id: build-camunda
         with:
@@ -1044,7 +1046,6 @@ jobs:
           dockerfile: camunda.Dockerfile
           # push is needed for multi-arch images as buildkit does not support loading them locally
           push: true
-          minimus: true
 
       # We need to free up some space to let the step after this block succeed.
       # With this cleanup, at the time of measuring, we go from a 100% disk usage (73/74 GB) to a
@@ -1511,6 +1512,7 @@ jobs:
           vault-address: ${{ secrets.VAULT_ADDR }}
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+          minimus: true
       - uses: ./.github/actions/build-frontend
         id: build-operate-fe
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1010,6 +1010,7 @@ jobs:
     env:
       LOCAL_DOCKER_IMAGE: localhost:5000/camunda/camunda
       TEST_ELASTICSEARCH_IMAGE: docker.elastic.co/elasticsearch/elasticsearch:8.16.4
+      DOCKER_PLATFORMS: "linux/arm64,linux/amd64" # build AMD64 last so it gets picked up by the test
     steps:
       - uses: actions/checkout@v4
       - uses: hadolint/hadolint-action@v3.1.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1044,6 +1044,7 @@ jobs:
           dockerfile: camunda.Dockerfile
           # push is needed for multi-arch images as buildkit does not support loading them locally
           push: true
+          minimus: true
 
       # We need to free up some space to let the step after this block succeed.
       # With this cleanup, at the time of measuring, we go from a 100% disk usage (73/74 GB) to a

--- a/.github/workflows/zeebe-testbench.yaml
+++ b/.github/workflows/zeebe-testbench.yaml
@@ -73,6 +73,7 @@ jobs:
           vault-address: ${{ secrets.VAULT_ADDR }}
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+          minimus: true
       - id: image-tag
         name: Calculate image tag
         shell: bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -165,12 +165,25 @@ dist/target/camunda-zeebe-X.Y.Z-SNAPSHOT.tar.gz
 dist/target/camunda-zeebe-X.Y.Z-SNAPSHOT.zip
 ```
 
-This distribution can be containerized with Docker (i.e. build a Docker image) by running:
+This distribution can be containerized with Docker (i.e. build a Docker image) with access to Minimus hardened base images](https://minimus.io/) by running:
 
 ```
 docker build \
   --tag camunda/zeebe:local \
   --build-arg DISTBALL='dist/target/camunda-zeebe*.tar.gz' \
+  --target app \
+  --file ./camunda.Dockerfile
+  .
+```
+
+If you don't have access to [Minimus hardened base images](https://minimus.io/), you can use public base images instead at your own risk by running:
+
+```
+docker build \
+  --tag camunda/zeebe:local \
+  --build-arg DISTBALL='dist/target/camunda-zeebe*.tar.gz' \
+  --build-arg BASE_IMAGE='eclipse-temurin:21-jre-noble' \
+  --build-arg BASE_DIGEST='sha256:20e7f7288e1c18eebe8f06a442c9f7183342d9b022d3b9a9677cae2b558ddddd' \
   --target app \
   --file ./camunda.Dockerfile
   .

--- a/camunda.Dockerfile
+++ b/camunda.Dockerfile
@@ -13,6 +13,8 @@ ARG DIST="distball"
 
 ### Build camunda from scratch ###
 FROM reg.mini.dev/openjdk:21-dev AS build
+
+# hadolint ignore=DL3002
 USER root
 WORKDIR /camunda
 ENV MAVEN_OPTS -XX:MaxRAMPercentage=80
@@ -25,6 +27,7 @@ RUN --mount=type=cache,target=/root/.m2,rw \
 # hadolint ignore=DL3006
 FROM ubuntu:noble@sha256:a08e551cb33850e4740772b38217fc1796a66da2506d312abe51acda354ff061 AS distball
 
+# hadolint ignore=DL3002
 USER root
 WORKDIR /camunda
 ARG DISTBALL="dist/target/camunda-zeebe-*.tar.gz"

--- a/camunda.Dockerfile
+++ b/camunda.Dockerfile
@@ -6,7 +6,6 @@
 # has trouble with custom versioning schemes
 ARG BASE_IMAGE="reg.mini.dev/openjre:21-dev"
 ARG BASE_DIGEST="sha256:80e113714c426176d4c8159d0729bfbe799784f04e4efac4b376a9f17e0fa689"
-ARG JDK_IMAGE=""
 
 # set to "build" to build camunda from scratch instead of using a distball
 ARG DIST="distball"
@@ -24,8 +23,8 @@ RUN --mount=type=cache,target=/root/.m2,rw \
     mv dist/target/camunda-zeebe .
 
 ### Extract camunda from distball ###
-# hadolint ignore=DL3006
-FROM ubuntu:noble@sha256:a08e551cb33850e4740772b38217fc1796a66da2506d312abe51acda354ff061 AS distball
+# hadolint ignore=DL3006,DL3007
+FROM ubuntu:noble AS distball
 
 # hadolint ignore=DL3002
 USER root

--- a/camunda.Dockerfile
+++ b/camunda.Dockerfile
@@ -4,14 +4,14 @@
 # see https://docs.docker.com/build/buildkit/#getting-started
 # Both ubuntu and eclipse-temurin are pinned via digest and not by a strict version tag, as Renovate
 # has trouble with custom versioning schemes
-ARG BASE_IMAGE="reg.mini.dev/openjre:21-dev"
-ARG BASE_DIGEST="sha256:80e113714c426176d4c8159d0729bfbe799784f04e4efac4b376a9f17e0fa689"
+ARG BASE_IMAGE="reg.mini.dev/openjre:21.0.8-dev"
+ARG BASE_DIGEST="sha256:fb5dc6ad558a42ad31117ce698f440862ff78dd3dcb3d94f59e3293ec038ff47"
 
 # set to "build" to build camunda from scratch instead of using a distball
 ARG DIST="distball"
 
 ### Build camunda from scratch ###
-FROM reg.mini.dev/openjdk:21-dev AS build
+FROM reg.mini.dev/openjdk:21.0.8-dev AS build
 
 # hadolint ignore=DL3002
 USER root

--- a/camunda.Dockerfile
+++ b/camunda.Dockerfile
@@ -3,7 +3,7 @@
 # DOCKER_BUILDKIT=1
 # see https://docs.docker.com/build/buildkit/#getting-started
 
-ARG BASE_IMAGE="reg.mini.dev/openjre:21.0.8-dev"
+ARG BASE_IMAGE="reg.mini.dev/openjre:21-dev"
 ARG BASE_DIGEST="sha256:fb5dc6ad558a42ad31117ce698f440862ff78dd3dcb3d94f59e3293ec038ff47"
 
 # If you don't have access to Minimus hardened base images, you can use public

--- a/camunda.Dockerfile
+++ b/camunda.Dockerfile
@@ -2,10 +2,14 @@
 # This Dockerfile requires BuildKit to be enabled, by setting the environment variable
 # DOCKER_BUILDKIT=1
 # see https://docs.docker.com/build/buildkit/#getting-started
-# Both ubuntu and eclipse-temurin are pinned via digest and not by a strict version tag, as Renovate
-# has trouble with custom versioning schemes
+
 ARG BASE_IMAGE="reg.mini.dev/openjre:21.0.8-dev"
 ARG BASE_DIGEST="sha256:fb5dc6ad558a42ad31117ce698f440862ff78dd3dcb3d94f59e3293ec038ff47"
+
+# If you don't have access to Minimus hardened base images, you can use public
+# base images like this instead on your own risk:
+#ARG BASE_IMAGE="eclipse-temurin:21-jre-noble"
+#ARG BASE_DIGEST="sha256:20e7f7288e1c18eebe8f06a442c9f7183342d9b022d3b9a9677cae2b558ddddd"
 
 # set to "build" to build camunda from scratch instead of using a distball
 ARG DIST="distball"

--- a/camunda.Dockerfile
+++ b/camunda.Dockerfile
@@ -4,82 +4,16 @@
 # see https://docs.docker.com/build/buildkit/#getting-started
 # Both ubuntu and eclipse-temurin are pinned via digest and not by a strict version tag, as Renovate
 # has trouble with custom versioning schemes
-ARG BASE_IMAGE="ubuntu:noble"
-ARG BASE_DIGEST="sha256:7c06e91f61fa88c08cc74f7e1b7c69ae24910d745357e0dfe1d2c0322aaf20f9"
-ARG JDK_IMAGE="eclipse-temurin:21-jdk-noble"
-ARG JDK_DIGEST="sha256:b61223d17588c60314b8f4cef03b62bb332ad11f68c3fd898e75a9b5ec8809ee"
+ARG BASE_IMAGE="reg.mini.dev/openjre:21-dev"
+ARG BASE_DIGEST="sha256:80e113714c426176d4c8159d0729bfbe799784f04e4efac4b376a9f17e0fa689"
+ARG JDK_IMAGE=""
 
 # set to "build" to build camunda from scratch instead of using a distball
 ARG DIST="distball"
 
-### Base image ###
-# All package installation, updates, etc., anything with APT should be done here in a single step
-# hadolint ignore=DL3006
-FROM ${BASE_IMAGE}@${BASE_DIGEST} AS base
-WORKDIR /
-
-# Use custom APT timeout and retry values for more resilient builds
-COPY .github/actions/build-platform-docker/99apt-timeout-and-retries /etc/apt/apt.conf.d/
-
-# Upgrade all outdated packages and install missing ones (e.g. locales, tini)
-# This breaks reproducibility of builds, but is acceptable to gain access to security patches faster
-# than the base image releases
-# FYI, installing packages via APT also updates the dpkg files, which are few MBs, but removing or
-# caching them could break stuff (like not knowing the package is present) or container scanners
-# hadolint ignore=DL3008
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
-    --mount=type=cache,target=/var/lib/apt,sharing=locked \
-    --mount=type=cache,target=/var/log/apt,sharing=locked \
-    apt-get -qq update && \
-    apt-get install -yqq --no-install-recommends tini ca-certificates systemd perl && \
-    apt-get upgrade -yqq --no-install-recommends systemd perl
-
-### Build custom JRE using the base JDK image
-# hadolint ignore=DL3006
-FROM ${JDK_IMAGE}@${JDK_DIGEST} AS jre-build
-
-# Build a custom JRE which will strip down and compress modules to end up with a smaller Java \
-# distribution than the official JRE. This will also include useful debugging tools like
-# jcmd, jmod, jps, etc., which take little to no space. Anecdotally, compressing modules add around
-# 10ms to the start up time, which is negligible considering our application takes ~10s to start up.
-# See https://adoptium.net/blog/2021/10/jlink-to-produce-own-runtime/
-# hadolint ignore=DL3018
-# required to compile a JRE on ARM64
-# see https://github.com/openzipkin/docker-java/issues/34
-ENV JAVA_TOOL_OPTIONS "-Djdk.lang.Process.launchMechanism=vfork"
-RUN jlink \
-     --add-modules ALL-MODULE-PATH \
-     --strip-debug \
-     --no-man-pages \
-     --no-header-files \
-     --compress=2 \
-     --output /jre && \
-   rm -rf /jre/lib/src.zip
-
-### Java base image
-FROM base AS java
-WORKDIR /
-
-# Inherit from previous build stage
-ARG JAVA_HOME=/opt/java/openjdk
-
-# Default to UTF-8 file encoding
-ENV LANG='C.UTF-8' LC_ALL='C.UTF-8'
-
-# Setup JAVA_HOME and binaries in the path
-ENV JAVA_HOME ${JAVA_HOME}
-ENV PATH $JAVA_HOME/bin:$PATH
-
-# Copy JRE from previous build stage
-COPY --from=jre-build /jre ${JAVA_HOME}
-
-# https://github.com/docker-library/openjdk/issues/212#issuecomment-420979840
-# https://openjdk.java.net/jeps/341
-# TL;DR generate some class data sharing for faster load time
-RUN java -Xshare:dump;
-
 ### Build camunda from scratch ###
-FROM java AS build
+FROM reg.mini.dev/openjdk:21-dev AS build
+USER root
 WORKDIR /camunda
 ENV MAVEN_OPTS -XX:MaxRAMPercentage=80
 COPY --link . ./
@@ -89,13 +23,16 @@ RUN --mount=type=cache,target=/root/.m2,rw \
 
 ### Extract camunda from distball ###
 # hadolint ignore=DL3006
-FROM base AS distball
+FROM ubuntu:noble@sha256:a08e551cb33850e4740772b38217fc1796a66da2506d312abe51acda354ff061 AS distball
+
+USER root
 WORKDIR /camunda
 ARG DISTBALL="dist/target/camunda-zeebe-*.tar.gz"
 COPY --link ${DISTBALL} camunda.tar.gz
 
 RUN mkdir camunda-zeebe && \
     tar xfvz camunda.tar.gz --strip 1 -C camunda-zeebe
+
 
 ### Image containing the camunda distribution ###
 # hadolint ignore=DL3006
@@ -104,7 +41,7 @@ FROM ${DIST} AS dist
 ### Application Image ###
 # https://docs.docker.com/engine/reference/builder/#automatic-platform-args-in-the-global-scope
 # hadolint ignore=DL3006
-FROM java AS app
+FROM ${BASE_IMAGE}@${BASE_DIGEST} AS app
 # leave unset to use the default value at the top of the file
 ARG BASE_IMAGE
 ARG BASE_DIGEST
@@ -114,7 +51,7 @@ ARG REVISION=""
 
 # OCI labels: https://github.com/opencontainers/image-spec/blob/main/annotations.md
 LABEL org.opencontainers.image.base.digest="${BASE_DIGEST}"
-LABEL org.opencontainers.image.base.name="docker.io/library/${BASE_IMAGE}"
+LABEL org.opencontainers.image.base.name="${BASE_IMAGE}"
 LABEL org.opencontainers.image.created="${DATE}"
 LABEL org.opencontainers.image.authors="community@camunda.com"
 LABEL org.opencontainers.image.url="https://camunda.com/platform/"
@@ -139,7 +76,7 @@ LABEL io.openshift.min-cpu="1"
 LABEL io.openshift.wants="elasticsearch"
 
 ENV CAMUNDA_HOME=/usr/local/camunda
-ENV PATH "${CAMUNDA_HOME}/bin:${PATH}"
+ENV PATH="${CAMUNDA_HOME}/bin:${PATH}"
 # Disable RocksDB runtime check for musl, which launches `ldd` as a shell process
 # We know there's no need to check for musl on this image
 ENV ROCKSDB_MUSL_LIBC=false
@@ -151,8 +88,10 @@ VOLUME ${CAMUNDA_HOME}/data
 VOLUME ${CAMUNDA_HOME}/logs
 VOLUME /driver-lib
 
-RUN groupadd --gid 1001 camunda && \
-    useradd --system --gid 1001 --uid 1001 --home ${CAMUNDA_HOME} camunda && \
+# Switch to root to allow setting up our own user
+USER root
+RUN addgroup --gid 1001 camunda && \
+    adduser -S -G camunda -u 1001 -h ${CAMUNDA_HOME} camunda && \
     chmod g=u /etc/passwd && \
     # These directories are to be mounted by users, eagerly creating them and setting ownership
     # helps to avoid potential permission issues due to default volume ownership.
@@ -167,4 +106,4 @@ RUN ln -s /driver-lib ${CAMUNDA_HOME}/driver-lib
 
 USER 1001:1001
 
-ENTRYPOINT ["tini", "--", "/usr/local/camunda/bin/camunda"]
+ENTRYPOINT ["/usr/local/camunda/bin/camunda"]


### PR DESCRIPTION
## Description

This PR migrates the `camunda/camunda` OCI image to use Minimus' OpenJDK's JRE image, which should greatly reduce the CVE surface of our application.

Once this is passing and everything is set up, we can migrate the other, standalone images.

## Related issues

Could not find an issue related to this, it seems to mostly docs and feature specs.
