### PR TITLE
Bugfix: failure to start if OIDC provider is unavailable

### DIFF
--- a/authentication/pom.xml
+++ b/authentication/pom.xml
@@ -103,7 +103,7 @@
     <dependency>
       <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
-      <scope>compile</scope>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/authentication/pom.xml
+++ b/authentication/pom.xml
@@ -101,6 +101,11 @@
       <artifactId>zeebe-auth</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/authentication/src/main/java/io/camunda/authentication/config/SafeInitClientRegistrationRepository.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/SafeInitClientRegistrationRepository.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.config;
+
+import java.util.function.Supplier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+
+/**
+ * Wrapper around ClientRegistrationRepository that ensures repository is created rather at a
+ * startup or during later retries.
+ */
+public class SafeInitClientRegistrationRepository implements ClientRegistrationRepository {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(SafeInitClientRegistrationRepository.class);
+
+  /**
+   * Helper that ensures ClientRegistrationRepository is created rather on startup or after retries
+   * if startup initialization failed.
+   */
+  private final SafeInitProxy<ClientRegistrationRepository> proxy;
+
+  public SafeInitClientRegistrationRepository(
+      final Supplier<ClientRegistrationRepository> repositoryFactory) {
+    // Try to create a repository. In case of failure - schedule async retries of creation.
+    proxy =
+        new SafeInitProxy<>(
+            repositoryFactory,
+            e -> LOG.error("Failed to initialize ClientRegistrationRepository. Retrying.", e));
+  }
+
+  @Override
+  public ClientRegistration findByRegistrationId(final String registrationId) {
+    // if repository is initialized, then delegate method call to it. If not, throw an exception
+    // that will be propagated to client.
+    return proxy
+        .orElseThrow(
+            () ->
+                new RuntimeException(
+                    "Authentication service unavailable: Unable to connect to the configured Identity Provider (OIDC). "
+                        + "Please try again later or contact your administrator."))
+        .findByRegistrationId(registrationId);
+  }
+}

--- a/authentication/src/main/java/io/camunda/authentication/config/SafeInitClientRegistrationRepository.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/SafeInitClientRegistrationRepository.java
@@ -44,7 +44,7 @@ public class SafeInitClientRegistrationRepository implements ClientRegistrationR
     return proxy
         .orElseThrow(
             () ->
-                new RuntimeException(
+                new IllegalStateException(
                     "Authentication service unavailable: Unable to connect to the configured Identity Provider (OIDC). "
                         + "Please try again later or contact your administrator."))
         .findByRegistrationId(registrationId);

--- a/authentication/src/main/java/io/camunda/authentication/config/SafeInitClientRegistrationRepository.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/SafeInitClientRegistrationRepository.java
@@ -34,7 +34,7 @@ public class SafeInitClientRegistrationRepository implements ClientRegistrationR
     proxy =
         new SafeInitProxy<>(
             repositoryFactory,
-            e -> LOG.error("Failed to initialize ClientRegistrationRepository. Retrying.", e));
+            e -> LOG.warn("Failed to initialize ClientRegistrationRepository. Retrying.", e));
   }
 
   @Override

--- a/authentication/src/main/java/io/camunda/authentication/config/SafeInitJwtDecoder.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/SafeInitJwtDecoder.java
@@ -38,6 +38,11 @@ public class SafeInitJwtDecoder implements JwtDecoder {
     return proxy
         .orElseThrow(
             () ->
+                // we have to throw AuthenticationCredentialsNotFoundException or any other
+                // Exception that extend AuthenticationException in order for Spring to pass it
+                // to our error handler.
+                // Please see `BearerTokenAuthenticationFilter` `authenticationFailureHandler`
+                // part and `doFilterInternal` method.
                 new AuthenticationCredentialsNotFoundException(
                     "Authentication service unavailable: Unable to connect to the configured Identity Provider (OIDC). "
                         + "Please try again later or contact your administrator."))

--- a/authentication/src/main/java/io/camunda/authentication/config/SafeInitJwtDecoder.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/SafeInitJwtDecoder.java
@@ -28,7 +28,7 @@ public class SafeInitJwtDecoder implements JwtDecoder {
     // Try to create a decoder. In case of failure - schedule async retries of creation.
     proxy =
         new SafeInitProxy<>(
-            decoderSupplier, e -> LOG.error("Failed to initialize JWT Decoder. Retrying.", e));
+            decoderSupplier, e -> LOG.debug("Failed to initialize JWT Decoder. Retrying.", e));
   }
 
   @Override

