### PR TITLE
Return meaningful error if OIDC provider is unavailable

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
@@ -563,8 +563,17 @@ public class WebSecurityConfig {
     @Bean
     public ClientRegistrationRepository clientRegistrationRepository(
         final SecurityConfiguration securityConfiguration) {
-      return new InMemoryClientRegistrationRepository(
-          OidcClientRegistration.create(securityConfiguration.getAuthentication().getOidc()));
+      try {
+        return new InMemoryClientRegistrationRepository(
+            OidcClientRegistration.create(securityConfiguration.getAuthentication().getOidc()));
+      } catch (final Exception e) {
+        final String issuerUri = securityConfiguration.getAuthentication().getOidc().getIssuerUri();
+        throw new IllegalStateException(
+            "Unable to connect to the Identity Provider endpoint `"
+                + issuerUri
+                + "'. Please try again later or contact your administrator.",
+            e);
+      }
     }
 
     @Bean

--- a/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
@@ -571,7 +571,8 @@ public class WebSecurityConfig {
         throw new IllegalStateException(
             "Unable to connect to the Identity Provider endpoint `"
                 + issuerUri
-                + "'. Please try again later or contact your administrator.",
+                + "'. Double check that it is configured correctly, and if the problem persists, "
+                + "contact your external Identity provider.",
             e);
       }
     }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/OidcAuthOverRestStartupIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/OidcAuthOverRestStartupIT.java
@@ -58,7 +58,8 @@ public class OidcAuthOverRestStartupIT {
     // given
     final String expectedMessage =
         "Unable to connect to the Identity Provider endpoint `http://localhost:1000/realms/camunda'. "
-            + "Please try again later or contact your administrator.";
+            + "Double check that it is configured correctly, and if the problem persists, "
+            + "contact your external Identity provider.";
 
     // when
     final Throwable exception = Assertions.assertThatThrownBy(broker::start).actual();

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/OidcAuthOverRestStartupIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/OidcAuthOverRestStartupIT.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.authorization;
+
+import io.camunda.security.entity.AuthenticationMethod;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.zeebe.test.util.testcontainers.TestSearchContainers;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.assertj.core.api.Assertions;
+import org.assertj.core.api.Fail;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.elasticsearch.ElasticsearchContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+@ZeebeIntegration
+public class OidcAuthOverRestStartupIT {
+  private static final String DEFAULT_USER_ID = UUID.randomUUID().toString();
+  private static final String KEYCLOAK_REALM = "camunda";
+
+  @Container
+  private static final ElasticsearchContainer CONTAINER =
+      TestSearchContainers.createDefeaultElasticsearchContainer();
+
+  @TestZeebe(autoStart = false, awaitCompleteTopology = false)
+  private final TestStandaloneBroker broker =
+      new TestStandaloneBroker()
+          .withAuthenticatedAccess()
+          .withAuthenticationMethod(AuthenticationMethod.OIDC)
+          .withCamundaExporter("http://" + CONTAINER.getHttpHostAddress())
+          .withSecurityConfig(
+              c -> {
+                c.getAuthorizations().setEnabled(true);
+                final var oidcConfig = c.getAuthentication().getOidc();
+                final String issuerUri = "http://localhost:1000" + "/realms/" + KEYCLOAK_REALM;
+                oidcConfig.setIssuerUri(issuerUri);
+                // The following two properties are only needed for the webapp login flow which we
+                // don't test here.
+                oidcConfig.setClientId("example");
+                oidcConfig.setRedirectUri("example.com");
+                c.getInitialization()
+                    .getDefaultRoles()
+                    .put("admin", Map.of("users", List.of(DEFAULT_USER_ID)));
+              });
+
+  @Test
+  public void shouldFailToStartWhenNoIdpAvailable() {
+    // given
+    final String expectedMessage =
+        "Unable to connect to the Identity Provider endpoint `http://localhost:1000/realms/camunda'. "
+            + "Please try again later or contact your administrator.";
+
+    // when
+    final Throwable exception = Assertions.assertThatThrownBy(broker::start).actual();
+
+    // then
+    assertHasNestedException(exception, IllegalStateException.class, expectedMessage);
+  }
+
+  private void assertHasNestedException(
+      Throwable exception, final Class<?> expectedClass, final String expectedMessage) {
+    while (exception != null) {
+      if (expectedClass.equals(exception.getClass())
+          && expectedMessage.equals(exception.getMessage())) {
+        return;
+      }
+      exception = exception.getCause();
+    }
+    Fail.fail(
+        "Exception has no cause with expectedClass: "
+            + expectedClass.getSimpleName()
+            + " and message: "
+            + expectedMessage);
+  }
+}


### PR DESCRIPTION
## Description

Wrap `ClientRegistrationRepository` creation in `try/catch` so we could provide the meaningful error message.

Please feel free to let me know if we'd like to modify the error message to be something else.
Currently, error message looks like this:
```
Unable to connect to the Identity Provider endpoint `"
                + issuerUri
                + "'. Double check that it is configured correctly, and if the problem persists, "
                + "contact your external Identity provider.
```

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #34189
