### PR TITLE
Attach tags to process instances

### DIFF
--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/process/ZeebeProcessInstanceDataDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/process/ZeebeProcessInstanceDataDto.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.protocol.record.value.BpmnEventType;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import org.apache.commons.lang3.StringUtils;
 
 public class ZeebeProcessInstanceDataDto implements ProcessInstanceRecordValue {
@@ -29,10 +30,10 @@ public class ZeebeProcessInstanceDataDto implements ProcessInstanceRecordValue {
   private long processInstanceKey;
   private String tenantId;
 
-  private BpmnEventType bpmnEventType;
-  private List<List<Long>> elementInstancePath;
-  private List<Long> processDefinitionPath;
-  private List<Integer> callingElementPath;
+  private final BpmnEventType bpmnEventType;
+  private final List<List<Long>> elementInstancePath;
+  private final List<Long> processDefinitionPath;
+  private final List<Integer> callingElementPath;
 
   public ZeebeProcessInstanceDataDto() {
     bpmnEventType = BpmnEventType.UNSPECIFIED;
@@ -113,6 +114,11 @@ public class ZeebeProcessInstanceDataDto implements ProcessInstanceRecordValue {
   @Override
   public List<Integer> getCallingElementPath() {
     return callingElementPath;
+  }
+
+  @Override
+  public Set<String> getTags() {
+    return Set.of();
   }
 
   public void setParentElementInstanceKey(final long parentElementInstanceKey) {

--- a/tasklist/importer-870/src/main/java/io/camunda/tasklist/zeebeimport/v870/record/value/ProcessInstanceRecordValueImpl.java
+++ b/tasklist/importer-870/src/main/java/io/camunda/tasklist/zeebeimport/v870/record/value/ProcessInstanceRecordValueImpl.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.protocol.record.value.BpmnEventType;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 
 public class ProcessInstanceRecordValueImpl extends RecordValueWithPayloadImpl
     implements ProcessInstanceRecordValue {
@@ -32,6 +33,7 @@ public class ProcessInstanceRecordValueImpl extends RecordValueWithPayloadImpl
   private List<List<Long>> elementInstancePath;
   private List<Long> processDefinitionPath;
   private List<Integer> callingElementPath;
+  private Set<String> tags;
 
   public ProcessInstanceRecordValueImpl() {}
 
@@ -98,6 +100,11 @@ public class ProcessInstanceRecordValueImpl extends RecordValueWithPayloadImpl
   @Override
   public List<Integer> getCallingElementPath() {
     return callingElementPath;
+  }
+
+  @Override
+  public Set<String> getTags() {
+    return tags;
   }
 
   @Override

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/template/ListViewTemplate.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/template/ListViewTemplate.java
@@ -56,6 +56,7 @@ public class ListViewTemplate extends AbstractTemplateDescriptor implements Prio
   public static final String ACTIVITIES_JOIN_RELATION =
       "activity"; // now we call it flow node instance
   public static final String VARIABLES_JOIN_RELATION = "variable";
+  public static final String TAGS = "tags";
 
   public ListViewTemplate(final String indexPrefix, final boolean isElasticsearch) {
     super(indexPrefix, isElasticsearch);

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/listview/ProcessInstanceForListViewEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/listview/ProcessInstanceForListViewEntity.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 
 public class ProcessInstanceForListViewEntity
     implements ExporterEntity<ProcessInstanceForListViewEntity>,
@@ -52,6 +53,7 @@ public class ProcessInstanceForListViewEntity
       new ListViewJoinRelation(PROCESS_INSTANCE_JOIN_RELATION);
 
   private Long position;
+  private Set<String> tags;
 
   @JsonIgnore private Object[] sortValues;
 
@@ -252,6 +254,15 @@ public class ProcessInstanceForListViewEntity
     return this;
   }
 
+  public Set<String> getTags() {
+    return tags;
+  }
+
+  public ProcessInstanceForListViewEntity setTags(final Set<String> tags) {
+    this.tags = tags;
+    return this;
+  }
+
   @Override
   public int hashCode() {
     return Objects.hash(
@@ -273,7 +284,8 @@ public class ProcessInstanceForListViewEntity
         incident,
         tenantId,
         joinRelation,
-        position);
+        position,
+        tags);
   }
 
   @Override
@@ -303,6 +315,7 @@ public class ProcessInstanceForListViewEntity
         && Objects.equals(treePath, that.treePath)
         && Objects.equals(tenantId, that.tenantId)
         && Objects.equals(joinRelation, that.joinRelation)
-        && Objects.equals(position, that.position);
+        && Objects.equals(position, that.position)
+        && Objects.equals(tags, that.tags);
   }
 }

--- a/webapps-schema/src/main/resources/schema/elasticsearch/create/template/operate-list-view.json
+++ b/webapps-schema/src/main/resources/schema/elasticsearch/create/template/operate-list-view.json
@@ -139,6 +139,9 @@
       "positionJob": {
         "type": "long",
         "index": false
+      },
+      "tags": {
+        "type": "keyword"
       }
 		}
 	}

--- a/webapps-schema/src/main/resources/schema/opensearch/create/template/operate-list-view.json
+++ b/webapps-schema/src/main/resources/schema/opensearch/create/template/operate-list-view.json
@@ -139,6 +139,9 @@
       "positionJob": {
         "type": "long",
         "index": false
+      },
+      "tags": {
+        "type": "keyword"
       }
 		}
 	}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreationCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreationCreateProcessor.java
