### PR TITLE
fix: align decision requirements definition permissions to docs

### DIFF
--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/saas/StaticEntities.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/saas/StaticEntities.java
@@ -212,13 +212,7 @@ public class StaticEntities {
             "*",
             AuthorizationResourceType.DECISION_DEFINITION,
             Set.of(
-                PermissionType.CREATE_DECISION_INSTANCE, PermissionType.DELETE_DECISION_INSTANCE)),
-        new CreateAuthorizationRequest(
-            clientId,
-            AuthorizationOwnerType.CLIENT,
-            "*",
-            AuthorizationResourceType.DECISION_REQUIREMENTS_DEFINITION,
-            Set.of(PermissionType.UPDATE, PermissionType.DELETE)));
+                PermissionType.CREATE_DECISION_INSTANCE, PermissionType.DELETE_DECISION_INSTANCE)));
   }
 
   public static List<CreateAuthorizationRequest> getOperateClientPermissions(

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/saas/StaticEntities.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/saas/StaticEntities.java
@@ -235,7 +235,7 @@ public class StaticEntities {
             AuthorizationOwnerType.CLIENT,
             "*",
             AuthorizationResourceType.RESOURCE,
-            Set.of(PermissionType.READ)),
+            Set.of(PermissionType.READ, PermissionType.DELETE_PROCESS, PermissionType.DELETE_DRD)),
         new CreateAuthorizationRequest(
             clientId,
             AuthorizationOwnerType.CLIENT,

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/saas/StaticEntities.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/saas/StaticEntities.java
@@ -73,6 +73,12 @@ public class StaticEntities {
               DEVELOPER_ROLE_ID,
               AuthorizationOwnerType.ROLE,
               "*",
+              AuthorizationResourceType.RESOURCE,
+              AuthorizationResourceType.RESOURCE.getSupportedPermissionTypes()),
+          new CreateAuthorizationRequest(
+              DEVELOPER_ROLE_ID,
+              AuthorizationOwnerType.ROLE,
+              "*",
               AuthorizationResourceType.BATCH,
               Set.of(PermissionType.CREATE, PermissionType.READ, PermissionType.UPDATE)),
           // OPERATIONS ENGINEER
@@ -106,6 +112,17 @@ public class StaticEntities {
               AuthorizationResourceType.DECISION_REQUIREMENTS_DEFINITION,
               AuthorizationResourceType.DECISION_REQUIREMENTS_DEFINITION
                   .getSupportedPermissionTypes()),
+          new CreateAuthorizationRequest(
+              OPERATIONS_ENGINEER_ROLE_ID,
+              AuthorizationOwnerType.ROLE,
+              "*",
+              AuthorizationResourceType.RESOURCE,
+              Set.of(
+                  PermissionType.READ,
+                  PermissionType.DELETE_RESOURCE,
+                  PermissionType.DELETE_PROCESS,
+                  PermissionType.DELETE_DRD,
+                  PermissionType.DELETE_FORM)),
           new CreateAuthorizationRequest(
               OPERATIONS_ENGINEER_ROLE_ID,
               AuthorizationOwnerType.ROLE,

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/sm/StaticEntities.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/sm/StaticEntities.java
@@ -206,7 +206,10 @@ public class StaticEntities {
                         ownerType,
                         "*",
                         AuthorizationResourceType.RESOURCE,
-                        Set.of(PermissionType.READ)),
+                        Set.of(
+                            PermissionType.READ,
+                            PermissionType.DELETE_PROCESS,
+                            PermissionType.DELETE_DRD)),
                     new CreateAuthorizationRequest(
                         ownerId,
                         ownerType,
@@ -222,7 +225,7 @@ public class StaticEntities {
                         ownerType,
                         "*",
                         AuthorizationResourceType.DECISION_REQUIREMENTS_DEFINITION,
-                        Set.of(PermissionType.READ, PermissionType.UPDATE, PermissionType.DELETE)),
+                        Set.of(PermissionType.READ)),
                     new CreateAuthorizationRequest(
                         ownerId,
                         ownerType,

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/sm/StaticEntities.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/sm/StaticEntities.java
@@ -323,13 +323,7 @@ public class StaticEntities {
                         AuthorizationResourceType.DECISION_DEFINITION,
                         Set.of(
                             PermissionType.CREATE_DECISION_INSTANCE,
-                            PermissionType.DELETE_DECISION_INSTANCE)),
-                    new CreateAuthorizationRequest(
-                        ownerId,
-                        ownerType,
-                        "*",
-                        AuthorizationResourceType.DECISION_REQUIREMENTS_DEFINITION,
-                        Set.of(PermissionType.UPDATE, PermissionType.DELETE)))));
+                            PermissionType.DELETE_DECISION_INSTANCE)))));
 
     return authorizations.stream()
         .filter(a -> a.key().equals(permission))

