### PR TITLE
fix: c8run align connectors port from 8085 to 8086

### DIFF
--- a/c8run/connectors-application.properties
+++ b/c8run/connectors-application.properties
@@ -3,4 +3,4 @@ zeebe.client.security.plaintext=true
 camunda.operate.client.url=http://localhost:8080
 camunda.operate.client.username=demo
 camunda.operate.client.password=demo
-server.port=8085
+server.port=8086

--- a/c8run/e2e_tests/api_tests.sh
+++ b/c8run/e2e_tests/api_tests.sh
@@ -51,7 +51,7 @@ fi
 
 printf "\nTest: connectors api \n"
 
-STATUS="$(curl localhost:8085/actuator/health | jq '.status')"
+STATUS="$(curl localhost:8086/actuator/health | jq '.status')"
 echo $STATUS
 if [[ "$STATUS" != "\"UP\"" ]]; then
         echo "test failed"

--- a/c8run/endpoints.txt
+++ b/c8run/endpoints.txt
@@ -8,7 +8,7 @@ Tasklist:                   http://localhost:{{.TasklistPort}}/tasklist
 Identity:                   http://localhost:{{.IdentityPort}}/identity
 
 Orchestration Cluster API:  http://localhost:{{.CamundaPort}}/v2/
-Inbound Connectors API:     http://localhost:8085/
+Inbound Connectors API:     http://localhost:8086/
 Zeebe API (gRPC):           http://localhost:26500/
 
 Camunda metrics endpoint:   http://localhost:9600/actuator/prometheus


### PR DESCRIPTION


## Description

As part of iteration 1 of

https://github.com/camunda/team-distribution/issues/578 ,

detailed in this comment
https://github.com/camunda/team-distribution/issues/578#issuecomment-3162202540

I will be aligning the port numbers between each deployment method.

The change in this PR switches the host port of connectors to be 8086 now instead of 8085.

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
