### PR TITLE
test: add extra filter to test utility to avoid flaky tests due to matching table head cells

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/waitForItemInList.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/waitForItemInList.ts
@@ -35,11 +35,19 @@ export const waitForItemInList = async (
 
       if (emptyStateLocator) {
         await Promise.race([
-          page.getByRole('cell').filter({hasText: /.+/}).first().waitFor(),
+          page
+            .getByRole('cell')
+            .filter({hasText: /.+/, hasNot: page.locator('div')})
+            .first()
+            .waitFor(),
           emptyStateLocator?.waitFor(),
         ]);
       } else {
-        await page.getByRole('cell').filter({hasText: /.+/}).first().waitFor();
+        await page
+          .getByRole('cell')
+          .filter({hasText: /.+/, hasNot: page.locator('div')})
+          .first()
+          .waitFor();
       }
 
       return await item.isVisible();


### PR DESCRIPTION
## Description

- Adds extra filter to `waitForItemInList` test utility to avoid flaky tests due to matching table head cells. 

Explanation for change: All header cells have static values in Identity, which means they load instantly, differently than the content for other cells (actual list items) that have to wait for the data to get returned from the API requests. Because of that, sometimes the tests are failing because this utility ends up matching to the cell of a table header. All table headers have a `div` inside them and I couldn't find any table list items that have one (they just have a `span` with the content usually), so by adding this new filter we ensure the utility function will actually wait until the list has been populated with data to check if a certain item is present on that list, which would previously fail due to the retry mechanism kicking in even before the data was loaded and visible.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

related to #36183 and #36120 
