### PR TITLE
fix: sanitize auth data when printing it

### DIFF
--- a/docs/zeebe/developer_handbook.md
+++ b/docs/zeebe/developer_handbook.md
@@ -52,6 +52,9 @@ Please have a look at [Message Versioning](https://github.com/real-logic/simple-
 
 1. Implement your new `RecordValue` interface in [protocol-impl](/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value).
    - Make sure to add annotations for properties (or getter methods) that shouldn't be serialized to JSON.
+   - If you have any properties which should not be printed in the logs, or when we call `toString()` on the object, but you still
+     want them serialized to JSON, then simply call `#sanitized()` on the property itself after declaring it,
+     e.g. `new IntegerProperty("int").sanitized()`.
 2. Add new cases to [JsonSerializableToJsonTest](/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java):
    - one case that provides a value for each property (as far nested as possible)
    - one case that has as few properties as possible (i.e. an empty record)

--- a/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/property/BaseProperty.java
+++ b/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/property/BaseProperty.java
@@ -60,6 +60,10 @@ public abstract class BaseProperty<T extends BaseValue> implements Recyclable {
     return isSet || defaultValue != null;
   }
 
+  public boolean isSet() {
+    return isSet;
+  }
+
   public StringValue getKey() {
     return key;
   }

--- a/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/property/BaseProperty.java
+++ b/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/property/BaseProperty.java
@@ -128,9 +128,17 @@ public abstract class BaseProperty<T extends BaseValue> implements Recyclable {
    *
    * <p>If false, disabled sanitization of this value in the cases above.
    *
-   * @return
-   * @param <U>
-   * @param <T>
+   * <p>The chaining portion is a bit hacky, but it allows you to declare fields as:
+   *
+   * <pre>{@code
+   * private final IntegerProperty myProperty = new IntegerProperty("myProperty").sanitized();
+   * }</pre>
+   *
+   * The proper way for chaining would be to add a type param to the class that would represent the
+   * current type, but that would create quite a lot of refactoring, and this is likely good enough
+   * in most cases. Feel free to improve on this.
+   *
+   * @return itself for chaining
    */
   public <U extends BaseValue, T extends BaseProperty<U>> T sanitized() {
     isSanitized = true;

--- a/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/property/BaseProperty.java
+++ b/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/property/BaseProperty.java
@@ -60,10 +60,6 @@ public abstract class BaseProperty<T extends BaseValue> implements Recyclable {
     return isSet || defaultValue != null;
   }
 
-  public boolean isSet() {
-    return isSet;
-  }
-
   public StringValue getKey() {
     return key;
   }
@@ -117,6 +113,13 @@ public abstract class BaseProperty<T extends BaseValue> implements Recyclable {
     }
   }
 
+  /**
+   * Returns true if the property should be masked when printing it out (e.g. in logs or {@link
+   * #toString}).
+   *
+   * <p>If false, it means the value is <em>always</em> printed out as is, and is not considered
+   * sensitive.
+   */
   public boolean isSanitized() {
     return isSanitized;
   }
@@ -126,8 +129,6 @@ public abstract class BaseProperty<T extends BaseValue> implements Recyclable {
    * {@link #toString()}, or {@link #writeJSON(StringBuilder, boolean)} with the second param set to
    * true.
    *
-   * <p>If false, disabled sanitization of this value in the cases above.
-   *
    * <p>The chaining portion is a bit hacky, but it allows you to declare fields as:
    *
    * <pre>{@code
@@ -136,7 +137,7 @@ public abstract class BaseProperty<T extends BaseValue> implements Recyclable {
    *
    * The proper way for chaining would be to add a type param to the class that would represent the
    * current type, but that would create quite a lot of refactoring, and this is likely good enough
-   * in most cases. Feel free to improve on this.
+   * in most cases.
    *
    * @return itself for chaining
    */

--- a/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/value/ObjectValue.java
+++ b/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/value/ObjectValue.java
@@ -72,8 +72,8 @@ public class ObjectValue extends BaseValue {
   public void writeJSON(final StringBuilder builder) {
     builder.append("{");
 
-    writeJson(builder, declaredProperties);
-    writeJson(builder, undeclaredProperties);
+    writeJson(builder, declaredProperties, false);
+    writeJson(builder, undeclaredProperties, false);
 
     builder.append("}");
   }
@@ -145,7 +145,7 @@ public class ObjectValue extends BaseValue {
   }
 
   private <T extends BaseProperty<?>> void writeJson(
-      final StringBuilder builder, final List<T> properties) {
+      final StringBuilder builder, final List<T> properties, final boolean maskSanitized) {
     for (int i = 0; i < properties.size(); i++) {
       if (i > 0) {
         builder.append(",");
@@ -154,7 +154,7 @@ public class ObjectValue extends BaseValue {
       final BaseProperty<? extends BaseValue> prop = properties.get(i);
 
       if (prop.hasValue()) {
-        prop.writeJSON(builder);
+        prop.writeJSON(builder, maskSanitized);
       }
     }
   }
@@ -207,5 +207,17 @@ public class ObjectValue extends BaseValue {
 
   public boolean isEmpty() {
     return declaredProperties.isEmpty() && undeclaredProperties.isEmpty();
+  }
+
+  @Override
+  public String toString() {
+    final StringBuilder builder = new StringBuilder();
+    builder.append("{");
+
+    writeJson(builder, declaredProperties, true);
+    writeJson(builder, undeclaredProperties, true);
+
+    builder.append("}");
+    return builder.toString();
   }
 }

--- a/zeebe/msgpack-value/src/test/java/io/camunda/zeebe/msgpack/BasePropertyTest.java
+++ b/zeebe/msgpack-value/src/test/java/io/camunda/zeebe/msgpack/BasePropertyTest.java
@@ -41,11 +41,40 @@ final class BasePropertyTest {
     assertThat(result).isEqualTo("test-key => non-sanitized-value");
   }
 
+  @Test
+  void shouldMaskSanitizedPropertiesWhenWritingJson() {
+    // given
+    final var sb = new StringBuilder();
+    final TestProperty property = new TestProperty("non-sanitized-value").sanitized();
+
+    // when
+    property.writeJSON(sb, true);
+
+    // then
+    assertThat(property.isSanitized()).isTrue();
+    assertThat(sb).hasToString("\"test-key\":\"***\"");
+  }
+
+  @Test
+  void shouldNotMaskSanitizedPropertiesWhenWritingJson() {
+    // given
+    final var sb = new StringBuilder();
+    final TestProperty property = new TestProperty("non-sanitized-value").sanitized();
+
+    // when
+    property.writeJSON(sb, false);
+
+    // then
+    assertThat(property.isSanitized()).isTrue();
+    assertThat(sb).hasToString("\"test-key\":\"non-sanitized-value\"");
+  }
+
   private static final class TestProperty extends BaseProperty<StringValue> {
 
     private TestProperty(final String value) {
       super("test-key", new StringValue());
       this.value.wrap(value.getBytes(StandardCharsets.UTF_8));
+      isSet = true;
     }
   }
 }

--- a/zeebe/msgpack-value/src/test/java/io/camunda/zeebe/msgpack/BasePropertyTest.java
+++ b/zeebe/msgpack-value/src/test/java/io/camunda/zeebe/msgpack/BasePropertyTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.msgpack;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.msgpack.property.BaseProperty;
+import io.camunda.zeebe.msgpack.value.StringValue;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Test;
+
+final class BasePropertyTest {
+  @Test
+  void shouldMaskSanitizedValuesInToString() {
+    // given
+    final TestProperty property = new TestProperty("non-sanitized-value").sanitized();
+
+    // when
+    final String result = property.toString();
+
+    // then
+    assertThat(property.isSanitized()).isTrue();
+    assertThat(result).isEqualTo("test-key => ***");
+  }
+
+  @Test
+  void shouldNotMaskNonSanitizedValuesInToString() {
+    // given
+    final TestProperty property = new TestProperty("non-sanitized-value");
+
+    // when
+    final String result = property.toString();
+
+    // then
+    assertThat(property.isSanitized()).isFalse();
+    assertThat(result).isEqualTo("test-key => non-sanitized-value");
+  }
+
+  private static final class TestProperty extends BaseProperty<StringValue> {
+
+    private TestProperty(final String value) {
+      super("test-key", new StringValue());
+      this.value.wrap(value.getBytes(StandardCharsets.UTF_8));
+    }
+  }
+}

--- a/zeebe/msgpack-value/src/test/java/io/camunda/zeebe/msgpack/ObjectValueTest.java
+++ b/zeebe/msgpack-value/src/test/java/io/camunda/zeebe/msgpack/ObjectValueTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.msgpack;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.msgpack.property.StringProperty;
+import io.camunda.zeebe.msgpack.value.ObjectValue;
+import org.junit.jupiter.api.Test;
+
+final class ObjectValueTest {
+  @Test
+  void shouldMaskSanitizedValuesInToString() {
+    // given
+    final TestObjectValue objectValue =
+        new TestObjectValue("non-sanitized-value", "sanitized-value");
+
+    // when
+    final String result = objectValue.toString();
+
+    // then
+    assertThat(result)
+        .isEqualTo(
+            "{\"non-sanitized-property\":\"non-sanitized-value\",\"sanitized-property\":\"***\"}");
+  }
+
+  private static final class TestObjectValue extends ObjectValue {
+    private final StringProperty nonSanitizedProperty =
+        new StringProperty("non-sanitized-property");
+    private final StringProperty sanitizedProperty =
+        new StringProperty("sanitized-property").sanitized();
+
+    private TestObjectValue(final String nonSanitizedProperty, final String sanitizedProperty) {
+      super(2);
+      declareProperty(this.nonSanitizedProperty).declareProperty(this.sanitizedProperty);
+      this.nonSanitizedProperty.setValue(nonSanitizedProperty);
+      this.sanitizedProperty.setValue(sanitizedProperty);
+    }
+  }
+}

--- a/zeebe/msgpack-value/src/test/java/io/camunda/zeebe/msgpack/UnpackedObjectTest.java
+++ b/zeebe/msgpack-value/src/test/java/io/camunda/zeebe/msgpack/UnpackedObjectTest.java
@@ -7,14 +7,26 @@
  */
 package io.camunda.zeebe.msgpack;
 
+import static io.camunda.zeebe.msgpack.MsgPackUtil.encodeMsgPack;
+import static io.camunda.zeebe.util.buffer.BufferUtil.wrapString;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.spy;
 
+import io.camunda.zeebe.msgpack.POJO.POJOEnum;
+import io.camunda.zeebe.msgpack.property.ArrayProperty;
+import io.camunda.zeebe.msgpack.property.BinaryProperty;
 import io.camunda.zeebe.msgpack.property.BooleanProperty;
+import io.camunda.zeebe.msgpack.property.DocumentProperty;
+import io.camunda.zeebe.msgpack.property.EnumProperty;
 import io.camunda.zeebe.msgpack.property.IntegerProperty;
+import io.camunda.zeebe.msgpack.property.LongProperty;
+import io.camunda.zeebe.msgpack.property.ObjectProperty;
+import io.camunda.zeebe.msgpack.property.PackedProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
+import io.camunda.zeebe.msgpack.value.IntegerValue;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.nio.ByteBuffer;
+import org.agrona.DirectBuffer;
 import org.agrona.MutableDirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.jupiter.api.Nested;
@@ -125,6 +137,98 @@ public class UnpackedObjectTest {
 
       // then
       assertThat(newSchemaObject.getLength()).isEqualTo(length);
+    }
+  }
+
+  @Nested
+  class SanitizationTest {
+
+    /**
+     * Test to ensure that all property types are covered by the sanitization feature, in the off
+     * chance we ever overrode toString() in a property and forgot to include the sanitization
+     * logic.
+     */
+    @Test
+    void shouldSanitizePojoWithAllProperties() {
+      // given
+      final TestSanitizedPojo pojo = new TestSanitizedPojo();
+
+      // when
+      final String result = pojo.toString();
+
+      // then
+      assertThat(result)
+          .isEqualTo(
+              """
+          {"arrayProp":"***","binaryProp":"***","booleanProp":"***","documentProp":"***","enumProp":"***",\
+          "intProp":"***","longProp":"***","objectProp":"***","packedProp":"***","stringProp":"***"}""");
+    }
+
+    @Test
+    void shouldNotSanitizeValuesWhenSerializingToJson() {
+      // given
+      final TestSanitizedPojo pojo = new TestSanitizedPojo();
+
+      // when
+      final var sb = new StringBuilder();
+      pojo.writeJSON(sb);
+      final var result = sb.toString();
+
+      // then
+      assertThat(result)
+          .isEqualTo(
+              """
+          {"arrayProp":[1],"binaryProp":"Zm9v","booleanProp":true,"documentProp":"gaNmb28C","enumProp":"BAR",\
+          "intProp":42,"longProp":4242,"objectProp":{"foo":243},"packedProp":[packed value (length=12)],"stringProp":"string-value"}""");
+    }
+  }
+
+  private static final class TestSanitizedPojo extends UnpackedObject {
+    private final ArrayProperty<IntegerValue> arrayProp =
+        new ArrayProperty<>("arrayProp", IntegerValue::new).sanitized();
+    private final BinaryProperty binaryProp = new BinaryProperty("binaryProp").sanitized();
+    private final BooleanProperty booleanProp = new BooleanProperty("booleanProp").sanitized();
+    private final DocumentProperty documentProp = new DocumentProperty("documentProp").sanitized();
+    private final EnumProperty<POJOEnum> enumProp =
+        ((EnumProperty<POJOEnum>) new EnumProperty("enumProp", POJOEnum.class)).sanitized();
+    private final IntegerProperty intProp = new IntegerProperty("intProp").sanitized();
+    private final LongProperty longProp = new LongProperty("longProp").sanitized();
+    private final ObjectProperty<POJONested> objectProp =
+        new ObjectProperty<>("objectProp", new POJONested()).sanitized();
+    private final PackedProperty packedProp = new PackedProperty("packedProp").sanitized();
+    private final StringProperty stringProp = new StringProperty("stringProp").sanitized();
+
+    public TestSanitizedPojo() {
+      super(11);
+      declareProperty(arrayProp)
+          .declareProperty(binaryProp)
+          .declareProperty(booleanProp)
+          .declareProperty(documentProp)
+          .declareProperty(enumProp)
+          .declareProperty(intProp)
+          .declareProperty(longProp)
+          .declareProperty(objectProp)
+          .declareProperty(packedProp)
+          .declareProperty(stringProp);
+
+      final DirectBuffer documentBytes =
+          encodeMsgPack(
+              (w) -> {
+                w.writeMapHeader(1);
+                w.writeString(wrapString("foo"));
+                w.writeInteger(2);
+              });
+
+      arrayProp.add().setValue(1);
+      binaryProp.setValue(BufferUtil.wrapString("foo"));
+      booleanProp.setValue(true);
+      documentProp.setValue(documentBytes);
+      enumProp.setValue(POJOEnum.BAR);
+      intProp.setValue(42);
+      longProp.setValue(4242L);
+      objectProp.getValue().setLong(243);
+      packedProp.setValue(BufferUtil.wrapString("packed-value"), 0, 12);
+      stringProp.setValue("string-value");
     }
   }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/AuthInfo.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/AuthInfo.java
@@ -103,10 +103,10 @@ public class AuthInfo extends UnpackedObject {
         + getFormat()
         + ", "
         + "authData="
-        + getAuthData()
+        + (authDataProp.isSet() ? "***" : "<unset|default>")
         + ", "
         + "claims="
-        + getClaims()
+        + (claimsProp.isSet() ? "***" : "<unset|default>")
         + '}';
   }
 

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/AuthInfo.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/AuthInfo.java
@@ -96,20 +96,6 @@ public class AuthInfo extends UnpackedObject {
     return getClaims();
   }
 
-  @Override
-  public String toString() {
-    return "AuthInfo{"
-        + "format="
-        + getFormat()
-        + ", "
-        + "authData="
-        + (authDataProp.isSet() ? "***" : "<unset|default>")
-        + ", "
-        + "claims="
-        + (claimsProp.isSet() ? "***" : "<unset|default>")
-        + '}';
-  }
-
   public enum AuthDataFormat {
     UNKNOWN((short) 0),
     JWT((short) 1);

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/AuthInfo.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/AuthInfo.java
@@ -24,8 +24,8 @@ public class AuthInfo extends UnpackedObject {
   private final EnumProperty<AuthDataFormat> formatProp =
       new EnumProperty<>("format", AuthDataFormat.class, AuthDataFormat.UNKNOWN);
 
-  private final StringProperty authDataProp = new StringProperty("authData", "");
-  private final DocumentProperty claimsProp = new DocumentProperty("claims");
+  private final StringProperty authDataProp = new StringProperty("authData", "").sanitized();
+  private final DocumentProperty claimsProp = new DocumentProperty("claims").sanitized();
 
   public AuthInfo() {
     super(3);

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/user/UserRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/user/UserRecord.java
@@ -21,7 +21,7 @@ public final class UserRecord extends UnifiedRecordValue implements UserRecordVa
   private final StringProperty usernameProp = new StringProperty("username");
   private final StringProperty nameProp = new StringProperty("name", "");
   private final StringProperty emailProp = new StringProperty("email", "");
-  private final StringProperty passwordProp = new StringProperty("password", "");
+  private final StringProperty passwordProp = new StringProperty("password", "").sanitized();
 
   public UserRecord() {
     super(5);

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/AuthInfoTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/AuthInfoTest.java
@@ -51,35 +51,22 @@ final class AuthInfoTest {
   }
 
   @RegressionTest("https://github.com/camunda/camunda/issues/35177")
-  void shouldSanitizeClaimsAndTokenOnToString() {
-    // given
-    final AuthInfo authInfo = new AuthInfo();
-    final Map<String, Object> authInfoMap = Map.of("key", "mySecretClaim");
-    authInfo.setFormat(AuthInfo.AuthDataFormat.JWT);
-    authInfo.setClaims(authInfoMap);
-
-    // when
-    final var authInfoString = authInfo.toString();
-
-    // then
-    assertThat(authInfoString)
-        .isEqualTo("AuthInfo{format=JWT, authData=<unset|default>, claims=***}");
-  }
-
-  @RegressionTest("https://github.com/camunda/camunda/issues/35177")
-  void shouldSanitizeTokenOnToString() {
+  void shouldSanitizeOnToString() {
     // given
     final AuthInfo authInfo = new AuthInfo();
     final String token = "token";
     authInfo.setFormat(AuthInfo.AuthDataFormat.JWT);
     authInfo.setAuthData(token);
+    authInfo.setClaims(Map.of("key", "value"));
 
     // when
     final var authInfoString = authInfo.toString();
 
     // then
     assertThat(authInfoString)
-        .isEqualTo("AuthInfo{format=JWT, authData=***, claims=<unset|default>}");
+        .isEqualTo(
+            """
+        {"format":"JWT","authData":"***","claims":"***"}""");
   }
 
   private void encodeDecode(final AuthInfo authInfo) {

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/record/value/UserRecordTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/record/value/UserRecordTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.protocol.impl.record.value;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.protocol.impl.record.value.user.UserRecord;
+import io.camunda.zeebe.test.util.junit.RegressionTest;
+import org.junit.jupiter.api.Test;
+
+final class UserRecordTest {
+  @RegressionTest("https://github.com/camunda/camunda/issues/35177")
+  void shouldSanitizePasswordOnToString() {
+    // given
+    final UserRecord userRecord = new UserRecord();
+    userRecord.setUsername("myUser");
+    userRecord.setPassword("mySecretPassword");
+
+    // when
+    final String userRecordString = userRecord.toString();
+
+    // then
+    assertThat(userRecordString)
+        .isEqualTo(
+            """
+      {"userKey":-1,"username":"myUser","name":"","email":"","password":"***"}""");
+  }
+}

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/record/value/UserRecordTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/record/value/UserRecordTest.java
@@ -11,7 +11,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.protocol.impl.record.value.user.UserRecord;
 import io.camunda.zeebe.test.util.junit.RegressionTest;
-import org.junit.jupiter.api.Test;
 
 final class UserRecordTest {
   @RegressionTest("https://github.com/camunda/camunda/issues/35177")


### PR DESCRIPTION
## Description

This PR omits the auth data and claims when printing out the `AuthInfo` as part of the record metadata.

Additionally, it extends the `msgpack-value` module to allow defining `UnpackedObject` properties as sanitized, meaning they will not be printed out when the object is stringified via `toString`, but will still be present in the JSON serialized representation via `toJson` (for exporting).

Finally, I noticed that `UserRecord` would also print the password, which I marked as sanitized as well.

## Related issues

closes #35177 
