### PR TITLE
fix: prevent random ID of custom filters from breaking Tasklist

### DIFF
--- a/tasklist/client/src/common/tasks/available-tasks/CollapsiblePanel/CustomFiltersModal/index.tsx
+++ b/tasklist/client/src/common/tasks/available-tasks/CollapsiblePanel/CustomFiltersModal/index.tsx
@@ -119,7 +119,7 @@ const CustomFiltersModal: React.FC<Props> = ({
       <FilterNameModal
         isOpen={isOpen && currentStep === 'name'}
         onApply={(filterName) => {
-          const filterId = crypto.randomUUID();
+          const filterId = `${Date.now()}${Math.random()}`;
           storeStateLocally('customFilters', {
             ...getStateLocally('customFilters'),
             [filterId]: {


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Some older browsers and envs that don't run on HTTPS don't support `crypto.randomUUID` so I'm replacing it with something more resilient

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #36540
