### PR TITLE
Add cluster ID broker topology and use it in PingConsole.

### DIFF
--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -533,7 +533,7 @@
       # clusterName: zeebe-cluster
 
       # Allows to configure the cluster ID.
-      # This setting is used to identify the cluster and should be unique across clusters. If not configured, the cluster ID will be set with a new UUID.
+      # This setting is used to identify the cluster and should be unique across clusters. If not configured, the cluster ID will be set with a new random UUID.
       # This setting can also be overridden using the environment variable ZEEBE_BROKER_CLUSTER_CLUSTERID.
       # clusterId:
 

--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -533,7 +533,7 @@
       # clusterName: zeebe-cluster
 
       # Allows to configure the cluster ID.
-      # This setting is used to identify the cluster and should be unique across clusters. If not set, it will be generated automatically.
+      # This setting is used to identify the cluster and should be unique across clusters. If not configured, the cluster ID will be set with a new UUID.
       # This setting can also be overridden using the environment variable ZEEBE_BROKER_CLUSTER_CLUSTERID.
       # clusterId:
 

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -450,7 +450,7 @@
       # clusterName: zeebe-cluster
 
       # Allows to configure the cluster ID.
-      # This setting is used to identify the cluster and should be unique across clusters. If not set, it will be generated automatically.
+      # This setting is used to identify the cluster and should be unique across clusters. If not configured, the cluster ID will be set with a new UUID.
       # This setting can also be overridden using the environment variable ZEEBE_BROKER_CLUSTER_CLUSTERID.
       # clusterId:
 

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -450,7 +450,7 @@
       # clusterName: zeebe-cluster
 
       # Allows to configure the cluster ID.
-      # This setting is used to identify the cluster and should be unique across clusters. If not configured, the cluster ID will be set with a new UUID.
+      # This setting is used to identify the cluster and should be unique across clusters. If not configured, the cluster ID will be set with a new random UUID.
       # This setting can also be overridden using the environment variable ZEEBE_BROKER_CLUSTER_CLUSTERID.
       # clusterId:
 

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -453,7 +453,7 @@
       # This setting is used to identify the cluster and should be unique across clusters. If not set, it will be generated automatically.
       # This setting can also be overridden using the environment variable ZEEBE_BROKER_CLUSTER_CLUSTERID.
       # clusterId:
-      
+
       # Configure heartbeatInterval. The leader sends a heartbeat to a follower every heartbeatInterval.
       # Note: This is an advanced setting.
       # This setting can also be overridden using the environment variable ZEEBE_BROKER_CLUSTER_HEARTBEATINTERVAL.

--- a/dist/src/main/java/io/camunda/application/commons/console/ping/PingConsoleRunner.java
+++ b/dist/src/main/java/io/camunda/application/commons/console/ping/PingConsoleRunner.java
@@ -56,7 +56,6 @@ public class PingConsoleRunner implements ApplicationRunner, BrokerTopologyListe
       final ConsolePingConfiguration pingConfigurationProperties,
       final ManagementServices managementServices,
       final ApplicationContext applicationContext,
-      final ManagementServices managementServices,
       final BrokerTopologyManager brokerTopologyManager) {
     pingConfiguration = pingConfigurationProperties;
     this.managementServices = managementServices;

--- a/dist/src/main/java/io/camunda/application/commons/console/ping/PingConsoleRunner.java
+++ b/dist/src/main/java/io/camunda/application/commons/console/ping/PingConsoleRunner.java
@@ -81,7 +81,7 @@ public class PingConsoleRunner implements ApplicationRunner, BrokerTopologyListe
       validateConfiguration();
       LOGGER.info(
           "Console ping is enabled cluster ID of {}, with endpoint: {}, and period of {}.",
-          pingConfiguration.clusterId(),
+          brokerTopologyManager.getClusterConfiguration().clusterId().get(),
           pingConfiguration.endpoint(),
           pingConfiguration.pingPeriod());
       final var executor = createTaskExecutor();
@@ -215,7 +215,6 @@ public class PingConsoleRunner implements ApplicationRunner, BrokerTopologyListe
   public record ConsolePingConfiguration(
       boolean enabled,
       URI endpoint,
-      String clusterId,
       String clusterName,
       Duration pingPeriod,
       RetryConfiguration retry,

--- a/dist/src/main/java/io/camunda/application/commons/console/ping/PingConsoleRunner.java
+++ b/dist/src/main/java/io/camunda/application/commons/console/ping/PingConsoleRunner.java
@@ -68,10 +68,8 @@ public class PingConsoleRunner implements ApplicationRunner, BrokerTopologyListe
   public void run(final ApplicationArguments args) {
     if (brokerTopologyManager.getClusterConfiguration().clusterId().isPresent()) {
       initialized = true;
-      LOGGER.debug("The cluster ID is initialized, no listener added.");
       startPingTask();
     } else {
-      LOGGER.debug("The cluster ID is not yet initialized, waiting for cluster change.");
       brokerTopologyManager.addTopologyListener(this);
     }
   }
@@ -82,7 +80,8 @@ public class PingConsoleRunner implements ApplicationRunner, BrokerTopologyListe
     try {
       validateConfiguration();
       LOGGER.info(
-          "Console ping is enabled with endpoint: {}, and delay of {}.",
+          "Console ping is enabled cluster ID of {}, with endpoint: {}, and period of {}.",
+          pingConfiguration.clusterId(),
           pingConfiguration.endpoint(),
           pingConfiguration.pingPeriod());
       final var executor = createTaskExecutor();

--- a/dist/src/test/java/io/camunda/application/commons/console/ping/PingConsoleConfigurationTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/console/ping/PingConsoleConfigurationTest.java
@@ -8,6 +8,7 @@
 package io.camunda.application.commons.console.ping;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatCode;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;

--- a/dist/src/test/java/io/camunda/application/commons/console/ping/PingConsoleConfigurationTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/console/ping/PingConsoleConfigurationTest.java
@@ -9,7 +9,6 @@ package io.camunda.application.commons.console.ping;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatCode;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -81,18 +80,19 @@ class PingConsoleConfigurationTest {
         new ConsolePingConfiguration(
             true, null, "clusterName", Duration.ofMillis(5000), new RetryConfiguration(), null);
 
+    final PingConsoleRunner runner =
+        new PingConsoleRunner(
+            consolePingConfiguration,
+            MANAGEMENT_SERVICES,
+            APPLICATION_CONTEXT,
+            BROKER_TOPOLOGY_MANAGER);
+
+    // when
+    final var result = runner.validateConfiguration();
+
     // then
-    final IllegalArgumentException exception =
-        assertThatExceptionOfType(IllegalArgumentException.class)
-            .isThrownBy(
-                new PingConsoleRunner(
-                        consolePingConfiguration,
-                        MANAGEMENT_SERVICES,
-                        APPLICATION_CONTEXT,
-                        BROKER_TOPOLOGY_MANAGER)
-                    ::validateConfiguration)
-            .actual();
-    assertThat(exception.getMessage()).isEqualTo("Ping endpoint must not be null.");
+    assertThat(result.isLeft()).isTrue();
+    assertThat(result.getLeft()).isEqualTo("Ping endpoint must not be null.");
   }
 
   @Test
@@ -107,18 +107,19 @@ class PingConsoleConfigurationTest {
             new RetryConfiguration(),
             null);
 
+    final PingConsoleRunner runner =
+        new PingConsoleRunner(
+            consolePingConfiguration,
+            MANAGEMENT_SERVICES,
+            APPLICATION_CONTEXT,
+            BROKER_TOPOLOGY_MANAGER);
+
+    // when
+    final var result = runner.validateConfiguration();
+
     // then
-    final IllegalArgumentException exception =
-        assertThatExceptionOfType(IllegalArgumentException.class)
-            .isThrownBy(
-                new PingConsoleRunner(
-                        consolePingConfiguration,
-                        MANAGEMENT_SERVICES,
-                        APPLICATION_CONTEXT,
-                        BROKER_TOPOLOGY_MANAGER)
-                    ::validateConfiguration)
-            .actual();
-    assertThat(exception.getMessage()).isEqualTo("Ping endpoint 123 must be a valid URI.");
+    assertThat(result.isLeft()).isTrue();
+    assertThat(result.getLeft()).isEqualTo("Ping endpoint 123 must be a valid URI.");
   }
 
   @Test
@@ -133,18 +134,19 @@ class PingConsoleConfigurationTest {
             new RetryConfiguration(),
             null);
 
+    final PingConsoleRunner runner =
+        new PingConsoleRunner(
+            consolePingConfiguration,
+            MANAGEMENT_SERVICES,
+            APPLICATION_CONTEXT,
+            BROKER_TOPOLOGY_MANAGER);
+
+    // when
+    final var result = runner.validateConfiguration();
+
     // then
-    final IllegalArgumentException exception =
-        assertThatExceptionOfType(IllegalArgumentException.class)
-            .isThrownBy(
-                new PingConsoleRunner(
-                        consolePingConfiguration,
-                        MANAGEMENT_SERVICES,
-                        APPLICATION_CONTEXT,
-                        BROKER_TOPOLOGY_MANAGER)
-                    ::validateConfiguration)
-            .actual();
-    assertThat(exception.getMessage()).isEqualTo("Cluster name must not be null or empty.");
+    assertThat(result.isLeft()).isTrue();
+    assertThat(result.getLeft()).isEqualTo("Cluster name must not be null or empty.");
   }
 
   @Test
@@ -159,18 +161,19 @@ class PingConsoleConfigurationTest {
             new RetryConfiguration(),
             null);
 
+    final PingConsoleRunner runner =
+        new PingConsoleRunner(
+            consolePingConfiguration,
+            MANAGEMENT_SERVICES,
+            APPLICATION_CONTEXT,
+            BROKER_TOPOLOGY_MANAGER);
+
+    // when
+    final var result = runner.validateConfiguration();
+
     // then
-    final IllegalArgumentException exception =
-        assertThatExceptionOfType(IllegalArgumentException.class)
-            .isThrownBy(
-                new PingConsoleRunner(
-                        consolePingConfiguration,
-                        MANAGEMENT_SERVICES,
-                        APPLICATION_CONTEXT,
-                        BROKER_TOPOLOGY_MANAGER)
-                    ::validateConfiguration)
-            .actual();
-    assertThat(exception.getMessage()).isEqualTo("Ping period must be greater than zero.");
+    assertThat(result.isLeft()).isTrue();
+    assertThat(result.getLeft()).isEqualTo("Ping period must be greater than zero.");
   }
 
   @Test