--- a/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/saas/ClientMigrationHandlerTest.java
+++ b/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/saas/ClientMigrationHandlerTest.java
@@ -139,7 +139,7 @@ public class ClientMigrationHandlerTest {
                 "client-id",
                 AuthorizationOwnerType.CLIENT,
                 AuthorizationResourceType.DECISION_REQUIREMENTS_DEFINITION,
-                Set.of(PermissionType.UPDATE, PermissionType.DELETE, PermissionType.READ)),
+                Set.of(PermissionType.READ)),
             tuple(
                 "client-id",
                 AuthorizationOwnerType.CLIENT,

--- a/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/saas/StaticConsoleRoleAuthorizationMigrationHandlerTest.java
+++ b/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/saas/StaticConsoleRoleAuthorizationMigrationHandlerTest.java
@@ -55,7 +55,7 @@ public class StaticConsoleRoleAuthorizationMigrationHandlerTest {
     migrationHandler.migrate();
 
     final var results = ArgumentCaptor.forClass(CreateAuthorizationRequest.class);
-    verify(authorizationServices, times(19)).createAuthorization(results.capture());
+    verify(authorizationServices, times(21)).createAuthorization(results.capture());
     final var requests = results.getAllValues();
     assertThat(requests).containsExactlyElementsOf(ROLE_PERMISSIONS);
   }
@@ -75,6 +75,6 @@ public class StaticConsoleRoleAuthorizationMigrationHandlerTest {
     migrationHandler.migrate();
 
     // then
-    verify(authorizationServices, times(20)).createAuthorization(any());
+    verify(authorizationServices, times(22)).createAuthorization(any());
   }
 }

