### PR TITLE
feat: use new validation pattern for edit mapping rule modal

### DIFF
--- a/identity/client/src/pages/mapping-rules/modals/EditModal.tsx
+++ b/identity/client/src/pages/mapping-rules/modals/EditModal.tsx
@@ -6,7 +6,8 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import { FC, useState } from "react";
+import { FC } from "react";
+import { Controller, useForm } from "react-hook-form";
 import { Stack } from "@carbon/react";
 import { spacing05 } from "@carbon/elements";
 import TextField from "src/components/form/TextField";
@@ -35,16 +36,33 @@ const EditModal: FC<UseEntityModalProps<MappingRule>> = ({
       suppressErrorNotification: true,
     },
   );
-  const [mappingRule, setMappingRule] = useState<MappingRule>(entity);
+  type FormData = Pick<
+    MappingRule,
+    "mappingRuleId" | "name" | "claimName" | "claimValue"
+  >;
+  const { control, handleSubmit } = useForm<FormData>({
+    defaultValues: {
+      mappingRuleId: entity.mappingRuleId,
+      name: entity.name,
+      claimName: entity.claimName,
+      claimValue: entity.claimValue,
+    },
+    mode: "all",
+  });
 
-  const handleSubmit = async () => {
-    const { success } = await callUpdateMappingRule(mappingRule);
+  const onSubmit = async (data: FormData) => {
+    const { success } = await callUpdateMappingRule({
+      mappingRuleId: data.mappingRuleId,
+      name: data.name,
+      claimName: data.claimName,
+      claimValue: data.claimValue,
+    });
     if (success) {
       enqueueNotification({
         kind: "success",
         title: t("mappingRuleUpdated"),
         subtitle: t("mappingRuleUpdatedSuccessfully", {
-          name: mappingRule.name,
+          name: data.name,
         }),
       });
       onSuccess();
@@ -56,58 +74,66 @@ const EditModal: FC<UseEntityModalProps<MappingRule>> = ({
       open={open}
       headline={t("editMappingRule")}
       onClose={onClose}
-      onSubmit={handleSubmit}
+      onSubmit={handleSubmit(onSubmit)}
       loading={loading}
       error={error}
       loadingDescription={t("updatingMappingRule")}
       confirmLabel={t("updateMappingRule")}
     >
-      <TextField
-        label={t("mappingRuleId")}
-        onChange={(mappingRuleId) =>
-          setMappingRule((mappingRule) => ({
-            ...mappingRule,
-            mappingRuleId: mappingRuleId,
-          }))
-        }
-        value={mappingRule.mappingRuleId}
-        readOnly
+      <Controller
+        name="mappingRuleId"
+        control={control}
+        render={({ field }) => (
+          <TextField {...field} label={t("mappingRuleId")} readOnly />
+        )}
       />
-      <TextField
-        label={t("mappingRuleName")}
-        placeholder={t("enterMappingRuleName")}
-        onChange={(name) =>
-          setMappingRule((mappingRule) => ({ ...mappingRule, name }))
-        }
-        value={mappingRule.name}
-        helperText={t("uniqueNameForMappingRule")}
-        autoFocus
+      <Controller
+        name="name"
+        control={control}
+        rules={{ required: t("mappingRuleNameRequired") }}
+        render={({ field, fieldState }) => (
+          <TextField
+            {...field}
+            label={t("mappingRuleName")}
+            placeholder={t("enterMappingRuleName")}
+            helperText={t("uniqueNameForMappingRule")}
+            errors={fieldState.error?.message}
+            autoFocus
+          />
+        )}
       />
       <MappingRuleContainer>
         <Stack gap={spacing05}>
           <h3>{t("mappingRule")}</h3>
           <CustomStack orientation="horizontal">
-            <TextField
-              label={t("claimName")}
-              placeholder={t("enterClaimName")}
-              onChange={(claimName) =>
-                setMappingRule((mappingRule) => ({ ...mappingRule, claimName }))
-              }
-              value={mappingRule.claimName}
-              helperText={t("customClaimName")}
+            <Controller
+              name="claimName"
+              control={control}
+              rules={{ required: t("claimNameRequired") }}
+              render={({ field, fieldState }) => (
+                <TextField
+                  {...field}
+                  label={t("claimName")}
+                  placeholder={t("enterClaimName")}
+                  helperText={t("customClaimName")}
+                  errors={fieldState.error?.message}
+                />
+              )}
             />
             <EqualSignContainer>=</EqualSignContainer>
-            <TextField
-              label={t("claimValue")}
-              placeholder={t("enterClaimValue")}
-              onChange={(claimValue) =>
-                setMappingRule((mappingRule) => ({
-                  ...mappingRule,
-                  claimValue,
-                }))
-              }
-              value={mappingRule.claimValue}
-              helperText={t("valueForClaim")}
+            <Controller
+              name="claimValue"
+              control={control}
+              rules={{ required: t("claimValueRequired") }}
+              render={({ field, fieldState }) => (
+                <TextField
+                  {...field}
+                  label={t("claimValue")}
+                  placeholder={t("enterClaimValue")}
+                  helperText={t("valueForClaim")}
+                  errors={fieldState.error?.message}
+                />
+              )}
             />
           </CustomStack>
         </Stack>


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
- Add the improved input field validation UX introduced in [this PR](https://github.com/camunda/camunda/pull/35843) also to the `Edit mapping rule` modal.
- Refactor the modal to use react hook form for form state and validation.


https://github.com/user-attachments/assets/5beae7d9-878a-4dc1-8b07-2e15a03b4e0b



## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
