### PR TITLE
feat: unified config: patch SearchEngineConnectProperties with DB type and URL

### DIFF
--- a/configuration/pom.xml
+++ b/configuration/pom.xml
@@ -100,5 +100,11 @@
       <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-search-client-connect</artifactId>
+      <version>${project.version}</version>
+    </dependency>
   </dependencies>
 </project>

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/SearchEngineConnectPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/SearchEngineConnectPropertiesOverride.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration.beanoverrides;
+
+import io.camunda.configuration.SecondaryStorage;
+import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
+import io.camunda.configuration.UnifiedConfiguration;
+import io.camunda.configuration.beans.SearchEngineConnectProperties;
+import io.camunda.search.connect.configuration.DatabaseType;
+import org.springframework.beans.BeanUtils;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.DependsOn;
+import org.springframework.context.annotation.Primary;
+
+@Configuration
+@EnableConfigurationProperties(SearchEngineConnectProperties.class)
+@DependsOn("unifiedConfigurationHelper")
+public class SearchEngineConnectPropertiesOverride {
+
+  private final UnifiedConfiguration unifiedConfiguration;
+  private final SearchEngineConnectProperties legacyProperties;
+
+  public SearchEngineConnectPropertiesOverride(
+      final UnifiedConfiguration unifiedConfiguration,
+      final SearchEngineConnectProperties legacyProperties) {
+    this.unifiedConfiguration = unifiedConfiguration;
+    this.legacyProperties = legacyProperties;
+  }
+
+  @Bean
+  @Primary
+  public SearchEngineConnectProperties searchEngineConnectProperties() {
+    final SearchEngineConnectProperties override = new SearchEngineConnectProperties();
+    BeanUtils.copyProperties(legacyProperties, override);
+
+    final SecondaryStorage database =
+        unifiedConfiguration.getCamunda().getData().getSecondaryStorage();
+
+    if (SecondaryStorageType.elasticsearch == database.getType()) {
+      override.setType(DatabaseType.ELASTICSEARCH.toString());
+      override.setUrl(database.getElasticsearch().getUrl());
+    } else if (SecondaryStorageType.opensearch == database.getType()) {
+      override.setType(DatabaseType.OPENSEARCH.toString());
+      override.setUrl(database.getOpensearch().getUrl());
+    }
+
+    // TODO: Populate the bean using unifiedConfiguration
+    //  override.setSampleField(unifiedConfiguration.getSampleField());
+
+    return override;
+  }
+}

--- a/configuration/src/main/java/io/camunda/configuration/beans/SearchEngineConnectProperties.java
+++ b/configuration/src/main/java/io/camunda/configuration/beans/SearchEngineConnectProperties.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration.beans;
+
+import io.camunda.search.connect.configuration.ConnectConfiguration;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties("camunda.database")
+public class SearchEngineConnectProperties extends ConnectConfiguration {}

--- a/configuration/src/test/java/io/camunda/configuration/SecondaryStorageFailureWithLegacySchemaTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/SecondaryStorageFailureWithLegacySchemaTest.java
@@ -10,6 +10,7 @@ package io.camunda.configuration;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.configuration.beanoverrides.OperatePropertiesOverride;
+import io.camunda.configuration.beanoverrides.SearchEngineConnectPropertiesOverride;
 import io.camunda.configuration.beanoverrides.TasklistPropertiesOverride;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
