### PR TITLE
AHSP3 35: Detect implementation type based on job worker properties

### DIFF
--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractAdHocSubProcessBuilder.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractAdHocSubProcessBuilder.java
@@ -23,7 +23,6 @@ import io.camunda.zeebe.model.bpmn.instance.FlowNode;
 import io.camunda.zeebe.model.bpmn.instance.bpmndi.BpmnShape;
 import io.camunda.zeebe.model.bpmn.instance.dc.Bounds;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeAdHoc;
-import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeAdHocImplementationType;
 
 public class AbstractAdHocSubProcessBuilder<B extends AbstractAdHocSubProcessBuilder<B>>
     extends AbstractSubProcessBuilder<B> implements ZeebeJobWorkerElementBuilder<B> {
@@ -71,18 +70,6 @@ public class AbstractAdHocSubProcessBuilder<B extends AbstractAdHocSubProcessBui
    */
   public B cancelRemainingInstances(final boolean cancelRemainingInstances) {
     ((AdHocSubProcess) element).setCancelRemainingInstances(cancelRemainingInstances);
-    return myself;
-  }
-
-  /**
-   * Sets the implementation type of the ad-hoc sub-process.
-   *
-   * @param implementationType the type of implementation
-   * @return the builder object
-   */
-  public B zeebeImplementation(final ZeebeAdHocImplementationType implementationType) {
-    final ZeebeAdHoc adHoc = getCreateSingleExtensionElement(ZeebeAdHoc.class);
-    adHoc.setImplementationType(implementationType);
     return myself;
   }
 

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/impl/instance/zeebe/ZeebeAdHocImpl.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/impl/instance/zeebe/ZeebeAdHocImpl.java
@@ -19,7 +19,6 @@ import io.camunda.zeebe.model.bpmn.impl.BpmnModelConstants;
 import io.camunda.zeebe.model.bpmn.impl.ZeebeConstants;
 import io.camunda.zeebe.model.bpmn.impl.instance.BpmnModelElementInstanceImpl;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeAdHoc;
-import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeAdHocImplementationType;
 import org.camunda.bpm.model.xml.ModelBuilder;
 import org.camunda.bpm.model.xml.impl.instance.ModelTypeInstanceContext;
 import org.camunda.bpm.model.xml.type.ModelElementTypeBuilder;
@@ -28,7 +27,6 @@ import org.camunda.bpm.model.xml.type.attribute.Attribute;
 public class ZeebeAdHocImpl extends BpmnModelElementInstanceImpl implements ZeebeAdHoc {
 
   private static Attribute<String> activeElementsCollectionAttribute;
-  private static Attribute<ZeebeAdHocImplementationType> implementationTypeAttribute;
 
   public ZeebeAdHocImpl(final ModelTypeInstanceContext instanceContext) {
     super(instanceContext);
@@ -47,15 +45,6 @@ public class ZeebeAdHocImpl extends BpmnModelElementInstanceImpl implements Zeeb
             .namespace(BpmnModelConstants.ZEEBE_NS)
             .build();
 
-    implementationTypeAttribute =
-        typeBuilder
-            .enumAttribute(
-                BpmnModelConstants.BPMN_ATTRIBUTE_IMPLEMENTATION,
-                ZeebeAdHocImplementationType.class)
-            .namespace(BpmnModelConstants.ZEEBE_NS)
-            .defaultValue(ZeebeAdHocImplementationType.BPMN)
-            .build();
-
     typeBuilder.build();
   }
 
@@ -67,15 +56,5 @@ public class ZeebeAdHocImpl extends BpmnModelElementInstanceImpl implements Zeeb
   @Override
   public void setActiveElementsCollection(final String activeElementsCollection) {
     activeElementsCollectionAttribute.setValue(this, activeElementsCollection);
-  }
-
-  @Override
-  public ZeebeAdHocImplementationType getImplementationType() {
-    return implementationTypeAttribute.getValue(this);
-  }
-
-  @Override
-  public void setImplementationType(final ZeebeAdHocImplementationType implementationType) {
-    implementationTypeAttribute.setValue(this, implementationType);
   }
 }

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeAdHoc.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeAdHoc.java
@@ -32,16 +32,4 @@ public interface ZeebeAdHoc extends BpmnModelElementInstance {
    * @param activateElements the collection of element to be activated
    */
   void setActiveElementsCollection(final String activateElements);
-
-  /**
-   * @return the implementation type of the ad-hoc sub-process
-   */
-  ZeebeAdHocImplementationType getImplementationType();
-
-  /**
-   * Sets the implementation type of the ad-hoc sub-process.
-   *
-   * @param implementationType the implementation type
-   */
-  void setImplementationType(ZeebeAdHocImplementationType implementationType);
 }

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/AdHocSubProcessValidator.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/AdHocSubProcessValidator.java
@@ -75,13 +75,12 @@ public final class AdHocSubProcessValidator implements ModelElementValidator<AdH
 
     if (!adHocSubProcess.isCancelRemainingInstances()) {
       validationResultCollector.addError(
-          0,
-          "Must not set cancelRemainingInstances to false in combination with zeebe:taskDefinition");
+          0, "Must not define cancelRemainingInstances in combination with zeebe:taskDefinition.");
     }
 
     if (adHocSubProcess.getCompletionCondition() != null) {
       validationResultCollector.addError(
-          0, "Must not set completionCondition in combination with zeebe:taskDefinition");
+          0, "Must not define completionCondition in combination with zeebe:taskDefinition.");
     }
 
     extensionElements.getChildElementsByType(ZeebeAdHoc.class).stream()
