### PR TITLE
feat: Add support for usage metrics OS/ES indices cleanup

### DIFF
--- a/dist/src/main/resources/application-elasticsearch.yaml
+++ b/dist/src/main/resources/application-elasticsearch.yaml
@@ -110,7 +110,8 @@ zeebe:
               enabled: false
               minimumAge: 30d
               policyName: camunda-retention-policy
-
+              usageMetricsMinimumAge: 730d
+              usageMetricsPolicyName: camunda-usage-metrics-retention-policy
           createSchema: true
 
           processCache:

--- a/dist/src/main/resources/application-opensearch.yaml
+++ b/dist/src/main/resources/application-opensearch.yaml
@@ -110,6 +110,8 @@ zeebe:
               enabled: false
               minimumAge: 30d
               policyName: camunda-retention-policy
+              usageMetricsMinimumAge: 730d
+              usageMetricsPolicyName: camunda-usage-metrics-retention-policy
 
           createSchema: true
 

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/MultiDbConfigurator.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/MultiDbConfigurator.java
@@ -115,6 +115,10 @@ public class MultiDbConfigurator {
                           "minimumAge",
                           // 0s causes ILM to move data asap - it is normally the default
                           // https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-index-lifecycle.html#ilm-phase-transitions
+                          "0s",
+                          "usageMetricsPolicyName",
+                          indexPrefix + "-usage-metrics-ilm",
+                          "usageMetricsMinimumAge",
                           "0s")),
                   "bulk",
                   Map.of("size", 1)));
@@ -230,6 +234,10 @@ public class MultiDbConfigurator {
                           "minimumAge",
                           // 0s causes ILM to move data asap - it is normally the default
                           // https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-index-lifecycle.html#ilm-phase-transitions
+                          "0s",
+                          "usageMetricsPolicyName",
+                          indexPrefix + "-usage-metrics-ilm",
+                          "usageMetricsMinimumAge",
                           "0s")),
                   "bulk",
                   Map.of("size", 1)));

--- a/qa/util/src/test/java/io/camunda/qa/util/multidb/MultiDbConfiguratorTest.java
+++ b/qa/util/src/test/java/io/camunda/qa/util/multidb/MultiDbConfiguratorTest.java
@@ -110,6 +110,10 @@ public class MultiDbConfiguratorTest {
                     "policyName",
                     EXPECTED_PREFIX + "-ilm",
                     "minimumAge",
+                    "0s",
+                    "usageMetricsPolicyName",
+                    EXPECTED_PREFIX + "-usage-metrics-ilm",
+                    "usageMetricsMinimumAge",
                     "0s")));
   }
 
@@ -148,6 +152,10 @@ public class MultiDbConfiguratorTest {
                     "policyName",
                     EXPECTED_PREFIX + "-ilm",
                     "minimumAge",
+                    "0s",
+                    "usageMetricsPolicyName",
+                    EXPECTED_PREFIX + "-usage-metrics-ilm",
+                    "usageMetricsMinimumAge",
                     "0s")));
   }
 
@@ -187,6 +195,10 @@ public class MultiDbConfiguratorTest {
                     "policyName",
                     EXPECTED_PREFIX + "-ilm",
                     "minimumAge",
+                    "0s",
+                    "usageMetricsPolicyName",
+                    EXPECTED_PREFIX + "-usage-metrics-ilm",
+                    "usageMetricsMinimumAge",
                     "0s")));
   }
 
@@ -374,6 +386,10 @@ public class MultiDbConfiguratorTest {
                     "policyName",
                     EXPECTED_PREFIX + "-ilm",
                     "minimumAge",
+                    "0s",
+                    "usageMetricsPolicyName",
+                    EXPECTED_PREFIX + "-usage-metrics-ilm",
+                    "usageMetricsMinimumAge",
                     "0s")));
   }
 