@@ -43,6 +43,7 @@ import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
 import io.camunda.zeebe.util.Either;
+import io.camunda.zeebe.util.TagUtil;
 import java.util.Arrays;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -176,7 +177,9 @@ public final class ProcessInstanceCreationCreateProcessor
         process.getBpmnProcessId(),
         process.getTenantId());
 
-    final var processInstance = initProcessInstanceRecord(process, processInstanceKey);
+    final var processInstance =
+        initProcessInstanceRecord(process, processInstanceKey, record.getTags());
+
     if (record.startInstructions().isEmpty()) {
       commandWriter.appendFollowUpCommand(
           processInstanceKey, ProcessInstanceIntent.ACTIVATE_ELEMENT, processInstance);
@@ -198,6 +201,7 @@ public final class ProcessInstanceCreationCreateProcessor
       final ProcessInstanceCreationRecord command, final DeployedProcess deployedProcess) {
     final var process = deployedProcess.getProcess();
     final var startInstructions = command.startInstructions();
+    final var tags = command.getTags();
 
     return validateHasNoneStartEventOrStartInstructions(process, startInstructions)
         .flatMap(valid -> validateElementsExist(process, startInstructions))
@@ -205,6 +209,7 @@ public final class ProcessInstanceCreationCreateProcessor
         .flatMap(valid -> validateTargetsSupportedElementType(process, startInstructions))
         .flatMap(
             valid -> validateElementNotBelongingToEventBasedGateway(process, startInstructions))
+        .flatMap(valid -> validateTags(tags))
         .map(valid -> deployedProcess);
   }
 
@@ -328,6 +333,29 @@ public final class ProcessInstanceCreationCreateProcessor
         .orElse(VALID);
   }
 
