### PR TITLE
fix: remove version tag requirement when deleting backup

### DIFF
--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/backup/BackupService.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/backup/BackupService.java
@@ -76,11 +76,10 @@ public class BackupService {
     repository.validateRepositoryExists(getRepositoryName());
     final String repositoryName = getRepositoryName();
     final int count = getIndexPatternsOrdered().length;
-    final String version = getCurrentOperateVersion();
     for (int index = 0; index < count; index++) {
       final String snapshotName =
           new Metadata()
-              .setVersion(version)
+              .setVersion("*")
               .setPartCount(count)
               .setPartNo(index + 1)
               .setBackupId(backupId)

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/es/backup/es/BackupManagerElasticSearch.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/es/backup/es/BackupManagerElasticSearch.java
@@ -104,11 +104,10 @@ public class BackupManagerElasticSearch extends BackupManager {
     validateRepositoryExists();
     final String repositoryName = getRepositoryName();
     final int count = getIndexPatternsOrdered().length;
-    final String version = getCurrentTasklistVersion();
     for (int index = 0; index < count; index++) {
       final String snapshotName =
           new Metadata()
-              .setVersion(version)
+              .setVersion("*")
               .setPartCount(count)
               .setPartNo(index + 1)
               .setBackupId(backupId)

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/es/backup/os/BackupManagerOpenSearch.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/es/backup/os/BackupManagerOpenSearch.java
@@ -97,11 +97,10 @@ public class BackupManagerOpenSearch extends BackupManager {
     validateRepositoryExists();
     final String repositoryName = getRepositoryName();
     final int count = getIndexPatternsOrdered().length;
-    final String version = getCurrentTasklistVersion();
     for (int index = 0; index < count; index++) {
       final String snapshotName =
           new Metadata()
-              .setVersion(version)
+              .setVersion("*")
               .setPartCount(count)
               .setPartNo(index + 1)
               .setBackupId(backupId)


### PR DESCRIPTION
## Description

fix: remove version tag requirement when deleting backup

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

Related to https://github.com/camunda/camunda/issues/18869, https://github.com/camunda/camunda/issues/20458
