### PR TITLE
feat: introduce a filter to refresh camunda authentication

### DIFF
--- a/authentication/pom.xml
+++ b/authentication/pom.xml
@@ -54,6 +54,10 @@
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
+      <artifactId>spring-jcl</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
       <artifactId>spring-context</artifactId>
     </dependency>
     <dependency>

--- a/authentication/src/main/java/io/camunda/authentication/DefaultCamundaAuthenticationProvider.java
+++ b/authentication/src/main/java/io/camunda/authentication/DefaultCamundaAuthenticationProvider.java
@@ -34,6 +34,12 @@ public class DefaultCamundaAuthenticationProvider implements CamundaAuthenticati
         .orElseGet(() -> convertAndSetInHolder(springBasedAuthentication));
   }
 
+  @Override
+  public void refresh() {
+    final var springBasedAuthentication = SecurityContextHolder.getContext().getAuthentication();
+    convertAndSetInHolder(springBasedAuthentication);
+  }
+
   private CamundaAuthentication getFromHolderIfPresent(final Authentication authentication) {
     return Optional.ofNullable(authentication).map(principal -> holder.get()).orElse(null);
   }

--- a/authentication/src/main/java/io/camunda/authentication/DefaultCamundaAuthenticationProvider.java
+++ b/authentication/src/main/java/io/camunda/authentication/DefaultCamundaAuthenticationProvider.java
@@ -45,7 +45,7 @@ public class DefaultCamundaAuthenticationProvider implements CamundaAuthenticati
   }
 
   private CamundaAuthentication convertAndSetInHolder(final Authentication authentication) {
-    final var result = converter.convert(authentication);
+    final var result = authentication == null ? null : converter.convert(authentication);
     Optional.ofNullable(result).filter(a -> !a.isAnonymous()).ifPresent(p -> holder.set(result));
     return result;
   }

--- a/authentication/src/main/java/io/camunda/authentication/DefaultCamundaAuthenticationProvider.java
+++ b/authentication/src/main/java/io/camunda/authentication/DefaultCamundaAuthenticationProvider.java
@@ -45,7 +45,7 @@ public class DefaultCamundaAuthenticationProvider implements CamundaAuthenticati
   }
 
   private CamundaAuthentication convertAndSetInHolder(final Authentication authentication) {
-    final var result = authentication == null ? null : converter.convert(authentication);
+    final var result = converter.convert(authentication);
     Optional.ofNullable(result).filter(a -> !a.isAnonymous()).ifPresent(p -> holder.set(result));
     return result;
   }

--- a/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
@@ -31,6 +31,7 @@ import io.camunda.authentication.csrf.CsrfProtectionRequestMatcher;
 import io.camunda.authentication.exception.BasicAuthenticationNotSupportedException;
 import io.camunda.authentication.filters.AdminUserCheckFilter;
 import io.camunda.authentication.filters.OAuth2RefreshTokenFilter;
+import io.camunda.authentication.filters.SessionAuthenticationRefreshFilter;
 import io.camunda.authentication.filters.WebComponentAuthorizationCheckFilter;
 import io.camunda.authentication.handler.AuthFailureHandler;
 import io.camunda.authentication.service.MembershipService;
@@ -77,6 +78,7 @@ import org.springframework.security.config.annotation.web.configurers.HeadersCon
 import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer.ContentTypeOptionsConfig;
 import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer.FrameOptionsConfig;
 import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer.HstsConfig;
+import org.springframework.security.config.annotation.web.configurers.RequestCacheConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -101,6 +103,7 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.access.intercept.AuthorizationFilter;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.security.web.authentication.logout.LogoutSuccessHandler;
+import org.springframework.security.web.context.SecurityContextHolderFilter;
 import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
 import org.springframework.security.web.csrf.CsrfFilter;
 import org.springframework.security.web.csrf.CsrfToken;
@@ -514,6 +517,9 @@ public class WebSecurityConfig {
                           .authenticationEntryPoint(authFailureHandler)
                           .accessDeniedHandler(authFailureHandler))
               .addFilterAfter(
+                  new SessionAuthenticationRefreshFilter(authenticationProvider),
+                  SecurityContextHolderFilter.class)
+              .addFilterAfter(
                   new WebComponentAuthorizationCheckFilter(
                       securityConfiguration, authenticationProvider, resourceAccessProvider),
                   AuthorizationFilter.class)
@@ -727,6 +733,9 @@ public class WebSecurityConfig {
                           .logoutUrl(LOGOUT_URL)
                           .logoutSuccessHandler(new NoContentResponseHandler())
                           .deleteCookies(SESSION_COOKIE, X_CSRF_TOKEN))
