### PR TITLE
feat: add rest executor section to unified configuration

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/Executor.java
+++ b/configuration/src/main/java/io/camunda/configuration/Executor.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import io.camunda.configuration.UnifiedConfigurationHelper.BackwardsCompatibilityMode;
+import java.time.Duration;
+import java.util.Set;
+
+public class Executor {
+  private static final String PREFIX = "camunda.api.rest.executor";
+  private static final Set<String> LEGACY_CORE_POOL_SIZE_MULTIPLIER_PROPERTIES =
+      Set.of("camunda.rest.apiExecutor.corePoolSizeMultiplier");
+  private static final Set<String> LEGACY_MAX_POOL_SIZE_MULTIPLIER_PROPERTIES =
+      Set.of("camunda.rest.apiExecutor.maxPoolSizeMultiplier");
+  private static final Set<String> LEGACY_KEEP_ALIVE_SECONDS_PROPERTIES =
+      Set.of("camunda.rest.apiExecutor.keepAliveSeconds");
+
+  /**
+   * Multiplier applied to the number of available processors to compute the executor's core pool
+   * size (minimum number of threads kept alive).
+   *
+   * <p>Effective value: {@code corePoolSize = availableProcessors * corePoolSizeMultiplier}.
+   *
+   * <p>Use a higher value if you have steady, continuous traffic and want to minimize cold-start
+   * latency; keep it low to allow the pool to scale down when idle.
+   *
+   * <p>Default value: 1 (as defined in {@code
+   * ApiExecutorConfiguration#DEFAULT_CORE_POOL_SIZE_MULTIPLIER})
+   */
+  private int corePoolSizeMultiplier = 1;
+
+  /**
+   * Multiplier applied to the number of available processors to compute the executor's maximum pool
+   * size (hard cap on threads).
+   *
+   * <p>Effective value: {@code maxPoolSize = availableProcessors * maxPoolSizeMultiplier}.
+   *
+   * <p>Must be >= {@code corePoolSizeMultiplier}. Increase cautiously; high values can cause
+   * oversubscription for CPU-bound workloads.
+   *
+   * <p>Default value: 2 (as defined in {@code
+   * ApiExecutorConfiguration#DEFAULT_MAX_POOL_SIZE_MULTIPLIER})
+   */
+  private int maxPoolSizeMultiplier = 2;
+
+  /**
+   * Time in seconds that threads above the core size may remain idle before being terminated. Lower
+   * values reclaim resources faster after bursts; higher values reduce thread creation/destruction
+   * churn if bursts are frequent.
+   *
+   * <p>Default value: 60 (as defined in {@code
+   * ApiExecutorConfiguration#DEFAULT_KEEP_ALIVE_SECONDS})
+   */
+  private Duration keepAlive = Duration.ofSeconds(60);
+
+  public int getCorePoolSizeMultiplier() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + ".core-pool-size-multiplier",
+        corePoolSizeMultiplier,
+        Integer.class,
+        BackwardsCompatibilityMode.SUPPORTED,
+        LEGACY_CORE_POOL_SIZE_MULTIPLIER_PROPERTIES);
+  }
+
+  public void setCorePoolSizeMultiplier(final int corePoolSizeMultiplier) {
+    this.corePoolSizeMultiplier = corePoolSizeMultiplier;
+  }
+
+  public int getMaxPoolSizeMultiplier() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + ".max-pool-size-multiplier",
+        maxPoolSizeMultiplier,
+        Integer.class,
+        BackwardsCompatibilityMode.SUPPORTED,
+        LEGACY_MAX_POOL_SIZE_MULTIPLIER_PROPERTIES);
+  }
+
+  public void setMaxPoolSizeMultiplier(final int maxPoolSizeMultiplier) {
+    this.maxPoolSizeMultiplier = maxPoolSizeMultiplier;
+  }
+
+  public Duration getKeepAlive() {
+    final Long currentKeepAliveSeconds =
+        UnifiedConfigurationHelper.validateLegacyConfiguration(
+            PREFIX + ".keep-alive",
+            keepAlive.getSeconds(),
+            Long.class,
+            BackwardsCompatibilityMode.SUPPORTED,
+            LEGACY_KEEP_ALIVE_SECONDS_PROPERTIES);
+    return Duration.ofSeconds(currentKeepAliveSeconds);
+  }
+
+  public void setKeepAlive(final Duration keepAlive) {
+    this.keepAlive = keepAlive;
+  }
+}