+  private Either<Rejection, ?> validateTags(final Set<String> tags) {
+    if (tags.size() > TagUtil.MAX_NUMBER_OF_TAGS) {
+      return Either.left(
+          new Rejection(
+              RejectionType.INVALID_ARGUMENT,
+              String.format(
+                  "Expected to create instance of process with tags, but the number of tags exceeds the limit of %s.",
+                  TagUtil.MAX_NUMBER_OF_TAGS)));
+    }
+
+    return tags.stream()
+        .filter(tag -> !TagUtil.isValidTag(tag))
+        .findAny()
+        .map(
+            tag ->
+                Either.left(
+                    new Rejection(
+                        RejectionType.INVALID_ARGUMENT,
+                        "Expected to create instance of process with tags, but tag '%s' is invalid. %s"
+                            .formatted(tag, TagUtil.TAG_FORMAT_DESCRIPTION))))
+        .orElse(VALID);
+  }
+
   private boolean doesElementBelongToAnEventBasedGateway(
       final ExecutableProcess process, final String elementId) {
     final ExecutableFlowNode element = process.getElementById(elementId, ExecutableFlowNode.class);
@@ -354,7 +382,7 @@ public final class ProcessInstanceCreationCreateProcessor
   }
 
   private ProcessInstanceRecord initProcessInstanceRecord(
-      final DeployedProcess process, final long processInstanceKey) {
+      final DeployedProcess process, final long processInstanceKey, final Set<String> tags) {
     newProcessInstance.reset();
     newProcessInstance.setBpmnProcessId(process.getBpmnProcessId());
     newProcessInstance.setVersion(process.getVersion());
@@ -364,6 +392,7 @@ public final class ProcessInstanceCreationCreateProcessor
     newProcessInstance.setElementId(process.getProcess().getId());
     newProcessInstance.setFlowScopeKey(-1);
     newProcessInstance.setTenantId(process.getTenantId());
+    newProcessInstance.setTags(tags);
     return newProcessInstance;
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceTest.java
@@ -263,10 +263,8 @@ public final class CreateProcessInstanceTest {
         .hasFlowScopeKey(-1)
         .hasBpmnProcessId("process")
         .hasProcessInstanceKey(processInstanceKey)
-        .hasTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
-
-    final var tags = value.getTags();
-    assertThat(tags).containsExactlyInAnyOrder("businessKey:1234", "priority:high");
+        .hasTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER)
+        .hasTags("businessKey:1234", "priority:high");
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceTest.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceCreationRecord;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.intent.MessageIntent;
@@ -215,6 +216,57 @@ public final class CreateProcessInstanceTest {
         .allMatch(v -> v.getScopeKey() == processInstanceKey)
         .extracting(v -> tuple(v.getName(), v.getValue()))
         .contains(tuple("x", "1"), tuple("y", "2"));
+  }
+
+  @Test
+  public void shouldCreateProcessInstanceWithTags() {
+    // given
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess("process")
+                .startEvent()
+                .serviceTask("my-task", t -> t.zeebeJobType("my-job"))
+                .endEvent()
+                .done())
+        .deploy();
+
+    // when
+    final long processInstanceKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId("process")
+            .withTags("businessKey:1234", "priority:high")
+            .create();
+
+    // then
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceCompleted()
+                .withElementType(BpmnElementType.PROCESS))
+        .extracting(Record::getIntent)
+        .containsSequence(
+            ProcessInstanceIntent.ELEMENT_ACTIVATING, ProcessInstanceIntent.ELEMENT_ACTIVATED);
+
+    final Record<ProcessInstanceRecordValue> process =
+        RecordingExporter.processInstanceRecords()
+            .withProcessInstanceKey(processInstanceKey)
+            .withIntent(ProcessInstanceIntent.ELEMENT_ACTIVATING)
+            .withElementType(BpmnElementType.PROCESS)
+            .getFirst();
+
+    final ProcessInstanceRecord value = (ProcessInstanceRecord) process.getValue();
+    Assertions.assertThat(value)
+        .hasElementId("process")
+        .hasBpmnElementType(BpmnElementType.PROCESS)
+        .hasFlowScopeKey(-1)
+        .hasBpmnProcessId("process")
+        .hasProcessInstanceKey(processInstanceKey)
+        .hasTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+
+    final var tags = value.getTags();
+    assertThat(tags).containsExactlyInAnyOrder("businessKey:1234", "priority:high");
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/ProcessInstanceClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/ProcessInstanceClient.java
@@ -132,6 +132,11 @@ public final class ProcessInstanceClient {
       return this;
     }
 
