### PR TITLE
[Backport stable/8.7] fix: prevent random ID of custom filters from breaking Tasklist

### DIFF
--- a/tasklist/client/src/Tasks/CollapsiblePanel/CustomFiltersModal/index.tsx
+++ b/tasklist/client/src/Tasks/CollapsiblePanel/CustomFiltersModal/index.tsx
@@ -119,7 +119,7 @@ const CustomFiltersModal: React.FC<Props> = ({
       <FilterNameModal
         isOpen={isOpen && currentStep === 'name'}
         onApply={(filterName) => {
-          const filterId = crypto.randomUUID();
+          const filterId = `${Date.now()}${Math.random()}`;
           storeStateLocally('customFilters', {
             ...getStateLocally('customFilters'),
             [filterId]: {


### PR DESCRIPTION
# Description
Backport of #36700 to `stable/8.7`.

relates to #36540