--- a/configuration/src/main/java/io/camunda/configuration/Rest.java
+++ b/configuration/src/main/java/io/camunda/configuration/Rest.java
@@ -18,6 +18,9 @@ public class Rest {
   /** Set the process cache configuration */
   private ProcessCache processCache = new ProcessCache();
 
+  /** Set the executor configuration */
+  private Executor executor = new Executor();
+
   public List<Filter> getFilters() {
     return filters;
   }
@@ -32,5 +35,13 @@ public class Rest {
 
   public void setProcessCache(final ProcessCache processCache) {
     this.processCache = processCache;
+  }
+
+  public Executor getExecutor() {
+    return executor;
+  }
+
+  public void setExecutor(final Executor executor) {
+    this.executor = executor;
   }
 }

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/GatewayRestPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/GatewayRestPropertiesOverride.java
@@ -7,10 +7,12 @@
  */
 package io.camunda.configuration.beanoverrides;
 
+import io.camunda.configuration.Executor;
 import io.camunda.configuration.ProcessCache;
 import io.camunda.configuration.UnifiedConfiguration;
 import io.camunda.configuration.beans.GatewayRestProperties;
 import io.camunda.configuration.beans.LegacyGatewayRestProperties;
+import io.camunda.zeebe.gateway.rest.config.GatewayRestConfiguration.ApiExecutorConfiguration;
 import io.camunda.zeebe.gateway.rest.config.GatewayRestConfiguration.ProcessCacheConfiguration;
 import org.springframework.beans.BeanUtils;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -41,6 +43,7 @@ public class GatewayRestPropertiesOverride {
     BeanUtils.copyProperties(legacyGatewayRestProperties, override);
 
     populateFromProcessCache(override);
+    populateFromExecutor(override);
 
     return override;
   }
@@ -51,5 +54,13 @@ public class GatewayRestPropertiesOverride {
     final ProcessCacheConfiguration processCacheConfiguration = override.getProcessCache();
     processCacheConfiguration.setMaxSize(processCache.getMaxSize());
     processCacheConfiguration.setExpirationIdleMillis(processCache.getExpirationIdle().toMillis());
+  }
+
+  private void populateFromExecutor(final GatewayRestProperties override) {
+    final Executor executor = unifiedConfiguration.getCamunda().getApi().getRest().getExecutor();
+    final ApiExecutorConfiguration apiExecutorConfiguration = override.getApiExecutor();
+    apiExecutorConfiguration.setCorePoolSizeMultiplier(executor.getCorePoolSizeMultiplier());
+    apiExecutorConfiguration.setMaxPoolSizeMultiplier(executor.getMaxPoolSizeMultiplier());
+    apiExecutorConfiguration.setKeepAliveSeconds(executor.getKeepAlive().getSeconds());
   }
 }

