### PR TITLE
[Backport stable/optimize-8.6] deps: upgrade netty to 4.1.124.Final

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -75,7 +75,7 @@
     <version.mockito>5.13.0</version.mockito>
     <version.model>7.7.0</version.model>
     <version.msgpack>0.9.8</version.msgpack>
-    <version.netty>4.1.113.Final</version.netty>
+    <version.netty>4.1.124.Final</version.netty>
     <version.objenesis>3.4</version.objenesis>
     <version.opensearch>2.9.0</version.opensearch>
     <version.opensearch.testcontainers>2.1.0</version.opensearch.testcontainers>


### PR DESCRIPTION
# Description
Backport of #36904 to `stable/optimize-8.6`.

relates to 