### PR TITLE
feat: prevent backups during scaling

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/shared/management/BackupEndpoint.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/BackupEndpoint.java
@@ -14,6 +14,7 @@ import io.camunda.management.backups.StateCode;
 import io.camunda.management.backups.TakeBackupRuntimeResponse;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.broker.client.api.BrokerErrorException;
+import io.camunda.zeebe.broker.client.api.BrokerRejectionException;
 import io.camunda.zeebe.gateway.admin.IncompleteTopologyException;
 import io.camunda.zeebe.gateway.admin.backup.BackupAlreadyExistException;
 import io.camunda.zeebe.gateway.admin.backup.BackupApi;
@@ -198,6 +199,10 @@ public final class BackupEndpoint {
               default -> WebEndpointResponse.STATUS_INTERNAL_SERVER_ERROR;
             };
         message = rootError.getMessage();
+      } else if (error instanceof final BrokerRejectionException brokerRejectionException) {
+        errorCode = 409; // Conflict with concurrent scaling operation
+        message =
+            "Cannot take backup while scaling is in progress. Please retry after scaling is completed.";
       } else {
         errorCode = WebEndpointResponse.STATUS_INTERNAL_SERVER_ERROR;
         message = error.getMessage();

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/api/BackupManager.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/api/BackupManager.java
@@ -29,7 +29,7 @@ public interface BackupManager {
   /**
    * Get the status of the backup
    *
-   * @param checkpointId
+   * @param checkpointId id of the backup to get status for
    * @return backup status
    */
   ActorFuture<BackupStatus> getBackupStatus(long checkpointId);
@@ -45,7 +45,7 @@ public interface BackupManager {
   /**
    * Deletes the backup.
    *
-   * @param checkpointId
+   * @param checkpointId id of the backup to delete
    * @return future which will be completed after the backup is deleted.
    */
   ActorFuture<Void> deleteBackup(long checkpointId);
@@ -54,4 +54,15 @@ public interface BackupManager {
   ActorFuture<Void> closeAsync();
 
   void failInProgressBackup(long lastCheckpointId);
+
+  /**
+   * Creates a backup with failed status. This is used when a backup cannot be taken due to system
+   * constraints (e.g., scaling in progress) but the backup entry needs to be recorded.
+   *
+   * @param checkpointId id of the backup
+   * @param checkpointPosition position of the record until which would have been included in the
+   *     backup
+   * @param failureReason reason why the backup failed
+   */
+  void createFailedBackup(long checkpointId, long checkpointPosition, String failureReason);
 }

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/management/BackupService.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/management/BackupService.java
@@ -177,6 +177,17 @@ public final class BackupService extends Actor implements BackupManager {
     internalBackupManager.failInProgressBackups(partitionId, lastCheckpointId, actor);
   }
 
+  @Override
+  public void createFailedBackup(
+      final long checkpointId, final long checkpointPosition, final String failureReason) {
+    actor.run(
+        () -> {
+          final var backupId = getBackupId(checkpointId);
+          internalBackupManager.createFailedBackup(
+              backupId, checkpointPosition, failureReason, actor);
+        });
+  }
+
   private BackupIdentifierImpl getBackupId(final long checkpointId) {
     return new BackupIdentifierImpl(nodeId, partitionId, checkpointId);
   }

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/management/NoopBackupManager.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/management/NoopBackupManager.java
@@ -65,4 +65,10 @@ public class NoopBackupManager implements BackupManager {
     }
     LOG.warn("Attempted to update in progress backup, but cannot do it. {}", errorMessage);
   }
+
+  @Override
+  public void createFailedBackup(
+      final long checkpointId, final long checkpointPosition, final String failureReason) {
+    LOG.warn("Attempted to create failed backup, but cannot do it. {}", errorMessage);
+  }
 }

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/ScalingStatusSupplier.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/ScalingStatusSupplier.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.backup.processing;
+
+@FunctionalInterface
+public interface ScalingStatusSupplier {
+  boolean isScalingInProgress();
+}

--- a/zeebe/backup/src/test/java/io/camunda/zeebe/backup/processing/MockProcessingResult.java
+++ b/zeebe/backup/src/test/java/io/camunda/zeebe/backup/processing/MockProcessingResult.java
@@ -25,7 +25,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
-record MockProcessingResult(List<Event> records) implements ProcessingResult {
+record MockProcessingResult(List<Event> records, Response response) implements ProcessingResult {
 
   @Override
   public ImmutableRecordBatch getRecordBatch() {
@@ -55,13 +55,17 @@ record MockProcessingResult(List<Event> records) implements ProcessingResult {
       long key,
       RecordValue value) {}
 
+  record Response(
+      RecordType recordType, Intent intent, RejectionType rejectionType, String rejectionReason) {}
+
   static class MockProcessingResultBuilder implements ProcessingResultBuilder {
 
     final List<Event> followupRecords = new ArrayList<>();
+    Response response;
 
-    @Override
-    public Either<RuntimeException, ProcessingResultBuilder> appendRecordReturnEither(
-        final long key, final RecordValue value, final RecordMetadata metadata) {
+    final @Override public Either<RuntimeException, ProcessingResultBuilder>
+        appendRecordReturnEither(
+            final long key, final RecordValue value, final RecordMetadata metadata) {
 
       final var record =
           new Event(
@@ -86,7 +90,9 @@ record MockProcessingResult(List<Event> records) implements ProcessingResult {
         final String rejectionReason,
         final long requestId,
         final int requestStreamId) {
-      return null;
+
+      response = new Response(type, intent, rejectionType, rejectionReason);
+      return this;
     }
 
     @Override
@@ -101,7 +107,7 @@ record MockProcessingResult(List<Event> records) implements ProcessingResult {
 
     @Override
     public ProcessingResult build() {
-      return new MockProcessingResult(followupRecords);
+      return new MockProcessingResult(followupRecords, response);
     }
 
     @Override

--- a/zeebe/backup/src/test/java/io/camunda/zeebe/backup/processing/MockTypedCheckpointRecord.java
+++ b/zeebe/backup/src/test/java/io/camunda/zeebe/backup/processing/MockTypedCheckpointRecord.java
@@ -20,8 +20,27 @@ record MockTypedCheckpointRecord(
     long sourceRecordPosition,
     Intent intent,
     RecordType recordType,
-    CheckpointRecord value)
+    CheckpointRecord value,
+    int requestStreamId,
+    long requestId)
     implements TypedRecord<CheckpointRecord> {
+
+  public MockTypedCheckpointRecord(
+      final long position,
+      final long sourceRecordPosition,
+      final Intent intent,
+      final RecordType recordType,
+      final CheckpointRecord value) {
+    this(
+        position,
+        sourceRecordPosition,
+        intent,
+        recordType,
+        value,
+        -1, // requestStreamId
+        -1L // requestId
+        );
+  }
 
   @Override
   public long getPosition() {
@@ -105,12 +124,12 @@ record MockTypedCheckpointRecord(
 
   @Override
   public int getRequestStreamId() {
-    return -1;
+    return requestStreamId;
   }
 
   @Override
   public long getRequestId() {
-    return -1L;
+    return requestId;
   }
 
   @Override

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/StreamProcessorTransitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/StreamProcessorTransitionStep.java
@@ -140,6 +140,10 @@ public final class StreamProcessorTransitionStep implements PartitionTransitionS
             context.getTypedRecordProcessorFactory(), engineCfg, context.getSecurityConfig());
     final List<RecordProcessor> recordProcessors =
         List.of(engine, context.getCheckpointProcessor());
+
+    // Set the scaling progress supplier to prevent checkpointing during scaling
+    context.getCheckpointProcessor().setScalingInProgressSupplier(engine::isScalingInProgress);
+
     final var scheduledCommandCache =
         BoundedScheduledCommandCache.ofIntent(
             new BoundedCommandCacheMetrics(context.getPartitionTransitionMeterRegistry()),

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
@@ -75,6 +75,29 @@ public class Engine implements RecordProcessor {
     this.securityConfig = securityConfig;
   }
 
+  /**
+   * Returns whether scaling is currently in progress. This can be used to determine if certain
+   * operations like checkpoint creation should be blocked.
+   *
+   * @return true if scaling is in progress, false otherwise
+   */
+  public boolean isScalingInProgress() {
+    if (processingState == null || processingState.getRoutingState() == null) {
+      return false;
+    }
+
+    final var routingState = processingState.getRoutingState();
+    if (!routingState.isInitialized()) {
+      return false;
+    }
+
+    // Scaling is in progress if desired partitions differ from current partitions
+    final var currentPartitions = routingState.currentPartitions();
+    final var desiredPartitions = routingState.desiredPartitions();
+
+    return !currentPartitions.equals(desiredPartitions);
+  }
+
   @Override
   public void init(final RecordProcessorContext recordProcessorContext) {
     eventApplier = new EventAppliers();

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/ConcurrentBackupScalingIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/ConcurrentBackupScalingIT.java
@@ -114,8 +114,6 @@ final class ConcurrentBackupScalingIT {
   }
 
   private void configureBackup(final TestStandaloneBroker broker) {
-    final String bucketName = "some-random-bucket";
-
     broker.withBrokerConfig(
         cfg -> {
           final var backup = cfg.getData().getBackup();

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/ConcurrentBackupScalingIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/ConcurrentBackupScalingIT.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.backup;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+import feign.FeignException;
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.broker.system.configuration.backup.BackupStoreCfg.BackupStoreType;
+import io.camunda.zeebe.management.cluster.ClusterConfigPatchRequest;
+import io.camunda.zeebe.management.cluster.ClusterConfigPatchRequestPartitions;
+import io.camunda.zeebe.qa.util.actuator.BackupActuator;
+import io.camunda.zeebe.qa.util.actuator.ClusterActuator;
+import io.camunda.zeebe.qa.util.cluster.TestApplication;
+import io.camunda.zeebe.qa.util.cluster.TestCluster;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import java.nio.file.Path;
+import java.time.Duration;
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+/** Integration test to verify that backup requests are rejected when scaling is in progress. */
+@Testcontainers
+@ZeebeIntegration
+final class ConcurrentBackupScalingIT {
+
+  @TempDir Path backupBasePath;
+
+  @TestZeebe(autoStart = false)
+  private final TestCluster cluster =
+      TestCluster.builder()
+          .withBrokersCount(
+              3) // Need 3 brokers to ensure we can stop one and still have scaling coordination
+          .withGatewaysCount(1)
+          .withReplicationFactor(3)
+          .withPartitionsCount(1)
+          .withEmbeddedGateway(false)
+          .withBrokerConfig(
+              b ->
+                  b.withBrokerConfig(
+                      bb -> {
+                        bb.getExperimental().getFeatures().setEnablePartitionScaling(true);
+                        bb.getCluster()
+                            .getMembership()
+                            .setSyncInterval(Duration.ofSeconds(1))
+                            .setGossipInterval(Duration.ofMillis(500));
+                      }))
+          .withNodeConfig(this::configureNode)
+          .build();
+
+  @BeforeEach
+  void beforeEach() {
+    cluster.brokers().values().forEach(this::configureBackup);
+
+    cluster.start().awaitCompleteTopology();
+  }
+
+  @Test
+  void shouldRejectBackupWhenScalingInProgress() {
+    // given
+    final var backupActuator = BackupActuator.of(cluster.availableGateway());
+    final var clusterActuator = ClusterActuator.of(cluster.availableGateway());
+
+    // Stop broker 2 to stall scaling progress (broker 0 remains as coordinator)
+    final var brokerToStop = cluster.brokers().get(MemberId.from("2"));
+    assertThat(brokerToStop).isNotNull();
+    brokerToStop.stop();
+
+    // Start scaling to trigger scaling in progress state
+    final var targetPartitionCount = 3; // Scale from 2 to 3 partitions
+    clusterActuator.patchCluster(
+        new ClusterConfigPatchRequest()
+            .partitions(
+                new ClusterConfigPatchRequestPartitions()
+                    .count(targetPartitionCount)
+                    .replicationFactor(3)),
+        false,
+        false);
+
+    // Verify scaling is in progress (routing state shows different current vs desired partitions)
+    Awaitility.await("until scaling starts")
+        .atMost(Duration.ofSeconds(30))
+        .untilAsserted(
+            () -> {
+              final var topology = clusterActuator.getTopology();
+              assertThat(topology.getPendingChange()).isNotNull();
+              assertThat(topology.getPendingChange().getCompleted()).isNotEmpty();
+            });
+
+    // when - try to take a backup while scaling is in progress
+    final long backupId = 999;
+
+    // then - backup request should be rejected
+    assertThatThrownBy(() -> backupActuator.take(backupId))
+        .asInstanceOf(InstanceOfAssertFactories.type(FeignException.class))
+        .satisfies(
+            exception -> {
+              assertThat(exception.status()).isEqualTo(409); // Client error status
+              assertThat(exception.contentUTF8())
+                  .containsIgnoringCase("Cannot take backup while scaling is in progress");
+            });
+  }
+
+  private void configureBackup(final TestStandaloneBroker broker) {
+    final String bucketName = "some-random-bucket";
+
+    broker.withBrokerConfig(
+        cfg -> {
+          final var backup = cfg.getData().getBackup();
+          backup.setStore(BackupStoreType.FILESYSTEM);
+          final var fileSystem = backup.getFilesystem();
+          fileSystem.setBasePath(backupBasePath.toAbsolutePath().toString());
+        });
+  }
+
+  private void configureNode(final TestApplication<?> node) {
+    node.withProperty("management.endpoints.web.exposure.include", "*");
+  }
+}


### PR DESCRIPTION
## Description

To prevent backups during scaling, we process checkpoint CREATE records as follows:

- A checkpoint is created : checkpointId and position is updated in the state, new checkpointId is used in all inter-partition communication.
- A failed backup is taken. This is for observability rather than correctness. When a user queries the status of the backup, they can see it is failed due to concurrent scaling.
- A rejection response is sent, which fails the backup request.

A checkpoint must be created even if we don't take a backup. This is to ensure consistent checkpoints across the partitions. If not, we may end up in a state where one partition has a checkpoint before scaling and the other one has a checkpoint after scaling resulting in a "complete" backup which is not consistent with each other. This can happen when a partition do not create checkpoint when it receives an inter-partition command with a new checkpoint id, but creates a checkpoint for a command received much later. For consistent checkpoint, it must be created up on the first communication from a remote partition that has already taken a checkpoint for that id. 

## Related issues

closes #34500 
