### PR TITLE
fix: disable newly introduced but flaky test #35023

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/historycleanup/HistoryCleanupIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/historycleanup/HistoryCleanupIT.java
@@ -22,6 +22,7 @@ import io.camunda.qa.util.multidb.HistoryMultiDbTest;
 import java.time.Duration;
 import java.util.Objects;
 import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
@@ -91,6 +92,7 @@ public class HistoryCleanupIT {
     assertThat(result.items().getFirst().getProcessInstanceKey()).isNotEqualTo(processInstanceKey);
   }
 
+  @Disabled("flaky, will be fixed #35023")
   @Test
   void shouldDeleteBatchOperationsWhichAreMarkedForCleanup() {
     // given


### PR DESCRIPTION
## Description

Disables the newly introduced but flaky test `HistoryCleanupIT#shouldDeleteBatchOperationsWhichAreMarkedForCleanup` because it leads to poor developer and merge experience. Will be fixed afterwards.

[Source](https://camunda.slack.com/archives/C08F5RD5X8B/p1754646518592629)