### PR TITLE
feat: use new validation pattern for create group modal

### DIFF
--- a/identity/client/src/utility/localization/en/groups.json
+++ b/identity/client/src/utility/localization/en/groups.json
@@ -21,6 +21,8 @@
   "groupDescriptionPlaceholder": "Enter a group description (Max 255 characters)",
   "pleaseEnterValidGroupId": "Please enter a valid group ID (only alphanumeric characters and max 256 characters)",
   "groupIdHelperText": "The group ID must be unique and can not be modified",
+  "groupIdRequired": "Group ID is required",
+  "groupNameRequired": "Group name is required",
   "openGroupContextMenu": "Open group context menu",
   "unableToLoadMembers": "We were unable to load the members. Click \"Retry\" to try again.",
   "assignUser": "Assign user",


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
- Add the improved input field validation UX introduced in [this PR](https://github.com/camunda/camunda/pull/35843) also to the `Create group` modal.
- Refactor the modal to use react hook form for form state and validation.


https://github.com/user-attachments/assets/bce1e025-133c-47e9-b8c5-1e316c5a72e6



## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).


