### PR TITLE
test: increase backup timeout to avoid flaky test

### DIFF
--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/ContinuousBackupIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/ContinuousBackupIT.java
@@ -215,6 +215,7 @@ final class ContinuousBackupIT {
   void takeAndAwaitBackup(final long backupId) {
     backupActuator.take(backupId);
     await("backup is completed")
+        .timeout(Duration.ofSeconds(20))
         .ignoreExceptions()
         .untilAsserted(
             () ->


### PR DESCRIPTION
Increases the timeout for awaiting a successful backup. Should resolve flaky test runs such as https://github.com/camunda/camunda/actions/runs/16881366322.