+    public ProcessInstanceCreationClient withTags(final String... tags) {
+      processInstanceCreationRecord.setTags(Set.of(tags));
+      return this;
+    }
+
     public ProcessInstanceCreationClient withRuntimeTerminateInstruction(
         final String afterElementId) {
       final var instruction =

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ListViewProcessInstanceFromProcessInstanceHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ListViewProcessInstanceFromProcessInstanceHandler.java
@@ -109,7 +109,7 @@ public class ListViewProcessInstanceFromProcessInstanceHandler
         .setProcessName(
             getProcessName(piEntity.getProcessDefinitionKey(), recordValue.getBpmnProcessId()))
         .setProcessVersionTag(getVersionTag(piEntity.getProcessDefinitionKey()))
-        .setTags(piEntity.getTags());
+        .setTags(recordValue.getTags());
 
     final OffsetDateTime timestamp =
         OffsetDateTime.ofInstant(Instant.ofEpochMilli(record.getTimestamp()), ZoneOffset.UTC);

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ListViewProcessInstanceFromProcessInstanceHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ListViewProcessInstanceFromProcessInstanceHandler.java
@@ -108,7 +108,8 @@ public class ListViewProcessInstanceFromProcessInstanceHandler
         .setProcessVersion(recordValue.getVersion())
         .setProcessName(
             getProcessName(piEntity.getProcessDefinitionKey(), recordValue.getBpmnProcessId()))
-        .setProcessVersionTag(getVersionTag(piEntity.getProcessDefinitionKey()));
+        .setProcessVersionTag(getVersionTag(piEntity.getProcessDefinitionKey()))
+        .setTags(piEntity.getTags());
 
     final OffsetDateTime timestamp =
         OffsetDateTime.ofInstant(Instant.ofEpochMilli(record.getTimestamp()), ZoneOffset.UTC);
@@ -168,6 +169,9 @@ public class ListViewProcessInstanceFromProcessInstanceHandler
     updateFields.put(POSITION, entity.getPosition());
     if (entity.getState() != null) {
       updateFields.put(ListViewTemplate.STATE, entity.getState());
+    }
+    if (entity.getTags() != null) {
+      updateFields.put(ListViewTemplate.TAGS, entity.getTags());
     }
 
     batchRequest.upsert(indexName, entity.getId(), entity, updateFields);

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ListViewProcessInstanceFromProcessInstanceHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ListViewProcessInstanceFromProcessInstanceHandler.java
@@ -170,7 +170,7 @@ public class ListViewProcessInstanceFromProcessInstanceHandler
     if (entity.getState() != null) {
       updateFields.put(ListViewTemplate.STATE, entity.getState());
     }
-    if (entity.getTags() != null) {
+    if (entity.getTags() != null && !entity.getTags().isEmpty()) {
       updateFields.put(ListViewTemplate.TAGS, entity.getTags());
     }
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ListViewProcessInstanceFromProcessInstanceHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ListViewProcessInstanceFromProcessInstanceHandlerTest.java
@@ -39,6 +39,7 @@ import java.util.Date;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
@@ -166,7 +167,8 @@ public class ListViewProcessInstanceFromProcessInstanceHandlerTest {
             .setStartDate(OffsetDateTime.now())
             .setEndDate(OffsetDateTime.now())
             .setState(ProcessInstanceState.ACTIVE)
-            .setTreePath("PI_111");
+            .setTreePath("PI_111")
+            .setTags(Set.of("businessKey:123", "priority:high"));
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     final Map<String, Object> expectedUpdateFields = new LinkedHashMap<>();
@@ -179,6 +181,7 @@ public class ListViewProcessInstanceFromProcessInstanceHandlerTest {
     expectedUpdateFields.put(ListViewTemplate.STATE, ProcessInstanceState.ACTIVE);
     expectedUpdateFields.put(ListViewTemplate.START_DATE, inputEntity.getStartDate());
     expectedUpdateFields.put(ListViewTemplate.END_DATE, inputEntity.getEndDate());
+    expectedUpdateFields.put(ListViewTemplate.TAGS, inputEntity.getTags());
     expectedUpdateFields.put(PARTITION_ID, 12);
     expectedUpdateFields.put(POSITION, 123L);
 
@@ -232,6 +235,7 @@ public class ListViewProcessInstanceFromProcessInstanceHandlerTest {
             .withBpmnElementType(BpmnElementType.PROCESS)
             .withElementInstancePath(List.of(List.of(111L)))
             .withProcessDefinitionPath(List.of(222L))
+            .withTags(Set.of("tag1", "tag2"))
             .build();
     final Record<ProcessInstanceRecordValue> processInstanceRecord =
         factory.generateRecord(
@@ -286,6 +290,7 @@ public class ListViewProcessInstanceFromProcessInstanceHandlerTest {
     assertThat(processInstanceForListViewEntity.getJoinRelation())
         .isEqualTo(new ListViewJoinRelation(ListViewTemplate.PROCESS_INSTANCE_JOIN_RELATION));
     assertThat(processInstanceForListViewEntity.getTreePath()).isEqualTo("PI_111");
+    assertThat(processInstanceForListViewEntity.getTags()).isEqualTo(Set.of("tag1", "tag2"));
 
     // process name and version tag is read from the cache
     assertThat(processInstanceForListViewEntity.getProcessName()).isEqualTo("test-process-name");

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-process-instance-creation-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-process-instance-creation-template.json
@@ -53,6 +53,9 @@
             },
             "tenantId": {
               "type": "keyword"
+            },
+            "tags": {
+              "type": "keyword"
             }
           }
         }

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-process-instance-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-process-instance-template.json
@@ -60,6 +60,9 @@
             },
             "callingElementPath": {
               "enabled": false
+            },
+            "tags": {
+              "type": "keyword"
             }
           }
         }

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-process-instance-creation-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-process-instance-creation-template.json
@@ -53,6 +53,9 @@
             },
             "tenantId": {
               "type": "keyword"
+            },
+            "tags": {
+              "type": "keyword"
             }
           }
         }

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-process-instance-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-process-instance-template.json
@@ -60,6 +60,9 @@
             },
             "callingElementPath": {
               "enabled": false
+            },
+            "tags": {
+              "type": "keyword"
             }
           }
         }

