### PR TITLE
feat: add backup properties to unified configuration

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/Backup.java
+++ b/configuration/src/main/java/io/camunda/configuration/Backup.java
@@ -7,15 +7,127 @@
  */
 package io.camunda.configuration;
 
+import io.camunda.configuration.UnifiedConfigurationHelper.BackwardsCompatibilityMode;
+import java.time.Duration;
+import java.util.Map;
+import java.util.Set;
+
 public class Backup {
+  private static final String PREFIX = "camunda.data.backup";
+
+  private static final Map<String, String> LEGACY_OPERATE_BACKUP_PROPERTIES =
+      Map.of(
+          "repositoryName",
+          "camunda.operate.backup.repositoryName",
+          "snapshotTimeout",
+          "camunda.operate.backup.snapshotTimeout",
+          "incompleteCheckTimeoutInSeconds",
+          "camunda.operate.backup.incompleteCheckTimeoutInSeconds");
+
+  private static final Map<String, String> LEGACY_TASKLIST_BACKUP_PROPERTIES =
+      Map.of("repositoryName", "camunda.tasklist.backup.repositoryName");
+
+  private static final Map<String, String> LEGACY_BROKER_BACKUP_PROPERTIES =
+      Map.of("store", "zeebe.broker.data.backup.store");
+
+  private Map<String, String> legacyPropertyMap = LEGACY_OPERATE_BACKUP_PROPERTIES;
+
+  /**
+   * Set the ES / OS snapshot repository name.
+   *
+   * <p>Note: This setting applies to backups of secondary storage.
+   */
+  private String repositoryName;
+
+  /**
+   * A backup of history data consists of multiple Elasticsearch/Opensearch snapshots.
+   * snapshotTimeout controls the maximum time to wait for a snapshot operation to complete during
+   * backup creation. When set to 0, the system will wait indefinitely for snapshots to finish.
+   *
+   * <p>Note: This setting applies to backups of secondary storage.
+   */
+  private int snapshotTimeout = 0;
+
+  /**
+   * Defines the timeout period for determining whether an incomplete backup should be considered as
+   * failed or still in progress. This property helps distinguish between backups that are actively
+   * running versus those that may have stalled or failed silently.
+   *
+   * <p>Note: This setting applies to backups of secondary storage.
+   */
+  private Duration incompleteCheckTimeout = Duration.ofMinutes(5);
+
+  /**
+   * Set the backup store type. Supported values are [NONE, S3, GCS, AZURE, FILESYSTEM]. Default
+   * value is NONE.
+   *
+   * <ul>
+   *   <li>When NONE, no backup store is configured and no backup will be taken.
+   *   <li>Use S3 to use any S3 compatible storage
+   *       (https://docs.aws.amazon.com/AmazonS3/latest/API/Type_API_Reference.html).
+   *   <li>Use GCS to use Google Cloud Storage (https://cloud.google.com/storage/)
+   *   <li>Use AZURE to use Azure Storage
+   *       (https://learn.microsoft.com/en-us/azure/storage/blobs/storage-blobs-introduction)
+   *   <li>Use FILESYSTEM to use filesystem storage
+   * </ul>
+   *
+   * <p>Note: This configuration applies to the backup of primary storage.
+   */
+  private BackupStoreType store = BackupStoreType.NONE;
+
   /** Configuration for backup store AWS S3 */
   private S3 s3 = new S3();
 
   /** Configuration for backup store GCS */
   private Gcs gcs = new Gcs();
 
+  /** Configuration for backup store Filesystem */
+  private Filesystem filesystem = new Filesystem();
+
   /** Configuration for backup store Azure */
   private Azure azure = new Azure();
+
+  public String getRepositoryName() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + ".repository-name",
+        repositoryName,
+        String.class,
+        BackwardsCompatibilityMode.SUPPORTED,
+        Set.of(legacyPropertyMap.get("repositoryName")));
+  }
+
+  public void setRepositoryName(final String repositoryName) {
+    this.repositoryName = repositoryName;
+  }
+
+  public int getSnapshotTimeout() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + ".snapshot-timeout",
+        snapshotTimeout,
+        Integer.class,
+        BackwardsCompatibilityMode.SUPPORTED,
+        Set.of(legacyPropertyMap.get("snapshotTimeout")));
+  }
+
+  public void setSnapshotTimeout(final int snapshotTimeout) {
+    this.snapshotTimeout = snapshotTimeout;
+  }
+
+  public Duration getIncompleteCheckTimeout() {
+    final long incompleteCheckTimeoutInSeconds =
+        UnifiedConfigurationHelper.validateLegacyConfiguration(
+            PREFIX + ".incomplete-check-timeout",
+            incompleteCheckTimeout.getSeconds(),
+            Long.class,
+            BackwardsCompatibilityMode.SUPPORTED,
+            Set.of(legacyPropertyMap.get("incompleteCheckTimeoutInSeconds")));
+
+    return Duration.ofSeconds(incompleteCheckTimeoutInSeconds);
+  }
+
+  public void setIncompleteCheckTimeout(final Duration incompleteCheckTimeout) {
+    this.incompleteCheckTimeout = incompleteCheckTimeout;
+  }
 
   public S3 getS3() {
     return s3;
@@ -33,11 +145,92 @@ public class Backup {
     this.gcs = gcs;
   }
 
+  public Filesystem getFilesystem() {
+    return filesystem;
+  }
+
+  public void setFilesystem(final Filesystem filesystem) {
+    this.filesystem = filesystem;
+  }
+
   public Azure getAzure() {
     return azure;
   }
 
   public void setAzure(final Azure azure) {
     this.azure = azure;
+  }
+
+  public BackupStoreType getStore() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + ".store",
+        store,
+        BackupStoreType.class,
+        BackwardsCompatibilityMode.SUPPORTED,
+        Set.of(legacyPropertyMap.get("store")));
+  }
+
+  public void setStore(final BackupStoreType store) {
+    this.store = store;
+  }
+
+  @Override
+  public Backup clone() {
+    final Backup copy = new Backup();
+    copy.repositoryName = repositoryName;
+    copy.snapshotTimeout = snapshotTimeout;
+    copy.incompleteCheckTimeout = incompleteCheckTimeout;
+    copy.store = store;
+    copy.s3 = s3;
+    copy.gcs = gcs;
+    copy.filesystem = filesystem;
+    copy.azure = azure;
+
+    return copy;
+  }
+
+  public Backup withOperateBackupProperties() {
+    final Backup copy = clone();
+    copy.legacyPropertyMap = LEGACY_OPERATE_BACKUP_PROPERTIES;
+    return copy;
+  }
+
+  public Backup withTasklistBackupProperties() {
+    final Backup copy = clone();
+    copy.legacyPropertyMap = LEGACY_TASKLIST_BACKUP_PROPERTIES;
+    return copy;
+  }
+
+  public Backup withBrokerBackupProperties() {
+    final Backup copy = clone();
+    copy.legacyPropertyMap = LEGACY_BROKER_BACKUP_PROPERTIES;
+    return copy;
+  }
+
+  public enum BackupStoreType {
+    /**
+     * When type = S3, {@link io.camunda.zeebe.backup.s3.S3BackupStore} will be used as the backup
+     * store
+     */
+    S3,
+
+    /**
+     * When type = GCS, {@link io.camunda.zeebe.backup.gcs.GcsBackupStore} will be used as the
+     * backup store
+     */
+    GCS,
+    /**
+     * When type = AZURE, {@link io.camunda.zeebe.backup.azure.AzureBackupStore} will be used as the
+     * backup store
+     */
+    AZURE,
+    /**
+     * When type = FILESYSTEM, {@link io.camunda.zeebe.backup.filesystem.FilesystemBackupStore} will
+     * be used as the backup store
+     */
+    FILESYSTEM,
+
+    /** Set type = NONE when no backup store is available. No backup will be taken. */
+    NONE
   }
 }

