### PR TITLE
Align authorizations to docs

### DIFF
--- a/security/security-protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AuthorizationResourceType.java
+++ b/security/security-protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AuthorizationResourceType.java
@@ -14,7 +14,7 @@ import java.util.stream.Collectors;
 
 public enum AuthorizationResourceType {
   AUTHORIZATION(
-      PermissionType.READ, PermissionType.UPDATE, PermissionType.DELETE, PermissionType.CREATE),
+      PermissionType.CREATE, PermissionType.READ, PermissionType.UPDATE, PermissionType.DELETE),
   BATCH(
       PermissionType.CREATE,
       PermissionType.CREATE_BATCH_OPERATION_CANCEL_PROCESS_INSTANCE,
@@ -25,13 +25,13 @@ public enum AuthorizationResourceType {
       PermissionType.CREATE_BATCH_OPERATION_DELETE_DECISION_INSTANCE,
       PermissionType.CREATE_BATCH_OPERATION_DELETE_DECISION_DEFINITION,
       PermissionType.CREATE_BATCH_OPERATION_DELETE_PROCESS_DEFINITION,
-      PermissionType.UPDATE,
-      PermissionType.READ),
+      PermissionType.READ,
+      PermissionType.UPDATE),
   COMPONENT(PermissionType.ACCESS),
   DECISION_DEFINITION(
+      PermissionType.CREATE_DECISION_INSTANCE,
       PermissionType.READ_DECISION_DEFINITION,
       PermissionType.READ_DECISION_INSTANCE,
-      PermissionType.CREATE_DECISION_INSTANCE,
       PermissionType.DELETE_DECISION_INSTANCE),
   DECISION_REQUIREMENTS_DEFINITION(PermissionType.READ),
   DOCUMENT(PermissionType.CREATE, PermissionType.READ, PermissionType.DELETE),
@@ -40,21 +40,21 @@ public enum AuthorizationResourceType {
       PermissionType.CREATE, PermissionType.READ, PermissionType.UPDATE, PermissionType.DELETE),
   MESSAGE(PermissionType.CREATE, PermissionType.READ),
   PROCESS_DEFINITION(
+      PermissionType.CREATE_PROCESS_INSTANCE,
       PermissionType.READ_PROCESS_DEFINITION,
       PermissionType.READ_PROCESS_INSTANCE,
       PermissionType.READ_USER_TASK,
       PermissionType.UPDATE_PROCESS_INSTANCE,
       PermissionType.UPDATE_USER_TASK,
-      PermissionType.CREATE_PROCESS_INSTANCE,
       PermissionType.MODIFY_PROCESS_INSTANCE,
       PermissionType.CANCEL_PROCESS_INSTANCE,
       PermissionType.DELETE_PROCESS_INSTANCE),
   RESOURCE(
-      PermissionType.READ,
       PermissionType.CREATE,
+      PermissionType.READ,
+      PermissionType.DELETE_DRD,
       PermissionType.DELETE_FORM,
       PermissionType.DELETE_PROCESS,
-      PermissionType.DELETE_DRD,
       PermissionType.DELETE_RESOURCE),
   ROLE(PermissionType.CREATE, PermissionType.READ, PermissionType.UPDATE, PermissionType.DELETE),
   SYSTEM(PermissionType.READ, PermissionType.READ_USAGE_METRIC, PermissionType.UPDATE),

