### PR TITLE
feat: Enable cleanup for message subscriptions in RDBMS

### DIFF
--- a/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.8.0.xml
+++ b/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.8.0.xml
@@ -665,6 +665,7 @@
       <column name="CORRELATION_KEY" type="VARCHAR(255)"/>
       <column name="TENANT_ID" type="VARCHAR(255)"/>
       <column name="PARTITION_ID" type="NUMBER"/>
+      <column name="HISTORY_CLEANUP_DATE" type="TIMESTAMP WITH TIME ZONE(3)" />
     </createTable>
 
     <modifySql dbms="mariadb">

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriter.java
@@ -146,6 +146,7 @@ public class RdbmsWriter {
             jobWriter,
             sequenceFlowWriter,
             batchOperationWriter,
+            messageSubscriptionWriter,
             metrics);
   }
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/MessageSubscriptionDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/MessageSubscriptionDbModel.java
@@ -25,6 +25,7 @@ public class MessageSubscriptionDbModel implements Copyable<MessageSubscriptionD
   private String correlationKey;
   private String tenantId;
   private int partitionId;
+  private OffsetDateTime historyCleanupDate;
 
   public MessageSubscriptionDbModel(final Long messageSubscriptionKey) {
     this.messageSubscriptionKey = messageSubscriptionKey;
@@ -42,7 +43,8 @@ public class MessageSubscriptionDbModel implements Copyable<MessageSubscriptionD
       final String messageName,
       final String correlationKey,
       final String tenantId,
-      final int partitionId) {
+      final int partitionId,
+      final OffsetDateTime historyCleanupDate) {
     this.messageSubscriptionKey = messageSubscriptionKey;
     this.processDefinitionId = processDefinitionId;
     this.processDefinitionKey = processDefinitionKey;
@@ -55,13 +57,14 @@ public class MessageSubscriptionDbModel implements Copyable<MessageSubscriptionD
     this.correlationKey = correlationKey;
     this.tenantId = tenantId;
     this.partitionId = partitionId;
+    this.historyCleanupDate = historyCleanupDate;
   }
 
   public Long messageSubscriptionKey() {
     return messageSubscriptionKey;
   }
 
-  public void setMessageSubscriptionKey(final Long messageSubscriptionKey) {
+  public void messageSubscriptionKey(final Long messageSubscriptionKey) {
     this.messageSubscriptionKey = messageSubscriptionKey;
   }
 
@@ -69,7 +72,7 @@ public class MessageSubscriptionDbModel implements Copyable<MessageSubscriptionD
     return processDefinitionId;
   }
 
-  public void setProcessDefinitionId(final String processDefinitionId) {
+  public void processDefinitionId(final String processDefinitionId) {
     this.processDefinitionId = processDefinitionId;
   }
 
@@ -77,7 +80,7 @@ public class MessageSubscriptionDbModel implements Copyable<MessageSubscriptionD
     return processDefinitionKey;
   }
 
-  public void setProcessDefinitionKey(final Long processDefinitionKey) {
+  public void processDefinitionKey(final Long processDefinitionKey) {
     this.processDefinitionKey = processDefinitionKey;
   }
 
@@ -85,7 +88,7 @@ public class MessageSubscriptionDbModel implements Copyable<MessageSubscriptionD
     return processInstanceKey;
   }
 
-  public void setProcessInstanceKey(final Long processInstanceKey) {
+  public void processInstanceKey(final Long processInstanceKey) {
     this.processInstanceKey = processInstanceKey;
   }
 
@@ -93,7 +96,7 @@ public class MessageSubscriptionDbModel implements Copyable<MessageSubscriptionD
     return flowNodeId;
   }
 
-  public void setFlowNodeId(final String flowNodeId) {
+  public void flowNodeId(final String flowNodeId) {
     this.flowNodeId = flowNodeId;
   }
 
@@ -101,7 +104,7 @@ public class MessageSubscriptionDbModel implements Copyable<MessageSubscriptionD
     return flowNodeInstanceKey;
   }
 
-  public void setFlowNodeInstanceKey(final Long flowNodeInstanceKey) {
+  public void flowNodeInstanceKey(final Long flowNodeInstanceKey) {
     this.flowNodeInstanceKey = flowNodeInstanceKey;
   }
 
@@ -109,7 +112,7 @@ public class MessageSubscriptionDbModel implements Copyable<MessageSubscriptionD
     return messageSubscriptionType;
   }
 
