### PR TITLE
feat: do not add null or empty assignees to usage metrics

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UserTaskAssignedV3Applier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UserTaskAssignedV3Applier.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskListenerEventType;
 import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
 import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
 import java.util.List;
+import org.apache.commons.lang3.StringUtils;
 
 public final class UserTaskAssignedV3Applier
     implements TypedEventApplier<UserTaskIntent, UserTaskRecord> {
@@ -52,6 +53,8 @@ public final class UserTaskAssignedV3Applier
       }
     }
 
-    usageMetricState.recordTUMetric(value.getTenantId(), value.getAssignee());
+    if (StringUtils.isNotEmpty(value.getAssignee())) {
+      usageMetricState.recordTUMetric(value.getTenantId(), value.getAssignee());
+    }
   }
 }

--- a/zeebe/engine/src/test/resources/state/appliers/golden/UserTask_ASSIGNED_v3.golden
+++ b/zeebe/engine/src/test/resources/state/appliers/golden/UserTask_ASSIGNED_v3.golden
@@ -17,6 +17,7 @@ import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskListenerEventType;
 import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
 import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
 import java.util.List;
+import org.apache.commons.lang3.StringUtils;
 
 public final class UserTaskAssignedV3Applier
     implements TypedEventApplier<UserTaskIntent, UserTaskRecord> {
@@ -52,6 +53,8 @@ public final class UserTaskAssignedV3Applier
       }
     }
 
-    usageMetricState.recordTUMetric(value.getTenantId(), value.getAssignee());
+    if (StringUtils.isNotEmpty(value.getAssignee())) {
+      usageMetricState.recordTUMetric(value.getTenantId(), value.getAssignee());
+    }
   }
 }


### PR DESCRIPTION
## Description
On task unassign, assignee is set to empty string " ".
Hash value of empty string is 0 and should not be stored.
UsageMetrics TU should not be increased

closes #36741 
