### PR TITLE
feat: return empty responses instead of null

### DIFF
--- a/clients/java/pom.xml
+++ b/clients/java/pom.xml
@@ -214,6 +214,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.instancio</groupId>
+      <artifactId>instancio-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-tcnative-boringssl-static</artifactId>
       <scope>runtime</scope>

--- a/clients/java/src/main/java/io/camunda/client/CamundaClient.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClient.java
@@ -33,8 +33,6 @@ import io.camunda.client.api.command.AssignUserToTenantCommandStep1;
 import io.camunda.client.api.command.BroadcastSignalCommandStep1;
 import io.camunda.client.api.command.CancelBatchOperationStep1;
 import io.camunda.client.api.command.CancelProcessInstanceCommandStep1;
-import io.camunda.client.api.command.ClockPinCommandStep1;
-import io.camunda.client.api.command.ClockResetCommandStep1;
 import io.camunda.client.api.command.CompleteUserTaskCommandStep1;
 import io.camunda.client.api.command.CorrelateMessageCommandStep1;
 import io.camunda.client.api.command.CreateAuthorizationCommandStep1;
@@ -60,7 +58,9 @@ import io.camunda.client.api.command.DeployResourceCommandStep1;
 import io.camunda.client.api.command.EvaluateDecisionCommandStep1;
 import io.camunda.client.api.command.MigrateProcessInstanceCommandStep1;
 import io.camunda.client.api.command.ModifyProcessInstanceCommandStep1;
+import io.camunda.client.api.command.PinClockCommandStep1;
 import io.camunda.client.api.command.PublishMessageCommandStep1;
+import io.camunda.client.api.command.ResetClockCommandStep1;
 import io.camunda.client.api.command.ResolveIncidentCommandStep1;
 import io.camunda.client.api.command.ResumeBatchOperationStep1;
 import io.camunda.client.api.command.SetVariablesCommandStep1;
@@ -596,7 +596,7 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    * long userTaskKey = ..;
    *
    * camundaClient
-   *  .newUserTaskCompleteCommand(userTaskKey)
+   *  .newCompleteUserTaskCommand(userTaskKey)
    *  .variables(map)
    *  .send();
    * </pre>
@@ -610,7 +610,7 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    * @param userTaskKey the key of the user task
    * @return a builder for the command
    */
-  CompleteUserTaskCommandStep1 newUserTaskCompleteCommand(long userTaskKey);
+  CompleteUserTaskCommandStep1 newCompleteUserTaskCommand(long userTaskKey);
 
   /**
    * Command to assign a user task.
@@ -619,7 +619,7 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    * long userTaskKey = ..;
    *
    * camundaClient
-   *  .newUserTaskAssignCommand(userTaskKey)
+   *  .newAssignUserTaskCommand(userTaskKey)
    *  .assignee(newAssignee)
    *  .send();
    * </pre>
@@ -630,7 +630,7 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    * @param userTaskKey the key of the user task
    * @return a builder for the command
    */
-  AssignUserTaskCommandStep1 newUserTaskAssignCommand(long userTaskKey);
+  AssignUserTaskCommandStep1 newAssignUserTaskCommand(long userTaskKey);
 
   /**
    * Command to update a user task.
@@ -639,7 +639,7 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    * long userTaskKey = ..;
    *
    * camundaClient
-   *  .newUserTaskUpdateCommand(userTaskKey)
+   *  .newUpdateUserTaskCommand(userTaskKey)
    *  .candidateGroups(newCandidateGroups)
    *  .send();
    * </pre>
@@ -650,7 +650,7 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    * @param userTaskKey the key of the user task
    * @return a builder for the command
    */
-  UpdateUserTaskCommandStep1 newUserTaskUpdateCommand(long userTaskKey);
+  UpdateUserTaskCommandStep1 newUpdateUserTaskCommand(long userTaskKey);
 
   /**
    * Command to unassign a user task.
@@ -659,7 +659,7 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    * long userTaskKey = ..;
    *
    * camundaClient
-   *  .newUserTaskUnassignCommand(userTaskKey)
+   *  .newUnassignUserTaskCommand(userTaskKey)
    *  .send();
    * </pre>
    *
@@ -669,7 +669,7 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    * @param userTaskKey the key of the user task
    * @return a builder for the command
    */
-  UnassignUserTaskCommandStep1 newUserTaskUnassignCommand(long userTaskKey);
+  UnassignUserTaskCommandStep1 newUnassignUserTaskCommand(long userTaskKey);
 
   /**
    * Command to update the retries and/or the timeout of a job.
@@ -737,13 +737,13 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    * <pre>{@code
    * final long pinnedTime = 1742461285000L; // Thu, Mar 20, 2025 09:01:25 GMT+0000
    * camundaClient
-   *  .newClockPinCommand()
+   *  .newPinClockCommand()
    *  .time(pinnedTime)
    *  .send();
    *
    * final Instant futureInstant = Instant.now().plus(Duration.ofDays(7));
    * camundaClient
-   *  .newClockPinCommand()
+   *  .newPinClockCommand()
    *  .time(futureInstant)
    *  .send();
    * }</pre>
@@ -754,7 +754,7 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    * @return a builder for the command that allows setting either a timestamp or an instant
    */
   @ExperimentalApi("https://github.com/camunda/camunda/issues/21647")
-  ClockPinCommandStep1 newClockPinCommand();
+  PinClockCommandStep1 newPinClockCommand();
 
   /**
    * Command to reset the Zeebe engine's internal clock to the system time.
@@ -764,7 +764,7 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    *
    * <pre>{@code
    * camundaClient
-   *  .newClockResetCommand()
+   *  .newResetClockCommand()
    *  .send();
    * }</pre>
    *
@@ -774,7 +774,7 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    * @return a builder for the command
    */
   @ExperimentalApi("https://github.com/camunda/camunda/issues/21647")
-  ClockResetCommandStep1 newClockResetCommand();
+  ResetClockCommandStep1 newResetClockCommand();
 
   /**
    * Gets a process definition by key.

--- a/clients/java/src/main/java/io/camunda/client/api/command/CancelBatchOperationStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/CancelBatchOperationStep1.java
@@ -15,4 +15,6 @@
  */
 package io.camunda.client.api.command;
 
-public interface CancelBatchOperationStep1 extends FinalCommandStep<Void> {}
+import io.camunda.client.api.response.CancelBatchOperationResponse;
+
+public interface CancelBatchOperationStep1 extends FinalCommandStep<CancelBatchOperationResponse> {}

--- a/clients/java/src/main/java/io/camunda/client/api/command/PinClockCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/PinClockCommandStep1.java
@@ -18,7 +18,7 @@ package io.camunda.client.api.command;
 import io.camunda.client.api.response.PinClockResponse;
 import java.time.Instant;
 
