### PR TITLE
feat: add license key to the unified config

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/Camunda.java
+++ b/configuration/src/main/java/io/camunda/configuration/Camunda.java
@@ -22,6 +22,7 @@ public class Camunda {
   private System system = new System();
   private Data data = new Data();
   private Api api = new Api();
+  private License license = new License();
 
   public Cluster getCluster() {
     return cluster;
@@ -53,5 +54,13 @@ public class Camunda {
 
   public void setData(final Data data) {
     this.data = data;
+  }
+
+  public License getLicense() {
+    return license;
+  }
+
+  public void setLicense(final License license) {
+    this.license = license;
   }
 }

--- a/configuration/src/main/java/io/camunda/configuration/License.java
+++ b/configuration/src/main/java/io/camunda/configuration/License.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+public class License {
+
+  private static final String PREFIX = "camunda.license";
+
+  private String key = "";
+
+  public String getKey() {
+    // No need to check anything: LicenseKeyProperties is already wired with the correct prefix.
+    return key;
+  }
+
+  public void setKey(String key) {
+    this.key = key;
+  }
+}


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
The Camunda license key configuration already respects the standard dictated by the Unified Configuration system. The reason why we add it here it for it to have visibility within the global config (we will be able to print the whole config, in the future, and the field for the license key should be part of it)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

related to [#34921](https://github.com/camunda/camunda/issues/34921)
closes #
