### PR TITLE
Verify event sub-process in ad-hoc sub-process

### DIFF
--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/ProcessInstanceRecordStream.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/ProcessInstanceRecordStream.java
@@ -12,6 +12,7 @@ import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.BpmnEventType;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
+import java.util.List;
 import java.util.stream.Stream;
 
 public final class ProcessInstanceRecordStream
@@ -57,6 +58,10 @@ public final class ProcessInstanceRecordStream
 
   public ProcessInstanceRecordStream withElementId(final String elementId) {
     return valueFilter(v -> elementId.equals(v.getElementId()));
+  }
+
+  public ProcessInstanceRecordStream withElementIdIn(final String... elementIds) {
+    return valueFilter(v -> List.of(elementIds).contains(v.getElementId()));
   }
 
   public ProcessInstanceRecordStream withFlowScopeKey(final long flowScopeKey) {


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Adds different scenarios for both job based and non job based ad-hoc sub-processes:

1. The process can be deployed if it contains an event sub-process inside of an ad-hoc sub-process.
2. The event sub-process can be triggered
3. The event sub-process can be triggered multiple times
4. The output collection is updated when the event sub-process completes
5. A job is recreated when the event sub-process completes.


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes https://github.com/camunda/ad-hoc-sub-process-phase-3/issues/19