@@ -21,7 +22,8 @@ public class SecondaryStorageFailureWithLegacySchemaTest {
           .withUserConfiguration(
               UnifiedConfiguration.class,
               UnifiedConfigurationHelper.class,
-              OperatePropertiesOverride.class)
+              OperatePropertiesOverride.class,
+              SearchEngineConnectPropertiesOverride.class)
           .withPropertyValues(
               "camunda.database.type=elasticsearch",
               "camunda.operate.database=elasticsearch",
@@ -33,7 +35,8 @@ public class SecondaryStorageFailureWithLegacySchemaTest {
           .withUserConfiguration(
               UnifiedConfiguration.class,
               UnifiedConfigurationHelper.class,
-              TasklistPropertiesOverride.class)
+              TasklistPropertiesOverride.class,
+              SearchEngineConnectPropertiesOverride.class)
           .withPropertyValues(
               "camunda.database.type=elasticsearch",
               "camunda.operate.database=elasticsearch",
@@ -45,7 +48,8 @@ public class SecondaryStorageFailureWithLegacySchemaTest {
           .withUserConfiguration(
               UnifiedConfiguration.class,
               UnifiedConfigurationHelper.class,
-              TasklistPropertiesOverride.class)
+              TasklistPropertiesOverride.class,
+              SearchEngineConnectPropertiesOverride.class)
           .withPropertyValues(
               // type
               "camunda.data.secondary-storage.type=elasticsearch",

--- a/configuration/src/test/java/io/camunda/configuration/SecondaryStorageTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/SecondaryStorageTest.java
@@ -10,7 +10,9 @@ package io.camunda.configuration;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.configuration.beanoverrides.OperatePropertiesOverride;
+import io.camunda.configuration.beanoverrides.SearchEngineConnectPropertiesOverride;
 import io.camunda.configuration.beanoverrides.TasklistPropertiesOverride;
+import io.camunda.configuration.beans.SearchEngineConnectProperties;
 import io.camunda.operate.conditions.DatabaseType;
 import io.camunda.operate.property.OperateProperties;
 import io.camunda.tasklist.property.TasklistProperties;
@@ -25,6 +27,7 @@ import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
   UnifiedConfigurationHelper.class,
   TasklistPropertiesOverride.class,
   OperatePropertiesOverride.class,
+  SearchEngineConnectPropertiesOverride.class
 })
 public class SecondaryStorageTest {
 
@@ -37,15 +40,18 @@ public class SecondaryStorageTest {
   class WithOnlyUnifiedConfigSet {
     final OperateProperties operateProperties;
     final TasklistProperties tasklistProperties;
+    final SearchEngineConnectProperties searchEngineConnectProperties;
 
     WithOnlyUnifiedConfigSet(
         @Autowired final OperateProperties operateProperties,
-        @Autowired final TasklistProperties tasklistProperties) {
+        @Autowired final TasklistProperties tasklistProperties,
+        @Autowired final SearchEngineConnectProperties searchEngineConnectProperties) {
       this.operateProperties = operateProperties;
       this.tasklistProperties = tasklistProperties;
+      this.searchEngineConnectProperties = searchEngineConnectProperties;
     }
 
-    // @Test
+    @Test
     void testCamundaDataSecondaryStorageType() {
       final DatabaseType expectedOperateDatabaseType = DatabaseType.Elasticsearch;
       assertThat(operateProperties.getDatabase()).isEqualTo(expectedOperateDatabaseType);
@@ -59,6 +65,7 @@ public class SecondaryStorageTest {
       final String expectedUrl = "http://expected-url:4321";
       assertThat(operateProperties.getElasticsearch().getUrl()).isEqualTo(expectedUrl);
       assertThat(tasklistProperties.getElasticsearch().getUrl()).isEqualTo(expectedUrl);
+      assertThat(searchEngineConnectProperties.getUrl()).isEqualTo(expectedUrl);
     }
   }
 
@@ -79,21 +86,27 @@ public class SecondaryStorageTest {
   class WithNewAndLegacySet {
     final OperateProperties operateProperties;
     final TasklistProperties tasklistProperties;
+    final SearchEngineConnectProperties searchEngineConnectProperties;
 
     WithNewAndLegacySet(
         @Autowired final OperateProperties operateProperties,
-        @Autowired final TasklistProperties tasklistProperties) {
+        @Autowired final TasklistProperties tasklistProperties,
+        @Autowired final SearchEngineConnectProperties searchEngineConnectProperties) {
       this.operateProperties = operateProperties;
       this.tasklistProperties = tasklistProperties;
+      this.searchEngineConnectProperties = searchEngineConnectProperties;
     }
 
-    // @Test
+    @Test
     void testCamundaDataSecondaryStorageType() {
       final DatabaseType expectedOperateDatabaseType = DatabaseType.Elasticsearch;
       assertThat(operateProperties.getDatabase()).isEqualTo(expectedOperateDatabaseType);
 
       final String expectedTasklistDatabaseType = "elasticsearch";
       assertThat(tasklistProperties.getDatabase()).isEqualTo(expectedTasklistDatabaseType);
+
+      assertThat(searchEngineConnectProperties.getType())
+          .isEqualTo(io.camunda.search.connect.configuration.DatabaseType.ELASTICSEARCH.toString());
     }
 
     @Test
@@ -101,6 +114,7 @@ public class SecondaryStorageTest {
       final String expectedUrl = "http://matching-url:4321";
       assertThat(operateProperties.getElasticsearch().getUrl()).isEqualTo(expectedUrl);
       assertThat(tasklistProperties.getElasticsearch().getUrl()).isEqualTo(expectedUrl);
+      assertThat(searchEngineConnectProperties.getUrl()).isEqualTo(expectedUrl);
     }
   }
 }

--- a/dist/src/main/java/io/camunda/application/StandaloneBackupManager.java
+++ b/dist/src/main/java/io/camunda/application/StandaloneBackupManager.java
@@ -13,7 +13,7 @@ import static java.util.Optional.ofNullable;
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import io.camunda.application.StandaloneBackupManager.BackupManagerConfiguration.BackupWebappsProperties;
 import io.camunda.application.commons.backup.BackupPriorityConfiguration;
-import io.camunda.application.commons.search.SearchEngineDatabaseConfiguration.SearchEngineConnectProperties;
+import io.camunda.configuration.beans.SearchEngineConnectProperties;
 import io.camunda.search.connect.configuration.ConnectConfiguration;
 import io.camunda.search.connect.es.ElasticsearchConnector;
 import io.camunda.webapps.backup.BackupRepository;

--- a/dist/src/main/java/io/camunda/application/StandaloneCamunda.java
+++ b/dist/src/main/java/io/camunda/application/StandaloneCamunda.java
@@ -21,6 +21,7 @@ import io.camunda.configuration.beanoverrides.BrokerBasedPropertiesOverride;
 import io.camunda.configuration.beanoverrides.GatewayBasedPropertiesOverride;
 import io.camunda.configuration.beanoverrides.IdleStrategyPropertiesOverride;
 import io.camunda.configuration.beanoverrides.OperatePropertiesOverride;
+import io.camunda.configuration.beanoverrides.SearchEngineConnectPropertiesOverride;
 import io.camunda.configuration.beanoverrides.TasklistPropertiesOverride;
 import io.camunda.identity.IdentityModuleConfiguration;
 import io.camunda.operate.OperateModuleConfiguration;
@@ -59,6 +60,7 @@ public class StandaloneCamunda {
                 UnifiedConfigurationHelper.class,
                 TasklistPropertiesOverride.class,
                 OperatePropertiesOverride.class,
+                SearchEngineConnectPropertiesOverride.class,
                 GatewayBasedPropertiesOverride.class,
                 BrokerBasedPropertiesOverride.class,
                 ActorClockControlledPropertiesOverride.class,

--- a/dist/src/main/java/io/camunda/application/StandaloneOperate.java
+++ b/dist/src/main/java/io/camunda/application/StandaloneOperate.java
@@ -15,6 +15,7 @@ import io.camunda.configuration.UnifiedConfiguration;
 import io.camunda.configuration.UnifiedConfigurationHelper;
 import io.camunda.configuration.beanoverrides.GatewayBasedPropertiesOverride;
 import io.camunda.configuration.beanoverrides.OperatePropertiesOverride;
+import io.camunda.configuration.beanoverrides.SearchEngineConnectPropertiesOverride;
 import io.camunda.operate.OperateModuleConfiguration;
 import io.camunda.webapps.WebappsModuleConfiguration;
 import java.util.HashMap;
@@ -48,6 +49,7 @@ public class StandaloneOperate {
                 UnifiedConfigurationHelper.class,
                 OperatePropertiesOverride.class,
                 GatewayBasedPropertiesOverride.class,
+                SearchEngineConnectPropertiesOverride.class,
                 // ---
                 CommonsModuleConfiguration.class,
                 OperateModuleConfiguration.class,

--- a/dist/src/main/java/io/camunda/application/StandalonePrefixMigration.java
+++ b/dist/src/main/java/io/camunda/application/StandalonePrefixMigration.java
@@ -12,6 +12,7 @@ import io.camunda.application.commons.search.SearchEngineDatabaseConfiguration;
 import io.camunda.configuration.UnifiedConfiguration;
 import io.camunda.configuration.UnifiedConfigurationHelper;
 import io.camunda.configuration.beanoverrides.OperatePropertiesOverride;
+import io.camunda.configuration.beanoverrides.SearchEngineConnectPropertiesOverride;
 import io.camunda.configuration.beanoverrides.TasklistPropertiesOverride;
 import io.camunda.operate.property.OperateProperties;
 import io.camunda.search.connect.configuration.ConnectConfiguration;
@@ -56,7 +57,8 @@ public class StandalonePrefixMigration implements CommandLineRunner {
                 UnifiedConfiguration.class,
                 UnifiedConfigurationHelper.class,
                 TasklistPropertiesOverride.class,
-                OperatePropertiesOverride.class)
+                OperatePropertiesOverride.class,
+                SearchEngineConnectPropertiesOverride.class)
             .addCommandLineProperties(true)
             .build(args);
 

--- a/dist/src/main/java/io/camunda/application/StandaloneTasklist.java
+++ b/dist/src/main/java/io/camunda/application/StandaloneTasklist.java
@@ -14,6 +14,7 @@ import io.camunda.application.listeners.ApplicationErrorListener;
 import io.camunda.configuration.UnifiedConfiguration;
 import io.camunda.configuration.UnifiedConfigurationHelper;
 import io.camunda.configuration.beanoverrides.GatewayBasedPropertiesOverride;
+import io.camunda.configuration.beanoverrides.SearchEngineConnectPropertiesOverride;
 import io.camunda.configuration.beanoverrides.TasklistPropertiesOverride;
 import io.camunda.tasklist.TasklistModuleConfiguration;
 import io.camunda.webapps.WebappsModuleConfiguration;
@@ -42,6 +43,7 @@ public class StandaloneTasklist {
                 UnifiedConfiguration.class,
                 UnifiedConfigurationHelper.class,
                 TasklistPropertiesOverride.class,
+                SearchEngineConnectPropertiesOverride.class,
                 GatewayBasedPropertiesOverride.class,
                 // ---
                 CommonsModuleConfiguration.class,

--- a/dist/src/main/java/io/camunda/application/commons/search/SearchEngineDatabaseConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/search/SearchEngineDatabaseConfiguration.java
@@ -8,12 +8,11 @@
 package io.camunda.application.commons.search;
 
 import io.camunda.application.commons.condition.ConditionalOnSecondaryStorageType;
-import io.camunda.application.commons.search.SearchEngineDatabaseConfiguration.SearchEngineConnectProperties;
 import io.camunda.application.commons.search.SearchEngineDatabaseConfiguration.SearchEngineIndexProperties;
 import io.camunda.application.commons.search.SearchEngineDatabaseConfiguration.SearchEngineRetentionProperties;
 import io.camunda.application.commons.search.SearchEngineDatabaseConfiguration.SearchEngineSchemaManagerProperties;
 import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
-import io.camunda.search.connect.configuration.ConnectConfiguration;
+import io.camunda.configuration.beans.SearchEngineConnectProperties;
 import io.camunda.search.connect.configuration.DatabaseConfig;
 import io.camunda.search.connect.configuration.DatabaseType;
 import io.camunda.search.schema.config.IndexConfiguration;
@@ -75,9 +74,6 @@ public class SearchEngineDatabaseConfiguration {
                 .retention(searchEngineRetentionProperties)
                 .schemaManager(searchEngineSchemaManagerProperties));
   }
-
-  @ConfigurationProperties("camunda.database")
-  public static final class SearchEngineConnectProperties extends ConnectConfiguration {}
 
   @ConfigurationProperties("camunda.database.index")
   public static final class SearchEngineIndexProperties extends IndexConfiguration {}

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/elasticsearch/ElasticsearchConnectorIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/elasticsearch/ElasticsearchConnectorIT.java
@@ -14,6 +14,7 @@ import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import io.camunda.configuration.UnifiedConfiguration;
 import io.camunda.configuration.UnifiedConfigurationHelper;
 import io.camunda.configuration.beanoverrides.OperatePropertiesOverride;
+import io.camunda.configuration.beanoverrides.SearchEngineConnectPropertiesOverride;
 import io.camunda.operate.conditions.DatabaseInfo;
 import io.camunda.operate.connect.ElasticsearchConnector;
 import io.camunda.operate.property.OperateProperties;
@@ -46,6 +47,7 @@ import org.testcontainers.utility.DockerImageName;
       ElasticsearchConnector.class,
       DatabaseInfo.class,
       OperatePropertiesOverride.class,
+      SearchEngineConnectPropertiesOverride.class,
       UnifiedConfigurationHelper.class,
       UnifiedConfiguration.class
     },

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/opensearch/OpensearchConnectorIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/opensearch/OpensearchConnectorIT.java
@@ -12,6 +12,7 @@ import com.github.tomakehurst.wiremock.client.CountMatchingStrategy;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import io.camunda.configuration.beanoverrides.OperatePropertiesOverride;
+import io.camunda.configuration.beanoverrides.SearchEngineConnectPropertiesOverride;
 import io.camunda.operate.JacksonConfig;
 import io.camunda.operate.conditions.DatabaseInfo;
 import io.camunda.operate.connect.OpensearchConnector;
@@ -48,7 +49,8 @@ import org.testcontainers.junit.jupiter.Testcontainers;
       JacksonConfig.class,
       OperateDateTimeFormatter.class,
       DatabaseInfo.class,
-      OperatePropertiesOverride.class
+      OperatePropertiesOverride.class,
+      SearchEngineConnectPropertiesOverride.class
     },
     properties = "camunda.data.secondary-storage.type=opensearch")
 public class OpensearchConnectorIT extends OperateAbstractIT {

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/properties/PropertiesIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/properties/PropertiesIT.java
@@ -13,6 +13,7 @@ import io.camunda.application.commons.security.CamundaSecurityConfiguration.Camu
 import io.camunda.configuration.UnifiedConfiguration;
 import io.camunda.configuration.UnifiedConfigurationHelper;
 import io.camunda.configuration.beanoverrides.OperatePropertiesOverride;
+import io.camunda.configuration.beanoverrides.SearchEngineConnectPropertiesOverride;
 import io.camunda.operate.conditions.DatabaseInfo;
 import io.camunda.operate.property.OperateProperties;
 import io.camunda.operate.util.apps.nobeans.TestApplicationWithNoBeans;
@@ -30,6 +31,7 @@ import org.springframework.test.context.junit4.SpringRunner;
       TestApplicationWithNoBeans.class,
       DatabaseInfo.class,
       OperatePropertiesOverride.class,
+      SearchEngineConnectPropertiesOverride.class,
       CamundaSecurityProperties.class,
       UnifiedConfiguration.class,
       UnifiedConfigurationHelper.class

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/rest/ClientConfigRestServiceEnterpriseIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/rest/ClientConfigRestServiceEnterpriseIT.java
@@ -16,6 +16,7 @@ import io.camunda.application.commons.security.CamundaSecurityConfiguration.Camu
 import io.camunda.configuration.UnifiedConfiguration;
 import io.camunda.configuration.UnifiedConfigurationHelper;
 import io.camunda.configuration.beanoverrides.OperatePropertiesOverride;
+import io.camunda.configuration.beanoverrides.SearchEngineConnectPropertiesOverride;
 import io.camunda.operate.JacksonConfig;
 import io.camunda.operate.OperateProfileService;
 import io.camunda.operate.conditions.DatabaseInfo;
@@ -40,6 +41,7 @@ import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilde
       OperateDateTimeFormatter.class,
       DatabaseInfo.class,
       OperatePropertiesOverride.class,
+      SearchEngineConnectPropertiesOverride.class,
       CamundaSecurityProperties.class,
       UnifiedConfigurationHelper.class,
       UnifiedConfiguration.class

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/rest/ClientConfigRestServiceIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/rest/ClientConfigRestServiceIT.java
@@ -16,6 +16,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import io.camunda.configuration.UnifiedConfiguration;
 import io.camunda.configuration.UnifiedConfigurationHelper;
 import io.camunda.configuration.beanoverrides.OperatePropertiesOverride;
+import io.camunda.configuration.beanoverrides.SearchEngineConnectPropertiesOverride;
 import io.camunda.operate.JacksonConfig;
 import io.camunda.operate.OperateProfileService;
 import io.camunda.operate.conditions.DatabaseInfo;
@@ -47,6 +48,7 @@ import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilde
       OperateDateTimeFormatter.class,
       DatabaseInfo.class,
       OperatePropertiesOverride.class,
+      SearchEngineConnectPropertiesOverride.class,
       SecurityConfiguration.class,
       UnifiedConfiguration.class,
       UnifiedConfigurationHelper.class

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/rest/DecisionInstanceRestServiceIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/rest/DecisionInstanceRestServiceIT.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.when;
 import io.camunda.configuration.UnifiedConfiguration;
 import io.camunda.configuration.UnifiedConfigurationHelper;
 import io.camunda.configuration.beanoverrides.OperatePropertiesOverride;
+import io.camunda.configuration.beanoverrides.SearchEngineConnectPropertiesOverride;
 import io.camunda.operate.JacksonConfig;
 import io.camunda.operate.OperateProfileService;
 import io.camunda.operate.conditions.DatabaseInfo;
@@ -37,6 +38,7 @@ import org.springframework.test.web.servlet.MvcResult;
       OperateDateTimeFormatter.class,
       DatabaseInfo.class,
       OperatePropertiesOverride.class,
+      SearchEngineConnectPropertiesOverride.class,
       UnifiedConfigurationHelper.class,
       UnifiedConfiguration.class
     })

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/rest/DecisionRestServiceIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/rest/DecisionRestServiceIT.java
@@ -16,6 +16,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import io.camunda.configuration.UnifiedConfiguration;
 import io.camunda.configuration.UnifiedConfigurationHelper;
 import io.camunda.configuration.beanoverrides.OperatePropertiesOverride;
+import io.camunda.configuration.beanoverrides.SearchEngineConnectPropertiesOverride;
 import io.camunda.operate.JacksonConfig;
 import io.camunda.operate.OperateProfileService;
 import io.camunda.operate.conditions.DatabaseInfo;
@@ -46,6 +47,7 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
       OperateDateTimeFormatter.class,
       DatabaseInfo.class,
       OperatePropertiesOverride.class,
+      SearchEngineConnectPropertiesOverride.class,
       UnifiedConfiguration.class,
       UnifiedConfigurationHelper.class
     })

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/rest/FlowNodeInstanceRestServiceIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/rest/FlowNodeInstanceRestServiceIT.java
@@ -15,6 +15,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import io.camunda.configuration.UnifiedConfiguration;
 import io.camunda.configuration.UnifiedConfigurationHelper;
 import io.camunda.configuration.beanoverrides.OperatePropertiesOverride;