--- a/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/value/StringValue.java
+++ b/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/value/StringValue.java
@@ -11,6 +11,7 @@ import static io.camunda.zeebe.util.buffer.BufferUtil.wrapString;
 
 import io.camunda.zeebe.msgpack.spec.MsgPackReader;
 import io.camunda.zeebe.msgpack.spec.MsgPackWriter;
+import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 import org.agrona.DirectBuffer;
 import org.agrona.MutableDirectBuffer;
@@ -64,6 +65,10 @@ public final class StringValue extends BaseValue {
 
   public void wrap(final StringValue anotherString) {
     wrap(anotherString.getValue());
+  }
+
+  public void wrap(final String anotherString) {
+    wrap(anotherString.getBytes(StandardCharsets.UTF_8));
   }
 
   public int getLength() {

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceCreationRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceCreationRecord.java
@@ -22,8 +22,10 @@ import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceCreationRecordValue;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.agrona.DirectBuffer;
 
 public final class ProcessInstanceCreationRecord extends UnifiedRecordValue
@@ -41,6 +43,7 @@ public final class ProcessInstanceCreationRecord extends UnifiedRecordValue
   private static final StringValue START_INSTRUCTIONS_KEY = new StringValue("startInstructions");
   private static final StringValue RUNTIME_INSTRUCTIONS_KEY =
       new StringValue("runtimeInstructions");
+  private static final StringValue TAGS_KEY = new StringValue("tags");
 
   private final StringProperty bpmnProcessIdProperty = new StringProperty(BPMN_PROCESS_ID_KEY, "");
   private final LongProperty processDefinitionKeyProperty =
@@ -60,9 +63,11 @@ public final class ProcessInstanceCreationRecord extends UnifiedRecordValue
       runtimeInstructionsProperty =
           new ArrayProperty<>(
               RUNTIME_INSTRUCTIONS_KEY, ProcessInstanceCreationRuntimeInstruction::new);
+  private final ArrayProperty<StringValue> tagsProperty =
+      new ArrayProperty<>(TAGS_KEY, StringValue::new);
 
   public ProcessInstanceCreationRecord() {
-    super(9);
+    super(10);
     declareProperty(bpmnProcessIdProperty)
         .declareProperty(processDefinitionKeyProperty)
         .declareProperty(processInstanceKeyProperty)
@@ -71,7 +76,8 @@ public final class ProcessInstanceCreationRecord extends UnifiedRecordValue
         .declareProperty(fetchVariablesProperty)
         .declareProperty(startInstructionsProperty)
         .declareProperty(runtimeInstructionsProperty)
-        .declareProperty(tenantIdProperty);
+        .declareProperty(tenantIdProperty)
+        .declareProperty(tagsProperty);
   }
 
   @Override
@@ -221,6 +227,19 @@ public final class ProcessInstanceCreationRecord extends UnifiedRecordValue
 
   public ProcessInstanceCreationRecord setTenantId(final String tenantId) {
     tenantIdProperty.setValue(tenantId);
+    return this;
+  }
+
+  @Override
+  public Set<String> getTags() {
+    final var tags = new HashSet<String>();
+    tagsProperty.forEach(e -> tags.add(e.toString()));
+    return tags;
+  }
+
+  public ProcessInstanceCreationRecord setTags(final Set<String> tags) {
+    tagsProperty.reset();
+    tags.forEach(e -> tagsProperty.add().wrap(e));
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -1597,7 +1597,8 @@ final class JsonSerializableToJsonTest {
                           MsgPackConverter.convertToMsgPack("{'foo':'bar','baz':'boz'}")))
                   .addStartInstruction(
                       new ProcessInstanceCreationStartInstruction().setElementId("element"))
-                  .setProcessInstanceKey(instanceKey);
+                  .setProcessInstanceKey(instanceKey)
+                  .setTags(Set.of("tag1", "tag2"));
             },
         """
         {
@@ -1615,7 +1616,8 @@ final class JsonSerializableToJsonTest {
             }
           ],
           "tenantId": "test-tenant",
-          "runtimeInstructions": []
+          "runtimeInstructions": [],
+          "tags": ["tag1", "tag2"]
         }
         """
       },
