### PR TITLE
test: ensure 0 limit search yields count

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/UserTaskSearchTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/UserTaskSearchTest.java
@@ -167,6 +167,21 @@ class UserTaskSearchTest {
   }
 
   @Test
+  public void shouldReturnCountWithPageZero() {
+    // when
+    final var result =
+        camundaClient
+            .newUserTaskSearchRequest()
+            .filter(f -> f.elementId("form_process"))
+            .page(p -> p.limit(0))
+            .send()
+            .join();
+    // then
+    assertThat(result.items()).hasSize(0);
+    assertThat(result.page().totalItems()).isEqualTo(1);
+  }
+
+  @Test
   public void shouldUseUserTaskElementIdIfNameNotSet() {
     // when
     final var result =


### PR DESCRIPTION
## Description

Verifies that a REST V2 search request with a limit of 0 yields no items but a correct page info.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

related to #19440 