### PR TITLE
36990-client-use-rest-by-default

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/CamundaClientBuilder.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClientBuilder.java
@@ -15,7 +15,6 @@
  */
 package io.camunda.client;
 
-import io.camunda.client.api.ExperimentalApi;
 import io.camunda.client.api.JsonMapper;
 import io.camunda.client.api.command.CommandWithTenantStep;
 import io.camunda.client.api.worker.JobHandler;
@@ -237,17 +236,13 @@ public interface CamundaClientBuilder {
 
   /**
    * If true, will prefer to use REST over gRPC for calls which can be done over both REST and gRPC.
-   * This is an experimental API which is present while we migrate the bulk of the API from gRPC to
-   * REST. Once done, this will also be removed.
+   * The default value is {@code true} (REST is preferred).
    *
-   * <p>NOTE: not all calls can be done over REST (or HTTP/1) yet, this is also subject to change.
+   * <p>NOTE: job streaming is only supported via gRPC
    *
    * @param preferRestOverGrpc if true, the client will use REST instead of gRPC whenever possible
-   * @deprecated since 8.5, will be removed in 8.8
    * @return this builder for chaining
    */
-  @ExperimentalApi("https://github.com/camunda/camunda/issues/16166")
-  @Deprecated
   CamundaClientBuilder preferRestOverGrpc(final boolean preferRestOverGrpc);
 
   /**

--- a/clients/java/src/main/java/io/camunda/client/api/worker/JobClient.java
+++ b/clients/java/src/main/java/io/camunda/client/api/worker/JobClient.java
@@ -180,6 +180,9 @@ public interface JobClient {
   /**
    * Activates and streams jobs of a specific type.
    *
+   * <p>This command will always try to use the gRPC communication protocol, even if the client is
+   * configured to prefer REST (streaming over REST is not supported).
+   *
    * <pre>{@code
    * final Consumer<ActivatedJob> consumer = ...; // do something with the consumed job
    * final CamundaFuture<StreamJobsResponse> stream = jobClient

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientBuilderImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientBuilderImpl.java
@@ -81,7 +81,7 @@ public final class CamundaClientBuilderImpl
   public static final URI DEFAULT_REST_ADDRESS = getURIFromString("http://0.0.0.0:8080");
   public static final String DEFAULT_JOB_WORKER_NAME_VAR = "default";
   public static final Duration DEFAULT_MESSAGE_TTL = Duration.ofHours(1);
-  public static final boolean DEFAULT_PREFER_REST_OVER_GRPC = false;
+  public static final boolean DEFAULT_PREFER_REST_OVER_GRPC = true;
   public static final int DEFAULT_NUM_JOB_WORKER_EXECUTION_THREADS = 1;
   public static final int DEFAULT_MAX_MESSAGE_SIZE = 5 * ONE_MB;
   public static final int DEFAULT_MAX_METADATA_SIZE = 16 * ONE_KB;

--- a/clients/java/src/main/java/io/camunda/zeebe/client/ClientProperties.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/ClientProperties.java
@@ -41,10 +41,8 @@ public final class ClientProperties {
   @Deprecated public static final String GATEWAY_ADDRESS = "zeebe.client.gateway.address";
 
   /**
-   * @deprecated since 8.5 for removal with 8.8, where toggling between both will not be possible
    * @see ZeebeClientBuilder#preferRestOverGrpc(boolean)
    */
-  @Deprecated
   public static final String PREFER_REST_OVER_GRPC = "zeebe.client.gateway.preferRestOverGrpc";
 
   /**

--- a/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClientBuilder.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClientBuilder.java
@@ -15,7 +15,6 @@
  */
 package io.camunda.zeebe.client;
 
-import io.camunda.zeebe.client.api.ExperimentalApi;
 import io.camunda.zeebe.client.api.JsonMapper;
 import io.camunda.zeebe.client.api.command.CommandWithTenantStep;
 import io.camunda.zeebe.client.api.worker.JobHandler;
@@ -229,17 +228,13 @@ public interface ZeebeClientBuilder {
 
   /**
    * If true, will prefer to use REST over gRPC for calls which can be done over both REST and gRPC.
-   * This is an experimental API which is present while we migrate the bulk of the API from gRPC to
-   * REST. Once done, this will also be removed.
+   * The default value is {@code false} (gRPC is preferred).
    *
    * <p>NOTE: not all calls can be done over REST (or HTTP/1) yet, this is also subject to change.
    *
    * @param preferRestOverGrpc if true, the client will use REST instead of gRPC whenever possible
-   * @deprecated since 8.5, will be removed in 8.8
    * @return this builder for chaining
    */
-  @ExperimentalApi("https://github.com/camunda/camunda/issues/16166")
-  @Deprecated
   ZeebeClientBuilder preferRestOverGrpc(final boolean preferRestOverGrpc);
 
   /**

--- a/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClientConfiguration.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClientConfiguration.java
@@ -15,7 +15,6 @@
  */
 package io.camunda.zeebe.client;
 
-import io.camunda.zeebe.client.api.ExperimentalApi;
 import io.camunda.zeebe.client.api.JsonMapper;
 import io.grpc.ClientInterceptor;
 import java.net.URI;
@@ -167,6 +166,5 @@ public interface ZeebeClientConfiguration {
   /**
    * @see ZeebeClientBuilder#preferRestOverGrpc(boolean)
    */
-  @ExperimentalApi("https://github.com/camunda/camunda/issues/16166")
   boolean preferRestOverGrpc();
 }

--- a/clients/java/src/test/java/io/camunda/client/CamundaClientTest.java
+++ b/clients/java/src/test/java/io/camunda/client/CamundaClientTest.java
@@ -116,7 +116,7 @@ public final class CamundaClientTest {
       assertThat(configuration.getDefaultJobWorkerStreamEnabled()).isFalse();
       assertThat(configuration.getDefaultJobWorkerTenantIds())
           .containsExactly(CommandWithTenantStep.DEFAULT_TENANT_IDENTIFIER);
-      assertThat(configuration.preferRestOverGrpc()).isFalse();
+      assertThat(configuration.preferRestOverGrpc()).isTrue();
     }
   }
 

--- a/clients/java/src/test/java/io/camunda/client/CredentialsTest.java
+++ b/clients/java/src/test/java/io/camunda/client/CredentialsTest.java
@@ -47,12 +47,15 @@ public final class CredentialsTest {
   private final RecordingInterceptor recordingInterceptor = new RecordingInterceptor();
   private final RecordingGatewayService gatewayService = new RecordingGatewayService();
   private CamundaClient client;
+  private final CamundaClientBuilderImpl builder = new CamundaClientBuilderImpl();
 
   @Before
   public void setUp() {
     serverRule
         .getServiceRegistry()
         .addService(ServerInterceptors.intercept(gatewayService, recordingInterceptor));
+
+    builder.preferRestOverGrpc(false);
   }
 
   @After
@@ -69,7 +72,6 @@ public final class CredentialsTest {
   public void shouldAddTokenToCallHeaders() {
     // given
     final String bearerToken = "Bearer someToken";
-    final CamundaClientBuilderImpl builder = new CamundaClientBuilderImpl();
 
     builder
         .usePlaintext()
@@ -97,8 +99,6 @@ public final class CredentialsTest {
   @Test
   public void shouldRetryRequest() {
     // given
-    final CamundaClientBuilderImpl builder = new CamundaClientBuilderImpl();
-
     recordingInterceptor.setInterceptAction(
         (call, headers) -> {
           recordingInterceptor.reset();
@@ -135,7 +135,6 @@ public final class CredentialsTest {
   public void shouldRetryMoreThanOnce() {
     // given
     final int retries = 2;
-    final CamundaClientBuilderImpl builder = new CamundaClientBuilderImpl();
 
     recordingInterceptor.setInterceptAction((call, headers) -> call.close(Status.UNKNOWN, headers));
 
@@ -155,6 +154,7 @@ public final class CredentialsTest {
                 return true;
               }
             });
+
     builder.usePlaintext().credentialsProvider(provider);
     client = new CamundaClientImpl(builder, serverRule.getChannel());
 
@@ -169,7 +169,6 @@ public final class CredentialsTest {
   @Test
   public void shouldNotChangeHeadersWithNoProvider() {
     // given
-    final CamundaClientBuilderImpl builder = new CamundaClientBuilderImpl();
     builder.usePlaintext();
     client = new CamundaClientImpl(builder, serverRule.getChannel());
 
@@ -183,8 +182,6 @@ public final class CredentialsTest {
   @Test
   public void shouldCredentialsProviderRunFromGRPCThreadPool() {
     // given
-    final CamundaClientBuilderImpl builder = new CamundaClientBuilderImpl();
-
     final AtomicReference<String> credentialsProviderThreadReference = new AtomicReference<>();
     builder
         .usePlaintext()

--- a/clients/java/src/test/java/io/camunda/client/impl/worker/JobWorkerImplTest.java
+++ b/clients/java/src/test/java/io/camunda/client/impl/worker/JobWorkerImplTest.java
@@ -94,7 +94,9 @@ public final class JobWorkerImplTest {
 
     client =
         new CamundaClientImpl(
-            new CamundaClientBuilderImpl(), channel, GatewayGrpc.newStub(channel));
+            new CamundaClientBuilderImpl().preferRestOverGrpc(false).build().getConfiguration(),
+            channel,
+            GatewayGrpc.newStub(channel));
   }
 
   @Test

--- a/clients/java/src/test/java/io/camunda/client/util/TestEnvironmentRule.java
+++ b/clients/java/src/test/java/io/camunda/client/util/TestEnvironmentRule.java
@@ -43,7 +43,7 @@ public final class TestEnvironmentRule extends ExternalResource {
   private final CamundaClientBuilderImpl builder = new CamundaClientBuilderImpl();
 
   public TestEnvironmentRule() {
-    this(b -> {});
+    this(b -> b.preferRestOverGrpc(false));
   }
 
   public TestEnvironmentRule(final Consumer<CamundaClientBuilder> clientConfigurator) {
@@ -62,6 +62,7 @@ public final class TestEnvironmentRule extends ExternalResource {
     serverRule.getServiceRegistry().addService(gatewayService);
 
     final ManagedChannel channel = serverRule.getChannel();
+
     clientConfigurator.accept(builder);
     gatewayStub = spy(CamundaClientImpl.buildGatewayStub(channel, builder));
     client = new CamundaClientImpl(builder, channel, gatewayStub);

--- a/clients/spring-boot-starter-camunda-sdk/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -175,7 +175,7 @@
     },
     {
       "name": "camunda.client.prefer-rest-over-grpc",
-      "defaultValue": false
+      "defaultValue": true
     },
     {
       "name": "camunda.client.max-message-size",

--- a/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/spring/client/config/CamundaClientConfigurationDefaultPropertiesTest.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/spring/client/config/CamundaClientConfigurationDefaultPropertiesTest.java
@@ -69,6 +69,6 @@ public class CamundaClientConfigurationDefaultPropertiesTest {
     assertThat(configuration.getNumJobWorkerExecutionThreads()).isEqualTo(1);
     assertThat(configuration.getOverrideAuthority()).isNull();
     assertThat(configuration.getRestAddress()).isEqualTo(new URI("http://0.0.0.0:8080"));
-    assertThat(configuration.preferRestOverGrpc()).isFalse();
+    assertThat(configuration.preferRestOverGrpc()).isTrue();
   }
 }

--- a/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/spring/client/config/legacy/CamundaClientStarterAutoConfigurationCustomJsonMapperTest.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/spring/client/config/legacy/CamundaClientStarterAutoConfigurationCustomJsonMapperTest.java
@@ -117,7 +117,7 @@ public class CamundaClientStarterAutoConfigurationCustomJsonMapperTest {
         .isFalse(); // because the grpc address points to https
     assertThat(configuration.getDefaultJobWorkerMaxJobsActive()).isEqualTo(99);
     assertThat(configuration.getDefaultJobPollInterval()).isEqualTo(Duration.ofSeconds(99));
-    assertThat(configuration.preferRestOverGrpc()).isFalse();
+    assertThat(configuration.preferRestOverGrpc()).isTrue();
   }
 
   @EnableConfigurationProperties(CamundaClientProperties.class)

--- a/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/spring/client/config/legacy/CamundaClientStarterAutoConfigurationTest.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/spring/client/config/legacy/CamundaClientStarterAutoConfigurationTest.java
@@ -110,7 +110,7 @@ public class CamundaClientStarterAutoConfigurationTest {
     assertThat(configuration.isPlaintextConnectionEnabled()).isFalse(); // grpc address is https
     assertThat(configuration.getDefaultJobWorkerMaxJobsActive()).isEqualTo(99);
     assertThat(configuration.getDefaultJobPollInterval()).isEqualTo(Duration.ofSeconds(99));
-    assertThat(configuration.preferRestOverGrpc()).isFalse();
+    assertThat(configuration.preferRestOverGrpc()).isTrue();
   }
 
   @EnableConfigurationProperties(CamundaClientProperties.class)

--- a/operate/common/src/main/java/io/camunda/operate/zeebe/ZeebeConnector.java
+++ b/operate/common/src/main/java/io/camunda/operate/zeebe/ZeebeConnector.java
@@ -38,6 +38,7 @@ public class ZeebeConnector {
     final var gatewayAddress = getGatewayAddress(zeebeProperties);
     final CamundaClientBuilder builder =
         CamundaClient.newClientBuilder()
+            .preferRestOverGrpc(false)
             .gatewayAddress(gatewayAddress)
             .defaultJobWorkerMaxJobsActive(JOB_WORKER_MAX_JOBS_ACTIVE);
     if (zeebeProperties.isSecure()) {

--- a/operate/qa/backup-restore-tests/src/test/java/io/camunda/operate/qa/backup/DataGenerator.java
+++ b/operate/qa/backup-restore-tests/src/test/java/io/camunda/operate/qa/backup/DataGenerator.java
@@ -83,6 +83,7 @@ public class DataGenerator {
   private void init(final BackupRestoreTestContext testContext) {
     camundaClient =
         CamundaClient.newClientBuilder()
+            .preferRestOverGrpc(false)
             .gatewayAddress(testContext.getExternalZeebeContactPoint())
             .usePlaintext()
             .build();

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/ElasticsearchOperateZeebeRuleProvider.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/ElasticsearchOperateZeebeRuleProvider.java
@@ -152,6 +152,7 @@ public class ElasticsearchOperateZeebeRuleProvider implements OperateZeebeRulePr
 
     client =
         CamundaClient.newClientBuilder()
+            .preferRestOverGrpc(false)
             .gatewayAddress(zeebeContainer.getExternalGatewayAddress())
             .usePlaintext()
             .defaultRequestTimeout(REQUEST_TIMEOUT)

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/OpensearchOperateZeebeRuleProvider.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/OpensearchOperateZeebeRuleProvider.java
@@ -131,6 +131,7 @@ public class OpensearchOperateZeebeRuleProvider implements OperateZeebeRuleProvi
 
     client =
         CamundaClient.newClientBuilder()
+            .preferRestOverGrpc(false)
             .gatewayAddress(zeebeContainer.getExternalGatewayAddress())
             .usePlaintext()
             .defaultRequestTimeout(REQUEST_TIMEOUT)

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/j5templates/ZeebeContainerManager.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/j5templates/ZeebeContainerManager.java
@@ -61,6 +61,7 @@ public abstract class ZeebeContainerManager {
 
     client =
         CamundaClient.newClientBuilder()
+            .preferRestOverGrpc(false)
             .gatewayAddress(zeebeContainer.getExternalGatewayAddress())
             .usePlaintext()
             .defaultRequestTimeout(REQUEST_TIMEOUT)

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/migration/PrefixMigrationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/migration/PrefixMigrationIT.java
@@ -318,6 +318,7 @@ public class PrefixMigrationIT {
   private CamundaClient createCamundaClient(final GenericContainer<?> container) {
 
     return CamundaClient.newClientBuilder()
+        .preferRestOverGrpc(false)
         .grpcAddress(URI.create("http://localhost:" + container.getMappedPort(GATEWAY.port())))
         .restAddress(URI.create("http://localhost:" + container.getMappedPort(REST.port())))
         .usePlaintext()

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/migration/util/CamundaMigrator.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/migration/util/CamundaMigrator.java
@@ -101,6 +101,7 @@ public class CamundaMigrator extends ApiCallable implements AutoCloseable {
             camundaContainer.getHost(), camundaContainer.getMappedPort(TestZeebePort.REST.port()));
     camundaClient =
         CamundaClient.newClientBuilder()
+            .preferRestOverGrpc(false)
             .grpcAddress(
                 URI.create(
                     RPC_URL.formatted(
@@ -165,7 +166,7 @@ public class CamundaMigrator extends ApiCallable implements AutoCloseable {
 
     camunda.start();
     camunda.awaitCompleteTopology();
-    camundaClient = camunda.newClientBuilder().build();
+    camundaClient = camunda.newClientBuilder().preferRestOverGrpc(false).build();
     url = URL.formatted(camunda.host(), camunda.mappedPort(TestZeebePort.REST));
     final var uri = URI.create(url + "/");
     tasklistClient = new TestRestTasklistClient(uri);

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/migration/util/MigrationDatabaseChecks.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/migration/util/MigrationDatabaseChecks.java
@@ -99,6 +99,21 @@ public class MigrationDatabaseChecks extends ElasticOpenSearchSetupHelper {
     return totalDocs > 0;
   }
 
+  public boolean checkDemoUserIsPresent() throws IOException, InterruptedException {
+    final String targetUrl =
+        String.format("%s/%s-camunda-user-8.8.0_/_doc/demo", endpoint, indexPrefix);
+    final HttpRequest request =
+        HttpRequest.newBuilder()
+            .uri(URI.create(targetUrl))
+            .header("Content-Type", "application/json")
+            .GET()
+            .build();
+
+    LOGGER.info("Checking if demo user is present");
+    final var response = httpClient.send(request, BodyHandlers.ofString());
+    return response.statusCode() == 200;
+  }
+
   @Override
   public void close() {
     cleanup(indexPrefix);

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/migration/util/MigrationITExtension.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/migration/util/MigrationITExtension.java
@@ -122,6 +122,7 @@ public class MigrationITExtension
 
     migrator.update(envOverrides);
     awaitExporterReadiness();
+    awaitDemoUserIsPresent();
 
     /* Ingest an 8.8 Record in order to trigger importers empty batch counting */
     ingestRecordToTriggerImporters(migrator.getCamundaClient());
@@ -129,6 +130,13 @@ public class MigrationITExtension
     awaitImportersFinished();
 
     awaitProcessMigrationFinished();
+  }
+
+  private void awaitDemoUserIsPresent() {
+    Awaitility.await("Await Demo user is present")
+        .timeout(Duration.ofMinutes(1))
+        .pollInterval(Duration.ofSeconds(1))
+        .until(() -> migrationDatabaseChecks.checkDemoUserIsPresent());
   }
 
   private boolean isNestedClass(final Class<?> currentClass) {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/nodb/NoAuthNoSecondaryStorageTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/nodb/NoAuthNoSecondaryStorageTest.java
@@ -42,7 +42,7 @@ public class NoAuthNoSecondaryStorageTest {
 
   @BeforeEach
   void beforeEach() {
-    camundaClient = broker.newClientBuilder().build();
+    camundaClient = broker.newClientBuilder().preferRestOverGrpc(false).build();
   }
 
   @Test

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/nodb/OidcNoSecondaryStorageTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/nodb/OidcNoSecondaryStorageTest.java
@@ -136,6 +136,7 @@ public class OidcNoSecondaryStorageTest {
     defaultClient =
         CamundaClient.newClientBuilder()
             .grpcAddress(broker.grpcAddress())
+            .restAddress(broker.restAddress())
             .usePlaintext()
             .defaultRequestTimeout(Duration.ofSeconds(15))
             .credentialsProvider(
@@ -154,6 +155,7 @@ public class OidcNoSecondaryStorageTest {
 
     serviceClient =
         CamundaClient.newClientBuilder()
+            .preferRestOverGrpc(false)
             .grpcAddress(broker.grpcAddress())
             .usePlaintext()
             .defaultRequestTimeout(Duration.ofSeconds(15))

--- a/tasklist/common/src/main/java/io/camunda/tasklist/zeebe/ZeebeConnector.java
+++ b/tasklist/common/src/main/java/io/camunda/tasklist/zeebe/ZeebeConnector.java
@@ -43,6 +43,7 @@ public class ZeebeConnector {
         "Zeebe Client - Using Gateway Configuration: {}", zeebeProperties.getGatewayAddress());
     final CamundaClientBuilder builder =
         CamundaClient.newClientBuilder()
+            .preferRestOverGrpc(false)
             .gatewayAddress(zeebeProperties.getGatewayAddress())
             // .restAddress(getURIFromString(zeebeProperties.getRestAddress()))
             .restAddress(getURIFromSaaSOrProperties(zeebeProperties.getRestAddress()))

--- a/tasklist/qa/backup-restore-tests/src/test/java/io/camunda/tasklist/qa/backup/generator/AbstractBackupRestoreDataGenerator.java
+++ b/tasklist/qa/backup-restore-tests/src/test/java/io/camunda/tasklist/qa/backup/generator/AbstractBackupRestoreDataGenerator.java
@@ -57,6 +57,7 @@ public abstract class AbstractBackupRestoreDataGenerator implements BackupRestor
   private void init(final BackupRestoreTestContext testContext) {
     camundaClient =
         CamundaClient.newClientBuilder()
+            .preferRestOverGrpc(false)
             .gatewayAddress(testContext.getExternalZeebeContactPoint())
             .usePlaintext()
             .build();

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TasklistZeebeExtension.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TasklistZeebeExtension.java
@@ -86,6 +86,7 @@ public abstract class TasklistZeebeExtension
 
     client =
         CamundaClient.newClientBuilder()
+            .preferRestOverGrpc(false)
             .gatewayAddress(zeebeContainer.getExternalGatewayAddress())
             .restAddress(
                 getURIFromString(

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/extension/CamundaProcessTestContextImpl.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/extension/CamundaProcessTestContextImpl.java
@@ -87,6 +87,7 @@ public class CamundaProcessTestContextImpl implements CamundaProcessTestContext 
   @Override
   public CamundaClient createClient(final Consumer<CamundaClientBuilder> modifier) {
     final CamundaClientBuilder builder = camundaClientBuilderFactory.get();
+    builder.preferRestOverGrpc(false);
 
     modifier.accept(builder);
 

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/PartitionLeaveTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/PartitionLeaveTest.java
@@ -69,6 +69,7 @@ final class PartitionLeaveTest {
 
     try (final var client =
         CamundaClient.newClientBuilder()
+            .preferRestOverGrpc(false)
             .usePlaintext()
             .gatewayAddress("localhost:" + broker0.getConfig().getGateway().getNetwork().getPort())
             .build()) {
@@ -124,6 +125,7 @@ final class PartitionLeaveTest {
 
     try (final var client =
         CamundaClient.newClientBuilder()
+            .preferRestOverGrpc(false)
             .usePlaintext()
             .gatewayAddress("localhost:" + broker0.getConfig().getGateway().getNetwork().getPort())
             .build()) {
@@ -183,6 +185,7 @@ final class PartitionLeaveTest {
 
     try (final var client =
         CamundaClient.newClientBuilder()
+            .preferRestOverGrpc(false)
             .usePlaintext()
             .gatewayAddress("localhost:" + broker0.getConfig().getGateway().getNetwork().getPort())
             .build()) {

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/BrokerSnapshotTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/BrokerSnapshotTest.java
@@ -52,7 +52,10 @@ public class BrokerSnapshotTest {
 
     final String contactPoint = NetUtil.toSocketAddressString(brokerRule.getGatewayAddress());
     final CamundaClientBuilder camundaClientBuilder =
-        CamundaClient.newClientBuilder().usePlaintext().gatewayAddress(contactPoint);
+        CamundaClient.newClientBuilder()
+            .usePlaintext()
+            .gatewayAddress(contactPoint)
+            .preferRestOverGrpc(false);
     client = camundaClientBuilder.build();
   }
 

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/test/EmbeddedBrokerRule.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/test/EmbeddedBrokerRule.java
@@ -267,6 +267,7 @@ public final class EmbeddedBrokerRule extends ExternalResource {
     if (brokerCfg.getGateway().isEnable()) {
       try (final var client =
           CamundaClient.newClientBuilder()
+              .preferRestOverGrpc(false)
               .gatewayAddress(NetUtil.toSocketAddressString(getGatewayAddress()))
               .usePlaintext()
               .build()) {

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/UnavailableBrokersTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/UnavailableBrokersTest.java
@@ -114,7 +114,12 @@ class UnavailableBrokersTest {
     gateway.start().join();
 
     final String gatewayAddress = NetUtil.toSocketAddressString(networkCfg.toSocketAddress());
-    client = CamundaClient.newClientBuilder().gatewayAddress(gatewayAddress).usePlaintext().build();
+    client =
+        CamundaClient.newClientBuilder()
+            .preferRestOverGrpc(false)
+            .gatewayAddress(gatewayAddress)
+            .usePlaintext()
+            .build();
   }
 
   @AfterAll

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/interceptors/InterceptorIT.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/interceptors/InterceptorIT.java
@@ -181,6 +181,7 @@ final class InterceptorIT {
 
   private CamundaClient createCamundaClient() {
     return CamundaClient.newClientBuilder()
+        .preferRestOverGrpc(false)
         .gatewayAddress(
             NetUtil.toSocketAddressString(gateway.getGatewayCfg().getNetwork().toSocketAddress()))
         .usePlaintext()

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/ClientCancelPendingCommandTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/ClientCancelPendingCommandTest.java
@@ -31,7 +31,8 @@ final class ClientCancelPendingCommandTest {
   private static final TestStandaloneBroker ZEEBE =
       new TestStandaloneBroker().withUnauthenticatedAccess().withUnauthenticatedAccess();
 
-  @AutoClose private final CamundaClient client = ZEEBE.newClientBuilder().build();
+  @AutoClose
+  private final CamundaClient client = ZEEBE.newClientBuilder().preferRestOverGrpc(false).build();
 
   @Test
   void shouldCancelCommandOnFutureCancellation() {

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/OperationReferenceTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/OperationReferenceTest.java
@@ -34,7 +34,11 @@ public class OperationReferenceTest {
 
   @AutoClose
   private final CamundaClient client =
-      zeebe.newClientBuilder().defaultRequestTimeout(Duration.ofMinutes(2)).build();
+      zeebe
+          .newClientBuilder()
+          .preferRestOverGrpc(false)
+          .defaultRequestTimeout(Duration.ofMinutes(2))
+          .build();
 
   @SuppressWarnings("unused")
   static void initTestStandaloneBroker() {

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/UserTaskListenersTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/UserTaskListenersTest.java
@@ -69,7 +69,12 @@ public class UserTaskListenersTest {
 
   @BeforeEach
   void init() {
-    client = ZEEBE.newClientBuilder().defaultRequestTimeout(Duration.ofSeconds(5)).build();
+    client =
+        ZEEBE
+            .newClientBuilder()
+            .preferRestOverGrpc(false)
+            .defaultRequestTimeout(Duration.ofSeconds(5))
+            .build();
     resourcesHelper = new ZeebeResourcesHelper(client);
   }
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ClusteringRule.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ClusteringRule.java
@@ -547,7 +547,7 @@ public class ClusteringRule extends ExternalResource {
         NetUtil.toSocketAddressString(
             gatewayResource.gateway.getGatewayCfg().getNetwork().toSocketAddress());
     final CamundaClientBuilder camundaClientBuilder =
-        CamundaClient.newClientBuilder().gatewayAddress(contactPoint);
+        CamundaClient.newClientBuilder().gatewayAddress(contactPoint).preferRestOverGrpc(false);
 
     clientConfigurator.accept(camundaClientBuilder);
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/RestoreTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/RestoreTest.java
@@ -46,6 +46,7 @@ public final class RestoreTest {
       new GrpcClientRule(
           config ->
               config
+                  .preferRestOverGrpc(false)
                   .gatewayAddress(NetUtil.toSocketAddressString(clusteringRule.getGatewayAddress()))
                   .defaultRequestTimeout(Duration.ofMinutes(1))
                   .usePlaintext());

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/StateMigrationTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/StateMigrationTest.java
@@ -35,6 +35,7 @@ public class StateMigrationTest {
       new GrpcClientRule(
           config ->
               config
+                  .preferRestOverGrpc(false)
                   .gatewayAddress(NetUtil.toSocketAddressString(clusteringRule.getGatewayAddress()))
                   .defaultRequestTimeout(Duration.ofMinutes(1))
                   .usePlaintext());

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/ForceScaleDownBrokersTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/ForceScaleDownBrokersTest.java
@@ -35,7 +35,8 @@ class ForceScaleDownBrokersTest {
   void shouldForceRemoveBrokers(final int oldClusterSize, final int newClusterSize) {
     // given
     try (final var cluster = createCluster(oldClusterSize, oldClusterSize);
-        final var camundaClient = cluster.availableGateway().newClientBuilder().build()) {
+        final var camundaClient =
+            cluster.availableGateway().newClientBuilder().preferRestOverGrpc(false).build()) {
       final var brokersToShutdown =
           IntStream.range(newClusterSize, oldClusterSize)
               .mapToObj(String::valueOf)

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/ScaleDownBrokersTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/ScaleDownBrokersTest.java
@@ -65,7 +65,7 @@ final class ScaleDownBrokersTest {
 
   @BeforeEach
   void createClient() {
-    camundaClient = cluster.availableGateway().newClientBuilder().build();
+    camundaClient = cluster.availableGateway().newClientBuilder().preferRestOverGrpc(false).build();
   }
 
   @Test

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/gateway/rest/FilterIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/gateway/rest/FilterIT.java
@@ -50,7 +50,12 @@ public class FilterIT {
 
   @BeforeEach
   void initClient() {
-    client = cluster.newClientBuilder().defaultRequestTimeout(Duration.ofSeconds(15)).build();
+    client =
+        cluster
+            .newClientBuilder()
+            .preferRestOverGrpc(false)
+            .defaultRequestTimeout(Duration.ofSeconds(15))
+            .build();
   }
 
   @Test

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/processing/MultipleInvalidResourceDeletionTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/processing/MultipleInvalidResourceDeletionTest.java
@@ -36,7 +36,7 @@ public class MultipleInvalidResourceDeletionTest {
 
   @BeforeEach
   void beforeEach() {
-    client = zeebe.newClientBuilder().build();
+    client = zeebe.newClientBuilder().preferRestOverGrpc(false).build();
   }
 
   @RegressionTest("https://github.com/camunda/camunda/issues/16429")

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/queryapi/QueryApiIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/queryapi/QueryApiIT.java
@@ -206,6 +206,7 @@ final class QueryApiIT {
   private static CamundaClient createCamundaClient(final String tenant) {
     return broker
         .newClientBuilder()
+        .preferRestOverGrpc(false)
         .withInterceptors(new TestAuthorizationClientInterceptor(tenant))
         .defaultRequestTimeout(Duration.ofMinutes(1))
         .build();

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/smoke/ContainerClusterSmokeIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/smoke/ContainerClusterSmokeIT.java
@@ -95,6 +95,9 @@ final class ContainerClusterSmokeIT {
   private CamundaClient createCamundaClient() {
     // increased request timeout as container tests might be less responsive when emulation is
     // involved e.g. emulation of ARM64
-    return newClientBuilder(cluster).defaultRequestTimeout(Duration.ofMinutes(2)).build();
+    return newClientBuilder(cluster)
+        .preferRestOverGrpc(false)
+        .defaultRequestTimeout(Duration.ofMinutes(2))
+        .build();
   }
 }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/startup/NonDefaultContainerSetupTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/startup/NonDefaultContainerSetupTest.java
@@ -95,6 +95,7 @@ public class NonDefaultContainerSetupTest {
       final ProcessInstanceResult result;
       try (final CamundaClient client =
           CamundaClient.newClientBuilder()
+              .preferRestOverGrpc(false)
               .usePlaintext()
               .gatewayAddress(gateway.getExternalGatewayAddress())
               .build()) {

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/system/BrokerAdminServiceTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/system/BrokerAdminServiceTest.java
@@ -104,7 +104,7 @@ public class BrokerAdminServiceTest {
 
     // when
     final Future<?> response;
-    try (final var client = zeebe.newClientBuilder().build()) {
+    try (final var client = zeebe.newClientBuilder().preferRestOverGrpc(true).build()) {
       response =
           client.newPublishMessageCommand().messageName("test").correlationKey("test-key").send();
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/system/BrokerAdminServiceTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/system/BrokerAdminServiceTest.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.it.system;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.client.api.command.ProblemException;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.broker.client.api.dto.BrokerExecuteCommand;
 import io.camunda.zeebe.broker.exporter.stream.ExporterPhase;
@@ -24,9 +25,6 @@ import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
 import io.camunda.zeebe.stream.impl.StreamProcessor.Phase;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.util.buffer.BufferWriter;
-import io.grpc.Status;
-import io.grpc.Status.Code;
-import io.grpc.StatusRuntimeException;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
@@ -115,11 +113,10 @@ public class BrokerAdminServiceTest {
           .failsWithin(Duration.ofSeconds(5))
           .withThrowableThat()
           .havingCause()
-          .withMessageContaining("UNAVAILABLE: Processing paused for partition")
-          .asInstanceOf(InstanceOfAssertFactories.throwable(StatusRuntimeException.class))
-          .extracting(StatusRuntimeException::getStatus)
-          .extracting(Status::getCode)
-          .isEqualTo(Code.UNAVAILABLE);
+          .withMessageContaining("Processing paused for partition")
+          .asInstanceOf(InstanceOfAssertFactories.throwable(ProblemException.class))
+          .extracting(ProblemException::code)
+          .isEqualTo(503);
     }
   }
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/util/GrpcClientRule.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/util/GrpcClientRule.java
@@ -39,6 +39,7 @@ public final class GrpcClientRule extends ExternalResource {
     this(
         config -> {
           config
+              .preferRestOverGrpc(false)
               .gatewayAddress(NetUtil.toSocketAddressString(brokerRule.getGatewayAddress()))
               .usePlaintext();
           configurator.accept(config);
@@ -49,6 +50,7 @@ public final class GrpcClientRule extends ExternalResource {
     this(
         config ->
             config
+                .preferRestOverGrpc(false)
                 .gatewayAddress(NetUtil.toSocketAddressString(clusteringRule.getGatewayAddress()))
                 .usePlaintext());
   }
@@ -71,7 +73,9 @@ public final class GrpcClientRule extends ExternalResource {
   public void before() {
     startTime = System.currentTimeMillis();
     final CamundaClientBuilder builder =
-        CamundaClient.newClientBuilder().defaultRequestTimeout(Duration.ofSeconds(10));
+        CamundaClient.newClientBuilder()
+            .preferRestOverGrpc(false)
+            .defaultRequestTimeout(Duration.ofSeconds(10));
     configurator.accept(builder);
     client = builder.build();
     resourcesHelper = new ZeebeResourcesHelper(client);

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/util/ZeebeContainerUtil.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/util/ZeebeContainerUtil.java
@@ -23,12 +23,14 @@ public final class ZeebeContainerUtil {
     final ZeebeGatewayNode<?> gateway = cluster.getAvailableGateway();
 
     return CamundaClient.newClientBuilder()
+        .preferRestOverGrpc(false)
         .usePlaintext()
         .gatewayAddress(gateway.getExternalGatewayAddress());
   }
 
   public static CamundaClientBuilder newClientBuilder(final ContainerEngine containerEngine) {
     return CamundaClient.newClientBuilder()
+        .preferRestOverGrpc(false)
         .usePlaintext()
         .gatewayAddress(containerEngine.getGatewayAddress());
   }

--- a/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/ContainerState.java
+++ b/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/ContainerState.java
@@ -189,7 +189,12 @@ final class ContainerState implements AutoCloseable {
       contactPoint = gateway.getExternalGatewayAddress();
     }
 
-    client = CamundaClient.newClientBuilder().gatewayAddress(contactPoint).usePlaintext().build();
+    client =
+        CamundaClient.newClientBuilder()
+            .gatewayAddress(contactPoint)
+            .usePlaintext()
+            .preferRestOverGrpc(false)
+            .build();
     partitionsActuator = PartitionsActuator.of(broker);
   }
 

--- a/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/RollingUpdateTest.java
+++ b/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/RollingUpdateTest.java
@@ -361,6 +361,7 @@ final class RollingUpdateTest {
 
   private CamundaClient newClient(final ZeebeGatewayNode<?> gateway) {
     return CamundaClient.newClientBuilder()
+        .preferRestOverGrpc(false)
         .usePlaintext()
         .gatewayAddress(gateway.getExternalGatewayAddress())
         .build();

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestCluster.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestCluster.java
@@ -266,6 +266,7 @@ public final class TestCluster implements CloseableSilently {
   @SuppressWarnings("resource")
   public CamundaClientBuilder newClientBuilder() {
     return CamundaClient.newClientBuilder()
+        .preferRestOverGrpc(false)
         .usePlaintext()
         .restAddress(availableGateway().restAddress())
         .grpcAddress(availableGateway().grpcAddress());
@@ -369,7 +370,7 @@ public final class TestCluster implements CloseableSilently {
    * @throws NoSuchElementException if no leader is found for the partition
    */
   public TestStandaloneBroker leaderForPartition(final int partitionId) {
-    try (final var client = newClientBuilder().build()) {
+    try (final var client = newClientBuilder().preferRestOverGrpc(false).build()) {
       final var leaderOfPartition2 =
           client.newTopologyRequest().send().join().getBrokers().stream()
               .filter(
@@ -414,7 +415,7 @@ public final class TestCluster implements CloseableSilently {
     assertThatCode(() -> node.probe(TestHealthProbe.READY))
         .as("gateway '%s' is ready", node.nodeId())
         .doesNotThrowAnyException();
-    try (final var client = node.newClientBuilder().build()) {
+    try (final var client = node.newClientBuilder().preferRestOverGrpc(false).build()) {
       TopologyAssert.assertThat(client.newTopologyRequest().send().join())
           .isComplete(clusterSize, partitionsCount, replicationFactor);
     }
@@ -424,7 +425,7 @@ public final class TestCluster implements CloseableSilently {
     assertThatCode(() -> node.probe(TestHealthProbe.READY))
         .as("gateway '%s' is ready", node.nodeId())
         .doesNotThrowAnyException();
-    try (final var client = node.newClientBuilder().build()) {
+    try (final var client = node.newClientBuilder().preferRestOverGrpc(false).build()) {
       TopologyAssert.assertThat(client.newTopologyRequest().send().join()).isHealthy();
     }
   }

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestGateway.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestGateway.java
@@ -103,7 +103,7 @@ public interface TestGateway<T extends TestGateway<T>> extends TestApplication<T
         CamundaClient.newClientBuilder()
             .grpcAddress(grpcAddress())
             .restAddress(restAddress())
-            .preferRestOverGrpc(true);
+            .preferRestOverGrpc(false);
     final var security = gatewayConfig().getSecurity();
     final var restSSL = property("server.ssl.enabled", Boolean.class, false);
     if (security.isEnabled() || restSSL) {

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestGateway.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestGateway.java
@@ -100,7 +100,10 @@ public interface TestGateway<T extends TestGateway<T>> extends TestApplication<T
   /** Returns a new pre-configured client builder for this gateway */
   default CamundaClientBuilder newClientBuilder() {
     final var builder =
-        CamundaClient.newClientBuilder().grpcAddress(grpcAddress()).restAddress(restAddress());
+        CamundaClient.newClientBuilder()
+            .grpcAddress(grpcAddress())
+            .restAddress(restAddress())
+            .preferRestOverGrpc(true);
     final var security = gatewayConfig().getSecurity();
     final var restSSL = property("server.ssl.enabled", Boolean.class, false);
     if (security.isEnabled() || restSSL) {


### PR DESCRIPTION
## Description

**feat: prefer REST over gRPC by default in CamundaClient**
- Set DEFAULT_PREFER_REST_OVER_GRPC to true for CamundaClient
- Remove @experimentalapi and deprecation from preferRestOverGrpc method
- Update Javadoc to clarify REST is now preferred by default


**refactor: remove deprecated and experimental annotations from preferRestOverGrpc in Zeebe Client**
- Removed @deprecated and @experimentalapi annotations from preferRestOverGrpc in Zeebe client API and configuration
- Updated Javadoc to clarify default is gRPC (false) for Zeebe client
Cleaned up legacy toggling documentation in ClientProperties


🚨 **no backporting to zeebe client, as we want to keep the old default on the zeebe client to make the migration/upgrade safer**

## Checklist

- [ ] add to 8.8 release announcements

## Related issues

closes #https://github.com/camunda/camunda/issues/36990
