### PR TITLE
feat: reduce number of unneeded put settings calls greatly

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManagerFactory.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManagerFactory.java
@@ -50,6 +50,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import org.opensearch.client.opensearch.generic.OpenSearchGenericClient;
 import org.slf4j.Logger;
 
 public final class BackgroundTaskManagerFactory {
@@ -257,6 +258,9 @@ public final class BackgroundTaskManagerFactory {
       }
       case OPENSEARCH -> {
         final var connector = new OpensearchConnector(config.getConnect());
+        final var asyncClient = connector.createAsyncClient();
+        final var genericClient =
+            new OpenSearchGenericClient(asyncClient._transport(), asyncClient._transportOptions());
         yield new OpenSearchArchiverRepository(
             partitionId,
             config.getHistory(),
@@ -265,7 +269,8 @@ public final class BackgroundTaskManagerFactory {
             listViewTemplate.getFullQualifiedName(),
             batchOperationTemplate.getFullQualifiedName(),
             config.getIndex().getZeebeIndexPrefix(),
-            connector.createAsyncClient(),
+            asyncClient,
+            genericClient,
             executor,
             metrics,
             logger);

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepository.java
@@ -41,6 +41,7 @@ import io.camunda.webapps.schema.descriptors.template.BatchOperationTemplate;
 import io.camunda.webapps.schema.descriptors.template.ListViewTemplate;
 import io.micrometer.core.instrument.Timer;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.regex.Pattern;
@@ -280,12 +281,22 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
       return CompletableFuture.completedFuture(null);
     }
 
-    logger.debug("Applying policy '{}' to {} indices: {}", policyName, indices.size(), indices);
+    final var indicesWithoutPolicy =
+        indices.stream()
+            .filter(
+                index -> !Objects.equals(lifeCyclePolicyApplied.getIfPresent(index), policyName))
+            .toList();
+
+    logger.debug(
+        "Applying policy '{}' to {} indices: {}",
+        policyName,
+        indicesWithoutPolicy.size(),
+        indicesWithoutPolicy);
 
     final var settingsRequest =
         new PutIndicesSettingsRequest.Builder()
             .settings(settings -> settings.lifecycle(lifecycle -> lifecycle.name(policyName)))
-            .index(indices)
+            .index(indicesWithoutPolicy)
             .allowNoIndices(true)
             .ignoreUnavailable(true)
             .build();

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepository.java
@@ -120,7 +120,6 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
             (response) -> createArchiveBatch(response, BatchOperationTemplate.END_DATE), executor);
   }
 
-  // keep map
   @Override
   public CompletableFuture<Void> setIndexLifeCycle(final String... destinationIndexName) {
     if (!retention.isEnabled()) {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepository.java
@@ -294,10 +294,21 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
             })) {
       return CompletableFuture.completedFuture(null);
     }
-    logger.debug("Applying policy '{}' to {} indices: {}", policyName, indices.size(), indices);
+
+    final var indicesWithoutPolicy =
+        indices.stream()
+            .filter(
+                index -> !Objects.equals(lifeCyclePolicyApplied.getIfPresent(index), policyName))
+            .toList();
+
+    logger.debug(
+        "Applying policy '{}' to {} indices: {}",
+        policyName,
+        indicesWithoutPolicy.size(),
+        indicesWithoutPolicy);
 
     final var requests =
-        indices.stream()
+        indicesWithoutPolicy.stream()
             .map(index -> applyPolicyToIndex(index, policyName))
             .toArray(CompletableFuture[]::new);
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepository.java
@@ -286,20 +286,14 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
   private CompletableFuture<Void> applyPolicyToIndices(
       final String policyName, final List<String> indices) {
 
-    if (indices.stream()
-        .allMatch(
-            index -> {
-              final String retentionPolicy = lifeCyclePolicyApplied.getIfPresent(index);
-              return retentionPolicy != null && retentionPolicy.equals(policyName);
-            })) {
-      return CompletableFuture.completedFuture(null);
-    }
-
     final var indicesWithoutPolicy =
         indices.stream()
             .filter(
-                index -> !Objects.equals(lifeCyclePolicyApplied.getIfPresent(index), policyName))
+                index -> !policyName.equals(lifeCyclePolicyApplied.getIfPresent(index)))
             .toList();
+    if (indicesWithoutPolicy.isEmpty()) {
+      return CompletableFuture.completedFuture(null);
+    }
 
     logger.debug(
         "Applying policy '{}' to {} indices: {}",

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepository.java
@@ -86,6 +86,7 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
       final String batchOperationIndex,
       final String zeebeIndexPrefix,
       @WillCloseWhenClosed final OpenSearchAsyncClient client,
+      final OpenSearchGenericClient genericClient,
       final Executor executor,
       final CamundaExporterMetrics metrics,
       final Logger logger) {
@@ -98,8 +99,7 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
     this.batchOperationIndex = batchOperationIndex;
     this.metrics = metrics;
     this.zeebeIndexPrefix = zeebeIndexPrefix;
-
-    genericClient = new OpenSearchGenericClient(client._transport(), client._transportOptions());
+    this.genericClient = genericClient;
   }
 
   @Override
@@ -288,8 +288,7 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
 
     final var indicesWithoutPolicy =
         indices.stream()
