### PR TITLE
Add IT to verify inherited auth for simple mappings

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/InheritedSimpleMappingAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/InheritedSimpleMappingAuthorizationIT.java
@@ -1,0 +1,246 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.auth;
+
+import dasniko.testcontainers.keycloak.KeycloakContainer;
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.command.ProblemException;
+import io.camunda.client.api.search.enums.PermissionType;
+import io.camunda.client.api.search.enums.ResourceType;
+import io.camunda.client.impl.oauth.OAuthCredentialsProviderBuilder;
+import io.camunda.qa.util.auth.ClientDefinition;
+import io.camunda.qa.util.auth.GroupDefinition;
+import io.camunda.qa.util.auth.Membership;
+import io.camunda.qa.util.auth.Permissions;
+import io.camunda.qa.util.auth.RoleDefinition;
+import io.camunda.qa.util.auth.TestClient;
+import io.camunda.qa.util.auth.TestGroup;
+import io.camunda.qa.util.auth.TestRole;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.qa.util.multidb.MultiDbTestApplication;
+import io.camunda.security.entity.AuthenticationMethod;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.value.EntityType;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.test.util.Strings;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.stream.Stream;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Named;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+@MultiDbTest(setupKeycloak = true)
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms")
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
+public class InheritedSimpleMappingAuthorizationIT {
+
+  @MultiDbTestApplication
+  static final TestStandaloneBroker BROKER =
+      new TestStandaloneBroker()
+          .withAuthenticationMethod(AuthenticationMethod.OIDC)
+          .withAuthorizationsEnabled()
+          .withSecurityConfig(c -> c.getAuthorizations().setEnabled(true))
+          .withSecurityConfig(c -> c.getAuthentication().getOidc().setClientIdClaim("client_id"))
+          .withSecurityConfig(c -> c.getAuthentication().getOidc().setUsernameClaim("no_username"));
+
+  // Injected by the MultiDbTest extension
+  private static KeycloakContainer keycloak;
+
+  @ClientDefinition
+  private static final TestClient CLIENT_THROUGH_AUTHORIZED_GROUP = createTestClient();
+
+  @ClientDefinition
+  private static final TestClient CLIENT_THROUGH_UNAUTHORIZED_GROUP = createTestClient();
+
+  @ClientDefinition
+  private static final TestClient CLIENT_THROUGH_AUTHORIZED_ROLE = createTestClient();
+
+  @ClientDefinition
+  private static final TestClient CLIENT_THROUGH_UNAUTHORIZED_ROLE = createTestClient();
+
+  @ClientDefinition
+  private static final TestClient CLIENT_THROUGH_GROUP_THROUGH_AUTHORIZED_ROLE = createTestClient();
+
+  @ClientDefinition
+  private static final TestClient CLIENT_THROUGH_GROUP_THROUGH_UNAUTHORIZED_ROLE =
+      createTestClient();
+
+  @GroupDefinition
+  private static final TestGroup UNAUTHORIZED_GROUP =
+      TestGroup.withoutPermissions(
+          "unauthorizedGroup",
+          "unauthorized",
+          List.of(new Membership(CLIENT_THROUGH_UNAUTHORIZED_GROUP.clientId(), EntityType.CLIENT)));
+
+  @GroupDefinition
+  private static final TestGroup AUTHORIZED_GROUP =
+      new TestGroup(
+          "authorizedGroup",
+          "authorized",
+          List.of(
+              new Permissions(ResourceType.RESOURCE, PermissionType.CREATE, List.of("*")),
+              new Permissions(
+                  ResourceType.GROUP, PermissionType.READ, List.of(UNAUTHORIZED_GROUP.id()))),
+          List.of(new Membership(CLIENT_THROUGH_AUTHORIZED_GROUP.clientId(), EntityType.CLIENT)));
+
+  @GroupDefinition
+  private static final TestGroup GROUP_THROUGH_AUTHORIZED_ROLE =
+      TestGroup.withoutPermissions(
+          "authorizedGroupThroughRole",
+          "authorized",
+          List.of(
+              new Membership(
+                  CLIENT_THROUGH_GROUP_THROUGH_AUTHORIZED_ROLE.clientId(), EntityType.CLIENT)));
+
+  @RoleDefinition
+  private static final TestRole AUTHORIZED_ROLE =
+      new TestRole(
+          "authorizedRole",
+          "authorized",
+          List.of(
+              new Permissions(ResourceType.RESOURCE, PermissionType.CREATE, List.of("*")),
+              new Permissions(
+                  ResourceType.GROUP, PermissionType.READ, List.of(UNAUTHORIZED_GROUP.id()))),
+          List.of(
+              new Membership(CLIENT_THROUGH_AUTHORIZED_ROLE.clientId(), EntityType.CLIENT),
+              new Membership(GROUP_THROUGH_AUTHORIZED_ROLE.id(), EntityType.GROUP)));
+
+  @GroupDefinition
+  private static final TestGroup GROUP_THROUGH_UNAUTHORIZED_ROLE =
+      TestGroup.withoutPermissions(
+          "unauthorizedGroupThroughRole",
+          "unauthorized",
+          List.of(
+              new Membership(
+                  CLIENT_THROUGH_GROUP_THROUGH_UNAUTHORIZED_ROLE.clientId(), EntityType.CLIENT)));
+
+  @RoleDefinition
+  private static final TestRole UNAUTHORIZED_ROLE =
+      TestRole.withoutPermissions(
+          "unauthorizedRole",
+          "unauthorized",
+          List.of(
+              new Membership(CLIENT_THROUGH_UNAUTHORIZED_ROLE.clientId(), EntityType.CLIENT),
+              new Membership(GROUP_THROUGH_UNAUTHORIZED_ROLE.id(), EntityType.GROUP)));
+
+  @ParameterizedTest
+  @MethodSource("provideAuthorizedClients")
+  void shouldBeAuthorizedToDeploy(final TestClient testClient, @TempDir final Path tempDir) {
+    // given
+    try (final CamundaClient client = createClient(testClient.clientId(), tempDir)) {
+
+      // then
+      Assertions.assertThatNoException()
+          .isThrownBy(
+              () ->
+                  client
+                      .newDeployResourceCommand()
+                      .addProcessModel(
+                          Bpmn.createExecutableProcess().startEvent().endEvent().done(),
+                          "process.bpmn")
+                      .send()
+                      .join());
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideUnauthorizedClients")
+  void shouldBeUnauthorizedToDeploy(final TestClient testClient, @TempDir final Path tempDir) {
+    // given
+    try (final CamundaClient client = createClient(testClient.clientId(), tempDir)) {
+
+      // then
+      Assertions.assertThatThrownBy(
+              () ->
+                  client
+                      .newDeployResourceCommand()
+                      .addProcessModel(
+                          Bpmn.createExecutableProcess().startEvent().endEvent().done(),
+                          "process.bpmn")
+                      .send()
+                      .join())
+          .isInstanceOf(ProblemException.class)
+          .hasMessageContaining("403: 'Forbidden'");
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideAuthorizedClients")
+  void shouldBeAuthorizedToRead(final TestClient testClient, @TempDir final Path tempDir) {
+    // given
+    try (final CamundaClient client = createClient(testClient.clientId(), tempDir)) {
+
+      // then
+      Assertions.assertThatNoException()
+          .isThrownBy(
+              () ->
+                  client
+                      .newGroupGetRequest(
+                          UNAUTHORIZED_GROUP.id()) /* Attempt to read a random group we've */
+                      .send()
+                      .join());
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideUnauthorizedClients")
+  void shouldBeUnauthorizedToRead(final TestClient testClient, @TempDir final Path tempDir) {
+    // given
+    try (final CamundaClient client = createClient(testClient.clientId(), tempDir)) {
+
+      // then
+      Assertions.assertThatThrownBy(
+              () ->
+                  client
+                      .newGroupGetRequest(
+                          UNAUTHORIZED_GROUP.id()) // Attempt to read a random group we've
+                      .send()
+                      .join())
+          .isInstanceOf(ProblemException.class)
+          .hasMessageContaining("403: 'Forbidden'");
+    }
+  }
+
+  private CamundaClient createClient(final String id, final Path tempDir) {
+    return BROKER
+        .newClientBuilder()
+        .preferRestOverGrpc(true)
+        .credentialsProvider(
+            new OAuthCredentialsProviderBuilder()
+                .clientId(id)
+                .clientSecret(id)
+                .audience("zeebe")
+                .authorizationServerUrl(
+                    keycloak.getAuthServerUrl() + "/realms/camunda/protocol/openid-connect/token")
+                .credentialsCachePath(tempDir.resolve("default").toString())
+                .build())
+        .build();
+  }
+
+  private static Stream<Named<TestClient>> provideAuthorizedClients() {
+    return Stream.of(
+        Named.of("#clientThroughGroup", CLIENT_THROUGH_AUTHORIZED_GROUP),
+        Named.of("#clientThroughRole", CLIENT_THROUGH_AUTHORIZED_ROLE),
+        Named.of("#clientThroughGroupThroughRole", CLIENT_THROUGH_GROUP_THROUGH_AUTHORIZED_ROLE));
+  }
+
+  private static Stream<Named<TestClient>> provideUnauthorizedClients() {
+    return Stream.of(
+        Named.of("#clientThroughGroup", CLIENT_THROUGH_UNAUTHORIZED_GROUP),
+        Named.of("#clientThroughRole", CLIENT_THROUGH_UNAUTHORIZED_ROLE),
+        Named.of("#clientThroughGroupThroughRole", CLIENT_THROUGH_GROUP_THROUGH_UNAUTHORIZED_ROLE));
+  }
+
+  private static TestClient createTestClient() {
+    return new TestClient(Strings.newRandomValidIdentityId(), List.of());
+  }
+}

--- a/qa/util/src/main/java/io/camunda/qa/util/auth/ClientDefinition.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/auth/ClientDefinition.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.qa.util.auth;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface ClientDefinition {}

--- a/qa/util/src/main/java/io/camunda/qa/util/auth/TestClient.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/auth/TestClient.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.qa.util.auth;
+
+import java.util.List;
+
+public record TestClient(String clientId, List<Permissions> permissions) {
+
+  public TestClient(final String clientId) {
+    this(clientId, List.of());
+  }
+}

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/EntityManager.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/EntityManager.java
@@ -146,6 +146,14 @@ public final class EntityManager {
                   .send()
                   .join();
               break;
+            case CLIENT:
+              defaultClient
+                  .newAssignClientToGroupCommand()
+                  .clientId(membership.memberId())
+                  .groupId(groupId)
+                  .send()
+                  .join();
+              break;
             default:
               throw new IllegalArgumentException("Unsupported entity type: " + entityType);
           }
@@ -178,6 +186,14 @@ public final class EntityManager {
                   .newAssignRoleToMappingRuleCommand()
                   .roleId(roleId)
                   .mappingRuleId(membership.memberId())
+                  .send()
+                  .join();
+              break;
+            case CLIENT:
+              defaultClient
+                  .newAssignRoleToClientCommand()
+                  .roleId(roleId)
+                  .clientId(membership.memberId())
                   .send()
                   .join();
               break;

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/OidcCamundaClientTestFactory.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/OidcCamundaClientTestFactory.java
@@ -10,6 +10,7 @@ package io.camunda.qa.util.multidb;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.impl.oauth.OAuthCredentialsProviderBuilder;
 import io.camunda.qa.util.auth.Authenticated;
+import io.camunda.qa.util.auth.TestClient;
 import io.camunda.qa.util.auth.TestMappingRule;
 import io.camunda.qa.util.multidb.CamundaMultiDBExtension.ApplicationUnderTest;
 import io.camunda.zeebe.qa.util.cluster.TestGateway;
@@ -84,6 +85,12 @@ public final class OidcCamundaClientTestFactory implements CamundaClientTestFact
     final var client =
         createAuthenticatedClient(gateway, mappingRule.id(), mappingRule.claimValue());
     cachedClients.put(mappingRule.id(), client);
+  }
+
+  public void createClientForClient(final TestGateway<?> gateway, final TestClient client) {
+    final var camundaClient =
+        createAuthenticatedClient(gateway, client.clientId(), client.clientId());
+    cachedClients.put(client.clientId(), camundaClient);
   }
 
   private CamundaClient createAuthenticatedClient(


### PR DESCRIPTION
## Description

Add IT to verify inherited auth for simple mappings

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #33709 