@@ -1635,7 +1637,8 @@ final class JsonSerializableToJsonTest {
           "processInstanceKey": -1,
           "startInstructions": [],
           "tenantId": "<default>",
-          "runtimeInstructions": []
+          "runtimeInstructions": [],
+          "tags": []
         }
         """
       },
@@ -1740,7 +1743,8 @@ final class JsonSerializableToJsonTest {
                   .setBpmnEventType(BpmnEventType.UNSPECIFIED)
                   .setElementInstancePath(elementInstancePath)
                   .setProcessDefinitionPath(processDefinitionPath)
-                  .setCallingElementPath(callingElementPath);
+                  .setCallingElementPath(callingElementPath)
+                  .setTags(Set.of("tag1", "tag2"));
             },
         """
         {
@@ -1757,7 +1761,8 @@ final class JsonSerializableToJsonTest {
           "tenantId": "<default>",
           "elementInstancePath":[[101, 102], [103, 104]],
           "processDefinitionPath": [101, 102],
-          "callingElementPath": [12345, 67890]
+          "callingElementPath": [12345, 67890],
+          "tags": ["tag1", "tag2"]
         }
         """
       },
@@ -1783,7 +1788,8 @@ final class JsonSerializableToJsonTest {
           "tenantId": "<default>",
           "elementInstancePath":[],
           "processDefinitionPath": [],
-          "callingElementPath": []
+          "callingElementPath": [],
+          "tags": []
         }
         """
       },

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessInstanceCreationRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessInstanceCreationRecordValue.java
@@ -18,6 +18,7 @@ package io.camunda.zeebe.protocol.record.value;
 import io.camunda.zeebe.protocol.record.ImmutableProtocol;
 import io.camunda.zeebe.protocol.record.RecordValueWithVariables;
 import java.util.List;
+import java.util.Set;
 import org.immutables.value.Value;
 
 @Value.Immutable
@@ -44,6 +45,9 @@ public interface ProcessInstanceCreationRecordValue
 
   /** Returns a list of runtime instructions (if available), or an empty list. */
   List<ProcessInstanceCreationRuntimeInstructionValue> getRuntimeInstructions();
+
+  /** Returns a set of tags */
+  Set<String> getTags();
 
   @Value.Immutable
   @ImmutableProtocol(builder = ImmutableProcessInstanceCreationStartInstructionValue.Builder.class)

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessInstanceRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessInstanceRecordValue.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.protocol.record.ImmutableProtocol;
 import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import java.util.List;
+import java.util.Set;
 import org.immutables.value.Value;
 
 /**
@@ -173,4 +174,9 @@ public interface ProcessInstanceRecordValue
    *     to the call activity in BPMN model containing an incident.
    */
   List<Integer> getCallingElementPath();
+
+  /**
+   * @return a set of tags associated with this process instance
+   */
+  Set<String> getTags();
 }

--- a/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/RecordBatchTest.java
+++ b/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/RecordBatchTest.java
@@ -159,7 +159,7 @@ class RecordBatchTest {
     assertThat(either.isLeft()).isTrue();
     assertThat(either.getLeft())
         .hasMessageContaining("Can't append entry")
-        .hasMessageContaining("[ currentBatchEntryCount: 1, currentBatchSize: 416]");
+        .hasMessageContaining("[ currentBatchEntryCount: 1, currentBatchSize: 422]");
   }
 
   @Test