--- a/configuration/src/main/java/io/camunda/configuration/Filesystem.java
+++ b/configuration/src/main/java/io/camunda/configuration/Filesystem.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import io.camunda.configuration.UnifiedConfigurationHelper.BackwardsCompatibilityMode;
+import java.util.Set;
+
+public class Filesystem {
+  private static final String PREFIX = "camunda.data.backup.filesystem";
+  private static final Set<String> LEGACY_BASE_PATH_PROPERTIES =
+      Set.of("zeebe.broker.data.backup.filesystem.basePath");
+
+  /** Set the base path to store all related backup files in. */
+  private String basePath;
+
+  public String getBasePath() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + ".base-path",
+        basePath,
+        String.class,
+        BackwardsCompatibilityMode.SUPPORTED,
+        LEGACY_BASE_PATH_PROPERTIES);
+  }
+
+  public void setBasePath(final String basePath) {
+    this.basePath = basePath;
+  }
+}

--- a/configuration/src/main/java/io/camunda/configuration/UnifiedConfigurationHelper.java
+++ b/configuration/src/main/java/io/camunda/configuration/UnifiedConfigurationHelper.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.configuration;
 
+import io.camunda.configuration.Backup.BackupStoreType;
 import io.camunda.configuration.Gcs.GcsBackupStoreAuth;
 import io.camunda.configuration.RocksDb.AccessMetricsKind;
 import java.io.File;
