### PR TITLE
update tasklist component template with configured number of shards and replicas

### DIFF
--- a/tasklist/common/src/main/java/io/camunda/tasklist/property/ElasticsearchProperties.java
+++ b/tasklist/common/src/main/java/io/camunda/tasklist/property/ElasticsearchProperties.java
@@ -38,6 +38,7 @@ public class ElasticsearchProperties {
   private Integer connectTimeout;
 
   private boolean createSchema = true;
+  private boolean updateSchemaSettings = true;
 
   private String url;
   private String username;
@@ -118,6 +119,14 @@ public class ElasticsearchProperties {
 
   public void setCreateSchema(final boolean createSchema) {
     this.createSchema = createSchema;
+  }
+
+  public boolean isUpdateSchemaSettings() {
+    return updateSchemaSettings;
+  }
+
+  public void setUpdateSchemaSettings(final boolean updateSchemaSettings) {
+    this.updateSchemaSettings = updateSchemaSettings;
   }
 
   public String getPassword() {

--- a/tasklist/common/src/main/java/io/camunda/tasklist/property/OpenSearchProperties.java
+++ b/tasklist/common/src/main/java/io/camunda/tasklist/property/OpenSearchProperties.java
@@ -38,6 +38,7 @@ public class OpenSearchProperties {
   private Integer connectTimeout;
 
   private boolean createSchema = true;
+  private boolean updateSchemaSettings = true;
 
   private String url;
   private String username;
@@ -194,5 +195,13 @@ public class OpenSearchProperties {
 
   public void setHealthCheckEnabled(final boolean healthCheckEnabled) {
     this.healthCheckEnabled = healthCheckEnabled;
+  }
+
+  public boolean isUpdateSchemaSettings() {
+    return updateSchemaSettings;
+  }
+
+  public void setUpdateSchemaSettings(final boolean updateSchemaSettings) {
+    this.updateSchemaSettings = updateSchemaSettings;
   }
 }

--- a/tasklist/common/src/main/java/io/camunda/tasklist/property/TasklistElasticsearchProperties.java
+++ b/tasklist/common/src/main/java/io/camunda/tasklist/property/TasklistElasticsearchProperties.java
@@ -67,11 +67,19 @@ public class TasklistElasticsearchProperties extends ElasticsearchProperties {
     this.numberOfShardsPerIndex = numberOfShardsPerIndex;
   }
 
+  public int getNumberOfShards(final String indexName) {
+    return numberOfShardsPerIndex.getOrDefault(indexName, numberOfShards);
+  }
+
   public Map<String, Integer> getNumberOfReplicasPerIndices() {
     return numberOfReplicasPerIndices;
   }
 
   public void setNumberOfReplicasPerIndices(final Map<String, Integer> numberOfReplicasPerIndices) {
     this.numberOfReplicasPerIndices = numberOfReplicasPerIndices;
+  }
+
+  public int getNumberOfReplicas(final String indexName) {
+    return numberOfReplicasPerIndices.getOrDefault(indexName, numberOfReplicas);
   }
 }

--- a/tasklist/common/src/main/java/io/camunda/tasklist/property/TasklistOpenSearchProperties.java
+++ b/tasklist/common/src/main/java/io/camunda/tasklist/property/TasklistOpenSearchProperties.java
@@ -67,11 +67,19 @@ public class TasklistOpenSearchProperties extends OpenSearchProperties {
     this.numberOfShardsPerIndex = numberOfShardsPerIndex;
   }
 
+  public int getNumberOfShards(final String indexName) {
+    return numberOfShardsPerIndex.getOrDefault(indexName, numberOfShards);
+  }
+
   public Map<String, Integer> getNumberOfReplicasPerIndex() {
     return numberOfReplicasPerIndex;
   }
 
   public void setNumberOfReplicasPerIndex(final Map<String, Integer> numberOfReplicasPerIndex) {
     this.numberOfReplicasPerIndex = numberOfReplicasPerIndex;
+  }
+
+  public int getNumberOfReplicas(final String indexName) {
+    return numberOfReplicasPerIndex.getOrDefault(indexName, numberOfReplicas);
   }
 }

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/schema/IndexSchemaValidator.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/schema/IndexSchemaValidator.java
@@ -28,4 +28,6 @@ public interface IndexSchemaValidator {
   Set<String> olderVersionsForIndex(final IndexDescriptor indexDescriptor);
 
   Set<String> newerVersionsForIndex(final IndexDescriptor indexDescriptor);
+
+  boolean validateIndexConfiguration();
 }

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/schema/IndexSchemaValidator.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/schema/IndexSchemaValidator.java
@@ -26,8 +26,4 @@ public interface IndexSchemaValidator {
   Map<IndexDescriptor, Set<IndexMappingProperty>> validateIndexMappings() throws IOException;
 
   Set<String> olderVersionsForIndex(final IndexDescriptor indexDescriptor);
-
-  Set<String> newerVersionsForIndex(final IndexDescriptor indexDescriptor);
-
-  boolean validateIndexConfiguration();
 }

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/schema/SchemaStartup.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/schema/SchemaStartup.java
@@ -53,6 +53,10 @@ public class SchemaStartup {
           TasklistProperties.OPEN_SEARCH.equalsIgnoreCase(tasklistProperties.getDatabase())
               ? tasklistProperties.getOpenSearch().isCreateSchema()
               : tasklistProperties.getElasticsearch().isCreateSchema();
+      final boolean isUpdateSchemaSettings =
+          TasklistProperties.OPEN_SEARCH.equalsIgnoreCase(tasklistProperties.getDatabase())
+              ? tasklistProperties.getOpenSearch().isUpdateSchemaSettings()
+              : tasklistProperties.getElasticsearch().isUpdateSchemaSettings();
       if (createSchema && !schemaValidator.schemaExists()) {
         LOGGER.info("SchemaStartup: schema is empty or not complete. Indices will be created.");
         schemaManager.createSchema();
@@ -70,7 +74,7 @@ public class SchemaStartup {
               "SchemaStartup: schema won't be updated as schema creation is disabled in configuration.");
         }
       }
-      if (createSchema) {
+      if (createSchema && isUpdateSchemaSettings) {
         schemaManager.updateIndexSettings();
       }
       LOGGER.info("SchemaStartup finished.");

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/schema/SchemaStartup.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/schema/SchemaStartup.java
@@ -53,7 +53,8 @@ public class SchemaStartup {
           TasklistProperties.OPEN_SEARCH.equalsIgnoreCase(tasklistProperties.getDatabase())
               ? tasklistProperties.getOpenSearch().isCreateSchema()
               : tasklistProperties.getElasticsearch().isCreateSchema();
-      if (createSchema && !schemaValidator.schemaExists()) {
+      if (createSchema
+          && !(schemaValidator.schemaExists() && schemaValidator.validateIndexConfiguration())) {
         LOGGER.info("SchemaStartup: schema is empty or not complete. Indices will be created.");
         schemaManager.createSchema();
         LOGGER.info("SchemaStartup: update index mappings.");

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/schema/SchemaStartup.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/schema/SchemaStartup.java
@@ -53,8 +53,7 @@ public class SchemaStartup {
           TasklistProperties.OPEN_SEARCH.equalsIgnoreCase(tasklistProperties.getDatabase())
               ? tasklistProperties.getOpenSearch().isCreateSchema()
               : tasklistProperties.getElasticsearch().isCreateSchema();
-      if (createSchema
-          && !(schemaValidator.schemaExists() && schemaValidator.validateIndexConfiguration())) {
+      if (createSchema && !schemaValidator.schemaExists()) {
         LOGGER.info("SchemaStartup: schema is empty or not complete. Indices will be created.");
         schemaManager.createSchema();
         LOGGER.info("SchemaStartup: update index mappings.");
@@ -70,6 +69,9 @@ public class SchemaStartup {
           LOGGER.info(
               "SchemaStartup: schema won't be updated as schema creation is disabled in configuration.");
         }
+      }
+      if (createSchema) {
+        schemaManager.updateIndexSettings();
       }
       LOGGER.info("SchemaStartup finished.");
     } catch (final Exception ex) {

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/schema/manager/ElasticsearchSchemaManager.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/schema/manager/ElasticsearchSchemaManager.java
@@ -189,7 +189,7 @@ public class ElasticsearchSchemaManager implements SchemaManager {
     final var actualReplicas = settings.get(NUMBERS_OF_REPLICA, NO_REPLICA);
 
     if (!expectedShards.equals(actualShards) || !expectedReplicas.equals(actualReplicas)) {
-      LOGGER.debug(
+      LOGGER.info(
           "Updating component template settings to shards={}, replicas={}",
           expectedShards,
           expectedReplicas);
@@ -212,7 +212,7 @@ public class ElasticsearchSchemaManager implements SchemaManager {
               if (!settings.values().stream()
                   .map(s -> s.get(NUMBERS_OF_REPLICA, NO_REPLICA))
                   .allMatch(expectedReplicas::equals)) {
-                LOGGER.debug(
+                LOGGER.info(
                     "Updating number of replicas of {} to {}",
                     indexDescriptor.getAlias(),
                     expectedReplicas);

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/schema/manager/OpenSearchSchemaManager.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/schema/manager/OpenSearchSchemaManager.java
@@ -268,7 +268,7 @@ public class OpenSearchSchemaManager implements SchemaManager {
     final var actualReplicas = ofNullable(settings.numberOfReplicas()).orElse(NO_REPLICA);
 
     if (!expectedShards.equals(actualShards) || !expectedReplicas.equals(actualReplicas)) {
-      LOGGER.debug(
+      LOGGER.info(
           "Updating component template settings to shards={}, replicas={}",
           expectedShards,
           expectedReplicas);
@@ -290,7 +290,7 @@ public class OpenSearchSchemaManager implements SchemaManager {
               if (!settings.values().stream()
                   .map(s -> ofNullable(s.settings().numberOfReplicas()).orElse(NO_REPLICA))
                   .allMatch(expectedReplicas::equals)) {
-                LOGGER.debug(
+                LOGGER.info(
                     "Updating number of replicas of {} to {}",
                     indexDescriptor.getAlias(),
                     expectedReplicas);

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/schema/manager/SchemaManager.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/schema/manager/SchemaManager.java
@@ -16,7 +16,7 @@ import java.util.Set;
 
 public interface SchemaManager {
 
-  public void createSchema();
+  void createSchema();
 
   IndexMapping getExpectedIndexFields(IndexDescriptor indexDescriptor);
 
@@ -27,4 +27,6 @@ public interface SchemaManager {
   void updateSchema(Map<IndexDescriptor, Set<IndexMappingProperty>> newFields);
 
   void createIndex(IndexDescriptor testIndex);
+
+  String getComponentTemplateName();
 }

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/schema/manager/SchemaManager.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/schema/manager/SchemaManager.java
@@ -28,5 +28,5 @@ public interface SchemaManager {
 
   void createIndex(IndexDescriptor testIndex);
 
-  String getComponentTemplateName();
+  void updateIndexSettings();
 }

--- a/tasklist/els-schema/src/test/java/io/camunda/tasklist/schema/manager/OpenSearchSchemaManagerTest.java
+++ b/tasklist/els-schema/src/test/java/io/camunda/tasklist/schema/manager/OpenSearchSchemaManagerTest.java
@@ -9,7 +9,6 @@ package io.camunda.tasklist.schema.manager;
 
 import static io.camunda.tasklist.property.TasklistProperties.OPEN_SEARCH;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -62,8 +61,10 @@ class OpenSearchSchemaManagerTest {
   @Test
   void createTemplateShouldCreateIndexWithSettingsAndAliasAndMappings() throws IOException {
     // given
-    when(tasklistProperties.getOpenSearch().getNumberOfShards()).thenReturn(3);
-    when(tasklistProperties.getOpenSearch().getNumberOfReplicas()).thenReturn(2);
+    when(tasklistProperties.getOpenSearch().getNumberOfShards(taskTemplate.getIndexName()))
+        .thenReturn(3);
+    when(tasklistProperties.getOpenSearch().getNumberOfReplicas(taskTemplate.getIndexName()))
+        .thenReturn(2);
     when(tasklistProperties.getOpenSearch().getIndexPrefix()).thenReturn("prefix");
 
     // when

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/es/ElasticSearchSchemaManagementIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/es/ElasticSearchSchemaManagementIT.java
@@ -13,13 +13,16 @@ import static io.camunda.tasklist.util.apps.schema.TestIndexDescriptorConfigurat
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import static org.springframework.test.annotation.DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.tasklist.entities.TaskEntity;
 import io.camunda.tasklist.property.TasklistProperties;
 import io.camunda.tasklist.qa.util.TestUtil;
 import io.camunda.tasklist.schema.IndexMapping;
 import io.camunda.tasklist.schema.IndexMapping.IndexMappingProperty;
 import io.camunda.tasklist.schema.indices.IndexDescriptor;
-import io.camunda.tasklist.schema.manager.SchemaManager;
+import io.camunda.tasklist.schema.manager.ElasticsearchSchemaManager;
 import io.camunda.tasklist.schema.templates.TemplateDescriptor;
 import io.camunda.tasklist.util.ElasticsearchHelper;
 import io.camunda.tasklist.util.ElasticsearchTestExtension;
@@ -36,8 +39,13 @@ import java.util.Map;
 import java.util.Set;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
 
 @SpringBootTest(
     classes = {
@@ -53,7 +61,11 @@ import org.springframework.boot.test.context.SpringBootTest;
       "camunda.webapps.default-app = tasklist",
     },
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@DirtiesContext(classMode = AFTER_EACH_TEST_METHOD)
 public class ElasticSearchSchemaManagementIT extends TasklistZeebeIntegrationTest {
+
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(ElasticSearchSchemaManagementIT.class);
 
   @Autowired private TasklistProperties tasklistProperties;
   @Autowired private List<IndexDescriptor> indexDescriptors;
@@ -61,13 +73,19 @@ public class ElasticSearchSchemaManagementIT extends TasklistZeebeIntegrationTes
   @Autowired private RetryElasticsearchClient retryElasticsearchClient;
   @Autowired private IndexSchemaValidatorElasticSearch indexSchemaValidator;
   @Autowired private ElasticsearchHelper noSqlHelper;
-  @Autowired private SchemaManager schemaManager;
+  @Autowired private ElasticsearchSchemaManager schemaManager;
   @Autowired private TestIndexDescriptor testIndexDescriptor;
   @Autowired private TestTemplateDescriptor testTemplateDescriptor;
 
   @BeforeAll
   public static void beforeClass() {
     assumeTrue(TestUtil.isElasticSearch());
+  }
+
+  @DynamicPropertySource
+  static void setProperties(final DynamicPropertyRegistry registry) {
+    // Disable schema creation for the test, as we want to manage it manually
+    registry.add("camunda.tasklist.elasticsearch.createSchema", () -> false);
   }
 
   @Test
@@ -92,9 +110,7 @@ public class ElasticSearchSchemaManagementIT extends TasklistZeebeIntegrationTes
 
     tasklistProperties.getElasticsearch().setNumberOfReplicas(modifiedNumberOfReplicas);
 
-    assertThat(indexSchemaValidator.validateIndexConfiguration()).isFalse();
-
-    schemaManager.createSchema();
+    schemaManager.updateIndexSettings();
 
     for (final IndexDescriptor indexDescriptor : indexDescriptors) {
       assertThat(
@@ -133,6 +149,7 @@ public class ElasticSearchSchemaManagementIT extends TasklistZeebeIntegrationTes
   @Test
   public void shouldAddFieldToIndex() throws Exception {
     // given
+    schemaManager.createSchema();
     testIndexDescriptor.setSchemaClasspathFilename(getSchemaFilePath("tasklist-test-after.json"));
     final Map<IndexDescriptor, Set<IndexMappingProperty>> indexDiff =
         indexSchemaValidator.validateIndexMappings();
@@ -167,6 +184,7 @@ public class ElasticSearchSchemaManagementIT extends TasklistZeebeIntegrationTes
   @Test
   public void shouldAddFieldToIndexTemplate() throws Exception {
     // given
+    schemaManager.createSchema();
     testTemplateDescriptor.setSchemaClasspathFilename(
         TestTemplateDescriptorConfiguration.getSchemaFilePath("tasklist-test-template-after.json"));
     final Map<IndexDescriptor, Set<IndexMappingProperty>> indexDiff =
@@ -230,28 +248,24 @@ public class ElasticSearchSchemaManagementIT extends TasklistZeebeIntegrationTes
     // Verify initial component template replica settings
     final String componentTemplateName = schemaManager.getComponentTemplateName();
     final var initialSettings =
-        retryElasticsearchClient.getComponentTemplateProperties(
-            componentTemplateName, NUMBERS_OF_REPLICA);
+        retryElasticsearchClient.getComponentTemplateSettings(componentTemplateName);
     assertThat(initialSettings.get(NUMBERS_OF_REPLICA))
         .isEqualTo(String.valueOf(initialNumberOfReplicas));
 
     tasklistProperties.getElasticsearch().setNumberOfReplicas(modifiedNumberOfReplicas);
 
-    assertThat(indexSchemaValidator.validateIndexConfiguration()).isFalse();
+    schemaManager.updateIndexSettings();
 
-    schemaManager.createSchema();
-
-    // Verify modified component template replica settings
-    final var modifiedSettings =
-        retryElasticsearchClient.getComponentTemplateProperties(
-            componentTemplateName, NUMBERS_OF_REPLICA);
-    assertThat(modifiedSettings.get(NUMBERS_OF_REPLICA))
+    // Verify updated component template replica settings
+    final var updatedSettings =
+        retryElasticsearchClient.getComponentTemplateSettings(componentTemplateName);
+    assertThat(updatedSettings.get(NUMBERS_OF_REPLICA))
         .isEqualTo(String.valueOf(modifiedNumberOfReplicas));
   }
 
   @Test
   public void shouldChangeNumberOfShardsForComponentTemplate() {
-    final int initialNumberOfShards = 2;
+    final int initialNumberOfShards = 1;
     final int modifiedNumberOfShards = 3;
 
     tasklistProperties.getElasticsearch().setNumberOfShards(initialNumberOfShards);
@@ -260,22 +274,87 @@ public class ElasticSearchSchemaManagementIT extends TasklistZeebeIntegrationTes
     // Verify initial component template shard settings
     final String componentTemplateName = schemaManager.getComponentTemplateName();
     final var initialSettings =
-        retryElasticsearchClient.getComponentTemplateProperties(
-            componentTemplateName, NUMBERS_OF_SHARDS);
+        retryElasticsearchClient.getComponentTemplateSettings(componentTemplateName);
     assertThat(initialSettings.get(NUMBERS_OF_SHARDS))
         .isEqualTo(String.valueOf(initialNumberOfShards));
 
     tasklistProperties.getElasticsearch().setNumberOfShards(modifiedNumberOfShards);
 
-    assertThat(indexSchemaValidator.validateIndexConfiguration()).isFalse();
+    schemaManager.updateIndexSettings();
 
+    // Verify updated component template shard settings
+    final var updatedSettings =
+        retryElasticsearchClient.getComponentTemplateSettings(componentTemplateName);
+    assertThat(updatedSettings.get(NUMBERS_OF_SHARDS))
+        .isEqualTo(String.valueOf(modifiedNumberOfShards));
+  }
+
+  @Test
+  public void shouldUpdateReplicasForAllTaskIndicesCreatedFromTemplate() throws IOException {
+    final Integer initialNumberOfReplicas = 0;
+    final Integer modifiedNumberOfReplicas = 2;
+
+    tasklistProperties.getElasticsearch().setNumberOfReplicas(initialNumberOfReplicas);
     schemaManager.createSchema();
 
-    // Verify modified component template shard settings
-    final Map<String, String> modifiedSettings =
-        retryElasticsearchClient.getComponentTemplateProperties(
-            componentTemplateName, NUMBERS_OF_SHARDS);
-    assertThat(modifiedSettings.get(NUMBERS_OF_SHARDS))
-        .isEqualTo(String.valueOf(modifiedNumberOfShards));
+    // Find the TaskTemplate from the template descriptors
+    final TemplateDescriptor taskTemplate =
+        templateDescriptors.stream()
+            .filter(template -> "task".equals(template.getIndexName()))
+            .findFirst()
+            .orElseThrow(() -> new IllegalStateException("TaskTemplate not found"));
+
+    // Create multiple task indices from the template by indexing TaskEntity objects
+    final String taskIndex1 = taskTemplate.getFullQualifiedName() + "-2025-01-01";
+    final String taskIndex2 = taskTemplate.getFullQualifiedName() + "-2025-01-02";
+    final String taskIndex3 = taskTemplate.getFullQualifiedName() + "-2025-01-03";
+    final TaskEntity task1 = createSampleTaskEntity(1L);
+    final TaskEntity task2 = createSampleTaskEntity(2L);
+    final TaskEntity task3 = createSampleTaskEntity(3L);
+
+    final ObjectMapper mapper = new ObjectMapper();
+
+    retryElasticsearchClient.createOrUpdateDocument(
+        taskIndex1, task1.getId(), mapper.convertValue(task1, Map.class));
+    retryElasticsearchClient.createOrUpdateDocument(
+        taskIndex2, task2.getId(), mapper.convertValue(task2, Map.class));
+    retryElasticsearchClient.createOrUpdateDocument(
+        taskIndex3, task3.getId(), mapper.convertValue(task3, Map.class));
+
+    // Verify all task indices have the initial replica settings
+    validateTaskIndicesReplicaSettings(taskTemplate.getAlias(), initialNumberOfReplicas);
+
+    // Update replica settings
+    tasklistProperties.getElasticsearch().setNumberOfReplicas(modifiedNumberOfReplicas);
+    schemaManager.updateIndexSettings();
+
+    // Verify all task indices (created from template) have updated replica settings
+    validateTaskIndicesReplicaSettings(taskTemplate.getAlias(), modifiedNumberOfReplicas);
+  }
+
+  private TaskEntity createSampleTaskEntity(final long taskKey) {
+    return new TaskEntity().setId(String.valueOf(taskKey)).setKey(taskKey);
+  }
+
+  private void validateTaskIndicesReplicaSettings(
+      final String taskAlias, final Integer expectedReplicas) throws IOException {
+    final Set<String> taskIndices = retryElasticsearchClient.getIndexNames(taskAlias);
+    assertThat(taskIndices).isNotEmpty();
+
+    for (final String indexName : taskIndices) {
+      assertThat(
+              retryElasticsearchClient
+                  .getIndexSettingsFor(indexName, NUMBERS_OF_REPLICA)
+                  .get(NUMBERS_OF_REPLICA))
+          .as("Task index %s should have %d replicas", indexName, expectedReplicas)
+          .isEqualTo(String.valueOf(expectedReplicas));
+    }
+
+    LOGGER.info(
+        "Validated replica settings for {} task indices under alias {}: expected={}, indices={}",
+        taskIndices.size(),
+        taskAlias,
+        expectedReplicas,
+        taskIndices);
   }
 }

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/os/OpenSearchSchemaManagementIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/os/OpenSearchSchemaManagementIT.java
@@ -12,6 +12,8 @@ import static org.assertj.core.api.Assertions.entry;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.opensearch.client.opensearch._types.mapping.Property.Kind.Keyword;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.tasklist.entities.TaskEntity;
 import io.camunda.tasklist.property.TasklistProperties;
 import io.camunda.tasklist.qa.util.TestUtil;
 import io.camunda.tasklist.schema.IndexMapping;
@@ -19,6 +21,7 @@ import io.camunda.tasklist.schema.IndexMapping.IndexMappingProperty;
 import io.camunda.tasklist.schema.IndexSchemaValidator;
 import io.camunda.tasklist.schema.indices.IndexDescriptor;
 import io.camunda.tasklist.schema.manager.OpenSearchSchemaManager;
+import io.camunda.tasklist.schema.templates.TemplateDescriptor;
 import io.camunda.tasklist.util.NoSqlHelper;
 import io.camunda.tasklist.util.OpenSearchTestExtension;
 import io.camunda.tasklist.util.TasklistZeebeIntegrationTest;
@@ -36,8 +39,12 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.opensearch.client.opensearch._types.mapping.Property;
 import org.opensearch.client.opensearch._types.mapping.TypeMapping;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
 
 @SpringBootTest(
     classes = {
@@ -55,8 +62,10 @@ import org.springframework.boot.test.context.SpringBootTest;
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 public class OpenSearchSchemaManagementIT extends TasklistZeebeIntegrationTest {
 
+  private static final Logger LOGGER = LoggerFactory.getLogger(OpenSearchSchemaManagementIT.class);
   @Autowired private TasklistProperties tasklistProperties;
   @Autowired private List<IndexDescriptor> indexDescriptors;
+  @Autowired private List<TemplateDescriptor> templateDescriptors;
   @Autowired private RetryOpenSearchClient retryOpenSearchClient;
   @Autowired private IndexSchemaValidator indexSchemaValidator;
   @Autowired private NoSqlHelper noSqlHelper;
@@ -67,6 +76,12 @@ public class OpenSearchSchemaManagementIT extends TasklistZeebeIntegrationTest {
   @BeforeAll
   public static void beforeClass() {
     assumeTrue(TestUtil.isOpenSearch());
+  }
+
+  @DynamicPropertySource
+  static void setProperties(final DynamicPropertyRegistry registry) {
+    // Disable schema creation for the test, as we want to manage it manually
+    registry.add("camunda.tasklist.opensearch.createSchema", () -> false);
   }
 
   @Test
@@ -91,9 +106,7 @@ public class OpenSearchSchemaManagementIT extends TasklistZeebeIntegrationTest {
 
     tasklistProperties.getOpenSearch().setNumberOfReplicas(modifiedNumberOfReplicas);
 
-    assertThat(indexSchemaValidator.validateIndexConfiguration()).isFalse();
-
-    schemaManager.createSchema();
+    schemaManager.updateIndexSettings();
 
     for (final IndexDescriptor indexDescriptor : indexDescriptors) {
       assertThat(
@@ -132,6 +145,7 @@ public class OpenSearchSchemaManagementIT extends TasklistZeebeIntegrationTest {
   @Test
   public void shouldAddFieldToIndex() throws Exception {
     // given
+    schemaManager.createSchema();
     testIndexDescriptor.setSchemaClasspathFilename(
         TestIndexDescriptorConfiguration.getSchemaFilePath("tasklist-test-after.json"));
     final Map<IndexDescriptor, Set<IndexMappingProperty>> indexDiff =
@@ -167,6 +181,7 @@ public class OpenSearchSchemaManagementIT extends TasklistZeebeIntegrationTest {
   @Test
   public void shouldAddFieldToIndexTemplate() throws Exception {
     // given
+    schemaManager.createSchema();
     testTemplateDescriptor.setSchemaClasspathFilename(
         TestTemplateDescriptorConfiguration.getSchemaFilePath("tasklist-test-template-after.json"));
     final Map<IndexDescriptor, Set<IndexMappingProperty>> indexDiff =
@@ -223,26 +238,24 @@ public class OpenSearchSchemaManagementIT extends TasklistZeebeIntegrationTest {
     // Verify initial component template replica settings
     final String componentTemplateName = schemaManager.getComponentTemplateName();
     final var initialSettings =
-        retryOpenSearchClient.getComponentTemplateProperties(componentTemplateName);
+        retryOpenSearchClient.getComponentTemplateSettings(componentTemplateName);
     assertThat(initialSettings.numberOfReplicas())
         .isEqualTo(String.valueOf(initialNumberOfReplicas));
 
     tasklistProperties.getOpenSearch().setNumberOfReplicas(modifiedNumberOfReplicas);
 
-    assertThat(indexSchemaValidator.validateIndexConfiguration()).isFalse();
+    schemaManager.updateIndexSettings();
 
-    schemaManager.createSchema();
-
-    // Verify modified component template replica settings
-    final var modifiedSettings =
-        retryOpenSearchClient.getComponentTemplateProperties(componentTemplateName);
-    assertThat(modifiedSettings.numberOfReplicas())
+    // Verify updated component template replica settings
+    final var updatedSettings =
+        retryOpenSearchClient.getComponentTemplateSettings(componentTemplateName);
+    assertThat(updatedSettings.numberOfReplicas())
         .isEqualTo(String.valueOf(modifiedNumberOfReplicas));
   }
 
   @Test
   public void shouldChangeNumberOfShardsForComponentTemplate() {
-    final int initialNumberOfShards = 2;
+    final int initialNumberOfShards = 1;
     final int modifiedNumberOfShards = 3;
 
     tasklistProperties.getOpenSearch().setNumberOfShards(initialNumberOfShards);
@@ -251,18 +264,82 @@ public class OpenSearchSchemaManagementIT extends TasklistZeebeIntegrationTest {
     // Verify initial component template shard settings
     final String componentTemplateName = schemaManager.getComponentTemplateName();
     final var initialSettings =
-        retryOpenSearchClient.getComponentTemplateProperties(componentTemplateName);
+        retryOpenSearchClient.getComponentTemplateSettings(componentTemplateName);
     assertThat(initialSettings.numberOfShards()).isEqualTo(String.valueOf(initialNumberOfShards));
 
     tasklistProperties.getOpenSearch().setNumberOfShards(modifiedNumberOfShards);
 
-    assertThat(indexSchemaValidator.validateIndexConfiguration()).isFalse();
+    schemaManager.updateIndexSettings();
 
+    // Verify updated component template shard settings
+    final var updatedSettings =
+        retryOpenSearchClient.getComponentTemplateSettings(componentTemplateName);
+    assertThat(updatedSettings.numberOfShards()).isEqualTo(String.valueOf(modifiedNumberOfShards));
+  }
+
+  @Test
+  public void shouldUpdateReplicasForAllTaskIndicesCreatedFromTemplate() throws IOException {
+    final int initialNumberOfReplicas = 0;
+    final int modifiedNumberOfReplicas = 2;
+
+    tasklistProperties.getOpenSearch().setNumberOfReplicas(initialNumberOfReplicas);
     schemaManager.createSchema();
 
-    // Verify modified component template shard settings
-    final var modifiedSettings =
-        retryOpenSearchClient.getComponentTemplateProperties(componentTemplateName);
-    assertThat(modifiedSettings.numberOfShards()).isEqualTo(String.valueOf(modifiedNumberOfShards));
+    // Find the TaskTemplate from the template descriptors
+    final TemplateDescriptor taskTemplate =
+        templateDescriptors.stream()
+            .filter(template -> "task".equals(template.getIndexName()))
+            .findFirst()
+            .orElseThrow(() -> new IllegalStateException("TaskTemplate not found"));
+
+    // Create multiple task indices from the template by indexing TaskEntity objects
+    final String taskIndex1 = taskTemplate.getFullQualifiedName() + "-2025-01-01";
+    final String taskIndex2 = taskTemplate.getFullQualifiedName() + "-2025-01-02";
+    final String taskIndex3 = taskTemplate.getFullQualifiedName() + "-2025-01-03";
+    final TaskEntity task1 = createSampleTaskEntity(1L);
+    final TaskEntity task2 = createSampleTaskEntity(2L);
+    final TaskEntity task3 = createSampleTaskEntity(3L);
+
+    final ObjectMapper mapper = new ObjectMapper();
+
+    retryOpenSearchClient.createOrUpdateDocument(
+        taskIndex1, task1.getId(), mapper.convertValue(task1, Map.class));
+    retryOpenSearchClient.createOrUpdateDocument(
+        taskIndex2, task2.getId(), mapper.convertValue(task2, Map.class));
+    retryOpenSearchClient.createOrUpdateDocument(
+        taskIndex3, task3.getId(), mapper.convertValue(task3, Map.class));
+
+    // Verify all task indices have the initial replica settings
+    validateTaskIndicesReplicaSettings(taskTemplate.getAlias(), initialNumberOfReplicas);
+
+    // Update replica settings
+    tasklistProperties.getOpenSearch().setNumberOfReplicas(modifiedNumberOfReplicas);
+    schemaManager.updateIndexSettings();
+
+    // Verify all task indices (created from template) have updated replica settings
+    validateTaskIndicesReplicaSettings(taskTemplate.getAlias(), modifiedNumberOfReplicas);
+  }
+
+  private TaskEntity createSampleTaskEntity(final long taskKey) {
+    return new TaskEntity().setId(String.valueOf(taskKey)).setKey(taskKey);
+  }
+
+  private void validateTaskIndicesReplicaSettings(
+      final String taskAlias, final Integer expectedReplicas) throws IOException {
+    final Set<String> taskIndices = retryOpenSearchClient.getIndexNames(taskAlias);
+    assertThat(taskIndices).isNotEmpty();
+
+    for (final String indexName : taskIndices) {
+      assertThat(retryOpenSearchClient.getIndexSettingsFor(indexName).numberOfReplicas())
+          .as("Task index %s should have %d replicas", indexName, expectedReplicas)
+          .isEqualTo(String.valueOf(expectedReplicas));
+    }
+
+    LOGGER.info(
+        "Validated replica settings for {} task indices under alias {}: expected={}, indices={}",
+        taskIndices.size(),
+        taskAlias,
+        expectedReplicas,
+        taskIndices);
   }
 }

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/os/ReindexOpenSearchIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/os/ReindexOpenSearchIT.java
@@ -31,10 +31,8 @@ public class ReindexOpenSearchIT extends TasklistIntegrationTest {
   private static final String SOURCE_INDEX_124 = "index-1.2.4";
 
   private static final String INDEX_NAME_123 = SOURCE_INDEX_123 + "_";
-
-  private static final String INDEX_NAME_124 = SOURCE_INDEX_124 + "_";
-
   private static final String INDEX_NAME_ARCHIVER_123 = INDEX_NAME_123 + "2021-05-23";
+  private static final String INDEX_NAME_124 = SOURCE_INDEX_124 + "_";
   private static final String INDEX_NAME_ARCHIVER_124 = INDEX_NAME_124 + "2021-05-23";
 
   @Autowired private RetryOpenSearchClient retryOpenSearchClient;
@@ -56,7 +54,7 @@ public class ReindexOpenSearchIT extends TasklistIntegrationTest {
     retryOpenSearchClient.deleteIndicesFor(idxName("index-*"));
   }
 
-  private String idxName(String name) {
+  private String idxName(final String name) {
     return indexPrefix + "-" + name;
   }
 
@@ -102,10 +100,7 @@ public class ReindexOpenSearchIT extends TasklistIntegrationTest {
             .build();
     retryOpenSearchClient.setIndexSettingsFor(settings, idxName(INDEX_NAME_123));
     final IndexSettings reindexSettings =
-        retryOpenSearchClient.getIndexSettingsFor(
-            idxName("index-1.2.3_"),
-            RetryOpenSearchClient.NUMBERS_OF_REPLICA,
-            RetryOpenSearchClient.REFRESH_INTERVAL);
+        retryOpenSearchClient.getIndexSettingsFor(idxName("index-1.2.3_"));
     assertThat(reindexSettings.numberOfReplicas()).isEqualTo(RetryOpenSearchClient.NO_REPLICA);
     assertThat(reindexSettings.refreshInterval().time())
         .isEqualTo(RetryOpenSearchClient.NO_REFRESH);
@@ -116,7 +111,7 @@ public class ReindexOpenSearchIT extends TasklistIntegrationTest {
         .isEqualTo("2");
   }
 
-  private void createIndex(final String indexName, List<Map<String, String>> documents) {
+  private void createIndex(final String indexName, final List<Map<String, String>> documents) {
 
     retryOpenSearchClient.createIndex(new CreateIndexRequest.Builder().index(indexName).build());
 


### PR DESCRIPTION
This pull request refactors and simplifies the index settings management in Tasklist. 
The main focus is was extracting the index settings update logic out of the `createSchema` that handles creating missing indices, templates and aliases
Now it is part of `updateIndexSettings` that makes sure that the number of replicas (for indices and component template) and shards (only in component template) are dynamically updated with the values from the configuration

If fixes 2 things:
- update the number of replicas even for dated indices (using the alias)
- update the number of shards in the component template, so that it is applied to the new indices created from the template

## Description

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #31238 
relates to https://github.com/camunda/camunda/issues/32872
