### PR TITLE
feat: add support for deleting exporter from runtime in broker

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
@@ -218,27 +218,29 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
   }
 
   /**
-   * Disables an already configured exporter. No records will be exported to this exporter anymore.
-   * We will not wait for acknowledgments for this exporter, allowing the log to be compacted.
+   * Removes the given exporter if it exists. Once removed, no records will be sent to it, and
+   * acknowledgments will no longer be awaited, allowing the log to be compacted.
    *
-   * @param exporterId id of the exporter to disabled
-   * @return future which will be completed after the exporter is disabled.
+   * @param exporterId ID of the exporter to remove
+   * @return a future completed when the removal is done
    */
-  public ActorFuture<Void> disableExporter(final String exporterId) {
+  public ActorFuture<Void> removeExporter(final String exporterId) {
     if (actor.isClosed()) {
       return CompletableActorFuture.completed(null);
     }
 
-    return actor.call(() -> removeExporter(exporterId));
-  }
-
-  private void removeExporter(final String exporterId) {
-    containers.stream()
-        .filter(c -> c.getId().equals(exporterId))
-        .findFirst()
-        .ifPresentOrElse(
-            container -> removeExporter(exporterId, container),
-            () -> LOG.debug("Exporter '{}' is not found. It may be already removed.", exporterId));
+    return actor.call(
+        () -> {
+          containers.stream()
+              .filter(c -> c.getId().equals(exporterId))
+              .findFirst()
+              .ifPresentOrElse(
+                  container -> removeExporter(exporterId, container),
+                  () ->
+                      LOG.debug(
+                          "Exporter '{}' is not found. It may already be removed.", exporterId));
+          return null;
+        });
   }
 
   private void removeExporter(final String exporterId, final ExporterContainer container) {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImpl.java
@@ -491,7 +491,9 @@ public final class PartitionManagerImpl
 
   @Override
   public ActorFuture<Void> deleteExporter(final int partitionId, final String exporterId) {
-    throw new UnsupportedOperationException("deleteExporter not yet implemented");
+    final var result = concurrencyControl.<Void>createFuture();
+    concurrencyControl.run(() -> deleteExporter(partitionId, exporterId, result));
+    return result;
   }
 
   @Override
@@ -532,6 +534,36 @@ public final class PartitionManagerImpl
           }
 
           LOGGER.info("Disabled exporter {} on partition {}", exporterId, partitionId);
+          result.complete(null);
+        });
+  }
+
+  private void deleteExporter(
+      final int partitionId, final String exporterId, final ActorFuture<Void> result) {
+    final var partition = partitions.get(partitionId);
+    if (partition == null) {
+      result.completeExceptionally(
+          new IllegalArgumentException("No partition with id %s".formatted(partitionId)));
+      return;
+    }
+
+    if (partition.zeebePartition() == null) {
+      result.completeExceptionally(
+          new IllegalArgumentException(
+              "Expected to delete exporter on partition %s, but zeebePartition is not ready"
+                  .formatted(partitionId)));
+      return;
+    }
+    LOGGER.trace("Deleting exporter {} on partition {}", exporterId, partitionId);
+    concurrencyControl.runOnCompletion(
+        partition.zeebePartition().deleteExporter(exporterId),
+        (ok, error) -> {
+          if (error != null) {
+            result.completeExceptionally(error);
+            return;
+          }
+
+          LOGGER.info("Delete exporter {} on partition {}", exporterId, partitionId);
           result.complete(null);
         });
   }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
@@ -536,6 +536,12 @@ public final class ZeebePartition extends Actor
     return future;
   }
 
+  public ActorFuture<Void> deleteExporter(final String exporterId) {
+    final var future = new CompletableActorFuture<Void>();
+    actor.run(() -> partitionConfigurationManager.deleteExporter(exporterId).onComplete(future));
+    return future;
+  }
+
   public ActorFuture<Void> enableExporter(
       final String exporterId, final long metadataVersion, final String initializeFrom) {
     final var future = new CompletableActorFuture<Void>();

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/ExporterDirectorPartitionTransitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/ExporterDirectorPartitionTransitionStep.java
@@ -151,20 +151,20 @@ public final class ExporterDirectorPartitionTransitionStep implements PartitionT
             }
 
             // The config might have changed after ExporterDirector has created
-            disableOrEnableExportersIfConfigChanged(exporterDescriptors, context);
+            deleteOrEnableExportersIfConfigChanged(exporterDescriptors, context);
           }
         });
     return startFuture;
   }
 
