### PR TITLE
feat: backport changes from 36305 to stable operate-8.5

### DIFF
--- a/operate/client/src/App/Processes/ListView/InstancesTable/useOperationApply/index.setup.ts
+++ b/operate/client/src/App/Processes/ListView/InstancesTable/useOperationApply/index.setup.ts
@@ -54,7 +54,7 @@ const mockData = {
       operationType: 'RESOLVE_INCIDENT',
       query: {
         ...baseQuery,
-        ids: ['1'],
+        ids: ['2251799813685594'],
         excludeIds: [],
       },
     },
@@ -78,7 +78,7 @@ const mockData = {
       operationType: 'RESOLVE_INCIDENT',
       query: {
         ...baseQuery,
-        ids: ['1'],
+        ids: ['2251799813685594'],
         excludeIds: [],
         processIds: ['demoProcess1'],
       },

--- a/operate/client/src/App/Processes/ListView/InstancesTable/useOperationApply/index.test.tsx
+++ b/operate/client/src/App/Processes/ListView/InstancesTable/useOperationApply/index.test.tsx
@@ -126,7 +126,7 @@ describe('useOperationApply', () => {
     processInstancesStore.init();
     processInstancesStore.fetchProcessInstancesFromFilters();
     mockedGetSearchString.mockImplementation(
-      () => '?active=true&running=true&incidents=true&ids=1',
+      () => '?active=true&running=true&incidents=true&ids=2251799813685594',
     );
 
     mockApplyBatchOperation().withSuccess(mockOperationCreated);
@@ -135,7 +135,7 @@ describe('useOperationApply', () => {
       expect(processInstancesStore.state.status).toBe('fetched'),
     );
 
-    processInstancesSelectionStore.selectProcessInstance('1');
+    processInstancesSelectionStore.selectProcessInstance('2251799813685594');
 
     expect(operationsStore.state.operations).toEqual([]);
     renderUseOperationApply();
@@ -146,6 +146,8 @@ describe('useOperationApply', () => {
     expect(applyBatchOperationSpy).toHaveBeenCalledWith({
       operationType: expectedBody.operationType,
       query: expectedBody.query,
+      migrationPlan: undefined,
+      modifications: undefined,
     });
   });
 
@@ -187,7 +189,7 @@ describe('useOperationApply', () => {
     processInstancesStore.fetchProcessInstancesFromFilters();
     mockedGetSearchString.mockImplementation(
       () =>
-        '?active=true&running=true&incidents=true&process=demoProcess&version=1&ids=1',
+        '?active=true&running=true&incidents=true&process=demoProcess&version=1&ids=2251799813685594',
     );
     await processesStore.fetchProcesses();
 
@@ -197,7 +199,7 @@ describe('useOperationApply', () => {
       expect(processInstancesStore.state.status).toBe('fetched'),
     );
 
-    processInstancesSelectionStore.selectProcessInstance('1');
+    processInstancesSelectionStore.selectProcessInstance('2251799813685594');
 
     expect(operationsStore.state.operations).toEqual([]);
     // @ts-expect-error ts-migrate(2554) FIXME: Expected 0 arguments, but got 1.
@@ -209,6 +211,8 @@ describe('useOperationApply', () => {
     expect(applyBatchOperationSpy).toHaveBeenCalledWith({
       operationType: expectedBody.operationType,
       query: expectedBody.query,
+      migrationPlan: undefined,
+      modifications: undefined,
     });
   });
 
@@ -276,7 +280,7 @@ describe('useOperationApply', () => {
   });
 
   it('should poll the selected instances', async () => {
-    const {expectedBody, ...context} = mockData.setProcessFilterSelectOne;
+    const {...context} = mockData.setProcessFilterSelectOne;
     processInstancesSelectionStore.selectProcessInstance('2251799813685594');
 
     jest.useFakeTimers();

--- a/operate/client/src/App/Processes/ListView/InstancesTable/useOperationApply/index.ts
+++ b/operate/client/src/App/Processes/ListView/InstancesTable/useOperationApply/index.ts
@@ -30,8 +30,12 @@ type ApplyBatchOperationParams = {
 };
 
 function useOperationApply() {
-  const {selectedProcessInstanceIds, excludedProcessInstanceIds, reset} =
-    processInstancesSelectionStore;
+  const {
+    selectedProcessInstanceIds,
+    excludedProcessInstanceIds,
+    checkedRunningProcessInstanceIds,
+    reset,
+  } = processInstancesSelectionStore;
 
   return {
     applyBatchOperation: ({
@@ -42,16 +46,22 @@ function useOperationApply() {
       const query = getProcessInstancesRequestFilters();
       const filterIds = query.ids || [];
 
-      // if ids are selected, ignore ids from filter
-      // if no ids are selected, apply ids from filter
+      const shouldFilterToRunningInstances =
+        operationType === 'CANCEL_PROCESS_INSTANCE' ||
+        operationType === 'RESOLVE_INCIDENT';
+
       const ids: string[] =
         selectedProcessInstanceIds.length > 0
-          ? selectedProcessInstanceIds
+          ? shouldFilterToRunningInstances
+            ? checkedRunningProcessInstanceIds
+            : selectedProcessInstanceIds
           : filterIds;
 
       if (selectedProcessInstanceIds.length > 0) {
         processInstancesStore.markProcessInstancesWithActiveOperations({
-          ids: selectedProcessInstanceIds,
+          ids: shouldFilterToRunningInstances
+            ? checkedRunningProcessInstanceIds
+            : selectedProcessInstanceIds,
           operationType,
         });
       } else {

--- a/operate/client/src/modules/stores/processInstancesSelection.ts
+++ b/operate/client/src/modules/stores/processInstancesSelection.ts
@@ -169,6 +169,28 @@ class ProcessInstancesSelection {
     );
   }
 
+  get checkedRunningProcessInstanceIds() {
+    const {selectionMode, selectedProcessInstanceIds} = this.state;
+    const runningInstances =
+      processInstancesStore.state.processInstances.filter((instance) =>
+        ['ACTIVE', 'INCIDENT'].includes(instance.state),
+      );
+
+    if (selectionMode === 'INCLUDE') {
+      return selectedProcessInstanceIds.filter((id) =>
+        runningInstances.some((instance) => instance.id === id),
+      );
+    }
+
+    const allRunningInstanceIds = runningInstances.map(
+      (instance) => instance.id,
+    );
+
+    return allRunningInstanceIds.filter(
+      (id) => !selectedProcessInstanceIds.includes(id),
+    );
+  }
+
   get selectedProcessInstanceIds() {
     const {selectionMode, selectedProcessInstanceIds} = this.state;
 


### PR DESCRIPTION
## Description

backport https://github.com/camunda/camunda/pull/36305 to operate-8.5

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

backport for https://github.com/camunda/camunda/pull/36305
