### PR TITLE
feat: added assertions to assert active message subscriptions

### DIFF
--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/assertions/ProcessInstanceAssert.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/assertions/ProcessInstanceAssert.java
@@ -496,4 +496,52 @@ public interface ProcessInstanceAssert {
    * @return the assertion object
    */
   ProcessInstanceAssert hasActiveIncidents();
+
+  /**
+   * Verifies that the process instance is currently waiting to receive one or more specified
+   * messages.
+   *
+   * <p>The assertion waits for the correct message subscription.
+   *
+   * @param expectedMessageName the name of the message
+   * @return the assertion object
+   */
+  ProcessInstanceAssert isWaitingForMessage(final String expectedMessageName);
+
+  /**
+   * Verifies that the process instance is currently waiting to receive one or more specified
+   * messages.
+   *
+   * <p>The assertion waits for the correct message subscription.
+   *
+   * @param expectedMessageName the name of the message
+   * @param correlationKey the message's correlation key
+   * @return the assertion object
+   */
+  ProcessInstanceAssert isWaitingForMessage(
+      final String expectedMessageName, final String correlationKey);
+
+  /**
+   * Verifies that the process instance is not currently waiting to receive one or more specified
+   * messages.
+   *
+   * <p>The assertion waits for a message subscription that may invalidate the assertion
+   *
+   * @param expectedMessageName the name of the message
+   * @return the assertion object
+   */
+  ProcessInstanceAssert isNotWaitingForMessage(final String expectedMessageName);
+
+  /**
+   * Verifies that the process instance is not currently waiting to receive one or more specified
+   * messages.
+   *
+   * <p>The assertion waits for a message subscription that may invalidate the assertion
+   *
+   * @param expectedMessageName the name of the message
+   * @param correlationKey the message's correlation key
+   * @return the assertion object
+   */
+  ProcessInstanceAssert isNotWaitingForMessage(
+      final String expectedMessageName, final String correlationKey);
 }

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/CamundaDataSource.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/CamundaDataSource.java
@@ -19,6 +19,7 @@ import io.camunda.client.CamundaClient;
 import io.camunda.client.api.search.filter.DecisionInstanceFilter;
 import io.camunda.client.api.search.filter.ElementInstanceFilter;
 import io.camunda.client.api.search.filter.IncidentFilter;
+import io.camunda.client.api.search.filter.MessageSubscriptionFilter;
 import io.camunda.client.api.search.filter.ProcessInstanceFilter;
 import io.camunda.client.api.search.filter.UserTaskFilter;
 import io.camunda.client.api.search.filter.VariableFilter;
@@ -26,6 +27,7 @@ import io.camunda.client.api.search.request.SearchRequestPage;
 import io.camunda.client.api.search.response.DecisionInstance;
 import io.camunda.client.api.search.response.ElementInstance;
 import io.camunda.client.api.search.response.Incident;
+import io.camunda.client.api.search.response.MessageSubscription;
 import io.camunda.client.api.search.response.ProcessDefinition;
 import io.camunda.client.api.search.response.ProcessInstance;
 import io.camunda.client.api.search.response.ProcessInstanceSequenceFlow;
