### PR TITLE
Fix grafana panels to work with partition dependent metrics

### DIFF
--- a/monitor/grafana/dashboards/data_layer.json
+++ b/monitor/grafana/dashboards/data_layer.json
@@ -242,7 +242,7 @@
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 817
+            "y": 753
           },
           "id": 32,
           "options": {
@@ -359,7 +359,7 @@
             "h": 5,
             "w": 24,
             "x": 0,
-            "y": 824
+            "y": 760
           },
           "id": 33,
           "options": {
@@ -485,7 +485,7 @@
             "h": 8,
             "w": 8,
             "x": 0,
-            "y": 829
+            "y": 765
           },
           "id": 34,
           "options": {
@@ -592,7 +592,7 @@
             "h": 8,
             "w": 8,
             "x": 8,
-            "y": 829
+            "y": 765
           },
           "id": 35,
           "options": {
@@ -699,7 +699,7 @@
             "h": 8,
             "w": 8,
             "x": 16,
-            "y": 829
+            "y": 765
           },
           "id": 36,
           "options": {
@@ -802,7 +802,7 @@
             "h": 5,
             "w": 24,
             "x": 0,
-            "y": 837
+            "y": 773
           },
           "id": 37,
           "options": {
@@ -1308,15 +1308,55 @@
           "description": "For every non empty flush of a bulk request, this is the number of entities flushed.",
           "fieldConfig": {
             "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
               "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
                 "hideFrom": {
                   "legend": false,
                   "tooltip": false,
                   "viz": false
                 },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
                 "scaleDistribution": {
                   "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
                 }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
               }
             },
             "overrides": []
@@ -1329,41 +1369,16 @@
           },
           "id": 11,
           "options": {
-            "calculate": false,
-            "calculation": {},
-            "cellGap": 2,
-            "cellValues": {},
-            "color": {
-              "exponent": 0.5,
-              "fill": "#ef843c",
-              "mode": "scheme",
-              "reverse": false,
-              "scale": "exponential",
-              "scheme": "Spectral",
-              "steps": 128
-            },
-            "exemplars": {
-              "color": "rgba(255,0,255,0.7)"
-            },
-            "filterValues": {
-              "le": 1e-9
-            },
             "legend": {
-              "show": false
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
             },
-            "rowsFrame": {
-              "layout": "auto"
-            },
-            "showValue": "never",
             "tooltip": {
+              "hideZeros": false,
               "mode": "single",
-              "showColorScale": false,
-              "yHistogram": false
-            },
-            "yAxis": {
-              "axisPlacement": "left",
-              "reverse": false,
-              "unit": "short"
+              "sort": "none"
             }
           },
           "pluginVersion": "12.1.0",
@@ -1373,17 +1388,17 @@
                 "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
-              "expr": "sum(increase(zeebe_camunda_exporter_bulk_size_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\"}[$__rate_interval])) by (le)",
+              "expr": "sum(increase(zeebe_camunda_exporter_bulk_size_sum{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\"}[$__rate_interval])) by (partition) / \nsum(increase(zeebe_camunda_exporter_bulk_size_count{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\"}[$__rate_interval])) by (partition)",
               "format": "heatmap",
               "interval": "30s",
               "intervalFactor": 1,
-              "legendFormat": "{{le}}",
+              "legendFormat": "partition-{{partition}}",
               "range": true,
               "refId": "A"
             }
           ],
           "title": "Camunda Exporter (Bulk Size)",
-          "type": "heatmap"
+          "type": "timeseries"
         },
         {
           "datasource": {
@@ -1478,9 +1493,9 @@
               },
               "editorMode": "code",
               "exemplar": true,
-              "expr": "min by (partition) (rate(zeebe_camunda_exporter_flush_latency_seconds_sum{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval]) / rate(zeebe_camunda_exporter_flush_latency_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval]))",
+              "expr": "rate(zeebe_camunda_exporter_flush_latency_seconds_sum{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval]) / rate(zeebe_camunda_exporter_flush_latency_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])",
               "interval": "",
-              "legendFormat": "partition-{{partition}}",
+              "legendFormat": "{{pod}} Exporter {{partition}}",
               "range": true,
               "refId": "A"
             }