--- a/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/sm/ClientMigrationHandlerTest.java
+++ b/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/sm/ClientMigrationHandlerTest.java
@@ -146,7 +146,7 @@ public class ClientMigrationHandlerTest {
                 AuthorizationOwnerType.CLIENT,
                 "*",
                 AuthorizationResourceType.DECISION_REQUIREMENTS_DEFINITION,
-                Set.of(PermissionType.READ, PermissionType.UPDATE, PermissionType.DELETE)),
+                Set.of(PermissionType.READ)),
             tuple(
                 "ClientOne",
                 AuthorizationOwnerType.CLIENT,
@@ -246,7 +246,7 @@ public class ClientMigrationHandlerTest {
     // then
     verify(managementIdentityClient, times(1)).fetchClientPermissions(validClientId);
     // zeebe write results in 6 authorizations
-    verify(authorizationServices, times(6)).createAuthorization(any());
+    verify(authorizationServices, times(5)).createAuthorization(any());
   }
 
   @Test

--- a/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/sm/KeycloakRoleMigrationHandlerTest.java
+++ b/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/sm/KeycloakRoleMigrationHandlerTest.java
@@ -118,10 +118,10 @@ public class KeycloakRoleMigrationHandlerTest {
         .isEqualTo("Description for Role with special chars");
 
     final var authorizationCaptor = ArgumentCaptor.forClass(CreateAuthorizationRequest.class);
-    verify(authorizationServices, Mockito.times(20))
+    verify(authorizationServices, Mockito.times(19))
         .createAuthorization(authorizationCaptor.capture());
     final var authorizationRequests = authorizationCaptor.getAllValues();
-    assertThat(authorizationRequests).hasSize(20);
+    assertThat(authorizationRequests).hasSize(19);
     assertThat(authorizationRequests)
         .extracting(
             CreateAuthorizationRequest::ownerId,
@@ -166,7 +166,8 @@ public class KeycloakRoleMigrationHandlerTest {
                 "role_1",
                 AuthorizationOwnerType.ROLE,
                 AuthorizationResourceType.RESOURCE,
-                Set.of(PermissionType.READ)),
+                Set.of(
+                    PermissionType.READ, PermissionType.DELETE_PROCESS, PermissionType.DELETE_DRD)),
             tuple(
                 "role_1",
                 AuthorizationOwnerType.ROLE,
@@ -208,7 +209,7 @@ public class KeycloakRoleMigrationHandlerTest {
                 "role_1",
                 AuthorizationOwnerType.ROLE,
                 AuthorizationResourceType.DECISION_REQUIREMENTS_DEFINITION,
-                Set.of(PermissionType.READ, PermissionType.UPDATE, PermissionType.DELETE)),
+                Set.of(PermissionType.READ)),
             tuple(
                 "role_1",
                 AuthorizationOwnerType.ROLE,
@@ -235,11 +236,6 @@ public class KeycloakRoleMigrationHandlerTest {
                 Set.of(
                     PermissionType.CREATE_DECISION_INSTANCE,
                     PermissionType.DELETE_DECISION_INSTANCE)),
-            tuple(
-                "role@name_with_special_chars",
-                AuthorizationOwnerType.ROLE,
-                AuthorizationResourceType.DECISION_REQUIREMENTS_DEFINITION,
-                Set.of(PermissionType.UPDATE, PermissionType.DELETE)),
             tuple(
                 "role@name_with_special_chars",
                 AuthorizationOwnerType.ROLE,
@@ -317,7 +313,7 @@ public class KeycloakRoleMigrationHandlerTest {
 
     // then
     verify(managementIdentityClient, times(2)).fetchPermissions(any());
-    verify(authorizationServices, times(20)).createAuthorization(any());
+    verify(authorizationServices, times(19)).createAuthorization(any());
   }
 
   @Test
@@ -380,7 +376,7 @@ public class KeycloakRoleMigrationHandlerTest {
 
     // then
     verify(roleServices, Mockito.times(2)).createRole(any(CreateRoleRequest.class));
-    verify(authorizationServices, Mockito.times(21))
+    verify(authorizationServices, Mockito.times(20))
         .createAuthorization(any(CreateAuthorizationRequest.class));
   }
 }

--- a/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/sm/OidcRoleMigrationHandlerTest.java
+++ b/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/sm/OidcRoleMigrationHandlerTest.java
@@ -122,10 +122,10 @@ public class OidcRoleMigrationHandlerTest {
         .isEqualTo("Description for Role with special chars");
 
     final var authorizationCaptor = ArgumentCaptor.forClass(CreateAuthorizationRequest.class);
-    verify(authorizationServices, Mockito.times(20))
+    verify(authorizationServices, Mockito.times(19))
         .createAuthorization(authorizationCaptor.capture());
     final var authorizationRequests = authorizationCaptor.getAllValues();
-    assertThat(authorizationRequests).hasSize(20);
+    assertThat(authorizationRequests).hasSize(19);
     assertThat(authorizationRequests)
         .extracting(
             CreateAuthorizationRequest::ownerId,
@@ -170,7 +170,8 @@ public class OidcRoleMigrationHandlerTest {
                 "role_1",
                 AuthorizationOwnerType.ROLE,
                 AuthorizationResourceType.RESOURCE,
-                Set.of(PermissionType.READ)),
+                Set.of(
+                    PermissionType.READ, PermissionType.DELETE_PROCESS, PermissionType.DELETE_DRD)),
             tuple(
                 "role_1",
                 AuthorizationOwnerType.ROLE,
@@ -212,7 +213,7 @@ public class OidcRoleMigrationHandlerTest {
                 "role_1",
                 AuthorizationOwnerType.ROLE,
                 AuthorizationResourceType.DECISION_REQUIREMENTS_DEFINITION,
-                Set.of(PermissionType.READ, PermissionType.UPDATE, PermissionType.DELETE)),
+                Set.of(PermissionType.READ)),
             tuple(
                 "role_1",
                 AuthorizationOwnerType.ROLE,
@@ -239,11 +240,6 @@ public class OidcRoleMigrationHandlerTest {
                 Set.of(
                     PermissionType.CREATE_DECISION_INSTANCE,
                     PermissionType.DELETE_DECISION_INSTANCE)),
-            tuple(
-                "role@name_with_special_chars",
-                AuthorizationOwnerType.ROLE,
-                AuthorizationResourceType.DECISION_REQUIREMENTS_DEFINITION,
-                Set.of(PermissionType.UPDATE, PermissionType.DELETE)),
             tuple(
                 "role@name_with_special_chars",
                 AuthorizationOwnerType.ROLE,
@@ -321,7 +317,7 @@ public class OidcRoleMigrationHandlerTest {
 
     // then
     verify(managementIdentityClient, times(2)).fetchPermissions(any());
-    verify(authorizationServices, times(20)).createAuthorization(any());
+    verify(authorizationServices, times(19)).createAuthorization(any());
   }
 
   @Test
@@ -384,7 +380,7 @@ public class OidcRoleMigrationHandlerTest {
 
     // then
     verify(roleServices, Mockito.times(2)).createRole(any(CreateRoleRequest.class));
-    verify(authorizationServices, Mockito.times(21))
+    verify(authorizationServices, Mockito.times(20))
         .createAuthorization(any(CreateAuthorizationRequest.class));
   }
 
@@ -444,10 +440,10 @@ public class OidcRoleMigrationHandlerTest {
         .isEqualTo("Description for Role with special chars");
 
     final var authorizationCaptor = ArgumentCaptor.forClass(CreateAuthorizationRequest.class);
-    verify(authorizationServices, Mockito.times(20))
+    verify(authorizationServices, Mockito.times(19))
         .createAuthorization(authorizationCaptor.capture());
     final var authorizationRequests = authorizationCaptor.getAllValues();
-    assertThat(authorizationRequests).hasSize(20);
+    assertThat(authorizationRequests).hasSize(19);
     assertThat(authorizationRequests)
         .extracting(
             CreateAuthorizationRequest::ownerId,
@@ -492,7 +488,8 @@ public class OidcRoleMigrationHandlerTest {
                 "role_1",
                 AuthorizationOwnerType.ROLE,
                 AuthorizationResourceType.RESOURCE,
-                Set.of(PermissionType.READ)),
+                Set.of(
+                    PermissionType.READ, PermissionType.DELETE_PROCESS, PermissionType.DELETE_DRD)),
             tuple(
                 "role_1",
                 AuthorizationOwnerType.ROLE,
@@ -534,7 +531,7 @@ public class OidcRoleMigrationHandlerTest {
                 "role_1",
                 AuthorizationOwnerType.ROLE,
                 AuthorizationResourceType.DECISION_REQUIREMENTS_DEFINITION,
-                Set.of(PermissionType.READ, PermissionType.UPDATE, PermissionType.DELETE)),
+                Set.of(PermissionType.READ)),
             tuple(
                 "role_1",
                 AuthorizationOwnerType.ROLE,
@@ -561,11 +558,6 @@ public class OidcRoleMigrationHandlerTest {
                 Set.of(
                     PermissionType.CREATE_DECISION_INSTANCE,
                     PermissionType.DELETE_DECISION_INSTANCE)),
-            tuple(
-                "role@name_with_special_chars",
-                AuthorizationOwnerType.ROLE,
-                AuthorizationResourceType.DECISION_REQUIREMENTS_DEFINITION,
-                Set.of(PermissionType.UPDATE, PermissionType.DELETE)),
             tuple(
                 "role@name_with_special_chars",
                 AuthorizationOwnerType.ROLE,

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/migration/KeycloakIdentityMigrationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/migration/KeycloakIdentityMigrationIT.java
@@ -241,7 +241,11 @@ public class KeycloakIdentityMigrationIT {
             a -> new HashSet<>(a.getPermissionTypes()))
         .contains(
             tuple("operate", ResourceType.MESSAGE, Set.of(PermissionType.READ)),
-            tuple("operate", ResourceType.RESOURCE, Set.of(PermissionType.READ)),
+            tuple(
+                "operate",
+                ResourceType.RESOURCE,
+                Set.of(
+                    PermissionType.READ, PermissionType.DELETE_PROCESS, PermissionType.DELETE_DRD)),
             tuple(
                 "operate",
                 ResourceType.DECISION_DEFINITION,
@@ -254,7 +258,7 @@ public class KeycloakIdentityMigrationIT {
             tuple(
                 "operate",
                 ResourceType.DECISION_REQUIREMENTS_DEFINITION,
-                Set.of(PermissionType.READ, PermissionType.UPDATE, PermissionType.DELETE)),
+                Set.of(PermissionType.READ)),
             tuple(
                 "operate",
                 ResourceType.PROCESS_DEFINITION,

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/migration/KeycloakIdentityMigrationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/migration/KeycloakIdentityMigrationIT.java
@@ -293,10 +293,6 @@ public class KeycloakIdentityMigrationIT {
                     PermissionType.DELETE_RESOURCE)),
             tuple("zeebe", ResourceType.SYSTEM, Set.of(PermissionType.READ, PermissionType.UPDATE)),
             tuple(
-                "zeebe",
-                ResourceType.DECISION_REQUIREMENTS_DEFINITION,
-                Set.of(PermissionType.UPDATE, PermissionType.DELETE)),
-            tuple(
                 "tasklist",
                 ResourceType.PROCESS_DEFINITION,
                 Set.of(

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/migration/KeycloakIdentityMigrationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/migration/KeycloakIdentityMigrationIT.java
@@ -496,11 +496,6 @@ public class KeycloakIdentityMigrationIT {
             tuple(
                 "migration-app",
                 OwnerType.CLIENT,
-                ResourceType.DECISION_REQUIREMENTS_DEFINITION,
-                Set.of(PermissionType.DELETE, PermissionType.UPDATE)),
-            tuple(
-                "migration-app",
-                OwnerType.CLIENT,
                 ResourceType.PROCESS_DEFINITION,
                 Set.of(
                     PermissionType.UPDATE_PROCESS_INSTANCE,

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/migration/OidcIdentityMigrationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/migration/OidcIdentityMigrationIT.java
@@ -238,10 +238,6 @@ public class OidcIdentityMigrationIT {
                     PermissionType.DELETE_RESOURCE)),
             tuple("zeebe", ResourceType.SYSTEM, Set.of(PermissionType.READ, PermissionType.UPDATE)),
             tuple(
-                "zeebe",
-                ResourceType.DECISION_REQUIREMENTS_DEFINITION,
-                Set.of(PermissionType.UPDATE, PermissionType.DELETE)),
-            tuple(
                 "tasklist",
                 ResourceType.PROCESS_DEFINITION,
                 Set.of(

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/migration/OidcIdentityMigrationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/migration/OidcIdentityMigrationIT.java
@@ -186,7 +186,11 @@ public class OidcIdentityMigrationIT {
             a -> new HashSet<>(a.getPermissionTypes()))
         .contains(
             tuple("operate", ResourceType.MESSAGE, Set.of(PermissionType.READ)),
-            tuple("operate", ResourceType.RESOURCE, Set.of(PermissionType.READ)),
+            tuple(
+                "operate",
+                ResourceType.RESOURCE,
+                Set.of(
+                    PermissionType.READ, PermissionType.DELETE_PROCESS, PermissionType.DELETE_DRD)),
             tuple(
                 "operate",
                 ResourceType.DECISION_DEFINITION,
@@ -199,7 +203,7 @@ public class OidcIdentityMigrationIT {
             tuple(
                 "operate",
                 ResourceType.DECISION_REQUIREMENTS_DEFINITION,
-                Set.of(PermissionType.READ, PermissionType.UPDATE, PermissionType.DELETE)),
+                Set.of(PermissionType.READ)),
             tuple(
                 "operate",
                 ResourceType.PROCESS_DEFINITION,

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/migration/SaaSIdentityMigrationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/migration/SaaSIdentityMigrationIT.java
@@ -333,7 +333,19 @@ public class SaaSIdentityMigrationIT {
                 OwnerType.ROLE,
                 "*",
                 ResourceType.DECISION_REQUIREMENTS_DEFINITION,
-                Set.of(PermissionType.READ, PermissionType.UPDATE, PermissionType.DELETE)),
+                Set.of(PermissionType.READ)),
+            tuple(
+                DEVELOPER_ROLE_ID,
+                OwnerType.ROLE,
+                "*",
+                ResourceType.RESOURCE,
+                Set.of(
+                    PermissionType.CREATE,
+                    PermissionType.DELETE_FORM,
+                    PermissionType.DELETE_PROCESS,
+                    PermissionType.DELETE_DRD,
+                    PermissionType.DELETE_RESOURCE,
+                    PermissionType.READ)),
             tuple(
                 DEVELOPER_ROLE_ID,
                 OwnerType.ROLE,
@@ -372,7 +384,18 @@ public class SaaSIdentityMigrationIT {
                 OwnerType.ROLE,
                 "*",
                 ResourceType.DECISION_REQUIREMENTS_DEFINITION,
-                Set.of(PermissionType.READ, PermissionType.UPDATE, PermissionType.DELETE)),
+                Set.of(PermissionType.READ)),
+            tuple(
+                OPERATIONS_ENGINEER_ROLE_ID,
+                OwnerType.ROLE,
+                "*",
+                ResourceType.RESOURCE,
+                Set.of(
+                    PermissionType.READ,
+                    PermissionType.DELETE_RESOURCE,
+                    PermissionType.DELETE_PROCESS,
+                    PermissionType.DELETE_DRD,
+                    PermissionType.DELETE_FORM)),
             tuple(
                 OPERATIONS_ENGINEER_ROLE_ID,
                 OwnerType.ROLE,
@@ -570,7 +593,7 @@ public class SaaSIdentityMigrationIT {
                 "client123",
                 OwnerType.CLIENT,
                 ResourceType.DECISION_REQUIREMENTS_DEFINITION,
-                Set.of(PermissionType.UPDATE, PermissionType.DELETE, PermissionType.READ)),
+                Set.of(PermissionType.READ)),
             tuple(
                 "client123",
                 OwnerType.CLIENT,

--- a/security/security-protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AuthorizationResourceType.java
+++ b/security/security-protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AuthorizationResourceType.java
@@ -38,8 +38,7 @@ public enum AuthorizationResourceType {
       PermissionType.MODIFY_PROCESS_INSTANCE,
       PermissionType.CANCEL_PROCESS_INSTANCE,
       PermissionType.DELETE_PROCESS_INSTANCE),
-  DECISION_REQUIREMENTS_DEFINITION(
-      PermissionType.READ, PermissionType.UPDATE, PermissionType.DELETE),
+  DECISION_REQUIREMENTS_DEFINITION(PermissionType.READ),
   DECISION_DEFINITION(
       PermissionType.READ_DECISION_DEFINITION,
       PermissionType.READ_DECISION_INSTANCE,

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/IdentitySetupInitializeDefaultsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/IdentitySetupInitializeDefaultsTest.java
@@ -125,8 +125,7 @@ public class IdentitySetupInitializeDefaultsTest {
             auth ->
                 Assertions.assertThat(auth)
                     .hasResourceType(AuthorizationResourceType.DECISION_REQUIREMENTS_DEFINITION)
-                    .hasOnlyPermissionTypes(
-                        PermissionType.READ, PermissionType.UPDATE, PermissionType.DELETE),
+                    .hasOnlyPermissionTypes(PermissionType.READ),
             auth ->
                 Assertions.assertThat(auth)
                     .hasResourceType(AuthorizationResourceType.DECISION_DEFINITION)


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Resource type `DECISION_REQUIREMENTS_DEFINITION` should only have `PermissionType.READ`. Creating and deleting happens through the `RESOURCE` resource type. Updating is not supported at all.

This results in changes to the 8.7 -> 8.8 Identity migration as well:
- `developer` now has all RESOURCE permissions, and only READ for DRD
- `operationsengineer` now has read and delete permissions for resources, and read only for DRD. It cannot create resources.
- `client123` now has the same permissions as developer for resources and DRD

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #35901