@@ -71,7 +72,13 @@ public class UnifiedConfigurationHelper {
       final String strValue = environment.getProperty(legacyProperty);
       final T legacyValue = parseLegacyValue(strValue, expectedType);
 
-      legacyValues.add(legacyValue);
+      if (legacyValue != null) {
+        legacyValues.add(legacyValue);
+      }
+    }
+
+    if (legacyValues.isEmpty()) {
+      return null;
     }
 
     if (legacyValues.size() > 1) {
@@ -222,6 +229,7 @@ public class UnifiedConfigurationHelper {
       case "File" -> (T) new File(strValue);
       case "SasTokenType" -> (T) SasToken.SasTokenType.valueOf(strValue.toUpperCase());
       case "AccessMetricsKind" -> (T) AccessMetricsKind.valueOf(strValue.toUpperCase());
+      case "BackupStoreType" -> (T) BackupStoreType.valueOf(strValue.toUpperCase());
       default -> throw new IllegalArgumentException("Unsupported type: " + type);
     };
   }

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/OperatePropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/OperatePropertiesOverride.java
@@ -7,18 +7,22 @@
  */
 package io.camunda.configuration.beanoverrides;
 
+import io.camunda.configuration.Backup;
 import io.camunda.configuration.UnifiedConfiguration;
+import io.camunda.operate.property.BackupProperties;
 import io.camunda.operate.property.OperateProperties;
 import org.springframework.beans.BeanUtils;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.DependsOn;
 import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.PropertySource;
 
 @Configuration
 @EnableConfigurationProperties(LegacyOperateProperties.class)
 @PropertySource("classpath:operate-version.properties")
+@DependsOn("unifiedConfigurationHelper")
 public class OperatePropertiesOverride {
 
   private final UnifiedConfiguration unifiedConfiguration;
@@ -37,9 +41,18 @@ public class OperatePropertiesOverride {
     final OperateProperties override = new OperateProperties();
     BeanUtils.copyProperties(legacyOperateProperties, override);
 
-    // TODO: Populate the bean using unifiedConfiguration
-    //  override.setSampleField(unifiedConfiguration.getSampleField());
+    pouplateFromBackup(override);
 
     return override;
+  }
+
+  private void pouplateFromBackup(final OperateProperties override) {
+    final Backup operateBackup =
+        unifiedConfiguration.getCamunda().getData().getBackup().withOperateBackupProperties();
+    final BackupProperties backupProperties = override.getBackup();
+    backupProperties.setRepositoryName(operateBackup.getRepositoryName());
+    backupProperties.setSnapshotTimeout(operateBackup.getSnapshotTimeout());
+    backupProperties.setIncompleteCheckTimeoutInSeconds(
+        operateBackup.getIncompleteCheckTimeout().getSeconds());
   }
 }

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/TasklistPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/TasklistPropertiesOverride.java
@@ -8,18 +8,22 @@
 
 package io.camunda.configuration.beanoverrides;
 
+import io.camunda.configuration.Backup;
 import io.camunda.configuration.UnifiedConfiguration;
+import io.camunda.tasklist.property.BackupProperties;
 import io.camunda.tasklist.property.TasklistProperties;
 import org.springframework.beans.BeanUtils;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.DependsOn;
 import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.PropertySource;
 
 @Configuration
 @EnableConfigurationProperties(LegacyTasklistProperties.class)
 @PropertySource("classpath:tasklist-version.properties")
+@DependsOn("unifiedConfigurationHelper")
 public class TasklistPropertiesOverride {
 
   private final UnifiedConfiguration unifiedConfiguration;
@@ -38,9 +42,15 @@ public class TasklistPropertiesOverride {
     final TasklistProperties override = new TasklistProperties();
     BeanUtils.copyProperties(legacyTasklistProperties, override);
 
-    // TODO: Populate the bean using unifiedConfiguration
-    //  override.setSampleField(unifiedConfiguration.getSampleField());
+    pouplateFromBackup(override);
 
     return override;
+  }
+
+  private void pouplateFromBackup(final TasklistProperties override) {
+    final Backup backup =
+        unifiedConfiguration.getCamunda().getData().getBackup().withTasklistBackupProperties();
+    final BackupProperties backupProperties = override.getBackup();
+    backupProperties.setRepositoryName(backup.getRepositoryName());
   }
 }

