### PR TITLE
feat: added missing config options

### DIFF
--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/CamundaProcessTestRuntimeBuilder.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/CamundaProcessTestRuntimeBuilder.java
@@ -41,7 +41,7 @@ public class CamundaProcessTestRuntimeBuilder {
       CamundaProcessTestRuntimeDefaults.CAMUNDA_DOCKER_IMAGE_VERSION;
 
   private String elasticsearchDockerImageName =
-      CamundaProcessTestRuntimeDefaults.ELASTICSEARCH_DOCKER_IMAGE_NAME;
+      CamundaProcessTestRuntimeDefaults.DEFAULT_ELASTICSEARCH_DOCKER_IMAGE_NAME;
   private String elasticsearchDockerImageVersion =
       CamundaProcessTestRuntimeDefaults.ELASTICSEARCH_DOCKER_IMAGE_VERSION;
 
@@ -60,11 +60,11 @@ public class CamundaProcessTestRuntimeBuilder {
       new ArrayList<>(CamundaProcessTestRuntimeDefaults.CAMUNDA_EXPOSED_PORTS);
   private final List<Integer> elasticsearchExposedPorts = new ArrayList<>();
   private final List<Integer> connectorsExposedPorts =
-      new ArrayList<>(CamundaProcessTestRuntimeDefaults.CAMUNDA_EXPOSED_PORTS);
+      new ArrayList<>(CamundaProcessTestRuntimeDefaults.CONNECTORS_EXPOSED_PORTS);
 
   private String camundaLoggerName = CamundaProcessTestRuntimeDefaults.CAMUNDA_LOGGER_NAME;
   private String elasticsearchLoggerName =
-      CamundaProcessTestRuntimeDefaults.ELASTICSEARCH_LOGGER_NAME;
+      CamundaProcessTestRuntimeDefaults.DEFAULT_ELASTICSEARCH_LOGGER_NAME;
   private String connectorsLoggerName = CamundaProcessTestRuntimeDefaults.CONNECTORS_LOGGER_NAME;
 
   private boolean connectorsEnabled = CamundaProcessTestRuntimeDefaults.CONNECTORS_ENABLED;

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/CamundaProcessTestRuntimeDefaults.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/CamundaProcessTestRuntimeDefaults.java
@@ -28,11 +28,11 @@ public class CamundaProcessTestRuntimeDefaults {
   public static final String DEFAULT_CONNECTORS_DOCKER_IMAGE_VERSION = "SNAPSHOT";
   public static final String DEFAULT_ELASTICSEARCH_VERSION = "8.13.0";
 
-  public static final String ELASTICSEARCH_DOCKER_IMAGE_NAME = "elasticsearch";
+  public static final String DEFAULT_ELASTICSEARCH_DOCKER_IMAGE_NAME = "elasticsearch";
 
-  public static final String ELASTICSEARCH_LOGGER_NAME = "tc.elasticsearch";
-  public static final String CAMUNDA_LOGGER_NAME = "tc.camunda";
-  public static final String CONNECTORS_LOGGER_NAME = "tc.connectors";
+  public static final String DEFAULT_ELASTICSEARCH_LOGGER_NAME = "tc.elasticsearch";
+  public static final String DEFAULT_CAMUNDA_LOGGER_NAME = "tc.camunda";
+  public static final String DEFAULT_CONNECTORS_LOGGER_NAME = "tc.connectors";
 
   public static final URI LOCAL_CAMUNDA_MONITORING_API_ADDRESS =
       URI.create("http://0.0.0.0:" + ContainerRuntimePorts.CAMUNDA_MONITORING_API);
@@ -54,6 +54,9 @@ public class CamundaProcessTestRuntimeDefaults {
   public static final List<Integer> CAMUNDA_EXPOSED_PORTS =
       PROPERTIES_UTIL.getCamundaExposedPorts();
 
+  public static final String CAMUNDA_LOGGER_NAME = PROPERTIES_UTIL.getCamundaLoggerName();
+  public static final String CONNECTORS_LOGGER_NAME = PROPERTIES_UTIL.getConnectorsLoggerName();
+
   public static final boolean CONNECTORS_ENABLED = PROPERTIES_UTIL.isConnectorsEnabled();
   public static final String CONNECTORS_DOCKER_IMAGE_NAME =
       PROPERTIES_UTIL.getConnectorsDockerImageName();
@@ -63,6 +66,8 @@ public class CamundaProcessTestRuntimeDefaults {
       PROPERTIES_UTIL.getConnectorsEnvVars();
   public static final Map<String, String> CONNECTORS_SECRETS =
       PROPERTIES_UTIL.getConnectorsSecrets();
+  public static final List<Integer> CONNECTORS_EXPOSED_PORTS =
+      PROPERTIES_UTIL.getConnectorsExposedPorts();
 
   public static final CamundaProcessTestRuntimeMode RUNTIME_MODE = PROPERTIES_UTIL.getRuntimeMode();
 

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/ContainerRuntimePropertiesUtil.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/ContainerRuntimePropertiesUtil.java
@@ -145,6 +145,14 @@ public final class ContainerRuntimePropertiesUtil {
     return camundaContainerRuntimeProperties.getCamundaExposedPorts();
   }
 
+  public String getCamundaLoggerName() {
+    return camundaContainerRuntimeProperties.getCamundaLoggerName();
+  }
+
+  public String getConnectorsLoggerName() {
+    return camundaContainerRuntimeProperties.getConnectorsLoggerName();
+  }
+
   public String getConnectorsDockerImageName() {
     return connectorsContainerRuntimeProperties.getConnectorsDockerImageName();
   }
@@ -163,6 +171,10 @@ public final class ContainerRuntimePropertiesUtil {
 
   public Map<String, String> getConnectorsSecrets() {
     return connectorsContainerRuntimeProperties.getConnectorsSecrets();
+  }
+
+  public List<Integer> getConnectorsExposedPorts() {
+    return connectorsContainerRuntimeProperties.getConnectorsExposedPorts();
   }
 
   public URI getRemoteCamundaMonitoringApiAddress() {

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/properties/CamundaContainerRuntimeProperties.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/properties/CamundaContainerRuntimeProperties.java
@@ -32,12 +32,17 @@ public class CamundaContainerRuntimeProperties {
       "camundaDockerImageVersion";
   public static final String PROPERTY_NAME_CAMUNDA_ENV_VARS_PREFIX = "camundaEnvVars";
   public static final String PROPERTY_NAME_CAMUNDA_EXPOSED_PORTS_PREFIX = "camundaExposedPorts";
+  public static final String PROPERTY_NAME_CAMUNDA_LOGGER_NAME = "camundaLoggerName";
+  public static final String PROPERTY_NAME_CONNECTORS_LOGGER_NAME = "connectorsLoggerName";
 
   private final String camundaVersion;
   private final String camundaDockerImageName;
   private final String camundaDockerImageVersion;
   private final Map<String, String> camundaEnvVars;
   private final List<Integer> camundaExposedPorts;
+
+  private final String camundaLoggerName;
+  private final String connectorsLoggerName;
 
   public CamundaContainerRuntimeProperties(final Properties properties) {
     camundaVersion =
@@ -59,6 +64,16 @@ public class CamundaContainerRuntimeProperties {
     camundaExposedPorts =
         getPropertyListOrEmpty(
             properties, PROPERTY_NAME_CAMUNDA_EXPOSED_PORTS_PREFIX, Integer::parseInt);
+    camundaLoggerName =
+        getPropertyOrDefault(
+            properties,
+            PROPERTY_NAME_CAMUNDA_LOGGER_NAME,
+            CamundaProcessTestRuntimeDefaults.DEFAULT_CAMUNDA_LOGGER_NAME);
+    connectorsLoggerName =
+        getPropertyOrDefault(
+            properties,
+            PROPERTY_NAME_CONNECTORS_LOGGER_NAME,
+            CamundaProcessTestRuntimeDefaults.DEFAULT_CONNECTORS_LOGGER_NAME);
   }
 
   public String getCamundaVersion() {
@@ -79,5 +94,13 @@ public class CamundaContainerRuntimeProperties {
 
   public List<Integer> getCamundaExposedPorts() {
     return camundaExposedPorts;
+  }
+
+  public String getCamundaLoggerName() {
+    return camundaLoggerName;
+  }
+
+  public String getConnectorsLoggerName() {
+    return connectorsLoggerName;
   }
 }

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/properties/ConnectorsContainerRuntimeProperties.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/properties/ConnectorsContainerRuntimeProperties.java
@@ -15,11 +15,13 @@
  */
 package io.camunda.process.test.impl.runtime.properties;
 
+import static io.camunda.process.test.impl.runtime.util.PropertiesUtil.getPropertyListOrEmpty;
 import static io.camunda.process.test.impl.runtime.util.PropertiesUtil.getPropertyMapOrEmpty;
 import static io.camunda.process.test.impl.runtime.util.PropertiesUtil.getPropertyOrDefault;
 import static io.camunda.process.test.impl.runtime.util.VersionedPropertiesUtil.getLatestReleasedVersion;
 
 import io.camunda.process.test.impl.runtime.CamundaProcessTestRuntimeDefaults;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
@@ -31,12 +33,15 @@ public class ConnectorsContainerRuntimeProperties {
   public static final String PROPERTY_NAME_CONNECTORS_ENABLED = "connectorsEnabled";
   public static final String PROPERTY_NAME_CONNECTORS_ENV_VARS_PREFIX = "connectorsEnvVars";
   public static final String PROPERTY_NAME_CONNECTORS_SECRETS_PREFIX = "connectorsSecrets";
+  public static final String PROPERTY_NAME_CONNECTORS_EXPOSED_PORTS_PREFIX =
+      "connectorsExposedPorts";
 
   private final boolean isConnectorsEnabled;
   private final String connectorsDockerImageName;
   private final String connectorsDockerImageVersion;
   private final Map<String, String> connectorsEnvVars;
   private final Map<String, String> connectorsSecrets;
+  private final List<Integer> connectorsExposedPorts;
 
   public ConnectorsContainerRuntimeProperties(final Properties properties) {
     // connectors are disabled by default
@@ -56,6 +61,9 @@ public class ConnectorsContainerRuntimeProperties {
             CamundaProcessTestRuntimeDefaults.DEFAULT_CONNECTORS_DOCKER_IMAGE_VERSION);
     connectorsEnvVars = getPropertyMapOrEmpty(properties, PROPERTY_NAME_CONNECTORS_ENV_VARS_PREFIX);
     connectorsSecrets = getPropertyMapOrEmpty(properties, PROPERTY_NAME_CONNECTORS_SECRETS_PREFIX);
+    connectorsExposedPorts =
+        getPropertyListOrEmpty(
+            properties, PROPERTY_NAME_CONNECTORS_EXPOSED_PORTS_PREFIX, Integer::parseInt);
   }
 
   public boolean isConnectorsEnabled() {
@@ -76,5 +84,9 @@ public class ConnectorsContainerRuntimeProperties {
 
   public Map<String, String> getConnectorsSecrets() {
     return connectorsSecrets;
+  }
+
+  public List<Integer> getConnectorsExposedPorts() {
+    return connectorsExposedPorts;
   }
 }

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/runtime/ContainerRuntimePropertiesUtilTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/runtime/ContainerRuntimePropertiesUtilTest.java
@@ -299,6 +299,8 @@ public class ContainerRuntimePropertiesUtilTest {
       assertThat(propertiesUtil.getElasticsearchVersion()).isEqualTo("1.1.0");
       assertThat(propertiesUtil.getCamundaDockerImageName()).isEqualTo("camunda/custom-camunda");
       assertThat(propertiesUtil.getCamundaDockerImageVersion()).isEqualTo("8.8.0-rc1");
+      assertThat(propertiesUtil.getCamundaLoggerName()).isEqualTo("camunda.custom.logger");
+      assertThat(propertiesUtil.getConnectorsLoggerName()).isEqualTo("connectors.custom.logger");
       assertThat(propertiesUtil.getConnectorsDockerImageName())
           .isEqualTo("camunda/connectors-bundle");
       assertThat(propertiesUtil.getConnectorsDockerImageVersion()).isEqualTo("8.8.3");
@@ -334,6 +336,8 @@ public class ContainerRuntimePropertiesUtilTest {
           .containsAllEntriesOf(expectedConnectorsEnvVars);
       assertThat(propertiesUtil.getConnectorsSecrets())
           .containsAllEntriesOf(expectedConnectorsSecrets);
+      assertThat(propertiesUtil.getConnectorsExposedPorts())
+          .containsExactlyInAnyOrder(9080, 9081, 9088);
 
       assertThat(propertiesUtil.getRuntimeMode()).isEqualTo(CamundaProcessTestRuntimeMode.REMOTE);
       assertThat(propertiesUtil.getRemoteCamundaMonitoringApiAddress())

--- a/testing/camunda-process-test-java/src/test/resources/containerRuntimePropertiesUtil/camunda-container-runtime.properties
+++ b/testing/camunda-process-test-java/src/test/resources/containerRuntimePropertiesUtil/camunda-container-runtime.properties
@@ -13,6 +13,9 @@ camundaExposedPorts[0]=8080
 camundaExposedPorts[1]=8081
 camundaExposedPorts[2]=8088
 
+camundaLoggerName=camunda.custom.logger
+connectorsLoggerName=connectors.custom.logger
+
 connectorsEnabled=true
 
 connectorsEnvVars.keyD=valueD
@@ -22,6 +25,10 @@ connectorsEnvVars.keyF=valueF
 connectorsSecrets.keyG=secret1
 connectorsSecrets.keyH=secret2
 connectorsSecrets.keyI=secret3
+
+connectorsExposedPorts[0]=9080
+connectorsExposedPorts[1]=9081
+connectorsExposedPorts[2]=9088
 
 runtimeMode=remote
 

--- a/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/configuration/CamundaProcessTestRuntimeConfiguration.java
+++ b/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/configuration/CamundaProcessTestRuntimeConfiguration.java
@@ -44,6 +44,11 @@ public class CamundaProcessTestRuntimeConfiguration {
       CamundaProcessTestRuntimeDefaults.CONNECTORS_DOCKER_IMAGE_VERSION;
   private Map<String, String> connectorsEnvVars = Collections.emptyMap();
   private Map<String, String> connectorsSecrets = Collections.emptyMap();
+  private List<Integer> connectorsExposedPorts = Collections.emptyList();
+
+  private String camundaLoggerName = CamundaProcessTestRuntimeDefaults.DEFAULT_CAMUNDA_LOGGER_NAME;
+  private String connectorsLoggerName =
+      CamundaProcessTestRuntimeDefaults.DEFAULT_CONNECTORS_LOGGER_NAME;
 
   private CamundaProcessTestRuntimeMode runtimeMode = CamundaProcessTestRuntimeMode.MANAGED;
 
@@ -153,6 +158,30 @@ public class CamundaProcessTestRuntimeConfiguration {
 
   public void setConnectorsSecrets(final Map<String, String> connectorsSecrets) {
     this.connectorsSecrets = connectorsSecrets;
+  }
+
+  public List<Integer> getConnectorsExposedPorts() {
+    return connectorsExposedPorts;
+  }
+
+  public void setConnectorsExposedPorts(final List<Integer> connectorsExposedPorts) {
+    this.connectorsExposedPorts = connectorsExposedPorts;
+  }
+
+  public String getCamundaLoggerName() {
+    return camundaLoggerName;
+  }
+
+  public void setCamundaLoggerName(final String camundaLoggerName) {
+    this.camundaLoggerName = camundaLoggerName;
+  }
+
+  public String getConnectorsLoggerName() {
+    return connectorsLoggerName;
+  }
+
+  public void setConnectorsLoggerName(final String connectorsLoggerName) {
+    this.connectorsLoggerName = connectorsLoggerName;
   }
 
   public CamundaProcessTestRuntimeMode getRuntimeMode() {

--- a/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/runtime/CamundaSpringProcessTestRuntimeBuilder.java
+++ b/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/runtime/CamundaSpringProcessTestRuntimeBuilder.java
@@ -53,7 +53,8 @@ public class CamundaSpringProcessTestRuntimeBuilder {
     runtimeBuilder
         .withCamundaDockerImageVersion(runtimeConfiguration.getCamundaDockerImageVersion())
         .withCamundaDockerImageName(runtimeConfiguration.getCamundaDockerImageName())
-        .withCamundaEnv(runtimeConfiguration.getCamundaEnvVars());
+        .withCamundaEnv(runtimeConfiguration.getCamundaEnvVars())
+        .withCamundaLogger(runtimeConfiguration.getCamundaLoggerName());
 
     runtimeConfiguration.getCamundaExposedPorts().forEach(runtimeBuilder::withCamundaExposedPort);
 
@@ -62,7 +63,12 @@ public class CamundaSpringProcessTestRuntimeBuilder {
         .withConnectorsDockerImageName(runtimeConfiguration.getConnectorsDockerImageName())
         .withConnectorsDockerImageVersion(runtimeConfiguration.getConnectorsDockerImageVersion())
         .withConnectorsEnv(runtimeConfiguration.getConnectorsEnvVars())
-        .withConnectorsSecrets(runtimeConfiguration.getConnectorsSecrets());
+        .withConnectorsSecrets(runtimeConfiguration.getConnectorsSecrets())
+        .withConnectorsLogger(runtimeConfiguration.getCamundaLoggerName());
+
+    runtimeConfiguration
+        .getConnectorsExposedPorts()
+        .forEach(runtimeBuilder::withConnectorsExposedPort);
   }
 
   private static void configureRemoteRuntime(

--- a/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/impl/CamundaSpringProcessTestRuntimeBuilderTest.java
+++ b/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/impl/CamundaSpringProcessTestRuntimeBuilderTest.java
@@ -84,6 +84,9 @@ public class CamundaSpringProcessTestRuntimeBuilderTest {
     final List<Integer> camundaExposedPorts = List.of(100, 200);
     runtimeConfiguration.setCamundaExposedPorts(camundaExposedPorts);
 
+    runtimeConfiguration.setCamundaLoggerName("io.camunda.custom.logger.name");
+    runtimeConfiguration.setConnectorsLoggerName("io.camunda.custom.logger.name");
+
     // when
     CamundaSpringProcessTestRuntimeBuilder.buildRuntime(runtimeBuilder, runtimeConfiguration);
 
@@ -92,6 +95,8 @@ public class CamundaSpringProcessTestRuntimeBuilderTest {
     assertThat(runtimeBuilder.getCamundaDockerImageVersion()).isEqualTo("8.6.0-custom");
     assertThat(runtimeBuilder.getCamundaEnvVars()).isEqualTo(camundaEnvVars);
     assertThat(runtimeBuilder.getCamundaExposedPorts()).isEqualTo(camundaExposedPorts);
+    assertThat(runtimeBuilder.getCamundaLoggerName()).isEqualTo("io.camunda.custom.logger.name");
+    assertThat(runtimeBuilder.getConnectorsLoggerName()).isEqualTo("io.camunda.custom.logger.name");
   }
 
   @Test
@@ -112,6 +117,7 @@ public class CamundaSpringProcessTestRuntimeBuilderTest {
     runtimeConfiguration.setConnectorsDockerImageVersion("8.6.0-custom");
     runtimeConfiguration.setConnectorsEnvVars(connectorsEnvVars);
     runtimeConfiguration.setConnectorsSecrets(connectorsSecrets);
+    runtimeConfiguration.setConnectorsExposedPorts(List.of(9090));
 
     // when
     CamundaSpringProcessTestRuntimeBuilder.buildRuntime(runtimeBuilder, runtimeConfiguration);
@@ -122,6 +128,7 @@ public class CamundaSpringProcessTestRuntimeBuilderTest {
     assertThat(runtimeBuilder.getConnectorsDockerImageVersion()).isEqualTo("8.6.0-custom");
     assertThat(runtimeBuilder.getConnectorsEnvVars()).isEqualTo(connectorsEnvVars);
     assertThat(runtimeBuilder.getConnectorsSecrets()).isEqualTo(connectorsSecrets);
+    assertThat(runtimeBuilder.getConnectorsExposedPorts()).isEqualTo(List.of(9090));
   }
 
   @Test


### PR DESCRIPTION
## Description
The spring CPT runtimeConfiguration was missing the config options 

- Connectors exposed ports
- Camunda logger name
- Connectors logger name

This PR adds the missing config options and tests to verify their behavior.

## Related issues

closes #34373 
