### PR TITLE
deps: upgrade netty to 4.1.124.Final

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -75,7 +75,7 @@
     <version.mockito>5.18.0</version.mockito>
     <version.model>7.7.0</version.model>
     <version.msgpack>0.9.10</version.msgpack>
-    <version.netty>4.1.119.Final</version.netty>
+    <version.netty>4.1.124.Final</version.netty>
     <version.objenesis>3.4</version.objenesis>
     <version.opensearch>2.17.0</version.opensearch>
     <version.opensearch-java>2.19.0</version.opensearch-java>


### PR DESCRIPTION
## Description

I'm updating netty dep to 4.1.124.Final to fix https://nvd.nist.gov/vuln/detail/CVE-2025-55163

## Related issues

https://jira.camunda.com/browse/SEC-1567
https://jira.camunda.com/browse/SEC-1569
https://jira.camunda.com/browse/SEC-1570
https://jira.camunda.com/browse/SEC-1571
