### PR TITLE
feat: Refine message subscription search

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/MessageSubscriptionFilter.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/MessageSubscriptionFilter.java
@@ -60,23 +60,6 @@ public interface MessageSubscriptionFilter extends SearchRequestFilter {
   MessageSubscriptionFilter processDefinitionId(Consumer<StringProperty> fn);
 
   /**
-   * Filter by process definition key.
-   *
-   * @param processDefinitionKey the key of the process definition
-   * @return the updated filter
-   */
-  MessageSubscriptionFilter processDefinitionKey(Long processDefinitionKey);
-
-  /**
-   * Filter by process definition key using a {@link BasicLongProperty} consumer.
-   *
-   * @param fn the process definition key {@link BasicLongProperty} consumer for the message
-   *     subscription
-   * @return the updated filter
-   */
-  MessageSubscriptionFilter processDefinitionKey(Consumer<BasicLongProperty> fn);
-
-  /**
    * Filter by process instance key.
    *
    * @param processInstanceKey the key of the process instance

--- a/clients/java/src/main/java/io/camunda/client/api/search/sort/MessageSubscriptionSort.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/sort/MessageSubscriptionSort.java
@@ -23,8 +23,6 @@ public interface MessageSubscriptionSort extends SearchRequestSort<MessageSubscr
 
   MessageSubscriptionSort processDefinitionId();
 
-  MessageSubscriptionSort processDefinitionKey();
-
   MessageSubscriptionSort processInstanceKey();
 
   MessageSubscriptionSort elementId();

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/MessageSubscriptionFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/MessageSubscriptionFilterImpl.java
@@ -67,19 +67,6 @@ public class MessageSubscriptionFilterImpl
   }
 
   @Override
-  public MessageSubscriptionFilter processDefinitionKey(final Long processDefinitionKey) {
-    return processDefinitionKey(f -> f.eq(processDefinitionKey));
-  }
-
-  @Override
-  public MessageSubscriptionFilter processDefinitionKey(final Consumer<BasicLongProperty> fn) {
-    final BasicLongProperty property = new BasicLongPropertyImpl();
-    fn.accept(property);
-    filter.setProcessDefinitionKey(provideSearchRequestProperty(property));
-    return this;
-  }
-
-  @Override
   public MessageSubscriptionFilter processInstanceKey(final Long processInstanceKey) {
     return processInstanceKey(f -> f.eq(processInstanceKey));
   }

--- a/clients/java/src/main/java/io/camunda/client/impl/search/sort/MessageSubscriptionSortImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/sort/MessageSubscriptionSortImpl.java
@@ -32,11 +32,6 @@ public class MessageSubscriptionSortImpl extends SearchRequestSortBase<MessageSu
   }
 
   @Override
-  public MessageSubscriptionSort processDefinitionKey() {
-    return field("processDefinitionKey");
-  }
-
-  @Override
   public MessageSubscriptionSort processInstanceKey() {
     return field("processInstanceKey");
   }

--- a/clients/java/src/test/java/io/camunda/client/messagesubscription/SearchMessageSubscriptionTest.java
+++ b/clients/java/src/test/java/io/camunda/client/messagesubscription/SearchMessageSubscriptionTest.java
@@ -63,7 +63,6 @@ public class SearchMessageSubscriptionTest extends ClientRestTest {
             f ->
                 f.messageSubscriptionKey(123L)
                     .processDefinitionId("process-definition-id")
-                    .processDefinitionKey(111L)
                     .processInstanceKey(456L)
                     .elementId("element-id")
                     .elementInstanceKey(789L)
@@ -84,8 +83,6 @@ public class SearchMessageSubscriptionTest extends ClientRestTest {
     assertThat(request.getFilter().getProcessDefinitionId()).isNotNull();
     assertThat(request.getFilter().getProcessDefinitionId().get$Eq())
         .isEqualTo("process-definition-id");
-    assertThat(request.getFilter().getProcessDefinitionKey()).isNotNull();
-    assertThat(request.getFilter().getProcessDefinitionKey().get$Eq()).isEqualTo("111");
     assertThat(request.getFilter().getProcessInstanceKey()).isNotNull();
     assertThat(request.getFilter().getProcessInstanceKey().get$Eq()).isEqualTo("456");
     assertThat(request.getFilter().getElementId()).isNotNull();
@@ -117,8 +114,6 @@ public class SearchMessageSubscriptionTest extends ClientRestTest {
                     .asc()
                     .processDefinitionId()
                     .desc()
-                    .processDefinitionKey()
-                    .asc()
                     .processInstanceKey()
                     .desc()
                     .elementId()
@@ -144,18 +139,17 @@ public class SearchMessageSubscriptionTest extends ClientRestTest {
     final List<SearchRequestSort> sorts =
         SearchRequestSortMapper.fromMessageSubscriptionSearchQuerySortRequest(
             Objects.requireNonNull(request.getSort()));
-    assertThat(sorts).hasSize(11);
+    assertThat(sorts).hasSize(10);
     assertSort(sorts.get(0), "messageSubscriptionKey", SortOrderEnum.ASC);
     assertSort(sorts.get(1), "processDefinitionId", SortOrderEnum.DESC);
-    assertSort(sorts.get(2), "processDefinitionKey", SortOrderEnum.ASC);
-    assertSort(sorts.get(3), "processInstanceKey", SortOrderEnum.DESC);
-    assertSort(sorts.get(4), "elementId", SortOrderEnum.ASC);
-    assertSort(sorts.get(5), "elementInstanceKey", SortOrderEnum.DESC);
-    assertSort(sorts.get(6), "messageSubscriptionType", SortOrderEnum.ASC);
-    assertSort(sorts.get(7), "lastUpdatedDate", SortOrderEnum.DESC);
-    assertSort(sorts.get(8), "messageName", SortOrderEnum.ASC);
-    assertSort(sorts.get(9), "correlationKey", SortOrderEnum.DESC);
-    assertSort(sorts.get(10), "tenantId", SortOrderEnum.ASC);
+    assertSort(sorts.get(2), "processInstanceKey", SortOrderEnum.DESC);
+    assertSort(sorts.get(3), "elementId", SortOrderEnum.ASC);
+    assertSort(sorts.get(4), "elementInstanceKey", SortOrderEnum.DESC);
+    assertSort(sorts.get(5), "messageSubscriptionType", SortOrderEnum.ASC);
+    assertSort(sorts.get(6), "lastUpdatedDate", SortOrderEnum.DESC);
+    assertSort(sorts.get(7), "messageName", SortOrderEnum.ASC);
+    assertSort(sorts.get(8), "correlationKey", SortOrderEnum.DESC);
+    assertSort(sorts.get(9), "tenantId", SortOrderEnum.ASC);
   }
 
   @Test

--- a/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.8.0.xml
+++ b/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.8.0.xml
@@ -656,7 +656,6 @@
         <constraints primaryKey="true"/>
       </column>
       <column name="PROCESS_DEFINITION_ID" type="VARCHAR(255)"/>
-      <column name="PROCESS_DEFINITION_KEY" type="BIGINT"/>
       <column name="PROCESS_INSTANCE_KEY" type="BIGINT"/>
       <column name="FLOW_NODE_ID" type="VARCHAR(255)"/>
       <column name="FLOW_NODE_INSTANCE_KEY" type="BIGINT"/>

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriter.java
@@ -134,7 +134,6 @@ public class RdbmsWriter {
     messageSubscriptionWriter =
         new MessageSubscriptionWriter(executionQueue, messageSubscriptionMapper);
 
-    // TODO: Do I need to update this?
     historyCleanupService =
         new HistoryCleanupService(
             config,

--- a/db/rdbms/src/main/resources/mapper/MessageSubscriptionMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/MessageSubscriptionMapper.xml
@@ -26,7 +26,6 @@
     SELECT
     MESSAGE_SUBSCRIPTION_KEY,
     PROCESS_DEFINITION_ID,
-    PROCESS_DEFINITION_KEY,
     PROCESS_INSTANCE_KEY,
     FLOW_NODE_ID,
     FLOW_NODE_INSTANCE_KEY,
@@ -57,12 +56,6 @@
     <if test="filter.processDefinitionIdOperations != null and !filter.processDefinitionIdOperations.isEmpty()">
       <foreach collection="filter.processDefinitionIdOperations" item="operation">
         AND PROCESS_DEFINITION_ID
-        <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
-      </foreach>
-    </if>
-    <if test="filter.processDefinitionKeyOperations != null and !filter.processDefinitionKeyOperations.isEmpty()">
-      <foreach collection="filter.processDefinitionKeyOperations" item="operation">
-        AND PROCESS_DEFINITION_KEY
         <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
       </foreach>
     </if>
@@ -121,7 +114,6 @@
       <idArg column="MESSAGE_SUBSCRIPTION_KEY" javaType="java.lang.Long" />
     </constructor>
     <result column="PROCESS_DEFINITION_ID" property="processDefinitionId" javaType="java.lang.String" />
-    <result column="PROCESS_DEFINITION_KEY" property="processDefinitionKey" javaType="java.lang.Long" />
     <result column="PROCESS_INSTANCE_KEY" property="processInstanceKey" javaType="java.lang.Long" />
     <result column="FLOW_NODE_ID" property="flowNodeId" javaType="java.lang.String" />
     <result column="FLOW_NODE_INSTANCE_KEY" property="flowNodeInstanceKey" javaType="java.lang.Long" />
@@ -138,7 +130,6 @@
     INSERT INTO ${prefix}MESSAGE_SUBSCRIPTION (
                                                MESSAGE_SUBSCRIPTION_KEY,
                                                PROCESS_DEFINITION_ID,
-                                               PROCESS_DEFINITION_KEY,
                                                PROCESS_INSTANCE_KEY,
                                                FLOW_NODE_ID,
                                                FLOW_NODE_INSTANCE_KEY,
@@ -152,7 +143,6 @@
     VALUES (
             #{messageSubscriptionKey},
             #{processDefinitionId},
-            #{processDefinitionKey},
             #{processInstanceKey},
             #{flowNodeId},
             #{flowNodeInstanceKey},
@@ -168,7 +158,6 @@
   <update id="update" parameterType="io.camunda.db.rdbms.write.domain.MessageSubscriptionDbModel">
     UPDATE ${prefix}MESSAGE_SUBSCRIPTION
     SET PROCESS_DEFINITION_ID = #{processDefinitionId},
-        PROCESS_DEFINITION_KEY =  #{processDefinitionKey},
         PROCESS_INSTANCE_KEY = #{processInstanceKey},
         FLOW_NODE_ID = #{flowNodeId},
         FLOW_NODE_INSTANCE_KEY = #{flowNodeInstanceKey},

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/MessageSubscriptionSearchTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/MessageSubscriptionSearchTest.java
@@ -22,10 +22,8 @@ import java.util.Comparator;
 import java.util.List;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 @MultiDbTest
-@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms")
 public class MessageSubscriptionSearchTest {
 
   private static final int NUMBER_OF_MESSAGE_SUBSCRIPTIONS = 3;

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/sort/MessageSubscriptionFieldSortingTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/sort/MessageSubscriptionFieldSortingTransformer.java
@@ -15,7 +15,6 @@ import static io.camunda.webapps.schema.descriptors.template.EventTemplate.EVENT
 import static io.camunda.webapps.schema.descriptors.template.EventTemplate.FLOW_NODE_ID;
 import static io.camunda.webapps.schema.descriptors.template.EventTemplate.FLOW_NODE_INSTANCE_KEY;
 import static io.camunda.webapps.schema.descriptors.template.EventTemplate.KEY;
-import static io.camunda.webapps.schema.descriptors.template.EventTemplate.PROCESS_KEY;
 
 public class MessageSubscriptionFieldSortingTransformer implements FieldSortingTransformer {
 
@@ -24,7 +23,6 @@ public class MessageSubscriptionFieldSortingTransformer implements FieldSortingT
     return switch (domainField) {
       case "messageSubscriptionKey" -> KEY;
       case "processDefinitionId" -> BPMN_PROCESS_ID;
-      case "processDefinitionKey" -> PROCESS_KEY;
       case "processInstanceKey" -> PROCESS_INSTANCE_KEY;
       case "flowNodeId" -> FLOW_NODE_ID;
       case "flowNodeInstanceKey" -> FLOW_NODE_INSTANCE_KEY;

--- a/search/search-domain/src/main/java/io/camunda/search/sort/MessageSubscriptionSort.java
+++ b/search/search-domain/src/main/java/io/camunda/search/sort/MessageSubscriptionSort.java
@@ -37,11 +37,6 @@ public record MessageSubscriptionSort(List<FieldSorting> orderings) implements S
       return this;
     }
 
-    public Builder processDefinitionKey() {
-      currentOrdering = new FieldSorting("processDefinitionKey", null);
-      return this;
-    }
-
     public Builder processInstanceKey() {
       currentOrdering = new FieldSorting("processInstanceKey", null);
       return this;

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/MessageSubscriptionExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/MessageSubscriptionExportHandler.java
@@ -23,7 +23,6 @@ import java.util.Set;
 public class MessageSubscriptionExportHandler
     implements RdbmsExportHandler<ProcessMessageSubscriptionRecordValue> {
 
-  // TODO: We could also export CORRELATED, but we don't do that for ES/OS.
   private static final Set<Intent> STATES =
       Set.of(ProcessMessageSubscriptionIntent.CREATED, ProcessMessageSubscriptionIntent.MIGRATED);
   private final MessageSubscriptionWriter messageSubscriptionWriter;
@@ -53,7 +52,6 @@ public class MessageSubscriptionExportHandler
     return new MessageSubscriptionDbModel.Builder()
         .messageSubscriptionKey(record.getKey())
         .processDefinitionId(value.getBpmnProcessId())
-        .processDefinitionKey(null) // TODO: Check if we need this
         .processInstanceKey(value.getProcessInstanceKey())
         .flowNodeId(value.getElementId())
         .flowNodeInstanceKey(value.getElementInstanceKey())

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -7123,7 +7123,6 @@ components:
           enum:
             - messageSubscriptionKey
             - processDefinitionId
-            - processDefinitionKey
             - processInstanceKey
             - elementId
             - elementInstanceKey
@@ -7162,10 +7161,6 @@ components:
           description: The process definition ID associated with this message subscription.
           allOf:
             - $ref: "#/components/schemas/StringFilterProperty"
-        processDefinitionKey:
-          description: The process definition key associated with this message subscription.
-          allOf:
-            - $ref: "#/components/schemas/BasicStringFilterProperty"
         processInstanceKey:
           description: The process instance key associated with this message subscription.
           allOf:

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
@@ -1310,9 +1310,6 @@ public final class SearchQueryRequestMapper {
       ofNullable(filter.getProcessDefinitionId())
           .map(mapToOperations(String.class))
           .ifPresent(builder::processDefinitionIdOperations);
-      ofNullable(filter.getProcessDefinitionKey())
-          .map(mapToOperations(Long.class))
-          .ifPresent(builder::processDefinitionKeyOperations);
       ofNullable(filter.getProcessInstanceKey())
           .map(mapToOperations(Long.class))
           .ifPresent(builder::processInstanceKeyOperations);
@@ -1748,7 +1745,6 @@ public final class SearchQueryRequestMapper {
       switch (field) {
         case MESSAGE_SUBSCRIPTION_KEY -> builder.messageSubscriptionKey();
         case PROCESS_DEFINITION_ID -> builder.processDefinitionId();
-        case PROCESS_DEFINITION_KEY -> builder.processDefinitionKey();
         case PROCESS_INSTANCE_KEY -> builder.processInstanceKey();
         case ELEMENT_ID -> builder.flowNodeId();
         case ELEMENT_INSTANCE_KEY -> builder.flowNodeInstanceKey();

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/MessageSubscriptionQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/MessageSubscriptionQueryControllerTest.java
@@ -37,7 +37,6 @@ public class MessageSubscriptionQueryControllerTest extends RestControllerTest {
                 {
                   "messageSubscriptionKey": "2251799813685854",
                   "processDefinitionId": "gg_msg_receive_id",
-                  "processDefinitionKey": "948",
                   "processInstanceKey": "2251799813685849",
                   "elementId": "Activity_1ludhs2",
                   "elementInstanceKey": "2251799813685853",
@@ -65,7 +64,6 @@ public class MessageSubscriptionQueryControllerTest extends RestControllerTest {
                   new MessageSubscriptionEntity.Builder()
                       .messageSubscriptionKey(2251799813685854L)
                       .processDefinitionId("gg_msg_receive_id")
-                      .processDefinitionKey(948L)
                       .processInstanceKey(2251799813685849L)
                       .flowNodeId("Activity_1ludhs2")
                       .flowNodeInstanceKey(2251799813685853L)
@@ -148,7 +146,6 @@ public class MessageSubscriptionQueryControllerTest extends RestControllerTest {
               "filter": {
                 "messageSubscriptionKey": 123,
                 "processDefinitionId": "gg_msg_receive_id",
-                "processDefinitionKey": 948,
                 "processInstanceKey": 2251799813685849,
                 "elementId": "Activity_1ludhs2",
                 "elementInstanceKey": 2251799813685853,
@@ -174,7 +171,6 @@ public class MessageSubscriptionQueryControllerTest extends RestControllerTest {
                     f ->
                         f.messageSubscriptionKeys(123L)
                             .processDefinitionIds("gg_msg_receive_id")
-                            .processDefinitionKeys(948L)
                             .processInstanceKeys(2251799813685849L)
                             .flowNodeIds("Activity_1ludhs2")
                             .flowNodeInstanceKeys(2251799813685853L)
@@ -209,10 +205,6 @@ public class MessageSubscriptionQueryControllerTest extends RestControllerTest {
                 {
                   "field": "processDefinitionId",
                   "order": "desc"
-                },
-                {
-                  "field": "processDefinitionKey",
-                  "order": "asc"
                 },
                 {
                   "field": "processInstanceKey",
@@ -265,8 +257,6 @@ public class MessageSubscriptionQueryControllerTest extends RestControllerTest {
                             .asc()
                             .processDefinitionId()
                             .desc()
-                            .processDefinitionKey()
-                            .asc()
                             .processInstanceKey()
                             .desc()
                             .flowNodeId()


### PR DESCRIPTION
## Description

* Ensure some message subscription acceptance tests are running with RDBMS too
* Remove process definition key from message subscription filters, sorting and fields in general

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes https://github.com/camunda/camunda/issues/34445
