### PR TITLE
[Backport stable/optimize-8.6] ci: add release branch patterns to license scanning

### DIFF
--- a/.github/workflows/check-licenses.yml
+++ b/.github/workflows/check-licenses.yml
@@ -5,6 +5,8 @@ on:
     branches:
     - main
     - stable/*
+    - release/*
+    - release-*
     tags:
     - '*'
 


### PR DESCRIPTION
# Description
Backport of #36532 to `stable/optimize-8.6`.

relates to 