@@ -188,19 +191,19 @@ class PingConsoleConfigurationTest {
             retryConfiguration,
             null);
 
+    final PingConsoleRunner runner =
+        new PingConsoleRunner(
+            consolePingConfiguration,
+            MANAGEMENT_SERVICES,
+            APPLICATION_CONTEXT,
+            BROKER_TOPOLOGY_MANAGER);
+
+    // when
+    final var result = runner.validateConfiguration();
+
     // then
-    final IllegalArgumentException exception =
-        assertThatExceptionOfType(IllegalArgumentException.class)
-            .isThrownBy(
-                new PingConsoleRunner(
-                        consolePingConfiguration,
-                        MANAGEMENT_SERVICES,
-                        APPLICATION_CONTEXT,
-                        BROKER_TOPOLOGY_MANAGER)
-                    ::validateConfiguration)
-            .actual();
-    assertThat(exception.getMessage())
-        .isEqualTo("Number of max retries must be greater than zero.");
+    assertThat(result.isLeft()).isTrue();
+    assertThat(result.getLeft()).isEqualTo("Number of max retries must be greater than zero.");
   }
 
   @Test
@@ -218,19 +221,19 @@ class PingConsoleConfigurationTest {
             retryConfiguration,
             null);
 
+    final PingConsoleRunner runner =
+        new PingConsoleRunner(
+            consolePingConfiguration,
+            MANAGEMENT_SERVICES,
+            APPLICATION_CONTEXT,
+            BROKER_TOPOLOGY_MANAGER);
+
+    // when
+    final var result = runner.validateConfiguration();
+
     // then
-    final IllegalArgumentException exception =
-        assertThatExceptionOfType(IllegalArgumentException.class)
-            .isThrownBy(
-                new PingConsoleRunner(
-                        consolePingConfiguration,
-                        MANAGEMENT_SERVICES,
-                        APPLICATION_CONTEXT,
-                        BROKER_TOPOLOGY_MANAGER)
-                    ::validateConfiguration)
-            .actual();
-    assertThat(exception.getMessage())
-        .isEqualTo("Retry delay multiplier must be greater than zero.");
+    assertThat(result.isLeft()).isTrue();
+    assertThat(result.getLeft()).isEqualTo("Retry delay multiplier must be greater than zero.");
   }
 
   @Test
@@ -269,18 +272,19 @@ class PingConsoleConfigurationTest {
             retryConfiguration,
             null);
 
+    final PingConsoleRunner runner =
+        new PingConsoleRunner(
+            consolePingConfiguration,
+            MANAGEMENT_SERVICES,
+            APPLICATION_CONTEXT,
+            BROKER_TOPOLOGY_MANAGER);
+
+    // when
+    final var result = runner.validateConfiguration();
+
     // then
-    final IllegalArgumentException exception =
-        assertThatExceptionOfType(IllegalArgumentException.class)
-            .isThrownBy(
-                new PingConsoleRunner(
-                        consolePingConfiguration,
-                        MANAGEMENT_SERVICES,
-                        APPLICATION_CONTEXT,
-                        BROKER_TOPOLOGY_MANAGER)
-                    ::validateConfiguration)
-            .actual();
-    assertThat(exception.getMessage()).isEqualTo("Max retry delay must be greater than zero.");
+    assertThat(result.isLeft()).isTrue();
+    assertThat(result.getLeft()).isEqualTo("Max retry delay must be greater than zero.");
   }
 
   @Test
@@ -298,18 +302,19 @@ class PingConsoleConfigurationTest {
             retryConfiguration,
             null);
 
+    final PingConsoleRunner runner =
+        new PingConsoleRunner(
+            consolePingConfiguration,
+            MANAGEMENT_SERVICES,
+            APPLICATION_CONTEXT,
+            BROKER_TOPOLOGY_MANAGER);
+
+    // when
+    final var result = runner.validateConfiguration();
+
     // then
-    final IllegalArgumentException exception =
-        assertThatExceptionOfType(IllegalArgumentException.class)
-            .isThrownBy(
-                new PingConsoleRunner(
-                        consolePingConfiguration,
-                        MANAGEMENT_SERVICES,
-                        APPLICATION_CONTEXT,
-                        BROKER_TOPOLOGY_MANAGER)
-                    ::validateConfiguration)
-            .actual();
-    assertThat(exception.getMessage()).isEqualTo("Min retry delay must be greater than zero.");
+    assertThat(result.isLeft()).isTrue();
+    assertThat(result.getLeft()).isEqualTo("Min retry delay must be greater than zero.");
   }
 
   @Test
