### PR TITLE
Re-enable rollover tests for AWS.

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryIT.java
@@ -38,7 +38,6 @@ import java.util.UUID;
 import org.apache.http.HttpHost;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
@@ -371,9 +370,6 @@ final class OpenSearchArchiverRepositoryIT {
 
   @Test
   void shouldSetTheCorrectFinishDateWithRollover() throws IOException {
-    Assumptions.assumeTrue(
-        System.getProperty(TEST_INTEGRATION_OPENSEARCH_AWS_URL, "").isEmpty(),
-        "Skipping test if AWS is used. See https://github.com/camunda/camunda/pull/35591");
     // given a rollover of 3 days:
     config.setRolloverInterval("3d");
     final var dateFormatter =
@@ -456,9 +452,6 @@ final class OpenSearchArchiverRepositoryIT {
 
   @Test
   void shouldFetchHistoricalDatesOnStart() throws IOException {
-    Assumptions.assumeTrue(
-        System.getProperty(TEST_INTEGRATION_OPENSEARCH_AWS_URL, "").isEmpty(),
-        "Skipping test if AWS is used. See https://github.com/camunda/camunda/pull/35591");
     final var dateFormatter =
         DateTimeFormatter.ofPattern("yyyy-MM-dd").withZone(ZoneId.systemDefault());
     final var now = Instant.now();
@@ -491,9 +484,6 @@ final class OpenSearchArchiverRepositoryIT {
 
   @Test
   void shouldFetchHistoricalDatesOnStartAndExcludeZeebePrefix() throws IOException {
-    Assumptions.assumeTrue(
-        System.getProperty(TEST_INTEGRATION_OPENSEARCH_AWS_URL, "").isEmpty(),
-        "Skipping test if AWS is used. See https://github.com/camunda/camunda/pull/35591");
 
     final var dateFormatter =
         DateTimeFormatter.ofPattern("yyyy-MM-dd").withZone(ZoneId.systemDefault());


### PR DESCRIPTION
## Description

After investigating the tests [here](https://github.com/camunda/camunda/pull/36783) and trying to run them, the rollover tests are no longer failing in AWS. 
All the class tests are now failing due to clean up step that tries to delete all indexes, which is something we currently dont have the permissions to due in operate. 
## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes https://github.com/camunda/camunda/issues/35675
