### PR TITLE
feat: retry batch operation initialization query on secondary db fail

### DIFF
--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -1455,6 +1455,22 @@
           # The default value is 1000, which is also the maximum supported by OracleDb.
           # queryInClauseSize: 1000
 
+          # Allows to configure the number of retries in case a query to the secondary database fails.
+          # The default value is 2, which means that in worst case the engine will query up to 3 times.
+          # queryRetryMax: 2
+
+          # Allows to configure the initial delay between retries in case a query to the secondary database fails.
+          # The default value is 1 second
+          # queryRetryInitialDelay: PT1S
+
+          # Allows to configure the max delay between retries in case a query to the secondary database fails.
+          # The default value is 60 second
+          # queryRetryMaxDelay: PT60S
+
+          # Allows to configure the factor by which the delay between retries is increased.
+          # The default value is 2, which means that the delay will be doubled after each retry.
+          # queryRetryBackoffFactor: 2
+
       # Allows to configure feature flags. These are used to test new features in dev and int environments prior
       # to rolling them out to production
       # features:

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -1369,6 +1369,22 @@
           # The default value is 1000, which is also the maximum supported by OracleDb.
           # queryInClauseSize: 1000
 
+          # Allows to configure the number of retries in case a query to the secondary database fails.
+          # The default value is 2, which means that in worst case the engine will query up to 3 times.
+          # queryRetryMax: 2
+
+          # Allows to configure the initial delay between retries in case a query to the secondary database fails.
+          # The default value is 1 second
+          # queryRetryInitialDelay: PT1S
+
+          # Allows to configure the max delay between retries in case a query to the secondary database fails.
+          # The default value is 60 second
+          # queryRetryMaxDelay: PT60S
+
+          # Allows to configure the factor by which the delay between retries is increased.
+          # The default value is 2, which means that the delay will be doubled after each retry.
+          # queryRetryBackoffFactor: 2
+
         # Allows to configure the maximum depth of child process instances that can be created.
         # The root process instance is considered depth `1`, and each called instance is considered
         # to be one level deeper. If a call activity attempts to create a child process instance

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
@@ -289,6 +289,42 @@ public final class SystemContext {
               config.getChunkSize()));
     }
 
