### PR TITLE
Expose tags for process instance via api and sdk

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/command/CreateProcessInstanceCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/CreateProcessInstanceCommandStep1.java
@@ -20,6 +20,7 @@ import io.camunda.client.api.response.ProcessInstanceResult;
 import java.io.InputStream;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public interface CreateProcessInstanceCommandStep1
     extends CommandWithCommunicationApiStep<CreateProcessInstanceCommandStep1> {
@@ -151,6 +152,70 @@ public interface CreateProcessInstanceCommandStep1
      *     it to the broker
      */
     CreateProcessInstanceWithResultCommandStep1 withResult();
+
+    /**
+     * Add tags to the process instance to be created.
+     *
+     * <p>Tags are de-duplicated. Each tag must follow this format:
+     *
+     * <ul>
+     *   <li>Start with a letter (a-z, A-Z)
+     *   <li>Subsequent characters may be letters, digits, underscore (_), minus (-), colon (:), or
+     *       period (.)
+     *   <li>Length between 1 and 100 characters
+     *   <li>Must not be {@code null} or blank
+     * </ul>
+     *
+     * At most 10 tags can be set.
+     *
+     * @param tags one or more tag values
+     * @return the builder for this command. Call {@link #send()} to complete the command and send
+     *     it to the broker.
+     */
+    CreateProcessInstanceCommandStep3 tags(String... tags);
+
+    /**
+     * Add tags to the process instance to be created.
+     *
+     * <p>Tags are de-duplicated. Each tag must follow this format:
+     *
+     * <ul>
+     *   <li>Start with a letter (a-z, A-Z)
+     *   <li>Subsequent characters may be letters, digits, underscore (_), minus (-), colon (:), or
+     *       period (.)
+     *   <li>Length between 1 and 100 characters
+     *   <li>Must not be {@code null} or blank
+     * </ul>
+     *
+     * At most 10 tags can be set.
+     *
+     * @param tags a collection of tag values
+     * @return the builder for this command. Call {@link #send()} to complete the command and send
+     *     it to the broker.
+     */
+    CreateProcessInstanceCommandStep3 tags(Iterable<String> tags);
+
+    /**
+     * Set the tags of the process instance to be created.
+     *
+     * <p>Duplicates are naturally excluded by the {@link Set} contract. Each tag must follow this
+     * format:
+     *
+     * <ul>
+     *   <li>Start with a letter (a-z, A-Z)
+     *   <li>Subsequent characters may be letters, digits, underscore (_), minus (-), colon (:), or
+     *       period (.)
+     *   <li>Length between 1 and 100 characters
+     *   <li>Must not be {@code null} or blank
+     * </ul>
+     *
+     * At most 10 tags can be set.
+     *
+     * @param tags the set of tag values to apply
+     * @return the builder for this command. Call {@link #send()} to complete the command and send
+     *     it to the broker.
+     */
+    CreateProcessInstanceCommandStep3 tags(Set<String> tags);
   }
 
   interface CreateProcessInstanceWithResultCommandStep1

--- a/clients/java/src/main/java/io/camunda/client/api/response/ProcessInstanceEvent.java
+++ b/clients/java/src/main/java/io/camunda/client/api/response/ProcessInstanceEvent.java
@@ -16,6 +16,7 @@
 package io.camunda.client.api.response;
 
 import io.camunda.client.api.ExperimentalApi;
