### PR TITLE
fix: change type of session refresh lock attribute to string

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/filters/SessionAuthenticationRefreshFilter.java
+++ b/authentication/src/main/java/io/camunda/authentication/filters/SessionAuthenticationRefreshFilter.java
@@ -77,7 +77,7 @@ public class SessionAuthenticationRefreshFilter extends OncePerRequestFilter {
 
   private static void initializeRefreshAttributes(final HttpSession session, final Instant now) {
     session.setAttribute(LAST_REFRESH_ATTR, now);
-    session.setAttribute(LAST_REFRESH_ATTR + "_LOCK", new Object());
+    session.setAttribute(LAST_REFRESH_ATTR + "_LOCK", session.getId() + "LOCK");
   }
 
   private boolean isRefreshRequired(final Instant lastRefresh, final Instant now) {

--- a/authentication/src/test/java/io/camunda/authentication/filters/SessionAuthenticationRefreshFilterTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/filters/SessionAuthenticationRefreshFilterTest.java
@@ -10,6 +10,7 @@ package io.camunda.authentication.filters;
 import static io.camunda.authentication.filters.SessionAuthenticationRefreshFilter.LAST_REFRESH_ATTR;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.within;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
@@ -141,7 +142,13 @@ public class SessionAuthenticationRefreshFilterTest {
     final MockHttpSession session = new MockHttpSession();
     setSessionRefreshAttribute(session, refreshInterval.multipliedBy(2));
     when(authenticationProvider.getCamundaAuthentication()).thenReturn(createMockAuthentication());
-
+    doAnswer(
+            invocation -> {
+              Thread.sleep(100);
+              return null; // because it's a void method
+            })
+        .when(authenticationProvider)
+        .refresh();
     final AtomicInteger successfulRequests = new AtomicInteger(0);
     final Runnable requestTask =
         () -> {
@@ -190,6 +197,6 @@ public class SessionAuthenticationRefreshFilterTest {
       final MockHttpSession session, final Duration refreshInterval) {
     final Instant lastRefreshRef = Instant.now().minus(refreshInterval);
     session.setAttribute(LAST_REFRESH_ATTR, lastRefreshRef);
-    session.setAttribute(LAST_REFRESH_ATTR + "_LOCK", new Object());
+    session.setAttribute(LAST_REFRESH_ATTR + "_LOCK", session.getId() + "LOCK");
   }
 }

--- a/authentication/src/test/java/io/camunda/authentication/session/WebSessionRepositoryTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/session/WebSessionRepositoryTest.java
@@ -100,6 +100,21 @@ class WebSessionRepositoryTest {
   }
 
   @Test
+  void saveSessionWithLockAndRefreshAttributePersistsSession() {
+    // given
+    final var webSession = webSessionRepository.createSession();
+    webSession.setLastAccessedTime(Instant.now());
+    webSession.setAttribute("lock", webSession.getId() + "LOCK");
+    webSession.setAttribute("refresh", Instant.now());
+
+    // when
+    webSessionRepository.save(webSession);
+
+    // then
+    assertThat(webSessionRepository.findById(webSession.getId())).isNotNull();
+  }
+
+  @Test
   void deleteExpiredWebSessions() {
     // given
     final var expiredLastAccessedTime =


### PR DESCRIPTION
## Description

Session persistence faced error after the lock attribute with object type is added to the session.

`org.springframework.core.convert.ConversionFailedException: Failed to convert from type [java.lang.Object] to type [byte[]] for value [java.lang.Object@b9a60e4]`

## Related issues

close #36932