### PR TITLE
Authorizations must be plural

### DIFF
--- a/dist/src/main/config/application.yaml
+++ b/dist/src/main/config/application.yaml
@@ -158,10 +158,10 @@ camunda:
       # Note! This setting should be combined with the 'camunda.security.mode' setting to fully manage authentications.
       # This setting can also be overridden using the environment variable CAMUNDA_SECURITY_AUTHENTICATION_UNPROTECTEDAPI.
       unprotectedApi: false
-    authorization:
+    authorizations:
       # Controls whether authorization checks are enabled or not.
       # See https://docs.camunda.io/docs/next/components/concepts/access-control/authorizations/ for more information on how to set up authorizations.
-      # This setting can also be overridden using the environment variable CAMUNDA_SECURITY_AUTHORIZATION_ENABLED.
+      # This setting can also be overridden using the environment variable CAMUNDA_SECURITY_AUTHORIZATIONS_ENABLED.
       enabled: true
     multiTenancy:
         # Controls whether multi-tenancy checks are enforced or not.

--- a/dist/src/main/config/application.yaml
+++ b/dist/src/main/config/application.yaml
@@ -146,16 +146,16 @@ camunda:
     # - OIDC:
     #     OpenID Connect with any compatible Identity Provider (for example, Keycloak, Microsoft EntraID, Okta).
     authentication:
-      # Controls which authentication mode is active, supported modes are 'basic' and 'oidc'.
+      # Controls which authentication method is active, supported methods are 'basic' and 'oidc'.
       # If 'basic' is set, authentication will be done using basic authentication. Users need to be created.
       # See https://docs.camunda.io/docs/next/components/identity/user/ for instructions on how to do this.
       # If 'oidc' is set, authentication will be done using an external IdP.
       # See https://docs.camunda.io/docs/next/self-managed/components/management-identity/what-is-identity/ for instructions on hwo to set this up.
       # Note! This setting should be combined with the 'camunda.security.unprotectedApi' setting to fully manage authentications.
-      # This setting can also be overridden using the environment variable CAMUNDA_SECURITY_AUTHENTICATION_MODE.
-      mode: basic
+      # This setting can also be overridden using the environment variable CAMUNDA_SECURITY_AUTHENTICATION_METHOD.
+      method: basic
       # Sets the API to protected or unprotected. If the API is unprotected, no authentication is required to access it.
-      # Note! This setting should be combined with the 'camunda.security.mode' setting to fully manage authentications.
+      # Note! This setting should be combined with the 'camunda.security.method' setting to fully manage authentications.
       # This setting can also be overridden using the environment variable CAMUNDA_SECURITY_AUTHENTICATION_UNPROTECTEDAPI.
       unprotectedApi: false
     authorizations:

--- a/dist/src/test/java/io/camunda/application/commons/DefaultConfigurationTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/DefaultConfigurationTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.application.commons;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.application.commons.security.CamundaSecurityConfiguration;
+import io.camunda.application.commons.security.CamundaSecurityConfiguration.CamundaSecurityProperties;
+import io.camunda.security.entity.AuthenticationMethod;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+@SpringBootTest(
+    classes = DefaultConfigurationTest.TestConfig.class,
+    properties = {"spring.config.location=file:src/main/config/application.yaml"})
+class DefaultConfigurationTest {
+
+  @Autowired private CamundaSecurityProperties camundaSecurityProperties;
+
+  @Test
+  void verifySecurityConfigurations() {
+    final var authenticationConfig = camundaSecurityProperties.getAuthentication();
+    assertThat(authenticationConfig.getMethod()).isEqualTo(AuthenticationMethod.BASIC);
+    assertThat(authenticationConfig.getUnprotectedApi()).isFalse();
+
+    final var authorizationsConfig = camundaSecurityProperties.getAuthorizations();
+    assertThat(authorizationsConfig.isEnabled()).isTrue();
+
+    final var multiTenancyConfig = camundaSecurityProperties.getMultiTenancy();
+    assertThat(multiTenancyConfig.isChecksEnabled()).isFalse();
+    assertThat(multiTenancyConfig.isApiEnabled()).isTrue();
+  }
+
+  @Configuration
+  @Import({CamundaSecurityConfiguration.class})
+  static class TestConfig {}
+}

--- a/tasklist/qa/backup-restore-tests/src/test/java/io/camunda/tasklist/qa/backup/BackupRestoreTest.java
+++ b/tasklist/qa/backup-restore-tests/src/test/java/io/camunda/tasklist/qa/backup/BackupRestoreTest.java
@@ -119,7 +119,10 @@ public class BackupRestoreTest {
                 INDEX_PREFIX)
             .withEnv("CAMUNDA_TASKLIST_CSRF_PREVENTION_ENABLED", "false")
             .withEnv("CAMUNDA_TASKLIST_ZEEBE_COMPATIBILITY_ENABLED", "true")
-            .withEnv("CAMUNDA_TASKLIST_IMPORTERENABLED", "false");
+            .withEnv("CAMUNDA_TASKLIST_IMPORTERENABLED", "false")
+            .withEnv("CAMUNDA_SECURITY_AUTHENTICATION_METHOD", "BASIC")
+            .withEnv("CAMUNDA_SECURITY_AUTHORIZATIONS_ENABLED", "false")
+            .withEnv("CAMUNDA_SECURITY_AUTHENTICATION_UNPROTECTEDAPI", "true");
 
     startTasklist();
   }

--- a/tasklist/qa/backup-restore-tests/src/test/java/io/camunda/tasklist/qa/backup/BackupRestoreTest.java
+++ b/tasklist/qa/backup-restore-tests/src/test/java/io/camunda/tasklist/qa/backup/BackupRestoreTest.java
@@ -120,6 +120,7 @@ public class BackupRestoreTest {
             .withEnv("CAMUNDA_TASKLIST_CSRF_PREVENTION_ENABLED", "false")
             .withEnv("CAMUNDA_TASKLIST_ZEEBE_COMPATIBILITY_ENABLED", "true")
             .withEnv("CAMUNDA_TASKLIST_IMPORTERENABLED", "false")
+            .withEnv("CAMUNDA_TASKLIST_FEATUREFLAG_ALLOWNONSELFASSIGNMENT", "true")
             .withEnv("CAMUNDA_SECURITY_AUTHENTICATION_METHOD", "BASIC")
             .withEnv("CAMUNDA_SECURITY_AUTHORIZATIONS_ENABLED", "false")
             .withEnv("CAMUNDA_SECURITY_AUTHENTICATION_UNPROTECTEDAPI", "true");


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

I accidentally put the config as singular instead of plural.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

Related to #34143