-  public void setMessageSubscriptionType(final MessageSubscriptionType messageSubscriptionType) {
+  public void messageSubscriptionType(final MessageSubscriptionType messageSubscriptionType) {
     this.messageSubscriptionType = messageSubscriptionType;
   }
 
@@ -117,7 +120,7 @@ public class MessageSubscriptionDbModel implements Copyable<MessageSubscriptionD
     return dateTime;
   }
 
-  public void setDateTime(final OffsetDateTime dateTime) {
+  public void dateTime(final OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
 
@@ -125,7 +128,7 @@ public class MessageSubscriptionDbModel implements Copyable<MessageSubscriptionD
     return messageName;
   }
 
-  public void setMessageName(final String messageName) {
+  public void messageName(final String messageName) {
     this.messageName = messageName;
   }
 
@@ -133,7 +136,7 @@ public class MessageSubscriptionDbModel implements Copyable<MessageSubscriptionD
     return correlationKey;
   }
 
-  public void setCorrelationKey(final String correlationKey) {
+  public void correlationKey(final String correlationKey) {
     this.correlationKey = correlationKey;
   }
 
@@ -141,7 +144,7 @@ public class MessageSubscriptionDbModel implements Copyable<MessageSubscriptionD
     return tenantId;
   }
 
-  public void setTenantId(final String tenantId) {
+  public void tenantId(final String tenantId) {
     this.tenantId = tenantId;
   }
 
@@ -149,8 +152,17 @@ public class MessageSubscriptionDbModel implements Copyable<MessageSubscriptionD
     return partitionId;
   }
 
-  public MessageSubscriptionDbModel setPartitionId(final int partitionId) {
+  public MessageSubscriptionDbModel partitionId(final int partitionId) {
     this.partitionId = partitionId;
+    return this;
+  }
+
+  public OffsetDateTime historyCleanupDate() {
+    return historyCleanupDate;
+  }
+
+  public MessageSubscriptionDbModel historyCleanupDate(final OffsetDateTime historyCleanupDate) {
+    this.historyCleanupDate = historyCleanupDate;
     return this;
   }
 
@@ -175,7 +187,8 @@ public class MessageSubscriptionDbModel implements Copyable<MessageSubscriptionD
         .messageName(messageName)
         .correlationKey(correlationKey)
         .tenantId(tenantId)
-        .partitionId(partitionId);
+        .partitionId(partitionId)
+        .historyCleanupDate(historyCleanupDate);
   }
 
   public static class Builder implements ObjectBuilder<MessageSubscriptionDbModel> {
@@ -191,6 +204,7 @@ public class MessageSubscriptionDbModel implements Copyable<MessageSubscriptionD
     private String correlationKey;
     private String tenantId;
     private int partitionId;
+    private OffsetDateTime historyCleanupDate;
 
     public Builder messageSubscriptionKey(final Long messageSubscriptionKey) {
       this.messageSubscriptionKey = messageSubscriptionKey;
@@ -252,6 +266,11 @@ public class MessageSubscriptionDbModel implements Copyable<MessageSubscriptionD
       return this;
     }
 
+    public Builder historyCleanupDate(final OffsetDateTime historyCleanupDate) {
+      this.historyCleanupDate = historyCleanupDate;
+      return this;
+    }
+
     @Override
     public MessageSubscriptionDbModel build() {
       return new MessageSubscriptionDbModel(
@@ -266,7 +285,8 @@ public class MessageSubscriptionDbModel implements Copyable<MessageSubscriptionD
           messageName,
           correlationKey,
           tenantId,
-          partitionId);
+          partitionId,
+          historyCleanupDate);
     }
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/HistoryCleanupService.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/HistoryCleanupService.java
@@ -42,6 +42,7 @@ public class HistoryCleanupService {
   private final JobWriter jobWriter;
   private final SequenceFlowWriter sequenceFlowWriter;
   private final BatchOperationWriter batchOperationWriter;
+  private final MessageSubscriptionWriter messageSubscriptionWriter;
 
   private final Map<Integer, Duration> lastCleanupInterval = new HashMap<>();
 
@@ -56,6 +57,7 @@ public class HistoryCleanupService {
       final JobWriter jobWriter,
       final SequenceFlowWriter sequenceFlowWriter,
       final BatchOperationWriter batchOperationWriter,
+      final MessageSubscriptionWriter messageSubscriptionWriter,
       final RdbmsWriterMetrics metrics) {
     LOG.info(
         "Creating HistoryCleanupService with default history ttl {}",
@@ -82,6 +84,7 @@ public class HistoryCleanupService {
     this.jobWriter = jobWriter;
     this.sequenceFlowWriter = sequenceFlowWriter;
     this.batchOperationWriter = batchOperationWriter;
+    this.messageSubscriptionWriter = messageSubscriptionWriter;
     this.metrics = metrics;
   }
 
@@ -101,6 +104,7 @@ public class HistoryCleanupService {
     decisionInstanceWriter.scheduleForHistoryCleanup(processInstanceKey, historyCleanupDate);
     jobWriter.scheduleForHistoryCleanup(processInstanceKey, historyCleanupDate);
     sequenceFlowWriter.scheduleForHistoryCleanup(processInstanceKey, historyCleanupDate);
+    messageSubscriptionWriter.scheduleForHistoryCleanup(processInstanceKey, historyCleanupDate);
   }
 
   public void scheduleBatchOperationForHistoryCleanup(
@@ -162,6 +166,9 @@ public class HistoryCleanupService {
         batchOperationWriter.cleanupItemHistory(cleanupDate, cleanupBatchSize));
     numDeletedRecords.put(
         "batchOperation", batchOperationWriter.cleanupHistory(cleanupDate, cleanupBatchSize));
+    numDeletedRecords.put(
+        "messageSubscription",
+        messageSubscriptionWriter.cleanupHistory(partitionId, cleanupDate, cleanupBatchSize));
     final long end = System.currentTimeMillis();
     sample.close();
 

--- a/db/rdbms/src/main/resources/mapper/MessageSubscriptionMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/MessageSubscriptionMapper.xml
@@ -34,7 +34,8 @@
     MESSAGE_NAME,
     CORRELATION_KEY,
     TENANT_ID,
-    PARTITION_ID
+    PARTITION_ID,
+    HISTORY_CLEANUP_DATE
     FROM ${prefix}MESSAGE_SUBSCRIPTION
 
     <include refid="io.camunda.db.rdbms.sql.MessageSubscriptionMapper.searchFilter" />
@@ -123,6 +124,7 @@
     <result column="CORRELATION_KEY" property="correlationKey" javaType="java.lang.String" />
     <result column="TENANT_ID" property="tenantId" javaType="java.lang.String" />
     <result column="PARTITION_ID" property="partitionId" javaType="java.lang.Integer" />
+    <result column="HISTORY_CLEANUP_DATE" property="historyCleanupDate" javaType="java.time.OffsetDateTime" />
   </resultMap>
 
 
@@ -138,7 +140,8 @@
                                                MESSAGE_NAME,
                                                CORRELATION_KEY,
                                                TENANT_ID,
-                                               PARTITION_ID
+                                               PARTITION_ID,
+                                               HISTORY_CLEANUP_DATE
     )
     VALUES (
             #{messageSubscriptionKey},
@@ -151,7 +154,8 @@
             #{messageName},
             #{correlationKey},
             #{tenantId},
-            #{partitionId}
+            #{partitionId},
+            #{historyCleanupDate, jdbcType=TIMESTAMP}
     )
   </insert>
 
@@ -165,7 +169,19 @@
         DATE_TIME = #{dateTime, jdbcType=TIMESTAMP},
         MESSAGE_NAME = #{messageName},
         CORRELATION_KEY = #{correlationKey},
-        TENANT_ID = #{tenantId}
+        TENANT_ID = #{tenantId},
+        HISTORY_CLEANUP_DATE = #{historyCleanupDate, jdbcType=TIMESTAMP},
     WHERE MESSAGE_SUBSCRIPTION_KEY = #{messageSubscriptionKey}
   </update>
+
+  <update id="updateHistoryCleanupDate">
+    UPDATE ${prefix}MESSAGE_SUBSCRIPTION SET
+      HISTORY_CLEANUP_DATE = #{historyCleanupDate, jdbcType=TIMESTAMP}
+    WHERE PROCESS_INSTANCE_KEY = #{processInstanceKey}
+  </update>
+
+  <delete id="cleanupHistory">
+    <bind name="tableName" value="'MESSAGE_SUBSCRIPTION'"/>
+    <include refid="io.camunda.db.rdbms.sql.Commons.historyCleanup"/>
+  </delete>
 </mapper>

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/write/service/HistoryCleanupServiceTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/write/service/HistoryCleanupServiceTest.java
@@ -39,6 +39,7 @@ class HistoryCleanupServiceTest {
   private JobWriter jobWriter;
   private SequenceFlowWriter sequenceFlowWriter;
   private BatchOperationWriter batchOperationWriter;
+  private MessageSubscriptionWriter messageSubscriptionWriter;
 
   private HistoryCleanupService historyCleanupService;
 
@@ -54,6 +55,7 @@ class HistoryCleanupServiceTest {
     jobWriter = mock(JobWriter.class);
     sequenceFlowWriter = mock(SequenceFlowWriter.class);
     batchOperationWriter = mock(BatchOperationWriter.class);
+    messageSubscriptionWriter = mock(MessageSubscriptionWriter.class);
 
     when(processInstanceWriter.cleanupHistory(anyInt(), any(), anyInt())).thenReturn(0);
     when(flowNodeInstanceWriter.cleanupHistory(anyInt(), any(), anyInt())).thenReturn(0);
@@ -65,6 +67,7 @@ class HistoryCleanupServiceTest {
     when(sequenceFlowWriter.cleanupHistory(anyInt(), any(), anyInt())).thenReturn(0);
     when(batchOperationWriter.cleanupItemHistory(any(), anyInt())).thenReturn(0);
     when(batchOperationWriter.cleanupHistory(any(), anyInt())).thenReturn(0);
+    when(messageSubscriptionWriter.cleanupHistory(anyInt(), any(), anyInt())).thenReturn(0);
 
     final var historyConfig = mock(RdbmsWriterConfig.HistoryConfig.class);
     when(config.history()).thenReturn(historyConfig);
@@ -92,6 +95,7 @@ class HistoryCleanupServiceTest {
             jobWriter,
             sequenceFlowWriter,
             batchOperationWriter,
+            messageSubscriptionWriter,
             mock(RdbmsWriterMetrics.class, Mockito.RETURNS_DEEP_STUBS));
   }
 
@@ -108,6 +112,7 @@ class HistoryCleanupServiceTest {
     when(sequenceFlowWriter.cleanupHistory(anyInt(), any(), anyInt())).thenReturn(1);
     when(batchOperationWriter.cleanupItemHistory(any(), anyInt())).thenReturn(1);
     when(batchOperationWriter.cleanupHistory(any(), anyInt())).thenReturn(1);
+    when(messageSubscriptionWriter.cleanupHistory(anyInt(), any(), anyInt())).thenReturn(1);
 
     // when
     final Duration nextCleanupInterval =
@@ -125,6 +130,7 @@ class HistoryCleanupServiceTest {
     verify(sequenceFlowWriter).cleanupHistory(PARTITION_ID, CLEANUP_DATE, 100);
     verify(batchOperationWriter).cleanupItemHistory(CLEANUP_DATE, 100);
     verify(batchOperationWriter).cleanupHistory(CLEANUP_DATE, 100);
+    verify(messageSubscriptionWriter).cleanupHistory(PARTITION_ID, CLEANUP_DATE, 100);
   }
 
   @Test
@@ -140,7 +146,8 @@ class HistoryCleanupServiceTest {
             "decisionInstance", 0,
             "job", 0,
             "sequenceFlow", 0,
-            "batchOperation", 0);
+            "batchOperation", 0,
+            "messageSubscription", 0);
 
     // when
     final Duration nextDuration =
@@ -154,18 +161,18 @@ class HistoryCleanupServiceTest {
   @Test
   void testCalculateNewDurationWhenExceededBatchSize() {
     // given
-    final Map<String, Integer> numDeletedRecords =
-        Map.of(
-            "processInstance", 100,
-            "flowNodeInstance", 100,
-            "incident", 100,
-            "userTask", 100,
-            "variable", 100,
-            "decisionInstance", 100,
-            "job", 100,
-            "sequenceFlow", 100,
-            "batchOperationItem", 100,
-            "batchOperation", 100);
+    final Map<String, Integer> numDeletedRecords = new java.util.HashMap<>();
+    numDeletedRecords.put("processInstance", 100);
+    numDeletedRecords.put("flowNodeInstance", 100);
+    numDeletedRecords.put("incident", 100);
+    numDeletedRecords.put("userTask", 100);
+    numDeletedRecords.put("variable", 100);
+    numDeletedRecords.put("decisionInstance", 100);
+    numDeletedRecords.put("job", 100);
+    numDeletedRecords.put("sequenceFlow", 100);
+    numDeletedRecords.put("batchOperationItem", 100);
+    numDeletedRecords.put("batchOperation", 100);
+    numDeletedRecords.put("messageSubscription", 100);
 
     // when
     final Duration nextDuration =
@@ -189,7 +196,8 @@ class HistoryCleanupServiceTest {
             "decisionInstance", 50,
             "job", 50,
             "sequenceFlow", 50,
-            "batchOperation", 50);
+            "batchOperation", 50,
+            "messageSubscription", 50);
 
     // when
     final Duration nextDuration =


### PR DESCRIPTION
## Description

This PR activates cleanup for message subscriptions given a process instance key

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes https://github.com/camunda/camunda/issues/34445
