### PR TITLE
feat: Filter authorizations correctly by owner/member

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/GroupDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/GroupDbReader.java
@@ -13,9 +13,11 @@ import io.camunda.db.rdbms.sql.columns.GroupSearchColumn;
 import io.camunda.db.rdbms.write.domain.GroupDbModel;
 import io.camunda.search.clients.reader.GroupReader;
 import io.camunda.search.entities.GroupEntity;
+import io.camunda.search.filter.GroupFilter;
 import io.camunda.search.query.GroupQuery;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.reader.ResourceAccessChecks;
+import java.util.List;
 import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -39,6 +41,10 @@ public class GroupDbReader extends AbstractEntityReader<GroupEntity> implements 
   @Override
   public SearchQueryResult<GroupEntity> search(
       final GroupQuery query, final ResourceAccessChecks resourceAccessChecks) {
+    if (shouldReturnEmptyResult(query.filter())) {
+      return new SearchQueryResult.Builder<GroupEntity>().total(0).items(List.of()).build();
+    }
+
     final var dbSort = convertSort(query.sort(), GroupSearchColumn.GROUP_ID);
     final var dbQuery =
         GroupDbQuery.of(
@@ -61,5 +67,9 @@ public class GroupDbReader extends AbstractEntityReader<GroupEntity> implements 
 
   private GroupEntity map(final GroupDbModel model) {
     return new GroupEntity(model.groupKey(), model.groupId(), model.name(), model.description());
+  }
+
+  private boolean shouldReturnEmptyResult(final GroupFilter filter) {
+    return filter.memberIds() != null && filter.memberIds().isEmpty();
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/RoleDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/RoleDbReader.java
@@ -13,9 +13,11 @@ import io.camunda.db.rdbms.sql.columns.RoleSearchColumn;
 import io.camunda.db.rdbms.write.domain.RoleDbModel;
 import io.camunda.search.clients.reader.RoleReader;
 import io.camunda.search.entities.RoleEntity;
+import io.camunda.search.filter.RoleFilter;
 import io.camunda.search.query.RoleQuery;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.reader.ResourceAccessChecks;
+import java.util.List;
 import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -39,6 +41,10 @@ public class RoleDbReader extends AbstractEntityReader<RoleEntity> implements Ro
   @Override
   public SearchQueryResult<RoleEntity> search(
       final RoleQuery query, final ResourceAccessChecks resourceAccessChecks) {
+    if (shouldReturnEmptyResult(query.filter())) {
+      return new SearchQueryResult.Builder<RoleEntity>().total(0).items(List.of()).build();
+    }
+
     final var dbSort = convertSort(query.sort(), RoleSearchColumn.ROLE_ID);
     final var dbQuery =
         RoleDbQuery.of(
@@ -61,5 +67,10 @@ public class RoleDbReader extends AbstractEntityReader<RoleEntity> implements Ro
 
   private RoleEntity map(final RoleDbModel model) {
     return new RoleEntity(model.roleKey(), model.roleId(), model.name(), model.description());
+  }
+
+  private boolean shouldReturnEmptyResult(final RoleFilter filter) {
+    return (filter.roleIds() != null && filter.roleIds().isEmpty())
+        || (filter.memberIds() != null && filter.memberIds().isEmpty());
   }
 }

--- a/db/rdbms/src/main/resources/mapper/AuthorizationsMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/AuthorizationsMapper.xml
@@ -39,6 +39,14 @@
     RESOURCE_ID
     FROM ${prefix}AUTHORIZATIONS
     <include refid="io.camunda.db.rdbms.sql.AuthorizationMapper.searchFilter"/>
+    <!--
+    <if test="authorizedResourceIds != null and !authorizedResourceIds.isEmpty()">
+      AND RESOURCE_ID IN
+      <foreach collection="authorizedResourceIds" item="resourceId" open="(" separator=","
+        close=")">
+        #{resourceId}
+      </foreach>
+    </if> -->
     ) t
     <include refid="io.camunda.db.rdbms.sql.Commons.keySetPageFilter"/>
     <!-- inner orderBy for keyset pagination -->

--- a/db/rdbms/src/main/resources/mapper/AuthorizationsMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/AuthorizationsMapper.xml
@@ -69,6 +69,16 @@
         close=")">#{value}
       </foreach>
     </if>
+    <if test="filter.ownerTypeToOwnerIds != null and !filter.ownerTypeToOwnerIds.isEmpty()">
+      <foreach collection="filter.ownerTypeToOwnerIds" index="ownerType" item="values" open="AND (" separator=" OR " close=")">
+        <if test="values != null and !values.isEmpty()">
+          OWNER_TYPE = #{ownerType} AND OWNER_ID IN
+          <foreach collection="values" item="value" open="(" separator=" , " close=")">
+            #{value}
+          </foreach>
+        </if>
+      </foreach>
+    </if>
     <if test="filter.resourceIds != null and !filter.resourceIds.isEmpty()">
       AND RESOURCE_ID IN
       <foreach collection="filter.resourceIds" item="value" open="(" separator=", "

--- a/db/rdbms/src/main/resources/mapper/GroupMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/GroupMapper.xml
@@ -13,53 +13,38 @@
   <select id="count" parameterType="io.camunda.db.rdbms.read.domain.GroupDbQuery">
     SELECT COUNT(*)
     FROM ${prefix}GROUPS g
-    <if test="filter.memberIds != null">
-      JOIN ${prefix}GROUP_MEMBER gm ON g.GROUP_ID = gm.GROUP_ID
-      AND gm.ENTITY_TYPE = #{filter.childMemberType}
-    </if>
-    <if test="filter.tenantId != null">
-      JOIN ${prefix}TENANT_MEMBER tm ON g.GROUP_ID = tm.ENTITY_ID AND tm.ENTITY_TYPE = 'GROUP'
-    </if>
-    <if test="filter.memberIdsByType != null and !filter.memberIdsByType.isEmpty()">
-      JOIN ${prefix}GROUP_MEMBER gmt ON g.GROUP_ID = gmt.GROUP_ID
-      AND gmt.ENTITY_TYPE IN (
-      <foreach collection="filter.memberIdsByType" index="memberType" item="values" separator=", ">
-        #{memberType}
-      </foreach>
-      )
-    </if>
     <include refid="io.camunda.db.rdbms.sql.GroupMapper.searchFilter"/>
   </select>
 
   <select id="search" parameterType="io.camunda.db.rdbms.read.domain.GroupDbQuery"
     resultMap="io.camunda.db.rdbms.sql.GroupMapper.groupResultMap">
+SELECT
+  t.GROUP_KEY,
+    t.GROUP_ID,
+    t.NAME,
+    t.DESCRIPTION,
+    gm.GROUP_ID AS MEMBER_GROUP_ID,
+    gm.ENTITY_ID AS MEMBER_ENTITY_ID,
+    gm.ENTITY_TYPE AS MEMBER_ENTITY_TYPE
+    FROM (
     SELECT * FROM (
     SELECT
     g.GROUP_KEY,
     g.GROUP_ID,
     g.NAME,
-    g.DESCRIPTION,
-    gm.GROUP_ID AS MEMBER_GROUP_ID,
-    gm.ENTITY_ID AS MEMBER_ENTITY_ID,
-    gm.ENTITY_TYPE AS MEMBER_ENTITY_TYPE
+    g.DESCRIPTION
     FROM ${prefix}GROUPS g
-    LEFT JOIN ${prefix}GROUP_MEMBER gm ON g.GROUP_ID = gm.GROUP_ID
-    <if test="filter.tenantId != null">
-      JOIN ${prefix}TENANT_MEMBER tm ON g.GROUP_ID = tm.ENTITY_ID AND tm.ENTITY_TYPE = 'GROUP'
-    </if>
-    <if test="filter.memberIdsByType != null and !filter.memberIdsByType.isEmpty()">
-      JOIN ${prefix}GROUP_MEMBER gmt ON g.GROUP_ID = gmt.GROUP_ID
-      AND gmt.ENTITY_TYPE IN (
-      <foreach collection="filter.memberIdsByType" index="memberType" item="values" separator=", ">
-        #{memberType}
-      </foreach>
-      )
-    </if>
     <include refid="io.camunda.db.rdbms.sql.GroupMapper.searchFilter"/>
     ) t
     <include refid="io.camunda.db.rdbms.sql.Commons.keySetPageFilter"/>
     <include refid="io.camunda.db.rdbms.sql.Commons.orderBy"/>
     <include refid="io.camunda.db.rdbms.sql.Commons.paging"/>
+    ) t
+    LEFT JOIN ${prefix}GROUP_MEMBER gm ON t.GROUP_ID = gm.GROUP_ID
+    <if test="filter.childMemberType != null">
+      AND gm.ENTITY_TYPE = #{filter.childMemberType}
+    </if>
+    <include refid="io.camunda.db.rdbms.sql.Commons.orderBy"/>
   </select>
 
   <sql id="searchFilter">
@@ -72,16 +57,23 @@
       </foreach>
     </if>
     <if test="filter.name != null">AND g.NAME = #{filter.name}</if>
-    <if test="filter.memberIds != null">
-      AND gm.ENTITY_ID IN
+
+    <if
+      test="filter.memberIds != null and !filter.memberIds.isEmpty() and filter.childMemberType != null">
+      AND g.GROUP_ID IN ( SELECT gmf.GROUP_ID FROM ${prefix}GROUP_MEMBER gmf
+      WHERE
+      gmf.ENTITY_TYPE = #{filter.childMemberType}
+      AND gmf.ENTITY_ID IN
       <foreach collection="filter.memberIds" item="memberId" open="(" separator="," close=")">
         #{memberId}
       </foreach>
-      AND gm.ENTITY_TYPE = #{filter.childMemberType}
+      )
     </if>
-    <if test="filter.tenantId != null">AND tm.TENANT_ID = #{filter.tenantId}</if>
     <if test="filter.memberIdsByType != null and !filter.memberIdsByType.isEmpty()">
-      <foreach collection="filter.memberIdsByType" index="memberType" item="values" open="AND (" separator=" OR " close=")">
+      AND g.GROUP_ID IN ( SELECT gmt.GROUP_ID FROM ${prefix}GROUP_MEMBER gmt
+      WHERE 1=1
+      <foreach collection="filter.memberIdsByType" index="memberType" item="values" open="AND ("
+        separator=" OR " close=")">
         <if test="values != null and !values.isEmpty()">
           gmt.ENTITY_TYPE = #{memberType} AND gmt.ENTITY_ID IN
           <foreach collection="values" item="value" open="(" separator=" , " close=")">
@@ -89,6 +81,12 @@
           </foreach>
         </if>
       </foreach>
+      )
+    </if>
+    <if test="filter.tenantId != null">
+      AND g.GROUP_ID IN ( SELECT tm.ENTITY_ID FROM ${prefix}TENANT_MEMBER tm
+      WHERE tm.ENTITY_TYPE = 'GROUP'
+      AND tm.TENANT_ID = #{filter.tenantId})
     </if>
   </sql>
 

--- a/db/rdbms/src/main/resources/mapper/GroupMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/GroupMapper.xml
@@ -13,10 +13,8 @@
   <select id="count" parameterType="io.camunda.db.rdbms.read.domain.GroupDbQuery">
     SELECT COUNT(*)
     FROM ${prefix}GROUPS g
-    <if test="filter.memberIds != null">
-      JOIN ${prefix}GROUP_MEMBER gm ON g.GROUP_ID = gm.GROUP_ID
-      AND gm.ENTITY_TYPE = #{filter.childMemberType}
-    </if>
+    LEFT JOIN ${prefix}GROUP_MEMBER gm ON g.GROUP_ID = gm.GROUP_ID
+    AND gm.ENTITY_TYPE = #{filter.childMemberType}
     <if test="filter.tenantId != null">
       JOIN ${prefix}TENANT_MEMBER tm ON g.GROUP_ID = tm.ENTITY_ID AND tm.ENTITY_TYPE = 'GROUP'
     </if>
@@ -64,6 +62,16 @@
       AND gm.ENTITY_TYPE = #{filter.childMemberType}
     </if>
     <if test="filter.tenantId != null">AND tm.TENANT_ID = #{filter.tenantId}</if>
+    <if test="filter.memberIdsByType != null and !filter.memberIdsByType.isEmpty()">
+      <foreach collection="filter.memberIdsByType" index="memberType" item="values" open="AND (" separator=" OR " close=")">
+        <if test="values != null and !values.isEmpty()">
+          gm.ENTITY_TYPE = #{memberType} AND gm.ENTITY_ID IN
+          <foreach collection="values" item="value" open="(" separator=" , " close=")">
+            #{value}
+          </foreach>
+        </if>
+      </foreach>
+    </if>
   </sql>
 
   <resultMap id="groupResultMap" type="io.camunda.db.rdbms.write.domain.GroupDbModel">

--- a/db/rdbms/src/main/resources/mapper/GroupMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/GroupMapper.xml
@@ -13,10 +13,20 @@
   <select id="count" parameterType="io.camunda.db.rdbms.read.domain.GroupDbQuery">
     SELECT COUNT(*)
     FROM ${prefix}GROUPS g
-    LEFT JOIN ${prefix}GROUP_MEMBER gm ON g.GROUP_ID = gm.GROUP_ID
-    AND gm.ENTITY_TYPE = #{filter.childMemberType}
+    <if test="filter.memberIds != null">
+      JOIN ${prefix}GROUP_MEMBER gm ON g.GROUP_ID = gm.GROUP_ID
+      AND gm.ENTITY_TYPE = #{filter.childMemberType}
+    </if>
     <if test="filter.tenantId != null">
       JOIN ${prefix}TENANT_MEMBER tm ON g.GROUP_ID = tm.ENTITY_ID AND tm.ENTITY_TYPE = 'GROUP'
+    </if>
+    <if test="filter.memberIdsByType != null and !filter.memberIdsByType.isEmpty()">
+      JOIN ${prefix}GROUP_MEMBER gmt ON g.GROUP_ID = gmt.GROUP_ID
+      AND gmt.ENTITY_TYPE IN (
+      <foreach collection="filter.memberIdsByType" index="memberType" item="values" separator=", ">
+        #{memberType}
+      </foreach>
+      )
     </if>
     <include refid="io.camunda.db.rdbms.sql.GroupMapper.searchFilter"/>
   </select>
@@ -36,6 +46,14 @@
     LEFT JOIN ${prefix}GROUP_MEMBER gm ON g.GROUP_ID = gm.GROUP_ID
     <if test="filter.tenantId != null">
       JOIN ${prefix}TENANT_MEMBER tm ON g.GROUP_ID = tm.ENTITY_ID AND tm.ENTITY_TYPE = 'GROUP'
+    </if>
+    <if test="filter.memberIdsByType != null and !filter.memberIdsByType.isEmpty()">
+      JOIN ${prefix}GROUP_MEMBER gmt ON g.GROUP_ID = gmt.GROUP_ID
+      AND gmt.ENTITY_TYPE IN (
+      <foreach collection="filter.memberIdsByType" index="memberType" item="values" separator=", ">
+        #{memberType}
+      </foreach>
+      )
     </if>
     <include refid="io.camunda.db.rdbms.sql.GroupMapper.searchFilter"/>
     ) t
@@ -65,7 +83,7 @@
     <if test="filter.memberIdsByType != null and !filter.memberIdsByType.isEmpty()">
       <foreach collection="filter.memberIdsByType" index="memberType" item="values" open="AND (" separator=" OR " close=")">
         <if test="values != null and !values.isEmpty()">
-          gm.ENTITY_TYPE = #{memberType} AND gm.ENTITY_ID IN
+          gmt.ENTITY_TYPE = #{memberType} AND gmt.ENTITY_ID IN
           <foreach collection="values" item="value" open="(" separator=" , " close=")">
             #{value}
           </foreach>

--- a/db/rdbms/src/main/resources/mapper/RoleMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/RoleMapper.xml
@@ -13,11 +13,21 @@
   <select id="count" parameterType="io.camunda.db.rdbms.read.domain.RoleDbQuery">
     SELECT COUNT(*)
     FROM ${prefix}ROLES r
-    LEFT JOIN ${prefix}ROLE_MEMBER rm ON r.ROLE_ID = rm.ROLE_ID
-    AND rm.ENTITY_TYPE = #{filter.childMemberType}
+    <if test="filter.memberIds != null">
+      JOIN ${prefix}ROLE_MEMBER rm ON r.ROLE_ID = rm.ROLE_ID
+      AND rm.ENTITY_TYPE = #{filter.childMemberType}
+    </if>
     <if test="filter.tenantId != null">
       JOIN ${prefix}TENANT_MEMBER tm ON r.ROLE_ID = tm.ENTITY_ID
       AND tm.ENTITY_TYPE = 'ROLE'
+    </if>
+    <if test="filter.memberIdsByType != null and !filter.memberIdsByType.isEmpty()">
+      JOIN ${prefix}ROLE_MEMBER rmt ON r.ROLE_ID = rmt.ROLE_ID
+      AND rmt.ENTITY_TYPE IN (
+      <foreach collection="filter.memberIdsByType" index="memberType" item="values" separator=", ">
+        #{memberType}
+      </foreach>
+      )
     </if>
     <include refid="io.camunda.db.rdbms.sql.RoleMapper.searchFilter"/>
   </select>
@@ -35,9 +45,18 @@
     rm.ENTITY_TYPE AS MEMBER_ENTITY_TYPE
     FROM ${prefix}ROLES r
     LEFT JOIN ${prefix}ROLE_MEMBER rm ON r.ROLE_ID = rm.ROLE_ID
+    AND rm.ENTITY_TYPE = #{filter.childMemberType}
     <if test="filter.tenantId != null">
       JOIN ${prefix}TENANT_MEMBER tm ON r.ROLE_ID = tm.ENTITY_ID
       AND tm.ENTITY_TYPE = 'ROLE'
+    </if>
+    <if test="filter.memberIdsByType != null and !filter.memberIdsByType.isEmpty()">
+      JOIN ${prefix}ROLE_MEMBER rmt ON r.ROLE_ID = rmt.ROLE_ID
+      AND rmt.ENTITY_TYPE IN (
+      <foreach collection="filter.memberIdsByType" index="memberType" item="values" separator=", ">
+        #{memberType}
+      </foreach>
+      )
     </if>
     <include refid="io.camunda.db.rdbms.sql.RoleMapper.searchFilter"/>
     ) t
@@ -58,9 +77,10 @@
       AND rm.ENTITY_TYPE = #{filter.childMemberType}
     </if>
     <if test="filter.memberIdsByType != null and !filter.memberIdsByType.isEmpty()">
-      <foreach collection="filter.memberIdsByType" index="memberType" item="values" open="AND (" separator=" OR " close=")">
+      <foreach collection="filter.memberIdsByType" index="memberType" item="values" open="AND ("
+        separator=" OR " close=")">
         <if test="values != null and !values.isEmpty()">
-          rm.ENTITY_TYPE = #{memberType} AND rm.ENTITY_ID IN
+          rmt.ENTITY_TYPE = #{memberType} AND rmt.ENTITY_ID IN
           <foreach collection="values" item="value" open="(" separator=" , " close=")">
             #{value}
           </foreach>
@@ -71,8 +91,8 @@
   </sql>
 
   <resultMap id="roleResultMap" type="io.camunda.db.rdbms.write.domain.RoleDbModel">
-    <id column="ROLE_ID" property="roleId" />
-    <result column="ROLE_KEY" property="roleKey" />
+    <id column="ROLE_ID" property="roleId"/>
+    <result column="ROLE_KEY" property="roleKey"/>
     <result column="NAME" property="name"/>
     <result column="DESCRIPTION" property="description"/>
     <collection property="members" ofType="io.camunda.db.rdbms.write.domain.RoleMemberDbModel"
@@ -92,7 +112,7 @@
 
   <update id="update" parameterType="io.camunda.db.rdbms.write.domain.RoleDbModel">
     UPDATE ${prefix}ROLES
-    SET NAME = #{name},
+    SET NAME        = #{name},
         DESCRIPTION = #{description}
     WHERE ROLE_ID = #{roleId}
   </update>

--- a/db/rdbms/src/main/resources/mapper/RoleMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/RoleMapper.xml
@@ -13,81 +13,75 @@
   <select id="count" parameterType="io.camunda.db.rdbms.read.domain.RoleDbQuery">
     SELECT COUNT(*)
     FROM ${prefix}ROLES r
-    <if test="filter.memberIds != null">
-      JOIN ${prefix}ROLE_MEMBER rm ON r.ROLE_ID = rm.ROLE_ID
-      AND rm.ENTITY_TYPE = #{filter.childMemberType}
-    </if>
-    <if test="filter.tenantId != null">
-      JOIN ${prefix}TENANT_MEMBER tm ON r.ROLE_ID = tm.ENTITY_ID
-      AND tm.ENTITY_TYPE = 'ROLE'
-    </if>
-    <if test="filter.memberIdsByType != null and !filter.memberIdsByType.isEmpty()">
-      JOIN ${prefix}ROLE_MEMBER rmt ON r.ROLE_ID = rmt.ROLE_ID
-      AND rmt.ENTITY_TYPE IN (
-      <foreach collection="filter.memberIdsByType" index="memberType" item="values" separator=", ">
-        #{memberType}
-      </foreach>
-      )
-    </if>
     <include refid="io.camunda.db.rdbms.sql.RoleMapper.searchFilter"/>
   </select>
 
   <select id="search" parameterType="io.camunda.db.rdbms.read.domain.RoleDbQuery"
     resultMap="io.camunda.db.rdbms.sql.RoleMapper.roleResultMap">
+SELECT
+    t.ROLE_ID,
+    t.ROLE_KEY,
+    t.NAME,
+    t.DESCRIPTION,
+    rm.ROLE_ID AS MEMBER_ROLE_ID,
+    rm.ENTITY_ID AS MEMBER_ENTITY_ID,
+    rm.ENTITY_TYPE AS MEMBER_ENTITY_TYPE
+FROM (
     SELECT * FROM (
     SELECT
     r.ROLE_ID,
     r.ROLE_KEY,
     r.NAME,
-    r.DESCRIPTION,
-    rm.ROLE_ID AS MEMBER_ROLE_ID,
-    rm.ENTITY_ID AS MEMBER_ENTITY_ID,
-    rm.ENTITY_TYPE AS MEMBER_ENTITY_TYPE
+    r.DESCRIPTION
     FROM ${prefix}ROLES r
-    LEFT JOIN ${prefix}ROLE_MEMBER rm ON r.ROLE_ID = rm.ROLE_ID
-    AND rm.ENTITY_TYPE = #{filter.childMemberType}
-    <if test="filter.tenantId != null">
-      JOIN ${prefix}TENANT_MEMBER tm ON r.ROLE_ID = tm.ENTITY_ID
-      AND tm.ENTITY_TYPE = 'ROLE'
-    </if>
-    <if test="filter.memberIdsByType != null and !filter.memberIdsByType.isEmpty()">
-      JOIN ${prefix}ROLE_MEMBER rmt ON r.ROLE_ID = rmt.ROLE_ID
-      AND rmt.ENTITY_TYPE IN (
-      <foreach collection="filter.memberIdsByType" index="memberType" item="values" separator=", ">
-        #{memberType}
-      </foreach>
-      )
-    </if>
     <include refid="io.camunda.db.rdbms.sql.RoleMapper.searchFilter"/>
     ) t
     <include refid="io.camunda.db.rdbms.sql.Commons.keySetPageFilter"/>
     <include refid="io.camunda.db.rdbms.sql.Commons.orderBy"/>
     <include refid="io.camunda.db.rdbms.sql.Commons.paging"/>
+             ) t
+    LEFT JOIN ${prefix}ROLE_MEMBER rm ON t.ROLE_ID = rm.ROLE_ID
+    <if test="filter.childMemberType != null">
+      AND rm.ENTITY_TYPE = #{filter.childMemberType}
+    </if>
+    <include refid="io.camunda.db.rdbms.sql.Commons.orderBy"/>
   </select>
 
   <sql id="searchFilter">
-    WHERE 1 = 1
-    <if test="filter.roleId != null">AND r.ROLE_ID = #{filter.roleId}</if>
-    <if test="filter.name != null">AND r.NAME = #{filter.name}</if>
-    <if test="filter.memberIds != null and !filter.memberIds.isEmpty()">
-      AND rm.ENTITY_ID IN
-      <foreach collection="filter.memberIds" item="memberId" open="(" separator="," close=")">
-        #{memberId}
-      </foreach>
-      AND rm.ENTITY_TYPE = #{filter.childMemberType}
-    </if>
-    <if test="filter.memberIdsByType != null and !filter.memberIdsByType.isEmpty()">
-      <foreach collection="filter.memberIdsByType" index="memberType" item="values" open="AND ("
-        separator=" OR " close=")">
-        <if test="values != null and !values.isEmpty()">
-          rmt.ENTITY_TYPE = #{memberType} AND rmt.ENTITY_ID IN
-          <foreach collection="values" item="value" open="(" separator=" , " close=")">
-            #{value}
-          </foreach>
-        </if>
-      </foreach>
-    </if>
-    <if test="filter.tenantId != null">AND tm.TENANT_ID = #{filter.tenantId}</if>
+    <where>
+      <if test="filter.roleId != null">AND r.ROLE_ID = #{filter.roleId}</if>
+      <if test="filter.name != null">AND r.NAME = #{filter.name}</if>
+      <if
+        test="filter.memberIds != null and !filter.memberIds.isEmpty() and filter.childMemberType != null">
+        AND r.ROLE_ID IN ( SELECT rmf.ROLE_ID FROM ${prefix}ROLE_MEMBER rmf
+        WHERE
+        rmf.ENTITY_TYPE = #{filter.childMemberType}
+        AND rmf.ENTITY_ID IN
+        <foreach collection="filter.memberIds" item="memberId" open="(" separator="," close=")">
+          #{memberId}
+        </foreach>
+        )
+      </if>
+      <if test="filter.memberIdsByType != null and !filter.memberIdsByType.isEmpty()">
+        AND r.ROLE_ID IN ( SELECT rmt.ROLE_ID FROM ${prefix}ROLE_MEMBER rmt
+        WHERE 1=1
+        <foreach collection="filter.memberIdsByType" index="memberType" item="values" open="AND ("
+          separator=" OR " close=")">
+          <if test="values != null and !values.isEmpty()">
+            rmt.ENTITY_TYPE = #{memberType} AND rmt.ENTITY_ID IN
+            <foreach collection="values" item="value" open="(" separator=" , " close=")">
+              #{value}
+            </foreach>
+          </if>
+        </foreach>
+        )
+      </if>
+      <if test="filter.tenantId != null">
+        AND r.ROLE_ID IN ( SELECT tm.ENTITY_ID FROM ${prefix}TENANT_MEMBER tm
+        WHERE tm.ENTITY_TYPE = 'ROLE'
+        AND tm.TENANT_ID = #{filter.tenantId})
+      </if>
+    </where>
   </sql>
 
   <resultMap id="roleResultMap" type="io.camunda.db.rdbms.write.domain.RoleDbModel">

--- a/db/rdbms/src/main/resources/mapper/RoleMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/RoleMapper.xml
@@ -13,10 +13,8 @@
   <select id="count" parameterType="io.camunda.db.rdbms.read.domain.RoleDbQuery">
     SELECT COUNT(*)
     FROM ${prefix}ROLES r
-    <if test="filter.memberIds != null">
-      JOIN ${prefix}ROLE_MEMBER rm ON r.ROLE_ID = rm.ROLE_ID
-      AND rm.ENTITY_TYPE = #{filter.childMemberType}
-    </if>
+    LEFT JOIN ${prefix}ROLE_MEMBER rm ON r.ROLE_ID = rm.ROLE_ID
+    AND rm.ENTITY_TYPE = #{filter.childMemberType}
     <if test="filter.tenantId != null">
       JOIN ${prefix}TENANT_MEMBER tm ON r.ROLE_ID = tm.ENTITY_ID
       AND tm.ENTITY_TYPE = 'ROLE'
@@ -58,6 +56,16 @@
         #{memberId}
       </foreach>
       AND rm.ENTITY_TYPE = #{filter.childMemberType}
+    </if>
+    <if test="filter.memberIdsByType != null and !filter.memberIdsByType.isEmpty()">
+      <foreach collection="filter.memberIdsByType" index="memberType" item="values" open="AND (" separator=" OR " close=")">
+        <if test="values != null and !values.isEmpty()">
+          rm.ENTITY_TYPE = #{memberType} AND rm.ENTITY_ID IN
+          <foreach collection="values" item="value" open="(" separator=" , " close=")">
+            #{value}
+          </foreach>
+        </if>
+      </foreach>
     </if>
     <if test="filter.tenantId != null">AND tm.TENANT_ID = #{filter.tenantId}</if>
   </sql>

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/GroupDbReaderTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/GroupDbReaderTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.read.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import io.camunda.db.rdbms.sql.GroupMapper;
+import io.camunda.search.query.GroupQuery;
+import io.camunda.zeebe.protocol.record.value.EntityType;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class GroupDbReaderTest {
+
+  private final GroupMapper mapper = mock(GroupMapper.class);
+  private final GroupDbReader reader = new GroupDbReader(mapper);
+
+  @Test
+  void shouldImmediatelyReturnEmptyResultWhenMemberIdsFilterIsEmpty() {
+    // When
+    final var result =
+        reader.search(
+            GroupQuery.of(
+                b -> b.filter(f -> f.memberIds(Set.of()).childMemberType(EntityType.USER))),
+            null);
+
+    // Then
+    assertThat(result.total()).isZero();
+    verifyNoInteractions(mapper);
+  }
+}

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/RoleDbReaderTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/RoleDbReaderTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.read.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import io.camunda.db.rdbms.sql.RoleMapper;
+import io.camunda.search.query.RoleQuery;
+import io.camunda.zeebe.protocol.record.value.EntityType;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class RoleDbReaderTest {
+
+  private final RoleMapper roleMapper = mock(RoleMapper.class);
+  private final RoleDbReader reader = new RoleDbReader(roleMapper);
+
+  @Test
+  void shouldImmediatelyReturnEmptyResultWhenMemberIdsFilterIsEmpty() {
+    // When
+    final var result =
+        reader.search(
+            RoleQuery.of(
+                b -> b.filter(f -> f.memberIds(Set.of()).childMemberType(EntityType.USER))),
+            null);
+
+    // Then
+    assertThat(result.total()).isZero();
+    verifyNoInteractions(roleMapper);
+  }
+
+  @Test
+  void shouldImmediatelyReturnEmptyResultWhenRoleIdsFilterIsEmpty() {
+    // When
+    final var result = reader.search(RoleQuery.of(b -> b.filter(f -> f.roleIds(Set.of()))), null);
+
+    // Then
+    assertThat(result.total()).isZero();
+    verifyNoInteractions(roleMapper);
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/CommonFixtures.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/CommonFixtures.java
@@ -7,6 +7,10 @@
  */
 package io.camunda.it.rdbms.db.fixtures;
 
+import io.camunda.security.auth.Authorization;
+import io.camunda.security.reader.AuthorizationCheck;
+import io.camunda.security.reader.ResourceAccessChecks;
+import io.camunda.security.reader.TenantCheck;
 import java.time.OffsetDateTime;
 import java.util.Arrays;
 import java.util.List;
@@ -82,5 +86,30 @@ public class CommonFixtures {
     }
     final int x = RANDOM.nextInt(validEnums.size());
     return validEnums.get(x);
+  }
+
+  public static ResourceAccessChecks resourceAccessChecks(
+      List<String> resourceIds, List<String> tenantIds) {
+    return ResourceAccessChecks.of(
+        AuthorizationCheck.enabled(Authorization.of(b -> b.resourceIds(resourceIds))),
+        TenantCheck.enabled(tenantIds));
+  }
+
+  public static ResourceAccessChecks resourceAccessChecksFromResourceIds(String... resourceIds) {
+    return resourceAccessChecksFromResourceIds(Arrays.asList(resourceIds));
+  }
+
+  public static ResourceAccessChecks resourceAccessChecksFromResourceIds(List<String> resourceIds) {
+    return ResourceAccessChecks.of(
+        AuthorizationCheck.enabled(Authorization.of(b -> b.resourceIds(resourceIds))),
+        TenantCheck.disabled());
+  }
+
+  public static ResourceAccessChecks resourceAccessChecksFromTenantIds(String... tenantIds) {
+    return resourceAccessChecksFromTenantIds(Arrays.asList(tenantIds));
+  }
+
+  public static ResourceAccessChecks resourceAccessChecksFromTenantIds(List<String> tenantIds) {
+    return ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.enabled(tenantIds));
   }
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/GroupFixtures.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/GroupFixtures.java
@@ -52,6 +52,19 @@ public final class GroupFixtures extends CommonFixtures {
     rdbmsWriter.flush();
   }
 
+  public static void createAndSaveRandomGroupsWithMembers(
+      final RdbmsWriter rdbmsWriter,
+      final Function<GroupDbModel.Builder, GroupDbModel.Builder> builderFunction) {
+    for (int i = 0; i < 20; i++) {
+      final var group = GroupFixtures.createRandomized(builderFunction);
+      rdbmsWriter.getGroupWriter().create(group);
+      GroupMemberFixtures.createAndSaveRandomGroupMembers(
+          rdbmsWriter, b -> b.groupId(group.groupId()));
+    }
+
+    rdbmsWriter.flush();
+  }
+
   public static GroupDbModel createAndSaveGroup(
       final RdbmsWriter rdbmsWriter, final Function<Builder, Builder> builderFunction) {
     final var definition = createRandomized(builderFunction);

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/GroupMemberFixtures.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/GroupMemberFixtures.java
@@ -32,4 +32,14 @@ public final class GroupMemberFixtures extends CommonFixtures {
     rdbmsWriter.getGroupWriter().addMember(createRandomized(builderFunction));
     rdbmsWriter.flush();
   }
+
+  public static void createAndSaveRandomGroupMembers(
+      final RdbmsWriter rdbmsWriter,
+      final Function<GroupMemberDbModel.Builder, GroupMemberDbModel.Builder> builderFunction) {
+    for (int i = 0; i < 20; i++) {
+      rdbmsWriter.getGroupWriter().addMember(createRandomized(builderFunction));
+    }
+
+    rdbmsWriter.flush();
+  }
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/group/GroupIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/group/GroupIT.java
@@ -9,6 +9,7 @@ package io.camunda.it.rdbms.db.group;
 
 import static io.camunda.it.rdbms.db.fixtures.GroupFixtures.createAndSaveGroup;
 import static io.camunda.it.rdbms.db.fixtures.GroupFixtures.createAndSaveRandomGroups;
+import static io.camunda.it.rdbms.db.fixtures.GroupFixtures.createAndSaveRandomGroupsWithMembers;
 import static io.camunda.it.rdbms.db.fixtures.UserFixtures.createAndSaveUser;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -165,7 +166,7 @@ public class GroupIT {
     final RdbmsWriter rdbmsWriter = rdbmsService.createWriter(PARTITION_ID);
     final GroupDbReader groupReader = rdbmsService.getGroupReader();
 
-    createAndSaveRandomGroups(rdbmsWriter, b -> b.name("John Doe"));
+    createAndSaveRandomGroupsWithMembers(rdbmsWriter, b -> b.name("John Doe"));
 
     final var searchResult =
         groupReader.search(

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/group/GroupSpecificFilterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/group/GroupSpecificFilterIT.java
@@ -110,24 +110,29 @@ public class GroupSpecificFilterIT {
 
   @ParameterizedTest
   @CsvSource({"USER, 1", "GROUP, 0"})
-  public void shouldFindWithMemberTyep(final EntityType memberType, final int expectedCount) {
+  public void shouldFindWithMemberType(final EntityType memberType, final int expectedCount) {
     createAndSaveRandomGroups(rdbmsWriter);
     createAndSaveGroup(
         rdbmsWriter,
         GroupFixtures.createRandomized(
-            b -> b.groupId("groupId").groupKey(1337L).name("Group 1337")));
+            b -> b.groupId("groupId1").groupKey(1337L).name("Group 1337")));
     GroupMemberFixtures.createAndSaveRandomGroupMember(
         rdbmsWriter,
-        b -> b.groupId("groupId").entityId("entityId").entityType(EntityType.USER.name()));
+        b -> b.groupId("groupId1").entityId("entityId1").entityType(EntityType.USER.name()));
+    GroupMemberFixtures.createAndSaveRandomGroupMember(
+        rdbmsWriter,
+        b -> b.groupId("groupId1").entityId("entityId2").entityType(EntityType.USER.name()));
 
     final var searchResult =
         groupReader.search(
             new GroupQuery(
                 new GroupFilter.Builder()
-                    .memberIdsByType(Map.of(memberType, Set.of("entityId")))
+                    .memberIdsByType(Map.of(memberType, Set.of("entityId1")))
                     .build(),
                 GroupSort.of(b -> b),
                 SearchQueryPage.of(b -> b.from(0).size(5))));
+
+    searchResult.items().forEach(System.out::println);
 
     assertThat(searchResult.total()).isEqualTo(expectedCount);
     assertThat(searchResult.items()).hasSize(expectedCount);

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/role/RoleIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/role/RoleIT.java
@@ -8,6 +8,7 @@
 package io.camunda.it.rdbms.db.role;
 
 import static io.camunda.it.rdbms.db.fixtures.RoleFixtures.createAndSaveRandomRoles;
+import static io.camunda.it.rdbms.db.fixtures.RoleFixtures.createAndSaveRandomRolesWithMembers;
 import static io.camunda.it.rdbms.db.fixtures.RoleFixtures.createAndSaveRole;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -119,7 +120,7 @@ public class RoleIT {
     final RdbmsWriter rdbmsWriter = rdbmsService.createWriter(PARTITION_ID);
     final RoleDbReader roleReader = rdbmsService.getRoleReader();
 
-    createAndSaveRandomRoles(rdbmsWriter, b -> b.name("John Doe"));
+    createAndSaveRandomRolesWithMembers(rdbmsWriter, b -> b.name("John Doe"));
 
     final var searchResult =
         roleReader.search(

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/role/RoleSpecificFilterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/role/RoleSpecificFilterIT.java
@@ -119,12 +119,14 @@ public class RoleSpecificFilterIT {
     final var roleId = Strings.newRandomValidIdentityId();
     final var anotherRoleId = Strings.newRandomValidIdentityId();
     final var group = GroupFixtures.createRandomized(b -> b);
+    final var otherGroup = GroupFixtures.createRandomized(b -> b);
     final var userId = Strings.newRandomValidIdentityId();
     createAndSaveUser(
         rdbmsWriter,
         UserFixtures.createRandomized(
             b -> b.username(userId).name("User 1337").password("password")));
     createAndSaveGroup(rdbmsWriter, group);
+    createAndSaveGroup(rdbmsWriter, otherGroup);
     createAndSaveRole(
         rdbmsWriter, RoleFixtures.createRandomized(b -> b.roleId(roleId).name("Role 1337")));
     createAndSaveRole(
@@ -133,13 +135,15 @@ public class RoleSpecificFilterIT {
 
     addUserToRole(roleId, userId);
     addGroupToRole(roleId, group.groupId());
+    addGroupToRole(roleId, otherGroup.groupId());
     addGroupToRole(anotherRoleId, group.groupId());
 
     final var roles =
         roleReader.search(
             new RoleQuery(
                 new RoleFilter.Builder()
-                    .memberIdsByType(Map.of(memberType, Set.of(group.groupId())))
+                    .memberIdsByType(
+                        Map.of(memberType, Set.of(group.groupId(), otherGroup.groupId())))
                     .build(),
                 RoleSort.of(b -> b),
                 SearchQueryPage.of(b -> b.from(0).size(5))));

--- a/qa/acceptance-tests/src/test/resources/logback.xml
+++ b/qa/acceptance-tests/src/test/resources/logback.xml
@@ -31,7 +31,7 @@
   <Logger name="io.atomix.raft" level="debug"/>
 
   <Logger name="org.apache.ibatis" level="debug"/>
-  <Logger name="io.camunda.db.rdbms" level="info"/>
+  <Logger name="io.camunda.db.rdbms" level="debug"/>
   <Logger name="io.camunda.exporter.rdbms" level="info"/>
   <Logger name="io.camunda.zeebe.engine.processing.batchoperation" level="debug"/>
   <Logger name="io.camunda.exporter.tasks.batchoperations" level="trace"/>

--- a/search/search-domain/src/main/java/io/camunda/search/filter/AuthorizationFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/AuthorizationFilter.java
@@ -18,7 +18,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 public record AuthorizationFilter(
     Long authorizationKey,
@@ -46,7 +45,7 @@ public record AuthorizationFilter(
     }
 
     public Builder ownerIds(final List<String> value) {
-      final var filteredList = value.stream().filter(Objects::nonNull).collect(Collectors.toList());
+      final var filteredList = value.stream().filter(Objects::nonNull).toList();
       ownerIds = addValuesToList(ownerIds, filteredList);
       return this;
     }

--- a/search/search-domain/src/main/java/io/camunda/search/filter/AuthorizationFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/AuthorizationFilter.java
@@ -16,7 +16,9 @@ import io.camunda.zeebe.protocol.record.value.EntityType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 public record AuthorizationFilter(
     Long authorizationKey,
@@ -44,7 +46,8 @@ public record AuthorizationFilter(
     }
 
     public Builder ownerIds(final List<String> value) {
-      ownerIds = addValuesToList(ownerIds, value);
+      final var filteredList = value.stream().filter(Objects::nonNull).collect(Collectors.toList());
+      ownerIds = addValuesToList(ownerIds, filteredList);
       return this;
     }
 

--- a/security/security-core/src/main/java/io/camunda/security/reader/ResourceAccessChecks.java
+++ b/security/security-core/src/main/java/io/camunda/security/reader/ResourceAccessChecks.java
@@ -7,6 +7,10 @@
  */
 package io.camunda.security.reader;
 
+import io.camunda.security.auth.Authorization;
+import java.util.List;
+import java.util.Optional;
+
 public record ResourceAccessChecks(AuthorizationCheck authorizationCheck, TenantCheck tenantCheck) {
 
   public static ResourceAccessChecks disabled() {
@@ -16,5 +20,24 @@ public record ResourceAccessChecks(AuthorizationCheck authorizationCheck, Tenant
   public static ResourceAccessChecks of(
       final AuthorizationCheck authorizationCheck, final TenantCheck tenantCheck) {
     return new ResourceAccessChecks(authorizationCheck, tenantCheck);
+  }
+
+  public List<String> getAuthorizedResourceIds() {
+    if (authorizationCheck == null || !authorizationCheck.enabled()) {
+      return List.of();
+    }
+
+    return Optional.of(authorizationCheck)
+        .map(AuthorizationCheck::authorization)
+        .map(Authorization::resourceIds)
+        .orElse(List.of());
+  }
+
+  public List<String> getAuthorizedTenantIds() {
+    if (tenantCheck == null || !tenantCheck.enabled()) {
+      return List.of();
+    }
+
+    return Optional.of(tenantCheck).map(TenantCheck::tenantIds).orElse(List.of());
   }
 }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
@@ -1956,7 +1956,7 @@ public final class SearchQueryRequestMapper {
         .map(
             f ->
                 FilterBuilders.authorization()
-                    .ownerIds(f.getOwnerId() == null ? null : f.getOwnerId())
+                    .ownerIds(f.getOwnerId())
                     .ownerType(f.getOwnerType() == null ? null : f.getOwnerType().getValue())
                     .resourceIds(f.getResourceIds())
                     .resourceType(

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
@@ -1956,7 +1956,7 @@ public final class SearchQueryRequestMapper {
         .map(
             f ->
                 FilterBuilders.authorization()
-                    .ownerIds(f.getOwnerId())
+                    .ownerIds(f.getOwnerId() == null ? null : f.getOwnerId())
                     .ownerType(f.getOwnerType() == null ? null : f.getOwnerType().getValue())
                     .resourceIds(f.getResourceIds())
                     .resourceType(


### PR DESCRIPTION
## Description

Authorizations, groups and roles are not correctly filtered by member or owner. This is essential, so that the correct authorizations for a user are selected in the first place.