### PR TITLE
feat: Enable per-index ILM configuration

### DIFF
--- a/dist/src/main/resources/application-elasticsearch.yaml
+++ b/dist/src/main/resources/application-elasticsearch.yaml
@@ -112,9 +112,10 @@ zeebe:
               policyName: camunda-retention-policy
               indexPolicies:
                 # Applies retention policy to 'camunda-usage-metric' and 'camunda-usage-metric-at' indices
-                - index: "camunda-usage-metric.*"
-                  policyName: "camunda-usage-metric-retention-policy"
+                - policyName: "camunda-usage-metric-retention-policy"
                   minimumAge: "730d"
+                  indices:
+                    - "camunda-usage-metric.*"
 
           createSchema: true
 

--- a/dist/src/main/resources/application-elasticsearch.yaml
+++ b/dist/src/main/resources/application-elasticsearch.yaml
@@ -110,6 +110,11 @@ zeebe:
               enabled: false
               minimumAge: 30d
               policyName: camunda-retention-policy
+              indexPolicies:
+                # Applies retention policy to 'camunda-usage-metric' and 'camunda-usage-metric-at' indices
+                - index: "camunda-usage-metric.*"
+                  policyName: "camunda-usage-metric-retention-policy"
+                  minimumAge: "730d"
 
           createSchema: true
 

--- a/dist/src/main/resources/application-opensearch.yaml
+++ b/dist/src/main/resources/application-opensearch.yaml
@@ -112,9 +112,10 @@ zeebe:
               policyName: camunda-retention-policy
               indexPolicies:
                 # Applies retention policy to 'camunda-usage-metric' and 'camunda-usage-metric-at' indices
-                - index: "camunda-usage-metric.*"
-                  policyName: "camunda-usage-metric-retention-policy"
+                - policyName: "camunda-usage-metric-retention-policy"
                   minimumAge: "730d"
+                  indices:
+                    - "camunda-usage-metric.*"
 
           createSchema: true
 

--- a/dist/src/main/resources/application-opensearch.yaml
+++ b/dist/src/main/resources/application-opensearch.yaml
@@ -110,6 +110,11 @@ zeebe:
               enabled: false
               minimumAge: 30d
               policyName: camunda-retention-policy
+              indexPolicies:
+                # Applies retention policy to 'camunda-usage-metric' and 'camunda-usage-metric-at' indices
+                - index: "camunda-usage-metric.*"
+                  policyName: "camunda-usage-metric-retention-policy"
+                  minimumAge: "730d"
 
           createSchema: true
 

