### PR TITLE
feat: track activatedJobs and allow assertions based on their state

### DIFF
--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/CamundaProcessTestContext.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/CamundaProcessTestContext.java
@@ -18,7 +18,7 @@ package io.camunda.process.test.api;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.CamundaClientBuilder;
 import io.camunda.process.test.api.assertions.UserTaskSelector;
-import io.camunda.process.test.api.mock.JobWorkerMock;
+import io.camunda.process.test.api.mock.JobWorkerMockBuilder;
 import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.client.ZeebeClientBuilder;
 import java.net.URI;
@@ -117,7 +117,7 @@ public interface CamundaProcessTestContext {
    * @param jobType the job type to mock, matching the `zeebeJobType` in the BPMN model.
    * @return a {@see JobWorkerMock} instance for configuring the mock behavior.
    */
-  JobWorkerMock mockJobWorker(final String jobType);
+  JobWorkerMockBuilder mockJobWorker(final String jobType);
 
   /**
    * Mocks a child process with the specified ID.

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/mock/JobWorkerMockBuilder.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/mock/JobWorkerMockBuilder.java
@@ -15,11 +15,13 @@
  */
 package io.camunda.process.test.api.mock;
 
+import io.camunda.client.api.response.ActivatedJob;
 import io.camunda.client.api.worker.JobHandler;
+import java.util.List;
 import java.util.Map;
 
 /**
- * Use this interface to mock job workers in your process tests.
+ * Use this interface to build mock job workers in your process tests.
  *
  * <p>Example usage:
  *
@@ -27,24 +29,24 @@ import java.util.Map;
  *   processTestContext.mockJobWorker("myworker").thenComplete();
  * </pre>
  */
-public interface JobWorkerMock {
+public interface JobWorkerMockBuilder {
 
   /** Configures the mock worker to complete jobs without any variables. */
-  void thenComplete();
+  JobWorkerMock thenComplete();
 
   /**
    * Configures the mock worker to complete jobs with the specified variables.
    *
    * @param variables the variables to include when completing the job.
    */
-  void thenComplete(Map<String, Object> variables);
+  JobWorkerMock thenComplete(Map<String, Object> variables);
 
   /**
    * Configures the mock worker to throw a BPMN error with the specified error code.
    *
    * @param errorCode the error code to throw.
    */
-  void thenThrowBpmnError(String errorCode);
+  JobWorkerMock thenThrowBpmnError(String errorCode);
 
   /**
    * Configures the mock worker to throw a BPMN error with the specified error code and variables.
@@ -52,12 +54,46 @@ public interface JobWorkerMock {
    * @param errorCode the error code to throw.
    * @param variables the variables to include when throwing the error.
    */
-  void thenThrowBpmnError(String errorCode, Map<String, Object> variables);
+  JobWorkerMock thenThrowBpmnError(String errorCode, Map<String, Object> variables);
 
   /**
    * Configures the mock worker with a custom job handler.
    *
    * @param jobHandler the custom job handler to use for processing jobs.
    */
-  void withHandler(JobHandler jobHandler);
+  JobWorkerMock withHandler(JobHandler jobHandler);
+
+  /**
+   * A JobWorkerMock is used in place of real job workers during camunda process tests. After the
+   * mock worker has been invoked, you can verify the state of the activated jobs and the number of
+   * invocations.
+   *
+   * <p>Example Usage:
+   *
+   * <pre>
+   *   final JobWorkerMock mock = processTestContext.mockJobWorker("myworker").thenComplete();
+   *
+   *   // start the process
+   *
+   *   // Assert that the worker has been invoked and verify its state
+   *   assert(mock.getInvocations()).isEqualTo(1);
+   *   assertThat(mock.getActivatedJobs().get(0).getVariablesAsMap())
+   *         .contains(entry("error_code", "404"));
+   * </pre>
+   */
+  interface JobWorkerMock {
+    /**
+     * Gets the number of times the Job Worker was invoked.
+     *
+     * @return number of Job Worker invocations.
+     */
+    int getInvocations();
+
+    /**
+     * Gets all activated jobs every time the Job Worker was invoked.
+     *
+     * @return the activated jobs, or empty if there are none.
+     */
+    List<ActivatedJob> getActivatedJobs();
+  }
 }

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/extension/CamundaProcessTestContextImpl.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/extension/CamundaProcessTestContextImpl.java
@@ -26,9 +26,9 @@ import io.camunda.process.test.api.CamundaClientBuilderFactory;
 import io.camunda.process.test.api.CamundaProcessTestContext;
 import io.camunda.process.test.api.assertions.UserTaskSelector;
 import io.camunda.process.test.api.assertions.UserTaskSelectors;
-import io.camunda.process.test.api.mock.JobWorkerMock;
+import io.camunda.process.test.api.mock.JobWorkerMockBuilder;
 import io.camunda.process.test.impl.client.CamundaManagementClient;
-import io.camunda.process.test.impl.mock.JobWorkerMockImpl;
+import io.camunda.process.test.impl.mock.JobWorkerMockBuilderImpl;
 import io.camunda.process.test.impl.runtime.CamundaProcessTestRuntime;
 import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.client.ZeebeClientBuilder;
@@ -150,9 +150,9 @@ public class CamundaProcessTestContextImpl implements CamundaProcessTestContext 
   }
 
   @Override
-  public JobWorkerMock mockJobWorker(final String jobType) {
+  public JobWorkerMockBuilder mockJobWorker(final String jobType) {
     final CamundaClient client = createClient();
-    return new JobWorkerMockImpl(jobType, client);
+    return new JobWorkerMockBuilderImpl(jobType, client);
   }
 
   @Override

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/mock/JobWorkerMockBuilderImpl.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/mock/JobWorkerMockBuilderImpl.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.impl.mock;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.worker.JobHandler;
+import io.camunda.process.test.api.mock.JobWorkerMockBuilder;
+import java.util.HashMap;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class JobWorkerMockBuilderImpl implements JobWorkerMockBuilder {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(JobWorkerMockBuilderImpl.class);
+
+  private final String jobType;
+  private final CamundaClient client;
+
+  /**
+   * Constructs a `JobWorkerMock` instance.
+   *
+   * @param jobType the job type to mock, matching the `zeebeJobType` in the BPMN model.
+   * @param client the Camunda client used to create the mock worker.
+   */
+  public JobWorkerMockBuilderImpl(final String jobType, final CamundaClient client) {
+    this.jobType = jobType;
+    this.client = client;
+  }
+
+  @Override
+  public JobWorkerMock thenComplete() {
+    return thenComplete(new HashMap<>());
+  }
+
+  @Override
+  public JobWorkerMock thenComplete(final Map<String, Object> variables) {
+    return withHandler(
+        (jobClient, job) -> {
+          LOGGER.debug(
+              "Mock: Complete job with variables {} [job-type: '{}', job-key: '{}']",
+              variables,
+              jobType,
+              job.getKey());
+          jobClient.newCompleteCommand(job).variables(variables).send().join();
+        });
+  }
+
+  @Override
+  public JobWorkerMock thenThrowBpmnError(final String errorCode) {
+    return thenThrowBpmnError(errorCode, new HashMap<>());
+  }
+
+  @Override
+  public JobWorkerMock thenThrowBpmnError(
+      final String errorCode, final Map<String, Object> variables) {
+    return withHandler(
+        (jobClient, job) -> {
+          LOGGER.debug(
+              "Mock: Throw BPMN error with error code {} and variables {} [job-type: '{}', job-key: '{}']",
+              errorCode,
+              variables,
+              jobType,
+              job.getKey());
+
+          jobClient
+              .newThrowErrorCommand(job)
+              .errorCode(errorCode)
+              .variables(variables)
+              .send()
+              .join();
+        });
+  }
+
+  @Override
+  public JobWorkerMock withHandler(final JobHandler jobHandler) {
+    return new JobWorkerMockImpl(jobType, client, jobHandler);
+  }
+}

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/mock/JobWorkerMockImpl.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/mock/JobWorkerMockImpl.java
@@ -16,10 +16,11 @@
 package io.camunda.process.test.impl.mock;
 
 import io.camunda.client.CamundaClient;
+import io.camunda.client.api.response.ActivatedJob;
 import io.camunda.client.api.worker.JobHandler;
-import io.camunda.process.test.api.mock.JobWorkerMock;
-import java.util.HashMap;
-import java.util.Map;
+import io.camunda.process.test.api.mock.JobWorkerMockBuilder.JobWorkerMock;
+import java.util.ArrayList;
+import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -27,74 +28,32 @@ public class JobWorkerMockImpl implements JobWorkerMock {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(JobWorkerMockImpl.class);
 
-  private final String jobType;
-  private final CamundaClient client;
+  private final List<ActivatedJob> activatedJobs = new ArrayList<>();
 
-  /**
-   * Constructs a `JobWorkerMock` instance.
-   *
-   * @param jobType the job type to mock, matching the `zeebeJobType` in the BPMN model.
-   * @param client the Camunda client used to create the mock worker.
-   */
-  public JobWorkerMockImpl(final String jobType, final CamundaClient client) {
-    this.jobType = jobType;
-    this.client = client;
-  }
+  public JobWorkerMockImpl(
+      final String jobType, final CamundaClient camundaClient, final JobHandler jobHandler) {
 
-  @Override
-  public void thenComplete() {
-    thenComplete(new HashMap<>());
-  }
-
-  @Override
-  public void thenComplete(final Map<String, Object> variables) {
-    withHandler(
-        (jobClient, job) -> {
-          LOGGER.debug(
-              "Mock: Complete job with variables {} [job-type: '{}', job-key: '{}']",
-              variables,
-              jobType,
-              job.getKey());
-          jobClient.newCompleteCommand(job).variables(variables).send().join();
-        });
-  }
-
-  @Override
-  public void thenThrowBpmnError(final String errorCode) {
-    thenThrowBpmnError(errorCode, new HashMap<>());
-  }
-
-  @Override
-  public void thenThrowBpmnError(final String errorCode, final Map<String, Object> variables) {
-    withHandler(
-        (jobClient, job) -> {
-          LOGGER.debug(
-              "Mock: Throw BPMN error with error code {} and variables {} [job-type: '{}', job-key: '{}']",
-              errorCode,
-              variables,
-              jobType,
-              job.getKey());
-          jobClient
-              .newThrowErrorCommand(job)
-              .errorCode(errorCode)
-              .variables(variables)
-              .send()
-              .join();
-        });
-  }
-
-  @Override
-  public void withHandler(final JobHandler jobHandler) {
     final JobHandler loggingJobHandler =
-        (client, job) -> {
+        (jobClient, job) -> {
           LOGGER.debug(
               "Mock: Pass job to custom handler [job-type: '{}', job-key: '{}']",
               jobType,
               job.getKey());
 
-          jobHandler.handle(client, job);
+          activatedJobs.add(job);
+          jobHandler.handle(jobClient, job);
         };
 
-    client.newWorker().jobType(jobType).handler(loggingJobHandler).open();
+    camundaClient.newWorker().jobType(jobType).handler(loggingJobHandler).open();
+  }
+
+  @Override
+  public int getInvocations() {
+    return activatedJobs.size();
+  }
+
+  @Override
+  public List<ActivatedJob> getActivatedJobs() {
+    return activatedJobs;
   }
 }


### PR DESCRIPTION
## Description

A JobWorkerMock now tracks its ActivatedJobs and allows tests to assert the number of invocations and the state of the ActivatedJobs. 

## Related issues

closes #35429 
