### PR TITLE
fix: add missing AD_HOC_SUB_PROCESS JobKind in gateway-protocol

### DIFF
--- a/zeebe/gateway-protocol/src/main/proto/gateway.proto
+++ b/zeebe/gateway-protocol/src/main/proto/gateway.proto
@@ -57,6 +57,7 @@ message ActivatedJob {
     BPMN_ELEMENT = 0;
     EXECUTION_LISTENER = 1;
     TASK_LISTENER = 2;
+    AD_HOC_SUB_PROCESS = 3;
   }
 
   // Describes the listener event type of the job.


### PR DESCRIPTION

## Description

Follow up to https://github.com/camunda/camunda/pull/35934 - adds missing JobKind to `gateway-protocol`.

Updates response mapper tests to test mapping of all enum values in order to catch similar issues early next time.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

related to https://github.com/camunda/ad-hoc-sub-process-phase-3/issues/6