### PR TITLE
[Backport stable/8.7] fix: always take a snapshot after update, even without any migrations

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/AsyncSnapshotDirector.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/AsyncSnapshotDirector.java
@@ -216,12 +216,9 @@ public final class AsyncSnapshotDirector extends Actor
               if (error != null) {
                 LOG.error(ERROR_MSG_ON_RESOLVE_PROCESSED_POS, error);
                 snapshotFuture.completeExceptionally(error);
-              } else if (position == StreamProcessor.UNSET_POSITION) {
-                LOG.debug(
-                    "We will skip taking this snapshot, because we haven't processed anything yet.");
-                snapshotFuture.complete(null);
               } else {
-                inProgressSnapshot.lowerBoundSnapshotPosition = position;
+                inProgressSnapshot.lowerBoundSnapshotPosition =
+                    position == StreamProcessor.UNSET_POSITION ? 0L : position;
                 snapshot(inProgressSnapshot).onComplete(snapshotFuture);
               }
             });

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/MigrationTransitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/MigrationTransitionStep.java
@@ -58,7 +58,7 @@ public class MigrationTransitionStep implements PartitionTransitionStep {
     try {
       final var migrationsPerformed = dbMigrator.runMigrations();
       zeebeDbContext.getCurrentTransaction().commit();
-      if (migrationsPerformed.migrations() > 0) {
+      if (migrationsPerformed.versionChanged()) {
         context.markMigrationsDone();
       }
     } catch (final Exception e) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigrator.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigrator.java
@@ -16,9 +16,9 @@ public interface DbMigrator {
    */
   MigrationsPerformed runMigrations();
 
-  record MigrationsPerformed(int initializations, int migrations) {
-    public static MigrationsPerformed zero() {
-      return new MigrationsPerformed(0, 0);
+  record MigrationsPerformed(int initializations, int migrations, boolean versionChanged) {
+    public static MigrationsPerformed none() {
+      return new MigrationsPerformed(0, 0, false);
     }
 
     public static MigrationsPerformed fromList(final List<MigrationTask> executedMigrations) {
@@ -31,7 +31,7 @@ public interface DbMigrator {
           migrations++;
         }
       }
-      return new MigrationsPerformed(initializations, migrations);
+      return new MigrationsPerformed(initializations, migrations, true);
     }
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigratorImpl.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigratorImpl.java
@@ -113,7 +113,7 @@ public class DbMigratorImpl implements DbMigrator {
         break;
       case final Compatible.SameVersion compatible:
         LOGGER.debug("No migrations to run, snapshot is the same as current version");
-        return MigrationsPerformed.zero();
+        return MigrationsPerformed.none();
       default:
         break;
     }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/BrokerAdminServiceEndpointTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/BrokerAdminServiceEndpointTest.java
@@ -37,125 +37,144 @@ public class BrokerAdminServiceEndpointTest {
   private static final String EXPECTED_PARTITIONS_JSON =
       // language=JSON
       """
-      {
-        "1": {
-          "role": "LEADER",
-          "processedPosition": -1,
-          "snapshotId": null,
-          "processedPositionInSnapshot": null,
-          "streamProcessorPhase": "PROCESSING",
-          "exporterPhase": "EXPORTING",
-          "exportedPosition": -1,
-          "clock": {
-            "instant": "2024-10-29T07:10:02.688Z",
-            "modificationType": "None",
-            "modification": {}
-          },
-          "health": {
-            "id": "Partition-1",
-            "name": "Partition-1",
-            "status": "HEALTHY",
-            "componentsState": "HEALTHY",
-            "children": [
-                {
-                 "id": "SnapshotDirector-1",
-                 "name": "SnapshotDirector-1",
-                 "status": "HEALTHY",
-                 "children": []
-               },
-               {
-                 "id": "ZeebePartitionHealth-1",
-                 "name": "ZeebePartitionHealth-1",
-                 "status": "HEALTHY",
-                 "children": []
-               },
-               {
-                 "id": "StreamProcessor-1",
-                 "name": "StreamProcessor-1",
-                 "status": "HEALTHY",
-                 "children": []
-               },
-               {
-                 "id": "Exporter-1",
-                 "name": "Exporter-1",
-                 "status": "HEALTHY",
-                 "children": []
-               },
-               {
-                 "id": "RaftPartition-1",
-                 "name": "RaftPartition-1",
-                 "status": "HEALTHY",
-                 "children": []
+          {
+            "1": {
+              "role": "LEADER",
+              "processedPosition": -1,
+              "snapshotId": "0-0-0-0-0",
+              "processedPositionInSnapshot": 0,
+              "streamProcessorPhase": "PROCESSING",
+              "exporterPhase": "EXPORTING",
+              "exportedPosition": -1,
+              "clock": {
+                "instant": "2024-10-29T07:10:02.688Z",
+                "modificationType": "None",
+                "modification": {}
+              },
+              "health": {
+                "id": "Partition-1",
+                "name": "Partition-1",
+                "status": "HEALTHY",
+                "componentsState": "HEALTHY",
+                "children": [
+                    {
+                     "id": "SnapshotDirector-1",
+                     "name": "SnapshotDirector-1",
+                     "status": "HEALTHY",
+                     "children": []
+                   },
+                   {
+                     "id": "ZeebePartitionHealth-1",
+                     "name": "ZeebePartitionHealth-1",
+                     "status": "HEALTHY",
+                     "children": []
+                   },
+                   {
+                     "id": "StreamProcessor-1",
+                     "name": "StreamProcessor-1",
+                     "status": "HEALTHY",
+                     "children": []
+                   },
+                   {
+                     "id": "Exporter-1",
+                     "name": "Exporter-1",
+                     "status": "HEALTHY",
+                     "children": []
+                   },
+                   {
+                     "id":"MigrationSnapshotDirector",
+                     "name":"MigrationSnapshotDirector",
+                     "status":"HEALTHY",
+                     "children":[]
+                   },
+                   {
+                     "id": "RaftPartition-1",
+                     "name": "RaftPartition-1",
+                     "status": "HEALTHY",
+                     "children": []
+                   }
+                 ]
                }
-             ]
-           }
-        }
-      }
-      """;
+            }
+          }
+          """;
   private static final String EXPECTED_PARTITION_JSON =
       // language=JSON
       """
-      {
-        "role": "LEADER",
-        "processedPosition": -1,
-        "snapshotId": null,
-        "processedPositionInSnapshot": null,
-        "streamProcessorPhase": "PROCESSING",
-        "exporterPhase": "EXPORTING",
-        "exportedPosition": -1,
-        "clock": {
-          "instant": "2024-10-29T07:24:41.576Z",
-          "modificationType": "None",
-          "modification": {}
-        },
-        "health": {
-             "id": "Partition-1",
-             "name": "Partition-1",
-             "status": "HEALTHY",
-             "componentsState": "HEALTHY",
-             "children": [
-               {
-                 "id": "SnapshotDirector-1",
-                 "name": "SnapshotDirector-1",
+          {
+            "role": "LEADER",
+            "processedPosition": -1,
+            "snapshotId": "0-0-0-0-0",
+            "processedPositionInSnapshot": 0,
+            "streamProcessorPhase": "PROCESSING",
+            "exporterPhase": "EXPORTING",
+            "exportedPosition": -1,
+            "clock": {
+              "instant": "2024-10-29T07:24:41.576Z",
+              "modificationType": "None",
+              "modification": {}
+            },
+            "health": {
+                 "id": "Partition-1",
+                 "name": "Partition-1",
                  "status": "HEALTHY",
-                 "children": []
-               },
-               {
-                 "id": "ZeebePartitionHealth-1",
-                 "name": "ZeebePartitionHealth-1",
-                 "status": "HEALTHY",
-                 "children": []
-               },
-               {
-                 "id": "StreamProcessor-1",
-                 "name": "StreamProcessor-1",
-                 "status": "HEALTHY",
-                 "children": []
-               },
-               {
-                 "id": "Exporter-1",
-                 "name": "Exporter-1",
-                 "status": "HEALTHY",
-                 "children": []
-               },
-               {
-                 "id": "RaftPartition-1",
-                 "name": "RaftPartition-1",
-                 "status": "HEALTHY",
-                 "children": []
+                 "componentsState": "HEALTHY",
+                 "children": [
+                   {
+                     "id": "SnapshotDirector-1",
+                     "name": "SnapshotDirector-1",
+                     "status": "HEALTHY",
+                     "children": []
+                   },
+                   {
+                     "id": "ZeebePartitionHealth-1",
+                     "name": "ZeebePartitionHealth-1",
+                     "status": "HEALTHY",
+                     "children": []
+                   },
+                   {
+                     "id": "StreamProcessor-1",
+                     "name": "StreamProcessor-1",
+                     "status": "HEALTHY",
+                     "children": []
+                   },
+                   {
+                     "id": "Exporter-1",
+                     "name": "Exporter-1",
+                     "status": "HEALTHY",
+                     "children": []
+                   },
+                   {
+                     "id":"MigrationSnapshotDirector",
+                     "name":"MigrationSnapshotDirector",
+                     "status":"HEALTHY",
+                     "children":[]
+                   },
+                   {
+                     "id": "RaftPartition-1",
+                     "name": "RaftPartition-1",
+                     "status": "HEALTHY",
+                     "children": []
+                   }
+                 ]
                }
-             ]
-           }
-      }
-      """;
+          }
+          """;
 
   private static String sanitizeJson(final String json) {
     final var timestampPattern =
         Pattern.compile("\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{3}Z");
     final var timestampReplacement = "2024-10-29T07:10:02.688Z";
+
+    // snapshot checksum is not deterministic, so we replace it with a constant value
+    final var snapshotChecksumPattern = Pattern.compile("\\d+-\\d+-\\d+-\\d+-\\d+-\\w+");
+    final var snapshotChecksumReplacement = "2-1-2-9223372036854775807-0-a06ff57d";
+
     return json
         // map timestamp into the same value
         .replaceAll(timestampPattern.pattern(), timestampReplacement)
+        // map snapshot checksum into a constant value
+        .replaceAll(snapshotChecksumPattern.pattern(), snapshotChecksumReplacement)
         // remove all whitespaces from the pretty printing
         .replaceAll("\\s", "");
   }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/system/BrokerAdminServiceClusterTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/system/BrokerAdminServiceClusterTest.java
@@ -73,16 +73,11 @@ public class BrokerAdminServiceClusterTest {
     followerStatus.forEach(
         partitionStatus -> {
           assertThat(partitionStatus.role()).isEqualTo(Role.FOLLOWER);
-          assertThat(partitionStatus.processedPosition()).isEqualTo(-1L);
-          assertThat(partitionStatus.snapshotId()).isNull();
-          assertThat(partitionStatus.processedPositionInSnapshot()).isNull();
           assertThat(partitionStatus.streamProcessorPhase()).isEqualTo(Phase.REPLAY);
         });
 
     assertThat(leaderStatus.role()).isEqualTo(Role.LEADER);
     assertThat(leaderStatus.processedPosition()).isEqualTo(-1);
-    assertThat(leaderStatus.snapshotId()).isNull();
-    assertThat(leaderStatus.processedPositionInSnapshot()).isNull();
     assertThat(leaderStatus.streamProcessorPhase()).isEqualTo(Phase.PROCESSING);
   }
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/system/BrokerAdminServiceWithOutExporterTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/system/BrokerAdminServiceWithOutExporterTest.java
@@ -36,8 +36,8 @@ public class BrokerAdminServiceWithOutExporterTest {
     final var partitionStatus = leaderAdminService.getPartitionStatus().get(1);
     assertThat(partitionStatus.role()).isEqualTo(Role.LEADER);
     assertThat(partitionStatus.processedPosition()).isEqualTo(-1);
-    assertThat(partitionStatus.snapshotId()).isNull();
-    assertThat(partitionStatus.processedPositionInSnapshot()).isNull();
+    assertThat(partitionStatus.snapshotId()).isNotNull();
+    assertThat(partitionStatus.processedPositionInSnapshot()).isEqualTo(0);
     assertThat(partitionStatus.streamProcessorPhase()).isEqualTo(Phase.PROCESSING);
     assertThat(partitionStatus.exporterPhase()).isEqualTo(ExporterPhase.EXPORTING);
     assertThat(partitionStatus.exportedPosition()).isEqualTo(-1);

--- a/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/NoSnapshotTest.java
+++ b/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/NoSnapshotTest.java
@@ -46,11 +46,11 @@ final class NoSnapshotTest {
     state.withNetwork(network).withOldBroker().start(true);
     final long processInstanceKey = testCase.setUp(state.client());
     final long key = testCase.runBefore(state);
+    assertThat(state).hasNoSnapshotAvailable(1);
 
     // when
     state.close();
     state.withNewBroker().start(true);
-    assertThat(state).hasNoSnapshotAvailable(1);
 
     // then
     testCase.runAfter(state, processInstanceKey, key);


### PR DESCRIPTION
We shouldn't rely on the number of migrations, even if we only just updated the version number, we must take a new snapshot.

(cherry picked from commit 81b7d075db6cb7cb2470bd9e53333b0953a0fa5b)

I also had to several other commits that adjusted tests.
The only new commit is 0aa3d73a3bd1fa1ed3e41d9ea1299c81e5e49742, somehow that wasn't necessary on main.