@@ -155,5 +157,21 @@ public class CamundaDataSource {
 
   public DecisionInstance getDecisionInstance(final String decisionInstanceId) {
     return client.newDecisionInstanceGetRequest(decisionInstanceId).send().join();
+  }
+
+  public List<MessageSubscription> getMessageSubscriptions() {
+    return getMessageSubscriptions(filter -> {});
+  }
+
+  public List<MessageSubscription> getMessageSubscriptions(
+      final Consumer<MessageSubscriptionFilter> filter) {
+    return client
+        .newMessageSubscriptionSearchRequest()
+        .filter(filter)
+        .sort(sort -> sort.lastUpdatedDate().asc())
+        .page(DEFAULT_PAGE_REQUEST)
+        .send()
+        .join()
+        .items();
   }
 }

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/MessageSubscriptionAssertj.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/MessageSubscriptionAssertj.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.impl.assertions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.api.search.filter.MessageSubscriptionFilter;
+import io.camunda.client.api.search.response.MessageSubscription;
+import io.camunda.process.test.api.CamundaAssertAwaitBehavior;
+import java.util.List;
+import java.util.function.Consumer;
+import org.assertj.core.api.AbstractAssert;
+
+public class MessageSubscriptionAssertj extends AbstractAssert<MessageSubscriptionAssertj, String> {
+
+  private final CamundaDataSource dataSource;
+  private final CamundaAssertAwaitBehavior awaitBehavior;
+
+  public MessageSubscriptionAssertj(
+      final CamundaDataSource dataSource,
+      final CamundaAssertAwaitBehavior awaitBehavior,
+      final String failureMessagePrefix) {
+    super(failureMessagePrefix, MessageSubscriptionAssertj.class);
+    this.dataSource = dataSource;
+    this.awaitBehavior = awaitBehavior;
+  }
+
+  public void isWaitingForMessage(final long processInstanceKey, final String expectedMessageName) {
+
+    awaitMessageSubscription(
+        processInstanceKey,
+        f -> f.messageName(expectedMessageName),
+        messageSubscriptions ->
+            assertThat(messageSubscriptions)
+                .withFailMessage(
+                    "%s should have an active message subscription [message-name: '%s'], but no such subscription was found.",
+                    actual, expectedMessageName)
+                .isNotEmpty());
+  }
+
+  public void isWaitingForMessage(
+      final long processInstanceKey,
+      final String expectedMessageName,
+      final String correlationKey) {
+
+    awaitMessageSubscription(
+        processInstanceKey,
+        f -> f.messageName(expectedMessageName).correlationKey(correlationKey),
+        messageSubscriptions ->
+            assertThat(messageSubscriptions)
+                .withFailMessage(
+                    "%s should have a message subscription [message-name: '%s', correlation-key: '%s'], but no such subscription was found.",
+                    actual, expectedMessageName, correlationKey)
+                .isNotEmpty());
+  }
+
+  public void isNotWaitingForMessage(
+      final long processInstanceKey, final String expectedMessageName) {
+
+    awaitMessageSubscription(
+        processInstanceKey,
+        f -> f.messageName(expectedMessageName),
+        messageSubscriptions ->
+            assertThat(messageSubscriptions)
+                .withFailMessage(
+                    "%s has an active message subscription [message-name: '%s'], but such a subscription was not expected.",
+                    actual, expectedMessageName)
+                .isEmpty());
+  }
+
+  public void isNotWaitingForMessage(
+      final long processInstanceKey,
+      final String expectedMessageName,
+      final String correlationKey) {
+
+    awaitMessageSubscription(
+        processInstanceKey,
+        f -> f.messageName(expectedMessageName).correlationKey(correlationKey),
+        messageSubscriptions ->
+            assertThat(messageSubscriptions)
+                .withFailMessage(
+                    "%s has an active message subscription [message-name: '%s', correlation-key: '%s'], but such a subscription was not expected.",
+                    actual, expectedMessageName, correlationKey)
+                .isEmpty());
+  }
+
+  private void awaitMessageSubscription(
+      final long processInstanceKey,
+      final Consumer<MessageSubscriptionFilter> filter,
+      final Consumer<List<MessageSubscription>> assertionCallback) {
+
+    awaitBehavior.untilAsserted(
+        () ->
+            dataSource.getMessageSubscriptions(
+                f -> filter.accept(f.processInstanceKey(processInstanceKey))),
+        assertionCallback);
+  }
+}

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/ProcessInstanceAssertj.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/ProcessInstanceAssertj.java
@@ -45,6 +45,7 @@ public class ProcessInstanceAssertj
   private final ElementAssertj elementAssertj;
   private final VariableAssertj variableAssertj;
   private final IncidentAssertj incidentAssertj;
+  private final MessageSubscriptionAssertj messageSubscriptionAssertj;
   private final String failureMessagePrefix;
   private final Function<String, ElementSelector> elementSelector;
 
@@ -76,6 +77,8 @@ public class ProcessInstanceAssertj
     elementAssertj = new ElementAssertj(dataSource, awaitBehavior, failureMessagePrefix);
     variableAssertj = new VariableAssertj(dataSource, awaitBehavior, failureMessagePrefix);
     incidentAssertj = new IncidentAssertj(dataSource, awaitBehavior, failureMessagePrefix);
+    messageSubscriptionAssertj =
+        new MessageSubscriptionAssertj(dataSource, awaitBehavior, failureMessagePrefix);
   }
 
   @Override
