### PR TITLE
Rename authorizedApplications to authorizedComponents in /v2/authentication/me

### DIFF
--- a/identity/client/src/components/global/AppRoot.tsx
+++ b/identity/client/src/components/global/AppRoot.tsx
@@ -96,8 +96,8 @@ const AppContent: FC<{ children?: ReactNode }> = ({ children }) => {
   }
 
   if (
-    !camundaUser?.authorizedApplications.includes("identity") &&
-    !camundaUser?.authorizedApplications.includes("*")
+    !camundaUser?.authorizedComponents.includes("identity") &&
+    !camundaUser?.authorizedComponents.includes("*")
   ) {
     return (
       <>

--- a/identity/client/src/utility/api/authentication/index.ts
+++ b/identity/client/src/utility/api/authentication/index.ts
@@ -23,7 +23,7 @@ export interface CamundaUser {
   userKey: number;
   displayName: string;
   email: string;
-  authorizedApplications: readonly string[];
+  authorizedComponents: readonly string[];
   tenants: readonly TenantInfo[];
   groups: readonly string[];
   roles: readonly string[];

--- a/operate/client/package-lock.json
+++ b/operate/client/package-lock.json
@@ -19,7 +19,7 @@
         "@tanstack/eslint-plugin-query": "5.81.2",
         "@tanstack/react-query": "5.83.0",
         "@tanstack/react-query-devtools": "5.83.0",
-        "@vzeta/camunda-api-zod-schemas": "2.0.9",
+        "@vzeta/camunda-api-zod-schemas": "2.0.11",
         "bpmn-js": "18.6.2",
         "bpmn-moddle": "9.0.2",
         "date-fns": "4.1.0",
@@ -4298,9 +4298,9 @@
       }
     },
     "node_modules/@vzeta/camunda-api-zod-schemas": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/@vzeta/camunda-api-zod-schemas/-/camunda-api-zod-schemas-2.0.9.tgz",
-      "integrity": "sha512-X/7ALR45e5rv4pWAatkEKx57H1Frx/CXJGc7qdjJ/912H+PL9q9DoPgbtCoLEMQIaDf0Anu1lxEtcEncHKTdAA==",
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@vzeta/camunda-api-zod-schemas/-/camunda-api-zod-schemas-2.0.11.tgz",
+      "integrity": "sha512-noom7UBDV0SgGW6/2DOXCmG/pWodpQb1jX+qFfd+K9ogsTp/RJkLTvh3sRBHSnW2su8+NkC/xleO3K6WHjsMnQ==",
       "license": "MIT",
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"

--- a/operate/client/package.json
+++ b/operate/client/package.json
@@ -15,7 +15,7 @@
     "@tanstack/eslint-plugin-query": "5.81.2",
     "@tanstack/react-query": "5.83.0",
     "@tanstack/react-query-devtools": "5.83.0",
-    "@vzeta/camunda-api-zod-schemas": "2.0.9",
+    "@vzeta/camunda-api-zod-schemas": "2.0.11",
     "bpmn-js": "18.6.2",
     "bpmn-moddle": "9.0.2",
     "date-fns": "4.1.0",

--- a/operate/client/src/App/Decisions/Filters/tests/index.test.tsx
+++ b/operate/client/src/App/Decisions/Filters/tests/index.test.tsx
@@ -67,8 +67,8 @@ const MOCK_FILTERS_PARAMS = {
 describe('<Filters />', () => {
   beforeEach(async () => {
     mockFetchGroupedDecisions().withSuccess(groupedDecisions);
-    mockMe().withSuccess(createUser({authorizedApplications: ['operate']}));
-    mockMe().withSuccess(createUser({authorizedApplications: ['operate']}));
+    mockMe().withSuccess(createUser({authorizedComponents: ['operate']}));
+    mockMe().withSuccess(createUser({authorizedComponents: ['operate']}));
     await groupedDecisionsStore.fetchDecisions();
     vi.useFakeTimers({shouldAdvanceTime: true});
   });

--- a/operate/client/src/App/Decisions/InstancesTable/index.test.tsx
+++ b/operate/client/src/App/Decisions/InstancesTable/index.test.tsx
@@ -60,7 +60,7 @@ const createWrapper = (initialPath: string = Paths.decisions()) => {
 describe('<InstancesTable />', () => {
   beforeEach(() => {
     mockFetchGroupedDecisions().withSuccess(mockGroupedDecisions);
-    mockMe().withSuccess(createUser({authorizedApplications: ['operate']}));
+    mockMe().withSuccess(createUser({authorizedComponents: ['operate']}));
   });
 
   it('should initially render skeleton', async () => {

--- a/operate/client/src/App/Layout/AppHeader/tests/appSwitcher.test.tsx
+++ b/operate/client/src/App/Layout/AppHeader/tests/appSwitcher.test.tsx
@@ -38,7 +38,7 @@ describe('App switcher', () => {
           {name: 'console', link: 'https://link-to-console'},
           {name: 'optimize', link: 'https://link-to-optimize'},
         ],
-        authorizedApplications: ['operate'],
+        authorizedComponents: ['operate'],
       }),
     );
 

--- a/operate/client/src/App/Layout/AppHeader/tests/index.test.tsx
+++ b/operate/client/src/App/Layout/AppHeader/tests/index.test.tsx
@@ -14,7 +14,7 @@ import {mockMe} from 'modules/mocks/api/v2/me';
 
 describe('Header', () => {
   beforeEach(() => {
-    mockMe().withSuccess(createUser({authorizedApplications: ['operate']}));
+    mockMe().withSuccess(createUser({authorizedComponents: ['operate']}));
   });
 
   it('should go to the correct pages when clicking on header links', async () => {

--- a/operate/client/src/App/Layout/AppHeader/tests/infoBar.test.tsx
+++ b/operate/client/src/App/Layout/AppHeader/tests/infoBar.test.tsx
@@ -24,7 +24,7 @@ const Wrapper: React.FC<{children?: React.ReactNode}> = ({children}) => {
 
 describe('Info bar', () => {
   it('should render with correct links', async () => {
-    mockMe().withSuccess(createUser({authorizedApplications: ['operate']}));
+    mockMe().withSuccess(createUser({authorizedComponents: ['operate']}));
     const mockOpenFn = vi.fn();
     vi.stubGlobal('open', mockOpenFn);
 
@@ -71,7 +71,7 @@ describe('Info bar', () => {
 
   it('should not render feedback and support link for free plan', async () => {
     mockMe().withSuccess(
-      createUser({salesPlanType: 'free', authorizedApplications: ['operate']}),
+      createUser({salesPlanType: 'free', authorizedComponents: ['operate']}),
     );
 
     const mockOpenFn = vi.fn();
@@ -101,7 +101,7 @@ describe('Info bar', () => {
       mockMe().withSuccess(
         createUser({
           salesPlanType,
-          authorizedApplications: ['operate'],
+          authorizedComponents: ['operate'],
         }),
       );
 

--- a/operate/client/src/App/Layout/AppHeader/tests/licenseNote.test.tsx
+++ b/operate/client/src/App/Layout/AppHeader/tests/licenseNote.test.tsx
@@ -18,7 +18,7 @@ vi.unmock('modules/stores/licenseTag');
 
 describe('license note', () => {
   beforeEach(() => {
-    mockMe().withSuccess(createUser({authorizedApplications: ['operate']}));
+    mockMe().withSuccess(createUser({authorizedComponents: ['operate']}));
   });
 
   it('should show non production tag if license is invalid', async () => {

--- a/operate/client/src/App/Layout/AppHeader/tests/userInfo.test.tsx
+++ b/operate/client/src/App/Layout/AppHeader/tests/userInfo.test.tsx
@@ -27,7 +27,7 @@ const Wrapper: React.FC<{children?: React.ReactNode}> = ({children}) => {
 const mockUser = createUser({
   displayName: 'Franz Kafka',
   canLogout: true,
-  authorizedApplications: ['operate'],
+  authorizedComponents: ['operate'],
 });
 
 const mockSsoUser = createUser({
@@ -199,7 +199,7 @@ describe('User info', () => {
     const mockUser = createUser({
       displayName: 'Franz Kafka',
       canLogout: true,
-      authorizedApplications: ['tasklist'],
+      authorizedComponents: ['tasklist'],
     });
 
     mockMe().withSuccess(mockUser);

--- a/operate/client/src/App/ProcessInstance/BottomPanel/Variables/tests/restrictedUserWithResourceBasedPermissions.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/Variables/tests/restrictedUserWithResourceBasedPermissions.test.tsx
@@ -33,7 +33,7 @@ describe('Restricted user with resource based permissions', () => {
       resourcePermissionsEnabled: true,
     });
 
-    mockMe().withSuccess(createUser({authorizedApplications: ['operate']}));
+    mockMe().withSuccess(createUser({authorizedComponents: ['operate']}));
     mockFetchProcessInstance().withSuccess(mockProcessInstance);
     mockFetchProcessInstance().withSuccess(mockProcessInstance);
     mockFetchProcessInstanceDeprecated().withSuccess(instanceMock);

--- a/operate/client/src/App/Processes/ListView/tests/index.test.tsx
+++ b/operate/client/src/App/Processes/ListView/tests/index.test.tsx
@@ -81,7 +81,7 @@ describe('Instances', () => {
     mockFetchGroupedProcesses().withSuccess(groupedProcessesMock);
     mockFetchProcessDefinitionXml().withSuccess(mockProcessXML);
     mockFetchBatchOperations().withSuccess([]);
-    mockMe().withSuccess(createUser({authorizedApplications: ['operate']}));
+    mockMe().withSuccess(createUser({authorizedComponents: ['operate']}));
   });
 
   it('should render title and document title', async () => {

--- a/operate/client/src/App/Processes/MigrationView/index.test.tsx
+++ b/operate/client/src/App/Processes/MigrationView/index.test.tsx
@@ -78,9 +78,9 @@ function createWrapper(options?: {initialPath?: string; contextPath?: string}) {
 describe('MigrationView', () => {
   beforeEach(() => {
     processInstanceMigrationStore.enable();
-    mockMe().withSuccess(createUser({authorizedApplications: ['operate']}));
+    mockMe().withSuccess(createUser({authorizedComponents: ['operate']}));
     mockMe({contextPath: '/custom'}).withSuccess(
-      createUser({authorizedApplications: ['operate']}),
+      createUser({authorizedComponents: ['operate']}),
     );
   });
 

--- a/operate/client/src/modules/auth/AuthorizationCheck.test.tsx
+++ b/operate/client/src/modules/auth/AuthorizationCheck.test.tsx
@@ -46,11 +46,11 @@ const getWrapper = () => {
 
 describe('<AuthorizationCheck />', () => {
   beforeEach(() => {
-    mockMe().withSuccess(createUser({authorizedApplications: ['operate']}));
+    mockMe().withSuccess(createUser({authorizedComponents: ['operate']}));
   });
 
   it('should show the provided content', async () => {
-    mockMe().withSuccess(createUser({authorizedApplications: ['operate']}));
+    mockMe().withSuccess(createUser({authorizedComponents: ['operate']}));
 
     render(
       <AuthorizationCheck>
@@ -63,7 +63,7 @@ describe('<AuthorizationCheck />', () => {
   });
 
   it('should redirect when user is not authorized', async () => {
-    mockMe().withSuccess(createUser({authorizedApplications: ['tasklist']}));
+    mockMe().withSuccess(createUser({authorizedComponents: ['tasklist']}));
 
     render(
       <AuthorizationCheck>

--- a/operate/client/src/modules/auth/isForbidden.test.ts
+++ b/operate/client/src/modules/auth/isForbidden.test.ts
@@ -20,30 +20,30 @@ describe('isForbidden', () => {
     tenants: [],
     groups: [],
     canLogout: true,
-    authorizedApplications: [],
+    authorizedComponents: [],
     apiUser: false,
   };
 
-  it('should return true when authorizedApplications does not contain "operate" or "*"', () => {
+  it('should return true when authorizedComponents does not contain "operate" or "*"', () => {
     const user: CurrentUser = {
       ...baseUser,
-      authorizedApplications: ['tasklilst'],
+      authorizedComponents: ['tasklilst'],
     };
     expect(isForbidden(user)).toBe(true);
   });
 
-  it('should return false when authorizedApplications contains "operate"', () => {
+  it('should return false when authorizedComponents contains "operate"', () => {
     const user: CurrentUser = {
       ...baseUser,
-      authorizedApplications: ['operate', 'tasklist'],
+      authorizedComponents: ['operate', 'tasklist'],
     };
     expect(isForbidden(user)).toBe(false);
   });
 
-  it('should return false when authorizedApplications contains "*"', () => {
+  it('should return false when authorizedComponents contains "*"', () => {
     const user: CurrentUser = {
       ...baseUser,
-      authorizedApplications: ['*'],
+      authorizedComponents: ['*'],
     };
     expect(isForbidden(user)).toBe(false);
   });

--- a/operate/client/src/modules/auth/isForbidden.ts
+++ b/operate/client/src/modules/auth/isForbidden.ts
@@ -10,9 +10,9 @@ import type {CurrentUser} from '@vzeta/camunda-api-zod-schemas/8.8';
 
 function isForbidden(user: CurrentUser | undefined) {
   return (
-    Array.isArray(user?.authorizedApplications) &&
-    !user.authorizedApplications.includes('operate') &&
-    !user.authorizedApplications.includes('*')
+    Array.isArray(user?.authorizedComponents) &&
+    !user.authorizedComponents.includes('operate') &&
+    !user.authorizedComponents.includes('*')
   );
 }
 

--- a/operate/client/src/modules/testUtils.tsx
+++ b/operate/client/src/modules/testUtils.tsx
@@ -177,7 +177,7 @@ const createUser = (options: Partial<CurrentUser> = {}): CurrentUser => ({
   username: 'demo',
   displayName: 'firstname lastname',
   email: 'firstname.lastname@camunda.com',
-  authorizedApplications: [],
+  authorizedComponents: [],
   tenants: [],
   groups: [],
   roles: [],

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/ApplicationAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/ApplicationAuthorizationIT.java
@@ -203,7 +203,7 @@ class ApplicationAuthorizationIT {
 
     // then
     final MeResponse meResponse = OBJECT_MAPPER.readValue(response.body(), MeResponse.class);
-    assertThat(meResponse.authorizedApplications).containsExactly("tasklist");
+    assertThat(meResponse.authorizedComponents).containsExactly("tasklist");
   }
 
   private static void assertRedirectToForbidden(
@@ -233,5 +233,5 @@ class ApplicationAuthorizationIT {
             HttpURLConnection.HTTP_MOVED_TEMP);
   }
 
-  private record MeResponse(List<String> authorizedApplications) {}
+  private record MeResponse(List<String> authorizedComponents) {}
 }

--- a/tasklist/client/package-lock.json
+++ b/tasklist/client/package-lock.json
@@ -18,7 +18,7 @@
         "@tanstack/eslint-plugin-query": "5.81.2",
         "@tanstack/react-query": "5.83.0",
         "@uidotdev/usehooks": "2.4.1",
-        "@vzeta/camunda-api-zod-schemas": "2.0.9",
+        "@vzeta/camunda-api-zod-schemas": "2.0.11",
         "bpmn-js": "18.6.2",
         "classnames": "2.5.1",
         "date-fns": "4.1.0",
@@ -4269,9 +4269,9 @@
       }
     },
     "node_modules/@vzeta/camunda-api-zod-schemas": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/@vzeta/camunda-api-zod-schemas/-/camunda-api-zod-schemas-2.0.9.tgz",
-      "integrity": "sha512-X/7ALR45e5rv4pWAatkEKx57H1Frx/CXJGc7qdjJ/912H+PL9q9DoPgbtCoLEMQIaDf0Anu1lxEtcEncHKTdAA==",
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@vzeta/camunda-api-zod-schemas/-/camunda-api-zod-schemas-2.0.11.tgz",
+      "integrity": "sha512-noom7UBDV0SgGW6/2DOXCmG/pWodpQb1jX+qFfd+K9ogsTp/RJkLTvh3sRBHSnW2su8+NkC/xleO3K6WHjsMnQ==",
       "license": "MIT",
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"

--- a/tasklist/client/package.json
+++ b/tasklist/client/package.json
@@ -14,7 +14,7 @@
     "@tanstack/eslint-plugin-query": "5.81.2",
     "@tanstack/react-query": "5.83.0",
     "@uidotdev/usehooks": "2.4.1",
-    "@vzeta/camunda-api-zod-schemas": "2.0.9",
+    "@vzeta/camunda-api-zod-schemas": "2.0.11",
     "bpmn-js": "18.6.2",
     "classnames": "2.5.1",
     "date-fns": "4.1.0",

--- a/tasklist/client/src/common/mocks/current-user.tsx
+++ b/tasklist/client/src/common/mocks/current-user.tsx
@@ -17,7 +17,7 @@ const currentUser: CurrentUser = {
   tenants: [],
   groups: [],
   canLogout: true,
-  authorizedApplications: ['*'],
+  authorizedComponents: ['*'],
   apiUser: false,
   email: 'demo@camunda.com',
 };
@@ -52,7 +52,7 @@ const currentUserWithC8Links: CurrentUser = {
   tenants: [],
   groups: [],
   canLogout: true,
-  authorizedApplications: ['*'],
+  authorizedComponents: ['*'],
   apiUser: false,
   email: 'demo-with-c8links@camunda.com',
 };
@@ -77,7 +77,7 @@ const currentUserWithTenants: CurrentUser = {
   ],
   groups: [],
   canLogout: true,
-  authorizedApplications: ['*'],
+  authorizedComponents: ['*'],
   apiUser: false,
   email: 'demo-with-tenants@camunda.com',
 };
@@ -91,7 +91,7 @@ const currentUserWithGroups: CurrentUser = {
   tenants: [],
   groups: ['admin', 'customer-support', 'guest'],
   canLogout: true,
-  authorizedApplications: ['*'],
+  authorizedComponents: ['*'],
   apiUser: false,
   email: 'demo-groups@camunda.com',
 };
@@ -105,7 +105,7 @@ const currentUnauthorizedUser: CurrentUser = {
   tenants: [],
   groups: ['admin', 'customer-support', 'guest'],
   canLogout: true,
-  authorizedApplications: ['operate'],
+  authorizedComponents: ['operate'],
   apiUser: false,
   email: 'demo-unauthorized@camunda.com',
 };

--- a/tasklist/client/src/common/utils/isForbidden.test.ts
+++ b/tasklist/client/src/common/utils/isForbidden.test.ts
@@ -19,31 +19,31 @@ describe('isForbidden', () => {
     tenants: [],
     groups: [],
     canLogout: true,
-    authorizedApplications: [],
+    authorizedComponents: [],
     apiUser: false,
     email: 'test@camunda.com',
   };
 
-  it('should return true when authorizedApplications does not contain "tasklist" or "*"', () => {
+  it('should return true when authorizedComponents does not contain "tasklist" or "*"', () => {
     const user: CurrentUser = {
       ...baseUser,
-      authorizedApplications: ['operate'],
+      authorizedComponents: ['operate'],
     };
     expect(isForbidden(user)).toBe(true);
   });
 
-  it('should return false when authorizedApplications contains "tasklist"', () => {
+  it('should return false when authorizedComponents contains "tasklist"', () => {
     const user: CurrentUser = {
       ...baseUser,
-      authorizedApplications: ['operate', 'tasklist'],
+      authorizedComponents: ['operate', 'tasklist'],
     };
     expect(isForbidden(user)).toBe(false);
   });
 
-  it('should return false when authorizedApplications contains "*"', () => {
+  it('should return false when authorizedComponents contains "*"', () => {
     const user: CurrentUser = {
       ...baseUser,
-      authorizedApplications: ['*'],
+      authorizedComponents: ['*'],
     };
     expect(isForbidden(user)).toBe(false);
   });

--- a/tasklist/client/src/common/utils/isForbidden.ts
+++ b/tasklist/client/src/common/utils/isForbidden.ts
@@ -10,9 +10,9 @@ import type {CurrentUser} from '@vzeta/camunda-api-zod-schemas/8.8';
 
 function isForbidden(user: CurrentUser | undefined) {
   return (
-    Array.isArray(user?.authorizedApplications) &&
-    !user.authorizedApplications.includes('tasklist') &&
-    !user.authorizedApplications.includes('*')
+    Array.isArray(user?.authorizedComponents) &&
+    !user.authorizedComponents.includes('tasklist') &&
+    !user.authorizedComponents.includes('*')
   );
 }
 

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -7691,8 +7691,8 @@ components:
         email:
           description: The email of the user.
           type: string
-        authorizedApplications:
-          description: The applications the user is authorized to use.
+        authorizedComponents:
+          description: The web components the user is authorized to use.
           type: array
           items:
             type: string

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
@@ -906,7 +906,7 @@ public final class SearchQueryResponseMapper {
         .displayName(camundaUser.displayName())
         .username(camundaUser.username())
         .email(camundaUser.email())
-        .authorizedApplications(camundaUser.authorizedComponents())
+        .authorizedComponents(camundaUser.authorizedComponents())
         .tenants(toTenants(camundaUser.tenants()))
         .groups(camundaUser.groups())
         .roles(camundaUser.roles())

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/authentication/AuthenticationControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/authentication/AuthenticationControllerTest.java
@@ -64,7 +64,7 @@ public class AuthenticationControllerTest extends RestControllerTest {
                   "displayName": "camunda user",
                   "username": "camundaUSer",
                   "email": "camunda.user@email.com",
-                  "authorizedApplications": ["test application"],
+                  "authorizedComponents": ["test application"],
                   "tenants": [{"tenantId":"testTenantId","name":"testTenantNem","description":"testTenantDescription"}],
                   "groups": ["test group"],
                   "roles": ["test role"],


### PR DESCRIPTION
## Description

* Rename authorizedApplications to authorizedComponents in /v2/authentication/me
* Renames the use of the property in the UIs

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #36692