+import java.util.Set;
 
 public interface ProcessInstanceEvent {
 
@@ -34,4 +35,6 @@ public interface ProcessInstanceEvent {
   /** Tenant identifier that owns this process instance */
   @ExperimentalApi("https://github.com/camunda/camunda/issues/13321")
   String getTenantId();
+
+  Set<String> getTags();
 }

--- a/clients/java/src/main/java/io/camunda/client/api/response/ProcessInstanceResult.java
+++ b/clients/java/src/main/java/io/camunda/client/api/response/ProcessInstanceResult.java
@@ -18,6 +18,7 @@ package io.camunda.client.api.response;
 import io.camunda.client.api.ExperimentalApi;
 import io.camunda.client.api.command.ClientException;
 import java.util.Map;
+import java.util.Set;
 
 public interface ProcessInstanceResult {
   /** Key of the process which this instance was created for */
@@ -65,4 +66,11 @@ public interface ProcessInstanceResult {
   /** Tenant identifier that owns this process instance */
   @ExperimentalApi("https://github.com/camunda/camunda/issues/13321")
   String getTenantId();
+
+  /**
+   * Tags associated with the process instance.
+   *
+   * @return a set of tags
+   */
+  Set<String> getTags();
 }

--- a/clients/java/src/main/java/io/camunda/client/api/search/response/ProcessInstance.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/response/ProcessInstance.java
@@ -16,6 +16,7 @@
 package io.camunda.client.api.search.response;
 
 import io.camunda.client.api.search.enums.ProcessInstanceState;
+import java.util.Set;
 
 public interface ProcessInstance {
 
@@ -44,4 +45,6 @@ public interface ProcessInstance {
   Boolean getHasIncident();
 
   String getTenantId();
+
+  Set<String> getTags();
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/command/CreateProcessInstanceCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/CreateProcessInstanceCommandImpl.java
@@ -30,6 +30,7 @@ import io.camunda.client.impl.http.HttpCamundaFuture;
 import io.camunda.client.impl.http.HttpClient;
 import io.camunda.client.impl.response.CreateProcessInstanceResponseImpl;
 import io.camunda.client.impl.util.ParseUtil;
+import io.camunda.client.impl.util.TagUtil;
 import io.camunda.client.protocol.rest.CreateProcessInstanceResult;
 import io.camunda.client.protocol.rest.ProcessInstanceCreationInstruction;
 import io.camunda.client.protocol.rest.ProcessInstanceCreationTerminateInstruction;
@@ -180,6 +181,7 @@ public final class CreateProcessInstanceCommandImpl
 
   @Override
   public CreateProcessInstanceCommandStep3 tags(final Set<String> tags) {
+    TagUtil.ensureValidTags("tags", tags);
     grpcRequestObjectBuilder.addAllTags(tags);
     httpRequestObject.setTags(tags);
     return this;

--- a/clients/java/src/main/java/io/camunda/client/impl/command/CreateProcessInstanceCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/CreateProcessInstanceCommandImpl.java
@@ -42,6 +42,9 @@ import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ProcessInstanceCreati
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.TerminateProcessInstanceInstruction;
 import io.grpc.stub.StreamObserver;
 import java.time.Duration;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
 import org.apache.hc.client5.http.config.RequestConfig;
@@ -156,6 +159,33 @@ public final class CreateProcessInstanceCommandImpl
         httpClient,
         useRest,
         httpRequestObject);
+  }
+
+  @Override
+  public CreateProcessInstanceCommandStep3 tags(final String... tags) {
+    final Set<String> uniqueTags = new HashSet<>(Arrays.asList(tags)); // ensure no duplicates
+
+    return tags(uniqueTags);
+  }
+
+  @Override
+  public CreateProcessInstanceCommandStep3 tags(final Iterable<String> tags) {
+
+    final Set<String> uniqueTags = new HashSet<>();
+    for (final String item : tags) {
+      uniqueTags.add(item);
+    }
+    return tags(uniqueTags);
+  }
+
+  @Override
+  public CreateProcessInstanceCommandStep3 tags(final Set<String> tags) {
+    // For gRPC, tags support may be added in the future
+    grpcRequestObjectBuilder.addAllTags(tags);
+
+    // For HTTP, use the List directly
+    httpRequestObject.setTags(tags);
+    return this;
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/client/impl/command/CreateProcessInstanceCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/CreateProcessInstanceCommandImpl.java
@@ -180,10 +180,7 @@ public final class CreateProcessInstanceCommandImpl
 
   @Override
   public CreateProcessInstanceCommandStep3 tags(final Set<String> tags) {
-    // For gRPC, tags support may be added in the future
     grpcRequestObjectBuilder.addAllTags(tags);
-
-    // For HTTP, use the List directly
     httpRequestObject.setTags(tags);
     return this;
   }

--- a/clients/java/src/main/java/io/camunda/client/impl/response/CreateProcessInstanceResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/CreateProcessInstanceResponseImpl.java
@@ -18,6 +18,9 @@ package io.camunda.client.impl.response;
 import io.camunda.client.api.response.ProcessInstanceEvent;
 import io.camunda.client.protocol.rest.CreateProcessInstanceResult;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
 
 public final class CreateProcessInstanceResponseImpl implements ProcessInstanceEvent {
 
@@ -26,6 +29,7 @@ public final class CreateProcessInstanceResponseImpl implements ProcessInstanceE
   private final int version;
   private final long processInstanceKey;
   private final String tenantId;
+  private final Set<String> tags;
 
   public CreateProcessInstanceResponseImpl(
       final GatewayOuterClass.CreateProcessInstanceResponse response) {
@@ -34,6 +38,7 @@ public final class CreateProcessInstanceResponseImpl implements ProcessInstanceE
     version = response.getVersion();
     processInstanceKey = response.getProcessInstanceKey();
     tenantId = response.getTenantId();
+    tags = Collections.unmodifiableSet(new HashSet<>(response.getTagsList()));
   }
 
   public CreateProcessInstanceResponseImpl(final CreateProcessInstanceResult response) {
@@ -42,6 +47,7 @@ public final class CreateProcessInstanceResponseImpl implements ProcessInstanceE
     version = response.getProcessDefinitionVersion();
     processInstanceKey = Long.parseLong(response.getProcessInstanceKey());
     tenantId = response.getTenantId();
+    tags = response.getTags();
   }
 
   @Override
@@ -67,6 +73,11 @@ public final class CreateProcessInstanceResponseImpl implements ProcessInstanceE
   @Override
   public String getTenantId() {
     return tenantId;
+  }
+
+  @Override
+  public Set<String> getTags() {
+    return tags;
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/client/impl/response/CreateProcessInstanceWithResultResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/CreateProcessInstanceWithResultResponseImpl.java
@@ -20,7 +20,10 @@ import io.camunda.client.api.command.ClientException;
 import io.camunda.client.api.response.ProcessInstanceResult;
 import io.camunda.client.protocol.rest.CreateProcessInstanceResult;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.CreateProcessInstanceWithResultResponse;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 public final class CreateProcessInstanceWithResultResponseImpl implements ProcessInstanceResult {
 
@@ -33,6 +36,7 @@ public final class CreateProcessInstanceWithResultResponseImpl implements Proces
   private final String variables;
 
   private Map<String, Object> variablesAsMap;
+  private final Set<String> tags;
 
   public CreateProcessInstanceWithResultResponseImpl(
       final JsonMapper jsonMapper, final CreateProcessInstanceResult response) {
@@ -43,6 +47,7 @@ public final class CreateProcessInstanceWithResultResponseImpl implements Proces
     processInstanceKey = Long.parseLong(response.getProcessInstanceKey());
     tenantId = response.getTenantId();
     variables = jsonMapper.toJson(response.getVariables());
+    tags = response.getTags();
   }
 
   public CreateProcessInstanceWithResultResponseImpl(
@@ -54,6 +59,7 @@ public final class CreateProcessInstanceWithResultResponseImpl implements Proces
     processInstanceKey = response.getProcessInstanceKey();
     variables = response.getVariables();
     tenantId = response.getTenantId();
+    tags = Collections.unmodifiableSet(new HashSet<>(response.getTagsList()));
   }
 
   @Override
@@ -109,6 +115,11 @@ public final class CreateProcessInstanceWithResultResponseImpl implements Proces
   }
 
   @Override
+  public Set<String> getTags() {
+    return tags;
+  }
+
+  @Override
   public String toString() {
     return "CreateProcessInstanceWithResultResponseImpl{"
         + "processDefinitionKey="
@@ -122,6 +133,9 @@ public final class CreateProcessInstanceWithResultResponseImpl implements Proces
         + processInstanceKey
         + ", variables='"
         + variables
+        + '\''
+        + ", tags='"
+        + tags
         + '\''
         + ", tenantId='"
         + tenantId

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/ProcessInstanceImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/ProcessInstanceImpl.java
@@ -20,6 +20,7 @@ import io.camunda.client.api.search.response.ProcessInstance;
 import io.camunda.client.impl.util.EnumUtil;
 import io.camunda.client.impl.util.ParseUtil;
 import io.camunda.client.protocol.rest.ProcessInstanceResult;
+import java.util.Set;
 
 public class ProcessInstanceImpl implements ProcessInstance {
 
@@ -36,6 +37,7 @@ public class ProcessInstanceImpl implements ProcessInstance {
   private final ProcessInstanceState state;
   private final Boolean hasIncident;
   private final String tenantId;
+  private final Set<String> tags;
 
   public ProcessInstanceImpl(final ProcessInstanceResult item) {
     processInstanceKey = ParseUtil.parseLongOrNull(item.getProcessInstanceKey());
@@ -51,6 +53,7 @@ public class ProcessInstanceImpl implements ProcessInstance {
     state = EnumUtil.convert(item.getState(), ProcessInstanceState.class);
     hasIncident = item.getHasIncident();
     tenantId = item.getTenantId();
+    tags = item.getTags();
   }
 
   @Override
@@ -116,5 +119,10 @@ public class ProcessInstanceImpl implements ProcessInstance {
   @Override
   public String getTenantId() {
     return tenantId;
+  }
+
+  @Override
+  public Set<String> getTags() {
+    return tags;
   }
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/util/TagUtil.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/util/TagUtil.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.client.impl.util;
+
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+/**
+ * Utility class for validating tags used in Zeebe. Tags are used to categorize and label resources
+ * within the system.
+ *
+ * <p>NOTE: Whenever you adjust the tag format or max number, also consider updating the REST API
+ * documentation and the duplicated zeebe engine validation (see TagUtil.java)
+ */
+public class TagUtil {
+
+  public static final int MAX_NUMBER_OF_TAGS = 10;
+  public static final int MAX_TAG_LENGTH = 100;
+  public static final String TAG_FORMAT_DESCRIPTION =
+      String.format(
+          "Tags must start with a letter (a-z, A-Z), followed by alphanumerics, underscores, minuses, colons, or periods. "
+              + "It must not be blank and must be %s characters or less.",
+          MAX_TAG_LENGTH);
+
+  // Pattern for valid tag format: starts with letter, followed by alphanumerics, _, -, :, .
+  private static final Pattern VALID_TAG_PATTERN = Pattern.compile("^[a-zA-Z][a-zA-Z0-9_\\-:.]*$");
+
+  /**
+   * Validates that a tag follows the required format and constraints: - Must start with a letter
+   * (a-z, A-Z) - After the first character, may contain: alphanumerics, underscores, minuses,
+   * colons, periods - Must not be blank and must be 100 characters or less
+   */
+  public static boolean isValidTag(final String tag) {
+    return tag != null
+        && tag.length() <= MAX_TAG_LENGTH
+        && VALID_TAG_PATTERN.matcher(tag).matches();
+  }
+
+  public static void ensureValidTags(final String context, final Set<String> tags) {
+    if (tags == null || tags.isEmpty()) {
+      return;
+    }
+
+    if (tags.size() > MAX_NUMBER_OF_TAGS) {
+      throw new IllegalArgumentException(
+          context
+              + ": Tags must not contain more than "
+              + MAX_NUMBER_OF_TAGS
+              + " tags, but found "
+              + tags.size());
+    }
+
+    final List<String> invalidTags =
+        tags.stream().filter(tag -> !isValidTag(tag)).collect(Collectors.toList());
+
+    if (!invalidTags.isEmpty()) {
+      throw new IllegalArgumentException(
+          context
+              + ": "
+              + TAG_FORMAT_DESCRIPTION
+              + ". Invalid tags: "
+              + invalidTags.stream().collect(Collectors.joining("', '"))
+              + "'");
+    }
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/util/TagUtil.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/util/TagUtil.java
@@ -1,9 +1,17 @@
 /*
- * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
- * one or more contributor license agreements. See the NOTICE file distributed
- * with this work for additional information regarding copyright ownership.
- * Licensed under the Camunda License 1.0. You may not use this file
- * except in compliance with the Camunda License 1.0.
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package io.camunda.client.impl.util;
 

--- a/clients/java/src/test/java/io/camunda/client/process/CreateProcessInstanceTest.java
+++ b/clients/java/src/test/java/io/camunda/client/process/CreateProcessInstanceTest.java
@@ -31,8 +31,11 @@ import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
@@ -357,6 +360,29 @@ public final class CreateProcessInstanceTest extends ClientTest {
                         suspend ->
                             assertThat(suspend.getAfterElementId())
                                 .isIn("elementId_A", "elementId_B")));
+  }
+
+  @Test
+  public void shouldCreateWithTags() {
+    // given
+    final Set<String> tags = new HashSet<>(Arrays.asList("tag1", "tag2"));
+
+    gatewayService.onCreateProcessInstanceRequest(123, "testProcess", 12, 32, tags);
+
+    // when
+    final ProcessInstanceEvent response =
+        client
+            .newCreateInstanceCommand()
+            .processDefinitionKey(123)
+            .tags("tag1", "tag2")
+            .send()
+            .join();
+
+    // then
+    final CreateProcessInstanceRequest request = gatewayService.getLastRequest();
+    assertThat(new HashSet<>(request.getTagsList())).isEqualTo(tags);
+
+    assertThat(response.getTags()).isEqualTo(tags);
   }
 
   public static class VariableDocument {

--- a/clients/java/src/test/java/io/camunda/client/process/CreateProcessInstanceWithResultTest.java
+++ b/clients/java/src/test/java/io/camunda/client/process/CreateProcessInstanceWithResultTest.java
@@ -25,6 +25,9 @@ import io.camunda.client.util.ClientTest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.CreateProcessInstanceRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.CreateProcessInstanceWithResultRequest;
 import java.time.Duration;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
 import org.junit.Test;
 
 public final class CreateProcessInstanceWithResultTest extends ClientTest {
@@ -218,6 +221,27 @@ public final class CreateProcessInstanceWithResultTest extends ClientTest {
     final CreateProcessInstanceWithResultRequest request = gatewayService.getLastRequest();
     final CreateProcessInstanceRequest piRequest = request.getRequest();
     assertThat(piRequest.getTenantId()).isEqualTo(tenantId);
+  }
+
+  @Test
+  public void shouldAddTags() {
+    // given
+    final Long processDefinitionKey = 1L;
+    final Set<String> tags = new HashSet<>(Arrays.asList("tag1", "tag2"));
+
+    // when
+    client
+        .newCreateInstanceCommand()
+        .processDefinitionKey(processDefinitionKey)
+        .tags(tags)
+        .withResult()
+        .send()
+        .join();
+
+    // then
+    final CreateProcessInstanceWithResultRequest request = gatewayService.getLastRequest();
+    final CreateProcessInstanceRequest piRequest = request.getRequest();
+    assertThat(new HashSet(piRequest.getTagsList())).isEqualTo(tags);
   }
 
   private static final class VariablesPojo {

--- a/clients/java/src/test/java/io/camunda/client/process/rest/CreateProcessInstanceRestTest.java
+++ b/clients/java/src/test/java/io/camunda/client/process/rest/CreateProcessInstanceRestTest.java
@@ -31,8 +31,11 @@ import io.camunda.client.util.RestGatewayPaths;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -293,6 +296,20 @@ public class CreateProcessInstanceRestTest extends ClientRestTest {
         gatewayService.getLastRequest(ProcessInstanceCreationInstruction.class);
     assertThat(request.getTenantId()).isEqualTo(customTenantId);
     assertThat(request.getProcessDefinitionKey()).isEqualTo(String.valueOf(processDefinitionKey));
+  }
+
+  @Test
+  public void shouldCreateProcessInstanceWithTags() {
+    // given
+    final Set<String> tags = new HashSet<>(Arrays.asList("tag1", "tag2"));
+
+    // when
+    client.newCreateInstanceCommand().processDefinitionKey(123).tags(tags).send().join();
+
+    // then
+    final ProcessInstanceCreationInstruction request =
+        gatewayService.getLastRequest(ProcessInstanceCreationInstruction.class);
+    Assertions.assertThat(request.getTags()).isEqualTo(tags);
   }
 
   public static class VariableDocument {

--- a/clients/java/src/test/java/io/camunda/client/process/rest/CreateProcessInstanceWithResultRestTest.java
+++ b/clients/java/src/test/java/io/camunda/client/process/rest/CreateProcessInstanceWithResultRestTest.java
@@ -22,6 +22,9 @@ import io.camunda.client.api.command.CommandWithTenantStep;
 import io.camunda.client.protocol.rest.ProcessInstanceCreationInstruction;
 import io.camunda.client.util.ClientRestTest;
 import java.time.Duration;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
 import org.junit.jupiter.api.Test;
 
 public class CreateProcessInstanceWithResultRestTest extends ClientRestTest {
@@ -179,6 +182,27 @@ public class CreateProcessInstanceWithResultRestTest extends ClientRestTest {
     final ProcessInstanceCreationInstruction request =
         gatewayService.getLastRequest(ProcessInstanceCreationInstruction.class);
     assertThat(request.getTenantId()).isEqualTo(tenantId);
+  }
+
+  @Test
+  public void shouldAllowTags() {
+    // given
+    final Long processDefinitionKey = 1L;
+    final Set<String> tags = new HashSet<>(Arrays.asList("tag1", "tag2"));
+
+    // when
+    client
+        .newCreateInstanceCommand()
+        .processDefinitionKey(processDefinitionKey)
+        .tags(tags)
+        .withResult()
+        .send()
+        .join();
+
+    // then
+    final ProcessInstanceCreationInstruction request =
+        gatewayService.getLastRequest(ProcessInstanceCreationInstruction.class);
+    assertThat(request.getTags()).isEqualTo(tags);
   }
 
   private static final class VariablesPojo {

--- a/clients/java/src/test/java/io/camunda/client/util/RecordingGatewayService.java
+++ b/clients/java/src/test/java/io/camunda/client/util/RecordingGatewayService.java
@@ -76,8 +76,10 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.BlockingDeque;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.LinkedBlockingDeque;
@@ -486,6 +488,16 @@ public final class RecordingGatewayService extends GatewayImplBase {
       final String bpmnProcessId,
       final int version,
       final long processInstanceKey) {
+    onCreateProcessInstanceRequest(
+        processDefinitionKey, bpmnProcessId, version, processInstanceKey, new HashSet<>());
+  }
+
+  public void onCreateProcessInstanceRequest(
+      final long processDefinitionKey,
+      final String bpmnProcessId,
+      final int version,
+      final long processInstanceKey,
+      final Set<String> tags) {
     addRequestHandler(
         CreateProcessInstanceRequest.class,
         request ->
@@ -494,6 +506,7 @@ public final class RecordingGatewayService extends GatewayImplBase {
                 .setBpmnProcessId(bpmnProcessId)
                 .setVersion(version)
                 .setProcessInstanceKey(processInstanceKey)
+                .addAllTags(tags)
                 .build());
   }
 

--- a/clients/java/src/test/java/io/camunda/client/util/StringUtil.java
+++ b/clients/java/src/test/java/io/camunda/client/util/StringUtil.java
@@ -29,4 +29,15 @@ public final class StringUtil {
   public static byte[] getBytes(final String value, final Charset charset) {
     return value.getBytes(charset);
   }
+
+  public static String repeat(final String s, final int count) {
+    if (count <= 0) {
+      return "";
+    }
+    final StringBuilder sb = new StringBuilder(s.length() * count);
+    for (int i = 0; i < count; i++) {
+      sb.append(s);
+    }
+    return sb.toString();
+  }
 }

--- a/clients/java/src/test/java/io/camunda/client/util/TagUtilTest.java
+++ b/clients/java/src/test/java/io/camunda/client/util/TagUtilTest.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.client.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.client.impl.util.TagUtil;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class TagUtilTest {
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "a", // single letter
+        "A", // single uppercase letter
+        "validTag", // camelCase
+        "valid_tag", // with underscore
+        "valid-tag", // with hyphen
+        "valid:tag", // with colon
+        "valid.tag", // with period
+        "a1", // letter followed by number
+        "A1", // uppercase letter followed by number
+        "tag123", // letters followed by numbers
+        "complex_tag-123:v1.0", // complex valid tag
+        "myTag_v1.2-final:release", // complex with all allowed characters
+        "production", // common use case
+        "development", // common use case
+        "test_env", // common use case
+        "api-v2.1", // versioned API tag
+        "user:admin", // role-based tag
+        "region.us-east", // geographic tag
+        "a0123456789", // digits after first letter
+        "aABCDEFGHIJKLMNOPQRSTUVWXYZ", // uppercase after first letter
+        "aabcdefghijklmnopqrstuvwxyz", // lowercase after first letter
+        "a_", // underscore after first letter
+        "a-", // hyphen after first letter
+        "a:", // colon after first letter
+        "a.", // period after first letter
+        "env:production", // real-world: environment
+        "version:1.2.3", // real-world: version
+        "team:backend-api", // real-world: team
+        "region:us-east-1", // real-world: region
+        "cost-center:eng-123", // real-world: cost center
+        "project_name", // real-world: project
+        "feature-flag:enabled", // real-world: feature flag
+        "service.auth.v2", // real-world: service
+        "critical:high-priority", // real-world: priority
+        "deployment:blue-green", // real-world: deployment strategy
+      })
+  void shouldAcceptValidTags(final String validTag) {
+    assertThat(TagUtil.isValidTag(validTag)).isTrue();
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "", // empty tag
+        " ", // blank tag
+        "   ", // multiple spaces
+        "\t", // tab character
+        "\n", // newline character
+        "\r", // carriage return character
+        "1", // single digit
+        "1tag", // starts with number
+        "9invalid", // starts with number
+        "_tag", // starts with underscore
+        "-tag", // starts with hyphen
+        ":tag", // starts with colon
+        ".tag", // starts with period
+        "tag with space", // contains space
+        "tag\ttab", // contains tab
+        "tag\nnewline", // contains newline
+        "tag@symbol", // contains @ symbol
+        "tag#hash", // contains hash
+        "tag$dollar", // contains dollar sign
+        "tag%percent", // contains percent
+        "tag^caret", // contains caret
+        "tag&ampersand", // contains ampersand
+        "tag*asterisk", // contains asterisk
+        "tag+plus", // contains plus
+        "tag=equals", // contains equals
+        "tag[bracket", // contains bracket
+        "tag]bracket", // contains bracket
+        "tag{brace", // contains brace
+        "tag}brace", // contains brace
+        "tag|pipe", // contains pipe
+        "tag\\backslash", // contains backslash
+        "tag/slash", // contains forward slash
+        "tag<less", // contains less than
+        "tag>greater", // contains greater than
+        "tag?question", // contains question mark
+        "tag\"quote", // contains quote
+        "tag'apostrophe", // contains apostrophe
+        "tag;semicolon", // contains semicolon
+        "tag,comma", // contains comma
+        "café", // contains accented character
+        "tağ", // contains non-ASCII character
+        "🏷️tag", // starts with emoji
+        "tag🏷️", // contains emoji
+        "тag", // contains Cyrillic character
+        "tag with multiple spaces", // contains multiple spaces
+        "tag\twith\ttabs", // contains multiple tabs
+        "tag\nwith\nnewlines", // contains multiple newlines
+        "tag@#$%^&*()", // contains special characters
+        "tag+=[]{}|\\", // contains special characters
+        "tag<>?\"';,", // contains special characters
+      })
+  void shouldRejectInvalidTags(final String invalidTag) {
+    assertThat(TagUtil.isValidTag(invalidTag)).isFalse();
+  }
+
+  @Test
+  void shouldRejectNullTag() {
+    assertThat(TagUtil.isValidTag(null)).isFalse();
+  }
+
+  @Test
+  void shouldRejectTagExceeding100Characters() {
+    final String tooLongTag =
+        "a" + StringUtil.repeat("b", TagUtil.MAX_TAG_LENGTH); // 101 characters
+    assertThat(TagUtil.isValidTag(tooLongTag)).isFalse();
+    assertThat(tooLongTag.length()).isEqualTo(TagUtil.MAX_TAG_LENGTH + 1);
+  }
+
+  @Test
+  void shouldAcceptTagWith100Characters() {
+    final String maxLengthTag =
+        "a" + StringUtil.repeat("b", TagUtil.MAX_TAG_LENGTH - 1); // exactly 100 characters
+    assertThat(TagUtil.isValidTag(maxLengthTag)).isTrue();
+    assertThat(maxLengthTag.length()).isEqualTo(TagUtil.MAX_TAG_LENGTH);
+  }
+
+  @Nested
+  class EnsureValidTags {
+    @Test
+    void shouldNotThrowForNullOrEmptyTags() {
+      TagUtil.ensureValidTags("context", null);
+      TagUtil.ensureValidTags("context", new HashSet<>());
+    }
+
+    @Test
+    void shouldNotThrowForValidTags() {
+      final Set<String> validTags =
+          new HashSet<>(Arrays.asList("validTag1", "valid_tag2", "valid-tag3"));
+
+      TagUtil.ensureValidTags("context", validTags);
+    }
+
+    @Test
+    void shouldThrowForInvalidTags() {
+      final Set<String> invalidTags = new HashSet<>(Arrays.asList("invalid tag", "invalid@tag"));
+      assertThatThrownBy(() -> TagUtil.ensureValidTags("context", invalidTags))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("Invalid tags: invalid@tag', 'invalid tag'");
+    }
+
+    @Test
+    void shouldThrowForTooManyTags() {
+      final Set<String> tooManyTags =
+          new HashSet<>(
+              Arrays.asList(
+                  "tag1", "tag2", "tag3", "tag4", "tag5", "tag6", "tag7", "tag8", "tag9", "tag10",
+                  "tag11"));
+
+      assertThatThrownBy(() -> TagUtil.ensureValidTags("context", tooManyTags))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("Tags must not contain more than 10 tags");
+    }
+  }
+}

--- a/clients/java/src/test/java/io/camunda/client/util/TagUtilTest.java
+++ b/clients/java/src/test/java/io/camunda/client/util/TagUtilTest.java
@@ -1,9 +1,17 @@
 /*
- * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
- * one or more contributor license agreements. See the NOTICE file distributed
- * with this work for additional information regarding copyright ownership.
- * Licensed under the Camunda License 1.0. You may not use this file
- * except in compliance with the Camunda License 1.0.
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package io.camunda.client.util;
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/typehandler/EmptyStringSetTypeHandler.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/typehandler/EmptyStringSetTypeHandler.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.typehandler;
+
+import java.sql.CallableStatement;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Collections;
+import java.util.Set;
+import org.apache.ibatis.type.BaseTypeHandler;
+import org.apache.ibatis.type.JdbcType;
+
+/**
+ * Maps a textual column to a Set<String> while defaulting to an empty set when the column is null
+ * or blank. Writing will serialize the set as a comma-separated String.
+ */
+public final class EmptyStringSetTypeHandler extends BaseTypeHandler<Set<String>> {
+
+  @Override
+  public void setNonNullParameter(
+      final PreparedStatement ps, final int i, final Set<String> parameter, final JdbcType jdbcType)
+      throws SQLException {
+    ps.setString(i, String.join(",", parameter));
+  }
+
+  @Override
+  public Set<String> getNullableResult(final ResultSet rs, final String columnName)
+      throws SQLException {
+    return parse(rs.getString(columnName));
+  }
+
+  @Override
+  public Set<String> getNullableResult(final ResultSet rs, final int columnIndex)
+      throws SQLException {
+    return parse(rs.getString(columnIndex));
+  }
+
+  @Override
+  public Set<String> getNullableResult(final CallableStatement cs, final int columnIndex)
+      throws SQLException {
+    return parse(cs.getString(columnIndex));
+  }
+
+  private Set<String> parse(final String value) {
+    if (value == null || value.isBlank()) {
+      return Collections.emptySet();
+    }
+    final String[] parts = value.split("\\s*,\\s*");
+    return Set.of(parts);
+  }
+}

--- a/db/rdbms/src/main/resources/mapper/ProcessInstanceMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/ProcessInstanceMapper.xml
@@ -28,7 +28,8 @@
            pi.VERSION AS PROCESS_DEFINITION_VERSION,
            pi.TREE_PATH,
            pd.NAME        AS PROCESS_DEFINITION_NAME,
-           pd.VERSION_TAG AS PROCESS_DEFINITION_VERSION_TAG
+           pd.VERSION_TAG AS PROCESS_DEFINITION_VERSION_TAG,
+           NULL AS TAGS
     FROM ${prefix}PROCESS_INSTANCE pi
            LEFT JOIN ${prefix}PROCESS_DEFINITION pd ON (pi.PROCESS_DEFINITION_KEY = pd.PROCESS_DEFINITION_KEY)
     WHERE PROCESS_INSTANCE_KEY = #{processInstanceKey}
@@ -66,7 +67,8 @@
     pi.VERSION PROCESS_DEFINITION_VERSION,
     pi.TREE_PATH,
     pd.NAME AS PROCESS_DEFINITION_NAME,
-    pd.VERSION_TAG AS PROCESS_DEFINITION_VERSION_TAG
+    pd.VERSION_TAG AS PROCESS_DEFINITION_VERSION_TAG,
+    NULL AS TAGS
     FROM ${prefix}PROCESS_INSTANCE pi
     LEFT JOIN ${prefix}PROCESS_DEFINITION pd ON (pi.PROCESS_DEFINITION_KEY = pd.PROCESS_DEFINITION_KEY)
     <where>
@@ -278,6 +280,8 @@
       <arg column="HAS_INCIDENT" javaType="java.lang.Boolean"/>
       <arg column="TENANT_ID" javaType="java.lang.String"/>
       <arg column="TREE_PATH" javaType="java.lang.String"/>
+      <arg column="TAGS" javaType="java.util.Set"
+           typeHandler="io.camunda.db.rdbms.typehandler.EmptyStringSetTypeHandler"/>
     </constructor>
 
   </resultMap>

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceCreateTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceCreateTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.client;
+
+import static io.camunda.it.util.TestHelper.deployProcessAndWaitForIt;
+import static io.camunda.it.util.TestHelper.waitForProcessInstance;
+import static java.util.Map.entry;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.response.Process;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.test.util.collection.Maps;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+
+@MultiDbTest
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms")
+public class ProcessInstanceCreateTest {
+
+  private static CamundaClient camundaClient;
+  private static final Set<String> TAGS = Set.of("tag1", "tag2");
+
+  private static Process process;
+
+  @BeforeAll
+  public static void beforeAll() {
+    final var processDefinition =
+        Bpmn.createExecutableProcess("process").name("my process").startEvent().endEvent().done();
+
+    process = deployProcessAndWaitForIt(camundaClient, processDefinition, "process.bpmn");
+  }
+
+  @Test
+  void shouldCreateProcessInstance() {
+    // given
+    final var processInstanceCreation =
+        camundaClient
+            .newCreateInstanceCommand()
+            .bpmnProcessId("process")
+            .latestVersion()
+            .tags(TAGS)
+            .send()
+            .join();
+
+    assertThat(processInstanceCreation).isNotNull();
+    assertThat(processInstanceCreation.getProcessInstanceKey()).isNotNull();
+    assertThat(processInstanceCreation.getBpmnProcessId()).isEqualTo(process.getBpmnProcessId());
+    assertThat(processInstanceCreation.getProcessDefinitionKey())
+        .isEqualTo(process.getProcessDefinitionKey());
+    assertThat(processInstanceCreation.getVersion()).isEqualTo(process.getVersion());
+    assertThat(processInstanceCreation.getTenantId()).isEqualTo(process.getTenantId());
+    assertThat(processInstanceCreation.getTags()).isEqualTo(TAGS);
+
+    waitForProcessInstance(
+        camundaClient,
+        f -> f.processInstanceKey(processInstanceCreation.getProcessInstanceKey()),
+        f -> assertThat(f).hasSize(1));
+
+    // when
+    final var result =
+        camundaClient
+            .newProcessInstanceGetRequest(processInstanceCreation.getProcessInstanceKey())
+            .send()
+            .join();
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.getProcessInstanceKey())
+        .isEqualTo(processInstanceCreation.getProcessInstanceKey());
+    assertThat(result.getProcessDefinitionKey()).isEqualTo(process.getProcessDefinitionKey());
+    assertThat(result.getProcessDefinitionId()).isEqualTo(process.getBpmnProcessId());
+    assertThat(result.getProcessDefinitionName()).isEqualTo("my process");
+    assertThat(result.getProcessDefinitionVersion()).isEqualTo(1);
+    assertThat(result.getTenantId()).isEqualTo("<default>");
+    assertThat(result.getTags()).isEqualTo(TAGS);
+  }
+
+  @Test
+  void shouldCreateProcessInstanceWithResult() {
+    final Map<String, Object> variables = Maps.of(entry("foo", "bar"));
+    // given
+    final var processInstanceCreation =
+        camundaClient
+            .newCreateInstanceCommand()
+            .bpmnProcessId("process")
+            .latestVersion()
+            .variables(variables)
+            .tags(TAGS)
+            .withResult()
+            .fetchVariables("foo")
+            .send()
+            .join();
+
+    assertThat(processInstanceCreation).isNotNull();
+    assertThat(processInstanceCreation.getProcessInstanceKey()).isNotNull();
+    assertThat(processInstanceCreation.getBpmnProcessId()).isEqualTo(process.getBpmnProcessId());
+    assertThat(processInstanceCreation.getProcessDefinitionKey())
+        .isEqualTo(process.getProcessDefinitionKey());
+    assertThat(processInstanceCreation.getVersion()).isEqualTo(process.getVersion());
+    assertThat(processInstanceCreation.getTenantId()).isEqualTo(process.getTenantId());
+    assertThat(processInstanceCreation.getVariablesAsMap()).isEqualTo(variables);
+    assertThat(processInstanceCreation.getTags()).isEqualTo(TAGS);
+
+    waitForProcessInstance(
+        camundaClient,
+        f -> f.processInstanceKey(processInstanceCreation.getProcessInstanceKey()),
+        f -> assertThat(f).hasSize(1));
+
+    // when
+    final var result =
+        camundaClient
+            .newProcessInstanceGetRequest(processInstanceCreation.getProcessInstanceKey())
+            .send()
+            .join();
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.getProcessInstanceKey())
+        .isEqualTo(processInstanceCreation.getProcessInstanceKey());
+    assertThat(result.getProcessDefinitionKey()).isEqualTo(process.getProcessDefinitionKey());
+    assertThat(result.getProcessDefinitionId()).isEqualTo(process.getBpmnProcessId());
+    assertThat(result.getProcessDefinitionName()).isEqualTo("my process");
+    assertThat(result.getProcessDefinitionVersion()).isEqualTo(1);
+
+    assertThat(result.getTenantId()).isEqualTo("<default>");
+    assertThat(result.getTags()).isEqualTo(TAGS);
+  }
+}

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/ProcessInstanceEntityTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/ProcessInstanceEntityTransformer.java
@@ -31,7 +31,8 @@ public class ProcessInstanceEntityTransformer
         toState(source.getState()),
         source.isIncident(),
         source.getTenantId(),
-        source.getTreePath());
+        source.getTreePath(),
+        source.getTags());
   }
 
   private ProcessInstanceState toState(

--- a/search/search-domain/src/main/java/io/camunda/search/entities/ProcessInstanceEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/ProcessInstanceEntity.java
@@ -9,6 +9,7 @@ package io.camunda.search.entities;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import java.time.OffsetDateTime;
+import java.util.Set;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record ProcessInstanceEntity(
@@ -25,7 +26,8 @@ public record ProcessInstanceEntity(
     ProcessInstanceState state,
     Boolean hasIncident,
     String tenantId,
-    String treePath)
+    String treePath,
+    Set<String> tags)
     implements TenantOwnedEntity {
 
   public enum ProcessInstanceState {

--- a/service/src/main/java/io/camunda/service/ProcessInstanceServices.java
+++ b/service/src/main/java/io/camunda/service/ProcessInstanceServices.java
@@ -54,6 +54,7 @@ import io.camunda.zeebe.protocol.record.value.BatchOperationType;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -192,7 +193,8 @@ public final class ProcessInstanceServices
             .setTenantId(request.tenantId())
             .setVariables(getDocumentOrEmpty(request.variables()))
             .setStartInstructionsFromRecord(request.startInstructions())
-            .setRuntimeInstructionsFromRecord(request.runtimeInstructions());
+            .setRuntimeInstructionsFromRecord(request.runtimeInstructions())
+            .setTags(request.tags());
 
     if (request.operationReference() != null) {
       brokerRequest.setOperationReference(request.operationReference());
@@ -210,7 +212,8 @@ public final class ProcessInstanceServices
             .setTenantId(request.tenantId())
             .setVariables(getDocumentOrEmpty(request.variables()))
             .setInstructions(request.startInstructions())
-            .setFetchVariables(request.fetchVariables());
+            .setFetchVariables(request.fetchVariables())
+            .setTags(request.tags());
 
     if (request.operationReference() != null) {
       brokerRequest.setOperationReference(request.operationReference());
@@ -341,7 +344,8 @@ public final class ProcessInstanceServices
       Long operationReference,
       List<ProcessInstanceCreationStartInstruction> startInstructions,
       List<ProcessInstanceCreationRuntimeInstruction> runtimeInstructions,
-      List<String> fetchVariables) {}
+      List<String> fetchVariables,
+      Set<String> tags) {}
 
   public record ProcessInstanceCancelRequest(Long processInstanceKey, Long operationReference) {}
 

--- a/service/src/main/java/io/camunda/service/ProcessInstanceServices.java
+++ b/service/src/main/java/io/camunda/service/ProcessInstanceServices.java
@@ -193,8 +193,11 @@ public final class ProcessInstanceServices
             .setTenantId(request.tenantId())
             .setVariables(getDocumentOrEmpty(request.variables()))
             .setStartInstructionsFromRecord(request.startInstructions())
-            .setRuntimeInstructionsFromRecord(request.runtimeInstructions())
-            .setTags(request.tags());
+            .setRuntimeInstructionsFromRecord(request.runtimeInstructions());
+
+    if (request.tags() != null) {
+      brokerRequest.setTags(request.tags());
+    }
 
     if (request.operationReference() != null) {
       brokerRequest.setOperationReference(request.operationReference());

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/service/CamundaServicesBasedAdapter.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/service/CamundaServicesBasedAdapter.java
@@ -36,6 +36,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.function.Function;
@@ -202,7 +203,18 @@ public class CamundaServicesBasedAdapter implements TasklistServicesAdapter {
 
     final var tenant = tenantValidationResult.get();
     return new ProcessInstanceCreateRequest(
-        -1L, bpmnProcessId, -1, variables, tenant, null, null, null, List.of(), List.of(), null);
+        -1L,
+        bpmnProcessId,
+        -1,
+        variables,
+        tenant,
+        null,
+        null,
+        null,
+        List.of(),
+        List.of(),
+        null,
+        Set.of());
   }
 
   private DeployResourcesRequest toDeployResourcesRequest(

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/utils/ProcessInstanceBuilder.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/utils/ProcessInstanceBuilder.java
@@ -17,6 +17,7 @@ package io.camunda.process.test.utils;
 
 import io.camunda.client.api.search.enums.ProcessInstanceState;
 import io.camunda.client.api.search.response.ProcessInstance;
+import java.util.Set;
 
 public class ProcessInstanceBuilder implements ProcessInstance {
 
@@ -37,6 +38,7 @@ public class ProcessInstanceBuilder implements ProcessInstance {
   private ProcessInstanceState state;
   private Boolean hasIncident;
   private String tenantId;
+  private Set<String> tags;
 
   @Override
   public Long getProcessInstanceKey() {
@@ -101,6 +103,16 @@ public class ProcessInstanceBuilder implements ProcessInstance {
   @Override
   public String getTenantId() {
     return tenantId;
+  }
+
+  @Override
+  public Set<String> getTags() {
+    return tags;
+  }
+
+  public ProcessInstanceBuilder setTags(final Set<String> tags) {
+    this.tags = tags;
+    return this;
   }
 
   public ProcessInstanceBuilder setTenantId(final String tenantId) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnElementContext.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnElementContext.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstan
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.BpmnEventType;
+import java.util.Set;
 import org.agrona.DirectBuffer;
 
 /** Process instance-related data of the element that is executed. */
@@ -49,6 +50,8 @@ public interface BpmnElementContext {
   String getTenantId();
 
   BpmnEventType getBpmnEventType();
+
+  Set<String> getTags();
 
   BpmnElementContext copy(
       long elementInstanceKey, ProcessInstanceRecord recordValue, ProcessInstanceIntent intent);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnElementContextImpl.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnElementContextImpl.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstan
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.BpmnEventType;
+import java.util.Set;
 import org.agrona.DirectBuffer;
 
 public final class BpmnElementContextImpl implements BpmnElementContext {
@@ -89,6 +90,11 @@ public final class BpmnElementContextImpl implements BpmnElementContext {
   @Override
   public BpmnEventType getBpmnEventType() {
     return recordValue.getBpmnEventType();
+  }
+
+  @Override
+  public Set<String> getTags() {
+    return recordValue.getTags();
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnProcessResultSenderBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnProcessResultSenderBehavior.java
@@ -66,7 +66,8 @@ public final class BpmnProcessResultSenderBehavior {
         .setBpmnProcessId(context.getBpmnProcessId())
         .setVersion(context.getProcessVersion())
         .setVariables(variablesAsDocument)
-        .setTenantId(context.getTenantId());
+        .setTenantId(context.getTenantId())
+        .setTags(context.getTags());
 
     responseWriter.writeResponse(
         context.getProcessInstanceKey(),

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/AbstractBatchOperationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/AbstractBatchOperationTest.java
@@ -286,7 +286,8 @@ abstract class AbstractBatchOperationTest {
         null,
         false,
         null,
-        null);
+        null,
+        Set.of());
   }
 
   protected IncidentEntity fakeIncidentEntity(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceRejectionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceRejectionTest.java
@@ -298,7 +298,7 @@ public class CreateProcessInstanceRejectionTest {
         .hasRejectionType(RejectionType.INVALID_ARGUMENT)
         .hasRejectionReason(
             String.format(
-                "Expected to create instance of process with tags, but tag '%s' is invalid. Tag must start with a letter (a-z, A-Z), followed by alphanumerics, underscores, minuses, colons, or periods. It must not be blank and must be 100 characters or less.",
+                "Expected to create instance of process with tags, but the tags '%s' are invalid. Tags must start with a letter (a-z, A-Z), followed by alphanumerics, underscores, minuses, colons, or periods. It must not be blank and must be 100 characters or less.",
                 invalidTag));
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceWithResultTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceWithResultTest.java
@@ -66,6 +66,7 @@ public final class CreateProcessInstanceWithResultTest {
             .withResult()
             .withRequestId(1L)
             .withRequestStreamId(1)
+            .withTags(Set.of("tag1", "tag2"))
             .create();
 
     // then
@@ -75,6 +76,7 @@ public final class CreateProcessInstanceWithResultTest {
     assertThat(response.getVariables()).containsExactly(Map.entry("x", "foo"));
     assertThat(response.getProcessInstanceKey()).isEqualTo(processInstanceKey);
     assertThat(response.getBpmnProcessId()).isEqualTo("PROCESS");
+    assertThat(response.getTags()).isEqualTo(Set.of("tag1", "tag2"));
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/ProcessInstanceClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/ProcessInstanceClient.java
@@ -210,6 +210,11 @@ public final class ProcessInstanceClient {
       return this;
     }
 
+    public ProcessInstanceCreationWithResultClient withTags(final Set<String> tags) {
+      record.setTags(tags);
+      return this;
+    }
+
     public long create() {
       final long position =
           writer.writeCommand(

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/RequestMapper.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/RequestMapper.java
@@ -63,6 +63,7 @@ import io.camunda.zeebe.protocol.record.value.JobResultType;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import java.util.regex.Pattern;
 import org.agrona.DirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
@@ -257,7 +258,8 @@ public final class RequestMapper extends RequestUtil {
         .setVersion(grpcRequest.getVersion())
         .setTenantId(ensureTenantIdSet("CreateProcessInstance", grpcRequest.getTenantId()))
         .setVariables(ensureJsonSet(grpcRequest.getVariables()))
-        .setStartInstructions(grpcRequest.getStartInstructionsList());
+        .setStartInstructions(grpcRequest.getStartInstructionsList())
+        .setTags(Set.copyOf(grpcRequest.getTagsList()));
 
     if (grpcRequest.hasOperationReference()) {
       brokerRequest.setOperationReference(grpcRequest.getOperationReference());
@@ -279,6 +281,7 @@ public final class RequestMapper extends RequestUtil {
         .setTenantId(ensureTenantIdSet("CreateProcessInstanceWithResult", request.getTenantId()))
         .setVariables(ensureJsonSet(request.getVariables()))
         .setStartInstructions(request.getStartInstructionsList())
+        .setTags(Set.copyOf(request.getTagsList()))
         .setFetchVariables(grpcRequest.getFetchVariablesList());
 
     if (request.hasOperationReference()) {

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/ResponseMapper.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/ResponseMapper.java
@@ -194,6 +194,7 @@ public final class ResponseMapper {
         .setVersion(brokerResponse.getVersion())
         .setTenantId(brokerResponse.getTenantId())
         .setProcessInstanceKey(brokerResponse.getProcessInstanceKey())
+        .addAllTags(brokerResponse.getTags())
         .build();
   }
 
@@ -206,6 +207,7 @@ public final class ResponseMapper {
         .setTenantId(brokerResponse.getTenantId())
         .setProcessInstanceKey(brokerResponse.getProcessInstanceKey())
         .setVariables(bufferAsJson(brokerResponse.getVariablesBuffer()))
+        .addAllTags(brokerResponse.getTags())
         .build();
   }
 

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/process/CreateProcessInstanceStub.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/process/CreateProcessInstanceStub.java
@@ -12,6 +12,7 @@ import io.camunda.zeebe.gateway.api.util.StubbedBrokerClient;
 import io.camunda.zeebe.gateway.api.util.StubbedBrokerClient.RequestStub;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerCreateProcessInstanceRequest;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceCreationRecord;
+import java.util.Set;
 
 public final class CreateProcessInstanceStub
     implements RequestStub<
@@ -21,6 +22,8 @@ public final class CreateProcessInstanceStub
   public static final String PROCESS_ID = "process";
   public static final int PROCESS_VERSION = 1;
   public static final long PROCESS_KEY = 456;
+  public static final Set<String> TAGS = Set.of("tag1", "tag2");
+
   private BrokerResponse<ProcessInstanceCreationRecord> response;
 
   @Override
@@ -50,6 +53,10 @@ public final class CreateProcessInstanceStub
     return PROCESS_KEY;
   }
 
+  public Set<String> getTags() {
+    return TAGS;
+  }
+
   @Override
   public BrokerResponse<ProcessInstanceCreationRecord> handle(
       final BrokerCreateProcessInstanceRequest request) {
@@ -71,7 +78,8 @@ public final class CreateProcessInstanceStub
         .setVersion(PROCESS_VERSION)
         .setTenantId(piCreationRecord.getTenantId())
         .setProcessDefinitionKey(PROCESS_KEY)
-        .setProcessInstanceKey(PROCESS_INSTANCE_KEY);
+        .setProcessInstanceKey(PROCESS_INSTANCE_KEY)
+        .setTags(TAGS);
 
     return new BrokerResponse<>(record, 0, PROCESS_INSTANCE_KEY);
   }

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/process/CreateProcessInstanceTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/process/CreateProcessInstanceTest.java
@@ -30,6 +30,7 @@ public final class CreateProcessInstanceTest extends GatewayTest {
     final CreateProcessInstanceRequest request =
         CreateProcessInstanceRequest.newBuilder()
             .setProcessDefinitionKey(stub.getProcessDefinitionKey())
+            .addAllTags(stub.getTags())
             .build();
 
     // when
@@ -41,6 +42,7 @@ public final class CreateProcessInstanceTest extends GatewayTest {
     assertThat(response.getProcessDefinitionKey()).isEqualTo(stub.getProcessDefinitionKey());
     assertThat(response.getProcessInstanceKey()).isEqualTo(stub.getProcessInstanceKey());
     assertThat(response.getTenantId()).isEqualTo(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+    assertThat(response.getTagsList()).containsAll(stub.getTags());
 
     final BrokerCreateProcessInstanceRequest brokerRequest = brokerClient.getSingleBrokerRequest();
     assertThat(brokerRequest.getIntent()).isEqualTo(ProcessInstanceCreationIntent.CREATE);
@@ -50,5 +52,6 @@ public final class CreateProcessInstanceTest extends GatewayTest {
     assertThat(brokerRequestValue.getProcessDefinitionKey())
         .isEqualTo(stub.getProcessDefinitionKey());
     assertThat(brokerRequestValue.getTenantId()).isEqualTo(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+    assertThat(brokerRequestValue.getTags()).isEqualTo(stub.getTags());
   }
 }

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/process/CreateProcessInstanceWithResultStub.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/process/CreateProcessInstanceWithResultStub.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.gateway.api.util.StubbedBrokerClient.RequestStub;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerCreateProcessInstanceWithResultRequest;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceCreationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceResultRecord;
+import java.util.Set;
 
 public final class CreateProcessInstanceWithResultStub
     implements RequestStub<
@@ -22,6 +23,7 @@ public final class CreateProcessInstanceWithResultStub
   public static final String PROCESS_ID = "process";
   public static final int PROCESS_VERSION = 1;
   public static final long PROCESS_KEY = 456;
+  public static final Set<String> TAGS = Set.of("tag1", "tag2");
 
   @Override
   public void registerWith(final StubbedBrokerClient brokerClient) {
@@ -44,6 +46,10 @@ public final class CreateProcessInstanceWithResultStub
     return PROCESS_KEY;
   }
 
+  public Set<String> getTags() {
+    return TAGS;
+  }
+
   @Override
   public BrokerResponse<ProcessInstanceResultRecord> handle(
       final BrokerCreateProcessInstanceWithResultRequest request) throws Exception {
@@ -55,7 +61,8 @@ public final class CreateProcessInstanceWithResultStub
         .setVersion(PROCESS_VERSION)
         .setTenantId(piCreationRecord.getTenantId())
         .setProcessDefinitionKey(PROCESS_KEY)
-        .setProcessInstanceKey(PROCESS_INSTANCE_KEY);
+        .setProcessInstanceKey(PROCESS_INSTANCE_KEY)
+        .setTags(TAGS);
 
     return new BrokerResponse<>(response, 0, PROCESS_INSTANCE_KEY);
   }

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/process/CreateProcessInstanceWithResultTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/process/CreateProcessInstanceWithResultTest.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstan
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
+import java.util.HashSet;
 import java.util.List;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -35,7 +36,8 @@ public final class CreateProcessInstanceWithResultTest extends GatewayTest {
         CreateProcessInstanceWithResultRequest.newBuilder()
             .setRequest(
                 CreateProcessInstanceRequest.newBuilder()
-                    .setProcessDefinitionKey(stub.getProcessDefinitionKey()))
+                    .setProcessDefinitionKey(stub.getProcessDefinitionKey())
+                    .addAllTags(stub.getTags()))
             .addAllFetchVariables(List.of("x"))
             .build();
 
@@ -55,6 +57,7 @@ public final class CreateProcessInstanceWithResultTest extends GatewayTest {
     assertThat(brokerRequestValue.fetchVariables().iterator().next().getValue())
         .isEqualTo(wrapString("x"));
     assertThat(brokerRequestValue.getTenantId()).isEqualTo(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+    assertThat(brokerRequestValue.getTags()).isEqualTo(stub.getTags());
   }
 
   @Test
@@ -67,7 +70,8 @@ public final class CreateProcessInstanceWithResultTest extends GatewayTest {
         CreateProcessInstanceWithResultRequest.newBuilder()
             .setRequest(
                 CreateProcessInstanceRequest.newBuilder()
-                    .setProcessDefinitionKey(stub.getProcessDefinitionKey()))
+                    .setProcessDefinitionKey(stub.getProcessDefinitionKey())
+                    .addAllTags(stub.getTags()))
             .build();
 
     // when
@@ -80,6 +84,7 @@ public final class CreateProcessInstanceWithResultTest extends GatewayTest {
     assertThat(response.getProcessDefinitionKey()).isEqualTo(stub.getProcessDefinitionKey());
     assertThat(response.getProcessInstanceKey()).isEqualTo(stub.getProcessInstanceKey());
     assertThat(response.getTenantId()).isEqualTo(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+    assertThat(new HashSet(response.getTagsList())).isEqualTo(stub.getTags());
   }
 
   @Test

--- a/zeebe/gateway-protocol/src/main/proto/gateway.proto
+++ b/zeebe/gateway-protocol/src/main/proto/gateway.proto
@@ -255,6 +255,9 @@ message CreateProcessInstanceRequest {
   // instance during its execution
   // if empty (default), the process instance will be executed normally
   repeated ProcessInstanceCreationRuntimeInstruction runtimeInstructions = 8;
+
+  // a list of tags that can be attached as meta-data to process instances
+  repeated string tags = 9;
 }
 
 message ProcessInstanceCreationStartInstruction {
@@ -295,6 +298,8 @@ message CreateProcessInstanceResponse {
   int64 processInstanceKey = 4;
   // the tenant identifier of the created process instance
   string tenantId = 5;
+  // tags attached to a process instance
+  repeated string tags = 6;
 }
 
 message CreateProcessInstanceWithResultRequest {
@@ -324,6 +329,8 @@ message CreateProcessInstanceWithResultResponse {
   string variables = 5;
   // the tenant identifier of the process definition
   string tenantId = 6;
+  // tags attached to a process instance
+  repeated string tags = 7;
 }
 
 message EvaluateDecisionRequest {

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -6559,8 +6559,7 @@ components:
           description: The parent element instance key.
         tags:
           description: Tags associated with the process instance
-          allOf:
-            - $ref: '#/components/schemas/TagSet'
+          $ref: '#/components/schemas/TagSet'
     ProcessInstanceStateEnum:
       description: Process instance states
       enum:
@@ -10161,8 +10160,7 @@ components:
           type: string
         tags:
           description: Tags associated with the process instance
-          allOf:
-            - $ref: '#/components/schemas/TagSet'
+          $ref: '#/components/schemas/TagSet'
         operationReference:
           $ref: '#/components/schemas/OperationReference'
         startInstructions:
@@ -10282,8 +10280,7 @@ components:
           type: string
         tags:
           description: Tags associated with the newly created process instance
-          allOf:
-            - $ref: '#/components/schemas/TagSet'
+          $ref: '#/components/schemas/TagSet'
     ProcessInstanceMigrationBatchOperationRequest:
       type: object
       properties:

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -6558,11 +6558,9 @@ components:
           type: string
           description: The parent element instance key.
         tags:
-          description: List of tags that will be associated with the process instance, and will also be forwarded to job workers etc.
-          type: array
-          items:
-            type: string
-          uniqueItems: true
+          description: Tags associated with the process instance
+          allOf:
+            - $ref: '#/components/schemas/TagSet'
     ProcessInstanceStateEnum:
       description: Process instance states
       enum:
@@ -10162,11 +10160,9 @@ components:
           description: The tenant ID of the process definition.
           type: string
         tags:
-          description: List of tags that will be associated with the process instance, and will also be forwarded to job workers etc.
-          type: array
-          items:
-            type: string
-          uniqueItems: true
+          description: Tags associated with the process instance
+          allOf:
+            - $ref: '#/components/schemas/TagSet'
         operationReference:
           $ref: '#/components/schemas/OperationReference'
         startInstructions:
@@ -10285,11 +10281,9 @@ components:
             needs a process instance key (e.g. CancelProcessInstanceRequest).
           type: string
         tags:
-          description: List of tags associated with the process instance, and will also be forwarded to job workers etc.
-          type: array
-          items:
-            type: string
-          uniqueItems: true
+          description: Tags associated with the newly created process instance
+          allOf:
+            - $ref: '#/components/schemas/TagSet'
     ProcessInstanceMigrationBatchOperationRequest:
       type: object
       properties:
@@ -10891,6 +10885,20 @@ components:
       required:
         - sourceElementId
         - targetElementId
+    Tag:
+      type: string
+      description: A tag. Needs to start with a letter; then alphanumerics, `_`, `-`, `:`, or `.`; length ≤ 100.
+      minLength: 1
+      maxLength: 100
+      pattern: '^[A-Za-z][A-Za-z0-9_\-:.]{0,99}$'
+      example: "business_key:1234"
+    TagSet:
+      description: List of tags
+      type: array
+      items:
+        $ref: '#/components/schemas/Tag'
+      uniqueItems: true
+      maxItems: 10
   responses:
     InternalServerError:
       description: >

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -6558,7 +6558,6 @@ components:
           type: string
           description: The parent element instance key.
         tags:
-          description: Tags associated with the process instance
           $ref: '#/components/schemas/TagSet'
     ProcessInstanceStateEnum:
       description: Process instance states
@@ -10159,7 +10158,6 @@ components:
           description: The tenant ID of the process definition.
           type: string
         tags:
-          description: Tags associated with the process instance
           $ref: '#/components/schemas/TagSet'
         operationReference:
           $ref: '#/components/schemas/OperationReference'
@@ -10279,7 +10277,6 @@ components:
             needs a process instance key (e.g. CancelProcessInstanceRequest).
           type: string
         tags:
-          description: Tags associated with the newly created process instance
           $ref: '#/components/schemas/TagSet'
     ProcessInstanceMigrationBatchOperationRequest:
       type: object

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -6558,7 +6558,7 @@ components:
           type: string
           description: The parent element instance key.
         tags:
-          description: list of tags that will be associated with the process instance, and will also be forwarded to job workers etc.
+          description: List of tags that will be associated with the process instance, and will also be forwarded to job workers etc.
           type: array
           items:
             type: string
@@ -10162,7 +10162,7 @@ components:
           description: The tenant ID of the process definition.
           type: string
         tags:
-          description: list of tags that will be associated with the process instance, and will also be forwarded to job workers etc.
+          description: List of tags that will be associated with the process instance, and will also be forwarded to job workers etc.
           type: array
           items:
             type: string
@@ -10285,7 +10285,7 @@ components:
             needs a process instance key (e.g. CancelProcessInstanceRequest).
           type: string
         tags:
-          description: list of tags associated with the process instance, and will also be forwarded to job workers etc.
+          description: List of tags associated with the process instance, and will also be forwarded to job workers etc.
           type: array
           items:
             type: string

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -6557,6 +6557,12 @@ components:
         parentElementInstanceKey:
           type: string
           description: The parent element instance key.
+        tags:
+          description: list of tags that will be associated with the process instance, and will also be forwarded to job workers etc.
+          type: array
+          items:
+            type: string
+          uniqueItems: true
     ProcessInstanceStateEnum:
       description: Process instance states
       enum:
@@ -10155,6 +10161,12 @@ components:
         tenantId:
           description: The tenant ID of the process definition.
           type: string
+        tags:
+          description: list of tags that will be associated with the process instance, and will also be forwarded to job workers etc.
+          type: array
+          items:
+            type: string
+          uniqueItems: true
         operationReference:
           $ref: '#/components/schemas/OperationReference'
         startInstructions:
@@ -10272,6 +10284,12 @@ components:
             The unique identifier of the created process instance; to be used wherever a request
             needs a process instance key (e.g. CancelProcessInstanceRequest).
           type: string
+        tags:
+          description: list of tags associated with the process instance, and will also be forwarded to job workers etc.
+          type: array
+          items:
+            type: string
+          uniqueItems: true
     ProcessInstanceMigrationBatchOperationRequest:
       type: object
       properties:

--- a/zeebe/gateway-rest/pom.xml
+++ b/zeebe/gateway-rest/pom.xml
@@ -305,6 +305,13 @@
     </dependency>
 
     <dependency>
+      <groupId>com.vaadin.external.google</groupId>
+      <artifactId>android-json</artifactId>
+      <version>0.0.20131108.vaadin1</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>com.jayway.jsonpath</groupId>
       <artifactId>json-path</artifactId>
       <scope>test</scope>

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RequestMapper.java
@@ -728,7 +728,8 @@ public class RequestMapper {
                               .setAfterElementId(instructionCasted.getAfterElementId());
                         })
                     .toList(),
-                request.getFetchVariables()));
+                request.getFetchVariables(),
+                request.getTags()));
   }
 
   public static Either<ProblemDetail, ProcessInstanceCancelRequest> toCancelProcessInstance(

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/ResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/ResponseMapper.java
@@ -100,6 +100,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -503,7 +504,8 @@ public final class ResponseMapper {
         brokerResponse.getVersion(),
         brokerResponse.getProcessInstanceKey(),
         brokerResponse.getTenantId(),
-        null);
+        null,
+        brokerResponse.getTags());
   }
 
   public static ResponseEntity<Object> toCreateProcessInstanceWithResultResponse(
@@ -514,7 +516,8 @@ public final class ResponseMapper {
         brokerResponse.getVersion(),
         brokerResponse.getProcessInstanceKey(),
         brokerResponse.getTenantId(),
-        brokerResponse.getVariables());
+        brokerResponse.getVariables(),
+        brokerResponse.getTags());
   }
 
   private static ResponseEntity<Object> buildCreateProcessInstanceResponse(
@@ -523,7 +526,8 @@ public final class ResponseMapper {
       final Integer version,
       final Long processInstanceKey,
       final String tenantId,
-      final Map<String, Object> variables) {
+      final Map<String, Object> variables,
+      final Set<String> tags) {
     final var response =
         new CreateProcessInstanceResult()
             .processDefinitionKey(KeyUtil.keyToString(processDefinitionKey))
@@ -533,6 +537,9 @@ public final class ResponseMapper {
             .tenantId(tenantId);
     if (variables != null) {
       response.variables(variables);
+    }
+    if (tags != null) {
+      response.setTags(tags);
     }
 
     return new ResponseEntity<>(response, HttpStatus.OK);

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
@@ -579,7 +579,8 @@ public final class SearchQueryResponseMapper {
         .endDate(formatDate(p.endDate()))
         .state(toProtocolState(p.state()))
         .hasIncident(p.hasIncident())
-        .tenantId(p.tenantId());
+        .tenantId(p.tenantId())
+        .tags(p.tags());
   }
 
   public static List<BatchOperationResponse> toBatchOperations(

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/ErrorMessages.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/ErrorMessages.java
@@ -40,4 +40,8 @@ public final class ErrorMessages {
   public static final String ERROR_MESSAGE_NULL_VARIABLE_VALUE = "Variable value must not be null";
   public static final String ERROR_MESSAGE_INVALID_KEY_FORMAT =
       "The provided %s '%s' is not a valid key. Expected a numeric value. Did you pass an entity id instead of an entity key?";
+  public static final String ERROR_MESSAGE_INVALID_TAG_FORMAT =
+      "The provided tag '%s' is not valid. %s";
+  public static final String ERROR_MESSAGE_INVALID_TAGS_COUNT =
+      "The provided number of tags '%s' is not supported. Ensure to not add more than %s tags.";
 }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/ProcessInstanceRequestValidator.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/ProcessInstanceRequestValidator.java
@@ -27,6 +27,7 @@ import io.camunda.zeebe.gateway.protocol.rest.ProcessInstanceModificationMoveBat
 import io.camunda.zeebe.gateway.protocol.rest.ProcessInstanceModificationTerminateInstruction;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Predicate;
 import org.springframework.http.ProblemDetail;
 
@@ -51,7 +52,12 @@ public class ProcessInstanceRequestValidator {
           // Validate processDefinitionKey format if provided
           validateKeyFormat(request.getProcessDefinitionKey(), "processDefinitionKey", violations);
           validateOperationReference(request.getOperationReference(), violations);
+          validateTags(request.getTags(), violations);
         });
+  }
+
+  private static void validateTags(final Set<String> tags, final List<String> violations) {
+    TagsValidator.validate(tags, violations);
   }
 
   public static Optional<ProblemDetail> validateCancelProcessInstanceRequest(

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/TagsValidator.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/TagsValidator.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.validator;
+
+import static io.camunda.zeebe.gateway.rest.validator.ErrorMessages.ERROR_MESSAGE_INVALID_TAGS_COUNT;
+import static io.camunda.zeebe.gateway.rest.validator.ErrorMessages.ERROR_MESSAGE_INVALID_TAG_FORMAT;
+
+import io.camunda.zeebe.util.TagUtil;
+import java.util.List;
+import java.util.Set;
+
+public class TagsValidator {
+
+  public static void validate(final Set<String> tags, final List<String> violations) {
+    if (tags == null || tags.isEmpty()) {
+      return;
+    }
+
+    if (tags.size() > TagUtil.MAX_NUMBER_OF_TAGS) {
+      violations.add(
+          ERROR_MESSAGE_INVALID_TAGS_COUNT.formatted(tags.size(), TagUtil.MAX_NUMBER_OF_TAGS));
+    }
+
+    for (final String tag : tags) {
+      if (!TagUtil.isValidTag(tag)) {
+        violations.add(
+            ERROR_MESSAGE_INVALID_TAG_FORMAT.formatted(tag, TagUtil.TAG_FORMAT_DESCRIPTION));
+      }
+    }
+  }
+}

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceControllerTest.java
@@ -63,7 +63,8 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
              "processDefinitionVersion":-1,
              "processInstanceKey":"123",
              "tenantId":"tenantId",
-             "variables":{}
+             "variables":{},
+             "tags":[]
           }""";
   static final String PROCESS_INSTANCES_START_URL = "/v2/process-instances";
   static final String CANCEL_PROCESS_URL = PROCESS_INSTANCES_START_URL + "/%s/cancellation";
@@ -159,7 +160,8 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
               "processDefinitionVersion":-1,
               "processInstanceKey":"123",
               "tenantId":"<default>",
-              "variables":{}
+              "variables":{},
+              "tags":[]
             }""";
 
     // when / then

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/validator/ProcessInstanceRequestValidatorTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/validator/ProcessInstanceRequestValidatorTest.java
@@ -60,7 +60,7 @@ class ProcessInstanceRequestValidatorTest {
     assertThat(result).isPresent();
     final ProblemDetail problem = result.get();
     assertThat(problem.getTitle()).isEqualTo("INVALID_ARGUMENT");
-    assertThat(problem.getDetail()).contains("is not valid. Tag must start with a letter");
+    assertThat(problem.getDetail()).contains("is not valid. Tags must start with a letter");
   }
 
   @Test

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerCreateProcessInstanceRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerCreateProcessInstanceRequest.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
 import io.camunda.zeebe.protocol.record.value.RuntimeInstructionType;
 import java.util.List;
+import java.util.Set;
 import org.agrona.DirectBuffer;
 
 public class BrokerCreateProcessInstanceRequest
@@ -49,6 +50,11 @@ public class BrokerCreateProcessInstanceRequest
 
   public BrokerCreateProcessInstanceRequest setTenantId(final String tenantId) {
     requestDto.setTenantId(tenantId);
+    return this;
+  }
+
+  public BrokerCreateProcessInstanceRequest setTags(final Set<String> tags) {
+    requestDto.setTags(tags);
     return this;
   }
 

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerCreateProcessInstanceWithResultRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerCreateProcessInstanceWithResultRequest.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstan
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
 import java.util.List;
+import java.util.Set;
 import org.agrona.DirectBuffer;
 
 public final class BrokerCreateProcessInstanceWithResultRequest
@@ -43,6 +44,11 @@ public final class BrokerCreateProcessInstanceWithResultRequest
 
   public BrokerCreateProcessInstanceWithResultRequest setTenantId(final String tenantId) {
     requestDto.setTenantId(tenantId);
+    return this;
+  }
+
+  public BrokerCreateProcessInstanceWithResultRequest setTags(final Set<String> tags) {
+    requestDto.setTags(tags);
     return this;
   }
 

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessInstanceResultRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessInstanceResultRecordValue.java
@@ -18,6 +18,7 @@ package io.camunda.zeebe.protocol.record.value;
 import io.camunda.zeebe.protocol.record.ImmutableProtocol;
 import io.camunda.zeebe.protocol.record.RecordValueWithVariables;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceResultIntent;
+import java.util.Set;
 import org.immutables.value.Value;
 
 /**
@@ -49,4 +50,9 @@ public interface ProcessInstanceResultRecordValue
    */
   @Override
   long getProcessInstanceKey();
+
+  /**
+   * @return the set of tags of the process instance
+   */
+  Set<String> getTags();
 }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/CreateProcessInstanceWithResultTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/CreateProcessInstanceWithResultTest.java
@@ -33,6 +33,7 @@ import java.time.Duration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestInfo;
@@ -174,6 +175,26 @@ public final class CreateProcessInstanceWithResultTest {
     assertThat(result.getBpmnProcessId()).isEqualTo(processId);
     assertThat(result.getProcessDefinitionKey()).isEqualTo(processDefinitionKey);
     assertThat(result.getVariablesAsMap()).containsExactly(entry("y", "bar"));
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  public void shouldCreateProcessInstanceAwaitResultsWithTags(
+      final boolean useRest, final TestInfo testInfo) {
+    deployProcesses(testInfo);
+    // when
+    final ProcessInstanceResult result =
+        getCommand(client, useRest)
+            .processDefinitionKey(processDefinitionKey)
+            .tags("tag1", "tag2")
+            .withResult()
+            .send()
+            .join();
+
+    // then
+    assertThat(result.getBpmnProcessId()).isEqualTo(processId);
+    assertThat(result.getProcessDefinitionKey()).isEqualTo(processDefinitionKey);
+    assertThat(result.getTags()).isEqualTo(Set.of("tag1", "tag2"));
   }
 
   @ParameterizedTest

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/TagUtil.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/TagUtil.java
@@ -9,13 +9,20 @@ package io.camunda.zeebe.util;
 
 import java.util.regex.Pattern;
 
+/**
+ * Utility class for validating tags used in Zeebe. Tags are used to categorize and label resources
+ * within the system.
+ *
+ * <p>NOTE: Whenever you adjust the tag format or max number, also consider updating the REST API
+ * documentation and the duplicated Camunda client validation (see TagUtil.java)
+ */
 public class TagUtil {
 
   public static final int MAX_NUMBER_OF_TAGS = 10;
   public static final int MAX_TAG_LENGTH = 100;
   public static final String TAG_FORMAT_DESCRIPTION =
       String.format(
-          "Tag must start with a letter (a-z, A-Z), followed by alphanumerics, underscores, minuses, colons, or periods. "
+          "Tags must start with a letter (a-z, A-Z), followed by alphanumerics, underscores, minuses, colons, or periods. "
               + "It must not be blank and must be %s characters or less.",
           MAX_TAG_LENGTH);
 


### PR DESCRIPTION
## Description
based on https://github.com/camunda/camunda/pull/36755

- [x] write tests for create process instance response
- [x] write tests for create process instance creation with result response
- [x] write tests for grpc as well (they seem to use the old zeebe client)
- [x] javadoc in client sdk

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes https://github.com/camunda/camunda/issues/36856
