### PR TITLE
Raise an incident on ad-hoc sub-process inner completion if the output collection variable is not an array

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/AdHocSubProcessOutputCollectionBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/AdHocSubProcessOutputCollectionBehavior.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.engine.processing.common.Failure;
 import io.camunda.zeebe.msgpack.spec.MsgPackReader;
 import io.camunda.zeebe.msgpack.spec.MsgPackType;
 import io.camunda.zeebe.msgpack.spec.MsgPackWriter;
+import io.camunda.zeebe.protocol.record.value.ErrorType;
 import io.camunda.zeebe.util.Either;
 import org.agrona.DirectBuffer;
 import org.agrona.ExpandableArrayBuffer;
@@ -32,7 +33,8 @@ public class AdHocSubProcessOutputCollectionBehavior {
       return Either.left(
           new Failure(
               "The output collection has the wrong type. Expected %s but was %s."
-                  .formatted(MsgPackType.ARRAY, token.getType())));
+                  .formatted(MsgPackType.ARRAY, token.getType()),
+              ErrorType.EXTRACT_VALUE_ERROR));
     }
     final int currentSize = token.getSize();
     final int valuesOffset = outputCollectionReader.getOffset();


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

We already have the check which determines if the output collection is of type array. If it isn't a `Failure` is returned. However, this `Failure` doesn't set an `ErrorType`. As a result this `ErrorType` will be `null` and the incident creation will result in an NPE.

I've added the `ErrorType` here and added some testcases to ensure the incident is created.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes https://github.com/camunda/ad-hoc-sub-process-phase-3/issues/37