--- a/security/security-protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AuthorizationResourceType.java
+++ b/security/security-protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AuthorizationResourceType.java
@@ -15,38 +15,6 @@ import java.util.stream.Collectors;
 public enum AuthorizationResourceType {
   AUTHORIZATION(
       PermissionType.READ, PermissionType.UPDATE, PermissionType.DELETE, PermissionType.CREATE),
-  MAPPING_RULE(
-      PermissionType.CREATE, PermissionType.READ, PermissionType.UPDATE, PermissionType.DELETE),
-  MESSAGE(PermissionType.CREATE, PermissionType.READ),
-  COMPONENT(PermissionType.ACCESS),
-  SYSTEM(PermissionType.READ, PermissionType.READ_USAGE_METRIC, PermissionType.UPDATE),
-  TENANT(PermissionType.CREATE, PermissionType.READ, PermissionType.UPDATE, PermissionType.DELETE),
-  RESOURCE(
-      PermissionType.READ,
-      PermissionType.CREATE,
-      PermissionType.DELETE_FORM,
-      PermissionType.DELETE_PROCESS,
-      PermissionType.DELETE_DRD,
-      PermissionType.DELETE_RESOURCE),
-  PROCESS_DEFINITION(
-      PermissionType.READ_PROCESS_DEFINITION,
-      PermissionType.READ_PROCESS_INSTANCE,
-      PermissionType.READ_USER_TASK,
-      PermissionType.UPDATE_PROCESS_INSTANCE,
-      PermissionType.UPDATE_USER_TASK,
-      PermissionType.CREATE_PROCESS_INSTANCE,
-      PermissionType.MODIFY_PROCESS_INSTANCE,
-      PermissionType.CANCEL_PROCESS_INSTANCE,
-      PermissionType.DELETE_PROCESS_INSTANCE),
-  DECISION_REQUIREMENTS_DEFINITION(PermissionType.READ),
-  DECISION_DEFINITION(
-      PermissionType.READ_DECISION_DEFINITION,
-      PermissionType.READ_DECISION_INSTANCE,
-      PermissionType.CREATE_DECISION_INSTANCE,
-      PermissionType.DELETE_DECISION_INSTANCE),
-  GROUP(PermissionType.CREATE, PermissionType.READ, PermissionType.UPDATE, PermissionType.DELETE),
-  USER(PermissionType.CREATE, PermissionType.READ, PermissionType.UPDATE, PermissionType.DELETE),
-  ROLE(PermissionType.CREATE, PermissionType.READ, PermissionType.UPDATE, PermissionType.DELETE),
   BATCH(
       PermissionType.CREATE,
       PermissionType.CREATE_BATCH_OPERATION_CANCEL_PROCESS_INSTANCE,
@@ -59,8 +27,40 @@ public enum AuthorizationResourceType {
       PermissionType.CREATE_BATCH_OPERATION_DELETE_PROCESS_DEFINITION,
       PermissionType.UPDATE,
       PermissionType.READ),
+  COMPONENT(PermissionType.ACCESS),
+  DECISION_DEFINITION(
+      PermissionType.READ_DECISION_DEFINITION,
+      PermissionType.READ_DECISION_INSTANCE,
+      PermissionType.CREATE_DECISION_INSTANCE,
+      PermissionType.DELETE_DECISION_INSTANCE),
+  DECISION_REQUIREMENTS_DEFINITION(PermissionType.READ),
   DOCUMENT(PermissionType.CREATE, PermissionType.READ, PermissionType.DELETE),
-  UNSPECIFIED();
+  GROUP(PermissionType.CREATE, PermissionType.READ, PermissionType.UPDATE, PermissionType.DELETE),
+  MAPPING_RULE(
+      PermissionType.CREATE, PermissionType.READ, PermissionType.UPDATE, PermissionType.DELETE),
+  MESSAGE(PermissionType.CREATE, PermissionType.READ),
+  PROCESS_DEFINITION(
+      PermissionType.READ_PROCESS_DEFINITION,
+      PermissionType.READ_PROCESS_INSTANCE,
+      PermissionType.READ_USER_TASK,
+      PermissionType.UPDATE_PROCESS_INSTANCE,
+      PermissionType.UPDATE_USER_TASK,
+      PermissionType.CREATE_PROCESS_INSTANCE,
+      PermissionType.MODIFY_PROCESS_INSTANCE,
+      PermissionType.CANCEL_PROCESS_INSTANCE,
+      PermissionType.DELETE_PROCESS_INSTANCE),
+  RESOURCE(
+      PermissionType.READ,
+      PermissionType.CREATE,
+      PermissionType.DELETE_FORM,
+      PermissionType.DELETE_PROCESS,
+      PermissionType.DELETE_DRD,
+      PermissionType.DELETE_RESOURCE),
+  ROLE(PermissionType.CREATE, PermissionType.READ, PermissionType.UPDATE, PermissionType.DELETE),
+  SYSTEM(PermissionType.READ, PermissionType.READ_USAGE_METRIC, PermissionType.UPDATE),
+  TENANT(PermissionType.CREATE, PermissionType.READ, PermissionType.UPDATE, PermissionType.DELETE),
+  UNSPECIFIED(),
+  USER(PermissionType.CREATE, PermissionType.READ, PermissionType.UPDATE, PermissionType.DELETE);
 
   private final Set<PermissionType> supportedPermissionTypes;
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

In an attempt to align the authorizations and documentation, this PR does not make changes to the authorizations except that it re-orders them.

This makes it easier for a human to compare the authorizations and the docs.

I also manually compared the authorizations and did not find any missing authorizations.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #35901