@@ -92,7 +91,7 @@ public final class AdHocSubProcessValidator implements ModelElementValidator<AdH
                   && !adHoc.getActiveElementsCollection().isEmpty()) {
                 validationResultCollector.addError(
                     0,
-                    "Must not set activeElementsCollection in combination with zeebe:taskDefinition");
+                    "Must not define activeElementsCollection in combination with zeebe:taskDefinition.");
               }
             });
   }

--- a/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/builder/AdHocSubProcessBuilderTest.java
+++ b/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/builder/AdHocSubProcessBuilderTest.java
@@ -25,14 +25,12 @@ import io.camunda.zeebe.model.bpmn.instance.CompletionCondition;
 import io.camunda.zeebe.model.bpmn.instance.ExtensionElements;
 import io.camunda.zeebe.model.bpmn.instance.FlowElement;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeAdHoc;
-import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeAdHocImplementationType;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeHeader;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskDefinition;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskHeaders;
 import org.camunda.bpm.model.xml.instance.ModelElementInstance;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 class AdHocSubProcessBuilderTest {
@@ -162,32 +160,6 @@ class AdHocSubProcessBuilderTest {
     assertThat(((AdHocSubProcess) adHocSubProcess).isCancelRemainingInstances()).isTrue();
   }
 
-  @ParameterizedTest
-  @EnumSource(ZeebeAdHocImplementationType.class)
-  void shouldSetImplementationType(final ZeebeAdHocImplementationType implementationType) {
-    // given
-    final BpmnModelInstance process =
-        Bpmn.createExecutableProcess("process")
-            .startEvent()
-            .adHocSubProcess("ad-hoc", adHocSubProcess -> adHocSubProcess.task("A"))
-            .zeebeImplementation(implementationType)
-            .endEvent()
-            .done();
-
-    // when/then
-    final ModelElementInstance adHocSubProcess = process.getModelElementById("ad-hoc");
-
-    final ExtensionElements extensionElements =
-        (ExtensionElements) adHocSubProcess.getUniqueChildElementByType(ExtensionElements.class);
-    assertThat(extensionElements).isNotNull();
-
-    assertThat(extensionElements.getChildElementsByType(ZeebeAdHoc.class))
-        .hasSize(1)
-        .first()
-        .extracting(ZeebeAdHoc::getImplementationType)
-        .isEqualTo(implementationType);
-  }
-
   @Test
   void shouldSetTaskDefinition() {
     // given
@@ -197,11 +169,7 @@ class AdHocSubProcessBuilderTest {
             .adHocSubProcess(
                 "ad-hoc",
                 adHocSubProcess ->
-                    adHocSubProcess
-                        .zeebeImplementation(ZeebeAdHocImplementationType.JOB_WORKER)
-                        .zeebeJobType("jobType")
-                        .zeebeJobRetries("3")
-                        .task("A"))
+                    adHocSubProcess.zeebeJobType("jobType").zeebeJobRetries("3").task("A"))
             .endEvent()
             .done();
 
@@ -229,7 +197,6 @@ class AdHocSubProcessBuilderTest {
                 "ad-hoc",
                 adHocSubProcess ->
                     adHocSubProcess
-                        .zeebeImplementation(ZeebeAdHocImplementationType.JOB_WORKER)
                         .zeebeJobTypeExpression("jobType")
                         .zeebeJobRetriesExpression("3")
                         .task("A"))
@@ -260,7 +227,6 @@ class AdHocSubProcessBuilderTest {
                 "ad-hoc",
                 adHocSubProcess ->
                     adHocSubProcess
-                        .zeebeImplementation(ZeebeAdHocImplementationType.JOB_WORKER)
                         .zeebeJobType("jobType")
                         .zeebeTaskHeader("headerKey1", "headerValue1")
                         .zeebeTaskHeader("headerKey2", "headerValue2")

--- a/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/AdHocSubProcessValidatorTest.java
+++ b/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/AdHocSubProcessValidatorTest.java
@@ -176,7 +176,7 @@ class AdHocSubProcessValidatorTest {
         process,
         expect(
             AdHocSubProcess.class,
-            "Must not set cancelRemainingInstances to false in combination with zeebe:taskDefinition"));
+            "Must not define cancelRemainingInstances in combination with zeebe:taskDefinition."));
   }
 
   @Test