+import io.camunda.configuration.beanoverrides.SearchEngineConnectPropertiesOverride;
 import io.camunda.operate.JacksonConfig;
 import io.camunda.operate.OperateProfileService;
 import io.camunda.operate.conditions.DatabaseInfo;
@@ -43,6 +44,7 @@ import org.springframework.test.web.servlet.MvcResult;
       TestApplicationWithNoBeans.class,
       FlowNodeInstanceRestService.class,
       OperatePropertiesOverride.class,
+      SearchEngineConnectPropertiesOverride.class,
       OperateProfileService.class,
       JacksonConfig.class,
       OperateDateTimeFormatter.class,

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/rest/ProcessRestServiceIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/rest/ProcessRestServiceIT.java
@@ -16,6 +16,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import io.camunda.configuration.UnifiedConfiguration;
 import io.camunda.configuration.UnifiedConfigurationHelper;
 import io.camunda.configuration.beanoverrides.OperatePropertiesOverride;
+import io.camunda.configuration.beanoverrides.SearchEngineConnectPropertiesOverride;
 import io.camunda.operate.JacksonConfig;
 import io.camunda.operate.OperateProfileService;
 import io.camunda.operate.conditions.DatabaseInfo;
@@ -47,6 +48,7 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
       OperateDateTimeFormatter.class,
       DatabaseInfo.class,
       OperatePropertiesOverride.class,