--- a/schema-manager/src/main/java/io/camunda/search/schema/SchemaManager.java
+++ b/schema-manager/src/main/java/io/camunda/search/schema/SchemaManager.java
@@ -121,7 +121,12 @@ public class SchemaManager {
     LOG.info("Update index schema. '{}' indices need to be updated", newIndexProperties.size());
     updateSchemaMappings(newIndexProperties);
     updateSchemaSettings();
+    createLifecyclePolicies();
 
+    LOG.info("Schema management completed.");
+  }
+
+  private void createLifecyclePolicies() {
     final RetentionConfiguration retention = config.retention();
     if (retention.isEnabled()) {
       LOG.info(
@@ -130,8 +135,14 @@ public class SchemaManager {
           retention.getMinimumAge());
       searchEngineClient.putIndexLifeCyclePolicy(
           retention.getPolicyName(), retention.getMinimumAge());
+
+      LOG.info(
+          "Create usage metrics ILM policy [name: '{}', retention: '{}']",
+          retention.getUsageMetricsPolicyName(),
+          retention.getUsageMetricsMinimumAge());
+      searchEngineClient.putIndexLifeCyclePolicy(
+          retention.getUsageMetricsPolicyName(), retention.getUsageMetricsMinimumAge());
     }
-    LOG.info("Schema management completed.");
   }
 
   private void updateSchemaSettings() {

--- a/schema-manager/src/main/java/io/camunda/search/schema/config/RetentionConfiguration.java
+++ b/schema-manager/src/main/java/io/camunda/search/schema/config/RetentionConfiguration.java
@@ -10,10 +10,16 @@ package io.camunda.search.schema.config;
 public class RetentionConfiguration {
 
   private static final String DEFAULT_RETENTION_MINIMUM_AGE = "30d";
-  private static final String DEFAULT_RETENTION_POLICY_NAME = "camunda-history-retention-policy";
+  private static final String DEFAULT_RETENTION_POLICY_NAME = "camunda-retention-policy";
+  private static final String DEFAULT_USAGE_METRICS_MINIMUM_AGE = "730d"; // 2 years
+  private static final String DEFAULT_USAGE_METRICS_POLICY_NAME =
+      "camunda-usage-metrics-retention-policy";
+
   private boolean enabled = false;
   private String minimumAge = DEFAULT_RETENTION_MINIMUM_AGE;
   private String policyName = DEFAULT_RETENTION_POLICY_NAME;
+  private String usageMetricsMinimumAge = DEFAULT_USAGE_METRICS_MINIMUM_AGE;
+  private String usageMetricsPolicyName = DEFAULT_USAGE_METRICS_POLICY_NAME;
 
   public boolean isEnabled() {
     return enabled;
@@ -39,6 +45,22 @@ public class RetentionConfiguration {
     this.policyName = policyName;
   }
 
+  public String getUsageMetricsMinimumAge() {
+    return usageMetricsMinimumAge;
+  }
+
+  public void setUsageMetricsMinimumAge(final String usageMetricsMinimumAge) {
+    this.usageMetricsMinimumAge = usageMetricsMinimumAge;
+  }
+
+  public String getUsageMetricsPolicyName() {
+    return usageMetricsPolicyName;
+  }
+
+  public void setUsageMetricsPolicyName(final String usageMetricsPolicyName) {
+    this.usageMetricsPolicyName = usageMetricsPolicyName;
+  }
+
   @Override
   public String toString() {
     return "RetentionConfiguration{"
@@ -49,6 +71,12 @@ public class RetentionConfiguration {
         + '\''
         + ", policyName='"
         + policyName
+        + '\''
+        + ", usageMetricsMinimumAge='"
+        + usageMetricsMinimumAge
+        + '\''
+        + ", usageMetricsPolicyName='"
+        + usageMetricsPolicyName
         + '\''
         + '}';
   }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepository.java
@@ -33,6 +33,8 @@ import io.camunda.exporter.tasks.util.DateOfArchivedDocumentsUtil;
 import io.camunda.exporter.tasks.util.ElasticsearchRepository;
 import io.camunda.search.schema.config.RetentionConfiguration;
 import io.camunda.webapps.schema.descriptors.AbstractIndexDescriptor;
+import io.camunda.webapps.schema.descriptors.ComponentNames;
+import io.camunda.webapps.schema.descriptors.index.UsageMetricIndex;
 import io.camunda.webapps.schema.descriptors.template.BatchOperationTemplate;
 import io.camunda.webapps.schema.descriptors.template.ListViewTemplate;
 import io.micrometer.core.instrument.Timer;
@@ -51,7 +53,8 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
   // Matches versioned index names with version suffixes: {name}-{major}.{minor}.{patch}_{suffix}
   // e.g. "camunda-tenant-8.8.0_2025-02-23"
   private static final String VERSIONED_INDEX_PATTERN = ".+-\\d+\\.\\d+\\.\\d+_.+$";
-  private static final String USAGE_METRIC_INDEX_PREFIX = "camunda-usage-metric";
+  private static final String USAGE_METRIC_INDEX_PREFIX =
+      "%s-%s".formatted(ComponentNames.CAMUNDA, UsageMetricIndex.INDEX_NAME);
 
   private static final Time REINDEX_SCROLL_TIMEOUT = Time.of(t -> t.time("30s"));
   private static final Slices AUTO_SLICES =

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepository.java
@@ -47,7 +47,9 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
     implements ArchiverRepository {
   private static final String ALL_INDICES = "*";
   private static final String ALL_INDICES_PATTERN = ".*";
-  private static final String INDEX_WILDCARD = ".+-\\d+\\.\\d+\\.\\d+_.+$";
+  // Matches versioned index names with version suffixes: {name}-{major}.{minor}.{patch}_{suffix}
+  // e.g. "camunda-tenant-8.8.0_2025-02-23"
+  private static final String VERSIONED_INDEX_PATTERN = ".+-\\d+\\.\\d+\\.\\d+_.+$";
 
   private static final Time REINDEX_SCROLL_TIMEOUT = Time.of(t -> t.time("30s"));
   private static final Slices AUTO_SLICES =
@@ -124,7 +126,7 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
       return CompletableFuture.completedFuture(null);
     }
     final var formattedPrefix = AbstractIndexDescriptor.formatIndexPrefix(indexPrefix);
-    final var indexWildcard = "^" + formattedPrefix + INDEX_WILDCARD;
+    final var indexWildcard = "^" + formattedPrefix + VERSIONED_INDEX_PATTERN;
     return fetchMatchingIndexes(indexWildcard)
         .thenComposeAsync(this::setIndexLifeCycleToMatchingIndices, executor);
   }
@@ -230,15 +232,22 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
   private CompletableFuture<Void> setIndexLifeCycleToMatchingIndices(
       final List<String> destinationIndexNames) {
     if (destinationIndexNames.isEmpty()) {
+      logger.debug("No indices to set lifecycle policies for");
       return CompletableFuture.completedFuture(null);
     }
 
+    return applyPolicyToIndices(destinationIndexNames, retention.getPolicyName());
+  }
+
+  private CompletableFuture<Void> applyPolicyToIndices(
+      final List<String> indices, final String policyName) {
+
+    logger.debug("Applying policy '{}' to {} indices: {}", policyName, indices.size(), indices);
+
     final var settingsRequest =
         new PutIndicesSettingsRequest.Builder()
-            .settings(
-                settings ->
-                    settings.lifecycle(lifecycle -> lifecycle.name(retention.getPolicyName())))
-            .index(destinationIndexNames)
+            .settings(settings -> settings.lifecycle(lifecycle -> lifecycle.name(policyName)))
+            .index(indices)
             .allowNoIndices(true)
             .ignoreUnavailable(true)
             .build();

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepository.java
@@ -14,6 +14,8 @@ import io.camunda.exporter.tasks.util.DateOfArchivedDocumentsUtil;
 import io.camunda.exporter.tasks.util.OpensearchRepository;
 import io.camunda.search.schema.config.RetentionConfiguration;
 import io.camunda.webapps.schema.descriptors.AbstractIndexDescriptor;
+import io.camunda.webapps.schema.descriptors.ComponentNames;
+import io.camunda.webapps.schema.descriptors.index.UsageMetricIndex;
 import io.camunda.webapps.schema.descriptors.template.BatchOperationTemplate;
 import io.camunda.webapps.schema.descriptors.template.ListViewTemplate;
 import io.camunda.zeebe.exporter.api.ExporterException;
@@ -57,7 +59,8 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
   // Matches versioned index names with version suffixes: {name}-{major}.{minor}.{patch}_{suffix}
   // e.g. "camunda-tenant-8.8.0_2025-02-23"
   private static final String VERSIONED_INDEX_PATTERN = ".+-\\d+\\.\\d+\\.\\d+_.+$";
-  private static final String USAGE_METRIC_INDEX_PREFIX = "camunda-usage-metric";
+  private static final String USAGE_METRIC_INDEX_PREFIX =
+      "%s-%s".formatted(ComponentNames.CAMUNDA, UsageMetricIndex.INDEX_NAME);
 
   private final int partitionId;
   private final HistoryConfiguration config;

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryIT.java
@@ -7,7 +7,9 @@
  */
 package io.camunda.exporter.tasks.archiver;
 
-import static io.camunda.search.test.utils.SearchDBExtension.*;
+import static io.camunda.search.test.utils.SearchDBExtension.ARCHIVER_IDX_PREFIX;
+import static io.camunda.search.test.utils.SearchDBExtension.TEST_INTEGRATION_OPENSEARCH_AWS_URL;
+import static io.camunda.search.test.utils.SearchDBExtension.create;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -84,9 +86,11 @@ final class OpenSearchArchiverRepositoryIT {
 
   @AfterEach
   void afterEach() throws IOException {
-    final DeleteIndexRequest deleteRequest =
-        new Builder().index(zeebeIndex + "*", batchOperationIndex + "*").build();
+    final DeleteIndexRequest deleteRequest = new Builder().index("*").build();
     testClient.indices().delete(deleteRequest);
+
+    // delete all policies created during the tests
+    deleteAllTestPolicies();
   }
 
   @Test
@@ -120,24 +124,34 @@ final class OpenSearchArchiverRepositoryIT {
   @Test
   void shouldSetIndexLifeCycle() throws IOException {
     // given
-    final var indexName = ARCHIVER_IDX_PREFIX + UUID.randomUUID().toString();
+    final var tenantIndex = "camunda-tenant-" + UUID.randomUUID();
+    final var usageMetricIndex = "app-camunda-usage-metric-tu-" + UUID.randomUUID();
     final var repository = createRepository();
-    testClient.indices().create(r -> r.index(indexName));
+
+    testClient.indices().create(r -> r.index(tenantIndex));
+    testClient.indices().create(r -> r.index(usageMetricIndex));
 
     retention.setEnabled(true);
-    retention.setPolicyName("operate_delete_archived_indices");
 
     // when
-    createLifeCyclePolicy();
-    final var result = repository.setIndexLifeCycle(indexName);
+    createLifeCyclePolicies();
+    final var result = repository.setIndexLifeCycle(tenantIndex, usageMetricIndex);
 
     // then
     assertThat(result).succeedsWithin(Duration.ofSeconds(30));
 
-    // Takes a while for the policy to be applied
-    Awaitility.await("until the policy has been visibly applied")
-        .untilAsserted(
-            () -> assertThat(fetchPolicyForIndex(indexName)).isEqualTo(retention.getPolicyName()));
+    assertThat(fetchPolicyForIndexWithAwait(tenantIndex))
+        .as(
+            "Expected '%s' policy to be applied for index: '%s'",
+            retention.getPolicyName(), tenantIndex)
+        .isNotNull()
+        .isEqualTo(retention.getPolicyName());
+    assertThat(fetchPolicyForIndexWithAwait(usageMetricIndex))
+        .as(
+            "Expected '%s' policy to be applied for index: '%s'",
+            retention.getUsageMetricsPolicyName(), usageMetricIndex)
+        .isNotNull()
+        .isEqualTo(retention.getUsageMetricsPolicyName());
   }
 
   @ParameterizedTest
@@ -149,7 +163,11 @@ final class OpenSearchArchiverRepositoryIT {
   void shouldSetIndexLifeCycleOnAllValidIndexes(final String prefix) throws IOException {
     // given
     final var formattedPrefix = AbstractIndexDescriptor.formatIndexPrefix(prefix);
-    final var expectedIndices =
+    final var usageMetricsIndices =
+        List.of(
+            formattedPrefix + "camunda-usage-metric-8.3.0_2024-01-02",
+            formattedPrefix + "camunda-usage-metric-tu-8.3.0_2024-01-02");
+    final var otherIndices =
         List.of(
             formattedPrefix + "operate-record-8.2.1_2024-01-02",
             formattedPrefix + "tasklist-record-8.3.0_2024-01");
@@ -167,13 +185,15 @@ final class OpenSearchArchiverRepositoryIT {
 
     connectConfiguration.setIndexPrefix(prefix);
     final var repository = createRepository();
-    final var indices = new ArrayList<>(expectedIndices);
+    final var indices = new ArrayList<>(otherIndices);
+    indices.addAll(usageMetricsIndices);
     indices.addAll(untouchedIndices);
 
     retention.setEnabled(true);
-    retention.setPolicyName(prefix + "operate_delete_archived_indices");
+    retention.setPolicyName("default-policy");
+    retention.setUsageMetricsPolicyName("custom-usage-metrics-policy");
 
-    createLifeCyclePolicy();
+    createLifeCyclePolicies();
     for (final var index : indices) {
       testClient.indices().create(r -> r.index(index));
     }
@@ -183,16 +203,19 @@ final class OpenSearchArchiverRepositoryIT {
 
     // then
     assertThat(result).succeedsWithin(Duration.ofSeconds(30));
-    for (final var index : expectedIndices) {
-      // In OS, it takes a little while for the policy to be visibly applied, and flushing seems to
-      // have no effect on that
-      Awaitility.await("until the policy has been visibly applied")
-          .untilAsserted(
-              () ->
-                  assertThat(fetchPolicyForIndex(index))
-                      .as("policy applied for %s", index)
-                      .isNotNull()
-                      .isEqualTo(prefix + "operate_delete_archived_indices"));
+    // verify that the usage metrics policy was applied to all usage metric indices
+    for (final var index : usageMetricsIndices) {
+      assertThat(fetchPolicyForIndexWithAwait(index))
+          .as("Expected 'custom-usage-metrics-policy' policy to be applied for %s", index)
+          .isNotNull()
+          .isEqualTo("custom-usage-metrics-policy");
+    }
+    // verify that the default policy was applied to all other indices
+    for (final var index : otherIndices) {
+      assertThat(fetchPolicyForIndexWithAwait(index))
+          .as("Expected 'os-default-policy' policy to be applied for %s", index)
+          .isNotNull()
+          .isEqualTo("default-policy");
     }
 
     for (final var index : untouchedIndices) {
@@ -522,12 +545,18 @@ final class OpenSearchArchiverRepositoryIT {
     }
   }
 
-  private void createLifeCyclePolicy() {
+  private void createLifeCyclePolicies() {
+    createLifeCyclePolicy(retention.getPolicyName(), retention.getMinimumAge());
+    createLifeCyclePolicy(
+        retention.getUsageMetricsPolicyName(), retention.getUsageMetricsMinimumAge());
+  }
+
+  private void createLifeCyclePolicy(final String policyName, final String minAge) {
     final var engineClient = new OpensearchEngineClient(testClient, MAPPER);
     try {
-      engineClient.putIndexLifeCyclePolicy(retention.getPolicyName(), retention.getMinimumAge());
+      engineClient.putIndexLifeCyclePolicy(policyName, minAge);
     } catch (final Exception e) {
-      // policy was already created
+      LOGGER.warn("Could not create life cycle policy", e);
     }
   }
 
@@ -551,6 +580,13 @@ final class OpenSearchArchiverRepositoryIT {
     } catch (final IOException e) {
       throw new AssertionError("Failed to fetch policy for index " + indexName, e);
     }
+  }
+
+  private String fetchPolicyForIndexWithAwait(final String indexName) {
+    // In OS, it takes a little while for the policy to be visibly applied, and flushing seems to
+    // have no effect on that
+    return Awaitility.await("until the policy has been visibly applied")
+        .until(() -> fetchPolicyForIndex(indexName), policy -> !policy.equals("null"));
   }
 
   // no need to close resource returned here, since the transport is closed above anyway
@@ -631,6 +667,43 @@ final class OpenSearchArchiverRepositoryIT {
               AwsSdk2TransportOptions.builder()
                   .setMapper(new JacksonJsonpMapper(new ObjectMapper()))
                   .build()));
+    }
+  }
+
+  private void deleteAllTestPolicies() {
+    final var genericClient =
+        new OpenSearchGenericClient(testClient._transport(), testClient._transportOptions());
+    try {
+      // Get all policies
+      final var listRequest =
+          Requests.builder().method("GET").endpoint("_plugins/_ism/policies").build();
+      final var listResponse = genericClient.execute(listRequest);
+      final var jsonString = listResponse.getBody().orElseThrow().bodyAsString();
+      final var json = MAPPER.readTree(jsonString);
+
+      // Extract policy names and delete each one
+      final var policies = json.get("policies");
+      if (policies != null && policies.isArray()) {
+        for (final var policy : policies) {
+          final var policyId = policy.get("_id");
+          if (policyId != null) {
+            final var policyName = policyId.asText();
+            try {
+              final var deleteRequest =
+                  Requests.builder()
+                      .method("DELETE")
+                      .endpoint("_plugins/_ism/policies/" + policyName)
+                      .build();
+              genericClient.execute(deleteRequest);
+              LOGGER.debug("Deleted ISM policy: {}", policyName);
+            } catch (final Exception e) {
+              LOGGER.warn("Could not delete ISM policy '{}': {}", policyName, e.getMessage());
+            }
+          }
+        }
+      }
+    } catch (final Exception e) {
+      LOGGER.warn("Could not delete test ISM policies", e);
     }
   }
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryIT.java
@@ -213,7 +213,7 @@ final class OpenSearchArchiverRepositoryIT {
     // verify that the default policy was applied to all other indices
     for (final var index : otherIndices) {
       assertThat(fetchPolicyForIndexWithAwait(index))
-          .as("Expected 'os-default-policy' policy to be applied for %s", index)
+          .as("Expected 'default-policy' policy to be applied for %s", index)
           .isNotNull()
           .isEqualTo("default-policy");
     }


### PR DESCRIPTION
## Description

This PR introduces a mechanism to configure ILM policy for usage metric indices to enable automated retention and cleanup (Elasticsearch/OpenSearch).

### Summary
- Adds two new retention configuration fields specific to usage metrics indices:
  - `retention.usageMetricsMinimumAge`: minimum age before indices are eligible for deletion.
  - `retention.usageMetricsPolicyName`: name of the ILM policy to apply to usage metrics indices.
- If explicit retention values are not provided, the following defaults are used:
  - policy name: `"camunda-usage-metrics-retention-policy"`
  - minimum age: `"730d"` (2 years)
- The custom policy is created and applied to usage metrics indices only when retention is enabled:
  - `retention.enabled: true`
- Scope-limited: only usage metrics indices are affected; other indices are unchanged.

#### Configuration example
```yaml
retention:
  enabled: true
  # other retention settings ...
  usageMetricsMinimumAge: 730d
  usageMetricsPolicyName: camunda-usage-metrics-retention-policy
```

### Behavior
- When `retention.enabled` is `true`:
  - A custom ILM policy is created.
  - The policy is attached to usage metrics indices to enforce age-based cleanup.
- When `retention.enabled` is `false` or omitted:
  - No policy is created or applied for usage metrics indices. Defaults remain inactive unless retention is enabled.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #34709