--- a/schema-manager/src/main/java/io/camunda/search/schema/SchemaManager.java
+++ b/schema-manager/src/main/java/io/camunda/search/schema/SchemaManager.java
@@ -143,10 +143,9 @@ public class SchemaManager {
     // Create index-specific ILM policies
     final var indexPolicies = retention.getIndexPolicies();
     if (!indexPolicies.isEmpty()) {
-      LOG.info("Creating {} index-specific ILM policies", indexPolicies.size());
       for (final var policy : indexPolicies) {
         LOG.info(
-            "Creating index-specific ILM policy [name: '{}', retention: '{}'] for indices '{}'",
+            "Creating index-specific ILM policy [name: '{}', retention: '{}'] for indices {}",
             policy.getPolicyName(),
             policy.getMinimumAge(),
             policy.getIndices());

--- a/schema-manager/src/main/java/io/camunda/search/schema/SchemaManager.java
+++ b/schema-manager/src/main/java/io/camunda/search/schema/SchemaManager.java
@@ -146,10 +146,10 @@ public class SchemaManager {
       LOG.info("Creating {} index-specific ILM policies", indexPolicies.size());
       for (final var policy : indexPolicies) {
         LOG.info(
-            "Creating index-specific ILM policy [name: '{}', retention: '{}'] for index '{}'",
+            "Creating index-specific ILM policy [name: '{}', retention: '{}'] for indices '{}'",
             policy.getPolicyName(),
             policy.getMinimumAge(),
-            policy.getIndex());
+            policy.getIndices());
         searchEngineClient.putIndexLifeCyclePolicy(policy.getPolicyName(), policy.getMinimumAge());
       }
     }

--- a/schema-manager/src/main/java/io/camunda/search/schema/SchemaManager.java
+++ b/schema-manager/src/main/java/io/camunda/search/schema/SchemaManager.java
@@ -144,14 +144,12 @@ public class SchemaManager {
     final var indexPolicies = retention.getIndexPolicies();
     if (!indexPolicies.isEmpty()) {
       LOG.info("Creating {} index-specific ILM policies", indexPolicies.size());
-      for (final var entry : indexPolicies.entrySet()) {
-        final var index = entry.getKey();
-        final var policy = entry.getValue();
+      for (final var policy : indexPolicies) {
         LOG.info(
             "Creating index-specific ILM policy [name: '{}', retention: '{}'] for index '{}'",
             policy.getPolicyName(),
             policy.getMinimumAge(),
-            index);
+            policy.getIndex());
         searchEngineClient.putIndexLifeCyclePolicy(policy.getPolicyName(), policy.getMinimumAge());
       }
     }

--- a/schema-manager/src/main/java/io/camunda/search/schema/config/IndexRetentionPolicy.java
+++ b/schema-manager/src/main/java/io/camunda/search/schema/config/IndexRetentionPolicy.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.schema.config;
+
+/**
+ * Represents a retention policy for a specific index or set of indices. Contains the policy name
+ * and minimum age for retention.
+ */
+public class IndexRetentionPolicy {
+
+  private String policyName;
+  private String minimumAge;
+
+  public IndexRetentionPolicy() {
+    // Default constructor for configuration binding
+  }
+
+  public IndexRetentionPolicy(final String policyName, final String minimumAge) {
+    this.policyName = policyName;
+    this.minimumAge = minimumAge;
+  }
+
+  public String getPolicyName() {
+    return policyName;
+  }
+
+  public void setPolicyName(final String policyName) {
+    this.policyName = policyName;
+  }
+
+  public String getMinimumAge() {
+    return minimumAge;
+  }
+
+  public void setMinimumAge(final String minimumAge) {
+    this.minimumAge = minimumAge;
+  }
+
+  @Override
+  public String toString() {
+    return "IndexRetentionPolicy{"
+        + "policyName='"
+        + policyName
+        + '\''
+        + ", minimumAge='"
+        + minimumAge
+        + '\''
+        + '}';
+  }
+}

--- a/schema-manager/src/main/java/io/camunda/search/schema/config/IndexRetentionPolicy.java
+++ b/schema-manager/src/main/java/io/camunda/search/schema/config/IndexRetentionPolicy.java
@@ -7,11 +7,14 @@
  */
 package io.camunda.search.schema.config;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
- * Represents a retention policy for a specific index or set of indices. Contains the policy name
- * and minimum age for retention.
+ * Represents a retention policy that can be applied to multiple indices. Contains the policy name,
+ * minimum age for retention, and a list of indices this policy applies to.
  *
- * <p>The `index` field can be:
+ * <p>The `indices` field can contain:
  *
  * <ul>
  *   <li>Exact index names as defined in IndexDescriptor implementations including component name
@@ -22,27 +25,19 @@ package io.camunda.search.schema.config;
  */
 public class IndexRetentionPolicy {
 
-  private String index;
   private String policyName;
   private String minimumAge;
+  private List<String> indices = new ArrayList<>();
 
   public IndexRetentionPolicy() {
     // Default constructor for configuration binding
   }
 
   public IndexRetentionPolicy(
-      final String index, final String policyName, final String minimumAge) {
-    this.index = index;
+      final String policyName, final String minimumAge, final List<String> indices) {
     this.policyName = policyName;
     this.minimumAge = minimumAge;
-  }
-
-  public String getIndex() {
-    return index;
-  }
-
-  public void setIndex(final String index) {
-    this.index = index;
+    this.indices = indices != null ? new ArrayList<>(indices) : new ArrayList<>();
   }
 
   public String getPolicyName() {
@@ -61,18 +56,25 @@ public class IndexRetentionPolicy {
     this.minimumAge = minimumAge;
   }
 
+  public List<String> getIndices() {
+    return indices;
+  }
+
+  public void setIndices(final List<String> indices) {
+    this.indices = indices != null ? new ArrayList<>(indices) : new ArrayList<>();
+  }
+
   @Override
   public String toString() {
     return "IndexRetentionPolicy{"
-        + "index='"
-        + index
-        + '\''
-        + ", policyName='"
+        + "policyName='"
         + policyName
         + '\''
         + ", minimumAge='"
         + minimumAge
         + '\''
+        + ", indices="
+        + indices
         + '}';
   }
 }

--- a/schema-manager/src/main/java/io/camunda/search/schema/config/IndexRetentionPolicy.java
+++ b/schema-manager/src/main/java/io/camunda/search/schema/config/IndexRetentionPolicy.java
@@ -10,9 +10,19 @@ package io.camunda.search.schema.config;
 /**
  * Represents a retention policy for a specific index or set of indices. Contains the policy name
  * and minimum age for retention.
+ *
+ * <p>The `index` field can be:
+ *
+ * <ul>
+ *   <li>Exact index names as defined in IndexDescriptor implementations including component name
+ *       (e.g., "camunda-usage-metric-tu").
+ *   <li>Patterns using wildcards to match multiple indices (e.g., "camunda-usage-metric.*" matches
+ *       "camunda-usage-metric" and "camunda-usage-metric-tu").
+ * </ul>
  */
 public class IndexRetentionPolicy {
 
+  private String index;
   private String policyName;
   private String minimumAge;
 
@@ -20,9 +30,19 @@ public class IndexRetentionPolicy {
     // Default constructor for configuration binding
   }
 
-  public IndexRetentionPolicy(final String policyName, final String minimumAge) {
+  public IndexRetentionPolicy(
+      final String index, final String policyName, final String minimumAge) {
+    this.index = index;
     this.policyName = policyName;
     this.minimumAge = minimumAge;
+  }
+
+  public String getIndex() {
+    return index;
+  }
+
+  public void setIndex(final String index) {
+    this.index = index;
   }
 
   public String getPolicyName() {
@@ -44,7 +64,10 @@ public class IndexRetentionPolicy {
   @Override
   public String toString() {
     return "IndexRetentionPolicy{"
-        + "policyName='"
+        + "index='"
+        + index
+        + '\''
+        + ", policyName='"
         + policyName
         + '\''
         + ", minimumAge='"

--- a/schema-manager/src/main/java/io/camunda/search/schema/config/RetentionConfiguration.java
+++ b/schema-manager/src/main/java/io/camunda/search/schema/config/RetentionConfiguration.java
@@ -7,8 +7,8 @@
  */
 package io.camunda.search.schema.config;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.ArrayList;
+import java.util.List;
 
 public class RetentionConfiguration {
 
@@ -18,13 +18,7 @@ public class RetentionConfiguration {
   private String minimumAge = DEFAULT_RETENTION_MINIMUM_AGE;
   private String policyName = DEFAULT_RETENTION_POLICY_NAME;
 
-  // Map of index names or patterns to index-specific retention policies.
-  // Keys can be:
-  // - Exact index names as defined in IndexDescriptor implementations including component name
-  //   (e.g., "camunda-usage-metric-tu")
-  // - Patterns using wildcards to match multiple indices (e.g., "camunda-usage-metric.*" matches
-  //   "camunda-usage-metric" and "camunda-usage-metric-tu")
-  private Map<String, IndexRetentionPolicy> indexPolicies = new HashMap<>();
+  private List<IndexRetentionPolicy> indexPolicies = new ArrayList<>();
 
   public boolean isEnabled() {
     return enabled;
@@ -50,12 +44,12 @@ public class RetentionConfiguration {
     this.policyName = policyName;
   }
 
-  public Map<String, IndexRetentionPolicy> getIndexPolicies() {
+  public List<IndexRetentionPolicy> getIndexPolicies() {
     return indexPolicies;
   }
 
-  public void setIndexPolicies(final Map<String, IndexRetentionPolicy> indexPolicies) {
-    this.indexPolicies = indexPolicies != null ? indexPolicies : new HashMap<>();
+  public void setIndexPolicies(final List<IndexRetentionPolicy> indexPolicies) {
+    this.indexPolicies = indexPolicies != null ? indexPolicies : new ArrayList<>();
   }
 
   @Override

--- a/schema-manager/src/main/java/io/camunda/search/schema/config/RetentionConfiguration.java
+++ b/schema-manager/src/main/java/io/camunda/search/schema/config/RetentionConfiguration.java
@@ -7,6 +7,9 @@
  */
 package io.camunda.search.schema.config;
 
+import java.util.HashMap;
+import java.util.Map;
+
 public class RetentionConfiguration {
 
   private static final String DEFAULT_RETENTION_MINIMUM_AGE = "30d";
@@ -14,6 +17,14 @@ public class RetentionConfiguration {
   private boolean enabled = false;
   private String minimumAge = DEFAULT_RETENTION_MINIMUM_AGE;
   private String policyName = DEFAULT_RETENTION_POLICY_NAME;
+
+  // Map of index names or patterns to index-specific retention policies.
+  // Keys can be:
+  // - Exact index names as defined in IndexDescriptor implementations including component name
+  //   (e.g., "camunda-usage-metric-tu")
+  // - Patterns using wildcards to match multiple indices (e.g., "camunda-usage-metric.*" matches
+  //   "camunda-usage-metric" and "camunda-usage-metric-tu")
+  private Map<String, IndexRetentionPolicy> indexPolicies = new HashMap<>();
 
   public boolean isEnabled() {
     return enabled;
@@ -39,6 +50,14 @@ public class RetentionConfiguration {
     this.policyName = policyName;
   }
 
+  public Map<String, IndexRetentionPolicy> getIndexPolicies() {
+    return indexPolicies;
+  }
+
+  public void setIndexPolicies(final Map<String, IndexRetentionPolicy> indexPolicies) {
+    this.indexPolicies = indexPolicies != null ? indexPolicies : new HashMap<>();
+  }
+
   @Override
   public String toString() {
     return "RetentionConfiguration{"
@@ -50,6 +69,8 @@ public class RetentionConfiguration {
         + ", policyName='"
         + policyName
         + '\''
+        + ", indexPolicies="
+        + indexPolicies
         + '}';
   }
 }

--- a/schema-manager/src/test/java/io/camunda/search/schema/SchemaManagerIT.java
+++ b/schema-manager/src/test/java/io/camunda/search/schema/SchemaManagerIT.java
@@ -43,6 +43,7 @@ import java.io.IOException;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -331,11 +332,9 @@ public class SchemaManagerIT {
     retention.setPolicyName("default_policy");
     retention.setMinimumAge("33d");
     retention.setIndexPolicies(
-        Map.of(
-            "index_1",
-            new IndexRetentionPolicy("custom_policy_1", "44d"),
-            "index_2",
-            new IndexRetentionPolicy("custom_policy_2", "55d")));
+        List.of(
+            new IndexRetentionPolicy("index_1", "custom_policy_1", "44d"),
+            new IndexRetentionPolicy("index_2", "custom_policy_2", "55d")));
 
     final var schemaManager =
         new SchemaManager(

--- a/schema-manager/src/test/java/io/camunda/search/schema/SchemaManagerIT.java
+++ b/schema-manager/src/test/java/io/camunda/search/schema/SchemaManagerIT.java
@@ -333,8 +333,8 @@ public class SchemaManagerIT {
     retention.setMinimumAge("33d");
     retention.setIndexPolicies(
         List.of(
-            new IndexRetentionPolicy("index_1", "custom_policy_1", "44d"),
-            new IndexRetentionPolicy("index_2", "custom_policy_2", "55d")));
+            new IndexRetentionPolicy("custom_policy_1", "44d", List.of("index_1")),
+            new IndexRetentionPolicy("custom_policy_2", "55d", List.of("index_2"))));
 
     final var schemaManager =
         new SchemaManager(

--- a/schema-manager/src/test/java/io/camunda/search/schema/config/RetentionConfigurationTest.java
+++ b/schema-manager/src/test/java/io/camunda/search/schema/config/RetentionConfigurationTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.schema.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class RetentionConfigurationTest {
+
+  @Test
+  void shouldThrowExceptionWhenDuplicatePolicyNamesInRetentionConfiguration() {
+    // given
+    final RetentionConfiguration retention = new RetentionConfiguration();
+
+    final List<IndexRetentionPolicy> duplicatePolicies =
+        List.of(
+            new IndexRetentionPolicy("user_policy", "7d", List.of("user-activity")),
+            new IndexRetentionPolicy("user_policy", "14d", List.of("user-logs")),
+            new IndexRetentionPolicy("admin_policy", "30d", List.of("admin-logs")),
+            new IndexRetentionPolicy("user_policy", "7d", List.of("user-events")));
+
+    // when & then
+    assertThatThrownBy(() -> retention.setIndexPolicies(duplicatePolicies))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Duplicate policy names found in retention policies configuration.")
+        .hasMessageContaining("Consider using a single policy with multiple indices instead.")
+        .hasMessageContaining("Duplicate policy details:")
+        .hasMessageContaining("Policy name 'user_policy' appears 3 times")
+        .hasMessageContaining("minimumAge: '7d', indices: [user-activity]")
+        .hasMessageContaining("minimumAge: '14d', indices: [user-logs]")
+        .hasMessageContaining("minimumAge: '7d', indices: [user-events]");
+  }
+
+  @Test
+  void shouldAcceptUniqueValidIndexRetentionPolicies() {
+    // given
+    final RetentionConfiguration retention = new RetentionConfiguration();
+
+    final List<IndexRetentionPolicy> validPolicies =
+        List.of(
+            new IndexRetentionPolicy("user_policy", "7d", List.of("user-activity", "user-logs")),
+            new IndexRetentionPolicy("admin_policy", "30d", List.of("admin-logs")),
+            new IndexRetentionPolicy("system_policy", "90d", List.of("system-events")));
+
+    // when & then
+    assertThatNoException().isThrownBy(() -> retention.setIndexPolicies(validPolicies));
+    assertThat(retention.getIndexPolicies()).hasSize(3);
+    assertThat(retention.getIndexPolicies().get(0).getPolicyName()).isEqualTo("user_policy");
+    assertThat(retention.getIndexPolicies().get(1).getPolicyName()).isEqualTo("admin_policy");
+    assertThat(retention.getIndexPolicies().get(2).getPolicyName()).isEqualTo("system_policy");
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepository.java
@@ -251,13 +251,16 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
             .collect(
                 groupingBy(
                     indexName -> {
-                      // Then check for pattern matches
+                      // Start with default policy
                       String lastMatchingPolicy = defaultPolicy;
+                      // Check for pattern matches - last match wins
                       for (final var policy : retention.getIndexPolicies()) {
-                        final var indexWithNamePattern =
-                            "^" + formattedPrefix + policy.getIndex() + VERSION_SUFFIX_PATTERN;
-                        if (Pattern.compile(indexWithNamePattern).matcher(indexName).matches()) {
-                          lastMatchingPolicy = policy.getPolicyName();
+                        for (final var indexPattern : policy.getIndices()) {
+                          final var indexWithNamePattern =
+                              "^" + formattedPrefix + indexPattern + VERSION_SUFFIX_PATTERN;
+                          if (Pattern.compile(indexWithNamePattern).matcher(indexName).matches()) {
+                            lastMatchingPolicy = policy.getPolicyName();
+                          }
                         }
                       }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepository.java
@@ -47,7 +47,9 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
     implements ArchiverRepository {
   private static final String ALL_INDICES = "*";
   private static final String ALL_INDICES_PATTERN = ".*";
-  private static final String INDEX_WILDCARD = ".+-\\d+\\.\\d+\\.\\d+_.+$";
+  // Matches versioned index names with suffixes: {name}-{major}.{minor}.{patch}_{suffix}
+  // e.g. "camunda-tenant-8.8.0_2025-02-23"
+  private static final String VERSIONED_INDEX_PATTERN = ".+-\\d+\\.\\d+\\.\\d+_.+$";
 
   private static final Time REINDEX_SCROLL_TIMEOUT = Time.of(t -> t.time("30s"));
   private static final Slices AUTO_SLICES =
@@ -124,7 +126,7 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
       return CompletableFuture.completedFuture(null);
     }
     final var formattedPrefix = AbstractIndexDescriptor.formatIndexPrefix(indexPrefix);
-    final var indexWildcard = "^" + formattedPrefix + INDEX_WILDCARD;
+    final var indexWildcard = "^" + formattedPrefix + VERSIONED_INDEX_PATTERN;
     return fetchMatchingIndexes(indexWildcard)
         .thenComposeAsync(this::setIndexLifeCycleToMatchingIndices, executor);
   }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepository.java
@@ -241,12 +241,10 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
       return CompletableFuture.completedFuture(null);
     }
 
-    logger.debug("Setting lifecycle policies for {} indices", destinationIndexNames);
     final var defaultPolicy = retention.getPolicyName();
     final var formattedPrefix = AbstractIndexDescriptor.formatIndexPrefix(indexPrefix);
 
-    // Group indices by their assigned policy
-    final var policiesMap =
+    final var policyToIndicesMap =
         destinationIndexNames.stream()
             .collect(
                 groupingBy(
@@ -269,13 +267,13 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
 
     // Create separate requests for each policy group
     final var requests =
-        policiesMap.entrySet().stream()
+        policyToIndicesMap.entrySet().stream()
             .map(
                 entry -> {
                   final String policyName = entry.getKey();
                   final List<String> indices = entry.getValue();
 
-                  logger.info(
+                  logger.debug(
                       "Applying policy '{}' to {} indices: {}",
                       policyName,
                       indices.size(),

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepository.java
@@ -270,10 +270,12 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
                       String lastMatchingPolicy = defaultPolicy;
                       // Check for pattern matches - last match wins
                       for (final var policy : retention.getIndexPolicies()) {
-                        final var indexWithNamePattern =
-                            "^" + formattedPrefix + policy.getIndex() + VERSION_SUFFIX_PATTERN;
-                        if (Pattern.compile(indexWithNamePattern).matcher(indexName).matches()) {
-                          lastMatchingPolicy = policy.getPolicyName();
+                        for (final var indexPattern : policy.getIndices()) {
+                          final var indexWithNamePattern =
+                              "^" + formattedPrefix + indexPattern + VERSION_SUFFIX_PATTERN;
+                          if (Pattern.compile(indexWithNamePattern).matcher(indexName).matches()) {
+                            lastMatchingPolicy = policy.getPolicyName();
+                          }
                         }
                       }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepository.java
@@ -256,12 +256,10 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
       return CompletableFuture.completedFuture(null);
     }
 
-    logger.debug("Setting lifecycle policies for {} indices", destinationIndexNames);
     final var defaultPolicy = retention.getPolicyName();
     final var formattedPrefix = AbstractIndexDescriptor.formatIndexPrefix(indexPrefix);
 
-    // Group indices by their assigned policy
-    final var policiesMap =
+    final var policyToIndicesMap =
         destinationIndexNames.stream()
             .collect(
                 groupingBy(
@@ -284,13 +282,13 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
 
     // Create separate requests for each policy group
     final var requests =
-        policiesMap.entrySet().stream()
+        policyToIndicesMap.entrySet().stream()
             .map(
                 entry -> {
                   final String policyName = entry.getKey();
                   final List<String> indices = entry.getValue();
 
-                  logger.info(
+                  logger.debug(
                       "Applying policy '{}' to {} indices: {}",
                       policyName,
                       indices.size(),

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepositoryIT.java
@@ -202,8 +202,9 @@ final class ElasticsearchArchiverRepositoryIT {
 
     retention.setIndexPolicies(
         List.of(
-            new IndexRetentionPolicy("camunda-user-task", "user_task_policy", "7d"),
-            new IndexRetentionPolicy("camunda-user-task-at", "user_task_at_policy", "14d")));
+            new IndexRetentionPolicy("user_task_policy", "7d", List.of("camunda-user-task")),
+            new IndexRetentionPolicy(
+                "user_task_at_policy", "14d", List.of("camunda-user-task-at"))));
 
     putLifecyclePolicies();
     for (final var index : expectedIndices) {
@@ -252,9 +253,10 @@ final class ElasticsearchArchiverRepositoryIT {
     // Configure pattern-based policies
     retention.setIndexPolicies(
         List.of(
-            new IndexRetentionPolicy("camunda.*", "camunda_policy", "40d"),
-            new IndexRetentionPolicy("operate.*", "operate_policy", "60d"),
-            new IndexRetentionPolicy("tasklist.*", "tasklist_policy", "90d")));
+            new IndexRetentionPolicy("camunda_policy", "40d", List.of("camunda.*")),
+            new IndexRetentionPolicy("operate_policy", "60d", List.of("operate.*")),
+            new IndexRetentionPolicy("tasklist_policy", "90d", List.of("tasklist.*")),
+            new IndexRetentionPolicy("auth_policy", "5d", List.of(".*authorization.*"))));
 
     putLifecyclePolicies();
     for (final var index : expectedIndices) {
@@ -273,7 +275,7 @@ final class ElasticsearchArchiverRepositoryIT {
     assertThat(getLifeCycle(formattedPrefix + "camunda-user-task-at-8.8.0_2025-08-10").name())
         .isEqualTo("camunda_policy");
     assertThat(getLifeCycle(formattedPrefix + "camunda-authorization-8.8.0_2025-08-10").name())
-        .isEqualTo("camunda_policy");
+        .isEqualTo("auth_policy");
 
     assertThat(getLifeCycle(formattedPrefix + "operate-list-view-8.3.0_2024-01-02").name())
         .isEqualTo("operate_policy");
@@ -302,9 +304,9 @@ final class ElasticsearchArchiverRepositoryIT {
     // Configure overlapping patterns, the implementation should apply the last one that matches
     retention.setIndexPolicies(
         List.of(
-            new IndexRetentionPolicy("user.*", "user_general_policy", "1d"),
-            new IndexRetentionPolicy("user-activity.*", "user_activity_policy", "2d"),
-            new IndexRetentionPolicy(".*logs", "logs_policy", "3d")));
+            new IndexRetentionPolicy("user_general_policy", "1d", List.of("user.*")),
+            new IndexRetentionPolicy("user_activity_policy", "2d", List.of("user-activity.*")),
+            new IndexRetentionPolicy("logs_policy", "3d", List.of(".*logs"))));
 
     putLifecyclePolicies();
     testClient.indices().create(r -> r.index(testIndex));
@@ -391,9 +393,9 @@ final class ElasticsearchArchiverRepositoryIT {
     retention.setPolicyName("default_policy");
     retention.setIndexPolicies(
         List.of(
-            new IndexRetentionPolicy("camunda-user-task", "user_task_policy", "7d"),
-            new IndexRetentionPolicy("operate.*", "operate_policy", "30d"),
-            new IndexRetentionPolicy("tasklist.*", "tasklist_policy", "90d")));
+            new IndexRetentionPolicy("user_task_policy", "7d", List.of("camunda-user-task")),
+            new IndexRetentionPolicy("operate_policy", "30d", List.of("operate.*")),
+            new IndexRetentionPolicy("tasklist_policy", "90d", List.of("tasklist.*"))));
 
     putLifecyclePolicies();
 
@@ -431,8 +433,8 @@ final class ElasticsearchArchiverRepositoryIT {
     retention.setPolicyName("default_policy");
     retention.setIndexPolicies(
         List.of(
-            new IndexRetentionPolicy("camunda-user-task", "custom_policy", "14d"),
-            new IndexRetentionPolicy("operate.*", "operate_policy", "60d")));
+            new IndexRetentionPolicy("custom_policy", "14d", List.of("camunda-user-task")),
+            new IndexRetentionPolicy("operate_policy", "60d", List.of("operate.*"))));
 
     putLifecyclePolicies();
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryIT.java
@@ -153,7 +153,7 @@ final class OpenSearchArchiverRepositoryIT {
     final var indices =
         List.of(
             formattedPrefix + "camunda-user-task-8.8.0_2025-06-10",
-            formattedPrefix + "camunda-user-task-at-8.8.0_2025-06-10",
+            formattedPrefix + "tasklist-user-task-8.8.0_2025-06-10",
             formattedPrefix + "operate-list-view-8.3.0_2024-06-02",
             formattedPrefix + "tasklist-task-8.5.0_2024-06-02");
 
@@ -162,9 +162,9 @@ final class OpenSearchArchiverRepositoryIT {
     retention.setPolicyName("default_policy");
     retention.setIndexPolicies(
         List.of(
-            new IndexRetentionPolicy("camunda-user-task", "user_task_policy", "7d"),
-            new IndexRetentionPolicy("camunda-user-task-at", "user_task_at_policy", "14d"),
-            new IndexRetentionPolicy("operate.*", "operate_policy", "30d")));
+            new IndexRetentionPolicy(
+                "user_task_policy", "7d", List.of("camunda-user-task", "tasklist-user-task")),
+            new IndexRetentionPolicy("operate_policy", "30d", List.of("operate.*"))));
 
     createLifeCyclePolicies();
     for (final var index : indices) {
@@ -180,8 +180,8 @@ final class OpenSearchArchiverRepositoryIT {
     assertThat(fetchPolicyForIndexWithAwait(formattedPrefix + "camunda-user-task-8.8.0_2025-06-10"))
         .isEqualTo("user_task_policy");
     assertThat(
-            fetchPolicyForIndexWithAwait(formattedPrefix + "camunda-user-task-at-8.8.0_2025-06-10"))
-        .isEqualTo("user_task_at_policy");
+            fetchPolicyForIndexWithAwait(formattedPrefix + "tasklist-user-task-8.8.0_2025-06-10"))
+        .isEqualTo("user_task_policy");
     assertThat(fetchPolicyForIndexWithAwait(formattedPrefix + "operate-list-view-8.3.0_2024-06-02"))
         .isEqualTo("operate_policy");
     assertThat(fetchPolicyForIndexWithAwait(formattedPrefix + "tasklist-task-8.5.0_2024-06-02"))
@@ -272,8 +272,9 @@ final class OpenSearchArchiverRepositoryIT {
     // Configure exact index name matches
     retention.setIndexPolicies(
         List.of(
-            new IndexRetentionPolicy("camunda-user-task", "user_task_policy", "7d"),
-            new IndexRetentionPolicy("camunda-user-task-at", "user_task_at_policy", "14d")));
+            new IndexRetentionPolicy("user_task_policy", "7d", List.of("camunda-user-task")),
+            new IndexRetentionPolicy(
+                "user_task_at_policy", "14d", List.of("camunda-user-task-at"))));
 
     createLifeCyclePolicies();
     for (final var index : expectedIndices) {
@@ -327,9 +328,10 @@ final class OpenSearchArchiverRepositoryIT {
     // Configure pattern-based policies
     retention.setIndexPolicies(
         List.of(
-            new IndexRetentionPolicy("camunda.*", "camunda_policy", "40d"),
-            new IndexRetentionPolicy("operate.*", "operate_policy", "60d"),
-            new IndexRetentionPolicy("tasklist.*", "tasklist_policy", "90d")));
+            new IndexRetentionPolicy("camunda_policy", "40d", List.of("camunda.*")),
+            new IndexRetentionPolicy(
+                "operate_policy", "60d", List.of("operate-list-view", "operate-process")),
+            new IndexRetentionPolicy("tasklist_policy", "90d", List.of("tasklist.*"))));
 
     createLifeCyclePolicies();
     for (final var index : expectedIndices) {
@@ -384,9 +386,9 @@ final class OpenSearchArchiverRepositoryIT {
     // Configure overlapping patterns, the implementation should apply the last one that matches
     retention.setIndexPolicies(
         List.of(
-            new IndexRetentionPolicy("user.*", "user_general_policy", "1d"),
-            new IndexRetentionPolicy("user-activity.*", "user_activity_policy", "2d"),
-            new IndexRetentionPolicy(".*logs", "logs_policy", "3d")));
+            new IndexRetentionPolicy("user_general_policy", "1d", List.of("user.*")),
+            new IndexRetentionPolicy("user_activity_policy", "2d", List.of("user-activity.*")),
+            new IndexRetentionPolicy("logs_policy", "3d", List.of(".*logs"))));
 
     createLifeCyclePolicies();
     testClient.indices().create(r -> r.index(testIndex));


### PR DESCRIPTION
## Description

This PR introduces a mechanism to configure ILM policies for any Elasticsearch/OpenSearch index by index name ([component](https://github.com/camunda/camunda/blob/459f453a04ca03771bb48d55f7a9b7d3224a3f9d/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/index/UsageMetricIndex.java#L37) + [index name](https://github.com/camunda/camunda/blob/459f453a04ca03771bb48d55f7a9b7d3224a3f9d/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/index/UsageMetricIndex.java#L42)) or by pattern. While the immediate use case is usage-metric indices, the implementation is generic and can target any index or index pattern.
As part of this change, policy configurations were added for `camunda-usage-metric` and `camunda-usage-metric-at` indices in `~/camunda/camunda/dist/src/main/resources/application-elasticsearch.yaml` and `application-opensearch.yaml`.

### Behavior and precedence
- Multiple matches: If an index matches several policy entries (via exact name and/or patterns), the last matching policy in the list takes precedence and is applied.
- Ordering matters: Place broader patterns first and more specific overrides later to ensure the intended policy is applied.
- No match: If no policy matches, the default one `RetentionConfiguration#getPolicyName()` will be applied.

### Configuration examples
- Example showing pattern-based and exact-name matching with “last matching policy wins.”

```yaml
retention:
  enabled: true

  # Policies are evaluated top-to-bottom; the LAST matching policy wins.
  indexPolicies:
    # Broad baseline for all Camunda indices
    - policyName: "camunda-indices-policy"
      minimumAge: "45d"
      indices:
        - "camunda-*"

    # More specific pattern for metrics; overrides the baseline if matched
    - policyName: "camunda-usage-metric-policy"
      minimumAge: "60d"
      indices:
        - "camunda-usage-metric.*"

    # Exact index overrides; appear last, so they take precedence when matched
    - policyName: "camunda-custom-policy"
      minimumAge: "90d"
      indices:
        - "camunda-tenant"
        - "camunda-user"
```

### Scope
- Generic ILM policy configuration capability; 
- Configured retention policies for `camunda-usage-metric` and `camunda-usage-metric-at` in `application-elasticsearch.yaml` and `application-opensearch.yaml`.

### Out of scope:
- Helm chart configuration for custom usage metrics policies (will be handled by [#36685](https://github.com/camunda/camunda/issues/36685) issue).


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #34709