+      SearchEngineConnectPropertiesOverride.class,
       UnifiedConfiguration.class,
       UnifiedConfigurationHelper.class
     })

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/TestApplication.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/TestApplication.java
@@ -11,6 +11,7 @@ import io.camunda.configuration.UnifiedConfiguration;
 import io.camunda.configuration.UnifiedConfigurationHelper;
 import io.camunda.configuration.beanoverrides.GatewayBasedPropertiesOverride;
 import io.camunda.configuration.beanoverrides.OperatePropertiesOverride;
+import io.camunda.configuration.beanoverrides.SearchEngineConnectPropertiesOverride;
 import io.camunda.operate.OperateModuleConfiguration;
 import io.camunda.webapps.WebappsModuleConfiguration;
 import org.springframework.boot.SpringApplication;
@@ -35,6 +36,7 @@ import org.springframework.context.annotation.Import;
 @Import({
   WebappsModuleConfiguration.class,
   OperatePropertiesOverride.class,
+  SearchEngineConnectPropertiesOverride.class,
   UnifiedConfiguration.class,
   UnifiedConfigurationHelper.class,
   GatewayBasedPropertiesOverride.class

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/apps/modules/ModulesTestApplication.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/apps/modules/ModulesTestApplication.java
@@ -11,6 +11,7 @@ import io.camunda.configuration.UnifiedConfiguration;
 import io.camunda.configuration.UnifiedConfigurationHelper;
 import io.camunda.configuration.beanoverrides.GatewayBasedPropertiesOverride;
 import io.camunda.configuration.beanoverrides.OperatePropertiesOverride;
+import io.camunda.configuration.beanoverrides.SearchEngineConnectPropertiesOverride;
 import io.camunda.operate.OperateModuleConfiguration;
 import io.camunda.operate.util.TestApplication;
 import io.camunda.webapps.WebappsModuleConfiguration;
@@ -47,6 +48,7 @@ import org.springframework.context.annotation.Import;
 @Import({
   WebappsModuleConfiguration.class,
   OperatePropertiesOverride.class,
+  SearchEngineConnectPropertiesOverride.class,
   UnifiedConfiguration.class,
   UnifiedConfigurationHelper.class,
   GatewayBasedPropertiesOverride.class,

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/migration/PrefixMigrationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/migration/PrefixMigrationIT.java
@@ -14,9 +14,9 @@ import static org.awaitility.Awaitility.await;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.dockerjava.api.command.CreateContainerCmd;
-import io.camunda.application.commons.search.SearchEngineDatabaseConfiguration.SearchEngineConnectProperties;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.response.ProcessInstanceEvent;
+import io.camunda.configuration.beans.SearchEngineConnectProperties;
 import io.camunda.exporter.adapters.ClientAdapter;
 import io.camunda.operate.property.OperateProperties;
 import io.camunda.qa.util.cluster.TestCamundaApplication;

--- a/qa/util/src/main/java/io/camunda/qa/util/cluster/TestCamundaApplication.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/cluster/TestCamundaApplication.java
@@ -20,6 +20,7 @@ import io.camunda.authentication.config.AuthenticationProperties;
 import io.camunda.configuration.UnifiedConfiguration;
 import io.camunda.configuration.UnifiedConfigurationHelper;
 import io.camunda.configuration.beanoverrides.OperatePropertiesOverride;
+import io.camunda.configuration.beanoverrides.SearchEngineConnectPropertiesOverride;
 import io.camunda.configuration.beanoverrides.TasklistPropertiesOverride;
 import io.camunda.configuration.beans.BrokerBasedProperties;
 import io.camunda.identity.IdentityModuleConfiguration;
@@ -72,6 +73,7 @@ public final class TestCamundaApplication extends TestSpringApplication<TestCamu
         UnifiedConfigurationHelper.class,
         TasklistPropertiesOverride.class,
         OperatePropertiesOverride.class,
+        SearchEngineConnectPropertiesOverride.class,
         UnifiedConfigurationHelper.class,
         // ---
         CommonsModuleConfiguration.class,

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/es/ElasticsearchConnectorIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/es/ElasticsearchConnectorIT.java
@@ -16,6 +16,7 @@ import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import io.camunda.configuration.UnifiedConfiguration;
 import io.camunda.configuration.UnifiedConfigurationHelper;
+import io.camunda.configuration.beanoverrides.SearchEngineConnectPropertiesOverride;
 import io.camunda.configuration.beanoverrides.TasklistPropertiesOverride;
 import io.camunda.search.connect.plugin.PluginConfiguration;
 import io.camunda.tasklist.connect.ElasticsearchConnector;
@@ -47,6 +48,7 @@ import org.testcontainers.utility.DockerImageName;
     classes = {
       ElasticsearchConnector.class,
       TasklistPropertiesOverride.class,
+      SearchEngineConnectPropertiesOverride.class,
       UnifiedConfiguration.class,
       UnifiedConfigurationHelper.class
     },

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/es/ElasticsearchConnectorSSLAuthIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/es/ElasticsearchConnectorSSLAuthIT.java
@@ -13,6 +13,7 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import io.camunda.configuration.UnifiedConfiguration;
 import io.camunda.configuration.UnifiedConfigurationHelper;
+import io.camunda.configuration.beanoverrides.SearchEngineConnectPropertiesOverride;
 import io.camunda.configuration.beanoverrides.TasklistPropertiesOverride;
 import io.camunda.tasklist.connect.ElasticsearchConnector;
 import io.camunda.tasklist.qa.util.TestUtil;
@@ -42,6 +43,7 @@ import org.testcontainers.utility.MountableFile;
       TestApplicationWithNoBeans.class,
       ElasticsearchConnector.class,
       TasklistPropertiesOverride.class,
+      SearchEngineConnectPropertiesOverride.class,
       UnifiedConfiguration.class,
       UnifiedConfigurationHelper.class
     })

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/it/ZeebeConnectorSecureIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/it/ZeebeConnectorSecureIT.java
@@ -14,6 +14,7 @@ import io.camunda.client.CamundaClient;
 import io.camunda.client.api.response.BrokerInfo;
 import io.camunda.configuration.UnifiedConfiguration;
 import io.camunda.configuration.UnifiedConfigurationHelper;
+import io.camunda.configuration.beanoverrides.SearchEngineConnectPropertiesOverride;
 import io.camunda.configuration.beanoverrides.TasklistPropertiesOverride;
 import io.camunda.tasklist.property.TasklistProperties;
 import io.camunda.tasklist.property.ZeebeProperties;
@@ -40,6 +41,7 @@ import org.testcontainers.utility.MountableFile;
     classes = {
       ZeebeConnector.class,
       TasklistPropertiesOverride.class,
+      SearchEngineConnectPropertiesOverride.class,
       UnifiedConfiguration.class,
       UnifiedConfigurationHelper.class
     },

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/management/HealthCheckIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/management/HealthCheckIT.java
@@ -16,6 +16,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 
 import io.camunda.configuration.UnifiedConfiguration;
 import io.camunda.configuration.UnifiedConfigurationHelper;
+import io.camunda.configuration.beanoverrides.SearchEngineConnectPropertiesOverride;
 import io.camunda.configuration.beanoverrides.TasklistPropertiesOverride;
 import io.camunda.tasklist.JacksonConfig;
 import io.camunda.tasklist.connect.ElasticsearchConnector;
@@ -43,6 +44,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
       ElasticsearchConnector.class,
       JacksonConfig.class,
       TasklistPropertiesOverride.class,
+      SearchEngineConnectPropertiesOverride.class,
       UnifiedConfiguration.class,
       UnifiedConfigurationHelper.class
     },

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/os/OpenSearchConnectorSSLAuthIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/os/OpenSearchConnectorSSLAuthIT.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.configuration.UnifiedConfiguration;
 import io.camunda.configuration.UnifiedConfigurationHelper;
+import io.camunda.configuration.beanoverrides.SearchEngineConnectPropertiesOverride;
 import io.camunda.configuration.beanoverrides.TasklistPropertiesOverride;
 import io.camunda.tasklist.util.TasklistIntegrationTest;
 import io.camunda.tasklist.util.apps.nobeans.TestApplicationWithNoBeans;
@@ -39,6 +40,7 @@ import org.testcontainers.utility.MountableFile;
       TestApplicationWithNoBeans.class,
       OpenSearchConnector.class,
       TasklistPropertiesOverride.class,
+      SearchEngineConnectPropertiesOverride.class,
       UnifiedConfiguration.class,
       UnifiedConfigurationHelper.class
     })

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/os/OpensearchConnectorIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/os/OpensearchConnectorIT.java
@@ -15,6 +15,7 @@ import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import io.camunda.configuration.UnifiedConfiguration;
 import io.camunda.configuration.UnifiedConfigurationHelper;
