### PR TITLE
feat: add cluster network command-api section to unified configuration

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/CommandApi.java
+++ b/configuration/src/main/java/io/camunda/configuration/CommandApi.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import io.camunda.configuration.UnifiedConfigurationHelper.BackwardsCompatibilityMode;
+import java.util.Set;
+
+public class CommandApi {
+  private static final String PREFIX = "camunda.cluster.network.command-api";
+  private static final Set<String> LEGACY_HOST_PROPERTIES =
+      Set.of("zeebe.broker.network.commandApi.host");
+  private static final Set<String> LEGACY_PORT_PROPERTIES =
+      Set.of("zeebe.broker.network.commandApi.port");
+  private static final Set<String> LEGACY_ADVERTISED_HOST_PROPERTIES =
+      Set.of("zeebe.broker.network.commandApi.advertisedHost");
+  private static final Set<String> LEGACY_ADVERTISED_PORT_PROPERTIES =
+      Set.of("zeebe.broker.network.commandApi.advertisedPort");
+
+  /** Overrides the host used for gateway-to-broker communication */
+  private String host;
+
+  /** Sets the port used for gateway-to-broker communication */
+  private Integer port;
+
+  /**
+   * Controls the advertised host. This is particularly useful if your broker stands behind a proxy.
+   * If omitted, defaults to:
+   *
+   * <ul>
+   *   <li>If zeebe.broker.network.commandApi.host was set, use this.
+   *   <li>Use the resolved value of zeebe.broker.network.advertisedHost
+   * </ul>
+   */
+  private String advertisedHost;
+
+  /**
+   * Controls the advertised port; if omitted defaults to the port. This is particularly useful if
+   * your broker stands behind a proxy.
+   */
+  private Integer advertisedPort;
+
+  public String getHost() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + ".host",
+        host,
+        String.class,
+        BackwardsCompatibilityMode.SUPPORTED,
+        LEGACY_HOST_PROPERTIES);
+  }
+
+  public void setHost(final String host) {
+    this.host = host;
+  }
+
+  public Integer getPort() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + ".port",
+        port,
+        Integer.class,
+        BackwardsCompatibilityMode.SUPPORTED,
+        LEGACY_PORT_PROPERTIES);
+  }
+
+  public void setPort(final Integer port) {
+    this.port = port;
+  }
+
+  public String getAdvertisedHost() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + ".advertised-host",
+        advertisedHost,
+        String.class,
+        BackwardsCompatibilityMode.SUPPORTED,
+        LEGACY_ADVERTISED_HOST_PROPERTIES);
+  }
+
+  public void setAdvertisedHost(final String advertisedHost) {
+    this.advertisedHost = advertisedHost;
+  }
+
+  public Integer getAdvertisedPort() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + ".advertised-port",
+        advertisedPort,
+        Integer.class,
+        BackwardsCompatibilityMode.SUPPORTED,
+        LEGACY_ADVERTISED_PORT_PROPERTIES);
+  }
+
+  public void setAdvertisedPort(final Integer advertisedPort) {
+    this.advertisedPort = advertisedPort;
+  }
+}