+    if (config.getQueryRetryMax() < 0) {
+      errors.add(
+          String.format(
+              "experimental.engine.batchOperation.queryRetryMax must be greater than or equal to 0, but was %s",
+              config.getQueryRetryMax()));
+    }
+
+    if (config.getQueryRetryInitialDelay().isNegative()
+        || config.getQueryRetryInitialDelay().isZero()) {
+      errors.add(
+          String.format(
+              "experimental.engine.batchOperation.queryRetryInitialDelay must be positive, but was %s",
+              config.getQueryRetryInitialDelay()));
+    }
+
+    if (config.getQueryRetryMaxDelay().isNegative() || config.getQueryRetryMaxDelay().isZero()) {
+      errors.add(
+          String.format(
+              "experimental.engine.batchOperation.queryRetryMaxDelay must be positive, but was %s",
+              config.getQueryRetryMaxDelay()));
+    }
+
+    if (config.getQueryRetryMaxDelay().compareTo(config.getQueryRetryInitialDelay()) < 0) {
+      errors.add(
+          String.format(
+              "experimental.engine.batchOperation.queryRetryMaxDelay must be greater than or equal to the experimental.engine.batchOperation.queryRetryInitialDelay of %s, but was %s",
+              config.getQueryRetryInitialDelay(), config.getQueryRetryMaxDelay()));
+    }
+
+    if (config.getQueryRetryBackoffFactor() < 1) {
+      errors.add(
+          String.format(
+              "experimental.engine.batchOperation.queryRetryBackoffFactor must be greater than or equal to 1, but was %s",
+              config.getQueryRetryBackoffFactor()));
+    }
+
     if (!errors.isEmpty()) {
       throw new InvalidConfigurationException(
           "Invalid BatchOperations configuration: " + String.join(", ", errors), null);

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/BatchOperationCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/BatchOperationCfg.java
@@ -26,6 +26,14 @@ public class BatchOperationCfg implements ConfigurationEntry {
   private int queryPageSize = EngineConfiguration.DEFAULT_BATCH_OPERATION_QUERY_PAGE_SIZE;
   private int queryInClauseSize = EngineConfiguration.DEFAULT_BATCH_OPERATION_QUERY_IN_CLAUSE_SIZE;
 
+  private int queryRetryMax = EngineConfiguration.DEFAULT_BATCH_OPERATION_QUERY_RETRY_MAX;
+  private Duration queryRetryInitialDelay =
+      EngineConfiguration.DEFAULT_BATCH_OPERATION_QUERY_RETRY_INITIAL_DELAY;
+  private Duration queryRetryMaxDelay =
+      EngineConfiguration.DEFAULT_BATCH_OPERATION_QUERY_RETRY_MAX_DELAY;
+  private int queryRetryBackoffFactor =
+      EngineConfiguration.DEFAULT_BATCH_OPERATION_QUERY_RETRY_BACKOFF_FACTOR;
+
   public Duration getSchedulerInterval() {
     return schedulerInterval;
   }
@@ -66,6 +74,38 @@ public class BatchOperationCfg implements ConfigurationEntry {
     this.queryInClauseSize = queryInClauseSize;
   }
 
+  public int getQueryRetryMax() {
+    return queryRetryMax;
+  }
+
+  public void setQueryRetryMax(final int queryRetryMax) {
+    this.queryRetryMax = queryRetryMax;
+  }
+
+  public Duration getQueryRetryInitialDelay() {
+    return queryRetryInitialDelay;
+  }
+
+  public void setQueryRetryInitialDelay(final Duration queryRetryMaxDelay) {
+    queryRetryInitialDelay = queryRetryMaxDelay;
+  }
+
+  public Duration getQueryRetryMaxDelay() {
+    return queryRetryMaxDelay;
+  }
+
+  public void setQueryRetryMaxDelay(final Duration queryRetryMaxDelay) {
+    this.queryRetryMaxDelay = queryRetryMaxDelay;
+  }
+
+  public int getQueryRetryBackoffFactor() {
+    return queryRetryBackoffFactor;
+  }
+
+  public void setQueryRetryBackoffFactor(final int queryRetryBackoffFactor) {
+    this.queryRetryBackoffFactor = queryRetryBackoffFactor;
+  }
+
   @Override
   public String toString() {
     return "BatchOperationCfg{"
@@ -79,6 +119,14 @@ public class BatchOperationCfg implements ConfigurationEntry {
         + queryPageSize
         + ", queryInClauseSize="
         + queryInClauseSize
+        + ", queryRetryMax="
+        + queryRetryMax
+        + ", queryRetryInitialDelay="
+        + queryRetryInitialDelay
+        + ", queryRetryMaxDelay="
+        + queryRetryMaxDelay
+        + ", queryRetryBackoffFactor="
+        + queryRetryBackoffFactor
         + '}';
   }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/EngineCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/EngineCfg.java
@@ -135,6 +135,10 @@ public final class EngineCfg implements ConfigurationEntry {
         .setBatchOperationDbChunkSize(batchOperations.getDbChunkSize())
         .setBatchOperationQueryPageSize(batchOperations.getQueryPageSize())
         .setBatchOperationQueryInClauseSize(batchOperations.getQueryInClauseSize())
+        .setBatchOperationQueryRetryMax(batchOperations.getQueryRetryMax())
+        .setBatchOperationQueryRetryInitialDelay(batchOperations.getQueryRetryInitialDelay())
+        .setBatchOperationQueryRetryMaxDelay(batchOperations.getQueryRetryMaxDelay())
+        .setBatchOperationQueryRetryBackoffFactor(batchOperations.getQueryRetryBackoffFactor())
         .setUsageMetricsExportInterval(usageMetrics.getExportInterval())
         .setCommandDistributionPaused(distribution.isPauseCommandDistribution())
         .setMaxProcessDepth(getMaxProcessDepth());

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/SystemContextTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/SystemContextTest.java
@@ -532,4 +532,86 @@ final class SystemContextTest {
         .hasMessageContaining(
             "experimental.engine.batchOperation.queryInClauseSize must be greater than 0");
   }
+
+  @Test
+  void shouldThrowExceptionIfBatchOperationQueryRetryMaxIsInvalid() {
+    // given
+    final BrokerCfg brokerCfg = new BrokerCfg();
+    brokerCfg.getExperimental().getEngine().getBatchOperations().setQueryRetryMax(-1);
+
+    // when - then
+    assertThatCode(() -> initSystemContext(brokerCfg))
+        .isInstanceOf(InvalidConfigurationException.class)
+        .hasMessageContaining(
+            "experimental.engine.batchOperation.queryRetryMax must be greater than or equal to 0");
+  }
+
+  @Test
+  void shouldThrowExceptionIfBatchOperationQueryRetryBackoffFactorInvalid() {
+    // given
+    final BrokerCfg brokerCfg = new BrokerCfg();
+    brokerCfg.getExperimental().getEngine().getBatchOperations().setQueryRetryBackoffFactor(0);
+
+    // when - then
+    assertThatCode(() -> initSystemContext(brokerCfg))
+        .isInstanceOf(InvalidConfigurationException.class)
+        .hasMessageContaining(
+            "experimental.engine.batchOperation.queryRetryBackoffFactor must be greater than or equal to");
+  }
+
+  @Test
+  void shouldThrowExceptionIfBatchOperationQueryRetryInitialDelayIsInvalid() {
+    // given
+    final BrokerCfg brokerCfg = new BrokerCfg();
+    brokerCfg
+        .getExperimental()
+        .getEngine()
+        .getBatchOperations()
+        .setQueryRetryInitialDelay(Duration.ofMillis(-1000));
+
+    // when - then
+    assertThatCode(() -> initSystemContext(brokerCfg))
+        .isInstanceOf(InvalidConfigurationException.class)
+        .hasMessageContaining(
+            "experimental.engine.batchOperation.queryRetryInitialDelay must be positive");
+  }
+
+  @Test
+  void shouldThrowExceptionIfBatchOperationQueryRetryMaxDelayIsInvalid() {
+    // given
+    final BrokerCfg brokerCfg = new BrokerCfg();
+    brokerCfg
+        .getExperimental()
+        .getEngine()
+        .getBatchOperations()
+        .setQueryRetryMaxDelay(Duration.ofMillis(-1000));
+
+    // when - then
+    assertThatCode(() -> initSystemContext(brokerCfg))
+        .isInstanceOf(InvalidConfigurationException.class)
+        .hasMessageContaining(
+            "experimental.engine.batchOperation.queryRetryMaxDelay must be positive");
+  }
+
+  @Test
+  void shouldThrowExceptionIfBatchOperationQueryRetryMaxDelayIsLowerThanInitialDelay() {
+    // given
+    final BrokerCfg brokerCfg = new BrokerCfg();
+    brokerCfg
+        .getExperimental()
+        .getEngine()
+        .getBatchOperations()
+        .setQueryRetryInitialDelay(Duration.ofMillis(1000));
+    brokerCfg
+        .getExperimental()
+        .getEngine()
+        .getBatchOperations()
+        .setQueryRetryMaxDelay(Duration.ofMillis(500));
+
+    // when - then
+    assertThatCode(() -> initSystemContext(brokerCfg))
+        .isInstanceOf(InvalidConfigurationException.class)
+        .hasMessageContaining(
+            "experimental.engine.batchOperation.queryRetryMaxDelay must be greater than or equal to the experimental.engine.batchOperation.queryRetryInitialDelay");
+  }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/EngineConfiguration.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/EngineConfiguration.java
@@ -40,6 +40,12 @@ public final class EngineConfiguration {
   public static final int DEFAULT_BATCH_OPERATION_QUERY_PAGE_SIZE = 10000;
   // Oracle can only have 1000 elements in `IN` clause
   public static final int DEFAULT_BATCH_OPERATION_QUERY_IN_CLAUSE_SIZE = 1000;
+  public static final int DEFAULT_BATCH_OPERATION_QUERY_RETRY_MAX = 0;
+  public static final Duration DEFAULT_BATCH_OPERATION_QUERY_RETRY_INITIAL_DELAY =
+      Duration.ofSeconds(1);
+  public static final Duration DEFAULT_BATCH_OPERATION_QUERY_RETRY_MAX_DELAY =
+      Duration.ofSeconds(60);
+  public static final int DEFAULT_BATCH_OPERATION_QUERY_RETRY_BACKOFF_FACTOR = 2;
   public static final boolean DEFAULT_COMMAND_DISTRIBUTION_PAUSED = false;
 
   private int messagesTtlCheckerBatchLimit = DEFAULT_MESSAGES_TTL_CHECKER_BATCH_LIMIT;
@@ -63,6 +69,12 @@ public final class EngineConfiguration {
   private int batchOperationDbChunkSize = DEFAULT_BATCH_OPERATION_DB_CHUNK_SIZE;
   private int batchOperationQueryPageSize = DEFAULT_BATCH_OPERATION_QUERY_PAGE_SIZE;
   private int batchOperationQueryInClauseSize = DEFAULT_BATCH_OPERATION_QUERY_IN_CLAUSE_SIZE;
+  private int batchOperationQueryRetryMax = DEFAULT_BATCH_OPERATION_QUERY_RETRY_MAX;
+  private Duration batchOperationQueryRetryInitialDelay =
+      DEFAULT_BATCH_OPERATION_QUERY_RETRY_INITIAL_DELAY;
+  private Duration batchOperationQueryRetryMaxDelay = DEFAULT_BATCH_OPERATION_QUERY_RETRY_MAX_DELAY;
+  private int batchOperationQueryRetryBackoffFactor =
+      DEFAULT_BATCH_OPERATION_QUERY_RETRY_BACKOFF_FACTOR;
 
   private Duration usageMetricsExportInterval = DEFAULT_USAGE_METRICS_EXPORT_INTERVAL;
 
@@ -215,6 +227,45 @@ public final class EngineConfiguration {
   public EngineConfiguration setBatchOperationQueryInClauseSize(
       final int batchOperationQueryInClauseSize) {
     this.batchOperationQueryInClauseSize = batchOperationQueryInClauseSize;
+    return this;
+  }
+
+  public int getBatchOperationQueryRetryMax() {
+    return batchOperationQueryRetryMax;
+  }
+
+  public EngineConfiguration setBatchOperationQueryRetryMax(final int batchOperationQueryRetryMax) {
+    this.batchOperationQueryRetryMax = batchOperationQueryRetryMax;
+    return this;
+  }
+
+  public Duration getBatchOperationQueryRetryInitialDelay() {
+    return batchOperationQueryRetryInitialDelay;
+  }
+
+  public EngineConfiguration setBatchOperationQueryRetryInitialDelay(
+      final Duration batchOperationQueryRetryInitialDelay) {
+    this.batchOperationQueryRetryInitialDelay = batchOperationQueryRetryInitialDelay;
+    return this;
+  }
+
+  public Duration getBatchOperationQueryRetryMaxDelay() {
+    return batchOperationQueryRetryMaxDelay;
+  }
+
+  public EngineConfiguration setBatchOperationQueryRetryMaxDelay(
+      final Duration batchOperationQueryRetryMaxDelay) {
+    this.batchOperationQueryRetryMaxDelay = batchOperationQueryRetryMaxDelay;
+    return this;
+  }
+
+  public int getBatchOperationQueryRetryBackoffFactor() {
+    return batchOperationQueryRetryBackoffFactor;
+  }
+
+  public EngineConfiguration setBatchOperationQueryRetryBackoffFactor(
+      final int batchOperationQueryRetryBackoffFactor) {
+    this.batchOperationQueryRetryBackoffFactor = batchOperationQueryRetryBackoffFactor;
     return this;
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationExecutionScheduler.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationExecutionScheduler.java
@@ -7,42 +7,29 @@
  */
 package io.camunda.zeebe.engine.processing.batchoperation;
 
-import com.google.common.collect.Lists;
+import com.google.common.base.Strings;
+import com.google.common.math.IntMath;
+import io.camunda.search.exception.CamundaSearchException;
+import io.camunda.search.exception.CamundaSearchException.Reason;
 import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.metrics.BatchOperationMetrics;
-import io.camunda.zeebe.engine.processing.batchoperation.itemprovider.ItemProvider.Item;
-import io.camunda.zeebe.engine.processing.batchoperation.itemprovider.ItemProvider.ItemPage;
 import io.camunda.zeebe.engine.processing.batchoperation.itemprovider.ItemProviderFactory;
 import io.camunda.zeebe.engine.state.batchoperation.PersistedBatchOperation;
 import io.camunda.zeebe.engine.state.immutable.BatchOperationState;
 import io.camunda.zeebe.engine.state.immutable.ScheduledTaskState;
-import io.camunda.zeebe.msgpack.value.StringValue;
-import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
-import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationChunkRecord;
-import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationError;
-import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationExecutionRecord;
-import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationInitializationRecord;
-import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationItem;
-import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationPartitionLifecycleRecord;
-import io.camunda.zeebe.protocol.record.intent.BatchOperationChunkIntent;
-import io.camunda.zeebe.protocol.record.intent.BatchOperationExecutionIntent;
-import io.camunda.zeebe.protocol.record.intent.BatchOperationIntent;
 import io.camunda.zeebe.protocol.record.value.BatchOperationErrorType;
-import io.camunda.zeebe.stream.api.FollowUpCommandMetadata;
 import io.camunda.zeebe.stream.api.ReadonlyStreamProcessorContext;
 import io.camunda.zeebe.stream.api.StreamProcessorLifecycleAware;
 import io.camunda.zeebe.stream.api.scheduling.AsyncTaskGroup;
 import io.camunda.zeebe.stream.api.scheduling.TaskResult;
 import io.camunda.zeebe.stream.api.scheduling.TaskResultBuilder;
 import java.time.Duration;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
-import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -60,25 +47,18 @@ public class BatchOperationExecutionScheduler implements StreamProcessorLifecycl
   public static final String ERROR_MSG_FAILED_FIRST_CHUNK_APPEND =
       "Unable to append first chunk of batch operation items. Number of items: %d";
   private static final Logger LOG = LoggerFactory.getLogger(BatchOperationExecutionScheduler.class);
-
-  private static final UnifiedRecordValue EMPTY_EXECUTION_RECORD =
-      new BatchOperationExecutionRecord().setBatchOperationKey(-1L);
-  private static final UnifiedRecordValue EMPTY_INITIALIZATION_RECORD =
-      new BatchOperationInitializationRecord()
-          .setBatchOperationKey(-1L)
-          .setSearchQueryPageSize(0) // random int
-          // random cursor string. 1024 chars should be enough for any cursor without sorting
-          .setSearchResultCursor(RandomStringUtils.insecure().next(1024));
-
-  private final Duration pollingInterval;
-  private final int chunkSize;
-  private final int queryPageSize;
+  private static final Set<Reason> FAIL_IMMEDIATELY_REASONS =
+      Set.of(
+          Reason.NOT_FOUND, Reason.NOT_UNIQUE, Reason.SECONDARY_STORAGE_NOT_SET, Reason.FORBIDDEN);
+  private final Duration initialPollingInterval;
+  private final Duration initialRetryDelay;
+  private final Duration maxRetryDelay;
+  private final int maxRetries;
+  private final int backoffFactor;
 
   private final BatchOperationState batchOperationState;
   private ReadonlyStreamProcessorContext processingContext;
-  private final ItemProviderFactory itemProviderFactory;
-  private final BatchOperationMetrics metrics;
-  private final int partitionId;
+  private final BatchOperationInitializer batchOperationInitializer;
 
   /** Marks if this scheduler is currently executing or not. */
   private final AtomicBoolean executing = new AtomicBoolean(false);
@@ -92,31 +72,33 @@ public class BatchOperationExecutionScheduler implements StreamProcessorLifecycl
       final int partitionId,
       final BatchOperationMetrics metrics) {
     batchOperationState = scheduledTaskStateFactory.get().getBatchOperationState();
-    this.itemProviderFactory = itemProviderFactory;
-    pollingInterval = engineConfiguration.getBatchOperationSchedulerInterval();
-    chunkSize = engineConfiguration.getBatchOperationChunkSize();
-    queryPageSize = engineConfiguration.getBatchOperationQueryPageSize();
-    this.metrics = metrics;
-    this.partitionId = partitionId;
+    initialPollingInterval = engineConfiguration.getBatchOperationSchedulerInterval();
+    initialRetryDelay = engineConfiguration.getBatchOperationQueryRetryInitialDelay();
+    maxRetryDelay = engineConfiguration.getBatchOperationQueryRetryMaxDelay();
+    maxRetries = engineConfiguration.getBatchOperationQueryRetryMax();
+    backoffFactor = engineConfiguration.getBatchOperationQueryRetryBackoffFactor();
+    batchOperationInitializer =
+        new BatchOperationInitializer(
+            itemProviderFactory, engineConfiguration, partitionId, metrics);
   }
 
   @Override
   public void onRecovered(final ReadonlyStreamProcessorContext context) {
     processingContext = context;
-    scheduleExecution();
+    scheduleExecution(initialPollingInterval);
   }
 
   @Override
   public void onResumed() {
-    scheduleExecution();
+    scheduleExecution(initialPollingInterval);
   }
 
   /** Schedules the next execution of the batch operation scheduler run. */
-  private void scheduleExecution() {
+  private void scheduleExecution(final Duration nextDelay) {
     if (!executing.get()) {
       processingContext
           .getScheduleService()
-          .runDelayedAsync(pollingInterval, this::execute, AsyncTaskGroup.BATCH_OPERATIONS);
+          .runDelayedAsync(nextDelay, this::execute, AsyncTaskGroup.BATCH_OPERATIONS);
     } else {
       LOG.warn("Execution is already in progress, skipping scheduling.");
     }
@@ -130,76 +112,69 @@ public class BatchOperationExecutionScheduler implements StreamProcessorLifecycl
    * @return the task result containing the commands to be executed
    */
   private TaskResult execute(final TaskResultBuilder taskResultBuilder) {
+    var nextDelay = initialPollingInterval;
     try {
       LOG.trace("Looking for the next pending batch operation to execute (scheduled).");
       executing.set(true);
-      batchOperationState
-          .getNextPendingBatchOperation()
-          .ifPresent(bo -> initializeBatchOperation(bo, taskResultBuilder));
-      return taskResultBuilder.build();
+      nextDelay =
+          executeRetrying(batchOperationState.getNextPendingBatchOperation(), taskResultBuilder);
     } finally {
       executing.set(false);
-      scheduleExecution();
+      scheduleExecution(nextDelay);
     }
+    return taskResultBuilder.build();
   }
 
-  private void initializeBatchOperation(
-      final PersistedBatchOperation batchOperation, final TaskResultBuilder taskResultBuilder) {
-    if (batchOperation.isSuspended()) {
-      LOG.trace("Batch operation {} is suspended.", batchOperation.getKey());
-      return;
+  private Duration executeRetrying(
+      final Optional<PersistedBatchOperation> batchOperation,
+      final TaskResultBuilder taskResultBuilder) {
+    if (batchOperation.isEmpty()) {
+      return initialPollingInterval;
     }
 
-    if (!validateNoReInitialization(batchOperation)) {
-      return;
+    if (!validateNoReInitialization(batchOperation.get())) {
+      return initialPollingInterval;
     }
 
-    final var itemProvider = itemProviderFactory.fromBatchOperation(batchOperation);
-
-    // use overall state variable for all parameters that are used in the loop
-    final InitLoopState loopState = new InitLoopState(batchOperation);
-    while (loopState.hasNextPage()) {
-      try {
-        loopState.page =
-            itemProvider.fetchItemPage(
-                loopState.lastSearchResultCursor, loopState.searchResultPageSize);
-      } catch (final Exception e) {
-        LOG.error(
-            "Failed to query keys for batch operation with key {}. It will be removed from queue",
-            batchOperation.getKey(),
-            e);
-        appendFailedCommand(
+    final var result =
+        batchOperationInitializer.initializeBatchOperation(batchOperation.get(), taskResultBuilder);
+    if (!result.isSuccess()) {
+      if (shouldFailImmediately(result.exception())
+          || initializing.get().numAttempts >= maxRetries) {
+        batchOperationInitializer.appendFailedCommand(
             taskResultBuilder,
-            batchOperation,
-            ExceptionUtils.getStackTrace(e),
+            batchOperation.get(),
+            ExceptionUtils.getStackTrace(result.exception()),
             BatchOperationErrorType.QUERY_FAILED);
-        return;
+        return initialPollingInterval;
       }
-
-      // Then try to append the items to the batch operation
-      final boolean appendedChunks =
-          appendChunks(batchOperation, taskResultBuilder, loopState.page.items());
-      if (appendedChunks) {
-        // everything went normally, so we can continue with the next page in the next loop
-
-        loopState.chunksAppendedThisRun = true;
-        loopState.lastSearchResultCursor = loopState.page.endCursor();
-        loopState.keysAdded += loopState.page.items().size();
-        if (loopState.page.isLastPage()) {
-          // If we have reached the last page, we can finalize the initialization and start the BO
-          // we always append the EXECUTE command at the end, even if no items were found, so we can
-          // leave the completion logic in that processor.
-          finishInitialization(loopState.batchOperation, taskResultBuilder);
-          startExecutionPhase(taskResultBuilder, loopState);
-
-          // this is the end of the initialization run, so we can break out of the loop
-          return;
-        }
-      } else {
-        handleFailedChunkAppend(taskResultBuilder, loopState);
-        return;
-      }
+      final var calculatedRetryDelay =
+          initialRetryDelay.multipliedBy(
+              IntMath.pow(backoffFactor, initializing.get().numAttempts()));
+      final var nextRetryDelay =
+          maxRetryDelay.compareTo(calculatedRetryDelay) < 0 ? maxRetryDelay : calculatedRetryDelay;
+      LOG.warn(
+          "Retryable operation failed, retries left: {}, retrying in {} ms. Error: {}",
+          initializing.get().numAttempts(),
+          nextRetryDelay,
+          result.exception().getLocalizedMessage());
+      initializing.set(
+          new ExecutionLoopState(
+              initializing.get().batchOperationKey,
+              Strings.nullToEmpty(initializing.get().searchResultCursor),
+              initializing.get().numAttempts() + 1));
+      return nextRetryDelay;
+    } else {
+      initializing.set(
+          new ExecutionLoopState(result.batchOperationKey(), result.searchResultCursor(), 0));
     }
+
+    return initialPollingInterval;
+  }
+
+  private boolean shouldFailImmediately(final Exception exception) {
+    return exception instanceof CamundaSearchException
+        && FAIL_IMMEDIATELY_REASONS.contains(((CamundaSearchException) exception).getReason());
   }
 
   private boolean validateNoReInitialization(final PersistedBatchOperation batchOperation) {
@@ -207,227 +182,23 @@ public class BatchOperationExecutionScheduler implements StreamProcessorLifecycl
     if (initializingBO != null
         && initializingBO.batchOperationKey == batchOperation.getKey()
         && !Objects.equals(
-            initializingBO.searchResultCursor, batchOperation.getInitializationSearchCursor())) {
+            initializingBO.searchResultCursor, batchOperation.getInitializationSearchCursor())
+        && initializingBO.numAttempts == 0) {
       // If the batch operation is already being initialized, we do not re-initialize it.
       LOG.trace(
           "Batch operation {} is already being executed, skipping re-initialization.",
           batchOperation.getKey());
       return false;
+    } else if (initializingBO == null) {
+      initializing.set(new ExecutionLoopState(batchOperation));
     }
-    initializing.set(
-        new ExecutionLoopState(
-            batchOperation.getKey(), batchOperation.getInitializationSearchCursor(), 0));
 
     return true;
   }
 
-  private void startExecutionPhase(
-      final TaskResultBuilder resultBuilder, final InitLoopState state) {
-    appendExecution(state.batchOperation.getKey(), resultBuilder);
-
-    // start some metrics for the execution phase
-    metrics.recordItemsPerPartition(
-        state.batchOperation.getNumTotalItems() + state.keysAdded,
-        state.batchOperation.getBatchOperationType());
-    metrics.startStartExecuteLatencyMeasure(
-        state.batchOperation.getKey(), state.batchOperation.getBatchOperationType());
-    metrics.startTotalExecutionLatencyMeasure(
-        state.batchOperation.getKey(), state.batchOperation.getBatchOperationType());
-  }
-
-  private boolean finishInitialization(
-      final PersistedBatchOperation batchOperation, final TaskResultBuilder resultBuilder) {
-    final long batchOperationKey = batchOperation.getKey();
-    final var command =
-        new BatchOperationInitializationRecord().setBatchOperationKey(batchOperationKey);
-    LOG.trace("Appending batch operation {} initializing finished command", batchOperationKey);
-
-    final boolean appended =
-        resultBuilder.appendCommandRecord(
-            batchOperationKey,
-            BatchOperationIntent.FINISH_INITIALIZATION,
-            command,
-            FollowUpCommandMetadata.of(b -> b.batchOperationReference(batchOperationKey)));
-    if (appended) {
-      initializing.set(new ExecutionLoopState(batchOperation.getKey(), "finished", 0));
-      metrics.recordInitialized(batchOperation.getBatchOperationType());
-    }
-    return appended;
-  }
-
-  private void handleFailedChunkAppend(
-      final TaskResultBuilder taskResultBuilder, final InitLoopState state) {
-    if (!state.chunksAppendedThisRun) {
-      // the first chunk of this init-run could not be appended. We try to reduce the page size
-      // and retry again. If the pageSize can be halved, we will fail this partition.
-      if (state.searchResultPageSize > 1) {
-        state.searchResultPageSize = state.searchResultPageSize / 2;
-        continueInitialization(taskResultBuilder, state);
-      } else {
-        // If we failed to append the first chunk even when the pageSize is 1,
-        // we need to fail the batch operation. Otherwise, we would be stuck in an infinite loop
-        appendFailedCommand(
-            taskResultBuilder,
-            state.batchOperation,
-            String.format(ERROR_MSG_FAILED_FIRST_CHUNK_APPEND, state.page.items().size()),
-            BatchOperationErrorType.RESULT_BUFFER_SIZE_EXCEEDED);
-      }
-    } else {
-      // The RecordBatch is full, so we need another init run to continue
-      continueInitialization(taskResultBuilder, state);
-    }
-  }
-
-  /**
-   * THis method will create chunk records from the given items and append them to the
-   * taskResultBuilder. This method is atomic. Either all chunks are appended or none.
-   *
-   * @param batchOperation the batch operation to which the chunks belong
-   * @param taskResultBuilder the task result builder to append the chunks to
-   * @param items the items to be chunked and appended
-   * @return true if the chunks were successfully appended, false otherwise
-   */
-  private boolean appendChunks(
-      final PersistedBatchOperation batchOperation,
-      final TaskResultBuilder taskResultBuilder,
-      final List<Item> items) {
-
-    final var chunkRecords =
-        Lists.partition(items, chunkSize).stream()
-            .map(chunkItems -> createChunkRecord(batchOperation, chunkItems))
-            .toList();
-
-    final FollowUpCommandMetadata metadata =
-        FollowUpCommandMetadata.of(b -> b.batchOperationReference(batchOperation.getKey()));
-
-    // we first ask the taskResultBuilder if we even can append the all the records. We also check
-    // for adding an EXECUTE and a CONTINUE_INITIALIZATION record
-    final List<UnifiedRecordValue> sizeCheckRecords = new ArrayList<>(chunkRecords);
-    sizeCheckRecords.add(EMPTY_EXECUTION_RECORD);
-    sizeCheckRecords.add(EMPTY_INITIALIZATION_RECORD);
-    final var canAppend = taskResultBuilder.canAppendRecords(sizeCheckRecords, metadata);
-
-    if (canAppend) {
-      chunkRecords.forEach(
-          command -> {
-            LOG.trace(
-                "Appending batch operation {} chunk with {} items.",
-                batchOperation.getKey(),
-                command.getItems().size());
-            taskResultBuilder.appendCommandRecord(
-                batchOperation.getKey(), BatchOperationChunkIntent.CREATE, command, metadata);
-            metrics.recordChunkCreated(batchOperation.getBatchOperationType());
-          });
-      return true;
-    } else {
-      return false;
-    }
-  }
-
-  private static BatchOperationChunkRecord createChunkRecord(
-      final PersistedBatchOperation batchOperation, final List<Item> chunkItems) {
-    final var command = new BatchOperationChunkRecord();
-    command.setBatchOperationKey(batchOperation.getKey());
-    command.setItems(
-        chunkItems.stream().map(BatchOperationExecutionScheduler::map).collect(Collectors.toSet()));
-    return command;
-  }
-
-  private static BatchOperationItem map(final Item i) {
-    return new BatchOperationItem()
-        .setItemKey(i.itemKey())
-        .setProcessInstanceKey(i.processInstanceKey());
-  }
-
-  private void continueInitialization(
-      final TaskResultBuilder taskResultBuilder, final InitLoopState state) {
-    final var batchOperation = state.batchOperation;
-    final var command =
-        new BatchOperationInitializationRecord()
-            .setBatchOperationKey(batchOperation.getKey())
-            .setSearchResultCursor( // no null values allowed in the protocol
-                state.lastSearchResultCursor == null
-                    ? StringValue.EMPTY_STRING
-                    : state.lastSearchResultCursor)
-            .setSearchQueryPageSize(state.searchResultPageSize);
-    LOG.trace("Appending batch operation {} initializing command", batchOperation.getKey());
-    initializing.set(
-        new ExecutionLoopState(batchOperation.getKey(), command.getSearchResultCursor(), 0));
-    taskResultBuilder.appendCommandRecord(
-        batchOperation.getKey(),
-        BatchOperationIntent.INITIALIZE,
-        command,
-        FollowUpCommandMetadata.of(b -> b.batchOperationReference(batchOperation.getKey())));
-  }
-
-  private void appendFailedCommand(
-      final TaskResultBuilder taskResultBuilder,
-      final PersistedBatchOperation batchOperation,
-      final String message,
-      final BatchOperationErrorType errorType) {
-    final var batchOperationKey = batchOperation.getKey();
-    final var command = new BatchOperationPartitionLifecycleRecord();
-    command.setBatchOperationKey(batchOperationKey);
-
-    final var error = new BatchOperationError();
-    error.setType(errorType);
-    error.setPartitionId(partitionId);
-    error.setMessage(message);
-    command.setError(error);
-
-    LOG.trace("Appending batch operation {} failed event", batchOperationKey);
-    taskResultBuilder.appendCommandRecord(
-        batchOperationKey,
-        BatchOperationIntent.FAIL,
-        command,
-        FollowUpCommandMetadata.of(b -> b.batchOperationReference(batchOperationKey)));
-  }
-
-  private boolean appendExecution(
-      final Long batchOperationKey, final TaskResultBuilder taskResultBuilder) {
-    final var command = new BatchOperationExecutionRecord();
-    command.setBatchOperationKey(batchOperationKey);
-
-    LOG.trace("Appending batch operation execution {}", batchOperationKey);
-    return taskResultBuilder.appendCommandRecord(
-        batchOperationKey,
-        BatchOperationExecutionIntent.EXECUTE,
-        command,
-        FollowUpCommandMetadata.of(b -> b.batchOperationReference(batchOperationKey)));
-  }
-
-  private record ExecutionLoopState(
-      long batchOperationKey, String searchResultCursor, int numRetries) {}
-
-  /**
-   * This is a mutable state class that is used to track the state of the initialization loop. Using
-   * this state class avoids the need to pass around multiple parameters.
-   */
-  private class InitLoopState {
-    public PersistedBatchOperation batchOperation;
-    public String lastSearchResultCursor;
-    public int searchResultPageSize;
-    public ItemPage page;
-    public int keysAdded;
-    public boolean chunksAppendedThisRun = false;
-
-    public InitLoopState(final PersistedBatchOperation batchOperation) {
-      this.batchOperation = batchOperation;
-      lastSearchResultCursor = batchOperation.getInitializationSearchCursor();
-      searchResultPageSize = batchOperation.getInitializationSearchQueryPageSize(queryPageSize);
-      page = null;
-      keysAdded = 0;
-      chunksAppendedThisRun = false;
-
-      // StringValue cannot be null, so we need to check for empty string and interpret it as NULL
-      if (lastSearchResultCursor != null && lastSearchResultCursor.isEmpty()) {
-        // If the cursor is empty, we need to initialize it with the first page
-        lastSearchResultCursor = null;
-      }
-    }
-
-    public boolean hasNextPage() {
-      return page == null || !page.isLastPage();
+  record ExecutionLoopState(long batchOperationKey, String searchResultCursor, int numAttempts) {
+    public ExecutionLoopState(final PersistedBatchOperation batchOperation) {
+      this(batchOperation.getKey(), batchOperation.getInitializationSearchCursor(), 0);
     }
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationInitializer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationInitializer.java
@@ -1,0 +1,351 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.batchoperation;
+
+import static com.google.common.base.Strings.emptyToNull;
+import static com.google.common.base.Strings.nullToEmpty;
+
+import com.google.common.collect.Lists;
+import io.camunda.search.exception.CamundaSearchException;
+import io.camunda.zeebe.engine.EngineConfiguration;
+import io.camunda.zeebe.engine.metrics.BatchOperationMetrics;
+import io.camunda.zeebe.engine.processing.batchoperation.itemprovider.ItemProvider.Item;
+import io.camunda.zeebe.engine.processing.batchoperation.itemprovider.ItemProvider.ItemPage;
+import io.camunda.zeebe.engine.processing.batchoperation.itemprovider.ItemProviderFactory;
+import io.camunda.zeebe.engine.state.batchoperation.PersistedBatchOperation;
+import io.camunda.zeebe.msgpack.value.StringValue;
+import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationChunkRecord;
+import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationError;
+import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationExecutionRecord;
+import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationInitializationRecord;
+import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationItem;
+import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationPartitionLifecycleRecord;
+import io.camunda.zeebe.protocol.record.intent.BatchOperationChunkIntent;
+import io.camunda.zeebe.protocol.record.intent.BatchOperationExecutionIntent;
+import io.camunda.zeebe.protocol.record.intent.BatchOperationIntent;
+import io.camunda.zeebe.protocol.record.value.BatchOperationErrorType;
+import io.camunda.zeebe.stream.api.FollowUpCommandMetadata;
+import io.camunda.zeebe.stream.api.scheduling.TaskResultBuilder;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The is class is a scheduler that periodically checks for newly created batch operations and
+ * initializes them with the itemKeys to be executed.
+ *
+ * <p>For this, it deserializes the filter object and queries the EntityKeyProvider for all matching
+ * itemKeys for this partition. Then this collection of itemKeys will be split into smaller chunks
+ * and appended to the TaskResultBuilder as BatchOperationChunkRecord.
+ */
+public class BatchOperationInitializer {
+
+  public static final String ERROR_MSG_FAILED_FIRST_CHUNK_APPEND =
+      "Unable to append first chunk of batch operation items. Number of items: %d";
+  private static final Logger LOG = LoggerFactory.getLogger(BatchOperationInitializer.class);
+  private static final UnifiedRecordValue EMPTY_EXECUTION_RECORD =
+      new BatchOperationExecutionRecord().setBatchOperationKey(-1L);
+  private static final UnifiedRecordValue EMPTY_INITIALIZATION_RECORD =
+      new BatchOperationInitializationRecord()
+          .setBatchOperationKey(-1L)
+          .setSearchQueryPageSize(0) // random int
+          // random cursor string. 1024 chars should be enough for any cursor without sorting
+          .setSearchResultCursor(RandomStringUtils.insecure().next(1024));
+  private final int chunkSize;
+  private final int queryPageSize;
+
+  private final ItemProviderFactory itemProviderFactory;
+  private final BatchOperationMetrics metrics;
+  private final int partitionId;
+
+  public BatchOperationInitializer(
+      final ItemProviderFactory itemProviderFactory,
+      final EngineConfiguration engineConfiguration,
+      final int partitionId,
+      final BatchOperationMetrics metrics) {
+    this.itemProviderFactory = itemProviderFactory;
+    chunkSize = engineConfiguration.getBatchOperationChunkSize();
+    queryPageSize = engineConfiguration.getBatchOperationQueryPageSize();
+    this.metrics = metrics;
+    this.partitionId = partitionId;
+  }
+
+  public BatchOperationInitializationResult initializeBatchOperation(
+      final PersistedBatchOperation batchOperation, final TaskResultBuilder taskResultBuilder) {
+    if (batchOperation.isSuspended()) {
+      LOG.trace("Batch operation {} is suspended.", batchOperation.getKey());
+      return new BatchOperationInitializationResult(
+          batchOperation.getKey(), batchOperation.getInitializationSearchCursor());
+    }
+
+    final var itemProvider = itemProviderFactory.fromBatchOperation(batchOperation);
+
+    // use overall state variable for all parameters that are used in the loop
+    final InitLoopState loopState = new InitLoopState(batchOperation);
+
+    while (loopState.hasNextPage()) {
+      try {
+        loopState.page =
+            itemProvider.fetchItemPage(
+                loopState.lastSearchResultCursor, loopState.searchResultPageSize);
+      } catch (final Exception e) {
+        // in case we already have appended records to the taskResultBuilder this run, we need to
+        // save the last working cursor to the state
+        if (loopState.chunksAppendedThisRun) {
+          continueInitialization(taskResultBuilder, loopState);
+        }
+        final var exception =
+            e instanceof CamundaSearchException ? e : new CamundaSearchException(e.getMessage());
+        return new BatchOperationInitializationResult(
+            batchOperation.getKey(), loopState.lastSearchResultCursor, exception);
+      }
+
+      // Then try to append the items to the batch operation
+      final boolean appendedChunks =
+          appendChunks(batchOperation, taskResultBuilder, loopState.page.items());
+      if (appendedChunks) {
+        // everything went normally, so we can continue with the next page in the next loop
+
+        loopState.chunksAppendedThisRun = true;
+        loopState.lastSearchResultCursor = loopState.page.endCursor();
+        loopState.keysAdded += loopState.page.items().size();
+        if (loopState.page.isLastPage()) {
+          // If we have reached the last page, we can finalize the initialization and start the BO
+          // we always append the EXECUTE command at the end, even if no items were found, so we can
+          // leave the completion logic in that processor.
+          finishInitialization(loopState.batchOperation, taskResultBuilder);
+          startExecutionPhase(taskResultBuilder, loopState);
+
+          // this is the end of the initialization run, so we can break out of the loop
+
+          return new BatchOperationInitializationResult(batchOperation.getKey(), "finished");
+        }
+      } else {
+        handleFailedChunkAppend(taskResultBuilder, loopState);
+        break;
+      }
+    }
+
+    return new BatchOperationInitializationResult(
+        batchOperation.getKey(), nullToEmpty(loopState.lastSearchResultCursor));
+  }
+
+  private void startExecutionPhase(
+      final TaskResultBuilder resultBuilder, final InitLoopState state) {
+    appendExecution(state.batchOperation.getKey(), resultBuilder);
+
+    // start some metrics for the execution phase
+    metrics.recordItemsPerPartition(
+        state.batchOperation.getNumTotalItems() + state.keysAdded,
+        state.batchOperation.getBatchOperationType());
+    metrics.startStartExecuteLatencyMeasure(
+        state.batchOperation.getKey(), state.batchOperation.getBatchOperationType());
+    metrics.startTotalExecutionLatencyMeasure(
+        state.batchOperation.getKey(), state.batchOperation.getBatchOperationType());
+  }
+
+  private void finishInitialization(
+      final PersistedBatchOperation batchOperation, final TaskResultBuilder resultBuilder) {
+    final long batchOperationKey = batchOperation.getKey();
+    final var command =
+        new BatchOperationInitializationRecord().setBatchOperationKey(batchOperationKey);
+    LOG.trace("Appending batch operation {} initializing finished command", batchOperationKey);
+
+    resultBuilder.appendCommandRecord(
+        batchOperationKey,
+        BatchOperationIntent.FINISH_INITIALIZATION,
+        command,
+        FollowUpCommandMetadata.of(b -> b.batchOperationReference(batchOperationKey)));
+    metrics.recordInitialized(batchOperation.getBatchOperationType());
+  }
+
+  private void handleFailedChunkAppend(
+      final TaskResultBuilder taskResultBuilder, final InitLoopState state) {
+    if (!state.chunksAppendedThisRun) {
+      // the first chunk of this init-run could not be appended. We try to reduce the page size
+      // and retry again. If the pageSize can be halved, we will fail this partition.
+      if (state.searchResultPageSize > 1) {
+        state.searchResultPageSize = state.searchResultPageSize / 2;
+        continueInitialization(taskResultBuilder, state);
+      } else {
+        // If we failed to append the first chunk even when the pageSize is 1,
+        // we need to fail the batch operation. Otherwise, we would be stuck in an infinite loop
+        appendFailedCommand(
+            taskResultBuilder,
+            state.batchOperation,
+            String.format(ERROR_MSG_FAILED_FIRST_CHUNK_APPEND, state.page.items().size()),
+            BatchOperationErrorType.RESULT_BUFFER_SIZE_EXCEEDED);
+      }
+    } else {
+      // The RecordBatch is full, so we need another init run to continue
+      continueInitialization(taskResultBuilder, state);
+    }
+  }
+
+  /**
+   * THis method will create chunk records from the given items and append them to the
+   * taskResultBuilder. This method is atomic. Either all chunks are appended or none.
+   *
+   * @param batchOperation the batch operation to which the chunks belong
+   * @param taskResultBuilder the task result builder to append the chunks to
+   * @param items the items to be chunked and appended
+   * @return true if the chunks were successfully appended, false otherwise
+   */
+  private boolean appendChunks(
+      final PersistedBatchOperation batchOperation,
+      final TaskResultBuilder taskResultBuilder,
+      final List<Item> items) {
+
+    final var chunkRecords =
+        Lists.partition(items, chunkSize).stream()
+            .map(chunkItems -> createChunkRecord(batchOperation, chunkItems))
+            .toList();
+
+    final FollowUpCommandMetadata metadata =
+        FollowUpCommandMetadata.of(b -> b.batchOperationReference(batchOperation.getKey()));
+
+    // we first ask the taskResultBuilder if we even can append the all the records. We also check
+    // for adding an EXECUTE and a CONTINUE_INITIALIZATION record
+    final List<UnifiedRecordValue> sizeCheckRecords = new ArrayList<>(chunkRecords);
+    sizeCheckRecords.add(EMPTY_EXECUTION_RECORD);
+    sizeCheckRecords.add(EMPTY_INITIALIZATION_RECORD);
+    final var canAppend = taskResultBuilder.canAppendRecords(sizeCheckRecords, metadata);
+
+    if (canAppend) {
+      chunkRecords.forEach(
+          command -> {
+            LOG.trace(
+                "Appending batch operation {} chunk with {} items.",
+                batchOperation.getKey(),
+                command.getItems().size());
+            taskResultBuilder.appendCommandRecord(
+                batchOperation.getKey(), BatchOperationChunkIntent.CREATE, command, metadata);
+            metrics.recordChunkCreated(batchOperation.getBatchOperationType());
+          });
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  private static BatchOperationChunkRecord createChunkRecord(
+      final PersistedBatchOperation batchOperation, final List<Item> chunkItems) {
+    final var command = new BatchOperationChunkRecord();
+    command.setBatchOperationKey(batchOperation.getKey());
+    command.setItems(
+        chunkItems.stream().map(BatchOperationInitializer::map).collect(Collectors.toSet()));
+    return command;
+  }
+
+  private static BatchOperationItem map(final Item i) {
+    return new BatchOperationItem()
+        .setItemKey(i.itemKey())
+        .setProcessInstanceKey(i.processInstanceKey());
+  }
+
+  private void continueInitialization(
+      final TaskResultBuilder taskResultBuilder, final InitLoopState state) {
+    final var batchOperation = state.batchOperation;
+    final var command =
+        new BatchOperationInitializationRecord()
+            .setBatchOperationKey(batchOperation.getKey())
+            .setSearchResultCursor( // no null values allowed in the protocol
+                state.lastSearchResultCursor == null
+                    ? StringValue.EMPTY_STRING
+                    : state.lastSearchResultCursor)
+            .setSearchQueryPageSize(state.searchResultPageSize);
+    LOG.trace("Appending batch operation {} initializing command", batchOperation.getKey());
+    taskResultBuilder.appendCommandRecord(
+        batchOperation.getKey(),
+        BatchOperationIntent.INITIALIZE,
+        command,
+        FollowUpCommandMetadata.of(b -> b.batchOperationReference(batchOperation.getKey())));
+  }
+
+  void appendFailedCommand(
+      final TaskResultBuilder taskResultBuilder,
+      final PersistedBatchOperation batchOperation,
+      final String message,
+      final BatchOperationErrorType errorType) {
+    final var batchOperationKey = batchOperation.getKey();
+    final var command = new BatchOperationPartitionLifecycleRecord();
+    command.setBatchOperationKey(batchOperationKey);
+
+    final var error = new BatchOperationError();
+    error.setType(errorType);
+    error.setPartitionId(partitionId);
+    error.setMessage(message);
+    command.setError(error);
+
+    LOG.trace("Appending batch operation {} failed event", batchOperationKey);
+    taskResultBuilder.appendCommandRecord(
+        batchOperationKey,
+        BatchOperationIntent.FAIL,
+        command,
+        FollowUpCommandMetadata.of(b -> b.batchOperationReference(batchOperationKey)));
+  }
+
+  private void appendExecution(
+      final Long batchOperationKey, final TaskResultBuilder taskResultBuilder) {
+    final var command = new BatchOperationExecutionRecord();
+    command.setBatchOperationKey(batchOperationKey);
+
+    LOG.trace("Appending batch operation execution {}", batchOperationKey);
+    taskResultBuilder.appendCommandRecord(
+        batchOperationKey,
+        BatchOperationExecutionIntent.EXECUTE,
+        command,
+        FollowUpCommandMetadata.of(b -> b.batchOperationReference(batchOperationKey)));
+  }
+
+  public record BatchOperationInitializationResult(
+      long batchOperationKey, String searchResultCursor, Exception exception) {
+    public BatchOperationInitializationResult(
+        final long batchOperationKey, final String searchResultCursor) {
+      this(batchOperationKey, searchResultCursor, null);
+    }
+
+    public boolean isSuccess() {
+      return exception == null;
+    }
+  }
+
+  /**
+   * This is a mutable state class that is used to track the state of the initialization loop. Using
+   * this state class avoids the need to pass around multiple parameters.
+   */
+  private class InitLoopState {
+    public PersistedBatchOperation batchOperation;
+    public String lastSearchResultCursor;
+    public int searchResultPageSize;
+    public ItemPage page;
+    public int keysAdded;
+    public boolean chunksAppendedThisRun = false;
+
+    public InitLoopState(final PersistedBatchOperation batchOperation) {
+      this.batchOperation = batchOperation;
+      lastSearchResultCursor = batchOperation.getInitializationSearchCursor();
+      searchResultPageSize = batchOperation.getInitializationSearchQueryPageSize(queryPageSize);
+      page = null;
+      keysAdded = 0;
+      chunksAppendedThisRun = false;
+
+      // StringValue cannot be null, so we need to check for empty string and interpret it as NULL
+      // If the cursor is empty, we need to initialize it with the first page
+      lastSearchResultCursor = emptyToNull(batchOperation.getInitializationSearchCursor());
+    }
+
+    public boolean hasNextPage() {
+      return page == null || !page.isLastPage();
+    }
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/AbstractBatchOperationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/AbstractBatchOperationTest.java
@@ -33,6 +33,7 @@ import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.protocol.record.value.UserRecordValue;
 import io.camunda.zeebe.test.util.BrokerClassRuleHelper;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -73,7 +74,11 @@ abstract class AbstractBatchOperationTest {
                   cfg.getInitialization()
                       .getDefaultRoles()
                       .put("admin", Map.of("users", List.of(DEFAULT_USER.getUsername()))))
-          .withEngineConfig(cfg -> cfg.setBatchOperationQueryPageSize(DEFAULT_QUERY_PAGE_SIZE))
+          .withEngineConfig(
+              cfg ->
+                  cfg.setBatchOperationQueryPageSize(DEFAULT_QUERY_PAGE_SIZE)
+                      .setBatchOperationQueryRetryMax(2)
+                      .setBatchOperationQueryRetryInitialDelay(Duration.ofMillis(100)))
           .withSearchClientsProxy(searchClientsProxy);
 
   @Before

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationExecutionSchedulerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationExecutionSchedulerTest.java
@@ -12,6 +12,7 @@ import static io.camunda.zeebe.protocol.record.value.BatchOperationType.MIGRATE_
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
+import io.camunda.search.exception.CamundaSearchException;
 import io.camunda.search.filter.FilterBuilders;
 import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.metrics.BatchOperationMetrics;
@@ -60,6 +61,10 @@ public class BatchOperationExecutionSchedulerTest {
   public static final Duration SCHEDULER_INTERVAL = Duration.ofSeconds(1);
   public static final int CHUNK_SIZE = 5;
   public static final int QUERY_PAGE_SIZE = 10;
+  public static final Duration QUERY_INITIAL_RETRY_DELAY = Duration.ofMillis(100);
+  public static final Duration QUERY_MAX_RETRY_DELAY = Duration.ofMillis(200);
+  public static final int QUERY_RETRY_MAX = 3;
+  public static final int QUERY_RETRY_BACKOFF_FACTOR = 2;
   public static final long BATCH_OPERATION_KEY = 123456789L;
   private static final int PARTITION_ID = 1;
   @Mock private Supplier<ScheduledTaskState> scheduledTaskStateFactory;
@@ -90,6 +95,13 @@ public class BatchOperationExecutionSchedulerTest {
     when(engineConfiguration.getBatchOperationSchedulerInterval()).thenReturn(SCHEDULER_INTERVAL);
     when(engineConfiguration.getBatchOperationChunkSize()).thenReturn(CHUNK_SIZE);
     when(engineConfiguration.getBatchOperationQueryPageSize()).thenReturn(QUERY_PAGE_SIZE);
+    when(engineConfiguration.getBatchOperationQueryRetryInitialDelay())
+        .thenReturn(QUERY_INITIAL_RETRY_DELAY);
+    when(engineConfiguration.getBatchOperationQueryRetryMaxDelay())
+        .thenReturn(QUERY_MAX_RETRY_DELAY);
+    when(engineConfiguration.getBatchOperationQueryRetryMax()).thenReturn(QUERY_RETRY_MAX);
+    when(engineConfiguration.getBatchOperationQueryRetryBackoffFactor())
+        .thenReturn(QUERY_RETRY_BACKOFF_FACTOR);
 
     lenient().when(itemProviderFactory.fromBatchOperation(any())).thenReturn(itemProvider);
 
@@ -119,6 +131,21 @@ public class BatchOperationExecutionSchedulerTest {
     execute();
 
     // then
+    verify(batchOperationState).getNextPendingBatchOperation();
+    verify(taskResultBuilder).build(); // is always called
+    verifyNoMoreInteractions(taskResultBuilder);
+  }
+
+  @Test
+  public void shouldDoNothingWhenNoBatchOperation() {
+    // given
+    when(batchOperationState.getNextPendingBatchOperation()).thenReturn(Optional.empty());
+
+    // when our scheduler fires
+    execute();
+
+    // then
+    verify(scheduleService, times(2)).runDelayedAsync(eq(SCHEDULER_INTERVAL), any(), any());
     verify(batchOperationState).getNextPendingBatchOperation();
     verify(taskResultBuilder).build(); // is always called
     verifyNoMoreInteractions(taskResultBuilder);
@@ -274,11 +301,13 @@ public class BatchOperationExecutionSchedulerTest {
     when(itemProvider.fetchItemPage(any(), anyInt()))
         .thenThrow(new RuntimeException("errors", new RuntimeException()));
 
-    // when our scheduler fires
+    // when our scheduler fires three times (two retries)
+    execute();
+    execute();
+    execute();
     execute();
 
     // then
-    verify(batchOperationState).getNextPendingBatchOperation();
     verify(taskResultBuilder)
         .appendCommandRecord(
             anyLong(),
@@ -295,6 +324,46 @@ public class BatchOperationExecutionSchedulerTest {
     assertThat(error.getPartitionId()).isEqualTo(PARTITION_ID);
     assertThat(error.getType()).isEqualTo(BatchOperationErrorType.QUERY_FAILED);
     assertThat(error.getMessage()).contains("errors");
+
+    final var durationCaptor = ArgumentCaptor.forClass(Duration.class);
+    verify(scheduleService, atLeastOnce()).runDelayedAsync(durationCaptor.capture(), any(), any());
+
+    // default scheduler delay is 1000ms, initial retry delay is 100ms.
+    // After the failure we are back at 1000ms
+    assertThat(durationCaptor.getAllValues())
+        .extracting(Duration::toMillis)
+        .containsSubsequence(1000L, 100L, 200L, 200L, 1000L);
+  }
+
+  @Test
+  public void shouldSaveCursorOnErrorEvent() {
+    // given
+    final var batchOperation = createBatchOperation();
+    when(batchOperationState.getNextPendingBatchOperation())
+        .thenReturn(Optional.of(batchOperation));
+    when(itemProvider.fetchItemPage(any(), anyInt()))
+        .thenReturn(createItemPage(new long[] {1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, "10", false))
+        .thenThrow(new CamundaSearchException("errors"));
+
+    // when our scheduler fires
+    execute();
+
+    // then
+    verify(batchOperationState).getNextPendingBatchOperation();
+    verify(taskResultBuilder)
+        .appendCommandRecord(
+            anyLong(),
+            eq(BatchOperationIntent.INITIALIZE),
+            initializeRecordArgumentCaptor.capture(),
+            any());
+
+    // and should NOT append an execute command
+    verifyNoExecuteCommandAppended();
+
+    // and should contain an errors
+    final var record = initializeRecordArgumentCaptor.getValue();
+    assertThat(record).isNotNull();
+    assertThat(record.getSearchResultCursor()).isEqualTo("10");
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationExecutionSchedulerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationExecutionSchedulerTest.java
@@ -61,9 +61,9 @@ public class BatchOperationExecutionSchedulerTest {
   public static final Duration SCHEDULER_INTERVAL = Duration.ofSeconds(1);
   public static final int CHUNK_SIZE = 5;
   public static final int QUERY_PAGE_SIZE = 10;
-  public static final Duration QUERY_INITIAL_RETRY_DELAY = Duration.ofMillis(100);
-  public static final Duration QUERY_MAX_RETRY_DELAY = Duration.ofMillis(200);
-  public static final int QUERY_RETRY_MAX = 3;
+  public static final Duration QUERY_INITIAL_RETRY_DELAY = Duration.ofMillis(50);
+  public static final Duration QUERY_MAX_RETRY_DELAY = Duration.ofMillis(500);
+  public static final int QUERY_RETRY_MAX = 5;
   public static final int QUERY_RETRY_BACKOFF_FACTOR = 2;
   public static final long BATCH_OPERATION_KEY = 123456789L;
   private static final int PARTITION_ID = 1;
@@ -306,6 +306,8 @@ public class BatchOperationExecutionSchedulerTest {
     execute();
     execute();
     execute();
+    execute();
+    execute();
 
     // then
     verify(taskResultBuilder)
@@ -332,7 +334,7 @@ public class BatchOperationExecutionSchedulerTest {
     // After the failure we are back at 1000ms
     assertThat(durationCaptor.getAllValues())
         .extracting(Duration::toMillis)
-        .containsSubsequence(1000L, 100L, 200L, 200L, 1000L);
+        .containsSubsequence(1000L, 50L, 100L, 200L, 400L, 500L, 1000L);
   }
 
   @Test


### PR DESCRIPTION
## Description

Adds a retry strategy to the `BatchOperationExecutionScheduler` in case the query failed.
- add configuration properties to control the query retry behaviour
- split the `BatchOperationExecutionScheduler` into two classes
  - `BatchOperationExecutionScheduler` is responsible for actual scheduling, retry and async execution
  - `BatchOperationInitializer` is responsible for actually fetching items and appending the correct records

## Related issues

closes #31222
