### PR TITLE
deps: bump angus mail to 2.0.4

### DIFF
--- a/optimize/backend/pom.xml
+++ b/optimize/backend/pom.xml
@@ -275,6 +275,12 @@
       <artifactId>jakarta.mail-api</artifactId>
       <version>2.1.3</version>
     </dependency>
+    <!-- The org.eclipse.angus:jakarta.mail dependency can be removed if a newer Spring Boot patch provides a version >2.0.3 -->
+    <dependency>
+      <groupId>org.eclipse.angus</groupId>
+      <artifactId>jakarta.mail</artifactId>
+      <version>2.0.4</version>
+    </dependency>
 
     <dependency>
       <groupId>org.freemarker</groupId>


### PR DESCRIPTION
## Description

Introduces a dedicated dependency for angus mail in version 2.0.4. This is a transitive dependency from spring-boot-starter-mail that needs a version bump that spring-boot-starter-mail currently doesn't provide in any patch.

On the `main` branch, this is solved differently with https://github.com/camunda/camunda/pull/36898. There, it's a dedicated dependency already.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

related to https://jira.camunda.com/browse/SEC-1561