@@ -328,18 +333,19 @@ class PingConsoleConfigurationTest {
             retryConfiguration,
             null);
 
+    final PingConsoleRunner runner =
+        new PingConsoleRunner(
+            consolePingConfiguration,
+            MANAGEMENT_SERVICES,
+            APPLICATION_CONTEXT,
+            BROKER_TOPOLOGY_MANAGER);
+
+    // when
+    final var result = runner.validateConfiguration();
+
     // then
-    final IllegalArgumentException exception =
-        assertThatExceptionOfType(IllegalArgumentException.class)
-            .isThrownBy(
-                new PingConsoleRunner(
-                        consolePingConfiguration,
-                        MANAGEMENT_SERVICES,
-                        APPLICATION_CONTEXT,
-                        BROKER_TOPOLOGY_MANAGER)
-                    ::validateConfiguration)
-            .actual();
-    assertThat(exception.getMessage())
+    assertThat(result.isLeft()).isTrue();
+    assertThat(result.getLeft())
         .isEqualTo("Max retry delay must be greater than or equal to min retry delay.");
   }
 

--- a/dist/src/test/java/io/camunda/application/commons/console/ping/PingConsoleConfigurationTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/console/ping/PingConsoleConfigurationTest.java
@@ -20,6 +20,7 @@ import io.camunda.application.commons.console.ping.PingConsoleRunner.ConsolePing
 import io.camunda.service.ManagementServices;
 import io.camunda.service.license.LicenseType;
 import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.util.retry.RetryConfiguration;
 import java.io.IOException;
 import java.net.URI;
