### PR TITLE
Fix overlapping ids with Identity entities

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/UniqueEntityIdentifiersIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/UniqueEntityIdentifiersIT.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.command.ProblemException;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+
+// regression test for https://github.com/camunda/camunda/issues/35549
+@MultiDbTest
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms")
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
+public class UniqueEntityIdentifiersIT {
+
+  private static CamundaClient client;
+
+  @Test
+  void shouldCreateUniqueIdsForTenantMembers() {
+    // given
+    final var conflictingId = "tenantMemberID";
+    final String tenantId = "testTenant";
+    // create group, role, and tenant
+    client.newCreateGroupCommand().groupId(conflictingId).name("testGroup").send().join();
+    client.newCreateRoleCommand().roleId(conflictingId).name("testRole").send().join();
+    client.newCreateTenantCommand().tenantId(tenantId).name("testTenant").send().join();
+    // assign group to tenant
+    client.newAssignGroupToTenantCommand().groupId(conflictingId).tenantId(tenantId).send().join();
+    Awaitility.await()
+        .ignoreExceptionsInstanceOf(ProblemException.class)
+        .untilAsserted(
+            () -> {
+              final var groupsResponse =
+                  client.newGroupsByTenantSearchRequest(tenantId).send().join();
+              assertThat(groupsResponse.items()).hasSize(1);
+              assertThat(groupsResponse.items().get(0).getGroupId()).isEqualTo(conflictingId);
+            });
+
+    // when
+    // assign role to tenant with the same ID
+    client.newAssignRoleToTenantCommand().roleId(conflictingId).tenantId(tenantId).send().join();
+    Awaitility.await()
+        .ignoreExceptionsInstanceOf(ProblemException.class)
+        .untilAsserted(
+            () -> {
+              final var rolesResponse =
+                  client.newRolesByTenantSearchRequest(tenantId).send().join();
+              assertThat(rolesResponse.items()).hasSize(1);
+              assertThat(rolesResponse.items().get(0).getRoleId()).isEqualTo(conflictingId);
+            });
+
+    // then
+    final var updatedGroupsResponse = client.newGroupsByTenantSearchRequest(tenantId).send().join();
+    assertThat(updatedGroupsResponse.items()).hasSize(1);
+    assertThat(updatedGroupsResponse.items().get(0).getGroupId()).isEqualTo(conflictingId);
+  }
+
+  @Test
+  void shouldCreateUniqueIdsForGroupMembers() {
+    // given
+    final var conflictingId = "groupMemberID";
+    final String groupId = "testGroup";
+    // create user, client, and group
+    client
+        .newCreateUserCommand()
+        .username(conflictingId)
+        .name("testUser")
+        .email("test@email.com")
+        .password("fakePassword")
+        .send()
+        .join();
+    client
+        .newCreateMappingRuleCommand()
+        .mappingRuleId(conflictingId)
+        .name("testMapping")
+        .claimName("testClaim")
+        .claimValue("testValue")
+        .send()
+        .join();
+    client.newCreateGroupCommand().groupId(groupId).name("Test Group").send().join();
+    // assign user to group
+    client.newAssignUserToGroupCommand().username(conflictingId).groupId(groupId).send().join();
+    Awaitility.await()
+        .ignoreExceptionsInstanceOf(ProblemException.class)
+        .untilAsserted(
+            () -> {
+              final var usersResponse = client.newUsersByGroupSearchRequest(groupId).send().join();
+              assertThat(usersResponse.items()).hasSize(1);
+              assertThat(usersResponse.items().get(0).getUsername()).isEqualTo(conflictingId);
+            });
+
+    // when
+    // assign client to group with the same ID
+    client
+        .newAssignMappingRuleToGroupCommand()
+        .mappingRuleId(conflictingId)
+        .groupId(groupId)
+        .send()
+        .join();
+    Awaitility.await()
+        .ignoreExceptionsInstanceOf(ProblemException.class)
+        .untilAsserted(
+            () -> {
+              final var clientsResponse =
+                  client.newMappingRulesByGroupSearchRequest(groupId).send().join();
+              assertThat(clientsResponse.items()).hasSize(1);
+              assertThat(clientsResponse.items().get(0).getMappingRuleId())
+                  .isEqualTo(conflictingId);
+            });
+
+    // then
+    final var updatedUsersResponse = client.newUsersByGroupSearchRequest(groupId).send().join();
+    assertThat(updatedUsersResponse.items()).hasSize(1);
+    assertThat(updatedUsersResponse.items().get(0).getUsername()).isEqualTo(conflictingId);
+  }
+
+  @Test
+  void shouldCreateUniqueIdsForRoleMembers() {
+    // given
+    final var conflictingId = "roleMemberID";
+    final String roleId = "testRole";
+    // create user, group, and role
+    client
+        .newCreateUserCommand()
+        .username(conflictingId)
+        .name("testUser")
+        .email("test@email.com")
+        .password("fakePassword")
+        .send()
+        .join();
+    client.newCreateGroupCommand().groupId(conflictingId).name("testGroup").send().join();
+    client.newCreateRoleCommand().roleId(roleId).name("Test Role").send().join();
+    // assign user to role
+    client.newAssignRoleToUserCommand().roleId(roleId).username(conflictingId).send().join();
+    Awaitility.await()
+        .ignoreExceptionsInstanceOf(ProblemException.class)
+        .untilAsserted(
+            () -> {
+              final var usersResponse = client.newUsersByRoleSearchRequest(roleId).send().join();
+              assertThat(usersResponse.items()).hasSize(1);
+              assertThat(usersResponse.items().get(0).getUsername()).isEqualTo(conflictingId);
+            });
+
+    // when
+    // assign group to role with the same ID
+    client.newAssignRoleToGroupCommand().roleId(roleId).groupId(conflictingId).send().join();
+    Awaitility.await()
+        .ignoreExceptionsInstanceOf(ProblemException.class)
+        .untilAsserted(
+            () -> {
+              final var groupsResponse = client.newGroupsByRoleSearchRequest(roleId).send().join();
+              assertThat(groupsResponse.items()).hasSize(1);
+              assertThat(groupsResponse.items().get(0).getGroupId()).isEqualTo(conflictingId);
+            });
+
+    // then
+    final var updatedUsersResponse = client.newUsersByRoleSearchRequest(roleId).send().join();
+    assertThat(updatedUsersResponse.items()).hasSize(1);
+    assertThat(updatedUsersResponse.items().get(0).getUsername()).isEqualTo(conflictingId);
+  }
+}

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/EntityJoinRelation.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/EntityJoinRelation.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.webapps.schema.entities.usermanagement;
 
