### PR TITLE
build: ensure PREFIX fields do not end with a dot in UC classes

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/ActorIdleStrategy.java
+++ b/configuration/src/main/java/io/camunda/configuration/ActorIdleStrategy.java
@@ -13,7 +13,8 @@ import java.time.Duration;
 import java.util.Set;
 
 public class ActorIdleStrategy {
-  private static final String PREFIX = "camunda.system.actor.idle.";
+  private static final String PREFIX = "camunda.system.actor.idle";
+
   private static final Set<String> LEGACY_MAX_SPINS_PROPERTIES =
       Set.of("zeebe.actor.idle.maxSpins");
   private static final Set<String> LEGACY_MAX_YIELDS_PROPERTIES =
@@ -32,7 +33,7 @@ public class ActorIdleStrategy {
 
   public long getMaxSpins() {
     return UnifiedConfigurationHelper.validateLegacyConfiguration(
-        PREFIX + "max-spins",
+        PREFIX + ".max-spins",
         maxSpins,
         Long.class,
         BackwardsCompatibilityMode.SUPPORTED,
@@ -45,7 +46,7 @@ public class ActorIdleStrategy {
 
   public long getMaxYields() {
     return UnifiedConfigurationHelper.validateLegacyConfiguration(
-        PREFIX + "max-yields",
+        PREFIX + ".max-yields",
         maxYields,
         Long.class,
         BackwardsCompatibilityMode.SUPPORTED,
@@ -58,7 +59,7 @@ public class ActorIdleStrategy {
 
   public Duration getMinParkPeriod() {
     return UnifiedConfigurationHelper.validateLegacyConfiguration(
-        PREFIX + "min-park-period",
+        PREFIX + ".min-park-period",
         minParkPeriod,
         Duration.class,
         BackwardsCompatibilityMode.SUPPORTED,
@@ -71,7 +72,7 @@ public class ActorIdleStrategy {
 
   public Duration getMaxParkPeriod() {
     return UnifiedConfigurationHelper.validateLegacyConfiguration(
-        PREFIX + "max-park-period",
+        PREFIX + ".max-park-period",
         maxParkPeriod,
         Duration.class,
         BackwardsCompatibilityMode.SUPPORTED,

--- a/configuration/src/main/java/io/camunda/configuration/Cluster.java
+++ b/configuration/src/main/java/io/camunda/configuration/Cluster.java
@@ -11,7 +11,8 @@ import java.util.Set;
 
 public class Cluster {
 
-  private static final String PREFIX = "camunda.cluster.";
+  private static final String PREFIX = "camunda.cluster";
+
   private static final String LEGACY_NODEID_PROPERTY = "zeebe.broker.cluster.nodeId";
   private static final String LEGACY_PARTITION_COUNT_PROPERTY =
       "zeebe.broker.cluster.partitionsCount";
@@ -61,7 +62,7 @@ public class Cluster {
 
   public int getNodeId() {
     return UnifiedConfigurationHelper.validateLegacyConfiguration(
-        PREFIX + "node-id",
+        PREFIX + ".node-id",
         nodeId,
         Integer.class,
         UnifiedConfigurationHelper.BackwardsCompatibilityMode.SUPPORTED,
@@ -74,7 +75,7 @@ public class Cluster {
 
   public int getPartitionCount() {
     return UnifiedConfigurationHelper.validateLegacyConfiguration(
-        PREFIX + "partition-count",
+        PREFIX + ".partition-count",
         partitionCount,
         Integer.class,
         UnifiedConfigurationHelper.BackwardsCompatibilityMode.SUPPORTED,
@@ -87,7 +88,7 @@ public class Cluster {
 
   public int getReplicationFactor() {
     return UnifiedConfigurationHelper.validateLegacyConfiguration(
-        PREFIX + "replication-factor",
+        PREFIX + ".replication-factor",
         replicationFactor,
         Integer.class,
         UnifiedConfigurationHelper.BackwardsCompatibilityMode.SUPPORTED,
@@ -100,7 +101,7 @@ public class Cluster {
 
   public int getSize() {
     return UnifiedConfigurationHelper.validateLegacyConfiguration(
-        PREFIX + "size",
+        PREFIX + ".size",
         size,
         Integer.class,
         UnifiedConfigurationHelper.BackwardsCompatibilityMode.SUPPORTED,

--- a/configuration/src/main/java/io/camunda/configuration/Disk.java
+++ b/configuration/src/main/java/io/camunda/configuration/Disk.java
@@ -13,7 +13,7 @@ import java.util.Set;
 
 public class Disk {
 
-  private static final String PREFIX = "camunda.data.primary-storage.disk.";
+  private static final String PREFIX = "camunda.data.primary-storage.disk";
 
   private static final Set<String> LEGACY_ENABLE_MONITORING_PROPERTIES =
       Set.of("zeebe.broker.data.disk.enableMonitoring");
@@ -42,7 +42,7 @@ public class Disk {
 
   public boolean isMonitoringEnabled() {
     return UnifiedConfigurationHelper.validateLegacyConfiguration(
-        PREFIX + "monitoring-enabled",
+        PREFIX + ".monitoring-enabled",
         monitoringEnabled,
         Boolean.class,
         BackwardsCompatibilityMode.SUPPORTED,
@@ -55,7 +55,7 @@ public class Disk {
 
   public Duration getMonitoringInterval() {
     return UnifiedConfigurationHelper.validateLegacyConfiguration(
-        PREFIX + "monitoring-interval",
+        PREFIX + ".monitoring-interval",
         monitoringInterval,
         Duration.class,
         BackwardsCompatibilityMode.SUPPORTED,

--- a/configuration/src/main/java/io/camunda/configuration/FreeSpace.java
+++ b/configuration/src/main/java/io/camunda/configuration/FreeSpace.java
@@ -12,7 +12,7 @@ import java.util.Set;
 import org.springframework.util.unit.DataSize;
 
 public class FreeSpace {
-  private static final String PREFIX = "camunda.data.primary-storage.disk.free-space.";
+  private static final String PREFIX = "camunda.data.primary-storage.disk.free-space";
 
   private static final Set<String> LEGACY_PROCESSING_PROPERTIES =
       Set.of("zeebe.broker.data.disk.freeSpace.processing");
@@ -36,7 +36,7 @@ public class FreeSpace {
 
   public DataSize getProcessing() {
     return UnifiedConfigurationHelper.validateLegacyConfiguration(
-        PREFIX + "processing",
+        PREFIX + ".processing",
         processing,
         DataSize.class,
         BackwardsCompatibilityMode.SUPPORTED,
@@ -49,7 +49,7 @@ public class FreeSpace {
 
   public DataSize getReplication() {
     return UnifiedConfigurationHelper.validateLegacyConfiguration(
-        PREFIX + "replication",
+        PREFIX + ".replication",
         replication,
         DataSize.class,
         BackwardsCompatibilityMode.SUPPORTED,

--- a/configuration/src/main/java/io/camunda/configuration/LogStream.java
+++ b/configuration/src/main/java/io/camunda/configuration/LogStream.java
@@ -12,7 +12,7 @@ import java.util.Set;
 import org.springframework.util.unit.DataSize;
 
 public class LogStream {
-  private static final String PREFIX = "camunda.data.primary-storage.log-stream.";
+  private static final String PREFIX = "camunda.data.primary-storage.log-stream";
 
   private static final Set<String> LEGACY_INDEX_DENSITY_PROPERTIES =
       Set.of("zeebe.broker.data.logIndexDensity");
@@ -35,7 +35,7 @@ public class LogStream {
 
   public int getLogIndexDensity() {
     return UnifiedConfigurationHelper.validateLegacyConfiguration(
-        PREFIX + "log-index-density",
+        PREFIX + ".log-index-density",
         logIndexDensity,
         Integer.class,
         BackwardsCompatibilityMode.SUPPORTED,
@@ -48,7 +48,7 @@ public class LogStream {
 
   public DataSize getLogSegmentSize() {
     return UnifiedConfigurationHelper.validateLegacyConfiguration(
-        PREFIX + "log-segment-size",
+        PREFIX + ".log-segment-size",
         logSegmentSize,
         DataSize.class,
         BackwardsCompatibilityMode.SUPPORTED,

--- a/configuration/src/main/java/io/camunda/configuration/LongPolling.java
+++ b/configuration/src/main/java/io/camunda/configuration/LongPolling.java
@@ -12,7 +12,8 @@ import io.camunda.zeebe.gateway.impl.configuration.ConfigurationDefaults;
 import java.util.Set;
 
 public class LongPolling {
-  private static final String PREFIX = "camunda.api.long-polling.";
+  private static final String PREFIX = "camunda.api.long-polling";
+
   private static final Set<String> LEGACY_ENABLED_PROPERTIES =
       Set.of("zeebe.gateway.longPolling.enabled");
   private static final Set<String> LEGACY_TIMEOUT_PROPERTIES =
@@ -40,7 +41,7 @@ public class LongPolling {
 
   public boolean isEnabled() {
     return UnifiedConfigurationHelper.validateLegacyConfiguration(
-        PREFIX + "enabled",
+        PREFIX + ".enabled",
         enabled,
         Boolean.class,
         BackwardsCompatibilityMode.SUPPORTED,
@@ -53,7 +54,7 @@ public class LongPolling {
 
   public long getTimeout() {
     return UnifiedConfigurationHelper.validateLegacyConfiguration(
-        PREFIX + "timeout",
+        PREFIX + ".timeout",
         timeout,
         Long.class,
         BackwardsCompatibilityMode.SUPPORTED,
@@ -66,7 +67,7 @@ public class LongPolling {
 
   public long getProbeTimeout() {
     return UnifiedConfigurationHelper.validateLegacyConfiguration(
-        PREFIX + "probe-timeout",
+        PREFIX + ".probe-timeout",
         probeTimeout,
         Long.class,
         BackwardsCompatibilityMode.SUPPORTED,
@@ -79,7 +80,7 @@ public class LongPolling {
 
   public int getMinEmptyResponses() {
     return UnifiedConfigurationHelper.validateLegacyConfiguration(
-        PREFIX + "min-empty-responses",
+        PREFIX + ".min-empty-responses",
         minEmptyResponses,
         Integer.class,
         BackwardsCompatibilityMode.SUPPORTED,

--- a/configuration/src/main/java/io/camunda/configuration/Metadata.java
+++ b/configuration/src/main/java/io/camunda/configuration/Metadata.java
@@ -14,7 +14,8 @@ import java.time.Duration;
 import java.util.Set;
 
 public class Metadata {
-  private static final String PREFIX = "camunda.cluster.metadata.";
+  private static final String PREFIX = "camunda.cluster.metadata";
+
   private static final Set<String> LEGACY_SYNC_DELAY_PROPERTIES =
       Set.of("zeebe.broker.cluster.configManager.gossip.syncDelay");
   private static final Set<String> LEGACY_SYNC_REQUEST_TIMEOUT_PROPERTIES =
@@ -37,7 +38,7 @@ public class Metadata {
 
   public Duration getSyncDelay() {
     return UnifiedConfigurationHelper.validateLegacyConfiguration(
-        PREFIX + "sync-delay", syncDelay, Duration.class, SUPPORTED, LEGACY_SYNC_DELAY_PROPERTIES);
+        PREFIX + ".sync-delay", syncDelay, Duration.class, SUPPORTED, LEGACY_SYNC_DELAY_PROPERTIES);
   }
 
   public void setSyncDelay(final Duration syncDelay) {
@@ -46,7 +47,7 @@ public class Metadata {
 
   public Duration getSyncRequestTimeout() {
     return UnifiedConfigurationHelper.validateLegacyConfiguration(
-        PREFIX + "sync-request-timeout",
+        PREFIX + ".sync-request-timeout",
         syncRequestTimeout,
         Duration.class,
         SUPPORTED,
@@ -59,7 +60,7 @@ public class Metadata {
 
   public int getGossipFanout() {
     return UnifiedConfigurationHelper.validateLegacyConfiguration(
-        PREFIX + "gossip-fanout",
+        PREFIX + ".gossip-fanout",
         gossipFanout,
         Integer.class,
         SUPPORTED,

--- a/configuration/src/main/java/io/camunda/configuration/Network.java
+++ b/configuration/src/main/java/io/camunda/configuration/Network.java
@@ -15,7 +15,7 @@ import java.util.Set;
 /** Network configuration for cluster communication. */
 public class Network {
 
-  private static final String PREFIX = "camunda.cluster.network.";
+  private static final String PREFIX = "camunda.cluster.network";
 
   private static final Map<String, String> LEGACY_GATEWAY_NETWORK_PROPERTIES =
       Map.of("host", "zeebe.gateway.cluster.host");
@@ -29,7 +29,7 @@ public class Network {
 
   public String getHost() {
     return UnifiedConfigurationHelper.validateLegacyConfiguration(
-        PREFIX + "host",
+        PREFIX + ".host",
         host,
         String.class,
         UnifiedConfigurationHelper.BackwardsCompatibilityMode.SUPPORTED,

--- a/configuration/src/main/java/io/camunda/configuration/PrimaryStorage.java
+++ b/configuration/src/main/java/io/camunda/configuration/PrimaryStorage.java
@@ -12,7 +12,7 @@ import java.util.Set;
 
 public class PrimaryStorage {
 
-  private static final String PREFIX = "camunda.data.primary-storage.";
+  private static final String PREFIX = "camunda.data.primary-storage";
 
   private static final Set<String> LEGACY_DIRECTORY_PROPERTIES =
       Set.of("zeebe.broker.data.directory");
@@ -38,7 +38,7 @@ public class PrimaryStorage {
 
   public String getDirectory() {
     return UnifiedConfigurationHelper.validateLegacyConfiguration(
-        PREFIX + "directory",
+        PREFIX + ".directory",
         directory,
         String.class,
         BackwardsCompatibilityMode.SUPPORTED,
@@ -51,7 +51,7 @@ public class PrimaryStorage {
 
   public String getRuntimeDirectory() {
     return UnifiedConfigurationHelper.validateLegacyConfiguration(
-        PREFIX + "runtime-directory",
+        PREFIX + ".runtime-directory",
         runtimeDirectory,
         String.class,
         BackwardsCompatibilityMode.SUPPORTED,

--- a/configuration/src/main/java/io/camunda/configuration/System.java
+++ b/configuration/src/main/java/io/camunda/configuration/System.java
@@ -11,7 +11,8 @@ import io.camunda.configuration.UnifiedConfigurationHelper.BackwardsCompatibilit
 import java.util.Set;
 
 public class System {
-  private static final String PREFIX = "camunda.system.";
+  private static final String PREFIX = "camunda.system";
+
   private static final Set<String> LEGACY_CPU_THREAD_COUNT_PROPERTIES =
       Set.of("zeebe.broker.threads.cpuThreadCount");
   private static final Set<String> LEGACY_IO_THREAD_COUNT_PROPERTIES =
@@ -44,7 +45,7 @@ public class System {
 
   public int getCpuThreadCount() {
     return UnifiedConfigurationHelper.validateLegacyConfiguration(
-        PREFIX + "cpu-thread-count",
+        PREFIX + ".cpu-thread-count",
         cpuThreadCount,
         Integer.class,
         BackwardsCompatibilityMode.SUPPORTED,
@@ -57,7 +58,7 @@ public class System {
 
   public int getIoThreadCount() {
     return UnifiedConfigurationHelper.validateLegacyConfiguration(
-        PREFIX + "io-thread-count",
+        PREFIX + ".io-thread-count",
         ioThreadCount,
         Integer.class,
         BackwardsCompatibilityMode.SUPPORTED,
@@ -70,7 +71,7 @@ public class System {
 
   public boolean getClockControlled() {
     return UnifiedConfigurationHelper.validateLegacyConfiguration(
-        PREFIX + "clock-controlled",
+        PREFIX + ".clock-controlled",
         clockControlled,
         Boolean.class,
         BackwardsCompatibilityMode.SUPPORTED,

--- a/configuration/src/main/java/io/camunda/configuration/Upgrade.java
+++ b/configuration/src/main/java/io/camunda/configuration/Upgrade.java
@@ -12,7 +12,7 @@ import io.camunda.zeebe.broker.system.configuration.ExperimentalCfg;
 import java.util.Set;
 
 public class Upgrade {
-  private static final String PREFIX = "camunda.system.upgrade.";
+  private static final String PREFIX = "camunda.system.upgrade";
 
   private static final Set<String> LEGACY_ENABLE_VERSION_CHECK_PROPERTIES =
       Set.of("zeebe.broker.experimental.versionCheckRestrictionEnabled");
@@ -26,7 +26,7 @@ public class Upgrade {
 
   public boolean getEnableVersionCheck() {
     return UnifiedConfigurationHelper.validateLegacyConfiguration(
-        PREFIX + "enable-version-check",
+        PREFIX + ".enable-version-check",
         enableVersionCheck,
         Boolean.class,
         BackwardsCompatibilityMode.SUPPORTED,

--- a/configuration/src/test/java/io/camunda/configuration/CodeQualityTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/CodeQualityTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+public class CodeQualityTest {
+
+  @Test
+  void testAllClassesPrefixEndWithoutDot()
+      throws ClassNotFoundException, IllegalAccessException, IOException {
+    final List<Class<?>> unifiedConfigurationClasses =
+        getAllClassesInPackage("io.camunda.configuration");
+
+    for (final Class<?> clazz : unifiedConfigurationClasses) {
+      try {
+        final Field prefixField = clazz.getDeclaredField("PREFIX");
+        prefixField.setAccessible(true);
+        final String prefix = (String) prefixField.get(null);
+        assertThat(prefix)
+            .withFailMessage("Field " + clazz.getName() + ".PREFIX ends with a dot (.)")
+            .doesNotEndWith(".");
+      } catch (NoSuchFieldException e) {
+        // The class doesn't have the field PREFIX.
+        // Nothing to do.
+      }
+    }
+  }
+
+  private static List<Class<?>> getAllClassesInPackage(final String packageName)
+      throws ClassNotFoundException, IOException {
+    final List<Class<?>> classes = new ArrayList<>();
+    final String path = packageName.replace('.', '/');
+    final ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+
+    if (classLoader == null) {
+      throw new IllegalStateException("Cannot get class loader.");
+    }
+
+    final Enumeration<URL> resources = classLoader.getResources(path);
+    while (resources.hasMoreElements()) {
+      final URL resource = resources.nextElement();
+      final File directory = new File(resource.getFile());
+      if (directory.exists()) {
+        for (final String fileName : directory.list()) {
+          if (fileName.endsWith(".class") && !fileName.contains("Test")) {
+            final String className =
+                packageName + '.' + fileName.substring(0, fileName.length() - 6);
+            final Class<?> clazz = Class.forName(className);
+            classes.add(clazz);
+          }
+        }
+      }
+    }
+
+    return classes;
+  }
+}


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
This PR enforces a coding standard to declare the field PREFIX that does not end with a dot.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
