### PR TITLE
[Backport stable/8.7] docs: remove outdated Zeebe CI docs and keep test debugging

### DIFF
--- a/zeebe/docs/failing-tests.md
+++ b/zeebe/docs/failing-tests.md
@@ -1,153 +1,9 @@
-# Continuous Integration Guide
-
-This is a small guide for things useful around our continuous integration setup.
-
-## Github Action
-
-### Maven repository cache
-
-Within
-our [Github action to setup build](/Users/megglos/git/zeebe/.github/actions/setup-build/action.yml)
-we make use of [action/cache](https://github.com/actions/cache) to store the content of
-the maven repository and share it across jobs and even branches. Primarily to speedup builds and
-reduce the
-risks of failures due to network hiccups to remote repositories (rare but happened).
-
-#### Delete Maven repository caches
-
-In case you encounter a corrupted cache which you suspect to be the cause of a build failure you may
-delete that cache to force a clean rebuild of it.
-
-[Github Actions Cache](https://github.com/actions/gh-actions-cache) provides convenient tooling for
-doing so.
-
-You can easily list existing caches with:
-
-```bash
-gh actions-cache list
-
-Linux-maven-default-dddf7912807d96783a168b6dda5c5b639c6eb183bfedaab524c6e34f695afba4        586.20 MB  refs/pull/10550/merge     10 minutes ago
-```
-
-and delete them via:
-
-```bash
-gh actions-cache delete Linux-maven-default-dddf7912807d96783a168b6dda5c5b639c6eb183bfedaab524c6e34f695afba4
-```
-
-To determine the key of the cache used you can take a look into the log of the setup-build job.
-
-```
-...
-Run actions/cache@v3
-  with:
-    path: ~/.m2/repository
-    key: Linux-maven-default-dddf7912807d96783a168b6dda5c5b639c6eb183bfedaab524c6e34f695afba4
-    restore-keys: Linux-maven-default-
-
-  env:
-    TC_CLOUD_TOKEN: ***
-    TC_CLOUD_CONCURRENCY: 4
-    ZEEBE_TEST_DOCKER_IMAGE: localhost:5000/camunda/zeebe:current-test
-    JAVA_HOME: /opt/hostedtoolcache/Java_Temurin-Hotspot_jdk/17.0.4-101/x64
-Received 0 of 614674276 (0.0%), 0.0 MBs/sec
-...
-```
-
-### Container-based tests (Testcontainers)
-
-We make heavy use of container-based tests when running integration tests in Zeebe, primarily by leveraging [Testcontainers](https://testcontainers.org).
-
-> This applies only to jobs which run integration tests, such as the update test, or the integration test jobs.
-
-When you run the tests locally, they will use your local Docker environment. However, as part of our CI pipeline, we make use of their SaaS offering, Testcontainers Cloud (TCC). This allows us to decouple resource usage used by containers and provides a modest performance boost to our tests by running the containers on different machines than the ones where our tests run.
-
-#### How it works
-
-Grossly simplified, TCC works by setting up an agent which will act as a Docker daemon, but proxy requests to remote VMs. It will then write a [Testcontainers configuration file](https://www.testcontainers.org/features/configuration/) that the Testcontainers library will automatically use when a test is executed.
-
-> Note that AtomicJar, the company behind TCC, specifically mentions that their product is not a Docker-as-a-Service product, and shouldn't be treated as such.
-
-You will find documentation, account management, settings, secret tokens, etc., in the [Testcontainers Cloud dashboard](https://app.testcontainers.cloud/dashboard). If you haven't been invited yet and cannot see the dashboard, ask one of the Zeebe team members for an invite.
-
-Make sure to join the private Slack channel Camunda has with AtomicJar around TCC. There you will find a private invite link, and can provide feedback, ask questions, and receive support.
-
-> If you are not yet in the channel, anybody from the Zeebe team can invite you. Note that this is only for core team members.
-
-#### Usage
-
-To use TCC with GitHub Actions, we first need to define a few environment variables to your job.
-
-```yaml
-env:
-  TC_CLOUD_LOGS_VERBOSE: true
-  TC_CLOUD_CONCURRENCY: 4
-  ZEEBE_TEST_DOCKER_IMAGE: localhost:5000/camunda/zeebe:current-test
-```
-
-Let's break this down a bit.
-
-1. Ensure the agent logs are verbose. TCC is still a beta product, so we want to make sure we can provide as much feedback as possible when troubleshooting any issues.
-2. Define how many concurrent remote VMs our tests can use to start containers on.
-3. Specify the name of the image our container based tests should use.
-
-You'll notice the image name starts with a URL, because we'll be using a local Docker registry. This is required because we want to use the image that we build as part of the pipeline, without pushing it to any public Docker registry. By using a local registry and exposing it to TCC, we can use "private" images.
-
-To set up a local Docker registry, we'll use a [GitHub Actions service container](https://docs.github.com/en/actions/using-containerized-services/about-service-containers). Add the following to your job definition:
-
-```yaml
-services:
-  registry:
-    image: registry:2
-    ports:
-      - 5000:5000
-```
-
-With the registry set up, the next step is to push the Docker image we're building to it.
-
-```yaml
-- uses: ./.github/actions/build-platform-docker
-  with:
-    repository: localhost:5000/camunda/zeebe
-    version: current-test
-    push: true
-    distball: ${{ steps.build-zeebe.outputs.distball }}
-```
-
-Finally, we set up the TCC agent. This can be added as a step in any workflow, provided the `TCC_CLOUD_TOKEN` secret is made available to the job.
-
-```yaml
-- name: Prepare Testcontainers Cloud agent
-  if: env.TC_CLOUD_TOKEN != ''
-  run: |
-    curl -L -o agent https://app.testcontainers.cloud/download/testcontainers-cloud-agent_linux_x86-64
-    chmod +x agent
-    ./agent --private-registry-url=http://localhost:5000 '--private-registry-allowed-image-name-globs=*,*/*' > .testcontainers-agent.log 2>&1 &
-    ./agent wait
-  env:
-    TC_CLOUD_TOKEN: ${{ secrets.TC_CLOUD_TOKEN }}
-```
-
-Let's break this down. This step is conditional on the authentication token being present. This is a simple way to have a kill switch to disable it, by either removing the secret, or removing its exposure from your workflow/job. Testcontainers will work normally with the local Docker daemon available on the node without the agent.
-
-Next the agent is downloaded (always using the latest version) and started. Since we want to test our own image that we built and pushed to our local registry, we'll expose it to the remote VM. Finally, we'll log everything to a file which will be included in the job's test published artifacts in case of failure.
-
-#### Troubleshooting
-
-For questions, support, feedback, documentation, etc., around TCC, Camunda has a private Slack channel with AtomicJar. The complete Zeebe team should have been invited already, but in case you were not, ask any other team member to add you.
-
-If we're having recurring problems which are blocking us from working, we can simply disable the step which runs the agent to disable TCC. Nothing else in the code will need to be changed. Do write in the Slack channel so the people behind TCC are aware and can help us troubleshoot the issue.
-
-> Note that disabling TCC may impact your tests, as now everything runs on the same VM and shares the same resources, which may increase flakiness, for example. If this is the case, we could consider temporarily increasing the runner VMs.
-
-When writing in the Slack channel, please provide the logs from the `Prepare Testcontainers Cloud agent` step, as well as the log file included in the job's uploaded artifacts (i.e. `.testcontainers-agent.log`), and a link to a failing run.
-
-### Failing tests
+# Failing tests
 
 At times, there will be tests which only fail intermittently. It's critical to determine if these
 are real bugs or if they are simply flaky tests.
 
-#### Determine flakiness
+## Determine flakiness
 
 In case the CI reports a flaky test, you can perform the following steps to determine your next
 action.
@@ -158,7 +14,7 @@ action.
   - If the flaky test is unrelated to your code changes, [create a new "Unstable test" issue](https://github.com/camunda/camunda/issues/new?assignees=&labels=kind%2Fflake&template=unstable_test.md&title=). Fill out the provided issue template with as much information about the flaky test.
   - If the flaky test is related to your code changes, you should fix the flakiness before merging your code changes. You can follow the sections below on what to do in order to reproduce and root cause the problem.
 
-#### Reproduce locally
+## Reproduce locally
 
 Your first approach should be to reproduce the failure locally in the simplest way.
 
@@ -174,11 +30,11 @@ Here are some tips to do so:
 
 If you cannot reproduce it locally, the next step is to reproduce it in our CI environment.
 
-#### Reproduce in CI
+## Reproduce in CI
 
 The first thing we'll do is create a branch so we can run everything in isolation.
 
-##### Isolate test environment
+### Isolate test environment
 
 ```shell
 git checkout -b 12983-flaky-test-issue-repro
@@ -190,7 +46,7 @@ run [the CI workflow](https://github.com/camunda/camunda/actions/workflows/zeebe
 branch as many times as you want. If you don't know how to do this, you can read up on
 it [here](https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow).
 
-##### Run a single job
+### Run a single job
 
 The next step is to narrow down the workflow to our failing test. This will make the feedback loop
 shorter, and minimize resource usage during investigation.
@@ -211,7 +67,7 @@ Commit and push this to your branch, then using workflow dispatch, run the CI wo
 times. If you can still reproduce it, then keep narrowing! If not, then revert the change, and give
 up on narrowing.
 
-##### Run a single test
+### Run a single test
 
 Assuming you can still narrow the scope of the workflow, the next step is to have the job execute
 only a single test. In
@@ -231,7 +87,7 @@ Then as before, commit, push and run the CI workflow manually - check its execut
 behaves as expected. Try to reproduce the failure with this; if it works, great, that's a much
 faster feedback loop. If it doesn't, then you unfortunately have to revert your changes.
 
-##### Debugging
+### Debugging
 
 > NOTE: the end of this process is somewhat convoluted, so do not hesitate to suggest things which may
 > simplify it.


### PR DESCRIPTION
# Description
Backport of #36840 to `stable/8.7`.

relates to 