--- a/configuration/src/main/java/io/camunda/configuration/Network.java
+++ b/configuration/src/main/java/io/camunda/configuration/Network.java
@@ -88,6 +88,8 @@ public class Network {
   /** Sets the internal api configuration */
   private InternalApi internalApi = new InternalApi();
 
+  private CommandApi commandApi = new CommandApi();
+
   public String getHost() {
     return UnifiedConfigurationHelper.validateLegacyConfiguration(
         PREFIX + ".host",
@@ -198,6 +200,14 @@ public class Network {
 
   public void setInternalApi(final InternalApi internalApi) {
     this.internalApi = internalApi;
+  }
+
+  public CommandApi getCommandApi() {
+    return commandApi;
+  }
+
+  public void setCommandApi(final CommandApi commandApi) {
+    this.commandApi = commandApi;
   }
 
   @Override

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
@@ -9,6 +9,7 @@ package io.camunda.configuration.beanoverrides;
 
 import io.camunda.configuration.Azure;
 import io.camunda.configuration.Backup;
+import io.camunda.configuration.CommandApi;
 import io.camunda.configuration.Data;
 import io.camunda.configuration.Export;
 import io.camunda.configuration.Filesystem;
@@ -35,6 +36,7 @@ import io.camunda.zeebe.broker.system.configuration.ExportingCfg;
 import io.camunda.zeebe.broker.system.configuration.MembershipCfg;
 import io.camunda.zeebe.broker.system.configuration.RaftCfg.FlushConfig;
 import io.camunda.zeebe.broker.system.configuration.SocketBindingCfg;
+import io.camunda.zeebe.broker.system.configuration.SocketBindingCfg.CommandApiCfg;
 import io.camunda.zeebe.broker.system.configuration.ThreadsCfg;
 import io.camunda.zeebe.broker.system.configuration.backup.AzureBackupStoreConfig;
 import io.camunda.zeebe.broker.system.configuration.backup.BackupStoreCfg;
@@ -295,6 +297,7 @@ public class BrokerBasedPropertiesOverride {
         unifiedConfiguration.getCamunda().getCluster().getNetwork().withBrokerNetworkProperties();
     override.getGateway().getNetwork().setMaxMessageSize(ucNetwork.getMaxMessageSize());
 
+    populateFromCommandApi(override);
     populateFromInternalApi(override);
   }
 
@@ -314,6 +317,17 @@ public class BrokerBasedPropertiesOverride {
     socketBindingCfg.setAdvertisedHost(internalApi.getAdvertisedHost());
     Optional.ofNullable(internalApi.getAdvertisedPort())
         .ifPresent(socketBindingCfg::setAdvertisedPort);
+  }
+
+  private void populateFromCommandApi(final BrokerBasedProperties override) {
+    final CommandApi commandApi =
+        unifiedConfiguration.getCamunda().getCluster().getNetwork().getCommandApi();
+    final CommandApiCfg commandApiCfg = override.getNetwork().getCommandApi();
+
+    commandApiCfg.setHost(commandApi.getHost());
+    Optional.ofNullable(commandApi.getPort()).ifPresent(commandApiCfg::setPort);
+    commandApiCfg.setAdvertisedHost(commandApi.getAdvertisedHost());
+    Optional.ofNullable(commandApi.getAdvertisedPort()).ifPresent(commandApiCfg::setAdvertisedPort);
   }
 
   private void populateFromRestFilters(final BrokerBasedProperties override) {

--- a/configuration/src/test/java/io/camunda/configuration/ClusterNetworkCommandApiTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/ClusterNetworkCommandApiTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.configuration.beanoverrides.BrokerBasedPropertiesOverride;
+import io.camunda.configuration.beans.BrokerBasedProperties;
+import io.camunda.zeebe.broker.system.configuration.SocketBindingCfg.CommandApiCfg;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+@SpringJUnitConfig({
+  UnifiedConfiguration.class,
+  BrokerBasedPropertiesOverride.class,
+  UnifiedConfigurationHelper.class
+})
+@ActiveProfiles("broker")
+public class ClusterNetworkCommandApiTest {
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "camunda.cluster.network.command-api.host=hostNew",
+        "camunda.cluster.network.command-api.port=10",
+        "camunda.cluster.network.command-api.advertised-host=advertisedHostNew",
+        "camunda.cluster.network.command-api.advertised-port=30",
+      })
+  class WithOnlyUnifiedConfigSet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithOnlyUnifiedConfigSet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldSetFromNew() {
+      assertThat(brokerCfg.getNetwork().getCommandApi())
+          .returns("hostNew", CommandApiCfg::getHost)
+          .returns(10, CommandApiCfg::getPort)
+          .returns("advertisedHostNew", CommandApiCfg::getAdvertisedHost)
+          .returns(30, CommandApiCfg::getAdvertisedPort);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "zeebe.broker.network.commandApi.host=hostLegacy",
+        "zeebe.broker.network.commandApi.port=20",
+        "zeebe.broker.network.commandApi.advertisedHost=advertisedHostLegacy",
+        "zeebe.broker.network.commandApi.advertisedPort=40",
+      })
+  class WithOnlyLegacySet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithOnlyLegacySet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldSetFromLegacy() {
+      assertThat(brokerCfg.getNetwork().getCommandApi())
+          .returns("hostLegacy", CommandApiCfg::getHost)
+          .returns(20, CommandApiCfg::getPort)
+          .returns("advertisedHostLegacy", CommandApiCfg::getAdvertisedHost)
+          .returns(40, CommandApiCfg::getAdvertisedPort);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        // new
+        "camunda.cluster.network.command-api.host=hostNew",
+        "camunda.cluster.network.command-api.port=10",
+        "camunda.cluster.network.command-api.advertised-host=advertisedHostNew",
+        "camunda.cluster.network.command-api.advertised-port=30",
+        // legacy
+        "zeebe.broker.network.commandApi.host=hostLegacy",
+        "zeebe.broker.network.commandApi.port=20",
+        "zeebe.broker.network.commandApi.advertisedHost=advertisedHostLegacy",
+        "zeebe.broker.network.commandApi.advertisedPort=40",
+      })
+  class WithNewAndLegacySet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithNewAndLegacySet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldSetFromNew() {
+      assertThat(brokerCfg.getNetwork().getCommandApi())
+          .returns("hostNew", CommandApiCfg::getHost)
+          .returns(10, CommandApiCfg::getPort)
+          .returns("advertisedHostNew", CommandApiCfg::getAdvertisedHost)
+          .returns(30, CommandApiCfg::getAdvertisedPort);
+    }
+  }
+}


### PR DESCRIPTION
## Description

This PR adds the properties from section camunda.cluster.network.command-api in unified config.

The legacy properties are:

zeebe.broker.network.commandApi.host
zeebe.broker.network.commandApi.port
zeebe.broker.network.commandApi.advertisedHost
zeebe.broker.network.commandApi.advertisedPort

The new properties are:

camunda.cluster.network.command-api.host
camunda.cluster.network.command-api.port
camunda.cluster.network.command-api.advertised-host
camunda.cluster.network.command-api.advertised-port

Backwards compatibility is supported for these properties. That means, if legacy is set and new property is not set, legacy value will be used.
## Checklist

- [ ] The legacy properties and the backwards compatibility strategy are updated in [schema doc](https://docs.google.com/spreadsheets/d/1R4epsy6DWemA8_76cUE6zOGUFbrXCXlM2reXnKFuz7Y/edit?gid=818158292#gid=818158292)
- [ ] The new property fields are documented in the code
## Related issues

related to #34906 