### PR TITLE
feat: add rest executor section to unified configuration

### DIFF
--- a/configuration/pom.xml
+++ b/configuration/pom.xml
@@ -72,6 +72,11 @@
     </dependency>
 
     <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-gateway-rest</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>

--- a/configuration/src/main/java/io/camunda/configuration/Executor.java
+++ b/configuration/src/main/java/io/camunda/configuration/Executor.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import io.camunda.configuration.UnifiedConfigurationHelper.BackwardsCompatibilityMode;
+import java.time.Duration;
+import java.util.Set;
+
+public class Executor {
+  private static final String PREFIX = "camunda.api.rest.executor";
+  private static final Set<String> LEGACY_CORE_POOL_SIZE_PROPERTIES =
+      Set.of("camunda.rest.apiExecutor.corePoolSize");
+  private static final Set<String> LEGACY_THREAD_COUNT_MULTIPLIER_PROPERTIES =
+      Set.of("camunda.rest.apiExecutor.threadCountMultiplier");
+  private static final Set<String> LEGACY_KEEP_ALIVE_SECONDS_PROPERTIES =
+      Set.of("camunda.rest.apiExecutor.keepAliveSeconds");
+
+  // TODO KPO add java doc
+  private int corePoolSize = 1;
+  private int threadCountMultiplier = 2;
+  private Duration keepAlive = Duration.ofSeconds(60);
+
+  public int getCorePoolSize() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + ".core-pool-size",
+        corePoolSize,
+        Integer.class,
+        BackwardsCompatibilityMode.SUPPORTED,
+        LEGACY_CORE_POOL_SIZE_PROPERTIES);
+  }
+
+  public void setCorePoolSize(final int corePoolSize) {
+    this.corePoolSize = corePoolSize;
+  }
+
+  public int getThreadCountMultiplier() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + ".thread-count-multiplier",
+        threadCountMultiplier,
+        Integer.class,
+        BackwardsCompatibilityMode.SUPPORTED,
+        LEGACY_THREAD_COUNT_MULTIPLIER_PROPERTIES);
+  }
+
+  public void setThreadCountMultiplier(final int threadCountMultiplier) {
+    this.threadCountMultiplier = threadCountMultiplier;
+  }
+
+  public Duration getKeepAlive() {
+    final Long currentKeepAliveSeconds =
+        UnifiedConfigurationHelper.validateLegacyConfiguration(
+            PREFIX + ".keep-alive",
+            keepAlive.getSeconds(),
+            Long.class,
+            BackwardsCompatibilityMode.SUPPORTED,
+            LEGACY_KEEP_ALIVE_SECONDS_PROPERTIES);
+    return Duration.ofSeconds(currentKeepAliveSeconds);
+  }
+
+  public void setKeepAlive(final Duration keepAlive) {
+    this.keepAlive = keepAlive;
+  }
+}

--- a/configuration/src/main/java/io/camunda/configuration/ProcessCache.java
+++ b/configuration/src/main/java/io/camunda/configuration/ProcessCache.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import io.camunda.configuration.UnifiedConfigurationHelper.BackwardsCompatibilityMode;
+import java.time.Duration;
+import java.util.Set;
+
+public class ProcessCache {
+  private static final String PREFIX = "camunda.api.rest.process-cache";
+  private static final Set<String> LEGACY_MAX_SIZE_PROPERTIES =
+      Set.of("camunda.rest.processCache.maxSize");
+  private static final Set<String> LEGACY_EXPIRATION_IDLE_PROPERTIES =
+      Set.of("camunda.rest.processCache.expirationIdleMillis");
+
+  /** Process cache max size */
+  private int maxSize = 100;
+
+  /** Process cache expiration milliseconds */
+  private Duration expirationIdle = Duration.ofMillis(0);
+
+  public int getMaxSize() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + ".max-size",
+        maxSize,
+        Integer.class,
+        BackwardsCompatibilityMode.SUPPORTED,
+        LEGACY_MAX_SIZE_PROPERTIES);
+  }
+
+  public void setMaxSize(final int maxSize) {
+    this.maxSize = maxSize;
+  }
+
+  public Duration getExpirationIdle() {
+    final Long currentExpirationIdle =
+        UnifiedConfigurationHelper.validateLegacyConfiguration(
+            PREFIX + ".expiration-idle",
+            expirationIdle.toMillis(),
+            Long.class,
+            BackwardsCompatibilityMode.SUPPORTED,
+            LEGACY_EXPIRATION_IDLE_PROPERTIES);
+
+    return Duration.ofMillis(currentExpirationIdle);
+  }
+
+  public void setExpirationIdle(final Duration expirationIdle) {
+    this.expirationIdle = expirationIdle;
+  }
+}

