### PR TITLE
feat: Avoid AHSP element activation if the completion condition is fulfilled

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/adhocsubprocess/AdHocSubProcessInstructionActivateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/adhocsubprocess/AdHocSubProcessInstructionActivateProcessor.java
@@ -114,6 +114,22 @@ public class AdHocSubProcessInstructionActivateProcessor
       return;
     }
 
+    final var activateElements =
+        command.getValue().activateElements().stream()
+            .map(AdHocSubProcessActivateElementInstruction::getElementId)
+            .toList();
+
+    final var thatCompletionConditionIsNotFulfilledWhenActivatingElements =
+        AdHocSubProcessUtils.validateThatCompletionConditionIsNotFulfilledWhenActivatingElements(
+            adHocSubProcessElementInstance.getKey(),
+            command.getValue().isCompletionConditionFulfilled(),
+            activateElements);
+    if (thatCompletionConditionIsNotFulfilledWhenActivatingElements.isLeft()) {
+      final var rejection = thatCompletionConditionIsNotFulfilledWhenActivatingElements.getLeft();
+      writeRejectionError(command, rejection.type(), rejection.reason());
+      return;
+    }
+
     final var adHocSubProcessDefinition =
         processState
             .getProcessByKeyAndTenant(
@@ -126,10 +142,6 @@ public class AdHocSubProcessInstructionActivateProcessor
                 adHocSubProcessElementInstance.getValue().getElementId());
 
     // check that the given elements exist within the ad-hoc sub-process
-    final var activateElements =
-        command.getValue().activateElements().stream()
-            .map(AdHocSubProcessActivateElementInstruction::getElementId)
-            .toList();
     final var activateElementsAreInProcess =
         AdHocSubProcessUtils.validateActivateElementsExistInAdHocSubProcess(
             adHocSubProcessElementInstance.getKey(), adHocSubProcessElement, activateElements);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/adhocsubprocess/AdHocSubProcessUtils.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/adhocsubprocess/AdHocSubProcessUtils.java