@@ -192,7 +192,7 @@ class AdHocSubProcessValidatorTest {
         process,
         expect(
             AdHocSubProcess.class,
-            "Must not set completionCondition in combination with zeebe:taskDefinition"));
+            "Must not define completionCondition in combination with zeebe:taskDefinition."));
   }
 
   @Test
@@ -211,7 +211,7 @@ class AdHocSubProcessValidatorTest {
         process,
         expect(
             AdHocSubProcess.class,
-            "Must not set activeElementsCollection in combination with zeebe:taskDefinition"));
+            "Must not define activeElementsCollection in combination with zeebe:taskDefinition."));
   }
 
   @Test

--- a/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/AdHocSubProcessValidatorTest.java
+++ b/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/AdHocSubProcessValidatorTest.java
@@ -22,7 +22,6 @@ import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.model.bpmn.builder.AdHocSubProcessBuilder;
 import io.camunda.zeebe.model.bpmn.instance.AdHocSubProcess;
 import io.camunda.zeebe.model.bpmn.instance.StartEvent;
-import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeAdHocImplementationType;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskDefinition;
 import java.util.function.Consumer;
 import org.camunda.bpm.model.xml.instance.ModelElementInstance;
@@ -133,54 +132,95 @@ class AdHocSubProcessValidatorTest {
   }
 
   @Test
-  void withTaskDefinitionOnBpmnImplementationType() {
-    // when
+  void withBpmnImplementationProperties() {
+    // given
     final BpmnModelInstance process =
         process(
             adHocSubProcess ->
                 adHocSubProcess
-                    .zeebeImplementation(ZeebeAdHocImplementationType.BPMN)
+                    .completionCondition("=true")
+                    .cancelRemainingInstances(false)
+                    .zeebeActiveElementsCollectionExpression("=activeElements")
+                    .task("A"));
+
+    // when/then
+    ProcessValidationUtil.assertThatProcessIsValid(process);
+  }
+
+  @Test
+  void withTaskDefinitionProperties() {
+    // given
+    final BpmnModelInstance process =
+        process(
+            adHocSubProcess ->
+                adHocSubProcess
                     .zeebeJobType("jobType")
+                    .zeebeJobRetries("1")
+                    .zeebeTaskHeader("header", "value")
                     .task("A"));
 
-    // then
+    // when/then
+    ProcessValidationUtil.assertThatProcessIsValid(process);
+  }
+
+  @Test
+  void withTaskDefinitionPropertiesAndCancelRemainingInstancesFalse() {
+    // given
+    final BpmnModelInstance process =
+        process(
+            adHocSubProcess ->
+                adHocSubProcess.zeebeJobType("jobType").cancelRemainingInstances(false).task("A"));
+
+    // when/then
     ProcessValidationUtil.assertThatProcessHasViolations(
         process,
         expect(
             AdHocSubProcess.class,
-            "Must not have a zeebe:taskDefinition extension element with implementation type BPMN."));
+            "Must not set cancelRemainingInstances to false in combination with zeebe:taskDefinition"));
   }
 
   @Test