@@ -189,7 +189,7 @@ class RecordBatchTest {
   @Test
   void shouldOnlyReturnTrueUntilMaxBatchSizeIsReached() {
     // given
-    final var recordBatch = new RecordBatch((count, size) -> size < 417);
+    final var recordBatch = new RecordBatch((count, size) -> size < 423);
     final var processInstanceRecord = Records.processInstance(1);
 
     recordBatch.appendRecord(1, RECORD_METADATA, -1, processInstanceRecord);

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/TagUtil.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/TagUtil.java
@@ -14,8 +14,10 @@ public class TagUtil {
   public static final int MAX_NUMBER_OF_TAGS = 10;
   public static final int MAX_TAG_LENGTH = 100;
   public static final String TAG_FORMAT_DESCRIPTION =
-      "Tag must start with a letter (a-z, A-Z), followed by alphanumerics, underscores, minuses, colons, or periods. "
-          + "It must not be blank and must be 100 characters or less.";
+      String.format(
+          "Tag must start with a letter (a-z, A-Z), followed by alphanumerics, underscores, minuses, colons, or periods. "
+              + "It must not be blank and must be %s characters or less.",
+          MAX_TAG_LENGTH);
 
   // Pattern for valid tag format: starts with letter, followed by alphanumerics, _, -, :, .
   private static final Pattern VALID_TAG_PATTERN = Pattern.compile("^[a-zA-Z][a-zA-Z0-9_\\-:.]*$");

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/TagUtil.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/TagUtil.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.util;
+
+import java.util.regex.Pattern;
+
+public class TagUtil {
+
+  public static final int MAX_NUMBER_OF_TAGS = 10;
+  public static final int MAX_TAG_LENGTH = 100;
+  public static final String TAG_FORMAT_DESCRIPTION =
+      "Tag must start with a letter (a-z, A-Z), followed by alphanumerics, underscores, minuses, colons, or periods. "
+          + "It must not be blank and must be 100 characters or less.";
+
+  // Pattern for valid tag format: starts with letter, followed by alphanumerics, _, -, :, .
+  private static final Pattern VALID_TAG_PATTERN = Pattern.compile("^[a-zA-Z][a-zA-Z0-9_\\-:.]*$");
+
+  /**
+   * Validates that a tag follows the required format and constraints: - Must start with a letter
+   * (a-z, A-Z) - After the first character, may contain: alphanumerics, underscores, minuses,
+   * colons, periods - Must not be blank and must be 100 characters or less
+   */
+  public static boolean isValidTag(final String tag) {
+    return tag != null
+        && tag.length() <= MAX_TAG_LENGTH
+        && VALID_TAG_PATTERN.matcher(tag).matches();
+  }
+}

--- a/zeebe/util/src/test/java/io/camunda/zeebe/util/TagUtilTest.java
+++ b/zeebe/util/src/test/java/io/camunda/zeebe/util/TagUtilTest.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class TagUtilTest {
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "a", // single letter
+        "A", // single uppercase letter
+        "validTag", // camelCase
+        "valid_tag", // with underscore
+        "valid-tag", // with hyphen
+        "valid:tag", // with colon
+        "valid.tag", // with period
+        "a1", // letter followed by number
+        "A1", // uppercase letter followed by number
+        "tag123", // letters followed by numbers
+        "complex_tag-123:v1.0", // complex valid tag
+        "myTag_v1.2-final:release", // complex with all allowed characters
+        "production", // common use case
+        "development", // common use case
+        "test_env", // common use case
+        "api-v2.1", // versioned API tag
+        "user:admin", // role-based tag
+        "region.us-east", // geographic tag
+        "a0123456789", // digits after first letter
+        "aABCDEFGHIJKLMNOPQRSTUVWXYZ", // uppercase after first letter
+        "aabcdefghijklmnopqrstuvwxyz", // lowercase after first letter
+        "a_", // underscore after first letter
+        "a-", // hyphen after first letter
+        "a:", // colon after first letter
+        "a.", // period after first letter
+        "env:production", // real-world: environment
+        "version:1.2.3", // real-world: version
+        "team:backend-api", // real-world: team
+        "region:us-east-1", // real-world: region
+        "cost-center:eng-123", // real-world: cost center
+        "project_name", // real-world: project
+        "feature-flag:enabled", // real-world: feature flag
+        "service.auth.v2", // real-world: service
+        "critical:high-priority", // real-world: priority
+        "deployment:blue-green", // real-world: deployment strategy
+      })
+  void shouldAcceptValidTags(final String validTag) {
+    assertThat(TagUtil.isValidTag(validTag)).isTrue();
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "", // empty tag
+        " ", // blank tag
+        "   ", // multiple spaces
+        "\t", // tab character
+        "\n", // newline character
+        "\r", // carriage return character
+        "1", // single digit
+        "1tag", // starts with number
+        "9invalid", // starts with number
+        "_tag", // starts with underscore
+        "-tag", // starts with hyphen
+        ":tag", // starts with colon
+        ".tag", // starts with period
+        "tag with space", // contains space
+        "tag\ttab", // contains tab
+        "tag\nnewline", // contains newline
+        "tag@symbol", // contains @ symbol
+        "tag#hash", // contains hash
+        "tag$dollar", // contains dollar sign
+        "tag%percent", // contains percent
+        "tag^caret", // contains caret
+        "tag&ampersand", // contains ampersand
+        "tag*asterisk", // contains asterisk
+        "tag+plus", // contains plus
+        "tag=equals", // contains equals
+        "tag[bracket", // contains bracket
+        "tag]bracket", // contains bracket
+        "tag{brace", // contains brace
+        "tag}brace", // contains brace
+        "tag|pipe", // contains pipe
+        "tag\\backslash", // contains backslash
+        "tag/slash", // contains forward slash
+        "tag<less", // contains less than
+        "tag>greater", // contains greater than
+        "tag?question", // contains question mark
+        "tag\"quote", // contains quote
+        "tag'apostrophe", // contains apostrophe
+        "tag;semicolon", // contains semicolon
+        "tag,comma", // contains comma
+        "café", // contains accented character
+        "tağ", // contains non-ASCII character
+        "🏷️tag", // starts with emoji
+        "tag🏷️", // contains emoji
+        "тag", // contains Cyrillic character
+        "tag with multiple spaces", // contains multiple spaces
+        "tag\twith\ttabs", // contains multiple tabs
+        "tag\nwith\nnewlines", // contains multiple newlines
+        "tag@#$%^&*()", // contains special characters
+        "tag+=[]{}|\\", // contains special characters
+        "tag<>?\"';,", // contains special characters
+      })
+  void shouldRejectInvalidTags(final String invalidTag) {
+    assertThat(TagUtil.isValidTag(invalidTag)).isFalse();
+  }
+
+  @Test
+  void shouldRejectNullTag() {
+    assertThat(TagUtil.isValidTag(null)).isFalse();
+  }
+
+  @Test
+  void shouldRejectTagExceeding100Characters() {
+    final String tooLongTag = "a" + "b".repeat(100); // 101 characters
+    assertThat(TagUtil.isValidTag(tooLongTag)).isFalse();
+    assertThat(tooLongTag.length()).isEqualTo(101);
+  }
+
+  @Test
+  void shouldAcceptTagWith100Characters() {
+    final String maxLengthTag = "a" + "b".repeat(99); // exactly 100 characters
+    assertThat(TagUtil.isValidTag(maxLengthTag)).isTrue();
+    assertThat(maxLengthTag.length()).isEqualTo(100);
+  }
+}

