### PR TITLE
Add `decisionEvaluationKey` and deprecate `decisionInstanceKey`

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/response/EvaluateDecisionResponse.java
+++ b/clients/java/src/main/java/io/camunda/client/api/response/EvaluateDecisionResponse.java
@@ -76,8 +76,12 @@ public interface EvaluateDecisionResponse {
    */
   String getTenantId();
 
+  /** Deprecated, please use {@link #getDecisionEvaluationKey()} instead. */
+  @Deprecated
+  long getDecisionInstanceKey();
+
   /**
    * @return the unique key identifying this decision evaluation
    */
-  long getDecisionInstanceKey();
+  long getDecisionEvaluationKey();
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/response/EvaluateDecisionResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/EvaluateDecisionResponseImpl.java
@@ -40,6 +40,7 @@ public class EvaluateDecisionResponseImpl implements EvaluateDecisionResponse {
   private final String failureMessage;
   private final String tenantId;
   private final long decisionInstanceKey;
+  private final long decisionEvaluationKey;
 
   public EvaluateDecisionResponseImpl(
       final EvaluateDecisionResult response, final JsonMapper jsonMapper) {
@@ -55,6 +56,7 @@ public class EvaluateDecisionResponseImpl implements EvaluateDecisionResponse {
     failureMessage = response.getFailureMessage();
     tenantId = response.getTenantId();
     decisionInstanceKey = Long.parseLong(response.getDecisionInstanceKey());
+    decisionEvaluationKey = Long.parseLong(response.getDecisionEvaluationKey());
     buildEvaluatedDecisions(response);
   }
 
@@ -73,6 +75,7 @@ public class EvaluateDecisionResponseImpl implements EvaluateDecisionResponse {
     failureMessage = response.getFailureMessage();
     tenantId = response.getTenantId();
     decisionInstanceKey = response.getDecisionInstanceKey();
+    decisionEvaluationKey = response.getDecisionEvaluationKey();
 
     response.getEvaluatedDecisionsList().stream()
         .map(evaluatedDecision -> new EvaluatedDecisionImpl(jsonMapper, evaluatedDecision))
@@ -147,5 +150,10 @@ public class EvaluateDecisionResponseImpl implements EvaluateDecisionResponse {
   @Override
   public long getDecisionInstanceKey() {
     return decisionInstanceKey;
+  }
+
+  @Override
+  public long getDecisionEvaluationKey() {
+    return decisionEvaluationKey;
   }
 }

--- a/clients/java/src/test/java/io/camunda/client/decision/StandaloneDecisionEvaluationTest.java
+++ b/clients/java/src/test/java/io/camunda/client/decision/StandaloneDecisionEvaluationTest.java
@@ -319,6 +319,8 @@ public class StandaloneDecisionEvaluationTest extends ClientTest {
     assertThat(response.getTenantId()).isEqualTo(evaluateDecisionResponse.getTenantId());
     assertThat(response.getDecisionInstanceKey())
         .isEqualTo(evaluateDecisionResponse.getDecisionInstanceKey());
+    assertThat(response.getDecisionEvaluationKey())
+        .isEqualTo(evaluateDecisionResponse.getDecisionEvaluationKey());
 
     // assert EvaluatedDecision
     assertThat(response.getEvaluatedDecisions()).hasSize(1);

--- a/clients/java/src/test/java/io/camunda/client/decision/rest/DecisionEvaluationRestTest.java
+++ b/clients/java/src/test/java/io/camunda/client/decision/rest/DecisionEvaluationRestTest.java
@@ -85,6 +85,7 @@ public class DecisionEvaluationRestTest extends ClientRestTest {
           .failureMessage("decision-evaluation-failure")
           .tenantId(TENANT_ID)
           .decisionInstanceKey(String.valueOf(DECISION_INSTANCE_KEY))
+          .decisionEvaluationKey(String.valueOf(DECISION_INSTANCE_KEY))
           .addEvaluatedDecisionsItem(EVALUATED_DECISION);
 
   @Test
@@ -286,6 +287,8 @@ public class DecisionEvaluationRestTest extends ClientRestTest {
     assertThat(response.getTenantId()).isEqualTo(EVALUATE_DECISION_RESPONSE.getTenantId());
     assertThat(String.valueOf(response.getDecisionInstanceKey()))
         .isEqualTo(EVALUATE_DECISION_RESPONSE.getDecisionInstanceKey());
+    assertThat(String.valueOf(response.getDecisionEvaluationKey()))
+        .isEqualTo(EVALUATE_DECISION_RESPONSE.getDecisionEvaluationKey());
 
     // assert EvaluatedDecision
     assertThat(response.getEvaluatedDecisions()).hasSize(1);

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/ResponseMapper.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/ResponseMapper.java
@@ -215,6 +215,7 @@ public final class ResponseMapper {
     final EvaluateDecisionResponse.Builder responseBuilder =
         EvaluateDecisionResponse.newBuilder()
             .setDecisionInstanceKey(key)
+            .setDecisionEvaluationKey(key)
             .setDecisionId(brokerResponse.getDecisionId())
             .setDecisionKey(brokerResponse.getDecisionKey())
             .setDecisionName(brokerResponse.getDecisionName())

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/ResponseMapper.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/ResponseMapper.java
@@ -214,6 +214,7 @@ public final class ResponseMapper {
 
     final EvaluateDecisionResponse.Builder responseBuilder =
         EvaluateDecisionResponse.newBuilder()
+            // deprecated in favor of decisionEvaluationKey
             .setDecisionInstanceKey(key)
             .setDecisionEvaluationKey(key)
             .setDecisionId(brokerResponse.getDecisionId())

--- a/zeebe/gateway-protocol/src/main/proto/gateway.proto
+++ b/zeebe/gateway-protocol/src/main/proto/gateway.proto
@@ -372,8 +372,10 @@ message EvaluateDecisionResponse {
   string failureMessage = 10;
   // the tenant identifier of the evaluated decision
   string tenantId = 11;
-  // the unique key identifying this decision evaluation
+  // deprecated, please refer to decisionEvaluationKey
   int64 decisionInstanceKey = 12;
+  // the unique key identifying this decision evaluation
+  int64 decisionEvaluationKey = 13;
 }
 
 message EvaluatedDecision {

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -9518,6 +9518,10 @@ components:
           description: The unique key identifying the decision requirements graph that the decision which was evaluated is part of.
           type: string
         decisionInstanceKey:
+          description: Deprecated, please refer to `decisionEvaluationKey`.
+          type: string
+          deprecated: true
+        decisionEvaluationKey:
           description: The unique key identifying this decision evaluation.
           type: string
         evaluatedDecisions:

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/ResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/ResponseMapper.java
@@ -673,7 +673,8 @@ public final class ResponseMapper {
             .failedDecisionDefinitionId(decisionEvaluationRecord.getFailedDecisionId())
             .failureMessage(decisionEvaluationRecord.getEvaluationFailureMessage())
             .tenantId(decisionEvaluationRecord.getTenantId())
-            .decisionInstanceKey(KeyUtil.keyToString(brokerResponse.getKey()));
+            .decisionInstanceKey(KeyUtil.keyToString(brokerResponse.getKey()))
+            .decisionEvaluationKey(KeyUtil.keyToString(brokerResponse.getKey()));
 
     buildEvaluatedDecisions(decisionEvaluationRecord, response);
     return new ResponseEntity<>(response, HttpStatus.OK);

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionDefinitionControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionDefinitionControllerTest.java
@@ -51,6 +51,7 @@ public class DecisionDefinitionControllerTest extends RestControllerTest {
              "failureMessage":"",
              "tenantId":"tenantId",
              "decisionInstanceKey":"123",
+             "decisionEvaluationKey":"123",
              "evaluatedDecisions":[]
           }""";
 


### PR DESCRIPTION
## Description

This PR add the new property to the response of `POST /decision-definitions/evaluation` endpoint. The new property has the same value of the old `decisionInstanceId` property, the old property has been deprecated

In this PR the gRPC endpoint is also updated and the Java Client

## Related issues

closes #36730 