+import io.camunda.zeebe.protocol.record.value.EntityType;
+
 public record EntityJoinRelation(String name, String parent) {
 
   public static class EntityJoinRelationFactory {
@@ -32,8 +34,15 @@ public record EntityJoinRelation(String name, String parent) {
       return parent.getType() + "-" + parentId;
     }
 
-    public String createChildId(final String parentId, final String childId) {
-      return child.getType() + "-" + parentId + "-" + childId;
+    public String createChildId(
+        final String parentId, final String childId, final EntityType childType) {
+      return child.getType()
+          + "-"
+          + parentId
+          + "-"
+          + childType.name().toLowerCase()
+          + "-"
+          + childId;
     }
   }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/GroupEntityAddedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/GroupEntityAddedHandler.java
@@ -46,7 +46,7 @@ public class GroupEntityAddedHandler implements ExportHandler<GroupMemberEntity,
     final var groupRecord = record.getValue();
     return List.of(
         GroupIndex.JOIN_RELATION_FACTORY.createChildId(
-            groupRecord.getGroupId(), groupRecord.getEntityId()));
+            groupRecord.getGroupId(), groupRecord.getEntityId(), groupRecord.getEntityType()));
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/GroupEntityRemovedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/GroupEntityRemovedHandler.java
@@ -47,7 +47,7 @@ public class GroupEntityRemovedHandler
     final var groupRecord = record.getValue();
     return List.of(
         GroupIndex.JOIN_RELATION_FACTORY.createChildId(
-            groupRecord.getGroupId(), groupRecord.getEntityId()));
+            groupRecord.getGroupId(), groupRecord.getEntityId(), groupRecord.getEntityType()));
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/RoleMemberAddedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/RoleMemberAddedHandler.java
@@ -45,7 +45,8 @@ public class RoleMemberAddedHandler implements ExportHandler<RoleMemberEntity, R
   public List<String> generateIds(final Record<RoleRecordValue> record) {
     final RoleRecordValue value = record.getValue();
     return List.of(
-        RoleIndex.JOIN_RELATION_FACTORY.createChildId(value.getRoleId(), value.getEntityId()));
+        RoleIndex.JOIN_RELATION_FACTORY.createChildId(
+            value.getRoleId(), value.getEntityId(), value.getEntityType()));
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/RoleMemberRemovedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/RoleMemberRemovedHandler.java
@@ -44,7 +44,8 @@ public class RoleMemberRemovedHandler implements ExportHandler<RoleMemberEntity,
   public List<String> generateIds(final Record<RoleRecordValue> record) {
     final RoleRecordValue value = record.getValue();
     return List.of(
-        RoleIndex.JOIN_RELATION_FACTORY.createChildId(value.getRoleId(), value.getEntityId()));
+        RoleIndex.JOIN_RELATION_FACTORY.createChildId(
+            value.getRoleId(), value.getEntityId(), value.getEntityType()));
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/TenantEntityAddedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/TenantEntityAddedHandler.java
@@ -46,7 +46,7 @@ public class TenantEntityAddedHandler
     final var tenantRecord = record.getValue();
     return List.of(
         TenantIndex.JOIN_RELATION_FACTORY.createChildId(
-            tenantRecord.getTenantId(), tenantRecord.getEntityId()));
+            tenantRecord.getTenantId(), tenantRecord.getEntityId(), tenantRecord.getEntityType()));
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/TenantEntityRemovedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/TenantEntityRemovedHandler.java
@@ -47,7 +47,7 @@ public class TenantEntityRemovedHandler
     final var tenantRecord = record.getValue();
     return List.of(
         TenantIndex.JOIN_RELATION_FACTORY.createChildId(
-            tenantRecord.getTenantId(), tenantRecord.getEntityId()));
+            tenantRecord.getTenantId(), tenantRecord.getEntityId(), tenantRecord.getEntityType()));
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/RoleMemberRemovedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/RoleMemberRemovedHandlerTest.java
@@ -62,7 +62,8 @@ public class RoleMemberRemovedHandlerTest {
     final var value = roleRecord.getValue();
     assertThat(idList)
         .containsExactly(
-            RoleIndex.JOIN_RELATION_FACTORY.createChildId(value.getRoleId(), value.getEntityId()));
+            RoleIndex.JOIN_RELATION_FACTORY.createChildId(
+                value.getRoleId(), value.getEntityId(), value.getEntityType()));
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/GroupEntityAddedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/GroupEntityAddedHandlerTest.java
@@ -64,7 +64,7 @@ public class GroupEntityAddedHandlerTest {
     assertThat(idList)
         .containsExactly(
             GroupIndex.JOIN_RELATION_FACTORY.createChildId(
-                value.getGroupId(), value.getEntityId()));
+                value.getGroupId(), value.getEntityId(), value.getEntityType()));
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/GroupEntityRemovedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/GroupEntityRemovedHandlerTest.java
@@ -64,7 +64,7 @@ public class GroupEntityRemovedHandlerTest {
     assertThat(idList)
         .containsExactly(
             GroupIndex.JOIN_RELATION_FACTORY.createChildId(
-                value.getGroupId(), value.getEntityId()));
+                value.getGroupId(), value.getEntityId(), value.getEntityType()));
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/RoleMemberAddedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/RoleMemberAddedHandlerTest.java
@@ -61,7 +61,8 @@ public class RoleMemberAddedHandlerTest {
     final var value = roleRecord.getValue();
     assertThat(idList)
         .containsExactly(
-            RoleIndex.JOIN_RELATION_FACTORY.createChildId(value.getRoleId(), value.getEntityId()));
+            RoleIndex.JOIN_RELATION_FACTORY.createChildId(
+                value.getRoleId(), value.getEntityId(), value.getEntityType()));
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/RoleMemberRemovedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/RoleMemberRemovedHandlerTest.java
@@ -5,7 +5,7 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.exporter;
+package io.camunda.exporter.handlers;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -13,7 +13,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import io.camunda.exporter.exceptions.PersistenceException;
-import io.camunda.exporter.handlers.RoleMemberRemovedHandler;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.descriptors.index.RoleIndex;
 import io.camunda.webapps.schema.entities.usermanagement.RoleMemberEntity;

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/TenantEntityAddedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/TenantEntityAddedHandlerTest.java
@@ -61,7 +61,7 @@ public class TenantEntityAddedHandlerTest {
     assertThat(idList)
         .containsExactly(
             TenantIndex.JOIN_RELATION_FACTORY.createChildId(
-                value.getTenantId(), value.getEntityId()));
+                value.getTenantId(), value.getEntityId(), value.getEntityType()));
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/TenantEntityRemovedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/TenantEntityRemovedHandlerTest.java
@@ -63,7 +63,7 @@ public class TenantEntityRemovedHandlerTest {
     assertThat(idList)
         .containsExactly(
             TenantIndex.JOIN_RELATION_FACTORY.createChildId(
-                value.getTenantId(), value.getEntityId()));
+                value.getTenantId(), value.getEntityId(), value.getEntityType()));
   }
 
   @Test


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Ensure there are no ID conflicts between Identity-related entities when they are persisted in ES/OS.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #35549 