+import io.camunda.configuration.beanoverrides.SearchEngineConnectPropertiesOverride;
 import io.camunda.configuration.beanoverrides.TasklistPropertiesOverride;
 import io.camunda.search.connect.plugin.PluginConfiguration;
 import io.camunda.tasklist.JacksonConfig;
@@ -45,6 +46,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
       OpenSearchConnector.class,
       JacksonConfig.class,
       TasklistPropertiesOverride.class,
+      SearchEngineConnectPropertiesOverride.class,
       UnifiedConfiguration.class,
       UnifiedConfigurationHelper.class
     },

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/properties/PropertiesTest.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/properties/PropertiesTest.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.configuration.UnifiedConfiguration;
 import io.camunda.configuration.UnifiedConfigurationHelper;
+import io.camunda.configuration.beanoverrides.SearchEngineConnectPropertiesOverride;
 import io.camunda.configuration.beanoverrides.TasklistPropertiesOverride;
 import io.camunda.tasklist.property.TasklistProperties;
 import io.camunda.tasklist.util.apps.nobeans.TestApplicationWithNoBeans;
@@ -26,6 +27,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
     classes = {
       TestApplicationWithNoBeans.class,
       TasklistPropertiesOverride.class,
+      SearchEngineConnectPropertiesOverride.class,
       UnifiedConfiguration.class,
       UnifiedConfigurationHelper.class
     },

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TestApplication.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TestApplication.java
@@ -11,6 +11,7 @@ import io.camunda.application.commons.CommonsModuleConfiguration;
 import io.camunda.configuration.UnifiedConfiguration;
 import io.camunda.configuration.UnifiedConfigurationHelper;
 import io.camunda.configuration.beanoverrides.GatewayBasedPropertiesOverride;