--- a/configuration/src/test/java/io/camunda/configuration/DataBackupBrokerPropertiesTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/DataBackupBrokerPropertiesTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.configuration.beanoverrides.BrokerBasedPropertiesOverride;
+import io.camunda.configuration.beans.BrokerBasedProperties;
+import io.camunda.zeebe.broker.system.configuration.backup.BackupStoreCfg.BackupStoreType;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+@SpringJUnitConfig({
+  UnifiedConfiguration.class,
+  BrokerBasedPropertiesOverride.class,
+  UnifiedConfigurationHelper.class
+})
+@ActiveProfiles("broker")
+public class DataBackupBrokerPropertiesTest {
+  @Nested
+  @TestPropertySource(properties = {"camunda.data.backup.store=azure"})
+  class WithOnlyUnifiedConfigSet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithOnlyUnifiedConfigSet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldSetStore() {
+      assertThat(brokerCfg.getData().getBackup().getStore()).isEqualTo(BackupStoreType.AZURE);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(properties = {"zeebe.broker.data.backup.store=azure"})
+  class WithOnlyLegacySet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithOnlyLegacySet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldSetStore() {
+      assertThat(brokerCfg.getData().getBackup().getStore()).isEqualTo(BackupStoreType.AZURE);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        // new
+        "camunda.data.backup.store=azure",
+        // legacy
+        "zeebe.broker.data.backup.store=azure",
+      })
+  class WithNewAndLegacySet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithNewAndLegacySet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldSetStoreFromNew() {
+      assertThat(brokerCfg.getData().getBackup().getStore()).isEqualTo(BackupStoreType.AZURE);
+    }
+  }
+}

--- a/configuration/src/test/java/io/camunda/configuration/DataBackupFilesystemTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/DataBackupFilesystemTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.configuration.beanoverrides.BrokerBasedPropertiesOverride;
+import io.camunda.configuration.beans.BrokerBasedProperties;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+@SpringJUnitConfig({
+  UnifiedConfiguration.class,
+  BrokerBasedPropertiesOverride.class,
+  UnifiedConfigurationHelper.class
+})
+@ActiveProfiles("broker")
+public class DataBackupFilesystemTest {
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "camunda.data.backup.filesystem.base-path=basePathNew",
+      })
+  class WithOnlyUnifiedConfigSet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithOnlyUnifiedConfigSet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldSetBasePath() {
+      assertThat(brokerCfg.getData().getBackup().getFilesystem().getBasePath())
+          .isEqualTo("basePathNew");
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "zeebe.broker.data.backup.filesystem.basePath=basePathLegacy",
+      })
+  class WithOnlyLegacySet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithOnlyLegacySet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldSetBasePath() {
+      assertThat(brokerCfg.getData().getBackup().getFilesystem().getBasePath())
+          .isEqualTo("basePathLegacy");
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        // new
+        "camunda.data.backup.filesystem.base-path=basePathNew",
+        // legacy
+        "zeebe.broker.data.backup.filesystem.basePath=basePathLegacy",
+      })
+  class WithNewAndLegacySet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithNewAndLegacySet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldSetBasePathFromNew() {
+      assertThat(brokerCfg.getData().getBackup().getFilesystem().getBasePath())
+          .isEqualTo("basePathNew");
+    }
+  }
+}

