### PR TITLE
Support ad-hoc sub-process inner instance in Tasklist

### DIFF
--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/VariableStoreElasticSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/VariableStoreElasticSearch.java
@@ -254,6 +254,7 @@ public class VariableStoreElasticSearch implements VariableStore {
         QueryBuilders.termsQuery(
             FlowNodeInstanceTemplate.TYPE,
             FlowNodeType.AD_HOC_SUB_PROCESS.toString(),
+            FlowNodeType.AD_HOC_SUB_PROCESS_INNER_INSTANCE.toString(),
             FlowNodeType.USER_TASK.toString(),
             FlowNodeType.SUB_PROCESS.toString(),
             FlowNodeType.EVENT_SUB_PROCESS.toString(),

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/opensearch/VariableStoreOpenSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/opensearch/VariableStoreOpenSearch.java
@@ -286,6 +286,8 @@ public class VariableStoreOpenSearch implements VariableStore {
                         t.value(
                             Arrays.asList(
                                 FieldValue.of(FlowNodeType.AD_HOC_SUB_PROCESS.toString()),
+                                FieldValue.of(
+                                    FlowNodeType.AD_HOC_SUB_PROCESS_INNER_INSTANCE.toString()),
                                 FieldValue.of(FlowNodeType.USER_TASK.toString()),
                                 FieldValue.of(FlowNodeType.SUB_PROCESS.toString()),
                                 FieldValue.of(FlowNodeType.EVENT_SUB_PROCESS.toString()),

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/zeebeimport/ZeebeImportAdHocSubProcessIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/zeebeimport/ZeebeImportAdHocSubProcessIT.java
@@ -28,12 +28,16 @@ import org.springframework.web.context.WebApplicationContext;
 
 public class ZeebeImportAdHocSubProcessIT extends TasklistZeebeIntegrationTest {
 
+  private static final String AD_HOC_SUB_PROCESS_ELEMENTS_VARIABLE_VALUE =
+      """
+      [{"elementId":"task1","elementName":"Task 1"},\
+      {"elementId":"task2","elementName":"Task 2"},\
+      {"elementId":"task3","elementName":"Task 3"}]\
+      """;
+
   @Autowired private TaskStore taskStore;
-
   @Autowired private ObjectMapper objectMapper;
-
   @Autowired private WebApplicationContext context;
-
   private MockMvcHelper mockMvcHelper;
 
   @BeforeEach
@@ -84,7 +88,11 @@ public class ZeebeImportAdHocSubProcessIT extends TasklistZeebeIntegrationTest {
                     tuple(
                         "tasks",
                         "[\"task1\",\"task2\",\"task3\"]",
-                        "[\"task1\",\"task2\",\"task3\"]"));
+                        "[\"task1\",\"task2\",\"task3\"]"),
+                    tuple(
+                        "adHocSubProcessElements",
+                        AD_HOC_SUB_PROCESS_ELEMENTS_VARIABLE_VALUE,
+                        AD_HOC_SUB_PROCESS_ELEMENTS_VARIABLE_VALUE));
         case "task2" ->
             assertThat(result)
                 .hasOkHttpStatus()
@@ -99,7 +107,11 @@ public class ZeebeImportAdHocSubProcessIT extends TasklistZeebeIntegrationTest {
                     tuple(
                         "tasks",
                         "[\"task1\",\"task2\",\"task3\"]",
-                        "[\"task1\",\"task2\",\"task3\"]"));
+                        "[\"task1\",\"task2\",\"task3\"]"),
+                    tuple(
+                        "adHocSubProcessElements",
+                        AD_HOC_SUB_PROCESS_ELEMENTS_VARIABLE_VALUE,
+                        AD_HOC_SUB_PROCESS_ELEMENTS_VARIABLE_VALUE));
         case "task3" ->
             assertThat(result)
                 .hasOkHttpStatus()
@@ -113,7 +125,11 @@ public class ZeebeImportAdHocSubProcessIT extends TasklistZeebeIntegrationTest {
                     tuple(
                         "tasks",
                         "[\"task1\",\"task2\",\"task3\"]",
-                        "[\"task1\",\"task2\",\"task3\"]"));
+                        "[\"task1\",\"task2\",\"task3\"]"),
+                    tuple(
+                        "adHocSubProcessElements",
+                        AD_HOC_SUB_PROCESS_ELEMENTS_VARIABLE_VALUE,
+                        AD_HOC_SUB_PROCESS_ELEMENTS_VARIABLE_VALUE));
         default -> fail("Unexpected task id: " + taskId);
       }
     }

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/zeebeimport/ZeebeImportAdHocSubProcessIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/zeebeimport/ZeebeImportAdHocSubProcessIT.java
@@ -21,13 +21,11 @@ import io.camunda.tasklist.webapp.security.TasklistURIs;
 import io.camunda.webapps.schema.entities.usertask.TaskEntity;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
-@Disabled("https://github.com/camunda/ad-hoc-sub-process-phase-3/issues/26")
 public class ZeebeImportAdHocSubProcessIT extends TasklistZeebeIntegrationTest {
 
   @Autowired private TaskStore taskStore;


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This ensures the ad-hoc sub-process inner instance is considered a flow scope for secondary storage. As a result the variables created here, and on the parent of the inner instance are shown on the user tasks.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes https://github.com/camunda/ad-hoc-sub-process-phase-3/issues/26
