### PR TITLE
feat: add rest process-cache section to unified configuration

### DIFF
--- a/configuration/pom.xml
+++ b/configuration/pom.xml
@@ -72,6 +72,11 @@
     </dependency>
 
     <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-gateway-rest</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>

--- a/configuration/src/main/java/io/camunda/configuration/ProcessCache.java
+++ b/configuration/src/main/java/io/camunda/configuration/ProcessCache.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import io.camunda.configuration.UnifiedConfigurationHelper.BackwardsCompatibilityMode;
+import java.time.Duration;
+import java.util.Set;
+
+public class ProcessCache {
+  private static final String PREFIX = "camunda.api.rest.process-cache";
+  private static final Set<String> LEGACY_MAX_SIZE_PROPERTIES =
+      Set.of("camunda.rest.processCache.maxSize");
+  private static final Set<String> LEGACY_EXPIRATION_IDLE_PROPERTIES =
+      Set.of("camunda.rest.processCache.expirationIdleMillis");
+
+  /** Process cache max size */
+  private int maxSize = 100;
+
+  /** Process cache expiration */
+  private Duration expirationIdle = Duration.ofMillis(0);
+
+  public int getMaxSize() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + ".max-size",
+        maxSize,
+        Integer.class,
+        BackwardsCompatibilityMode.SUPPORTED,
+        LEGACY_MAX_SIZE_PROPERTIES);
+  }
+
+  public void setMaxSize(final int maxSize) {
+    this.maxSize = maxSize;
+  }
+
+  public Duration getExpirationIdle() {
+    final Long currentExpirationIdle =
+        UnifiedConfigurationHelper.validateLegacyConfiguration(
+            PREFIX + ".expiration-idle",
+            expirationIdle.toMillis(),
+            Long.class,
+            BackwardsCompatibilityMode.SUPPORTED,
+            LEGACY_EXPIRATION_IDLE_PROPERTIES);
+
+    return Duration.ofMillis(currentExpirationIdle);
+  }
+
+  public void setExpirationIdle(final Duration expirationIdle) {
+    this.expirationIdle = expirationIdle;
+  }
+}

