### PR TITLE
fix: the different application audiences in Management Identity can have the same value

### DIFF
--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/sm/StaticEntities.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/sm/StaticEntities.java
@@ -13,8 +13,8 @@ import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 public class StaticEntities {
 
@@ -22,302 +22,318 @@ public class StaticEntities {
   private static final String OPERATE_RESOURCE_ID = "operate";
   private static final String TASKLIST_RESOURCE_ID = "tasklist";
 
-  public static List<CreateAuthorizationRequest> getAuthorizationsByAudience(
+  public static Set<CreateAuthorizationRequest> getAuthorizationsByAudience(
       final Audiences audiences,
       final String permission,
       final String ownerId,
       final AuthorizationOwnerType ownerType) {
-    final var authorizations =
-        Map.of(
-            audiences.getIdentity() + ":read",
-            List.of(
-                new CreateAuthorizationRequest(
-                    ownerId,
-                    ownerType,
-                    "*",
-                    AuthorizationResourceType.AUTHORIZATION,
-                    Set.of(PermissionType.READ)),
-                new CreateAuthorizationRequest(
-                    ownerId,
-                    ownerType,
-                    IDENTITY_RESOURCE_ID,
-                    AuthorizationResourceType.APPLICATION,
-                    Set.of(PermissionType.ACCESS)),
-                new CreateAuthorizationRequest(
-                    ownerId,
-                    ownerType,
-                    "*",
-                    AuthorizationResourceType.TENANT,
-                    Set.of(PermissionType.READ)),
-                new CreateAuthorizationRequest(
-                    ownerId,
-                    ownerType,
-                    "*",
-                    AuthorizationResourceType.GROUP,
-                    Set.of(PermissionType.READ)),
-                new CreateAuthorizationRequest(
-                    ownerId,
-                    ownerType,
-                    "*",
-                    AuthorizationResourceType.USER,
-                    Set.of(PermissionType.READ)),
-                new CreateAuthorizationRequest(
-                    ownerId,
-                    ownerType,
-                    "*",
-                    AuthorizationResourceType.ROLE,
-                    Set.of(PermissionType.READ))),
-            audiences.getIdentity() + ":read:users",
-            List.of(
-                new CreateAuthorizationRequest(
-                    ownerId,
-                    ownerType,
-                    IDENTITY_RESOURCE_ID,
-                    AuthorizationResourceType.APPLICATION,
-                    Set.of(PermissionType.ACCESS)),
-                new CreateAuthorizationRequest(
-                    ownerId,
-                    ownerType,
-                    "*",
-                    AuthorizationResourceType.USER,
-                    Set.of(PermissionType.READ)),
-                new CreateAuthorizationRequest(
-                    ownerId,
-                    ownerType,
-                    "*",
-                    AuthorizationResourceType.ROLE,
-                    Set.of(PermissionType.READ))),
-            audiences.getIdentity() + ":write",
-            List.of(
-                new CreateAuthorizationRequest(
-                    ownerId,
-                    ownerType,
-                    "*",
-                    AuthorizationResourceType.AUTHORIZATION,
-                    AuthorizationResourceType.AUTHORIZATION.getSupportedPermissionTypes()),
-                new CreateAuthorizationRequest(
-                    ownerId,
-                    ownerType,
-                    IDENTITY_RESOURCE_ID,
-                    AuthorizationResourceType.APPLICATION,
-                    Set.of(PermissionType.ACCESS)),
-                new CreateAuthorizationRequest(
-                    ownerId,
-                    ownerType,
-                    "*",
-                    AuthorizationResourceType.TENANT,
-                    AuthorizationResourceType.TENANT.getSupportedPermissionTypes()),
-                new CreateAuthorizationRequest(
-                    ownerId,
-                    ownerType,
-                    "*",
-                    AuthorizationResourceType.GROUP,
-                    AuthorizationResourceType.GROUP.getSupportedPermissionTypes()),
-                new CreateAuthorizationRequest(
-                    ownerId,
-                    ownerType,
-                    "*",
-                    AuthorizationResourceType.USER,
-                    Set.of(PermissionType.READ)),
-                new CreateAuthorizationRequest(
-                    ownerId,
-                    ownerType,
-                    "*",
-                    AuthorizationResourceType.ROLE,
-                    AuthorizationResourceType.ROLE.getSupportedPermissionTypes())),
-            audiences.getOperate() + ":read:*",
-            List.of(
-                new CreateAuthorizationRequest(
-                    ownerId,
-                    ownerType,
-                    "*",
-                    AuthorizationResourceType.MESSAGE,
-                    Set.of(PermissionType.READ)),
-                new CreateAuthorizationRequest(
-                    ownerId,
-                    ownerType,
-                    "*",
-                    AuthorizationResourceType.BATCH,
-                    Set.of(PermissionType.READ)),
-                new CreateAuthorizationRequest(
-                    ownerId,
-                    ownerType,
-                    OPERATE_RESOURCE_ID,
-                    AuthorizationResourceType.APPLICATION,
-                    Set.of(PermissionType.ACCESS)),
-                new CreateAuthorizationRequest(
-                    ownerId,
-                    ownerType,
-                    "*",
-                    AuthorizationResourceType.RESOURCE,
-                    Set.of(PermissionType.READ)),
-                new CreateAuthorizationRequest(
-                    ownerId,
-                    ownerType,
-                    "*",
-                    AuthorizationResourceType.PROCESS_DEFINITION,
-                    Set.of(
-                        PermissionType.READ_PROCESS_DEFINITION,
-                        PermissionType.READ_PROCESS_INSTANCE)),
-                new CreateAuthorizationRequest(
-                    ownerId,
-                    ownerType,
-                    "*",
-                    AuthorizationResourceType.DECISION_REQUIREMENTS_DEFINITION,
-                    Set.of(PermissionType.READ)),
-                new CreateAuthorizationRequest(
-                    ownerId,
-                    ownerType,
-                    "*",
-                    AuthorizationResourceType.DECISION_DEFINITION,
-                    Set.of(
-                        PermissionType.READ_DECISION_DEFINITION,
-                        PermissionType.READ_DECISION_INSTANCE))),
-            audiences.getOperate() + ":write:*",
-            List.of(
-                new CreateAuthorizationRequest(
-                    ownerId,
-                    ownerType,
-                    "*",
-                    AuthorizationResourceType.MESSAGE,
-                    Set.of(PermissionType.READ)),
-                new CreateAuthorizationRequest(
-                    ownerId,
-                    ownerType,
-                    "*",
-                    AuthorizationResourceType.BATCH,
-                    Set.of(PermissionType.READ, PermissionType.CREATE, PermissionType.UPDATE)),
-                new CreateAuthorizationRequest(
-                    ownerId,
-                    ownerType,
-                    OPERATE_RESOURCE_ID,
-                    AuthorizationResourceType.APPLICATION,
-                    Set.of(PermissionType.ACCESS)),
-                new CreateAuthorizationRequest(
-                    ownerId,
-                    ownerType,
-                    "*",
-                    AuthorizationResourceType.RESOURCE,
-                    Set.of(PermissionType.READ)),
-                new CreateAuthorizationRequest(
-                    ownerId,
-                    ownerType,
-                    "*",
-                    AuthorizationResourceType.PROCESS_DEFINITION,
-                    Set.of(
-                        PermissionType.READ_PROCESS_DEFINITION,
-                        PermissionType.READ_PROCESS_INSTANCE,
-                        PermissionType.UPDATE_PROCESS_INSTANCE,
-                        PermissionType.DELETE_PROCESS_INSTANCE)),
-                new CreateAuthorizationRequest(
-                    ownerId,
-                    ownerType,
-                    "*",
-                    AuthorizationResourceType.DECISION_REQUIREMENTS_DEFINITION,
-                    Set.of(PermissionType.READ, PermissionType.UPDATE, PermissionType.DELETE)),
-                new CreateAuthorizationRequest(
-                    ownerId,
-                    ownerType,
-                    "*",
-                    AuthorizationResourceType.DECISION_DEFINITION,
-                    Set.of(
-                        PermissionType.READ_DECISION_DEFINITION,
-                        PermissionType.READ_DECISION_INSTANCE,
-                        PermissionType.CREATE_DECISION_INSTANCE,
-                        PermissionType.DELETE_DECISION_INSTANCE))),
-            audiences.getTasklist() + ":read:*",
-            List.of(
-                new CreateAuthorizationRequest(
-                    ownerId,
-                    ownerType,
-                    TASKLIST_RESOURCE_ID,
-                    AuthorizationResourceType.APPLICATION,
-                    Set.of(PermissionType.ACCESS)),
-                new CreateAuthorizationRequest(
-                    ownerId,
-                    ownerType,
-                    "*",
-                    AuthorizationResourceType.RESOURCE,
-                    Set.of(PermissionType.READ)),
-                new CreateAuthorizationRequest(
-                    ownerId,
-                    ownerType,
-                    "*",
-                    AuthorizationResourceType.PROCESS_DEFINITION,
-                    Set.of(PermissionType.READ_PROCESS_DEFINITION, PermissionType.READ_USER_TASK))),
-            audiences.getTasklist() + ":write:*",
-            List.of(
-                new CreateAuthorizationRequest(
-                    ownerId,
-                    ownerType,
-                    TASKLIST_RESOURCE_ID,
-                    AuthorizationResourceType.APPLICATION,
-                    Set.of(PermissionType.ACCESS)),
-                new CreateAuthorizationRequest(
-                    ownerId,
-                    ownerType,
-                    "*",
-                    AuthorizationResourceType.RESOURCE,
-                    Set.of(PermissionType.READ)),
-                new CreateAuthorizationRequest(
-                    ownerId,
-                    ownerType,
-                    "*",
-                    AuthorizationResourceType.PROCESS_DEFINITION,
-                    Set.of(
-                        PermissionType.READ_PROCESS_DEFINITION,
-                        PermissionType.READ_USER_TASK,
-                        PermissionType.UPDATE_USER_TASK))),
-            audiences.getZeebe() + ":write:*",
-            List.of(
-                new CreateAuthorizationRequest(
-                    ownerId,
-                    ownerType,
-                    "*",
-                    AuthorizationResourceType.MESSAGE,
-                    Set.of(PermissionType.CREATE)),
-                new CreateAuthorizationRequest(
-                    ownerId,
-                    ownerType,
-                    "*",
-                    AuthorizationResourceType.SYSTEM,
-                    Set.of(PermissionType.UPDATE, PermissionType.READ)),
-                new CreateAuthorizationRequest(
-                    ownerId,
-                    ownerType,
-                    "*",
-                    AuthorizationResourceType.RESOURCE,
-                    Set.of(
-                        PermissionType.CREATE,
-                        PermissionType.DELETE_FORM,
-                        PermissionType.DELETE_PROCESS,
-                        PermissionType.DELETE_DRD,
-                        PermissionType.DELETE_RESOURCE)),
-                new CreateAuthorizationRequest(
-                    ownerId,
-                    ownerType,
-                    "*",
-                    AuthorizationResourceType.PROCESS_DEFINITION,
-                    Set.of(
-                        PermissionType.UPDATE_PROCESS_INSTANCE,
-                        PermissionType.UPDATE_USER_TASK,
-                        PermissionType.CREATE_PROCESS_INSTANCE,
-                        PermissionType.DELETE_PROCESS_INSTANCE)),
-                new CreateAuthorizationRequest(
-                    ownerId,
-                    ownerType,
-                    "*",
-                    AuthorizationResourceType.DECISION_DEFINITION,
-                    Set.of(
-                        PermissionType.CREATE_DECISION_INSTANCE,
-                        PermissionType.DELETE_DECISION_INSTANCE)),
-                new CreateAuthorizationRequest(
-                    ownerId,
-                    ownerType,
-                    "*",
-                    AuthorizationResourceType.DECISION_REQUIREMENTS_DEFINITION,
-                    Set.of(PermissionType.UPDATE, PermissionType.DELETE))));
 
-    return authorizations.getOrDefault(permission, List.of());
+    record AuthEntry(String key, List<CreateAuthorizationRequest> value) {}
+
+    final var authorizations =
+        List.of(
+            new AuthEntry(
+                audiences.getIdentity() + ":read",
+                List.of(
+                    new CreateAuthorizationRequest(
+                        ownerId,
+                        ownerType,
+                        "*",
+                        AuthorizationResourceType.AUTHORIZATION,
+                        Set.of(PermissionType.READ)),
+                    new CreateAuthorizationRequest(
+                        ownerId,
+                        ownerType,
+                        IDENTITY_RESOURCE_ID,
+                        AuthorizationResourceType.APPLICATION,
+                        Set.of(PermissionType.ACCESS)),
+                    new CreateAuthorizationRequest(
+                        ownerId,
+                        ownerType,
+                        "*",
+                        AuthorizationResourceType.TENANT,
+                        Set.of(PermissionType.READ)),
+                    new CreateAuthorizationRequest(
+                        ownerId,
+                        ownerType,
+                        "*",
+                        AuthorizationResourceType.GROUP,
+                        Set.of(PermissionType.READ)),
+                    new CreateAuthorizationRequest(
+                        ownerId,
+                        ownerType,
+                        "*",
+                        AuthorizationResourceType.USER,
+                        Set.of(PermissionType.READ)),
+                    new CreateAuthorizationRequest(
+                        ownerId,
+                        ownerType,
+                        "*",
+                        AuthorizationResourceType.ROLE,
+                        Set.of(PermissionType.READ)))),
+            new AuthEntry(
+                audiences.getIdentity() + ":read:users",
+                List.of(
+                    new CreateAuthorizationRequest(
+                        ownerId,
+                        ownerType,
+                        IDENTITY_RESOURCE_ID,
+                        AuthorizationResourceType.APPLICATION,
+                        Set.of(PermissionType.ACCESS)),
+                    new CreateAuthorizationRequest(
+                        ownerId,
+                        ownerType,
+                        "*",
+                        AuthorizationResourceType.USER,
+                        Set.of(PermissionType.READ)),
+                    new CreateAuthorizationRequest(
+                        ownerId,
+                        ownerType,
+                        "*",
+                        AuthorizationResourceType.ROLE,
+                        Set.of(PermissionType.READ)))),
+            new AuthEntry(
+                audiences.getIdentity() + ":write",
+                List.of(
+                    new CreateAuthorizationRequest(
+                        ownerId,
+                        ownerType,
+                        "*",
+                        AuthorizationResourceType.AUTHORIZATION,
+                        AuthorizationResourceType.AUTHORIZATION.getSupportedPermissionTypes()),
+                    new CreateAuthorizationRequest(
+                        ownerId,
+                        ownerType,
+                        IDENTITY_RESOURCE_ID,
+                        AuthorizationResourceType.APPLICATION,
+                        Set.of(PermissionType.ACCESS)),
+                    new CreateAuthorizationRequest(
+                        ownerId,
+                        ownerType,
+                        "*",
+                        AuthorizationResourceType.TENANT,
+                        AuthorizationResourceType.TENANT.getSupportedPermissionTypes()),
+                    new CreateAuthorizationRequest(
+                        ownerId,
+                        ownerType,
+                        "*",
+                        AuthorizationResourceType.GROUP,
+                        AuthorizationResourceType.GROUP.getSupportedPermissionTypes()),
+                    new CreateAuthorizationRequest(
+                        ownerId,
+                        ownerType,
+                        "*",
+                        AuthorizationResourceType.USER,
+                        Set.of(PermissionType.READ)),
+                    new CreateAuthorizationRequest(
+                        ownerId,
+                        ownerType,
+                        "*",
+                        AuthorizationResourceType.ROLE,
+                        AuthorizationResourceType.ROLE.getSupportedPermissionTypes()))),
+            new AuthEntry(
+                audiences.getOperate() + ":read:*",
+                List.of(
+                    new CreateAuthorizationRequest(
+                        ownerId,
+                        ownerType,
+                        "*",
+                        AuthorizationResourceType.MESSAGE,
+                        Set.of(PermissionType.READ)),
+                    new CreateAuthorizationRequest(
+                        ownerId,
+                        ownerType,
+                        "*",
+                        AuthorizationResourceType.BATCH,
+                        Set.of(PermissionType.READ)),
+                    new CreateAuthorizationRequest(
+                        ownerId,
+                        ownerType,
+                        OPERATE_RESOURCE_ID,
+                        AuthorizationResourceType.APPLICATION,
+                        Set.of(PermissionType.ACCESS)),
+                    new CreateAuthorizationRequest(
+                        ownerId,
+                        ownerType,
+                        "*",
+                        AuthorizationResourceType.RESOURCE,
+                        Set.of(PermissionType.READ)),
+                    new CreateAuthorizationRequest(
+                        ownerId,
+                        ownerType,
+                        "*",
+                        AuthorizationResourceType.PROCESS_DEFINITION,
+                        Set.of(
+                            PermissionType.READ_PROCESS_DEFINITION,
+                            PermissionType.READ_PROCESS_INSTANCE)),
+                    new CreateAuthorizationRequest(
+                        ownerId,
+                        ownerType,
+                        "*",
+                        AuthorizationResourceType.DECISION_REQUIREMENTS_DEFINITION,
+                        Set.of(PermissionType.READ)),
+                    new CreateAuthorizationRequest(
+                        ownerId,
+                        ownerType,
+                        "*",
+                        AuthorizationResourceType.DECISION_DEFINITION,
+                        Set.of(
+                            PermissionType.READ_DECISION_DEFINITION,
+                            PermissionType.READ_DECISION_INSTANCE)))),
+            new AuthEntry(
+                audiences.getOperate() + ":write:*",
+                List.of(
+                    new CreateAuthorizationRequest(
+                        ownerId,
+                        ownerType,
+                        "*",
+                        AuthorizationResourceType.MESSAGE,
+                        Set.of(PermissionType.READ)),
+                    new CreateAuthorizationRequest(
+                        ownerId,
+                        ownerType,
+                        "*",
+                        AuthorizationResourceType.BATCH,
+                        Set.of(PermissionType.READ, PermissionType.CREATE, PermissionType.UPDATE)),
+                    new CreateAuthorizationRequest(
+                        ownerId,
+                        ownerType,
+                        OPERATE_RESOURCE_ID,
+                        AuthorizationResourceType.APPLICATION,
+                        Set.of(PermissionType.ACCESS)),
+                    new CreateAuthorizationRequest(
+                        ownerId,
+                        ownerType,
+                        "*",
+                        AuthorizationResourceType.RESOURCE,
+                        Set.of(PermissionType.READ)),
+                    new CreateAuthorizationRequest(
+                        ownerId,
+                        ownerType,
+                        "*",
+                        AuthorizationResourceType.PROCESS_DEFINITION,
+                        Set.of(
+                            PermissionType.READ_PROCESS_DEFINITION,
+                            PermissionType.READ_PROCESS_INSTANCE,
+                            PermissionType.UPDATE_PROCESS_INSTANCE,
+                            PermissionType.DELETE_PROCESS_INSTANCE)),
+                    new CreateAuthorizationRequest(
+                        ownerId,
+                        ownerType,
+                        "*",
+                        AuthorizationResourceType.DECISION_REQUIREMENTS_DEFINITION,
+                        Set.of(PermissionType.READ, PermissionType.UPDATE, PermissionType.DELETE)),
+                    new CreateAuthorizationRequest(
+                        ownerId,
+                        ownerType,
+                        "*",
+                        AuthorizationResourceType.DECISION_DEFINITION,
+                        Set.of(
+                            PermissionType.READ_DECISION_DEFINITION,
+                            PermissionType.READ_DECISION_INSTANCE,
+                            PermissionType.CREATE_DECISION_INSTANCE,
+                            PermissionType.DELETE_DECISION_INSTANCE)))),
+            new AuthEntry(
+                audiences.getTasklist() + ":read:*",
+                List.of(
+                    new CreateAuthorizationRequest(
+                        ownerId,
+                        ownerType,
+                        TASKLIST_RESOURCE_ID,
+                        AuthorizationResourceType.APPLICATION,
+                        Set.of(PermissionType.ACCESS)),
+                    new CreateAuthorizationRequest(
+                        ownerId,
+                        ownerType,
+                        "*",
+                        AuthorizationResourceType.RESOURCE,
+                        Set.of(PermissionType.READ)),
+                    new CreateAuthorizationRequest(
+                        ownerId,
+                        ownerType,
+                        "*",
+                        AuthorizationResourceType.PROCESS_DEFINITION,
+                        Set.of(
+                            PermissionType.READ_PROCESS_DEFINITION,
+                            PermissionType.READ_USER_TASK)))),
+            new AuthEntry(
+                audiences.getTasklist() + ":write:*",
+                List.of(
+                    new CreateAuthorizationRequest(
+                        ownerId,
+                        ownerType,
+                        TASKLIST_RESOURCE_ID,
+                        AuthorizationResourceType.APPLICATION,
+                        Set.of(PermissionType.ACCESS)),
+                    new CreateAuthorizationRequest(
+                        ownerId,
+                        ownerType,
+                        "*",
+                        AuthorizationResourceType.RESOURCE,
+                        Set.of(PermissionType.READ)),
+                    new CreateAuthorizationRequest(
+                        ownerId,
+                        ownerType,
+                        "*",
+                        AuthorizationResourceType.PROCESS_DEFINITION,
+                        Set.of(
+                            PermissionType.READ_PROCESS_DEFINITION,
+                            PermissionType.READ_USER_TASK,
+                            PermissionType.UPDATE_USER_TASK)))),
+            new AuthEntry(
+                audiences.getZeebe() + ":write:*",
+                List.of(
+                    new CreateAuthorizationRequest(
+                        ownerId,
+                        ownerType,
+                        "*",
+                        AuthorizationResourceType.MESSAGE,
+                        Set.of(PermissionType.CREATE)),
+                    new CreateAuthorizationRequest(
+                        ownerId,
+                        ownerType,
+                        "*",
+                        AuthorizationResourceType.SYSTEM,
+                        Set.of(PermissionType.UPDATE, PermissionType.READ)),
+                    new CreateAuthorizationRequest(
+                        ownerId,
+                        ownerType,
+                        "*",
+                        AuthorizationResourceType.RESOURCE,
+                        Set.of(
+                            PermissionType.CREATE,
+                            PermissionType.DELETE_FORM,
+                            PermissionType.DELETE_PROCESS,
+                            PermissionType.DELETE_DRD,
+                            PermissionType.DELETE_RESOURCE)),
+                    new CreateAuthorizationRequest(
+                        ownerId,
+                        ownerType,
+                        "*",
+                        AuthorizationResourceType.PROCESS_DEFINITION,
+                        Set.of(
+                            PermissionType.UPDATE_PROCESS_INSTANCE,
+                            PermissionType.UPDATE_USER_TASK,
+                            PermissionType.CREATE_PROCESS_INSTANCE,
+                            PermissionType.DELETE_PROCESS_INSTANCE)),
+                    new CreateAuthorizationRequest(
+                        ownerId,
+                        ownerType,
+                        "*",
+                        AuthorizationResourceType.DECISION_DEFINITION,
+                        Set.of(
+                            PermissionType.CREATE_DECISION_INSTANCE,
+                            PermissionType.DELETE_DECISION_INSTANCE)),
+                    new CreateAuthorizationRequest(
+                        ownerId,
+                        ownerType,
+                        "*",
+                        AuthorizationResourceType.DECISION_REQUIREMENTS_DEFINITION,
+                        Set.of(PermissionType.UPDATE, PermissionType.DELETE)))));
+
+    return authorizations.stream()
+        .filter(a -> a.key().equals(permission))
+        .flatMap(a -> a.value().stream())
+        .collect(Collectors.toSet());
   }
 }

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/handler/sm/ClientMigrationHandler.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/handler/sm/ClientMigrationHandler.java
@@ -19,6 +19,7 @@ import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.AuthorizationServices;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class ClientMigrationHandler extends MigrationHandler<Client> {
@@ -94,7 +95,7 @@ public class ClientMigrationHandler extends MigrationHandler<Client> {
                                   permission,
                                   clientId,
                                   AuthorizationOwnerType.CLIENT))
-                      .flatMap(List::stream)
+                      .flatMap(Set::stream)
                       .toList();
 
               final var combinedPermissions = extractCombinedPermissions(authorizations);

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/handler/sm/RoleMigrationHandler.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/handler/sm/RoleMigrationHandler.java
@@ -23,6 +23,7 @@ import io.camunda.service.RoleServices;
 import io.camunda.service.RoleServices.CreateRoleRequest;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class RoleMigrationHandler extends MigrationHandler<Role> {
@@ -109,7 +110,7 @@ public class RoleMigrationHandler extends MigrationHandler<Role> {
                 permission ->
                     getAuthorizationsByAudience(
                         audiences, permission, roleId, AuthorizationOwnerType.ROLE))
-            .flatMap(List::stream)
+            .flatMap(Set::stream)
             .toList();
 
     final var combinedPermissions = extractCombinedPermissions(authorizations);


### PR DESCRIPTION
## Description

Even if not recommended, audiences might have the same value in Management Identity. For this reason we can't use a Map to transform the old permissions into the new ones, we might end up in a key collision.
