### PR TITLE
build: remove invalid npm configuration parameter

### DIFF
--- a/operate/client/pom.xml
+++ b/operate/client/pom.xml
@@ -61,7 +61,6 @@
               <goal>npm</goal>
             </goals>
             <configuration>
-              <failOnError>false</failOnError>
               <skip>${skip.fe.build}</skip>
               <arguments>ci</arguments>
             </configuration>
@@ -73,7 +72,6 @@
               <goal>npm</goal>
             </goals>
             <configuration>
-              <failOnError>false</failOnError>
               <skip>${skip.fe.build}</skip>
               <arguments>run build</arguments>
             </configuration>

--- a/optimize/client/pom.xml
+++ b/optimize/client/pom.xml
@@ -40,7 +40,6 @@
               <goal>yarn</goal>
             </goals>
             <configuration>
-              <failOnError>false</failOnError>
               <skip>${skip.fe.build}</skip>
               <arguments>install --mutex file:/tmp/.yarn-mutex</arguments>
             </configuration>

--- a/tasklist/client/pom.xml
+++ b/tasklist/client/pom.xml
@@ -55,7 +55,6 @@
               <goal>npm</goal>
             </goals>
             <configuration>
-              <failOnError>false</failOnError>
               <skip>${skip.fe.build}</skip>
               <arguments>ci</arguments>
             </configuration>
@@ -67,7 +66,6 @@
               <goal>npm</goal>
             </goals>
             <configuration>
-              <failOnError>false</failOnError>
               <skip>${skip.fe.build}</skip>
               <arguments>run build</arguments>
             </configuration>


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

There were some build warnings about this being invalid, so simply removing them
