### PR TITLE
Apply number_of_replicas and number_of_shards ES/OS configuration changes

### DIFF
--- a/operate/common/src/main/java/io/camunda/operate/property/ElasticsearchProperties.java
+++ b/operate/common/src/main/java/io/camunda/operate/property/ElasticsearchProperties.java
@@ -38,6 +38,7 @@ public class ElasticsearchProperties {
   private Integer connectTimeout;
 
   private boolean createSchema = true;
+  private boolean updateSchemaSettings = true;
 
   /** Indicates whether operate does a proper health check for ES clusters. */
   private boolean healthCheckEnabled = true;
@@ -121,6 +122,14 @@ public class ElasticsearchProperties {
 
   public void setCreateSchema(final boolean createSchema) {
     this.createSchema = createSchema;
+  }
+
+  public boolean isUpdateSchemaSettings() {
+    return updateSchemaSettings;
+  }
+
+  public void setUpdateSchemaSettings(final boolean updateSchemaSettings) {
+    this.updateSchemaSettings = updateSchemaSettings;
   }
 
   public boolean isHealthCheckEnabled() {

--- a/operate/common/src/main/java/io/camunda/operate/property/OpensearchProperties.java
+++ b/operate/common/src/main/java/io/camunda/operate/property/OpensearchProperties.java
@@ -38,6 +38,7 @@ public class OpensearchProperties {
   private Integer connectTimeout;
 
   private boolean createSchema = true;
+  private boolean updateSchemaSettings = true;
 
   /** Indicates whether operate does a proper health check for ES/OS clusters. */
   private boolean healthCheckEnabled = true;
@@ -123,6 +124,14 @@ public class OpensearchProperties {
 
   public void setCreateSchema(final boolean createSchema) {
     this.createSchema = createSchema;
+  }
+
+  public boolean isUpdateSchemaSettings() {
+    return updateSchemaSettings;
+  }
+
+  public void setUpdateSchemaSettings(final boolean updateSchemaSettings) {
+    this.updateSchemaSettings = updateSchemaSettings;
   }
 
   public boolean isHealthCheckEnabled() {

--- a/operate/common/src/main/java/io/camunda/operate/property/OperateElasticsearchProperties.java
+++ b/operate/common/src/main/java/io/camunda/operate/property/OperateElasticsearchProperties.java
@@ -27,7 +27,7 @@ public class OperateElasticsearchProperties extends ElasticsearchProperties {
     return indexPrefix;
   }
 
-  public void setIndexPrefix(String indexPrefix) {
+  public void setIndexPrefix(final String indexPrefix) {
     this.indexPrefix = indexPrefix;
   }
 
@@ -55,7 +55,7 @@ public class OperateElasticsearchProperties extends ElasticsearchProperties {
     return refreshInterval;
   }
 
-  public void setRefreshInterval(String refreshInterval) {
+  public void setRefreshInterval(final String refreshInterval) {
     this.refreshInterval = refreshInterval;
   }
 
@@ -63,7 +63,7 @@ public class OperateElasticsearchProperties extends ElasticsearchProperties {
     return numberOfShardsForIndices;
   }
 
-  public void setNumberOfShardsForIndices(Map<String, Integer> numberOfShardsForIndices) {
+  public void setNumberOfShardsForIndices(final Map<String, Integer> numberOfShardsForIndices) {
     this.numberOfShardsForIndices = numberOfShardsForIndices;
   }
 
@@ -71,7 +71,15 @@ public class OperateElasticsearchProperties extends ElasticsearchProperties {
     return numberOfReplicasForIndices;
   }
 
-  public void setNumberOfReplicasForIndices(Map<String, Integer> numberOfReplicasForIndices) {
+  public void setNumberOfReplicasForIndices(final Map<String, Integer> numberOfReplicasForIndices) {
     this.numberOfReplicasForIndices = numberOfReplicasForIndices;
+  }
+
+  public int getNumberOfReplicas(final String indexName) {
+    return numberOfReplicasForIndices.getOrDefault(indexName, numberOfReplicas);
+  }
+
+  public int getNumberOfShards(final String indexName) {
+    return numberOfShardsForIndices.getOrDefault(indexName, numberOfShards);
   }
 }

--- a/operate/common/src/main/java/io/camunda/operate/property/OperateOpensearchProperties.java
+++ b/operate/common/src/main/java/io/camunda/operate/property/OperateOpensearchProperties.java
@@ -27,7 +27,7 @@ public class OperateOpensearchProperties extends OpensearchProperties {
     return indexPrefix;
   }
 
-  public void setIndexPrefix(String indexPrefix) {
+  public void setIndexPrefix(final String indexPrefix) {
     this.indexPrefix = indexPrefix;
   }
 
@@ -55,7 +55,7 @@ public class OperateOpensearchProperties extends OpensearchProperties {
     return refreshInterval;
   }
 
-  public void setRefreshInterval(String refreshInterval) {
+  public void setRefreshInterval(final String refreshInterval) {
     this.refreshInterval = refreshInterval;
   }
 
@@ -63,7 +63,7 @@ public class OperateOpensearchProperties extends OpensearchProperties {
     return numberOfShardsForIndices;
   }
 
-  public void setNumberOfShardsForIndices(Map<String, Integer> numberOfShardsForIndices) {
+  public void setNumberOfShardsForIndices(final Map<String, Integer> numberOfShardsForIndices) {
     this.numberOfShardsForIndices = numberOfShardsForIndices;
   }
 
@@ -71,7 +71,15 @@ public class OperateOpensearchProperties extends OpensearchProperties {
     return numberOfReplicasForIndices;
   }
 
-  public void setNumberOfReplicasForIndices(Map<String, Integer> numberOfReplicasForIndices) {
+  public void setNumberOfReplicasForIndices(final Map<String, Integer> numberOfReplicasForIndices) {
     this.numberOfReplicasForIndices = numberOfReplicasForIndices;
+  }
+
+  public int getNumberOfReplicas(final String indexName) {
+    return numberOfReplicasForIndices.getOrDefault(indexName, numberOfReplicas);
+  }
+
+  public int getNumberOfShards(final String indexName) {
+    return numberOfShardsForIndices.getOrDefault(indexName, numberOfShards);
   }
 }

--- a/operate/pom.xml
+++ b/operate/pom.xml
@@ -169,7 +169,7 @@
     <profile>
       <id>operateItOpensearch</id>
       <properties>
-        <includeITNames>**/api/v1/**/*IT.java,io/camunda/operate/opensearch/Opensearch*IT.java</includeITNames>
+        <includeITNames>**/api/v1/**/*IT.java,io/camunda/operate/opensearch/Opensearch*IT.java,io/camunda/operate/schema/*IT.java</includeITNames>
         <excludeITNames>none</excludeITNames>
         <skipSurefire>true</skipSurefire>
       </properties>

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/schema/IndexSchemaValidatorIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/schema/IndexSchemaValidatorIT.java
@@ -20,7 +20,6 @@ import io.camunda.operate.schema.IndexMapping.IndexMappingProperty;
 import io.camunda.operate.schema.elasticsearch.ElasticsearchSchemaManager;
 import io.camunda.operate.schema.indices.IndexDescriptor;
 import io.camunda.operate.schema.opensearch.OpensearchSchemaManager;
-import io.camunda.operate.schema.util.SchemaTestHelper;
 import io.camunda.operate.schema.util.TestDynamicIndex;
 import io.camunda.operate.schema.util.TestIndex;
 import io.camunda.operate.schema.util.TestTemplate;
@@ -30,7 +29,6 @@ import io.camunda.operate.store.elasticsearch.ElasticsearchTaskStore;
 import io.camunda.operate.store.opensearch.OpensearchTaskStore;
 import java.util.Map;
 import java.util.Set;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -60,7 +58,6 @@ public class IndexSchemaValidatorIT extends AbstractSchemaIT {
   @Autowired public IndexSchemaValidator validator;
 
   @Autowired public SchemaManager schemaManager;
-  @Autowired public SchemaTestHelper schemaHelper;
 
   @Autowired public TestIndex testIndex;
   @Autowired public TestDynamicIndex testDynamicIndex;
@@ -69,11 +66,6 @@ public class IndexSchemaValidatorIT extends AbstractSchemaIT {
   @BeforeEach
   public void createDefault() {
     schemaManager.createDefaults();
-  }
-
-  @AfterEach
-  public void dropSchema() {
-    schemaHelper.dropSchema();
   }
 
   @Test

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/schema/SchemaStartupIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/schema/SchemaStartupIT.java
@@ -28,7 +28,6 @@ import io.camunda.operate.schema.opensearch.OpensearchStepsRepository;
 import io.camunda.operate.schema.templates.IncidentTemplate;
 import io.camunda.operate.schema.templates.ListViewTemplate;
 import io.camunda.operate.schema.templates.PostImporterQueueTemplate;
-import io.camunda.operate.schema.util.SchemaTestHelper;
 import io.camunda.operate.schema.util.TestIndex;
 import io.camunda.operate.schema.util.TestSchemaStartup;
 import io.camunda.operate.schema.util.TestTemplate;
@@ -76,7 +75,6 @@ import org.springframework.test.context.ContextConfiguration;
 public class SchemaStartupIT extends AbstractSchemaIT {
 
   @Autowired public SchemaManager schemaManager;
-  @Autowired public SchemaTestHelper schemaHelper;
 
   @Autowired public TestSchemaStartup schemaStartup;
   @Autowired public TestIndex testIndex;
@@ -107,6 +105,7 @@ public class SchemaStartupIT extends AbstractSchemaIT {
                 new IndexMapping()
                     .setIndexName(indexName)
                     .setDynamic("strict")
+                    .setMetaProperties(Map.of())
                     .setProperties(
                         Set.of(
                             new IndexMappingProperty()

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/schema/util/SchemaTestHelper.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/schema/util/SchemaTestHelper.java
@@ -10,6 +10,7 @@ package io.camunda.operate.schema.util;
 import io.camunda.operate.schema.IndexMapping;
 import io.camunda.operate.schema.indices.IndexDescriptor;
 import io.camunda.operate.schema.templates.TemplateDescriptor;
+import java.util.Map;
 
 public interface SchemaTestHelper {
 
@@ -20,4 +21,8 @@ public interface SchemaTestHelper {
   void createIndex(IndexDescriptor indexDescriptor, String indexName, String indexSchemaFilename);
 
   void setReadOnly(String indexName, boolean readOnly);
+
+  Map<String, String> getComponentTemplateSettings(String componentTemplateName);
+
+  Map<String, String> getIndexTemplateSettings(String indexTemplateName);
 }

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/schema/util/opensearch/OpenSearchSchemaTestHelper.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/schema/util/opensearch/OpenSearchSchemaTestHelper.java
@@ -7,6 +7,9 @@
  */
 package io.camunda.operate.schema.util.opensearch;
 
+import static io.camunda.operate.schema.SchemaManager.NUMBERS_OF_REPLICA;
+import static io.camunda.operate.schema.SchemaManager.NUMBER_OF_SHARDS;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -129,6 +132,36 @@ public class OpenSearchSchemaTestHelper implements SchemaTestHelper {
     } catch (final IOException e) {
       throw new OperateRuntimeException(e);
     }
+  }
+
+  @Override
+  public Map<String, String> getComponentTemplateSettings(final String componentTemplateName) {
+    final var settings =
+        openSearchClient.template().getComponentTemplateIndexSettings(componentTemplateName);
+    return Map.of(
+        NUMBER_OF_SHARDS,
+        settings.numberOfShards(),
+        NUMBERS_OF_REPLICA,
+        settings.numberOfReplicas());
+  }
+
+  @Override
+  public Map<String, String> getIndexTemplateSettings(final String indexTemplateName) {
+    final var indexSettings =
+        openSearchClient
+            .template()
+            .getIndexTemplate(indexTemplateName)
+            .template()
+            .settings()
+            .get("index")
+            .toJson()
+            .asJsonObject();
+
+    return Map.of(
+        NUMBER_OF_SHARDS,
+        indexSettings.getString("number_of_shards"),
+        NUMBERS_OF_REPLICA,
+        indexSettings.getString("number_of_replicas"));
   }
 
   protected IndexMappingProperty mapProperty(final Entry<String, Property> property)

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/OpensearchOperateZeebeRuleProvider.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/OpensearchOperateZeebeRuleProvider.java
@@ -74,7 +74,7 @@ public class OpensearchOperateZeebeRuleProvider implements OperateZeebeRuleProvi
     assertTrue(
         zeebeRichOpenSearchClient
             .template()
-            .createComponentTemplateWithRetries(requestBuilder.build()));
+            .createComponentTemplateWithRetries(requestBuilder.build(), true));
   }
 
   @Override

--- a/operate/schema/src/main/java/io/camunda/operate/schema/SchemaManager.java
+++ b/operate/schema/src/main/java/io/camunda/operate/schema/SchemaManager.java
@@ -19,6 +19,8 @@ public interface SchemaManager {
   String NO_REFRESH = "-1";
   String NUMBERS_OF_REPLICA = "index.number_of_replicas";
   String NO_REPLICA = "0";
+  String NUMBER_OF_SHARDS = "index.number_of_shards";
+  String DEFAULT_SHARDS = "1";
 
   String OPERATE_DELETE_ARCHIVED_INDICES = "operate_delete_archived_indices";
   String INDEX_LIFECYCLE_NAME = "index.lifecycle.name";
@@ -65,4 +67,6 @@ public interface SchemaManager {
   void updateSchema(Map<IndexDescriptor, Set<IndexMappingProperty>> newFields);
 
   IndexMapping getExpectedIndexFields(IndexDescriptor indexDescriptor);
+
+  void updateIndexSettings();
 }

--- a/operate/schema/src/main/java/io/camunda/operate/schema/SchemaStartup.java
+++ b/operate/schema/src/main/java/io/camunda/operate/schema/SchemaStartup.java
@@ -54,6 +54,10 @@ public class SchemaStartup {
           DatabaseInfo.isOpensearch()
               ? operateProperties.getOpensearch().isCreateSchema()
               : operateProperties.getElasticsearch().isCreateSchema();
+      final boolean updateSchemaSettings =
+          DatabaseInfo.isOpensearch()
+              ? operateProperties.getOpensearch().isUpdateSchemaSettings()
+              : operateProperties.getElasticsearch().isUpdateSchemaSettings();
       if (createSchema && !schemaValidator.schemaExists()) {
         LOGGER.info("SchemaStartup: schema is empty or not complete. Indices will be created.");
         schemaManager.createSchema();
@@ -70,6 +74,9 @@ public class SchemaStartup {
           LOGGER.info(
               "SchemaStartup: schema won't be updated as schema creation is disabled in configuration.");
         }
+      }
+      if (createSchema && updateSchemaSettings) {
+        schemaManager.updateIndexSettings();
       }
       if (migrationProperties.isMigrationEnabled()) {
         LOGGER.info("SchemaStartup: migrate schema.");

--- a/operate/schema/src/main/java/io/camunda/operate/schema/elasticsearch/ElasticsearchSchemaManager.java
+++ b/operate/schema/src/main/java/io/camunda/operate/schema/elasticsearch/ElasticsearchSchemaManager.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.operate.schema.elasticsearch;
 
+import static io.camunda.operate.store.elasticsearch.RetryElasticsearchClient.NUMBERS_OF_SHARDS;
+
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.operate.conditions.ElasticsearchCondition;
@@ -30,6 +32,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.elasticsearch.action.admin.indices.alias.Alias;
 import org.elasticsearch.client.indexlifecycle.DeleteAction;
 import org.elasticsearch.client.indexlifecycle.LifecycleAction;
@@ -90,22 +93,13 @@ public class ElasticsearchSchemaManager implements SchemaManager {
   @Override
   public void createDefaults() {
     final OperateElasticsearchProperties elsConfig = operateProperties.getElasticsearch();
-    final String settingsTemplate = settingsTemplateName();
+    final String settingsTemplate = componentTemplateName();
     LOGGER.info(
         "Create default settings from '{}' with {} shards and {} replicas per index.",
         settingsTemplate,
         elsConfig.getNumberOfShards(),
         elsConfig.getNumberOfReplicas());
-
-    final Settings settings = getDefaultIndexSettings();
-
-    final Template template = new Template(settings, null, null);
-    final ComponentTemplate componentTemplate = new ComponentTemplate(template, null, null);
-    final PutComponentTemplateRequest request =
-        new PutComponentTemplateRequest()
-            .name(settingsTemplate)
-            .componentTemplate(componentTemplate);
-    retryElasticsearchClient.createComponentTemplate(request);
+    createComponentTemplate(false);
   }
 
   @Override
@@ -126,7 +120,7 @@ public class ElasticsearchSchemaManager implements SchemaManager {
       final TemplateDescriptor templateDescriptor, final String templateClasspathResource) {
     final PutComposableIndexTemplateRequest request =
         prepareComposableTemplateRequest(templateDescriptor, templateClasspathResource);
-    putIndexTemplate(request);
+    putIndexTemplate(request, false);
 
     // This is necessary, otherwise operate won't find indexes at startup
     final String indexName = templateDescriptor.getFullQualifiedName();
@@ -273,7 +267,93 @@ public class ElasticsearchSchemaManager implements SchemaManager {
     }
   }
 
-  private String settingsTemplateName() {
+  @Override
+  public void updateIndexSettings() {
+    updateIndicesNumberOfReplicas();
+    updateIndexTemplateSettings();
+    updateComponentTemplateSettings();
+  }
+
+  private void updateIndexTemplateSettings() {
+    for (final var templateDescriptor : templateDescriptors) {
+      final var expectedShards =
+          String.valueOf(
+              operateProperties
+                  .getElasticsearch()
+                  .getNumberOfShards(templateDescriptor.getIndexName()));
+      final var expectedReplicas =
+          String.valueOf(
+              operateProperties
+                  .getElasticsearch()
+                  .getNumberOfReplicas(templateDescriptor.getIndexName()));
+      String actualShards = null;
+      String actualReplicas = null;
+      final var indexTemplate =
+          retryElasticsearchClient.getIndexTemplate(templateDescriptor.getTemplateName());
+      if (indexTemplate.template().settings() != null) {
+        actualShards = indexTemplate.template().settings().get(NUMBERS_OF_SHARDS);
+        actualReplicas = indexTemplate.template().settings().get(NUMBERS_OF_REPLICA);
+      }
+
+      if (!expectedShards.equals(actualShards) || !expectedReplicas.equals(actualReplicas)) {
+        LOGGER.info(
+            "Updating index template {} to shards={}, replicas={}",
+            templateDescriptor.getTemplateName(),
+            expectedShards,
+            expectedReplicas);
+        putIndexTemplate(prepareComposableTemplateRequest(templateDescriptor, null), true);
+      }
+    }
+  }
+
+  private void updateComponentTemplateSettings() {
+    final var settings =
+        retryElasticsearchClient.getComponentTemplateSettings(componentTemplateName());
+
+    final var expectedShards =
+        String.valueOf(operateProperties.getElasticsearch().getNumberOfShards());
+    final var expectedReplicas =
+        String.valueOf(operateProperties.getElasticsearch().getNumberOfReplicas());
+    final var actualShards = settings.get(NUMBERS_OF_SHARDS, DEFAULT_SHARDS);
+    final var actualReplicas = settings.get(NUMBERS_OF_REPLICA, NO_REPLICA);
+
+    if (!expectedShards.equals(actualShards) || !expectedReplicas.equals(actualReplicas)) {
+      LOGGER.info(
+          "Updating component template settings to shards={}, replicas={}",
+          expectedShards,
+          expectedReplicas);
+      createComponentTemplate(true);
+    }
+  }
+
+  private void updateIndicesNumberOfReplicas() {
+    Stream.concat(indexDescriptors.stream(), templateDescriptors.stream())
+        .forEach(
+            indexDescriptor -> {
+              final var expectedReplicas =
+                  String.valueOf(
+                      operateProperties
+                          .getElasticsearch()
+                          .getNumberOfReplicas(indexDescriptor.getIndexName()));
+
+              final var settings =
+                  retryElasticsearchClient.getIndexSettingsForIndexPattern(
+                      indexDescriptor.getAlias());
+              if (!settings.values().stream()
+                  .map(s -> s.get(NUMBERS_OF_REPLICA, NO_REPLICA))
+                  .allMatch(expectedReplicas::equals)) {
+                LOGGER.info(
+                    "Updating number of replicas of {} to {}",
+                    indexDescriptor.getAlias(),
+                    expectedReplicas);
+                retryElasticsearchClient.setIndexSettingsFor(
+                    Settings.builder().put(NUMBERS_OF_REPLICA, expectedReplicas).build(),
+                    indexDescriptor.getAlias());
+              }
+            });
+  }
+
+  private String componentTemplateName() {
     final OperateElasticsearchProperties elsConfig = operateProperties.getElasticsearch();
     return String.format("%s_template", elsConfig.getIndexPrefix());
   }
@@ -288,14 +368,8 @@ public class ElasticsearchSchemaManager implements SchemaManager {
 
   private Settings getIndexSettings(final String indexName) {
     final OperateElasticsearchProperties elsConfig = operateProperties.getElasticsearch();
-    final var shards =
-        elsConfig
-            .getNumberOfShardsForIndices()
-            .getOrDefault(indexName, elsConfig.getNumberOfShards());
-    final var replicas =
-        elsConfig
-            .getNumberOfReplicasForIndices()
-            .getOrDefault(indexName, elsConfig.getNumberOfReplicas());
+    final var shards = elsConfig.getNumberOfShards(indexName);
+    final var replicas = elsConfig.getNumberOfReplicas(indexName);
     return Settings.builder()
         .put(NUMBER_OF_SHARDS, shards)
         .put(NUMBER_OF_REPLICAS, replicas)
@@ -349,7 +423,7 @@ public class ElasticsearchSchemaManager implements SchemaManager {
         new ComposableIndexTemplate.Builder()
             .indexPatterns(List.of(templateDescriptor.getIndexPattern()))
             .template(template)
-            .componentTemplates(List.of(settingsTemplateName()))
+            .componentTemplates(List.of(componentTemplateName()))
             .build();
     final PutComposableIndexTemplateRequest request =
         new PutComposableIndexTemplateRequest()
@@ -401,10 +475,6 @@ public class ElasticsearchSchemaManager implements SchemaManager {
     }
   }
 
-  private void putIndexTemplate(final PutComposableIndexTemplateRequest request) {
-    putIndexTemplate(request, false);
-  }
-
   private void putIndexTemplate(
       final PutComposableIndexTemplateRequest request, final boolean overwrite) {
     final boolean created = retryElasticsearchClient.createTemplate(request, overwrite);
@@ -413,5 +483,16 @@ public class ElasticsearchSchemaManager implements SchemaManager {
     } else {
       LOGGER.debug("Template [{}] was NOT created", request.name());
     }
+  }
+
+  private void createComponentTemplate(final boolean overwrite) {
+    final Settings settings = getDefaultIndexSettings();
+    final Template template = new Template(settings, null, null);
+    final ComponentTemplate componentTemplate = new ComponentTemplate(template, null, null);
+    final PutComponentTemplateRequest request =
+        new PutComponentTemplateRequest()
+            .name(componentTemplateName())
+            .componentTemplate(componentTemplate);
+    retryElasticsearchClient.createComponentTemplate(request, overwrite);
   }
 }

--- a/operate/schema/src/main/java/io/camunda/operate/schema/opensearch/OpensearchSchemaManager.java
+++ b/operate/schema/src/main/java/io/camunda/operate/schema/opensearch/OpensearchSchemaManager.java
@@ -9,6 +9,7 @@ package io.camunda.operate.schema.opensearch;
 
 import static io.camunda.operate.schema.indices.AbstractIndexDescriptor.SCHEMA_FOLDER_OPENSEARCH;
 import static java.lang.String.format;
+import static java.util.Optional.ofNullable;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -30,8 +31,13 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringReader;
 import java.nio.charset.StandardCharsets;
-import java.util.*;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.opensearch.client.json.JsonpDeserializer;
 import org.opensearch.client.json.jsonb.JsonbJsonpMapper;
 import org.opensearch.client.opensearch._types.OpenSearchException;
@@ -106,21 +112,14 @@ public class OpensearchSchemaManager implements SchemaManager {
   public void createDefaults() {
     final OperateOpensearchProperties osConfig = operateProperties.getOpensearch();
 
-    final String settingsTemplateName = settingsTemplateName();
+    final String settingsTemplateName = componentTemplateName();
     LOGGER.info(
         "Create default settings '{}' with {} shards and {} replicas per index.",
         settingsTemplateName,
         osConfig.getNumberOfShards(),
         osConfig.getNumberOfReplicas());
 
-    final IndexSettings settings = getDefaultIndexSettings();
-    richOpenSearchClient
-        .template()
-        .createComponentTemplateWithRetries(
-            new PutComponentTemplateRequest.Builder()
-                .name(settingsTemplateName)
-                .template(t -> t.settings(settings))
-                .build());
+    createComponentTemplate(false);
   }
 
   @Override
@@ -331,6 +330,119 @@ public class OpensearchSchemaManager implements SchemaManager {
     }
   }
 
+  @Override
+  public void updateIndexSettings() {
+    updateIndicesNumberOfReplicas();
+    updateIndexTemplateSettings();
+    updateComponentTemplateSettings();
+  }
+
+  private void createComponentTemplate(final boolean overwrite) {
+    final String settingsTemplateName = componentTemplateName();
+    final IndexSettings settings = getDefaultIndexSettings();
+    richOpenSearchClient
+        .template()
+        .createComponentTemplateWithRetries(
+            new PutComponentTemplateRequest.Builder()
+                .name(settingsTemplateName)
+                .template(t -> t.settings(settings))
+                .build(),
+            overwrite);
+  }
+
+  private void updateIndicesNumberOfReplicas() {
+    Stream.concat(indexDescriptors.stream(), templateDescriptors.stream())
+        .forEach(
+            indexDescriptor -> {
+              final var expectedReplicas =
+                  String.valueOf(
+                      operateProperties
+                          .getOpensearch()
+                          .getNumberOfReplicas(indexDescriptor.getIndexName()));
+              final var settings =
+                  richOpenSearchClient
+                      .index()
+                      .getIndexSettingsForIndexPattern(indexDescriptor.getAlias());
+              if (!settings.values().stream()
+                  .map(s -> ofNullable(s.settings().numberOfReplicas()).orElse(NO_REPLICA))
+                  .allMatch(expectedReplicas::equals)) {
+                LOGGER.info(
+                    "Updating number of replicas of {} to {}",
+                    indexDescriptor.getAlias(),
+                    expectedReplicas);
+                richOpenSearchClient
+                    .index()
+                    .setIndexSettingsFor(
+                        IndexSettings.of(b -> b.numberOfReplicas(expectedReplicas)),
+                        indexDescriptor.getAlias());
+              }
+            });
+  }
+
+  private void updateIndexTemplateSettings() {
+    for (final var templateDescriptor : templateDescriptors) {
+      final var expectedShards =
+          String.valueOf(
+              operateProperties
+                  .getOpensearch()
+                  .getNumberOfShards(templateDescriptor.getIndexName()));
+      final var expectedReplicas =
+          String.valueOf(
+              operateProperties
+                  .getOpensearch()
+                  .getNumberOfReplicas(templateDescriptor.getIndexName()));
+
+      String actualShards = null;
+      String actualReplicas = null;
+
+      final var indexTemplate =
+          richOpenSearchClient.template().getIndexTemplate(templateDescriptor.getTemplateName());
+
+      final var templateSettings = indexTemplate.template().settings();
+
+      if (templateSettings.containsKey("index")) {
+        final var indexSettingsData = templateSettings.get("index");
+        final var indexSettingsJson = indexSettingsData.toJson().asJsonObject();
+        actualShards = indexSettingsJson.getString("number_of_shards", null);
+        actualReplicas = indexSettingsJson.getString("number_of_replicas", null);
+      }
+
+      if (!expectedShards.equals(actualShards) || !expectedReplicas.equals(actualReplicas)) {
+        LOGGER.info(
+            "Updating index template settings for {} to shards={}, replicas={}",
+            templateDescriptor.getTemplateName(),
+            expectedShards,
+            expectedReplicas);
+
+        // Recreate the template with updated settings
+        final String json = readTemplateJson(templateDescriptor.getSchemaClasspathFilename());
+        final PutIndexTemplateRequest indexTemplateRequest =
+            prepareIndexTemplateRequest(templateDescriptor, json);
+        putIndexTemplate(indexTemplateRequest, true);
+      }
+    }
+  }
+
+  private void updateComponentTemplateSettings() {
+    final var settings =
+        richOpenSearchClient.template().getComponentTemplateIndexSettings(componentTemplateName());
+
+    final var expectedShards =
+        String.valueOf(operateProperties.getOpensearch().getNumberOfShards());
+    final var expectedReplicas =
+        String.valueOf(operateProperties.getOpensearch().getNumberOfReplicas());
+    final var actualShards = ofNullable(settings.numberOfShards()).orElse(DEFAULT_SHARDS);
+    final var actualReplicas = ofNullable(settings.numberOfReplicas()).orElse(NO_REPLICA);
+
+    if (!expectedShards.equals(actualShards) || !expectedReplicas.equals(actualReplicas)) {
+      LOGGER.info(
+          "Updating component template settings to shards={}, replicas={}",
+          expectedShards,
+          expectedReplicas);
+      createComponentTemplate(true);
+    }
+  }
+
   private IndexSettings getDefaultIndexSettings() {
     final OperateOpensearchProperties osConfig = operateProperties.getOpensearch();
     return new IndexSettings.Builder()
@@ -341,14 +453,8 @@ public class OpensearchSchemaManager implements SchemaManager {
 
   private IndexSettings getIndexSettings(final String indexName) {
     final OperateOpensearchProperties osConfig = operateProperties.getOpensearch();
-    final var shards =
-        osConfig
-            .getNumberOfShardsForIndices()
-            .getOrDefault(indexName, osConfig.getNumberOfShards());
-    final var replicas =
-        osConfig
-            .getNumberOfReplicasForIndices()
-            .getOrDefault(indexName, osConfig.getNumberOfReplicas());
+    final var shards = osConfig.getNumberOfShards(indexName);
+    final var replicas = osConfig.getNumberOfReplicas(indexName);
 
     return new IndexSettings.Builder()
         .numberOfShards(String.valueOf(shards))
@@ -356,7 +462,7 @@ public class OpensearchSchemaManager implements SchemaManager {
         .build();
   }
 
-  private String settingsTemplateName() {
+  private String componentTemplateName() {
     final OperateOpensearchProperties osConfig = operateProperties.getOpensearch();
     return format("%s_template", osConfig.getIndexPrefix());
   }
@@ -367,31 +473,14 @@ public class OpensearchSchemaManager implements SchemaManager {
 
   private IndexSettings templateSettings(final TemplateDescriptor indexDescriptor) {
     final var shards =
-        operateProperties
-            .getOpensearch()
-            .getNumberOfShardsForIndices()
-            .get(indexDescriptor.getIndexName());
+        String.valueOf(
+            operateProperties.getOpensearch().getNumberOfShards(indexDescriptor.getIndexName()));
 
     final var replicas =
-        operateProperties
-            .getOpensearch()
-            .getNumberOfReplicasForIndices()
-            .get(indexDescriptor.getIndexName());
+        String.valueOf(
+            operateProperties.getOpensearch().getNumberOfReplicas(indexDescriptor.getIndexName()));
 
-    if (shards != null || replicas != null) {
-      final var indexSettingsBuilder = new IndexSettings.Builder();
-
-      if (shards != null) {
-        indexSettingsBuilder.numberOfShards(shards.toString());
-      }
-
-      if (replicas != null) {
-        indexSettingsBuilder.numberOfReplicas(replicas.toString());
-      }
-
-      return indexSettingsBuilder.build();
-    }
-    return null;
+    return IndexSettings.of(b -> b.numberOfShards(shards).numberOfReplicas(replicas));
   }
 
   private void createTemplate(final TemplateDescriptor templateDescriptor) {
@@ -449,7 +538,7 @@ public class OpensearchSchemaManager implements SchemaManager {
               .name(templateDescriptor.getTemplateName())
               .indexPatterns(templateDescriptor.getIndexPattern())
               .template(template)
-              .composedOf(settingsTemplateName())
+              .composedOf(componentTemplateName())
               .build();
       return request;
     } catch (final Exception ex) {

--- a/operate/schema/src/main/java/io/camunda/operate/store/elasticsearch/RetryElasticsearchClient.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/elasticsearch/RetryElasticsearchClient.java
@@ -10,6 +10,7 @@ package io.camunda.operate.store.elasticsearch;
 import static io.camunda.operate.schema.IndexMapping.IndexMappingProperty.createIndexMappingProperty;
 import static io.camunda.operate.util.CollectionUtil.getOrDefaultForNullValue;
 import static io.camunda.operate.util.CollectionUtil.map;
+import static java.util.Optional.ofNullable;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -23,7 +24,14 @@ import io.camunda.operate.util.CollectionUtil;
 import io.camunda.operate.util.RetryOperation;
 import java.io.IOException;
 import java.time.temporal.ChronoUnit;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
@@ -57,9 +65,12 @@ import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestHighLevelClient;
 import org.elasticsearch.client.core.CountRequest;
 import org.elasticsearch.client.indexlifecycle.PutLifecyclePolicyRequest;
+import org.elasticsearch.client.indices.ComponentTemplatesExistRequest;
 import org.elasticsearch.client.indices.ComposableIndexTemplateExistRequest;
 import org.elasticsearch.client.indices.CreateIndexRequest;
 import org.elasticsearch.client.indices.DeleteComposableIndexTemplateRequest;
+import org.elasticsearch.client.indices.GetComponentTemplatesRequest;
+import org.elasticsearch.client.indices.GetComposableIndexTemplateRequest;
 import org.elasticsearch.client.indices.GetIndexRequest;
 import org.elasticsearch.client.indices.GetIndexResponse;
 import org.elasticsearch.client.indices.GetMappingsRequest;
@@ -68,9 +79,11 @@ import org.elasticsearch.client.indices.PutComposableIndexTemplateRequest;
 import org.elasticsearch.client.indices.PutMappingRequest;
 import org.elasticsearch.cluster.health.ClusterHealthStatus;
 import org.elasticsearch.cluster.metadata.AliasMetadata;
+import org.elasticsearch.cluster.metadata.ComposableIndexTemplate;
 import org.elasticsearch.cluster.metadata.MappingMetadata;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.reindex.ReindexRequest;
@@ -91,7 +104,9 @@ public class RetryElasticsearchClient {
   public static final String REFRESH_INTERVAL = "index.refresh_interval";
   public static final String NO_REFRESH = "-1";
   public static final String NUMBERS_OF_REPLICA = "index.number_of_replicas";
+  public static final String NUMBERS_OF_SHARDS = "index.number_of_shards";
   public static final String NO_REPLICA = "0";
+  public static final String DEFAULT_SHARDS = "1";
   public static final int SCROLL_KEEP_ALIVE_MS = 60_000;
   public static final int DEFAULT_NUMBER_OF_RETRIES =
       30 * 10; // 30*10 with 2 seconds = 10 minutes retry loop
@@ -230,7 +245,7 @@ public class RetryElasticsearchClient {
                           properties.entrySet().stream()
                               .map(p -> createIndexMappingProperty(p))
                               .collect(Collectors.toSet()))
-                      .setMetaProperties(metaProperties));
+                      .setMetaProperties(ofNullable(metaProperties).orElse(Map.of())));
             }
             return mappingsMap;
           } catch (final ElasticsearchException e) {
@@ -309,7 +324,7 @@ public class RetryElasticsearchClient {
   }
 
   public boolean createOrUpdateDocument(
-      final String name, final String id, String routing, final Map source) {
+      final String name, final String id, final String routing, final Map source) {
     return executeWithRetries(
         "RetryElasticsearchClient#createOrUpdateDocument",
         () -> {
@@ -380,11 +395,16 @@ public class RetryElasticsearchClient {
             new ComposableIndexTemplateExistRequest(templatePattern), requestOptions);
   }
 
-  public boolean createComponentTemplate(final PutComponentTemplateRequest request) {
+  public boolean createComponentTemplate(
+      final PutComponentTemplateRequest request, final boolean overwrite) {
     return executeWithRetries(
         "CreateComponentTemplate " + request.name(),
         () -> {
-          if (!templatesExist(request.name())) {
+          if (overwrite
+              || !esClient
+                  .cluster()
+                  .existsComponentTemplate(
+                      new ComponentTemplatesExistRequest(request.name()), requestOptions)) {
             return esClient
                 .cluster()
                 .putComponentTemplate(request, requestOptions)
@@ -800,5 +820,36 @@ public class RetryElasticsearchClient {
               fieldName, value));
     }
     putMapping(request);
+  }
+
+  public Settings getComponentTemplateSettings(final String componentTemplateName) {
+    return executeWithRetries(
+        "GetComponentTemplateSettings " + componentTemplateName,
+        () -> {
+          final var request = new GetComponentTemplatesRequest(componentTemplateName);
+          final var response = esClient.cluster().getComponentTemplate(request, requestOptions);
+          return response.getComponentTemplates().get(componentTemplateName).template().settings();
+        });
+  }
+
+  public ComposableIndexTemplate getIndexTemplate(final String templateName) {
+    return executeWithRetries(
+        "GetIndexTemplate " + templateName,
+        () -> {
+          final var request = new GetComposableIndexTemplateRequest(templateName);
+          final var response = esClient.indices().getIndexTemplate(request, requestOptions);
+          return response.getIndexTemplates().get(templateName);
+        });
+  }
+
+  public ImmutableOpenMap<String, Settings> getIndexSettingsForIndexPattern(
+      final String indexPattern) {
+    return executeWithRetries(
+        "GetIndexSettings for indexPattern" + indexPattern,
+        () ->
+            esClient
+                .indices()
+                .getSettings(new GetSettingsRequest().indices(indexPattern), requestOptions)
+                .getIndexToSettings());
   }
 }

--- a/operate/schema/src/main/java/io/camunda/operate/store/elasticsearch/RetryElasticsearchClient.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/elasticsearch/RetryElasticsearchClient.java
@@ -842,6 +842,16 @@ public class RetryElasticsearchClient {
         });
   }
 
+  public Map<String, ComposableIndexTemplate> getIndexTemplates(final String templateNamePattern) {
+    return executeWithRetries(
+        "GetIndexTemplate " + templateNamePattern,
+        () -> {
+          final var request = new GetComposableIndexTemplateRequest(templateNamePattern);
+          final var response = esClient.indices().getIndexTemplate(request, requestOptions);
+          return response.getIndexTemplates();
+        });
+  }
+
   public ImmutableOpenMap<String, Settings> getIndexSettingsForIndexPattern(
       final String indexPattern) {
     return executeWithRetries(

--- a/operate/schema/src/main/java/io/camunda/operate/store/opensearch/client/sync/OpenSearchIndexOperations.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/opensearch/client/sync/OpenSearchIndexOperations.java
@@ -213,6 +213,16 @@ public class OpenSearchIndexOperations extends OpenSearchRetryOperation {
         });
   }
 
+  public Map<String, IndexState> getIndexSettingsForIndexPattern(final String indexPattern) {
+    return executeWithRetries(
+        "GetIndexSettings " + indexPattern,
+        () -> {
+          final GetIndicesSettingsResponse response =
+              openSearchClient.indices().getSettings(s -> s.index(indexPattern));
+          return response.result();
+        });
+  }
+
   public Map<String, IndexMapping> getIndexMappings(final String indexNamePattern) {
     return executeWithRetries(
         "GetIndexMappings " + indexNamePattern,

--- a/operate/schema/src/main/java/io/camunda/operate/store/opensearch/client/sync/OpenSearchTemplateOperations.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/opensearch/client/sync/OpenSearchTemplateOperations.java
@@ -17,6 +17,7 @@ import org.opensearch.client.opensearch.cluster.PutComponentTemplateRequest;
 import org.opensearch.client.opensearch.indices.IndexSettings;
 import org.opensearch.client.opensearch.indices.PutIndexTemplateRequest;
 import org.opensearch.client.opensearch.indices.get_index_template.IndexTemplate;
+import org.opensearch.client.opensearch.indices.get_index_template.IndexTemplateItem;
 import org.slf4j.Logger;
 
 public class OpenSearchTemplateOperations extends OpenSearchRetryOperation {
@@ -91,6 +92,19 @@ public class OpenSearchTemplateOperations extends OpenSearchRetryOperation {
                 .indexTemplates()
                 .getFirst()
                 .indexTemplate());
+  }
+
+  public Map<String, IndexTemplate> getIndexTemplates(final String templateNamePattern) {
+    return executeWithRetries(
+        "GetIndexTemplate " + templateNamePattern,
+        () ->
+            openSearchClient
+                .indices()
+                .getIndexTemplate(it -> it.name(templateNamePattern))
+                .indexTemplates()
+                .stream()
+                .collect(
+                    Collectors.toMap(IndexTemplateItem::name, IndexTemplateItem::indexTemplate)));
   }
 
   public IndexSettings getComponentTemplateIndexSettings(final String componentTemplateName) {

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/es/RetryElasticsearchClient.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/es/RetryElasticsearchClient.java
@@ -808,6 +808,16 @@ public class RetryElasticsearchClient {
         });
   }
 
+  public Map<String, ComposableIndexTemplate> getIndexTemplates(final String templateNamePattern) {
+    return executeWithRetries(
+        "GetIndexTemplate " + templateNamePattern,
+        () -> {
+          final var request = new GetComposableIndexTemplateRequest(templateNamePattern);
+          final var response = esClient.indices().getIndexTemplate(request, requestOptions);
+          return response.getIndexTemplates();
+        });
+  }
+
   public Map<String, IndexMapping> getIndexMappings(final String namePattern) {
     return executeWithRetries(
         "Get indices mappings for " + namePattern,

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/es/RetryElasticsearchClient.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/es/RetryElasticsearchClient.java
@@ -65,6 +65,7 @@ import org.elasticsearch.client.indexlifecycle.PutLifecyclePolicyRequest;
 import org.elasticsearch.client.indices.*;
 import org.elasticsearch.cluster.health.ClusterHealthStatus;
 import org.elasticsearch.cluster.metadata.AliasMetadata;
+import org.elasticsearch.cluster.metadata.ComposableIndexTemplate;
 import org.elasticsearch.cluster.metadata.MappingMetadata;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
@@ -795,6 +796,16 @@ public class RetryElasticsearchClient {
         () ->
             esClient.indexLifecycle().getLifecyclePolicy(getLifecyclePolicyRequest, requestOptions),
         null);
+  }
+
+  public ComposableIndexTemplate getIndexTemplate(final String templateName) {
+    return executeWithRetries(
+        "GetIndexTemplate " + templateName,
+        () -> {
+          final var request = new GetComposableIndexTemplateRequest(templateName);
+          final var response = esClient.indices().getIndexTemplate(request, requestOptions);
+          return response.getIndexTemplates().get(templateName);
+        });
   }
 
   public Map<String, IndexMapping> getIndexMappings(final String namePattern) {

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/os/RetryOpenSearchClient.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/os/RetryOpenSearchClient.java
@@ -74,6 +74,7 @@ import org.opensearch.client.opensearch.indices.IndexSettings;
 import org.opensearch.client.opensearch.indices.IndexState;
 import org.opensearch.client.opensearch.indices.PutIndexTemplateRequest;
 import org.opensearch.client.opensearch.indices.PutMappingRequest;
+import org.opensearch.client.opensearch.indices.get_index_template.IndexTemplate;
 import org.opensearch.client.opensearch.ingest.Processor;
 import org.opensearch.client.opensearch.tasks.GetTasksResponse;
 import org.slf4j.Logger;
@@ -88,7 +89,6 @@ import org.springframework.stereotype.Component;
 @Conditional(OpenSearchCondition.class)
 public class RetryOpenSearchClient {
 
-  public static final String REFRESH_INTERVAL = "index.refresh_interval";
   public static final String NO_REFRESH = "-1";
   public static final String DEFAULT_SHARDS = "1";
   public static final String NO_REPLICA = "0";
@@ -609,7 +609,7 @@ public class RetryOpenSearchClient {
         });
   }
 
-  public IndexSettings getComponentTemplateSettings(final String componentTemplateName) {
+  public IndexSettings getComponentTemplateIndexSettings(final String componentTemplateName) {
     return executeWithRetries(
         "GetComponentTemplateSettings " + componentTemplateName,
         () -> {
@@ -617,7 +617,7 @@ public class RetryOpenSearchClient {
               openSearchClient.cluster().getComponentTemplate(ct -> ct.name(componentTemplateName));
           return response
               .componentTemplates()
-              .get(0)
+              .getFirst()
               .componentTemplate()
               .template()
               .settings()
@@ -812,5 +812,17 @@ public class RetryOpenSearchClient {
             throw e;
           }
         });
+  }
+
+  public IndexTemplate getIndexTemplate(final String templateName) {
+    return executeWithRetries(
+        "GetIndexTemplate " + templateName,
+        () ->
+            openSearchClient
+                .indices()
+                .getIndexTemplate(it -> it.name(templateName))
+                .indexTemplates()
+                .getFirst()
+                .indexTemplate());
   }
 }

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/os/RetryOpenSearchClient.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/os/RetryOpenSearchClient.java
@@ -75,6 +75,7 @@ import org.opensearch.client.opensearch.indices.IndexState;
 import org.opensearch.client.opensearch.indices.PutIndexTemplateRequest;
 import org.opensearch.client.opensearch.indices.PutMappingRequest;
 import org.opensearch.client.opensearch.indices.get_index_template.IndexTemplate;
+import org.opensearch.client.opensearch.indices.get_index_template.IndexTemplateItem;
 import org.opensearch.client.opensearch.ingest.Processor;
 import org.opensearch.client.opensearch.tasks.GetTasksResponse;
 import org.slf4j.Logger;
@@ -824,5 +825,18 @@ public class RetryOpenSearchClient {
                 .indexTemplates()
                 .getFirst()
                 .indexTemplate());
+  }
+
+  public Map<String, IndexTemplate> getIndexTemplates(final String templateNamePattern) {
+    return executeWithRetries(
+        "GetIndexTemplate " + templateNamePattern,
+        () ->
+            openSearchClient
+                .indices()
+                .getIndexTemplate(it -> it.name(templateNamePattern))
+                .indexTemplates()
+                .stream()
+                .collect(
+                    Collectors.toMap(IndexTemplateItem::name, IndexTemplateItem::indexTemplate)));
   }
 }

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/schema/manager/OpenSearchSchemaManager.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/schema/manager/OpenSearchSchemaManager.java
@@ -249,7 +249,61 @@ public class OpenSearchSchemaManager implements SchemaManager {
   @Override
   public void updateIndexSettings() {
     updateIndicesNumberOfReplicas();
+    updateIndexTemplateSettings();
     updateComponentTemplateSettings();
+  }
+
+  private void updateIndexTemplateSettings() {
+    for (final var templateDescriptor : templateDescriptors) {
+      final var expectedShards =
+          String.valueOf(
+              tasklistProperties
+                  .getOpenSearch()
+                  .getNumberOfShards(templateDescriptor.getIndexName()));
+      final var expectedReplicas =
+          String.valueOf(
+              tasklistProperties
+                  .getOpenSearch()
+                  .getNumberOfReplicas(templateDescriptor.getIndexName()));
+
+      String actualShards = null;
+      String actualReplicas = null;
+      final var indexTemplate =
+          retryOpenSearchClient.getIndexTemplate(templateDescriptor.getTemplateName());
+
+      final var templateSettings = indexTemplate.template().settings();
+
+      if (templateSettings.containsKey("index")) {
+        final var indexSettingsData = templateSettings.get("index");
+        final var indexSettingsJson = indexSettingsData.toJson().asJsonObject();
+
+        actualShards = indexSettingsJson.getString("number_of_shards", null);
+        actualReplicas = indexSettingsJson.getString("number_of_replicas", null);
+      }
+
+      if (!expectedShards.equals(actualShards) || !expectedReplicas.equals(actualReplicas)) {
+        LOGGER.info(
+            "Updating index template settings for {} to shards={}, replicas={}",
+            templateDescriptor.getTemplateName(),
+            expectedShards,
+            expectedReplicas);
+
+        // Recreate the template with updated settings
+        putIndexTemplate(templateDescriptor, true);
+      }
+    }
+  }
+
+  private void putIndexTemplate(
+      final TemplateDescriptor templateDescriptor, final boolean overwrite) {
+    putIndexTemplate(
+        new PutIndexTemplateRequest.Builder()
+            .indexPatterns(List.of(templateDescriptor.getIndexPattern()))
+            .template(getTemplateFrom(templateDescriptor))
+            .name(templateDescriptor.getTemplateName())
+            .composedOf(List.of(getComponentTemplateName()))
+            .build(),
+        overwrite);
   }
 
   public String getComponentTemplateName() {
@@ -258,14 +312,16 @@ public class OpenSearchSchemaManager implements SchemaManager {
 
   private void updateComponentTemplateSettings() {
     final var settings =
-        retryOpenSearchClient.getComponentTemplateSettings(getComponentTemplateName());
+        retryOpenSearchClient.getComponentTemplateIndexSettings(getComponentTemplateName());
 
     final var expectedShards =
         String.valueOf(tasklistProperties.getOpenSearch().getNumberOfShards());
     final var expectedReplicas =
         String.valueOf(tasklistProperties.getOpenSearch().getNumberOfReplicas());
-    final var actualShards = ofNullable(settings.numberOfShards()).orElse(DEFAULT_SHARDS);
-    final var actualReplicas = ofNullable(settings.numberOfReplicas()).orElse(NO_REPLICA);
+    final var actualShards =
+        ofNullable(settings).map(IndexSettings::numberOfShards).orElse(DEFAULT_SHARDS);
+    final var actualReplicas =
+        ofNullable(settings).map(IndexSettings::numberOfReplicas).orElse(NO_REPLICA);
 
     if (!expectedShards.equals(actualShards) || !expectedReplicas.equals(actualReplicas)) {
       LOGGER.info(
@@ -408,17 +464,7 @@ public class OpenSearchSchemaManager implements SchemaManager {
 
   private void createTemplate(
       final TemplateDescriptor templateDescriptor, final boolean overwrite) {
-    final IndexTemplateMapping template = getTemplateFrom(templateDescriptor);
-
-    putIndexTemplate(
-        new PutIndexTemplateRequest.Builder()
-            .indexPatterns(List.of(templateDescriptor.getIndexPattern()))
-            .template(template)
-            .name(templateDescriptor.getTemplateName())
-            .composedOf(List.of(getComponentTemplateName()))
-            .build(),
-        overwrite);
-
+    putIndexTemplate(templateDescriptor, overwrite);
     // This is necessary, otherwise tasklist won't find indexes at startup
     createIndex(templateDescriptor);
   }
@@ -444,6 +490,7 @@ public class OpenSearchSchemaManager implements SchemaManager {
       return new IndexTemplateMapping.Builder()
           .mappings(TypeMapping._DESERIALIZER.deserialize(parser, mapper))
           .aliases(templateDescriptor.getAlias(), new Alias.Builder().build())
+          .settings(templateSettings(templateDescriptor))
           .build();
     } catch (final IOException e) {
       throw new TasklistRuntimeException(
@@ -466,31 +513,12 @@ public class OpenSearchSchemaManager implements SchemaManager {
 
   private IndexSettings templateSettings(final TemplateDescriptor indexDescriptor) {
     final var shards =
-        tasklistProperties
-            .getOpenSearch()
-            .getNumberOfShardsPerIndex()
-            .get(indexDescriptor.getIndexName());
-
+        String.valueOf(
+            tasklistProperties.getOpenSearch().getNumberOfShards(indexDescriptor.getIndexName()));
     final var replicas =
-        tasklistProperties
-            .getOpenSearch()
-            .getNumberOfReplicasPerIndex()
-            .get(indexDescriptor.getIndexName());
-
-    if (shards != null || replicas != null) {
-      final var indexSettingsBuilder = new IndexSettings.Builder();
-
-      if (shards != null) {
-        indexSettingsBuilder.numberOfShards(shards.toString());
-      }
-
-      if (replicas != null) {
-        indexSettingsBuilder.numberOfReplicas(replicas.toString());
-      }
-
-      return indexSettingsBuilder.build();
-    }
-    return null;
+        String.valueOf(
+            tasklistProperties.getOpenSearch().getNumberOfReplicas(indexDescriptor.getIndexName()));
+    return IndexSettings.of(b -> b.numberOfShards(shards).numberOfReplicas(replicas));
   }
 
   private IndexSettings getCustomSettings(


### PR DESCRIPTION
This pull request introduces support for dynamic application of `number_of_replicas` and `number_of_shards` configuration changes at application startup, ensuring consistent schema management across Elasticsearch and OpenSearch implementations for both Operate and Tasklist.


* New `updateIndexSettings()` method in the schema manager that runs on application startup when both `camunda.operate.elasticsearch.createSchema` and the new `camunda.operate.elasticsearch.updateSchemaSettings `properties are enabled
* Dynamic index updates: automatically updates the replicas count of all existing indices using either global replica configuration or per-index specific configuration
* Index Templates: updates shards/replicas count settings in index templates to match current configuration values (global or per-index)
* Component template: updates the `operate_component` component template settings with current global shards/replicas configuration
* Implementation Consistency: aling behavior between Elasticsearch and OpenSearch implementations. Previously, Elasticsearch always set shards/replicas at index template level while OpenSearch only set them when different from defaults, both implementations now consistently set index template settings regardless of default values, this is consistent with 8.8 implementation
Testing Infrastructure:

* there was a discrepency between Elasticsearch and Opensearch implementation: for Elasticsearch, the shards/replicas settings are always set at index template level, while for Opensearch they are set only when different from the default global configuration. Aligned both implementations to always set the index template settings (also for Tasklist) , this will be also the behavior of 8.8
 
* Expanded the integration `operateItOpensearch` test profile in `operate/pom.xml` to include schema-related tests to be run in Opensearch IT tests.

## Description

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #32872 