-public interface ClockPinCommandStep1 extends FinalCommandStep<PinClockResponse> {
+public interface PinClockCommandStep1 extends FinalCommandStep<PinClockResponse> {
 
   /**
    * Specifies the exact time to which the Zeebe engine's internal clock should be pinned using an
@@ -28,7 +28,7 @@ public interface ClockPinCommandStep1 extends FinalCommandStep<PinClockResponse>
    * @return the builder for this command. Call {@link #send()} to complete the command and send it
    *     to the broker.
    */
-  ClockPinCommandStep1 time(long timestamp);
+  PinClockCommandStep1 time(long timestamp);
 
   /**
    * Specifies the exact time to which the Zeebe engine's internal clock should be pinned using an
@@ -38,5 +38,5 @@ public interface ClockPinCommandStep1 extends FinalCommandStep<PinClockResponse>
    * @return the builder for this command. Call {@link #send()} to complete the command and send it
    *     to the broker.
    */
-  ClockPinCommandStep1 time(Instant instant);
+  PinClockCommandStep1 time(Instant instant);
 }

--- a/clients/java/src/main/java/io/camunda/client/api/command/ResetClockCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/ResetClockCommandStep1.java
@@ -17,6 +17,6 @@ package io.camunda.client.api.command;
 
 import io.camunda.client.api.response.ResetClockResponse;
 
-public interface ClockResetCommandStep1 extends FinalCommandStep<ResetClockResponse> {
+public interface ResetClockCommandStep1 extends FinalCommandStep<ResetClockResponse> {
   // the place for new optional parameters
 }

--- a/clients/java/src/main/java/io/camunda/client/api/command/SuspendBatchOperationStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/SuspendBatchOperationStep1.java
@@ -15,4 +15,7 @@
  */
 package io.camunda.client.api.command;
 
-public interface SuspendBatchOperationStep1 extends FinalCommandStep<Void> {}
+import io.camunda.client.api.response.SuspendBatchOperationResponse;
+
+public interface SuspendBatchOperationStep1
+    extends FinalCommandStep<SuspendBatchOperationResponse> {}

--- a/clients/java/src/main/java/io/camunda/client/api/command/ThrowErrorCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/ThrowErrorCommandStep1.java
@@ -15,6 +15,7 @@
  */
 package io.camunda.client.api.command;
 
+import io.camunda.client.api.response.ThrowErrorResponse;
 import java.io.InputStream;
 import java.util.Map;
 
@@ -33,7 +34,7 @@ public interface ThrowErrorCommandStep1
   ThrowErrorCommandStep2 errorCode(String errorCode);
 
   interface ThrowErrorCommandStep2
-      extends FinalCommandStep<Void>, CommandWithVariables<ThrowErrorCommandStep2> {
+      extends FinalCommandStep<ThrowErrorResponse>, CommandWithVariables<ThrowErrorCommandStep2> {
     /**
      * Provide an error message describing the reason for the non-technical error. If the error is
      * not caught by an error catch event, this message will be a part of the raised incident.

--- a/clients/java/src/main/java/io/camunda/client/api/response/CancelBatchOperationResponse.java
+++ b/clients/java/src/main/java/io/camunda/client/api/response/CancelBatchOperationResponse.java
@@ -13,8 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.camunda.client.api.command;
+package io.camunda.client.api.response;
 
-import io.camunda.client.api.response.ResumeBatchOperationResponse;
-
-public interface ResumeBatchOperationStep1 extends FinalCommandStep<ResumeBatchOperationResponse> {}
+public interface CancelBatchOperationResponse {}

--- a/clients/java/src/main/java/io/camunda/client/api/response/ResumeBatchOperationResponse.java
+++ b/clients/java/src/main/java/io/camunda/client/api/response/ResumeBatchOperationResponse.java
@@ -13,8 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.camunda.client.api.command;
+package io.camunda.client.api.response;
 
-import io.camunda.client.api.response.ResumeBatchOperationResponse;
-
-public interface ResumeBatchOperationStep1 extends FinalCommandStep<ResumeBatchOperationResponse> {}
+public interface ResumeBatchOperationResponse {}

--- a/clients/java/src/main/java/io/camunda/client/api/response/SuspendBatchOperationResponse.java
+++ b/clients/java/src/main/java/io/camunda/client/api/response/SuspendBatchOperationResponse.java
@@ -13,8 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.camunda.client.api.command;
+package io.camunda.client.api.response;
 
-import io.camunda.client.api.response.ResumeBatchOperationResponse;
-
-public interface ResumeBatchOperationStep1 extends FinalCommandStep<ResumeBatchOperationResponse> {}
+public interface SuspendBatchOperationResponse {}

--- a/clients/java/src/main/java/io/camunda/client/api/response/ThrowErrorResponse.java
+++ b/clients/java/src/main/java/io/camunda/client/api/response/ThrowErrorResponse.java
@@ -13,8 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.camunda.client.api.command;
+package io.camunda.client.api.response;
 
-import io.camunda.client.api.response.ResumeBatchOperationResponse;
-
-public interface ResumeBatchOperationStep1 extends FinalCommandStep<ResumeBatchOperationResponse> {}
+public interface ThrowErrorResponse {}

--- a/clients/java/src/main/java/io/camunda/client/api/search/response/BatchOperationError.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/response/BatchOperationError.java
@@ -23,5 +23,5 @@ public interface BatchOperationError {
 
   String getMessage();
 
-  int getPartitionId();
+  Integer getPartitionId();
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
@@ -40,8 +40,6 @@ import io.camunda.client.api.command.BroadcastSignalCommandStep1;
 import io.camunda.client.api.command.CancelBatchOperationStep1;
 import io.camunda.client.api.command.CancelProcessInstanceCommandStep1;
 import io.camunda.client.api.command.ClientException;
-import io.camunda.client.api.command.ClockPinCommandStep1;
-import io.camunda.client.api.command.ClockResetCommandStep1;
 import io.camunda.client.api.command.CompleteJobCommandStep1;
 import io.camunda.client.api.command.CompleteUserTaskCommandStep1;
 import io.camunda.client.api.command.CorrelateMessageCommandStep1;
@@ -69,7 +67,9 @@ import io.camunda.client.api.command.EvaluateDecisionCommandStep1;
 import io.camunda.client.api.command.FailJobCommandStep1;
 import io.camunda.client.api.command.MigrateProcessInstanceCommandStep1;
 import io.camunda.client.api.command.ModifyProcessInstanceCommandStep1;
+import io.camunda.client.api.command.PinClockCommandStep1;
 import io.camunda.client.api.command.PublishMessageCommandStep1;
+import io.camunda.client.api.command.ResetClockCommandStep1;
 import io.camunda.client.api.command.ResolveIncidentCommandStep1;
 import io.camunda.client.api.command.ResumeBatchOperationStep1;
 import io.camunda.client.api.command.SetVariablesCommandStep1;
@@ -176,8 +176,6 @@ import io.camunda.client.impl.command.AssignUserToTenantCommandImpl;
 import io.camunda.client.impl.command.BroadcastSignalCommandImpl;
 import io.camunda.client.impl.command.CancelBatchOperationCommandImpl;
 import io.camunda.client.impl.command.CancelProcessInstanceCommandImpl;
-import io.camunda.client.impl.command.ClockPinCommandImpl;
-import io.camunda.client.impl.command.ClockResetCommandImpl;
 import io.camunda.client.impl.command.CompleteUserTaskCommandImpl;
 import io.camunda.client.impl.command.CorrelateMessageCommandImpl;
 import io.camunda.client.impl.command.CreateAuthorizationCommandImpl;
@@ -201,12 +199,13 @@ import io.camunda.client.impl.command.DeleteUserCommandImpl;
 import io.camunda.client.impl.command.DeployProcessCommandImpl;
 import io.camunda.client.impl.command.DeployResourceCommandImpl;
 import io.camunda.client.impl.command.EvaluateDecisionCommandImpl;
-import io.camunda.client.impl.command.JobUpdateCommandImpl;
 import io.camunda.client.impl.command.JobUpdateRetriesCommandImpl;
 import io.camunda.client.impl.command.JobUpdateTimeoutCommandImpl;
 import io.camunda.client.impl.command.MigrateProcessInstanceCommandImpl;
 import io.camunda.client.impl.command.ModifyProcessInstanceCommandImpl;
+import io.camunda.client.impl.command.PinClockCommandImpl;
 import io.camunda.client.impl.command.PublishMessageCommandImpl;
+import io.camunda.client.impl.command.ResetClockCommandImpl;
 import io.camunda.client.impl.command.ResolveIncidentCommandImpl;
 import io.camunda.client.impl.command.ResumeBatchOperationCommandImpl;
 import io.camunda.client.impl.command.SetVariablesCommandImpl;
@@ -226,6 +225,7 @@ import io.camunda.client.impl.command.UnassignUserFromTenantCommandImpl;
 import io.camunda.client.impl.command.UnassignUserTaskCommandImpl;
 import io.camunda.client.impl.command.UpdateAuthorizationCommandImpl;
 import io.camunda.client.impl.command.UpdateGroupCommandImpl;
+import io.camunda.client.impl.command.UpdateJobCommandImpl;
 import io.camunda.client.impl.command.UpdateRoleCommandImpl;
 import io.camunda.client.impl.command.UpdateTenantCommandImpl;
 import io.camunda.client.impl.command.UpdateUserCommandImpl;
@@ -707,28 +707,28 @@ public final class CamundaClientImpl implements CamundaClient {
   }
 
   @Override
-  public CompleteUserTaskCommandStep1 newUserTaskCompleteCommand(final long userTaskKey) {
+  public CompleteUserTaskCommandStep1 newCompleteUserTaskCommand(final long userTaskKey) {
     return new CompleteUserTaskCommandImpl(httpClient, jsonMapper, userTaskKey);
   }
 
   @Override
-  public AssignUserTaskCommandStep1 newUserTaskAssignCommand(final long userTaskKey) {
+  public AssignUserTaskCommandStep1 newAssignUserTaskCommand(final long userTaskKey) {
     return new AssignUserTaskCommandImpl(httpClient, jsonMapper, userTaskKey);
   }
 
   @Override
-  public UpdateUserTaskCommandStep1 newUserTaskUpdateCommand(final long userTaskKey) {
+  public UpdateUserTaskCommandStep1 newUpdateUserTaskCommand(final long userTaskKey) {
     return new UpdateUserTaskCommandImpl(httpClient, jsonMapper, userTaskKey);
   }
 
   @Override
-  public UnassignUserTaskCommandStep1 newUserTaskUnassignCommand(final long userTaskKey) {
+  public UnassignUserTaskCommandStep1 newUnassignUserTaskCommand(final long userTaskKey) {
     return new UnassignUserTaskCommandImpl(httpClient, userTaskKey);
   }
 
   @Override
   public UpdateJobCommandStep1 newUpdateJobCommand(final long jobKey) {
-    return new JobUpdateCommandImpl(jobKey, httpClient, jsonMapper);
+    return new UpdateJobCommandImpl(jobKey, httpClient, jsonMapper);
   }
 
   @Override
@@ -737,13 +737,13 @@ public final class CamundaClientImpl implements CamundaClient {
   }
 
   @Override
-  public ClockPinCommandStep1 newClockPinCommand() {
-    return new ClockPinCommandImpl(httpClient, jsonMapper);
+  public PinClockCommandStep1 newPinClockCommand() {
+    return new PinClockCommandImpl(httpClient, jsonMapper);
   }
 
   @Override
-  public ClockResetCommandStep1 newClockResetCommand() {
-    return new ClockResetCommandImpl(httpClient);
+  public ResetClockCommandStep1 newResetClockCommand() {
+    return new ResetClockCommandImpl(httpClient);
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/client/impl/command/ActivateAdHocSubProcessActivitiesCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/ActivateAdHocSubProcessActivitiesCommandImpl.java
@@ -23,6 +23,7 @@ import io.camunda.client.api.command.FinalCommandStep;
 import io.camunda.client.api.response.ActivateAdHocSubProcessActivitiesResponse;
 import io.camunda.client.impl.http.HttpCamundaFuture;
 import io.camunda.client.impl.http.HttpClient;
+import io.camunda.client.impl.response.ActivateAdHocSubProcessActivitiesResponseImpl;
 import io.camunda.client.protocol.rest.AdHocSubProcessActivateActivitiesInstruction;
 import io.camunda.client.protocol.rest.AdHocSubProcessActivateActivityReference;
 import java.time.Duration;
@@ -93,6 +94,7 @@ public final class ActivateAdHocSubProcessActivitiesCommandImpl
         "/element-instances/ad-hoc-activities/" + adHocSubProcessInstanceKey + "/activation",
         jsonMapper.toJson(httpRequestObject),
         httpRequestConfig.build(),
+        ActivateAdHocSubProcessActivitiesResponseImpl::new,
         result);
     return result;
   }

--- a/clients/java/src/main/java/io/camunda/client/impl/command/AssignClientToGroupCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/AssignClientToGroupCommandImpl.java
@@ -22,6 +22,7 @@ import io.camunda.client.api.command.FinalCommandStep;
 import io.camunda.client.api.response.AssignClientToGroupResponse;
 import io.camunda.client.impl.http.HttpCamundaFuture;
 import io.camunda.client.impl.http.HttpClient;
+import io.camunda.client.impl.response.AssignClientToGroupResponseImpl;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import org.apache.hc.client5.http.config.RequestConfig;
@@ -67,6 +68,7 @@ public class AssignClientToGroupCommandImpl
         "/groups/" + groupId + "/clients/" + clientId,
         null, // No request body needed
         httpRequestConfig.build(),
+        AssignClientToGroupResponseImpl::new,
         result);
     return result;
   }

--- a/clients/java/src/main/java/io/camunda/client/impl/command/AssignClientToTenantCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/AssignClientToTenantCommandImpl.java
@@ -22,6 +22,7 @@ import io.camunda.client.api.command.FinalCommandStep;
 import io.camunda.client.api.response.AssignClientToTenantResponse;
 import io.camunda.client.impl.http.HttpCamundaFuture;
 import io.camunda.client.impl.http.HttpClient;
+import io.camunda.client.impl.response.AssignClientToTenantResponseImpl;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import org.apache.hc.client5.http.config.RequestConfig;
@@ -67,6 +68,7 @@ public class AssignClientToTenantCommandImpl
         "/tenants/" + tenantId + "/clients/" + clientId,
         null, // No request body needed
         httpRequestConfig.build(),
+        AssignClientToTenantResponseImpl::new,
         result);
     return result;
   }

--- a/clients/java/src/main/java/io/camunda/client/impl/command/AssignGroupToTenantCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/AssignGroupToTenantCommandImpl.java
@@ -21,6 +21,7 @@ import io.camunda.client.api.command.AssignGroupToTenantCommandStep1.AssignGroup
 import io.camunda.client.api.response.AssignGroupToTenantResponse;
 import io.camunda.client.impl.http.HttpCamundaFuture;
 import io.camunda.client.impl.http.HttpClient;
+import io.camunda.client.impl.response.AssignGroupToTenantResponseImpl;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import org.apache.hc.client5.http.config.RequestConfig;
@@ -65,6 +66,7 @@ public final class AssignGroupToTenantCommandImpl
         "/tenants/" + tenantId + "/groups/" + groupId,
         null, // No request body needed
         httpRequestConfig.build(),
+        AssignGroupToTenantResponseImpl::new,
         result);
     return result;
   }

--- a/clients/java/src/main/java/io/camunda/client/impl/command/AssignMappingRuleToGroupCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/AssignMappingRuleToGroupCommandImpl.java
@@ -22,6 +22,7 @@ import io.camunda.client.api.command.FinalCommandStep;
 import io.camunda.client.api.response.AssignMappingRuleToGroupResponse;
 import io.camunda.client.impl.http.HttpCamundaFuture;
 import io.camunda.client.impl.http.HttpClient;
+import io.camunda.client.impl.response.AssignMappingRuleToGroupResponseImpl;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import org.apache.hc.client5.http.config.RequestConfig;
@@ -67,6 +68,7 @@ public class AssignMappingRuleToGroupCommandImpl
         "/groups/" + groupId + "/mapping-rules/" + mappingRuleId,
         null,
         httpRequestConfig.build(),
+        AssignMappingRuleToGroupResponseImpl::new,
         result);
     return result;
   }

--- a/clients/java/src/main/java/io/camunda/client/impl/command/AssignMappingRuleToTenantCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/AssignMappingRuleToTenantCommandImpl.java
@@ -22,6 +22,7 @@ import io.camunda.client.api.command.FinalCommandStep;
 import io.camunda.client.api.response.AssignMappingRuleToTenantResponse;
 import io.camunda.client.impl.http.HttpCamundaFuture;
 import io.camunda.client.impl.http.HttpClient;
+import io.camunda.client.impl.response.AssignMappingRuleToTenantResponseImpl;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import org.apache.hc.client5.http.config.RequestConfig;
@@ -62,7 +63,12 @@ public final class AssignMappingRuleToTenantCommandImpl
   public CamundaFuture<AssignMappingRuleToTenantResponse> send() {
     final HttpCamundaFuture<AssignMappingRuleToTenantResponse> result = new HttpCamundaFuture<>();
     final String endpoint = String.format("/tenants/%s/mapping-rules/%s", tenantId, mappingRuleId);
-    httpClient.put(endpoint, null, httpRequestConfig.build(), result);
+    httpClient.put(
+        endpoint,
+        null,
+        httpRequestConfig.build(),
+        AssignMappingRuleToTenantResponseImpl::new,
+        result);
     return result;
   }
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/command/AssignRoleToClientCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/AssignRoleToClientCommandImpl.java
@@ -22,6 +22,7 @@ import io.camunda.client.api.command.FinalCommandStep;
 import io.camunda.client.api.response.AssignRoleToClientResponse;
 import io.camunda.client.impl.http.HttpCamundaFuture;
 import io.camunda.client.impl.http.HttpClient;
+import io.camunda.client.impl.response.AssignRoleToClientResponseImpl;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import org.apache.hc.client5.http.config.RequestConfig;
@@ -67,6 +68,7 @@ public class AssignRoleToClientCommandImpl
         "/roles/" + roleId + "/clients/" + clientId,
         null, // No request body needed
         httpRequestConfig.build(),
+        AssignRoleToClientResponseImpl::new,
         result);
     return result;
   }

--- a/clients/java/src/main/java/io/camunda/client/impl/command/AssignRoleToGroupCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/AssignRoleToGroupCommandImpl.java
@@ -22,6 +22,7 @@ import io.camunda.client.api.command.FinalCommandStep;
 import io.camunda.client.api.response.AssignRoleToGroupResponse;
 import io.camunda.client.impl.http.HttpCamundaFuture;
 import io.camunda.client.impl.http.HttpClient;
+import io.camunda.client.impl.response.AssignRoleToGroupResponseImpl;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import org.apache.hc.client5.http.config.RequestConfig;
@@ -66,6 +67,7 @@ public class AssignRoleToGroupCommandImpl
         "/roles/" + roleId + "/groups/" + groupId,
         null, // No request body needed
         httpRequestConfig.build(),
+        AssignRoleToGroupResponseImpl::new,
         result);
     return result;
   }

--- a/clients/java/src/main/java/io/camunda/client/impl/command/AssignRoleToMappingRuleCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/AssignRoleToMappingRuleCommandImpl.java
@@ -22,6 +22,7 @@ import io.camunda.client.api.command.FinalCommandStep;
 import io.camunda.client.api.response.AssignRoleToMappingRuleResponse;
 import io.camunda.client.impl.http.HttpCamundaFuture;
 import io.camunda.client.impl.http.HttpClient;
+import io.camunda.client.impl.response.AssignRoleToMappingRuleResponseImpl;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import org.apache.hc.client5.http.config.RequestConfig;
@@ -66,6 +67,7 @@ public class AssignRoleToMappingRuleCommandImpl
         "/roles/" + roleId + "/mapping-rules/" + mappingRuleId,
         null, // No request body needed
         httpRequestConfig.build(),
+        AssignRoleToMappingRuleResponseImpl::new,
         result);
     return result;
   }

--- a/clients/java/src/main/java/io/camunda/client/impl/command/AssignRoleToTenantCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/AssignRoleToTenantCommandImpl.java
@@ -22,6 +22,7 @@ import io.camunda.client.api.command.FinalCommandStep;
 import io.camunda.client.api.response.AssignRoleToTenantResponse;
 import io.camunda.client.impl.http.HttpCamundaFuture;
 import io.camunda.client.impl.http.HttpClient;
+import io.camunda.client.impl.response.AssignRoleToTenantResponseImpl;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import org.apache.hc.client5.http.config.RequestConfig;
@@ -64,7 +65,8 @@ public final class AssignRoleToTenantCommandImpl
     ArgumentUtil.ensureNotNullNorEmpty("roleId", roleId);
     final HttpCamundaFuture<AssignRoleToTenantResponse> result = new HttpCamundaFuture<>();
     final String endpoint = String.format("/tenants/%s/roles/%s", tenantId, roleId);
-    httpClient.put(endpoint, null, httpRequestConfig.build(), result);
+    httpClient.put(
+        endpoint, null, httpRequestConfig.build(), AssignRoleToTenantResponseImpl::new, result);
     return result;
   }
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/command/AssignRoleToUserCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/AssignRoleToUserCommandImpl.java
@@ -22,6 +22,7 @@ import io.camunda.client.api.command.FinalCommandStep;
 import io.camunda.client.api.response.AssignRoleToUserResponse;
 import io.camunda.client.impl.http.HttpCamundaFuture;
 import io.camunda.client.impl.http.HttpClient;
+import io.camunda.client.impl.response.AssignRoleToUserResponseImpl;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import org.apache.hc.client5.http.config.RequestConfig;
@@ -63,7 +64,8 @@ public final class AssignRoleToUserCommandImpl
     ArgumentUtil.ensureNotNullNorEmpty("username", username);
     final HttpCamundaFuture<AssignRoleToUserResponse> result = new HttpCamundaFuture<>();
     final String endpoint = String.format("/roles/%s/users/%s", roleId, username);
-    httpClient.put(endpoint, null, httpRequestConfig.build(), result);
+    httpClient.put(
+        endpoint, null, httpRequestConfig.build(), AssignRoleToUserResponseImpl::new, result);
     return result;
   }
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/command/AssignUserTaskCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/AssignUserTaskCommandImpl.java
@@ -22,6 +22,7 @@ import io.camunda.client.api.command.FinalCommandStep;
 import io.camunda.client.api.response.AssignUserTaskResponse;
 import io.camunda.client.impl.http.HttpCamundaFuture;
 import io.camunda.client.impl.http.HttpClient;
+import io.camunda.client.impl.response.AssignUserTaskResponseImpl;
 import io.camunda.client.protocol.rest.UserTaskAssignmentRequest;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
@@ -57,6 +58,7 @@ public final class AssignUserTaskCommandImpl implements AssignUserTaskCommandSte
         "/user-tasks/" + userTaskKey + "/assignment",
         jsonMapper.toJson(request),
         httpRequestConfig.build(),
+        AssignUserTaskResponseImpl::new,
         result);
     return result;
   }

--- a/clients/java/src/main/java/io/camunda/client/impl/command/AssignUserToGroupCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/AssignUserToGroupCommandImpl.java
@@ -22,6 +22,7 @@ import io.camunda.client.api.command.FinalCommandStep;
 import io.camunda.client.api.response.AssignUserToGroupResponse;
 import io.camunda.client.impl.http.HttpCamundaFuture;
 import io.camunda.client.impl.http.HttpClient;
+import io.camunda.client.impl.response.AssignUserToGroupResponseImpl;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import org.apache.hc.client5.http.config.RequestConfig;
@@ -63,7 +64,11 @@ public class AssignUserToGroupCommandImpl
     ArgumentUtil.ensureNotNullNorEmpty("username", username);
     final HttpCamundaFuture<AssignUserToGroupResponse> result = new HttpCamundaFuture<>();
     httpClient.put(
-        "/groups/" + groupId + "/users/" + username, null, httpRequestConfig.build(), result);
+        "/groups/" + groupId + "/users/" + username,
+        null,
+        httpRequestConfig.build(),
+        AssignUserToGroupResponseImpl::new,
+        result);
     return result;
   }
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/command/AssignUserToTenantCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/AssignUserToTenantCommandImpl.java
@@ -22,6 +22,7 @@ import io.camunda.client.api.command.FinalCommandStep;
 import io.camunda.client.api.response.AssignUserToTenantResponse;
 import io.camunda.client.impl.http.HttpCamundaFuture;
 import io.camunda.client.impl.http.HttpClient;
+import io.camunda.client.impl.response.AssignUserToTenantResponseImpl;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import org.apache.hc.client5.http.config.RequestConfig;
@@ -62,7 +63,8 @@ public final class AssignUserToTenantCommandImpl
   public CamundaFuture<AssignUserToTenantResponse> send() {
     final HttpCamundaFuture<AssignUserToTenantResponse> result = new HttpCamundaFuture<>();
     final String endpoint = String.format("/tenants/%s/users/%s", tenantId, username);
-    httpClient.put(endpoint, null, httpRequestConfig.build(), result);
+    httpClient.put(
+        endpoint, null, httpRequestConfig.build(), AssignUserToTenantResponseImpl::new, result);
     return result;
   }
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/command/CancelBatchOperationCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/CancelBatchOperationCommandImpl.java
@@ -18,8 +18,10 @@ package io.camunda.client.impl.command;
 import io.camunda.client.api.CamundaFuture;
 import io.camunda.client.api.command.CancelBatchOperationStep1;
 import io.camunda.client.api.command.FinalCommandStep;
+import io.camunda.client.api.response.CancelBatchOperationResponse;
 import io.camunda.client.impl.http.HttpCamundaFuture;
 import io.camunda.client.impl.http.HttpClient;
+import io.camunda.client.impl.response.CancelBatchOperationResponseImpl;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import org.apache.hc.client5.http.config.RequestConfig;
@@ -39,18 +41,20 @@ public final class CancelBatchOperationCommandImpl implements CancelBatchOperati
   }
 
   @Override
-  public FinalCommandStep<Void> requestTimeout(final Duration requestTimeout) {
+  public FinalCommandStep<CancelBatchOperationResponse> requestTimeout(
+      final Duration requestTimeout) {
     httpRequestConfig.setResponseTimeout(requestTimeout.toMillis(), TimeUnit.MILLISECONDS);
     return this;
   }
 
   @Override
-  public CamundaFuture<Void> send() {
-    final HttpCamundaFuture<Void> result = new HttpCamundaFuture<>();
+  public CamundaFuture<CancelBatchOperationResponse> send() {
+    final HttpCamundaFuture<CancelBatchOperationResponse> result = new HttpCamundaFuture<>();
     httpClient.post(
         "/batch-operations/" + batchOperationKey + "/cancellation",
         null,
         httpRequestConfig.build(),
+        CancelBatchOperationResponseImpl::new,
         result);
     return result;
   }

--- a/clients/java/src/main/java/io/camunda/client/impl/command/CancelProcessInstanceCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/CancelProcessInstanceCommandImpl.java
@@ -93,6 +93,7 @@ public final class CancelProcessInstanceCommandImpl implements CancelProcessInst
         "/process-instances/" + processInstanceKey + "/cancellation",
         jsonMapper.toJson(httpRequestObject),
         httpRequestConfig.build(),
+        CancelProcessInstanceResponseImpl::new,
         result);
     return result;
   }

--- a/clients/java/src/main/java/io/camunda/client/impl/command/ClockPinCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/ClockPinCommandImpl.java
@@ -22,6 +22,7 @@ import io.camunda.client.api.command.FinalCommandStep;
 import io.camunda.client.api.response.PinClockResponse;
 import io.camunda.client.impl.http.HttpCamundaFuture;
 import io.camunda.client.impl.http.HttpClient;
+import io.camunda.client.impl.response.PinClockResponseImpl;
 import io.camunda.client.protocol.rest.ClockPinRequest;
 import java.time.Duration;
 import java.time.Instant;
@@ -65,7 +66,12 @@ public class ClockPinCommandImpl implements ClockPinCommandStep1 {
   @Override
   public CamundaFuture<PinClockResponse> send() {
     final HttpCamundaFuture<PinClockResponse> result = new HttpCamundaFuture<>();
-    httpClient.put("/clock", jsonMapper.toJson(request), httpRequestConfig.build(), result);
+    httpClient.put(
+        "/clock",
+        jsonMapper.toJson(request),
+        httpRequestConfig.build(),
+        PinClockResponseImpl::new,
+        result);
     return result;
   }
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/command/ClockResetCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/ClockResetCommandImpl.java
@@ -21,6 +21,7 @@ import io.camunda.client.api.command.FinalCommandStep;
 import io.camunda.client.api.response.ResetClockResponse;
 import io.camunda.client.impl.http.HttpCamundaFuture;
 import io.camunda.client.impl.http.HttpClient;
+import io.camunda.client.impl.response.ResetClockResponseImpl;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import org.apache.hc.client5.http.config.RequestConfig;
@@ -44,7 +45,8 @@ public class ClockResetCommandImpl implements ClockResetCommandStep1 {
   @Override
   public CamundaFuture<ResetClockResponse> send() {
     final HttpCamundaFuture<ResetClockResponse> result = new HttpCamundaFuture<>();
-    httpClient.post("/clock/reset", "", httpRequestConfig.build(), result);
+    httpClient.post(
+        "/clock/reset", "", httpRequestConfig.build(), ResetClockResponseImpl::new, result);
     return result;
   }
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/command/CompleteJobCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/CompleteJobCommandImpl.java
@@ -265,6 +265,7 @@ public final class CompleteJobCommandImpl extends CommandWithVariables<CompleteJ
         "/jobs/" + jobKey + "/completion",
         jsonMapper.toJson(httpRequestObject),
         httpRequestConfig.build(),
+        CompleteJobResponseImpl::new,
         result);
     return result;
   }

--- a/clients/java/src/main/java/io/camunda/client/impl/command/CompleteUserTaskCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/CompleteUserTaskCommandImpl.java
@@ -22,6 +22,7 @@ import io.camunda.client.api.command.FinalCommandStep;
 import io.camunda.client.api.response.CompleteUserTaskResponse;
 import io.camunda.client.impl.http.HttpCamundaFuture;
 import io.camunda.client.impl.http.HttpClient;
+import io.camunda.client.impl.response.CompleteUserTaskResponseImpl;
 import io.camunda.client.protocol.rest.UserTaskCompletionRequest;
 import java.time.Duration;
 import java.util.Map;
@@ -67,6 +68,7 @@ public final class CompleteUserTaskCommandImpl
         "/user-tasks/" + userTaskKey + "/completion",
         jsonMapper.toJson(request),
         httpRequestConfig.build(),
+        CompleteUserTaskResponseImpl::new,
         result);
     return result;
   }

--- a/clients/java/src/main/java/io/camunda/client/impl/command/DeleteAuthorizationCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/DeleteAuthorizationCommandImpl.java
@@ -21,6 +21,7 @@ import io.camunda.client.api.command.FinalCommandStep;
 import io.camunda.client.api.response.DeleteAuthorizationResponse;
 import io.camunda.client.impl.http.HttpCamundaFuture;
 import io.camunda.client.impl.http.HttpClient;
+import io.camunda.client.impl.response.DeleteAuthorizationResponseImpl;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import org.apache.hc.client5.http.config.RequestConfig;
@@ -47,7 +48,11 @@ public class DeleteAuthorizationCommandImpl implements DeleteAuthorizationComman
   @Override
   public CamundaFuture<DeleteAuthorizationResponse> send() {
     final HttpCamundaFuture<DeleteAuthorizationResponse> result = new HttpCamundaFuture<>();
-    httpClient.delete("/authorizations/" + authorizationKey, httpRequestConfig.build(), result);
+    httpClient.delete(
+        "/authorizations/" + authorizationKey,
+        httpRequestConfig.build(),
+        DeleteAuthorizationResponseImpl::new,
+        result);
     return result;
   }
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/command/DeleteDocumentCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/DeleteDocumentCommandImpl.java
@@ -24,6 +24,7 @@ import io.camunda.client.api.command.FinalCommandStep;
 import io.camunda.client.api.response.DeleteDocumentResponse;
 import io.camunda.client.impl.http.HttpCamundaFuture;
 import io.camunda.client.impl.http.HttpClient;
+import io.camunda.client.impl.response.DeleteDocumentResponseImpl;
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
@@ -71,7 +72,11 @@ public class DeleteDocumentCommandImpl implements DeleteDocumentCommandStep1 {
     }
     final HttpCamundaFuture<DeleteDocumentResponse> result = new HttpCamundaFuture<>();
     client.delete(
-        String.format("/documents/%s", documentId), queryParams, requestConfig.build(), result);
+        String.format("/documents/%s", documentId),
+        queryParams,
+        requestConfig.build(),
+        DeleteDocumentResponseImpl::new,
+        result);
     return result;
   }
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/command/DeleteGroupCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/DeleteGroupCommandImpl.java
@@ -21,6 +21,7 @@ import io.camunda.client.api.command.FinalCommandStep;
 import io.camunda.client.api.response.DeleteGroupResponse;
 import io.camunda.client.impl.http.HttpCamundaFuture;
 import io.camunda.client.impl.http.HttpClient;
+import io.camunda.client.impl.response.DeleteGroupResponseImpl;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import org.apache.hc.client5.http.config.RequestConfig;
@@ -46,7 +47,8 @@ public class DeleteGroupCommandImpl implements DeleteGroupCommandStep1 {
   @Override
   public CamundaFuture<DeleteGroupResponse> send() {
     final HttpCamundaFuture<DeleteGroupResponse> result = new HttpCamundaFuture<>();
-    httpClient.delete("/groups/" + groupId, httpRequestConfig.build(), result);
+    httpClient.delete(
+        "/groups/" + groupId, httpRequestConfig.build(), DeleteGroupResponseImpl::new, result);
     return result;
   }
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/command/DeleteResourceCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/DeleteResourceCommandImpl.java
@@ -90,6 +90,7 @@ public class DeleteResourceCommandImpl implements DeleteResourceCommandStep1 {
         "/resources/" + resourceKey + "/deletion",
         jsonMapper.toJson(httpRequestObject),
         httpRequestConfig.build(),
+        DeleteResourceResponseImpl::new,
         result);
     return result;
   }

--- a/clients/java/src/main/java/io/camunda/client/impl/command/DeleteRoleCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/DeleteRoleCommandImpl.java
@@ -21,6 +21,7 @@ import io.camunda.client.api.command.FinalCommandStep;
 import io.camunda.client.api.response.DeleteRoleResponse;
 import io.camunda.client.impl.http.HttpCamundaFuture;
 import io.camunda.client.impl.http.HttpClient;
+import io.camunda.client.impl.response.DeleteRoleResponseImpl;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import org.apache.hc.client5.http.config.RequestConfig;
@@ -47,7 +48,8 @@ public class DeleteRoleCommandImpl implements DeleteRoleCommandStep1 {
   public CamundaFuture<DeleteRoleResponse> send() {
     ArgumentUtil.ensureNotNullNorEmpty("roleId", roleId);
     final HttpCamundaFuture<DeleteRoleResponse> result = new HttpCamundaFuture<>();
-    httpClient.delete("/roles/" + roleId, httpRequestConfig.build(), result);
+    httpClient.delete(
+        "/roles/" + roleId, httpRequestConfig.build(), DeleteRoleResponseImpl::new, result);
     return result;
   }
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/command/DeleteTenantCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/DeleteTenantCommandImpl.java
@@ -21,6 +21,7 @@ import io.camunda.client.api.command.FinalCommandStep;
 import io.camunda.client.api.response.DeleteTenantResponse;
 import io.camunda.client.impl.http.HttpCamundaFuture;
 import io.camunda.client.impl.http.HttpClient;
+import io.camunda.client.impl.response.DeleteTenantResponseImpl;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import org.apache.hc.client5.http.config.RequestConfig;
@@ -50,7 +51,8 @@ public final class DeleteTenantCommandImpl implements DeleteTenantCommandStep1 {
   @Override
   public CamundaFuture<DeleteTenantResponse> send() {
     final HttpCamundaFuture<DeleteTenantResponse> result = new HttpCamundaFuture<>();
-    httpClient.delete("/tenants/" + tenantId, httpRequestConfig.build(), result);
+    httpClient.delete(
+        "/tenants/" + tenantId, httpRequestConfig.build(), DeleteTenantResponseImpl::new, result);
     return result;
   }
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/command/DeleteUserCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/DeleteUserCommandImpl.java
@@ -21,6 +21,7 @@ import io.camunda.client.api.command.FinalCommandStep;
 import io.camunda.client.api.response.DeleteUserResponse;
 import io.camunda.client.impl.http.HttpCamundaFuture;
 import io.camunda.client.impl.http.HttpClient;
+import io.camunda.client.impl.response.DeleteUserResponseImpl;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import org.apache.hc.client5.http.config.RequestConfig;
@@ -47,7 +48,8 @@ public class DeleteUserCommandImpl implements DeleteUserCommandStep1 {
   public CamundaFuture<DeleteUserResponse> send() {
     ArgumentUtil.ensureNotNullNorEmpty("username", username);
     final HttpCamundaFuture<DeleteUserResponse> result = new HttpCamundaFuture<>();
-    httpClient.delete("/users/" + username, httpRequestConfig.build(), result);
+    httpClient.delete(
+        "/users/" + username, httpRequestConfig.build(), DeleteUserResponseImpl::new, result);
     return result;
   }
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/command/FailJobCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/FailJobCommandImpl.java
@@ -130,6 +130,7 @@ public final class FailJobCommandImpl extends CommandWithVariables<FailJobComman
         "/jobs/" + jobKey + "/failure",
         objectMapper.toJson(httpRequestObject),
         httpRequestConfig.build(),
+        FailJobResponseImpl::new,
         result);
     return result;
   }

--- a/clients/java/src/main/java/io/camunda/client/impl/command/JobUpdateCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/JobUpdateCommandImpl.java
@@ -24,6 +24,7 @@ import io.camunda.client.api.command.UpdateJobCommandStep1.UpdateJobCommandStep2
 import io.camunda.client.api.response.UpdateJobResponse;
 import io.camunda.client.impl.http.HttpCamundaFuture;
 import io.camunda.client.impl.http.HttpClient;
+import io.camunda.client.impl.response.UpdateJobResponseImpl;
 import io.camunda.client.protocol.rest.JobUpdateRequest;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
@@ -56,7 +57,11 @@ public class JobUpdateCommandImpl implements UpdateJobCommandStep1, UpdateJobCom
   public CamundaFuture<UpdateJobResponse> send() {
     final HttpCamundaFuture<UpdateJobResponse> result = new HttpCamundaFuture<>();
     httpClient.patch(
-        "/jobs/" + jobKey, jsonMapper.toJson(httpRequestObject), httpRequestConfig.build(), result);
+        "/jobs/" + jobKey,
+        jsonMapper.toJson(httpRequestObject),
+        httpRequestConfig.build(),
+        UpdateJobResponseImpl::new,
+        result);
     return result;
   }
 

--- a/clients/java/src/main/java/io/camunda/client/impl/command/JobUpdateRetriesCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/JobUpdateRetriesCommandImpl.java
@@ -100,7 +100,11 @@ public final class JobUpdateRetriesCommandImpl
   private CamundaFuture<UpdateRetriesJobResponse> sendRestRequest() {
     final HttpCamundaFuture<UpdateRetriesJobResponse> result = new HttpCamundaFuture<>();
     httpClient.patch(
-        "/jobs/" + jobKey, jsonMapper.toJson(httpRequestObject), httpRequestConfig.build(), result);
+        "/jobs/" + jobKey,
+        jsonMapper.toJson(httpRequestObject),
+        httpRequestConfig.build(),
+        UpdateRetriesJobResponseImpl::new,
+        result);
     return result;
   }
 

--- a/clients/java/src/main/java/io/camunda/client/impl/command/JobUpdateTimeoutCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/JobUpdateTimeoutCommandImpl.java
@@ -104,7 +104,11 @@ public class JobUpdateTimeoutCommandImpl
   private CamundaFuture<UpdateTimeoutJobResponse> sendRestRequest() {
     final HttpCamundaFuture<UpdateTimeoutJobResponse> result = new HttpCamundaFuture<>();
     httpClient.patch(
-        "/jobs/" + jobKey, jsonMapper.toJson(httpRequestObject), httpRequestConfig.build(), result);
+        "/jobs/" + jobKey,
+        jsonMapper.toJson(httpRequestObject),
+        httpRequestConfig.build(),
+        UpdateTimeoutJobResponseImpl::new,
+        result);
     return result;
   }
 

--- a/clients/java/src/main/java/io/camunda/client/impl/command/MigrateProcessInstanceCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/MigrateProcessInstanceCommandImpl.java
@@ -157,6 +157,7 @@ public final class MigrateProcessInstanceCommandImpl
         "/process-instances/" + processInstanceKey + "/migration",
         jsonMapper.toJson(httpRequestObject),
         httpRequestConfig.build(),
+        MigrateProcessInstanceResponseImpl::new,
         result);
     return result;
   }

--- a/clients/java/src/main/java/io/camunda/client/impl/command/ModifyProcessInstanceCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/ModifyProcessInstanceCommandImpl.java
@@ -305,6 +305,7 @@ public final class ModifyProcessInstanceCommandImpl
         "/process-instances/" + processInstanceKey + "/modification",
         jsonMapper.toJson(httpRequestObject),
         httpRequestConfig.build(),
+        ModifyProcessInstanceResponseImpl::new,
         result);
     return result;
   }

--- a/clients/java/src/main/java/io/camunda/client/impl/command/PinClockCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/PinClockCommandImpl.java
@@ -17,8 +17,8 @@ package io.camunda.client.impl.command;
 
 import io.camunda.client.api.CamundaFuture;
 import io.camunda.client.api.JsonMapper;
-import io.camunda.client.api.command.ClockPinCommandStep1;
 import io.camunda.client.api.command.FinalCommandStep;
+import io.camunda.client.api.command.PinClockCommandStep1;
 import io.camunda.client.api.response.PinClockResponse;
 import io.camunda.client.impl.http.HttpCamundaFuture;
 import io.camunda.client.impl.http.HttpClient;
@@ -29,14 +29,14 @@ import java.time.Instant;
 import java.util.concurrent.TimeUnit;
 import org.apache.hc.client5.http.config.RequestConfig;
 
-public class ClockPinCommandImpl implements ClockPinCommandStep1 {
+public class PinClockCommandImpl implements PinClockCommandStep1 {
 
   private final ClockPinRequest request;
   private final JsonMapper jsonMapper;
   private final HttpClient httpClient;
   private final RequestConfig.Builder httpRequestConfig;
 
-  public ClockPinCommandImpl(final HttpClient httpClient, final JsonMapper jsonMapper) {
+  public PinClockCommandImpl(final HttpClient httpClient, final JsonMapper jsonMapper) {
     this.jsonMapper = jsonMapper;
     this.httpClient = httpClient;
     httpRequestConfig = httpClient.newRequestConfig();
@@ -44,14 +44,14 @@ public class ClockPinCommandImpl implements ClockPinCommandStep1 {
   }
 
   @Override
-  public ClockPinCommandStep1 time(final long timestamp) {
+  public PinClockCommandStep1 time(final long timestamp) {
     ArgumentUtil.ensureNotNegative("timestamp", timestamp);
     request.setTimestamp(timestamp);
     return this;
   }
 
   @Override
-  public ClockPinCommandStep1 time(final Instant instant) {
+  public PinClockCommandStep1 time(final Instant instant) {
     ArgumentUtil.ensureNotNull("instant", instant);
     ArgumentUtil.ensureNotBefore("instant", instant, Instant.EPOCH);
     return time(instant.toEpochMilli());

--- a/clients/java/src/main/java/io/camunda/client/impl/command/ResetClockCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/ResetClockCommandImpl.java
@@ -16,8 +16,8 @@
 package io.camunda.client.impl.command;
 
 import io.camunda.client.api.CamundaFuture;
-import io.camunda.client.api.command.ClockResetCommandStep1;
 import io.camunda.client.api.command.FinalCommandStep;
+import io.camunda.client.api.command.ResetClockCommandStep1;
 import io.camunda.client.api.response.ResetClockResponse;
 import io.camunda.client.impl.http.HttpCamundaFuture;
 import io.camunda.client.impl.http.HttpClient;
@@ -26,12 +26,12 @@ import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import org.apache.hc.client5.http.config.RequestConfig;
 
-public class ClockResetCommandImpl implements ClockResetCommandStep1 {
+public class ResetClockCommandImpl implements ResetClockCommandStep1 {
 
   private final HttpClient httpClient;
   private final RequestConfig.Builder httpRequestConfig;
 
-  public ClockResetCommandImpl(final HttpClient httpClient) {
+  public ResetClockCommandImpl(final HttpClient httpClient) {
     this.httpClient = httpClient;
     httpRequestConfig = httpClient.newRequestConfig();
   }

--- a/clients/java/src/main/java/io/camunda/client/impl/command/ResolveIncidentCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/ResolveIncidentCommandImpl.java
@@ -91,6 +91,7 @@ public final class ResolveIncidentCommandImpl implements ResolveIncidentCommandS
         "/incidents/" + incidentKey + "/resolution",
         jsonMapper.toJson(incidentResolutionRequest),
         httpRequestConfig.build(),
+        ResolveIncidentResponseImpl::new,
         result);
     return result;
   }

--- a/clients/java/src/main/java/io/camunda/client/impl/command/ResumeBatchOperationCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/ResumeBatchOperationCommandImpl.java
@@ -18,8 +18,10 @@ package io.camunda.client.impl.command;
 import io.camunda.client.api.CamundaFuture;
 import io.camunda.client.api.command.FinalCommandStep;
 import io.camunda.client.api.command.ResumeBatchOperationStep1;
+import io.camunda.client.api.response.ResumeBatchOperationResponse;
 import io.camunda.client.impl.http.HttpCamundaFuture;
 import io.camunda.client.impl.http.HttpClient;
+import io.camunda.client.impl.response.ResumeBatchOperationResponseImpl;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import org.apache.hc.client5.http.config.RequestConfig;
@@ -39,18 +41,20 @@ public final class ResumeBatchOperationCommandImpl implements ResumeBatchOperati
   }
 
   @Override
-  public FinalCommandStep<Void> requestTimeout(final Duration requestTimeout) {
+  public FinalCommandStep<ResumeBatchOperationResponse> requestTimeout(
+      final Duration requestTimeout) {
     httpRequestConfig.setResponseTimeout(requestTimeout.toMillis(), TimeUnit.MILLISECONDS);
     return this;
   }
 
   @Override
-  public CamundaFuture<Void> send() {
-    final HttpCamundaFuture<Void> result = new HttpCamundaFuture<>();
+  public CamundaFuture<ResumeBatchOperationResponse> send() {
+    final HttpCamundaFuture<ResumeBatchOperationResponse> result = new HttpCamundaFuture<>();
     httpClient.post(
         "/batch-operations/" + batchOperationKey + "/resumption",
         null,
         httpRequestConfig.build(),
+        ResumeBatchOperationResponseImpl::new,
         result);
     return result;
   }

--- a/clients/java/src/main/java/io/camunda/client/impl/command/SetVariablesCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/SetVariablesCommandImpl.java
@@ -95,6 +95,7 @@ public final class SetVariablesCommandImpl extends CommandWithVariables<SetVaria
         "/element-instances/" + elementInstanceKey + "/variables",
         jsonMapper.toJson(httpRequestObject),
         httpRequestConfig.build(),
+        SetVariablesResponseImpl::new,
         result);
     return result;
   }

--- a/clients/java/src/main/java/io/camunda/client/impl/command/SuspendBatchOperationCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/SuspendBatchOperationCommandImpl.java
@@ -18,8 +18,10 @@ package io.camunda.client.impl.command;
 import io.camunda.client.api.CamundaFuture;
 import io.camunda.client.api.command.FinalCommandStep;
 import io.camunda.client.api.command.SuspendBatchOperationStep1;
+import io.camunda.client.api.response.SuspendBatchOperationResponse;
 import io.camunda.client.impl.http.HttpCamundaFuture;
 import io.camunda.client.impl.http.HttpClient;
+import io.camunda.client.impl.response.SuspendBatchOperationResponseImpl;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import org.apache.hc.client5.http.config.RequestConfig;
@@ -39,18 +41,20 @@ public final class SuspendBatchOperationCommandImpl implements SuspendBatchOpera
   }
 
   @Override
-  public FinalCommandStep<Void> requestTimeout(final Duration requestTimeout) {
+  public FinalCommandStep<SuspendBatchOperationResponse> requestTimeout(
+      final Duration requestTimeout) {
     httpRequestConfig.setResponseTimeout(requestTimeout.toMillis(), TimeUnit.MILLISECONDS);
     return this;
   }
 
   @Override
-  public CamundaFuture<Void> send() {
-    final HttpCamundaFuture<Void> result = new HttpCamundaFuture<>();
+  public CamundaFuture<SuspendBatchOperationResponse> send() {
+    final HttpCamundaFuture<SuspendBatchOperationResponse> result = new HttpCamundaFuture<>();
     httpClient.post(
         "/batch-operations/" + batchOperationKey + "/suspension",
         null,
         httpRequestConfig.build(),
+        SuspendBatchOperationResponseImpl::new,
         result);
     return result;
   }

--- a/clients/java/src/main/java/io/camunda/client/impl/command/ThrowErrorCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/ThrowErrorCommandImpl.java
@@ -21,14 +21,16 @@ import io.camunda.client.api.JsonMapper;
 import io.camunda.client.api.command.FinalCommandStep;
 import io.camunda.client.api.command.ThrowErrorCommandStep1;
 import io.camunda.client.api.command.ThrowErrorCommandStep1.ThrowErrorCommandStep2;
+import io.camunda.client.api.response.ThrowErrorResponse;
 import io.camunda.client.impl.RetriableClientFutureImpl;
 import io.camunda.client.impl.http.HttpCamundaFuture;
 import io.camunda.client.impl.http.HttpClient;
+import io.camunda.client.impl.response.ThrowErrorResponseImpl;
 import io.camunda.client.protocol.rest.JobErrorRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayGrpc.GatewayStub;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ThrowErrorRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ThrowErrorRequest.Builder;
-import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ThrowErrorResponse;
 import io.grpc.stub.StreamObserver;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
@@ -100,14 +102,14 @@ public final class ThrowErrorCommandImpl extends CommandWithVariables<ThrowError
   }
 
   @Override
-  public FinalCommandStep<Void> requestTimeout(final Duration requestTimeout) {
+  public FinalCommandStep<ThrowErrorResponse> requestTimeout(final Duration requestTimeout) {
     this.requestTimeout = requestTimeout;
     httpRequestConfig.setResponseTimeout(requestTimeout.toMillis(), TimeUnit.MILLISECONDS);
     return this;
   }
 
   @Override
-  public CamundaFuture<Void> send() {
+  public CamundaFuture<ThrowErrorResponse> send() {
     if (useRest) {
       return sendRestRequest();
     } else {
@@ -115,29 +117,34 @@ public final class ThrowErrorCommandImpl extends CommandWithVariables<ThrowError
     }
   }
 
-  private CamundaFuture<Void> sendRestRequest() {
-    final HttpCamundaFuture<Void> result = new HttpCamundaFuture<>();
+  private CamundaFuture<ThrowErrorResponse> sendRestRequest() {
+    final HttpCamundaFuture<ThrowErrorResponse> result = new HttpCamundaFuture<>();
     httpClient.post(
         "/jobs/" + jobKey + "/error",
         objectMapper.toJson(httpRequestObject),
         httpRequestConfig.build(),
+        ThrowErrorResponseImpl::new,
         result);
     return result;
   }
 
-  private CamundaFuture<Void> sendGrpcRequest() {
+  private CamundaFuture<ThrowErrorResponse> sendGrpcRequest() {
     final ThrowErrorRequest request = grpcRequestObjectBuilder.build();
 
-    final RetriableClientFutureImpl<Void, ThrowErrorResponse> future =
-        new RetriableClientFutureImpl<>(
-            retryPredicate, streamObserver -> sendGrpcRequest(request, streamObserver));
+    final RetriableClientFutureImpl<ThrowErrorResponse, GatewayOuterClass.ThrowErrorResponse>
+        future =
+            new RetriableClientFutureImpl<>(
+                ThrowErrorResponseImpl::new,
+                retryPredicate,
+                streamObserver -> sendGrpcRequest(request, streamObserver));
 
     sendGrpcRequest(request, future);
     return future;
   }
 
   private void sendGrpcRequest(
-      final ThrowErrorRequest request, final StreamObserver<ThrowErrorResponse> streamObserver) {
+      final ThrowErrorRequest request,
+      final StreamObserver<GatewayOuterClass.ThrowErrorResponse> streamObserver) {
     asyncStub
         .withDeadlineAfter(requestTimeout.toMillis(), TimeUnit.MILLISECONDS)
         .throwError(request, streamObserver);

--- a/clients/java/src/main/java/io/camunda/client/impl/command/UnassignClientFromGroupCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/UnassignClientFromGroupCommandImpl.java
@@ -22,6 +22,7 @@ import io.camunda.client.api.command.UnassignClientFromGroupCommandStep1.Unassig
 import io.camunda.client.api.response.UnassignClientFromGroupResponse;
 import io.camunda.client.impl.http.HttpCamundaFuture;
 import io.camunda.client.impl.http.HttpClient;
+import io.camunda.client.impl.response.UnassignClientFromGroupResponseImpl;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import org.apache.hc.client5.http.config.RequestConfig;
@@ -67,6 +68,7 @@ public class UnassignClientFromGroupCommandImpl
         "/groups/" + groupId + "/clients/" + clientId,
         null, // No request body needed
         httpRequestConfig.build(),
+        UnassignClientFromGroupResponseImpl::new,
         result);
     return result;
   }

--- a/clients/java/src/main/java/io/camunda/client/impl/command/UnassignGroupFromTenantCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/UnassignGroupFromTenantCommandImpl.java
@@ -21,6 +21,7 @@ import io.camunda.client.api.command.UnassignGroupFromTenantCommandStep1;
 import io.camunda.client.api.response.UnassignGroupFromTenantResponse;
 import io.camunda.client.impl.http.HttpCamundaFuture;
 import io.camunda.client.impl.http.HttpClient;
+import io.camunda.client.impl.response.UnassignGroupFromTenantResponseImpl;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import org.apache.hc.client5.http.config.RequestConfig;
@@ -57,7 +58,8 @@ public final class UnassignGroupFromTenantCommandImpl
     ArgumentUtil.ensureNotNullNorEmpty("groupId", groupId);
     final HttpCamundaFuture<UnassignGroupFromTenantResponse> result = new HttpCamundaFuture<>();
     final String endpoint = String.format("/tenants/%s/groups/%s", tenantId, groupId);
-    httpClient.delete(endpoint, httpRequestConfig.build(), result);
+    httpClient.delete(
+        endpoint, httpRequestConfig.build(), UnassignGroupFromTenantResponseImpl::new, result);
     return result;
   }
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/command/UnassignMappingRuleFromGroupCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/UnassignMappingRuleFromGroupCommandImpl.java
@@ -22,6 +22,7 @@ import io.camunda.client.api.command.UnassignMappingRuleFromGroupStep1.UnassignM
 import io.camunda.client.api.response.UnassignMappingRuleFromGroupResponse;
 import io.camunda.client.impl.http.HttpCamundaFuture;
 import io.camunda.client.impl.http.HttpClient;
+import io.camunda.client.impl.response.UnassignMappingRuleFromGroupResponseImpl;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import org.apache.hc.client5.http.config.RequestConfig;
@@ -68,6 +69,7 @@ public class UnassignMappingRuleFromGroupCommandImpl
         "/groups/" + groupId + "/mapping-rules/" + mappingRuleId,
         null,
         httpRequestConfig.build(),
+        UnassignMappingRuleFromGroupResponseImpl::new,
         result);
     return result;
   }

--- a/clients/java/src/main/java/io/camunda/client/impl/command/UnassignRoleFromClientCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/UnassignRoleFromClientCommandImpl.java
@@ -22,6 +22,7 @@ import io.camunda.client.api.command.UnassignRoleFromClientCommandStep1.Unassign
 import io.camunda.client.api.response.UnassignRoleFromClientResponse;
 import io.camunda.client.impl.http.HttpCamundaFuture;
 import io.camunda.client.impl.http.HttpClient;
+import io.camunda.client.impl.response.UnassignRoleFromClientResponseImpl;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import org.apache.hc.client5.http.config.RequestConfig;
@@ -67,6 +68,7 @@ public class UnassignRoleFromClientCommandImpl
         "/roles/" + roleId + "/clients/" + clientId,
         null, // No request body needed
         httpRequestConfig.build(),
+        UnassignRoleFromClientResponseImpl::new,
         result);
     return result;
   }

--- a/clients/java/src/main/java/io/camunda/client/impl/command/UnassignRoleFromGroupCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/UnassignRoleFromGroupCommandImpl.java
@@ -22,6 +22,7 @@ import io.camunda.client.api.command.UnassignRoleFromGroupCommandStep1.UnassignR
 import io.camunda.client.api.response.UnassignRoleFromGroupResponse;
 import io.camunda.client.impl.http.HttpCamundaFuture;
 import io.camunda.client.impl.http.HttpClient;
+import io.camunda.client.impl.response.UnassignRoleFromGroupResponseImpl;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import org.apache.hc.client5.http.config.RequestConfig;
@@ -67,6 +68,7 @@ public class UnassignRoleFromGroupCommandImpl
         "/roles/" + roleId + "/groups/" + groupId,
         null, // No request body needed
         httpRequestConfig.build(),
+        UnassignRoleFromGroupResponseImpl::new,
         result);
     return result;
   }

--- a/clients/java/src/main/java/io/camunda/client/impl/command/UnassignRoleFromMappingRuleCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/UnassignRoleFromMappingRuleCommandImpl.java
@@ -22,6 +22,7 @@ import io.camunda.client.api.command.UnassignRoleFromMappingRuleCommandStep1.Una
 import io.camunda.client.api.response.UnassignRoleFromMappingRuleResponse;
 import io.camunda.client.impl.http.HttpCamundaFuture;
 import io.camunda.client.impl.http.HttpClient;
+import io.camunda.client.impl.response.UnassignRoleFromMappingRuleResponseImpl;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import org.apache.hc.client5.http.config.RequestConfig;
@@ -67,6 +68,7 @@ public class UnassignRoleFromMappingRuleCommandImpl
         "/roles/" + roleId + "/mapping-rules/" + mappingRuleId,
         null, // No request body needed
         httpRequestConfig.build(),
+        UnassignRoleFromMappingRuleResponseImpl::new,
         result);
     return result;
   }

--- a/clients/java/src/main/java/io/camunda/client/impl/command/UnassignRoleFromTenantCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/UnassignRoleFromTenantCommandImpl.java
@@ -22,6 +22,7 @@ import io.camunda.client.api.command.UnassignRoleFromTenantCommandStep1.Unassign
 import io.camunda.client.api.response.UnassignRoleFromTenantResponse;
 import io.camunda.client.impl.http.HttpCamundaFuture;
 import io.camunda.client.impl.http.HttpClient;
+import io.camunda.client.impl.response.UnassignRoleFromTenantResponseImpl;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import org.apache.hc.client5.http.config.RequestConfig;
@@ -66,6 +67,7 @@ public final class UnassignRoleFromTenantCommandImpl
         String.format("/tenants/%s/roles/%s", tenantId, roleId),
         null,
         httpRequestConfig.build(),
+        UnassignRoleFromTenantResponseImpl::new,
         result);
     return result;
   }

--- a/clients/java/src/main/java/io/camunda/client/impl/command/UnassignRoleFromUserCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/UnassignRoleFromUserCommandImpl.java
@@ -22,6 +22,7 @@ import io.camunda.client.api.command.UnassignRoleFromUserCommandStep1.UnassignRo
 import io.camunda.client.api.response.UnassignUserFromRoleResponse;
 import io.camunda.client.impl.http.HttpCamundaFuture;
 import io.camunda.client.impl.http.HttpClient;
+import io.camunda.client.impl.response.UnassignUserFromRoleResponseImpl;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import org.apache.hc.client5.http.config.RequestConfig;
@@ -64,7 +65,10 @@ public class UnassignRoleFromUserCommandImpl
     ArgumentUtil.ensureNotNullNorEmpty("username", username);
     final HttpCamundaFuture<UnassignUserFromRoleResponse> result = new HttpCamundaFuture<>();
     httpClient.delete(
-        String.format("/roles/%s/users/%s", roleId, username), httpRequestConfig.build(), result);
+        String.format("/roles/%s/users/%s", roleId, username),
+        httpRequestConfig.build(),
+        UnassignUserFromRoleResponseImpl::new,
+        result);
     return result;
   }
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/command/UnassignUserFromGroupCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/UnassignUserFromGroupCommandImpl.java
@@ -22,6 +22,7 @@ import io.camunda.client.api.command.UnassignUserFromGroupCommandStep1.UnassignU
 import io.camunda.client.api.response.UnassignUserFromGroupResponse;
 import io.camunda.client.impl.http.HttpCamundaFuture;
 import io.camunda.client.impl.http.HttpClient;
+import io.camunda.client.impl.response.UnassignUserFromGroupResponseImpl;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import org.apache.hc.client5.http.config.RequestConfig;
@@ -64,7 +65,10 @@ public class UnassignUserFromGroupCommandImpl
     ArgumentUtil.ensureNotNullNorEmpty("username", username);
     final HttpCamundaFuture<UnassignUserFromGroupResponse> result = new HttpCamundaFuture<>();
     httpClient.delete(
-        "/groups/" + groupId + "/users/" + username, httpRequestConfig.build(), result);
+        "/groups/" + groupId + "/users/" + username,
+        httpRequestConfig.build(),
+        UnassignUserFromGroupResponseImpl::new,
+        result);
     return result;
   }
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/command/UnassignUserFromTenantCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/UnassignUserFromTenantCommandImpl.java
@@ -22,6 +22,7 @@ import io.camunda.client.api.command.UnassignUserFromTenantCommandStep1.Unassign
 import io.camunda.client.api.response.UnassignUserFromTenantResponse;
 import io.camunda.client.impl.http.HttpCamundaFuture;
 import io.camunda.client.impl.http.HttpClient;
+import io.camunda.client.impl.response.UnassignUserFromTenantResponseImpl;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import org.apache.hc.client5.http.config.RequestConfig;
@@ -62,7 +63,8 @@ public final class UnassignUserFromTenantCommandImpl
   public CamundaFuture<UnassignUserFromTenantResponse> send() {
     final HttpCamundaFuture<UnassignUserFromTenantResponse> result = new HttpCamundaFuture<>();
     final String endpoint = String.format("/tenants/%s/users/%s", tenantId, username);
-    httpClient.delete(endpoint, null, httpRequestConfig.build(), result);
+    httpClient.delete(
+        endpoint, null, httpRequestConfig.build(), UnassignUserFromTenantResponseImpl::new, result);
     return result;
   }
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/command/UnassignUserTaskCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/UnassignUserTaskCommandImpl.java
@@ -21,6 +21,7 @@ import io.camunda.client.api.command.UnassignUserTaskCommandStep1;
 import io.camunda.client.api.response.UnassignUserTaskResponse;
 import io.camunda.client.impl.http.HttpCamundaFuture;
 import io.camunda.client.impl.http.HttpClient;
+import io.camunda.client.impl.response.UnassignUserTaskResponseImpl;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import org.apache.hc.client5.http.config.RequestConfig;
@@ -47,7 +48,10 @@ public final class UnassignUserTaskCommandImpl implements UnassignUserTaskComman
   public CamundaFuture<UnassignUserTaskResponse> send() {
     final HttpCamundaFuture<UnassignUserTaskResponse> result = new HttpCamundaFuture<>();
     httpClient.delete(
-        "/user-tasks/" + userTaskKey + "/assignee", httpRequestConfig.build(), result);
+        "/user-tasks/" + userTaskKey + "/assignee",
+        httpRequestConfig.build(),
+        UnassignUserTaskResponseImpl::new,
+        result);
     return result;
   }
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/command/UpdateAuthorizationCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/UpdateAuthorizationCommandImpl.java
@@ -30,6 +30,7 @@ import io.camunda.client.api.search.enums.PermissionType;
 import io.camunda.client.api.search.enums.ResourceType;
 import io.camunda.client.impl.http.HttpCamundaFuture;
 import io.camunda.client.impl.http.HttpClient;
+import io.camunda.client.impl.response.UpdateAuthorizationResponseImpl;
 import io.camunda.client.impl.util.EnumUtil;
 import io.camunda.client.protocol.rest.AuthorizationRequest;
 import io.camunda.client.protocol.rest.OwnerTypeEnum;
@@ -117,6 +118,7 @@ public class UpdateAuthorizationCommandImpl
         "/authorizations/" + authorizationKey,
         jsonMapper.toJson(request),
         httpRequestConfig.build(),
+        UpdateAuthorizationResponseImpl::new,
         result);
     return result;
   }

--- a/clients/java/src/main/java/io/camunda/client/impl/command/UpdateJobCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/UpdateJobCommandImpl.java
@@ -30,7 +30,7 @@ import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import org.apache.hc.client5.http.config.RequestConfig;
 
-public class JobUpdateCommandImpl implements UpdateJobCommandStep1, UpdateJobCommandStep2 {
+public class UpdateJobCommandImpl implements UpdateJobCommandStep1, UpdateJobCommandStep2 {
 
   private final JobUpdateRequest httpRequestObject;
   private final HttpClient httpClient;
@@ -38,7 +38,7 @@ public class JobUpdateCommandImpl implements UpdateJobCommandStep1, UpdateJobCom
   private final long jobKey;
   private final JsonMapper jsonMapper;
 
-  public JobUpdateCommandImpl(
+  public UpdateJobCommandImpl(
       final long jobKey, final HttpClient httpClient, final JsonMapper jsonMapper) {
     this.httpClient = httpClient;
     httpRequestConfig = httpClient.newRequestConfig();

--- a/clients/java/src/main/java/io/camunda/client/impl/command/UpdateUserTaskCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/UpdateUserTaskCommandImpl.java
@@ -22,6 +22,7 @@ import io.camunda.client.api.command.UpdateUserTaskCommandStep1;
 import io.camunda.client.api.response.UpdateUserTaskResponse;
 import io.camunda.client.impl.http.HttpCamundaFuture;
 import io.camunda.client.impl.http.HttpClient;
+import io.camunda.client.impl.response.UpdateUserTaskResponseImpl;
 import io.camunda.client.protocol.rest.Changeset;
 import io.camunda.client.protocol.rest.UserTaskUpdateRequest;
 import java.time.Duration;
@@ -61,6 +62,7 @@ public final class UpdateUserTaskCommandImpl implements UpdateUserTaskCommandSte
         "/user-tasks/" + userTaskKey,
         jsonMapper.toJson(request),
         httpRequestConfig.build(),
+        UpdateUserTaskResponseImpl::new,
         result);
     return result;
   }

--- a/clients/java/src/main/java/io/camunda/client/impl/http/ApiCallback.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/http/ApiCallback.java
@@ -128,7 +128,7 @@ final class ApiCallback<HttpT, RespT> implements FutureCallback<ApiResponse<Http
   private void handleSuccessResponse(
       final ApiEntity<HttpT> body, final int code, final String reason) {
     if (body == null) {
-      response.complete(null);
+      completeResponse(code, reason, null);
       return;
     }
 
@@ -153,8 +153,12 @@ final class ApiCallback<HttpT, RespT> implements FutureCallback<ApiResponse<Http
       return;
     }
 
+    completeResponse(code, reason, body.response());
+  }
+
+  private void completeResponse(final int code, final String reason, final HttpT httpResponse) {
     try {
-      response.complete(transformer.transform(body.response()));
+      response.complete(transformer.transform(httpResponse));
     } catch (final Exception e) {
       response.completeExceptionally(new MalformedResponseException(code, reason, e));
     }

--- a/clients/java/src/main/java/io/camunda/client/impl/http/HttpClient.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/http/HttpClient.java
@@ -129,8 +129,9 @@ public final class HttpClient implements AutoCloseable {
       final String path,
       final String body,
       final RequestConfig requestConfig,
+      final JsonResponseTransformer<Void, RespT> transformer,
       final HttpCamundaFuture<RespT> result) {
-    post(path, body, requestConfig, Void.class, r -> null, result);
+    post(path, body, requestConfig, Void.class, transformer, result);
   }
 
   public <HttpT, RespT> void post(
@@ -191,6 +192,7 @@ public final class HttpClient implements AutoCloseable {
       final String path,
       final String body,
       final RequestConfig requestConfig,
+      final JsonResponseTransformer<Void, RespT> transformer,
       final HttpCamundaFuture<RespT> result) {
     sendRequest(
         Method.PUT,
@@ -199,7 +201,7 @@ public final class HttpClient implements AutoCloseable {
         body,
         requestConfig,
         Void.class,
-        r -> null,
+        transformer,
         result);
   }
 
@@ -225,8 +227,9 @@ public final class HttpClient implements AutoCloseable {
       final String path,
       final String body,
       final RequestConfig requestConfig,
+      final JsonResponseTransformer<Void, RespT> transformer,
       final HttpCamundaFuture<RespT> result) {
-    patch(path, body, requestConfig, Void.class, r -> null, result);
+    patch(path, body, requestConfig, Void.class, transformer, result);
   }
 
   public <HttpT, RespT> void patch(
@@ -248,17 +251,21 @@ public final class HttpClient implements AutoCloseable {
   }
 
   public <RespT> void delete(
-      final String path, final RequestConfig requestConfig, final HttpCamundaFuture<RespT> result) {
-    delete(path, Collections.emptyMap(), requestConfig, result);
+      final String path,
+      final RequestConfig requestConfig,
+      final JsonResponseTransformer<Void, RespT> transformer,
+      final HttpCamundaFuture<RespT> result) {
+    delete(path, Collections.emptyMap(), requestConfig, transformer, result);
   }
 
   public <RespT> void delete(
       final String path,
       final Map<String, String> queryParams,
       final RequestConfig requestConfig,
+      final JsonResponseTransformer<Void, RespT> transformer,
       final HttpCamundaFuture<RespT> result) {
     sendRequest(
-        Method.DELETE, path, queryParams, null, requestConfig, Void.class, r -> null, result);
+        Method.DELETE, path, queryParams, null, requestConfig, Void.class, transformer, result);
   }
 
   private <HttpT, RespT> void sendRequest(

--- a/clients/java/src/main/java/io/camunda/client/impl/response/ActivateAdHocSubProcessActivitiesResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/ActivateAdHocSubProcessActivitiesResponseImpl.java
@@ -18,4 +18,6 @@ package io.camunda.client.impl.response;
 import io.camunda.client.api.response.ActivateAdHocSubProcessActivitiesResponse;
 
 public class ActivateAdHocSubProcessActivitiesResponseImpl
-    implements ActivateAdHocSubProcessActivitiesResponse {}
+    implements ActivateAdHocSubProcessActivitiesResponse {
+  public ActivateAdHocSubProcessActivitiesResponseImpl(final Void nothing) {}
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/response/AssignClientToGroupResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/AssignClientToGroupResponseImpl.java
@@ -15,12 +15,9 @@
  */
 package io.camunda.client.impl.response;
 
-import io.camunda.client.api.response.DeleteResourceResponse;
-import io.camunda.zeebe.gateway.protocol.GatewayOuterClass;
+import io.camunda.client.api.response.AssignClientToGroupResponse;
 
-public class DeleteResourceResponseImpl implements DeleteResourceResponse {
+public class AssignClientToGroupResponseImpl implements AssignClientToGroupResponse {
 
-  public DeleteResourceResponseImpl(final GatewayOuterClass.DeleteResourceResponse response) {}
-
-  public DeleteResourceResponseImpl(final Void nothing) {}
+  public AssignClientToGroupResponseImpl(final Void nothing) {}
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/response/AssignClientToTenantResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/AssignClientToTenantResponseImpl.java
@@ -15,12 +15,9 @@
  */
 package io.camunda.client.impl.response;
 
-import io.camunda.client.api.response.DeleteResourceResponse;
-import io.camunda.zeebe.gateway.protocol.GatewayOuterClass;
+import io.camunda.client.api.response.AssignClientToTenantResponse;
 
-public class DeleteResourceResponseImpl implements DeleteResourceResponse {
+public class AssignClientToTenantResponseImpl implements AssignClientToTenantResponse {
 
-  public DeleteResourceResponseImpl(final GatewayOuterClass.DeleteResourceResponse response) {}
-
-  public DeleteResourceResponseImpl(final Void nothing) {}
+  public AssignClientToTenantResponseImpl(final Void nothing) {}
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/response/AssignGroupToTenantResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/AssignGroupToTenantResponseImpl.java
@@ -15,12 +15,9 @@
  */
 package io.camunda.client.impl.response;
 
-import io.camunda.client.api.response.DeleteResourceResponse;
-import io.camunda.zeebe.gateway.protocol.GatewayOuterClass;
+import io.camunda.client.api.response.AssignGroupToTenantResponse;
 
-public class DeleteResourceResponseImpl implements DeleteResourceResponse {
+public class AssignGroupToTenantResponseImpl implements AssignGroupToTenantResponse {
 
-  public DeleteResourceResponseImpl(final GatewayOuterClass.DeleteResourceResponse response) {}
-
-  public DeleteResourceResponseImpl(final Void nothing) {}
+  public AssignGroupToTenantResponseImpl(final Void nothing) {}
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/response/AssignMappingRuleToGroupResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/AssignMappingRuleToGroupResponseImpl.java
@@ -15,12 +15,9 @@
  */
 package io.camunda.client.impl.response;
 
-import io.camunda.client.api.response.DeleteResourceResponse;
-import io.camunda.zeebe.gateway.protocol.GatewayOuterClass;
+import io.camunda.client.api.response.AssignMappingRuleToGroupResponse;
 
-public class DeleteResourceResponseImpl implements DeleteResourceResponse {
+public class AssignMappingRuleToGroupResponseImpl implements AssignMappingRuleToGroupResponse {
 
-  public DeleteResourceResponseImpl(final GatewayOuterClass.DeleteResourceResponse response) {}
-
-  public DeleteResourceResponseImpl(final Void nothing) {}
+  public AssignMappingRuleToGroupResponseImpl(final Void nothing) {}
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/response/AssignMappingRuleToTenantResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/AssignMappingRuleToTenantResponseImpl.java
@@ -15,12 +15,9 @@
  */
 package io.camunda.client.impl.response;
 
-import io.camunda.client.api.response.DeleteResourceResponse;
-import io.camunda.zeebe.gateway.protocol.GatewayOuterClass;
+import io.camunda.client.api.response.AssignMappingRuleToTenantResponse;
 
-public class DeleteResourceResponseImpl implements DeleteResourceResponse {
+public class AssignMappingRuleToTenantResponseImpl implements AssignMappingRuleToTenantResponse {
 
-  public DeleteResourceResponseImpl(final GatewayOuterClass.DeleteResourceResponse response) {}
-
-  public DeleteResourceResponseImpl(final Void nothing) {}
+  public AssignMappingRuleToTenantResponseImpl(final Void nothing) {}
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/response/AssignRoleToClientResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/AssignRoleToClientResponseImpl.java
@@ -15,12 +15,9 @@
  */
 package io.camunda.client.impl.response;
 
-import io.camunda.client.api.response.DeleteResourceResponse;
-import io.camunda.zeebe.gateway.protocol.GatewayOuterClass;
+import io.camunda.client.api.response.AssignRoleToClientResponse;
 
-public class DeleteResourceResponseImpl implements DeleteResourceResponse {
+public class AssignRoleToClientResponseImpl implements AssignRoleToClientResponse {
 
-  public DeleteResourceResponseImpl(final GatewayOuterClass.DeleteResourceResponse response) {}
-
-  public DeleteResourceResponseImpl(final Void nothing) {}
+  public AssignRoleToClientResponseImpl(final Void nothing) {}
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/response/AssignRoleToGroupResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/AssignRoleToGroupResponseImpl.java
@@ -15,12 +15,9 @@
  */
 package io.camunda.client.impl.response;
 
-import io.camunda.client.api.response.DeleteResourceResponse;
-import io.camunda.zeebe.gateway.protocol.GatewayOuterClass;
+import io.camunda.client.api.response.AssignRoleToGroupResponse;
 
-public class DeleteResourceResponseImpl implements DeleteResourceResponse {
+public class AssignRoleToGroupResponseImpl implements AssignRoleToGroupResponse {
 
-  public DeleteResourceResponseImpl(final GatewayOuterClass.DeleteResourceResponse response) {}
-
-  public DeleteResourceResponseImpl(final Void nothing) {}
+  public AssignRoleToGroupResponseImpl(final Void nothing) {}
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/response/AssignRoleToMappingRuleResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/AssignRoleToMappingRuleResponseImpl.java
@@ -15,12 +15,9 @@
  */
 package io.camunda.client.impl.response;
 
-import io.camunda.client.api.response.DeleteResourceResponse;
-import io.camunda.zeebe.gateway.protocol.GatewayOuterClass;
+import io.camunda.client.api.response.AssignRoleToMappingRuleResponse;
 
-public class DeleteResourceResponseImpl implements DeleteResourceResponse {
+public class AssignRoleToMappingRuleResponseImpl implements AssignRoleToMappingRuleResponse {
 
-  public DeleteResourceResponseImpl(final GatewayOuterClass.DeleteResourceResponse response) {}
-
-  public DeleteResourceResponseImpl(final Void nothing) {}
+  public AssignRoleToMappingRuleResponseImpl(final Void nothing) {}
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/response/AssignRoleToTenantResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/AssignRoleToTenantResponseImpl.java
@@ -15,12 +15,9 @@
  */
 package io.camunda.client.impl.response;
 
-import io.camunda.client.api.response.DeleteResourceResponse;
-import io.camunda.zeebe.gateway.protocol.GatewayOuterClass;
+import io.camunda.client.api.response.AssignRoleToTenantResponse;
 
-public class DeleteResourceResponseImpl implements DeleteResourceResponse {
+public class AssignRoleToTenantResponseImpl implements AssignRoleToTenantResponse {
 
-  public DeleteResourceResponseImpl(final GatewayOuterClass.DeleteResourceResponse response) {}
-
-  public DeleteResourceResponseImpl(final Void nothing) {}
+  public AssignRoleToTenantResponseImpl(final Void nothing) {}
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/response/AssignRoleToUserResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/AssignRoleToUserResponseImpl.java
@@ -15,12 +15,9 @@
  */
 package io.camunda.client.impl.response;
 
-import io.camunda.client.api.response.DeleteResourceResponse;
-import io.camunda.zeebe.gateway.protocol.GatewayOuterClass;
+import io.camunda.client.api.response.AssignRoleToUserResponse;
 
-public class DeleteResourceResponseImpl implements DeleteResourceResponse {
+public class AssignRoleToUserResponseImpl implements AssignRoleToUserResponse {
 
-  public DeleteResourceResponseImpl(final GatewayOuterClass.DeleteResourceResponse response) {}
-
-  public DeleteResourceResponseImpl(final Void nothing) {}
+  public AssignRoleToUserResponseImpl(final Void nothing) {}
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/response/AssignUserTaskResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/AssignUserTaskResponseImpl.java
@@ -15,12 +15,9 @@
  */
 package io.camunda.client.impl.response;
 
-import io.camunda.client.api.response.DeleteResourceResponse;
-import io.camunda.zeebe.gateway.protocol.GatewayOuterClass;
+import io.camunda.client.api.response.AssignUserTaskResponse;
 
-public class DeleteResourceResponseImpl implements DeleteResourceResponse {
+public class AssignUserTaskResponseImpl implements AssignUserTaskResponse {
 
-  public DeleteResourceResponseImpl(final GatewayOuterClass.DeleteResourceResponse response) {}
-
-  public DeleteResourceResponseImpl(final Void nothing) {}
+  public AssignUserTaskResponseImpl(final Void nothing) {}
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/response/AssignUserToGroupResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/AssignUserToGroupResponseImpl.java
@@ -17,4 +17,6 @@ package io.camunda.client.impl.response;
 
 import io.camunda.client.api.response.AssignUserToGroupResponse;
 
-public class AssignUserToGroupResponseImpl implements AssignUserToGroupResponse {}
+public class AssignUserToGroupResponseImpl implements AssignUserToGroupResponse {
+  public AssignUserToGroupResponseImpl(final Void nothing) {}
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/response/AssignUserToTenantResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/AssignUserToTenantResponseImpl.java
@@ -15,12 +15,9 @@
  */
 package io.camunda.client.impl.response;
 
-import io.camunda.client.api.response.DeleteResourceResponse;
-import io.camunda.zeebe.gateway.protocol.GatewayOuterClass;
+import io.camunda.client.api.response.AssignUserToTenantResponse;
 
-public class DeleteResourceResponseImpl implements DeleteResourceResponse {
+public class AssignUserToTenantResponseImpl implements AssignUserToTenantResponse {
 
-  public DeleteResourceResponseImpl(final GatewayOuterClass.DeleteResourceResponse response) {}
-
-  public DeleteResourceResponseImpl(final Void nothing) {}
+  public AssignUserToTenantResponseImpl(final Void nothing) {}
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/response/CancelBatchOperationResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/CancelBatchOperationResponseImpl.java
@@ -15,12 +15,9 @@
  */
 package io.camunda.client.impl.response;
 
-import io.camunda.client.api.response.DeleteResourceResponse;
-import io.camunda.zeebe.gateway.protocol.GatewayOuterClass;
+import io.camunda.client.api.response.CancelBatchOperationResponse;
 
-public class DeleteResourceResponseImpl implements DeleteResourceResponse {
+public class CancelBatchOperationResponseImpl implements CancelBatchOperationResponse {
 
-  public DeleteResourceResponseImpl(final GatewayOuterClass.DeleteResourceResponse response) {}
-
-  public DeleteResourceResponseImpl(final Void nothing) {}
+  public CancelBatchOperationResponseImpl(final Void nothing) {}
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/response/CancelProcessInstanceResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/CancelProcessInstanceResponseImpl.java
@@ -22,4 +22,6 @@ public class CancelProcessInstanceResponseImpl implements CancelProcessInstanceR
 
   public CancelProcessInstanceResponseImpl(
       final GatewayOuterClass.CancelProcessInstanceResponse response) {}
+
+  public CancelProcessInstanceResponseImpl(final Void nothing) {}
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/response/CompleteJobResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/CompleteJobResponseImpl.java
@@ -21,4 +21,6 @@ import io.camunda.zeebe.gateway.protocol.GatewayOuterClass;
 public class CompleteJobResponseImpl implements CompleteJobResponse {
 
   public CompleteJobResponseImpl(final GatewayOuterClass.CompleteJobResponse response) {}
+
+  public CompleteJobResponseImpl(final Void nothing) {}
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/response/CompleteUserTaskResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/CompleteUserTaskResponseImpl.java
@@ -15,12 +15,9 @@
  */
 package io.camunda.client.impl.response;
 
-import io.camunda.client.api.response.DeleteResourceResponse;
-import io.camunda.zeebe.gateway.protocol.GatewayOuterClass;
+import io.camunda.client.api.response.CompleteUserTaskResponse;
 
-public class DeleteResourceResponseImpl implements DeleteResourceResponse {
+public class CompleteUserTaskResponseImpl implements CompleteUserTaskResponse {
 
-  public DeleteResourceResponseImpl(final GatewayOuterClass.DeleteResourceResponse response) {}
-
-  public DeleteResourceResponseImpl(final Void nothing) {}
+  public CompleteUserTaskResponseImpl(final Void nothing) {}
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/response/DeleteAuthorizationResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/DeleteAuthorizationResponseImpl.java
@@ -15,12 +15,9 @@
  */
 package io.camunda.client.impl.response;
 
-import io.camunda.client.api.response.DeleteResourceResponse;
-import io.camunda.zeebe.gateway.protocol.GatewayOuterClass;
+import io.camunda.client.api.response.DeleteAuthorizationResponse;
 
-public class DeleteResourceResponseImpl implements DeleteResourceResponse {
+public class DeleteAuthorizationResponseImpl implements DeleteAuthorizationResponse {
 
-  public DeleteResourceResponseImpl(final GatewayOuterClass.DeleteResourceResponse response) {}
-
-  public DeleteResourceResponseImpl(final Void nothing) {}
+  public DeleteAuthorizationResponseImpl(final Void nothing) {}
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/response/DeleteDocumentResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/DeleteDocumentResponseImpl.java
@@ -15,12 +15,9 @@
  */
 package io.camunda.client.impl.response;
 
-import io.camunda.client.api.response.DeleteResourceResponse;
-import io.camunda.zeebe.gateway.protocol.GatewayOuterClass;
+import io.camunda.client.api.response.DeleteDocumentResponse;
 
-public class DeleteResourceResponseImpl implements DeleteResourceResponse {
+public class DeleteDocumentResponseImpl implements DeleteDocumentResponse {
 
-  public DeleteResourceResponseImpl(final GatewayOuterClass.DeleteResourceResponse response) {}
-
-  public DeleteResourceResponseImpl(final Void nothing) {}
+  public DeleteDocumentResponseImpl(final Void nothing) {}
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/response/DeleteGroupResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/DeleteGroupResponseImpl.java
@@ -17,4 +17,6 @@ package io.camunda.client.impl.response;
 
 import io.camunda.client.api.response.DeleteGroupResponse;
 
-public class DeleteGroupResponseImpl implements DeleteGroupResponse {}
+public class DeleteGroupResponseImpl implements DeleteGroupResponse {
+  public DeleteGroupResponseImpl(final Void nothing) {}
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/response/DeleteRoleResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/DeleteRoleResponseImpl.java
@@ -15,12 +15,9 @@
  */
 package io.camunda.client.impl.response;
 
-import io.camunda.client.api.response.DeleteResourceResponse;
-import io.camunda.zeebe.gateway.protocol.GatewayOuterClass;
+import io.camunda.client.api.response.DeleteRoleResponse;
 
-public class DeleteResourceResponseImpl implements DeleteResourceResponse {
+public class DeleteRoleResponseImpl implements DeleteRoleResponse {
 
-  public DeleteResourceResponseImpl(final GatewayOuterClass.DeleteResourceResponse response) {}
-
-  public DeleteResourceResponseImpl(final Void nothing) {}
+  public DeleteRoleResponseImpl(final Void nothing) {}
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/response/DeleteTenantResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/DeleteTenantResponseImpl.java
@@ -15,12 +15,9 @@
  */
 package io.camunda.client.impl.response;
 
-import io.camunda.client.api.response.DeleteResourceResponse;
-import io.camunda.zeebe.gateway.protocol.GatewayOuterClass;
+import io.camunda.client.api.response.DeleteTenantResponse;
 
-public class DeleteResourceResponseImpl implements DeleteResourceResponse {
+public class DeleteTenantResponseImpl implements DeleteTenantResponse {
 
-  public DeleteResourceResponseImpl(final GatewayOuterClass.DeleteResourceResponse response) {}
-
-  public DeleteResourceResponseImpl(final Void nothing) {}
+  public DeleteTenantResponseImpl(final Void nothing) {}
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/response/DeleteUserResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/DeleteUserResponseImpl.java
@@ -15,12 +15,9 @@
  */
 package io.camunda.client.impl.response;
 
-import io.camunda.client.api.response.DeleteResourceResponse;
-import io.camunda.zeebe.gateway.protocol.GatewayOuterClass;
+import io.camunda.client.api.response.DeleteUserResponse;
 
-public class DeleteResourceResponseImpl implements DeleteResourceResponse {
+public class DeleteUserResponseImpl implements DeleteUserResponse {
 
-  public DeleteResourceResponseImpl(final GatewayOuterClass.DeleteResourceResponse response) {}
-
-  public DeleteResourceResponseImpl(final Void nothing) {}
+  public DeleteUserResponseImpl(final Void nothing) {}
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/response/FailJobResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/FailJobResponseImpl.java
@@ -21,4 +21,6 @@ import io.camunda.zeebe.gateway.protocol.GatewayOuterClass;
 public class FailJobResponseImpl implements FailJobResponse {
 
   public FailJobResponseImpl(final GatewayOuterClass.FailJobResponse response) {}
+
+  public FailJobResponseImpl(final Void nothing) {}
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/response/MigrateProcessInstanceResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/MigrateProcessInstanceResponseImpl.java
@@ -22,4 +22,6 @@ public final class MigrateProcessInstanceResponseImpl implements MigrateProcessI
 
   public MigrateProcessInstanceResponseImpl(
       final GatewayOuterClass.MigrateProcessInstanceResponse response) {}
+
+  public MigrateProcessInstanceResponseImpl(final Void nothing) {}
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/response/ModifyProcessInstanceResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/ModifyProcessInstanceResponseImpl.java
@@ -22,4 +22,6 @@ public class ModifyProcessInstanceResponseImpl implements ModifyProcessInstanceR
 
   public ModifyProcessInstanceResponseImpl(
       final GatewayOuterClass.ModifyProcessInstanceResponse response) {}
+
+  public ModifyProcessInstanceResponseImpl(final Void nothing) {}
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/response/PinClockResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/PinClockResponseImpl.java
@@ -15,12 +15,9 @@
  */
 package io.camunda.client.impl.response;
 
-import io.camunda.client.api.response.DeleteResourceResponse;
-import io.camunda.zeebe.gateway.protocol.GatewayOuterClass;
+import io.camunda.client.api.response.PinClockResponse;
 
-public class DeleteResourceResponseImpl implements DeleteResourceResponse {
+public class PinClockResponseImpl implements PinClockResponse {
 
-  public DeleteResourceResponseImpl(final GatewayOuterClass.DeleteResourceResponse response) {}
-
-  public DeleteResourceResponseImpl(final Void nothing) {}
+  public PinClockResponseImpl(final Void nothing) {}
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/response/ResetClockResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/ResetClockResponseImpl.java
@@ -15,12 +15,9 @@
  */
 package io.camunda.client.impl.response;
 
-import io.camunda.client.api.response.DeleteResourceResponse;
-import io.camunda.zeebe.gateway.protocol.GatewayOuterClass;
+import io.camunda.client.api.response.ResetClockResponse;
 
-public class DeleteResourceResponseImpl implements DeleteResourceResponse {
+public class ResetClockResponseImpl implements ResetClockResponse {
 
-  public DeleteResourceResponseImpl(final GatewayOuterClass.DeleteResourceResponse response) {}
-
-  public DeleteResourceResponseImpl(final Void nothing) {}
+  public ResetClockResponseImpl(final Void nothing) {}
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/response/ResolveIncidentResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/ResolveIncidentResponseImpl.java
@@ -21,4 +21,6 @@ import io.camunda.zeebe.gateway.protocol.GatewayOuterClass;
 public class ResolveIncidentResponseImpl implements ResolveIncidentResponse {
 
   public ResolveIncidentResponseImpl(final GatewayOuterClass.ResolveIncidentResponse response) {}
+
+  public ResolveIncidentResponseImpl(final Void nothing) {}
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/response/ResumeBatchOperationResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/ResumeBatchOperationResponseImpl.java
@@ -15,12 +15,9 @@
  */
 package io.camunda.client.impl.response;
 
-import io.camunda.client.api.response.DeleteResourceResponse;
-import io.camunda.zeebe.gateway.protocol.GatewayOuterClass;
+import io.camunda.client.api.response.ResumeBatchOperationResponse;
 
-public class DeleteResourceResponseImpl implements DeleteResourceResponse {
+public class ResumeBatchOperationResponseImpl implements ResumeBatchOperationResponse {
 
-  public DeleteResourceResponseImpl(final GatewayOuterClass.DeleteResourceResponse response) {}
-
-  public DeleteResourceResponseImpl(final Void nothing) {}
+  public ResumeBatchOperationResponseImpl(final Void nothing) {}
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/response/SetVariablesResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/SetVariablesResponseImpl.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.gateway.protocol.GatewayOuterClass;
 
 public final class SetVariablesResponseImpl implements SetVariablesResponse {
 
+  private static final long DEFAULT_KEY = -1;
   private final long key;
 
   public SetVariablesResponseImpl(final GatewayOuterClass.SetVariablesResponse response) {
@@ -27,7 +28,7 @@ public final class SetVariablesResponseImpl implements SetVariablesResponse {
   }
 
   public SetVariablesResponseImpl(final Void nothing) {
-    key = -1;
+    key = DEFAULT_KEY;
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/client/impl/response/SetVariablesResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/SetVariablesResponseImpl.java
@@ -26,6 +26,10 @@ public final class SetVariablesResponseImpl implements SetVariablesResponse {
     key = response.getKey();
   }
 
+  public SetVariablesResponseImpl(final Void nothing) {
+    key = -1;
+  }
+
   @Override
   public long getKey() {
     return key;

--- a/clients/java/src/main/java/io/camunda/client/impl/response/SuspendBatchOperationResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/SuspendBatchOperationResponseImpl.java
@@ -15,12 +15,9 @@
  */
 package io.camunda.client.impl.response;
 
-import io.camunda.client.api.response.DeleteResourceResponse;
-import io.camunda.zeebe.gateway.protocol.GatewayOuterClass;
+import io.camunda.client.api.response.SuspendBatchOperationResponse;
 
-public class DeleteResourceResponseImpl implements DeleteResourceResponse {
+public class SuspendBatchOperationResponseImpl implements SuspendBatchOperationResponse {
 
-  public DeleteResourceResponseImpl(final GatewayOuterClass.DeleteResourceResponse response) {}
-
-  public DeleteResourceResponseImpl(final Void nothing) {}
+  public SuspendBatchOperationResponseImpl(final Void nothing) {}
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/response/ThrowErrorResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/ThrowErrorResponseImpl.java
@@ -15,12 +15,12 @@
  */
 package io.camunda.client.impl.response;
 
-import io.camunda.client.api.response.DeleteResourceResponse;
+import io.camunda.client.api.response.ThrowErrorResponse;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass;
 
-public class DeleteResourceResponseImpl implements DeleteResourceResponse {
+public class ThrowErrorResponseImpl implements ThrowErrorResponse {
 
-  public DeleteResourceResponseImpl(final GatewayOuterClass.DeleteResourceResponse response) {}
+  public ThrowErrorResponseImpl(final Void nothing) {}
 
-  public DeleteResourceResponseImpl(final Void nothing) {}
+  public ThrowErrorResponseImpl(final GatewayOuterClass.ThrowErrorResponse response) {}
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/response/UnassignClientFromGroupResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/UnassignClientFromGroupResponseImpl.java
@@ -15,12 +15,9 @@
  */
 package io.camunda.client.impl.response;
 
-import io.camunda.client.api.response.DeleteResourceResponse;
-import io.camunda.zeebe.gateway.protocol.GatewayOuterClass;
+import io.camunda.client.api.response.UnassignClientFromGroupResponse;
 
-public class DeleteResourceResponseImpl implements DeleteResourceResponse {
+public class UnassignClientFromGroupResponseImpl implements UnassignClientFromGroupResponse {
 
-  public DeleteResourceResponseImpl(final GatewayOuterClass.DeleteResourceResponse response) {}
-
-  public DeleteResourceResponseImpl(final Void nothing) {}
+  public UnassignClientFromGroupResponseImpl(final Void nothing) {}
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/response/UnassignGroupFromTenantResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/UnassignGroupFromTenantResponseImpl.java
@@ -15,12 +15,9 @@
  */
 package io.camunda.client.impl.response;
 
-import io.camunda.client.api.response.DeleteResourceResponse;
-import io.camunda.zeebe.gateway.protocol.GatewayOuterClass;
+import io.camunda.client.api.response.UnassignGroupFromTenantResponse;
 
-public class DeleteResourceResponseImpl implements DeleteResourceResponse {
+public class UnassignGroupFromTenantResponseImpl implements UnassignGroupFromTenantResponse {
 
-  public DeleteResourceResponseImpl(final GatewayOuterClass.DeleteResourceResponse response) {}
-
-  public DeleteResourceResponseImpl(final Void nothing) {}
+  public UnassignGroupFromTenantResponseImpl(final Void nothing) {}
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/response/UnassignMappingRuleFromGroupResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/UnassignMappingRuleFromGroupResponseImpl.java
@@ -15,12 +15,10 @@
  */
 package io.camunda.client.impl.response;
 
-import io.camunda.client.api.response.DeleteResourceResponse;
-import io.camunda.zeebe.gateway.protocol.GatewayOuterClass;
+import io.camunda.client.api.response.UnassignMappingRuleFromGroupResponse;
 
-public class DeleteResourceResponseImpl implements DeleteResourceResponse {
+public class UnassignMappingRuleFromGroupResponseImpl
+    implements UnassignMappingRuleFromGroupResponse {
 
-  public DeleteResourceResponseImpl(final GatewayOuterClass.DeleteResourceResponse response) {}
-
-  public DeleteResourceResponseImpl(final Void nothing) {}
+  public UnassignMappingRuleFromGroupResponseImpl(final Void nothing) {}
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/response/UnassignRoleFromClientResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/UnassignRoleFromClientResponseImpl.java
@@ -15,12 +15,9 @@
  */
 package io.camunda.client.impl.response;
 
-import io.camunda.client.api.response.DeleteResourceResponse;
-import io.camunda.zeebe.gateway.protocol.GatewayOuterClass;
+import io.camunda.client.api.response.UnassignRoleFromClientResponse;
 
-public class DeleteResourceResponseImpl implements DeleteResourceResponse {
+public class UnassignRoleFromClientResponseImpl implements UnassignRoleFromClientResponse {
 
-  public DeleteResourceResponseImpl(final GatewayOuterClass.DeleteResourceResponse response) {}
-
-  public DeleteResourceResponseImpl(final Void nothing) {}
+  public UnassignRoleFromClientResponseImpl(final Void nothing) {}
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/response/UnassignRoleFromGroupResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/UnassignRoleFromGroupResponseImpl.java
@@ -15,12 +15,9 @@
  */
 package io.camunda.client.impl.response;
 
-import io.camunda.client.api.response.DeleteResourceResponse;
-import io.camunda.zeebe.gateway.protocol.GatewayOuterClass;
+import io.camunda.client.api.response.UnassignRoleFromGroupResponse;
 
-public class DeleteResourceResponseImpl implements DeleteResourceResponse {
+public class UnassignRoleFromGroupResponseImpl implements UnassignRoleFromGroupResponse {
 
-  public DeleteResourceResponseImpl(final GatewayOuterClass.DeleteResourceResponse response) {}
-
-  public DeleteResourceResponseImpl(final Void nothing) {}
+  public UnassignRoleFromGroupResponseImpl(final Void nothing) {}
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/response/UnassignRoleFromMappingRuleResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/UnassignRoleFromMappingRuleResponseImpl.java
@@ -15,12 +15,10 @@
  */
 package io.camunda.client.impl.response;
 
-import io.camunda.client.api.response.DeleteResourceResponse;
-import io.camunda.zeebe.gateway.protocol.GatewayOuterClass;
+import io.camunda.client.api.response.UnassignRoleFromMappingRuleResponse;
 
-public class DeleteResourceResponseImpl implements DeleteResourceResponse {
+public class UnassignRoleFromMappingRuleResponseImpl
+    implements UnassignRoleFromMappingRuleResponse {
 
-  public DeleteResourceResponseImpl(final GatewayOuterClass.DeleteResourceResponse response) {}
-
-  public DeleteResourceResponseImpl(final Void nothing) {}
+  public UnassignRoleFromMappingRuleResponseImpl(final Void nothing) {}
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/response/UnassignRoleFromTenantResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/UnassignRoleFromTenantResponseImpl.java
@@ -15,12 +15,9 @@
  */
 package io.camunda.client.impl.response;
 
-import io.camunda.client.api.response.DeleteResourceResponse;
-import io.camunda.zeebe.gateway.protocol.GatewayOuterClass;
+import io.camunda.client.api.response.UnassignRoleFromTenantResponse;
 
-public class DeleteResourceResponseImpl implements DeleteResourceResponse {
+public class UnassignRoleFromTenantResponseImpl implements UnassignRoleFromTenantResponse {
 
-  public DeleteResourceResponseImpl(final GatewayOuterClass.DeleteResourceResponse response) {}
-
-  public DeleteResourceResponseImpl(final Void nothing) {}
+  public UnassignRoleFromTenantResponseImpl(final Void nothing) {}
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/response/UnassignUserFromGroupResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/UnassignUserFromGroupResponseImpl.java
@@ -17,4 +17,7 @@ package io.camunda.client.impl.response;
 
 import io.camunda.client.api.response.UnassignUserFromGroupResponse;
 
-public class UnassignUserFromGroupResponseImpl implements UnassignUserFromGroupResponse {}
+public class UnassignUserFromGroupResponseImpl implements UnassignUserFromGroupResponse {
+
+  public UnassignUserFromGroupResponseImpl(final Void nothing) {}
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/response/UnassignUserFromRoleResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/UnassignUserFromRoleResponseImpl.java
@@ -15,12 +15,9 @@
  */
 package io.camunda.client.impl.response;
 
-import io.camunda.client.api.response.DeleteResourceResponse;
-import io.camunda.zeebe.gateway.protocol.GatewayOuterClass;
+import io.camunda.client.api.response.UnassignUserFromRoleResponse;
 
-public class DeleteResourceResponseImpl implements DeleteResourceResponse {
+public class UnassignUserFromRoleResponseImpl implements UnassignUserFromRoleResponse {
 
-  public DeleteResourceResponseImpl(final GatewayOuterClass.DeleteResourceResponse response) {}
-
-  public DeleteResourceResponseImpl(final Void nothing) {}
+  public UnassignUserFromRoleResponseImpl(final Void nothing) {}
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/response/UnassignUserFromTenantResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/UnassignUserFromTenantResponseImpl.java
@@ -15,12 +15,9 @@
  */
 package io.camunda.client.impl.response;
 
-import io.camunda.client.api.response.DeleteResourceResponse;
-import io.camunda.zeebe.gateway.protocol.GatewayOuterClass;
+import io.camunda.client.api.response.UnassignUserFromTenantResponse;
 
-public class DeleteResourceResponseImpl implements DeleteResourceResponse {
+public class UnassignUserFromTenantResponseImpl implements UnassignUserFromTenantResponse {
 
-  public DeleteResourceResponseImpl(final GatewayOuterClass.DeleteResourceResponse response) {}
-
-  public DeleteResourceResponseImpl(final Void nothing) {}
+  public UnassignUserFromTenantResponseImpl(final Void nothing) {}
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/response/UnassignUserTaskResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/UnassignUserTaskResponseImpl.java
@@ -15,12 +15,9 @@
  */
 package io.camunda.client.impl.response;
 
-import io.camunda.client.api.response.DeleteResourceResponse;
-import io.camunda.zeebe.gateway.protocol.GatewayOuterClass;
+import io.camunda.client.api.response.UnassignUserTaskResponse;
 
-public class DeleteResourceResponseImpl implements DeleteResourceResponse {
+public class UnassignUserTaskResponseImpl implements UnassignUserTaskResponse {
 
-  public DeleteResourceResponseImpl(final GatewayOuterClass.DeleteResourceResponse response) {}
-
-  public DeleteResourceResponseImpl(final Void nothing) {}
+  public UnassignUserTaskResponseImpl(final Void nothing) {}
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/response/UpdateAuthorizationResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/UpdateAuthorizationResponseImpl.java
@@ -15,12 +15,9 @@
  */
 package io.camunda.client.impl.response;
 
-import io.camunda.client.api.response.DeleteResourceResponse;
-import io.camunda.zeebe.gateway.protocol.GatewayOuterClass;
+import io.camunda.client.api.response.UpdateAuthorizationResponse;
 
-public class DeleteResourceResponseImpl implements DeleteResourceResponse {
+public class UpdateAuthorizationResponseImpl implements UpdateAuthorizationResponse {
 
-  public DeleteResourceResponseImpl(final GatewayOuterClass.DeleteResourceResponse response) {}
-
-  public DeleteResourceResponseImpl(final Void nothing) {}
+  public UpdateAuthorizationResponseImpl(final Void nothing) {}
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/response/UpdateJobResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/UpdateJobResponseImpl.java
@@ -15,12 +15,9 @@
  */
 package io.camunda.client.impl.response;
 
-import io.camunda.client.api.response.DeleteResourceResponse;
-import io.camunda.zeebe.gateway.protocol.GatewayOuterClass;
+import io.camunda.client.api.response.UpdateJobResponse;
 
-public class DeleteResourceResponseImpl implements DeleteResourceResponse {
+public class UpdateJobResponseImpl implements UpdateJobResponse {
 
-  public DeleteResourceResponseImpl(final GatewayOuterClass.DeleteResourceResponse response) {}
-
-  public DeleteResourceResponseImpl(final Void nothing) {}
+  public UpdateJobResponseImpl(final Void nothing) {}
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/response/UpdateRetriesJobResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/UpdateRetriesJobResponseImpl.java
@@ -21,4 +21,6 @@ import io.camunda.zeebe.gateway.protocol.GatewayOuterClass;
 public class UpdateRetriesJobResponseImpl implements UpdateRetriesJobResponse {
 
   public UpdateRetriesJobResponseImpl(final GatewayOuterClass.UpdateJobRetriesResponse response) {}
+
+  public UpdateRetriesJobResponseImpl(final Void nothing) {}
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/response/UpdateTimeoutJobResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/UpdateTimeoutJobResponseImpl.java
@@ -21,4 +21,6 @@ import io.camunda.zeebe.gateway.protocol.GatewayOuterClass;
 public class UpdateTimeoutJobResponseImpl implements UpdateTimeoutJobResponse {
 
   public UpdateTimeoutJobResponseImpl(final GatewayOuterClass.UpdateJobTimeoutResponse response) {}
+
+  public UpdateTimeoutJobResponseImpl(final Void nothing) {}
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/response/UpdateUserTaskResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/UpdateUserTaskResponseImpl.java
@@ -15,12 +15,9 @@
  */
 package io.camunda.client.impl.response;
 
-import io.camunda.client.api.response.DeleteResourceResponse;
-import io.camunda.zeebe.gateway.protocol.GatewayOuterClass;
+import io.camunda.client.api.response.UpdateUserTaskResponse;
 
-public class DeleteResourceResponseImpl implements DeleteResourceResponse {
+public class UpdateUserTaskResponseImpl implements UpdateUserTaskResponse {
 
-  public DeleteResourceResponseImpl(final GatewayOuterClass.DeleteResourceResponse response) {}
-
-  public DeleteResourceResponseImpl(final Void nothing) {}
+  public UpdateUserTaskResponseImpl(final Void nothing) {}
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/BatchOperationErrorImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/BatchOperationErrorImpl.java
@@ -17,15 +17,16 @@ package io.camunda.client.impl.search.response;
 
 import io.camunda.client.api.search.enums.BatchOperationErrorType;
 import io.camunda.client.api.search.response.BatchOperationError;
+import io.camunda.client.impl.util.EnumUtil;
 
 public class BatchOperationErrorImpl implements BatchOperationError {
 
   private final BatchOperationErrorType type;
   private final String message;
-  private final int partitionId;
+  private final Integer partitionId;
 
   public BatchOperationErrorImpl(final io.camunda.client.protocol.rest.BatchOperationError item) {
-    type = item.getType() != null ? BatchOperationErrorType.valueOf(item.getType().name()) : null;
+    type = EnumUtil.convert(item.getType(), BatchOperationErrorType.class);
     message = item.getMessage();
     partitionId = item.getPartitionId();
   }
@@ -41,7 +42,7 @@ public class BatchOperationErrorImpl implements BatchOperationError {
   }
 
   @Override
-  public int getPartitionId() {
+  public Integer getPartitionId() {
     return partitionId;
   }
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/FormImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/FormImpl.java
@@ -16,21 +16,24 @@
 package io.camunda.client.impl.search.response;
 
 import io.camunda.client.api.search.response.Form;
+import io.camunda.client.impl.util.ParseUtil;
 import io.camunda.client.protocol.rest.FormResult;
 
 public class FormImpl implements Form {
-  private final String formId;
-  private final long version;
-  private final long formKey;
-  private final Object schema;
-  private final String tenantId;
+  private String formId;
+  private Long version;
+  private Long formKey;
+  private Object schema;
+  private String tenantId;
 
   public FormImpl(final FormResult item) {
-    formId = item.getFormId();
-    version = item.getVersion();
-    formKey = Long.parseLong(item.getFormKey());
-    schema = item.getSchema();
-    tenantId = item.getTenantId();
+    if (item != null) {
+      formId = item.getFormId();
+      version = item.getVersion();
+      formKey = ParseUtil.parseLongOrNull(item.getFormKey());
+      schema = item.getSchema();
+      tenantId = item.getTenantId();
+    }
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/ClockPinCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/ClockPinCommandStep1.java
@@ -20,7 +20,7 @@ import java.time.Instant;
 
 /**
  * @deprecated since 8.8 for removal in 8.10, replaced by {@link
- *     io.camunda.client.api.command.ClockPinCommandStep1}
+ *     io.camunda.client.api.command.PinClockCommandStep1}
  */
 @Deprecated
 public interface ClockPinCommandStep1 extends FinalCommandStep<PinClockResponse> {

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/ClockResetCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/ClockResetCommandStep1.java
@@ -19,7 +19,7 @@ import io.camunda.zeebe.client.api.response.ResetClockResponse;
 
 /**
  * @deprecated since 8.8 for removal in 8.10, replaced by {@link
- *     io.camunda.client.api.command.ClockResetCommandStep1}
+ *     io.camunda.client.api.command.ResetClockCommandStep1}
  */
 @Deprecated
 public interface ClockResetCommandStep1 extends FinalCommandStep<ResetClockResponse> {

--- a/clients/java/src/test/java/io/camunda/client/ClientRestInterceptorTest.java
+++ b/clients/java/src/test/java/io/camunda/client/ClientRestInterceptorTest.java
@@ -102,7 +102,7 @@ public class ClientRestInterceptorTest {
 
     // when
     final Future<CompleteUserTaskResponse> response =
-        client.newUserTaskCompleteCommand(1234L).send();
+        client.newCompleteUserTaskCommand(1234L).send();
 
     // then
     assertThatThrownBy(() -> response.get())

--- a/clients/java/src/test/java/io/camunda/client/authorization/CreateAuthorizationTest.java
+++ b/clients/java/src/test/java/io/camunda/client/authorization/CreateAuthorizationTest.java
@@ -21,14 +21,20 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import io.camunda.client.api.search.enums.OwnerType;
 import io.camunda.client.api.search.enums.PermissionType;
 import io.camunda.client.api.search.enums.ResourceType;
+import io.camunda.client.protocol.rest.AuthorizationCreateResult;
 import io.camunda.client.protocol.rest.AuthorizationRequest;
 import io.camunda.client.util.ClientRestTest;
+import org.instancio.Instancio;
 import org.junit.jupiter.api.Test;
 
 public class CreateAuthorizationTest extends ClientRestTest {
 
   @Test
   void shouldSendCommand() {
+    // given
+    gatewayService.onCreateAuthorizationRequest(
+        Instancio.create(AuthorizationCreateResult.class).authorizationKey("3"));
+
     // when
     client
         .newCreateAuthorizationCommand()

--- a/clients/java/src/test/java/io/camunda/client/authorization/SearchAuthorizationTest.java
+++ b/clients/java/src/test/java/io/camunda/client/authorization/SearchAuthorizationTest.java
@@ -20,7 +20,10 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.github.tomakehurst.wiremock.http.RequestMethod;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+import io.camunda.client.protocol.rest.AuthorizationResult;
 import io.camunda.client.util.ClientRestTest;
+import io.camunda.client.util.RestGatewayPaths;
+import org.instancio.Instancio;
 import org.junit.jupiter.api.Test;
 
 public class SearchAuthorizationTest extends ClientRestTest {
@@ -29,12 +32,16 @@ public class SearchAuthorizationTest extends ClientRestTest {
 
   @Test
   public void shouldSearchAuthorizationByAuthorizationKey() {
+    // given
+    gatewayService.onAuthorizationRequest(
+        AUTHORIZATION_KEY, Instancio.create(AuthorizationResult.class).authorizationKey("1"));
+
     // when
     client.newAuthorizationGetRequest(AUTHORIZATION_KEY).send().join();
 
     // then
     final LoggedRequest request = gatewayService.getLastRequest();
-    assertThat(request.getUrl()).isEqualTo("/v2/authorizations/" + AUTHORIZATION_KEY);
+    assertThat(request.getUrl()).isEqualTo(RestGatewayPaths.getAuthorizationUrl(AUTHORIZATION_KEY));
     assertThat(request.getMethod()).isEqualTo(RequestMethod.GET);
   }
 

--- a/clients/java/src/test/java/io/camunda/client/batchoperation/CreateBatchOperationTest.java
+++ b/clients/java/src/test/java/io/camunda/client/batchoperation/CreateBatchOperationTest.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.github.tomakehurst.wiremock.http.RequestMethod;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+import io.camunda.client.protocol.rest.BatchOperationCreatedResult;
 import io.camunda.client.protocol.rest.MigrateProcessInstanceMappingInstruction;
 import io.camunda.client.protocol.rest.ProcessInstanceFilter;
 import io.camunda.client.protocol.rest.ProcessInstanceMigrationBatchOperationPlan;
@@ -27,12 +28,17 @@ import io.camunda.client.protocol.rest.ProcessInstanceModificationBatchOperation
 import io.camunda.client.util.ClientRestTest;
 import io.camunda.client.util.RestGatewayService;
 import java.util.List;
+import org.instancio.Instancio;
 import org.junit.jupiter.api.Test;
 
 public final class CreateBatchOperationTest extends ClientRestTest {
 
   @Test
   public void shouldSendProcessInstanceCancelCommandEmptyFilter() {
+    // given
+    gatewayService.onCancelProcessInstancesRequest(
+        Instancio.create(BatchOperationCreatedResult.class).batchOperationKey("2"));
+
     // when
     client
         .newCreateBatchOperationCommand()
@@ -52,6 +58,10 @@ public final class CreateBatchOperationTest extends ClientRestTest {
 
   @Test
   public void shouldSendProcessInstanceCancelCommandWithFilter() {
+    // given
+    gatewayService.onCancelProcessInstancesRequest(
+        Instancio.create(BatchOperationCreatedResult.class).batchOperationKey("2"));
+
     // when
     client
         .newCreateBatchOperationCommand()
@@ -71,6 +81,10 @@ public final class CreateBatchOperationTest extends ClientRestTest {
 
   @Test
   public void shouldSendProcessInstanceMigrationCommand() {
+    // given
+    gatewayService.onMigrateProcessInstancesRequest(
+        Instancio.create(BatchOperationCreatedResult.class).batchOperationKey("2"));
+
     // when
     client
         .newCreateBatchOperationCommand()
@@ -104,6 +118,10 @@ public final class CreateBatchOperationTest extends ClientRestTest {
 
   @Test
   public void shouldSendProcessInstanceModificationCommand() {
+    // given
+    gatewayService.onModifyProcessInstances(
+        Instancio.create(BatchOperationCreatedResult.class).batchOperationKey("2"));
+
     // when
     client
         .newCreateBatchOperationCommand()

--- a/clients/java/src/test/java/io/camunda/client/batchoperation/QueryBatchOperationTest.java
+++ b/clients/java/src/test/java/io/camunda/client/batchoperation/QueryBatchOperationTest.java
@@ -23,14 +23,20 @@ import io.camunda.client.protocol.rest.*;
 import io.camunda.client.util.ClientRestTest;
 import io.camunda.client.util.RestGatewayService;
 import java.util.*;
+import org.instancio.Instancio;
 import org.junit.jupiter.api.Test;
 
 public class QueryBatchOperationTest extends ClientRestTest {
 
   @Test
   public void shouldGetBatchOperationByKey() {
+    // given
+    final String batchOperationKey = "123";
+    gatewayService.onBatchOperationRequest(
+        batchOperationKey, Instancio.create(BatchOperationResponse.class));
+
     // when
-    client.newBatchOperationGetRequest("123").send().join();
+    client.newBatchOperationGetRequest(batchOperationKey).send().join();
 
     // then
     final LoggedRequest request = RestGatewayService.getLastRequest();

--- a/clients/java/src/test/java/io/camunda/client/clock/PinClockTest.java
+++ b/clients/java/src/test/java/io/camunda/client/clock/PinClockTest.java
@@ -40,7 +40,7 @@ public final class PinClockTest extends ClientRestTest {
     final long timestamp = 1742461285000L;
 
     // when
-    client.newClockPinCommand().time(timestamp).send().join();
+    client.newPinClockCommand().time(timestamp).send().join();
 
     // then
     assertThat(RestGatewayService.getLastRequest())
@@ -53,7 +53,7 @@ public final class PinClockTest extends ClientRestTest {
   @Test
   void shouldRaiseIllegalArgumentExceptionWhenNegativeTimestampProvided() {
     // when / then
-    assertThatThrownBy(() -> client.newClockPinCommand().time(-1L).send().join())
+    assertThatThrownBy(() -> client.newPinClockCommand().time(-1L).send().join())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("timestamp must be not negative");
   }
@@ -66,7 +66,7 @@ public final class PinClockTest extends ClientRestTest {
   @MethodSource("validInstantValues")
   void shouldPinClockToInstant(final Instant validInstant) {
     // when
-    client.newClockPinCommand().time(validInstant).send().join();
+    client.newPinClockCommand().time(validInstant).send().join();
 
     // then
     assertThat(RestGatewayService.getLastRequest())
@@ -89,7 +89,7 @@ public final class PinClockTest extends ClientRestTest {
   void shouldRaiseIllegalArgumentExceptionWhenInvalidInstantProvided(
       final Instant invalidInstant, final String expectedMessage) {
     // when / then
-    assertThatThrownBy(() -> client.newClockPinCommand().time(invalidInstant).send().join())
+    assertThatThrownBy(() -> client.newPinClockCommand().time(invalidInstant).send().join())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage(expectedMessage);
   }

--- a/clients/java/src/test/java/io/camunda/client/clock/ResetClockTest.java
+++ b/clients/java/src/test/java/io/camunda/client/clock/ResetClockTest.java
@@ -28,7 +28,7 @@ public final class ResetClockTest extends ClientRestTest {
   @Test
   void shouldResetClock() {
     // when
-    client.newClockResetCommand().send().join();
+    client.newResetClockCommand().send().join();
 
     // then
     assertThat(RestGatewayService.getLastRequest())

--- a/clients/java/src/test/java/io/camunda/client/decision/GetDecisionDefinitionTest.java
+++ b/clients/java/src/test/java/io/camunda/client/decision/GetDecisionDefinitionTest.java
@@ -19,15 +19,24 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.github.tomakehurst.wiremock.http.RequestMethod;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+import io.camunda.client.protocol.rest.DecisionDefinitionResult;
 import io.camunda.client.util.ClientRestTest;
+import org.instancio.Instancio;
 import org.junit.jupiter.api.Test;
 
 public final class GetDecisionDefinitionTest extends ClientRestTest {
 
   @Test
   void shouldGetDecisionDefinition() {
-    // when
+    // given
     final long decisionDefinitionKey = 1L;
+    gatewayService.onDecisionDefinitionRequest(
+        decisionDefinitionKey,
+        Instancio.create(DecisionDefinitionResult.class)
+            .decisionDefinitionKey("1")
+            .decisionRequirementsKey("3"));
+
+    // when
     client.newDecisionDefinitionGetRequest(decisionDefinitionKey).send().join();
 
     // then

--- a/clients/java/src/test/java/io/camunda/client/decision/GetDecisionInstanceTest.java
+++ b/clients/java/src/test/java/io/camunda/client/decision/GetDecisionInstanceTest.java
@@ -19,15 +19,27 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.github.tomakehurst.wiremock.http.RequestMethod;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+import io.camunda.client.protocol.rest.DecisionInstanceResult;
 import io.camunda.client.util.ClientRestTest;
+import org.instancio.Instancio;
 import org.junit.jupiter.api.Test;
 
 public final class GetDecisionInstanceTest extends ClientRestTest {
 
   @Test
   void shouldGetDecisionInstance() {
-    // when
+    // given
     final String decisionInstanceId = "1-1";
+    gatewayService.onDecisionInstanceRequest(
+        decisionInstanceId,
+        Instancio.create(DecisionInstanceResult.class)
+            .decisionInstanceKey("1")
+            .decisionDefinitionKey("2")
+            .elementInstanceKey("3")
+            .processDefinitionKey("4")
+            .processInstanceKey("5"));
+
+    // when
     client.newDecisionInstanceGetRequest(decisionInstanceId).send().join();
 
     // then

--- a/clients/java/src/test/java/io/camunda/client/decision/GetDecisionRequirementsTest.java
+++ b/clients/java/src/test/java/io/camunda/client/decision/GetDecisionRequirementsTest.java
@@ -19,19 +19,28 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.github.tomakehurst.wiremock.http.RequestMethod;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+import io.camunda.client.protocol.rest.DecisionRequirementsResult;
 import io.camunda.client.util.ClientRestTest;
+import io.camunda.client.util.RestGatewayPaths;
+import org.instancio.Instancio;
 import org.junit.jupiter.api.Test;
 
 public class GetDecisionRequirementsTest extends ClientRestTest {
   @Test
   void shouldGetDecisionRequirements() {
-    // when
+    // given
     final long decisionRequirementsKey = 1L;
+    gatewayService.onDecisionRequirementsRequest(
+        decisionRequirementsKey,
+        Instancio.create(DecisionRequirementsResult.class).decisionRequirementsKey("3"));
+
+    // when
     client.newDecisionRequirementsGetRequest(decisionRequirementsKey).send().join();
 
     // then
     final LoggedRequest request = gatewayService.getLastRequest();
-    assertThat(request.getUrl()).isEqualTo("/v2/decision-requirements/" + decisionRequirementsKey);
+    assertThat(request.getUrl())
+        .isEqualTo(RestGatewayPaths.getDecisionRequirementsUrl(decisionRequirementsKey));
     assertThat(request.getMethod()).isEqualTo(RequestMethod.GET);
   }
 }

--- a/clients/java/src/test/java/io/camunda/client/decision/rest/DecisionEvaluationRestTest.java
+++ b/clients/java/src/test/java/io/camunda/client/decision/rest/DecisionEvaluationRestTest.java
@@ -117,6 +117,7 @@ public class DecisionEvaluationRestTest extends ClientRestTest {
   @Test
   public void shouldEvaluateStandaloneDecisionWithStringVariables() {
     // given
+    gatewayService.onEvaluateDecisionRequest(EVALUATE_DECISION_RESPONSE);
     client
         .newEvaluateDecisionCommand()
         .decisionKey(DECISION_KEY)
@@ -135,9 +136,11 @@ public class DecisionEvaluationRestTest extends ClientRestTest {
   @Test
   public void shouldEvaluateStandaloneDecisionWithInputStreamVariables() {
     // given
+
     final String variables = "{\"foo\": \"bar\"}";
     final InputStream inputStream =
         new ByteArrayInputStream(variables.getBytes(StandardCharsets.UTF_8));
+    gatewayService.onEvaluateDecisionRequest(EVALUATE_DECISION_RESPONSE);
     client
         .newEvaluateDecisionCommand()
         .decisionKey(DECISION_KEY)
@@ -156,6 +159,7 @@ public class DecisionEvaluationRestTest extends ClientRestTest {
   @Test
   public void shouldEvaluateStandaloneDecisionWithMapVariables() {
     // given
+    gatewayService.onEvaluateDecisionRequest(EVALUATE_DECISION_RESPONSE);
     client
         .newEvaluateDecisionCommand()
         .decisionKey(DECISION_KEY)
@@ -174,6 +178,7 @@ public class DecisionEvaluationRestTest extends ClientRestTest {
   @Test
   public void shouldEvaluateStandaloneDecisionWithObjectVariables() {
     // given
+    gatewayService.onEvaluateDecisionRequest(EVALUATE_DECISION_RESPONSE);
     client
         .newEvaluateDecisionCommand()
         .decisionKey(DECISION_KEY)
@@ -194,6 +199,7 @@ public class DecisionEvaluationRestTest extends ClientRestTest {
     // given
     final String key = "key";
     final String value = "value";
+    gatewayService.onEvaluateDecisionRequest(EVALUATE_DECISION_RESPONSE);
     client
         .newEvaluateDecisionCommand()
         .decisionKey(DECISION_KEY)
@@ -241,6 +247,7 @@ public class DecisionEvaluationRestTest extends ClientRestTest {
   public void shouldAllowSpecifyingTenantIdByDecisionId() {
     // given
     final String tenantId = "test-tenant";
+    gatewayService.onEvaluateDecisionRequest(EVALUATE_DECISION_RESPONSE);
 
     // when
     client.newEvaluateDecisionCommand().decisionId("dmn").tenantId(tenantId).send().join();
@@ -255,6 +262,7 @@ public class DecisionEvaluationRestTest extends ClientRestTest {
   public void shouldAllowSpecifyingTenantIdByDecisionKey() {
     // given
     final String tenantId = "test-tenant";
+    gatewayService.onEvaluateDecisionRequest(EVALUATE_DECISION_RESPONSE);
 
     // when
     client.newEvaluateDecisionCommand().decisionKey(1L).tenantId(tenantId).send().join();

--- a/clients/java/src/test/java/io/camunda/client/elementinstance/ElementInstanceTest.java
+++ b/clients/java/src/test/java/io/camunda/client/elementinstance/ElementInstanceTest.java
@@ -29,6 +29,7 @@ import io.camunda.client.util.ClientRestTest;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Objects;
+import org.instancio.Instancio;
 import org.junit.jupiter.api.Test;
 
 public class ElementInstanceTest extends ClientRestTest {
@@ -344,8 +345,17 @@ public class ElementInstanceTest extends ClientRestTest {
 
   @Test
   public void shouldGetElementInstance() {
-    // when
+    // given
     final long elementInstanceKey = 0xC00L;
+    gatewayService.onElementInstanceRequest(
+        elementInstanceKey,
+        Instancio.create(ElementInstanceResult.class)
+            .elementInstanceKey("1")
+            .processInstanceKey("2")
+            .incidentKey("3")
+            .processDefinitionKey("4"));
+
+    // when
     client.newElementInstanceGetRequest(elementInstanceKey).send().join();
 
     // then

--- a/clients/java/src/test/java/io/camunda/client/group/CreateGroupTest.java
+++ b/clients/java/src/test/java/io/camunda/client/group/CreateGroupTest.java
@@ -15,14 +15,16 @@
  */
 package io.camunda.client.group;
 
-import static io.camunda.client.impl.http.HttpClientFactory.REST_API_PATH;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.client.api.command.ProblemException;
 import io.camunda.client.protocol.rest.GroupCreateRequest;
+import io.camunda.client.protocol.rest.GroupCreateResult;
 import io.camunda.client.protocol.rest.ProblemDetail;
 import io.camunda.client.util.ClientRestTest;
+import io.camunda.client.util.RestGatewayPaths;
+import org.instancio.Instancio;
 import org.junit.jupiter.api.Test;
 
 public class CreateGroupTest extends ClientRestTest {
@@ -33,6 +35,9 @@ public class CreateGroupTest extends ClientRestTest {
 
   @Test
   void shouldCreateGroup() {
+    // given
+    gatewayService.onCreateGroupRequest(Instancio.create(GroupCreateResult.class));
+
     // when
     client
         .newCreateGroupCommand()
@@ -51,6 +56,9 @@ public class CreateGroupTest extends ClientRestTest {
 
   @Test
   void shouldCreateGroupWithoutDescription() {
+    // given
+    gatewayService.onCreateGroupRequest(Instancio.create(GroupCreateResult.class));
+
     // when
     client.newCreateGroupCommand().groupId(GROUP_ID).name(NAME).send().join();
 
@@ -65,7 +73,7 @@ public class CreateGroupTest extends ClientRestTest {
   void shouldRaiseExceptionOnRequestError() {
     // given
     gatewayService.errorOnRequest(
-        REST_API_PATH + "/groups", () -> new ProblemDetail().title("Not Found").status(404));
+        RestGatewayPaths.getGroupsUrl(), () -> new ProblemDetail().title("Not Found").status(404));
 
     // when / then
     assertThatThrownBy(
@@ -77,10 +85,11 @@ public class CreateGroupTest extends ClientRestTest {
   @Test
   void shouldRaiseExceptionIfGroupAlreadyExists() {
     // given
+    gatewayService.onCreateGroupRequest(Instancio.create(GroupCreateResult.class));
     client.newCreateGroupCommand().groupId(GROUP_ID).name(NAME).send().join();
 
     gatewayService.errorOnRequest(
-        REST_API_PATH + "/groups", () -> new ProblemDetail().title("Conflict").status(409));
+        RestGatewayPaths.getGroupsUrl(), () -> new ProblemDetail().title("Conflict").status(409));
 
     // when / then
     assertThatThrownBy(
@@ -93,7 +102,8 @@ public class CreateGroupTest extends ClientRestTest {
   void shouldHandleValidationErrorResponse() {
     // given
     gatewayService.errorOnRequest(
-        REST_API_PATH + "/groups", () -> new ProblemDetail().title("Bad Request").status(400));
+        RestGatewayPaths.getGroupsUrl(),
+        () -> new ProblemDetail().title("Bad Request").status(400));
 
     // when / then
     assertThatThrownBy(

--- a/clients/java/src/test/java/io/camunda/client/group/GroupSearchTest.java
+++ b/clients/java/src/test/java/io/camunda/client/group/GroupSearchTest.java
@@ -27,7 +27,9 @@ import io.camunda.client.api.search.sort.GroupSort;
 import io.camunda.client.api.search.sort.GroupUserSort;
 import io.camunda.client.api.search.sort.MappingRuleSort;
 import io.camunda.client.api.search.sort.RoleSort;
+import io.camunda.client.protocol.rest.GroupResult;
 import io.camunda.client.util.ClientRestTest;
+import org.instancio.Instancio;
 import org.junit.jupiter.api.Test;
 
 public class GroupSearchTest extends ClientRestTest {
@@ -36,6 +38,9 @@ public class GroupSearchTest extends ClientRestTest {
 
   @Test
   public void testGroupSearch() {
+    // given
+    gatewayService.onGroupRequest(GROUP_ID, Instancio.create(GroupResult.class));
+
     // when
     client.newGroupGetRequest(GROUP_ID).send().join();
 

--- a/clients/java/src/test/java/io/camunda/client/group/UpdateGroupTest.java
+++ b/clients/java/src/test/java/io/camunda/client/group/UpdateGroupTest.java
@@ -21,8 +21,10 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.client.api.command.ProblemException;
 import io.camunda.client.protocol.rest.GroupUpdateRequest;
+import io.camunda.client.protocol.rest.GroupUpdateResult;
 import io.camunda.client.protocol.rest.ProblemDetail;
 import io.camunda.client.util.ClientRestTest;
+import org.instancio.Instancio;
 import org.junit.jupiter.api.Test;
 
 public class UpdateGroupTest extends ClientRestTest {
@@ -33,6 +35,9 @@ public class UpdateGroupTest extends ClientRestTest {
 
   @Test
   void shouldUpdateGroup() {
+    // given
+    gatewayService.onUpdateGroupRequest(GROUP_ID, Instancio.create(GroupUpdateResult.class));
+
     // when
     client
         .newUpdateGroupCommand(GROUP_ID)

--- a/clients/java/src/test/java/io/camunda/client/incident/SearchIncidentTest.java
+++ b/clients/java/src/test/java/io/camunda/client/incident/SearchIncidentTest.java
@@ -31,6 +31,7 @@ import io.camunda.client.util.ClientRestTest;
 import io.camunda.zeebe.protocol.record.value.ErrorType;
 import java.util.List;
 import java.util.Objects;
+import org.instancio.Instancio;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
@@ -39,8 +40,18 @@ public class SearchIncidentTest extends ClientRestTest {
 
   @Test
   void shouldGetIncident() {
-    // when
+    // given
     final long incidentKey = 0xC00L;
+    gatewayService.onIncidentRequest(
+        incidentKey,
+        Instancio.create(IncidentResult.class)
+            .incidentKey("1")
+            .elementInstanceKey("2")
+            .processInstanceKey("3")
+            .processDefinitionKey("4")
+            .jobKey("5"));
+
+    // when
     client.newIncidentGetRequest(incidentKey).send().join();
 
     // then

--- a/clients/java/src/test/java/io/camunda/client/job/rest/ActivateJobsRestTest.java
+++ b/clients/java/src/test/java/io/camunda/client/job/rest/ActivateJobsRestTest.java
@@ -165,55 +165,6 @@ public final class ActivateJobsRestTest extends ClientRestTest {
     assertThat(request.getWorker()).isEqualTo("worker1");
   }
 
-  private static Stream<ActivateJobWithUserTaskPropsTestCase> userTaskPropertiesProvider() {
-    return Stream.of(
-        new ActivateJobWithUserTaskPropsTestCase(
-            "should activate job with all user task properties set",
-            new UserTaskProperties()
-                .action("update")
-                .assignee("tony")
-                .addCandidateGroupsItem("assistants")
-                .addCandidateUsersItem("jarvis")
-                .addCandidateUsersItem("friday")
-                .addChangedAttributesItem("assignee")
-                .dueDate("2019-04-22T00:00:00Z")
-                .followUpDate("2018-04-23T00:00:00Z")
-                .formKey("1")
-                .priority(10)
-                .userTaskKey("123"),
-            props -> {
-              assertThat(props.getAction()).isEqualTo("update");
-              assertThat(props.getAssignee()).isEqualTo("tony");
-              assertThat(props.getCandidateGroups()).containsExactly("assistants");
-              assertThat(props.getCandidateUsers()).containsExactly("jarvis", "friday");
-              assertThat(props.getChangedAttributes()).containsExactly("assignee");
-              assertThat(props.getDueDate()).isEqualTo("2019-04-22T00:00:00Z");
-              assertThat(props.getFollowUpDate()).isEqualTo("2018-04-23T00:00:00Z");
-              assertThat(props.getFormKey()).isEqualTo(1);
-              assertThat(props.getPriority()).isEqualTo(10);
-              assertThat(props.getUserTaskKey()).isEqualTo(123);
-            }),
-        new ActivateJobWithUserTaskPropsTestCase(
-            "should activate job with empty user task properties",
-            new UserTaskProperties(),
-            props -> {
-              assertThat(props.getAction()).isNull();
-              assertThat(props.getAssignee()).isNull();
-              assertThat(props.getCandidateGroups()).isEmpty();
-              assertThat(props.getCandidateUsers()).isEmpty();
-              assertThat(props.getChangedAttributes()).isEmpty();
-              assertThat(props.getDueDate()).isNull();
-              assertThat(props.getFollowUpDate()).isNull();
-              assertThat(props.getFormKey()).isNull();
-              assertThat(props.getPriority()).isNull();
-              assertThat(props.getUserTaskKey()).isNull();
-            }),
-        new ActivateJobWithUserTaskPropsTestCase(
-            "should activate job with null user task properties",
-            null,
-            props -> assertThat(props).isNull()));
-  }
-
   @ParameterizedTest
   @MethodSource("userTaskPropertiesProvider")
   public void shouldActivateJobsWithUserTaskProperties(
@@ -246,6 +197,7 @@ public final class ActivateJobsRestTest extends ClientRestTest {
   void shouldSetTimeoutFromDuration() {
     // given
     final Duration timeout = Duration.ofMinutes(2);
+    gatewayService.onActivateJobsRequest(new JobActivationResult());
 
     // when
     client
@@ -265,6 +217,7 @@ public final class ActivateJobsRestTest extends ClientRestTest {
   void shouldSetFetchVariables() {
     // given
     final List<String> fetchVariables = Arrays.asList("foo", "bar", "baz");
+    gatewayService.onActivateJobsRequest(new JobActivationResult());
 
     // when
     client
@@ -285,6 +238,7 @@ public final class ActivateJobsRestTest extends ClientRestTest {
   void shouldSetFetchVariablesAsVargs() {
     // given
     final String[] fetchVariables = new String[] {"foo", "bar", "baz"};
+    gatewayService.onActivateJobsRequest(new JobActivationResult());
 
     // when
     client
@@ -302,6 +256,9 @@ public final class ActivateJobsRestTest extends ClientRestTest {
 
   @Test
   void shouldSetDefaultValues() {
+    // given
+    gatewayService.onActivateJobsRequest(new JobActivationResult());
+
     // when
     client.newActivateJobsCommand().jobType("foo").maxJobsToActivate(3).send().join();
 
@@ -333,6 +290,7 @@ public final class ActivateJobsRestTest extends ClientRestTest {
   void shouldSetRequestTimeout() {
     // given
     final Duration requestTimeout = Duration.ofHours(124);
+    gatewayService.onActivateJobsRequest(new JobActivationResult());
 
     // when
     client
@@ -369,6 +327,7 @@ public final class ActivateJobsRestTest extends ClientRestTest {
   @Test
   void shouldAllowSpecifyingTenantIdsAsList() {
     // given
+    gatewayService.onActivateJobsRequest(new JobActivationResult());
     client
         .newActivateJobsCommand()
         .jobType("foo")
@@ -387,6 +346,7 @@ public final class ActivateJobsRestTest extends ClientRestTest {
   @Test
   void shouldAllowSpecifyingTenantIdsAsVarArgs() {
     // given
+    gatewayService.onActivateJobsRequest(new JobActivationResult());
     client
         .newActivateJobsCommand()
         .jobType("foo")
@@ -405,6 +365,7 @@ public final class ActivateJobsRestTest extends ClientRestTest {
   @Test
   void shouldAllowSpecifyingTenantIds() {
     // given
+    gatewayService.onActivateJobsRequest(new JobActivationResult());
     client
         .newActivateJobsCommand()
         .jobType("foo")
@@ -426,6 +387,7 @@ public final class ActivateJobsRestTest extends ClientRestTest {
   @Test
   void shouldNotAccumulateTenantsOnSuccessiveOpen() {
     // given
+    gatewayService.onActivateJobsRequest(new JobActivationResult());
     final ActivateJobsCommandStep3 command =
         client
             .newActivateJobsCommand()
@@ -519,12 +481,64 @@ public final class ActivateJobsRestTest extends ClientRestTest {
 
   @Test
   void shouldSetDefaultWorkerNameWhenMissingInCommand() {
+    // given
+    gatewayService.onActivateJobsRequest(new JobActivationResult());
+
     // when
     client.newActivateJobsCommand().jobType("foo").maxJobsToActivate(1).send().join();
 
     // then
     final JobActivationRequest request = gatewayService.getLastRequest(JobActivationRequest.class);
     assertThat(request.getWorker()).isEqualTo(CamundaClientBuilderImpl.DEFAULT_JOB_WORKER_NAME_VAR);
+  }
+
+  private static Stream<ActivateJobWithUserTaskPropsTestCase> userTaskPropertiesProvider() {
+    return Stream.of(
+        new ActivateJobWithUserTaskPropsTestCase(
+            "should activate job with all user task properties set",
+            new UserTaskProperties()
+                .action("update")
+                .assignee("tony")
+                .addCandidateGroupsItem("assistants")
+                .addCandidateUsersItem("jarvis")
+                .addCandidateUsersItem("friday")
+                .addChangedAttributesItem("assignee")
+                .dueDate("2019-04-22T00:00:00Z")
+                .followUpDate("2018-04-23T00:00:00Z")
+                .formKey("1")
+                .priority(10)
+                .userTaskKey("123"),
+            props -> {
+              assertThat(props.getAction()).isEqualTo("update");
+              assertThat(props.getAssignee()).isEqualTo("tony");
+              assertThat(props.getCandidateGroups()).containsExactly("assistants");
+              assertThat(props.getCandidateUsers()).containsExactly("jarvis", "friday");
+              assertThat(props.getChangedAttributes()).containsExactly("assignee");
+              assertThat(props.getDueDate()).isEqualTo("2019-04-22T00:00:00Z");
+              assertThat(props.getFollowUpDate()).isEqualTo("2018-04-23T00:00:00Z");
+              assertThat(props.getFormKey()).isEqualTo(1);
+              assertThat(props.getPriority()).isEqualTo(10);
+              assertThat(props.getUserTaskKey()).isEqualTo(123);
+            }),
+        new ActivateJobWithUserTaskPropsTestCase(
+            "should activate job with empty user task properties",
+            new UserTaskProperties(),
+            props -> {
+              assertThat(props.getAction()).isNull();
+              assertThat(props.getAssignee()).isNull();
+              assertThat(props.getCandidateGroups()).isEmpty();
+              assertThat(props.getCandidateUsers()).isEmpty();
+              assertThat(props.getChangedAttributes()).isEmpty();
+              assertThat(props.getDueDate()).isNull();
+              assertThat(props.getFollowUpDate()).isNull();
+              assertThat(props.getFormKey()).isNull();
+              assertThat(props.getPriority()).isNull();
+              assertThat(props.getUserTaskKey()).isNull();
+            }),
+        new ActivateJobWithUserTaskPropsTestCase(
+            "should activate job with null user task properties",
+            null,
+            props -> assertThat(props).isNull()));
   }
 
   private static final class VariablesPojo {

--- a/clients/java/src/test/java/io/camunda/client/mappingrule/CreateMappingRuleTest.java
+++ b/clients/java/src/test/java/io/camunda/client/mappingrule/CreateMappingRuleTest.java
@@ -19,7 +19,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.client.protocol.rest.MappingRuleCreateRequest;
+import io.camunda.client.protocol.rest.MappingRuleCreateResult;
 import io.camunda.client.util.ClientRestTest;
+import org.instancio.Instancio;
 import org.junit.jupiter.api.Test;
 
 public class CreateMappingRuleTest extends ClientRestTest {
@@ -31,6 +33,9 @@ public class CreateMappingRuleTest extends ClientRestTest {
 
   @Test
   void shouldCreateMappingRule() {
+    // given
+    gatewayService.onCreateMappingRuleRequest(Instancio.create(MappingRuleCreateResult.class));
+
     // when
     client
         .newCreateMappingRuleCommand()

--- a/clients/java/src/test/java/io/camunda/client/metrics/UsageMetricsStatisticsTest.java
+++ b/clients/java/src/test/java/io/camunda/client/metrics/UsageMetricsStatisticsTest.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.github.tomakehurst.wiremock.http.RequestMethod;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+import io.camunda.client.protocol.rest.UsageMetricsResponse;
 import io.camunda.client.util.ClientRestTest;
 import io.camunda.client.util.RestGatewayService;
 import java.io.UnsupportedEncodingException;
@@ -26,6 +27,7 @@ import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
+import org.instancio.Instancio;
 import org.junit.jupiter.api.Test;
 
 public class UsageMetricsStatisticsTest extends ClientRestTest {
@@ -41,6 +43,9 @@ public class UsageMetricsStatisticsTest extends ClientRestTest {
 
   @Test
   void shouldGetUsageMetricStatistics() {
+    // given
+    gatewayService.onUsageMetricsRequest(Instancio.create(UsageMetricsResponse.class));
+
     // when
     final OffsetDateTime startTime = OffsetDateTime.now().minusDays(1);
     final OffsetDateTime endTime = OffsetDateTime.now();
@@ -58,6 +63,9 @@ public class UsageMetricsStatisticsTest extends ClientRestTest {
 
   @Test
   void shouldGetUsageMetricStatisticsWithTenants() {
+    // given
+    gatewayService.onUsageMetricsRequest(Instancio.create(UsageMetricsResponse.class));
+
     // when
     final OffsetDateTime startTime = OffsetDateTime.now().minusDays(1);
     final OffsetDateTime endTime = OffsetDateTime.now();

--- a/clients/java/src/test/java/io/camunda/client/process/CorrelateMessageTest.java
+++ b/clients/java/src/test/java/io/camunda/client/process/CorrelateMessageTest.java
@@ -20,12 +20,17 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.client.api.command.InternalClientException;
 import io.camunda.client.protocol.rest.MessageCorrelationRequest;
+import io.camunda.client.protocol.rest.MessageCorrelationResult;
 import io.camunda.client.util.ClientRestTest;
 import java.util.Collections;
 import java.util.Map;
+import org.instancio.Instancio;
 import org.junit.jupiter.api.Test;
 
 final class CorrelateMessageTest extends ClientRestTest {
+
+  private static final MessageCorrelationResult DUMMY_RESPONSE =
+      Instancio.create(MessageCorrelationResult.class).messageKey("1").processInstanceKey("2");
 
   @Test
   void shouldCorrelateMessageWithCorrelationKey() {
@@ -34,6 +39,7 @@ final class CorrelateMessageTest extends ClientRestTest {
     final String correlationKey = "correlationKey";
     final String tenantId = "tenant";
     final Map<String, Object> variables = Collections.singletonMap("foo", "bar");
+    gatewayService.onCorrelateMessageRequest(DUMMY_RESPONSE);
 
     // when
     client
@@ -60,6 +66,7 @@ final class CorrelateMessageTest extends ClientRestTest {
     final String messageName = "name";
     final String tenantId = "tenant";
     final Map<String, Object> variables = Collections.singletonMap("foo", "bar");
+    gatewayService.onCorrelateMessageRequest(DUMMY_RESPONSE);
 
     // when
     client

--- a/clients/java/src/test/java/io/camunda/client/process/QueryProcessInstanceSequenceFlowsTest.java
+++ b/clients/java/src/test/java/io/camunda/client/process/QueryProcessInstanceSequenceFlowsTest.java
@@ -19,21 +19,30 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.github.tomakehurst.wiremock.http.RequestMethod;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+import io.camunda.client.protocol.rest.ProcessInstanceSequenceFlowsQueryResult;
 import io.camunda.client.util.ClientRestTest;
+import io.camunda.client.util.RestGatewayPaths;
 import io.camunda.client.util.RestGatewayService;
+import org.instancio.Instancio;
 import org.junit.jupiter.api.Test;
 
 public class QueryProcessInstanceSequenceFlowsTest extends ClientRestTest {
 
   @Test
   public void shouldGetProcessInstanceSequenceFlowsByKey() {
+    // given
+    final long processInstanceKey = 123L;
+    gatewayService.onProcessInstanceSequenceFlowsRequest(
+        processInstanceKey, Instancio.create(ProcessInstanceSequenceFlowsQueryResult.class));
+
     // when
-    client.newProcessInstanceSequenceFlowsRequest(123L).send().join();
+    client.newProcessInstanceSequenceFlowsRequest(processInstanceKey).send().join();
 
     // then
     final LoggedRequest request = RestGatewayService.getLastRequest();
     assertThat(request.getMethod()).isEqualTo(RequestMethod.GET);
-    assertThat(request.getUrl()).isEqualTo("/v2/process-instances/123/sequence-flows");
+    assertThat(request.getUrl())
+        .isEqualTo(RestGatewayPaths.getProcessInstanceSequenceFlowsUrl(processInstanceKey));
     assertThat(request.getBodyAsString()).isEmpty();
   }
 }

--- a/clients/java/src/test/java/io/camunda/client/process/QueryProcessInstanceTest.java
+++ b/clients/java/src/test/java/io/camunda/client/process/QueryProcessInstanceTest.java
@@ -27,6 +27,7 @@ import io.camunda.client.impl.search.request.SearchRequestSort;
 import io.camunda.client.impl.search.request.SearchRequestSortMapper;
 import io.camunda.client.protocol.rest.*;
 import io.camunda.client.util.ClientRestTest;
+import io.camunda.client.util.RestGatewayPaths;
 import io.camunda.client.util.RestGatewayService;
 import java.lang.reflect.Modifier;
 import java.time.OffsetDateTime;
@@ -38,13 +39,18 @@ public class QueryProcessInstanceTest extends ClientRestTest {
 
   @Test
   public void shouldGetProcessInstanceByKey() {
+    // given
+    final long processInstanceKey = 123L;
+    gatewayService.onProcessInstanceRequest(processInstanceKey, new ProcessInstanceResult());
+
     // when
-    client.newProcessInstanceGetRequest(123L).send().join();
+    client.newProcessInstanceGetRequest(processInstanceKey).send().join();
 
     // then
     final LoggedRequest request = RestGatewayService.getLastRequest();
     assertThat(request.getMethod()).isEqualTo(RequestMethod.GET);
-    assertThat(request.getUrl()).isEqualTo("/v2/process-instances/123");
+    assertThat(request.getUrl())
+        .isEqualTo(RestGatewayPaths.getProcessInstancesUrl(processInstanceKey));
     assertThat(request.getBodyAsString()).isEmpty();
   }
 
@@ -360,13 +366,18 @@ public class QueryProcessInstanceTest extends ClientRestTest {
 
   @Test
   public void shouldFetchProcessInstanceCallHierarchy() {
+    // given
+    final long processInstanceKey = 123L;
+    gatewayService.onProcessInstanceCallHierarchyRequest(processInstanceKey, new Object[0]);
+
     // when
-    client.newProcessInstanceGetCallHierarchyRequest(123L).send().join();
+    client.newProcessInstanceGetCallHierarchyRequest(processInstanceKey).send().join();
 
     // then
     final LoggedRequest request = RestGatewayService.getLastRequest();
     assertThat(request.getMethod()).isEqualTo(RequestMethod.GET);
-    assertThat(request.getUrl()).isEqualTo("/v2/process-instances/123/call-hierarchy");
+    assertThat(request.getUrl())
+        .isEqualTo(RestGatewayPaths.getProcessInstanceCallHierarchyUrl(processInstanceKey));
     assertThat(request.getBodyAsString()).isEmpty();
   }
 

--- a/clients/java/src/test/java/io/camunda/client/process/rest/BroadcastSignalRestTest.java
+++ b/clients/java/src/test/java/io/camunda/client/process/rest/BroadcastSignalRestTest.java
@@ -22,18 +22,26 @@ import static org.assertj.core.api.Assertions.entry;
 import io.camunda.client.api.command.ProblemException;
 import io.camunda.client.protocol.rest.ProblemDetail;
 import io.camunda.client.protocol.rest.SignalBroadcastRequest;
+import io.camunda.client.protocol.rest.SignalBroadcastResult;
 import io.camunda.client.util.ClientRestTest;
 import io.camunda.client.util.RestGatewayPaths;
 import java.io.ByteArrayInputStream;
 import java.util.HashMap;
 import java.util.Map;
 import org.assertj.core.api.Assertions;
+import org.instancio.Instancio;
 import org.junit.jupiter.api.Test;
 
 public class BroadcastSignalRestTest extends ClientRestTest {
 
+  private static final SignalBroadcastResult DUMMY_RESPONSE =
+      Instancio.create(SignalBroadcastResult.class).signalKey("1");
+
   @Test
   public void shouldBroadcastSignalWithStringVariables() {
+    // given
+    gatewayService.onBroadcastSignalRequest(DUMMY_RESPONSE);
+
     // when
     client
         .newBroadcastSignalCommand()
@@ -54,6 +62,7 @@ public class BroadcastSignalRestTest extends ClientRestTest {
     final String variables = "{\"foo\":\"bar\"}";
     final ByteArrayInputStream byteArrayInputStream =
         new ByteArrayInputStream(variables.getBytes());
+    gatewayService.onBroadcastSignalRequest(DUMMY_RESPONSE);
 
     // when
     client
@@ -74,6 +83,7 @@ public class BroadcastSignalRestTest extends ClientRestTest {
     // given
     final Map<String, Object> variables = new HashMap<>();
     variables.put("foo", "bar");
+    gatewayService.onBroadcastSignalRequest(DUMMY_RESPONSE);
 
     // when
     client.newBroadcastSignalCommand().signalName("name").variables(variables).send().join();
@@ -86,6 +96,9 @@ public class BroadcastSignalRestTest extends ClientRestTest {
 
   @Test
   public void shouldBroadcastSignalWithObjectVariables() {
+    // given
+    gatewayService.onBroadcastSignalRequest(DUMMY_RESPONSE);
+
     // when
     client
         .newBroadcastSignalCommand()
@@ -102,6 +115,9 @@ public class BroadcastSignalRestTest extends ClientRestTest {
 
   @Test
   public void shouldBroadcastSignalWithSingleVariable() {
+    // given
+    gatewayService.onBroadcastSignalRequest(DUMMY_RESPONSE);
+
     // when
     final String key = "key";
     final String value = "value";
@@ -128,7 +144,10 @@ public class BroadcastSignalRestTest extends ClientRestTest {
 
   @Test
   public void shouldAllowSpecifyingTenantIdBy() {
-    // given/when
+    // given
+    gatewayService.onBroadcastSignalRequest(DUMMY_RESPONSE);
+
+    // when
     client.newBroadcastSignalCommand().signalName("").tenantId("custom-tenant").send().join();
 
     // then

--- a/clients/java/src/test/java/io/camunda/client/process/rest/CreateProcessInstanceRestTest.java
+++ b/clients/java/src/test/java/io/camunda/client/process/rest/CreateProcessInstanceRestTest.java
@@ -26,6 +26,7 @@ import io.camunda.client.api.response.ProcessInstanceEvent;
 import io.camunda.client.protocol.rest.ProblemDetail;
 import io.camunda.client.protocol.rest.ProcessInstanceCreationInstruction;
 import io.camunda.client.protocol.rest.ProcessInstanceCreationStartInstruction;
+import io.camunda.client.protocol.rest.ProcessInstanceResult;
 import io.camunda.client.util.ClientRestTest;
 import io.camunda.client.util.RestGatewayPaths;
 import java.io.ByteArrayInputStream;
@@ -34,6 +35,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.List;
 import org.assertj.core.api.Assertions;
+import org.instancio.Instancio;
 import org.junit.jupiter.api.Test;
 
 public class CreateProcessInstanceRestTest extends ClientRestTest {
@@ -41,8 +43,18 @@ public class CreateProcessInstanceRestTest extends ClientRestTest {
   public static final String ELEMENT_ID_A = "elementId_A";
   public static final String ELEMENT_ID_B = "elementId_B";
 
+  private static final ProcessInstanceResult DUMMY_RESPONSE =
+      Instancio.create(ProcessInstanceResult.class)
+          .processInstanceKey("1")
+          .parentProcessInstanceKey("2")
+          .parentElementInstanceKey("3")
+          .processDefinitionKey("4");
+
   @Test
   public void shouldCreateProcessInstanceByProcessInstanceKey() {
+    // given
+    gatewayService.onCreateProcessInstanceRequest(DUMMY_RESPONSE);
+
     // when
     final ProcessInstanceEvent response =
         client.newCreateInstanceCommand().processDefinitionKey(123).send().join();
@@ -55,6 +67,9 @@ public class CreateProcessInstanceRestTest extends ClientRestTest {
 
   @Test
   public void shouldCreateProcessInstanceByBpmnProcessId() {
+    // given
+    gatewayService.onCreateProcessInstanceRequest(DUMMY_RESPONSE);
+
     // when
     client.newCreateInstanceCommand().bpmnProcessId("testProcess").latestVersion().send().join();
 
@@ -67,6 +82,9 @@ public class CreateProcessInstanceRestTest extends ClientRestTest {
 
   @Test
   public void shouldCreateProcessInstanceByBpmnProcessIdAndVersion() {
+    // given
+    gatewayService.onCreateProcessInstanceRequest(DUMMY_RESPONSE);
+
     // when
     client.newCreateInstanceCommand().bpmnProcessId("testProcess").version(123).send().join();
 
@@ -79,6 +97,9 @@ public class CreateProcessInstanceRestTest extends ClientRestTest {
 
   @Test
   public void shouldCreateProcessInstanceWithStringVariables() {
+    // given
+    gatewayService.onCreateProcessInstanceRequest(DUMMY_RESPONSE);
+
     // when
     client
         .newCreateInstanceCommand()
@@ -99,6 +120,7 @@ public class CreateProcessInstanceRestTest extends ClientRestTest {
     final String variables = "{\"foo\": \"bar\"}";
     final InputStream inputStream =
         new ByteArrayInputStream(variables.getBytes(StandardCharsets.UTF_8));
+    gatewayService.onCreateProcessInstanceRequest(DUMMY_RESPONSE);
 
     // when
     client
@@ -119,6 +141,7 @@ public class CreateProcessInstanceRestTest extends ClientRestTest {
     // given
     final String key = "key";
     final String value = "value";
+    gatewayService.onCreateProcessInstanceRequest(DUMMY_RESPONSE);
 
     // when
     client.newCreateInstanceCommand().processDefinitionKey(123).variable(key, value).send().join();
@@ -131,6 +154,9 @@ public class CreateProcessInstanceRestTest extends ClientRestTest {
 
   @Test
   public void shouldCreateProcessInstanceWithMapVariables() {
+    // given
+    gatewayService.onCreateProcessInstanceRequest(DUMMY_RESPONSE);
+
     // when
     client
         .newCreateInstanceCommand()
@@ -147,6 +173,9 @@ public class CreateProcessInstanceRestTest extends ClientRestTest {
 
   @Test
   public void shouldCreateProcessInstanceWithObjectVariables() {
+    // given
+    gatewayService.onCreateProcessInstanceRequest(DUMMY_RESPONSE);
+
     // when
     client
         .newCreateInstanceCommand()
@@ -165,7 +194,7 @@ public class CreateProcessInstanceRestTest extends ClientRestTest {
   public void shouldRaiseAnErrorIfRequestFails() {
     // given
     gatewayService.errorOnRequest(
-        RestGatewayPaths.getCreateProcessInstanceUrl(),
+        RestGatewayPaths.getProcessInstancesUrl(),
         () -> new ProblemDetail().title("Invalid request").status(400));
 
     // when
@@ -177,6 +206,9 @@ public class CreateProcessInstanceRestTest extends ClientRestTest {
 
   @Test
   public void shouldAddStartInstruction() {
+    // given
+    gatewayService.onCreateProcessInstanceRequest(DUMMY_RESPONSE);
+
     // when
     client
         .newCreateInstanceCommand()
@@ -198,6 +230,9 @@ public class CreateProcessInstanceRestTest extends ClientRestTest {
 
   @Test
   public void shouldAddMultipleStartInstructions() {
+    // given
+    gatewayService.onCreateProcessInstanceRequest(DUMMY_RESPONSE);
+
     // when
     client
         .newCreateInstanceCommand()
@@ -222,6 +257,9 @@ public class CreateProcessInstanceRestTest extends ClientRestTest {
 
   @Test
   public void shouldUseDefaultTenantId() {
+    // given
+    gatewayService.onCreateProcessInstanceRequest(DUMMY_RESPONSE);
+
     // when
     client.newCreateInstanceCommand().bpmnProcessId("test").latestVersion().send().join();
 
@@ -236,6 +274,7 @@ public class CreateProcessInstanceRestTest extends ClientRestTest {
     // given
     final String bpmnProcessId = "testProcess";
     final String tenantId = "test-tenant";
+    gatewayService.onCreateProcessInstanceRequest(DUMMY_RESPONSE);
 
     // when
     client
@@ -258,6 +297,7 @@ public class CreateProcessInstanceRestTest extends ClientRestTest {
     final String bpmnProcessId = "testProcess";
     final int version = 3;
     final String tenantId = "test-tenant";
+    gatewayService.onCreateProcessInstanceRequest(DUMMY_RESPONSE);
 
     // when
     client
@@ -279,6 +319,7 @@ public class CreateProcessInstanceRestTest extends ClientRestTest {
     // given
     final String customTenantId = "test-tenant";
     final Long processDefinitionKey = 1L;
+    gatewayService.onCreateProcessInstanceRequest(DUMMY_RESPONSE);
 
     // when
     client

--- a/clients/java/src/test/java/io/camunda/client/process/rest/CreateProcessInstanceWithResultRestTest.java
+++ b/clients/java/src/test/java/io/camunda/client/process/rest/CreateProcessInstanceWithResultRestTest.java
@@ -20,14 +20,26 @@ import static org.assertj.core.api.Assertions.entry;
 
 import io.camunda.client.api.command.CommandWithTenantStep;
 import io.camunda.client.protocol.rest.ProcessInstanceCreationInstruction;
+import io.camunda.client.protocol.rest.ProcessInstanceResult;
 import io.camunda.client.util.ClientRestTest;
 import java.time.Duration;
+import org.instancio.Instancio;
 import org.junit.jupiter.api.Test;
 
 public class CreateProcessInstanceWithResultRestTest extends ClientRestTest {
 
+  private static final ProcessInstanceResult DUMMY_RESPONSE =
+      Instancio.create(ProcessInstanceResult.class)
+          .processInstanceKey("1")
+          .parentProcessInstanceKey("2")
+          .parentElementInstanceKey("3")
+          .processDefinitionKey("4");
+
   @Test
   public void shouldCreateProcessInstanceByProcessInstanceKey() {
+    // given
+    gatewayService.onCreateProcessInstanceRequest(DUMMY_RESPONSE);
+
     // when
     client
         .newCreateInstanceCommand()
@@ -46,6 +58,9 @@ public class CreateProcessInstanceWithResultRestTest extends ClientRestTest {
 
   @Test
   public void shouldCreateProcessInstanceByBpmnProcessIdAndVersion() {
+    // given
+    gatewayService.onCreateProcessInstanceRequest(DUMMY_RESPONSE);
+
     // when
     client
         .newCreateInstanceCommand()
@@ -64,6 +79,9 @@ public class CreateProcessInstanceWithResultRestTest extends ClientRestTest {
 
   @Test
   public void shouldCreateProcessInstanceWithStringVariables() {
+    // given
+    gatewayService.onCreateProcessInstanceRequest(DUMMY_RESPONSE);
+
     // when
     client
         .newCreateInstanceCommand()
@@ -81,6 +99,9 @@ public class CreateProcessInstanceWithResultRestTest extends ClientRestTest {
 
   @Test
   public void shouldCreateProcessInstanceWithSingleVariable() {
+    // given
+    gatewayService.onCreateProcessInstanceRequest(DUMMY_RESPONSE);
+
     // when
     final String key = "key";
     final String value = "value";
@@ -100,6 +121,9 @@ public class CreateProcessInstanceWithResultRestTest extends ClientRestTest {
 
   @Test
   public void shouldUseDefaultTenantId() {
+    // given
+    gatewayService.onCreateProcessInstanceRequest(DUMMY_RESPONSE);
+
     // when
     client
         .newCreateInstanceCommand()
@@ -120,6 +144,7 @@ public class CreateProcessInstanceWithResultRestTest extends ClientRestTest {
     // given
     final String bpmnProcessId = "testProcess";
     final String tenantId = "test-tenant";
+    gatewayService.onCreateProcessInstanceRequest(DUMMY_RESPONSE);
 
     // when
     client
@@ -143,6 +168,7 @@ public class CreateProcessInstanceWithResultRestTest extends ClientRestTest {
     final String bpmnProcessId = "testProcess";
     final int version = 3;
     final String tenantId = "test-tenant";
+    gatewayService.onCreateProcessInstanceRequest(DUMMY_RESPONSE);
 
     // when
     client
@@ -165,6 +191,7 @@ public class CreateProcessInstanceWithResultRestTest extends ClientRestTest {
     // given
     final Long processDefinitionKey = 1L;
     final String tenantId = "test-tenant";
+    gatewayService.onCreateProcessInstanceRequest(DUMMY_RESPONSE);
 
     // when
     client

--- a/clients/java/src/test/java/io/camunda/client/process/rest/PublishMessageRestTest.java
+++ b/clients/java/src/test/java/io/camunda/client/process/rest/PublishMessageRestTest.java
@@ -23,6 +23,7 @@ import static org.assertj.core.api.Assertions.entry;
 import io.camunda.client.api.command.CommandWithTenantStep;
 import io.camunda.client.api.command.ProblemException;
 import io.camunda.client.protocol.rest.MessagePublicationRequest;
+import io.camunda.client.protocol.rest.MessagePublicationResult;
 import io.camunda.client.protocol.rest.ProblemDetail;
 import io.camunda.client.util.ClientRestTest;
 import io.camunda.client.util.RestGatewayPaths;
@@ -31,12 +32,19 @@ import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 import org.assertj.core.api.Assertions;
+import org.instancio.Instancio;
 import org.junit.jupiter.api.Test;
 
 public class PublishMessageRestTest extends ClientRestTest {
 
+  private static final MessagePublicationResult DUMMY_RESPONSE =
+      Instancio.create(MessagePublicationResult.class).messageKey("1");
+
   @Test
   public void shouldPublishMessage() {
+    // given
+    gatewayService.onPublishMessageRequest(DUMMY_RESPONSE);
+
     // when
     client
         .newPublishMessageCommand()
@@ -59,6 +67,9 @@ public class PublishMessageRestTest extends ClientRestTest {
 
   @Test
   public void shouldPublishMessageWithDefaultTtl() {
+    // given
+    gatewayService.onPublishMessageRequest(DUMMY_RESPONSE);
+
     // when
     client.newPublishMessageCommand().messageName("name").correlationKey("key").send().join();
 
@@ -70,6 +81,9 @@ public class PublishMessageRestTest extends ClientRestTest {
 
   @Test
   public void shouldPublishMessageWithStringVariables() {
+    // given
+    gatewayService.onPublishMessageRequest(DUMMY_RESPONSE);
+
     // when
     client
         .newPublishMessageCommand()
@@ -91,6 +105,7 @@ public class PublishMessageRestTest extends ClientRestTest {
     final String variables = "{\"foo\":\"bar\"}";
     final ByteArrayInputStream byteArrayInputStream =
         new ByteArrayInputStream(variables.getBytes());
+    gatewayService.onPublishMessageRequest(DUMMY_RESPONSE);
 
     // when
     client
@@ -112,6 +127,7 @@ public class PublishMessageRestTest extends ClientRestTest {
     // given
     final Map<String, Object> variables = new HashMap<>();
     variables.put("foo", "bar");
+    gatewayService.onPublishMessageRequest(DUMMY_RESPONSE);
 
     // when
     client
@@ -130,6 +146,9 @@ public class PublishMessageRestTest extends ClientRestTest {
 
   @Test
   public void shouldPublishMessageWithObjectVariables() {
+    // given
+    gatewayService.onPublishMessageRequest(DUMMY_RESPONSE);
+
     // when
     client
         .newPublishMessageCommand()
@@ -147,6 +166,9 @@ public class PublishMessageRestTest extends ClientRestTest {
 
   @Test
   public void shouldPublishMessageWithSingleVariable() {
+    // given
+    gatewayService.onPublishMessageRequest(DUMMY_RESPONSE);
+
     // when
     final String key = "key";
     final String value = "value";
@@ -166,6 +188,9 @@ public class PublishMessageRestTest extends ClientRestTest {
 
   @Test
   public void shouldPublishMessageWithoutCorrelationKey() {
+    // given
+    gatewayService.onPublishMessageRequest(DUMMY_RESPONSE);
+
     // when
     client
         .newPublishMessageCommand()
@@ -222,7 +247,10 @@ public class PublishMessageRestTest extends ClientRestTest {
 
   @Test
   public void shouldAllowSpecifyingTenantId() {
-    // given when
+    // given
+    gatewayService.onPublishMessageRequest(DUMMY_RESPONSE);
+
+    // when
     client
         .newPublishMessageCommand()
         .messageName("")

--- a/clients/java/src/test/java/io/camunda/client/resource/rest/DeployResourceRestTest.java
+++ b/clients/java/src/test/java/io/camunda/client/resource/rest/DeployResourceRestTest.java
@@ -63,10 +63,14 @@ public class DeployResourceRestTest extends ClientRestTest {
   private static final String FORM_FILENAME_2 = "/form/test-form-2.form";
   private static final String DEFAULT_TENANT = "<default>";
 
+  private static final DeploymentResult DUMMY_RESPONSE =
+      new DeploymentResult().deploymentKey("1").tenantId(DEFAULT_TENANT);
+
   @Test
   public void shouldDeployResourceFromFile() {
     // given
     final String path = DeployResourceTest.class.getResource(BPMN_1_FILENAME).getPath();
+    gatewayService.onDeploymentsRequest(DUMMY_RESPONSE);
 
     // when
     client.newDeployResourceCommand().addResourceFile(path).send().join();
@@ -81,6 +85,7 @@ public class DeployResourceRestTest extends ClientRestTest {
   public void shouldDeployRequestFromClasspath() {
     // given
     final String filename = BPMN_1_FILENAME.substring(1);
+    gatewayService.onDeploymentsRequest(DUMMY_RESPONSE);
 
     // when
     client.newDeployResourceCommand().addResourceFromClasspath(filename).send().join();
@@ -96,6 +101,7 @@ public class DeployResourceRestTest extends ClientRestTest {
     // given
     final String filename = BPMN_1_FILENAME;
     final InputStream resourceAsStream = DeployResourceTest.class.getResourceAsStream(filename);
+    gatewayService.onDeploymentsRequest(DUMMY_RESPONSE);
 
     // when
     client.newDeployResourceCommand().addResourceStream(resourceAsStream, filename).send().join();
@@ -111,6 +117,7 @@ public class DeployResourceRestTest extends ClientRestTest {
     // given
     final String filename = BPMN_1_FILENAME;
     final byte[] bytes = getBytes(filename);
+    gatewayService.onDeploymentsRequest(DUMMY_RESPONSE);
 
     // when
     client.newDeployResourceCommand().addResourceBytes(bytes, filename).send().join();
@@ -126,6 +133,7 @@ public class DeployResourceRestTest extends ClientRestTest {
     // given
     final String filename = BPMN_1_FILENAME;
     final String xml = new String(getBytes(filename));
+    gatewayService.onDeploymentsRequest(DUMMY_RESPONSE);
 
     // when
     client
@@ -145,6 +153,7 @@ public class DeployResourceRestTest extends ClientRestTest {
     // given
     final String filename = BPMN_1_FILENAME;
     final String xml = new String(getBytes(filename), StandardCharsets.UTF_8);
+    gatewayService.onDeploymentsRequest(DUMMY_RESPONSE);
 
     // when
     client.newDeployResourceCommand().addResourceStringUtf8(xml, filename).send().join();
@@ -165,6 +174,7 @@ public class DeployResourceRestTest extends ClientRestTest {
     final ByteArrayOutputStream outStream = new ByteArrayOutputStream();
     Bpmn.writeModelToStream(outStream, processModel);
     final byte[] expectedBytes = outStream.toByteArray();
+    gatewayService.onDeploymentsRequest(DUMMY_RESPONSE);
 
     // when
     client.newDeployResourceCommand().addProcessModel(processModel, filename).send().join();
@@ -182,6 +192,7 @@ public class DeployResourceRestTest extends ClientRestTest {
     final String tenantId = "test-tenant";
     final String filename1 = BPMN_1_FILENAME.substring(1);
     final String filename2 = BPMN_2_FILENAME.substring(1);
+    gatewayService.onDeploymentsRequest(DUMMY_RESPONSE);
 
     // when
     client

--- a/clients/java/src/test/java/io/camunda/client/role/CreateRoleTest.java
+++ b/clients/java/src/test/java/io/camunda/client/role/CreateRoleTest.java
@@ -15,14 +15,16 @@
  */
 package io.camunda.client.role;
 
-import static io.camunda.client.impl.http.HttpClientFactory.REST_API_PATH;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.client.api.command.ProblemException;
 import io.camunda.client.protocol.rest.ProblemDetail;
 import io.camunda.client.protocol.rest.RoleCreateRequest;
+import io.camunda.client.protocol.rest.RoleCreateResult;
 import io.camunda.client.util.ClientRestTest;
+import io.camunda.client.util.RestGatewayPaths;
+import org.instancio.Instancio;
 import org.junit.jupiter.api.Test;
 
 public class CreateRoleTest extends ClientRestTest {
@@ -33,6 +35,9 @@ public class CreateRoleTest extends ClientRestTest {
 
   @Test
   void shouldCreateRole() {
+    // given
+    gatewayService.onCreateRoleRequest(Instancio.create(RoleCreateResult.class));
+
     // when
     client.newCreateRoleCommand().roleId(ROLE_ID).name(NAME).description(DESCRIPTION).send().join();
 
@@ -45,6 +50,9 @@ public class CreateRoleTest extends ClientRestTest {
 
   @Test
   void shouldCreateRoleWithoutDescription() {
+    // given
+    gatewayService.onCreateRoleRequest(Instancio.create(RoleCreateResult.class));
+
     // when
     client.newCreateRoleCommand().roleId(ROLE_ID).name(NAME).send().join();
 
@@ -59,7 +67,7 @@ public class CreateRoleTest extends ClientRestTest {
   void shouldRaiseExceptionOnRequestError() {
     // given
     gatewayService.errorOnRequest(
-        REST_API_PATH + "/roles", () -> new ProblemDetail().title("Not Found").status(404));
+        RestGatewayPaths.getRolesUrl(), () -> new ProblemDetail().title("Not Found").status(404));
 
     // when / then
     assertThatThrownBy(() -> client.newCreateRoleCommand().roleId(ROLE_ID).name(NAME).send().join())
@@ -86,10 +94,11 @@ public class CreateRoleTest extends ClientRestTest {
   @Test
   void shouldRaiseExceptionIfRoleAlreadyExists() {
     // given
+    gatewayService.onCreateRoleRequest(Instancio.create(RoleCreateResult.class));
     client.newCreateRoleCommand().roleId(ROLE_ID).name(NAME).send().join();
 
     gatewayService.errorOnRequest(
-        REST_API_PATH + "/roles", () -> new ProblemDetail().title("Conflict").status(409));
+        RestGatewayPaths.getRolesUrl(), () -> new ProblemDetail().title("Conflict").status(409));
 
     // when / then
     assertThatThrownBy(() -> client.newCreateRoleCommand().roleId(ROLE_ID).name(NAME).send().join())
@@ -101,7 +110,7 @@ public class CreateRoleTest extends ClientRestTest {
   void shouldHandleValidationErrorResponse() {
     // given
     gatewayService.errorOnRequest(
-        REST_API_PATH + "/roles", () -> new ProblemDetail().title("Bad Request").status(400));
+        RestGatewayPaths.getRolesUrl(), () -> new ProblemDetail().title("Bad Request").status(400));
 
     // when / then
     assertThatThrownBy(() -> client.newCreateRoleCommand().roleId(ROLE_ID).name(NAME).send().join())

--- a/clients/java/src/test/java/io/camunda/client/role/SearchRoleTest.java
+++ b/clients/java/src/test/java/io/camunda/client/role/SearchRoleTest.java
@@ -26,7 +26,9 @@ import io.camunda.client.api.search.filter.ClientFilter;
 import io.camunda.client.api.search.sort.ClientSort;
 import io.camunda.client.api.search.sort.RoleSort;
 import io.camunda.client.protocol.rest.ProblemDetail;
+import io.camunda.client.protocol.rest.RoleResult;
 import io.camunda.client.util.ClientRestTest;
+import org.instancio.Instancio;
 import org.junit.jupiter.api.Test;
 
 public class SearchRoleTest extends ClientRestTest {
@@ -35,6 +37,9 @@ public class SearchRoleTest extends ClientRestTest {
 
   @Test
   public void shouldSearchRoleByRoleId() {
+    // given
+    gatewayService.onRoleRequest(ROLE_ID, Instancio.create(RoleResult.class));
+
     // when
     client.newRoleGetRequest(ROLE_ID).send().join();
 

--- a/clients/java/src/test/java/io/camunda/client/role/UpdateRoleTest.java
+++ b/clients/java/src/test/java/io/camunda/client/role/UpdateRoleTest.java
@@ -19,7 +19,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.client.protocol.rest.RoleUpdateRequest;
+import io.camunda.client.protocol.rest.RoleUpdateResult;
 import io.camunda.client.util.ClientRestTest;
+import org.instancio.Instancio;
 import org.junit.jupiter.api.Test;
 
 public class UpdateRoleTest extends ClientRestTest {
@@ -29,6 +31,9 @@ public class UpdateRoleTest extends ClientRestTest {
 
   @Test
   void shouldUpdateRole() {
+    // given
+    gatewayService.onUpdateRoleRequest(ROLE_ID, Instancio.create(RoleUpdateResult.class));
+
     // when
     client
         .newUpdateRoleCommand(ROLE_ID)

--- a/clients/java/src/test/java/io/camunda/client/tenant/SearchTenantTest.java
+++ b/clients/java/src/test/java/io/camunda/client/tenant/SearchTenantTest.java
@@ -21,7 +21,9 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import com.github.tomakehurst.wiremock.http.RequestMethod;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
 import io.camunda.client.api.search.sort.TenantSort;
+import io.camunda.client.protocol.rest.TenantResult;
 import io.camunda.client.util.ClientRestTest;
+import org.instancio.Instancio;
 import org.junit.jupiter.api.Test;
 
 public class SearchTenantTest extends ClientRestTest {
@@ -30,6 +32,9 @@ public class SearchTenantTest extends ClientRestTest {
 
   @Test
   public void shouldSearchTenantByTenantId() {
+    // given
+    gatewayService.onTenantRequest(TENANT_ID, Instancio.create(TenantResult.class));
+
     // when
     client.newTenantGetRequest(TENANT_ID).send().join();
 

--- a/clients/java/src/test/java/io/camunda/client/tenant/UpdateTenantTest.java
+++ b/clients/java/src/test/java/io/camunda/client/tenant/UpdateTenantTest.java
@@ -22,7 +22,9 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import io.camunda.client.api.command.ProblemException;
 import io.camunda.client.protocol.rest.ProblemDetail;
 import io.camunda.client.protocol.rest.TenantUpdateRequest;
+import io.camunda.client.protocol.rest.TenantUpdateResult;
 import io.camunda.client.util.ClientRestTest;
+import org.instancio.Instancio;
 import org.junit.jupiter.api.Test;
 
 public class UpdateTenantTest extends ClientRestTest {
@@ -33,6 +35,9 @@ public class UpdateTenantTest extends ClientRestTest {
 
   @Test
   void shouldUpdateTenantName() {
+    // given
+    gatewayService.onUpdateTenantRequest(TENANT_ID, Instancio.create(TenantUpdateResult.class));
+
     // when
     client.newUpdateTenantCommand(TENANT_ID).name(UPDATED_NAME).send().join();
 
@@ -43,6 +48,9 @@ public class UpdateTenantTest extends ClientRestTest {
 
   @Test
   void shouldUpdateTenantDescription() {
+    // given
+    gatewayService.onUpdateTenantRequest(TENANT_ID, Instancio.create(TenantUpdateResult.class));
+
     // when
     client.newUpdateTenantCommand(TENANT_ID).description(UPDATED_DESCRIPTION).send().join();
 
@@ -53,6 +61,9 @@ public class UpdateTenantTest extends ClientRestTest {
 
   @Test
   void shouldUpdateTenantNameAndDescription() {
+    // given
+    gatewayService.onUpdateTenantRequest(TENANT_ID, Instancio.create(TenantUpdateResult.class));
+
     // when
     client
         .newUpdateTenantCommand(TENANT_ID)

--- a/clients/java/src/test/java/io/camunda/client/user/CreateUserTest.java
+++ b/clients/java/src/test/java/io/camunda/client/user/CreateUserTest.java
@@ -21,8 +21,10 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.client.api.command.ProblemException;
 import io.camunda.client.protocol.rest.ProblemDetail;
+import io.camunda.client.protocol.rest.UserCreateResult;
 import io.camunda.client.protocol.rest.UserRequest;
 import io.camunda.client.util.ClientRestTest;
+import org.instancio.Instancio;
 import org.junit.jupiter.api.Test;
 
 public class CreateUserTest extends ClientRestTest {
@@ -34,6 +36,9 @@ public class CreateUserTest extends ClientRestTest {
 
   @Test
   void shouldCreateUser() {
+    // given
+    gatewayService.onCreateUserRequest(Instancio.create(UserCreateResult.class));
+
     // when
     client
         .newCreateUserCommand()

--- a/clients/java/src/test/java/io/camunda/client/user/SearchUsersTest.java
+++ b/clients/java/src/test/java/io/camunda/client/user/SearchUsersTest.java
@@ -21,7 +21,10 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import com.github.tomakehurst.wiremock.http.RequestMethod;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
 import io.camunda.client.api.search.sort.UserSort;
+import io.camunda.client.protocol.rest.UserResult;
 import io.camunda.client.util.ClientRestTest;
+import io.camunda.client.util.RestGatewayPaths;
+import org.instancio.Instancio;
 import org.junit.jupiter.api.Test;
 
 public class SearchUsersTest extends ClientRestTest {
@@ -45,12 +48,16 @@ public class SearchUsersTest extends ClientRestTest {
 
   @Test
   public void shouldSearchUserByUsername() {
+    // given
+    final String username = "username";
+    gatewayService.onUserRequest(username, Instancio.create(UserResult.class));
+
     // when
-    client.newUserGetRequest("username").send().join();
+    client.newUserGetRequest(username).send().join();
 
     // then
     final LoggedRequest request = gatewayService.getLastRequest();
-    assertThat(request.getUrl()).isEqualTo("/v2/users/" + "username");
+    assertThat(request.getUrl()).isEqualTo(RestGatewayPaths.getUserUrl(username));
     assertThat(request.getMethod()).isEqualTo(RequestMethod.GET);
   }
 

--- a/clients/java/src/test/java/io/camunda/client/user/UpdateUserTest.java
+++ b/clients/java/src/test/java/io/camunda/client/user/UpdateUserTest.java
@@ -21,8 +21,10 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.github.tomakehurst.wiremock.http.RequestMethod;
 import io.camunda.client.protocol.rest.UserUpdateRequest;
+import io.camunda.client.protocol.rest.UserUpdateResult;
 import io.camunda.client.util.ClientRestTest;
 import io.camunda.client.util.RestGatewayService;
+import org.instancio.Instancio;
 import org.junit.jupiter.api.Test;
 
 public class UpdateUserTest extends ClientRestTest {
@@ -33,6 +35,9 @@ public class UpdateUserTest extends ClientRestTest {
 
   @Test
   void shouldUpdateUser() {
+    // given
+    gatewayService.onUpdateUserRequest(USERNAME, Instancio.create(UserUpdateResult.class));
+
     // when
     client.newUpdateUserCommand(USERNAME).name(NAME).email(EMAIL).password(PASSWORD).send().join();
 

--- a/clients/java/src/test/java/io/camunda/client/usertask/AssignUserTaskTest.java
+++ b/clients/java/src/test/java/io/camunda/client/usertask/AssignUserTaskTest.java
@@ -30,7 +30,7 @@ public final class AssignUserTaskTest extends ClientRestTest {
   @Test
   void shouldAssignUserTask() {
     // when
-    client.newUserTaskAssignCommand(123L).assignee("foo").send().join();
+    client.newAssignUserTaskCommand(123L).assignee("foo").send().join();
 
     // then
     final UserTaskAssignmentRequest request =
@@ -43,7 +43,7 @@ public final class AssignUserTaskTest extends ClientRestTest {
   @Test
   void shouldAssignUserTaskWithAction() {
     // when
-    client.newUserTaskAssignCommand(123L).action("foo").send().join();
+    client.newAssignUserTaskCommand(123L).action("foo").send().join();
 
     // then
     final UserTaskAssignmentRequest request =
@@ -57,7 +57,7 @@ public final class AssignUserTaskTest extends ClientRestTest {
   void shouldAssignUserTaskWithAllowOverride() {
     // when
 
-    client.newUserTaskAssignCommand(123L).allowOverride(true).send().join();
+    client.newAssignUserTaskCommand(123L).allowOverride(true).send().join();
 
     // then
     final UserTaskAssignmentRequest request =
@@ -71,7 +71,7 @@ public final class AssignUserTaskTest extends ClientRestTest {
   void shouldAssignUserTaskWithAllowOverrideDisabled() {
     // when
 
-    client.newUserTaskAssignCommand(123L).allowOverride(false).send().join();
+    client.newAssignUserTaskCommand(123L).allowOverride(false).send().join();
 
     // then
     final UserTaskAssignmentRequest request =
@@ -84,7 +84,7 @@ public final class AssignUserTaskTest extends ClientRestTest {
   @Test
   void shouldRaiseExceptionOnNullAssignee() {
     // when / then
-    assertThatThrownBy(() -> client.newUserTaskAssignCommand(123L).assignee(null).send().join())
+    assertThatThrownBy(() -> client.newAssignUserTaskCommand(123L).assignee(null).send().join())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("assignee must not be null");
   }
@@ -97,7 +97,7 @@ public final class AssignUserTaskTest extends ClientRestTest {
         () -> new ProblemDetail().title("Not Found").status(404));
 
     // when / then
-    assertThatThrownBy(() -> client.newUserTaskAssignCommand(123L).send().join())
+    assertThatThrownBy(() -> client.newAssignUserTaskCommand(123L).send().join())
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 404: 'Not Found'");
   }

--- a/clients/java/src/test/java/io/camunda/client/usertask/CompleteUserTaskTest.java
+++ b/clients/java/src/test/java/io/camunda/client/usertask/CompleteUserTaskTest.java
@@ -31,7 +31,7 @@ public final class CompleteUserTaskTest extends ClientRestTest {
   @Test
   void shouldCompleteUserTask() {
     // when
-    client.newUserTaskCompleteCommand(123L).send().join();
+    client.newCompleteUserTaskCommand(123L).send().join();
 
     // then
     final UserTaskCompletionRequest request =
@@ -43,7 +43,7 @@ public final class CompleteUserTaskTest extends ClientRestTest {
   @Test
   void shouldCompleteUserTaskWithAction() {
     // when
-    client.newUserTaskCompleteCommand(123L).action("foo").send().join();
+    client.newCompleteUserTaskCommand(123L).action("foo").send().join();
 
     // then
     final UserTaskCompletionRequest request =
@@ -56,7 +56,7 @@ public final class CompleteUserTaskTest extends ClientRestTest {
   void shouldCompleteUserTaskWithVariables() {
     // when
 
-    client.newUserTaskCompleteCommand(123L).variables(singletonMap("foo", "bar")).send().join();
+    client.newCompleteUserTaskCommand(123L).variables(singletonMap("foo", "bar")).send().join();
 
     // then
     final UserTaskCompletionRequest request =
@@ -73,7 +73,7 @@ public final class CompleteUserTaskTest extends ClientRestTest {
         () -> new ProblemDetail().title("Not Found").status(404));
 
     // when / then
-    assertThatThrownBy(() -> client.newUserTaskCompleteCommand(123L).send().join())
+    assertThatThrownBy(() -> client.newCompleteUserTaskCommand(123L).send().join())
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 404: 'Not Found'");
   }

--- a/clients/java/src/test/java/io/camunda/client/usertask/GetUserTaskTest.java
+++ b/clients/java/src/test/java/io/camunda/client/usertask/GetUserTaskTest.java
@@ -19,19 +19,32 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.github.tomakehurst.wiremock.http.RequestMethod;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+import io.camunda.client.protocol.rest.UserTaskResult;
 import io.camunda.client.util.ClientRestTest;
+import io.camunda.client.util.RestGatewayPaths;
+import org.instancio.Instancio;
 import org.junit.jupiter.api.Test;
 
 public class GetUserTaskTest extends ClientRestTest {
   @Test
   void shouldGetUserTask() {
-    // when
+    // given
     final long userTaskKey = 1L;
+    gatewayService.onUserTaskRequest(
+        userTaskKey,
+        Instancio.create(UserTaskResult.class)
+            .formKey("1")
+            .elementInstanceKey("2")
+            .processDefinitionKey("3")
+            .processInstanceKey("4")
+            .userTaskKey("5"));
+
+    // when
     client.newUserTaskGetRequest(userTaskKey).send().join();
 
     // then
     final LoggedRequest request = gatewayService.getLastRequest();
-    assertThat(request.getUrl()).isEqualTo("/v2/user-tasks/" + userTaskKey);
+    assertThat(request.getUrl()).isEqualTo(RestGatewayPaths.getUserTaskUrl(userTaskKey));
     assertThat(request.getMethod()).isEqualTo(RequestMethod.GET);
   }
 }

--- a/clients/java/src/test/java/io/camunda/client/usertask/SearchUserTaskTest.java
+++ b/clients/java/src/test/java/io/camunda/client/usertask/SearchUserTaskTest.java
@@ -21,6 +21,7 @@ import com.github.tomakehurst.wiremock.http.RequestMethod;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
 import io.camunda.client.api.search.enums.UserTaskState;
 import io.camunda.client.api.search.filter.builder.UserTaskStateProperty;
+import io.camunda.client.protocol.rest.FormResult;
 import io.camunda.client.protocol.rest.IntegerFilterProperty;
 import io.camunda.client.protocol.rest.StringFilterProperty;
 import io.camunda.client.protocol.rest.UserTaskFilter;
@@ -34,6 +35,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
+import org.instancio.Instancio;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Named;
 import org.junit.jupiter.api.Test;
@@ -274,8 +276,12 @@ public final class SearchUserTaskTest extends ClientRestTest {
 
   @Test
   void shouldReturnFormByUserTaskKey() {
-    // when
+    // given
     final long userTaskKey = 1L;
+    gatewayService.onUserTaskFormRequest(
+        userTaskKey, Instancio.create(FormResult.class).formKey("1"));
+
+    // when
     client.newUserTaskGetFormRequest(userTaskKey).send().join();
 
     // then

--- a/clients/java/src/test/java/io/camunda/client/usertask/UnassignUserTaskTest.java
+++ b/clients/java/src/test/java/io/camunda/client/usertask/UnassignUserTaskTest.java
@@ -31,7 +31,7 @@ public final class UnassignUserTaskTest extends ClientRestTest {
   @Test
   void shouldUnassignUserTask() {
     // when
-    client.newUserTaskUnassignCommand(123L).send().join();
+    client.newUnassignUserTaskCommand(123L).send().join();
 
     // then
     assertThat(RestGatewayService.getLastRequest())
@@ -47,7 +47,7 @@ public final class UnassignUserTaskTest extends ClientRestTest {
         () -> new ProblemDetail().title("Not Found").status(404));
 
     // when / then
-    assertThatThrownBy(() -> client.newUserTaskUnassignCommand(123L).send().join())
+    assertThatThrownBy(() -> client.newUnassignUserTaskCommand(123L).send().join())
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 404: 'Not Found'");
   }

--- a/clients/java/src/test/java/io/camunda/client/usertask/UpdateUserTaskTest.java
+++ b/clients/java/src/test/java/io/camunda/client/usertask/UpdateUserTaskTest.java
@@ -40,7 +40,7 @@ public final class UpdateUserTaskTest extends ClientRestTest {
   @Test
   void shouldUpdateUserTask() {
     // when
-    client.newUserTaskUpdateCommand(123L).send().join();
+    client.newUpdateUserTaskCommand(123L).send().join();
 
     // then
     final UserTaskUpdateRequest request =
@@ -52,7 +52,7 @@ public final class UpdateUserTaskTest extends ClientRestTest {
   @Test
   void shouldUpdateUserTaskWithAction() {
     // when
-    client.newUserTaskUpdateCommand(123L).action("foo").send().join();
+    client.newUpdateUserTaskCommand(123L).action("foo").send().join();
 
     // then
     final UserTaskUpdateRequest request =
@@ -64,7 +64,7 @@ public final class UpdateUserTaskTest extends ClientRestTest {
   @Test
   void shouldUpdateUserTaskWithDueDate() {
     // when
-    client.newUserTaskUpdateCommand(123L).dueDate(TEST_TIME).send().join();
+    client.newUpdateUserTaskCommand(123L).dueDate(TEST_TIME).send().join();
 
     // then
     final UserTaskUpdateRequest request =
@@ -76,7 +76,7 @@ public final class UpdateUserTaskTest extends ClientRestTest {
   @Test
   void shouldUpdateUserTaskWithFollowUpDate() {
     // when
-    client.newUserTaskUpdateCommand(123L).followUpDate(TEST_TIME).send().join();
+    client.newUpdateUserTaskCommand(123L).followUpDate(TEST_TIME).send().join();
 
     // then
     final UserTaskUpdateRequest request =
@@ -88,7 +88,7 @@ public final class UpdateUserTaskTest extends ClientRestTest {
   @Test
   void shouldUpdateUserTaskWithDueDateAndFollowUpDate() {
     // when
-    client.newUserTaskUpdateCommand(123L).dueDate(TEST_TIME).followUpDate(TEST_TIME).send().join();
+    client.newUpdateUserTaskCommand(123L).dueDate(TEST_TIME).followUpDate(TEST_TIME).send().join();
 
     // then
     final UserTaskUpdateRequest request =
@@ -102,7 +102,7 @@ public final class UpdateUserTaskTest extends ClientRestTest {
   @Test
   void shouldUpdateUserTaskWithCandidateGroup() {
     // when
-    client.newUserTaskUpdateCommand(123L).candidateGroups("foo").send().join();
+    client.newUpdateUserTaskCommand(123L).candidateGroups("foo").send().join();
 
     // then
     final UserTaskUpdateRequest request =
@@ -116,7 +116,7 @@ public final class UpdateUserTaskTest extends ClientRestTest {
   @Test
   void shouldUpdateUserTaskWithCandidateGroups() {
     // when
-    client.newUserTaskUpdateCommand(123L).candidateGroups("foo", "bar").send().join();
+    client.newUpdateUserTaskCommand(123L).candidateGroups("foo", "bar").send().join();
 
     // then
     final UserTaskUpdateRequest request =
@@ -131,7 +131,7 @@ public final class UpdateUserTaskTest extends ClientRestTest {
   void shouldUpdateUserTaskWithCandidateGroupsList() {
     // when
     client
-        .newUserTaskUpdateCommand(123L)
+        .newUpdateUserTaskCommand(123L)
         .candidateGroups(Arrays.asList("foo", "bar"))
         .send()
         .join();
@@ -148,7 +148,7 @@ public final class UpdateUserTaskTest extends ClientRestTest {
   @Test
   void shouldUpdateUserTaskWithCandidateUser() {
     // when
-    client.newUserTaskUpdateCommand(123L).candidateUsers("foo").send().join();
+    client.newUpdateUserTaskCommand(123L).candidateUsers("foo").send().join();
 
     // then
     final UserTaskUpdateRequest request =
@@ -162,7 +162,7 @@ public final class UpdateUserTaskTest extends ClientRestTest {
   @Test
   void shouldUpdateUserTaskWithCandidateUsers() {
     // when
-    client.newUserTaskUpdateCommand(123L).candidateUsers("foo", "bar").send().join();
+    client.newUpdateUserTaskCommand(123L).candidateUsers("foo", "bar").send().join();
 
     // then
     final UserTaskUpdateRequest request =
@@ -176,7 +176,7 @@ public final class UpdateUserTaskTest extends ClientRestTest {
   @Test
   void shouldUpdateUserTaskWithCandidateUsersList() {
     // when
-    client.newUserTaskUpdateCommand(123L).candidateUsers(Arrays.asList("foo", "bar")).send().join();
+    client.newUpdateUserTaskCommand(123L).candidateUsers(Arrays.asList("foo", "bar")).send().join();
 
     // then
     final UserTaskUpdateRequest request =
@@ -191,7 +191,7 @@ public final class UpdateUserTaskTest extends ClientRestTest {
   void shouldClearUserTaskDueDate() {
     // given
     final UpdateUserTaskCommandStep1 updateUserTaskCommandStep1 =
-        client.newUserTaskUpdateCommand(123L).dueDate(TEST_TIME);
+        client.newUpdateUserTaskCommand(123L).dueDate(TEST_TIME);
 
     // when
     updateUserTaskCommandStep1.clearDueDate().send().join();
@@ -207,7 +207,7 @@ public final class UpdateUserTaskTest extends ClientRestTest {
   void shouldClearUserTaskFollowUpDate() {
     // given
     final UpdateUserTaskCommandStep1 updateUserTaskCommandStep1 =
-        client.newUserTaskUpdateCommand(123L).followUpDate(TEST_TIME);
+        client.newUpdateUserTaskCommand(123L).followUpDate(TEST_TIME);
 
     // when
     updateUserTaskCommandStep1.clearFollowUpDate().send().join();
@@ -223,7 +223,7 @@ public final class UpdateUserTaskTest extends ClientRestTest {
   void shouldClearUserTaskCandidateGroups() {
     // given
     final UpdateUserTaskCommandStep1 updateUserTaskCommandStep1 =
-        client.newUserTaskUpdateCommand(123L).candidateGroups("foo");
+        client.newUpdateUserTaskCommand(123L).candidateGroups("foo");
 
     // when
     updateUserTaskCommandStep1.clearCandidateGroups().send().join();
@@ -241,7 +241,7 @@ public final class UpdateUserTaskTest extends ClientRestTest {
   void shouldClearUserTaskCandidateUsers() {
     // given
     final UpdateUserTaskCommandStep1 updateUserTaskCommandStep1 =
-        client.newUserTaskUpdateCommand(123L).candidateUsers("foo");
+        client.newUpdateUserTaskCommand(123L).candidateUsers("foo");
 
     // when
     updateUserTaskCommandStep1.clearCandidateUsers().send().join();
@@ -263,7 +263,7 @@ public final class UpdateUserTaskTest extends ClientRestTest {
         () -> new ProblemDetail().title("Not Found").status(404));
 
     // when / then
-    assertThatThrownBy(() -> client.newUserTaskUpdateCommand(123L).send().join())
+    assertThatThrownBy(() -> client.newUpdateUserTaskCommand(123L).send().join())
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 404: 'Not Found'");
   }
@@ -271,7 +271,7 @@ public final class UpdateUserTaskTest extends ClientRestTest {
   @Test
   void shouldUpdateTaskPriority() {
     // when
-    client.newUserTaskUpdateCommand(123L).priority(95).send().join();
+    client.newUpdateUserTaskCommand(123L).priority(95).send().join();
 
     // then
     final UserTaskUpdateRequest request =
@@ -292,7 +292,7 @@ public final class UpdateUserTaskTest extends ClientRestTest {
                 .detail("Priority field must be an integer between 0 and 100. Provided: 120"));
 
     // when / then
-    assertThatThrownBy(() -> client.newUserTaskUpdateCommand(123L).priority(120).send().join())
+    assertThatThrownBy(() -> client.newUpdateUserTaskCommand(123L).priority(120).send().join())
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Priority field must be an integer between 0 and 100. Provided: 120");
   }

--- a/clients/java/src/test/java/io/camunda/client/util/RestGatewayPaths.java
+++ b/clients/java/src/test/java/io/camunda/client/util/RestGatewayPaths.java
@@ -19,27 +19,63 @@ import static io.camunda.client.impl.http.HttpClientFactory.REST_API_PATH;
 
 public class RestGatewayPaths {
 
+  private static final String URL_AUTHORIZATION = REST_API_PATH + "/authorizations/%s";
+  private static final String URL_AUTHORIZATIONS = REST_API_PATH + "/authorizations";
+  private static final String URL_BATCH_OPERATION = REST_API_PATH + "/batch-operations/%s";
   private static final String URL_CLOCK_PIN = REST_API_PATH + "/clock";
   private static final String URL_CLOCK_RESET = REST_API_PATH + "/clock/reset";
+  private static final String URL_DECISION_DEFINITION = REST_API_PATH + "/decision-definitions/%s";
   private static final String URL_DECISION_EVALUATION =
       REST_API_PATH + "/decision-definitions/evaluation";
-  private static final String URL_DEPLOYMENTS_URL = REST_API_PATH + "/deployments";
+  private static final String URL_DECISION_INSTANCE = REST_API_PATH + "/decision-instances/%s";
+  private static final String URL_DECISION_REQUIREMENTS =
+      REST_API_PATH + "/decision-requirements/%s";
+  private static final String URL_DEPLOYMENTS = REST_API_PATH + "/deployments";
+  private static final String URL_ELEMENT_INSTANCE = REST_API_PATH + "/element-instances/%s";
+  private static final String URL_GROUP = REST_API_PATH + "/groups/%s";
+  private static final String URL_GROUPS = REST_API_PATH + "/groups";
+  private static final String URL_INCIDENT = REST_API_PATH + "/incidents/%s";
   private static final String URL_INCIDENT_RESOLUTION = REST_API_PATH + "/incidents/%s/resolution";
   private static final String URL_JOB_ACTIVATION = REST_API_PATH + "/jobs/activation";
+  private static final String URL_MAPPING_RULES = REST_API_PATH + "/mapping-rules";
   private static final String URL_MESSAGE_PUBLICATION = REST_API_PATH + "/messages/publication";
+  private static final String URL_MESSAGE_CORRELATION = REST_API_PATH + "/messages/correlation";
+  private static final String URL_PROCESS_DEFINITION = REST_API_PATH + "/process-definitions/%s";
+  private static final String URL_PROCESS_DEFINITION_FORM =
+      REST_API_PATH + "/process-definitions/%s/form";
+  private static final String URL_PROCESS_INSTANCE = REST_API_PATH + "/process-instances/%s";
   private static final String URL_PROCESS_INSTANCE_CANCELLATION =
       REST_API_PATH + "/process-instances/%s/cancellation";
-  private static final String URL_PROCESS_INSTANCE_CREATION = REST_API_PATH + "/process-instances";
+  private static final String URL_PROCESS_INSTANCE_CALL_HIERARCHY =
+      REST_API_PATH + "/process-instances/%s/call-hierarchy";
+  private static final String URL_PROCESS_INSTANCE_SEQUENCE_FLOWS =
+      REST_API_PATH + "/process-instances/%s/sequence-flows";
+  private static final String URL_PROCESS_INSTANCES = REST_API_PATH + "/process-instances";
+  private static final String URL_PROCESS_INSTANCES_CANCELLATION =
+      REST_API_PATH + "/process-instances/cancellation";
+  private static final String URL_PROCESS_INSTANCES_MIGRATION =
+      REST_API_PATH + "/process-instances/migration";
+  private static final String URL_PROCESS_INSTANCES_MODIFICATION =
+      REST_API_PATH + "/process-instances/modification";
+  private static final String URL_ROLE = REST_API_PATH + "/roles/%s";
+  private static final String URL_ROLES = REST_API_PATH + "/roles";
   private static final String URL_SIGNAL_BROADCAST = REST_API_PATH + "/signals/broadcast";
+  private static final String URL_TENANT = REST_API_PATH + "/tenants/%s";
+  private static final String URL_TENANTS = REST_API_PATH + "/tenants";
   private static final String URL_TOPOLOGY = REST_API_PATH + "/topology";
   private static final String URL_USAGE_METRICS = REST_API_PATH + "/system/usage-metrics";
+  private static final String URL_USER = REST_API_PATH + "/users/%s";
+  private static final String URL_USERS = REST_API_PATH + "/users";
+  private static final String URL_USER_TASK = REST_API_PATH + "/user-tasks/%s";
   private static final String URL_USER_TASK_ASSIGNMENT =
       REST_API_PATH + "/user-tasks/%s/assignment";
   private static final String URL_USER_TASK_COMPLETION =
       REST_API_PATH + "/user-tasks/%s/completion";
+  private static final String URL_USER_TASK_FORM = REST_API_PATH + "/user-tasks/%s/form";
   private static final String URL_USER_TASK_UNASSIGNMENT =
       REST_API_PATH + "/user-tasks/%s/assignee";
   private static final String URL_USER_TASK_UPDATE = REST_API_PATH + "/user-tasks/%s";
+  private static final String URL_VARIABLE = REST_API_PATH + "/variables/%s";
 
   /**
    * @return the topology request URL
@@ -129,17 +165,133 @@ public class RestGatewayPaths {
   }
 
   /**
-   * @return create process instance request URL
+   * @return process instances request URL
    */
-  public static String getCreateProcessInstanceUrl() {
-    return URL_PROCESS_INSTANCE_CREATION;
+  public static String getProcessInstancesUrl() {
+    return URL_PROCESS_INSTANCES;
   }
 
   public static String getDeploymentsUrl() {
-    return URL_DEPLOYMENTS_URL;
+    return URL_DEPLOYMENTS;
   }
 
   public static String getUsageMetricsUrl() {
     return URL_USAGE_METRICS;
+  }
+
+  public static String getDecisionDefinitionUrl(final long decisionDefinitionKey) {
+    return String.format(URL_DECISION_DEFINITION, decisionDefinitionKey);
+  }
+
+  public static String getCreateTenantUrl() {
+    return URL_TENANTS;
+  }
+
+  public static String getCreateUserUrl() {
+    return URL_USERS;
+  }
+
+  public static String getMessageCorrelationUrl() {
+    return URL_MESSAGE_CORRELATION;
+  }
+
+  public static String getProcessInstanceCallHierarchyUrl(final long processInstanceKey) {
+    return String.format(URL_PROCESS_INSTANCE_CALL_HIERARCHY, processInstanceKey);
+  }
+
+  public static String getProcessInstancesUrl(final long processInstanceKey) {
+    return String.format(URL_PROCESS_INSTANCE, processInstanceKey);
+  }
+
+  public static String getGroupUrl(final String groupId) {
+    return String.format(URL_GROUP, groupId);
+  }
+
+  public static String getProcessDefinitionFormUrl(final long processDefinitionKey) {
+    return String.format(URL_PROCESS_DEFINITION_FORM, processDefinitionKey);
+  }
+
+  public static String getProcessDefinitionUrl(final long processDefinitionKey) {
+    return String.format(URL_PROCESS_DEFINITION, processDefinitionKey);
+  }
+
+  public static String getUserUrl(final String username) {
+    return String.format(URL_USER, username);
+  }
+
+  public static String getMappingRulesUrl() {
+    return URL_MAPPING_RULES;
+  }
+
+  public static String getGroupsUrl() {
+    return URL_GROUPS;
+  }
+
+  public static String getProcessInstancesCancelUrl() {
+    return URL_PROCESS_INSTANCES_CANCELLATION;
+  }
+
+  public static String getProcessInstancesMigrateUrl() {
+    return URL_PROCESS_INSTANCES_MIGRATION;
+  }
+
+  public static String getProcessInstancesModifyUrl() {
+    return URL_PROCESS_INSTANCES_MODIFICATION;
+  }
+
+  public static String getAuthorizationsUrl() {
+    return URL_AUTHORIZATIONS;
+  }
+
+  public static String getTenantUrl(final String tenantId) {
+    return String.format(URL_TENANT, tenantId);
+  }
+
+  public static String getRoleUrl(final String roleId) {
+    return String.format(URL_ROLE, roleId);
+  }
+
+  public static String getDecisionRequirementsUrl(final long decisionRequirementsKey) {
+    return String.format(URL_DECISION_REQUIREMENTS, decisionRequirementsKey);
+  }
+
+  public static String getIncidentUrl(final long incidentKey) {
+    return String.format(URL_INCIDENT, incidentKey);
+  }
+
+  public static String getDecisionInstanceUrl(final String decisionInstanceId) {
+    return String.format(URL_DECISION_INSTANCE, decisionInstanceId);
+  }
+
+  public static String getUserTaskFormUrl(final long userTaskKey) {
+    return String.format(URL_USER_TASK_FORM, userTaskKey);
+  }
+
+  public static String getProcessInstanceSequenceFlowsUrl(final long processInstanceKey) {
+    return String.format(URL_PROCESS_INSTANCE_SEQUENCE_FLOWS, processInstanceKey);
+  }
+
+  public static String getBatchOperationUrl(final String batchOperationKey) {
+    return String.format(URL_BATCH_OPERATION, batchOperationKey);
+  }
+
+  public static String getVariableUrl(final long variableKey) {
+    return String.format(URL_VARIABLE, variableKey);
+  }
+
+  public static String getRolesUrl() {
+    return URL_ROLES;
+  }
+
+  public static String getAuthorizationUrl(final long authorizationKey) {
+    return String.format(URL_AUTHORIZATION, authorizationKey);
+  }
+
+  public static String getUserTaskUrl(final long userTaskKey) {
+    return String.format(URL_USER_TASK, userTaskKey);
+  }
+
+  public static String getElementInstanceUrl(final long elementInstanceKey) {
+    return String.format(URL_ELEMENT_INSTANCE, elementInstanceKey);
   }
 }

--- a/clients/java/src/test/java/io/camunda/client/util/RestGatewayPaths.java
+++ b/clients/java/src/test/java/io/camunda/client/util/RestGatewayPaths.java
@@ -19,8 +19,20 @@ import static io.camunda.client.impl.http.HttpClientFactory.REST_API_PATH;
 
 public class RestGatewayPaths {
 
-  private static final String URL_TOPOLOGY = REST_API_PATH + "/topology";
+  private static final String URL_CLOCK_PIN = REST_API_PATH + "/clock";
+  private static final String URL_CLOCK_RESET = REST_API_PATH + "/clock/reset";
+  private static final String URL_DECISION_EVALUATION =
+      REST_API_PATH + "/decision-definitions/evaluation";
+  private static final String URL_DEPLOYMENTS_URL = REST_API_PATH + "/deployments";
+  private static final String URL_INCIDENT_RESOLUTION = REST_API_PATH + "/incidents/%s/resolution";
   private static final String URL_JOB_ACTIVATION = REST_API_PATH + "/jobs/activation";
+  private static final String URL_MESSAGE_PUBLICATION = REST_API_PATH + "/messages/publication";
+  private static final String URL_PROCESS_INSTANCE_CANCELLATION =
+      REST_API_PATH + "/process-instances/%s/cancellation";
+  private static final String URL_PROCESS_INSTANCE_CREATION = REST_API_PATH + "/process-instances";
+  private static final String URL_SIGNAL_BROADCAST = REST_API_PATH + "/signals/broadcast";
+  private static final String URL_TOPOLOGY = REST_API_PATH + "/topology";
+  private static final String URL_USAGE_METRICS = REST_API_PATH + "/system/usage-metrics";
   private static final String URL_USER_TASK_ASSIGNMENT =
       REST_API_PATH + "/user-tasks/%s/assignment";
   private static final String URL_USER_TASK_COMPLETION =
@@ -28,19 +40,6 @@ public class RestGatewayPaths {
   private static final String URL_USER_TASK_UNASSIGNMENT =
       REST_API_PATH + "/user-tasks/%s/assignee";
   private static final String URL_USER_TASK_UPDATE = REST_API_PATH + "/user-tasks/%s";
-  private static final String URL_MESSAGE_PUBLICATION = REST_API_PATH + "/messages/publication";
-  private static final String URL_CLOCK_PIN = REST_API_PATH + "/clock";
-  private static final String URL_CLOCK_RESET = REST_API_PATH + "/clock/reset";
-  private static final String URL_INCIDENT_RESOLUTION = REST_API_PATH + "/incidents/%s/resolution";
-  private static final String URL_CANCEL_PROCESS =
-      REST_API_PATH + "/process-instances/%s/cancellation";
-  private static final String URL_BROADCAST_SIGNAL = REST_API_PATH + "/signals/broadcast";
-  private static final String URL_EVALUATE_DECISION =
-      REST_API_PATH + "/decision-definitions/evaluation";
-  private static final String URL_CREATE_PROCESS_INSTANCE = REST_API_PATH + "/process-instances";
-  private static final String URL_DEPLOYMENTS_URL = REST_API_PATH + "/deployments";
-  private static final String URL_AD_HOC_SUB_PROCESS_ACTIVITIES_SEARCH =
-      REST_API_PATH + "/element-instances/ad-hoc-activities/search";
 
   /**
    * @return the topology request URL
@@ -118,29 +117,29 @@ public class RestGatewayPaths {
   }
 
   public static String getCancelProcessUrl(final long processInstanceKey) {
-    return String.format(URL_CANCEL_PROCESS, processInstanceKey);
+    return String.format(URL_PROCESS_INSTANCE_CANCELLATION, processInstanceKey);
   }
 
   public static String getBroadcastSignalUrl() {
-    return URL_BROADCAST_SIGNAL;
+    return URL_SIGNAL_BROADCAST;
   }
 
   public static String getEvaluateDecisionUrl() {
-    return URL_EVALUATE_DECISION;
+    return URL_DECISION_EVALUATION;
   }
 
   /**
    * @return create process instance request URL
    */
   public static String getCreateProcessInstanceUrl() {
-    return URL_CREATE_PROCESS_INSTANCE;
+    return URL_PROCESS_INSTANCE_CREATION;
   }
 
   public static String getDeploymentsUrl() {
     return URL_DEPLOYMENTS_URL;
   }
 
-  public static String getAdHocSubProcessActivitiesSearchUrl() {
-    return URL_AD_HOC_SUB_PROCESS_ACTIVITIES_SEARCH;
+  public static String getUsageMetricsUrl() {
+    return URL_USAGE_METRICS;
   }
 }

--- a/clients/java/src/test/java/io/camunda/client/util/RestGatewayService.java
+++ b/clients/java/src/test/java/io/camunda/client/util/RestGatewayService.java
@@ -15,18 +15,51 @@
  */
 package io.camunda.client.util;
 
+import com.github.tomakehurst.wiremock.client.MappingBuilder;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
 import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
 import io.camunda.client.impl.CamundaObjectMapper;
+import io.camunda.client.protocol.rest.AuthorizationCreateResult;
+import io.camunda.client.protocol.rest.AuthorizationResult;
+import io.camunda.client.protocol.rest.BatchOperationCreatedResult;
+import io.camunda.client.protocol.rest.BatchOperationResponse;
+import io.camunda.client.protocol.rest.DecisionDefinitionResult;
+import io.camunda.client.protocol.rest.DecisionInstanceResult;
+import io.camunda.client.protocol.rest.DecisionRequirementsResult;
 import io.camunda.client.protocol.rest.DeploymentResult;
+import io.camunda.client.protocol.rest.ElementInstanceResult;
 import io.camunda.client.protocol.rest.EvaluateDecisionResult;
+import io.camunda.client.protocol.rest.FormResult;
+import io.camunda.client.protocol.rest.GroupCreateResult;
+import io.camunda.client.protocol.rest.GroupResult;
+import io.camunda.client.protocol.rest.GroupUpdateResult;
+import io.camunda.client.protocol.rest.IncidentResult;
 import io.camunda.client.protocol.rest.JobActivationResult;
+import io.camunda.client.protocol.rest.MappingRuleCreateResult;
+import io.camunda.client.protocol.rest.MessageCorrelationResult;
+import io.camunda.client.protocol.rest.MessagePublicationResult;
 import io.camunda.client.protocol.rest.ProblemDetail;
+import io.camunda.client.protocol.rest.ProcessDefinitionResult;
+import io.camunda.client.protocol.rest.ProcessInstanceResult;
+import io.camunda.client.protocol.rest.ProcessInstanceSequenceFlowsQueryResult;
+import io.camunda.client.protocol.rest.RoleCreateResult;
+import io.camunda.client.protocol.rest.RoleResult;
+import io.camunda.client.protocol.rest.RoleUpdateResult;
 import io.camunda.client.protocol.rest.SearchQueryResponse;
+import io.camunda.client.protocol.rest.SignalBroadcastResult;
+import io.camunda.client.protocol.rest.TenantCreateResult;
+import io.camunda.client.protocol.rest.TenantResult;
+import io.camunda.client.protocol.rest.TenantUpdateResult;
 import io.camunda.client.protocol.rest.TopologyResponse;
 import io.camunda.client.protocol.rest.UsageMetricsResponse;
+import io.camunda.client.protocol.rest.UserCreateResult;
+import io.camunda.client.protocol.rest.UserResult;
+import io.camunda.client.protocol.rest.UserTaskResult;
+import io.camunda.client.protocol.rest.UserUpdateResult;
+import io.camunda.client.protocol.rest.VariableResult;
+import java.util.Collections;
 import java.util.List;
 import java.util.function.Supplier;
 import org.assertj.core.api.Assertions;
@@ -47,69 +80,49 @@ public class RestGatewayService {
      * registration can simply invoke commands and send requests.
      * Otherwise, Wiremock fails if no stubs are registered but a request is sent.
      */
-    mockInfo.getWireMock().register(WireMock.any(WireMock.anyUrl()).willReturn(WireMock.ok()));
+    this.mockInfo.getWireMock().register(WireMock.any(WireMock.anyUrl()).willReturn(WireMock.ok()));
     // Register a default search response
-    mockInfo
-        .getWireMock()
-        .register(
-            WireMock.post(WireMock.urlPathMatching(".*/search"))
-                .willReturn(WireMock.okJson(JSON_MAPPER.toJson(DUMMY_SEARCH_RESULT))));
+    register(WireMock.post(WireMock.urlPathMatching(".*/search")), DUMMY_SEARCH_RESULT);
     // Register an empty default statistics response
-    mockInfo
-        .getWireMock()
-        .register(
-            WireMock.any(WireMock.urlPathMatching(".*/statistics/.*"))
-                .willReturn(WireMock.okJson("{\"items\":  []}")));
+    register(
+        WireMock.any(WireMock.urlPathMatching(".*/statistics/.*")),
+        Collections.singletonMap("items", Collections.emptyList()));
   }
 
   /**
    * Register the given response for job activation requests.
    *
-   * @param jobActivationResponse the response to provide upon a job activation request
+   * @param response the response to provide upon a job activation request
    */
-  public void onActivateJobsRequest(final JobActivationResult jobActivationResponse) {
-    mockInfo
-        .getWireMock()
-        .register(
-            WireMock.post(RestGatewayPaths.getJobActivationUrl())
-                .willReturn(WireMock.okJson(JSON_MAPPER.toJson(jobActivationResponse))));
+  public void onActivateJobsRequest(final JobActivationResult response) {
+    registerPost(RestGatewayPaths.getJobActivationUrl(), response);
   }
 
   /**
    * Register the given response for topology requests.
    *
-   * @param topologyResponse the response to provide upon a topology request
+   * @param response the response to provide upon a topology request
    */
-  public void onTopologyRequest(final TopologyResponse topologyResponse) {
-    mockInfo
-        .getWireMock()
-        .register(
-            WireMock.get(RestGatewayPaths.getTopologyUrl())
-                .willReturn(WireMock.okJson(JSON_MAPPER.toJson(topologyResponse))));
+  public void onTopologyRequest(final TopologyResponse response) {
+    registerGet(RestGatewayPaths.getTopologyUrl(), response);
   }
 
   public void onEvaluateDecisionRequest(final EvaluateDecisionResult response) {
-    mockInfo
-        .getWireMock()
-        .register(
-            WireMock.post(RestGatewayPaths.getEvaluateDecisionUrl())
-                .willReturn(WireMock.okJson(JSON_MAPPER.toJson(response))));
+    registerPost(RestGatewayPaths.getEvaluateDecisionUrl(), response);
   }
 
   public void onDeploymentsRequest(final DeploymentResult response) {
-    mockInfo
-        .getWireMock()
-        .register(
-            WireMock.post(RestGatewayPaths.getDeploymentsUrl())
-                .willReturn(WireMock.okJson(JSON_MAPPER.toJson(response))));
+    registerPost(RestGatewayPaths.getDeploymentsUrl(), response);
   }
 
-  public void onUsageMetricsRequest(final UsageMetricsResponse usageMetricsResponse) {
-    mockInfo
-        .getWireMock()
-        .register(
-            WireMock.get(WireMock.urlMatching(RestGatewayPaths.getUsageMetricsUrl() + ".*"))
-                .willReturn(WireMock.okJson(JSON_MAPPER.toJson(usageMetricsResponse))));
+  public void onUsageMetricsRequest(final UsageMetricsResponse response) {
+    register(
+        WireMock.get(WireMock.urlMatching(RestGatewayPaths.getUsageMetricsUrl() + ".*")), response);
+  }
+
+  public void onDecisionDefinitionRequest(
+      final long decisionDefinitionKey, final DecisionDefinitionResult response) {
+    registerGet(RestGatewayPaths.getDecisionDefinitionUrl(decisionDefinitionKey), response);
   }
 
   /**
@@ -158,5 +171,173 @@ public class RestGatewayService {
                             JSON_MAPPER.toJson(problemDetail),
                             problemDetail.getStatus() == null ? 400 : problemDetail.getStatus())
                         .withHeader("Content-Type", "application/problem+json")));
+  }
+
+  private void registerPost(final String url, final Object response) {
+    register(WireMock.post(url), response);
+  }
+
+  private void registerGet(final String url, final Object response) {
+    register(WireMock.get(url), response);
+  }
+
+  private void registerPut(final String url, final Object response) {
+    register(WireMock.put(url), response);
+  }
+
+  private void register(final MappingBuilder builder, final Object response) {
+    mockInfo
+        .getWireMock()
+        .register(builder.willReturn(WireMock.okJson(JSON_MAPPER.toJson(response))));
+  }
+
+  public void onCreateTenantRequest(final TenantCreateResult response) {
+    registerPost(RestGatewayPaths.getCreateTenantUrl(), response);
+  }
+
+  public void onCreateUserRequest(final UserCreateResult response) {
+    registerPost(RestGatewayPaths.getCreateUserUrl(), response);
+  }
+
+  public void onCorrelateMessageRequest(final MessageCorrelationResult response) {
+    registerPost(RestGatewayPaths.getMessageCorrelationUrl(), response);
+  }
+
+  public void onProcessInstanceCallHierarchyRequest(
+      final long processInstanceKey, final Object[] response) {
+    registerGet(RestGatewayPaths.getProcessInstanceCallHierarchyUrl(processInstanceKey), response);
+  }
+
+  public void onProcessInstanceRequest(
+      final long processInstanceKey, final ProcessInstanceResult response) {
+    registerGet(RestGatewayPaths.getProcessInstancesUrl(processInstanceKey), response);
+  }
+
+  public void onUpdateGroupRequest(final String groupId, final GroupUpdateResult response) {
+    registerPut(RestGatewayPaths.getGroupUrl(groupId), response);
+  }
+
+  public void onUpdateUserRequest(final String username, final UserUpdateResult response) {
+    registerPut(RestGatewayPaths.getUserUrl(username), response);
+  }
+
+  public void onProcessDefinitionFormRequest(
+      final long processDefinitionKey, final FormResult response) {
+    registerGet(RestGatewayPaths.getProcessDefinitionFormUrl(processDefinitionKey), response);
+  }
+
+  public void onProcessDefinitionRequest(
+      final long processDefinitionKey, final ProcessDefinitionResult response) {
+    registerGet(RestGatewayPaths.getProcessDefinitionUrl(processDefinitionKey), response);
+  }
+
+  public void onUserRequest(final String username, final UserResult response) {
+    registerGet(RestGatewayPaths.getUserUrl(username), response);
+  }
+
+  public void onCreateMappingRuleRequest(final MappingRuleCreateResult response) {
+    registerPost(RestGatewayPaths.getMappingRulesUrl(), response);
+  }
+
+  public void onCreateGroupRequest(final GroupCreateResult response) {
+    registerPost(RestGatewayPaths.getGroupsUrl(), response);
+  }
+
+  public void onCancelProcessInstancesRequest(final BatchOperationCreatedResult response) {
+    registerPost(RestGatewayPaths.getProcessInstancesCancelUrl(), response);
+  }
+
+  public void onMigrateProcessInstancesRequest(final BatchOperationCreatedResult response) {
+    registerPost(RestGatewayPaths.getProcessInstancesMigrateUrl(), response);
+  }
+
+  public void onModifyProcessInstances(final BatchOperationCreatedResult response) {
+    registerPost(RestGatewayPaths.getProcessInstancesModifyUrl(), response);
+  }
+
+  public void onCreateAuthorizationRequest(final AuthorizationCreateResult response) {
+    registerPost(RestGatewayPaths.getAuthorizationsUrl(), response);
+  }
+
+  public void onTenantRequest(final String tenantId, final TenantResult response) {
+    registerGet(RestGatewayPaths.getTenantUrl(tenantId), response);
+  }
+
+  public void onUpdateRoleRequest(final String roleId, final RoleUpdateResult response) {
+    registerPut(RestGatewayPaths.getRoleUrl(roleId), response);
+  }
+
+  public void onDecisionRequirementsRequest(
+      final long decisionRequirementsKey, final DecisionRequirementsResult response) {
+    registerGet(RestGatewayPaths.getDecisionRequirementsUrl(decisionRequirementsKey), response);
+  }
+
+  public void onCreateProcessInstanceRequest(final ProcessInstanceResult response) {
+    registerPost(RestGatewayPaths.getProcessInstancesUrl(), response);
+  }
+
+  public void onIncidentRequest(final long incidentKey, final IncidentResult response) {
+    registerGet(RestGatewayPaths.getIncidentUrl(incidentKey), response);
+  }
+
+  public void onUpdateTenantRequest(final String tenantId, final TenantUpdateResult response) {
+    registerPut(RestGatewayPaths.getTenantUrl(tenantId), response);
+  }
+
+  public void onDecisionInstanceRequest(
+      final String decisionInstanceId, final DecisionInstanceResult response) {
+    registerGet(RestGatewayPaths.getDecisionInstanceUrl(decisionInstanceId), response);
+  }
+
+  public void onPublishMessageRequest(final MessagePublicationResult response) {
+    registerPost(RestGatewayPaths.getMessagePublicationUrl(), response);
+  }
+
+  public void onGroupRequest(final String groupId, final GroupResult response) {
+    registerGet(RestGatewayPaths.getGroupUrl(groupId), response);
+  }
+
+  public void onUserTaskFormRequest(final long userTaskKey, final FormResult response) {
+    registerGet(RestGatewayPaths.getUserTaskFormUrl(userTaskKey), response);
+  }
+
+  public void onProcessInstanceSequenceFlowsRequest(
+      final long processInstanceKey, final ProcessInstanceSequenceFlowsQueryResult response) {
+    registerGet(RestGatewayPaths.getProcessInstanceSequenceFlowsUrl(processInstanceKey), response);
+  }
+
+  public void onBatchOperationRequest(
+      final String batchOperationKey, final BatchOperationResponse response) {
+    registerGet(RestGatewayPaths.getBatchOperationUrl(batchOperationKey), response);
+  }
+
+  public void onVariableRequest(final long variableKey, final VariableResult response) {
+    registerGet(RestGatewayPaths.getVariableUrl(variableKey), response);
+  }
+
+  public void onCreateRoleRequest(final RoleCreateResult response) {
+    registerPost(RestGatewayPaths.getRolesUrl(), response);
+  }
+
+  public void onAuthorizationRequest(
+      final long authorizationKey, final AuthorizationResult response) {
+    registerGet(RestGatewayPaths.getAuthorizationUrl(authorizationKey), response);
+  }
+
+  public void onUserTaskRequest(final long userTaskKey, final UserTaskResult response) {
+    registerGet(RestGatewayPaths.getUserTaskUrl(userTaskKey), response);
+  }
+
+  public void onElementInstanceRequest(
+      final long elementInstanceKey, final ElementInstanceResult response) {
+    registerGet(RestGatewayPaths.getElementInstanceUrl(elementInstanceKey), response);
+  }
+
+  public void onBroadcastSignalRequest(final SignalBroadcastResult response) {
+    registerPost(RestGatewayPaths.getBroadcastSignalUrl(), response);
+  }
+
+  public void onRoleRequest(final String roleId, final RoleResult response) {
+    registerGet(RestGatewayPaths.getRoleUrl(roleId), response);
   }
 }

--- a/clients/java/src/test/java/io/camunda/client/variable/GetVariableTest.java
+++ b/clients/java/src/test/java/io/camunda/client/variable/GetVariableTest.java
@@ -19,19 +19,31 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.github.tomakehurst.wiremock.http.RequestMethod;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+import io.camunda.client.protocol.rest.VariableResult;
 import io.camunda.client.util.ClientRestTest;
+import io.camunda.client.util.RestGatewayPaths;
+import org.instancio.Instancio;
 import org.junit.jupiter.api.Test;
 
 public class GetVariableTest extends ClientRestTest {
   @Test
   void shouldGetVariable() {
-    // when
+    // given
     final long variableKey = 1L;
+    gatewayService.onVariableRequest(
+        variableKey,
+        Instancio.create(VariableResult.class)
+            .variableKey("1")
+            .processInstanceKey("2")
+            .scopeKey("3")
+            .processInstanceKey("4"));
+
+    // when
     client.newVariableGetRequest(variableKey).send().join();
 
     // then
     final LoggedRequest request = gatewayService.getLastRequest();
-    assertThat(request.getUrl()).isEqualTo("/v2/variables/" + variableKey);
+    assertThat(request.getUrl()).isEqualTo(RestGatewayPaths.getVariableUrl(variableKey));
     assertThat(request.getMethod()).isEqualTo(RequestMethod.GET);
   }
 }

--- a/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/spring/client/jobhandling/DefaultJobExceptionHandlingStrategy.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/spring/client/jobhandling/DefaultJobExceptionHandlingStrategy.java
@@ -20,6 +20,7 @@ import io.camunda.client.api.command.FinalCommandStep;
 import io.camunda.client.api.command.ThrowErrorCommandStep1.ThrowErrorCommandStep2;
 import io.camunda.client.api.response.ActivatedJob;
 import io.camunda.client.api.response.FailJobResponse;
+import io.camunda.client.api.response.ThrowErrorResponse;
 import io.camunda.client.api.worker.JobClient;
 import io.camunda.spring.client.annotation.value.JobWorkerValue;
 import io.camunda.spring.client.exception.BpmnError;
@@ -82,7 +83,7 @@ public class DefaultJobExceptionHandlingStrategy implements JobExceptionHandling
     }
   }
 
-  private FinalCommandStep<Void> createThrowErrorCommand(
+  private FinalCommandStep<ThrowErrorResponse> createThrowErrorCommand(
       final JobClient jobClient, final ActivatedJob job, final BpmnError bpmnError) {
     final ThrowErrorCommandStep2 command =
         jobClient

--- a/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/spring/client/jobhandling/JobHandlerInvokingSpringBeansTest.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/spring/client/jobhandling/JobHandlerInvokingSpringBeansTest.java
@@ -32,6 +32,7 @@ import io.camunda.client.api.command.ThrowErrorCommandStep1.ThrowErrorCommandSte
 import io.camunda.client.api.response.ActivatedJob;
 import io.camunda.client.api.response.CompleteJobResponse;
 import io.camunda.client.api.response.FailJobResponse;
+import io.camunda.client.api.response.ThrowErrorResponse;
 import io.camunda.client.api.worker.BackoffSupplier;
 import io.camunda.client.api.worker.JobClient;
 import io.camunda.client.impl.CamundaObjectMapper;
@@ -162,7 +163,7 @@ public class JobHandlerInvokingSpringBeansTest {
     final JobClient jobClient = mock(JobClient.class);
     final ThrowErrorCommandStep1 throwErrorCommandStep1 = mock(ThrowErrorCommandStep1.class);
     final ThrowErrorCommandStep2 throwErrorCommandStep2 = mock(ThrowErrorCommandStep2.class);
-    final CamundaFuture<Void> future = mock(CamundaFuture.class);
+    final CamundaFuture<ThrowErrorResponse> future = mock(CamundaFuture.class);
     when(jobClient.newThrowErrorCommand(anyLong())).thenReturn(throwErrorCommandStep1);
     when(throwErrorCommandStep1.errorCode(any())).thenReturn(throwErrorCommandStep2);
     when(throwErrorCommandStep2.errorMessage(any())).thenReturn(throwErrorCommandStep2);

--- a/optimize/backend/src/it/java/io/camunda/optimize/test/it/extension/ZeebeExtension.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/test/it/extension/ZeebeExtension.java
@@ -203,20 +203,20 @@ public class ZeebeExtension implements BeforeEachCallback, AfterEachCallback {
   }
 
   public void completeZeebeUserTask(final long userTaskKey) {
-    camundaClient.newUserTaskCompleteCommand(userTaskKey).send().join();
+    camundaClient.newCompleteUserTaskCommand(userTaskKey).send().join();
   }
 
   public void assignUserTask(final long userTaskKey, final String assigneeId) {
-    camundaClient.newUserTaskAssignCommand(userTaskKey).assignee(assigneeId).send().join();
+    camundaClient.newAssignUserTaskCommand(userTaskKey).assignee(assigneeId).send().join();
   }
 
   public void unassignUserTask(final long userTaskKey) {
-    camundaClient.newUserTaskUnassignCommand(userTaskKey).send().join();
+    camundaClient.newUnassignUserTaskCommand(userTaskKey).send().join();
   }
 
   public void updateCandidateGroupForUserTask(final long userTaskKey, final String candidateGroup) {
     camundaClient
-        .newUserTaskUpdateCommand(userTaskKey)
+        .newUpdateUserTaskCommand(userTaskKey)
         .candidateGroups(candidateGroup)
         .send()
         .join();

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/backup/DataGenerator.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/backup/DataGenerator.java
@@ -155,7 +155,7 @@ public class DataGenerator implements AutoCloseable {
           LOGGER.debug("Completing user task {}", item.getUserTaskKey());
           assertThat(
                   camundaClient
-                      .newUserTaskCompleteCommand(item.getUserTaskKey())
+                      .newCompleteUserTaskCommand(item.getUserTaskKey())
                       .send()
                       .toCompletableFuture())
               .succeedsWithin(timeout);

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/backup/StandaloneBackupManagerIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/backup/StandaloneBackupManagerIT.java
@@ -358,7 +358,7 @@ final class StandaloneBackupManagerIT {
 
   private void completeUserTask(final long userTaskKey) {
     try (final var camundaClient = camunda.newClientBuilder().build()) {
-      camundaClient.newUserTaskCompleteCommand(userTaskKey).execute();
+      camundaClient.newCompleteUserTaskCommand(userTaskKey).execute();
     }
   }
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/JobSearchTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/JobSearchTest.java
@@ -110,7 +110,7 @@ public class JobSearchTest {
             .getFirst();
 
     camundaClient
-        .newUserTaskAssignCommand(userTask.getUserTaskKey())
+        .newAssignUserTaskCommand(userTask.getUserTaskKey())
         .assignee("testAssignee")
         .send();
 
@@ -134,7 +134,7 @@ public class JobSearchTest {
 
     waitForSingleUserTaskWithCreatedState();
     camundaClient
-        .newUserTaskAssignCommand(userTask.getUserTaskKey())
+        .newAssignUserTaskCommand(userTask.getUserTaskKey())
         .assignee("testAssignee")
         .send();
 
@@ -158,7 +158,7 @@ public class JobSearchTest {
 
     waitForSingleUserTaskWithCreatedState();
     camundaClient
-        .newUserTaskCompleteCommand(userTask.getUserTaskKey())
+        .newCompleteUserTaskCommand(userTask.getUserTaskKey())
         .variable("name", "test")
         .send();
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessDefinitionStatisticsTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessDefinitionStatisticsTest.java
@@ -419,7 +419,7 @@ public class ProcessDefinitionStatisticsTest {
         camundaClient, f -> f.processDefinitionKey(processDefinitionKey).state(ACTIVE), 2);
     waitForActiveScopedUserTasks(camundaClient, testScopeId, 2);
     final var userTask = getUserTask(processDefinitionKey);
-    camundaClient.newUserTaskCompleteCommand(userTask.getUserTaskKey()).send().join();
+    camundaClient.newCompleteUserTaskCommand(userTask.getUserTaskKey()).send().join();
     waitForProcessInstances(
         camundaClient,
         f ->
@@ -454,7 +454,7 @@ public class ProcessDefinitionStatisticsTest {
         camundaClient, f -> f.processDefinitionKey(processDefinitionKey).state(ACTIVE), 2);
     waitForActiveScopedUserTasks(camundaClient, testScopeId, 2);
     final var userTask = getUserTask(processDefinitionKey);
-    camundaClient.newUserTaskCompleteCommand(userTask.getUserTaskKey()).send().join();
+    camundaClient.newCompleteUserTaskCommand(userTask.getUserTaskKey()).send().join();
     waitForProcessInstances(
         camundaClient,
         f ->
@@ -490,7 +490,7 @@ public class ProcessDefinitionStatisticsTest {
     // waitForUserTasks(3, processDefinitionKey);
     waitForActiveScopedUserTasks(camundaClient, testScopeId, 3);
     final var userTask = getUserTask(processDefinitionKey);
-    camundaClient.newUserTaskCompleteCommand(userTask.getUserTaskKey()).send().join();
+    camundaClient.newCompleteUserTaskCommand(userTask.getUserTaskKey()).send().join();
     waitForProcessInstances(
         camundaClient,
         f ->
@@ -567,7 +567,7 @@ public class ProcessDefinitionStatisticsTest {
         camundaClient, f -> f.processDefinitionKey(processDefinitionKey).state(ACTIVE), 2);
     waitForActiveScopedUserTasks(camundaClient, testScopeId, 2);
     final var userTask = getUserTask(processDefinitionKey);
-    camundaClient.newUserTaskCompleteCommand(userTask.getUserTaskKey()).send().join();
+    camundaClient.newCompleteUserTaskCommand(userTask.getUserTaskKey()).send().join();
     waitForProcessInstances(
         camundaClient,
         f ->
@@ -750,7 +750,7 @@ public class ProcessDefinitionStatisticsTest {
     waitForScopedProcessInstancesToStart(camundaClient, testScopeId, 2);
     waitForActiveScopedUserTasks(camundaClient, testScopeId, 2);
     final var userTask = getUserTask(processDefinitionKey);
-    camundaClient.newUserTaskCompleteCommand(userTask.getUserTaskKey()).send().join();
+    camundaClient.newCompleteUserTaskCommand(userTask.getUserTaskKey()).send().join();
     waitForProcessInstances(
         camundaClient,
         f ->
@@ -783,7 +783,7 @@ public class ProcessDefinitionStatisticsTest {
         camundaClient, f -> f.processDefinitionKey(processDefinitionKey).state(ACTIVE), 2);
     waitForActiveScopedUserTasks(camundaClient, testScopeId, 2);
     final var userTask = getUserTask(processDefinitionKey);
-    camundaClient.newUserTaskCompleteCommand(userTask.getUserTaskKey()).send().join();
+    camundaClient.newCompleteUserTaskCommand(userTask.getUserTaskKey()).send().join();
     waitForProcessInstances(
         camundaClient,
         f ->

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/UsageMetricsTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/UsageMetricsTest.java
@@ -296,7 +296,7 @@ public class UsageMetricsTest {
                       .getUserTaskKey();
             });
     camundaClient
-        .newUserTaskAssignCommand(userTaskKey)
+        .newAssignUserTaskCommand(userTaskKey)
         .assignee(ASSIGNEE)
         .action("assignee")
         .allowOverride(true)
@@ -319,7 +319,7 @@ public class UsageMetricsTest {
                       .orElseThrow()
                       .getUserTaskKey();
             });
-    camundaClient.newUserTaskUnassignCommand(userTaskKey).send().join();
+    camundaClient.newUnassignUserTaskCommand(userTaskKey).send().join();
   }
 
   private static void assertTaskReassigned(final CamundaClient adminClient) {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/UserTaskSearchTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/UserTaskSearchTest.java
@@ -672,7 +672,7 @@ class UserTaskSearchTest {
             .send()
             .join();
     // then
-    assertThat(result).isNull();
+    assertThat(result).hasAllNullFieldsOrProperties();
   }
 
   @Test

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/UserTaskSearchTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/UserTaskSearchTest.java
@@ -1425,13 +1425,13 @@ class UserTaskSearchTest {
             });
 
     camundaClient
-        .newUserTaskAssignCommand(userTaskKeyTaskAssigned)
+        .newAssignUserTaskCommand(userTaskKeyTaskAssigned)
         .assignee("demo")
         .action("assignee")
         .send()
         .join();
 
-    camundaClient.newUserTaskCompleteCommand(userTaskKeyTaskAssigned).send().join();
+    camundaClient.newCompleteUserTaskCommand(userTaskKeyTaskAssigned).send().join();
 
     Awaitility.await("should export Assigned task and Completed to ElasticSearch")
         .atMost(TIMEOUT_DATA_AVAILABILITY)

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/cluster/ClusterPurgeMultiDbIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/cluster/ClusterPurgeMultiDbIT.java
@@ -167,7 +167,7 @@ public class ClusterPurgeMultiDbIT {
 
     // THEN
     assertThatChangesAreApplied(planChangeResponse);
-    assertThatEntityNotFound(() -> client.newUserTaskCompleteCommand(userTaskKey.get()).send());
+    assertThatEntityNotFound(() -> client.newCompleteUserTaskCommand(userTaskKey.get()).send());
 
     Awaitility.await("until user task query returns empty list")
         .atMost(Duration.ofSeconds(2 * TIMEOUT))

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/historycleanup/HistoryCleanupIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/historycleanup/HistoryCleanupIT.java
@@ -55,7 +55,7 @@ public class HistoryCleanupIT {
             .until(
                 () -> camundaClient.newUserTaskSearchRequest().send().join().items().getFirst(),
                 Objects::nonNull);
-    camundaClient.newUserTaskCompleteCommand(userTask.getUserTaskKey()).send().join();
+    camundaClient.newCompleteUserTaskCommand(userTask.getUserTaskKey()).send().join();
 
     // then one of the process instance should be ended, but still exist to query
     final Long processInstanceKey = userTask.getProcessInstanceKey();
@@ -115,7 +115,7 @@ public class HistoryCleanupIT {
             .until(
                 () -> camundaClient.newUserTaskSearchRequest().send().join().items().getFirst(),
                 Objects::nonNull);
-    camundaClient.newUserTaskCompleteCommand(userTask.getUserTaskKey()).send().join();
+    camundaClient.newCompleteUserTaskCommand(userTask.getUserTaskKey()).send().join();
 
     // then one of the process instance should be ended, but still exist to query
     final Long processInstanceKey = userTask.getProcessInstanceKey();

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/migration/usertask/AssignUserTaskMigrationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/migration/usertask/AssignUserTaskMigrationIT.java
@@ -49,7 +49,7 @@ public class AssignUserTaskMigrationIT extends UserTaskMigrationHelper {
 
     final long taskKey = USER_TASK_KEYS.get("second");
 
-    migrator.getCamundaClient().newUserTaskAssignCommand(taskKey).assignee("demo").send().join();
+    migrator.getCamundaClient().newAssignUserTaskCommand(taskKey).assignee("demo").send().join();
 
     shouldBeAssigned(migrator.getCamundaClient(), taskKey);
   }
@@ -82,7 +82,7 @@ public class AssignUserTaskMigrationIT extends UserTaskMigrationHelper {
             PROCESS_DEFINITION_KEYS.get(TaskImplementation.ZEEBE_USER_TASK));
     final var taskKey = waitFor88CreatedTaskToBeImportedReturningId(migrator, piKey);
 
-    migrator.getCamundaClient().newUserTaskAssignCommand(taskKey).assignee("demo").send().join();
+    migrator.getCamundaClient().newAssignUserTaskCommand(taskKey).assignee("demo").send().join();
 
     shouldBeAssigned(migrator.getCamundaClient(), taskKey);
   }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/migration/usertask/CompleteUserTaskMigrationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/migration/usertask/CompleteUserTaskMigrationIT.java
@@ -47,7 +47,7 @@ public class CompleteUserTaskMigrationIT extends UserTaskMigrationHelper {
 
     final long taskKey = USER_TASK_KEYS.get("second");
 
-    migrator.getCamundaClient().newUserTaskCompleteCommand(taskKey).send().join();
+    migrator.getCamundaClient().newCompleteUserTaskCommand(taskKey).send().join();
 
     shouldBeCompleted(migrator.getCamundaClient(), taskKey);
   }
@@ -77,7 +77,7 @@ public class CompleteUserTaskMigrationIT extends UserTaskMigrationHelper {
             PROCESS_DEFINITION_KEYS.get(TaskImplementation.ZEEBE_USER_TASK));
     final var taskKey = waitFor88CreatedTaskToBeImportedReturningId(migrator, piKey);
 
-    migrator.getCamundaClient().newUserTaskCompleteCommand(taskKey).send().join();
+    migrator.getCamundaClient().newCompleteUserTaskCommand(taskKey).send().join();
 
     shouldBeCompleted(migrator.getCamundaClient(), taskKey);
   }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/migration/usertask/UnassignUserTaskMigrationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/migration/usertask/UnassignUserTaskMigrationIT.java
@@ -47,7 +47,7 @@ public class UnassignUserTaskMigrationIT extends UserTaskMigrationHelper {
 
     final long taskKey = USER_TASK_KEYS.get("second");
 
-    migrator.getCamundaClient().newUserTaskUnassignCommand(taskKey).send().join();
+    migrator.getCamundaClient().newUnassignUserTaskCommand(taskKey).send().join();
 
     shouldBeUnassigned(migrator.getCamundaClient(), taskKey);
   }
@@ -77,7 +77,7 @@ public class UnassignUserTaskMigrationIT extends UserTaskMigrationHelper {
             PROCESS_DEFINITION_KEYS.get(TaskImplementation.ZEEBE_USER_TASK));
     final var taskKey = waitFor88CreatedTaskToBeImportedReturningId(migrator, piKey);
 
-    migrator.getCamundaClient().newUserTaskUnassignCommand(taskKey).send().join();
+    migrator.getCamundaClient().newUnassignUserTaskCommand(taskKey).send().join();
 
     shouldBeUnassigned(migrator.getCamundaClient(), taskKey);
   }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/schema/StandaloneSchemaManagerIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/schema/StandaloneSchemaManagerIT.java
@@ -239,8 +239,8 @@ final class StandaloneSchemaManagerIT {
                           .getFirst()
                           .getUserTaskKey(),
                   Objects::nonNull);
-      camundaClient.newUserTaskAssignCommand(userTaskKey).assignee("demo").send().join();
-      camundaClient.newUserTaskCompleteCommand(userTaskKey).send().join();
+      camundaClient.newAssignUserTaskCommand(userTaskKey).assignee("demo").send().join();
+      camundaClient.newCompleteUserTaskCommand(userTaskKey).send().join();
 
       // then -- process instance is completed
       Awaitility.await("process instance should be completed")

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/task/UserTaskIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/task/UserTaskIT.java
@@ -88,7 +88,7 @@ public class UserTaskIT {
 
     var userTasks = fetchUserTasks(client, processInstanceId);
 
-    client.newUserTaskCompleteCommand(userTasks.getFirst().getUserTaskKey()).send().join();
+    client.newCompleteUserTaskCommand(userTasks.getFirst().getUserTaskKey()).send().join();
     // then
     waitForTask(
         client,
@@ -114,7 +114,7 @@ public class UserTaskIT {
     var userTasks = fetchUserTasks(client, processInstanceId);
 
     client
-        .newUserTaskUpdateCommand(userTasks.getFirst().getUserTaskKey())
+        .newUpdateUserTaskCommand(userTasks.getFirst().getUserTaskKey())
         .priority(99)
         .candidateUsers("demoUsers")
         .candidateGroups("demoGroup")
@@ -151,7 +151,7 @@ public class UserTaskIT {
     var userTasks = fetchUserTasks(client, processInstanceId);
 
     client
-        .newUserTaskAssignCommand(userTasks.getFirst().getUserTaskKey())
+        .newAssignUserTaskCommand(userTasks.getFirst().getUserTaskKey())
         .assignee("demo")
         .send()
         .join();
@@ -178,7 +178,7 @@ public class UserTaskIT {
 
     final var userTasks = fetchUserTasks(client, processInstanceId);
 
-    client.newUserTaskUnassignCommand(userTasks.getFirst().getUserTaskKey()).send().join();
+    client.newUnassignUserTaskCommand(userTasks.getFirst().getUserTaskKey()).send().join();
 
     // then
     Awaitility.await()

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TasklistTester.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TasklistTester.java
@@ -487,7 +487,7 @@ public class TasklistTester {
                 flowNodeBpmnId, processDefinitionKey, TaskState.CREATED));
       }
     }
-    camundaClient.newUserTaskCompleteCommand(Long.valueOf(taskId)).variables(variables).send();
+    camundaClient.newCompleteUserTaskCommand(Long.valueOf(taskId)).variables(variables).send();
     return taskIsCompleted(flowNodeBpmnId);
   }
 

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/service/CamundaClientBasedAdapter.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/service/CamundaClientBasedAdapter.java
@@ -74,7 +74,7 @@ public class CamundaClientBasedAdapter implements TasklistServicesAdapter {
 
     if (!isJobBasedUserTask(task)) {
       try {
-        camundaClient.newUserTaskAssignCommand(task.getKey()).assignee(assignee).send().join();
+        camundaClient.newAssignUserTaskCommand(task.getKey()).assignee(assignee).send().join();
       } catch (final ClientException exception) {
         throw new TasklistRuntimeException(getErrorMessageFromClientException(exception));
       }
@@ -90,7 +90,7 @@ public class CamundaClientBasedAdapter implements TasklistServicesAdapter {
 
     if (!isJobBasedUserTask(task)) {
       try {
-        camundaClient.newUserTaskUnassignCommand(task.getKey()).send().join();
+        camundaClient.newUnassignUserTaskCommand(task.getKey()).send().join();
       } catch (final ClientException exception) {
         throw new TasklistRuntimeException(getErrorMessageFromClientException(exception));
       }
@@ -108,7 +108,7 @@ public class CamundaClientBasedAdapter implements TasklistServicesAdapter {
       if (isJobBasedUserTask(task)) {
         camundaClient.newCompleteCommand(task.getKey()).variables(variables).send().join();
       } else {
-        camundaClient.newUserTaskCompleteCommand(task.getKey()).variables(variables).send().join();
+        camundaClient.newCompleteUserTaskCommand(task.getKey()).variables(variables).send().join();
       }
     } catch (final ClientException exception) {
       throw new TasklistRuntimeException(getErrorMessageFromClientException(exception));

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/extension/CamundaProcessTestContextImpl.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/extension/CamundaProcessTestContextImpl.java
@@ -265,7 +265,7 @@ public class CamundaProcessTestContextImpl implements CamundaProcessTestContext 
 
     LOGGER.debug(
         "Complete user task with variables {} [user-task-key: '{}']", variables, userTaskKey.get());
-    client.newUserTaskCompleteCommand(userTaskKey.get()).variables(variables).send().join();
+    client.newCompleteUserTaskCommand(userTaskKey.get()).variables(variables).send().join();
   }
 
   @Override

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/CamundaProcessTestExtensionIT.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/CamundaProcessTestExtensionIT.java
@@ -188,7 +188,7 @@ public class CamundaProcessTestExtensionIT {
         .returns(60, UserTask::getPriority);
 
     // when: complete the user task
-    client.newUserTaskCompleteCommand(userTask.getUserTaskKey()).send().join();
+    client.newCompleteUserTaskCommand(userTask.getUserTaskKey()).send().join();
 
     // then: verify that the user task and the process instance are completed
     CamundaAssert.assertThatProcessInstance(processInstance)

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/AssignUserTaskTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/AssignUserTaskTest.java
@@ -43,7 +43,7 @@ class AssignUserTaskTest {
   @Test
   void shouldAssignUserTaskWithAssignee() {
     // when
-    client.newUserTaskAssignCommand(userTaskKey).assignee("barbar").send().join();
+    client.newAssignUserTaskCommand(userTaskKey).assignee("barbar").send().join();
 
     // then
     ZeebeAssertHelper.assertUserTaskAssigned(
@@ -57,10 +57,10 @@ class AssignUserTaskTest {
   @Test
   void shouldAssignUserTaskWithAssigneeWithImplicitAllowOverride() {
     // given
-    client.newUserTaskAssignCommand(userTaskKey).assignee("foobar").send().join();
+    client.newAssignUserTaskCommand(userTaskKey).assignee("foobar").send().join();
 
     // when
-    client.newUserTaskAssignCommand(userTaskKey).assignee("barbar").send().join();
+    client.newAssignUserTaskCommand(userTaskKey).assignee("barbar").send().join();
 
     // then
     ZeebeAssertHelper.assertUserTaskAssigned(
@@ -70,11 +70,11 @@ class AssignUserTaskTest {
   @Test
   void shouldAssignUserTaskWithAssigneeWithExplicitAllowOverride() {
     // given
-    client.newUserTaskAssignCommand(userTaskKey).assignee("foobar").send().join();
+    client.newAssignUserTaskCommand(userTaskKey).assignee("foobar").send().join();
 
     // when
     client
-        .newUserTaskAssignCommand(userTaskKey)
+        .newAssignUserTaskCommand(userTaskKey)
         .assignee("barbar")
         .allowOverride(true)
         .send()
@@ -88,7 +88,7 @@ class AssignUserTaskTest {
   @Test
   void shouldAssignUserTaskWithAssigneeAndAction() {
     // when
-    client.newUserTaskAssignCommand(userTaskKey).assignee("barbar").action("foo").send().join();
+    client.newAssignUserTaskCommand(userTaskKey).assignee("barbar").action("foo").send().join();
 
     // then
     ZeebeAssertHelper.assertUserTaskAssigned(
@@ -102,13 +102,13 @@ class AssignUserTaskTest {
   @Test
   void shouldRejectIfUserTaskIsAlreadyAssignedWithProhibitedOverride() {
     // given
-    client.newUserTaskAssignCommand(userTaskKey).assignee("foobar").send().join();
+    client.newAssignUserTaskCommand(userTaskKey).assignee("foobar").send().join();
 
     // when / then
     assertThatThrownBy(
             () ->
                 client
-                    .newUserTaskAssignCommand(userTaskKey)
+                    .newAssignUserTaskCommand(userTaskKey)
                     .assignee("barbar")
                     .allowOverride(false)
                     .send()
@@ -120,7 +120,7 @@ class AssignUserTaskTest {
   @Test
   void shouldRejectIfMissingAssignee() {
     // when / then
-    assertThatThrownBy(() -> client.newUserTaskAssignCommand(userTaskKey).send().join())
+    assertThatThrownBy(() -> client.newAssignUserTaskCommand(userTaskKey).send().join())
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 400: 'Bad Request'");
   }
@@ -129,7 +129,7 @@ class AssignUserTaskTest {
   void shouldRejectIfMissingAssigneeWithProhibitedOverride() {
     // when / then
     assertThatThrownBy(
-            () -> client.newUserTaskAssignCommand(userTaskKey).allowOverride(false).send().join())
+            () -> client.newAssignUserTaskCommand(userTaskKey).allowOverride(false).send().join())
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 400: 'Bad Request'");
   }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/ClockTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/ClockTest.java
@@ -58,7 +58,7 @@ class ClockTest {
   @Test
   void shouldPinClockToTimestamp() {
     // when
-    client.newClockPinCommand().time(FIXED_TIME).send().join();
+    client.newPinClockCommand().time(FIXED_TIME).send().join();
 
     // then
     assertClockPinned(c -> assertThat(c).hasTime(FIXED_TIME));
@@ -67,7 +67,7 @@ class ClockTest {
   @Test
   void shouldPinClockToInstant() {
     // when
-    client.newClockPinCommand().time(FUTURE_FIXED_INSTANT).send().join();
+    client.newPinClockCommand().time(FUTURE_FIXED_INSTANT).send().join();
 
     // then
     assertClockPinned(c -> assertThat(c).hasTime(FIXED_TIME));
@@ -76,7 +76,7 @@ class ClockTest {
   @Test
   void shouldRejectPinOperationIfNoTimestampProvided() {
     // when / then
-    assertThatThrownBy(() -> client.newClockPinCommand().send().join())
+    assertThatThrownBy(() -> client.newPinClockCommand().send().join())
         .isInstanceOf(ProblemException.class)
         .extracting(e -> (ProblemException) e)
         .satisfies(
@@ -90,7 +90,7 @@ class ClockTest {
   @Test
   void shouldResetClock() {
     // when
-    client.newClockResetCommand().send().join();
+    client.newResetClockCommand().send().join();
 
     // then
     assertClockResetted(c -> assertThat(c).hasTime(0L));
@@ -111,7 +111,7 @@ class ClockTest {
         resourcesHelper.deployProcess(
             Bpmn.createExecutableProcess("simple_process").startEvent().endEvent().done());
 
-    client.newClockPinCommand().time(validInstant).send().join();
+    client.newPinClockCommand().time(validInstant).send().join();
 
     // when: create a process instance while clock is pinned
     final long processInstanceKey = resourcesHelper.createProcessInstance(processDefinitionKey);
@@ -134,7 +134,7 @@ class ClockTest {
             Bpmn.createExecutableProcess("simple_process").startEvent().endEvent().done());
 
     // and: pin the clock to a fixed time
-    client.newClockPinCommand().time(FUTURE_FIXED_INSTANT).send().join();
+    client.newPinClockCommand().time(FUTURE_FIXED_INSTANT).send().join();
 
     // when: create a process instance while clock is pinned
     final long firstProcessInstanceKey =
@@ -153,7 +153,7 @@ class ClockTest {
         });
 
     // when: reset the clock back to the current system time
-    client.newClockResetCommand().send().join();
+    client.newResetClockCommand().send().join();
 
     // and: create a new process instance after the clock reset
     final long secondProcessInstanceKey =
@@ -176,7 +176,7 @@ class ClockTest {
     final Instant timerInstant = PAST_FIXED_INSTANT.plus(Duration.ofDays(5));
 
     // when: pin the clock to a time before the timer event
-    client.newClockPinCommand().time(PAST_FIXED_INSTANT).send().join();
+    client.newPinClockCommand().time(PAST_FIXED_INSTANT).send().join();
 
     // deploy a process with an intermediate timer event set to the past date
     final long processDefinitionKey =
@@ -201,7 +201,7 @@ class ClockTest {
                 "Timer event should be activated at the time set before the timer"));
 
     // when: pin the clock to the exact timer time
-    client.newClockPinCommand().time(timerInstant).send().join();
+    client.newPinClockCommand().time(timerInstant).send().join();
 
     // then: ensure the timer event completes when the clock is pinned to the timer time
     assertElementRecordInState(
@@ -222,7 +222,7 @@ class ClockTest {
     final Instant timerInstant = PAST_FIXED_INSTANT.plus(timerDuration);
 
     // when: pin the clock to the time in the past before the timer duration
-    client.newClockPinCommand().time(PAST_FIXED_INSTANT).send().join();
+    client.newPinClockCommand().time(PAST_FIXED_INSTANT).send().join();
 
     // deploy a process with an intermediate timer event based on duration
     final long processDefinitionKey =
@@ -247,7 +247,7 @@ class ClockTest {
                 "Timer event should be activated at the instant in the past"));
 
     // when: pin the clock to the timer's calculated completion time (instant + duration)
-    client.newClockPinCommand().time(timerInstant).send().join();
+    client.newPinClockCommand().time(timerInstant).send().join();
 
     // then: ensure the timer event completes when the clock reaches the calculated timer time
     assertElementRecordInState(
@@ -286,7 +286,7 @@ class ClockTest {
                 r.getTimestamp(), "Timer event should be activated near the current time"));
 
     // when: pin the clock to the timer date
-    client.newClockPinCommand().time(FUTURE_FIXED_INSTANT).send().join();
+    client.newPinClockCommand().time(FUTURE_FIXED_INSTANT).send().join();
 
     // then
     assertElementRecordInState(
@@ -312,7 +312,7 @@ class ClockTest {
                 .done());
 
     // when: pin the clock to the timer date
-    client.newClockPinCommand().time(FUTURE_FIXED_INSTANT).send().join();
+    client.newPinClockCommand().time(FUTURE_FIXED_INSTANT).send().join();
 
     // then
     final long processInstanceKey = getProcessInstanceKey(processDefinitionKey);
@@ -356,7 +356,7 @@ class ClockTest {
 
     // when: pin the clock to the timer date
     final Instant futureInstant = FUTURE_FIXED_INSTANT.plus(Duration.ofHours(1));
-    client.newClockPinCommand().time(futureInstant).send().join();
+    client.newPinClockCommand().time(futureInstant).send().join();
 
     // then
     assertElementRecordInState(

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/CompleteUserTaskTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/CompleteUserTaskTest.java
@@ -45,7 +45,7 @@ class CompleteUserTaskTest {
   @Test
   void shouldCompleteUserTask() {
     // when
-    client.newUserTaskCompleteCommand(userTaskKey).send().join();
+    client.newCompleteUserTaskCommand(userTaskKey).send().join();
 
     // then
     ZeebeAssertHelper.assertUserTaskCompleted(
@@ -59,7 +59,7 @@ class CompleteUserTaskTest {
   @Test
   void shouldCompleteUserTaskWithAction() {
     // when
-    client.newUserTaskCompleteCommand(userTaskKey).action("foo").send().join();
+    client.newCompleteUserTaskCommand(userTaskKey).action("foo").send().join();
 
     // then
     ZeebeAssertHelper.assertUserTaskCompleted(
@@ -74,7 +74,7 @@ class CompleteUserTaskTest {
   void shouldCompleteUserTaskWithVariables() {
     // when
 
-    client.newUserTaskCompleteCommand(userTaskKey).variables(Map.of("foo", "bar")).send().join();
+    client.newCompleteUserTaskCommand(userTaskKey).variables(Map.of("foo", "bar")).send().join();
 
     // then
     ZeebeAssertHelper.assertUserTaskCompleted(
@@ -85,10 +85,10 @@ class CompleteUserTaskTest {
   @Test
   void shouldRejectIfJobIsAlreadyCompleted() {
     // given
-    client.newUserTaskCompleteCommand(userTaskKey).send().join();
+    client.newCompleteUserTaskCommand(userTaskKey).send().join();
 
     // when / then
-    assertThatThrownBy(() -> client.newUserTaskCompleteCommand(userTaskKey).send().join())
+    assertThatThrownBy(() -> client.newCompleteUserTaskCommand(userTaskKey).send().join())
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 404: 'Not Found'");
   }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/SetVariablesTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/SetVariablesTest.java
@@ -65,9 +65,14 @@ public final class SetVariablesTest {
     final long processInstanceKey = resourcesHelper.createProcessInstance(processDefinitionKey);
 
     // when
-    getCommand(client, useRest, processInstanceKey).variables(Map.of("foo", "bar")).send().join();
+    final SetVariablesResponse response =
+        getCommand(client, useRest, processInstanceKey)
+            .variables(Map.of("foo", "bar"))
+            .send()
+            .join();
 
     // then
+    assertThat(response).isNotNull().isInstanceOf(SetVariablesResponse.class);
     ZeebeAssertHelper.assertVariableDocumentUpdated(
         (variableDocument) ->
             assertThat(variableDocument.getVariables()).containsOnly(entry("foo", "bar")));

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/ThrowErrorTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/ThrowErrorTest.java
@@ -16,6 +16,7 @@ import io.camunda.client.api.command.ActivateJobsCommandStep1;
 import io.camunda.client.api.command.CompleteJobCommandStep1;
 import io.camunda.client.api.command.ThrowErrorCommandStep1;
 import io.camunda.client.api.response.ActivatedJob;
+import io.camunda.client.api.response.ThrowErrorResponse;
 import io.camunda.zeebe.it.util.ZeebeResourcesHelper;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.protocol.record.Assertions;
@@ -62,9 +63,12 @@ public final class ThrowErrorTest {
     final long jobKey = activateJob(client, useRest, jobType).getKey();
 
     // when
-    getCommand(client, useRest, jobKey).errorCode(ERROR_CODE).send().join();
+    final ThrowErrorResponse response =
+        getCommand(client, useRest, jobKey).errorCode(ERROR_CODE).send().join();
 
     // then
+    assertThat(response).isNotNull().isInstanceOf(ThrowErrorResponse.class);
+
     final Record<JobRecordValue> record =
         jobRecords(JobIntent.ERROR_THROWN).withRecordKey(jobKey).getFirst();
     Assertions.assertThat(record.getValue()).hasErrorCode(ERROR_CODE).hasErrorMessage("");

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/UnassignGroupFromTenantTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/UnassignGroupFromTenantTest.java
@@ -12,6 +12,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ProblemException;
+import io.camunda.client.api.response.UnassignGroupFromTenantResponse;
 import io.camunda.zeebe.it.util.ZeebeAssertHelper;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
@@ -62,9 +63,11 @@ class UnassignGroupFromTenantTest {
   @Test
   void shouldUnassignGroupFromTenant() {
     // when
-    client.newUnassignGroupFromTenantCommand(tenantId).groupId(groupId).send().join();
+    final UnassignGroupFromTenantResponse response =
+        client.newUnassignGroupFromTenantCommand(tenantId).groupId(groupId).send().join();
 
     // then
+    assertThat(response).isNotNull().isInstanceOf(UnassignGroupFromTenantResponse.class);
     ZeebeAssertHelper.assertGroupUnassignedFromTenant(
         tenantId,
         (tenant) -> {

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/UnassignUserTaskTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/UnassignUserTaskTest.java
@@ -41,10 +41,10 @@ class UnassignUserTaskTest {
   @Test
   void shouldUnassignUserTask() {
     // given
-    client.newUserTaskAssignCommand(userTaskKey).assignee("foobar").send().join();
+    client.newAssignUserTaskCommand(userTaskKey).assignee("foobar").send().join();
 
     // when
-    client.newUserTaskUnassignCommand(userTaskKey).send().join();
+    client.newUnassignUserTaskCommand(userTaskKey).send().join();
 
     // then
     ZeebeAssertHelper.assertUserTaskAssigned(

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/UpdateJobTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/UpdateJobTest.java
@@ -17,6 +17,7 @@ import io.camunda.client.api.command.JobChangeset;
 import io.camunda.client.api.command.UpdateRetriesJobCommandStep1;
 import io.camunda.client.api.command.UpdateTimeoutJobCommandStep1;
 import io.camunda.client.api.response.ActivatedJob;
+import io.camunda.client.api.response.UpdateJobResponse;
 import io.camunda.zeebe.it.util.ZeebeResourcesHelper;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
@@ -150,9 +151,11 @@ public class UpdateJobTest {
     final var initialDeadline = job.getDeadline();
 
     // when
-    client.newUpdateJobCommand(jobKey).update(jobChangeset).send().join();
+    final UpdateJobResponse response =
+        client.newUpdateJobCommand(jobKey).update(jobChangeset).send().join();
 
     // then
+    assertThat(response).isNotNull().isInstanceOf(UpdateJobResponse.class);
     assertTimeoutIncreased(initialDeadline, jobKey, true);
     assertRetriesUpdated(jobKey, true, retries);
   }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/UpdateUserTaskTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/UpdateUserTaskTest.java
@@ -49,7 +49,7 @@ class UpdateUserTaskTest {
   @Test
   void shouldUpdateUserTaskWithAction() {
     // when
-    client.newUserTaskUpdateCommand(userTaskKey).action("foo").send().join();
+    client.newUpdateUserTaskCommand(userTaskKey).action("foo").send().join();
 
     // then
     ZeebeAssertHelper.assertUserTaskUpdated(
@@ -59,7 +59,7 @@ class UpdateUserTaskTest {
   @Test
   void shouldUpdateUserTaskWithDueDate() {
     // when
-    client.newUserTaskUpdateCommand(userTaskKey).dueDate(TEST_TIME).send().join();
+    client.newUpdateUserTaskCommand(userTaskKey).dueDate(TEST_TIME).send().join();
 
     // then
     ZeebeAssertHelper.assertUserTaskUpdated(
@@ -69,7 +69,7 @@ class UpdateUserTaskTest {
   @Test
   void shouldUpdateUserTaskWithFollowUpDate() {
     // when
-    client.newUserTaskUpdateCommand(userTaskKey).followUpDate(TEST_TIME).send().join();
+    client.newUpdateUserTaskCommand(userTaskKey).followUpDate(TEST_TIME).send().join();
 
     // then
     ZeebeAssertHelper.assertUserTaskUpdated(
@@ -80,7 +80,7 @@ class UpdateUserTaskTest {
   void shouldUpdateUserTaskWithDueDateAndFollowUpDate() {
     // when
     client
-        .newUserTaskUpdateCommand(userTaskKey)
+        .newUpdateUserTaskCommand(userTaskKey)
         .dueDate(TEST_TIME)
         .followUpDate(TEST_TIME)
         .send()
@@ -98,7 +98,7 @@ class UpdateUserTaskTest {
   @Test
   void shouldUpdateUserTaskWithCandidateGroup() {
     // when
-    client.newUserTaskUpdateCommand(userTaskKey).candidateGroups("foo").send().join();
+    client.newUpdateUserTaskCommand(userTaskKey).candidateGroups("foo").send().join();
 
     // then
     ZeebeAssertHelper.assertUserTaskUpdated(
@@ -109,7 +109,7 @@ class UpdateUserTaskTest {
   @Test
   void shouldUpdateUserTaskWithCandidateGroups() {
     // when
-    client.newUserTaskUpdateCommand(userTaskKey).candidateGroups("foo", "bar").send().join();
+    client.newUpdateUserTaskCommand(userTaskKey).candidateGroups("foo", "bar").send().join();
 
     // then
     ZeebeAssertHelper.assertUserTaskUpdated(
@@ -121,7 +121,7 @@ class UpdateUserTaskTest {
   void shouldUpdateUserTaskWithCandidateGroupsList() {
     // when
     client
-        .newUserTaskUpdateCommand(userTaskKey)
+        .newUpdateUserTaskCommand(userTaskKey)
         .candidateGroups(List.of("foo", "bar"))
         .send()
         .join();
@@ -135,7 +135,7 @@ class UpdateUserTaskTest {
   @Test
   void shouldUpdateUserTaskWithCandidateUser() {
     // when
-    client.newUserTaskUpdateCommand(userTaskKey).candidateUsers("foo").send().join();
+    client.newUpdateUserTaskCommand(userTaskKey).candidateUsers("foo").send().join();
 
     // then
     ZeebeAssertHelper.assertUserTaskUpdated(
@@ -146,7 +146,7 @@ class UpdateUserTaskTest {
   @Test
   void shouldUpdateUserTaskWithCandidateUsers() {
     // when
-    client.newUserTaskUpdateCommand(userTaskKey).candidateUsers("foo", "bar").send().join();
+    client.newUpdateUserTaskCommand(userTaskKey).candidateUsers("foo", "bar").send().join();
 
     // then
     ZeebeAssertHelper.assertUserTaskUpdated(
@@ -158,7 +158,7 @@ class UpdateUserTaskTest {
   void shouldUpdateUserTaskWithCandidateUsersList() {
     // when
     client
-        .newUserTaskUpdateCommand(userTaskKey)
+        .newUpdateUserTaskCommand(userTaskKey)
         .candidateUsers(List.of("foo", "bar"))
         .send()
         .join();
@@ -172,10 +172,10 @@ class UpdateUserTaskTest {
   @Test
   void shouldClearUserTaskDueDate() {
     // given
-    client.newUserTaskUpdateCommand(userTaskKey).dueDate(TEST_TIME).send().join();
+    client.newUpdateUserTaskCommand(userTaskKey).dueDate(TEST_TIME).send().join();
 
     // when
-    client.newUserTaskUpdateCommand(userTaskKey).clearDueDate().send().join();
+    client.newUpdateUserTaskCommand(userTaskKey).clearDueDate().send().join();
 
     // then
     ZeebeAssertHelper.assertUserTaskUpdated(
@@ -185,10 +185,10 @@ class UpdateUserTaskTest {
   @Test
   void shouldClearUserTaskFollowUpDate() {
     // given
-    client.newUserTaskUpdateCommand(userTaskKey).followUpDate(TEST_TIME).send().join();
+    client.newUpdateUserTaskCommand(userTaskKey).followUpDate(TEST_TIME).send().join();
 
     // when
-    client.newUserTaskUpdateCommand(userTaskKey).clearFollowUpDate().send().join();
+    client.newUpdateUserTaskCommand(userTaskKey).clearFollowUpDate().send().join();
 
     // then
     ZeebeAssertHelper.assertUserTaskUpdated(
@@ -198,10 +198,10 @@ class UpdateUserTaskTest {
   @Test
   void shouldClearUserTaskCandidateGroups() {
     // given
-    client.newUserTaskUpdateCommand(userTaskKey).candidateGroups("foo").send().join();
+    client.newUpdateUserTaskCommand(userTaskKey).candidateGroups("foo").send().join();
 
     // when
-    client.newUserTaskUpdateCommand(userTaskKey).clearCandidateGroups().send().join();
+    client.newUpdateUserTaskCommand(userTaskKey).clearCandidateGroups().send().join();
 
     // then
     ZeebeAssertHelper.assertUserTaskUpdated(
@@ -211,10 +211,10 @@ class UpdateUserTaskTest {
   @Test
   void shouldClearUserTaskCandidateUsers() {
     // given
-    client.newUserTaskUpdateCommand(userTaskKey).candidateUsers("foo").send().join();
+    client.newUpdateUserTaskCommand(userTaskKey).candidateUsers("foo").send().join();
 
     // when
-    client.newUserTaskUpdateCommand(userTaskKey).clearCandidateUsers().send().join();
+    client.newUpdateUserTaskCommand(userTaskKey).clearCandidateUsers().send().join();
 
     // then
     ZeebeAssertHelper.assertUserTaskUpdated(
@@ -224,7 +224,7 @@ class UpdateUserTaskTest {
   @Test
   void shouldRejectIfMissingUpdateData() {
     // when / then
-    assertThatThrownBy(() -> client.newUserTaskUpdateCommand(userTaskKey).send().join())
+    assertThatThrownBy(() -> client.newUpdateUserTaskCommand(userTaskKey).send().join())
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 400: 'Bad Request'");
   }
@@ -233,7 +233,7 @@ class UpdateUserTaskTest {
   public void shouldRejectIfMalformedDueDate() {
     // when / then
     assertThatThrownBy(
-            () -> client.newUserTaskUpdateCommand(userTaskKey).dueDate("foo").send().join())
+            () -> client.newUpdateUserTaskCommand(userTaskKey).dueDate("foo").send().join())
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 400: 'Bad Request'")
         .hasMessageContaining("The provided due date 'foo' cannot be parsed as a date");
@@ -243,7 +243,7 @@ class UpdateUserTaskTest {
   public void shouldRejectIfMalformedFollowUpDate() {
     // when / then
     assertThatThrownBy(
-            () -> client.newUserTaskUpdateCommand(userTaskKey).followUpDate("foo").send().join())
+            () -> client.newUpdateUserTaskCommand(userTaskKey).followUpDate("foo").send().join())
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 400: 'Bad Request'")
         .hasMessageContaining("The provided follow-up date 'foo' cannot be parsed as a date");
@@ -255,7 +255,7 @@ class UpdateUserTaskTest {
     assertThatThrownBy(
             () ->
                 client
-                    .newUserTaskUpdateCommand(userTaskKey)
+                    .newUpdateUserTaskCommand(userTaskKey)
                     .dueDate("bar")
                     .followUpDate("foo")
                     .send()

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/UserTaskListenersTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/UserTaskListenersTest.java
@@ -92,7 +92,7 @@ public class UserTaskListenersTest {
 
     // when: invoke complete user task command
     final var completeUserTaskFuture =
-        client.newUserTaskCompleteCommand(userTaskKey).action(action).send();
+        client.newCompleteUserTaskCommand(userTaskKey).action(action).send();
 
     // TL job should be successfully completed with the result "denied" set correctly
     ZeebeAssertHelper.assertJobCompleted(
@@ -128,7 +128,7 @@ public class UserTaskListenersTest {
 
     // when: invoke `ASSIGN` user task command
     final var assignUserTaskFuture =
-        client.newUserTaskAssignCommand(userTaskKey).assignee(assignee).action(action).send();
+        client.newAssignUserTaskCommand(userTaskKey).assignee(assignee).action(action).send();
 
     // wait for successful `ASSIGN` user task command completion
     assertThatCode(assignUserTaskFuture::join).doesNotThrowAnyException();
@@ -158,7 +158,7 @@ public class UserTaskListenersTest {
     // when: invoke `UPDATE` user task command
     final var updateUserTaskFuture =
         client
-            .newUserTaskUpdateCommand(userTaskKey)
+            .newUpdateUserTaskCommand(userTaskKey)
             .candidateUsers("frodo", "samwise")
             .priority(88)
             .action(action)
@@ -281,7 +281,7 @@ public class UserTaskListenersTest {
 
     // when
     final var completeUserTaskFuture =
-        client.newUserTaskCompleteCommand(userTaskKey).send().toCompletableFuture();
+        client.newCompleteUserTaskCommand(userTaskKey).send().toCompletableFuture();
     waitForJobRetriesToBeExhausted(recordingHandler);
 
     // then
@@ -374,7 +374,7 @@ public class UserTaskListenersTest {
 
     // when: invoke `UPDATE` user task command
     final var updateUserTaskFuture =
-        client.newUserTaskUpdateCommand(userTaskKey).candidateUsers("user123").send();
+        client.newUpdateUserTaskCommand(userTaskKey).candidateUsers("user123").send();
 
     // then: TL job should be successfully completed with the result "denied" set correctly
     ZeebeAssertHelper.assertJobCompleted(
@@ -430,7 +430,7 @@ public class UserTaskListenersTest {
 
     // when: invoke complete user task command
     final CamundaFuture<CompleteUserTaskResponse> completeUserTaskFuture =
-        client.newUserTaskCompleteCommand(userTaskKey).send();
+        client.newCompleteUserTaskCommand(userTaskKey).send();
 
     // TL job should be successfully completed with the result "denied" set correctly
     ZeebeAssertHelper.assertJobCompleted(
@@ -485,7 +485,7 @@ public class UserTaskListenersTest {
 
     // when: invoke complete user task command
     final CamundaFuture<CompleteUserTaskResponse> completeUserTaskFuture =
-        client.newUserTaskCompleteCommand(userTaskKey).send();
+        client.newCompleteUserTaskCommand(userTaskKey).send();
 
     // TL job should be successfully completed with the result "denied" set correctly
     ZeebeAssertHelper.assertJobCompleted(
@@ -544,7 +544,7 @@ public class UserTaskListenersTest {
     // when: invoke complete user task command
 
     final CamundaFuture<AssignUserTaskResponse> assignUserTaskFuture =
-        client.newUserTaskAssignCommand(userTaskKey).assignee("john").send();
+        client.newAssignUserTaskCommand(userTaskKey).assignee("john").send();
 
     // TL job should be successfully completed with the result "denied" set correctly
     ZeebeAssertHelper.assertJobCompleted(
@@ -609,7 +609,7 @@ public class UserTaskListenersTest {
 
     // when: invoke `UPDATE` user task command
     final var updateUserTaskFuture =
-        client.newUserTaskUpdateCommand(userTaskKey).priority(55).action("escalate").send();
+        client.newUpdateUserTaskCommand(userTaskKey).priority(55).action("escalate").send();
 
     final JobResult expectedResult =
         new JobResult()
@@ -694,7 +694,7 @@ public class UserTaskListenersTest {
     // when: send an `UPDATE` command with explicit changes
     final var updateUserTaskFuture =
         client
-            .newUserTaskUpdateCommand(userTaskKey)
+            .newUpdateUserTaskCommand(userTaskKey)
             .dueDate(updatedDueDate)
             .candidateGroups("updated_group")
             .priority(99) // will be reset to the initial value by correction
@@ -771,7 +771,7 @@ public class UserTaskListenersTest {
     client.newWorker().jobType("my_listener").handler(completeJobHandler).open();
 
     // when: invoke complete user task command
-    final var completeUserTaskFuture = client.newUserTaskCompleteCommand(userTaskKey).send();
+    final var completeUserTaskFuture = client.newCompleteUserTaskCommand(userTaskKey).send();
 
     final JobResult expectedResult =
         new JobResult()
@@ -838,7 +838,7 @@ public class UserTaskListenersTest {
     client.newWorker().jobType("my_listener").handler(completeJobHandler).open();
 
     // when: invoke complete user task command
-    final var completeUserTaskFuture = client.newUserTaskCompleteCommand(userTaskKey).send();
+    final var completeUserTaskFuture = client.newCompleteUserTaskCommand(userTaskKey).send();
 
     final JobResult expectedResult =
         new JobResult()
@@ -953,7 +953,7 @@ public class UserTaskListenersTest {
 
     // trigger task update and wait for UPDATING event
     final var updateUserTaskFuture =
-        client.newUserTaskUpdateCommand(userTaskKey).candidateUsers("frodo", "samwise").send();
+        client.newUpdateUserTaskCommand(userTaskKey).candidateUsers("frodo", "samwise").send();
     RecordingExporter.userTaskRecords(UserTaskIntent.UPDATING).withRecordKey(userTaskKey).await();
 
     // when: cancel the process instance

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/gateway/rest/FilterIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/gateway/rest/FilterIT.java
@@ -64,7 +64,7 @@ public class FilterIT {
   @Test
   void shouldFailWithSecondFilterThrowingException() {
     // when / then
-    assertThatThrownBy(() -> client.newUserTaskCompleteCommand(12345).send().join())
+    assertThatThrownBy(() -> client.newCompleteUserTaskCommand(12345).send().join())
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("No user task interactions while testing");
   }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/multitenancy/MultiTenancyIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/multitenancy/MultiTenancyIT.java
@@ -1438,7 +1438,7 @@ public class MultiTenancyIT {
 
       // when
       final Future<AssignUserTaskResponse> result =
-          clientTenantB.newUserTaskAssignCommand(userTaskKey).assignee("Skeletor").send();
+          clientTenantB.newAssignUserTaskCommand(userTaskKey).assignee("Skeletor").send();
 
       // then
       assertThat(result).succeedsWithin(Duration.ofSeconds(10));
@@ -1455,7 +1455,7 @@ public class MultiTenancyIT {
 
       // when
       final Future<AssignUserTaskResponse> result =
-          skeletorClient.newUserTaskAssignCommand(userTaskKey).assignee("Skeletor").send();
+          skeletorClient.newAssignUserTaskCommand(userTaskKey).assignee("Skeletor").send();
 
       // then
       assertThat(result)
@@ -1477,7 +1477,7 @@ public class MultiTenancyIT {
 
       // when
       final Future<CompleteUserTaskResponse> result =
-          clientTenantB.newUserTaskCompleteCommand(userTaskKey).send();
+          clientTenantB.newCompleteUserTaskCommand(userTaskKey).send();
 
       // then
       assertThat(result).succeedsWithin(Duration.ofSeconds(10));
@@ -1494,7 +1494,7 @@ public class MultiTenancyIT {
 
       // when
       final Future<CompleteUserTaskResponse> result =
-          invalidClient.newUserTaskCompleteCommand(userTaskKey).send();
+          invalidClient.newCompleteUserTaskCommand(userTaskKey).send();
 
       // then
       assertThat(result)
@@ -1513,11 +1513,11 @@ public class MultiTenancyIT {
       // given
       final var resourceHelper = new ZeebeResourcesHelper(clientTenantA);
       final var userTaskKey = resourceHelper.createSingleUserTask(TENANT_A);
-      clientTenantA.newUserTaskAssignCommand(userTaskKey).assignee("Skeletor").send().join();
+      clientTenantA.newAssignUserTaskCommand(userTaskKey).assignee("Skeletor").send().join();
 
       // when
       final Future<UnassignUserTaskResponse> result =
-          clientTenantB.newUserTaskUnassignCommand(userTaskKey).send();
+          clientTenantB.newUnassignUserTaskCommand(userTaskKey).send();
 
       // then
       assertThat(result).succeedsWithin(Duration.ofSeconds(10));
@@ -1531,11 +1531,11 @@ public class MultiTenancyIT {
       // given
       final var resourceHelper = new ZeebeResourcesHelper(clientTenantA);
       final var userTaskKey = resourceHelper.createSingleUserTask(TENANT_A);
-      clientTenantA.newUserTaskAssignCommand(userTaskKey).assignee("Skeletor").send().join();
+      clientTenantA.newAssignUserTaskCommand(userTaskKey).assignee("Skeletor").send().join();
 
       // when
       final Future<UnassignUserTaskResponse> result =
-          invalidClient.newUserTaskUnassignCommand(userTaskKey).send();
+          invalidClient.newUnassignUserTaskCommand(userTaskKey).send();
 
       // then
       assertThat(result)
@@ -1557,7 +1557,7 @@ public class MultiTenancyIT {
 
       // when
       final Future<UpdateUserTaskResponse> result =
-          clientTenantB.newUserTaskUpdateCommand(userTaskKey).candidateUsers("Skeletor").send();
+          clientTenantB.newUpdateUserTaskCommand(userTaskKey).candidateUsers("Skeletor").send();
 
       // then
       assertThat(result).succeedsWithin(Duration.ofSeconds(10));
@@ -1574,7 +1574,7 @@ public class MultiTenancyIT {
 
       // when
       final Future<UpdateUserTaskResponse> result =
-          invalidClient.newUserTaskUpdateCommand(userTaskKey).candidateUsers("Skeletor").send();
+          invalidClient.newUpdateUserTaskCommand(userTaskKey).candidateUsers("Skeletor").send();
 
       // then
       assertThat(result)

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/processing/IdentitySetupInitializerIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/processing/IdentitySetupInitializerIT.java
@@ -103,7 +103,7 @@ final class IdentitySetupInitializerIT {
     // We send a clock reset command so we have a record we can limit our RecordingExporter on
     // We don't join the future, because we are unauthorized to send this command. Joining it will
     // result in an exception.
-    client.newClockResetCommand().send();
+    client.newResetClockCommand().send();
 
     assertThat(
             RecordingExporter.records()


### PR DESCRIPTION
## Description

In the Java client, commands that receive empty results from 204 endpoints return empty results as well instead of `null` values.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes camunda/camunda#23075 
