### PR TITLE
ci: sign cherry-picked commits by backport-action

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -32,6 +32,15 @@ jobs:
         with:
           # Token for git actions, e.g. git push
           token: ${{ secrets.BACKPORT_ACTION_PAT }}
+      - name: Import GPG key
+        id: import-gpg
+        uses: crazy-max/ghaction-import-gpg@e89d40939c28e39f97cf32126055eeae86ba74ec #v6.3.0
+        with:
+          gpg_private_key: ${{ secrets.BACKPORT_ACTION_GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.BACKPORT_ACTION_GPG_PASSPHRASE }}
+          git_config_global: true
+          git_user_signingkey: true
+          git_commit_gpgsign: true
       - name: Create backport PRs
         uses: korthout/backport-action@v3
         with:
@@ -53,3 +62,5 @@ jobs:
             {
               "conflict_resolution": "draft_commit_conflicts"
             }
+          git_committer_name: ${{ steps.import-gpg.outputs.name }}
+          git_committer_email: ${{ steps.import-gpg.outputs.email }}

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -42,7 +42,7 @@ jobs:
           git_user_signingkey: true
           git_commit_gpgsign: true
       - name: Create backport PRs
-        uses: korthout/backport-action@v3
+        uses: korthout/backport-action@ca4972adce8039ff995e618f5fc02d1b7961f27a #v3.3.0
         with:
           # Token to authenticate requests to GitHub
           github_token: ${{ secrets.BACKPORT_ACTION_PAT }}


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This adds a GPG key for backport-action with which it can sign the cherry-picked commits that it creates. This is supported since [backport-action v3.3.0](https://github.com/korthout/backport-action/releases/tag/v3.3.0) (see [signing cherry-picked commits](https://github.com/korthout/backport-action?tab=readme-ov-file#signing-cherry-picked-commits)).

This is achieved using [crazy-max/ghaction-import-gpg](https://github.com/crazy-max/ghaction-import-gpg) and two secrets. The secrets specify the private key and corresponding passphrase. The key is imported and the git config is adjusted to allow signing of commits using this key. In addition, backport-action is instructed to use the corresponding user id and email when creating git commits - which it does only through cherry-picking.

crazy-max/ghaction-import-gpg seems to be a respectable action to import a gpg key for usage in signing git commits. I've tested it in [korthout/backport-action-test](https://github.com/korthout/backport-action-test) successfully using the exact same changes as made here. The repo seems to receive semi-regular updates, although [it's behind on its opengpg version currently](https://github.com/crazy-max/ghaction-import-gpg/pull/222). Given the context of this workflow (used only to set up a gpg key for git commit signing by the backport-action), this is an acceptable security risk. The exposed gpg key (set up in a secret) is linked to the [github.com/backport-action](https://github.com/backport-action) bot account only.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

Tested in https://github.com/korthout/backport-action-test/pull/386
