### PR TITLE
ArchUnit rule to support both camelCase and kebab-case in ConditionalOnProperty

### DIFF
--- a/operate/importer/src/main/java/io/camunda/operate/ImportModuleConfiguration.java
+++ b/operate/importer/src/main/java/io/camunda/operate/ImportModuleConfiguration.java
@@ -20,7 +20,7 @@ import org.springframework.context.annotation.FullyQualifiedAnnotationBeanNameGe
     basePackages = "io.camunda.operate.zeebeimport",
     nameGenerator = FullyQualifiedAnnotationBeanNameGenerator.class)
 @ConditionalOnProperty(
-    name = "camunda.operate.importerEnabled",
+    name = "camunda.operate.importer-enabled",
     havingValue = "true",
     matchIfMissing = true)
 public class ImportModuleConfiguration {

--- a/operate/webapp/src/main/java/io/camunda/operate/WebappModuleConfiguration.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/WebappModuleConfiguration.java
@@ -20,7 +20,7 @@ import org.springframework.context.annotation.FullyQualifiedAnnotationBeanNameGe
     basePackages = "io.camunda.operate.webapp",
     nameGenerator = FullyQualifiedAnnotationBeanNameGenerator.class)
 @ConditionalOnProperty(
-    name = "camunda.operate.webappEnabled",
+    name = "camunda.operate.webapp-enabled",
     havingValue = "true",
     matchIfMissing = true)
 public class WebappModuleConfiguration {

--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,7 @@
     <module>security</module>
     <module>migration</module>
     <module>configuration</module>
+    <module>qa</module>
   </modules>
 
   <scm>

--- a/qa/README.md
+++ b/qa/README.md
@@ -4,4 +4,5 @@ This module contains different tests to ensure the quality of the Camunda 8 Plat
 
 * [E2E- Component test suite](/qa/c8-orchestration-cluster-e2e-test-suite/README.md) - maintained by QA
 * [Camunda 8 - Orchestration cluster acceptance tests](/qa/acceptance-tests/README.md) - mainted by the Orchestration Cluster Engineers
+* [Camunda 8 - Orchestration cluster ArchUnit tests](/qa/archunit-tests/README.md) - maintained by the Orchestration Cluster Engineers
 

--- a/qa/archunit-tests/README.md
+++ b/qa/archunit-tests/README.md
@@ -1,12 +1,14 @@
 # Camunda 8 - Orchestration cluster ArchUnit tests
 
 This module contains [ArchUnit](https://www.archunit.org/) tests for the Camunda 8 orchestration cluster, ensuring that the production code adheres to architectural rules and best practices.
-These tests can also enforce certain coding standards that prevent bugs like [RequireKebabCaseInConditionalOnPropertyArchTest](./src/test/java/io/camunda/archunit/RequireKebabCaseInConditionalOnPropertyArchTest.java).
+These tests can also enforce certain coding standards that prevent bugs like [RequireKebabCaseInConditionalOnPropertyArchTest](./src/test/java/io/camunda/RequireKebabCaseInConditionalOnPropertyArchTest.java).
 
 To run these tests, you can use the following command:
 
 ```sh
 ./mvnw test -pl :camunda-archunit-tests
 ```
+
+ArchUnit tests in this module can be organized in packages reflecting the structure of the codebase.
 
 For more information on how to write ArchUnit tests, see the [ArchUnit documentation](https://www.archunit.org/userguide/html/000_Index.html).

--- a/qa/archunit-tests/README.md
+++ b/qa/archunit-tests/README.md
@@ -1,0 +1,11 @@
+# Camunda 8 - Orchestration cluster ArchUnit tests
+
+This module contains [ArchUnit](https://www.archunit.org/) tests for the Camunda 8 orchestration cluster, ensuring that the production code adheres to architectural rules and best practices.
+
+To run these tests, you can use the following command:
+
+```sh
+./mvnw test -pl :camunda-archunit-tests
+```
+
+For more information on how to write ArchUnit tests, see the [ArchUnit documentation](https://www.archunit.org/userguide/html/000_Index.html).

--- a/qa/archunit-tests/README.md
+++ b/qa/archunit-tests/README.md
@@ -1,6 +1,7 @@
 # Camunda 8 - Orchestration cluster ArchUnit tests
 
 This module contains [ArchUnit](https://www.archunit.org/) tests for the Camunda 8 orchestration cluster, ensuring that the production code adheres to architectural rules and best practices.
+These tests can also enforce certain coding standards that prevent bugs like [RequireKebabCaseInConditionalOnPropertyArchTest](./src/test/java/io/camunda/archunit/RequireKebabCaseInConditionalOnPropertyArchTest.java).
 
 To run these tests, you can use the following command:
 

--- a/qa/archunit-tests/pom.xml
+++ b/qa/archunit-tests/pom.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>io.camunda</groupId>
+    <artifactId>camunda-qa</artifactId>
+    <version>8.8.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>camunda-archunit-tests</artifactId>
+  <packaging>jar</packaging>
+  <name>Camunda ArchUnit Tests</name>
+
+  <dependencies>
+    <!-- Depend on dist [camunda-zeebe] to cover all production code  -->
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-zeebe</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.tngtech.archunit</groupId>
+      <artifactId>archunit</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.tngtech.archunit</groupId>
+      <artifactId>archunit-junit5-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.tngtech.archunit</groupId>
+      <artifactId>archunit-junit5-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <!-- Run ArchUnit with surefire rather than failsafe -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <skip>${skipUTs}</skip>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <configuration>
+          <ignoredUnusedDeclaredDependencies>
+            <dep>io.camunda:camunda-zeebe</dep>
+          </ignoredUnusedDeclaredDependencies>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/qa/archunit-tests/pom.xml
+++ b/qa/archunit-tests/pom.xml
@@ -37,6 +37,12 @@
       <artifactId>archunit-junit5-engine</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-autoconfigure</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/qa/archunit-tests/src/test/java/io/camunda/RequireKebabCaseInConditionalOnPropertyArchTest.java
+++ b/qa/archunit-tests/src/test/java/io/camunda/RequireKebabCaseInConditionalOnPropertyArchTest.java
@@ -5,7 +5,7 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.archunit;
+package io.camunda;
 
 import com.tngtech.archunit.core.domain.JavaAnnotation;
 import com.tngtech.archunit.core.domain.JavaClass;

--- a/qa/archunit-tests/src/test/java/io/camunda/archunit/RequireKebabCaseInConditionalOnPropertyArchTest.java
+++ b/qa/archunit-tests/src/test/java/io/camunda/archunit/RequireKebabCaseInConditionalOnPropertyArchTest.java
@@ -47,8 +47,7 @@ public final class RequireKebabCaseInConditionalOnPropertyArchTest {
           .that()
           .areAnnotatedWith(ConditionalOnProperty.class)
           .should(
-              new ArchCondition<>(
-                  "Expect attributes of @ConditionalOnProperty to use kebab-case not camelCase") {
+              new ArchCondition<>("Expect attributes of @ConditionalOnProperty to use kebab-case") {
                 @Override
                 public void check(final JavaClass item, final ConditionEvents events) {
                   validateConditionalOnPropertyAnnotations(item.getAnnotations(), item, events);
@@ -61,8 +60,7 @@ public final class RequireKebabCaseInConditionalOnPropertyArchTest {
           .that()
           .areAnnotatedWith(ConditionalOnProperty.class)
           .should(
-              new ArchCondition<>(
-                  "have attributes of @ConditionalOnProperty to use kebab-case not camelCase") {
+              new ArchCondition<>("Expect attributes of @ConditionalOnProperty to use kebab-case") {
                 @Override
                 public void check(final JavaMethod item, final ConditionEvents events) {
                   validateConditionalOnPropertyAnnotations(item.getAnnotations(), item, events);

--- a/qa/archunit-tests/src/test/java/io/camunda/archunit/RequireKebabCaseInConditionalOnPropertyArchTest.java
+++ b/qa/archunit-tests/src/test/java/io/camunda/archunit/RequireKebabCaseInConditionalOnPropertyArchTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.archunit;
+
+import com.tngtech.archunit.core.domain.JavaAnnotation;
+import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.domain.JavaMethod;
+import com.tngtech.archunit.core.domain.properties.HasName;
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.ArchCondition;
+import com.tngtech.archunit.lang.ArchRule;
+import com.tngtech.archunit.lang.ConditionEvent;
+import com.tngtech.archunit.lang.ConditionEvents;
+import com.tngtech.archunit.lang.SimpleConditionEvent;
+import com.tngtech.archunit.lang.syntax.ArchRuleDefinition;
+import java.util.Collection;
+import java.util.regex.Pattern;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+
+/**
+ * ArchUnit rules around Spring's {@link ConditionalOnProperty} to ensure we support both kebab-case
+ * and camelCase segments in properties, by requiring kebab-case in the attributes of
+ * ConditionalOnProperty.
+ *
+ * <p>ConditionalOnProperty attributes require kebab-case to ensure relaxed binding can be applied.
+ * If camelCase is used in the attributes of ConditionalOnProperty, kebab-case configured properties
+ * won't match the conditional's attributes. Vice versa that is not a problem, therefore spring-boot
+ * is clear about requiring kebab-case in the ConditionalOnProperty javadoc. These rules ensure that
+ * we do not accidentally use camelCase in the attributes of this annotation.
+ */
+@AnalyzeClasses(packages = "io.camunda", importOptions = ImportOption.DoNotIncludeTests.class)
+public final class RequireKebabCaseInConditionalOnPropertyArchTest {
+
+  /** Matches any string that contains at least one uppercase character. */
+  static final Pattern FORBIDDEN_CHARS = Pattern.compile(".*([A-Z]).*");
+
+  @ArchTest
+  static final ArchRule REQUIRE_KEBAB_CASE_IN_CONDITIONAL_ON_PROPERTY_ON_TYPES =
+      ArchRuleDefinition.classes()
+          .that()
+          .areAnnotatedWith(ConditionalOnProperty.class)
+          .should(
+              new ArchCondition<>(
+                  "Expect attributes of @ConditionalOnProperty to use kebab-case not camelCase") {
+                @Override
+                public void check(final JavaClass item, final ConditionEvents events) {
+                  validateConditionalOnPropertyAnnotations(item.getAnnotations(), item, events);
+                }
+              });
+
+  @ArchTest
+  static final ArchRule REQUIRE_KEBAB_CASE_IN_CONDITIONAL_ON_PROPERTY_ON_METHODS =
+      ArchRuleDefinition.methods()
+          .that()
+          .areAnnotatedWith(ConditionalOnProperty.class)
+          .should(
+              new ArchCondition<>(
+                  "have attributes of @ConditionalOnProperty to use kebab-case not camelCase") {
+                @Override
+                public void check(final JavaMethod item, final ConditionEvents events) {
+                  validateConditionalOnPropertyAnnotations(item.getAnnotations(), item, events);
+                }
+              });
+
+  /**
+   * Validates that the attributes of {@link ConditionalOnProperty} annotations do not contain
+   * forbidden characters (uppercase). ConditionalOnProperty requires all lower case.
+   *
+   * @param annotations the annotations to validate, e.g. from a class or method
+   * @param owner the element that owns the annotations, e.g. a class or method
+   * @param events collection of events to which violations are added
+   */
+  private static void validateConditionalOnPropertyAnnotations(
+      final Collection<? extends JavaAnnotation<?>> annotations,
+      final HasName.AndFullName owner,
+      final ConditionEvents events) {
+    for (final JavaAnnotation<?> ann : annotations) {
+      if (!ann.getRawType().isEquivalentTo(ConditionalOnProperty.class)) {
+        continue;
+      }
+
+      final ConditionalOnProperty cop = ann.as(ConditionalOnProperty.class);
+
+      // prefix
+      final String prefix = cop.prefix();
+      if (valueContainsForbiddenCharacters(prefix)) {
+        events.add(addViolation(owner, "prefix", prefix));
+      }
+
+      // name
+      for (final String name : cop.name()) {
+        if (valueContainsForbiddenCharacters(name)) {
+          events.add(addViolation(owner, "name", name));
+        }
+      }
+
+      // havingValue
+      final String havingValue = cop.havingValue();
+      if (valueContainsForbiddenCharacters(havingValue)) {
+        events.add(addViolation(owner, "havingValue", havingValue));
+      }
+
+      // value
+      for (final String value : cop.value()) {
+        if (valueContainsForbiddenCharacters(value)) {
+          events.add(addViolation(owner, "value", value));
+        }
+      }
+    }
+  }
+
+  private static boolean valueContainsForbiddenCharacters(final String value) {
+    return value != null && FORBIDDEN_CHARS.matcher(value).matches();
+  }
+
+  private static ConditionEvent addViolation(
+      final HasName.AndFullName element, final String attribute, final String rawValue) {
+    final String message =
+        String.format(
+            """
+            @ConditionalOnProperty on '%s' has invalid %s: '%s' (contains uppercase). \
+            Please use kebab-case instead.""",
+            element.getFullName(), attribute, rawValue);
+    return SimpleConditionEvent.violated(element, message);
+  }
+}

--- a/qa/pom.xml
+++ b/qa/pom.xml
@@ -17,6 +17,7 @@
 
   <modules>
     <module>acceptance-tests</module>
+    <module>archunit-tests</module>
     <module>util</module>
   </modules>
 

--- a/tasklist/data-generator/src/main/java/io/camunda/tasklist/data/es/DevDataGeneratorElasticSearch.java
+++ b/tasklist/data-generator/src/main/java/io/camunda/tasklist/data/es/DevDataGeneratorElasticSearch.java
@@ -30,7 +30,7 @@ import org.springframework.stereotype.Component;
 @Component
 @Profile("dev-data")
 @Conditional(ElasticSearchCondition.class)
-@ConditionalOnProperty(value = "camunda.tasklist.webappEnabled", matchIfMissing = true)
+@ConditionalOnProperty(value = "camunda.tasklist.webapp-enabled", matchIfMissing = true)
 @DependsOn("searchEngineSchemaInitializer")
 public class DevDataGeneratorElasticSearch extends DevDataGeneratorAbstract
     implements DataGenerator {

--- a/tasklist/data-generator/src/main/java/io/camunda/tasklist/data/os/DevDataGeneratorOpenSearch.java
+++ b/tasklist/data-generator/src/main/java/io/camunda/tasklist/data/os/DevDataGeneratorOpenSearch.java
@@ -27,7 +27,7 @@ import org.springframework.stereotype.Component;
 @Component
 @Profile("dev-data")
 @Conditional(OpenSearchCondition.class)
-@ConditionalOnProperty(value = "camunda.tasklist.webappEnabled", matchIfMissing = true)
+@ConditionalOnProperty(value = "camunda.tasklist.webapp-enabled", matchIfMissing = true)
 @DependsOn("searchEngineSchemaInitializer")
 public class DevDataGeneratorOpenSearch extends DevDataGeneratorAbstract implements DataGenerator {
 

--- a/tasklist/importer/src/main/java/io/camunda/tasklist/ImportModuleConfiguration.java
+++ b/tasklist/importer/src/main/java/io/camunda/tasklist/ImportModuleConfiguration.java
@@ -26,7 +26,7 @@ import org.springframework.context.annotation.FullyQualifiedAnnotationBeanNameGe
     },
     nameGenerator = FullyQualifiedAnnotationBeanNameGenerator.class)
 @ConditionalOnProperty(
-    name = "camunda.tasklist.importerEnabled",
+    name = "camunda.tasklist.importer-enabled",
     havingValue = "true",
     matchIfMissing = true)
 public class ImportModuleConfiguration {

--- a/tasklist/importer/src/main/java/io/camunda/tasklist/zeebeimport/security/ImporterSecurityModuleConfiguration.java
+++ b/tasklist/importer/src/main/java/io/camunda/tasklist/zeebeimport/security/ImporterSecurityModuleConfiguration.java
@@ -17,7 +17,7 @@ import org.springframework.context.annotation.FullyQualifiedAnnotationBeanNameGe
     basePackages = "io.camunda.tasklist.zeebeimport.security",
     nameGenerator = FullyQualifiedAnnotationBeanNameGenerator.class)
 @ConditionalOnProperty(
-    name = "camunda.tasklist.importerEnabled",
+    name = "camunda.tasklist.importer-enabled",
     havingValue = "true",
     matchIfMissing = true)
 public class ImporterSecurityModuleConfiguration {}

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/WebappModuleConfiguration.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/WebappModuleConfiguration.java
@@ -26,7 +26,7 @@ import org.springframework.context.annotation.FullyQualifiedAnnotationBeanNameGe
     },
     nameGenerator = FullyQualifiedAnnotationBeanNameGenerator.class)
 @ConditionalOnProperty(
-    name = "camunda.tasklist.webappEnabled",
+    name = "camunda.tasklist.webapp-enabled",
     havingValue = "true",
     matchIfMissing = true)
 public class WebappModuleConfiguration {

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/api/rest/v1/controllers/external/ProcessExternalController.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/api/rest/v1/controllers/external/ProcessExternalController.java
@@ -45,7 +45,7 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "External Process", description = "API to manage processes by external consumers.")
 @RestController
 @ConditionalOnProperty(
-    value = "camunda.tasklist.featureFlag.processPublicEndpoints",
+    value = "camunda.tasklist.feature-flag.process-public-endpoints",
     matchIfMissing = true)
 @RequestMapping(
     value = TasklistURIs.EXTERNAL_PROCESS_URL_V1,

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/management/WebappManagementModuleConfiguration.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/management/WebappManagementModuleConfiguration.java
@@ -17,7 +17,7 @@ import org.springframework.context.annotation.FullyQualifiedAnnotationBeanNameGe
     basePackages = "io.camunda.tasklist.webapp.management",
     nameGenerator = FullyQualifiedAnnotationBeanNameGenerator.class)
 @ConditionalOnProperty(
-    name = "camunda.tasklist.webappEnabled",
+    name = "camunda.tasklist.webapp-enabled",
     havingValue = "true",
     matchIfMissing = true)
 public class WebappManagementModuleConfiguration {}


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR introduces a new module `qa/archunit-test` (`io.camunda:camunda-archunit-tests`) that can be used to define ArchUnit tests to cover the entire production code base.

It also adds an ArchUnit test to this module `RequireKebabCaseInConditionalOnPropertyArchTest` which helps ensure that we support both camelCase and kebab-case for config properties. The `ConditionalOnProperty` annotation requires the usage of kebab-case to support relaxed binding to properties.

To satisfy the new rule, I've also updated several usages of `ConditionalOnProperty` towards the following properties:

| Before | After |
|--------|--------|
|`camunda.tasklist.webappEnabled` | `camunda.tasklist.webapp-enabled` |
|`camunda.operate.webappEnabled` | `camunda.operate.webapp-enabled` |
|`camunda.tasklist.importerEnabled` | `camunda.tasklist.importer-enabled` |
| `camunda.operate.importerEnabled` | `camunda.operate.importer-enabled` | 
| `camunda.tasklist.featureFlag.processPublicEndpoints` | `camunda.tasklist.feature-flag.process-public-endpoints` |

This change is backward compatible.

> [!NOTE]
> This PR does not yet move over existing ArchUnit tests to the new module. I'll raise a discussion about this separately through https://github.com/camunda/camunda/issues/37010.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #36869 