+import io.camunda.configuration.beanoverrides.SearchEngineConnectPropertiesOverride;
 import io.camunda.configuration.beanoverrides.TasklistPropertiesOverride;
 import io.camunda.tasklist.TasklistModuleConfiguration;
 import io.camunda.tasklist.data.DataGenerator;
@@ -43,6 +44,7 @@ import org.springframework.context.annotation.Profile;
   WebappsModuleConfiguration.class,
   CommonsModuleConfiguration.class,
   TasklistPropertiesOverride.class,
+  SearchEngineConnectPropertiesOverride.class,
   UnifiedConfiguration.class,
   UnifiedConfigurationHelper.class,
   GatewayBasedPropertiesOverride.class

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/apps/modules/ModulesTestApplication.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/apps/modules/ModulesTestApplication.java
@@ -10,6 +10,7 @@ package io.camunda.tasklist.util.apps.modules;
 import io.camunda.configuration.UnifiedConfiguration;
 import io.camunda.configuration.UnifiedConfigurationHelper;
 import io.camunda.configuration.beanoverrides.GatewayBasedPropertiesOverride;
+import io.camunda.configuration.beanoverrides.SearchEngineConnectPropertiesOverride;
 import io.camunda.configuration.beanoverrides.TasklistPropertiesOverride;
 import io.camunda.tasklist.TasklistModuleConfiguration;
 import io.camunda.tasklist.data.DataGenerator;
