### PR TITLE
[Backport stable/8.6] ci: add release branch patterns to license scanning

### DIFF
--- a/.github/workflows/check-licenses.yml
+++ b/.github/workflows/check-licenses.yml
@@ -8,6 +8,8 @@ on:
     branches:
     - main
     - stable/*
+    - release/*
+    - release-*
     tags:
     - '*'
 


### PR DESCRIPTION
# Description
Backport of #36532 to `stable/8.6`.

relates to 