### PR TITLE
fix: remove version tag requirement when deleting backup

### DIFF
--- a/webapps-backup/src/main/java/io/camunda/webapps/backup/BackupServiceImpl.java
+++ b/webapps-backup/src/main/java/io/camunda/webapps/backup/BackupServiceImpl.java
@@ -56,7 +56,9 @@ public class BackupServiceImpl implements BackupService {
     final int partCount = backupMetadata.partCount();
     for (int partIdx = 1; partIdx <= partCount; partIdx++) {
       final String snapshotName =
-          repository.snapshotNameProvider().getSnapshotName(backupMetadata.withPart(partIdx));
+          repository
+              .snapshotNameProvider()
+              .getSnapshotName(backupMetadata.withPart(partIdx).withVersion("*"));
       repository.deleteSnapshot(repositoryName, snapshotName);
     }
   }

--- a/webapps-backup/src/main/java/io/camunda/webapps/backup/Metadata.java
+++ b/webapps-backup/src/main/java/io/camunda/webapps/backup/Metadata.java
@@ -20,4 +20,8 @@ public record Metadata(Long backupId, String version, Integer partNo, Integer pa
   public Metadata withPart(final int part) {
     return new Metadata(backupId, version, part, partCount);
   }
+
+  public Metadata withVersion(final String version) {
+    return new Metadata(backupId, version, partNo, partCount);
+  }
 }

--- a/webapps-backup/src/test/java/io/camunda/webapps/backup/BackupServiceImplTest.java
+++ b/webapps-backup/src/test/java/io/camunda/webapps/backup/BackupServiceImplTest.java
@@ -153,9 +153,9 @@ public class BackupServiceImplTest {
     // all the snapshot parts created are removed
     assertThat(backupRepository.removedSnasphotNames)
         .contains(
-            "camunda_webapps_1_8.3_part_1_of_3",
-            "camunda_webapps_1_8.3_part_2_of_3",
-            "camunda_webapps_1_8.3_part_3_of_3");
+            "camunda_webapps_1_*_part_1_of_3",
+            "camunda_webapps_1_*_part_2_of_3",
+            "camunda_webapps_1_*_part_3_of_3");
   }
 
   private void waitForAllTasks() {


### PR DESCRIPTION
## Description

fix: remove version tag requirement when deleting backup

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

Related to https://github.com/camunda/camunda/issues/18869, https://github.com/camunda/camunda/issues/20458
