### PR TITLE
feat: apply authorization checks to document service class

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
@@ -31,6 +31,7 @@ import io.camunda.search.clients.UserSearchClient;
 import io.camunda.search.clients.UserTaskSearchClient;
 import io.camunda.search.clients.VariableSearchClient;
 import io.camunda.search.clients.reader.AuthorizationReader;
+import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.security.impl.AuthorizationChecker;
 import io.camunda.service.AdHocSubProcessActivityServices;
 import io.camunda.service.AuthorizationServices;
@@ -246,12 +247,17 @@ public class CamundaServicesConfiguration {
 
   @Bean
   public DocumentServices documentServices(
-      final BrokerClient brokerClient, final SecurityContextProvider securityContextProvider) {
+      final BrokerClient brokerClient,
+      final SecurityContextProvider securityContextProvider,
+      final AuthorizationChecker authorizationChecker,
+      final SecurityConfiguration securityConfiguration) {
     return new DocumentServices(
         brokerClient,
         securityContextProvider,
         null,
-        new SimpleDocumentStoreRegistry(new EnvironmentConfigurationLoader()));
+        new SimpleDocumentStoreRegistry(new EnvironmentConfigurationLoader()),
+        authorizationChecker,
+        securityConfiguration);
   }
 
   @Bean

--- a/security/security-core/src/main/java/io/camunda/security/auth/Authorization.java
+++ b/security/security-core/src/main/java/io/camunda/security/auth/Authorization.java
@@ -11,6 +11,7 @@ import static io.camunda.zeebe.protocol.record.value.AuthorizationResourceType.A
 import static io.camunda.zeebe.protocol.record.value.AuthorizationResourceType.BATCH;
 import static io.camunda.zeebe.protocol.record.value.AuthorizationResourceType.DECISION_DEFINITION;
 import static io.camunda.zeebe.protocol.record.value.AuthorizationResourceType.DECISION_REQUIREMENTS_DEFINITION;
+import static io.camunda.zeebe.protocol.record.value.AuthorizationResourceType.DOCUMENT;
 import static io.camunda.zeebe.protocol.record.value.AuthorizationResourceType.GROUP;
 import static io.camunda.zeebe.protocol.record.value.AuthorizationResourceType.MAPPING_RULE;
 import static io.camunda.zeebe.protocol.record.value.AuthorizationResourceType.PROCESS_DEFINITION;
