### PR TITLE
refactor: groups are not migrated as BYOG is enabled in SM setup

### DIFF
--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/client/ManagementIdentityClient.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/client/ManagementIdentityClient.java
@@ -27,7 +27,6 @@ public class ManagementIdentityClient {
   private static final String MIGRATION_GROUP_TENANTS_ENDPOINT = "/api/tenants/{0}/groups";
   private static final String MIGRATION_CLIENT_TENANTS_ENDPOINT = "/api/tenants/{0}/applications";
   private static final String MIGRATION_GROUPS_ENDPOINT = "/api/groups?page={0}&organizationId={1}";
-  private static final String MIGRATION_GROUPS_ROLES_ENDPOINT = "/api/groups/{0}/roles";
   private static final String MIGRATION_GROUPS_AUTHORISATIONS_ENDPOINT =
       "/api/groups/{0}/authorizations";
   private static final String MIGRATION_USER_GROUPS_ENDPOINT =
@@ -96,13 +95,6 @@ public class ManagementIdentityClient {
             Objects.requireNonNull(
                 restTemplate.getForObject(
                     MIGRATION_USER_GROUPS_ENDPOINT, User[].class, groupId, organizationId)))
-        .toList();
-  }
-
-  public List<Role> fetchGroupRoles(final String groupId) {
-    return Arrays.stream(
-            Objects.requireNonNull(
-                restTemplate.getForObject(MIGRATION_GROUPS_ROLES_ENDPOINT, Role[].class, groupId)))
         .toList();
   }
 

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/sm/SMKeycloakMigrationHandlerConfig.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/sm/SMKeycloakMigrationHandlerConfig.java
@@ -11,13 +11,12 @@ import io.camunda.migration.identity.client.ManagementIdentityClient;
 import io.camunda.migration.identity.config.IdentityMigrationProperties;
 import io.camunda.migration.identity.handler.sm.AuthorizationMigrationHandler;
 import io.camunda.migration.identity.handler.sm.ClientMigrationHandler;
-import io.camunda.migration.identity.handler.sm.GroupMigrationHandler;
+import io.camunda.migration.identity.handler.sm.GroupAuthorizationMigrationHandler;
 import io.camunda.migration.identity.handler.sm.RoleMigrationHandler;
 import io.camunda.migration.identity.handler.sm.TenantMigrationHandler;
 import io.camunda.migration.identity.handler.sm.UserRoleMigrationHandler;
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.AuthorizationServices;
-import io.camunda.service.GroupServices;
 import io.camunda.service.RoleServices;
 import io.camunda.service.TenantServices;
 import org.springframework.context.annotation.Bean;
@@ -45,18 +44,13 @@ public class SMKeycloakMigrationHandlerConfig {
 
   @Bean
   @Order(2)
-  public GroupMigrationHandler groupMigrationHandler(
+  public GroupAuthorizationMigrationHandler groupMigrationHandler(
       final ManagementIdentityClient managementIdentityClient,
-      final GroupServices groupServices,
       final AuthorizationServices authorizationServices,
       final CamundaAuthentication authentication,
       final IdentityMigrationProperties migrationProperties) {
-    return new GroupMigrationHandler(
-        managementIdentityClient,
-        groupServices,
-        authorizationServices,
-        authentication,
-        migrationProperties);
+    return new GroupAuthorizationMigrationHandler(
+        managementIdentityClient, authorizationServices, authentication, migrationProperties);
   }
 
   @Bean

--- a/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/sm/SMKeycloakMigrationHandlerConfigTest.java
+++ b/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/sm/SMKeycloakMigrationHandlerConfigTest.java
@@ -32,7 +32,7 @@ public class SMKeycloakMigrationHandlerConfigTest {
     final List<String> expectedOrder =
         List.of(
             "RoleMigrationHandler",
-            "GroupMigrationHandler",
+            "GroupAuthorizationMigrationHandler",
             "UserRoleMigrationHandler",
             "ClientMigrationHandler",
             "AuthorizationMigrationHandler",

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/migration/KeycloakIdentityMigrationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/migration/KeycloakIdentityMigrationIT.java
@@ -24,8 +24,6 @@ import io.camunda.client.api.search.enums.OwnerType;
 import io.camunda.client.api.search.enums.PermissionType;
 import io.camunda.client.api.search.enums.ResourceType;
 import io.camunda.client.api.search.response.Authorization;
-import io.camunda.client.api.search.response.Group;
-import io.camunda.client.api.search.response.GroupUser;
 import io.camunda.client.api.search.response.Role;
 import io.camunda.client.api.search.response.RoleUser;
 import io.camunda.client.api.search.response.Tenant;
@@ -354,11 +352,6 @@ public class KeycloakIdentityMigrationIT {
         .ignoreExceptions()
         .untilAsserted(
             () -> {
-              final var groups = client.newGroupsSearchRequest().send().join();
-              assertThat(groups.items())
-                  .extracting(Group::getGroupId)
-                  .contains("groupa", "groupb", "groupc");
-
               final var authorizations = client.newAuthorizationSearchRequest().send().join();
               assertThat(authorizations.items())
                   .extracting(Authorization::getOwnerId)
@@ -367,18 +360,6 @@ public class KeycloakIdentityMigrationIT {
 
     // then
     assertThat(migration.getExitCode()).isEqualTo(0);
-
-    final var groups = client.newGroupsSearchRequest().send().join();
-    assertThat(groups.items())
-        .extracting(Group::getGroupId, Group::getName)
-        .contains(tuple("groupa", "groupA"), tuple("groupb", "groupB"), tuple("groupc", "groupC"));
-
-    final var usersGroupA = client.newUsersByGroupSearchRequest("groupa").send().join();
-    assertThat(usersGroupA.items()).extracting(GroupUser::getUsername).containsExactly("user0");
-    final var usersGroupB = client.newUsersByGroupSearchRequest("groupb").send().join();
-    assertThat(usersGroupB.items()).extracting(GroupUser::getUsername).containsExactly("user0");
-    final var usersGroupC = client.newUsersByGroupSearchRequest("groupc").send().join();
-    assertThat(usersGroupC.items()).extracting(GroupUser::getUsername).containsExactly("user1");
 
     final var authorizations = client.newAuthorizationSearchRequest().send().join();
     assertThat(authorizations.items())


### PR DESCRIPTION
## Description

Since BYOG is enabled for SM setup, groups are not migrated by the Migration App. For this reason also their users and roles can't be assigned. Only groups permissions are migrated. The decision was made [here](https://docs.google.com/document/d/1XqG9Y9SXvakwcJ7ZheE8lgd6X0PMWSuyH4IbYTzLYeE/edit?pli=1&tab=t.0#heading=h.imv75xk1efgn)

## Related issues

closes #34774 
