### PR TITLE
ci: fix optimize build issue when zeebe is changes

### DIFF
--- a/.github/workflows/optimize-ci-build-reusable.yml
+++ b/.github/workflows/optimize-ci-build-reusable.yml
@@ -84,6 +84,11 @@ jobs:
         with:
           directory: ./optimize/client
 
+      - uses: ./.github/actions/build-zeebe
+        id: build-camunda
+        with:
+          maven-extra-args: -PskipFrontendBuild
+
       #########################################################################
       # Build optimize dependencies
       - name: Build optimize dependencies

--- a/.github/workflows/optimize-ci-core-features.yml
+++ b/.github/workflows/optimize-ci-core-features.yml
@@ -111,6 +111,11 @@ jobs:
           ELASTIC_JVM_MEMORY: 16
           ELASTIC_HTTP_PORT: 9200
 
+      - uses: ./.github/actions/build-zeebe
+        id: build-camunda
+        with:
+          maven-extra-args: -PskipFrontendBuild
+
       - name: Verify integration
         uses: ./.github/actions/run-maven
         env:
@@ -189,6 +194,11 @@ jobs:
           OPENSEARCH_VERSION: ${{ env.OPENSEARCH_VERSION }}
           OPENSEARCH_JVM_MEMORY: 16
           OPENSEARCH_HTTP_PORT: 9200
+
+      - uses: ./.github/actions/build-zeebe
+        id: build-camunda
+        with:
+          maven-extra-args: -PskipFrontendBuild
 
       - name: Verify integration
         uses: ./.github/actions/run-maven

--- a/.github/workflows/optimize-ci-data-layer.yml
+++ b/.github/workflows/optimize-ci-data-layer.yml
@@ -168,6 +168,12 @@ jobs:
           OPENSEARCH_VERSION: ${{ steps.pom-info.outputs.x_opensearch_test_version }}
           OPENSEARCH_JVM_MEMORY: 1
           OPENSEARCH_HTTP_PORT: ${{ steps.pom-info.outputs.x_new_database_port }}
+
+      - uses: ./.github/actions/build-zeebe
+        id: build-camunda
+        with:
+          maven-extra-args: -PskipFrontendBuild
+
       - name: Install optimize dependencies
         uses: ./.github/actions/run-maven
         with:
@@ -233,6 +239,11 @@ jobs:
           OPENSEARCH_VERSION: ${{ steps.pom-info.outputs.x_opensearch_test_version }}
           OPENSEARCH_JVM_MEMORY: 1
           OPENSEARCH_HTTP_PORT: ${{ steps.pom-info.outputs.x_new_elasticsearch_port }}
+
+      - uses: ./.github/actions/build-zeebe
+        id: build-camunda
+        with:
+          maven-extra-args: -PskipFrontendBuild
 
       - name: Install optimize dependencies
         uses: ./.github/actions/run-maven

--- a/.github/workflows/optimize-e2e-test-cloud.yml
+++ b/.github/workflows/optimize-e2e-test-cloud.yml
@@ -85,6 +85,10 @@ jobs:
         uses: ./.github/actions/build-frontend
         with:
           directory: ./optimize/client
+      - uses: ./.github/actions/build-zeebe
+        id: build-camunda
+        with:
+          maven-extra-args: -PskipFrontendBuild
       - name: 'build backend & frontend'
         run: ./mvnw clean install -DskipTests -Dskip.docker -pl optimize/backend -am -PskipFrontendBuild
       - name: 'start backend'

--- a/.github/workflows/optimize-e2e-tests-sm.yml
+++ b/.github/workflows/optimize-e2e-tests-sm.yml
@@ -82,6 +82,11 @@ jobs:
           project_name: e2e
           additional_flags: "--profile self-managed"
 
+      - uses: ./.github/actions/build-zeebe
+        id: build-camunda
+        with:
+          maven-extra-args: -PskipFrontendBuild
+
       - name: Build backend
         run: mvn -f optimize/pom.xml clean install -T1C -DskipTests -Dskip.docker -pl backend -am
 

--- a/.github/workflows/optimize-e2e-tests-sm.yml
+++ b/.github/workflows/optimize-e2e-tests-sm.yml
@@ -88,7 +88,7 @@ jobs:
           maven-extra-args: -PskipFrontendBuild
 
       - name: Build backend
-        run: mvn -f optimize/pom.xml clean install -T1C -DskipTests -Dskip.docker -pl backend -am
+        run: ./mvnw clean install -DskipTests -Dskip.docker -pl optimize/backend -am -PskipFrontendBuild
 
       - name: Create backend logs file
         run: mkdir -p ./optimize/client/build && touch ./optimize/client/build/backendLogs.log

--- a/optimize/pom.xml
+++ b/optimize/pom.xml
@@ -48,8 +48,8 @@
     <project.previousVersion>8.7.0</project.previousVersion>
     <camunda.maven.artifacts.version>7.22.0</camunda.maven.artifacts.version>
 
+    <zeebe.version>8.8.0-SNAPSHOT</zeebe.version>
     <!-- We use this version to compile but run IT against containers with zeebe.docker.version -->
-    <zeebe.version>8.7.10</zeebe.version>
     <identity.version>8.7.5</identity.version>
     <!-- We use this for the Zeebe test container version only -->
     <zeebe.docker.version>8.7.0-alpha4</zeebe.docker.version>


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Build Zeebe in the broken Optimize legacy tests so that the zeebe dependency will be built and will be available as a SNAPSHOT for Optimize to use. 

This fixes an issue where Optimize was having compilation error on a Zeebe change

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes https://github.com/camunda/camunda/issues/36884