-  private void disableOrEnableExportersIfConfigChanged(
+  private void deleteOrEnableExportersIfConfigChanged(
       final Map<ExporterDescriptor, ExporterInitializationInfo> startedExporters,
       final PartitionTransitionContext context) {
     final var currentEnabledExporters = getEnabledExporterDescriptors(context);
 
     for (final var exporter : startedExporters.keySet()) {
       if (!currentEnabledExporters.containsKey(exporter)) {
-        context.getExporterDirector().disableExporter(exporter.getId());
+        context.getExporterDirector().removeExporter(exporter.getId());
       }
     }
 

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterEnableTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterEnableTest.java
@@ -137,7 +137,7 @@ public class ExporterEnableTest {
     rule.writeEvent(JobIntent.COMPLETED, new JobRecord());
 
     // when
-    rule.getDirector().disableExporter(EXPORTER_ID_2).join();
+    rule.getDirector().removeExporter(EXPORTER_ID_2).join();
     rule.writeEvent(JobIntent.COMPLETED, new JobRecord());
     Awaitility.await()
         .untilAsserted(
@@ -171,8 +171,8 @@ public class ExporterEnableTest {
   public void shouldReStartExportingAfterNewExporterIsEnabledWhenNoExporterIsConfigured() {
     // given
     rule.startExporterDirector(exporterDescriptors);
-    rule.getDirector().disableExporter(EXPORTER_ID_1).join();
-    rule.getDirector().disableExporter(EXPORTER_ID_2).join();
+    rule.getDirector().removeExporter(EXPORTER_ID_1).join();
+    rule.getDirector().removeExporter(EXPORTER_ID_2).join();
 
     // when
     final var newExporterId = "new-exporter";
@@ -192,7 +192,7 @@ public class ExporterEnableTest {
   public void shouldRetryExporterEnableIfCalledWithRetry() {
     // given
     rule.startExporterDirector(exporterDescriptors);
-    rule.getDirector().disableExporter(EXPORTER_ID_2).join();
+    rule.getDirector().removeExporter(EXPORTER_ID_2).join();
 
     final var descriptor = createExporter(EXPORTER_ID_2, Collections.singletonMap("x", 1));
     final var exporter = exporters.get(EXPORTER_ID_2);

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterRemoveTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterRemoveTest.java
@@ -27,7 +27,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
-public class ExporterDisableTest {
+public class ExporterRemoveTest {
   private static final String EXPORTER_ID_1 = "exporter-1";
   private static final String EXPORTER_ID_2 = "exporter-2";
 
@@ -62,13 +62,13 @@ public class ExporterDisableTest {
   }
 
   @Test
-  public void shouldDisableExporter() {
+  public void shouldRemoveExporter() {
     // given
     rule.startExporterDirector(exporterDescriptors);
     rule.writeEvent(DeploymentIntent.CREATED, new DeploymentRecord());
 
     // when
-    rule.getDirector().disableExporter(EXPORTER_ID_1).join();
+    rule.getDirector().removeExporter(EXPORTER_ID_1).join();
 
     rule.writeEvent(DeploymentIntent.CREATED, new DeploymentRecord());
     final long expectedLastExportedPosition =
@@ -81,7 +81,7 @@ public class ExporterDisableTest {
             () -> assertThat(exporters.get(EXPORTER_ID_2).getExportedRecords()).hasSize(3));
 
     assertThat(rule.getDirector().getLowestPosition().join())
-        .describedAs("The lowest position should be updated when one exporter is disabled")
+        .describedAs("The lowest position should be updated when one exporter is removed")
         .isEqualTo(expectedLastExportedPosition);
 
     assertThat(exporters.get(EXPORTER_ID_1).getExportedRecords())
@@ -90,13 +90,13 @@ public class ExporterDisableTest {
   }
 
   @Test
-  public void shouldSucceedWhenDisablingAlreadyDisabledExporter() {
+  public void shouldSucceedWhenDisablingAlreadyRemovedExporter() {
     // given
     rule.startExporterDirector(exporterDescriptors);
-    rule.getDirector().disableExporter(EXPORTER_ID_1).join();
+    rule.getDirector().removeExporter(EXPORTER_ID_1).join();
 
     // when - then
-    assertThat(rule.getDirector().disableExporter(EXPORTER_ID_1))
+    assertThat(rule.getDirector().removeExporter(EXPORTER_ID_1))
         .succeedsWithin(Duration.ofSeconds(5));
   }
 
@@ -106,7 +106,7 @@ public class ExporterDisableTest {
     rule.startExporterDirector(exporterDescriptors);
 
     // when - then
-    assertThat(rule.getDirector().disableExporter("non-existing-exporter"))
+    assertThat(rule.getDirector().removeExporter("non-existing-exporter"))
         .succeedsWithin(Duration.ofSeconds(5));
   }
 
@@ -119,7 +119,7 @@ public class ExporterDisableTest {
     rule.getDirector().close();
 
     // then
-    assertThat(rule.getDirector().disableExporter(EXPORTER_ID_1))
+    assertThat(rule.getDirector().removeExporter(EXPORTER_ID_1))
         .succeedsWithin(Duration.ofSeconds(5));
   }
 }


### PR DESCRIPTION
## Description

When exporter is deleted, it is removed from the runtime state by the ExporterDirector. Concurrent changes during transition are handled by ExporterDirectorTransitionStep already. Since disable and delete behaves similar with in ExporterDirector, the method is renamed to "removeExporter".

The original PR for this feature is #36516 by @giampa91 

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #35324 
closes #35323 