--- a/authentication/src/main/java/io/camunda/authentication/config/SafeInitJwtDecoder.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/SafeInitJwtDecoder.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.config;
+
+import java.util.function.Supplier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtException;
+
+/**
+ * Wrapper around JwtDecoder that ensures decoder is created rather at a startup or during later
+ * retries.
+ */
+public class SafeInitJwtDecoder implements JwtDecoder {
+  private static final Logger LOG = LoggerFactory.getLogger(SafeInitJwtDecoder.class);
+
+  private final SafeInitProxy<JwtDecoder> proxy;
+
+  public SafeInitJwtDecoder(final Supplier<JwtDecoder> decoderSupplier) {
+    // Try to create a decoder. In case of failure - schedule async retries of creation.
+    proxy =
+        new SafeInitProxy<>(
+            decoderSupplier, e -> LOG.error("Failed to initialize JWT Decoder. Retrying.", e));
+  }
+
+  @Override
+  public Jwt decode(final String token) throws JwtException {
+    // if JWT Decoder is initialized, then delegate method call to it. If not, throw an exception
+    // that will be propagated to client.
+    return proxy
+        .orElseThrow(
+            () ->
+                new AuthenticationCredentialsNotFoundException(
+                    "Authentication service unavailable: Unable to connect to the configured Identity Provider (OIDC). "
+                        + "Please try again later or contact your administrator."))
+        .decode(token);
+  }
+}

--- a/authentication/src/main/java/io/camunda/authentication/config/SafeInitProxy.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/SafeInitProxy.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.config;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+/**
+ * Helper class that ensures eventual creation of the object. It will try to create the object on a
+ * startup and in case of failure it will keep retrying the creation in async way until it succeeds.
+ *
+ * @param <T> type of object to initialize
+ */
+public class SafeInitProxy<T> {
+  private static final long DEFAULT_RETRY_DELAY_MS = 1_000;
+
+  /** Reference to an object that has to be created. */
+  private final AtomicReference<T> reference = new AtomicReference<>();
+
+  /** Supplier function for object creation */
+  private final Supplier<T> initSupplier;
+
+  /** Listener function for creation errors. */
+  private final Consumer<Exception> errorListener;
+
+  /** Retry delay */
+  private final long retryDelayMs;
+
+  /** Executor that will run retry task with the configured delay. */
+  private Executor delayedExecutor;
+
+  public SafeInitProxy(final Supplier<T> initSupplier, final Consumer<Exception> errorListener) {
+    this(initSupplier, errorListener, DEFAULT_RETRY_DELAY_MS);
+  }
+
+  public SafeInitProxy(
+      final Supplier<T> initSupplier,
+      final Consumer<Exception> errorListener,
+      final long retryDelayMs) {
+    this.initSupplier = initSupplier;
+    this.errorListener = errorListener;
+    this.retryDelayMs = retryDelayMs;
+
+    try {
+      reference.set(initSupplier.get());
+    } catch (final Exception e) {
+      errorListener.accept(e);
+
+      // Failed to initialize, schedule async retries
+      delayedExecutor = CompletableFuture.delayedExecutor(retryDelayMs, TimeUnit.MILLISECONDS);
+      scheduleRetry();
+    }
+  }
+
+  private void scheduleRetry() {
+    CompletableFuture.runAsync(
+        () -> {
+          try {
+            // try to initialize the object on retry
+            reference.set(initSupplier.get());
+          } catch (final Exception e) {
+            // if initialization fails, notify error listener and schedule next retry
+            errorListener.accept(e);
+            scheduleRetry();
+          }
+        },
+        delayedExecutor);
+  }
+
+  public <E extends Throwable> T orElseThrow(final Supplier<? extends E> exceptionSupplier)
+      throws E {
+    final T value = reference.get();
+    if (value == null) {
+      throw exceptionSupplier.get();
+    }
+    return value;
+  }
+}

