### PR TITLE
deps: upgrade tomcat to 10.1.44

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -105,7 +105,7 @@
     <version.spring>6.2.8</version.spring>
     <version.spring-security>6.5.2</version.spring-security>
     <version.spring-boot>3.4.7</version.spring-boot>
-    <version.tomcat>10.1.43</version.tomcat>
+    <version.tomcat>10.1.44</version.tomcat>
     <version.concurrentunit>0.4.6</version.concurrentunit>
     <version.kryo>5.6.2</version.kryo>
     <version.failsafe>2.4.4</version.failsafe>


### PR DESCRIPTION
## Description

I'm updating tomcat dep to 10.1.44 to fix https://nvd.nist.gov/vuln/detail/CVE-2025-48989

## Related issues

https://jira.camunda.com/browse/SEC-1568
https://jira.camunda.com/browse/SEC-1566