### PR TITLE
fix: identity e2e test on CI

### DIFF
--- a/.github/workflows/identity-e2e-tests.yml
+++ b/.github/workflows/identity-e2e-tests.yml
@@ -72,6 +72,10 @@ jobs:
           vault-address: ${{ secrets.VAULT_ADDR }}
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+      - name: Build frontend
+        uses: ./.github/actions/build-frontend
+        with:
+          directory: ./identity/client
       - name: Install QA Test Suite Dependencies
         run: npm install
         working-directory: ./qa/c8-orchestration-cluster-e2e-test-suite


### PR DESCRIPTION
## Description

Fixes Identity E2E tests on the CI adding previously removed (by accident) step in CI workflow file.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
