### PR TITLE
feat: add additional grpc properties to unified configuration

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/Grpc.java
+++ b/configuration/src/main/java/io/camunda/configuration/Grpc.java
@@ -16,6 +16,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import org.springframework.util.unit.DataSize;
 
 public class Grpc {
   private static final String PREFIX = "camunda.api.grpc";
@@ -24,12 +25,14 @@ public class Grpc {
           "host", "zeebe.gateway.network.host",
           "port", "zeebe.gateway.network.port",
           "minKeepAliveInterval", "zeebe.gateway.network.minKeepAliveInterval",
+          "maxMessageSize", "zeebe.gateway.network.maxMessageSize",
           "managementThreads", "zeebe.gateway.threads.managementThreads");
   private static final Map<String, String> LEGACY_BROKER_PROPERTIES =
       Map.of(
           "host", "zeebe.broker.gateway.network.host",
           "port", "zeebe.broker.gateway.network.port",
           "minKeepAliveInterval", "zeebe.broker.gateway.network.minKeepAliveInterval",
+          "maxMessageSize", "zeebe.broker.gateway.network.maxMessageSize",
           "managementThreads", "zeebe.broker.gateway.threads.managementThreads");
 
   private Map<String, String> legacyPropertiesMap = LEGACY_BROKER_PROPERTIES;
@@ -46,6 +49,9 @@ public class Grpc {
    * for seconds, 'm' for minutes or 'h' for hours.
    */
   private Duration minKeepAliveInterval = Duration.ofSeconds(30);
+
+  /** Sets the maximum size of the incoming and outgoing messages (i.e. commands and events). */
+  private DataSize maxMessageSize = DataSize.ofMegabytes(4);
 
   /** Sets the ssl configuration for the gateway */
   private Ssl ssl = new Ssl();
@@ -95,6 +101,19 @@ public class Grpc {
     this.minKeepAliveInterval = minKeepAliveInterval;
   }
 
+  public DataSize getMaxMessageSize() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + ".max-message-size",
+        maxMessageSize,
+        DataSize.class,
+        BackwardsCompatibilityMode.SUPPORTED,
+        Set.of(legacyPropertiesMap.get("maxMessageSize")));
+  }
+
+  public void setMaxMessageSize(final DataSize maxMessageSize) {
+    this.maxMessageSize = maxMessageSize;
+  }
+
   public Ssl getSsl() {
     return ssl;
   }
@@ -130,6 +149,7 @@ public class Grpc {
     copy.address = address;
     copy.port = port;
     copy.minKeepAliveInterval = minKeepAliveInterval;
+    copy.maxMessageSize = maxMessageSize;
     copy.ssl = ssl;
     copy.interceptors = interceptors;
     copy.managementThreads = managementThreads;

--- a/configuration/src/main/java/io/camunda/configuration/Grpc.java
+++ b/configuration/src/main/java/io/camunda/configuration/Grpc.java
@@ -11,6 +11,7 @@ import static io.camunda.zeebe.gateway.impl.configuration.ConfigurationDefaults.
 import static io.camunda.zeebe.gateway.impl.configuration.ConfigurationDefaults.DEFAULT_PORT;
 
 import io.camunda.configuration.UnifiedConfigurationHelper.BackwardsCompatibilityMode;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -22,11 +23,13 @@ public class Grpc {
       Map.of(
           "host", "zeebe.gateway.network.host",
           "port", "zeebe.gateway.network.port",
+          "minKeepAliveInterval", "zeebe.gateway.network.minKeepAliveInterval",
           "managementThreads", "zeebe.gateway.threads.managementThreads");
   private static final Map<String, String> LEGACY_BROKER_PROPERTIES =
       Map.of(
           "host", "zeebe.broker.gateway.network.host",
           "port", "zeebe.broker.gateway.network.port",
+          "minKeepAliveInterval", "zeebe.broker.gateway.network.minKeepAliveInterval",
           "managementThreads", "zeebe.broker.gateway.threads.managementThreads");
 
   private Map<String, String> legacyPropertiesMap = LEGACY_BROKER_PROPERTIES;
@@ -36,6 +39,13 @@ public class Grpc {
 
   /** Sets the port the gateway binds to */
   private int port = DEFAULT_PORT;
+
+  /**
+   * Sets the minimum keep alive interval. This setting specifies the minimum accepted interval
+   * between keep alive pings. This value must be specified as a positive integer followed by 's'
+   * for seconds, 'm' for minutes or 'h' for hours.
+   */
+  private Duration minKeepAliveInterval = Duration.ofSeconds(30);
 
   /** Sets the ssl configuration for the gateway */
   private Ssl ssl = new Ssl();
@@ -72,6 +82,19 @@ public class Grpc {
     this.port = port;
   }
 
+  public Duration getMinKeepAliveInterval() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + ".min-keep-alive-interval",
+        minKeepAliveInterval,
+        Duration.class,
+        BackwardsCompatibilityMode.SUPPORTED,
+        Set.of(legacyPropertiesMap.get("minKeepAliveInterval")));
+  }
+
+  public void setMinKeepAliveInterval(final Duration minKeepAliveInterval) {
+    this.minKeepAliveInterval = minKeepAliveInterval;
+  }
+
   public Ssl getSsl() {
     return ssl;
   }
@@ -106,6 +129,7 @@ public class Grpc {
     final Grpc copy = new Grpc();
     copy.address = address;
     copy.port = port;
+    copy.minKeepAliveInterval = minKeepAliveInterval;
     copy.ssl = ssl;
     copy.interceptors = interceptors;
     copy.managementThreads = managementThreads;

--- a/configuration/src/main/java/io/camunda/configuration/KeyStore.java
+++ b/configuration/src/main/java/io/camunda/configuration/KeyStore.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import io.camunda.configuration.UnifiedConfigurationHelper.BackwardsCompatibilityMode;
+import java.io.File;
+import java.util.Map;
+import java.util.Set;
+
+public class KeyStore {
+  private static final String PREFIX = "camunda.api.grpc.ssl.key-store";
+  private static final Map<String, String> LEGACY_GATEWAY_KEY_STORE_PROPERTIES =
+      Map.of(
+          "filePath", "zeebe.gateway.security.keyStore.filePath",
+          "password", "zeebe.gateway.security.keyStore.password");
+  private static final Map<String, String> LEGACY_BROKER_KEY_STORE_PROPERTIES =
+      Map.of(
+          "filePath", "zeebe.broker.gateway.security.keyStore.filePath",
+          "password", "zeebe.broker.gateway.security.keyStore.password");
+
+  private Map<String, String> legacyPropertiesMap = LEGACY_BROKER_KEY_STORE_PROPERTIES;
+
+  /** The path for keystore file */
+  private File filePath;
+
+  /** Sets the password for the keystore file, if not set it is assumed there is no password */
+  private String password;
+
+  public File getFilePath() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + ".file-path",
+        filePath,
+        File.class,
+        BackwardsCompatibilityMode.SUPPORTED,
+        Set.of(legacyPropertiesMap.get("filePath")));
+  }
+
+  public void setFilePath(final File filePath) {
+    this.filePath = filePath;
+  }
+
+  public String getPassword() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + ".password",
+        password,
+        String.class,
+        BackwardsCompatibilityMode.SUPPORTED,
+        Set.of(legacyPropertiesMap.get("password")));
+  }
+
+  public void setPassword(final String password) {
+    this.password = password;
+  }
+
+  @Override
+  public KeyStore clone() {
+    final KeyStore copy = new KeyStore();
+    copy.filePath = filePath;
+    copy.password = password;
+
+    return copy;
+  }
+
+  public KeyStore withBrokerKeyStoreProperties() {
+    final var copy = clone();
+    copy.legacyPropertiesMap = LEGACY_BROKER_KEY_STORE_PROPERTIES;
+    return copy;
+  }
+
+  public KeyStore withGatewayKeyStoreProperties() {
+    final var copy = clone();
+    copy.legacyPropertiesMap = LEGACY_GATEWAY_KEY_STORE_PROPERTIES;
+    return copy;
+  }
+}