+              .addFilterAfter(
+                  new SessionAuthenticationRefreshFilter(authenticationProvider),
+                  SecurityContextHolderFilter.class)
               .addFilterAfter(
                   new WebComponentAuthorizationCheckFilter(
                       securityConfiguration, authenticationProvider, resourceAccessProvider),

--- a/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
@@ -78,6 +78,7 @@ import org.springframework.security.config.annotation.web.configurers.HeadersCon
 import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer.ContentTypeOptionsConfig;
 import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer.FrameOptionsConfig;
 import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer.HstsConfig;
+import org.springframework.security.config.annotation.web.configurers.RequestCacheConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;

--- a/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
@@ -78,7 +78,6 @@ import org.springframework.security.config.annotation.web.configurers.HeadersCon
 import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer.ContentTypeOptionsConfig;
 import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer.FrameOptionsConfig;
 import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer.HstsConfig;
-import org.springframework.security.config.annotation.web.configurers.RequestCacheConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;

--- a/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
@@ -517,7 +517,8 @@ public class WebSecurityConfig {
                           .authenticationEntryPoint(authFailureHandler)
                           .accessDeniedHandler(authFailureHandler))
               .addFilterAfter(
-                  new SessionAuthenticationRefreshFilter(authenticationProvider),
+                  new SessionAuthenticationRefreshFilter(
+                      authenticationProvider, securityConfiguration.getAuthentication()),
                   SecurityContextHolderFilter.class)
               .addFilterAfter(
                   new WebComponentAuthorizationCheckFilter(
@@ -734,7 +735,8 @@ public class WebSecurityConfig {
                           .logoutSuccessHandler(new NoContentResponseHandler())
                           .deleteCookies(SESSION_COOKIE, X_CSRF_TOKEN))
               .addFilterAfter(
-                  new SessionAuthenticationRefreshFilter(authenticationProvider),
+                  new SessionAuthenticationRefreshFilter(
+                      authenticationProvider, securityConfiguration.getAuthentication()),
                   SecurityContextHolderFilter.class)
               .addFilterAfter(
                   new WebComponentAuthorizationCheckFilter(

--- a/authentication/src/main/java/io/camunda/authentication/filters/SessionAuthenticationRefreshFilter.java
+++ b/authentication/src/main/java/io/camunda/authentication/filters/SessionAuthenticationRefreshFilter.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.filters;
+
+import io.camunda.security.auth.CamundaAuthenticationProvider;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import java.io.IOException;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.function.Supplier;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+public class SessionAuthenticationRefreshFilter extends OncePerRequestFilter {
+  // TODO move to a configuration class
+  private static final Duration SESSION_REFRESH_INTERVAL = Duration.ofSeconds(120L);
+  private static final String LAST_REFRESH_ATTR = "AUTH_LAST_REFRESH";
+  private final CamundaAuthenticationProvider authenticationProvider;
+  private final Supplier<SecurityContext> securityContextSupplier;
+
+  public SessionAuthenticationRefreshFilter(
+      final CamundaAuthenticationProvider authenticationProvider) {
+    this(authenticationProvider, SecurityContextHolder::getContext);
+  }
+
+  public SessionAuthenticationRefreshFilter(
+      final CamundaAuthenticationProvider authenticationProvider,
+      final Supplier<SecurityContext> securityContextSupplier) {
+    this.authenticationProvider = authenticationProvider;
+    this.securityContextSupplier = securityContextSupplier;
+  }
+
+  @Override
+  protected void doFilterInternal(
+      final HttpServletRequest request,
+      final HttpServletResponse response,
+      final FilterChain filterChain)
+      throws ServletException, IOException {
+    final var session = request.getSession(false);
+    if (session != null && securityContextSupplier.get().getAuthentication() != null) {
+      handleSessionRefresh(session);
+    }
+    filterChain.doFilter(request, response);
+  }
+
+  private void handleSessionRefresh(final HttpSession session) {
+    final Instant now = Instant.now();
+    final Instant lastRefresh = (Instant) session.getAttribute(LAST_REFRESH_ATTR);
+
+    // Initialize if first access
+    if (lastRefresh == null) {
+      session.setAttribute(LAST_REFRESH_ATTR, now);
+      return;
+    }
+
+    // Check if refresh needed
+    // TODO Lock or find another way to skip concurrent update
+    if (ChronoUnit.MILLIS.between(lastRefresh, now) >= SESSION_REFRESH_INTERVAL.toMillis()) {
+      authenticationProvider.refresh();
+      session.setAttribute(LAST_REFRESH_ATTR, now);
+    }
+  }
+}

--- a/authentication/src/main/java/io/camunda/authentication/filters/SessionAuthenticationRefreshFilter.java
+++ b/authentication/src/main/java/io/camunda/authentication/filters/SessionAuthenticationRefreshFilter.java
@@ -22,7 +22,7 @@ import java.time.Instant;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 public class SessionAuthenticationRefreshFilter extends OncePerRequestFilter {
-  private static final String LAST_REFRESH_ATTR = "AUTH_LAST_REFRESH";
+  public static final String LAST_REFRESH_ATTR = "AUTH_LAST_REFRESH";
   private final CamundaAuthenticationProvider authenticationProvider;
   private final Duration authenticationRefreshInterval;
 
@@ -40,35 +40,44 @@ public class SessionAuthenticationRefreshFilter extends OncePerRequestFilter {
       final HttpServletResponse response,
       final FilterChain filterChain)
       throws ServletException, IOException {
-    final var session = request.getSession(false);
-    if (session != null && authenticationProvider.getCamundaAuthentication() != null) {
-      handleSessionRefresh(session);
+    try {
+      handleAuthenticationRefresh(request);
+    } catch (final Exception e) {
+      logger.debug("The session can't be refreshed.");
     }
     filterChain.doFilter(request, response);
   }
 
-  private void handleSessionRefresh(final HttpSession session) {
-    final Instant now = Instant.now();
-    Instant lastRefresh = (Instant) session.getAttribute(LAST_REFRESH_ATTR);
+  private void handleAuthenticationRefresh(final HttpServletRequest request) {
 
-    // Initialize if first access
-    if (lastRefresh == null) {
-      session.setAttribute(LAST_REFRESH_ATTR, now);
-      session.setAttribute(LAST_REFRESH_ATTR + "_LOCK", new Object());
-      return;
-    }
-
-    // Check if refresh needed
-    if (isRefreshRequired(lastRefresh, now)) {
-      synchronized (session.getAttribute(LAST_REFRESH_ATTR + "_LOCK")) {
-        lastRefresh = (Instant) session.getAttribute(LAST_REFRESH_ATTR);
-        // Double check if refresh still needed
-        if (isRefreshRequired(lastRefresh, now)) {
-          authenticationProvider.refresh();
-          session.setAttribute(LAST_REFRESH_ATTR, now);
-        }
+    final var session = request.getSession(false);
+    if (session != null && authenticationProvider.getCamundaAuthentication() != null) {
+      final Instant now = Instant.now();
+      final Instant lastRefresh = (Instant) session.getAttribute(LAST_REFRESH_ATTR);
+      if (lastRefresh == null) {
+        initializeRefreshAttributes(session, now);
+        return;
+      }
+      if (isRefreshRequired(lastRefresh, now)) {
+        lockAndRefresh(session, now);
       }
     }
+  }
+
+  private void lockAndRefresh(final HttpSession session, final Instant now) {
+    final Instant lastRefresh;
+    synchronized (session.getAttribute(LAST_REFRESH_ATTR + "_LOCK")) {
+      lastRefresh = (Instant) session.getAttribute(LAST_REFRESH_ATTR);
+      if (isRefreshRequired(lastRefresh, now)) {
+        authenticationProvider.refresh();
+        session.setAttribute(LAST_REFRESH_ATTR, now);
+      }
+    }
+  }
+
+  private static void initializeRefreshAttributes(final HttpSession session, final Instant now) {
+    session.setAttribute(LAST_REFRESH_ATTR, now);
+    session.setAttribute(LAST_REFRESH_ATTR + "_LOCK", new Object());
   }
 
   private boolean isRefreshRequired(final Instant lastRefresh, final Instant now) {

--- a/authentication/src/main/java/io/camunda/authentication/filters/SessionAuthenticationRefreshFilter.java
+++ b/authentication/src/main/java/io/camunda/authentication/filters/SessionAuthenticationRefreshFilter.java
@@ -7,10 +7,7 @@
  */
 package io.camunda.authentication.filters;
 
-import static java.time.temporal.ChronoUnit.MILLIS;
-
 import io.camunda.security.auth.CamundaAuthenticationProvider;
-import io.camunda.security.configuration.AuthenticationConfiguration;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -19,19 +16,29 @@ import jakarta.servlet.http.HttpSession;
 import java.io.IOException;
 import java.time.Duration;
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.function.Supplier;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 public class SessionAuthenticationRefreshFilter extends OncePerRequestFilter {
+  // TODO move to a configuration class
+  private static final Duration SESSION_REFRESH_INTERVAL = Duration.ofSeconds(120L);
   private static final String LAST_REFRESH_ATTR = "AUTH_LAST_REFRESH";
   private final CamundaAuthenticationProvider authenticationProvider;
-  private final Duration authenticationRefreshInterval;
+  private final Supplier<SecurityContext> securityContextSupplier;
+
+  public SessionAuthenticationRefreshFilter(
+      final CamundaAuthenticationProvider authenticationProvider) {
+    this(authenticationProvider, SecurityContextHolder::getContext);
+  }
 
   public SessionAuthenticationRefreshFilter(
       final CamundaAuthenticationProvider authenticationProvider,
-      final AuthenticationConfiguration authenticationConfiguration) {
+      final Supplier<SecurityContext> securityContextSupplier) {
     this.authenticationProvider = authenticationProvider;
-    authenticationRefreshInterval =
-        Duration.parse(authenticationConfiguration.getAuthenticationRefreshInterval());
+    this.securityContextSupplier = securityContextSupplier;
   }
 
   @Override
@@ -41,7 +48,7 @@ public class SessionAuthenticationRefreshFilter extends OncePerRequestFilter {
       final FilterChain filterChain)
       throws ServletException, IOException {
     final var session = request.getSession(false);
-    if (session != null && authenticationProvider.getCamundaAuthentication() != null) {
+    if (session != null && securityContextSupplier.get().getAuthentication() != null) {
       handleSessionRefresh(session);
     }
     filterChain.doFilter(request, response);
@@ -49,29 +56,19 @@ public class SessionAuthenticationRefreshFilter extends OncePerRequestFilter {
 
   private void handleSessionRefresh(final HttpSession session) {
     final Instant now = Instant.now();
-    Instant lastRefresh = (Instant) session.getAttribute(LAST_REFRESH_ATTR);
+    final Instant lastRefresh = (Instant) session.getAttribute(LAST_REFRESH_ATTR);
 
     // Initialize if first access
     if (lastRefresh == null) {
       session.setAttribute(LAST_REFRESH_ATTR, now);
-      session.setAttribute(LAST_REFRESH_ATTR + "_LOCK", new Object());
       return;
     }
 
     // Check if refresh needed
-    if (isRefreshRequired(lastRefresh, now)) {
-      synchronized (session.getAttribute(LAST_REFRESH_ATTR + "_LOCK")) {
-        lastRefresh = (Instant) session.getAttribute(LAST_REFRESH_ATTR);
-        // Double check if refresh still needed
-        if (isRefreshRequired(lastRefresh, now)) {
-          authenticationProvider.refresh();
-          session.setAttribute(LAST_REFRESH_ATTR, now);
-        }
-      }
+    // TODO Lock or find another way to skip concurrent update
+    if (ChronoUnit.MILLIS.between(lastRefresh, now) >= SESSION_REFRESH_INTERVAL.toMillis()) {
+      authenticationProvider.refresh();
+      session.setAttribute(LAST_REFRESH_ATTR, now);
     }
-  }
-
-  private boolean isRefreshRequired(final Instant lastRefresh, final Instant now) {
-    return MILLIS.between(lastRefresh, now) >= authenticationRefreshInterval.toMillis();
   }
 }

--- a/authentication/src/test/java/io/camunda/authentication/DefaultCamundaAuthenticationProviderTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/DefaultCamundaAuthenticationProviderTest.java
@@ -10,6 +10,7 @@ package io.camunda.authentication;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -96,5 +97,24 @@ public class DefaultCamundaAuthenticationProviderTest {
     assertThat(actualAuthentication).isNotNull();
     assertThat(actualAuthentication).isEqualTo(expectedAuthentication);
     verify(holder, times(0)).set(eq(expectedAuthentication));
+  }
+
+  @Test
+  void shouldNotCheckCacheWhenRefreshCalled() {
+    // given
+    final var expectedAuthentication = CamundaAuthentication.of(b -> b.user("foo"));
+
+    final var mockAuthentication = mock(Authentication.class);
+    when(mockAuthentication.getPrincipal()).thenReturn("foo");
+    SecurityContextHolder.getContext().setAuthentication(mockAuthentication);
+    when(authenticationConverter.convert(eq(mockAuthentication)))
+        .thenReturn(expectedAuthentication);
+
+    // when
+    authenticationProvider.refresh();
+
+    // then
+    verify(holder, never()).get();
+    verify(holder).set(eq(expectedAuthentication));
   }
 }

--- a/authentication/src/test/java/io/camunda/authentication/config/AbstractWebSecurityConfigTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/AbstractWebSecurityConfigTest.java
@@ -24,6 +24,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
 
 import io.camunda.authentication.config.controllers.TestApiController;
+import io.camunda.security.auth.CamundaAuthenticationProvider;
 import io.camunda.security.configuration.headers.ContentSecurityPolicyConfig;
 import io.camunda.security.configuration.headers.PermissionsPolicyConfig;
 import java.util.List;
@@ -32,6 +33,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureWebMvc;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.assertj.MockMvcTester;
 import org.springframework.test.web.servlet.assertj.MvcTestResult;
 
@@ -64,6 +66,8 @@ public class AbstractWebSecurityConfigTest {
    * logging.level.org.springframework.security=DEBUG to the Spring Boot config
    */
   @Autowired MockMvcTester mockMvcTester;
+
+  @MockitoBean private CamundaAuthenticationProvider authenticationProvider;
 
   /**
    * Different types of endpoints that the security config handles specifically

--- a/authentication/src/test/java/io/camunda/authentication/config/controllers/OidcFlowTestContext.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/controllers/OidcFlowTestContext.java
@@ -32,9 +32,16 @@ public class OidcFlowTestContext {
 
   @Bean
   public CamundaAuthenticationProvider createCamundaAuthenticationProvider() {
-    return () ->
-        new CamundaAuthentication(
+    return new CamundaAuthenticationProvider() {
+      @Override
+      public CamundaAuthentication getCamundaAuthentication() {
+        return new CamundaAuthentication(
             "dummyUsername", "dummyClientId", List.of(), List.of(), List.of(), List.of(), Map.of());
+      }
+
+      @Override
+      public void refresh() {}
+    };
   }
 
   @Bean

--- a/authentication/src/test/java/io/camunda/authentication/filters/SessionAuthenticationRefreshFilterTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/filters/SessionAuthenticationRefreshFilterTest.java
@@ -66,7 +66,7 @@ public class SessionAuthenticationRefreshFilterTest {
   void shouldOnlyRefreshOnceWhenMultipleConcurrentRequests() throws Exception {
     // Setup session with refresh needed
     final MockHttpSession session = new MockHttpSession();
-    setSessionRefreshAttribute(session);
+    setSessionRefreshAttribute(session, refreshInterval.multipliedBy(2));
     when(authenticationProvider.getCamundaAuthentication()).thenReturn(createMockAuthentication());
 
     // Simulate concurrent requests
@@ -109,7 +109,7 @@ public class SessionAuthenticationRefreshFilterTest {
   @Test
   void shouldNotRefreshBeforeInterval() {
     final MockHttpSession session = new MockHttpSession();
-    setSessionRefreshAttribute(session);
+    setSessionRefreshAttribute(session, refreshInterval.minus(Duration.ofSeconds(5)));
     when(authenticationProvider.getCamundaAuthentication()).thenReturn(createMockAuthentication());
 
     final MvcTestResult testResult =
@@ -162,7 +162,7 @@ public class SessionAuthenticationRefreshFilterTest {
   @Test
   void shouldRefreshAfterInterval() {
     final MockHttpSession session = new MockHttpSession();
-    setSessionRefreshAttribute(session);
+    setSessionRefreshAttribute(session, refreshInterval.multipliedBy(2));
     when(authenticationProvider.getCamundaAuthentication()).thenReturn(createMockAuthentication());
     final Instant oldRefresh = (Instant) session.getAttribute("AUTH_LAST_REFRESH");
 
@@ -190,8 +190,9 @@ public class SessionAuthenticationRefreshFilterTest {
         new HashMap<>());
   }
 
-  private void setSessionRefreshAttribute(final MockHttpSession session) {
-    final Instant lastRefreshRef = Instant.now().minus(refreshInterval.multipliedBy(2));
+  private void setSessionRefreshAttribute(
+      final MockHttpSession session, final Duration refreshInterval) {
+    final Instant lastRefreshRef = Instant.now().minus(refreshInterval);
     session.setAttribute("AUTH_LAST_REFRESH", lastRefreshRef);
     session.setAttribute("AUTH_LAST_REFRESH" + "_LOCK", new Object());
   }

--- a/authentication/src/test/java/io/camunda/authentication/filters/SessionAuthenticationRefreshFilterTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/filters/SessionAuthenticationRefreshFilterTest.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.filters;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.authentication.config.WebSecurityConfig;
+import io.camunda.authentication.config.controllers.TestApiController;
+import io.camunda.authentication.config.controllers.TestUserDetailsService;
+import io.camunda.authentication.config.controllers.WebSecurityConfigTestContext;
+import io.camunda.security.auth.CamundaAuthentication;
+import io.camunda.security.auth.CamundaAuthenticationProvider;
+import io.camunda.security.configuration.SecurityConfiguration;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureWebMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.assertj.MockMvcTester;
+import org.springframework.test.web.servlet.assertj.MvcTestResult;
+
+@SpringBootTest(
+    classes = {
+      WebSecurityConfigTestContext.class,
+      WebSecurityConfig.class,
+    })
+@AutoConfigureMockMvc
+@AutoConfigureWebMvc
+@ActiveProfiles("consolidated-auth")
+public class SessionAuthenticationRefreshFilterTest {
+  @Autowired MockMvcTester mockMvcTester;
+  Duration refreshInterval;
+  @MockitoBean private CamundaAuthenticationProvider authenticationProvider;
+  @Autowired private SecurityConfiguration securityConfiguration;
+
+  @BeforeEach
+  public void setup() {
+    reset(authenticationProvider);
+    refreshInterval =
+        Duration.parse(
+            securityConfiguration.getAuthentication().getAuthenticationRefreshInterval());
+  }
+
+  @Test
+  void shouldOnlyRefreshOnceWhenMultipleConcurrentRequests() throws Exception {
+    // Setup session with refresh needed
+    final MockHttpSession session = new MockHttpSession();
+    setSessionRefreshAttribute(session);
+    when(authenticationProvider.getCamundaAuthentication()).thenReturn(createMockAuthentication());
+
+    // Simulate concurrent requests
+    final AtomicInteger successfulRequests = new AtomicInteger(0);
+    final Runnable requestTask =
+        () -> {
+          try {
+            final MvcTestResult testResult =
+                mockMvcTester
+                    .get()
+                    .session(session)
+                    .uri("https://localhost" + TestApiController.DUMMY_WEBAPP_ENDPOINT)
+                    .exchange();
+            assertThat(testResult).hasStatusOk();
+            successfulRequests.incrementAndGet();
+          } catch (final Exception e) {
+            throw new RuntimeException(e);
+          }
+        };
+
+    // Create multiple threads
+    final Thread[] threads = new Thread[10];
+    for (int i = 0; i < threads.length; i++) {
+      threads[i] = new Thread(requestTask);
+      threads[i].start();
+    }
+
+    // Wait for completion
+    for (final Thread thread : threads) {
+      thread.join();
+    }
+
+    // Verify results
+    assertThat(successfulRequests.get()).isEqualTo(threads.length);
+    verify(authenticationProvider, times(1)).refresh();
+    final Instant newRefreshTime = (Instant) session.getAttribute("AUTH_LAST_REFRESH");
+    assertThat(newRefreshTime).isAfter(Instant.now().minusMillis(refreshInterval.toMillis()));
+  }
+
+  @Test
+  void shouldNotRefreshBeforeInterval() {
+    final MockHttpSession session = new MockHttpSession();
+    setSessionRefreshAttribute(session);
+    when(authenticationProvider.getCamundaAuthentication()).thenReturn(createMockAuthentication());
+
+    final MvcTestResult testResult =
+        mockMvcTester
+            .get()
+            .session(session)
+            .uri("https://localhost" + TestApiController.DUMMY_WEBAPP_ENDPOINT)
+            .exchange();
+
+    assertThat(testResult).hasStatusOk();
+    verify(authenticationProvider, never()).refresh();
+  }
+
+  @Test
+  void shouldInitializeOnFirstRequest() {
+    final MockHttpSession session = new MockHttpSession();
+    when(authenticationProvider.getCamundaAuthentication()).thenReturn(createMockAuthentication());
+
+    final MvcTestResult testResult =
+        mockMvcTester
+            .get()
+            .session(session)
+            .uri("https://localhost" + TestApiController.DUMMY_WEBAPP_ENDPOINT)
+            .exchange();
+
+    assertThat(testResult).hasStatusOk();
+    final Instant lastRefreshTime = (Instant) session.getAttribute("AUTH_LAST_REFRESH");
+    assertThat(lastRefreshTime).isNotNull();
+    assertThat(lastRefreshTime)
+        .isCloseTo(Instant.now(), within(refreshInterval.toMillis(), ChronoUnit.MILLIS));
+    verify(authenticationProvider, never()).refresh();
+  }
+
+  @Test
+  void shouldNotInitializeWithoutAuthentication() {
+    final MockHttpSession session = new MockHttpSession();
+
+    final MvcTestResult testResult =
+        mockMvcTester
+            .get()
+            .session(session)
+            .uri("https://localhost" + TestApiController.DUMMY_WEBAPP_ENDPOINT)
+            .exchange();
+
+    assertThat(testResult).hasStatusOk();
+    final Instant lastRefreshTime = (Instant) session.getAttribute("AUTH_LAST_REFRESH");
+    assertThat(lastRefreshTime).isNull();
+  }
+
+  @Test
+  void shouldRefreshAfterInterval() {
+    final MockHttpSession session = new MockHttpSession();
+    setSessionRefreshAttribute(session);
+    when(authenticationProvider.getCamundaAuthentication()).thenReturn(createMockAuthentication());
+    final Instant oldRefresh = (Instant) session.getAttribute("AUTH_LAST_REFRESH");
+
+    final MvcTestResult testResult =
+        mockMvcTester
+            .get()
+            .session(session)
+            .uri("https://localhost" + TestApiController.DUMMY_WEBAPP_ENDPOINT)
+            .exchange();
+
+    assertThat(testResult).hasStatusOk();
+    verify(authenticationProvider, times(1)).refresh();
+    final Instant lastRefreshTime = (Instant) session.getAttribute("AUTH_LAST_REFRESH");
+    assertThat(lastRefreshTime).isAfter(oldRefresh);
+  }
+
+  private CamundaAuthentication createMockAuthentication() {
+    return new CamundaAuthentication(
+        TestUserDetailsService.DEMO_USERNAME,
+        "",
+        Collections.emptyList(),
+        Collections.emptyList(),
+        Collections.emptyList(),
+        Collections.emptyList(),
+        new HashMap<>());
+  }
+
+  private void setSessionRefreshAttribute(final MockHttpSession session) {
+    final Instant lastRefreshRef = Instant.now().minus(refreshInterval.multipliedBy(2));
+    session.setAttribute("AUTH_LAST_REFRESH", lastRefreshRef);
+    session.setAttribute("AUTH_LAST_REFRESH" + "_LOCK", new Object());
+  }
+}

--- a/authentication/src/test/java/io/camunda/authentication/filters/SessionAuthenticationRefreshFilterTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/filters/SessionAuthenticationRefreshFilterTest.java
@@ -66,7 +66,7 @@ public class SessionAuthenticationRefreshFilterTest {
   void shouldOnlyRefreshOnceWhenMultipleConcurrentRequests() throws Exception {
     // Setup session with refresh needed
     final MockHttpSession session = new MockHttpSession();
-    setSessionRefreshAttribute(session, refreshInterval.multipliedBy(2));
+    setSessionRefreshAttribute(session);
     when(authenticationProvider.getCamundaAuthentication()).thenReturn(createMockAuthentication());
 
     // Simulate concurrent requests
@@ -109,7 +109,7 @@ public class SessionAuthenticationRefreshFilterTest {
   @Test
   void shouldNotRefreshBeforeInterval() {
     final MockHttpSession session = new MockHttpSession();
-    setSessionRefreshAttribute(session, refreshInterval.minus(Duration.ofSeconds(5)));
+    setSessionRefreshAttribute(session);
     when(authenticationProvider.getCamundaAuthentication()).thenReturn(createMockAuthentication());
 
     final MvcTestResult testResult =
@@ -162,7 +162,7 @@ public class SessionAuthenticationRefreshFilterTest {
   @Test
   void shouldRefreshAfterInterval() {
     final MockHttpSession session = new MockHttpSession();
-    setSessionRefreshAttribute(session, refreshInterval.multipliedBy(2));
+    setSessionRefreshAttribute(session);
     when(authenticationProvider.getCamundaAuthentication()).thenReturn(createMockAuthentication());
     final Instant oldRefresh = (Instant) session.getAttribute("AUTH_LAST_REFRESH");
 
@@ -190,9 +190,8 @@ public class SessionAuthenticationRefreshFilterTest {
         new HashMap<>());
   }
 
-  private void setSessionRefreshAttribute(
-      final MockHttpSession session, final Duration refreshInterval) {
-    final Instant lastRefreshRef = Instant.now().minus(refreshInterval);
+  private void setSessionRefreshAttribute(final MockHttpSession session) {
+    final Instant lastRefreshRef = Instant.now().minus(refreshInterval.multipliedBy(2));
     session.setAttribute("AUTH_LAST_REFRESH", lastRefreshRef);
     session.setAttribute("AUTH_LAST_REFRESH" + "_LOCK", new Object());
   }

--- a/authentication/src/test/java/io/camunda/authentication/filters/SessionAuthenticationRefreshFilterTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/filters/SessionAuthenticationRefreshFilterTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.authentication.filters;
 
+import static io.camunda.authentication.filters.SessionAuthenticationRefreshFilter.LAST_REFRESH_ATTR;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.within;
 import static org.mockito.Mockito.never;
@@ -63,50 +64,6 @@ public class SessionAuthenticationRefreshFilterTest {
   }
 
   @Test
-  void shouldOnlyRefreshOnceWhenMultipleConcurrentRequests() throws Exception {
-    // Setup session with refresh needed
-    final MockHttpSession session = new MockHttpSession();
-    setSessionRefreshAttribute(session, refreshInterval.multipliedBy(2));
-    when(authenticationProvider.getCamundaAuthentication()).thenReturn(createMockAuthentication());
-
-    // Simulate concurrent requests
-    final AtomicInteger successfulRequests = new AtomicInteger(0);
-    final Runnable requestTask =
-        () -> {
-          try {
-            final MvcTestResult testResult =
-                mockMvcTester
-                    .get()
-                    .session(session)
-                    .uri("https://localhost" + TestApiController.DUMMY_WEBAPP_ENDPOINT)
-                    .exchange();
-            assertThat(testResult).hasStatusOk();
-            successfulRequests.incrementAndGet();
-          } catch (final Exception e) {
-            throw new RuntimeException(e);
-          }
-        };
-
-    // Create multiple threads
-    final Thread[] threads = new Thread[10];
-    for (int i = 0; i < threads.length; i++) {
-      threads[i] = new Thread(requestTask);
-      threads[i].start();
-    }
-
-    // Wait for completion
-    for (final Thread thread : threads) {
-      thread.join();
-    }
-
-    // Verify results
-    assertThat(successfulRequests.get()).isEqualTo(threads.length);
-    verify(authenticationProvider, times(1)).refresh();
-    final Instant newRefreshTime = (Instant) session.getAttribute("AUTH_LAST_REFRESH");
-    assertThat(newRefreshTime).isAfter(Instant.now().minusMillis(refreshInterval.toMillis()));
-  }
-
-  @Test
   void shouldNotRefreshBeforeInterval() {
     final MockHttpSession session = new MockHttpSession();
     setSessionRefreshAttribute(session, refreshInterval.minus(Duration.ofSeconds(5)));
@@ -136,7 +93,7 @@ public class SessionAuthenticationRefreshFilterTest {
             .exchange();
 
     assertThat(testResult).hasStatusOk();
-    final Instant lastRefreshTime = (Instant) session.getAttribute("AUTH_LAST_REFRESH");
+    final Instant lastRefreshTime = (Instant) session.getAttribute(LAST_REFRESH_ATTR);
     assertThat(lastRefreshTime).isNotNull();
     assertThat(lastRefreshTime)
         .isCloseTo(Instant.now(), within(refreshInterval.toMillis(), ChronoUnit.MILLIS));
@@ -155,7 +112,7 @@ public class SessionAuthenticationRefreshFilterTest {
             .exchange();
 
     assertThat(testResult).hasStatusOk();
-    final Instant lastRefreshTime = (Instant) session.getAttribute("AUTH_LAST_REFRESH");
+    final Instant lastRefreshTime = (Instant) session.getAttribute(LAST_REFRESH_ATTR);
     assertThat(lastRefreshTime).isNull();
   }
 
@@ -164,7 +121,7 @@ public class SessionAuthenticationRefreshFilterTest {
     final MockHttpSession session = new MockHttpSession();
     setSessionRefreshAttribute(session, refreshInterval.multipliedBy(2));
     when(authenticationProvider.getCamundaAuthentication()).thenReturn(createMockAuthentication());
-    final Instant oldRefresh = (Instant) session.getAttribute("AUTH_LAST_REFRESH");
+    final Instant oldRefresh = (Instant) session.getAttribute(LAST_REFRESH_ATTR);
 
     final MvcTestResult testResult =
         mockMvcTester
@@ -175,8 +132,47 @@ public class SessionAuthenticationRefreshFilterTest {
 
     assertThat(testResult).hasStatusOk();
     verify(authenticationProvider, times(1)).refresh();
-    final Instant lastRefreshTime = (Instant) session.getAttribute("AUTH_LAST_REFRESH");
+    final Instant lastRefreshTime = (Instant) session.getAttribute(LAST_REFRESH_ATTR);
     assertThat(lastRefreshTime).isAfter(oldRefresh);
+  }
+
+  @Test
+  void shouldOnlyRefreshOnceWhenMultipleConcurrentRequests() throws Exception {
+    final MockHttpSession session = new MockHttpSession();
+    setSessionRefreshAttribute(session, refreshInterval.multipliedBy(2));
+    when(authenticationProvider.getCamundaAuthentication()).thenReturn(createMockAuthentication());
+
+    final AtomicInteger successfulRequests = new AtomicInteger(0);
+    final Runnable requestTask =
+        () -> {
+          try {
+            final MvcTestResult testResult =
+                mockMvcTester
+                    .get()
+                    .session(session)
+                    .uri("https://localhost" + TestApiController.DUMMY_WEBAPP_ENDPOINT)
+                    .exchange();
+            assertThat(testResult).hasStatusOk();
+            successfulRequests.incrementAndGet();
+          } catch (final Exception e) {
+            throw new RuntimeException(e);
+          }
+        };
+
+    final Thread[] threads = new Thread[10];
+    for (int i = 0; i < threads.length; i++) {
+      threads[i] = new Thread(requestTask);
+      threads[i].start();
+    }
+
+    for (final Thread thread : threads) {
+      thread.join();
+    }
+
+    assertThat(successfulRequests.get()).isEqualTo(threads.length);
+    verify(authenticationProvider, times(1)).refresh();
+    final Instant newRefreshTime = (Instant) session.getAttribute(LAST_REFRESH_ATTR);
+    assertThat(newRefreshTime).isAfter(Instant.now().minusMillis(refreshInterval.toMillis()));
   }
 
   private CamundaAuthentication createMockAuthentication() {
@@ -193,7 +189,7 @@ public class SessionAuthenticationRefreshFilterTest {
   private void setSessionRefreshAttribute(
       final MockHttpSession session, final Duration refreshInterval) {
     final Instant lastRefreshRef = Instant.now().minus(refreshInterval);
-    session.setAttribute("AUTH_LAST_REFRESH", lastRefreshRef);
-    session.setAttribute("AUTH_LAST_REFRESH" + "_LOCK", new Object());
+    session.setAttribute(LAST_REFRESH_ATTR, lastRefreshRef);
+    session.setAttribute(LAST_REFRESH_ATTR + "_LOCK", new Object());
   }
 }

--- a/security/security-core/src/main/java/io/camunda/security/auth/CamundaAuthenticationProvider.java
+++ b/security/security-core/src/main/java/io/camunda/security/auth/CamundaAuthenticationProvider.java
@@ -11,6 +11,8 @@ public interface CamundaAuthenticationProvider {
 
   CamundaAuthentication getCamundaAuthentication();
 
+  void refresh();
+
   default CamundaAuthentication getAnonymousCamundaAuthentication() {
     return CamundaAuthentication.anonymous();
   }

--- a/security/security-core/src/main/java/io/camunda/security/configuration/AuthenticationConfiguration.java
+++ b/security/security-core/src/main/java/io/camunda/security/configuration/AuthenticationConfiguration.java
@@ -14,6 +14,7 @@ public class AuthenticationConfiguration {
   public static final boolean DEFAULT_UNPROTECTED_API = false;
 
   private AuthenticationMethod method = DEFAULT_METHOD;
+  private String authenticationRefreshInterval = "PT30S";
   private OidcAuthenticationConfiguration oidcAuthenticationConfiguration =
       new OidcAuthenticationConfiguration();
   private boolean unprotectedApi = DEFAULT_UNPROTECTED_API;
@@ -32,6 +33,14 @@ public class AuthenticationConfiguration {
 
   public void setMethod(final AuthenticationMethod method) {
     this.method = method;
+  }
+
+  public String getAuthenticationRefreshInterval() {
+    return authenticationRefreshInterval;
+  }
+
+  public void setAuthenticationRefreshInterval(final String authenticationRefreshInterval) {
+    this.authenticationRefreshInterval = authenticationRefreshInterval;
   }
 
   public OidcAuthenticationConfiguration getOidc() {


### PR DESCRIPTION
## Description

When a user logs in, we determine their associations once (membership in roles, groups, tenants; application authorizations) and put them into the web session.

When these associations change (e.g. user is removed from a group; authorizations change), then this is not reflected in this cached state. Accordingly, as long as the user's session is alive, the changes do not take effect for them.

## Related issues

closes #34698 