@@ -61,6 +62,7 @@ import org.springframework.context.annotation.Profile;
   ImporterSecurityModuleConfiguration.class,
   WebappManagementModuleConfiguration.class,
   TasklistPropertiesOverride.class,
+  SearchEngineConnectPropertiesOverride.class,
   UnifiedConfiguration.class,
   UnifiedConfigurationHelper.class,
   GatewayBasedPropertiesOverride.class,

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/rest/ClientConfigRestServiceIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/rest/ClientConfigRestServiceIT.java
@@ -14,6 +14,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import io.camunda.configuration.UnifiedConfiguration;
 import io.camunda.configuration.UnifiedConfigurationHelper;
+import io.camunda.configuration.beanoverrides.SearchEngineConnectPropertiesOverride;
 import io.camunda.configuration.beanoverrides.TasklistPropertiesOverride;
 import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.tasklist.property.TasklistProperties;
@@ -41,6 +42,7 @@ import org.springframework.web.context.WebApplicationContext;
       ClientConfigRestService.class,
       SecurityConfiguration.class,
       TasklistPropertiesOverride.class,
+      SearchEngineConnectPropertiesOverride.class,
       UnifiedConfiguration.class,
       UnifiedConfigurationHelper.class
     },

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestPrefixMigrationApp.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestPrefixMigrationApp.java
@@ -10,7 +10,7 @@ package io.camunda.zeebe.qa.util.cluster;
 import io.atomix.cluster.MemberId;
 import io.camunda.application.StandalonePrefixMigration;
 import io.camunda.application.commons.search.SearchEngineDatabaseConfiguration;
