### PR TITLE
Add headers to ping request.

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/console/ping/PingConsoleTask.java
+++ b/dist/src/main/java/io/camunda/application/commons/console/ping/PingConsoleTask.java
@@ -57,6 +57,8 @@ public class PingConsoleTask implements Runnable {
       final HttpRequest request =
           HttpRequest.newBuilder()
               .uri(pingConfiguration.endpoint())
+              .header("Accept", "application/json")
+              .header("Content-Type", "application/json")
               .POST(HttpRequest.BodyPublishers.ofString(licensePayload))
               .build();
 


### PR DESCRIPTION
## Description

This PR adds `Accept` and `Content-Type` headers with `application/json` to the ping request. 

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes https://github.com/camunda/camunda/issues/36766
