### PR TITLE
docs: clarify filter method chaining in Java client

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/search/request/TypedFilterableRequest.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/request/TypedFilterableRequest.java
@@ -20,7 +20,8 @@ import java.util.function.Consumer;
 public interface TypedFilterableRequest<F, SELF extends TypedFilterableRequest<F, SELF>> {
 
   /**
-   * Sets the filter to be included in the search request.
+   * Sets the filter to be included in the search request. Invoking the method overrides previously
+   * set filters.
    *
    * @param value the filter
    * @return the builder for the search request
@@ -28,7 +29,9 @@ public interface TypedFilterableRequest<F, SELF extends TypedFilterableRequest<F
   SELF filter(final F value);
 
   /**
-   * Provides a fluent builder to create a filter to be included in the search request.
+   * Provides a fluent builder to create a filter to be included in the search request. Invoking the
+   * method overrides previously set filters. You can chain multiple filter criteria inside the
+   * consumer you provide for such cases.
    *
    * @param fn consumer to create the filter
    * @return the builder for the search request


### PR DESCRIPTION
## Description

Clarifies that invoking the `filter` method in client search requests overrides previous filter criteria.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

Related to [this Slack discussion](https://camunda.slack.com/archives/C06UKS51QV9/p1755008774538649).