-import io.camunda.application.commons.search.SearchEngineDatabaseConfiguration.SearchEngineConnectProperties;
+import io.camunda.configuration.beans.SearchEngineConnectProperties;
 import io.camunda.operate.property.OperateProperties;
 import io.camunda.tasklist.property.TasklistProperties;
 import io.camunda.zeebe.qa.util.actuator.HealthActuator;

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneBroker.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneBroker.java
@@ -13,12 +13,12 @@ import static io.camunda.spring.utils.DatabaseTypeUtils.UNIFIED_CONFIG_PROPERTY_
 import io.atomix.cluster.MemberId;
 import io.camunda.application.Profile;
 import io.camunda.application.commons.CommonsModuleConfiguration;
-import io.camunda.application.commons.search.SearchEngineDatabaseConfiguration.SearchEngineConnectProperties;
 import io.camunda.application.commons.security.CamundaSecurityConfiguration.CamundaSecurityProperties;
 import io.camunda.authentication.config.AuthenticationProperties;
 import io.camunda.configuration.UnifiedConfiguration;
 import io.camunda.configuration.UnifiedConfigurationHelper;
 import io.camunda.configuration.beans.BrokerBasedProperties;
+import io.camunda.configuration.beans.SearchEngineConnectProperties;
 import io.camunda.security.configuration.ConfiguredMappingRule;
 import io.camunda.security.configuration.ConfiguredUser;
 import io.camunda.security.configuration.InitializationConfiguration;

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneGateway.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneGateway.java
@@ -17,6 +17,7 @@ import io.camunda.configuration.beanoverrides.ActorClockControlledPropertiesOver
 import io.camunda.configuration.beanoverrides.BrokerBasedPropertiesOverride;
 import io.camunda.configuration.beanoverrides.IdleStrategyPropertiesOverride;
 import io.camunda.configuration.beanoverrides.OperatePropertiesOverride;
+import io.camunda.configuration.beanoverrides.SearchEngineConnectPropertiesOverride;
 import io.camunda.configuration.beanoverrides.TasklistPropertiesOverride;
 import io.camunda.configuration.beans.GatewayBasedProperties;
 import io.camunda.zeebe.gateway.GatewayModuleConfiguration;
@@ -37,7 +38,9 @@ public final class TestStandaloneGateway extends TestSpringApplication<TestStand
         UnifiedConfiguration.class,
         UnifiedConfigurationHelper.class,
         TasklistPropertiesOverride.class,
+        SearchEngineConnectPropertiesOverride.class,
         OperatePropertiesOverride.class,
+        SearchEngineConnectPropertiesOverride.class,
         BrokerBasedPropertiesOverride.class,
         ActorClockControlledPropertiesOverride.class,
         IdleStrategyPropertiesOverride.class);


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
This PR takes care of patching the SearchEngineConnectProperties object with the secondary-storage DB type and URL.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

related to [#34902](https://github.com/camunda/camunda/issues/34902)
closes #