--- a/configuration/src/main/java/io/camunda/configuration/Rest.java
+++ b/configuration/src/main/java/io/camunda/configuration/Rest.java
@@ -12,8 +12,11 @@ import java.util.List;
 
 public class Rest {
 
-  /** Sets the filters */
+  /** Set the filters */
   private List<Filter> filters = new ArrayList<>();
+
+  /** Set the process cache configuration */
+  private ProcessCache processCache = new ProcessCache();
 
   public List<Filter> getFilters() {
     return filters;
@@ -21,5 +24,13 @@ public class Rest {
 
   public void setFilters(final List<Filter> filters) {
     this.filters = filters;
+  }
+
+  public ProcessCache getProcessCache() {
+    return processCache;
+  }
+
+  public void setProcessCache(final ProcessCache processCache) {
+    this.processCache = processCache;
   }
 }

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/GatewayRestPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/GatewayRestPropertiesOverride.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration.beanoverrides;
+
+import io.camunda.configuration.ProcessCache;
+import io.camunda.configuration.UnifiedConfiguration;
+import io.camunda.configuration.beans.GatewayRestProperties;
+import io.camunda.configuration.beans.LegacyGatewayRestProperties;
+import io.camunda.zeebe.gateway.rest.config.GatewayRestConfiguration.ProcessCacheConfiguration;
+import org.springframework.beans.BeanUtils;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.DependsOn;
+import org.springframework.context.annotation.Primary;
+
+@Configuration
+@EnableConfigurationProperties(LegacyGatewayRestProperties.class)
+@DependsOn("unifiedConfigurationHelper")
+public class GatewayRestPropertiesOverride {
+
+  private final UnifiedConfiguration unifiedConfiguration;
+  private final LegacyGatewayRestProperties legacyGatewayRestProperties;
+
+  public GatewayRestPropertiesOverride(
+      final UnifiedConfiguration unifiedConfiguration,
+      final LegacyGatewayRestProperties legacyGatewayRestProperties) {
+    this.unifiedConfiguration = unifiedConfiguration;
+    this.legacyGatewayRestProperties = legacyGatewayRestProperties;
+  }
+
+  @Bean
+  @Primary
+  public GatewayRestProperties gatewayRestProperties() {
+    final GatewayRestProperties override = new GatewayRestProperties();
+    BeanUtils.copyProperties(legacyGatewayRestProperties, override);
+
+    populateFromProcessCache(override);
+
+    return override;
+  }
+
+  private void populateFromProcessCache(final GatewayRestProperties override) {
+    final ProcessCache processCache =
+        unifiedConfiguration.getCamunda().getApi().getRest().getProcessCache();
+    final ProcessCacheConfiguration processCacheConfiguration = override.getProcessCache();
+    processCacheConfiguration.setMaxSize(processCache.getMaxSize());
+    processCacheConfiguration.setExpirationIdleMillis(processCache.getExpirationIdle().toMillis());
+  }
+}

--- a/configuration/src/main/java/io/camunda/configuration/beans/GatewayRestProperties.java
+++ b/configuration/src/main/java/io/camunda/configuration/beans/GatewayRestProperties.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration.beans;
+
+import io.camunda.zeebe.gateway.rest.config.GatewayRestConfiguration;
+
+// NOTE: This class has been moved away from dist. The reason for this is that as, for now,
+//  we're storing the unified configuration objects and beans in the configuration module,
+//  the fact that dist depends on configuration doesn't allow us to declare that configuration
+//  depends on dist, to extend and override these classes. Nevertheless, depending on dist is
+//  a conceptual misrepresentation of what the configuration module belongs to.
+//
+//  As we are planning, as a future refactoring, to move all the configuration classes and beans
+//  within dist (reason: configuration should be part of the Presentation layer of the app), when
+//  such refactoring happens, we can bring back GatewayBasedProperties within dist, as there will
+//  be no more circular dependency issues.
+
+public class GatewayRestProperties extends GatewayRestConfiguration {}

--- a/configuration/src/main/java/io/camunda/configuration/beans/LegacyGatewayRestProperties.java
+++ b/configuration/src/main/java/io/camunda/configuration/beans/LegacyGatewayRestProperties.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration.beans;
+
+import io.camunda.zeebe.gateway.rest.config.GatewayRestConfiguration;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties("camunda.rest")
+public class LegacyGatewayRestProperties extends GatewayRestConfiguration {}

--- a/configuration/src/test/java/io/camunda/configuration/ApiRestProcessCacheTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/ApiRestProcessCacheTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.configuration.beanoverrides.GatewayRestPropertiesOverride;
+import io.camunda.configuration.beans.GatewayRestProperties;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+@SpringJUnitConfig({
+  UnifiedConfiguration.class,
+  GatewayRestPropertiesOverride.class,
+  UnifiedConfigurationHelper.class
+})
+public class ApiRestProcessCacheTest {
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "camunda.api.rest.process-cache.max-size=200",
+        "camunda.api.rest.process-cache.expiration-idle=10ms",
+      })
+  class WithOnlyUnifiedConfigSet {
+    final GatewayRestProperties gatewayRestProperties;
+
+    WithOnlyUnifiedConfigSet(@Autowired final GatewayRestProperties gatewayRestProperties) {
+      this.gatewayRestProperties = gatewayRestProperties;
+    }
+
+    @Test
+    void shouldSetMaxSize() {
+      assertThat(gatewayRestProperties.getProcessCache().getMaxSize()).isEqualTo(200);
+    }
+
+    @Test
+    void shouldSetExpirationIdle() {
+      assertThat(gatewayRestProperties.getProcessCache().getExpirationIdleMillis()).isEqualTo(10);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "camunda.rest.processCache.maxSize=300",
+        "camunda.rest.processCache.expirationIdleMillis=20",
+      })
+  class WithOnlyLegacySet {
+    final GatewayRestProperties gatewayRestProperties;
+
+    WithOnlyLegacySet(@Autowired final GatewayRestProperties gatewayRestProperties) {
+      this.gatewayRestProperties = gatewayRestProperties;
+    }
+
+    @Test
+    void shouldSetMaxSize() {
+      assertThat(gatewayRestProperties.getProcessCache().getMaxSize()).isEqualTo(300);
+    }
+
+    @Test
+    void shouldSetExpirationIdle() {
+      assertThat(gatewayRestProperties.getProcessCache().getExpirationIdleMillis()).isEqualTo(20);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        // new
+        "camunda.api.rest.process-cache.max-size=200",
+        "camunda.api.rest.process-cache.expiration-idle=10ms",
+        // legacy
+        "camunda.rest.processCache.maxSize=300",
+        "camunda.rest.processCache.expirationIdleMillis=20",
+      })
+  class WithNewAndLegacySet {
+    final GatewayRestProperties gatewayRestProperties;
+
+    WithNewAndLegacySet(@Autowired final GatewayRestProperties gatewayRestProperties) {
+      this.gatewayRestProperties = gatewayRestProperties;
+    }
+
+    @Test
+    void shouldSetMaxSizeFromNew() {
+      assertThat(gatewayRestProperties.getProcessCache().getMaxSize()).isEqualTo(200);
+    }
+
+    @Test
+    void shouldSetExpirationIdleFromNew() {
+      assertThat(gatewayRestProperties.getProcessCache().getExpirationIdleMillis()).isEqualTo(10);
+    }
+  }
+}