--- a/configuration/src/test/java/io/camunda/configuration/DataBackupOperatePropertiesTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/DataBackupOperatePropertiesTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.configuration.beanoverrides.OperatePropertiesOverride;
+import io.camunda.operate.property.OperateProperties;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+@SpringJUnitConfig({
+  UnifiedConfiguration.class,
+  OperatePropertiesOverride.class,
+  UnifiedConfigurationHelper.class
+})
+public class DataBackupOperatePropertiesTest {
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "camunda.data.backup.repository-name=repositoryNameNew",
+        "camunda.data.backup.snapshot-timeout=5",
+        "camunda.data.backup.incomplete-check-timeout=3m",
+      })
+  class WithOnlyUnifiedConfigSet {
+    final OperateProperties operateProperties;
+
+    WithOnlyUnifiedConfigSet(@Autowired final OperateProperties operateProperties) {
+      this.operateProperties = operateProperties;
+    }
+
+    @Test
+    void shouldSetRepositoryName() {
+      assertThat(operateProperties.getBackup().getRepositoryName()).isEqualTo("repositoryNameNew");
+    }
+
+    @Test
+    void shouldSetSnapshotTimeout() {
+      assertThat(operateProperties.getBackup().getSnapshotTimeout()).isEqualTo(5);
+    }
+
+    @Test
+    void shouldSetIncompleteCheckTimeout() {
+      assertThat(operateProperties.getBackup().getIncompleteCheckTimeoutInSeconds()).isEqualTo(180);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "camunda.tasklist.backup.repositoryName=repositoryNameLegacyTasklist",
+      })
+  class WithOnlyTasklistLegacySet {
+    final OperateProperties operateProperties;
+
+    WithOnlyTasklistLegacySet(@Autowired final OperateProperties operateProperties) {
+      this.operateProperties = operateProperties;
+    }
+
+    @Test
+    void shouldNotSetRepositoryNameFromLegacyTasklist() {
+      assertThat(operateProperties.getBackup().getRepositoryName()).isNull();
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "camunda.operate.backup.repositoryName=repositoryNameLegacyOperate",
+        "camunda.operate.backup.snapshotTimeout=5",
+        "camunda.operate.backup.incompleteCheckTimeoutInSeconds=180",
+      })
+  class WithOnlyOperateLegacySet {
+    final OperateProperties operateProperties;
+
+    WithOnlyOperateLegacySet(@Autowired final OperateProperties operateProperties) {
+      this.operateProperties = operateProperties;
+    }
+
+    @Test
+    void shouldSetRepositoryNameFromLegacyOperate() {
+      assertThat(operateProperties.getBackup().getRepositoryName())
+          .isEqualTo("repositoryNameLegacyOperate");
+    }
+
+    @Test
+    void shouldSetSnapshotTimeoutFromLegacyOperate() {
+      assertThat(operateProperties.getBackup().getSnapshotTimeout()).isEqualTo(5);
+    }
+
+    @Test
+    void shouldSetIncompleteCheckTimeoutFromLegacyOperate() {
+      assertThat(operateProperties.getBackup().getIncompleteCheckTimeoutInSeconds()).isEqualTo(180);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        // new
+        "camunda.data.backup.repository-name=repositoryNameNew",
+        "camunda.data.backup.snapshot-timeout=5",
+        "camunda.data.backup.incomplete-check-timeout=3m",
+        // legacy configuration tasklist
+        "camunda.tasklist.backup.repositoryName=repositoryNameLegacyTasklist",
+        // legacy configuration operate
+        "camunda.operate.backup.repositoryName=repositoryNameLegacyOperate",
+        "camunda.operate.backup.snapshotTimeout=2",
+        "camunda.operate.backup.incompleteCheckTimeoutInSeconds=90",
+      })
+  class WithNewAndLegacySet {
+    final OperateProperties operateProperties;
+
+    WithNewAndLegacySet(@Autowired final OperateProperties operateProperties) {
+      this.operateProperties = operateProperties;
+    }
+
+    @Test
+    void shouldSetRepositoryNameFromNew() {
+      assertThat(operateProperties.getBackup().getRepositoryName()).isEqualTo("repositoryNameNew");
+    }
+
+    @Test
+    void shouldSetSnapshotTimeoutFromNew() {
+      assertThat(operateProperties.getBackup().getSnapshotTimeout()).isEqualTo(5);
+    }
+
+    @Test
+    void shouldSetIncompleteCheckTimeoutFromNew() {
+      assertThat(operateProperties.getBackup().getIncompleteCheckTimeoutInSeconds()).isEqualTo(180);
+    }
+  }
+}