-            .filter(
-                index -> !policyName.equals(lifeCyclePolicyApplied.getIfPresent(index)))
+            .filter(index -> !policyName.equals(lifeCyclePolicyApplied.getIfPresent(index)))
             .toList();
     if (indicesWithoutPolicy.isEmpty()) {
       return CompletableFuture.completedFuture(null);

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepositoryIT.java
@@ -8,6 +8,7 @@
 package io.camunda.exporter.tasks.archiver;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
 
 import co.elastic.clients.elasticsearch.ElasticsearchAsyncClient;
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
@@ -16,6 +17,7 @@ import co.elastic.clients.elasticsearch._types.mapping.TypeMapping;
 import co.elastic.clients.elasticsearch.core.search.Hit;
 import co.elastic.clients.elasticsearch.ilm.Phase;
 import co.elastic.clients.elasticsearch.indices.IndexSettingsLifecycle;
+import co.elastic.clients.elasticsearch.indices.PutIndicesSettingsRequest;
 import co.elastic.clients.json.jackson.JacksonJsonpMapper;
 import co.elastic.clients.transport.rest_client.RestClientTransport;
 import io.camunda.exporter.config.ExporterConfiguration.HistoryConfiguration;
@@ -47,6 +49,7 @@ import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -524,6 +527,49 @@ final class ElasticsearchArchiverRepositoryIT {
     }
   }
 
+  @Test
+  void shouldCacheIndicesWhichHaveRetentionPolicyAppliedAndNotReapplyPointlessly() {
+    // given
+    retention.setEnabled(true);
+    final var sourceIndexName = UUID.randomUUID().toString();
+    final var destIndexName = UUID.randomUUID().toString();
+
+    final var clientSpy = spy(new ElasticsearchAsyncClient(transport));
+    final var indicesClientSpy = spy(clientSpy.indices());
+
+    doReturn(indicesClientSpy).when(clientSpy).indices();
+
+    final var repository = createRepository(clientSpy);
+
+    // when - first time setting policy for destIndexName it should make the put settings for
+    // destIndexName
+    repository.setIndexLifeCycle(destIndexName);
+
+    final ArgumentCaptor<PutIndicesSettingsRequest> captor =
+        ArgumentCaptor.forClass(PutIndicesSettingsRequest.class);
+
+    Awaitility.await().untilAsserted(() -> verify(indicesClientSpy).putSettings(captor.capture()));
+
+    final List<PutIndicesSettingsRequest> putIndicesSettingsRequests = captor.getAllValues();
+    assertThat(putIndicesSettingsRequests.getFirst().index()).containsExactly(destIndexName);
+
+    // setting policy first time for srcIndexName but second time for destIndexName, it
+    // should have cached the fact that destIndexName already has a policy and not be included in
+    // the request.
+    repository.setIndexLifeCycle(sourceIndexName, destIndexName);
+
+    // then
+    final var captor2 = ArgumentCaptor.forClass(PutIndicesSettingsRequest.class);
+
+    Awaitility.await()
+        .untilAsserted(() -> verify(indicesClientSpy, times(2)).putSettings(captor2.capture()));
+
+    final List<PutIndicesSettingsRequest> putIndicesSettingsRequests2 = captor2.getAllValues();
+    assertThat(putIndicesSettingsRequests2).hasSize(2);
+
+    assertThat(putIndicesSettingsRequests2.getLast().index()).containsExactly(sourceIndexName);
+  }
+
   private void putLifecyclePolicies() throws IOException {
     putLifecyclePolicy(retention.getPolicyName(), retention.getMinimumAge());
     putLifecyclePolicy(
@@ -540,6 +586,11 @@ final class ElasticsearchArchiverRepositoryIT {
   // no need to close resource returned here, since the transport is closed above anyway
   private ElasticsearchArchiverRepository createRepository() {
     final var client = new ElasticsearchAsyncClient(transport);
+
+    return createRepository(client);
+  }
+
+  private ElasticsearchArchiverRepository createRepository(final ElasticsearchAsyncClient client) {
     final var metrics = new CamundaExporterMetrics(meterRegistry);
 
     return new ElasticsearchArchiverRepository(

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryTest.java
@@ -20,6 +20,7 @@ import org.mockito.Mockito;
 import org.opensearch.client.RestClient;
 import org.opensearch.client.json.jackson.JacksonJsonpMapper;
 import org.opensearch.client.opensearch.OpenSearchAsyncClient;
+import org.opensearch.client.opensearch.generic.OpenSearchGenericClient;
 import org.opensearch.client.transport.rest_client.RestClientTransport;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -71,6 +72,7 @@ final class OpenSearchArchiverRepositoryTest {
         "batch",
         "zeebe-record",
         client,
+        new OpenSearchGenericClient(client._transport(), client._transportOptions()),
         Runnable::run,
         metrics,
         LOGGER);


### PR DESCRIPTION
## Description

Currently it makes the put settings to apply the retention policy every time we move documents to a historical index, there is no need to do this every time, we just cache the result in memory and skip if we have already applied the policy.

https://cloudlogging.app.goo.gl/jMYtjhifXzyhztGW7
Looking at the logs here we can see in a 3 hour timespan 85_000 put settings requests are made, this is 28000~ an hour, yes it is under high load but this is unnecessary.