--- a/authentication/src/test/java/io/camunda/authentication/config/SafeInitProxyTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/SafeInitProxyTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.config;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Supplier;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class SafeInitProxyTest {
+
+  @Mock Supplier<String> initMethod;
+
+  @Test
+  void shouldInitializeAfterRetries() {
+    Mockito.when(initMethod.get())
+        .thenThrow(new RuntimeException("Startup failure"))
+        .thenThrow(new RuntimeException("Retry failure 1"))
+        .thenThrow(new RuntimeException("Retry failure 2"))
+        .thenReturn("created object");
+
+    final List<String> receivedErrors = new ArrayList<>();
+
+    final SafeInitProxy<String> proxy =
+        new SafeInitProxy<>(
+            initMethod,
+            e -> {
+              receivedErrors.add(e.getMessage());
+            },
+            0);
+
+    Awaitility.await("Object is initialised")
+        .untilAsserted(
+            () -> {
+              final String result =
+                  proxy.orElseThrow(() -> new IllegalStateException("Object must be initialized"));
+              assertEquals("created object", result);
+              assertEquals(
+                  List.of("Startup failure", "Retry failure 1", "Retry failure 2"), receivedErrors);
+            });
+  }
+
+  @Test
+  void shouldInitializeOnStartup() {
+    Mockito.when(initMethod.get()).thenReturn("created object");
+
+    final List<String> receivedErrors = new ArrayList<>();
+
+    final SafeInitProxy<String> proxy =
+        new SafeInitProxy<>(
+            initMethod,
+            e -> {
+              receivedErrors.add(e.getMessage());
+            },
+            0);
+
+    Awaitility.await("Object is initialised")
+        .untilAsserted(
+            () -> {
+              final String result =
+                  proxy.orElseThrow(() -> new IllegalStateException("Object must be initialized"));
+              assertEquals("created object", result);
+              assertEquals(List.of(), receivedErrors);
+            });
+  }
+}

--- a/authentication/src/test/java/io/camunda/authentication/config/SafeInitProxyTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/SafeInitProxyTest.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.authentication.config;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -47,9 +47,9 @@ class SafeInitProxyTest {
             () -> {
               final String result =
                   proxy.orElseThrow(() -> new IllegalStateException("Object must be initialized"));
-              assertEquals("created object", result);
-              assertEquals(
-                  List.of("Startup failure", "Retry failure 1", "Retry failure 2"), receivedErrors);
+              assertThat("created object").isEqualTo(result);
+              assertThat(List.of("Startup failure", "Retry failure 1", "Retry failure 2"))
+                  .isEqualTo(receivedErrors);
             });
   }
 
@@ -72,8 +72,8 @@ class SafeInitProxyTest {
             () -> {
               final String result =
                   proxy.orElseThrow(() -> new IllegalStateException("Object must be initialized"));
-              assertEquals("created object", result);
-              assertEquals(List.of(), receivedErrors);
+              assertThat("created object").isEqualTo(result);
+              assertThat(List.of()).isEqualTo(receivedErrors);
             });
   }
 }

--- a/zeebe/qa/integration-tests/pom.xml
+++ b/zeebe/qa/integration-tests/pom.xml
@@ -21,6 +21,10 @@
 
   <name>Zeebe QA Integration Tests</name>
 
+  <properties>
+    <mockserver.version>5.15.0</mockserver.version>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>io.camunda</groupId>
@@ -585,6 +589,27 @@
       <groupId>io.camunda</groupId>
       <artifactId>configuration</artifactId>
       <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.mock-server</groupId>
