### PR TITLE
Fix flaky Elasticsearch/Opensearch exporter IT tests

### DIFF
--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporter.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporter.java
@@ -70,8 +70,6 @@ public class ElasticsearchExporter implements Exporter {
     pluginRepository.load(configuration.getInterceptorPlugins());
 
     context.setFilter(new ElasticsearchRecordFilter(configuration));
-    // Re-create the schema manager on every configuration change
-    schemaManager = new ElasticsearchExporterSchemaManager(client, configuration);
     registry = context.getMeterRegistry();
   }
 

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterIT.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterIT.java
@@ -44,14 +44,11 @@ import java.util.function.Consumer;
 import java.util.function.UnaryOperator;
 import org.agrona.CloseHelper;
 import org.awaitility.Awaitility;
-import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assumptions;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
-import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mockito;
@@ -67,7 +64,6 @@ import org.testcontainers.junit.jupiter.Testcontainers;
  * down, should be done elsewhere (e.g. {@link FaultToleranceIT}
  */
 @Testcontainers
-@TestInstance(Lifecycle.PER_CLASS)
 final class ElasticsearchExporterIT {
   @Container
   private static final ElasticsearchContainer CONTAINER =
@@ -85,8 +81,8 @@ final class ElasticsearchExporterIT {
   private TestClient testClient;
   private ExporterTestContext exporterTestContext;
 
-  @BeforeAll
-  public void beforeAll() {
+  @BeforeEach
+  public void beforeEach() {
     config.url = CONTAINER.getHttpHostAddress();
     config.setIncludeEnabledRecords(true);
     config.index.setNumberOfShards(1);
@@ -106,16 +102,12 @@ final class ElasticsearchExporterIT {
     exporter.open(controller);
   }
 
-  @AfterAll
-  void afterAll() {
-    CloseHelper.quietCloseAll(testClient);
-  }
-
-  @BeforeEach
-  void cleanup() {
-    config.setIncludeEnabledRecords(true);
+  @AfterEach
+  void afterEach() {
     testClient.deleteIndices();
-    exporter.configure(exporterTestContext);
+    testClient.deleteIndexTemplates();
+    testClient.deleteComponentTemplates();
+    CloseHelper.quietCloseAll(testClient);
   }
 
   @ParameterizedTest(name = "{0}")
@@ -492,6 +484,7 @@ final class ElasticsearchExporterIT {
         final Consumer<ElasticsearchExporterConfiguration> configurator) {
       configurator.accept(config);
       exporter.configure(exporterTestContext);
+      exporter.open(controller);
     }
 
     @Test

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/TestClient.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/TestClient.java
@@ -136,9 +136,28 @@ final class TestClient implements CloseableSilently {
 
   void deleteIndexTemplates() {
     try {
-      final var request = new Request("DELETE", "/_index_template/*");
+      final var request =
+          new Request("DELETE", "/_index_template/%s*".formatted(config.index.prefix));
       restClient.performRequest(request);
     } catch (final IOException e) {
+      if (e.getMessage() != null && e.getMessage().contains("404 Not Found")) {
+        // Ignore 404 errors - no templates to delete
+        return;
+      }
+      throw new UncheckedIOException(e);
+    }
+  }
+
+  void deleteComponentTemplates() {
+    try {
+      final var request =
+          new Request("DELETE", "/_component_template/%s*".formatted(config.index.prefix));
+      restClient.performRequest(request);
+    } catch (final IOException e) {
+      if (e.getMessage() != null && e.getMessage().contains("404 Not Found")) {
+        // Ignore 404 errors - no templates to delete
+        return;
+      }
       throw new UncheckedIOException(e);
     }
   }

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterIT.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterIT.java
@@ -38,14 +38,11 @@ import java.util.Optional;
 import java.util.function.Consumer;
 import org.agrona.CloseHelper;
 import org.awaitility.Awaitility;
-import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assumptions;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
-import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mockito;
@@ -64,7 +61,6 @@ import org.testcontainers.junit.jupiter.Testcontainers;
  * down, should be done elsewhere (e.g. {@link FaultToleranceIT}
  */
 @Testcontainers
-@TestInstance(Lifecycle.PER_CLASS)
 final class OpensearchExporterIT {
   @Container
   private static final OpensearchContainer<?> CONTAINER =
@@ -81,8 +77,8 @@ final class OpensearchExporterIT {
   private TestClient testClient;
   private ExporterTestContext exporterTestContext;
 
-  @BeforeAll
-  public void beforeAll() {
+  @BeforeEach
+  public void beforeEach() {
     config.url = CONTAINER.getHttpHostAddress();
     config.setIncludeEnabledRecords(true);
     config.index.setNumberOfShards(1);
@@ -103,17 +99,12 @@ final class OpensearchExporterIT {
     exporter.open(controller);
   }
 
-  @AfterAll
-  void afterAll() {
-    CloseHelper.quietCloseAll(testClient);
-  }
-
-  @BeforeEach
-  void cleanup() {
-    config.setIncludeEnabledRecords(true);
+  @AfterEach
+  void afterEach() {
     testClient.deleteIndices();
     testClient.deleteIndexTemplates();
-    configureExporter(true);
+    testClient.deleteComponentTemplates();
+    CloseHelper.quietCloseAll(testClient);
   }
 
   @ParameterizedTest(name = "{0}")
@@ -391,6 +382,7 @@ final class OpensearchExporterIT {
   private void configureExporter(final Consumer<OpensearchExporterConfiguration> configurator) {
     configurator.accept(config);
     exporter.configure(exporterTestContext);
+    exporter.open(controller);
   }
 
   private <T extends RecordValue> Record<T> generateRecord(final ValueType valueType) {

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/TestClient.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/TestClient.java
@@ -221,9 +221,28 @@ final class TestClient implements CloseableSilently {
 
   void deleteIndexTemplates() {
     try {
-      final var request = new Request("DELETE", "/_index_template/*");
+      final var request =
+          new Request("DELETE", "/_index_template/%s*".formatted(config.index.prefix));
       restClient.performRequest(request);
     } catch (final IOException e) {
+      if (e.getMessage() != null && e.getMessage().contains("404 Not Found")) {
+        // Ignore 404 errors - no templates to delete
+        return;
+      }
+      throw new UncheckedIOException(e);
+    }
+  }
+
+  void deleteComponentTemplates() {
+    try {
+      final var request =
+          new Request("DELETE", "/_component_template/%s*".formatted(config.index.prefix));
+      restClient.performRequest(request);
+    } catch (final IOException e) {
+      if (e.getMessage() != null && e.getMessage().contains("404 Not Found")) {
+        // Ignore 404 errors - no templates to delete
+        return;
+      }
       throw new UncheckedIOException(e);
     }
   }


### PR DESCRIPTION
This pull request refactors the integration tests for both the Elasticsearch and Opensearch exporters to improve test isolation, reliability, and cleanup. The main changes include switching test lifecycle hooks from per-class to per-method, enhancing cleanup routines, and improving template deletion logic to be more targeted and robust.

**Test lifecycle and structure improvements:**

* Changed test classes (`ElasticsearchExporterIT`, `OpensearchExporterIT`) from using `@BeforeAll`/`@AfterAll` and `@TestInstance(Lifecycle.PER_CLASS)` to `@BeforeEach`/`@AfterEach` with the default per-method lifecycle for better test isolation. [[1]](diffhunk://#diff-0bce9ff1fc33b1422e61a4b0abe2096b17b409ef6d0417993484d8732fae1517L47-L54) [[2]](diffhunk://#diff-0bce9ff1fc33b1422e61a4b0abe2096b17b409ef6d0417993484d8732fae1517L70) [[3]](diffhunk://#diff-0bce9ff1fc33b1422e61a4b0abe2096b17b409ef6d0417993484d8732fae1517L88-R85) [[4]](diffhunk://#diff-0bce9ff1fc33b1422e61a4b0abe2096b17b409ef6d0417993484d8732fae1517L109-R110) [[5]](diffhunk://#diff-a46f16f4db2867901ac0b08863c037b3a8eaefbf9f68c8f5535fd5ade836fa7cL41-L48) [[6]](diffhunk://#diff-a46f16f4db2867901ac0b08863c037b3a8eaefbf9f68c8f5535fd5ade836fa7cL67) [[7]](diffhunk://#diff-a46f16f4db2867901ac0b08863c037b3a8eaefbf9f68c8f5535fd5ade836fa7cL84-R81) [[8]](diffhunk://#diff-a46f16f4db2867901ac0b08863c037b3a8eaefbf9f68c8f5535fd5ade836fa7cL106-R107)

* Moved exporter configuration and opening into each test setup to ensure a fresh exporter state per test. [[1]](diffhunk://#diff-0bce9ff1fc33b1422e61a4b0abe2096b17b409ef6d0417993484d8732fae1517R487) [[2]](diffhunk://#diff-a46f16f4db2867901ac0b08863c037b3a8eaefbf9f68c8f5535fd5ade836fa7cR385)

**Cleanup and resource management enhancements:**

* Improved cleanup in `@AfterEach` to delete indices, index templates, and new component templates, and to close test clients after every test, ensuring no leftover state between tests. [[1]](diffhunk://#diff-0bce9ff1fc33b1422e61a4b0abe2096b17b409ef6d0417993484d8732fae1517L109-R110) [[2]](diffhunk://#diff-a46f16f4db2867901ac0b08863c037b3a8eaefbf9f68c8f5535fd5ade836fa7cL106-R107)

**Template deletion logic improvements:**

* Updated `deleteIndexTemplates` and added `deleteComponentTemplates` in both `TestClient` classes to only delete templates matching the current test's index prefix, and to gracefully handle 404 errors when templates do not exist. [[1]](diffhunk://#diff-695b9f7e96172d637701cd8befce7e8627ab8c96c5f4b72396496de1c0cbd1a6L139-R160) [[2]](diffhunk://#diff-9883b5bb9908b681eef3f3a5de6226660fdd8cfd8b97031367b4458fdfd1cf70L224-R245)

**Exporter logic adjustment:**

* Removed redundant re-creation of the `schemaManager` on every configuration change in the Elasticsearch exporter, as it is no longer needed with the new test structure.## Description

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
