### PR TITLE
fix: assign document permissions to connectors role

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/IdentitySetupInitializer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/IdentitySetupInitializer.java
@@ -214,6 +214,15 @@ public final class IdentitySetupInitializer implements StreamProcessorLifecycleA
             .setResourceMatcher(WILDCARD.getMatcher())
             .setResourceId(WILDCARD.getResourceId())
             .setPermissionTypes(Set.of(PermissionType.CREATE)));
+    setupRecord.addAuthorization(
+        new AuthorizationRecord()
+            .setOwnerType(AuthorizationOwnerType.ROLE)
+            .setOwnerId(connectorsRoleId)
+            .setResourceType(AuthorizationResourceType.DOCUMENT)
+            .setResourceMatcher(WILDCARD.getMatcher())
+            .setResourceId(WILDCARD.getResourceId())
+            .setPermissionTypes(
+                Set.of(PermissionType.CREATE, PermissionType.READ, PermissionType.DELETE)));
     setupRecord.addTenantMember(
         new TenantRecord()
             .setTenantId(DEFAULT_TENANT_ID)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/IdentitySetupInitializeDefaultsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/IdentitySetupInitializeDefaultsTest.java
@@ -296,7 +296,12 @@ public class IdentitySetupInitializeDefaultsTest {
             auth ->
                 Assertions.assertThat(auth)
                     .hasResourceType(AuthorizationResourceType.MESSAGE)
-                    .hasOnlyPermissionTypes(PermissionType.CREATE));
+                    .hasOnlyPermissionTypes(PermissionType.CREATE),
+            auth ->
+                Assertions.assertThat(auth)
+                    .hasResourceType(AuthorizationResourceType.DOCUMENT)
+                    .hasOnlyPermissionTypes(
+                        PermissionType.CREATE, PermissionType.READ, PermissionType.DELETE));
   }
 
   @Test


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

In https://github.com/camunda/camunda/pull/36509 we introduced the `DOCUMENT` resource type and applicable permissions. These permissions were assigned to the admin role/readonly-admin role by default but they were not included in the `connectors` role.

As mentioned in Slack [here](https://camunda.slack.com/archives/C0828J9F08P/p1755001229618759?thread_ts=1734713891.810749&cid=C0828J9F08P), the Connectors runtime needs these permissions to be able to operate as expected, for this reason, in this PR we alter the `connectors` role to include authorizations for the `DOCUMENT` resource type (with all permissions).

