### PR TITLE
fix: remove the update permission on user create to prevent circumventing password changes

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserCreateProcessor.java
@@ -122,7 +122,7 @@ public class UserCreateProcessor implements DistributedTypedRecordProcessor<User
             .setResourceType(AuthorizationResourceType.USER)
             .setResourceMatcher(AuthorizationResourceMatcher.ID)
             .setResourceId(username)
-            .setPermissionTypes(Set.of(PermissionType.READ, PermissionType.UPDATE));
+            .setPermissionTypes(Set.of(PermissionType.READ));
 
     commandWriter.appendFollowUpCommand(key, AuthorizationIntent.CREATE, authorizationRecord);
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/user/CreateUserTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/user/CreateUserTest.java
@@ -132,7 +132,7 @@ public class CreateUserTest {
         .hasOwnerType(AuthorizationOwnerType.USER)
         .hasResourceType(AuthorizationResourceType.USER)
         .hasResourceId(username)
-        .hasOnlyPermissionTypes(PermissionType.READ, PermissionType.UPDATE);
+        .hasOnlyPermissionTypes(PermissionType.READ);
 
     // Verify that UserIntent.CREATE and UserIntent.CREATED events exist
     final var intents =


### PR DESCRIPTION
## Description
<!-- Describe the goal and purpose of this PR. -->
To prevent circumventing a proper password reset flow we are removing the `UPDATE` permission that is applied to a user upon creation.

## Related issues

closes https://github.com/camunda/camunda/issues/29868
