### PR TITLE
fix: reset permissions selected when resource type changes

### DIFF
--- a/identity/client/src/pages/authorizations/modals/AddModal.tsx
+++ b/identity/client/src/pages/authorizations/modals/AddModal.tsx
@@ -241,9 +241,10 @@ const AddModal: FC<UseEntityModalProps<ResourceType>> = ({
               label={t("selectResourceType")}
               titleText={t("resourceType")}
               items={resourceTypeItems}
-              onChange={(item: { selectedItem: ResourceType }) =>
-                field.onChange(item.selectedItem)
-              }
+              onChange={(item: { selectedItem: ResourceType }) => {
+                setValue("permissionTypes", []);
+                field.onChange(item.selectedItem);
+              }}
               itemToString={(item: string) => (item ? t(item) : "")}
               selectedItem={
                 resourceTypeItems.find((item) => item === field.value) || ""


### PR DESCRIPTION
## Description

Reset permissions selected when a different Resource Type gets selected from the Dropdown in the Authorizations creation modal.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #34663 
