### PR TITLE
fix: upgrade netty to 4.1.124.Final

### DIFF
--- a/operate/pom.xml
+++ b/operate/pom.xml
@@ -89,7 +89,7 @@
     <elasticsearch-test-container.version>1.19.8</elasticsearch-test-container.version>
     <postgres-test-container.version>1.17.6</postgres-test-container.version>
     <wiremock.version>3.9.2</wiremock.version>
-    <netty.version>4.1.118.Final</netty.version>
+    <netty.version>4.1.124.Final</netty.version>
     <version.docker-java-api>3.3.6</version.docker-java-api>
     <version.httpclient>4.5.14</version.httpclient>
     <version.elasticsearch7>7.17.29</version.elasticsearch7>


### PR DESCRIPTION
## Description

I'm updating netty dep to 4.1.124.Final to fix https://nvd.nist.gov/vuln/detail/CVE-2025-55163

## Related issues

https://jira.camunda.com/browse/SEC-1567
https://jira.camunda.com/browse/SEC-1569
https://jira.camunda.com/browse/SEC-1570
https://jira.camunda.com/browse/SEC-1571