--- a/configuration/src/main/java/io/camunda/configuration/Ssl.java
+++ b/configuration/src/main/java/io/camunda/configuration/Ssl.java
@@ -38,6 +38,12 @@ public class Ssl {
   /** Sets the path to the private key file location */
   private File certificatePrivateKey;
 
+  /**
+   * Configures the keystore file containing both the certificate chain and the private key.
+   * Currently only supports PKCS12 format.
+   */
+  private KeyStore keyStore = new KeyStore();
+
   public boolean isEnabled() {
     return UnifiedConfigurationHelper.validateLegacyConfiguration(
         PREFIX + ".enabled",
@@ -77,12 +83,21 @@ public class Ssl {
     this.certificatePrivateKey = certificatePrivateKey;
   }
 
+  public KeyStore getKeyStore() {
+    return keyStore;
+  }
+
+  public void setKeyStore(final KeyStore keyStore) {
+    this.keyStore = keyStore;
+  }
+
   @Override
   public Ssl clone() {
     final Ssl copy = new Ssl();
     copy.enabled = enabled;
     copy.certificate = certificate;
     copy.certificatePrivateKey = certificatePrivateKey;
+    copy.keyStore = keyStore.clone();
 
     return copy;
   }

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
@@ -95,6 +95,7 @@ public class BrokerBasedPropertiesOverride {
     final NetworkCfg networkCfg = override.getGateway().getNetwork();
     networkCfg.setHost(grpc.getAddress());
     networkCfg.setPort(grpc.getPort());
+    networkCfg.setMinKeepAliveInterval(grpc.getMinKeepAliveInterval());
 
     populateFromSsl(override);
     populateFromInterceptors(override);

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
@@ -96,6 +96,7 @@ public class BrokerBasedPropertiesOverride {
     networkCfg.setHost(grpc.getAddress());
     networkCfg.setPort(grpc.getPort());
     networkCfg.setMinKeepAliveInterval(grpc.getMinKeepAliveInterval());
+    networkCfg.setMaxMessageSize(grpc.getMaxMessageSize());
 
     populateFromSsl(override);
     populateFromInterceptors(override);

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
@@ -11,6 +11,7 @@ import io.camunda.configuration.Azure;
 import io.camunda.configuration.Filter;
 import io.camunda.configuration.Gcs;
 import io.camunda.configuration.Interceptor;
+import io.camunda.configuration.KeyStore;
 import io.camunda.configuration.S3;
 import io.camunda.configuration.SasToken;
 import io.camunda.configuration.Ssl;
@@ -28,6 +29,7 @@ import io.camunda.zeebe.broker.system.configuration.backup.S3BackupStoreConfig;
 import io.camunda.zeebe.dynamic.config.gossip.ClusterConfigurationGossiperConfig;
 import io.camunda.zeebe.gateway.impl.configuration.FilterCfg;
 import io.camunda.zeebe.gateway.impl.configuration.InterceptorCfg;
+import io.camunda.zeebe.gateway.impl.configuration.KeyStoreCfg;
 import io.camunda.zeebe.gateway.impl.configuration.NetworkCfg;
 import io.camunda.zeebe.gateway.impl.configuration.SecurityCfg;
 import java.util.List;
@@ -113,6 +115,22 @@ public class BrokerBasedPropertiesOverride {
     securityCfg.setEnabled(ssl.isEnabled());
     securityCfg.setCertificateChainPath(ssl.getCertificate());
     securityCfg.setPrivateKeyPath(ssl.getCertificatePrivateKey());
+
+    populateFromKeyStore(override);
+  }
+
+  private void populateFromKeyStore(final BrokerBasedProperties override) {
+    final KeyStore keyStore =
+        unifiedConfiguration
+            .getCamunda()
+            .getApi()
+            .getGrpc()
+            .getSsl()
+            .getKeyStore()
+            .withBrokerKeyStoreProperties();
+    final KeyStoreCfg keyStoreCfg = override.getGateway().getSecurity().getKeyStore();
+    keyStoreCfg.setFilePath(keyStore.getFilePath());
+    keyStoreCfg.setPassword(keyStore.getPassword());
   }
 
   private void populateFromInterceptors(final BrokerBasedProperties override) {

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/GatewayBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/GatewayBasedPropertiesOverride.java
@@ -10,12 +10,14 @@ package io.camunda.configuration.beanoverrides;
 import io.camunda.configuration.Filter;
 import io.camunda.configuration.Grpc;
 import io.camunda.configuration.Interceptor;
+import io.camunda.configuration.KeyStore;
 import io.camunda.configuration.Ssl;
 import io.camunda.configuration.UnifiedConfiguration;
 import io.camunda.configuration.beans.GatewayBasedProperties;
 import io.camunda.configuration.beans.LegacyGatewayBasedProperties;
 import io.camunda.zeebe.gateway.impl.configuration.FilterCfg;
 import io.camunda.zeebe.gateway.impl.configuration.InterceptorCfg;
+import io.camunda.zeebe.gateway.impl.configuration.KeyStoreCfg;
 import io.camunda.zeebe.gateway.impl.configuration.NetworkCfg;
 import io.camunda.zeebe.gateway.impl.configuration.SecurityCfg;
 import io.camunda.zeebe.gateway.impl.configuration.ThreadsCfg;
@@ -84,10 +86,27 @@ public class GatewayBasedPropertiesOverride {
   private void populateFromSsl(final GatewayBasedProperties override) {
     final Ssl ssl =
         unifiedConfiguration.getCamunda().getApi().getGrpc().getSsl().withGatewaySslProperties();
+
     final SecurityCfg securityCfg = override.getSecurity();
     securityCfg.setEnabled(ssl.isEnabled());
     securityCfg.setCertificateChainPath(ssl.getCertificate());
     securityCfg.setPrivateKeyPath(ssl.getCertificatePrivateKey());
+
+    populateFromKeyStore(override);
+  }
+
+  private void populateFromKeyStore(final GatewayBasedProperties override) {
+    final KeyStore keyStore =
+        unifiedConfiguration
+            .getCamunda()
+            .getApi()
+            .getGrpc()
+            .getSsl()
+            .getKeyStore()
+            .withGatewayKeyStoreProperties();
+    final KeyStoreCfg keyStoreCfg = override.getSecurity().getKeyStore();
+    keyStoreCfg.setFilePath(keyStore.getFilePath());
+    keyStoreCfg.setPassword(keyStore.getPassword());
   }
 
   private void populateFromInterceptors(final GatewayBasedProperties override) {

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/GatewayBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/GatewayBasedPropertiesOverride.java
@@ -71,6 +71,7 @@ public class GatewayBasedPropertiesOverride {
     final NetworkCfg networkCfg = override.getNetwork();
     networkCfg.setHost(grpc.getAddress());
     networkCfg.setPort(grpc.getPort());
+    networkCfg.setMinKeepAliveInterval(grpc.getMinKeepAliveInterval());
 
     populateFromSsl(override);
     populateFromInterceptors(override);

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/GatewayBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/GatewayBasedPropertiesOverride.java
@@ -72,6 +72,7 @@ public class GatewayBasedPropertiesOverride {
     networkCfg.setHost(grpc.getAddress());
     networkCfg.setPort(grpc.getPort());
     networkCfg.setMinKeepAliveInterval(grpc.getMinKeepAliveInterval());
+    networkCfg.setMaxMessageSize(grpc.getMaxMessageSize());
 
     populateFromSsl(override);
     populateFromInterceptors(override);

--- a/configuration/src/test/java/io/camunda/configuration/ApiGrpcBrokerPropertiesTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/ApiGrpcBrokerPropertiesTest.java
@@ -20,6 +20,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+import org.springframework.util.unit.DataSize;
 
 @SpringJUnitConfig({
   UnifiedConfiguration.class,
@@ -34,6 +35,7 @@ public class ApiGrpcBrokerPropertiesTest {
         "camunda.api.grpc.address=10.0.0.7",
         "camunda.api.grpc.port=27900",
         "camunda.api.grpc.min-keep-alive-interval=40s",
+        "camunda.api.grpc.max-message-size=40MB",
         "camunda.api.grpc.management-threads=5",
       })
   class WithOnlyUnifiedConfigSet {
@@ -60,6 +62,12 @@ public class ApiGrpcBrokerPropertiesTest {
     }
 
     @Test
+    void shouldSetMaxMessageSize() {
+      assertThat(brokerCfg.getGateway().getNetwork().getMaxMessageSize())
+          .isEqualTo(DataSize.ofMegabytes(40));
+    }
+
+    @Test
     void shouldSetManagementThreads() {
       assertThat(brokerCfg.getGateway().getThreads().getManagementThreads()).isEqualTo(5);
     }
@@ -71,6 +79,7 @@ public class ApiGrpcBrokerPropertiesTest {
         "zeebe.gateway.network.host=198.0.0.1",
         "zeebe.gateway.network.port=38900",
         "zeebe.gateway.network.minKeepAliveInterval=50s",
+        "zeebe.gateway.network.maxMessageSize=50MB",
         "zeebe.gateway.threads.managementThreads=10",
       })
   class WithOnlyLegacyGatewayPropertiesSet {
@@ -97,6 +106,12 @@ public class ApiGrpcBrokerPropertiesTest {
     }
 
     @Test
+    void shouldNotSetMaxMessageSizeFromLegacyGatewayNetwork() {
+      assertThat(brokerCfg.getGateway().getNetwork().getMaxMessageSize())
+          .isEqualTo(DataSize.ofMegabytes(4));
+    }
+
+    @Test
     void shouldNotSetManagementThreadsFromLegacyGatewayThreads() {
       assertThat(brokerCfg.getGateway().getThreads().getManagementThreads())
           .isEqualTo(DEFAULT_MANAGEMENT_THREADS);
@@ -109,6 +124,7 @@ public class ApiGrpcBrokerPropertiesTest {
         "zeebe.broker.gateway.network.host=192.0.0.1",
         "zeebe.broker.gateway.network.port=28900",
         "zeebe.broker.gateway.network.minKeepAliveInterval=60s",
+        "zeebe.broker.gateway.network.maxMessageSize=60MB",
         "zeebe.broker.gateway.threads.managementThreads=6",
       })
   class WithOnlyLegacyBrokerPropertiesSet {
@@ -135,6 +151,12 @@ public class ApiGrpcBrokerPropertiesTest {
     }
 
     @Test
+    void shouldSetMaxMessageSizeFromLegacyBrokerNetwork() {
+      assertThat(brokerCfg.getGateway().getNetwork().getMaxMessageSize())
+          .isEqualTo(DataSize.ofMegabytes(60));
+    }
+
+    @Test
     void shouldSetManagementThreadsFromLegacyBrokerThreads() {
       assertThat(brokerCfg.getGateway().getThreads().getManagementThreads()).isEqualTo(6);
     }
@@ -147,16 +169,19 @@ public class ApiGrpcBrokerPropertiesTest {
         "camunda.api.grpc.address=10.0.0.7",
         "camunda.api.grpc.port=27900",
         "camunda.api.grpc.min-keep-alive-interval=40s",
+        "camunda.api.grpc.max-message-size=40MB",
         "camunda.api.grpc.management-threads=5",
         // legacy gateway configuration
         "zeebe.gateway.network.host=198.0.0.1",
         "zeebe.gateway.network.port=38900",
         "zeebe.gateway.network.minKeepAliveInterval=50s",
+        "zeebe.gateway.network.maxMessageSize=50MB",
         "zeebe.gateway.threads.managementThreads=10",
         // legacy broker configuration
         "zeebe.broker.gateway.network.host=192.0.0.1",
         "zeebe.broker.gateway.network.port=28900",
-        "zeebe.broker.network.minKeepAliveInterval=60s",
+        "zeebe.broker.gateway.network.minKeepAliveInterval=60s",
+        "zeebe.broker.gateway.network.maxMessageSize=60MB",
         "zeebe.broker.gateway.threads.managementThreads=6"
       })
   class WithNewAndLegacySet {
@@ -180,6 +205,12 @@ public class ApiGrpcBrokerPropertiesTest {
     void shouldSetMinKeepAliveIntervalFromNew() {
       assertThat(brokerCfg.getGateway().getNetwork().getMinKeepAliveInterval())
           .isEqualTo(Duration.ofSeconds(40));
+    }
+
+    @Test
+    void shouldSetMaxMessageSizeFromNew() {
+      assertThat(brokerCfg.getGateway().getNetwork().getMaxMessageSize())
+          .isEqualTo(DataSize.ofMegabytes(40));
     }
 
     @Test

--- a/configuration/src/test/java/io/camunda/configuration/ApiGrpcBrokerPropertiesTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/ApiGrpcBrokerPropertiesTest.java
@@ -13,6 +13,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.configuration.beanoverrides.BrokerBasedPropertiesOverride;
 import io.camunda.configuration.beans.BrokerBasedProperties;
+import java.time.Duration;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -32,6 +33,7 @@ public class ApiGrpcBrokerPropertiesTest {
       properties = {
         "camunda.api.grpc.address=10.0.0.7",
         "camunda.api.grpc.port=27900",
+        "camunda.api.grpc.min-keep-alive-interval=40s",
         "camunda.api.grpc.management-threads=5",
       })
   class WithOnlyUnifiedConfigSet {
@@ -52,6 +54,12 @@ public class ApiGrpcBrokerPropertiesTest {
     }
 
     @Test
+    void shouldSetMinKeepAliveInterval() {
+      assertThat(brokerCfg.getGateway().getNetwork().getMinKeepAliveInterval())
+          .isEqualTo(Duration.ofSeconds(40));
+    }
+
+    @Test
     void shouldSetManagementThreads() {
       assertThat(brokerCfg.getGateway().getThreads().getManagementThreads()).isEqualTo(5);
     }
@@ -62,6 +70,7 @@ public class ApiGrpcBrokerPropertiesTest {
       properties = {
         "zeebe.gateway.network.host=198.0.0.1",
         "zeebe.gateway.network.port=38900",
+        "zeebe.gateway.network.minKeepAliveInterval=50s",
         "zeebe.gateway.threads.managementThreads=10",
       })
   class WithOnlyLegacyGatewayPropertiesSet {
@@ -82,6 +91,12 @@ public class ApiGrpcBrokerPropertiesTest {
     }
 
     @Test
+    void shouldNotSetMinKeepAliveIntervalFromLegacyGatewayNetwork() {
+      assertThat(brokerCfg.getGateway().getNetwork().getMinKeepAliveInterval())
+          .isEqualTo(Duration.ofSeconds(30));
+    }
+
+    @Test
     void shouldNotSetManagementThreadsFromLegacyGatewayThreads() {
       assertThat(brokerCfg.getGateway().getThreads().getManagementThreads())
           .isEqualTo(DEFAULT_MANAGEMENT_THREADS);
@@ -93,6 +108,7 @@ public class ApiGrpcBrokerPropertiesTest {
       properties = {
         "zeebe.broker.gateway.network.host=192.0.0.1",
         "zeebe.broker.gateway.network.port=28900",
+        "zeebe.broker.gateway.network.minKeepAliveInterval=60s",
         "zeebe.broker.gateway.threads.managementThreads=6",
       })
   class WithOnlyLegacyBrokerPropertiesSet {
@@ -113,6 +129,12 @@ public class ApiGrpcBrokerPropertiesTest {
     }
 
     @Test
+    void shouldSetMinKeepAliveIntervalFromLegacyBrokerNetwork() {
+      assertThat(brokerCfg.getGateway().getNetwork().getMinKeepAliveInterval())
+          .isEqualTo(Duration.ofSeconds(60));
+    }
+
+    @Test
     void shouldSetManagementThreadsFromLegacyBrokerThreads() {
       assertThat(brokerCfg.getGateway().getThreads().getManagementThreads()).isEqualTo(6);
     }
@@ -124,14 +146,17 @@ public class ApiGrpcBrokerPropertiesTest {
         // new unified configuration
         "camunda.api.grpc.address=10.0.0.7",
         "camunda.api.grpc.port=27900",
+        "camunda.api.grpc.min-keep-alive-interval=40s",
         "camunda.api.grpc.management-threads=5",
         // legacy gateway configuration
         "zeebe.gateway.network.host=198.0.0.1",
         "zeebe.gateway.network.port=38900",
+        "zeebe.gateway.network.minKeepAliveInterval=50s",
         "zeebe.gateway.threads.managementThreads=10",
         // legacy broker configuration
         "zeebe.broker.gateway.network.host=192.0.0.1",
         "zeebe.broker.gateway.network.port=28900",
+        "zeebe.broker.network.minKeepAliveInterval=60s",
         "zeebe.broker.gateway.threads.managementThreads=6"
       })
   class WithNewAndLegacySet {
@@ -149,6 +174,12 @@ public class ApiGrpcBrokerPropertiesTest {
     @Test
     void shouldSetPortFromNew() {
       assertThat(brokerCfg.getGateway().getNetwork().getPort()).isEqualTo(27900);
+    }
+
+    @Test
+    void shouldSetMinKeepAliveIntervalFromNew() {
+      assertThat(brokerCfg.getGateway().getNetwork().getMinKeepAliveInterval())
+          .isEqualTo(Duration.ofSeconds(40));
     }
 
     @Test

--- a/configuration/src/test/java/io/camunda/configuration/ApiGrpcGatewayPropertiesTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/ApiGrpcGatewayPropertiesTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+import org.springframework.util.unit.DataSize;
 
 @SpringJUnitConfig({
   UnifiedConfiguration.class,
@@ -32,6 +33,7 @@ public class ApiGrpcGatewayPropertiesTest {
         "camunda.api.grpc.address=10.0.0.7",
         "camunda.api.grpc.port=27900",
         "camunda.api.grpc.min-keep-alive-interval=40s",
+        "camunda.api.grpc.max-message-size=40MB",
         "camunda.api.grpc.management-threads=5",
       })
   class WithOnlyUnifiedConfigSet {
@@ -58,6 +60,11 @@ public class ApiGrpcGatewayPropertiesTest {
     }
 
     @Test
+    void shouldSetMaxMessageSize() {
+      assertThat(gatewayCfg.getNetwork().getMaxMessageSize()).isEqualTo(DataSize.ofMegabytes(40));
+    }
+
+    @Test
     void shouldSetManagementThreads() {
       assertThat(gatewayCfg.getThreads().getManagementThreads()).isEqualTo(5);
     }
@@ -69,6 +76,7 @@ public class ApiGrpcGatewayPropertiesTest {
         "zeebe.broker.gateway.network.host=198.0.0.1",
         "zeebe.broker.gateway.network.port=38900",
         "zeebe.broker.gateway.network.minKeepAliveInterval=50s",
+        "zeebe.broker.gateway.network.maxMessageSize=50MB",
         "zeebe.broker.gateway.threads.managementThreads=10",
       })
   class WithOnlyLegacyBrokerPropertiesSet {
@@ -95,6 +103,11 @@ public class ApiGrpcGatewayPropertiesTest {
     }
 
     @Test
+    void shouldNotSetMaxMessageSizeFromLegacyBrokerNetwork() {
+      assertThat(gatewayCfg.getNetwork().getMaxMessageSize()).isEqualTo(DataSize.ofMegabytes(4));
+    }
+
+    @Test
     void shouldNotSetManagementThreadsFromLegacyBrokerThreads() {
       assertThat(gatewayCfg.getThreads().getManagementThreads())
           .isEqualTo(DEFAULT_MANAGEMENT_THREADS);
@@ -107,6 +120,7 @@ public class ApiGrpcGatewayPropertiesTest {
         "zeebe.gateway.network.host=192.0.0.1",
         "zeebe.gateway.network.port=28900",
         "zeebe.gateway.network.minKeepAliveInterval=60s",
+        "zeebe.gateway.network.maxMessageSize=60MB",
         "zeebe.gateway.threads.managementThreads=6",
       })
   class WithOnlyLegacyGatewayPropertiesSet {
@@ -133,6 +147,11 @@ public class ApiGrpcGatewayPropertiesTest {
     }
 
     @Test
+    void shouldSetMaxMessageSizeFromLegacyGatewayNetwork() {
+      assertThat(gatewayCfg.getNetwork().getMaxMessageSize()).isEqualTo(DataSize.ofMegabytes(60));
+    }
+
+    @Test
     void shouldSetManagementThreadsFromLegacyGatewayThreads() {
       assertThat(gatewayCfg.getThreads().getManagementThreads()).isEqualTo(6);
     }
@@ -145,16 +164,19 @@ public class ApiGrpcGatewayPropertiesTest {
         "camunda.api.grpc.address=10.0.0.7",
         "camunda.api.grpc.port=27900",
         "camunda.api.grpc.min-keep-alive-interval=40s",
+        "camunda.api.grpc.max-message-size=40MB",
         "camunda.api.grpc.management-threads=5",
         // legacy broker configuration
         "zeebe.broker.gateway.network.host=198.0.0.1",
         "zeebe.broker.gateway.network.port=38900",
         "zeebe.broker.gateway.network.minKeepAliveInterval=60s",
+        "zeebe.broker.gateway.network.maxMessageSize=50MB",
         "zeebe.broker.gateway.threads.managementThreads=10",
         // legacy gateway configuration
         "zeebe.gateway.network.host=192.0.0.1",
         "zeebe.gateway.network.port=28900",
         "zeebe.gateway.network.minKeepAliveInterval=50s",
+        "zeebe.gateway.network.maxMessageSize=60MB",
         "zeebe.gateway.threads.managementThreads=6",
       })
   class WithNewAndLegacySet {
@@ -178,6 +200,11 @@ public class ApiGrpcGatewayPropertiesTest {
     void shouldSetMinKeepAliveIntervalFromNew() {
       assertThat(gatewayCfg.getNetwork().getMinKeepAliveInterval())
           .isEqualTo(Duration.ofSeconds(40));
+    }
+
+    @Test
+    void shouldSetMaxMessageSizeFromNew() {
+      assertThat(gatewayCfg.getNetwork().getMaxMessageSize()).isEqualTo(DataSize.ofMegabytes(40));
     }
 
     @Test

--- a/configuration/src/test/java/io/camunda/configuration/ApiGrpcGatewayPropertiesTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/ApiGrpcGatewayPropertiesTest.java
@@ -13,6 +13,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.configuration.beanoverrides.GatewayBasedPropertiesOverride;
 import io.camunda.configuration.beans.GatewayBasedProperties;
+import java.time.Duration;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -30,6 +31,7 @@ public class ApiGrpcGatewayPropertiesTest {
       properties = {
         "camunda.api.grpc.address=10.0.0.7",
         "camunda.api.grpc.port=27900",
+        "camunda.api.grpc.min-keep-alive-interval=40s",
         "camunda.api.grpc.management-threads=5",
       })
   class WithOnlyUnifiedConfigSet {
@@ -50,6 +52,12 @@ public class ApiGrpcGatewayPropertiesTest {
     }
 
     @Test
+    void shouldSetMinKeepAliveInterval() {
+      assertThat(gatewayCfg.getNetwork().getMinKeepAliveInterval())
+          .isEqualTo(Duration.ofSeconds(40));
+    }
+
+    @Test
     void shouldSetManagementThreads() {
       assertThat(gatewayCfg.getThreads().getManagementThreads()).isEqualTo(5);
     }
@@ -60,6 +68,7 @@ public class ApiGrpcGatewayPropertiesTest {
       properties = {
         "zeebe.broker.gateway.network.host=198.0.0.1",
         "zeebe.broker.gateway.network.port=38900",
+        "zeebe.broker.gateway.network.minKeepAliveInterval=50s",
         "zeebe.broker.gateway.threads.managementThreads=10",
       })
   class WithOnlyLegacyBrokerPropertiesSet {
@@ -80,6 +89,12 @@ public class ApiGrpcGatewayPropertiesTest {
     }
 
     @Test
+    void shouldNotSetMinKeepAliveIntervalFromLegacyBrokerNetwork() {
+      assertThat(gatewayCfg.getNetwork().getMinKeepAliveInterval())
+          .isEqualTo(Duration.ofSeconds(30));
+    }
+
+    @Test
     void shouldNotSetManagementThreadsFromLegacyBrokerThreads() {
       assertThat(gatewayCfg.getThreads().getManagementThreads())
           .isEqualTo(DEFAULT_MANAGEMENT_THREADS);
@@ -91,6 +106,7 @@ public class ApiGrpcGatewayPropertiesTest {
       properties = {
         "zeebe.gateway.network.host=192.0.0.1",
         "zeebe.gateway.network.port=28900",
+        "zeebe.gateway.network.minKeepAliveInterval=60s",
         "zeebe.gateway.threads.managementThreads=6",
       })
   class WithOnlyLegacyGatewayPropertiesSet {
@@ -111,6 +127,12 @@ public class ApiGrpcGatewayPropertiesTest {
     }
 
     @Test
+    void shouldSetMinKeepAliveIntervalFromLegacyGatewayNetwork() {
+      assertThat(gatewayCfg.getNetwork().getMinKeepAliveInterval())
+          .isEqualTo(Duration.ofSeconds(60));
+    }
+
+    @Test
     void shouldSetManagementThreadsFromLegacyGatewayThreads() {
       assertThat(gatewayCfg.getThreads().getManagementThreads()).isEqualTo(6);
     }
@@ -122,14 +144,17 @@ public class ApiGrpcGatewayPropertiesTest {
         // new unified configuration
         "camunda.api.grpc.address=10.0.0.7",
         "camunda.api.grpc.port=27900",
+        "camunda.api.grpc.min-keep-alive-interval=40s",
         "camunda.api.grpc.management-threads=5",
         // legacy broker configuration
         "zeebe.broker.gateway.network.host=198.0.0.1",
         "zeebe.broker.gateway.network.port=38900",
+        "zeebe.broker.gateway.network.minKeepAliveInterval=60s",
         "zeebe.broker.gateway.threads.managementThreads=10",
         // legacy gateway configuration
         "zeebe.gateway.network.host=192.0.0.1",
         "zeebe.gateway.network.port=28900",
+        "zeebe.gateway.network.minKeepAliveInterval=50s",
         "zeebe.gateway.threads.managementThreads=6",
       })
   class WithNewAndLegacySet {
@@ -147,6 +172,12 @@ public class ApiGrpcGatewayPropertiesTest {
     @Test
     void shouldSetPortFromNew() {
       assertThat(gatewayCfg.getNetwork().getPort()).isEqualTo(27900);
+    }
+
+    @Test
+    void shouldSetMinKeepAliveIntervalFromNew() {
+      assertThat(gatewayCfg.getNetwork().getMinKeepAliveInterval())
+          .isEqualTo(Duration.ofSeconds(40));
     }
 
     @Test

--- a/configuration/src/test/java/io/camunda/configuration/ApiGrpcSslBrokerKeyStoreTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/ApiGrpcSslBrokerKeyStoreTest.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.configuration.beanoverrides.BrokerBasedPropertiesOverride;
+import io.camunda.configuration.beans.BrokerBasedProperties;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+@SpringJUnitConfig({
+  UnifiedConfiguration.class,
+  BrokerBasedPropertiesOverride.class,
+  UnifiedConfigurationHelper.class
+})
+@ActiveProfiles("broker")
+public class ApiGrpcSslBrokerKeyStoreTest {
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "camunda.api.grpc.ssl.key-store.file-path=filePathNew",
+        "camunda.api.grpc.ssl.key-store.password=passwordNew",
+      })
+  class WithOnlyUnifiedConfigSslSet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithOnlyUnifiedConfigSslSet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldSetFilePath() {
+      assertThat(brokerCfg.getGateway().getSecurity().getKeyStore().getFilePath().getPath())
+          .isEqualTo("filePathNew");
+    }
+
+    @Test
+    void shouldSetPassword() {
+      assertThat(brokerCfg.getGateway().getSecurity().getKeyStore().getPassword())
+          .isEqualTo("passwordNew");
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "zeebe.gateway.security.keyStore.filePath=filePathLegacyGateway",
+        "zeebe.gateway.security.keyStore.password=passwordLegacyGateway"
+      })
+  class WithOnlyLegacyBrokerSecuritySet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithOnlyLegacyBrokerSecuritySet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldNotSetFilePathFromLegacyGateway() {
+      assertThat(brokerCfg.getGateway().getSecurity().getKeyStore().getFilePath()).isNull();
+    }
+
+    @Test
+    void shouldNotSetPasswordFromLegacyGateway() {
+      assertThat(brokerCfg.getGateway().getSecurity().getKeyStore().getPassword()).isNull();
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "zeebe.broker.gateway.security.keyStore.filePath=filePathLegacyBroker",
+        "zeebe.broker.gateway.security.keyStore.password=passwordLegacyBroker",
+      })
+  class WithOnlyLegacyGatewaySecuritySet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithOnlyLegacyGatewaySecuritySet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldSetFilePathFromLegacyBroker() {
+      assertThat(brokerCfg.getGateway().getSecurity().getKeyStore().getFilePath().getPath())
+          .isEqualTo("filePathLegacyBroker");
+    }
+
+    @Test
+    void shouldSetPasswordFromLegacyBroker() {
+      assertThat(brokerCfg.getGateway().getSecurity().getKeyStore().getPassword())
+          .isEqualTo("passwordLegacyBroker");
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        // new unified configuration
+        "camunda.api.grpc.ssl.key-store.file-path=filePathNew",
+        "camunda.api.grpc.ssl.key-store.password=passwordNew",
+        // legacy gateway configuration
+        "zeebe.gateway.security.keyStore.filePath=filePathLegacyGateway",
+        "zeebe.gateway.security.keyStore.password=passwordLegacyGateway",
+        // legacy broker configuration
+        "zeebe.broker.gateway.security.keyStore.filePath=filePathLegacyBroker",
+        "zeebe.broker.gateway.security.keyStore.password=passwordLegacyBroker",
+      })
+  class WithNewAndLegacySet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithNewAndLegacySet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldSetFilePathFromNew() {
+      assertThat(brokerCfg.getGateway().getSecurity().getKeyStore().getFilePath().getPath())
+          .isEqualTo("filePathNew");
+    }
+
+    @Test
+    void shouldSetPasswordFromNew() {
+      assertThat(brokerCfg.getGateway().getSecurity().getKeyStore().getPassword())
+          .isEqualTo("passwordNew");
+    }
+  }
+}

--- a/configuration/src/test/java/io/camunda/configuration/ApiGrpcSslGatewayKeyStoreTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/ApiGrpcSslGatewayKeyStoreTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.configuration.beanoverrides.GatewayBasedPropertiesOverride;
+import io.camunda.configuration.beans.GatewayBasedProperties;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+@SpringJUnitConfig({
+  UnifiedConfiguration.class,
+  GatewayBasedPropertiesOverride.class,
+  UnifiedConfigurationHelper.class
+})
+public class ApiGrpcSslGatewayKeyStoreTest {
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "camunda.api.grpc.ssl.key-store.file-path=filePathNew",
+        "camunda.api.grpc.ssl.key-store.password=passwordNew",
+      })
+  class WithOnlyUnifiedConfigSslSet {
+    final GatewayBasedProperties gatewayCfg;
+
+    WithOnlyUnifiedConfigSslSet(@Autowired final GatewayBasedProperties gatewayCfg) {
+      this.gatewayCfg = gatewayCfg;
+    }
+
+    @Test
+    void shouldSetFilePath() {
+      assertThat(gatewayCfg.getSecurity().getKeyStore().getFilePath().getPath())
+          .isEqualTo("filePathNew");
+    }
+
+    @Test
+    void shouldSetPassword() {
+      assertThat(gatewayCfg.getSecurity().getKeyStore().getPassword()).isEqualTo("passwordNew");
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "zeebe.broker.gateway.security.keyStore.filePath=filePathLegacyBroker",
+        "zeebe.broker.gateway.security.keyStore.password=passwordLegacyBroker"
+      })
+  class WithOnlyLegacyBrokerSecuritySet {
+    final GatewayBasedProperties gatewayCfg;
+
+    WithOnlyLegacyBrokerSecuritySet(@Autowired final GatewayBasedProperties gatewayCfg) {
+      this.gatewayCfg = gatewayCfg;
+    }
+
+    @Test
+    void shouldNotSetFilePathFromLegacyBroker() {
+      assertThat(gatewayCfg.getSecurity().getKeyStore().getFilePath()).isNull();
+    }
+
+    @Test
+    void shouldNotSetPasswordFromLegacyBroker() {
+      assertThat(gatewayCfg.getSecurity().getKeyStore().getPassword()).isNull();
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "zeebe.gateway.security.keyStore.filePath=filePathLegacyGateway",
+        "zeebe.gateway.security.keyStore.password=passwordLegacyGateway",
+      })
+  class WithOnlyLegacyGatewaySecuritySet {
+    final GatewayBasedProperties gatewayCfg;
+
+    WithOnlyLegacyGatewaySecuritySet(@Autowired final GatewayBasedProperties gatewayCfg) {
+      this.gatewayCfg = gatewayCfg;
+    }
+
+    @Test
+    void shouldSetFilePathFromLegacyGateway() {
+      assertThat(gatewayCfg.getSecurity().getKeyStore().getFilePath().getPath())
+          .isEqualTo("filePathLegacyGateway");
+    }
+
+    @Test
+    void shouldSetPasswordFromLegacyGateway() {
+      assertThat(gatewayCfg.getSecurity().getKeyStore().getPassword())
+          .isEqualTo("passwordLegacyGateway");
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        // new unified configuration
+        "camunda.api.grpc.ssl.key-store.file-path=filePathNew",
+        "camunda.api.grpc.ssl.key-store.password=passwordNew",
+        // legacy broker configuration
+        "zeebe.broker.gateway.security.keyStore.filePath=filePathLegacyBroker",
+        "zeebe.broker.gateway.security.keyStore.password=passwordLegacyBroker",
+        // legacy gateway configuration
+        "zeebe.gateway.security.keyStore.filePath=filePathLegacyBroker",
+        "zeebe.gateway.security.keyStore.password=passwordLegacyBroker"
+      })
+  class WithNewAndLegacySet {
+    final GatewayBasedProperties gatewayCfg;
+
+    WithNewAndLegacySet(@Autowired final GatewayBasedProperties gatewayCfg) {
+      this.gatewayCfg = gatewayCfg;
+    }
+
+    @Test
+    void shouldSetFilePathFromNew() {
+      assertThat(gatewayCfg.getSecurity().getKeyStore().getFilePath().getPath())
+          .isEqualTo("filePathNew");
+    }
+
+    @Test
+    void shouldSetPasswordFromNew() {
+      assertThat(gatewayCfg.getSecurity().getKeyStore().getPassword()).isEqualTo("passwordNew");
+    }
+  }
+}


### PR DESCRIPTION
## Description

This PR adds additional properties from section camunda.api.grpc in unified config.

The legacy properties are:

zeebe.gateway.network.minKeepAliveInterval
zeebe.gateway.network.maxMessageSize
zeebe.gateway.security.keyStore.filePath
zeebe.gateway.security.keyStore.password
zeebe.broker.gateway.network.minKeepAliveInterval
zeebe.broker.gateway.network.maxMessageSize
zeebe.broker.gateway.security.keyStore.filePath
zeebe.broker.gateway.security.keyStore.password

The new properties are:
camunda.api.grpc.min-keep-alive-interval
camunda.api.grpc.max-message-size
camunda.api.grpc.ssl.key-store.file-path
camunda.api.grpc.ssl.key-store.password

Backwards compatibility is supported for these properties. That means, if legacy is set and new property is not set, legacy value will be used.
## Checklist

- [ ] The legacy properties and the backwards compatibility strategy are updated in [schema doc](https://docs.google.com/spreadsheets/d/1R4epsy6DWemA8_76cUE6zOGUFbrXCXlM2reXnKFuz7Y/edit?gid=818158292#gid=818158292)
- [ ] The new property fields are documented in the code
## Related issues

related to #34911
