### PR TITLE
[Backport stable/8.6] [Backport stable/8.7] Fix `CompletableActorFuture.andThen` methods to catch exceptions and complete futures exceptionally

### DIFF
--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/future/CompletableActorFuture.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/future/CompletableActorFuture.java
@@ -284,7 +284,15 @@ public final class CompletableActorFuture<V> implements ActorFuture<V> {
 
   @Override
   public <U> ActorFuture<U> andThen(final Supplier<ActorFuture<U>> next, final Executor executor) {
-    return andThen(ignored -> next.get(), executor);
+    return andThen(
+        ignored -> {
+          try {
+            return next.get();
+          } catch (final Exception e) {
+            return CompletableActorFuture.completedExceptionally(e);
+          }
+        },
+        executor);
   }
 
   @Override
@@ -295,7 +303,11 @@ public final class CompletableActorFuture<V> implements ActorFuture<V> {
           if (err != null) {
             return CompletableActorFuture.completedExceptionally(err);
           } else {
-            return next.apply(v);
+            try {
+              return next.apply(v);
+            } catch (final Exception e) {
+              return CompletableActorFuture.completedExceptionally(e);
+            }
           }
         },
         executor);
@@ -307,8 +319,12 @@ public final class CompletableActorFuture<V> implements ActorFuture<V> {
     final ActorFuture<U> nextFuture = new CompletableActorFuture<>();
     onComplete(
         (thisResult, thisError) -> {
-          final var future = next.apply(thisResult, thisError);
-          future.onComplete(nextFuture, executor);
+          try {
+            final var future = next.apply(thisResult, thisError);
+            future.onComplete(nextFuture, executor);
+          } catch (final Exception e) {
+            nextFuture.completeExceptionally(e);
+          }
         },
         executor);
     return nextFuture;

--- a/zeebe/scheduler/src/test/java/io/camunda/zeebe/scheduler/functional/ActorFutureTest.java
+++ b/zeebe/scheduler/src/test/java/io/camunda/zeebe/scheduler/functional/ActorFutureTest.java
@@ -856,6 +856,63 @@ final class ActorFutureTest {
   }
 
   @Test
+  void andThenSupplierShouldCompleteExceptionallyOnException() {
+    // given
+    final var expectedException = new RuntimeException("Supplier exception");
+    final var chained =
+        CompletableActorFuture.completed("input")
+            .andThen(
+                () -> {
+                  throw expectedException;
+                },
+                Runnable::run);
+
+    // then
+    assertThat(chained)
+        .failsWithin(Duration.ofSeconds(1))
+        .withThrowableThat()
+        .withCause(expectedException);
+  }
+
+  @Test
+  void andThenFunctionShouldCompleteExceptionallyOnException() {
+    // given
+    final var expectedException = new RuntimeException("Function exception");
+    final var chained =
+        CompletableActorFuture.completed("input")
+            .andThen(
+                input -> {
+                  throw expectedException;
+                },
+                Runnable::run);
+
+    // then
+    assertThat(chained)
+        .failsWithin(Duration.ofSeconds(1))
+        .withThrowableThat()
+        .withCause(expectedException);
+  }
+
+  @Test
+  void andThenBiFunctionShouldCompleteExceptionallyOnException() {
+    // given
+    final var expectedException = new RuntimeException("BiFunction exception");
+    final var chained =
+        CompletableActorFuture.completed("input")
+            .andThen(
+                (value, error) -> {
+                  throw expectedException;
+                },
+                Runnable::run);
+
+    // then
+    assertThat(chained)
+        .failsWithin(Duration.ofSeconds(1))
+        .withThrowableThat()
+        .withCause(expectedException);
+  }
+
+  @Test
   void shouldChainThenApply() {
     // given
     final var future = new CompletableActorFuture<Integer>();


### PR DESCRIPTION
# Description
Backport of #34563 to `stable/8.6`.

relates to #34544