### PR TITLE
feat: copy long polling properties in unified configuration to EmbeddedGatewayCfg in BrokerCfg

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/LongPolling.java
+++ b/configuration/src/main/java/io/camunda/configuration/LongPolling.java
@@ -9,19 +9,27 @@ package io.camunda.configuration;
 
 import io.camunda.configuration.UnifiedConfigurationHelper.BackwardsCompatibilityMode;
 import io.camunda.zeebe.gateway.impl.configuration.ConfigurationDefaults;
+import java.util.Map;
 import java.util.Set;
 
 public class LongPolling {
   private static final String PREFIX = "camunda.api.long-polling";
 
-  private static final Set<String> LEGACY_ENABLED_PROPERTIES =
-      Set.of("zeebe.gateway.longPolling.enabled");
-  private static final Set<String> LEGACY_TIMEOUT_PROPERTIES =
-      Set.of("zeebe.gateway.longPolling.timeout");
-  private static final Set<String> LEGACY_PROBE_TIMEOUT_PROPERTIES =
-      Set.of("zeebe.gateway.longPolling.probeTimeout");
-  private static final Set<String> LEGACY_MIN_EMPTY_RESPONSES_PROPERTIES =
-      Set.of("zeebe.gateway.longPolling.minEmptyResponses");
+  private static final Map<String, String> LEGACY_GATEWAY_PROPERTIES =
+      Map.of(
+          "enabled", "zeebe.gateway.longPolling.enabled",
+          "timeout", "zeebe.gateway.longPolling.timeout",
+          "probeTimeout", "zeebe.gateway.longPolling.probeTimeout",
+          "minEmptyResponses", "zeebe.gateway.longPolling.minEmptyResponses");
+
+  private static final Map<String, String> LEGACY_BROKER_PROPERTIES =
+      Map.of(
+          "enabled", "zeebe.broker.gateway.longPolling.enabled",
+          "timeout", "zeebe.broker.gateway.longPolling.timeout",
+          "probeTimeout", "zeebe.broker.gateway.longPolling.probeTimeout",
+          "minEmptyResponses", "zeebe.broker.gateway.longPolling.minEmptyResponses");
+
+  private Map<String, String> legacyPropertiesMap = LEGACY_BROKER_PROPERTIES;
 
   /** Enables long polling for available jobs */
   private boolean enabled = ConfigurationDefaults.DEFAULT_LONG_POLLING_ENABLED;
@@ -45,7 +53,7 @@ public class LongPolling {
         enabled,
         Boolean.class,
         BackwardsCompatibilityMode.SUPPORTED,
-        LEGACY_ENABLED_PROPERTIES);
+        Set.of(legacyPropertiesMap.get("enabled")));
   }
 
   public void setEnabled(final boolean enabled) {
@@ -58,7 +66,7 @@ public class LongPolling {
         timeout,
         Long.class,
         BackwardsCompatibilityMode.SUPPORTED,
-        LEGACY_TIMEOUT_PROPERTIES);
+        Set.of(legacyPropertiesMap.get("timeout")));
   }
 
   public void setTimeout(final long timeout) {
@@ -71,7 +79,7 @@ public class LongPolling {
         probeTimeout,
         Long.class,
         BackwardsCompatibilityMode.SUPPORTED,
-        LEGACY_PROBE_TIMEOUT_PROPERTIES);
+        Set.of(legacyPropertiesMap.get("probeTimeout")));
   }
 
   public void setProbeTimeout(final long probeTimeout) {
@@ -84,10 +92,33 @@ public class LongPolling {
         minEmptyResponses,
         Integer.class,
         BackwardsCompatibilityMode.SUPPORTED,
-        LEGACY_MIN_EMPTY_RESPONSES_PROPERTIES);
+        Set.of(legacyPropertiesMap.get("minEmptyResponses")));
   }
 
   public void setMinEmptyResponses(final int minEmptyResponses) {
     this.minEmptyResponses = minEmptyResponses;
+  }
+
+  @Override
+  public LongPolling clone() {
+    final LongPolling copy = new LongPolling();
+    copy.enabled = enabled;
+    copy.timeout = timeout;
+    copy.probeTimeout = probeTimeout;
+    copy.minEmptyResponses = minEmptyResponses;
+
+    return copy;
+  }
+
+  public LongPolling withBrokerLongPollingProperties() {
+    final var copy = clone();
+    copy.legacyPropertiesMap = LEGACY_BROKER_PROPERTIES;
+    return copy;
+  }
+
+  public LongPolling withGatewayLongPollingProperties() {
+    final var copy = clone();
+    copy.legacyPropertiesMap = LEGACY_GATEWAY_PROPERTIES;
+    return copy;
   }
 }

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
@@ -62,6 +62,8 @@ public class BrokerBasedPropertiesOverride {
     // from camunda.cluster.* sections
     populateFromCluster(override);
 
+    populateFromLongPolling(override);
+
     // from camunda.system.* sections in relation
     // with zeebe.broker.*
     populateFromSystem(override);
@@ -135,6 +137,20 @@ public class BrokerBasedPropertiesOverride {
     populateFromClusterMetadata(override);
     populateFromClusterNetwork(override);
     // Rest of camunda.cluster.* sections
+  }
+
+  private void populateFromLongPolling(final BrokerBasedProperties override) {
+    final var longPolling =
+        unifiedConfiguration
+            .getCamunda()
+            .getApi()
+            .getLongPolling()
+            .withBrokerLongPollingProperties();
+    final var longPollingCfg = override.getGateway().getLongPolling();
+    longPollingCfg.setEnabled(longPolling.isEnabled());
+    longPollingCfg.setTimeout(longPolling.getTimeout());
+    longPollingCfg.setProbeTimeout(longPolling.getProbeTimeout());
+    longPollingCfg.setMinEmptyResponses(longPolling.getMinEmptyResponses());
   }
 
   private void populateFromRaftProperties(final BrokerBasedProperties override) {

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/GatewayBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/GatewayBasedPropertiesOverride.java
@@ -106,7 +106,12 @@ public class GatewayBasedPropertiesOverride {
   }
 
   private void populateFromLongPolling(final GatewayBasedProperties override) {
-    final var longPolling = unifiedConfiguration.getCamunda().getApi().getLongPolling();
+    final var longPolling =
+        unifiedConfiguration
+            .getCamunda()
+            .getApi()
+            .getLongPolling()
+            .withGatewayLongPollingProperties();
     final var longPollingCfg = override.getLongPolling();
     longPollingCfg.setEnabled(longPolling.isEnabled());
     longPollingCfg.setTimeout(longPolling.getTimeout());

--- a/configuration/src/test/java/io/camunda/configuration/ApiBrokerLongPollingTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/ApiBrokerLongPollingTest.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.configuration.beanoverrides.BrokerBasedPropertiesOverride;
+import io.camunda.configuration.beans.BrokerBasedProperties;
+import io.camunda.zeebe.gateway.impl.configuration.ConfigurationDefaults;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+@SpringJUnitConfig({
+  UnifiedConfiguration.class,
+  BrokerBasedPropertiesOverride.class,
+  UnifiedConfigurationHelper.class
+})
+@ActiveProfiles("broker")
+public class ApiBrokerLongPollingTest {
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "camunda.api.long-polling.enabled=true",
+        "camunda.api.long-polling.timeout=20000",
+        "camunda.api.long-polling.probe-timeout=30000",
+        "camunda.api.long-polling.min-empty-responses=5"
+      })
+  class WithOnlyUnifiedConfigSet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithOnlyUnifiedConfigSet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldSetEnabled() {
+      assertThat(brokerCfg.getGateway().getLongPolling().isEnabled()).isTrue();
+    }
+
+    @Test
+    void shouldSetTimeout() {
+      assertThat(brokerCfg.getGateway().getLongPolling().getTimeout()).isEqualTo(20000);
+    }
+
+    @Test
+    void shouldSetProbeTimeout() {
+      assertThat(brokerCfg.getGateway().getLongPolling().getProbeTimeout()).isEqualTo(30000);
+    }
+
+    @Test
+    void shouldSetMinEmptyResponses() {
+      assertThat(brokerCfg.getGateway().getLongPolling().getMinEmptyResponses()).isEqualTo(5);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "zeebe.gateway.longPolling.enabled=false",
+        "zeebe.gateway.longPolling.timeout=2",
+        "zeebe.gateway.longPolling.probeTimeout=3",
+        "zeebe.gateway.longPolling.minEmptyResponses=4"
+      })
+  class WithOnlyLegacyGatewayLongPollingSet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithOnlyLegacyGatewayLongPollingSet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldNoSetEnabledFromLegacyGateway() {
+      assertThat(brokerCfg.getGateway().getLongPolling().isEnabled())
+          .isEqualTo(ConfigurationDefaults.DEFAULT_LONG_POLLING_ENABLED);
+    }
+
+    @Test
+    void shouldNotSetTimeoutFromLegacyGateway() {
+      assertThat(brokerCfg.getGateway().getLongPolling().getTimeout())
+          .isEqualTo(ConfigurationDefaults.DEFAULT_LONG_POLLING_TIMEOUT);
+    }
+
+    @Test
+    void shouldNotSetProbeTimeoutFromLegacyGateway() {
+      assertThat(brokerCfg.getGateway().getLongPolling().getProbeTimeout())
+          .isEqualTo(ConfigurationDefaults.DEFAULT_PROBE_TIMEOUT);
+    }
+
+    @Test
+    void shouldNotSetMinEmptyResponsesFromLegacyGateway() {
+      assertThat(brokerCfg.getGateway().getLongPolling().getMinEmptyResponses())
+          .isEqualTo(ConfigurationDefaults.DEFAULT_LONG_POLLING_EMPTY_RESPONSE_THRESHOLD);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "zeebe.broker.gateway.longPolling.enabled=true",
+        "zeebe.broker.gateway.longPolling.timeout=2",
+        "zeebe.broker.gateway.longPolling.probeTimeout=3",
+        "zeebe.broker.gateway.longPolling.minEmptyResponses=4"
+      })
+  class WithOnlyLegacyBrokerLongPollingSet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithOnlyLegacyBrokerLongPollingSet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldSetEnabledFromLegacyBroker() {
+      assertThat(brokerCfg.getGateway().getLongPolling().isEnabled()).isTrue();
+    }
+
+    @Test
+    void shouldSetTimeoutFromLegacyBroker() {
+      assertThat(brokerCfg.getGateway().getLongPolling().getTimeout()).isEqualTo(2);
+    }
+
+    @Test
+    void shouldSetProbeTimeoutFromLegacyBroker() {
+      assertThat(brokerCfg.getGateway().getLongPolling().getProbeTimeout()).isEqualTo(3);
+    }
+
+    @Test
+    void shouldSetMinEmptyResponsesFromLegacyBroker() {
+      assertThat(brokerCfg.getGateway().getLongPolling().getMinEmptyResponses()).isEqualTo(4);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        // new
+        "camunda.api.long-polling.enabled=true",
+        "camunda.api.long-polling.timeout=20000",
+        "camunda.api.long-polling.probe-timeout=30000",
+        "camunda.api.long-polling.min-empty-responses=5",
+        // legacy gateway configuration
+        "zeebe.gateway.longPolling.enabled=false",
+        "zeebe.gateway.longPolling.timeout=2",
+        "zeebe.gateway.longPolling.probeTimeout=3",
+        "zeebe.gateway.longPolling.minEmptyResponses=4",
+        // legacy broker configuration
+        "zeebe.broker.gateway.longPolling.enabled=false",
+        "zeebe.broker.gateway.longPolling.timeout=2",
+        "zeebe.broker.gateway.longPolling.probeTimeout=3",
+        "zeebe.broker.gateway.longPolling.minEmptyResponses=4",
+      })
+  class WithNewAndLegacySet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithNewAndLegacySet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldSetEnabledFromNew() {
+      assertThat(brokerCfg.getGateway().getLongPolling().isEnabled()).isTrue();
+    }
+
+    @Test
+    void shouldSetTimeoutFromNew() {
+      assertThat(brokerCfg.getGateway().getLongPolling().getTimeout()).isEqualTo(20000);
+    }
+
+    @Test
+    void shouldSetProbeTimeoutFromNew() {
+      assertThat(brokerCfg.getGateway().getLongPolling().getProbeTimeout()).isEqualTo(30000);
+    }
+
+    @Test
+    void shouldSetMinEmptyResponseFromNew() {
+      assertThat(brokerCfg.getGateway().getLongPolling().getMinEmptyResponses()).isEqualTo(5);
+    }
+  }
+}

