### PR TITLE
[Backport stable/optimize-8.6] deps: bump angus mail to 2.0.4

### DIFF
--- a/optimize/backend/pom.xml
+++ b/optimize/backend/pom.xml
@@ -270,6 +270,12 @@
       <artifactId>jakarta.mail-api</artifactId>
       <version>2.1.3</version>
     </dependency>
+    <!-- The org.eclipse.angus:jakarta.mail dependency can be removed if a newer Spring Boot patch provides a version >2.0.3 -->
+    <dependency>
+      <groupId>org.eclipse.angus</groupId>
+      <artifactId>jakarta.mail</artifactId>
+      <version>2.0.4</version>
+    </dependency>
 
     <dependency>
       <groupId>org.freemarker</groupId>


### PR DESCRIPTION
# Description
Backport of #36902 to `stable/optimize-8.6`.

relates to 
original author: @tmetzke