@@ -27,6 +28,7 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.time.Duration;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -45,11 +47,12 @@ class PingConsoleConfigurationTest {
   private static final ApplicationContext APPLICATION_CONTEXT = mock(ApplicationContext.class);
   private static final BrokerTopologyManager BROKER_TOPOLOGY_MANAGER =
       mock(BrokerTopologyManager.class);
+  private static final ClusterConfiguration BROKER_CLUSTER_CONFIGURATION =
+      mock(ClusterConfiguration.class);
   private final ConsolePingConfiguration pingConfiguration =
       new ConsolePingConfiguration(
           true,
           URI.create("http://fake-endpoint.com"),
-          "clusterId",
           "clusterName",
           Duration.ofMillis(1000),
           new RetryConfiguration(),
@@ -66,6 +69,9 @@ class PingConsoleConfigurationTest {
     when(MANAGEMENT_SERVICES.getCamundaLicenseExpiresAt()).thenReturn(null);
     when(APPLICATION_CONTEXT.getEnvironment()).thenReturn(ENVIRONMENT);
     when(ENVIRONMENT.getActiveProfiles()).thenReturn(new String[] {"broker"});
+    when(BROKER_TOPOLOGY_MANAGER.getClusterConfiguration())
+        .thenReturn(BROKER_CLUSTER_CONFIGURATION);
+    when(BROKER_CLUSTER_CONFIGURATION.clusterId()).thenReturn(Optional.of("clusterId"));
   }
 
   @Test
@@ -73,13 +79,7 @@ class PingConsoleConfigurationTest {
     // given
     final ConsolePingConfiguration consolePingConfiguration =
         new ConsolePingConfiguration(
-            true,
-            null,
-            "clusterId",
-            "clusterName",
-            Duration.ofMillis(5000),
-            new RetryConfiguration(),
-            null);
+            true, null, "clusterName", Duration.ofMillis(5000), new RetryConfiguration(), null);
 
     // then
     final IllegalArgumentException exception =
@@ -102,7 +102,6 @@ class PingConsoleConfigurationTest {
         new ConsolePingConfiguration(
             true,
             URI.create("123"),
-            "clusterId",
             "clusterName",
             Duration.ofMillis(5000),
             new RetryConfiguration(),
@@ -123,40 +122,12 @@ class PingConsoleConfigurationTest {
   }
 
   @Test
-  void clusterIdShouldNotBeNullOrEmpty() {
-    // given
-    final ConsolePingConfiguration consolePingConfiguration =
-        new ConsolePingConfiguration(
-            true,
-            URI.create("http://localhost:8080"),
-            null,
-            "clusterName",
-            Duration.ofMillis(5000),
-            new RetryConfiguration(),
-            null);
-
-    // then
-    final IllegalArgumentException exception =
-        assertThatExceptionOfType(IllegalArgumentException.class)
-            .isThrownBy(
-                new PingConsoleRunner(
-                        consolePingConfiguration,
-                        MANAGEMENT_SERVICES,
-                        APPLICATION_CONTEXT,
-                        BROKER_TOPOLOGY_MANAGER)
-                    ::validateConfiguration)
-            .actual();
-    assertThat(exception.getMessage()).isEqualTo("Cluster ID must not be null or empty.");
-  }
-
-  @Test
   void clusterNameMustNotBeNullOrEmpty() {
     // given
     final ConsolePingConfiguration consolePingConfiguration =
         new ConsolePingConfiguration(
             true,
             URI.create("http://localhost:8080"),
-            "clusterId",
             "",
             Duration.ofMillis(5000),
             new RetryConfiguration(),
@@ -183,7 +154,6 @@ class PingConsoleConfigurationTest {
         new ConsolePingConfiguration(
             true,
             URI.create("http://localhost:8080"),
-            "clusterId",
             "clusterName",
             Duration.ofMillis(-333),
             new RetryConfiguration(),
@@ -213,7 +183,6 @@ class PingConsoleConfigurationTest {
         new ConsolePingConfiguration(
             true,
             URI.create("http://localhost:8080"),
-            "clusterId",
             "clusterName",
             Duration.ofMillis(5000),
             retryConfiguration,
@@ -244,7 +213,6 @@ class PingConsoleConfigurationTest {
         new ConsolePingConfiguration(
             true,
             URI.create("http://localhost:8080"),
-            "clusterId",
             "clusterName",
             Duration.ofMillis(5000),
             retryConfiguration,
@@ -272,7 +240,6 @@ class PingConsoleConfigurationTest {
         new ConsolePingConfiguration(
             true,
             URI.create("http://localhost:8080"),
-            "clusterId",
             "clusterName",
             Duration.ofMillis(5000),
             null,
@@ -297,7 +264,6 @@ class PingConsoleConfigurationTest {
         new ConsolePingConfiguration(
             true,
             URI.create("http://localhost:8080"),
-            "clusterId",
             "clusterName",
             Duration.ofMillis(5000),
             retryConfiguration,
@@ -327,7 +293,6 @@ class PingConsoleConfigurationTest {
         new ConsolePingConfiguration(
             true,
             URI.create("http://localhost:8080"),
-            "clusterId",
             "clusterName",
             Duration.ofMillis(5000),
             retryConfiguration,
@@ -358,7 +323,6 @@ class PingConsoleConfigurationTest {
         new ConsolePingConfiguration(
             true,
             URI.create("http://localhost:8080"),
-            "clusterId",
             "clusterName",
             Duration.ofMillis(5000),
             retryConfiguration,
@@ -386,7 +350,6 @@ class PingConsoleConfigurationTest {
         new ConsolePingConfiguration(
             true,
             URI.create("http://localhost:8080"),
-            "clusterId",
             "clusterName",
             Duration.ofMillis(5000),
             new RetryConfiguration(),
@@ -407,7 +370,6 @@ class PingConsoleConfigurationTest {
         new ConsolePingConfiguration(
             false,
             URI.create("123"),
-            "",
             null,
             Duration.ofMillis(-300),
             new RetryConfiguration(),

--- a/dist/src/test/java/io/camunda/application/commons/console/ping/PingConsoleRunnerIT.java
+++ b/dist/src/test/java/io/camunda/application/commons/console/ping/PingConsoleRunnerIT.java
@@ -24,6 +24,7 @@ import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
 import io.camunda.application.commons.console.ping.PingConsoleRunner.ConsolePingConfiguration;
 import io.camunda.service.ManagementServices;
 import io.camunda.service.license.LicenseType;
+import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
 import io.camunda.zeebe.util.VersionUtil;
 import io.camunda.zeebe.util.retry.RetryConfiguration;
 import java.net.URI;
@@ -41,6 +42,7 @@ public class PingConsoleRunnerIT {
   private ApplicationContext applicationContext;
   private WireMockServer wireMockServer;
   private ManagementServices managementServices;
+  private BrokerTopologyManager brokerTopologyManager;
 
   @BeforeEach
   void setup() {
@@ -89,10 +91,17 @@ public class PingConsoleRunnerIT {
 
     final ConsolePingConfiguration config =
         new ConsolePingConfiguration(
-            true, URI.create(mockUrl), "test-cluster-name", pingPeriod, retryConfig, null);
+            true,
+            URI.create(mockUrl),
+            "test-cluster-id",
+            "test-cluster-name",
+            pingPeriod,
+            retryConfig,
+            null);
 
     final PingConsoleRunner pingConsoleRunner =
-        new PingConsoleRunner(config, managementServices, applicationContext, "test-cluster-id");
+        new PingConsoleRunner(config, managementServices, applicationContext
+            , brokerTopologyManager);
 
     // when
     pingConsoleRunner.run(null);

--- a/dist/src/test/java/io/camunda/application/commons/console/ping/PingConsoleRunnerIT.java
+++ b/dist/src/test/java/io/camunda/application/commons/console/ping/PingConsoleRunnerIT.java
@@ -100,8 +100,8 @@ public class PingConsoleRunnerIT {
             null);
 
     final PingConsoleRunner pingConsoleRunner =
-        new PingConsoleRunner(config, managementServices, applicationContext
-            , brokerTopologyManager);
+        new PingConsoleRunner(
+            config, managementServices, applicationContext, brokerTopologyManager);
 
     // when
     pingConsoleRunner.run(null);

--- a/dist/src/test/java/io/camunda/application/commons/console/ping/PingConsoleRunnerIT.java
+++ b/dist/src/test/java/io/camunda/application/commons/console/ping/PingConsoleRunnerIT.java
@@ -25,11 +25,13 @@ import io.camunda.application.commons.console.ping.PingConsoleRunner.ConsolePing
 import io.camunda.service.ManagementServices;
 import io.camunda.service.license.LicenseType;
 import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.util.VersionUtil;
 import io.camunda.zeebe.util.retry.RetryConfiguration;
 import java.net.URI;
 import java.time.Duration;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -39,10 +41,13 @@ import org.springframework.core.env.Environment;
 
 public class PingConsoleRunnerIT {
 
+  private static final BrokerTopologyManager BROKER_TOPOLOGY_MANAGER =
+      mock(BrokerTopologyManager.class);
+  private static final ClusterConfiguration BROKER_CLUSTER_CONFIGURATION =
+      mock(ClusterConfiguration.class);
   private ApplicationContext applicationContext;
   private WireMockServer wireMockServer;
   private ManagementServices managementServices;
-  private BrokerTopologyManager brokerTopologyManager;
 
   @BeforeEach
   void setup() {
@@ -50,6 +55,9 @@ public class PingConsoleRunnerIT {
     wireMockServer.start();
     configureFor("localhost", wireMockServer.port());
     stubFor(post(urlEqualTo("/ping")).willReturn(aResponse().withStatus(200).withBody("PONG")));
+    when(BROKER_TOPOLOGY_MANAGER.getClusterConfiguration())
+        .thenReturn(BROKER_CLUSTER_CONFIGURATION);
+    when(BROKER_CLUSTER_CONFIGURATION.clusterId()).thenReturn(Optional.of("test-cluster-id"));
   }
 
   @AfterEach
@@ -91,17 +99,11 @@ public class PingConsoleRunnerIT {
 
     final ConsolePingConfiguration config =
         new ConsolePingConfiguration(
-            true,
-            URI.create(mockUrl),
-            "test-cluster-id",
-            "test-cluster-name",
-            pingPeriod,
-            retryConfig,
-            null);
+            true, URI.create(mockUrl), "test-cluster-name", pingPeriod, retryConfig, null);
 
     final PingConsoleRunner pingConsoleRunner =
         new PingConsoleRunner(
-            config, managementServices, applicationContext, brokerTopologyManager);
+            config, managementServices, applicationContext, BROKER_TOPOLOGY_MANAGER);
 
     // when
     pingConsoleRunner.run(null);

--- a/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/api/BrokerTopologyManagerTest.java
+++ b/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/api/BrokerTopologyManagerTest.java
@@ -409,6 +409,7 @@ final class BrokerTopologyManagerTest {
             Map.of(),
             Optional.of(new CompletedChange(1, Status.COMPLETED, Instant.now(), Instant.now())),
             Optional.empty(),
+            Optional.empty(),
             Optional.empty());
 
     topologyManager.onClusterConfigurationUpdated(clusterTopology);

--- a/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/impl/RoundRobinDispatchStrategyTest.java
+++ b/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/impl/RoundRobinDispatchStrategyTest.java
@@ -66,7 +66,8 @@ final class RoundRobinDispatchStrategyTest {
                 Optional.empty(),
                 Optional.empty(),
                 Optional.of(
-                    new RoutingState(1, new AllPartitions(2), new MessageCorrelation.HashMod(2)))));
+                    new RoutingState(1, new AllPartitions(2), new MessageCorrelation.HashMod(2))),
+                Optional.empty()));
 
     // when - then
     assertThat(dispatchStrategy.determinePartition(topologyManager)).isEqualTo(1);
@@ -94,7 +95,8 @@ final class RoundRobinDispatchStrategyTest {
                     new RoutingState(
                         1,
                         new ActivePartitions(1, Set.of(3), Set.of()),
-                        new MessageCorrelation.HashMod(3)))));
+                        new MessageCorrelation.HashMod(3))),
+                Optional.empty()));
 
     // when - then
     assertThat(dispatchStrategy.determinePartition(topologyManager)).isEqualTo(1);
@@ -120,7 +122,8 @@ final class RoundRobinDispatchStrategyTest {
                 new RoutingState(
                     1,
                     new ActivePartitions(1, Set.of(3), Set.of()),
-                    new MessageCorrelation.HashMod(1)))));
+                    new MessageCorrelation.HashMod(1))),
+            Optional.empty()));
 
     // then
     assertThat(dispatchStrategy.determinePartition(topologyManager)).isEqualTo(1);
@@ -134,7 +137,8 @@ final class RoundRobinDispatchStrategyTest {
             Optional.empty(),
             Optional.empty(),
             Optional.of(
-                new RoutingState(2, new AllPartitions(3), new MessageCorrelation.HashMod(1)))));
+                new RoutingState(2, new AllPartitions(3), new MessageCorrelation.HashMod(1))),
+            Optional.empty()));
 
     // then
     assertThat(dispatchStrategy.determinePartition(topologyManager)).isEqualTo(3);

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/StaticConfigurationGenerator.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/StaticConfigurationGenerator.java
@@ -50,6 +50,7 @@ public final class StaticConfigurationGenerator {
     final var clusterMembers = getRaftGroupMembers(clusterCfg);
     final var partitionIds = getSortedPartitionIds(partitionCount);
     final var partitionConfig = generatePartitionConfig(brokerCfg);
+    final var clusterId = clusterCfg.getClusterId();
 
     return new StaticConfiguration(
         enablePartitionScaling,
@@ -58,7 +59,8 @@ public final class StaticConfigurationGenerator {
         localMemberId,
         partitionIds,
         replicationFactor,
-        partitionConfig);
+        partitionConfig,
+        clusterId);
   }
 
   private static PartitionDistributor getPartitionDistributor(final PartitioningCfg partitionCfg) {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ClusterCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ClusterCfg.java
@@ -51,7 +51,6 @@ public final class ClusterCfg implements ConfigurationEntry {
   private int replicationFactor = DEFAULT_REPLICATION_FACTOR;
   private int clusterSize = DEFAULT_CLUSTER_SIZE;
   private String clusterName = DEFAULT_CLUSTER_NAME;
-  private String clusterId;
   private Duration heartbeatInterval = DEFAULT_HEARTBEAT_INTERVAL;
   private Duration electionTimeout = DEFAULT_ELECTION_TIMEOUT;
   private MembershipCfg membership = new MembershipCfg();
@@ -117,14 +116,6 @@ public final class ClusterCfg implements ConfigurationEntry {
 
   public void setNodeId(final int nodeId) {
     this.nodeId = nodeId;
-  }
-
-  public String getClusterId() {
-    return clusterId;
-  }
-
-  public void setClusterId(final String clusterId) {
-    this.clusterId = clusterId;
   }
 
   public int getPartitionsCount() {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ClusterCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ClusterCfg.java
@@ -51,6 +51,7 @@ public final class ClusterCfg implements ConfigurationEntry {
   private int replicationFactor = DEFAULT_REPLICATION_FACTOR;
   private int clusterSize = DEFAULT_CLUSTER_SIZE;
   private String clusterName = DEFAULT_CLUSTER_NAME;
+  private String clusterId;
   private Duration heartbeatInterval = DEFAULT_HEARTBEAT_INTERVAL;
   private Duration electionTimeout = DEFAULT_ELECTION_TIMEOUT;
   private MembershipCfg membership = new MembershipCfg();
@@ -160,6 +161,14 @@ public final class ClusterCfg implements ConfigurationEntry {
 
   public void setClusterName(final String clusterName) {
     this.clusterName = clusterName;
+  }
+
+  public String getClusterId() {
+    return clusterId;
+  }
+
+  public void setClusterId(final String clusterId) {
+    this.clusterId = clusterId;
   }
 
   public MembershipCfg getMembership() {

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerService.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerService.java
@@ -148,6 +148,8 @@ public final class ClusterConfigurationManagerService
             new RoutingStateInitializer(
                 staticConfiguration.enablePartitionScaling(),
                 staticConfiguration.partitionCount()));
+    // This initializer does not set the cluster ID, as it is not required for non-coordinators.
+    // Non-coordinators will receive the cluster ID from the coordinator via gossip.
   }
 
   private ClusterConfigurationInitializer getCoordinatorInitializer(
@@ -171,8 +173,8 @@ public final class ClusterConfigurationManagerService
                 managerActor))
         .andThen(
             new RoutingStateInitializer(
-                staticConfiguration.enablePartitionScaling(),
-                staticConfiguration.partitionCount()));
+                staticConfiguration.enablePartitionScaling(), staticConfiguration.partitionCount()))
+        .andThen(new ClusterIdInitializer(staticConfiguration.clusterId()));
   }
 
   /** Starts ClusterConfigurationManager which initializes ClusterConfiguration */

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerService.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerService.java
@@ -51,7 +51,6 @@ public final class ClusterConfigurationManagerService
   private static final String COORDINATOR_ID = "0";
   private final ClusterConfigurationManagerImpl clusterConfigurationManager;
   private final ClusterConfigurationGossiper clusterConfigurationGossiper;
-  private final ClusterMembershipService memberShipService;
   private final boolean isCoordinator;
   private final PersistedClusterConfiguration persistedClusterConfiguration;
   private final Path configurationFile;
@@ -72,7 +71,6 @@ public final class ClusterConfigurationManagerService
       final ClusterChangeExecutor clusterChangeExecutor,
       final MeterRegistry meterRegistry) {
     this.clusterChangeExecutor = clusterChangeExecutor;
-    this.memberShipService = memberShipService;
     topologyMetrics = new TopologyMetrics(meterRegistry);
     topologyManagerMetrics = new TopologyManagerMetrics(meterRegistry);
     try {
@@ -118,7 +116,6 @@ public final class ClusterConfigurationManagerService
   }
 
   private ClusterConfigurationInitializer getNonCoordinatorInitializer(
-      final ClusterMembershipService membershipService,
       final StaticConfiguration staticConfiguration) {
     final var otherKnownMembers =
         staticConfiguration.clusterMembers().stream()
@@ -201,7 +198,7 @@ public final class ClusterConfigurationManagerService
     final ClusterConfigurationInitializer clusterConfigurationInitializer =
         isCoordinator
             ? getCoordinatorInitializer(staticConfiguration)
-            : getNonCoordinatorInitializer(memberShipService, staticConfiguration);
+            : getNonCoordinatorInitializer(staticConfiguration);
 
     configurationRequestServer.start();
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterIdInitializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterIdInitializer.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config;
+
+import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Initializes the routing state of the cluster configuration if the partition scaling feature is
+ * enabled. All members will initialize the same routing state (as long as their statically
+ * configured partition counts match).
+ */
+public class ClusterIdInitializer implements ClusterConfigurationModifier {
+
+  private final String clusterId;
+
+  public ClusterIdInitializer(final String clusterId) {
+    // if not cluster id is configured a new one is generated.
+    this.clusterId = Optional.ofNullable(clusterId).orElse(UUID.randomUUID().toString());
+  }
+
+  @Override
+  public ActorFuture<ClusterConfiguration> modify(final ClusterConfiguration configuration) {
+    // If the cluster ID is already set, we do not need to modify the configuration.
+    if (configuration.clusterId().isPresent()) {
+      return CompletableActorFuture.completed(configuration);
+    }
+
+    final var withClusterId =
+        new ClusterConfiguration(
+            configuration.version(),
+            configuration.members(),
+            configuration.lastChange(),
+            configuration.pendingChanges(),
+            configuration.routingState(),
+            Optional.ofNullable(clusterId));
+    return CompletableActorFuture.completed(withClusterId);
+  }
+}

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterIdInitializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterIdInitializer.java
@@ -12,6 +12,8 @@ import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import java.util.Optional;
 import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Initializes the routing state of the cluster configuration if the partition scaling feature is
@@ -20,6 +22,7 @@ import java.util.UUID;
  */
 public class ClusterIdInitializer implements ClusterConfigurationModifier {
 
+  private static final Logger LOGGER = LoggerFactory.getLogger(ClusterIdInitializer.class);
   private final String clusterId;
 
   public ClusterIdInitializer(final String clusterId) {
@@ -31,6 +34,12 @@ public class ClusterIdInitializer implements ClusterConfigurationModifier {
   public ActorFuture<ClusterConfiguration> modify(final ClusterConfiguration configuration) {
     // If the cluster ID is already set, we do not need to modify the configuration.
     if (configuration.clusterId().isPresent()) {
+      if (!configuration.clusterId().get().equals(clusterId)) {
+        LOGGER.warn(
+            "Cluster ID is already set to '{}', but the configured cluster ID is '{}'. Using the existing cluster ID.",
+            configuration.clusterId().get(),
+            clusterId);
+      }
       return CompletableActorFuture.completed(configuration);
     }
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/RoutingStateInitializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/RoutingStateInitializer.java
@@ -42,7 +42,8 @@ public class RoutingStateInitializer implements ClusterConfigurationModifier {
             configuration.members(),
             configuration.lastChange(),
             configuration.pendingChanges(),
-            Optional.of(routingState));
+            Optional.of(routingState),
+            configuration.clusterId());
     return CompletableActorFuture.completed(withRoutingState);
   }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/StaticConfiguration.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/StaticConfiguration.java
@@ -23,7 +23,8 @@ public record StaticConfiguration(
     MemberId localMemberId,
     List<PartitionId> partitionIds,
     int replicationFactor,
-    DynamicPartitionConfig partitionConfig) {
+    DynamicPartitionConfig partitionConfig,
+    String clusterId) {
 
   public int partitionCount() {
     return partitionIds.size();
@@ -32,7 +33,7 @@ public record StaticConfiguration(
   public ClusterConfiguration generateTopology() {
     final Set<PartitionMetadata> partitionDistribution = generatePartitionDistribution();
     return ConfigurationUtil.getClusterConfigFrom(
-        enablePartitionScaling, partitionDistribution, partitionConfig);
+        enablePartitionScaling, partitionDistribution, partitionConfig, clusterId);
   }
 
   public Set<PartitionMetadata> generatePartitionDistribution() {

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/AwaitRedistributionCompletionApplier.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/AwaitRedistributionCompletionApplier.java
@@ -83,7 +83,8 @@ public class AwaitRedistributionCompletionApplier implements ClusterOperationApp
         config.members(),
         config.lastChange(),
         config.pendingChanges(),
-        Optional.of(routingState));
+        Optional.of(routingState),
+        config.clusterId());
   }
 
   private RequestHandling updateRequestHandling(final RequestHandling requestHandling) {

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/StartPartitionScaleUpApplier.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/StartPartitionScaleUpApplier.java
@@ -114,7 +114,8 @@ final class StartPartitionScaleUpApplier implements ClusterOperationApplier {
                             config.members(),
                             config.lastChange(),
                             config.pendingChanges(),
-                            config.routingState().map(this::updateRoutingState)));
+                            config.routingState().map(this::updateRoutingState),
+                            config.clusterId()));
               }
             });
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
@@ -154,9 +154,9 @@ public class ProtoBufSerializer
             : Optional.empty();
 
     final Optional<String> clusterId =
-        encodedClusterTopology.hasClusterId()
-            ? decodeClusterId(encodedClusterTopology.getClusterId())
-            : Optional.empty();
+        encodedClusterTopology.getClusterId().isEmpty()
+            ? Optional.empty()
+            : Optional.of(encodedClusterTopology.getClusterId());
 
     return new ClusterConfiguration(
         encodedClusterTopology.getVersion(),
@@ -192,9 +192,7 @@ public class ProtoBufSerializer
     clusterConfiguration
         .routingState()
         .ifPresent(routingState -> builder.setRoutingState(encodeRoutingState(routingState)));
-    clusterConfiguration
-        .clusterId()
-        .ifPresent(clusterId -> builder.setClusterId(encodeClusterId(clusterId)));
+    clusterConfiguration.clusterId().ifPresent(clusterId -> builder.setClusterId(clusterId));
 
     return builder.build();
   }
@@ -550,14 +548,6 @@ public class ProtoBufSerializer
     }
   }
 
-  private Optional<String> decodeClusterId(final Topology.ClusterId clusterId) {
-    if (clusterId.equals(Topology.ClusterId.getDefaultInstance())) {
-      return Optional.empty();
-    } else {
-      return Optional.of(clusterId.getClusterId());
-    }
-  }
-
   private RequestHandling decodeRequestHandling(final Topology.RequestHandling requestHandling) {
     return switch (requestHandling.getStrategyCase()) {
       case ALLPARTITIONS ->
@@ -588,10 +578,6 @@ public class ProtoBufSerializer
         .setRequestHandling(encodeRequestHandling(routingState.requestHandling()))
         .setMessageCorrelation(encodeMessageCorrelation(routingState.messageCorrelation()))
         .build();
-  }
-
-  private Topology.ClusterId encodeClusterId(final String clusterId) {
-    return Topology.ClusterId.newBuilder().setClusterId(clusterId).build();
   }
 
   private Topology.RequestHandling encodeRequestHandling(final RequestHandling requestHandling) {

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
@@ -153,8 +153,14 @@ public class ProtoBufSerializer
             ? decodeRoutingState(encodedClusterTopology.getRoutingState())
             : Optional.empty();
 
+    // TODO: implement decoding of cluster id.
     return new ClusterConfiguration(
-        encodedClusterTopology.getVersion(), members, completedChange, currentChange, routingState);
+        encodedClusterTopology.getVersion(),
+        members,
+        completedChange,
+        currentChange,
+        routingState,
+        Optional.empty());
   }
 
   private Map<MemberId, io.camunda.zeebe.dynamic.config.state.MemberState> decodeMemberStateMap(

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/util/ConfigurationUtil.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/util/ConfigurationUtil.java
@@ -30,7 +30,8 @@ public final class ConfigurationUtil {
   public static ClusterConfiguration getClusterConfigFrom(
       final boolean enablePartitionScaling,
       final Set<PartitionMetadata> partitionDistribution,
-      final DynamicPartitionConfig partitionConfig) {
+      final DynamicPartitionConfig partitionConfig,
+      final String clusterId) {
     final var partitionStatesByMember = new HashMap<MemberId, Map<Integer, PartitionState>>();
     for (final var partitionMetadata : partitionDistribution) {
       final var partitionId = partitionMetadata.id().id();
@@ -57,7 +58,7 @@ public final class ConfigurationUtil {
         Optional.empty(),
         Optional.empty(),
         routingState,
-        Optional.empty());
+        Optional.of(clusterId));
   }
 
   public static Set<PartitionMetadata> getPartitionDistributionFrom(

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/util/ConfigurationUtil.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/util/ConfigurationUtil.java
@@ -56,7 +56,8 @@ public final class ConfigurationUtil {
         Map.copyOf(memberStates),
         Optional.empty(),
         Optional.empty(),
-        routingState);
+        routingState,
+        Optional.empty());
   }
 
   public static Set<PartitionMetadata> getPartitionDistributionFrom(

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/util/ConfigurationUtil.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/util/ConfigurationUtil.java
@@ -58,7 +58,7 @@ public final class ConfigurationUtil {
         Optional.empty(),
         Optional.empty(),
         routingState,
-        Optional.of(clusterId));
+        Optional.ofNullable(clusterId));
   }
 
   public static Set<PartitionMetadata> getPartitionDistributionFrom(

--- a/zeebe/dynamic-config/src/main/resources/proto/topology.proto
+++ b/zeebe/dynamic-config/src/main/resources/proto/topology.proto
@@ -13,12 +13,17 @@ message ClusterTopology {
   CompletedChange lastChange = 3;
   ClusterChangePlan currentChange = 4;
   RoutingState routingState = 5;
+  ClusterId clusterId = 6;
 }
 
 message RoutingState {
   int64 version = 1;
   RequestHandling requestHandling = 2;
   MessageCorrelation messageCorrelation = 3;
+}
+
+message ClusterId {
+  string clusterId = 1;
 }
 
 message RequestHandling {

--- a/zeebe/dynamic-config/src/main/resources/proto/topology.proto
+++ b/zeebe/dynamic-config/src/main/resources/proto/topology.proto
@@ -13,17 +13,13 @@ message ClusterTopology {
   CompletedChange lastChange = 3;
   ClusterChangePlan currentChange = 4;
   RoutingState routingState = 5;
-  ClusterId clusterId = 6;
+  string clusterId = 6;
 }
 
 message RoutingState {
   int64 version = 1;
   RequestHandling requestHandling = 2;
   MessageCorrelation messageCorrelation = 3;
-}
-
-message ClusterId {
-  string clusterId = 1;
 }
 
 message RequestHandling {

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationInitializerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationInitializerTest.java
@@ -212,7 +212,8 @@ final class ClusterConfigurationInitializerTest {
             member,
             List.of(partitionId),
             1,
-            DynamicPartitionConfig.init()));
+            DynamicPartitionConfig.init(),
+            "clusterId"));
   }
 
   private static final class TestClusterConfigurationNotifier

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagementIntegrationTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagementIntegrationTest.java
@@ -313,7 +313,8 @@ class ClusterConfigurationManagementIntegrationTest {
                   cluster.getMembershipService().getLocalMember().id(),
                   List.of(),
                   3,
-                  DynamicPartitionConfig.init()));
+                  DynamicPartitionConfig.init(),
+                  "clusterId"));
       startFuture.onComplete(
           (ignore, error) -> {
             if (error == null) {

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerTest.java
@@ -320,7 +320,8 @@ final class ClusterConfigurationManagerTest {
             topologyWithoutMember.members(),
             topologyWithoutMember.lastChange(),
             topologyWithoutMember.pendingChanges(),
-            topologyWithoutMember.routingState());
+            topologyWithoutMember.routingState(),
+            topologyWithoutMember.clusterId());
     clusterTopologyManager.onGossipReceived(notConflictingTopology);
 
     // then

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterScaleRequestTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterScaleRequestTransformerTest.java
@@ -135,7 +135,7 @@ final class ClusterScaleRequestTransformerTest {
                 getSortedPartitionIds(oldPartitionCount),
                 oldReplicationFactor);
     ClusterConfiguration oldClusterTopology =
-        ConfigurationUtil.getClusterConfigFrom(true, oldDistribution, partitionConfig);
+        ConfigurationUtil.getClusterConfigFrom(true, oldDistribution, partitionConfig, "clusterId");
     for (final MemberId member : getClusterMembers(oldClusterSize)) {
       if (!oldClusterTopology.hasMember(member)) {
         oldClusterTopology =

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/PartitionReassignRequestTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/PartitionReassignRequestTransformerTest.java
@@ -120,7 +120,7 @@ class PartitionReassignRequestTransformerTest {
                 getSortedPartitionIds(partitionCount),
                 replicationFactor);
     var oldClusterTopology =
-        ConfigurationUtil.getClusterConfigFrom(true, oldDistribution, partitionConfig);
+        ConfigurationUtil.getClusterConfigFrom(true, oldDistribution, partitionConfig, "clusterId");
     for (int i = 0; i < max(oldClusterSize, newClusterSize); i++) {
       oldClusterTopology =
           oldClusterTopology.updateMember(
@@ -188,7 +188,7 @@ class PartitionReassignRequestTransformerTest {
                 getSortedPartitionIds(oldPartitionCount),
                 oldReplicationFactor);
     var oldClusterTopology =
-        ConfigurationUtil.getClusterConfigFrom(true, oldDistribution, partitionConfig);
+        ConfigurationUtil.getClusterConfigFrom(true, oldDistribution, partitionConfig, "clusterId");
     for (int i = 0; i < max(oldClusterSize, newClusterSize); i++) {
       oldClusterTopology =
           oldClusterTopology.updateMember(

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ScaleRequestTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ScaleRequestTransformerTest.java
@@ -128,7 +128,7 @@ class ScaleRequestTransformerTest {
                 getSortedPartitionIds(partitionCount),
                 replicationFactor);
     final var oldClusterTopology =
-        ConfigurationUtil.getClusterConfigFrom(true, oldDistribution, partitionConfig);
+        ConfigurationUtil.getClusterConfigFrom(true, oldDistribution, partitionConfig, "clusterId");
 
     //  when
     final var operationsEither =
@@ -162,7 +162,7 @@ class ScaleRequestTransformerTest {
                 getSortedPartitionIds(partitionCount),
                 replicationFactor);
     final var oldClusterTopology =
-        ConfigurationUtil.getClusterConfigFrom(true, oldDistribution, partitionConfig);
+        ConfigurationUtil.getClusterConfigFrom(true, oldDistribution, partitionConfig, "clusterId");
 
     // when
     final var operations =
@@ -210,7 +210,8 @@ class ScaleRequestTransformerTest {
                     .map(i -> PartitionId.from("temp", i))
                     .toList(),
                 replicationFactor);
-    final var config = ConfigurationUtil.getClusterConfigFrom(true, distribution, partitionConfig);
+    final var config =
+        ConfigurationUtil.getClusterConfigFrom(true, distribution, partitionConfig, "clusterId");
     final var transformer =
         new ScaleRequestTransformer(
             getClusterMembers(clusterSize), Optional.of(3), Optional.of(desiredPartitionCount));

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/AwaitRedistributionCompletionTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/AwaitRedistributionCompletionTest.java
@@ -36,7 +36,8 @@ public class AwaitRedistributionCompletionTest extends AbstractApplierTest {
           Map.of(),
           Optional.empty(),
           Optional.empty(),
-          Optional.of(RoutingState.initializeWithPartitionCount(3)));
+          Optional.of(RoutingState.initializeWithPartitionCount(3)),
+          Optional.empty());
 
   ClusterConfiguration valid3OutOf6Partitions =
       new ClusterConfiguration(
@@ -46,7 +47,8 @@ public class AwaitRedistributionCompletionTest extends AbstractApplierTest {
           Optional.empty(),
           Optional.of(
               new RoutingState(
-                  1, new ActivePartitions(3, Set.of(), Set.of(4, 5, 6)), new HashMod(3))));
+                  1, new ActivePartitions(3, Set.of(), Set.of(4, 5, 6)), new HashMod(3))),
+          Optional.empty());
 
   PartitionScalingChangeExecutor executor = new NoopPartitionScalingChangeExecutor();
 

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/StartPartitionScaleUpApplierTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/StartPartitionScaleUpApplierTest.java
@@ -109,7 +109,8 @@ final class StartPartitionScaleUpApplierTest {
             initialConfiguration.members(),
             initialConfiguration.lastChange(),
             initialConfiguration.pendingChanges(),
-            Optional.of(routingState));
+            Optional.of(routingState),
+            initialConfiguration.clusterId());
 
     // when - trying to init the operation to scale up
     final var result = new StartPartitionScaleUpApplier(executor, 4).init(configuration);
@@ -132,7 +133,8 @@ final class StartPartitionScaleUpApplierTest {
             initialConfiguration.members(),
             initialConfiguration.lastChange(),
             initialConfiguration.pendingChanges(),
-            Optional.of(routingState));
+            Optional.of(routingState),
+            initialConfiguration.clusterId());
 
     // when - trying to init the operation to scale "up" to 2 partitions
     final var result = new StartPartitionScaleUpApplier(executor, 2).init(configuration);
@@ -155,7 +157,8 @@ final class StartPartitionScaleUpApplierTest {
             initialConfiguration.members(),
             initialConfiguration.lastChange(),
             initialConfiguration.pendingChanges(),
-            Optional.of(routingState));
+            Optional.of(routingState),
+            initialConfiguration.clusterId());
 
     // when - applying the operation to scale up to three once
     final var expectedFailure = new RuntimeException("Expected failure");
@@ -180,7 +183,8 @@ final class StartPartitionScaleUpApplierTest {
             initialConfiguration.members(),
             initialConfiguration.lastChange(),
             initialConfiguration.pendingChanges(),
-            Optional.of(routingState));
+            Optional.of(routingState),
+            initialConfiguration.clusterId());
 
     // when - applying the operation to scale up to three once
     when(executor.initiateScaleUp(anyInt())).thenReturn(CompletableActorFuture.completed(null));
@@ -201,7 +205,8 @@ final class StartPartitionScaleUpApplierTest {
             initialConfiguration.members(),
             initialConfiguration.lastChange(),
             initialConfiguration.pendingChanges(),
-            Optional.of(routingState));
+            Optional.of(routingState),
+            initialConfiguration.clusterId());
 
     // when - applying the operation to scale up to three once
     when(executor.initiateScaleUp(anyInt())).thenReturn(CompletableActorFuture.completed(null));

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/ClusterConfigurationTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/ClusterConfigurationTest.java
@@ -255,6 +255,7 @@ class ClusterConfigurationTest {
             Optional.of(
                 new CompletedChange(changeId, Status.COMPLETED, Instant.now(), Instant.now())),
             Optional.empty(),
+            Optional.empty(),
             Optional.empty());
 
     ClusterConfigurationAssert.assertThatClusterTopology(finalTopology).hasSameTopologyAs(expected);
