### PR TITLE
Add `decisionEvaluationInstanceKey` in Zeebe

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/response/EvaluatedDecision.java
+++ b/clients/java/src/main/java/io/camunda/client/api/response/EvaluatedDecision.java
@@ -26,6 +26,11 @@ public interface EvaluatedDecision {
   String getDecisionId();
 
   /**
+   * @return the key of the decision evaluation instance
+   */
+  String getDecisionEvaluationInstanceKey();
+
+  /**
    * @return the assigned decision version
    */
   int getDecisionVersion();

--- a/clients/java/src/main/java/io/camunda/client/impl/response/EvaluatedDecisionImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/EvaluatedDecisionImpl.java
@@ -30,6 +30,7 @@ public class EvaluatedDecisionImpl implements EvaluatedDecision {
 
   @JsonIgnore private final JsonMapper jsonMapper;
   private final String decisionId;
+  private final String decisionEvaluationInstanceKey;
   private final long decisionKey;
   private final int decisionVersion;
   private final String decisionName;
@@ -43,6 +44,7 @@ public class EvaluatedDecisionImpl implements EvaluatedDecision {
       final EvaluatedDecisionResult evaluatedDecisionItem, final JsonMapper jsonMapper) {
     this.jsonMapper = jsonMapper;
     decisionId = evaluatedDecisionItem.getDecisionDefinitionId();
+    decisionEvaluationInstanceKey = evaluatedDecisionItem.getDecisionEvaluationInstanceKey();
     decisionKey = Long.parseLong(evaluatedDecisionItem.getDecisionDefinitionKey());
     decisionVersion = evaluatedDecisionItem.getDecisionDefinitionVersion();
     decisionName = evaluatedDecisionItem.getDecisionDefinitionName();
@@ -58,6 +60,7 @@ public class EvaluatedDecisionImpl implements EvaluatedDecision {
     this.jsonMapper = jsonMapper;
 
     decisionId = evaluatedDecision.getDecisionId();
+    decisionEvaluationInstanceKey = evaluatedDecision.getDecisionEvaluationInstanceKey();
     decisionKey = evaluatedDecision.getDecisionKey();
     decisionName = evaluatedDecision.getDecisionName();
     decisionVersion = evaluatedDecision.getDecisionVersion();
@@ -97,6 +100,11 @@ public class EvaluatedDecisionImpl implements EvaluatedDecision {
   @Override
   public String getDecisionId() {
     return decisionId;
+  }
+
+  @Override
+  public String getDecisionEvaluationInstanceKey() {
+    return decisionEvaluationInstanceKey;
   }
 
   @Override

--- a/clients/java/src/test/java/io/camunda/client/decision/StandaloneDecisionEvaluationTest.java
+++ b/clients/java/src/test/java/io/camunda/client/decision/StandaloneDecisionEvaluationTest.java
@@ -76,6 +76,7 @@ public class StandaloneDecisionEvaluationTest extends ClientTest {
     evaluatedDecision =
         GatewayOuterClass.EvaluatedDecision.newBuilder()
             .setDecisionId("my-decision")
+            .setDecisionEvaluationInstanceKey("decision-instance-key")
             .setDecisionKey(DECISION_KEY)
             .setDecisionName("My Decision")
             .setDecisionVersion(1)
@@ -327,6 +328,8 @@ public class StandaloneDecisionEvaluationTest extends ClientTest {
     final EvaluatedDecision evaluatedDecisionResponse = response.getEvaluatedDecisions().get(0);
     assertThat(evaluatedDecisionResponse.getDecisionId())
         .isEqualTo(evaluatedDecision.getDecisionId());
+    assertThat(evaluatedDecisionResponse.getDecisionEvaluationInstanceKey())
+        .isEqualTo(evaluatedDecision.getDecisionEvaluationInstanceKey());
     assertThat(evaluatedDecisionResponse.getDecisionKey())
         .isEqualTo(evaluatedDecision.getDecisionKey());
     assertThat(evaluatedDecisionResponse.getDecisionName())

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnDecisionBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnDecisionBehavior.java
@@ -96,9 +96,11 @@ public final class BpmnDecisionBehavior {
               final var evaluationResult =
                   decisionBehavior.evaluateDecisionInDrg(drg, decisionId, variables);
 
+              final var newDecisionEvaluationKey = keyGenerator.nextKey();
               final Tuple<DecisionEvaluationIntent, DecisionEvaluationRecord> eventTuple =
-                  decisionBehavior.createDecisionEvaluationEvent(decision, evaluationResult);
-              writeDecisionEvaluationEvent(eventTuple, context);
+                  decisionBehavior.createDecisionEvaluationEvent(
+                      decision, evaluationResult, newDecisionEvaluationKey);
+              writeDecisionEvaluationEvent(eventTuple, context, newDecisionEvaluationKey);
 
               if (evaluationResult.isFailure()) {
                 return Either.left(
@@ -165,7 +167,8 @@ public final class BpmnDecisionBehavior {
 
   private void writeDecisionEvaluationEvent(
       final Tuple<DecisionEvaluationIntent, DecisionEvaluationRecord> decisionEvaluationEventTuple,
-      final BpmnElementContext context) {
+      final BpmnElementContext context,
+      final long newDecisionEvaluationKey) {
 
     final DecisionEvaluationRecord evaluationEvent = decisionEvaluationEventTuple.getRight();
 
@@ -176,7 +179,6 @@ public final class BpmnDecisionBehavior {
         .setElementInstanceKey(context.getElementInstanceKey())
         .setElementId(context.getElementId());
 
-    final var newDecisionEvaluationKey = keyGenerator.nextKey();
     stateWriter.appendFollowUpEvent(
         newDecisionEvaluationKey,
         decisionEvaluationEventTuple.getLeft(),

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/DecisionBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/DecisionBehavior.java
@@ -154,10 +154,13 @@ public class DecisionBehavior {
                     DecisionInfo::new));
 
     final var evaluatedDecisions = decisionResult.getEvaluatedDecisions();
-    for (int index = 1; index <= evaluatedDecisions.size(); index++) {
+    for (int index = 0; index < evaluatedDecisions.size(); index++) {
       final EvaluatedDecision evaluatedDecision = evaluatedDecisions.get(index);
+      // The decisionEvaluationInstanceKey is used to uniquely identify the evaluation of a
+      // decision within a decision evaluation event. It is constructed by appending the decision
+      // evaluation key to the index of the evaluated decision (starting from 1).
       final var decisionEvaluationInstanceKey =
-          String.format("%d-%d", decisionEvaluationKey, index);
+          String.format("%d-%d", decisionEvaluationKey, index + 1);
       addDecisionToEvaluationEvent(
           evaluatedDecision,
           decisionKeysByDecisionId.getOrDefault(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/DecisionBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/DecisionBehavior.java
@@ -153,21 +153,17 @@ public class DecisionBehavior {
                     persistedDecision -> bufferAsString(persistedDecision.getDecisionId()),
                     DecisionInfo::new));
 
-    final var evaluatedDecisions = decisionResult.getEvaluatedDecisions();
-    for (int index = 0; index < evaluatedDecisions.size(); index++) {
-      final EvaluatedDecision evaluatedDecision = evaluatedDecisions.get(index);
-      // The decisionEvaluationInstanceKey is used to uniquely identify the evaluation of a
-      // decision within a decision evaluation event. It is constructed by appending the decision
-      // evaluation key to the index of the evaluated decision (starting from 1).
-      final var decisionEvaluationInstanceKey =
-          String.format("%d-%d", decisionEvaluationKey, index + 1);
-      addDecisionToEvaluationEvent(
-          evaluatedDecision,
-          decisionKeysByDecisionId.getOrDefault(
-              evaluatedDecision.decisionId(), UNKNOWN_DECISION_INFO),
-          decisionEvaluationEvent,
-          decisionEvaluationInstanceKey);
-    }
+    final var generator = new DecisionEvaluationInstanceKeyGenerator(decisionEvaluationKey);
+    decisionResult
+        .getEvaluatedDecisions()
+        .forEach(
+            evaluatedDecision ->
+                addDecisionToEvaluationEvent(
+                    evaluatedDecision,
+                    decisionKeysByDecisionId.getOrDefault(
+                        evaluatedDecision.decisionId(), UNKNOWN_DECISION_INFO),
+                    decisionEvaluationEvent,
+                    generator.next()));
 
     final DecisionEvaluationIntent decisionEvaluationIntent;
     if (decisionResult.isFailure()) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/DecisionEvaluationInstanceKeyGenerator.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/DecisionEvaluationInstanceKeyGenerator.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.common;
+
+public class DecisionEvaluationInstanceKeyGenerator {
+
+  private static final String ID_FORMAT = "%d-%d";
+
+  private final long decisionEvaluationKey;
+  private int index;
+
+  public DecisionEvaluationInstanceKeyGenerator(final long decisionEvaluationKey) {
+    this.decisionEvaluationKey = decisionEvaluationKey;
+    index = 0;
+  }
+
+  public String generateKey(final int index) {
+    // The decisionEvaluationInstanceKey is used to uniquely identify the evaluation of a
+    // decision within a decision evaluation event. It is constructed by appending the decision
+    // evaluation key to the index of the evaluated decision (starting from 1).
+    return String.format(ID_FORMAT, decisionEvaluationKey, index);
+  }
+
+  public String next() {
+    return generateKey(++index);
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/dmn/DecisionEvaluationEvaluteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/dmn/DecisionEvaluationEvaluteProcessor.java
@@ -103,11 +103,11 @@ public class DecisionEvaluationEvaluteProcessor
                   decisionBehavior.evaluateDecisionInDrg(
                       drg, BufferUtil.bufferAsString(decision.getDecisionId()), variables);
 
+              final var evaluationRecordKey = keyGenerator.nextKey();
               final Tuple<DecisionEvaluationIntent, DecisionEvaluationRecord>
                   evaluationRecordTuple =
-                      decisionBehavior.createDecisionEvaluationEvent(decision, evaluationResult);
-
-              final var evaluationRecordKey = keyGenerator.nextKey();
+                      decisionBehavior.createDecisionEvaluationEvent(
+                          decision, evaluationResult, evaluationRecordKey);
               stateWriter.appendFollowUpEvent(
                   evaluationRecordKey,
                   evaluationRecordTuple.getLeft(),

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/common/DecisionEvaluationInstanceKeyGeneratorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/common/DecisionEvaluationInstanceKeyGeneratorTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.common;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class DecisionEvaluationInstanceKeyGeneratorTest {
+
+  private DecisionEvaluationInstanceKeyGenerator generator;
+
+  @BeforeEach
+  void setUp() {
+    generator = new DecisionEvaluationInstanceKeyGenerator(42L);
+  }
+
+  @Test
+  void shouldGenerateNextKey() {
+    final String result = generator.next();
+    assertThat("42-1").isEqualTo(result);
+  }
+
+  @Test
+  void shouldIncrementOnEachCall() {
+    assertThat("42-1").isEqualTo(generator.next());
+    assertThat("42-2").isEqualTo(generator.next());
+    assertThat("42-3").isEqualTo(generator.next());
+  }
+
+  @Test
+  void testMultipleGeneratorsIndependentCounters() {
+    final DecisionEvaluationInstanceKeyGenerator gen1 =
+        new DecisionEvaluationInstanceKeyGenerator(1L);
+    final DecisionEvaluationInstanceKeyGenerator gen2 =
+        new DecisionEvaluationInstanceKeyGenerator(2L);
+
+    assertThat("1-1").isEqualTo(gen1.next());
+    assertThat("2-1").isEqualTo(gen2.next());
+    assertThat("1-2").isEqualTo(gen1.next());
+    assertThat("2-2").isEqualTo(gen2.next());
+  }
+}

--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/BulkIndexRequest.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/BulkIndexRequest.java
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.annotation.JsonAppend;
 import io.camunda.zeebe.exporter.dto.BulkIndexAction;
 import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.value.EvaluatedDecisionValue;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.ArrayList;
@@ -29,11 +30,14 @@ final class BulkIndexRequest implements ContentProducer {
   private static final ObjectMapper MAPPER =
       new ObjectMapper()
           .addMixIn(Record.class, RecordSequenceMixin.class)
+          .addMixIn(EvaluatedDecisionValue.class, EvaluatedDecisionMixin.class)
           .enable(Feature.ALLOW_SINGLE_QUOTES);
 
   // The property of the ES record template to store the sequence of the record.
   private static final String RECORD_SEQUENCE_PROPERTY = "sequence";
   private static final String RECORD_AUTHORIZATIONS_PROPERTY = "authorizations";
+  private static final String RECORD_DECISION_EVALUATION_INSTANCE_KEY_PROPERTY =
+      "decisionEvaluationInstanceKey";
 
   private final List<BulkOperation> operations = new ArrayList<>();
 
@@ -139,4 +143,7 @@ final class BulkIndexRequest implements ContentProducer {
   @JsonAppend(attrs = {@JsonAppend.Attr(value = RECORD_SEQUENCE_PROPERTY)})
   @JsonIgnoreProperties({RECORD_AUTHORIZATIONS_PROPERTY})
   private static final class RecordSequenceMixin {}
+
+  @JsonIgnoreProperties({RECORD_DECISION_EVALUATION_INSTANCE_KEY_PROPERTY})
+  private static final class EvaluatedDecisionMixin {}
 }

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequest.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequest.java
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.annotation.JsonAppend;
 import io.camunda.zeebe.exporter.opensearch.dto.BulkIndexAction;
 import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.value.EvaluatedDecisionValue;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.ArrayList;
@@ -29,11 +30,14 @@ final class BulkIndexRequest implements ContentProducer {
   private static final ObjectMapper MAPPER =
       new ObjectMapper()
           .addMixIn(Record.class, RecordSequenceMixin.class)
+          .addMixIn(EvaluatedDecisionValue.class, EvaluatedDecisionMixin.class)
           .enable(Feature.ALLOW_SINGLE_QUOTES);
 
   // The property of the ES record template to store the sequence of the record.
   private static final String RECORD_SEQUENCE_PROPERTY = "sequence";
   private static final String RECORD_AUTHORIZATIONS_PROPERTY = "authorizations";
+  private static final String RECORD_DECISION_EVALUATION_INSTANCE_KEY_PROPERTY =
+      "decisionEvaluationInstanceKey";
 
   private final List<BulkOperation> operations = new ArrayList<>();
 
@@ -138,4 +142,7 @@ final class BulkIndexRequest implements ContentProducer {
   @JsonAppend(attrs = {@JsonAppend.Attr(value = RECORD_SEQUENCE_PROPERTY)})
   @JsonIgnoreProperties({RECORD_AUTHORIZATIONS_PROPERTY})
   private static final class RecordSequenceMixin {}
+
+  @JsonIgnoreProperties({RECORD_DECISION_EVALUATION_INSTANCE_KEY_PROPERTY})
+  private static final class EvaluatedDecisionMixin {}
 }

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/ResponseMapper.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/ResponseMapper.java
@@ -230,6 +230,8 @@ public final class ResponseMapper {
       final EvaluatedDecision.Builder evaluatedDecisionBuilder =
           EvaluatedDecision.newBuilder()
               .setDecisionId(intermediateDecision.getDecisionId())
+              .setDecisionEvaluationInstanceKey(
+                  intermediateDecision.getDecisionEvaluationInstanceKey())
               .setDecisionKey(intermediateDecision.getDecisionKey())
               .setDecisionName(intermediateDecision.getDecisionName())
               .setDecisionVersion(intermediateDecision.getDecisionVersion())

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/decision/EvaluateDecisionStub.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/decision/EvaluateDecisionStub.java
@@ -35,6 +35,7 @@ public class EvaluateDecisionStub
         evaluationRecord.evaluatedDecisions().add();
     evaluatedDecisionRecord
         .setDecisionId("intermediateDecision")
+        .setDecisionEvaluationInstanceKey("testInstanceKey")
         .setDecisionKey(125L)
         .setDecisionName("Intermediate Decision")
         .setDecisionVersion(2)

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/decision/EvaluateDecisionTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/decision/EvaluateDecisionTest.java
@@ -96,6 +96,8 @@ public class EvaluateDecisionTest extends GatewayTest {
     final var expectedIntermediateDecisionResult = evaluationRecord.getEvaluatedDecisions().get(0);
     assertThat(intermediateResultResponse.getDecisionId())
         .isEqualTo(expectedIntermediateDecisionResult.getDecisionId());
+    assertThat(intermediateResultResponse.getDecisionEvaluationInstanceKey())
+        .isEqualTo(expectedIntermediateDecisionResult.getDecisionEvaluationInstanceKey());
     assertThat(intermediateResultResponse.getDecisionKey())
         .isEqualTo(expectedIntermediateDecisionResult.getDecisionKey());
     assertThat(intermediateResultResponse.getDecisionName())

--- a/zeebe/gateway-protocol/src/main/proto/gateway.proto
+++ b/zeebe/gateway-protocol/src/main/proto/gateway.proto
@@ -400,6 +400,8 @@ message EvaluatedDecision {
   repeated EvaluatedDecisionInput evaluatedInputs = 8;
   // the tenant identifier of the evaluated decision
   string tenantId = 9;
+  // the key of the decision evaluation instance
+  string decisionEvaluationInstanceKey = 10;
 }
 
 message EvaluatedDecisionInput {

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -9566,6 +9566,9 @@ components:
         decisionDefinitionKey:
           description: The unique key identifying the decision which was evaluate.
           type: string
+        decisionEvaluationInstanceKey:
+          description: The unique key identifying this decision evaluation instance.
+          type: string
     MatchedDecisionRuleItem:
       type: object
       description: A decision rule that matched within this decision evaluation.

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/ResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/ResponseMapper.java
@@ -689,6 +689,8 @@ public final class ResponseMapper {
                 new EvaluatedDecisionResult()
                     .decisionDefinitionKey(KeyUtil.keyToString(evaluatedDecision.getDecisionKey()))
                     .decisionDefinitionId(evaluatedDecision.getDecisionId())
+                    .decisionEvaluationInstanceKey(
+                        evaluatedDecision.getDecisionEvaluationInstanceKey())
                     .decisionDefinitionName(evaluatedDecision.getDecisionName())
                     .decisionDefinitionVersion(evaluatedDecision.getDecisionVersion())
                     .output(evaluatedDecision.getDecisionOutput())

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/decision/EvaluatedDecisionRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/decision/EvaluatedDecisionRecord.java
@@ -31,6 +31,8 @@ public final class EvaluatedDecisionRecord extends UnifiedRecordValue
     implements EvaluatedDecisionValue {
 
   private final StringProperty decisionIdProp = new StringProperty("decisionId");
+  private final StringProperty decisionEvaluationInstanceKeyProp =
+      new StringProperty("decisionEvaluationInstanceKey");
   private final StringProperty decisionNameProp = new StringProperty("decisionName");
   private final LongProperty decisionKeyProp = new LongProperty("decisionKey");
   private final IntegerProperty decisionVersionProp = new IntegerProperty("decisionVersion");
@@ -47,8 +49,9 @@ public final class EvaluatedDecisionRecord extends UnifiedRecordValue
       new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
 
   public EvaluatedDecisionRecord() {
-    super(9);
+    super(10);
     declareProperty(decisionIdProp)
+        .declareProperty(decisionEvaluationInstanceKeyProp)
         .declareProperty(decisionNameProp)
         .declareProperty(decisionKeyProp)
         .declareProperty(decisionVersionProp)
@@ -66,6 +69,17 @@ public final class EvaluatedDecisionRecord extends UnifiedRecordValue
 
   public EvaluatedDecisionRecord setDecisionId(final String decisionId) {
     decisionIdProp.setValue(decisionId);
+    return this;
+  }
+
+  @Override
+  public String getDecisionEvaluationInstanceKey() {
+    return bufferAsString(decisionEvaluationInstanceKeyProp.getValue());
+  }
+
+  public EvaluatedDecisionRecord setDecisionEvaluationInstanceKey(
+      final String decisionEvaluationInstanceKey) {
+    decisionEvaluationInstanceKeyProp.setValue(decisionEvaluationInstanceKey);
     return this;
   }
 

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/decision/EvaluatedDecisionRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/decision/EvaluatedDecisionRecord.java
@@ -73,6 +73,7 @@ public final class EvaluatedDecisionRecord extends UnifiedRecordValue
   }
 
   @Override
+  @JsonIgnore
   public String getDecisionEvaluationInstanceKey() {
     return bufferAsString(decisionEvaluationInstanceKeyProp.getValue());
   }

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -1907,6 +1907,7 @@ final class JsonSerializableToJsonTest {
               final var evaluatedDecisionRecord = record.evaluatedDecisions().add();
               evaluatedDecisionRecord
                   .setDecisionId("decision-id")
+                  .setDecisionEvaluationInstanceKey("decision-evaluation-instance-key")
                   .setDecisionName("decision-name")
                   .setDecisionKey(6L)
                   .setDecisionVersion(7)
@@ -1952,6 +1953,7 @@ final class JsonSerializableToJsonTest {
           "evaluatedDecisions":[
             {
               "decisionId":"decision-id",
+              "decisionEvaluationInstanceKey":"decision-evaluation-instance-key",
               "decisionName":"decision-name",
               "decisionKey":6,
               "decisionVersion":7,
@@ -2015,6 +2017,7 @@ final class JsonSerializableToJsonTest {
               final var evaluatedDecisionRecord = record.evaluatedDecisions().add();
               evaluatedDecisionRecord
                   .setDecisionId("decision-id")
+                  .setDecisionEvaluationInstanceKey("decision-evaluation-instance-key")
                   .setDecisionName("decision-name")
                   .setDecisionKey(6L)
                   .setDecisionVersion(7)
@@ -2061,6 +2064,7 @@ final class JsonSerializableToJsonTest {
           "evaluatedDecisions":[
             {
               "decisionId":"decision-id",
+              "decisionEvaluationInstanceKey":"decision-evaluation-instance-key",
               "decisionName":"decision-name",
               "decisionKey":6,
               "decisionVersion":7,

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -1953,7 +1953,6 @@ final class JsonSerializableToJsonTest {
           "evaluatedDecisions":[
             {
               "decisionId":"decision-id",
-              "decisionEvaluationInstanceKey":"decision-evaluation-instance-key",
               "decisionName":"decision-name",
               "decisionKey":6,
               "decisionVersion":7,
@@ -2064,7 +2063,6 @@ final class JsonSerializableToJsonTest {
           "evaluatedDecisions":[
             {
               "decisionId":"decision-id",
-              "decisionEvaluationInstanceKey":"decision-evaluation-instance-key",
               "decisionName":"decision-name",
               "decisionKey":6,
               "decisionVersion":7,

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/EvaluatedDecisionValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/EvaluatedDecisionValue.java
@@ -33,6 +33,11 @@ public interface EvaluatedDecisionValue extends RecordValue, TenantOwned {
   String getDecisionId();
 
   /**
+   * @return the key of the evaluated decision
+   */
+  String getDecisionEvaluationInstanceKey();
+
+  /**
    * @return the name of the evaluated decision
    */
   String getDecisionName();


### PR DESCRIPTION
## Description

This PR adds a new property `decisionEvaluationInstanceKey` in the `EvaluatedDecisionRecord`. This property is the unique identifier of the decision evaluation instance and follow the following format: `123456-1` (record key of the decision - index of the evaluation within the decision).

## Related issues

closes #36731 