--- a/configuration/src/test/java/io/camunda/configuration/DataBackupTasklistPropertiesTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/DataBackupTasklistPropertiesTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.configuration.beanoverrides.TasklistPropertiesOverride;
+import io.camunda.tasklist.property.TasklistProperties;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+@SpringJUnitConfig({
+  UnifiedConfiguration.class,
+  TasklistPropertiesOverride.class,
+  UnifiedConfigurationHelper.class
+})
+public class DataBackupTasklistPropertiesTest {
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "camunda.data.backup.repository-name=repositoryNameNew",
+      })
+  class WithOnlyUnifiedConfigSet {
+    final TasklistProperties tasklistProperties;
+
+    WithOnlyUnifiedConfigSet(@Autowired final TasklistProperties tasklistProperties) {
+      this.tasklistProperties = tasklistProperties;
+    }
+
+    @Test
+    void shouldSetRepositoryName() {
+      assertThat(tasklistProperties.getBackup().getRepositoryName()).isEqualTo("repositoryNameNew");
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "camunda.operate.backup.repositoryName=repositoryNameLegacyOperate",
+      })
+  class WithOnlyOperateLegacySet {
+    final TasklistProperties tasklistProperties;
+
+    WithOnlyOperateLegacySet(@Autowired final TasklistProperties tasklistProperties) {
+      this.tasklistProperties = tasklistProperties;
+    }
+
+    @Test
+    void shouldNotSetRepositoryNameFromLegacyOperate() {
+      assertThat(tasklistProperties.getBackup().getRepositoryName()).isNull();
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "camunda.tasklist.backup.repositoryName=repositoryNameLegacyTasklist",
+      })
+  class WithOnlyTasklistLegacySet {
+    final TasklistProperties tasklistProperties;
+
+    WithOnlyTasklistLegacySet(@Autowired final TasklistProperties tasklistProperties) {
+      this.tasklistProperties = tasklistProperties;
+    }
+
+    @Test
+    void shouldSetRepositoryNameFromLegacyTasklist() {
+      assertThat(tasklistProperties.getBackup().getRepositoryName())
+          .isEqualTo("repositoryNameLegacyTasklist");
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        // new
+        "camunda.data.backup.repository-name=repositoryNameNew",
+        // legacy configuration operate
+        "camunda.operate.backup.repositoryName=repositoryNameLegacyOperate",
+        // legacy configuration tasklist
+        "camunda.tasklist.backup.repositoryName=repositoryNameLegacyTasklist",
+      })
+  class WithNewAndLegacySet {
+    final TasklistProperties tasklistProperties;
+
+    WithNewAndLegacySet(@Autowired final TasklistProperties tasklistProperties) {
+      this.tasklistProperties = tasklistProperties;
+    }
+
+    @Test
+    void shouldSetRepositoryNameFromNew() {
+      assertThat(tasklistProperties.getBackup().getRepositoryName()).isEqualTo("repositoryNameNew");
+    }
+  }
+}

--- a/dist/src/main/java/io/camunda/application/StandalonePrefixMigration.java
+++ b/dist/src/main/java/io/camunda/application/StandalonePrefixMigration.java
@@ -10,6 +10,7 @@ package io.camunda.application;
 import io.camunda.application.commons.migration.PrefixMigrationHelper;
 import io.camunda.application.commons.search.SearchEngineDatabaseConfiguration;
 import io.camunda.configuration.UnifiedConfiguration;
+import io.camunda.configuration.UnifiedConfigurationHelper;
 import io.camunda.configuration.beanoverrides.OperatePropertiesOverride;
 import io.camunda.configuration.beanoverrides.TasklistPropertiesOverride;
 import io.camunda.operate.property.OperateProperties;
@@ -53,6 +54,7 @@ public class StandalonePrefixMigration implements CommandLineRunner {
                 StandalonePrefixMigration.class,
                 SearchEngineDatabaseConfiguration.class,
                 UnifiedConfiguration.class,
+                UnifiedConfigurationHelper.class,
                 TasklistPropertiesOverride.class,
                 OperatePropertiesOverride.class)
             .addCommandLineProperties(true)


### PR DESCRIPTION
## Description

This PR adds additional properties from section camunda.api.backup in unified config.

The legacy properties are:

camunda.tasklist.backup.repositoryName
camunda.operate.backup.repositoryName
camunda.operate.backup.snapshotTimeout
camunda.operate.backup.incompleteCheckTimeoutInSeconds
zeebe.broker.data.backup.store
zeebe.broker.data.backup.filesystem.basePath

The new properties are:

camunda.data.backup.repository-name
camunda.data.backup.snapshot-timeout
camunda.data.backup.incomplete-check-timeout
camunda.data.backup.store
camunda.data.backup.filesystem.base-path

Backwards compatibility is supported for these properties. That means, if legacy is set and new property is not set, legacy value will be used.

## Checklist

- [ ] The legacy properties and the backwards compatibility strategy are updated in [schema doc](https://docs.google.com/spreadsheets/d/1R4epsy6DWemA8_76cUE6zOGUFbrXCXlM2reXnKFuz7Y/edit?gid=818158292#gid=818158292)
- [ ] The new property fields are documented in the code
## Related issues

closes #34908
