### PR TITLE
[Backport stable/8.5] deps: upgrade netty to 4.1.124.Final

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -73,9 +73,16 @@
     <version.model>7.7.0</version.model>
     <version.msgpack>0.9.10</version.msgpack>
     <version.netty>4.1.124.Final</version.netty>
+<<<<<<< HEAD
     <version.objenesis>3.3</version.objenesis>
     <version.opensearch>2.5.0</version.opensearch>
     <version.opensearch.testcontainers>2.0.2</version.opensearch.testcontainers>
+=======
+    <version.objenesis>3.4</version.objenesis>
+    <version.opensearch>2.17.0</version.opensearch>
+    <version.opensearch-java>2.19.0</version.opensearch-java>
+    <version.opensearch.testcontainers>2.1.4</version.opensearch.testcontainers>
+>>>>>>> 254151dc (deps: upgrade netty to 4.1.124.Final)
     <version.prometheus>0.16.0</version.prometheus>
     <version.protobuf>3.25.8</version.protobuf>
     <version.protobuf-common>2.37.1</version.protobuf-common>


### PR DESCRIPTION
# Description
Backport of #36904 to `stable/8.5`.

relates to 