### PR TITLE
AHSP 36: Fix missing AD_HOC_SUB_PROCESS JobKind enum entry on search APIs

### DIFF
--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/JobEntityTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/JobEntityTransformer.java
@@ -69,6 +69,7 @@ public class JobEntityTransformer
       case "BPMN_ELEMENT" -> JobKind.BPMN_ELEMENT;
       case "EXECUTION_LISTENER" -> JobKind.EXECUTION_LISTENER;
       case "TASK_LISTENER" -> JobKind.TASK_LISTENER;
+      case "AD_HOC_SUB_PROCESS" -> JobKind.AD_HOC_SUB_PROCESS;
       default -> throw new IllegalArgumentException("Unknown job kind: " + value);
     };
   }

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/entity/JobEntityTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/entity/JobEntityTransformerTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import io.camunda.search.entities.JobEntity.JobKind;
+import io.camunda.search.entities.JobEntity.JobState;
+import io.camunda.search.entities.JobEntity.ListenerEventType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class JobEntityTransformerTest {
+
+  private final JobEntityTransformer transformer = new JobEntityTransformer();
+
+  @Mock private io.camunda.webapps.schema.entities.JobEntity entityValue;
+
+  @BeforeEach
+  void setUp() {
+    when(entityValue.getKey()).thenReturn(123456L);
+    when(entityValue.getState()).thenReturn(JobState.CREATED.name());
+    when(entityValue.getJobKind()).thenReturn(JobKind.BPMN_ELEMENT.name());
+    when(entityValue.getListenerEventType()).thenReturn(ListenerEventType.UNSPECIFIED.name());
+  }
+
+  @ParameterizedTest
+  @EnumSource(ListenerEventType.class)
+  void handlesAllListenerEventTypes(final ListenerEventType listenerEventType) {
+    when(entityValue.getListenerEventType()).thenReturn(listenerEventType.name());
+
+    final var transformed = transformer.apply(entityValue);
+    assertThat(transformed.listenerEventType()).isEqualTo(listenerEventType);
+  }
+
+  @ParameterizedTest
+  @EnumSource(JobKind.class)
+  void handlesAllJobKinds(final JobKind jobKind) {
+    when(entityValue.getJobKind()).thenReturn(jobKind.name());
+
+    final var transformed = transformer.apply(entityValue);
+    assertThat(transformed.kind()).isEqualTo(jobKind);
+  }
+
+  @ParameterizedTest
+  @EnumSource(JobState.class)
+  void handlesAllJobStates(final JobState jobState) {
+    when(entityValue.getState()).thenReturn(jobState.name());
+
+    final var transformed = transformer.apply(entityValue);
+    assertThat(transformed.state()).isEqualTo(jobState);
+  }
+}

--- a/search/search-domain/src/main/java/io/camunda/search/entities/JobEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/JobEntity.java
@@ -208,7 +208,8 @@ public record JobEntity(
   public enum JobKind {
     BPMN_ELEMENT,
     EXECUTION_LISTENER,
-    TASK_LISTENER
+    TASK_LISTENER,
+    AD_HOC_SUB_PROCESS
   }
 
   public enum ListenerEventType {

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -9186,6 +9186,7 @@ components:
         - BPMN_ELEMENT
         - EXECUTION_LISTENER
         - TASK_LISTENER
+        - AD_HOC_SUB_PROCESS
     JobListenerEventTypeEnum:
       description: The listener event type of the job.
       enum:


### PR DESCRIPTION
## Description

Follow up to https://github.com/camunda/camunda/pull/35934

- Adds missing `AD_HOC_SUB_PROCESS` JobKind entry to the search APIs
- Adds tests for enum conversions (also for state and listener type) to catch missing enum values early

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes https://github.com/camunda/ad-hoc-sub-process-phase-3/issues/36
