### PR TITLE
[Backport stable/8.6] deps: upgrade tomcat to 10.1.44

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -99,7 +99,11 @@
     <version.rest-assured>5.5.6</version.rest-assured>
     <version.spring>6.2.10</version.spring>
     <version.spring-security>6.5.2</version.spring-security>
+<<<<<<< HEAD
     <version.spring-boot>3.4.8</version.spring-boot>
+=======
+    <version.spring-boot>3.4.7</version.spring-boot>
+>>>>>>> 960c32a4 (deps: upgrade tomcat to 10.1.44)
     <version.tomcat>10.1.44</version.tomcat>
     <version.concurrentunit>0.4.6</version.concurrentunit>
     <version.kryo>5.6.2</version.kryo>


### PR DESCRIPTION
# Description
Backport of #36906 to `stable/8.6`.

relates to 