### PR TITLE
feat: Static Header & 401 Header for Unauthorized API Access

### DIFF
--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -10881,6 +10881,10 @@ components:
             $ref: "#/components/schemas/ProblemDetail"
     Unauthorized:
       description: The request lacks valid authentication credentials.
+      headers:
+        WWW-Authenticate:
+          schema:
+            type: string
       content:
         application/problem+json:
           schema:

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/ApiDescriptionConfig.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/ApiDescriptionConfig.java
@@ -23,7 +23,7 @@ public class ApiDescriptionConfig {
         API for communicating with a Camunda 8 SaaS cluster.
 
         **Authentication:**
-        - **OIDC Authentication**: Log into `/operate/login` to get proper credentials
+        - **OAuth 2.0 Authentication**: Log into `/operate/login` to get proper credentials
         - **Bearer Token**: Use the Authorize button in Swagger UI to provide a Bearer token""");
   }
 
@@ -35,10 +35,9 @@ public class ApiDescriptionConfig {
         API for communicating with a Camunda 8 Self-Managed cluster.
 
         **Authentication Options:**
-        - **Basic Authentication**: Use username/password credentials
-        - **OIDC Authentication**: Both OAuth2 flow and Bearer token supported
-          - Use Swagger UI's Authorize flow, or
-          - Log into `/operate/login` to get proper credentials""");
+        - **Basic Authentication**: Use the Authorize button to provide username/password credentials
+        - **OAuth 2.0 Authentication**: Log into `/operate/login` to get proper credentials
+        - **Bearer Token**: Use the Authorize button in Swagger UI to provide a Bearer token""");
   }
 
   public static class ApiDescription {

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/ApiDescriptionConfig.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/ApiDescriptionConfig.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.config;
+
+import io.camunda.security.ConditionalOnSaaSConfigured;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ApiDescriptionConfig {
+
+  @Bean
+  @ConditionalOnSaaSConfigured
+  public ApiDescription saasApiDescription() {
+    return new ApiDescription(
+        """
+        API for communicating with a Camunda 8 SaaS cluster.
+
+        **Authentication:**
+        - **OIDC Authentication**: Log into `/operate/login` to get proper credentials
+        - **Bearer Token**: Use the Authorize button in Swagger UI to provide a Bearer token""");
+  }
+
+  @Bean
+  @ConditionalOnMissingBean(ApiDescription.class)
+  public ApiDescription selfManagedApiDescription() {
+    return new ApiDescription(
+        """
+        API for communicating with a Camunda 8 Self-Managed cluster.
+
+        **Authentication Options:**
+        - **Basic Authentication**: Use username/password credentials
+        - **OIDC Authentication**: Both OAuth2 flow and Bearer token supported
+          - Use Swagger UI's Authorize flow, or
+          - Log into `/operate/login` to get proper credentials""");
+  }
+
+  public static class ApiDescription {
+    private final String description;
+
+    public ApiDescription(final String description) {
+      this.description = description;
+    }
+
+    public String getDescription() {
+      return description;
+    }
+  }
+}

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/OpenApiResourceConfig.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/OpenApiResourceConfig.java
@@ -16,6 +16,7 @@ import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springdoc.core.models.GroupedOpenApi;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -26,6 +27,8 @@ public class OpenApiResourceConfig {
   public static final SecurityScheme BEARER_SECURITY_SCHEMA =
       new SecurityScheme().type(SecurityScheme.Type.HTTP).scheme("bearer").bearerFormat("JWT");
   private static final Logger LOGGER = LoggerFactory.getLogger(OpenApiResourceConfig.class);
+  @Autowired
+  private ApiDescriptionConfig.ApiDescription apiDescription;
 
   @Bean
   public GroupedOpenApi restApiV2() {
@@ -54,6 +57,6 @@ public class OpenApiResourceConfig {
   }
 
   private String getApiDescription() {
-    return "API for communicating with a Camunda 8 cluster.";
+    return apiDescription.getDescription();
   }
 }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/OpenApiResourceConfig.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/OpenApiResourceConfig.java
@@ -27,8 +27,7 @@ public class OpenApiResourceConfig {
   public static final SecurityScheme BEARER_SECURITY_SCHEMA =
       new SecurityScheme().type(SecurityScheme.Type.HTTP).scheme("bearer").bearerFormat("JWT");
   private static final Logger LOGGER = LoggerFactory.getLogger(OpenApiResourceConfig.class);
-  @Autowired
-  private ApiDescriptionConfig.ApiDescription apiDescription;
+  @Autowired private ApiDescriptionConfig.ApiDescription apiDescription;
 
   @Bean
   public GroupedOpenApi restApiV2() {


### PR DESCRIPTION
## Description

In this PR I'm
- Adding a WWW-Authenticate header as recommended in the [swagger auth docs](https://swagger.io/docs/specification/v3_0/authentication/basic-authentication/#401-response)
- Adding an API description depending on whether we're running on SaaS or SM (since the supported auth are slightly different) 

The actual auth support are introduced in #36838

Screenshots
- SaaS
<img width="1023" height="239" alt="Screenshot 2568-08-15 at 14 06 45" src="https://github.com/user-attachments/assets/7c3baf43-45d0-439f-8242-10407ff6cee3" />

- SM
<img width="897" height="217" alt="Screenshot 2568-08-19 at 11 03 07" src="https://github.com/user-attachments/assets/5075ee5d-8b93-41bf-b4b3-0b04a4f7b76b" />

- WWW-Authenticate header which specifies the auth method (Basic)
<img width="892" height="455" alt="Screenshot 2568-08-15 at 14 04 33" src="https://github.com/user-attachments/assets/e3cb8138-c598-4624-a221-ab68b9bdadab" />


## Related issues

closes #36759