--- a/configuration/src/test/java/io/camunda/configuration/ApiRestExecutorTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/ApiRestExecutorTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.configuration.beanoverrides.GatewayRestPropertiesOverride;
+import io.camunda.configuration.beans.GatewayRestProperties;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+@SpringJUnitConfig({
+  UnifiedConfiguration.class,
+  GatewayRestPropertiesOverride.class,
+  UnifiedConfigurationHelper.class
+})
+public class ApiRestExecutorTest {
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "camunda.api.rest.executor.core-pool-size-multiplier=5",
+        "camunda.api.rest.executor.max-pool-size-multiplier=10",
+        "camunda.api.rest.executor.keep-alive=120s",
+      })
+  class WithOnlyUnifiedConfigSet {
+    final GatewayRestProperties gatewayRestProperties;
+
+    WithOnlyUnifiedConfigSet(@Autowired final GatewayRestProperties gatewayRestProperties) {
+      this.gatewayRestProperties = gatewayRestProperties;
+    }
+
+    @Test
+    void shouldSetCorePoolSizeMultiplier() {
+      assertThat(gatewayRestProperties.getApiExecutor().getCorePoolSizeMultiplier()).isEqualTo(5);
+    }
+
+    @Test
+    void shouldSetMaxPoolSizeMultiplier() {
+
+      assertThat(gatewayRestProperties.getApiExecutor().getMaxPoolSizeMultiplier()).isEqualTo(10);
+    }
+
+    @Test
+    void shouldSetKeepAliveSeconds() {
+      assertThat(gatewayRestProperties.getApiExecutor().getKeepAliveSeconds()).isEqualTo(120);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "camunda.rest.apiExecutor.corePoolSizeMultiplier=10",
+        "camunda.rest.apiExecutor.maxPoolSizeMultiplier=15",
+        "camunda.rest.apiExecutor.keepAliveSeconds=180",
+      })
+  class WithOnlyLegacySet {
+    final GatewayRestProperties gatewayRestProperties;
+
+    WithOnlyLegacySet(@Autowired final GatewayRestProperties gatewayRestProperties) {
+      this.gatewayRestProperties = gatewayRestProperties;
+    }
+
+    @Test
+    void shouldSetCorePoolSizeMultiplier() {
+      assertThat(gatewayRestProperties.getApiExecutor().getCorePoolSizeMultiplier()).isEqualTo(10);
+    }
+
+    @Test
+    void shouldSetMaxPoolSizeMultiplier() {
+      assertThat(gatewayRestProperties.getApiExecutor().getMaxPoolSizeMultiplier()).isEqualTo(15);
+    }
+
+    @Test
+    void shouldSetKeepAliveSeconds() {
+      assertThat(gatewayRestProperties.getApiExecutor().getKeepAliveSeconds()).isEqualTo(180);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        // new
+        "camunda.api.rest.executor.core-pool-size-multiplier=5",
+        "camunda.api.rest.executor.max-pool-size-multiplier=10",
+        "camunda.api.rest.executor.keep-alive=120s",
+        // legacy
+        "camunda.rest.apiExecutor.corePoolSizeMultiplier=10",
+        "camunda.rest.apiExecutor.maxPoolSizeMultiplier=15",
+        "camunda.rest.apiExecutor.keepAliveSeconds=180",
+      })
+  class WithNewAndLegacySet {
+    final GatewayRestProperties gatewayRestProperties;
+
+    WithNewAndLegacySet(@Autowired final GatewayRestProperties gatewayRestProperties) {
+      this.gatewayRestProperties = gatewayRestProperties;
+    }
+
+    @Test
+    void shouldSetCorePoolSizeMultiplierFromNew() {
+      assertThat(gatewayRestProperties.getApiExecutor().getCorePoolSizeMultiplier()).isEqualTo(5);
+    }
+
+    @Test
+    void shouldSetMaxPoolSizeMultiplierFromNew() {
+      assertThat(gatewayRestProperties.getApiExecutor().getMaxPoolSizeMultiplier()).isEqualTo(10);
+    }
+
+    @Test
+    void shouldSetKeepAliveSecondsFromNew() {
+      assertThat(gatewayRestProperties.getApiExecutor().getKeepAliveSeconds()).isEqualTo(120);
+    }
+  }
+}

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/GatewayRestConfiguration.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/GatewayRestConfiguration.java
@@ -10,9 +10,14 @@ package io.camunda.zeebe.gateway.rest.config;
 public class GatewayRestConfiguration {
 
   private final ProcessCacheConfiguration processCache = new ProcessCacheConfiguration();
+  private final ApiExecutorConfiguration apiExecutor = new ApiExecutorConfiguration();
 
   public ProcessCacheConfiguration getProcessCache() {
     return processCache;
+  }
+
+  public ApiExecutorConfiguration getApiExecutor() {
+    return apiExecutor;
   }
 
   public static class ProcessCacheConfiguration {
@@ -40,6 +45,115 @@ public class GatewayRestConfiguration {
 
     public void setExpirationIdleMillis(final Long expirationIdleMillis) {
       this.expirationIdleMillis = expirationIdleMillis;
+    }
+  }
+
+  /**
+   * Configuration for the REST API executor thread pool.
+   *
+   * <p>The executor is sized proportionally to the number of available CPU cores using multipliers
+   * instead of absolute thread counts, so it scales sensibly across different deployment sizes
+   * without manual retuning.
+   *
+   * <p>Effective sizes (evaluated at startup):
+   *
+   * <pre>
+   *   corePoolSize = availableProcessors * corePoolSizeMultiplier
+   *   maxPoolSize  = availableProcessors * maxPoolSizeMultiplier
+   * </pre>
+   *
+   * <p>Threads above the core size are created on demand and reclaimed after being idle for {@code
+   * keepAliveSeconds}. A {@code SynchronousQueue} + direct handoff + a {@code CallerRunsPolicy} (or
+   * similar strategy, depending on the executor implementation) is typically used to:
+   *
+   * <ul>
+   *   <li>Avoid unbounded internal task buffering
+   *   <li>Apply natural back-pressure when saturated (caller executes work)
+   * </ul>
+   *
+   * <p><b>Constraints:</b>
+   *
+   * <ul>
+   *   <li>{@code corePoolSizeMultiplier} should be &gt;= 0 (0 means no core threads, only on-demand
+   *       threads).
+   *   <li>{@code maxPoolSizeMultiplier} should be &gt; 0
+   * </ul>
+   */
+  public static class ApiExecutorConfiguration {
+
+    private static final int DEFAULT_CORE_POOL_SIZE_MULTIPLIER = 1;
+    private static final int DEFAULT_MAX_POOL_SIZE_MULTIPLIER = 2;
+    private static final long DEFAULT_KEEP_ALIVE_SECONDS = 60L;
+
+    /**
+     * Multiplier applied to the number of available processors to compute the executor's core pool
+     * size (minimum number of threads kept alive).
+     *
+     * <p>Effective value: {@code corePoolSize = availableProcessors * corePoolSizeMultiplier}.
+     *
+     * <p>Use a higher value if you have steady, continuous traffic and want to minimize cold-start
+     * latency; keep it low to allow the pool to scale down when idle.
+     *
+     * <p>Default value: {@link #DEFAULT_CORE_POOL_SIZE_MULTIPLIER}.
+     */
+    private int corePoolSizeMultiplier = DEFAULT_CORE_POOL_SIZE_MULTIPLIER;
+
+    /**
+     * Multiplier applied to the number of available processors to compute the executor's maximum
+     * pool size (hard cap on threads).
+     *
+     * <p>Effective value: {@code maxPoolSize = availableProcessors * maxPoolSizeMultiplier}.
+     *
+     * <p>Must be >= {@code corePoolSizeMultiplier}. Increase cautiously; high values can cause
+     * oversubscription for CPU-bound workloads.
+     *
+     * <p>Default value: {@link #DEFAULT_MAX_POOL_SIZE_MULTIPLIER}.
+     */
+    private int maxPoolSizeMultiplier = DEFAULT_MAX_POOL_SIZE_MULTIPLIER;
+
+    /**
+     * Time in seconds that threads above the core size may remain idle before being terminated.
+     * Lower values reclaim resources faster after bursts; higher values reduce thread
+     * creation/destruction churn if bursts are frequent.
+     *
+     * <p>Default value: {@link #DEFAULT_KEEP_ALIVE_SECONDS}.
+     */
+    private long keepAliveSeconds = DEFAULT_KEEP_ALIVE_SECONDS;
+
+    public int getCorePoolSizeMultiplier() {
+      return corePoolSizeMultiplier;
+    }
+
+    public void setCorePoolSizeMultiplier(final int corePoolSizeMultiplier) {
+      if (corePoolSizeMultiplier < 0) {
+        throw new IllegalArgumentException(
+            "corePoolSizeMultiplier must be >= 0 (was " + corePoolSizeMultiplier + ")");
+      }
+      this.corePoolSizeMultiplier = corePoolSizeMultiplier;
+    }
+
+    public int getMaxPoolSizeMultiplier() {
+      return maxPoolSizeMultiplier;
+    }
+
+    public void setMaxPoolSizeMultiplier(final int maxPoolSizeMultiplier) {
+      if (maxPoolSizeMultiplier <= 0) {
+        throw new IllegalArgumentException(
+            "maxPoolSizeMultiplier must be > 0 (was " + maxPoolSizeMultiplier + ")");
+      }
+      this.maxPoolSizeMultiplier = maxPoolSizeMultiplier;
+    }
+
+    public long getKeepAliveSeconds() {
+      return keepAliveSeconds;
+    }
+
+    public void setKeepAliveSeconds(final long keepAliveSeconds) {
+      if (keepAliveSeconds <= 0) {
+        throw new IllegalArgumentException(
+            "keepAliveSeconds must be > 0 (was " + keepAliveSeconds + ")");
+      }
+      this.keepAliveSeconds = keepAliveSeconds;
     }
   }
 }


### PR DESCRIPTION
## Description

This PR adds the properties from section camunda.api.rest.executor in unified config.

NOTE: The class ApiExecutorConfiguration in GatewayRestConfiguration has been cherry-picked from the PR https://github.com/camunda/camunda/pull/36517

The legacy properties are:

camunda.rest.apiExecutor.corePoolSizeMultiplier
camunda.rest.apiExecutor.maxPoolSizeMultiplier
camunda.rest.apiExecutor.keepAliveSeconds

The new properties are:

camunda.api.rest.executor.core-pool-size-multiplier
camunda.api.rest.executor.max-pool-size-multiplier
camunda.api.rest.executor.keep-alive

Backwards compatibility is supported for these properties. That means, if legacy is set and new property is not set, legacy value will be used.
## Checklist

- [x] The legacy properties and the backwards compatibility strategy are updated in [schema doc](https://docs.google.com/spreadsheets/d/1R4epsy6DWemA8_76cUE6zOGUFbrXCXlM2reXnKFuz7Y/edit?gid=818158292#gid=818158292)
- [x] The new property fields are documented in the code
## Related issues

related to #34911