+      <artifactId>mockserver-netty</artifactId>
+      <version>${mockserver.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.mock-server</groupId>
+      <artifactId>mockserver-core</artifactId>
+      <version>${mockserver.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.mock-server</groupId>
+      <artifactId>mockserver-client-java</artifactId>
+      <version>${mockserver.version}</version>
       <scope>test</scope>
     </dependency>
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/OidcAuthOverRestIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/OidcAuthOverRestIT.java
@@ -200,16 +200,6 @@ public class OidcAuthOverRestIT {
   void shouldBeUnauthorizedWithMappingWithoutPermissions() {
     // given
     final var processId = Strings.newRandomValidBpmnId();
-    final var claimName = UUID.randomUUID().toString();
-    final var claimValue = UUID.randomUUID().toString();
-    defaultMappingRuleClient
-        .newCreateMappingRuleCommand()
-        .mappingRuleId(UUID.randomUUID().toString())
-        .claimName(claimName)
-        .claimValue(claimValue)
-        .name(claimValue)
-        .send()
-        .join();
 
     // when
     final var deployFuture =

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/OidcAuthOverRestStartupIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/OidcAuthOverRestStartupIT.java
@@ -80,7 +80,7 @@ public class OidcAuthOverRestStartupIT {
                 c.getAuthorizations().setEnabled(true);
 
                 final var oidcConfig = c.getAuthentication().getOidc();
-                String issuerUri =
+                final String issuerUri =
                     "http://localhost:"
                         + keycloakProxy.getLocalPort()
                         + "/realms/"

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/OidcAuthOverRestStartupIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/OidcAuthOverRestStartupIT.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.authorization;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockserver.model.HttpRequest.request;
+
+import dasniko.testcontainers.keycloak.KeycloakContainer;
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.command.ProblemException;
+import io.camunda.client.impl.oauth.OAuthCredentialsProviderBuilder;
+import io.camunda.security.configuration.ConfiguredMappingRule;
+import io.camunda.security.entity.AuthenticationMethod;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.zeebe.test.testcontainers.DefaultTestContainers;
+import io.camunda.zeebe.test.util.Strings;
+import io.camunda.zeebe.test.util.testcontainers.TestSearchContainers;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AutoClose;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.keycloak.representations.idm.ClientRepresentation;
+import org.keycloak.representations.idm.RealmRepresentation;
+import org.keycloak.representations.idm.UserRepresentation;
+import org.mockserver.configuration.Configuration;
+import org.mockserver.integration.ClientAndServer;
+import org.mockserver.model.HttpForward;
+import org.mockserver.model.HttpForward.Scheme;
+import org.slf4j.event.Level;
+import org.testcontainers.elasticsearch.ElasticsearchContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+@ZeebeIntegration
+public class OidcAuthOverRestStartupIT {
+
+  private static final String DEFAULT_USER_ID = UUID.randomUUID().toString();
+  private static final String KEYCLOAK_REALM = "camunda";
+  private static final String DEFAULT_CLIENT_ID = "zeebe";
+  private static final String DEFAULT_CLIENT_SECRET = "secret";
+  private static final String USER_ID_CLAIM_NAME = "sub";
+
+  @Container
+  private static final ElasticsearchContainer CONTAINER =
+      TestSearchContainers.createDefeaultElasticsearchContainer();
+
+  @Container
+  private static final KeycloakContainer KEYCLOAK = DefaultTestContainers.createDefaultKeycloak();
+
+  @AutoClose private static CamundaClient client;
+
+  private final ClientAndServer keycloakProxy =
+      ClientAndServer.startClientAndServer(new Configuration().logLevel(Level.ERROR));
+
+  @TestZeebe(awaitCompleteTopology = false)
+  private final TestStandaloneBroker broker =
+      new TestStandaloneBroker()
+          .withAuthenticatedAccess()
+          .withAuthenticationMethod(AuthenticationMethod.OIDC)
+          .withCamundaExporter("http://" + CONTAINER.getHttpHostAddress())
+          .withSecurityConfig(
+              c -> {
+                c.getAuthorizations().setEnabled(true);
+
+                final var oidcConfig = c.getAuthentication().getOidc();
+                String issuerUri =
+                    "http://localhost:"
+                        + keycloakProxy.getLocalPort()
+                        + "/realms/"
+                        + KEYCLOAK_REALM;
+                oidcConfig.setIssuerUri(issuerUri);
+                // The following two properties are only needed for the webapp login flow which we
+                // don't test here.
+                oidcConfig.setClientId("example");
+                oidcConfig.setRedirectUri("example.com");
+                c.getInitialization()
+                    .setMappingRules(
+                        List.of(
+                            new ConfiguredMappingRule(
+                                DEFAULT_USER_ID, USER_ID_CLAIM_NAME, DEFAULT_USER_ID)));
+                c.getInitialization()
+                    .getDefaultRoles()
+                    .put("admin", Map.of("users", List.of(DEFAULT_USER_ID)));
+              });
+
+  @BeforeAll
+  static void setupKeycloak() {
+    final var defaultClient = new ClientRepresentation();
+    defaultClient.setClientId(DEFAULT_CLIENT_ID);
+    defaultClient.setEnabled(true);
+    defaultClient.setClientAuthenticatorType("client-secret");
+    defaultClient.setSecret(DEFAULT_CLIENT_SECRET);
+    defaultClient.setServiceAccountsEnabled(true);
+
+    final var defaultUser = new UserRepresentation();
+    defaultUser.setId(DEFAULT_USER_ID);
+    defaultUser.setUsername("zeebe-service-account");
+    defaultUser.setServiceAccountClientId(DEFAULT_CLIENT_ID);
+    defaultUser.setEnabled(true);
+
+    final var realm = new RealmRepresentation();
+    realm.setRealm("camunda");
+    realm.setEnabled(true);
+    realm.setClients(List.of(defaultClient));
+    realm.setUsers(List.of(defaultUser));
+
+    try (final var keycloak = KEYCLOAK.getKeycloakAdminClient()) {
+      keycloak.realms().create(realm);
+    }
+  }
+
+  @BeforeEach
+  void beforeEach(@TempDir final Path tempDir) {
+
+    client =
+        CamundaClient.newClientBuilder()
+            .grpcAddress(broker.grpcAddress())
+            .restAddress(broker.restAddress())
+            .usePlaintext()
+            .preferRestOverGrpc(true)
+            .defaultRequestTimeout(Duration.ofSeconds(15))
+            .credentialsProvider(
+                new OAuthCredentialsProviderBuilder()
+                    .clientId(DEFAULT_CLIENT_ID)
+                    .clientSecret(DEFAULT_CLIENT_SECRET)
+                    .audience("zeebe")
+                    .authorizationServerUrl(
+                        KEYCLOAK.getAuthServerUrl()
+                            + "/realms/"
+                            + KEYCLOAK_REALM
+                            + "/protocol/openid-connect/token")
+                    .credentialsCachePath(tempDir.resolve("default").toString())
+                    .build())
+            .build();
+  }
+
+  @Test
+  void shouldStartWhenKeycloakIsNotAvailableOnStartup() {
+    // given
+    final var processId = Strings.newRandomValidBpmnId();
+
+    // when/then
+    // keycloak is not available, so we expect the error
+    assertThatThrownBy(
+            () ->
+                client
+                    .newDeployResourceCommand()
+                    .addProcessModel(
+                        Bpmn.createExecutableProcess(processId).startEvent().endEvent().done(),
+                        "process.bpmn")
+                    .send()
+                    .join())
+        .isInstanceOf(ProblemException.class)
+        .hasMessageContaining(
+            "Authentication service unavailable: Unable to connect to the configured Identity Provider (OIDC). "
+                + "Please try again later or contact your administrator.");
+
+    // when
+    // point proxy to keycloak
+    keycloakProxy
+        .when(request())
+        .forward(
+            HttpForward.forward()
+                .withScheme(Scheme.HTTP)
+                .withHost(KEYCLOAK.getHost())
+                .withPort(KEYCLOAK.getHttpPort()));
+
+    Awaitility.await()
+        .pollDelay(Duration.ofSeconds(5))
+        .untilAsserted(
+            () -> {
+              final var deploymentEvent =
+                  client
+                      .newDeployResourceCommand()
+                      .addProcessModel(
+                          Bpmn.createExecutableProcess(processId).startEvent().endEvent().done(),
+                          "process.bpmn")
+                      .send()
+                      .join();
+
+              // then
+              assertThat(deploymentEvent.getProcesses().getFirst().getBpmnProcessId())
+                  .isEqualTo(processId);
+            });
+  }
+}


### PR DESCRIPTION
## Description
The bug:
- application tries to obtain the OpenID configuration from the IdP at startup, and if it's not available (as in, the server is not available), it fails to launch.

Expected behaviour:

- the application should still star successfully, but authentication will fail until the IdP is available.

Solution (please see commit messages for more details):
Two places are affected by this bug:
- `clientRegistrationRepository` bean creation
- `jwtDecoder` bean creation (as it needs the `clientRegistrationRepository`) 


Lets introduce custom `ClientRegistrationRepository`  and `JwtDecoder` implementations that:

- will attempt to construct `InMemoryClientRegistrationRepository` and `decoder` the same way as it is done now (on application startup). Let's attempt it once. This would ensure that if there are no issues we are ready to authenticate after startup straight away.
- if for some reason construction of the above beans fails:
  - we log a warning message (as it is recoverable error)
  - we will schedule async retries to create the repository and the decoder in separate threads. We will continue with Spring start up.
  - we will throw an exception telling that the configuration is not yet initialised until the retries succeed.
  - the exception will be propagated to the user
  - once retries succeed - we construct both repository and decoder and use them under the hood.
  - users are able to authenticate

Integration test with the below scenario was also added:
- set up the application to point to a proxy instead of keycloak first
- verify that application is up but client request fails with the expected message
- point proxy to keycloak
- verify that client request succeeds

❓ Open question:
- Error handling. @Ben-Sheppard I'd appreciate your help here 🙏 

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #34189