--- a/dist/src/main/java/io/camunda/application/StandaloneBroker.java
+++ b/dist/src/main/java/io/camunda/application/StandaloneBroker.java
@@ -13,6 +13,7 @@ import io.camunda.configuration.UnifiedConfiguration;
 import io.camunda.configuration.UnifiedConfigurationHelper;
 import io.camunda.configuration.beanoverrides.ActorClockControlledPropertiesOverride;
 import io.camunda.configuration.beanoverrides.BrokerBasedPropertiesOverride;
+import io.camunda.configuration.beanoverrides.GatewayRestPropertiesOverride;
 import io.camunda.configuration.beanoverrides.IdleStrategyPropertiesOverride;
 import io.camunda.zeebe.broker.BrokerModuleConfiguration;
 import org.springframework.boot.SpringBootConfiguration;
@@ -34,6 +35,7 @@ public class StandaloneBroker {
                 BrokerBasedPropertiesOverride.class,
                 ActorClockControlledPropertiesOverride.class,
                 IdleStrategyPropertiesOverride.class,
+                GatewayRestPropertiesOverride.class,
                 BrokerModuleConfiguration.class)
             .profiles(Profile.BROKER.getId(), Profile.STANDALONE.getId())
             .initializers(new HealthConfigurationInitializer())

--- a/dist/src/main/java/io/camunda/application/StandaloneCamunda.java
+++ b/dist/src/main/java/io/camunda/application/StandaloneCamunda.java
@@ -19,6 +19,7 @@ import io.camunda.configuration.UnifiedConfigurationHelper;
 import io.camunda.configuration.beanoverrides.ActorClockControlledPropertiesOverride;
 import io.camunda.configuration.beanoverrides.BrokerBasedPropertiesOverride;
 import io.camunda.configuration.beanoverrides.GatewayBasedPropertiesOverride;
+import io.camunda.configuration.beanoverrides.GatewayRestPropertiesOverride;
 import io.camunda.configuration.beanoverrides.IdleStrategyPropertiesOverride;
 import io.camunda.configuration.beanoverrides.OperatePropertiesOverride;
 import io.camunda.configuration.beanoverrides.TasklistPropertiesOverride;
