### PR TITLE
Reject requests when users are externally managed

### DIFF
--- a/authentication/pom.xml
+++ b/authentication/pom.xml
@@ -65,6 +65,10 @@
       <artifactId>jackson-databind</artifactId>
     </dependency>
     <dependency>
+      <groupId>jakarta.annotation</groupId>
+      <artifactId>jakarta.annotation-api</artifactId>
+    </dependency>
+    <dependency>
       <groupId>jakarta.servlet</groupId>
       <artifactId>jakarta.servlet-api</artifactId>
     </dependency>

--- a/authentication/src/main/java/io/camunda/authentication/ConditionalOnInternalUserManagement.java
+++ b/authentication/src/main/java/io/camunda/authentication/ConditionalOnInternalUserManagement.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+
+@Target({TYPE, METHOD})
+@Retention(RUNTIME)
+@Documented
+@ConditionalOnExpression("'${camunda.security.authentication.method:}'.toLowerCase() != 'oidc'")
+public @interface ConditionalOnInternalUserManagement {}

--- a/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
@@ -38,6 +38,7 @@ import io.camunda.authentication.service.MembershipService;
 import io.camunda.security.auth.CamundaAuthenticationConverter;
 import io.camunda.security.auth.CamundaAuthenticationProvider;
 import io.camunda.security.auth.OidcGroupsLoader;
+import io.camunda.security.configuration.ConfiguredUser;
 import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.security.configuration.headers.HeaderConfiguration;
 import io.camunda.security.configuration.headers.values.FrameOptionMode;
@@ -49,6 +50,7 @@ import io.camunda.service.TenantServices;
 import io.camunda.service.UserServices;
 import io.camunda.spring.utils.ConditionalOnSecondaryStorageDisabled;
 import io.camunda.spring.utils.ConditionalOnSecondaryStorageEnabled;
