### PR TITLE
Release 8.8.0 update ci release notes step

### DIFF
--- a/.github/workflows/optimize-release-optimize-c8-only.yml
+++ b/.github/workflows/optimize-release-optimize-c8-only.yml
@@ -285,8 +285,9 @@ jobs:
           draft: true
           name: ${{ env.TAG }}
           tag_name: ${{ env.TAG }}
-          generate_release_notes: true
           make_latest: \"false\"
+          body: |
+            Please refer to the [Camunda Monorepo ${{ env.RELEASE_VERSION }} Release Notes](https://github.com/camunda/camunda/releases/tag/${{ env.RELEASE_VERSION }}) for full details.
 
       - name: Auto-update previous version
         run: |

--- a/optimize-distro/pom.xml
+++ b/optimize-distro/pom.xml
@@ -137,7 +137,7 @@
     <profile>
       <id>add-license-key</id>
       <properties>
-        <exclude.from.config />
+        <exclude.from.config></exclude.from.config>
       </properties>
     </profile>
     <profile>

--- a/optimize/upgrade/pom.xml
+++ b/optimize/upgrade/pom.xml
@@ -289,15 +289,15 @@
             <configuration>
               <skip>${skip.docker}</skip>
               <target description="Check whether ES is running" name="check-es-is-up">
-                <echo message="Check ES is running..." />
+                <echo message="Check ES is running..."></echo>
                 <waitfor checkevery="1" checkeveryunit="second" maxwait="30" maxwaitunit="second">
-                  <socket port="9200" server="localhost" />
+                  <socket port="9200" server="localhost"></socket>
                 </waitfor>
-                <echo message="ES http socket is open. Checking for ES cluster state..." />
+                <echo message="ES http socket is open. Checking for ES cluster state..."></echo>
                 <waitfor checkevery="1" checkeveryunit="second" maxwait="30" maxwaitunit="second">
-                  <http url="http://localhost:9200/_cluster/state" />
+                  <http url="http://localhost:9200/_cluster/state"></http>
                 </waitfor>
-                <echo message="ES is running." />
+                <echo message="ES is running."></echo>
               </target>
             </configuration>
           </execution>


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
This PR updates the GitHub release creation step in the Optimize release workflow to disable automatic generation of release notes.

Instead, it provides a static body message that points users to the corresponding Camunda Monorepo release notes for full details.

This change addresses issues where the release body could exceed GitHub’s 125,000-character limit, and avoids duplicating the monorepo release notes for alpha releases.


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