--- a/configuration/src/main/java/io/camunda/configuration/Rest.java
+++ b/configuration/src/main/java/io/camunda/configuration/Rest.java
@@ -12,8 +12,14 @@ import java.util.List;
 
 public class Rest {
 
-  /** Sets the filters */
+  /** Set the filters */
   private List<Filter> filters = new ArrayList<>();
+
+  /** Set the process cache configuration */
+  private ProcessCache processCache = new ProcessCache();
+
+  /** Set the executor configuration */
+  private Executor executor = new Executor();
 
   public List<Filter> getFilters() {
     return filters;
@@ -21,5 +27,21 @@ public class Rest {
 
   public void setFilters(final List<Filter> filters) {
     this.filters = filters;
+  }
+
+  public ProcessCache getProcessCache() {
+    return processCache;
+  }
+
+  public void setProcessCache(final ProcessCache processCache) {
+    this.processCache = processCache;
+  }
+
+  public Executor getExecutor() {
+    return executor;
+  }
+
+  public void setExecutor(final Executor executor) {
+    this.executor = executor;
   }
 }

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/GatewayRestPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/GatewayRestPropertiesOverride.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration.beanoverrides;
+
+import io.camunda.configuration.Executor;
+import io.camunda.configuration.ProcessCache;
+import io.camunda.configuration.UnifiedConfiguration;
+import io.camunda.configuration.beans.GatewayRestProperties;
+import io.camunda.configuration.beans.LegacyGatewayRestProperties;
+import io.camunda.zeebe.gateway.rest.config.GatewayRestConfiguration.ApiExecutorConfiguration;
+import io.camunda.zeebe.gateway.rest.config.GatewayRestConfiguration.ProcessCacheConfiguration;
+import org.springframework.beans.BeanUtils;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.DependsOn;
+import org.springframework.context.annotation.Primary;
+
+@Configuration
+@EnableConfigurationProperties(LegacyGatewayRestProperties.class)
+@DependsOn("unifiedConfigurationHelper")
+public class GatewayRestPropertiesOverride {
+
+  private final UnifiedConfiguration unifiedConfiguration;
+  private final LegacyGatewayRestProperties legacyGatewayRestProperties;
+
+  public GatewayRestPropertiesOverride(
+      final UnifiedConfiguration unifiedConfiguration,
+      final LegacyGatewayRestProperties legacyGatewayRestProperties) {
+    this.unifiedConfiguration = unifiedConfiguration;
+    this.legacyGatewayRestProperties = legacyGatewayRestProperties;
+  }
+
+  @Bean
+  @Primary
+  public GatewayRestProperties gatewayRestProperties() {
+    final GatewayRestProperties override = new GatewayRestProperties();
+    BeanUtils.copyProperties(legacyGatewayRestProperties, override);
+
+    populateFromProcessCache(override);
+    populateFromExecutor(override);
+
+    return override;
+  }
+
+  private void populateFromProcessCache(final GatewayRestProperties override) {
+    final ProcessCache processCache =
+        unifiedConfiguration.getCamunda().getApi().getRest().getProcessCache();
+    final ProcessCacheConfiguration processCacheConfiguration = override.getProcessCache();
+    processCacheConfiguration.setMaxSize(processCache.getMaxSize());
+    processCacheConfiguration.setExpirationIdleMillis(processCache.getExpirationIdle().toMillis());
+  }
+
+  private void populateFromExecutor(final GatewayRestProperties override) {
+    final Executor executor = unifiedConfiguration.getCamunda().getApi().getRest().getExecutor();
+    final ApiExecutorConfiguration apiExecutorConfiguration = override.getApiExecutor();
+    apiExecutorConfiguration.setCorePoolSize(executor.getCorePoolSize());
+    apiExecutorConfiguration.setThreadCountMultiplier(executor.getThreadCountMultiplier());
+    apiExecutorConfiguration.setKeepAliveSeconds(executor.getKeepAlive().getSeconds());
+  }
+}

--- a/configuration/src/main/java/io/camunda/configuration/beans/GatewayRestProperties.java
+++ b/configuration/src/main/java/io/camunda/configuration/beans/GatewayRestProperties.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration.beans;
+
+import io.camunda.zeebe.gateway.rest.config.GatewayRestConfiguration;
+
+// NOTE: This class has been moved away from dist. The reason for this is that as, for now,
+//  we're storing the unified configuration objects and beans in the configuration module,
+//  the fact that dist depends on configuration doesn't allow us to declare that configuration
+//  depends on dist, to extend and override these classes. Nevertheless, depending on dist is
+//  a conceptual misrepresentation of what the configuration module belongs to.
+//
+//  As we are planning, as a future refactoring, to move all the configuration classes and beans
+//  within dist (reason: configuration should be part of the Presentation layer of the app), when
+//  such refactoring happens, we can bring back GatewayBasedProperties within dist, as there will
+//  be no more circular dependency issues.
+
+public class GatewayRestProperties extends GatewayRestConfiguration {}

--- a/configuration/src/main/java/io/camunda/configuration/beans/LegacyGatewayRestProperties.java
+++ b/configuration/src/main/java/io/camunda/configuration/beans/LegacyGatewayRestProperties.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration.beans;
+
+import io.camunda.zeebe.gateway.rest.config.GatewayRestConfiguration;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties("camunda.rest")
+public class LegacyGatewayRestProperties extends GatewayRestConfiguration {}

--- a/configuration/src/test/java/io/camunda/configuration/ApiRestExecutorTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/ApiRestExecutorTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.configuration.beanoverrides.GatewayRestPropertiesOverride;
+import io.camunda.configuration.beans.GatewayRestProperties;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+@SpringJUnitConfig({
+  UnifiedConfiguration.class,
+  GatewayRestPropertiesOverride.class,
+  UnifiedConfigurationHelper.class
+})
+public class ApiRestExecutorTest {
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "camunda.api.rest.executor.core-pool-size=5",
+        "camunda.api.rest.executor.thread-count-multiplier=10",
+        "camunda.api.rest.executor.keep-alive=120s",
+      })
+  class WithOnlyUnifiedConfigSet {
+    final GatewayRestProperties gatewayRestProperties;
+
+    WithOnlyUnifiedConfigSet(@Autowired final GatewayRestProperties gatewayRestProperties) {
+      this.gatewayRestProperties = gatewayRestProperties;
+    }
+
+    @Test
+    void shouldSetCorePoolSize() {
+      assertThat(gatewayRestProperties.getApiExecutor().getCorePoolSize()).isEqualTo(5);
+    }
+
+    @Test
+    void shouldSetThreadCountMultiplier() {
+      assertThat(gatewayRestProperties.getApiExecutor().getThreadCountMultiplier()).isEqualTo(10);
+    }
+
+    @Test
+    void shouldSetKeepAliveSeconds() {
+      assertThat(gatewayRestProperties.getApiExecutor().getKeepAliveSeconds()).isEqualTo(120);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "camunda.rest.apiExecutor.corePoolSize=10",
+        "camunda.rest.apiExecutor.threadCountMultiplier=15",
+        "camunda.rest.apiExecutor.keepAliveSeconds=180",
+      })
+  class WithOnlyLegacySet {
+    final GatewayRestProperties gatewayRestProperties;
+
+    WithOnlyLegacySet(@Autowired final GatewayRestProperties gatewayRestProperties) {
+      this.gatewayRestProperties = gatewayRestProperties;
+    }
+
+    @Test
+    void shouldSetCorePoolSize() {
+      assertThat(gatewayRestProperties.getApiExecutor().getCorePoolSize()).isEqualTo(10);
+    }
+
+    @Test
+    void shouldSetThreadCountMultiplier() {
+      assertThat(gatewayRestProperties.getApiExecutor().getThreadCountMultiplier()).isEqualTo(15);
+    }
+
+    @Test
+    void shouldSetKeepAliveSeconds() {
+      assertThat(gatewayRestProperties.getApiExecutor().getKeepAliveSeconds()).isEqualTo(180);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        // new
+        "camunda.api.rest.executor.core-pool-size=5",
+        "camunda.api.rest.executor.thread-count-multiplier=10",
+        "camunda.api.rest.executor.keep-alive=120s",
+        // legacy
+        "camunda.rest.apiExecutor.corePoolSize=10",
+        "camunda.rest.apiExecutor.threadCountMultiplier=15",
+        "camunda.rest.apiExecutor.keepAliveSeconds=180",
+      })
+  class WithNewAndLegacySet {
+    final GatewayRestProperties gatewayRestProperties;
+
+    WithNewAndLegacySet(@Autowired final GatewayRestProperties gatewayRestProperties) {
+      this.gatewayRestProperties = gatewayRestProperties;
+    }
+
+    @Test
+    void shouldSetCorePoolSizeFromNew() {
+      assertThat(gatewayRestProperties.getApiExecutor().getCorePoolSize()).isEqualTo(5);
+    }
+
+    @Test
+    void shouldSetThreadCountMultiplierFromNew() {
+      assertThat(gatewayRestProperties.getApiExecutor().getThreadCountMultiplier()).isEqualTo(10);
+    }
+
+    @Test
+    void shouldSetKeepAliveSecondsFromNew() {
+      assertThat(gatewayRestProperties.getApiExecutor().getKeepAliveSeconds()).isEqualTo(120);
+    }
+  }
+}

