### PR TITLE
fix: update dashboard for new flow control metric naming

### DIFF
--- a/monitor/grafana/zeebe.json
+++ b/monitor/grafana/zeebe.json
@@ -14948,7 +14948,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum by (context, partition) (rate(zeebe_flow_control_outcome_total{namespace=~\"$namespace\", pod=~\"$pod\", partition=~\"$partition\", outcome=\"accepted\"}[$__rate_interval]))",
+              "expr": "sum by (context, partition) (rate(zeebe_flow_control_total{namespace=~\"$namespace\", pod=~\"$pod\", partition=~\"$partition\", outcome=\"accepted\"}[$__rate_interval]))",
               "instant": false,
               "legendFormat": "Partition {{partition}}: {{context}}",
               "range": true,
@@ -15040,7 +15040,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum by (context, partition, outcome) (rate(zeebe_flow_control_outcome_total{namespace=~\"$namespace\", pod=~\"$pod\", partition=~\"$partition\", outcome!=\"accepted\"}[$__rate_interval]))",
+              "expr": "sum by (context, partition, outcome) (rate(zeebe_flow_control_total{namespace=~\"$namespace\", pod=~\"$pod\", partition=~\"$partition\", outcome!=\"accepted\"}[$__rate_interval]))",
               "instant": false,
               "legendFormat": "Partition {{partition}} rejected {{context}}: {{outcome}}",
               "range": true,


### PR DESCRIPTION
The naming was accidentally changed in 658a74d7. Rather than changing it again, we just update the query.