### PR TITLE
fix: align form fields when errors active in create authorization modal

### DIFF
--- a/identity/client/src/pages/authorizations/modals/add-modal/AddModal.tsx
+++ b/identity/client/src/pages/authorizations/modals/add-modal/AddModal.tsx
@@ -221,24 +221,22 @@ export const AddModal: FC<UseEntityModalProps<ResourceType>> = ({
             )}
           />
         </DropdownAutoFocus>
-        <TextFieldContainer>
-          <Controller
-            name="ownerId"
-            control={control}
-            rules={{
-              required: "EMPTY",
-            }}
-            render={({ field, fieldState }) => (
-              <OwnerSelection
-                type={watchedOwnerType}
-                ownerId={field.value}
-                onChange={field.onChange}
-                onBlur={field.onBlur}
-                isEmpty={!!fieldState.error?.message}
-              />
-            )}
-          />
-        </TextFieldContainer>
+        <Controller
+          name="ownerId"
+          control={control}
+          rules={{
+            required: "EMPTY",
+          }}
+          render={({ field, fieldState }) => (
+            <OwnerSelection
+              type={watchedOwnerType}
+              ownerId={field.value}
+              onChange={field.onChange}
+              onBlur={field.onBlur}
+              isEmpty={!!fieldState.error?.message}
+            />
+          )}
+        />
       </Row>
       <Divider />
       <Row>

--- a/identity/client/src/pages/authorizations/modals/components.tsx
+++ b/identity/client/src/pages/authorizations/modals/components.tsx
@@ -12,7 +12,7 @@ export const Row = styled.div`
   display: grid;
   width: 100%;
   flex-direction: row;
-  align-items: center;
+  align-items: start;
   justify-content: center;
   gap: 1rem;
   grid-template-columns: 1fr 2fr;


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Fix the alignment of the fields in Create authorization modal when validation errors are active.

**Before**

<img width="932" height="557" alt="Image" src="https://github.com/user-attachments/assets/bef56d18-d871-4b4d-8b6a-db376692f15c" />

**After**

https://github.com/user-attachments/assets/9d4e1fa2-97bc-4389-8f1a-6eb2220bdbff

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

- Follow-up of https://github.com/camunda/camunda/issues/33468