@@ -306,6 +307,7 @@ class ClusterConfigurationTest {
                     Map.of(1, PartitionState.active(1, DynamicPartitionConfig.uninitialized())))),
             Optional.empty(),
             Optional.empty(),
+            Optional.empty(),
             Optional.empty());
 
     final DynamicPartitionConfig validConfig =
@@ -317,6 +319,7 @@ class ClusterConfigurationTest {
             Map.of(
                 member(1),
                 MemberState.initializeAsActive(Map.of(1, PartitionState.active(1, validConfig)))),
+            Optional.empty(),
             Optional.empty(),
             Optional.empty(),
             Optional.empty());
@@ -340,12 +343,14 @@ class ClusterConfigurationTest {
     final var oldRoutingState =
         Optional.of(new RoutingState(1, new AllPartitions(3), new HashMod(3)));
     final var oldConfig =
-        new ClusterConfiguration(1, Map.of(), Optional.empty(), Optional.empty(), oldRoutingState);
+        new ClusterConfiguration(
+            1, Map.of(), Optional.empty(), Optional.empty(), oldRoutingState, Optional.empty());
 
     final var newRoutingState =
         Optional.of(new RoutingState(2, new AllPartitions(4), new HashMod(4)));
     final var newConfig =
-        new ClusterConfiguration(1, Map.of(), Optional.empty(), Optional.empty(), newRoutingState);
+        new ClusterConfiguration(
+            1, Map.of(), Optional.empty(), Optional.empty(), newRoutingState, Optional.empty());
 
     // when
     final var merged = oldConfig.merge(newConfig);

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/ClusterTopologyDomain.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/ClusterTopologyDomain.java
@@ -50,12 +50,14 @@ public final class ClusterTopologyDomain extends DomainContextBase {
     final var arbitraryChangePlan =
         Arbitraries.forType(ClusterChangePlan.class).enableRecursion().optional();
     final var arbitraryRoutingState = routingStates().optional();
+    final var arbitraryClusterId = Arbitraries.strings().ofMinLength(1).ofMaxLength(50).optional();
     return Combinators.combine(
             arbitraryVersion,
             arbitraryMembers,
             arbitraryCompletedChange,
             arbitraryChangePlan,
-            arbitraryRoutingState)
+            arbitraryRoutingState,
+            arbitraryClusterId)
         .as(ClusterConfiguration::new);
   }
 

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/ConfigurationUtilTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/ConfigurationUtilTest.java
@@ -56,7 +56,8 @@ class ConfigurationUtilTest {
 
     // when
     final var topology =
-        ConfigurationUtil.getClusterConfigFrom(true, partitionDistribution, partitionConfig);
+        ConfigurationUtil.getClusterConfigFrom(
+            true, partitionDistribution, partitionConfig, "clusterId");
 
     // then
     ClusterConfigurationAssert.assertThatClusterTopology(topology)
@@ -246,7 +247,8 @@ class ConfigurationUtilTest {
 
     // when
     final var topology =
-        ConfigurationUtil.getClusterConfigFrom(true, partitionDistribution, partitionConfig);
+        ConfigurationUtil.getClusterConfigFrom(
+            true, partitionDistribution, partitionConfig, "clusterId");
 
     // then
     ClusterConfigurationAssert.assertThatClusterTopology(topology)

--- a/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/impl/broker/PublishMessageDispatchStrategyTest.java
+++ b/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/impl/broker/PublishMessageDispatchStrategyTest.java
@@ -57,7 +57,12 @@ final class PublishMessageDispatchStrategyTest {
         new RoutingState(1, new AllPartitions(3), new HashMod(messagePartitionCount));
     final var clusterConfiguration =
         new ClusterConfiguration(
-            1, Map.of(), Optional.empty(), Optional.empty(), Optional.of(routingState));
+            1,
+            Map.of(),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.of(routingState),
+            Optional.empty());
     final var topologyManager =
         new TestTopologyManager(new TestBrokerClusterState(partitionCount), clusterConfiguration);
 

--- a/zeebe/restore/src/main/java/io/camunda/zeebe/restore/RestoreManager.java
+++ b/zeebe/restore/src/main/java/io/camunda/zeebe/restore/RestoreManager.java
@@ -124,7 +124,7 @@ public class RestoreManager {
             Optional.of(
                 ClusterChangePlan.init(
                     1L, List.of(new UpdateRoutingState(coordinatorId, Optional.empty())))),
-            base.routingState());
+            base.routingState(), base.clusterId());
     final var persistedConfiguration =
         PersistedClusterConfiguration.ofFile(file, new ProtoBufSerializer());
     persistedConfiguration.update(configuration);

--- a/zeebe/restore/src/main/java/io/camunda/zeebe/restore/RestoreManager.java
+++ b/zeebe/restore/src/main/java/io/camunda/zeebe/restore/RestoreManager.java
@@ -124,7 +124,8 @@ public class RestoreManager {
             Optional.of(
                 ClusterChangePlan.init(
                     1L, List.of(new UpdateRoutingState(coordinatorId, Optional.empty())))),
-            base.routingState(), base.clusterId());
+            base.routingState(),
+            base.clusterId());
     final var persistedConfiguration =
         PersistedClusterConfiguration.ofFile(file, new ProtoBufSerializer());
     persistedConfiguration.update(configuration);


### PR DESCRIPTION
## Description

This PR adds the cluster Id from the broker topology. This would enable us to either configure a cluster ID in the configuration that will be shared by all the brokers, or to use a generated one that is also distributed.

To guarantee that cluster ID is equal across the brokers, the goal is to have the coordinator initialize the cluster ID and distribute this across the non-coordinators. 

The intentition of this PR is that the cluster ID should not be possible to change once set during initialization. Once distributed via gossip this is saved on the `topology.meta`. 

In the PingConsoleRunner, when it starts, it will wait for the cluster Id in the topology to be initialized before creating the payload to passing it to the PingConsoleTask. For this we are using a broker topology listenner checking for the initialization of the cluster ID value.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

relates to https://github.com/camunda/camunda/issues/35085