-  void withMissingTaskDefinition() {
-    // when
+  void withTaskDefinitionPropertiesAndCompletionCondition() {
+    // given
     final BpmnModelInstance process =
         process(
             adHocSubProcess ->
-                adHocSubProcess
-                    .zeebeImplementation(ZeebeAdHocImplementationType.JOB_WORKER)
-                    .task("A"));
+                adHocSubProcess.zeebeJobType("jobType").completionCondition("=true").task("A"));
 
-    // then
+    // when/then
     ProcessValidationUtil.assertThatProcessHasViolations(
         process,
         expect(
             AdHocSubProcess.class,
-            "Must have exactly one zeebe:taskDefinition extension element with implementation type JOB_WORKER."));
+            "Must not set completionCondition in combination with zeebe:taskDefinition"));
   }
 
   @Test
-  void withEmptyJobType() {
-    // when
+  void withTaskDefinitionPropertiesAndActiveElementsCollection() {
+    // given
     final BpmnModelInstance process =
         process(
             adHocSubProcess ->
                 adHocSubProcess
-                    .zeebeImplementation(ZeebeAdHocImplementationType.JOB_WORKER)
-                    .zeebeJobType("")
+                    .zeebeJobType("jobType")
+                    .zeebeActiveElementsCollectionExpression("=activeElements")
                     .task("A"));
 
-    // then
+    // when/then
+    ProcessValidationUtil.assertThatProcessHasViolations(
+        process,
+        expect(
+            AdHocSubProcess.class,
+            "Must not set activeElementsCollection in combination with zeebe:taskDefinition"));
+  }
+
+  @Test
+  void withTaskDefinitionPropertiesAndEmptyJobType() {
+    // given
+    final BpmnModelInstance process =
+        process(adHocSubProcess -> adHocSubProcess.zeebeJobType("").task("A"));
+
+    // when/then
     ProcessValidationUtil.assertThatProcessHasViolations(
         process,
         expect(ZeebeTaskDefinition.class, "Attribute 'type' must be present and not empty"));

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/AdHocSubProcessTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/AdHocSubProcessTransformer.java
@@ -93,10 +93,16 @@ public final class AdHocSubProcessTransformer implements ModelElementTransformer
 
   private static void setImplementationType(
       final ExecutableAdHocSubProcess executableAdHocSubProcess, final AdHocSubProcess element) {
+
     final var implementationType =
-        Optional.ofNullable(element.getSingleExtensionElement(ZeebeAdHoc.class))
-            .map(ZeebeAdHoc::getImplementationType)
+        Optional.ofNullable(element.getExtensionElements())
+            .map(
+                extensionElements ->
+                    extensionElements.getChildElementsByType(ZeebeTaskDefinition.class))
+            .filter(taskDefinitions -> !taskDefinitions.isEmpty())
+            .map(taskDefinitions -> ZeebeAdHocImplementationType.JOB_WORKER)
             .orElse(ZeebeAdHocImplementationType.BPMN);
+
     executableAdHocSubProcess.setImplementationType(implementationType);
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/JobBasedAdHocSubProcessTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/JobBasedAdHocSubProcessTest.java
@@ -17,7 +17,6 @@ import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.model.bpmn.builder.AdHocSubProcessBuilder;
 import io.camunda.zeebe.model.bpmn.impl.ZeebeConstants;
-import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeAdHocImplementationType;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.impl.record.value.adhocsubprocess.AdHocSubProcessInstructionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobResult;
@@ -63,7 +62,6 @@ public class JobBasedAdHocSubProcessTest {
     return Bpmn.createExecutableProcess(PROCESS_ID)
         .startEvent()
         .adHocSubProcess(AHSP_ELEMENT_ID, modifier)
-        .zeebeImplementation(ZeebeAdHocImplementationType.JOB_WORKER)
         .zeebeJobType(jobType)
         .endEvent()
         .done();


### PR DESCRIPTION
## Description

Instead of relying on an `implementation` attribute, with this change the ad-hoc sub-process detects its implementation type based on the existence of `zeebe:taskDefinition`. This aligns the behavior to other implementations, such as business rules.

- Removes `implementation` attribute
- Updates transformer to set the implementation based on the existence of `zeebe:taskDefinition`
- Updates validator to ensure either job worker properties or BPMN type properties are set

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes https://github.com/camunda/ad-hoc-sub-process-phase-3/issues/35