@@ -63,6 +64,7 @@ public class StandaloneCamunda {
                 BrokerBasedPropertiesOverride.class,
                 ActorClockControlledPropertiesOverride.class,
                 IdleStrategyPropertiesOverride.class,
+                GatewayRestPropertiesOverride.class,
                 // ---
                 CommonsModuleConfiguration.class,
                 OperateModuleConfiguration.class,

--- a/dist/src/main/java/io/camunda/application/StandaloneGateway.java
+++ b/dist/src/main/java/io/camunda/application/StandaloneGateway.java
@@ -12,6 +12,7 @@ import io.camunda.application.initializers.HealthConfigurationInitializer;
 import io.camunda.configuration.UnifiedConfiguration;
 import io.camunda.configuration.UnifiedConfigurationHelper;
 import io.camunda.configuration.beanoverrides.GatewayBasedPropertiesOverride;
+import io.camunda.configuration.beanoverrides.GatewayRestPropertiesOverride;
 import io.camunda.zeebe.gateway.GatewayModuleConfiguration;
 import org.springframework.boot.SpringBootConfiguration;
 
@@ -30,7 +31,8 @@ public class StandaloneGateway {
                 GatewayModuleConfiguration.class,
                 UnifiedConfiguration.class,
                 UnifiedConfigurationHelper.class,
-                GatewayBasedPropertiesOverride.class)
+                GatewayBasedPropertiesOverride.class,
+                GatewayRestPropertiesOverride.class)
             .profiles(Profile.GATEWAY.getId(), Profile.STANDALONE.getId())
             .initializers(new HealthConfigurationInitializer())
             .build(args);

--- a/dist/src/main/java/io/camunda/application/StandaloneOperate.java
+++ b/dist/src/main/java/io/camunda/application/StandaloneOperate.java
@@ -14,6 +14,7 @@ import io.camunda.application.listeners.ApplicationErrorListener;
 import io.camunda.configuration.UnifiedConfiguration;
 import io.camunda.configuration.UnifiedConfigurationHelper;
 import io.camunda.configuration.beanoverrides.GatewayBasedPropertiesOverride;
+import io.camunda.configuration.beanoverrides.GatewayRestPropertiesOverride;
 import io.camunda.configuration.beanoverrides.OperatePropertiesOverride;
 import io.camunda.operate.OperateModuleConfiguration;
 import io.camunda.webapps.WebappsModuleConfiguration;
