### PR TITLE
Support `camunda.security.multi-tenancy.checks-enabled` (kebab-case)

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/search/ResourceAccessControllerConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/search/ResourceAccessControllerConfiguration.java
@@ -23,7 +23,6 @@ import io.camunda.security.reader.ResourceAccessProvider;
 import io.camunda.security.reader.TenantAccessProvider;
 import io.camunda.spring.utils.ConditionalOnSecondaryStorageEnabled;
 import io.camunda.zeebe.gateway.rest.ConditionalOnRestGatewayEnabled;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -33,22 +32,11 @@ import org.springframework.context.annotation.Configuration;
 public class ResourceAccessControllerConfiguration {
 
   @Bean
-  @ConditionalOnProperty(
-      prefix = "camunda.security.authorizations",
-      name = "enabled",
-      havingValue = "true",
-      matchIfMissing = true)
-  public ResourceAccessProvider resourceAccessProvider(final AuthorizationChecker checker) {
-    return new DefaultResourceAccessProvider(checker);
-  }
-
-  @Bean
-  @ConditionalOnProperty(
-      prefix = "camunda.security.authorizations",
-      name = "enabled",
-      havingValue = "false")
-  public ResourceAccessProvider disabledResourceAccessProvider() {
-    return new DisabledResourceAccessProvider();
+  public ResourceAccessProvider resourceAccessProvider(
+      final SecurityConfiguration securityConfiguration, final AuthorizationChecker checker) {
+    return securityConfiguration.getAuthorizations().isEnabled()
+        ? new DefaultResourceAccessProvider(checker)
+        : new DisabledResourceAccessProvider();
   }
 
   @Bean

--- a/dist/src/main/java/io/camunda/application/commons/search/ResourceAccessControllerConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/search/ResourceAccessControllerConfiguration.java
@@ -16,6 +16,7 @@ import io.camunda.search.clients.auth.DisabledResourceAccessProvider;
 import io.camunda.search.clients.auth.DisabledTenantAccessProvider;
 import io.camunda.search.clients.auth.DocumentBasedResourceAccessController;
 import io.camunda.search.connect.configuration.DatabaseConfig;
+import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.security.impl.AuthorizationChecker;
 import io.camunda.security.reader.ResourceAccessController;
 import io.camunda.security.reader.ResourceAccessProvider;
@@ -51,22 +52,11 @@ public class ResourceAccessControllerConfiguration {
   }
 
   @Bean
-  @ConditionalOnProperty(
-      prefix = "camunda.security.multiTenancy",
-      name = "checksEnabled",
-      havingValue = "true")
-  public TenantAccessProvider tenantAccessProvider() {
-    return new DefaultTenantAccessProvider();
-  }
-
-  @Bean
-  @ConditionalOnProperty(
-      prefix = "camunda.security.multiTenancy",
-      name = "checksEnabled",
-      havingValue = "false",
-      matchIfMissing = true)
-  public TenantAccessProvider disabledTenantAccessProvider() {
-    return new DisabledTenantAccessProvider();
+  public TenantAccessProvider tenantAccessProvider(
+      final SecurityConfiguration securityConfiguration) {
+    return securityConfiguration.getMultiTenancy().isChecksEnabled()
+        ? new DefaultTenantAccessProvider()
+        : new DisabledTenantAccessProvider();
   }
 
   @Bean

--- a/dist/src/test/java/io/camunda/application/commons/search/ResourceAccessControllerConfigurationTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/search/ResourceAccessControllerConfigurationTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.application.commons.search;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import io.camunda.application.commons.security.CamundaSecurityConfiguration;
+import io.camunda.configuration.UnifiedConfiguration;
+import io.camunda.configuration.UnifiedConfigurationHelper;
+import io.camunda.search.clients.auth.DefaultTenantAccessProvider;
+import io.camunda.search.clients.auth.DisabledTenantAccessProvider;
+import io.camunda.security.impl.AuthorizationChecker;
+import io.camunda.security.reader.TenantAccessProvider;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
+
+public class ResourceAccessControllerConfigurationTest {
+
+  private WebApplicationContextRunner baseRunner() {
+    return new WebApplicationContextRunner()
+        .withUserConfiguration(
+            ResourceAccessControllerConfiguration.class,
+            CamundaSecurityConfiguration.class,
+            UnifiedConfiguration.class,
+            UnifiedConfigurationHelper.class)
+        .withBean(AuthorizationChecker.class, () -> mock(AuthorizationChecker.class))
+        // make REST gateway condition pass
+        .withPropertyValues(
+            "zeebe.broker.gateway.enable=true",
+            "camunda.rest.enabled=true",
+            // avoid needing AuthorizationChecker by disabling authorizations
+            "camunda.security.authorizations.enabled=false",
+            // choose a supported secondary storage type for document-based RAC beans
+            "camunda.database.type=elasticsearch");
+  }
+
+  @Test
+  public void camelCaseEnabledCreatesDefaultTenantProvider() {
+    baseRunner()
+        .withPropertyValues("camunda.security.multiTenancy.checksEnabled=true")
+        .run(
+            context -> {
+              assertThat(context).hasSingleBean(TenantAccessProvider.class);
+              final var tap = context.getBean(TenantAccessProvider.class);
+              assertThat(tap).isInstanceOf(DefaultTenantAccessProvider.class);
+            });
+  }
+
+  @Test
+  public void camelCaseDisabledCreatesDisabledTenantProvider() {
+    baseRunner()
+        .withPropertyValues("camunda.security.multiTenancy.checksEnabled=false")
+        .run(
+            context -> {
+              assertThat(context).hasSingleBean(TenantAccessProvider.class);
+              final var tap = context.getBean(TenantAccessProvider.class);
+              assertThat(tap).isInstanceOf(DisabledTenantAccessProvider.class);
+            });
+  }
+
+  @Test
+  public void kebabCaseEnabledCreatesDefaultTenantProvider() {
+    baseRunner()
+        .withPropertyValues("camunda.security.multi-tenancy.checks-enabled=true")
+        .run(
+            context -> {
+              assertThat(context).hasSingleBean(TenantAccessProvider.class);
+              final var tap = context.getBean(TenantAccessProvider.class);
+              assertThat(tap).isInstanceOf(DefaultTenantAccessProvider.class);
+            });
+  }
+
+  @Test
+  public void kebabCaseDisabledCreatesDisabledTenantProvider() {
+    baseRunner()
+        .withPropertyValues("camunda.security.multi-tenancy.checks-enabled=false")
+        .run(
+            context -> {
+              assertThat(context).hasSingleBean(TenantAccessProvider.class);
+              final var tap = context.getBean(TenantAccessProvider.class);
+              assertThat(tap).isInstanceOf(DisabledTenantAccessProvider.class);
+            });
+  }
+
+  @Test
+  public void missingPropertyCreatesDisabledTenantProvider() {
+    baseRunner()
+        .run(
+            context -> {
+              assertThat(context).hasSingleBean(TenantAccessProvider.class);
+              final var tap = context.getBean(TenantAccessProvider.class);
+              assertThat(tap).isInstanceOf(DisabledTenantAccessProvider.class);
+            });
+  }
+}

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/properties/MultiTenancyChecksIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/properties/MultiTenancyChecksIT.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.operate.properties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.application.commons.security.CamundaSecurityConfiguration.CamundaSecurityProperties;
+import io.camunda.configuration.UnifiedConfiguration;
+import io.camunda.configuration.UnifiedConfigurationHelper;
+import io.camunda.security.configuration.SecurityConfiguration;
+import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(Enclosed.class)
+public class MultiTenancyChecksIT {
+
+  @RunWith(SpringRunner.class)
+  @TestPropertySource(properties = {"camunda.security.multiTenancy.checksEnabled=true"})
+  public static class EnabledCamelCaseIT extends BaseIT {
+
+    @Test
+    public void shouldEnableChecksWithCamelCaseProperty() {
+      assertThat(securityConfiguration.getMultiTenancy().isChecksEnabled()).isEqualTo(true);
+    }
+  }
+
+  @RunWith(SpringRunner.class)
+  @TestPropertySource(properties = {"camunda.security.multiTenancy.checksEnabled=false"})
+  public static class DisabledCamelCaseIT extends BaseIT {
+
+    @Test
+    public void shouldDisableChecksWithCamelCaseProperty() {
+      assertThat(securityConfiguration.getMultiTenancy().isChecksEnabled()).isEqualTo(false);
+    }
+  }
+
+  @RunWith(SpringRunner.class)
+  @TestPropertySource(properties = {"camunda.security.multi-tenancy.checks-enabled=true"})
+  public static class EnabledKebabCaseIT extends BaseIT {
+
+    @Test
+    public void shouldEnableChecksWithKebabCaseProperty() {
+      assertThat(securityConfiguration.getMultiTenancy().isChecksEnabled()).isEqualTo(true);
+    }
+  }
+
+  @RunWith(SpringRunner.class)
+  @TestPropertySource(properties = {"camunda.security.multi-tenancy.checks-enabled=false"})
+  public static class DisabledKebabCaseIT extends BaseIT {
+
+    @Test
+    public void shouldDisableChecksWithKebabCaseProperty() {
+      assertThat(securityConfiguration.getMultiTenancy().isChecksEnabled()).isEqualTo(false);
+    }
+  }
+
+  @SpringBootTest(
+      classes = {
+        CamundaSecurityProperties.class,
+        UnifiedConfiguration.class,
+        UnifiedConfigurationHelper.class
+      },
+      webEnvironment = SpringBootTest.WebEnvironment.NONE)
+  public abstract static class BaseIT {
+    @Autowired protected SecurityConfiguration securityConfiguration;
+  }
+}


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR adds support for configuring the multi-tenancy checks using kebab-case:
- `camunda.security.multi-tenancy.checks-enabled`

This comes in addition to the already supported camelCase style:
- `camunda.security.multiTenancy.checksEnabled`

It achieves this by depending on the SecurityConfiguration which correctly handle the different cases.

The PR adds test cases to show that the tenant provider can be configured using either of these properties.

> [!NOTE]
> This PR does not add anything to discourage the conflicting configuration using a combination of both styles, e.g.:
> ```
> camunda.security.multi-tenancy.checks-enabled=true
> camunda.security.multiTenancy.checksEnabled=false
> ```

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #36597 