@@ -346,6 +349,34 @@ public class ProcessInstanceAssertj
   @Override
   public ProcessInstanceAssert hasActiveIncidents() {
     incidentAssertj.hasActiveIncidents(getProcessInstanceKey());
+    return this;
+  }
+
+  @Override
+  public ProcessInstanceAssert isWaitingForMessage(final String expectedMessageName) {
+    messageSubscriptionAssertj.isWaitingForMessage(getProcessInstanceKey(), expectedMessageName);
+    return this;
+  }
+
+  @Override
+  public ProcessInstanceAssert isWaitingForMessage(
+      final String expectedMessageName, final String correlationKey) {
+    messageSubscriptionAssertj.isWaitingForMessage(
+        getProcessInstanceKey(), expectedMessageName, correlationKey);
+    return this;
+  }
+
+  @Override
+  public ProcessInstanceAssert isNotWaitingForMessage(final String expectedMessageName) {
+    messageSubscriptionAssertj.isNotWaitingForMessage(getProcessInstanceKey(), expectedMessageName);
+    return this;
+  }
+
+  @Override
+  public ProcessInstanceAssert isNotWaitingForMessage(
+      final String expectedMessageName, final String correlationKey) {
+    messageSubscriptionAssertj.isNotWaitingForMessage(
+        getProcessInstanceKey(), expectedMessageName, correlationKey);
     return this;
   }
 

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/ProcessInstanceAssertMessageAssertIT.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/ProcessInstanceAssertMessageAssertIT.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.api;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.response.ProcessInstanceEvent;
+import org.junit.jupiter.api.Test;
+
+@CamundaProcessTest
+public class ProcessInstanceAssertMessageAssertIT {
+
+  // to be injected
+  private CamundaClient client;
+  private CamundaProcessTestContext processTestContext;
+
+  @Test
+  public void processInstanceAssertMessageAssert() {
+    // given
+    client
+        .newDeployResourceCommand()
+        .addResourceFromClasspath("processInstanceAssertMessageAssertIT/await-message.bpmn")
+        .send()
+        .join();
+
+    // when starting the process and waiting for the first message
+    final ProcessInstanceEvent processInstance =
+        client
+            .newCreateInstanceCommand()
+            .bpmnProcessId("process_message_subscriptions")
+            .latestVersion()
+            .variable("eventId", 1)
+            .send()
+            .join();
+
+    // then: waiting for first message
+    CamundaAssert.assertThatProcessInstance(processInstance)
+        .isActive()
+        .hasVariable("eventId", 1)
+        .isWaitingForMessage("message_awaiting")
+        .isNotWaitingForMessage("message_await_before_parallel")
+        .isNotWaitingForMessage("message_parallel_a")
+        .isNotWaitingForMessage("message_parallel_b");
+
+    // when sending a first message
+    client
+        .newPublishMessageCommand()
+        .messageName("message_awaiting")
+        .correlationKey("1")
+        .send()
+        .join();
+
+    // then has two message subscriptions
+    CamundaAssert.assertThatProcessInstance(processInstance)
+        .isActive()
+        .hasVariable("eventId", 1)
+        .isWaitingForMessage("message_awaiting")
+        .isWaitingForMessage("message_await_before_parallel")
+        .isNotWaitingForMessage("message_parallel_a")
+        .isNotWaitingForMessage("message_parallel_b");
+
+    // when sending a second message
+    client
+        .newPublishMessageCommand()
+        .messageName("message_await_before_parallel")
+        .correlationKey("1")
+        .send()
+        .join();
+
+    // then has all four message subscriptions
+    CamundaAssert.assertThatProcessInstance(processInstance)
+        .isActive()
+        .hasVariable("eventId", 1)
+        .isWaitingForMessage("message_awaiting")
+        .isWaitingForMessage("message_await_before_parallel")
+        .isWaitingForMessage("message_parallel_a")
+        .isWaitingForMessage("message_parallel_b");
+  }
+}

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/ProcessInstanceAssertTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/ProcessInstanceAssertTest.java
@@ -15,6 +15,7 @@
  */
 package io.camunda.process.test.api;
 
+import static io.camunda.process.test.utils.ProcessInstanceBuilder.newActiveProcessInstance;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -23,9 +24,12 @@ import static org.mockito.Mockito.when;
 
 import io.camunda.client.api.response.ProcessInstanceEvent;
 import io.camunda.client.api.response.ProcessInstanceResult;
+import io.camunda.client.api.search.filter.MessageSubscriptionFilter;
 import io.camunda.client.api.search.filter.ProcessInstanceFilter;
 import io.camunda.client.api.search.response.ElementInstance;
 import io.camunda.client.api.search.response.Variable;
