### PR TITLE
fix: unified config: Integration tests that use the Opensearch overrides

### DIFF
--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/os/OpenSearchConnectorBasicAuthIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/os/OpenSearchConnectorBasicAuthIT.java
@@ -98,9 +98,19 @@ public class OpenSearchConnectorBasicAuthIT extends TasklistIntegrationTest {
       final String osUrl =
           String.format("http://%s:%s", opensearch.getHost(), opensearch.getMappedPort(9200));
       TestPropertyValues.of(
+              // Unified Config compatibility: DB type
+              "camunda.data.secondary-storage.type=opensearch",
+              "camunda.database.type=opensearch",
+              "camunda.operate.database=opensearch",
+              "camunda.tasklist.database=opensearch",
+              // Unified Config compatibility: DB URL
+              "camunda.data.secondary-storage.opensearch.url=" + osUrl,
+              "camunda.database.url=" + osUrl,
+              "camunda.tasklist.opensearch.url=" + osUrl,
+              "camunda.operate.opensearch.url=" + osUrl,
+              // ---
               "camunda.tasklist.opensearch.username=opensearch",
               "camunda.tasklist.opensearch.password=changeme",
-              "camunda.tasklist.opensearch.url=" + osUrl,
               "camunda.tasklist.opensearch.clusterName=docker-cluster",
               "camunda.tasklist.zeebeOpensearch.url=" + osUrl,
               "camunda.tasklist.zeebeOpensearch.username=opensearch",

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/os/OpensearchConnectorIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/os/OpensearchConnectorIT.java
@@ -144,8 +144,12 @@ public class OpensearchConnectorIT {
 
     setPluginConfig(registry, TasklistProperties.PREFIX + ".openSearch", plugin);
     setPluginConfig(registry, TasklistProperties.PREFIX + ".zeebeOpenSearch", plugin);
-    registry.add(TasklistProperties.PREFIX + ".opensearch.url", WIRE_MOCK_SERVER::baseUrl);
-    registry.add(TasklistProperties.PREFIX + ".zeebeopensearch.url", WIRE_MOCK_SERVER::baseUrl);
+    // Unified configuration: db url + compatibility
+    registry.add("camunda.data.secondary-storage.opensearch.url", WIRE_MOCK_SERVER::baseUrl);
+    registry.add("camunda.database.url", WIRE_MOCK_SERVER::baseUrl);
+    registry.add("camunda.operate.opensearch.url", WIRE_MOCK_SERVER::baseUrl);
+    registry.add("camunda.tasklist.opensearch.url", WIRE_MOCK_SERVER::baseUrl);
+    registry.add("camunda.tasklist.zeebeopensearch.url", WIRE_MOCK_SERVER::baseUrl);
   }
 
   private static void setPluginConfig(

--- a/tasklist/qa/util/src/main/java/io/camunda/tasklist/qa/util/TestContainerUtil.java
+++ b/tasklist/qa/util/src/main/java/io/camunda/tasklist/qa/util/TestContainerUtil.java
@@ -436,14 +436,17 @@ public class TestContainerUtil {
       final Integer osPort = testContext.getInternalOsPort();
       final String osUrl = String.format("http://%s:%s", osHost, osPort);
       tasklistContainer
+          // Unified config for db url + compatibility
+          .withEnv("CAMUNDA_DATA_SECONDARY_STORAGE_OPENSEARCH_URL", osUrl)
           .withEnv("CAMUNDA_DATABASE_URL", osUrl)
+          .withEnv("CAMUNDA_TASKLIST_OPENSEARCH_URL", osUrl)
+          .withEnv("CAMUNDA_OPERATE_OPENSEARCH_URL", osUrl)
           // Unified config for db type + compatibility vars
           .withEnv("CAMUNDA_DATABASE_TYPE", "opensearch")
           .withEnv("CAMUNDA_DATA_SECONDARY_STORAGE_TYPE", "opensearch")
           .withEnv("CAMUNDA_OPERATE_DATABASE", "opensearch")
           .withEnv("CAMUNDA_TASKLIST_DATABASE", "opensearch")
           // ---
-          .withEnv("CAMUNDA_TASKLIST_OPENSEARCH_URL", osUrl)
           .withEnv("CAMUNDA_TASKLIST_OPENSEARCH_HOST", osHost)
           .withEnv("CAMUNDA_TASKLIST_OPENSEARCH_PORT", String.valueOf(osPort))
           .withEnv("CAMUNDA_TASKLIST_ZEEBEOPENSEARCH_URL", osUrl)
@@ -458,24 +461,22 @@ public class TestContainerUtil {
       final Integer elsPort = testContext.getInternalElsPort();
       final String esUrl = String.format("http://%s:%s", elsHost, elsPort);
       tasklistContainer
+          // Unified config for db type + compatibility vars
           .withEnv("CAMUNDA_DATABASE_URL", esUrl)
           .withEnv("CAMUNDA_DATA_SECONDARY_STORAGE_ELASTICSEARCH_URL", esUrl)
+          .withEnv("CAMUNDA_TASKLIST_ELASTICSEARCH_URL", esUrl)
+          .withEnv("CAMUNDA_OPERATE_ELASTICSEARCH_URL", esUrl)
           // Unified config for db type + compatibility vars
           .withEnv("CAMUNDA_DATABASE_TYPE", "elasticsearch")
           .withEnv("CAMUNDA_DATA_SECONDARY_STORAGE_TYPE", "elasticsearch")
           .withEnv("CAMUNDA_OPERATE_DATABASE", "elasticsearch")
           .withEnv("CAMUNDA_TASKLIST_DATABASE", "elasticsearch")
           // ---
-          .withEnv("CAMUNDA_TASKLIST_ELASTICSEARCH_URL", esUrl)
           .withEnv("CAMUNDA_TASKLIST_ELASTICSEARCH_HOST", elsHost)
           .withEnv("CAMUNDA_TASKLIST_ELASTICSEARCH_PORT", String.valueOf(elsPort))
           .withEnv("CAMUNDA_TASKLIST_ZEEBEELASTICSEARCH_URL", esUrl)
           .withEnv("CAMUNDA_TASKLIST_ZEEBEELASTICSEARCH_HOST", elsHost)
-          .withEnv("CAMUNDA_TASKLIST_ZEEBEELASTICSEARCH_PORT", String.valueOf(elsPort))
-
-          /* these need to match the URL value even if they're not used */
-          .withEnv("CAMUNDA_OPERATE_ELASTICSEARCH_URL", esUrl)
-          .withEnv("CAMUNDA_OPERATE_ZEEBEELASTICSEARCH_URL", esUrl);
+          .withEnv("CAMUNDA_TASKLIST_ZEEBEELASTICSEARCH_PORT", String.valueOf(elsPort));
       if (testContext.getZeebeIndexPrefix() != null) {
         tasklistContainer.withEnv(
             "CAMUNDA_TASKLIST_ZEEBEELASTICSEARCH_PREFIX", testContext.getZeebeIndexPrefix());


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
This PR fixes some ITs that did not show before, for some reason. The problem is related to the compatibility values for the unified configuration that were missing in some ITs.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

part of #34902
closes #