--- a/configuration/src/test/java/io/camunda/configuration/ApiRestProcessCacheTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/ApiRestProcessCacheTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.configuration.beanoverrides.GatewayRestPropertiesOverride;
+import io.camunda.configuration.beans.GatewayRestProperties;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+@SpringJUnitConfig({
+  UnifiedConfiguration.class,
+  GatewayRestPropertiesOverride.class,
+  UnifiedConfigurationHelper.class
+})
+public class ApiRestProcessCacheTest {
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "camunda.api.rest.process-cache.max-size=200",
+        "camunda.api.rest.process-cache.expiration-idle=10ms",
+      })
+  class WithOnlyUnifiedConfigSet {
+    final GatewayRestProperties gatewayRestProperties;
+
+    WithOnlyUnifiedConfigSet(@Autowired final GatewayRestProperties gatewayRestProperties) {
+      this.gatewayRestProperties = gatewayRestProperties;
+    }
+
+    @Test
+    void shouldSetMaxSize() {
+      assertThat(gatewayRestProperties.getProcessCache().getMaxSize()).isEqualTo(200);
+    }
+
+    @Test
+    void shouldSetExpirationIdle() {
+      assertThat(gatewayRestProperties.getProcessCache().getExpirationIdleMillis()).isEqualTo(10);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "camunda.rest.processCache.maxSize=300",
+        "camunda.rest.processCache.expirationIdleMillis=20",
+      })
+  class WithOnlyLegacySet {
+    final GatewayRestProperties gatewayRestProperties;
+
+    WithOnlyLegacySet(@Autowired final GatewayRestProperties gatewayRestProperties) {
+      this.gatewayRestProperties = gatewayRestProperties;
+    }
+
+    @Test
+    void shouldSetMaxSize() {
+      assertThat(gatewayRestProperties.getProcessCache().getMaxSize()).isEqualTo(300);
+    }
+
+    @Test
+    void shouldSetExpirationIdle() {
+      assertThat(gatewayRestProperties.getProcessCache().getExpirationIdleMillis()).isEqualTo(20);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        // new
+        "camunda.api.rest.process-cache.max-size=200",
+        "camunda.api.rest.process-cache.expiration-idle=10ms",
+        // legacy
+        "camunda.rest.processCache.maxSize=300",
+        "camunda.rest.processCache.expirationIdleMillis=20",
+      })
+  class WithNewAndLegacySet {
+    final GatewayRestProperties gatewayRestProperties;
+
+    WithNewAndLegacySet(@Autowired final GatewayRestProperties gatewayRestProperties) {
+      this.gatewayRestProperties = gatewayRestProperties;
+    }
+
+    @Test
+    void shouldSetMaxSizeFromNew() {
+      assertThat(gatewayRestProperties.getProcessCache().getMaxSize()).isEqualTo(200);
+    }
+
+    @Test
+    void shouldSetExpirationIdleFromNew() {
+      assertThat(gatewayRestProperties.getProcessCache().getExpirationIdleMillis()).isEqualTo(10);
+    }
+  }
+}

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/GatewayRestConfiguration.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/GatewayRestConfiguration.java
@@ -10,9 +10,14 @@ package io.camunda.zeebe.gateway.rest.config;
 public class GatewayRestConfiguration {
 
   private final ProcessCacheConfiguration processCache = new ProcessCacheConfiguration();
+  private final ApiExecutorConfiguration apiExecutor = new ApiExecutorConfiguration();
 
   public ProcessCacheConfiguration getProcessCache() {
     return processCache;
+  }
+
+  public ApiExecutorConfiguration getApiExecutor() {
+    return apiExecutor;
   }
 
   public static class ProcessCacheConfiguration {
@@ -40,6 +45,41 @@ public class GatewayRestConfiguration {
 
     public void setExpirationIdleMillis(final Long expirationIdleMillis) {
       this.expirationIdleMillis = expirationIdleMillis;
+    }
+  }
+
+  public static class ApiExecutorConfiguration {
+
+    private static final int DEFAULT_CORE_POOL_SIZE_MULTIPLIER = 1;
+    private static final int DEFAULT_MAX_POOL_SIZE_MULTIPLIER = 2;
+    private static final long DEFAULT_KEEP_ALIVE_SECONDS = 60L;
+
+    private int corePoolSize = DEFAULT_CORE_POOL_SIZE_MULTIPLIER;
+    private int threadCountMultiplier = DEFAULT_MAX_POOL_SIZE_MULTIPLIER;
+    private long keepAliveSeconds = DEFAULT_KEEP_ALIVE_SECONDS;
+
+    public int getCorePoolSize() {
+      return corePoolSize;
+    }
+
+    public void setCorePoolSize(final int corePoolSize) {
+      this.corePoolSize = corePoolSize;
+    }
+
+    public int getThreadCountMultiplier() {
+      return threadCountMultiplier;
+    }
+
+    public void setThreadCountMultiplier(final int threadCountMultiplier) {
+      this.threadCountMultiplier = threadCountMultiplier;
+    }
+
+    public long getKeepAliveSeconds() {
+      return keepAliveSeconds;
+    }
+
+    public void setKeepAliveSeconds(final long keepAliveSeconds) {
+      this.keepAliveSeconds = keepAliveSeconds;
     }
   }
 }


### PR DESCRIPTION
## Description

This PR adds the properties from section camunda.api.rest.executor in unified config.

NOTE: The class ApiExecutorConfiguration in GatewayRestConfiguration has been cherry-picked from PR https://github.com/camunda/camunda/pull/36517

The legacy properties are:

camunda.rest.apiExecutor.corePoolSize
camunda.rest.apiExecutor.threadCountMultiplier
camunda.rest.apiExecutor.keepAliveSeconds

The new properties are:

camunda.api.rest.executor.core-pool-size
camunda.api.rest.executor.thread-count-multiplier
camunda.api.rest.executor.keep-alive

Backwards compatibility is supported for these properties. That means, if legacy is set and new property is not set, legacy value will be used.
## Checklist

- [ ] The legacy properties and the backwards compatibility strategy are updated in [schema doc](https://docs.google.com/spreadsheets/d/1R4epsy6DWemA8_76cUE6zOGUFbrXCXlM2reXnKFuz7Y/edit?gid=818158292#gid=818158292)
- [ ] The new property fields are documented in the code
## Related issues

related to #34911