+import io.camunda.client.impl.search.response.MessageSubscriptionImpl;
+import io.camunda.client.protocol.rest.MessageSubscriptionResult;
 import io.camunda.process.test.api.assertions.ProcessInstanceSelectors;
 import io.camunda.process.test.impl.assertions.CamundaDataSource;
 import io.camunda.process.test.utils.CamundaAssertExpectFailure;
@@ -41,6 +45,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
@@ -77,7 +82,7 @@ public class ProcessInstanceAssertTest {
       when(camundaDataSource.findProcessInstances(any()))
           .thenReturn(
               Arrays.asList(
-                  ProcessInstanceBuilder.newActiveProcessInstance(ACTIVE_PROCESS_INSTANCE_KEY)
+                  newActiveProcessInstance(ACTIVE_PROCESS_INSTANCE_KEY)
                       .setProcessDefinitionId("active-process")
                       .build(),
                   ProcessInstanceBuilder.newCompletedProcessInstance(COMPLETED_PROCESS_INSTANCE_KEY)
@@ -238,8 +243,7 @@ public class ProcessInstanceAssertTest {
       // given
       when(camundaDataSource.findProcessInstances(any()))
           .thenReturn(
-              Collections.singletonList(
-                  ProcessInstanceBuilder.newActiveProcessInstance(PROCESS_INSTANCE_KEY).build()));
+              Collections.singletonList(newActiveProcessInstance(PROCESS_INSTANCE_KEY).build()));
 
       // when
       when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
@@ -353,8 +357,7 @@ public class ProcessInstanceAssertTest {
       // given
       when(camundaDataSource.findProcessInstances(any()))
           .thenReturn(
-              Collections.singletonList(
-                  ProcessInstanceBuilder.newActiveProcessInstance(PROCESS_INSTANCE_KEY).build()))
+              Collections.singletonList(newActiveProcessInstance(PROCESS_INSTANCE_KEY).build()))
           .thenReturn(
               Collections.singletonList(
                   ProcessInstanceBuilder.newCompletedProcessInstance(PROCESS_INSTANCE_KEY)
@@ -375,8 +378,7 @@ public class ProcessInstanceAssertTest {
       // given
       when(camundaDataSource.findProcessInstances(any()))
           .thenReturn(
-              Collections.singletonList(
-                  ProcessInstanceBuilder.newActiveProcessInstance(PROCESS_INSTANCE_KEY).build()));
+              Collections.singletonList(newActiveProcessInstance(PROCESS_INSTANCE_KEY).build()));
 
       // when
       when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
@@ -454,8 +456,7 @@ public class ProcessInstanceAssertTest {
       // given
       when(camundaDataSource.findProcessInstances(any()))
           .thenReturn(
-              Collections.singletonList(
-                  ProcessInstanceBuilder.newActiveProcessInstance(PROCESS_INSTANCE_KEY).build()))
+              Collections.singletonList(newActiveProcessInstance(PROCESS_INSTANCE_KEY).build()))
           .thenReturn(
               Collections.singletonList(
                   ProcessInstanceBuilder.newTerminatedProcessInstance(PROCESS_INSTANCE_KEY)
@@ -476,8 +477,7 @@ public class ProcessInstanceAssertTest {
       // given
       when(camundaDataSource.findProcessInstances(any()))
           .thenReturn(
-              Collections.singletonList(
-                  ProcessInstanceBuilder.newActiveProcessInstance(PROCESS_INSTANCE_KEY).build()));
+              Collections.singletonList(newActiveProcessInstance(PROCESS_INSTANCE_KEY).build()));
 
       // when
       when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
@@ -518,8 +518,7 @@ public class ProcessInstanceAssertTest {
       // given
       when(camundaDataSource.findProcessInstances(any()))
           .thenReturn(
-              Collections.singletonList(
-                  ProcessInstanceBuilder.newActiveProcessInstance(PROCESS_INSTANCE_KEY).build()));
+              Collections.singletonList(newActiveProcessInstance(PROCESS_INSTANCE_KEY).build()));
 
       // when
       when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
@@ -590,8 +589,7 @@ public class ProcessInstanceAssertTest {
     void configureMocks() {
       when(camundaDataSource.findProcessInstances(any()))
           .thenReturn(
-              Collections.singletonList(
-                  ProcessInstanceBuilder.newActiveProcessInstance(PROCESS_INSTANCE_KEY).build()));
+              Collections.singletonList(newActiveProcessInstance(PROCESS_INSTANCE_KEY).build()));
     }
 
     @Test
@@ -684,6 +682,250 @@ public class ProcessInstanceAssertTest {
       CamundaAssert.assertThatProcessInstance(processInstanceEvent)
           .hasVariable("x", 1)
           .hasActiveElements("A");
+    }
+  }
+
+  @Nested
+  class MessageSubscriptions {
+
+    @Captor private ArgumentCaptor<Consumer<MessageSubscriptionFilter>> filterCaptor;
+
+    @Mock(answer = Answers.RETURNS_SELF)
+    private MessageSubscriptionFilter messageSubscriptionFilter;
+
+    @Test
+    void shouldFindMessageSubscription() {
+      // given
+      when(camundaDataSource.findProcessInstances(any()))
+          .thenReturn(
+              Collections.singletonList(newActiveProcessInstance(PROCESS_INSTANCE_KEY).build()));
+
+      when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+
+      when(camundaDataSource.getMessageSubscriptions(filterCaptor.capture()))
+          .thenReturn(
+              Collections.singletonList(
+                  new MessageSubscriptionImpl(new MessageSubscriptionResult())));
+
+      // then
+      CamundaAssert.assertThatProcessInstance(processInstanceEvent).isWaitingForMessage("expected");
+
+      filterCaptor.getValue().accept(messageSubscriptionFilter);
+      verify(messageSubscriptionFilter).processInstanceKey(PROCESS_INSTANCE_KEY);
+      verify(messageSubscriptionFilter).messageName("expected");
+    }
+
+    @Test
+    void shouldFindMessageSubscriptionWithCorrelationKey() {
+      // given
+      when(camundaDataSource.findProcessInstances(any()))
+          .thenReturn(
+              Collections.singletonList(newActiveProcessInstance(PROCESS_INSTANCE_KEY).build()));
+
+      when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+
+      when(camundaDataSource.getMessageSubscriptions(filterCaptor.capture()))
+          .thenReturn(
+              Collections.singletonList(
+                  new MessageSubscriptionImpl(new MessageSubscriptionResult())));
+
+      // then
+      CamundaAssert.assertThatProcessInstance(processInstanceEvent)
+          .isWaitingForMessage("expected", "correlation-key");
+
+      filterCaptor.getValue().accept(messageSubscriptionFilter);
+      verify(messageSubscriptionFilter).processInstanceKey(PROCESS_INSTANCE_KEY);
+      verify(messageSubscriptionFilter).messageName("expected");
+      verify(messageSubscriptionFilter).correlationKey("correlation-key");
+    }
+
+    @Test
+    void shouldAssertNoMessageSubscriptionFound() {
+      // given
+      when(camundaDataSource.findProcessInstances(any()))
+          .thenReturn(
+              Collections.singletonList(newActiveProcessInstance(PROCESS_INSTANCE_KEY).build()));
+
+      when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+
+      when(camundaDataSource.getMessageSubscriptions(filterCaptor.capture()))
+          .thenReturn(Collections.emptyList());
+
+      // then
+      CamundaAssert.assertThatProcessInstance(processInstanceEvent)
+          .isNotWaitingForMessage("expected");
+
+      filterCaptor.getValue().accept(messageSubscriptionFilter);
+      verify(messageSubscriptionFilter).processInstanceKey(PROCESS_INSTANCE_KEY);
+      verify(messageSubscriptionFilter).messageName("expected");
+    }
+
+    @Test
+    void shouldAssertNoMessageSubscriptionFoundWithCorrelationKey() {
+      // given
+      when(camundaDataSource.findProcessInstances(any()))
+          .thenReturn(
+              Collections.singletonList(newActiveProcessInstance(PROCESS_INSTANCE_KEY).build()));
+
+      when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+
+      when(camundaDataSource.getMessageSubscriptions(filterCaptor.capture()))
+          .thenReturn(Collections.emptyList());
+
+      // then
+      CamundaAssert.assertThatProcessInstance(processInstanceEvent)
+          .isNotWaitingForMessage("expected", "correlation-key");
+
+      filterCaptor.getValue().accept(messageSubscriptionFilter);
+      verify(messageSubscriptionFilter).processInstanceKey(PROCESS_INSTANCE_KEY);
+      verify(messageSubscriptionFilter).messageName("expected");
+      verify(messageSubscriptionFilter).correlationKey("correlation-key");
+    }
+
+    @Test
+    void shouldAwaitMessageSubscription() {
+      // given
+      when(camundaDataSource.findProcessInstances(any()))
+          .thenReturn(Collections.emptyList())
+          .thenReturn(Collections.emptyList())
+          .thenReturn(Collections.emptyList())
+          .thenReturn(
+              Collections.singletonList(newActiveProcessInstance(PROCESS_INSTANCE_KEY).build()));
+
+      when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+
+      when(camundaDataSource.getMessageSubscriptions(filterCaptor.capture()))
+          .thenReturn(Collections.emptyList())
+          .thenReturn(Collections.emptyList())
+          .thenReturn(Collections.emptyList())
+          .thenReturn(
+              Collections.singletonList(
+                  new MessageSubscriptionImpl(new MessageSubscriptionResult())));
+
+      // then
+      CamundaAssert.assertThatProcessInstance(processInstanceEvent).isWaitingForMessage("expected");
+
+      filterCaptor.getValue().accept(messageSubscriptionFilter);
+      verify(messageSubscriptionFilter).processInstanceKey(PROCESS_INSTANCE_KEY);
+      verify(messageSubscriptionFilter).messageName("expected");
+    }
+
+    @Test
+    void shouldAwaitNoMessageSubscription() {
+      // given
+      when(camundaDataSource.findProcessInstances(any()))
+          .thenReturn(Collections.emptyList())
+          .thenReturn(Collections.emptyList())
+          .thenReturn(Collections.emptyList())
+          .thenReturn(
+              Collections.singletonList(newActiveProcessInstance(PROCESS_INSTANCE_KEY).build()));
+
+      when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+
+      when(camundaDataSource.getMessageSubscriptions(filterCaptor.capture()))
+          .thenReturn(Collections.emptyList())
+          .thenReturn(Collections.emptyList())
+          .thenReturn(Collections.emptyList());
+
+      // then
+      CamundaAssert.assertThatProcessInstance(processInstanceEvent)
+          .isNotWaitingForMessage("expected");
+
+      filterCaptor.getValue().accept(messageSubscriptionFilter);
+      verify(messageSubscriptionFilter).processInstanceKey(PROCESS_INSTANCE_KEY);
+      verify(messageSubscriptionFilter).messageName("expected");
+    }
+
+    @Test
+    @CamundaAssertExpectFailure
+    void shouldErrorIfNoMessageSubscriptionWasFound() {
+      // given
+      when(camundaDataSource.findProcessInstances(any()))
+          .thenReturn(
+              Collections.singletonList(newActiveProcessInstance(PROCESS_INSTANCE_KEY).build()));
+
+      when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+
+      when(camundaDataSource.getMessageSubscriptions(filterCaptor.capture()))
+          .thenReturn(Collections.emptyList());
+
+      // then
+      Assertions.assertThatThrownBy(
+              () ->
+                  CamundaAssert.assertThatProcessInstance(processInstanceEvent)
+                      .isWaitingForMessage("expected"))
+          .hasMessage(
+              "Process instance [key: 1] should have an active message subscription [message-name: 'expected'], but no such subscription was found.");
+    }
+
+    @Test
+    @CamundaAssertExpectFailure
+    void shouldErrorIfNoMessageSubscriptionWasFoundWithCorrelationKey() {
+      // given
+      when(camundaDataSource.findProcessInstances(any()))
+          .thenReturn(
+              Collections.singletonList(newActiveProcessInstance(PROCESS_INSTANCE_KEY).build()));
+
+      when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+
+      when(camundaDataSource.getMessageSubscriptions(filterCaptor.capture()))
+          .thenReturn(Collections.emptyList());
+
+      // then
+      Assertions.assertThatThrownBy(
+              () ->
+                  CamundaAssert.assertThatProcessInstance(processInstanceEvent)
+                      .isWaitingForMessage("expected", "correlation-key"))
+          .hasMessage(
+              "Process instance [key: 1] should have a message subscription [message-name: 'expected', correlation-key: 'correlation-key'], but no such subscription was found.");
+    }
+
+    @Test
+    @CamundaAssertExpectFailure
+    void shouldErrorIfMessageSubscriptionWasFoundDespiteNotExpectingOne() {
+      // given
+      when(camundaDataSource.findProcessInstances(any()))
+          .thenReturn(
+              Collections.singletonList(newActiveProcessInstance(PROCESS_INSTANCE_KEY).build()));
+
+      when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+
+      when(camundaDataSource.getMessageSubscriptions(filterCaptor.capture()))
+          .thenReturn(
+              Collections.singletonList(
+                  new MessageSubscriptionImpl(new MessageSubscriptionResult())));
+
+      // then
+      Assertions.assertThatThrownBy(
+              () ->
+                  CamundaAssert.assertThatProcessInstance(processInstanceEvent)
+                      .isNotWaitingForMessage("expected"))
+          .hasMessage(
+              "Process instance [key: 1] has an active message subscription [message-name: 'expected'], but such a subscription was not expected.");
+    }
+
+    @Test
+    @CamundaAssertExpectFailure
+    void shouldErrorIfMessageSubscriptionWithCorrelationKeyWasFoundDespiteNotExpectingOne() {
+      // given
+      when(camundaDataSource.findProcessInstances(any()))
+          .thenReturn(
+              Collections.singletonList(newActiveProcessInstance(PROCESS_INSTANCE_KEY).build()));
+
+      when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+
+      when(camundaDataSource.getMessageSubscriptions(filterCaptor.capture()))
+          .thenReturn(
+              Collections.singletonList(
+                  new MessageSubscriptionImpl(new MessageSubscriptionResult())));
+
+      // then
+      Assertions.assertThatThrownBy(
+              () ->
+                  CamundaAssert.assertThatProcessInstance(processInstanceEvent)
+                      .isNotWaitingForMessage("expected", "correlation-key"))
+          .hasMessage(
+              "Process instance [key: 1] has an active message subscription [message-name: 'expected', correlation-key: 'correlation-key'], but such a subscription was not expected.");
     }
   }
 }

--- a/testing/camunda-process-test-java/src/test/resources/processInstanceAssertMessageAssertIT/await-message.bpmn
+++ b/testing/camunda-process-test-java/src/test/resources/processInstanceAssertMessageAssertIT/await-message.bpmn
@@ -1,0 +1,136 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Web Modeler" exporterVersion="c59cb54" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.7.0">
+  <bpmn:process id="process_message_subscriptions" name="message-subscription" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:output source="=1" target="eventId" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:outgoing>Flow_0yffp2u</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_0yffp2u" sourceRef="StartEvent_1" targetRef="Event_0czpcok" />
+    <bpmn:intermediateCatchEvent id="Event_0czpcok">
+      <bpmn:incoming>Flow_0yffp2u</bpmn:incoming>
+      <bpmn:outgoing>Flow_018hpp0</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_1yi5rnl" messageRef="Message_1vdtrd7" />
+    </bpmn:intermediateCatchEvent>
+    <bpmn:sequenceFlow id="Flow_018hpp0" sourceRef="Event_0czpcok" targetRef="Event_0080tev" />
+    <bpmn:intermediateCatchEvent id="Event_0080tev">
+      <bpmn:incoming>Flow_018hpp0</bpmn:incoming>
+      <bpmn:outgoing>Flow_0dno77r</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_1ov33ik" messageRef="Message_1pgj0lt" />
+    </bpmn:intermediateCatchEvent>
+    <bpmn:sequenceFlow id="Flow_0dno77r" sourceRef="Event_0080tev" targetRef="Gateway_0rn7wno" />
+    <bpmn:parallelGateway id="Gateway_0rn7wno">
+      <bpmn:incoming>Flow_0dno77r</bpmn:incoming>
+      <bpmn:outgoing>Flow_0vsj9s3</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1dvhzum</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:sequenceFlow id="Flow_0vsj9s3" sourceRef="Gateway_0rn7wno" targetRef="Event_139879g" />
+    <bpmn:sequenceFlow id="Flow_1dvhzum" sourceRef="Gateway_0rn7wno" targetRef="Event_182db43" />
+    <bpmn:intermediateCatchEvent id="Event_182db43">
+      <bpmn:incoming>Flow_1dvhzum</bpmn:incoming>
+      <bpmn:outgoing>Flow_1m8bqoc</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_08kpm9z" messageRef="Message_00d4ric" />
+    </bpmn:intermediateCatchEvent>
+    <bpmn:intermediateCatchEvent id="Event_139879g">
+      <bpmn:incoming>Flow_0vsj9s3</bpmn:incoming>
+      <bpmn:outgoing>Flow_02kmuqr</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_0av1neh" messageRef="Message_07ef50o" />
+    </bpmn:intermediateCatchEvent>
+    <bpmn:exclusiveGateway id="Gateway_1ugf1oj">
+      <bpmn:incoming>Flow_02kmuqr</bpmn:incoming>
+      <bpmn:incoming>Flow_1m8bqoc</bpmn:incoming>
+      <bpmn:outgoing>Flow_0cdiiri</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_02kmuqr" sourceRef="Event_139879g" targetRef="Gateway_1ugf1oj" />
+    <bpmn:endEvent id="Event_1n5ctua">
+      <bpmn:incoming>Flow_0cdiiri</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0cdiiri" sourceRef="Gateway_1ugf1oj" targetRef="Event_1n5ctua" />
+    <bpmn:sequenceFlow id="Flow_1m8bqoc" sourceRef="Event_182db43" targetRef="Gateway_1ugf1oj" />
+  </bpmn:process>
+  <bpmn:message id="Message_1vdtrd7" name="message_awaiting">
+    <bpmn:extensionElements>
+      <zeebe:subscription correlationKey="=eventId" />
+    </bpmn:extensionElements>
+  </bpmn:message>
+  <bpmn:message id="Message_1pgj0lt" name="message_await_before_parallel">
+    <bpmn:extensionElements>
+      <zeebe:subscription correlationKey="=eventId" />
+    </bpmn:extensionElements>
+  </bpmn:message>
+  <bpmn:message id="Message_07ef50o" name="message_parallel_a">
+    <bpmn:extensionElements>
+      <zeebe:subscription correlationKey="=eventId" />
+    </bpmn:extensionElements>
+  </bpmn:message>
+  <bpmn:message id="Message_00d4ric" name="message_parallel_b">
+    <bpmn:extensionElements>
+      <zeebe:subscription correlationKey="=eventId" />
+    </bpmn:extensionElements>
+  </bpmn:message>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_0sezdp2">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="150" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0v7grqs_di" bpmnElement="Event_0czpcok">
+        <dc:Bounds x="242" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_02y4bl2_di" bpmnElement="Event_0080tev">
+        <dc:Bounds x="342" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_10fz2rz_di" bpmnElement="Gateway_0rn7wno">
+        <dc:Bounds x="445" y="93" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_07dm6tm_di" bpmnElement="Event_182db43">
+        <dc:Bounds x="562" y="212" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1eemizf_di" bpmnElement="Event_139879g">
+        <dc:Bounds x="562" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1ugf1oj_di" bpmnElement="Gateway_1ugf1oj" isMarkerVisible="true">
+        <dc:Bounds x="665" y="93" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1n5ctua_di" bpmnElement="Event_1n5ctua">
+        <dc:Bounds x="782" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0yffp2u_di" bpmnElement="Flow_0yffp2u">
+        <di:waypoint x="186" y="118" />
+        <di:waypoint x="242" y="118" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_018hpp0_di" bpmnElement="Flow_018hpp0">
+        <di:waypoint x="278" y="118" />
+        <di:waypoint x="342" y="118" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0dno77r_di" bpmnElement="Flow_0dno77r">
+        <di:waypoint x="378" y="118" />
+        <di:waypoint x="445" y="118" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0vsj9s3_di" bpmnElement="Flow_0vsj9s3">
+        <di:waypoint x="495" y="118" />
+        <di:waypoint x="562" y="118" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1dvhzum_di" bpmnElement="Flow_1dvhzum">
+        <di:waypoint x="470" y="143" />
+        <di:waypoint x="470" y="230" />
+        <di:waypoint x="562" y="230" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_02kmuqr_di" bpmnElement="Flow_02kmuqr">
+        <di:waypoint x="598" y="118" />
+        <di:waypoint x="665" y="118" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0cdiiri_di" bpmnElement="Flow_0cdiiri">
+        <di:waypoint x="715" y="118" />
+        <di:waypoint x="782" y="118" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1m8bqoc_di" bpmnElement="Flow_1m8bqoc">
+        <di:waypoint x="598" y="230" />
+        <di:waypoint x="690" y="230" />
+        <di:waypoint x="690" y="143" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
## Description

Adds new assertions to verify active message subscriptions and the lack thereof. 

## Related issues

closes #23256
closes #23257

Requires #28194
Requires #34445