@@ -161,6 +162,10 @@ public record Authorization<T>(
 
     public Builder<T> usageMetric() {
       return resourceType(USAGE_METRIC);
+    }
+
+    public Builder<T> document() {
+      return resourceType(DOCUMENT);
     }
 
     public Builder<T> resourceId(final String resourceId) {

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -179,5 +179,9 @@
       <artifactId>instancio-core</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-security-services</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/service/src/main/java/io/camunda/service/DocumentServices.java
+++ b/service/src/main/java/io/camunda/service/DocumentServices.java
@@ -17,11 +17,16 @@ import io.camunda.document.api.DocumentReference;
 import io.camunda.document.api.DocumentStore;
 import io.camunda.document.api.DocumentStoreRecord;
 import io.camunda.document.store.SimpleDocumentStoreRegistry;
+import io.camunda.security.auth.Authorization;
 import io.camunda.security.auth.CamundaAuthentication;
+import io.camunda.security.configuration.SecurityConfiguration;
+import io.camunda.security.impl.AuthorizationChecker;
 import io.camunda.service.exception.ErrorMapper;
 import io.camunda.service.exception.ServiceException;
 import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
+import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.util.Either;
 import java.io.InputStream;
 import java.time.Duration;
@@ -36,24 +41,42 @@ public class DocumentServices extends ApiServices<DocumentServices> {
   private static final Logger LOG = LoggerFactory.getLogger(DocumentServices.class);
 
   private final SimpleDocumentStoreRegistry registry;
+  private final AuthorizationChecker authorizationChecker;
+  private final SecurityConfiguration securityConfig;
 
   public DocumentServices(
       final BrokerClient brokerClient,
       final SecurityContextProvider securityContextProvider,
       final CamundaAuthentication authentication,
-      final SimpleDocumentStoreRegistry registry) {
+      final SimpleDocumentStoreRegistry registry,
+      final AuthorizationChecker authorizationChecker,
+      final SecurityConfiguration securityConfig) {
     super(brokerClient, securityContextProvider, authentication);
     this.registry = registry;
+    this.authorizationChecker = authorizationChecker;
+    this.securityConfig = securityConfig;
   }
 
   @Override
   public DocumentServices withAuthentication(final CamundaAuthentication authentication) {
-    return new DocumentServices(brokerClient, securityContextProvider, authentication, registry);
+    return new DocumentServices(
+        brokerClient,
+        securityContextProvider,
+        authentication,
+        registry,
+        authorizationChecker,
+        securityConfig);
   }
 
   /** Will return a failed future for any error returned by the store */
   public CompletableFuture<DocumentReferenceResponse> createDocument(
       final DocumentCreateRequest request) {
+
+    if (!hasDocumentPermission(PermissionType.CREATE)) {
+      return CompletableFuture.failedFuture(
+          ErrorMapper.createForbiddenException(
+              Authorization.of(a -> a.document().permissionType(PermissionType.CREATE))));
+    }
 
     final DocumentCreationRequest storeRequest =
         new DocumentCreationRequest(
@@ -77,6 +100,12 @@ public class DocumentServices extends ApiServices<DocumentServices> {
   /** Will never return a failed future; an Either type is returned instead */
   public CompletableFuture<List<Either<DocumentErrorResponse, DocumentReferenceResponse>>>
       createDocumentBatch(final List<DocumentCreateRequest> requests) {
+
+    if (!hasDocumentPermission(PermissionType.CREATE)) {
+      return CompletableFuture.failedFuture(
+          ErrorMapper.createForbiddenException(
+              Authorization.of(a -> a.document().permissionType(PermissionType.CREATE))));
+    }
 
     final List<Either<DocumentErrorResponse, DocumentReferenceResponse>> results =
         new ArrayList<>();
@@ -113,6 +142,12 @@ public class DocumentServices extends ApiServices<DocumentServices> {
   public CompletableFuture<DocumentContentResponse> getDocumentContent(
       final String documentId, final String storeId, final String contentHash) {
 
+    if (!hasDocumentPermission(PermissionType.READ)) {
+      return CompletableFuture.failedFuture(
+          ErrorMapper.createForbiddenException(
+              Authorization.of(a -> a.document().permissionType(PermissionType.READ))));
+    }
+
     final DocumentStore documentStore = getDocumentStore(storeId).instance();
     return documentStore
         .verifyContentHash(documentId, contentHash)
@@ -133,6 +168,12 @@ public class DocumentServices extends ApiServices<DocumentServices> {
 
   public CompletableFuture<Void> deleteDocument(final String documentId, final String storeId) {
 
+    if (!hasDocumentPermission(PermissionType.DELETE)) {
+      return CompletableFuture.failedFuture(
+          ErrorMapper.createForbiddenException(
+              Authorization.of(a -> a.document().permissionType(PermissionType.DELETE))));
+    }
+
     return getDocumentStore(storeId)
         .instance()
         .deleteDocument(documentId)
@@ -144,6 +185,12 @@ public class DocumentServices extends ApiServices<DocumentServices> {
       final String storeId,
       final String contentHash,
       final DocumentLinkParams params) {
+
+    if (!hasDocumentPermission(PermissionType.CREATE)) {
+      return CompletableFuture.failedFuture(
+          ErrorMapper.createForbiddenException(
+              Authorization.of(a -> a.document().permissionType(PermissionType.CREATE))));
+    }
 
     final long ttl = params.timeToLive().toMillis();
 
@@ -207,6 +254,17 @@ public class DocumentServices extends ApiServices<DocumentServices> {
     } else {
       return response.get();
     }
+  }
+
+  private boolean hasDocumentPermission(final PermissionType permission) {
+    if (!securityConfig.getAuthorizations().isEnabled()) {
+      return true;
+    }
+
+    return authorizationChecker
+        .collectPermissionTypes(
+            Authorization.WILDCARD, AuthorizationResourceType.DOCUMENT, authentication)
+        .contains(permission);
   }
 
   public record DocumentCreateRequest(

--- a/service/src/test/java/io/camunda/service/DocumentServicesTest.java
+++ b/service/src/test/java/io/camunda/service/DocumentServicesTest.java
@@ -8,11 +8,13 @@
 package io.camunda.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.camunda.document.api.DocumentContent;
 import io.camunda.document.api.DocumentCreationRequest;
 import io.camunda.document.api.DocumentMetadataModel;
 import io.camunda.document.api.DocumentReference;
@@ -20,16 +22,26 @@ import io.camunda.document.api.DocumentStore;
 import io.camunda.document.api.DocumentStoreRecord;
 import io.camunda.document.store.SimpleDocumentStoreRegistry;
 import io.camunda.security.auth.CamundaAuthentication;
+import io.camunda.security.configuration.AuthorizationsConfiguration;
+import io.camunda.security.configuration.SecurityConfiguration;
+import io.camunda.security.impl.AuthorizationChecker;
 import io.camunda.service.DocumentServices.DocumentCreateRequest;
 import io.camunda.service.DocumentServices.DocumentReferenceResponse;
 import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
+import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.util.Either;
+import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -37,6 +49,8 @@ public class DocumentServicesTest {
 
   private DocumentServices services;
   private final SimpleDocumentStoreRegistry registry = mock(SimpleDocumentStoreRegistry.class);
+  private final AuthorizationChecker authorizationChecker = mock(AuthorizationChecker.class);
+  private final SecurityConfiguration securityConfiguration = mock(SecurityConfiguration.class);
 
   @BeforeEach
   public void before() {
@@ -45,7 +59,179 @@ public class DocumentServicesTest {
             mock(BrokerClient.class),
             mock(SecurityContextProvider.class),
             mock(CamundaAuthentication.class),
-            registry);
+            registry,
+            authorizationChecker,
+            securityConfiguration);
+
+    final var authorizationConfiguration = new AuthorizationsConfiguration();
+    authorizationConfiguration.setEnabled(false);
+    when(securityConfiguration.getAuthorizations()).thenReturn(authorizationConfiguration);
+  }
+
+  @Test
+  public void createDocumentShouldCompleteExceptionallyWhenAUserHasNoAuthorizations() {
+    // given
+    // Authorizations are enabled by default
+    final var authorizationConfiguration = new AuthorizationsConfiguration();
+    when(securityConfiguration.getAuthorizations()).thenReturn(authorizationConfiguration);
+    when(authorizationChecker.collectPermissionTypes(any(), any(), any()))
+        .thenReturn(Collections.emptySet());
+    final var fileMock = mock(DocumentCreateRequest.class);
+
+    // when
+    final var future = services.createDocument(fileMock);
+
+    assertThat(future.isCompletedExceptionally()).isTrue();
+  }
+
+  @Test
+  public void createDocumentShouldCompleteExceptionallyWhenAUserIsNotAuthorizedToCreate() {
+    // given
+    // Authorizations are enabled by default
+    final var authorizationConfiguration = new AuthorizationsConfiguration();
+    when(securityConfiguration.getAuthorizations()).thenReturn(authorizationConfiguration);
+    when(authorizationChecker.collectPermissionTypes(any(), any(), any()))
+        .thenReturn(Set.of(PermissionType.READ));
+    final var fileMock = mock(DocumentCreateRequest.class);
+
+    // when
+    final var future = services.createDocument(fileMock);
+
+    assertThat(future.isCompletedExceptionally()).isTrue();
+  }
+
+  @Test
+  public void deleteDocumentShouldCompleteExceptionallyWhenAUserIsNotAuthorizedToDelete() {
+    // given
+    // Authorizations are enabled by default
+    final var authorizationConfiguration = new AuthorizationsConfiguration();
+    when(securityConfiguration.getAuthorizations()).thenReturn(authorizationConfiguration);
+    when(authorizationChecker.collectPermissionTypes(any(), any(), any()))
+        .thenReturn(Set.of(PermissionType.READ));
+
+    // when
+    final var future = services.deleteDocument("irrelevant-document-id", "irrelevant-store-id");
+
+    assertThat(future.isCompletedExceptionally()).isTrue();
+  }
+
+  @Test
+  public void getDocumentShouldCompleteExceptionallyWhenAUserIsNotAuthorizedToRead() {
+    // given
+    // Authorizations are enabled by default
+    final var authorizationConfiguration = new AuthorizationsConfiguration();
+    when(securityConfiguration.getAuthorizations()).thenReturn(authorizationConfiguration);
+    when(authorizationChecker.collectPermissionTypes(any(), any(), any()))
+        .thenReturn(Collections.emptySet());
+
+    // when
+    final var future =
+        services.getDocumentContent(
+            "irrelevant-document-id", "irrelevant-store-id", "irrelevant-hash");
+
+    assertThat(future.isCompletedExceptionally()).isTrue();
+  }
+
+  @Test
+  public void shouldSkipAuthorizationChecksWhenNotEnabled() {
+    // given
+    final var storeRecord = mock(DocumentStoreRecord.class);
+    final var storeInstance = mock(DocumentStore.class);
+    final var storeId = "in-memory-store";
+    when(storeRecord.instance()).thenReturn(storeInstance);
+    when(storeRecord.storeId()).thenReturn(storeId);
+    when(registry.getDefaultDocumentStore()).thenReturn(storeRecord);
+
+    final var content1 = "hello world";
+    final var file1 = createDocRequest(content1);
+    final var expectedResult1 = createDocumentReference(file1);
+    when(storeInstance.createDocument(
+            new DocumentCreationRequest(
+                file1.documentId(), file1.contentInputStream(), file1.metadata())))
+        .thenReturn(CompletableFuture.completedFuture(Either.right(expectedResult1)));
+
+    // when
+    final var response = services.createDocument(file1).join();
+
+    // then
+    assertThat(response)
+        .isNotNull()
+        .isEqualTo(
+            new DocumentReferenceResponse(
+                expectedResult1.documentId(),
+                storeId,
+                expectedResult1.contentHash(),
+                expectedResult1.metadata()));
+
+    verify(authorizationChecker, times(0)).collectPermissionTypes(any(), any(), any());
+    verify(registry, times(1)).getDefaultDocumentStore();
+    verify(storeRecord, times(1)).instance();
+  }
+
+  @Test
+  public void shouldDeleteDocumentWhenUserIsAuthorized() {
+    // given
+    // Authorizations are enabled by default
+    final var authorizationConfiguration = new AuthorizationsConfiguration();
+    when(securityConfiguration.getAuthorizations()).thenReturn(authorizationConfiguration);
+    when(authorizationChecker.collectPermissionTypes(any(), any(), any()))
+        .thenReturn(Set.of(PermissionType.DELETE));
+
+    final var storeRecord = mock(DocumentStoreRecord.class);
+    final var storeInstance = mock(DocumentStore.class);
+    final var storeId = "in-memory-store";
+    final var documentId = "test-document-id-1";
+    when(registry.getDocumentStore(storeId)).thenReturn(storeRecord);
+    when(storeRecord.instance()).thenReturn(storeInstance);
+    when(storeInstance.deleteDocument(documentId))
+        .thenReturn(CompletableFuture.completedFuture(Either.right(null)));
+
+    // when
+    final var future = services.deleteDocument(documentId, storeId);
+
+    // then
+    assertThat(future).isNotNull();
+  }
+
+  @Test
+  public void shouldCreateADocumentWhenUserIsAuthorized() {
+    // given
+    // Authorizations are enabled by default
+    final var authorizationConfiguration = new AuthorizationsConfiguration();
+    when(securityConfiguration.getAuthorizations()).thenReturn(authorizationConfiguration);
+    when(authorizationChecker.collectPermissionTypes(any(), any(), any()))
+        .thenReturn(Set.of(PermissionType.CREATE));
+
+    final var storeRecord = mock(DocumentStoreRecord.class);
+    final var storeInstance = mock(DocumentStore.class);
+    final var storeId = "in-memory-store";
+    when(storeRecord.instance()).thenReturn(storeInstance);
+    when(storeRecord.storeId()).thenReturn(storeId);
+    when(registry.getDefaultDocumentStore()).thenReturn(storeRecord);
+
+    final var content1 = "hello world";
+    final var file1 = createDocRequest(content1);
+    final var expectedResult1 = createDocumentReference(file1);
+    when(storeInstance.createDocument(
+            new DocumentCreationRequest(
+                file1.documentId(), file1.contentInputStream(), file1.metadata())))
+        .thenReturn(CompletableFuture.completedFuture(Either.right(expectedResult1)));
+
+    // when
+    final var response = services.createDocument(file1).join();
+
+    // then
+    assertThat(response)
+        .isNotNull()
+        .isEqualTo(
+            new DocumentReferenceResponse(
+                expectedResult1.documentId(),
+                storeId,
+                expectedResult1.contentHash(),
+                expectedResult1.metadata()));
+
+    verify(registry, times(1)).getDefaultDocumentStore();
+    verify(storeRecord, times(1)).instance();
   }
 
   @Test
@@ -103,6 +289,41 @@ public class DocumentServicesTest {
     verify(storeRecord, times(2)).instance();
   }
 
+  @Test
+  public void shouldGetDocumentWhenUserIsAuthorized() {
+    // given
+    // Authorizations are enabled by default
+    final var authorizationConfiguration = new AuthorizationsConfiguration();
+    when(securityConfiguration.getAuthorizations()).thenReturn(authorizationConfiguration);
+    when(authorizationChecker.collectPermissionTypes(any(), any(), any()))
+        .thenReturn(Set.of(PermissionType.READ));
+
+    final var storeRecord = mock(DocumentStoreRecord.class);
+    final var storeInstance = mock(DocumentStore.class);
+    final var storeId = "in-memory-store";
+    final var documentId = "test-document-id-1";
+    final var contentHash = "test-document-hash";
+    when(registry.getDocumentStore(storeId)).thenReturn(storeRecord);
+    when(storeRecord.instance()).thenReturn(storeInstance);
+    when(storeInstance.verifyContentHash(documentId, contentHash))
+        .thenReturn(CompletableFuture.completedFuture(Either.right(null)));
+
+    final var content = "hello world";
+    final var documentContent =
+        new DocumentContent(new ByteArrayInputStream(content.getBytes()), "text/plain");
+    when(storeInstance.getDocument(documentId))
+        .thenReturn(CompletableFuture.completedFuture(Either.right(documentContent)));
+
+    // when
+    final var actualDocumentContent =
+        services.getDocumentContent(documentId, storeId, contentHash).join();
+
+    // then
+    assertThat(actualDocumentContent).isNotNull();
+    assertThat(actualDocumentContent.contentType()).isEqualTo("text/plain");
+    assertThat(getDocumentContent(actualDocumentContent.content())).isEqualTo(content);
+  }
+
   private DocumentCreateRequest createDocRequest(final String content) {
     return new DocumentCreateRequest(
         null,
@@ -130,5 +351,11 @@ public class DocumentServicesTest {
             request.metadata().processDefinitionId(),
             request.metadata().processInstanceKey(),
             request.metadata().customProperties()));
+  }
+
+  private String getDocumentContent(final InputStream inputStream) {
+    return new BufferedReader(new InputStreamReader(inputStream))
+        .lines()
+        .collect(Collectors.joining("\n"));
   }
 }


### PR DESCRIPTION
Requires: https://github.com/camunda/camunda/pull/36509
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR introduces authorization checks to the Document services classes, the `document` resource type and related permissions are added in https://github.com/camunda/camunda/pull/36509, this PR is just the changes required to apply the permissions.

A couple of notes:
* I elected to apply the permissions in the service class itself because its a single and central place for the feature
* As the permissions are coming from our secondary storage and not the document store, and the permissions are not applied to the document store i.e. with filters, I decided against adding the permissions within the different store implementations
* I opted against adding in the REST controller incase the service methods are called from other service classes
* I have used the `CREATE` permission to also protect the link generation, this felt aligned with intention but is up for discussion

## Related issues

closes #36496 