--- a/zeebe/util/src/test/java/io/camunda/zeebe/util/TagUtilTest.java
+++ b/zeebe/util/src/test/java/io/camunda/zeebe/util/TagUtilTest.java
@@ -123,15 +123,16 @@ class TagUtilTest {
 
   @Test
   void shouldRejectTagExceeding100Characters() {
-    final String tooLongTag = "a" + "b".repeat(100); // 101 characters
+    final String tooLongTag = "a" + "b".repeat(TagUtil.MAX_TAG_LENGTH); // 101 characters
     assertThat(TagUtil.isValidTag(tooLongTag)).isFalse();
-    assertThat(tooLongTag.length()).isEqualTo(101);
+    assertThat(tooLongTag.length()).isEqualTo(TagUtil.MAX_TAG_LENGTH + 1);
   }
 
   @Test
   void shouldAcceptTagWith100Characters() {
-    final String maxLengthTag = "a" + "b".repeat(99); // exactly 100 characters
+    final String maxLengthTag =
+        "a" + "b".repeat(TagUtil.MAX_TAG_LENGTH - 1); // exactly 100 characters
     assertThat(TagUtil.isValidTag(maxLengthTag)).isTrue();
-    assertThat(maxLengthTag.length()).isEqualTo(100);
+    assertThat(maxLengthTag.length()).isEqualTo(TagUtil.MAX_TAG_LENGTH);
   }
 }


### PR DESCRIPTION
**Dear Reviewer, I am not super familiar with the exporting/datalayer schemas, thus please have a careful look if I didn't miss something. I left some comments to especially discuss some points. Thank you. 🙏** 

## Description

This is the first one of a series of PRs to attach tags to a process instance, thus within this PR the main changes are:
- add tags to zeebe records for process instances
- export tags to es/os also using the legacy exporters (skip RDBMS for now)
- adjust the process instance creation to attach tags to the record(s)

## Related issues

closes https://github.com/camunda/camunda/issues/36850
