### PR TITLE
Add assign client to tenant command to Java client

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/CamundaClient.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClient.java
@@ -18,6 +18,7 @@ package io.camunda.client;
 import io.camunda.client.api.ExperimentalApi;
 import io.camunda.client.api.command.ActivateAdHocSubProcessActivitiesCommandStep1;
 import io.camunda.client.api.command.AssignClientToGroupCommandStep1;
+import io.camunda.client.api.command.AssignClientToTenantCommandStep1;
 import io.camunda.client.api.command.AssignGroupToTenantCommandStep1;
 import io.camunda.client.api.command.AssignMappingRuleToGroupStep1;
 import io.camunda.client.api.command.AssignMappingRuleToTenantCommandStep1;
@@ -2217,6 +2218,24 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    * @return a builder for the unassign client from group command
    */
   UnassignClientFromGroupCommandStep1 newUnassignClientFromGroupCommand();
+
+  /**
+   * Command to assign a client to a tenant.
+   *
+   * <pre>
+   *
+   * camundaClient
+   *  .newAssignClientToTenantCommand()
+   *  .clientId("clientId")
+   *  .tenantId("tenantId")
+   *  .send();
+   * </pre>
+   *
+   * <p>This command is only sent via REST over HTTP, not via gRPC <br>
+   *
+   * @return a builder to configure and send the assign client to tenant command
+   */
+  AssignClientToTenantCommandStep1 newAssignClientToTenantCommand();
 
   /**
    * Command to create an authorization

--- a/clients/java/src/main/java/io/camunda/client/api/command/AssignClientToTenantCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/AssignClientToTenantCommandStep1.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.command;
+
+import io.camunda.client.api.response.AssignClientToTenantResponse;
+
+public interface AssignClientToTenantCommandStep1 {
+
+  /**
+   * Sets the ID of the client to be assigned to a tenant.
+   *
+   * @param clientId the ID of the client
+   * @return the builder for this command.
+   */
+  AssignClientToTenantCommandStep2 clientId(String clientId);
+
+  interface AssignClientToTenantCommandStep2
+      extends FinalCommandStep<AssignClientToTenantResponse> {
+
+    /**
+     * Sets the tenant ID.
+     *
+     * @param tenantId the ID of the tenant
+     * @return the builder for this command. Call {@link #send()} to complete the command and send
+     *     it to the broker.
+     */
+    AssignClientToTenantCommandStep2 tenantId(String tenantId);
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/api/response/AssignClientToTenantResponse.java
+++ b/clients/java/src/main/java/io/camunda/client/api/response/AssignClientToTenantResponse.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.response;
+
+public interface AssignClientToTenantResponse {}

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
@@ -24,6 +24,7 @@ import io.camunda.client.api.JsonMapper;
 import io.camunda.client.api.command.ActivateAdHocSubProcessActivitiesCommandStep1;
 import io.camunda.client.api.command.ActivateJobsCommandStep1;
 import io.camunda.client.api.command.AssignClientToGroupCommandStep1;
+import io.camunda.client.api.command.AssignClientToTenantCommandStep1;
 import io.camunda.client.api.command.AssignGroupToTenantCommandStep1;
 import io.camunda.client.api.command.AssignMappingRuleToGroupStep1;
 import io.camunda.client.api.command.AssignMappingRuleToTenantCommandStep1;
@@ -160,6 +161,7 @@ import io.camunda.client.api.worker.JobClient;
 import io.camunda.client.api.worker.JobWorkerBuilderStep1;
 import io.camunda.client.impl.command.ActivateAdHocSubProcessActivitiesCommandImpl;
 import io.camunda.client.impl.command.AssignClientToGroupCommandImpl;
+import io.camunda.client.impl.command.AssignClientToTenantCommandImpl;
 import io.camunda.client.impl.command.AssignGroupToTenantCommandImpl;
 import io.camunda.client.impl.command.AssignMappingRuleToGroupCommandImpl;
 import io.camunda.client.impl.command.AssignMappingRuleToTenantCommandImpl;
@@ -1178,6 +1180,11 @@ public final class CamundaClientImpl implements CamundaClient {
   @Override
   public UnassignClientFromGroupCommandStep1 newUnassignClientFromGroupCommand() {
     return new UnassignClientFromGroupCommandImpl(httpClient);
+  }
+
+  @Override
+  public AssignClientToTenantCommandStep1 newAssignClientToTenantCommand() {
+    return new AssignClientToTenantCommandImpl(httpClient);
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/client/impl/command/AssignClientToTenantCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/AssignClientToTenantCommandImpl.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.command;
+
+import io.camunda.client.api.CamundaFuture;
+import io.camunda.client.api.command.AssignClientToTenantCommandStep1;
+import io.camunda.client.api.command.AssignClientToTenantCommandStep1.AssignClientToTenantCommandStep2;
+import io.camunda.client.api.command.FinalCommandStep;
+import io.camunda.client.api.response.AssignClientToTenantResponse;
+import io.camunda.client.impl.http.HttpCamundaFuture;
+import io.camunda.client.impl.http.HttpClient;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import org.apache.hc.client5.http.config.RequestConfig;
+
+public class AssignClientToTenantCommandImpl
+    implements AssignClientToTenantCommandStep1, AssignClientToTenantCommandStep2 {
+
+  private final HttpClient httpClient;
+  private final RequestConfig.Builder httpRequestConfig;
+  private String clientId;
+  private String tenantId;
+
+  public AssignClientToTenantCommandImpl(final HttpClient httpClient) {
+    this.httpClient = httpClient;
+    httpRequestConfig = httpClient.newRequestConfig();
+  }
+
+  @Override
+  public AssignClientToTenantCommandStep2 clientId(final String clientId) {
+    this.clientId = clientId;
+    return this;
+  }
+
+  @Override
+  public AssignClientToTenantCommandStep2 tenantId(final String tenantId) {
+    this.tenantId = tenantId;
+    return this;
+  }
+
+  @Override
+  public FinalCommandStep<AssignClientToTenantResponse> requestTimeout(
+      final Duration requestTimeout) {
+    httpRequestConfig.setResponseTimeout(requestTimeout.toMillis(), TimeUnit.MILLISECONDS);
+    return this;
+  }
+
+  @Override
+  public CamundaFuture<AssignClientToTenantResponse> send() {
+    ArgumentUtil.ensureNotNullNorEmpty("clientId", clientId);
+    ArgumentUtil.ensureNotNullNorEmpty("tenantId", tenantId);
+    final HttpCamundaFuture<AssignClientToTenantResponse> result = new HttpCamundaFuture<>();
+    httpClient.put(
+        "/tenants/" + tenantId + "/clients/" + clientId,
+        null, // No request body needed
+        httpRequestConfig.build(),
+        result);
+    return result;
+  }
+}

--- a/clients/java/src/test/java/io/camunda/client/tenant/AssignClientToTenantTest.java
+++ b/clients/java/src/test/java/io/camunda/client/tenant/AssignClientToTenantTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.tenant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.github.tomakehurst.wiremock.http.RequestMethod;
+import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+import io.camunda.client.util.ClientRestTest;
+import io.camunda.client.util.RestGatewayService;
+import org.junit.jupiter.api.Test;
+
+public class AssignClientToTenantTest extends ClientRestTest {
+
+  public static final String CLIENT_ID = "clientId";
+  public static final String TENANT_ID = "tenantId";
+
+  @Test
+  void shouldAssignClientToTenant() {
+    // when
+    client.newAssignClientToTenantCommand().clientId(CLIENT_ID).tenantId(TENANT_ID).send().join();
+
+    // then
+    final LoggedRequest request = RestGatewayService.getLastRequest();
+    assertThat(request.getUrl().contains(TENANT_ID + "/clients/" + CLIENT_ID)).isTrue();
+    assertThat(RestGatewayService.getLastRequest().getMethod()).isEqualTo(RequestMethod.PUT);
+  }
+
+  @Test
+  void shouldRaiseExceptionOnNullClientIdWhenAssigningClientToTenant() {
+    // when / then
+    assertThatThrownBy(
+            () ->
+                client
+                    .newAssignClientToTenantCommand()
+                    .clientId(null)
+                    .tenantId(TENANT_ID)
+                    .send()
+                    .join())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("clientId must not be null");
+  }
+
+  @Test
+  void shouldRaiseExceptionOnEmptyClientIdWhenAssigningClientToTenant() {
+    // when / then
+    assertThatThrownBy(
+            () ->
+                client
+                    .newAssignClientToTenantCommand()
+                    .clientId("")
+                    .tenantId(TENANT_ID)
+                    .send()
+                    .join())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("clientId must not be empty");
+  }
+
+  @Test
+  void shouldRaiseExceptionOnNullTenantIdWhenAssigningClientToTenant() {
+    // when / then
+    assertThatThrownBy(
+            () ->
+                client
+                    .newAssignClientToTenantCommand()
+                    .clientId(CLIENT_ID)
+                    .tenantId(null)
+                    .send()
+                    .join())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("tenantId must not be null");
+  }
+
+  @Test
+  void shouldRaiseExceptionOnEmptyTenantIdWhenAssigningClientToTenant() {
+    // when / then
+    assertThatThrownBy(
+            () ->
+                client
+                    .newAssignClientToTenantCommand()
+                    .clientId(CLIENT_ID)
+                    .tenantId("")
+                    .send()
+                    .join())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("tenantId must not be empty");
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ClientsByTenantIntegrationTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ClientsByTenantIntegrationTest.java
@@ -91,66 +91,6 @@ public class ClientsByTenantIntegrationTest {
   }
 
   @Test
-  void shouldRejectAssignClientToTenantIfMissingTenantId() {
-    // when / then
-    assertThatThrownBy(
-            () ->
-                camundaClient
-                    .newAssignClientToTenantCommand()
-                    .clientId(Strings.newRandomValidIdentityId())
-                    .tenantId(null)
-                    .send()
-                    .join())
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("tenantId must not be null");
-  }
-
-  @Test
-  void shouldRejectAssignClientToTenantIfEmptyTenantId() {
-    // when / then
-    assertThatThrownBy(
-            () ->
-                camundaClient
-                    .newAssignClientToTenantCommand()
-                    .clientId(Strings.newRandomValidIdentityId())
-                    .tenantId("")
-                    .send()
-                    .join())
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("tenantId must not be empty");
-  }
-
-  @Test
-  void shouldRejectAssignClientToTenantIfMissingClientId() {
-    // when / then
-    assertThatThrownBy(
-            () ->
-                camundaClient
-                    .newAssignClientToTenantCommand()
-                    .clientId(null)
-                    .tenantId(Strings.newRandomValidIdentityId())
-                    .send()
-                    .join())
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("clientId must not be null");
-  }
-
-  @Test
-  void shouldRejectAssignClientToTenantIfEmptyClientId() {
-    // when / then
-    assertThatThrownBy(
-            () ->
-                camundaClient
-                    .newAssignClientToTenantCommand()
-                    .clientId("")
-                    .tenantId(Strings.newRandomValidIdentityId())
-                    .send()
-                    .join())
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("clientId must not be empty");
-  }
-
-  @Test
   void searchClientsShouldReturnEmptyListWhenSearchingForNonExistingTenantId() {
     final var clientsSearchResponse =
         camundaClient.newClientsByTenantSearchRequest("someTenantId").send().join();

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ClientsByTenantIntegrationTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ClientsByTenantIntegrationTest.java
@@ -16,15 +16,7 @@ import io.camunda.client.api.search.response.Client;
 import io.camunda.client.api.search.response.SearchResponse;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.zeebe.test.util.Strings;
-import java.io.IOException;
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpRequest.BodyPublishers;
-import java.net.http.HttpResponse;
-import java.net.http.HttpResponse.BodyHandlers;
-import org.assertj.core.api.AssertionsForClassTypes;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.BeforeAll;
@@ -46,17 +38,24 @@ public class ClientsByTenantIntegrationTest {
   }
 
   @Test
-  void shouldSearchClientsByTenantAndSort()
-      throws URISyntaxException, IOException, InterruptedException {
+  void shouldSearchAssignedClientsByTenantAndSort() {
     // given
     final var firstClientId = "aClientId";
     final var secondClientId = "bClientId";
 
     // when
-    assignClientToTenant(
-        camundaClient.getConfiguration().getRestAddress().toString(), TENANT_ID, firstClientId);
-    assignClientToTenant(
-        camundaClient.getConfiguration().getRestAddress().toString(), TENANT_ID, secondClientId);
+    camundaClient
+        .newAssignClientToTenantCommand()
+        .clientId(firstClientId)
+        .tenantId(TENANT_ID)
+        .send()
+        .join();
+    camundaClient
+        .newAssignClientToTenantCommand()
+        .clientId(secondClientId)
+        .tenantId(TENANT_ID)
+        .send()
+        .join();
 
     // then
     Awaitility.await("Clients are assigned to the tenant and can be searched")
@@ -73,6 +72,82 @@ public class ClientsByTenantIntegrationTest {
                   .map(Client::getClientId)
                   .containsExactly(secondClientId, firstClientId);
             });
+  }
+
+  @Test
+  void shouldReturnNotFoundOnAssigningClientToTenantIfTenantDoesNotExist() {
+    // when / then
+    assertThatThrownBy(
+            () ->
+                camundaClient
+                    .newAssignClientToTenantCommand()
+                    .clientId(Strings.newRandomValidIdentityId())
+                    .tenantId(Strings.newRandomValidIdentityId())
+                    .send()
+                    .join())
+        .isInstanceOf(ProblemException.class)
+        .hasMessageContaining("Failed with code 404: 'Not Found'")
+        .hasMessageContaining("no tenant with this ID exists.");
+  }
+
+  @Test
+  void shouldRejectAssignClientToTenantIfMissingTenantId() {
+    // when / then
+    assertThatThrownBy(
+            () ->
+                camundaClient
+                    .newAssignClientToTenantCommand()
+                    .clientId(Strings.newRandomValidIdentityId())
+                    .tenantId(null)
+                    .send()
+                    .join())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("tenantId must not be null");
+  }
+
+  @Test
+  void shouldRejectAssignClientToTenantIfEmptyTenantId() {
+    // when / then
+    assertThatThrownBy(
+            () ->
+                camundaClient
+                    .newAssignClientToTenantCommand()
+                    .clientId(Strings.newRandomValidIdentityId())
+                    .tenantId("")
+                    .send()
+                    .join())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("tenantId must not be empty");
+  }
+
+  @Test
+  void shouldRejectAssignClientToTenantIfMissingClientId() {
+    // when / then
+    assertThatThrownBy(
+            () ->
+                camundaClient
+                    .newAssignClientToTenantCommand()
+                    .clientId(null)
+                    .tenantId(Strings.newRandomValidIdentityId())
+                    .send()
+                    .join())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("clientId must not be null");
+  }
+
+  @Test
+  void shouldRejectAssignClientToTenantIfEmptyClientId() {
+    // when / then
+    assertThatThrownBy(
+            () ->
+                camundaClient
+                    .newAssignClientToTenantCommand()
+                    .clientId("")
+                    .tenantId(Strings.newRandomValidIdentityId())
+                    .send()
+                    .join())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("clientId must not be empty");
   }
 
   @Test
@@ -96,24 +171,5 @@ public class ClientsByTenantIntegrationTest {
     assertThatThrownBy(() -> camundaClient.newClientsByTenantSearchRequest("").send().join())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("tenantId must not be empty");
-  }
-
-  // TODO once available in #35767, this test should use the client to make the request
-  private static void assignClientToTenant(
-      final String restAddress, final String tenantId, final String clientId)
-      throws URISyntaxException, IOException, InterruptedException {
-    final HttpRequest request =
-        HttpRequest.newBuilder()
-            .uri(
-                new URI(
-                    "%s%s%s%s%s"
-                        .formatted(restAddress, "v2/tenants/", tenantId, "/clients/", clientId)))
-            .PUT(BodyPublishers.ofString(""))
-            .build();
-
-    // Send the request and get the response
-    final HttpResponse<String> response = HTTP_CLIENT.send(request, BodyHandlers.ofString());
-
-    AssertionsForClassTypes.assertThat(response.statusCode()).isEqualTo(204);
   }
 }


### PR DESCRIPTION
## Description

This PR adds `assignClientToTenant` command to Java Client.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #35767