@@ -2270,7 +2285,7 @@
           "targets": [
             {
               "editorMode": "code",
-              "expr": "max by (partition) (zeebe_camunda_exporter_process_instances_awaiting_archival{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\"})\n",
+              "expr": "zeebe_camunda_exporter_process_instances_awaiting_archival{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\"}\n",
               "legendFormat": "Partition {{partition}}",
               "range": true,
               "refId": "A"
@@ -2518,7 +2533,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 566
+            "y": 502
           },
           "id": 2,
           "options": {
@@ -2642,7 +2657,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 566
+            "y": 502
           },
           "id": 3,
           "options": {
@@ -2699,7 +2714,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 592
+            "y": 528
           },
           "id": 4,
           "options": {
@@ -2823,7 +2838,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 592
+            "y": 528
           },
           "id": 5,
           "options": {
@@ -2894,7 +2909,7 @@
             "h": 8,
             "w": 10,
             "x": 0,
-            "y": 455
+            "y": 391
           },
           "id": 22,
           "options": {
@@ -2980,7 +2995,7 @@
             "h": 8,
             "w": 11,
             "x": 10,
-            "y": 455
+            "y": 391
           },
           "id": 23,
           "options": {
@@ -3081,7 +3096,7 @@
             "h": 8,
             "w": 3,
             "x": 21,
-            "y": 455
+            "y": 391
           },
           "id": 24,
           "options": {
@@ -3141,7 +3156,7 @@
             "h": 10,
             "w": 11,
             "x": 0,
-            "y": 527
+            "y": 463
           },
           "id": 25,
           "options": {
@@ -3268,7 +3283,7 @@
             "h": 10,
             "w": 8,
             "x": 11,
-            "y": 527
+            "y": 463
           },
           "id": 26,
           "options": {
@@ -3345,7 +3360,7 @@
             "h": 10,
             "w": 5,
             "x": 19,
-            "y": 527
+            "y": 463
           },
           "id": 27,
           "options": {

--- a/monitor/grafana/dashboards/data_layer.json
+++ b/monitor/grafana/dashboards/data_layer.json
@@ -19,7 +19,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 4,
+  "id": 611,
   "links": [],
   "panels": [
     {
@@ -82,8 +82,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": 0
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -116,7 +115,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "12.1.0",
+          "pluginVersion": "12.0.2",
           "targets": [
             {
               "datasource": {
@@ -227,8 +226,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": 0
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -244,7 +242,7 @@
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 3
+            "y": 753
           },
           "id": 32,
           "options": {
@@ -260,7 +258,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "12.1.0",
+          "pluginVersion": "12.0.2",
           "targets": [
             {
               "datasource": {
@@ -345,8 +343,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": 0
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -362,7 +359,7 @@
             "h": 5,
             "w": 24,
             "x": 0,
-            "y": 138
+            "y": 760
           },
           "id": 33,
           "options": {
@@ -378,7 +375,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "12.1.0",
+          "pluginVersion": "12.0.2",
           "targets": [
             {
               "datasource": {
@@ -472,8 +469,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": 0
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -489,7 +485,7 @@
             "h": 8,
             "w": 8,
             "x": 0,
-            "y": 143
+            "y": 765
           },
           "id": 34,
           "options": {
@@ -512,7 +508,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "12.1.0",
+          "pluginVersion": "12.0.2",
           "targets": [
             {
               "datasource": {
@@ -580,8 +576,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": 0
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -597,7 +592,7 @@
             "h": 8,
             "w": 8,
             "x": 8,
-            "y": 143
+            "y": 765
           },
           "id": 35,
           "options": {
@@ -620,7 +615,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "12.1.0",
+          "pluginVersion": "12.0.2",
           "targets": [
             {
               "datasource": {
@@ -688,8 +683,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": 0
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -705,7 +699,7 @@
             "h": 8,
             "w": 8,
             "x": 16,
-            "y": 143
+            "y": 765
           },
           "id": 36,
           "options": {
@@ -726,7 +720,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "12.1.0",
+          "pluginVersion": "12.0.2",
           "targets": [
             {
               "datasource": {
@@ -793,8 +787,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": 0
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -809,7 +802,7 @@
             "h": 5,
             "w": 24,
             "x": 0,
-            "y": 151
+            "y": 773
           },
           "id": 37,
           "options": {
@@ -825,7 +818,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "12.1.0",
+          "pluginVersion": "12.0.2",
           "targets": [
             {
               "datasource": {
@@ -936,7 +929,7 @@
               "unit": "dtdurations"
             }
           },
-          "pluginVersion": "12.1.0",
+          "pluginVersion": "12.0.2",
           "targets": [
             {
               "datasource": {
@@ -972,8 +965,7 @@
                 "mode": "percentage",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": 0
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -1007,7 +999,7 @@
             "showThresholdMarkers": true,
             "sizing": "auto"
           },
-          "pluginVersion": "12.1.0",
+          "pluginVersion": "12.0.2",
           "targets": [
             {
               "datasource": {
@@ -1074,8 +1066,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": 0
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -1106,7 +1097,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "12.1.0",
+          "pluginVersion": "12.0.2",
           "targets": [
             {
               "editorMode": "code",
@@ -1168,8 +1159,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": 0
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -1200,7 +1190,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "12.1.0",
+          "pluginVersion": "12.0.2",
           "targets": [
             {
               "editorMode": "code",
@@ -1262,8 +1252,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": 0
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -1294,7 +1283,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "12.1.0",
+          "pluginVersion": "12.0.2",
           "targets": [
             {
               "editorMode": "code",
@@ -1356,8 +1345,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": 0
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -1388,7 +1376,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "12.1.0",
+          "pluginVersion": "12.0.2",
           "targets": [
             {
               "datasource": {
@@ -1459,8 +1447,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": 0
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -1492,7 +1479,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "12.1.0",
+          "pluginVersion": "12.0.2",
           "targets": [
             {
               "datasource": {
@@ -1500,7 +1487,7 @@
               },
               "editorMode": "code",
               "exemplar": true,
-              "expr": "min by (partition) (\n  rate(zeebe_camunda_exporter_flush_latency_seconds_sum{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval]) / \n  rate(zeebe_camunda_exporter_flush_latency_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])\n)",
+              "expr": "min by (partition) (\n  rate(zeebe_camunda_exporter_flush_latency_seconds_sum{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\", pod=~\"$pod\"}[$__rate_interval]) / \n  rate(zeebe_camunda_exporter_flush_latency_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\",partition=~\"$partition\", pod=~\"$pod\"}[$__rate_interval])\n)",
               "interval": "",
               "legendFormat": "Partition {{partition}}",
               "range": true,
@@ -1559,8 +1546,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": 0
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -1591,7 +1577,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "12.1.0",
+          "pluginVersion": "12.0.2",
           "targets": [
             {
               "datasource": {
@@ -1658,8 +1644,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": 0
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -1692,7 +1677,7 @@
               "sort": "desc"
             }
           },
-          "pluginVersion": "12.1.0",
+          "pluginVersion": "12.0.2",
           "targets": [
             {
               "datasource": {
@@ -1791,7 +1776,7 @@
               "reverse": false
             }
           },
-          "pluginVersion": "12.1.0",
+          "pluginVersion": "12.0.2",
           "targets": [
             {
               "datasource": {
@@ -1906,7 +1891,7 @@
               "unit": "dtdurations"
             }
           },
-          "pluginVersion": "12.1.0",
+          "pluginVersion": "12.0.2",
           "targets": [
             {
               "datasource": {
@@ -1990,7 +1975,7 @@
               "unit": "dtdurations"
             }
           },
-          "pluginVersion": "12.1.0",
+          "pluginVersion": "12.0.2",
           "targets": [
             {
               "datasource": {
@@ -2073,7 +2058,7 @@
               "unit": "dtdurations"
             }
           },
-          "pluginVersion": "12.1.0",
+          "pluginVersion": "12.0.2",
           "targets": [
             {
               "datasource": {
@@ -2142,8 +2127,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": 0
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -2174,7 +2158,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "12.1.0",
+          "pluginVersion": "12.0.2",
           "targets": [
             {
               "datasource": {
@@ -2256,8 +2240,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": 0
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -2288,11 +2271,11 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "12.1.0",
+          "pluginVersion": "12.0.2",
           "targets": [
             {
               "editorMode": "code",
-              "expr": "zeebe_camunda_exporter_process_instances_awaiting_archival{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\"}\n",
+              "expr": "max by (partition) (zeebe_camunda_exporter_process_instances_awaiting_archival{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\"})",
               "legendFormat": "Partition {{partition}}",
               "range": true,
               "refId": "A"
@@ -2364,7 +2347,7 @@
               "unit": "dtdurations"
             }
           },
-          "pluginVersion": "12.1.0",
+          "pluginVersion": "12.0.2",
           "targets": [
             {
               "datasource": {
@@ -2434,8 +2417,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": 0
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -2470,7 +2452,7 @@
               "sort": "desc"
             }
           },
-          "pluginVersion": "12.1.0",
+          "pluginVersion": "12.0.2",
           "targets": [
             {
               "datasource": {
@@ -2540,7 +2522,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 663
+            "y": 502
           },
           "id": 2,
           "options": {
@@ -2664,7 +2646,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 663
+            "y": 502
           },
           "id": 3,
           "options": {
@@ -2721,7 +2703,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 689
+            "y": 528
           },
           "id": 4,
           "options": {
@@ -2845,7 +2827,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 689
+            "y": 528
           },
           "id": 5,
           "options": {
@@ -2916,7 +2898,7 @@
             "h": 8,
             "w": 10,
             "x": 0,
-            "y": 552
+            "y": 391
           },
           "id": 22,
           "options": {
@@ -3002,7 +2984,7 @@
             "h": 8,
             "w": 11,
             "x": 10,
-            "y": 552
+            "y": 391
           },
           "id": 23,
           "options": {
@@ -3103,7 +3085,7 @@
             "h": 8,
             "w": 3,
             "x": 21,
-            "y": 552
+            "y": 391
           },
           "id": 24,
           "options": {
@@ -3163,7 +3145,7 @@
             "h": 10,
             "w": 11,
             "x": 0,
-            "y": 624
+            "y": 463
           },
           "id": 25,
           "options": {
@@ -3290,7 +3272,7 @@
             "h": 10,
             "w": 8,
             "x": 11,
-            "y": 624
+            "y": 463
           },
           "id": 26,
           "options": {
@@ -3367,7 +3349,7 @@
             "h": 10,
             "w": 5,
             "x": 19,
-            "y": 624
+            "y": 463
           },
           "id": 27,
           "options": {
@@ -3444,8 +3426,8 @@
       {
         "allValue": ".*",
         "current": {
-          "text": "All",
-          "value": "$__all"
+          "text": "load",
+          "value": "load"
         },
         "definition": "label_values(atomix_role{cluster=~\"$cluster\"},namespace)",
         "includeAll": true,
@@ -3485,7 +3467,7 @@
       {
         "current": {
           "text": "Prometheus",
-          "value": "PBFA97CFB590B2093"
+          "value": "prometheus"
         },
         "label": "datasource",
         "name": "DS_PROMETHEUS",
@@ -3525,6 +3507,6 @@
   "timepicker": {},
   "timezone": "browser",
   "title": "Data Layer",
-  "uid": "71add83b-578c-4493-8ea7-30580b17caf5",
+  "uid": "eulfd8z",
   "version": 1
 }

--- a/monitor/grafana/dashboards/data_layer.json
+++ b/monitor/grafana/dashboards/data_layer.json
@@ -19,7 +19,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 6,
+  "id": 8,
   "links": [],
   "panels": [
     {
@@ -242,7 +242,7 @@
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 625
+            "y": 817
           },
           "id": 32,
           "options": {
@@ -359,7 +359,7 @@
             "h": 5,
             "w": 24,
             "x": 0,
-            "y": 632
+            "y": 824
           },
           "id": 33,
           "options": {
@@ -485,7 +485,7 @@
             "h": 8,
             "w": 8,
             "x": 0,
-            "y": 637
+            "y": 829
           },
           "id": 34,
           "options": {
@@ -592,7 +592,7 @@
             "h": 8,
             "w": 8,
             "x": 8,
-            "y": 637
+            "y": 829
           },
           "id": 35,
           "options": {
@@ -699,7 +699,7 @@
             "h": 8,
             "w": 8,
             "x": 16,
-            "y": 637
+            "y": 829
           },
           "id": 36,
           "options": {
@@ -802,7 +802,7 @@
             "h": 5,
             "w": 24,
             "x": 0,
-            "y": 645
+            "y": 837
           },
           "id": 37,
           "options": {
@@ -1197,7 +1197,7 @@
           "targets": [
             {
               "editorMode": "code",
-              "expr": "zeebe_camunda_exporter_since_last_flush_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\"}",
+              "expr": "min by (partition) (zeebe_camunda_exporter_since_last_flush_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\"})",
               "legendFormat": "partition-{{partition}}",
               "range": true,
               "refId": "A"
@@ -1478,9 +1478,9 @@
               },
               "editorMode": "code",
               "exemplar": true,
-              "expr": "rate(zeebe_camunda_exporter_flush_latency_seconds_sum{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval]) / rate(zeebe_camunda_exporter_flush_latency_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])",
+              "expr": "min by (partition) (rate(zeebe_camunda_exporter_flush_latency_seconds_sum{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval]) / rate(zeebe_camunda_exporter_flush_latency_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval]))",
               "interval": "",
-              "legendFormat": "{{pod}} Exporter {{partition}}",
+              "legendFormat": "partition-{{partition}}",
               "range": true,
               "refId": "A"
             }
@@ -2270,7 +2270,7 @@
           "targets": [
             {
               "editorMode": "code",
-              "expr": "zeebe_camunda_exporter_process_instances_awaiting_archival{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\"}\n",
+              "expr": "max by (partition) (zeebe_camunda_exporter_process_instances_awaiting_archival{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\"})\n",
               "legendFormat": "Partition {{partition}}",
               "range": true,
               "refId": "A"
@@ -2518,7 +2518,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 374
+            "y": 566
           },
           "id": 2,
           "options": {
@@ -2642,7 +2642,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 374
+            "y": 566
           },
           "id": 3,
           "options": {
@@ -2699,7 +2699,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 400
+            "y": 592
           },
           "id": 4,
           "options": {
@@ -2823,7 +2823,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 400
+            "y": 592
           },
           "id": 5,
           "options": {
@@ -2894,7 +2894,7 @@
             "h": 8,
             "w": 10,
             "x": 0,
-            "y": 263
+            "y": 455
           },
           "id": 22,
           "options": {
@@ -2980,7 +2980,7 @@
             "h": 8,
             "w": 11,
             "x": 10,
-            "y": 263
+            "y": 455
           },
           "id": 23,
           "options": {
@@ -3081,7 +3081,7 @@
             "h": 8,
             "w": 3,
             "x": 21,
-            "y": 263
+            "y": 455
           },
           "id": 24,
           "options": {
@@ -3141,7 +3141,7 @@
             "h": 10,
             "w": 11,
             "x": 0,
-            "y": 335
+            "y": 527
           },
           "id": 25,
           "options": {
@@ -3268,7 +3268,7 @@
             "h": 10,
             "w": 8,
             "x": 11,
-            "y": 335
+            "y": 527
           },
           "id": 26,
           "options": {
@@ -3345,7 +3345,7 @@
             "h": 10,
             "w": 5,
             "x": 19,
-            "y": 335
+            "y": 527
           },
           "id": 27,
           "options": {

--- a/monitor/grafana/dashboards/data_layer.json
+++ b/monitor/grafana/dashboards/data_layer.json
@@ -19,7 +19,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 8,
+  "id": 4,
   "links": [],
   "panels": [
     {
@@ -82,7 +82,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -115,7 +116,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "12.0.2",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -226,7 +227,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -242,7 +244,7 @@
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 753
+            "y": 3
           },
           "id": 32,
           "options": {
@@ -258,7 +260,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "12.0.2",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -343,7 +345,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -359,7 +362,7 @@
             "h": 5,
             "w": 24,
             "x": 0,
-            "y": 760
+            "y": 138
           },
           "id": 33,
           "options": {
@@ -375,7 +378,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "12.0.2",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -469,7 +472,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -485,7 +489,7 @@
             "h": 8,
             "w": 8,
             "x": 0,
-            "y": 765
+            "y": 143
           },
           "id": 34,
           "options": {
@@ -508,7 +512,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "12.0.2",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -576,7 +580,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -592,7 +597,7 @@
             "h": 8,
             "w": 8,
             "x": 8,
-            "y": 765
+            "y": 143
           },
           "id": 35,
           "options": {
@@ -615,7 +620,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "12.0.2",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -683,7 +688,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -699,7 +705,7 @@
             "h": 8,
             "w": 8,
             "x": 16,
-            "y": 765
+            "y": 143
           },
           "id": 36,
           "options": {
@@ -720,7 +726,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "12.0.2",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -787,7 +793,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -802,7 +809,7 @@
             "h": 5,
             "w": 24,
             "x": 0,
-            "y": 773
+            "y": 151
           },
           "id": 37,
           "options": {
@@ -818,7 +825,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "12.0.2",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -1493,9 +1500,9 @@
               },
               "editorMode": "code",
               "exemplar": true,
-              "expr": "rate(zeebe_camunda_exporter_flush_latency_seconds_sum{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval]) / rate(zeebe_camunda_exporter_flush_latency_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])",
+              "expr": "min by (partition) (\n  rate(zeebe_camunda_exporter_flush_latency_seconds_sum{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval]) / \n  rate(zeebe_camunda_exporter_flush_latency_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])\n)",
               "interval": "",
-              "legendFormat": "{{pod}} Exporter {{partition}}",
+              "legendFormat": "Partition {{partition}}",
               "range": true,
               "refId": "A"
             }
@@ -2533,7 +2540,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 502
+            "y": 663
           },
           "id": 2,
           "options": {
@@ -2657,7 +2664,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 502
+            "y": 663
           },
           "id": 3,
           "options": {
@@ -2714,7 +2721,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 528
+            "y": 689
           },
           "id": 4,
           "options": {
@@ -2838,7 +2845,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 528
+            "y": 689
           },
           "id": 5,
           "options": {
@@ -2909,7 +2916,7 @@
             "h": 8,
             "w": 10,
             "x": 0,
-            "y": 391
+            "y": 552
           },
           "id": 22,
           "options": {
@@ -2995,7 +3002,7 @@
             "h": 8,
             "w": 11,
             "x": 10,
-            "y": 391
+            "y": 552
           },
           "id": 23,
           "options": {
@@ -3096,7 +3103,7 @@
             "h": 8,
             "w": 3,
             "x": 21,
-            "y": 391
+            "y": 552
           },
           "id": 24,
           "options": {
@@ -3156,7 +3163,7 @@
             "h": 10,
             "w": 11,
             "x": 0,
-            "y": 463
+            "y": 624
           },
           "id": 25,
           "options": {
@@ -3283,7 +3290,7 @@
             "h": 10,
             "w": 8,
             "x": 11,
-            "y": 463
+            "y": 624
           },
           "id": 26,
           "options": {
@@ -3360,7 +3367,7 @@
             "h": 10,
             "w": 5,
             "x": 19,
-            "y": 463
+            "y": 624
           },
           "id": 27,
           "options": {


### PR DESCRIPTION
## Description

fix partition dependent metrics such as time since last flush, flush latency (since the broker with exporter-1 will have an always increasing time since last flush for exporter-2)

Also changed bulk size from heat map to line graph as I find it easier to read
<img width="700" height="313" alt="image" src="https://github.com/user-attachments/assets/cacfb2ae-412d-49ba-b340-8ab9e9094927" />

vs old
<img width="734" height="305" alt="image" src="https://github.com/user-attachments/assets/5c02f662-a143-4308-ae3c-eccc691fb47a" />