@@ -48,6 +49,7 @@ public class StandaloneOperate {
                 UnifiedConfigurationHelper.class,
                 OperatePropertiesOverride.class,
                 GatewayBasedPropertiesOverride.class,
+                GatewayRestPropertiesOverride.class,
                 // ---
                 CommonsModuleConfiguration.class,
                 OperateModuleConfiguration.class,

--- a/dist/src/main/java/io/camunda/application/StandaloneTasklist.java
+++ b/dist/src/main/java/io/camunda/application/StandaloneTasklist.java
@@ -14,6 +14,7 @@ import io.camunda.application.listeners.ApplicationErrorListener;
 import io.camunda.configuration.UnifiedConfiguration;
 import io.camunda.configuration.UnifiedConfigurationHelper;
 import io.camunda.configuration.beanoverrides.GatewayBasedPropertiesOverride;
+import io.camunda.configuration.beanoverrides.GatewayRestPropertiesOverride;
 import io.camunda.configuration.beanoverrides.TasklistPropertiesOverride;
 import io.camunda.tasklist.TasklistModuleConfiguration;
 import io.camunda.webapps.WebappsModuleConfiguration;
@@ -43,6 +44,7 @@ public class StandaloneTasklist {
                 UnifiedConfigurationHelper.class,
                 TasklistPropertiesOverride.class,
                 GatewayBasedPropertiesOverride.class,
+                GatewayRestPropertiesOverride.class,
                 // ---
                 CommonsModuleConfiguration.class,
                 TasklistModuleConfiguration.class,

--- a/dist/src/main/java/io/camunda/application/commons/rest/RestApiConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/rest/RestApiConfiguration.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.application.commons.rest;
 
-import io.camunda.application.commons.rest.RestApiConfiguration.GatewayRestProperties;
 import io.camunda.authentication.ConditionalOnUnprotectedApi;
 import io.camunda.authentication.DefaultCamundaAuthenticationProvider;
 import io.camunda.authentication.converter.CamundaAuthenticationDelegatingConverter;
@@ -19,11 +18,8 @@ import io.camunda.security.auth.CamundaAuthenticationConverter;
 import io.camunda.security.auth.CamundaAuthenticationHolder;
 import io.camunda.security.auth.CamundaAuthenticationProvider;
 import io.camunda.zeebe.gateway.rest.ConditionalOnRestGatewayEnabled;
-import io.camunda.zeebe.gateway.rest.config.GatewayRestConfiguration;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.List;
-import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
@@ -32,7 +28,6 @@ import org.springframework.security.core.Authentication;
 @Configuration(proxyBeanMethods = false)
 @ComponentScan(basePackages = {"io.camunda.zeebe.gateway.rest", "io.camunda.service.validation"})
 @ConditionalOnRestGatewayEnabled
-@EnableConfigurationProperties(GatewayRestProperties.class)
 public class RestApiConfiguration {
 
   @Bean
@@ -61,7 +56,4 @@ public class RestApiConfiguration {
         new CamundaAuthenticationDelegatingHolder(holders),
         new CamundaAuthenticationDelegatingConverter(converters));
   }
-
-  @ConfigurationProperties("camunda.rest")
-  public static final class GatewayRestProperties extends GatewayRestConfiguration {}
 }

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/modules/ModuleAbstractIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/modules/ModuleAbstractIT.java
@@ -7,8 +7,6 @@
  */
 package io.camunda.operate.modules;
 
-import io.camunda.configuration.UnifiedConfiguration;
-import io.camunda.configuration.UnifiedConfigurationHelper;
 import io.camunda.operate.property.OperateProperties;
 import io.camunda.operate.util.apps.modules.ModulesTestApplication;
 import org.junit.runner.RunWith;
@@ -19,11 +17,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(
-    classes = {
-      ModulesTestApplication.class,
-      UnifiedConfigurationHelper.class,
-      UnifiedConfiguration.class,
-    },
+    classes = {ModulesTestApplication.class},
     properties = {
       OperateProperties.PREFIX + ".importer.startLoadingDataOnStartup = false",
       OperateProperties.PREFIX + ".archiver.rolloverEnabled = false",

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/TestApplication.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/TestApplication.java
@@ -10,6 +10,7 @@ package io.camunda.operate.util;
 import io.camunda.configuration.UnifiedConfiguration;
 import io.camunda.configuration.UnifiedConfigurationHelper;
 import io.camunda.configuration.beanoverrides.GatewayBasedPropertiesOverride;
+import io.camunda.configuration.beanoverrides.GatewayRestPropertiesOverride;
 import io.camunda.configuration.beanoverrides.OperatePropertiesOverride;
 import io.camunda.operate.OperateModuleConfiguration;
 import io.camunda.webapps.WebappsModuleConfiguration;
@@ -37,7 +38,8 @@ import org.springframework.context.annotation.Import;
   OperatePropertiesOverride.class,
   UnifiedConfiguration.class,
   UnifiedConfigurationHelper.class,
-  GatewayBasedPropertiesOverride.class
+  GatewayBasedPropertiesOverride.class,
+  GatewayRestPropertiesOverride.class
 })
 public class TestApplication {
 

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/apps/modules/ModulesTestApplication.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/apps/modules/ModulesTestApplication.java
@@ -10,6 +10,7 @@ package io.camunda.operate.util.apps.modules;
 import io.camunda.configuration.UnifiedConfiguration;
 import io.camunda.configuration.UnifiedConfigurationHelper;
 import io.camunda.configuration.beanoverrides.GatewayBasedPropertiesOverride;
+import io.camunda.configuration.beanoverrides.GatewayRestPropertiesOverride;
 import io.camunda.configuration.beanoverrides.OperatePropertiesOverride;
 import io.camunda.operate.OperateModuleConfiguration;
 import io.camunda.operate.util.TestApplication;
@@ -50,6 +51,7 @@ import org.springframework.context.annotation.Import;
   UnifiedConfiguration.class,
   UnifiedConfigurationHelper.class,
   GatewayBasedPropertiesOverride.class,
+  GatewayRestPropertiesOverride.class
 })
 public class ModulesTestApplication {
 

--- a/qa/util/src/main/java/io/camunda/qa/util/cluster/TestCamundaApplication.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/cluster/TestCamundaApplication.java
@@ -19,6 +19,7 @@ import io.camunda.application.initializers.WebappsConfigurationInitializer;
 import io.camunda.authentication.config.AuthenticationProperties;
 import io.camunda.configuration.UnifiedConfiguration;
 import io.camunda.configuration.UnifiedConfigurationHelper;
+import io.camunda.configuration.beanoverrides.GatewayRestPropertiesOverride;
 import io.camunda.configuration.beanoverrides.OperatePropertiesOverride;
 import io.camunda.configuration.beanoverrides.TasklistPropertiesOverride;
 import io.camunda.configuration.beans.BrokerBasedProperties;
@@ -72,6 +73,7 @@ public final class TestCamundaApplication extends TestSpringApplication<TestCamu
         TasklistPropertiesOverride.class,
         OperatePropertiesOverride.class,
         UnifiedConfigurationHelper.class,
+        GatewayRestPropertiesOverride.class,
         // ---
         CommonsModuleConfiguration.class,
         OperateModuleConfiguration.class,

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/modules/ModuleIntegrationTest.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/modules/ModuleIntegrationTest.java
@@ -7,8 +7,6 @@
  */
 package io.camunda.tasklist.modules;
 
-import io.camunda.configuration.UnifiedConfiguration;
-import io.camunda.configuration.UnifiedConfigurationHelper;
 import io.camunda.tasklist.property.TasklistProperties;
 import io.camunda.tasklist.util.apps.modules.ModulesTestApplication;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -20,11 +18,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 @ExtendWith(SpringExtension.class)
 @SpringBootTest(
-    classes = {
-      ModulesTestApplication.class,
-      UnifiedConfigurationHelper.class,
-      UnifiedConfiguration.class,
-    },
+    classes = {ModulesTestApplication.class},
     properties = {
       TasklistProperties.PREFIX + ".elasticsearch.createSchema = false",
       TasklistProperties.PREFIX + ".importer.startLoadingDataOnStartup = false",

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TasklistIntegrationTest.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TasklistIntegrationTest.java
@@ -9,8 +9,6 @@ package io.camunda.tasklist.util;
 
 import static org.mockito.Mockito.when;
 
-import io.camunda.configuration.UnifiedConfiguration;
-import io.camunda.configuration.UnifiedConfigurationHelper;
 import io.camunda.tasklist.property.TasklistProperties;
 import io.camunda.tasklist.zeebe.PartitionHolder;
 import java.time.OffsetDateTime;
@@ -26,7 +24,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 @ExtendWith(SpringExtension.class)
 @SpringBootTest(
-    classes = {TestApplication.class, UnifiedConfigurationHelper.class, UnifiedConfiguration.class},
+    classes = {TestApplication.class},
     properties = {
       TasklistProperties.PREFIX + ".importer.startLoadingDataOnStartup = false",
       TasklistProperties.PREFIX + ".archiver.rolloverEnabled = false",

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TestApplication.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TestApplication.java
@@ -11,6 +11,7 @@ import io.camunda.application.commons.CommonsModuleConfiguration;
 import io.camunda.configuration.UnifiedConfiguration;
 import io.camunda.configuration.UnifiedConfigurationHelper;
 import io.camunda.configuration.beanoverrides.GatewayBasedPropertiesOverride;
+import io.camunda.configuration.beanoverrides.GatewayRestPropertiesOverride;
 import io.camunda.configuration.beanoverrides.TasklistPropertiesOverride;
 import io.camunda.tasklist.TasklistModuleConfiguration;
 import io.camunda.tasklist.data.DataGenerator;
@@ -45,7 +46,8 @@ import org.springframework.context.annotation.Profile;
   TasklistPropertiesOverride.class,
   UnifiedConfiguration.class,
   UnifiedConfigurationHelper.class,
-  GatewayBasedPropertiesOverride.class
+  GatewayBasedPropertiesOverride.class,
+  GatewayRestPropertiesOverride.class,
 })
 public class TestApplication {
 

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/apps/modules/ModulesTestApplication.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/apps/modules/ModulesTestApplication.java
@@ -10,6 +10,7 @@ package io.camunda.tasklist.util.apps.modules;
 import io.camunda.configuration.UnifiedConfiguration;
 import io.camunda.configuration.UnifiedConfigurationHelper;
 import io.camunda.configuration.beanoverrides.GatewayBasedPropertiesOverride;
+import io.camunda.configuration.beanoverrides.GatewayRestPropertiesOverride;
 import io.camunda.configuration.beanoverrides.TasklistPropertiesOverride;
 import io.camunda.tasklist.TasklistModuleConfiguration;
 import io.camunda.tasklist.data.DataGenerator;
@@ -64,6 +65,7 @@ import org.springframework.context.annotation.Profile;
   UnifiedConfiguration.class,
   UnifiedConfigurationHelper.class,
   GatewayBasedPropertiesOverride.class,
+  GatewayRestPropertiesOverride.class
 })
 public class ModulesTestApplication {
 

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneBroker.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneBroker.java
@@ -17,6 +17,7 @@ import io.camunda.application.commons.security.CamundaSecurityConfiguration.Camu
 import io.camunda.authentication.config.AuthenticationProperties;
 import io.camunda.configuration.UnifiedConfiguration;
 import io.camunda.configuration.UnifiedConfigurationHelper;
+import io.camunda.configuration.beanoverrides.GatewayRestPropertiesOverride;
 import io.camunda.configuration.beans.BrokerBasedProperties;
 import io.camunda.security.configuration.ConfiguredMappingRule;
 import io.camunda.security.configuration.ConfiguredUser;
@@ -56,7 +57,8 @@ public final class TestStandaloneBroker extends TestSpringApplication<TestStanda
         BrokerModuleConfiguration.class,
         CommonsModuleConfiguration.class,
         UnifiedConfigurationHelper.class,
-        UnifiedConfiguration.class);
+        UnifiedConfiguration.class,
+        GatewayRestPropertiesOverride.class);
 
     config = new BrokerBasedProperties();
 

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneGateway.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneGateway.java
@@ -15,6 +15,7 @@ import io.camunda.configuration.UnifiedConfiguration;
 import io.camunda.configuration.UnifiedConfigurationHelper;
 import io.camunda.configuration.beanoverrides.ActorClockControlledPropertiesOverride;
 import io.camunda.configuration.beanoverrides.BrokerBasedPropertiesOverride;
+import io.camunda.configuration.beanoverrides.GatewayRestPropertiesOverride;
 import io.camunda.configuration.beanoverrides.IdleStrategyPropertiesOverride;
 import io.camunda.configuration.beanoverrides.OperatePropertiesOverride;
 import io.camunda.configuration.beanoverrides.TasklistPropertiesOverride;
@@ -40,7 +41,8 @@ public final class TestStandaloneGateway extends TestSpringApplication<TestStand
         OperatePropertiesOverride.class,
         BrokerBasedPropertiesOverride.class,
         ActorClockControlledPropertiesOverride.class,
-        IdleStrategyPropertiesOverride.class);
+        IdleStrategyPropertiesOverride.class,
+        GatewayRestPropertiesOverride.class);
     config = new GatewayBasedProperties();
 
     config.getNetwork().setHost("0.0.0.0");


### PR DESCRIPTION
## Description

This PR adds the properties from section camunda.api.rest.process-cache in unified config.

The legacy properties are:

camunda.rest.processCache.maxSize
camunda.rest.processCache.expirationIdleMillis

The new properties are:

camunda.api.rest.process-cache.max-size
camunda.api.rest.process-cache.expiration-idle

Backwards compatibility is supported for these properties. That means, if legacy is set and new property is not set, legacy value will be used.
## Checklist

- [ ] The legacy properties and the backwards compatibility strategy are updated in [schema doc](https://docs.google.com/spreadsheets/d/1R4epsy6DWemA8_76cUE6zOGUFbrXCXlM2reXnKFuz7Y/edit?gid=818158292#gid=818158292)
- [ ] The new property fields are documented in the code
## Related issues

related to #34911