--- a/configuration/src/test/java/io/camunda/configuration/ApiGatewayLongPollingTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/ApiGatewayLongPollingTest.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.configuration.beanoverrides.GatewayBasedPropertiesOverride;
 import io.camunda.configuration.beans.GatewayBasedProperties;
+import io.camunda.zeebe.gateway.impl.configuration.ConfigurationDefaults;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -22,7 +23,7 @@ import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
   GatewayBasedPropertiesOverride.class,
   UnifiedConfigurationHelper.class
 })
-public class ApiLongPollingTest {
+public class ApiGatewayLongPollingTest {
   @Nested
   @TestPropertySource(
       properties = {
@@ -62,35 +63,75 @@ public class ApiLongPollingTest {
   @Nested
   @TestPropertySource(
       properties = {
-        "zeebe.gateway.longPolling.enabled=false",
-        "zeebe.gateway.longPolling.timeout=2",
-        "zeebe.gateway.longPolling.probeTimeout=3",
-        "zeebe.gateway.longPolling.minEmptyResponses=4"
+        "zeebe.broker.gateway.longPolling.enabled=false",
+        "zeebe.broker.gateway.longPolling.timeout=2",
+        "zeebe.broker.gateway.longPolling.probeTimeout=3",
+        "zeebe.broker.gateway.longPolling.minEmptyResponses=4"
       })
-  class WithOnlyLegacySet {
+  class WithOnlyLegacyBrokerLongPollingSet {
     final GatewayBasedProperties gatewayCfg;
 
-    WithOnlyLegacySet(@Autowired final GatewayBasedProperties gatewayCfg) {
+    WithOnlyLegacyBrokerLongPollingSet(@Autowired final GatewayBasedProperties gatewayCfg) {
       this.gatewayCfg = gatewayCfg;
     }
 
     @Test
-    void shouldSetEnabled() {
-      assertThat(gatewayCfg.getLongPolling().isEnabled()).isFalse();
+    void shouldNoSetEnabledFromLegacyBroker() {
+      assertThat(gatewayCfg.getLongPolling().isEnabled())
+          .isEqualTo(ConfigurationDefaults.DEFAULT_LONG_POLLING_ENABLED);
     }
 
     @Test
-    void shouldSetTimeout() {
+    void shouldNotSetTimeoutFromLegacyBroker() {
+      assertThat(gatewayCfg.getLongPolling().getTimeout())
+          .isEqualTo(ConfigurationDefaults.DEFAULT_LONG_POLLING_TIMEOUT);
+    }
+
+    @Test
+    void shouldNotSetProbeTimeoutFromLegacyBroker() {
+      assertThat(gatewayCfg.getLongPolling().getProbeTimeout())
+          .isEqualTo(ConfigurationDefaults.DEFAULT_PROBE_TIMEOUT);
+    }
+
+    @Test
+    void shouldNotSetMinEmptyResponsesFromLegacyBroker() {
+      assertThat(gatewayCfg.getLongPolling().getMinEmptyResponses())
+          .isEqualTo(ConfigurationDefaults.DEFAULT_LONG_POLLING_EMPTY_RESPONSE_THRESHOLD);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "zeebe.gateway.longPolling.enabled=true",
+        "zeebe.gateway.longPolling.timeout=2",
+        "zeebe.gateway.longPolling.probeTimeout=3",
+        "zeebe.gateway.longPolling.minEmptyResponses=4"
+      })
+  class WithOnlyLegacyGatewayLongPollingSet {
+    final GatewayBasedProperties gatewayCfg;
+
+    WithOnlyLegacyGatewayLongPollingSet(@Autowired final GatewayBasedProperties gatewayCfg) {
+      this.gatewayCfg = gatewayCfg;
+    }
+
+    @Test
+    void shouldSetEnabledFromLegacyGateway() {
+      assertThat(gatewayCfg.getLongPolling().isEnabled()).isTrue();
+    }
+
+    @Test
+    void shouldSetTimeoutFromLegacyGateway() {
       assertThat(gatewayCfg.getLongPolling().getTimeout()).isEqualTo(2);
     }
 
     @Test
-    void shouldSetProbeTimeout() {
+    void shouldSetProbeTimeoutFromLegacyGateway() {
       assertThat(gatewayCfg.getLongPolling().getProbeTimeout()).isEqualTo(3);
     }
 
     @Test
-    void shouldSetMinEmptyResponses() {
+    void shouldSetMinEmptyResponsesFromLegacyGateway() {
       assertThat(gatewayCfg.getLongPolling().getMinEmptyResponses()).isEqualTo(4);
     }
   }
@@ -103,7 +144,12 @@ public class ApiLongPollingTest {
         "camunda.api.long-polling.timeout=20000",
         "camunda.api.long-polling.probe-timeout=30000",
         "camunda.api.long-polling.min-empty-responses=5",
-        // legacy
+        // legacy broker configuration
+        "zeebe.broker.gateway.longPolling.enabled=false",
+        "zeebe.broker.gateway.longPolling.timeout=2",
+        "zeebe.broker.gateway.longPolling.probeTimeout=3",
+        "zeebe.broker.gateway.longPolling.minEmptyResponses=4",
+        // legacy gateway configuration
         "zeebe.gateway.longPolling.enabled=false",
         "zeebe.gateway.longPolling.timeout=2",
         "zeebe.gateway.longPolling.probeTimeout=3",


### PR DESCRIPTION
## Description

This PR copies the properties from section camunda.api.long-polling in unified config to embedded gateway configuration in broker configuration

The legacy properties are:

zeebe.broker.gateway.longPolling.enabled
zeebe.broker.gateway.longPolling.timeout
zeebe.broker.gateway.longPolling.probeTimeout
zeebe.broker.gateway.longPolling.minEmptyResponses

The new properties are:

camunda.api.long-polling.enabled
camunda.api.long-polling.timeout
camunda.api.long-polling.probe-timeout
camunda.api.long-polling.min-empty-responses

Backwards compatibility is supported for these properties. That means, if legacy is set and new property is not set, legacy value will be used.
## Checklist

- [ ] The legacy properties and the backwards compatibility strategy are updated in [schema doc](https://docs.google.com/spreadsheets/d/1R4epsy6DWemA8_76cUE6zOGUFbrXCXlM2reXnKFuz7Y/edit?gid=818158292#gid=818158292)
- [ ] The new property fields are documented in the code
## Related issues

related to #34911