+import jakarta.annotation.PostConstruct;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -536,6 +538,21 @@ public class WebSecurityConfig {
   @Configuration
   @ConditionalOnAuthenticationMethod(AuthenticationMethod.OIDC)
   public static class OidcConfiguration {
+
+    private final SecurityConfiguration securityConfiguration;
+
+    public OidcConfiguration(final SecurityConfiguration securityConfiguration) {
+      this.securityConfiguration = securityConfiguration;
+    }
+
+    @PostConstruct
+    public void verifyOidcConfiguration() {
+      final List<ConfiguredUser> users = securityConfiguration.getInitialization().getUsers();
+      if (users != null && !users.isEmpty()) {
+        throw new IllegalStateException(
+            "Creation of initial users is not supported with `OIDC` authentication method");
+      }
+    }
 
     @Bean
     public TokenClaimsConverter tokenClaimsConverter(

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/ApiFiltersConfiguration.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/ApiFiltersConfiguration.java
@@ -39,7 +39,7 @@ public class ApiFiltersConfiguration {
 
   @ConditionalOnExpression("'${camunda.security.authentication.oidc.groupsClaim:}' != ''")
   @Bean
-  public FilterRegistrationBean<EndpointAccessErrorFilter> registerFilter(
+  public FilterRegistrationBean<EndpointAccessErrorFilter> disableGroupApiFilter(
       final ObjectMapper objectMapper) {
     final FilterRegistrationBean<EndpointAccessErrorFilter> registration =
         new FilterRegistrationBean<>();
@@ -52,7 +52,7 @@ public class ApiFiltersConfiguration {
 
   @ConditionalOnAuthenticationMethod(AuthenticationMethod.OIDC)
   @Bean
-  public FilterRegistrationBean<EndpointAccessErrorFilter> registerUsersFilter(
+  public FilterRegistrationBean<EndpointAccessErrorFilter> disableUserApiFilter(
       final ObjectMapper objectMapper) {
     final FilterRegistrationBean<EndpointAccessErrorFilter> registration =
         new FilterRegistrationBean<>();

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/ApiFiltersConfiguration.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/ApiFiltersConfiguration.java
@@ -11,6 +11,8 @@ import static io.camunda.security.configuration.MultiTenancyConfiguration.API_EN
 import static io.camunda.security.configuration.OidcAuthenticationConfiguration.GROUPS_CLAIM_PROPERTY;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.authentication.ConditionalOnAuthenticationMethod;
+import io.camunda.security.entity.AuthenticationMethod;
 import io.camunda.zeebe.gateway.rest.controller.EndpointAccessErrorFilter;
 import io.camunda.zeebe.util.VisibleForTesting;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
@@ -23,8 +25,12 @@ public class ApiFiltersConfiguration {
 
   @VisibleForTesting
   public static final String GROUPS_API_DISABLED_ERROR_MESSAGE =
-      "Groups API is disabled because the application is configured in group claim mode. To use the Groups API, reconfigure the application to to manage group mode removing the '%s' property."
+      "Groups API is disabled because the application is configured in group claim mode. To use the Groups API, reconfigure the application to manage group mode removing the '%s' property."
           .formatted(GROUPS_CLAIM_PROPERTY);
+
+  @VisibleForTesting
+  public static final String USERS_API_DISABLED_ERROR_MESSAGE =
+      "Users API is disabled because the application is configured in OIDC mode.";
 
   @VisibleForTesting
   public static final String TENANTS_API_DISABLED_ERROR_MESSAGE =
@@ -40,6 +46,19 @@ public class ApiFiltersConfiguration {
     registration.setFilter(
         new EndpointAccessErrorFilter(objectMapper, GROUPS_API_DISABLED_ERROR_MESSAGE));
     registration.addUrlPatterns("/v2/groups/*");
+    registration.setOrder(1);
+    return registration;
+  }
+
+  @ConditionalOnAuthenticationMethod(AuthenticationMethod.OIDC)
+  @Bean
+  public FilterRegistrationBean<EndpointAccessErrorFilter> registerUsersFilter(
+      final ObjectMapper objectMapper) {
+    final FilterRegistrationBean<EndpointAccessErrorFilter> registration =
+        new FilterRegistrationBean<>();
+    registration.setFilter(
+        new EndpointAccessErrorFilter(objectMapper, USERS_API_DISABLED_ERROR_MESSAGE));
+    registration.addUrlPatterns("/v2/users/*");
     registration.setOrder(1);
     return registration;
   }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/UserController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/UserController.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.gateway.rest.controller.usermanagement;
 
 import static io.camunda.zeebe.gateway.rest.RestErrorMapper.mapErrorToResponse;
 
+import io.camunda.authentication.ConditionalOnInternalUserManagement;
 import io.camunda.search.query.UserQuery;
 import io.camunda.security.auth.CamundaAuthenticationProvider;
 import io.camunda.security.configuration.InitializationConfiguration;
@@ -38,6 +39,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 @CamundaRestController
 @RequiresSecondaryStorage
 @RequestMapping("/v2/users")
+@ConditionalOnInternalUserManagement()
 public class UserController {
   private final UserServices userServices;
   private final CamundaAuthenticationProvider authenticationProvider;

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupControllerTest.java
@@ -96,7 +96,6 @@ public class GroupControllerTest {
     @Test
     void shouldReturnErrorOnUpdate() {
       // given
-      final var groupKey = 111L;
       final var groupId = "111";
       final var groupName = "updatedName";
       final var description = "updatedDescription";

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/UserControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/UserControllerTest.java
@@ -437,7 +437,7 @@ public class UserControllerTest {
       // given
       final var dto = new UserDTO("alice-test", "Alice", "test+alice@camunda.com", null);
 
-      // when
+      // when/then
       webClient
           .post()
           .uri(USER_BASE_URL)
@@ -458,7 +458,7 @@ public class UserControllerTest {
       final UserDTO user = new UserDTO(username, "Alice", "test+alice@camunda.com", null);
       final var uri = USER_BASE_URL + "/" + username;
 
-      // when
+      // when/then
       webClient
           .put()
           .uri(uri)
@@ -481,7 +481,8 @@ public class UserControllerTest {
       // given
       final String username = "alice-test";
       final var uri = USER_BASE_URL + "/" + username;
-      // when
+
+      // when/then
       webClient
           .delete()
           .uri(uri)
@@ -498,7 +499,8 @@ public class UserControllerTest {
       // given
       final String username = "alice-test";
       final var uri = USER_BASE_URL + "/" + username;
-      // when
+
+      // when/then
       webClient
           .get()
           .uri(uri)
@@ -512,9 +514,11 @@ public class UserControllerTest {
 
     @Test
     void shouldReturnErrorOnSearch() {
+      // given
       final String request = "{}";
       final var uri = USER_BASE_URL + "/search";
 
+      // when/then
       webClient
           .post()
           .uri(uri)

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/UserControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/UserControllerTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.gateway.rest.controller.usermanagement;
 
+import static io.camunda.zeebe.gateway.rest.config.ApiFiltersConfiguration.USERS_API_DISABLED_ERROR_MESSAGE;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -23,6 +24,7 @@ import io.camunda.zeebe.broker.client.api.dto.BrokerRejection;
 import io.camunda.zeebe.gateway.protocol.rest.UserRequest;
 import io.camunda.zeebe.gateway.protocol.rest.UserUpdateRequest;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
+import io.camunda.zeebe.gateway.rest.config.ApiFiltersConfiguration;
 import io.camunda.zeebe.protocol.impl.record.value.user.UserRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.UserIntent;
@@ -30,126 +32,134 @@ import java.net.URI;
 import java.util.concurrent.CompletableFuture;
 import java.util.regex.Pattern;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ProblemDetail;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.json.JsonCompareMode;
 
-@WebMvcTest(UserController.class)
-public class UserControllerTest extends RestControllerTest {
+public class UserControllerTest {
 
   private static final String USER_BASE_URL = "/v2/users";
   private static final Pattern ID_PATTERN =
       Pattern.compile(InitializationConfiguration.DEFAULT_ID_REGEX);
 
-  @MockitoBean private UserServices userServices;
-  @MockitoBean private CamundaAuthenticationProvider authenticationProvider;
-  @MockitoBean private InitializationConfiguration initializationConfiguration;
+  @Nested
+  @WebMvcTest(UserController.class)
+  @TestPropertySource(properties = "camunda.security.authentication.method=basic")
+  public class CamundaUsersEnabledTest extends RestControllerTest {
 
-  @BeforeEach
-  void setup() {
-    when(authenticationProvider.getCamundaAuthentication())
-        .thenReturn(AUTHENTICATION_WITH_DEFAULT_TENANT);
-    when(userServices.withAuthentication(any(CamundaAuthentication.class)))
-        .thenReturn(userServices);
-    when(initializationConfiguration.getIdentifierPattern()).thenReturn(ID_PATTERN);
-  }
+    @MockitoBean private UserServices userServices;
+    @MockitoBean private CamundaAuthenticationProvider authenticationProvider;
+    @MockitoBean private InitializationConfiguration initializationConfiguration;
 
-  @ParameterizedTest
-  @ValueSource(
-      strings = {
-        "foo",
-        "Foo",
-        "foo@bar.baz",
-        "f_oo@bar.baz",
-        "foo123",
-        "foo-",
-        "foo+camunda-platform@bar.baz"
-      })
-  void createUserShouldReturnCreated(final String username) {
-    // given
-    final var dto = validCreateUserRequest(username);
+    @BeforeEach
+    void setup() {
+      when(authenticationProvider.getCamundaAuthentication())
+          .thenReturn(AUTHENTICATION_WITH_DEFAULT_TENANT);
+      when(userServices.withAuthentication(any(CamundaAuthentication.class)))
+          .thenReturn(userServices);
+      when(initializationConfiguration.getIdentifierPattern()).thenReturn(ID_PATTERN);
+    }
 
-    final var userRecord =
-        new UserRecord()
-            .setUsername(dto.username())
-            .setName(dto.name())
-            .setEmail(dto.email())
-            .setPassword(dto.password());
+    @ParameterizedTest
+    @ValueSource(
+        strings = {
+          "foo",
+          "Foo",
+          "foo@bar.baz",
+          "f_oo@bar.baz",
+          "foo123",
+          "foo-",
+          "foo+camunda-platform@bar.baz"
+        })
+    void createUserShouldReturnCreated(final String username) {
+      // given
+      final var dto = validCreateUserRequest(username);
 
-    when(userServices.createUser(dto)).thenReturn(CompletableFuture.completedFuture(userRecord));
+      final var userRecord =
+          new UserRecord()
+              .setUsername(dto.username())
+              .setName(dto.name())
+              .setEmail(dto.email())
+              .setPassword(dto.password());
 
-    // when
-    webClient
-        .post()
-        .uri(USER_BASE_URL)
-        .accept(MediaType.APPLICATION_JSON)
-        .contentType(MediaType.APPLICATION_JSON)
-        .bodyValue(dto)
-        .exchange()
-        .expectStatus()
-        .isCreated()
-        .expectBody()
-        .json(
-            """
+      when(userServices.createUser(dto)).thenReturn(CompletableFuture.completedFuture(userRecord));
+
+      // when
+      webClient
+          .post()
+          .uri(USER_BASE_URL)
+          .accept(MediaType.APPLICATION_JSON)
+          .contentType(MediaType.APPLICATION_JSON)
+          .bodyValue(dto)
+          .exchange()
+          .expectStatus()
+          .isCreated()
+          .expectBody()
+          .json(
+              """
           {
             "username": "%s",
             "name": "Foo Bar",
             "email": "bar@baz.com"
           }
         """
-                .formatted(username),
-            JsonCompareMode.STRICT);
+                  .formatted(username),
+              JsonCompareMode.STRICT);
 
-    // then
-    verify(userServices, times(1)).createUser(dto);
-  }
+      // then
+      verify(userServices, times(1)).createUser(dto);
+    }
 
-  @Test
-  void createUserThrowsExceptionWhenServiceThrowsException() {
-    // given
-    final String message = "message";
+    @Test
+    void createUserThrowsExceptionWhenServiceThrowsException() {
+      // given
+      final String message = "message";
 
-    final var dto = validCreateUserRequest("foo");
+      final var dto = validCreateUserRequest("foo");
 
-    when(userServices.createUser(dto))
-        .thenThrow(
-            ErrorMapper.mapBrokerRejection(
-                new BrokerRejection(UserIntent.CREATE, -1, RejectionType.ALREADY_EXISTS, message)));
+      when(userServices.createUser(dto))
+          .thenThrow(
+              ErrorMapper.mapBrokerRejection(
+                  new BrokerRejection(
+                      UserIntent.CREATE, -1, RejectionType.ALREADY_EXISTS, message)));
 
-    final var expectedBody = ProblemDetail.forStatusAndDetail(HttpStatus.CONFLICT, message);
-    expectedBody.setTitle(RejectionType.ALREADY_EXISTS.name());
-    expectedBody.setDetail("Command 'CREATE' rejected with code 'ALREADY_EXISTS': " + message);
-    expectedBody.setInstance(URI.create(USER_BASE_URL));
+      final var expectedBody = ProblemDetail.forStatusAndDetail(HttpStatus.CONFLICT, message);
+      expectedBody.setTitle(RejectionType.ALREADY_EXISTS.name());
+      expectedBody.setDetail("Command 'CREATE' rejected with code 'ALREADY_EXISTS': " + message);
+      expectedBody.setInstance(URI.create(USER_BASE_URL));
 
-    // when then
-    webClient
-        .post()
-        .uri(USER_BASE_URL)
-        .accept(MediaType.APPLICATION_JSON)
-        .contentType(MediaType.APPLICATION_JSON)
-        .bodyValue(dto)
-        .exchange()
-        .expectStatus()
-        .isEqualTo(HttpStatus.CONFLICT.value())
-        .expectBody(ProblemDetail.class)
-        .isEqualTo(expectedBody);
-  }
+      // when then
+      webClient
+          .post()
+          .uri(USER_BASE_URL)
+          .accept(MediaType.APPLICATION_JSON)
+          .contentType(MediaType.APPLICATION_JSON)
+          .bodyValue(dto)
+          .exchange()
+          .expectStatus()
+          .isEqualTo(HttpStatus.CONFLICT.value())
+          .expectBody(ProblemDetail.class)
+          .isEqualTo(expectedBody);
+    }
 
-  @Test
-  void shouldRejectUserCreationWithMissingUsername() {
-    // given
-    final var request = validUserWithPasswordRequest().username(null);
+    @Test
+    void shouldRejectUserCreationWithMissingUsername() {
+      // given
+      final var request = validUserWithPasswordRequest().username(null);
 
-    // when then
-    assertRequestRejectedExceptionally(
-        request,
-        """
+      // when then
+      assertRequestRejectedExceptionally(
+          request,
+          """
             {
               "type": "about:blank",
               "status": 400,
@@ -157,19 +167,19 @@ public class UserControllerTest extends RestControllerTest {
               "detail": "No username provided.",
               "instance": "%s"
             }"""
-            .formatted(USER_BASE_URL));
-    verifyNoInteractions(userServices);
-  }
+              .formatted(USER_BASE_URL));
+      verifyNoInteractions(userServices);
+    }
 
-  @Test
-  void shouldRejectUserCreationWithBlankUsername() {
-    // given
-    final var request = validUserWithPasswordRequest().username("");
+    @Test
+    void shouldRejectUserCreationWithBlankUsername() {
+      // given
+      final var request = validUserWithPasswordRequest().username("");
 
-    // when then
-    assertRequestRejectedExceptionally(
-        request,
-        """
+      // when then
+      assertRequestRejectedExceptionally(
+          request,
+          """
             {
               "type": "about:blank",
               "status": 400,
@@ -177,19 +187,19 @@ public class UserControllerTest extends RestControllerTest {
               "detail": "No username provided.",
               "instance": "%s"
             }"""
-            .formatted(USER_BASE_URL));
-    verifyNoInteractions(userServices);
-  }
+              .formatted(USER_BASE_URL));
+      verifyNoInteractions(userServices);
+    }
 
-  @Test
-  void shouldRejectUserCreationWithEmptyPassword() {
-    // given
-    final var request = validUserWithPasswordRequest().password(null);
+    @Test
+    void shouldRejectUserCreationWithEmptyPassword() {
+      // given
+      final var request = validUserWithPasswordRequest().password(null);
 
-    // when then
-    assertRequestRejectedExceptionally(
-        request,
-        """
+      // when then
+      assertRequestRejectedExceptionally(
+          request,
+          """
             {
               "type": "about:blank",
               "status": 400,
@@ -197,19 +207,19 @@ public class UserControllerTest extends RestControllerTest {
               "detail": "No password provided.",
               "instance": "%s"
             }"""
-            .formatted(USER_BASE_URL));
-    verifyNoInteractions(userServices);
-  }
+              .formatted(USER_BASE_URL));
+      verifyNoInteractions(userServices);
+    }
 
-  @Test
-  void shouldRejectUserCreationWithBlankPassword() {
-    // given
-    final var request = validUserWithPasswordRequest().password("");
+    @Test
+    void shouldRejectUserCreationWithBlankPassword() {
+      // given
+      final var request = validUserWithPasswordRequest().password("");
 
-    // when then
-    assertRequestRejectedExceptionally(
-        request,
-        """
+      // when then
+      assertRequestRejectedExceptionally(
+          request,
+          """
             {
               "type": "about:blank",
               "status": 400,
@@ -217,53 +227,54 @@ public class UserControllerTest extends RestControllerTest {
               "detail": "No password provided.",
               "instance": "%s"
             }"""
-            .formatted(USER_BASE_URL));
-    verifyNoInteractions(userServices);
-  }
+              .formatted(USER_BASE_URL));
+      verifyNoInteractions(userServices);
+    }
 
-  @Test
-  void shouldCreateUserWithEmptyNameAndEmail() {
-    // given
-    final var dto = new UserDTO("foo", null, null, "zabraboof");
-    final var userRecord = new UserRecord().setUsername(dto.username()).setPassword(dto.password());
-    when(userServices.createUser(dto)).thenReturn(CompletableFuture.completedFuture(userRecord));
+    @Test
+    void shouldCreateUserWithEmptyNameAndEmail() {
+      // given
+      final var dto = new UserDTO("foo", null, null, "zabraboof");
+      final var userRecord =
+          new UserRecord().setUsername(dto.username()).setPassword(dto.password());
+      when(userServices.createUser(dto)).thenReturn(CompletableFuture.completedFuture(userRecord));
 
-    // when
-    webClient
-        .post()
-        .uri(USER_BASE_URL)
-        .accept(MediaType.APPLICATION_JSON)
-        .contentType(MediaType.APPLICATION_JSON)
-        .bodyValue(dto)
-        .exchange()
-        .expectStatus()
-        .isCreated()
-        .expectBody()
-        .json(
-            """
+      // when
+      webClient
+          .post()
+          .uri(USER_BASE_URL)
+          .accept(MediaType.APPLICATION_JSON)
+          .contentType(MediaType.APPLICATION_JSON)
+          .bodyValue(dto)
+          .exchange()
+          .expectStatus()
+          .isCreated()
+          .expectBody()
+          .json(
+              """
           {
             "username": "%s",
             "name": "",
             "email": ""
           }
         """
-                .formatted(dto.username()),
-            JsonCompareMode.STRICT);
+                  .formatted(dto.username()),
+              JsonCompareMode.STRICT);
 
-    // then
-    verify(userServices, times(1)).createUser(dto);
-  }
+      // then
+      verify(userServices, times(1)).createUser(dto);
+    }
 
-  @Test
-  void shouldRejectUserCreationWithInvalidEmail() {
-    // given
-    final var email = "invalid@email.reject";
-    final var request = validUserWithPasswordRequest().email(email);
+    @Test
+    void shouldRejectUserCreationWithInvalidEmail() {
+      // given
+      final var email = "invalid@email.reject";
+      final var request = validUserWithPasswordRequest().email(email);
 
-    // when then
-    assertRequestRejectedExceptionally(
-        request,
-        """
+      // when then
+      assertRequestRejectedExceptionally(
+          request,
+          """
             {
               "type": "about:blank",
               "status": 400,
@@ -271,20 +282,20 @@ public class UserControllerTest extends RestControllerTest {
               "detail": "The provided email '%s' is not valid.",
               "instance": "%s"
             }"""
-            .formatted(email, USER_BASE_URL));
-    verifyNoInteractions(userServices);
-  }
+              .formatted(email, USER_BASE_URL));
+      verifyNoInteractions(userServices);
+    }
 
-  @Test
-  void shouldRejectUserCreationWithTooLongUsername() {
-    // given
-    final var username = "x".repeat(257);
-    final var request = validUserWithPasswordRequest().username(username);
+    @Test
+    void shouldRejectUserCreationWithTooLongUsername() {
+      // given
+      final var username = "x".repeat(257);
+      final var request = validUserWithPasswordRequest().username(username);
 
-    // when then
-    assertRequestRejectedExceptionally(
-        request,
-        """
+      // when then
+      assertRequestRejectedExceptionally(
+          request,
+          """
             {
               "type": "about:blank",
               "status": 400,
@@ -292,25 +303,25 @@ public class UserControllerTest extends RestControllerTest {
               "detail": "The provided username exceeds the limit of 256 characters.",
               "instance": "%s"
             }"""
-            .formatted(USER_BASE_URL));
-    verifyNoInteractions(userServices);
-  }
+              .formatted(USER_BASE_URL));
+      verifyNoInteractions(userServices);
+    }
 
-  @ParameterizedTest
-  @ValueSource(
-      strings = {
-        "foo~", "foo!", "foo#", "foo$", "foo%", "foo^", "foo&", "foo*", "foo(", "foo)", "foo=",
-        "foo{", "foo[", "foo}", "foo]", "foo|", "foo\\", "foo:", "foo;", "foo\"", "foo'", "foo<",
-        "foo>", "foo,", "foo?", "foo/", "foo ", "foo\t", "foo\n", "foo\r"
-      })
-  void shouldRejectUserCreationWithIllegalCharactersInUsername(final String username) {
-    // given
-    final var request = validUserWithPasswordRequest().username(username);
+    @ParameterizedTest
+    @ValueSource(
+        strings = {
+          "foo~", "foo!", "foo#", "foo$", "foo%", "foo^", "foo&", "foo*", "foo(", "foo)", "foo=",
+          "foo{", "foo[", "foo}", "foo]", "foo|", "foo\\", "foo:", "foo;", "foo\"", "foo'", "foo<",
+          "foo>", "foo,", "foo?", "foo/", "foo ", "foo\t", "foo\n", "foo\r"
+        })
+    void shouldRejectUserCreationWithIllegalCharactersInUsername(final String username) {
+      // given
+      final var request = validUserWithPasswordRequest().username(username);
 
-    // when then
-    assertRequestRejectedExceptionally(
-        request,
-        """
+      // when then
+      assertRequestRejectedExceptionally(
+          request,
+          """
             {
               "type": "about:blank",
               "status": 400,
@@ -318,85 +329,202 @@ public class UserControllerTest extends RestControllerTest {
               "detail": "The provided username contains illegal characters. It must match the pattern '%s'.",
               "instance": "%s"
             }"""
-            .formatted(InitializationConfiguration.DEFAULT_ID_REGEX, USER_BASE_URL));
-    verifyNoInteractions(userServices);
+              .formatted(InitializationConfiguration.DEFAULT_ID_REGEX, USER_BASE_URL));
+      verifyNoInteractions(userServices);
+    }
+
+    @Test
+    void deleteUserShouldReturnNoContent() {
+      // given
+      final String username = "tester";
+
+      final var userRecord = new UserRecord().setUsername(username);
+
+      when(userServices.deleteUser(username))
+          .thenReturn(CompletableFuture.completedFuture(userRecord));
+
+      // when
+      webClient
+          .delete()
+          .uri("%s/%s".formatted(USER_BASE_URL, username))
+          .accept(MediaType.APPLICATION_JSON)
+          .exchange()
+          .expectStatus()
+          .isNoContent();
+
+      // then
+      verify(userServices, times(1)).deleteUser(username);
+    }
+
+    @Test
+    void updateUserShouldReturnOk() {
+      // given
+      final String username = "alice-test";
+      final UserDTO user = new UserDTO(username, "Alice", "test+alice@camunda.com", null);
+      when(userServices.updateUser(any()))
+          .thenReturn(
+              CompletableFuture.completedFuture(
+                  new UserRecord()
+                      .setName(user.name())
+                      .setUsername(user.username())
+                      .setEmail(user.email())));
+
+      // when / then
+      webClient
+          .put()
+          .uri("%s/%s".formatted(USER_BASE_URL, user.username()))
+          .accept(MediaType.APPLICATION_JSON)
+          .contentType(MediaType.APPLICATION_JSON)
+          .bodyValue(
+              new UserUpdateRequest()
+                  .name(user.name())
+                  .email(user.email())
+                  .password(user.password()))
+          .exchange()
+          .expectStatus()
+          .isOk();
+
+      verify(userServices, times(1)).updateUser(user);
+    }
+
+    private UserDTO validCreateUserRequest(final String username) {
+      return new UserDTO(username, "Foo Bar", "bar@baz.com", "zabraboof");
+    }
+
+    private UserRequest validUserWithPasswordRequest() {
+      return new UserRequest()
+          .username("foo")
+          .name("Foo Bar")
+          .email("bar@baz.com")
+          .password("zabraboof");
+    }
+
+    private void assertRequestRejectedExceptionally(
+        final UserRequest request, final String expectedError) {
+      webClient
+          .post()
+          .uri(USER_BASE_URL)
+          .accept(MediaType.APPLICATION_JSON)
+          .contentType(MediaType.APPLICATION_JSON)
+          .bodyValue(request)
+          .exchange()
+          .expectStatus()
+          .isBadRequest()
+          .expectBody()
+          .json(expectedError, JsonCompareMode.STRICT);
+    }
   }
 
-  @Test
-  void deleteUserShouldReturnNoContent() {
-    // given
-    final String username = "tester";
+  @Nested
+  @WebMvcTest(UserController.class)
+  @Import(ApiFiltersConfiguration.class)
+  @TestPropertySource(properties = "camunda.security.authentication.method=oidc")
+  public class CamundaUsersDisabledTest extends RestControllerTest {
 
-    final var userRecord = new UserRecord().setUsername(username);
+    public static final String FORBIDDEN_MESSAGE =
+        """
+        {
+          "type": "about:blank",
+          "status": 403,
+          "title": "Access issue",
+          "detail": "%%s endpoint is not accessible: %s",
+          "instance": "%%s"
+        }"""
+            .formatted(USERS_API_DISABLED_ERROR_MESSAGE);
 
-    when(userServices.deleteUser(username))
-        .thenReturn(CompletableFuture.completedFuture(userRecord));
+    @Test
+    void shouldReturnErrorOnCreate() {
+      // given
+      final var dto = new UserDTO("alice-test", "Alice", "test+alice@camunda.com", null);
 
-    // when
-    webClient
-        .delete()
-        .uri("%s/%s".formatted(USER_BASE_URL, username))
-        .accept(MediaType.APPLICATION_JSON)
-        .exchange()
-        .expectStatus()
-        .isNoContent();
+      // when
+      webClient
+          .post()
+          .uri(USER_BASE_URL)
+          .accept(MediaType.APPLICATION_JSON)
+          .contentType(MediaType.APPLICATION_JSON)
+          .bodyValue(dto)
+          .exchange()
+          .expectStatus()
+          .isForbidden()
+          .expectBody()
+          .json(FORBIDDEN_MESSAGE.formatted(USER_BASE_URL, USER_BASE_URL), JsonCompareMode.STRICT);
+    }
 
-    // then
-    verify(userServices, times(1)).deleteUser(username);
-  }
+    @Test
+    void shouldReturnErrorOnUpdate() {
+      // given
+      final String username = "alice-test";
+      final UserDTO user = new UserDTO(username, "Alice", "test+alice@camunda.com", null);
+      final var uri = USER_BASE_URL + "/" + username;
 
-  @Test
-  void updateUserShouldReturnOk() {
-    // given
-    final String username = "alice-test";
-    final UserDTO user = new UserDTO(username, "Alice", "test+alice@camunda.com", null);
-    when(userServices.updateUser(any()))
-        .thenReturn(
-            CompletableFuture.completedFuture(
-                new UserRecord()
-                    .setName(user.name())
-                    .setUsername(user.username())
-                    .setEmail(user.email())));
+      // when
+      webClient
+          .put()
+          .uri(uri)
+          .accept(MediaType.APPLICATION_JSON)
+          .contentType(MediaType.APPLICATION_JSON)
+          .bodyValue(
+              new UserUpdateRequest()
+                  .name(user.name())
+                  .email(user.email())
+                  .password(user.password()))
+          .exchange()
+          .expectStatus()
+          .isForbidden()
+          .expectBody()
+          .json(FORBIDDEN_MESSAGE.formatted(uri, uri), JsonCompareMode.STRICT);
+    }
 
-    // when / then
-    webClient
-        .put()
-        .uri("%s/%s".formatted(USER_BASE_URL, user.username()))
-        .accept(MediaType.APPLICATION_JSON)
-        .contentType(MediaType.APPLICATION_JSON)
-        .bodyValue(
-            new UserUpdateRequest().name(user.name()).email(user.email()).password(user.password()))
-        .exchange()
-        .expectStatus()
-        .isOk();
+    @Test
+    void shouldReturnErrorOnDelete() {
+      // given
+      final String username = "alice-test";
+      final var uri = USER_BASE_URL + "/" + username;
+      // when
+      webClient
+          .delete()
+          .uri(uri)
+          .accept(MediaType.APPLICATION_JSON)
+          .exchange()
+          .expectStatus()
+          .isForbidden()
+          .expectBody()
+          .json(FORBIDDEN_MESSAGE.formatted(uri, uri), JsonCompareMode.STRICT);
+    }
 
-    verify(userServices, times(1)).updateUser(user);
-  }
+    @Test
+    void shouldReturnErrorOnGet() {
+      // given
+      final String username = "alice-test";
+      final var uri = USER_BASE_URL + "/" + username;
+      // when
+      webClient
+          .get()
+          .uri(uri)
+          .accept(MediaType.APPLICATION_JSON)
+          .exchange()
+          .expectStatus()
+          .isForbidden()
+          .expectBody()
+          .json(FORBIDDEN_MESSAGE.formatted(uri, uri), JsonCompareMode.STRICT);
+    }
 
-  private UserDTO validCreateUserRequest(final String username) {
-    return new UserDTO(username, "Foo Bar", "bar@baz.com", "zabraboof");
-  }
+    @Test
+    void shouldReturnErrorOnSearch() {
+      final String request = "{}";
+      final var uri = USER_BASE_URL + "/search";
 
-  private UserRequest validUserWithPasswordRequest() {
-    return new UserRequest()
-        .username("foo")
-        .name("Foo Bar")
-        .email("bar@baz.com")
-        .password("zabraboof");
-  }
-
-  private void assertRequestRejectedExceptionally(
-      final UserRequest request, final String expectedError) {
-    webClient
-        .post()
-        .uri(USER_BASE_URL)
-        .accept(MediaType.APPLICATION_JSON)
-        .contentType(MediaType.APPLICATION_JSON)
-        .bodyValue(request)
-        .exchange()
-        .expectStatus()
-        .isBadRequest()
-        .expectBody()
-        .json(expectedError, JsonCompareMode.STRICT);
+      webClient
+          .post()
+          .uri(uri)
+          .accept(MediaType.APPLICATION_JSON)
+          .bodyValue(request)
+          .exchange()
+          .expectStatus()
+          .isForbidden()
+          .expectBody()
+          .json(FORBIDDEN_MESSAGE.formatted(uri, uri), JsonCompareMode.STRICT);
+    }
   }
 }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/OidcAuthOverRestInitializerIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/OidcAuthOverRestInitializerIT.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.authorization;
+
+import dasniko.testcontainers.keycloak.KeycloakContainer;
+import io.camunda.security.configuration.ConfiguredUser;
+import io.camunda.security.entity.AuthenticationMethod;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.zeebe.test.testcontainers.DefaultTestContainers;
+import io.camunda.zeebe.test.util.testcontainers.TestSearchContainers;
+import java.util.List;
+import java.util.UUID;
+import org.assertj.core.api.Assertions;
+import org.assertj.core.api.Fail;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.keycloak.representations.idm.ClientRepresentation;
+import org.keycloak.representations.idm.RealmRepresentation;
+import org.keycloak.representations.idm.UserRepresentation;
+import org.testcontainers.elasticsearch.ElasticsearchContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+@ZeebeIntegration
+public class OidcAuthOverRestInitializerIT {
+
+  private static final String DEFAULT_USER_ID = UUID.randomUUID().toString();
+  private static final String KEYCLOAK_REALM = "camunda";
+  private static final String DEFAULT_CLIENT_ID = "zeebe";
+  private static final String DEFAULT_CLIENT_SECRET = "secret";
+
+  @Container
+  private static final ElasticsearchContainer CONTAINER =
+      TestSearchContainers.createDefeaultElasticsearchContainer();
+
+  @Container
+  private static final KeycloakContainer KEYCLOAK = DefaultTestContainers.createDefaultKeycloak();
+
+  @TestZeebe(autoStart = false, awaitCompleteTopology = false)
+  private final TestStandaloneBroker broker =
+      new TestStandaloneBroker()
+          .withAuthenticatedAccess()
+          .withAuthenticationMethod(AuthenticationMethod.OIDC)
+          .withCamundaExporter("http://" + CONTAINER.getHttpHostAddress())
+          .withSecurityConfig(
+              c -> {
+                c.getAuthorizations().setEnabled(true);
+                final var oidcConfig = c.getAuthentication().getOidc();
+                oidcConfig.setIssuerUri(KEYCLOAK.getAuthServerUrl() + "/realms/" + KEYCLOAK_REALM);
+
+                // The following two properties are only needed for the webapp login flow which we
+                // don't test here.
+                oidcConfig.setClientId("example");
+                oidcConfig.setRedirectUri("example.com");
+                // add a preconfigured user. This should not be allowed with OIDC
+                c.getInitialization()
+                    .getUsers()
+                    .add(
+                        new ConfiguredUser(
+                            "someUser", "somepassword", "Some User", "some_user@email.com"));
+              });
+
+  @BeforeAll
+  static void setupKeycloak() {
+    final var defaultClient = new ClientRepresentation();
+    defaultClient.setClientId(DEFAULT_CLIENT_ID);
+    defaultClient.setEnabled(true);
+    defaultClient.setClientAuthenticatorType("client-secret");
+    defaultClient.setSecret(DEFAULT_CLIENT_SECRET);
+    defaultClient.setServiceAccountsEnabled(true);
+
+    final var defaultUser = new UserRepresentation();
+    defaultUser.setId(DEFAULT_USER_ID);
+    defaultUser.setUsername("zeebe-service-account");
+    defaultUser.setServiceAccountClientId(DEFAULT_CLIENT_ID);
+    defaultUser.setEnabled(true);
+
+    final var realm = new RealmRepresentation();
+    realm.setRealm("camunda");
+    realm.setEnabled(true);
+    realm.setClients(List.of(defaultClient));
+    realm.setUsers(List.of(defaultUser));
+
+    try (final var keycloak = KEYCLOAK.getKeycloakAdminClient()) {
+      keycloak.realms().create(realm);
+    }
+  }
+
+  @Test
+  public void shouldFailToStartWithPreConfiguredUsersInOidc() {
+    // given
+    final String expectedMessage =
+        "Creation of initial users is not supported with `OIDC` authentication method";
+    // when
+    final Throwable throwable = Assertions.assertThatThrownBy(broker::start).actual();
+    // then
+    assertHasNestedException(throwable, IllegalStateException.class, expectedMessage);
+  }
+
+  private void assertHasNestedException(
+      Throwable exception, final Class<?> expectedClass, final String expectedMessage) {
+    while (exception != null) {
+      if (expectedClass.equals(exception.getClass())
+          && expectedMessage.equals(exception.getMessage())) {
+        return;
+      }
+      exception = exception.getCause();
+    }
+    Fail.fail(
+        "Exception has no cause with expectedClass: "
+            + expectedClass.getSimpleName()
+            + " and message: "
+            + expectedMessage);
+  }
+}

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneBroker.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneBroker.java
@@ -31,6 +31,7 @@ import io.camunda.zeebe.qa.util.actuator.HealthActuator;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.socket.SocketUtil;
 import java.net.URI;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -134,6 +135,18 @@ public final class TestStandaloneBroker extends TestSpringApplication<TestStanda
     // it when we override a property.
     AuthenticationProperties.applyToSecurityConfig(securityConfig, key, value);
     return super.withProperty(key, value);
+  }
+
+  @Override
+  public TestStandaloneBroker withAuthenticationMethod(
+      final AuthenticationMethod authenticationMethod) {
+    // as mode is OIDC, and we have a user created by default in `TestStandaloneBroker`
+    // we need to reset the list of users to empty list as having pre-configured user in
+    // OIDC is not allowed
+    if (authenticationMethod == AuthenticationMethod.OIDC) {
+      securityConfig.getInitialization().setUsers(new ArrayList<>());
+    }
+    return super.withAuthenticationMethod(authenticationMethod);
   }
 
   @Override


### PR DESCRIPTION
## Description

When users are externally managed, internal user management should be disabled.
This is the first PR for this issue. It includes disabling all user endpoints that create/update/return internal users.

Also, an error should be thrown on startup if initial users are configured.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #31908