@@ -18,6 +18,16 @@ public class AdHocSubProcessUtils {
   private static final String ERROR_MSG_ELEMENTS_NOT_FOUND =
       "Expected to activate activities for ad-hoc sub-process with key '%s', but the given elements %s do not exist.";
 
+  private static final String AHSP_JOB_CANNOT_ACTIVATE_ELEMENTS_WITH_COMPLETE_CONDITION_FULFILLED =
+      """
+      Expected to complete ad-hoc sub-process job, but the job result contains elements to \
+      be activated while the completion condition is fulfilled \
+      (job key '%d'). \
+      When the completion condition is fulfilled, no further element activations are allowed. \
+      Either remove the elements to be activated from the job result, or set the \
+      completion condition to not fulfilled.
+      """;
+
   public static Either<Rejection, List<String>> validateActivateElementsExistInAdHocSubProcess(
       final long adHocSubProcessKey,
       final ExecutableAdHocSubProcess adHocSubProcess,
@@ -36,6 +46,23 @@ public class AdHocSubProcessUtils {
           new Rejection(
               RejectionType.NOT_FOUND,
               ERROR_MSG_ELEMENTS_NOT_FOUND.formatted(adHocSubProcessKey, elementsNotFound)));
+    }
+  }
+
+  public static Either<Rejection, List<String>>
+      validateThatCompletionConditionIsNotFulfilledWhenActivatingElements(
+          final long adHocSubProcessKey,
+          final boolean completionConditionFulfilled,
+          final List<String> activateElementsCollection) {
+
+    if (!activateElementsCollection.isEmpty() && completionConditionFulfilled) {
+      return Either.left(
+          new Rejection(
+              RejectionType.INVALID_ARGUMENT,
+              AHSP_JOB_CANNOT_ACTIVATE_ELEMENTS_WITH_COMPLETE_CONDITION_FULFILLED.formatted(
+                  adHocSubProcessKey)));
+    } else {
+      return Either.right(activateElementsCollection);
     }
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/adhocsubprocess/AdHocSubProcessUtils.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/adhocsubprocess/AdHocSubProcessUtils.java
@@ -18,15 +18,9 @@ public class AdHocSubProcessUtils {
   private static final String ERROR_MSG_ELEMENTS_NOT_FOUND =
       "Expected to activate activities for ad-hoc sub-process with key '%s', but the given elements %s do not exist.";
 
-  private static final String AHSP_JOB_CANNOT_ACTIVATE_ELEMENTS_WITH_COMPLETE_CONDITION_FULFILLED =
-      """
-      Expected to complete ad-hoc sub-process job, but the job result contains elements to \
-      be activated while the completion condition is fulfilled \
-      (job key '%d'). \
-      When the completion condition is fulfilled, no further element activations are allowed. \
-      Either remove the elements to be activated from the job result, or set the \
-      completion condition to not fulfilled.
-      """;
+  private static final String
+      ERROR_MSG_AHSP_CANNOT_ACTIVATE_ELEMENTS_WITH_COMPLETE_CONDITION_FULFILLED =
+          "No elements can be activated for ad-hoc sub-process with key '%s' because the completion condition is fulfilled.";
 
   public static Either<Rejection, List<String>> validateActivateElementsExistInAdHocSubProcess(
       final long adHocSubProcessKey,
@@ -59,7 +53,7 @@ public class AdHocSubProcessUtils {
       return Either.left(
           new Rejection(
               RejectionType.INVALID_ARGUMENT,
-              AHSP_JOB_CANNOT_ACTIVATE_ELEMENTS_WITH_COMPLETE_CONDITION_FULFILLED.formatted(
+              ERROR_MSG_AHSP_CANNOT_ACTIVATE_ELEMENTS_WITH_COMPLETE_CONDITION_FULFILLED.formatted(
                   adHocSubProcessKey)));
     } else {
       return Either.right(activateElementsCollection);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
@@ -228,11 +228,6 @@ public final class JobCompleteProcessor implements CommandProcessor<JobRecord> {
 
     final var jobResult = jobRecord.getResult();
 
-    if (jobResult.isCompletionConditionFulfilled() && !jobResult.getActivateElements().isEmpty()) {
-      // reject
-      System.out.println("debug point");
-    }
-
     final AdHocSubProcessInstructionRecord instructionRecord =
         new AdHocSubProcessInstructionRecord()
             .setAdHocSubProcessInstanceKey(jobRecord.getElementInstanceKey())

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
@@ -134,6 +134,7 @@ public final class JobCompleteProcessor implements CommandProcessor<JobRecord> {
             List.of(
                 this::checkAdHocSubprocessActivationTargetsAreValid,
                 this::checkAdHocSubprocessInstanceIsActive,
+                this::checkAdHocSubProcessCompletionConditionNotFulfilledForElementActivation,
                 this::checkTaskListenerJobForProvidingVariables,
                 this::checkTaskListenerJobForSupportingDenying,
                 this::checkTaskListenerJobForDenyingWithCorrections,
@@ -227,6 +228,11 @@ public final class JobCompleteProcessor implements CommandProcessor<JobRecord> {
 
     final var jobResult = jobRecord.getResult();
 
+    if (jobResult.isCompletionConditionFulfilled() && !jobResult.getActivateElements().isEmpty()) {
+      // reject
+      System.out.println("debug point");
+    }
+
     final AdHocSubProcessInstructionRecord instructionRecord =
         new AdHocSubProcessInstructionRecord()
             .setAdHocSubProcessInstanceKey(jobRecord.getElementInstanceKey())
@@ -273,6 +279,26 @@ public final class JobCompleteProcessor implements CommandProcessor<JobRecord> {
         targetAdHocSubProcessInstanceValue.getBpmnProcessIdBuffer(),
         targetAdHocSubProcessInstanceValue.getTenantId(),
         completingJobRecord.getVariablesBuffer());
+  }
+
+  private Either<Rejection, JobRecord>
+      checkAdHocSubProcessCompletionConditionNotFulfilledForElementActivation(
+          final TypedRecord<JobRecord> command, final JobRecord job) {
+
+    if (job.getJobKind() == JobKind.AD_HOC_SUB_PROCESS) {
+      final List<String> elementsToBeActivated =
+          command.getValue().getResult().getActivateElements().stream()
+              .map(JobResultActivateElementValue::getElementId)
+              .toList();
+
+      return AdHocSubProcessUtils
+          .validateThatCompletionConditionIsNotFulfilledWhenActivatingElements(
+              job.getElementInstanceKey(),
+              command.getValue().getResult().isCompletionConditionFulfilled(),
+              elementsToBeActivated)
+          .map(right -> job);
+    }
+    return Either.right(job);
   }
 
   private Either<Rejection, JobRecord> checkAdHocSubprocessActivationTargetsAreValid(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/JobBasedAdHocSubProcessTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/JobBasedAdHocSubProcessTest.java
@@ -1082,7 +1082,7 @@ public class JobBasedAdHocSubProcessTest {
   }
 
   @Test
-  public void shouldRejectWhenCompletionConditionIsFullfilledAndActivatingElements() {
+  public void shouldRejectWhenCompletionConditionIsFulfilledAndActivatingElements() {
     // given
     final var jobType = UUID.randomUUID().toString();
     final BpmnModelInstance process =
@@ -1094,6 +1094,8 @@ public class JobBasedAdHocSubProcessTest {
               adHocSubProcess.userTask("C");
             });
     ENGINE.deployment().withXmlResource(process).deploy();
+
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
 
     // when
     completeJob(jobType, true, false, activateElement("A"), activateElement("B"));


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Reject when the completion condition is fulfilled and elements are being activated

- Added the validation logic to `AdHocSubProcessUtils` so it can be used by both `JobCompleteProcessor` and `AdHocSubProcessInstructionActivateProcessor`

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes https://github.com/camunda/ad-hoc-sub-process-phase-3/issues/17
