### PR TITLE
ci: reposition clean release step

### DIFF
--- a/.github/workflows/optimize-release-optimize-c8-only.yml
+++ b/.github/workflows/optimize-release-optimize-c8-only.yml
@@ -228,6 +228,10 @@ jobs:
         with:
           work-dir: ./optimize
 
+      - name: Clean release
+        run: |
+          mvn release:clean
+
       - name: Prepare release
         run: |
           ./mvnw -f optimize \
@@ -249,10 +253,6 @@ jobs:
         run: |
           git push --tags
           git push --all
-
-      - name: Clean Release
-        run: |
-          mvn release:clean
 
       - name: Perform release
         run: |


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
This PR repositions the `mvn clean release` step before the `mvn prepare releas`e step.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
