### PR TITLE
Process identity setup in separate batches

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/IdentitySetupInitializeProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/IdentitySetupInitializeProcessor.java
@@ -60,6 +60,11 @@ public final class IdentitySetupInitializeProcessor
         initializationKey, IdentitySetupIntent.INITIALIZED, setupRecord);
   }
 
+  @Override
+  public boolean shouldProcessResultsInSeparateBatches() {
+    return true;
+  }
+
   private void createDefaultTenant(final long key, final TenantRecord defaultTenant) {
     commandWriter.appendFollowUpCommand(key, TenantIntent.CREATE, defaultTenant);
   }

--- a/zeebe/qa/integration-tests/pom.xml
+++ b/zeebe/qa/integration-tests/pom.xml
@@ -587,6 +587,18 @@
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/zeebe/qa/integration-tests/pom.xml
+++ b/zeebe/qa/integration-tests/pom.xml
@@ -589,14 +589,14 @@
     </dependency>
 
     <dependency>
-      <groupId>ch.qos.logback</groupId>
-      <artifactId>logback-core</artifactId>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
       <scope>test</scope>
     </dependency>
 
     <dependency>
-      <groupId>ch.qos.logback</groupId>
-      <artifactId>logback-classic</artifactId>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core-test</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/BrokerAdminServiceEndpointTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/BrokerAdminServiceEndpointTest.java
@@ -170,11 +170,19 @@ public class BrokerAdminServiceEndpointTest {
     final var snapshotChecksumPattern = Pattern.compile("\\d+-\\d+-\\d+-\\d+-\\d+-\\w+");
     final var snapshotChecksumReplacement = "2-1-2-9223372036854775807-0-a06ff57d";
 
+    // processed positions are also not deterministic
+    final var processedPositionPattern = Pattern.compile("\"processedPosition\": *\\d+");
+    final var processedPositionInSnapshotPattern =
+        Pattern.compile("\"processedPositionInSnapshot\": *\\d+");
+
     return json
         // map timestamp into the same value
         .replaceAll(timestampPattern.pattern(), timestampReplacement)
         // map snapshot checksum into a constant value
         .replaceAll(snapshotChecksumPattern.pattern(), snapshotChecksumReplacement)
+        .replaceAll(processedPositionPattern.pattern(), "\"processedPosition\": 2")
+        .replaceAll(
+            processedPositionInSnapshotPattern.pattern(), "\"processedPositionInSnapshot\": 2")
         // remove all whitespaces from the pretty printing
         .replaceAll("\\s", "");
   }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/startup/IdentitySetupOnStartupTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/startup/IdentitySetupOnStartupTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.startup;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import io.camunda.zeebe.it.clustering.ClusteringRuleExtension;
+import io.camunda.zeebe.logstreams.impl.Loggers;
+import io.camunda.zeebe.protocol.record.intent.IdentitySetupIntent;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import java.util.concurrent.TimeUnit;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.springframework.util.unit.DataSize;
+
+final class IdentitySetupOnStartupTest {
+
+  private static final LogCapturer LOG_CAPTURER = new LogCapturer();
+
+  /**
+   * Cluster with 3 partitions (to induce command distribution), and reduced sizes for max message
+   * size and log segment size, should still be able to setup identity.
+   */
+  @RegisterExtension
+  private final ClusteringRuleExtension clusteringRule =
+      new ClusteringRuleExtension(
+          3,
+          3,
+          3,
+          cfg -> {
+            cfg.getExperimental().getFeatures().setEnableIdentitySetup(true);
+            cfg.getNetwork().setMaxMessageSize(DataSize.ofKilobytes(32));
+            cfg.getProcessing().setMaxCommandsInBatch(100);
+          });
+
+  @BeforeAll
+  static void setup() {
+    final Logger logger = (Logger) Loggers.PROCESSOR_LOGGER;
+    LOG_CAPTURER.stop();
+    LOG_CAPTURER.list.clear();
+    LOG_CAPTURER.setContext(logger.getLoggerContext());
+    LOG_CAPTURER.start();
+    logger.addAppender(LOG_CAPTURER);
+  }
+
+  @Test
+  @Timeout(unit = TimeUnit.SECONDS, value = 30)
+  void shouldInitializeIdentitySetup() {
+    Assertions.assertThat(
+            RecordingExporter.identitySetupRecords(IdentitySetupIntent.INITIALIZED).getFirst())
+        .describedAs("Expect that identity setup was completed regardless of small max msg size")
+        .isNotNull();
+
+    assertThat(
+            LOG_CAPTURER.contains(
+                "Expected to process commands in a batch, but exceeded the resulting batch size after processing",
+                Level.WARN))
+        .describedAs("Expect that the command batch size is not exceeded by identity setup")
+        .isFalse();
+  }
+
+  static class LogCapturer extends ListAppender<ILoggingEvent> {
+
+    public boolean contains(final String string, final Level level) {
+      return list.stream()
+          .anyMatch(event -> event.toString().contains(string) && event.getLevel().equals(level));
+    }
+  }
+}

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
@@ -94,8 +94,13 @@ import org.slf4j.Logger;
  */
 public final class ProcessingStateMachine {
 
+  /**
+   * Warn message when the batch processing exceeded the maximum message size. If this message is
+   * ever changed, please also update the string in IdentitySetupOnStartupTest as it depends on it.
+   */
   public static final String WARN_MESSAGE_BATCH_PROCESSING_RETRY =
       "Expected to process commands in a batch, but exceeded the resulting batch size after processing {} commands (maxCommandsInBatch: {}).";
+
   private static final Logger LOG = Loggers.PROCESSOR_LOGGER;
   private static final String ERROR_MESSAGE_WRITE_RECORD_ABORTED =
       "Expected to write one or more follow-up records for record '{} {}' without errors, but exception was thrown.";


### PR DESCRIPTION


## Description

<!-- Describe the goal and purpose of this PR. -->

By enabling this flag, the follow-up commands of the identity setup INITIALIZE command are processed in separate command batches.

This reduces the number of bytes written by the system at startup in a single step, and allows users to set MAX_MESSAGE_SIZE to low settings like 32 KB.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

discussion https://camunda.slack.com/archives/C06UYJMMETZ/p1754578542574069?thread_ts=1754560790.580269&cid=C06UYJMMETZ
