### PR TITLE
feat: removing contentHash from Documents API

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/fetch/DocumentContentGetRequest.java
+++ b/clients/java/src/main/java/io/camunda/client/api/fetch/DocumentContentGetRequest.java
@@ -34,10 +34,4 @@ public interface DocumentContentGetRequest extends FinalCommandStep<InputStream>
    */
   DocumentContentGetRequest storeId(String storeId);
 
-  /**
-   * Sets the documents content hash.
-   *
-   * @param contentHash the documents content Hash
-   */
-  DocumentContentGetRequest contentHash(String contentHash);
 }

--- a/clients/java/src/main/java/io/camunda/client/api/fetch/DocumentContentGetRequest.java
+++ b/clients/java/src/main/java/io/camunda/client/api/fetch/DocumentContentGetRequest.java
@@ -33,5 +33,4 @@ public interface DocumentContentGetRequest extends FinalCommandStep<InputStream>
    * @param storeId optional document store ID
    */
   DocumentContentGetRequest storeId(String storeId);
-
 }

--- a/clients/java/src/main/java/io/camunda/client/api/response/DocumentReferenceResponse.java
+++ b/clients/java/src/main/java/io/camunda/client/api/response/DocumentReferenceResponse.java
@@ -43,13 +43,6 @@ public interface DocumentReferenceResponse {
   String getStoreId();
 
   /**
-   * The hash of the associated document
-   *
-   * @return the hash value of the document
-   */
-  String getContentHash();
-
-  /**
    * @return the metadata of the document reference
    */
   DocumentMetadata getMetadata();

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
@@ -1084,16 +1084,12 @@ public final class CamundaClientImpl implements CamundaClient {
   public DocumentContentGetRequest newDocumentContentGetRequest(
       final DocumentReferenceResponse documentReference) {
     return new DocumentContentGetRequestImpl(
-        httpClient,
-        documentReference.getDocumentId(),
-        documentReference.getStoreId(),
-        config);
+        httpClient, documentReference.getDocumentId(), documentReference.getStoreId(), config);
   }
 
   @Override
   public CreateDocumentLinkCommandStep1 newCreateDocumentLinkCommand(final String documentId) {
-    return new CreateDocumentLinkCommandImpl(
-        documentId, null, jsonMapper, httpClient, config);
+    return new CreateDocumentLinkCommandImpl(documentId, null, jsonMapper, httpClient, config);
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
@@ -1077,7 +1077,7 @@ public final class CamundaClientImpl implements CamundaClient {
 
   @Override
   public DocumentContentGetRequest newDocumentContentGetRequest(final String documentId) {
-    return new DocumentContentGetRequestImpl(httpClient, documentId, null, null, config);
+    return new DocumentContentGetRequestImpl(httpClient, documentId, null, config);
   }
 
   @Override
@@ -1087,14 +1087,13 @@ public final class CamundaClientImpl implements CamundaClient {
         httpClient,
         documentReference.getDocumentId(),
         documentReference.getStoreId(),
-        documentReference.getContentHash(),
         config);
   }
 
   @Override
   public CreateDocumentLinkCommandStep1 newCreateDocumentLinkCommand(final String documentId) {
     return new CreateDocumentLinkCommandImpl(
-        documentId, null, null, jsonMapper, httpClient, config);
+        documentId, null, jsonMapper, httpClient, config);
   }
 
   @Override
@@ -1103,7 +1102,6 @@ public final class CamundaClientImpl implements CamundaClient {
     return new CreateDocumentLinkCommandImpl(
         documentReference.getDocumentId(),
         documentReference.getStoreId(),
-        documentReference.getContentHash(),
         jsonMapper,
         httpClient,
         config);

--- a/clients/java/src/main/java/io/camunda/client/impl/command/CreateDocumentLinkCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/CreateDocumentLinkCommandImpl.java
@@ -45,7 +45,6 @@ public class CreateDocumentLinkCommandImpl implements CreateDocumentLinkCommandS
   public CreateDocumentLinkCommandImpl(
       final String documentId,
       final String storeId,
-      final String contentHash,
       final JsonMapper jsonMapper,
       final HttpClient httpClient,
       final CamundaClientConfiguration configuration) {
@@ -55,7 +54,6 @@ public class CreateDocumentLinkCommandImpl implements CreateDocumentLinkCommandS
     if (storeId != null) {
       queryParams.put("storeId", storeId);
     }
-    queryParams.put("contentHash", contentHash);
     documentLinkRequest = new DocumentLinkRequest();
     this.jsonMapper = jsonMapper;
     this.httpClient = httpClient;

--- a/clients/java/src/main/java/io/camunda/client/impl/fetch/DocumentContentGetRequestImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/fetch/DocumentContentGetRequestImpl.java
@@ -78,5 +78,4 @@ public class DocumentContentGetRequestImpl implements DocumentContentGetRequest 
     this.storeId = storeId;
     return this;
   }
-
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/fetch/DocumentContentGetRequestImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/fetch/DocumentContentGetRequestImpl.java
@@ -35,20 +35,17 @@ public class DocumentContentGetRequestImpl implements DocumentContentGetRequest 
   private final RequestConfig.Builder httpRequestConfig;
   private final String documentId;
   private String storeId;
-  private String contentHash;
 
   public DocumentContentGetRequestImpl(
       final HttpClient httpClient,
       final String documentId,
       final String storeId,
-      final String contentHash,
       final CamundaClientConfiguration configuration) {
     ensureNotNull("documentId", documentId);
     this.httpClient = httpClient;
     httpRequestConfig = httpClient.newRequestConfig();
     this.documentId = documentId;
     this.storeId = storeId;
-    this.contentHash = contentHash;
     requestTimeout(configuration.getDefaultRequestTimeout());
   }
 
@@ -66,7 +63,6 @@ public class DocumentContentGetRequestImpl implements DocumentContentGetRequest 
     if (storeId != null) {
       queryParams.put("storeId", storeId);
     }
-    queryParams.put("contentHash", contentHash);
     httpClient.get(
         String.format("/documents/%s", documentId),
         queryParams,
@@ -83,9 +79,4 @@ public class DocumentContentGetRequestImpl implements DocumentContentGetRequest 
     return this;
   }
 
-  @Override
-  public DocumentContentGetRequest contentHash(final String contentHash) {
-    this.contentHash = contentHash;
-    return this;
-  }
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/response/DocumentReferenceResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/DocumentReferenceResponseImpl.java
@@ -22,15 +22,12 @@ public class DocumentReferenceResponseImpl implements DocumentReferenceResponse 
 
   private final String documentId;
   private final String storeId;
-  private final String contentHash;
   private final DocumentMetadata metadata;
 
   public DocumentReferenceResponseImpl(
       final io.camunda.client.protocol.rest.DocumentReference documentReference) {
     documentId = documentReference.getDocumentId();
     storeId = documentReference.getStoreId();
-    contentHash = documentReference.getContentHash();
-
     metadata = new DocumentMetadataImpl(documentReference.getMetadata());
   }
 
@@ -42,11 +39,6 @@ public class DocumentReferenceResponseImpl implements DocumentReferenceResponse 
   @Override
   public String getStoreId() {
     return storeId;
-  }
-
-  @Override
-  public String getContentHash() {
-    return contentHash;
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/fetch/DocumentContentGetRequest.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/fetch/DocumentContentGetRequest.java
@@ -35,5 +35,4 @@ public interface DocumentContentGetRequest extends FinalCommandStep<InputStream>
    * @param storeId optional document store ID
    */
   DocumentContentGetRequest storeId(String storeId);
-
 }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/fetch/DocumentContentGetRequest.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/fetch/DocumentContentGetRequest.java
@@ -36,10 +36,4 @@ public interface DocumentContentGetRequest extends FinalCommandStep<InputStream>
    */
   DocumentContentGetRequest storeId(String storeId);
 
-  /**
-   * Sets the documents content hash.
-   *
-   * @param contentHash the documents content Hash
-   */
-  DocumentContentGetRequest contentHash(String contentHash);
 }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/DocumentReferenceResponse.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/DocumentReferenceResponse.java
@@ -46,13 +46,6 @@ public interface DocumentReferenceResponse {
   String getStoreId();
 
   /**
-   * The hash of the associated document
-   *
-   * @return the hash value of the document
-   */
-  String getContentHash();
-
-  /**
    * @return the metadata of the document reference
    */
   DocumentMetadata getMetadata();

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientImpl.java
@@ -647,7 +647,7 @@ public final class ZeebeClientImpl implements ZeebeClient {
 
   @Override
   public DocumentContentGetRequest newDocumentContentGetRequest(final String documentId) {
-    return new DocumentContentGetRequestImpl(httpClient, documentId, null, null, config);
+    return new DocumentContentGetRequestImpl(httpClient, documentId, null, config);
   }
 
   @Override
@@ -657,14 +657,13 @@ public final class ZeebeClientImpl implements ZeebeClient {
         httpClient,
         documentReference.getDocumentId(),
         documentReference.getStoreId(),
-        documentReference.getContentHash(),
         config);
   }
 
   @Override
   public CreateDocumentLinkCommandStep1 newCreateDocumentLinkCommand(final String documentId) {
     return new CreateDocumentLinkCommandImpl(
-        documentId, null, null, jsonMapper, httpClient, config);
+        documentId, null, jsonMapper, httpClient, config);
   }
 
   @Override
@@ -673,7 +672,6 @@ public final class ZeebeClientImpl implements ZeebeClient {
     return new CreateDocumentLinkCommandImpl(
         documentReference.getDocumentId(),
         documentReference.getStoreId(),
-        documentReference.getContentHash(),
         jsonMapper,
         httpClient,
         config);

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientImpl.java
@@ -654,16 +654,12 @@ public final class ZeebeClientImpl implements ZeebeClient {
   public DocumentContentGetRequest newDocumentContentGetRequest(
       final DocumentReferenceResponse documentReference) {
     return new DocumentContentGetRequestImpl(
-        httpClient,
-        documentReference.getDocumentId(),
-        documentReference.getStoreId(),
-        config);
+        httpClient, documentReference.getDocumentId(), documentReference.getStoreId(), config);
   }
 
   @Override
   public CreateDocumentLinkCommandStep1 newCreateDocumentLinkCommand(final String documentId) {
-    return new CreateDocumentLinkCommandImpl(
-        documentId, null, jsonMapper, httpClient, config);
+    return new CreateDocumentLinkCommandImpl(documentId, null, jsonMapper, httpClient, config);
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/CreateDocumentLinkCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/CreateDocumentLinkCommandImpl.java
@@ -45,7 +45,6 @@ public class CreateDocumentLinkCommandImpl implements CreateDocumentLinkCommandS
   public CreateDocumentLinkCommandImpl(
       final String documentId,
       final String storeId,
-      final String contentHash,
       final JsonMapper jsonMapper,
       final HttpClient httpClient,
       final ZeebeClientConfiguration configuration) {
@@ -55,7 +54,6 @@ public class CreateDocumentLinkCommandImpl implements CreateDocumentLinkCommandS
     if (storeId != null) {
       queryParams.put("storeId", storeId);
     }
-    queryParams.put("contentHash", contentHash);
     documentLinkRequest = new DocumentLinkRequest();
     this.jsonMapper = jsonMapper;
     this.httpClient = httpClient;

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/fetch/DocumentContentGetRequestImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/fetch/DocumentContentGetRequestImpl.java
@@ -78,5 +78,4 @@ public class DocumentContentGetRequestImpl implements DocumentContentGetRequest 
     this.storeId = storeId;
     return this;
   }
-
 }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/fetch/DocumentContentGetRequestImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/fetch/DocumentContentGetRequestImpl.java
@@ -35,20 +35,17 @@ public class DocumentContentGetRequestImpl implements DocumentContentGetRequest 
   private final RequestConfig.Builder httpRequestConfig;
   private final String documentId;
   private String storeId;
-  private String contentHash;
 
   public DocumentContentGetRequestImpl(
       final HttpClient httpClient,
       final String documentId,
       final String storeId,
-      final String contentHash,
       final ZeebeClientConfiguration configuration) {
     ensureNotNull("documentId", documentId);
     this.httpClient = httpClient;
     httpRequestConfig = httpClient.newRequestConfig();
     this.documentId = documentId;
     this.storeId = storeId;
-    this.contentHash = contentHash;
     requestTimeout(configuration.getDefaultRequestTimeout());
   }
 
@@ -66,7 +63,6 @@ public class DocumentContentGetRequestImpl implements DocumentContentGetRequest 
     if (storeId != null) {
       queryParams.put("storeId", storeId);
     }
-    queryParams.put("contentHash", contentHash);
     httpClient.get(
         String.format("/documents/%s", documentId),
         queryParams,
@@ -83,9 +79,4 @@ public class DocumentContentGetRequestImpl implements DocumentContentGetRequest 
     return this;
   }
 
-  @Override
-  public DocumentContentGetRequest contentHash(final String contentHash) {
-    this.contentHash = contentHash;
-    return this;
-  }
 }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/DocumentReferenceResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/DocumentReferenceResponseImpl.java
@@ -23,14 +23,11 @@ public class DocumentReferenceResponseImpl implements DocumentReferenceResponse 
 
   private final String documentId;
   private final String storeId;
-  private final String contentHash;
   private final DocumentMetadata metadata;
 
   public DocumentReferenceResponseImpl(final DocumentReference documentReference) {
     documentId = documentReference.getDocumentId();
     storeId = documentReference.getStoreId();
-    contentHash = documentReference.getContentHash();
-
     metadata = new DocumentMetadataImpl(documentReference.getMetadata());
   }
 
@@ -42,11 +39,6 @@ public class DocumentReferenceResponseImpl implements DocumentReferenceResponse 
   @Override
   public String getStoreId() {
     return storeId;
-  }
-
-  @Override
-  public String getContentHash() {
-    return contentHash;
   }
 
   @Override

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/CreateDocumentLinkTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/CreateDocumentLinkTest.java
@@ -68,7 +68,6 @@ public class CreateDocumentLinkTest {
                     camundaClient
                         .newCreateDocumentLinkCommand(documentId)
                         .storeId(storeId)
-                        .contentHash(documentReference.getContentHash())
                         .send()
                         .join())
             .isInstanceOf(ProblemException.class)

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/GetDocumentContentTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/GetDocumentContentTest.java
@@ -89,43 +89,4 @@ public class GetDocumentContentTest {
     assertThat(exception.details().getDetail())
         .isEqualTo("Document store with id 'non-existing-store' does not exist");
   }
-
-  @Test
-  public void shouldReturnBadRequestIfNoHashProvided() {
-    // when
-    final var command =
-        camundaClient.newDocumentContentGetRequest(documentReference.getDocumentId()).send();
-
-    // then
-    final var exception =
-        (ProblemException)
-            assertThatThrownBy(command::join).isInstanceOf(ProblemException.class).actual();
-    assertThat(exception.details()).isNotNull();
-    assertThat(exception.details().getStatus()).isEqualTo(400);
-    assertThat(exception.details().getDetail())
-        .isEqualTo("No document hash provided for document " + documentReference.getDocumentId());
-  }
-
-  @Test
-  public void shouldReturnBadRequestIfWrongHashProvided() {
-    // when
-    final var command =
-        camundaClient
-            .newDocumentContentGetRequest(
-                new DocumentReferenceResponseImpl(
-                    new DocumentReference()
-                        .documentId(documentReference.getDocumentId())))
-            .send();
-
-    // then
-    final var exception =
-        (ProblemException)
-            assertThatThrownBy(command::join).isInstanceOf(ProblemException.class).actual();
-    assertThat(exception.details()).isNotNull();
-    assertThat(exception.details().getStatus()).isEqualTo(400);
-    assertThat(exception.details().getDetail())
-        .isEqualTo(
-            "Document hash for document %s doesn't match the provided hash %s"
-                .formatted(documentReference.getDocumentId(), "foobar"));
-  }
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/GetDocumentContentTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/GetDocumentContentTest.java
@@ -114,8 +114,7 @@ public class GetDocumentContentTest {
             .newDocumentContentGetRequest(
                 new DocumentReferenceResponseImpl(
                     new DocumentReference()
-                        .documentId(documentReference.getDocumentId())
-                        .contentHash("foobar")))
+                        .documentId(documentReference.getDocumentId())))
             .send();
 
     // then

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/GetDocumentContentTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/GetDocumentContentTest.java
@@ -13,8 +13,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ProblemException;
 import io.camunda.client.api.response.DocumentReferenceResponse;
-import io.camunda.client.impl.response.DocumentReferenceResponseImpl;
-import io.camunda.client.protocol.rest.DocumentReference;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import java.io.InputStream;
 import org.junit.jupiter.api.BeforeAll;

--- a/service/src/main/java/io/camunda/service/DocumentServices.java
+++ b/service/src/main/java/io/camunda/service/DocumentServices.java
@@ -178,9 +178,7 @@ public class DocumentServices extends ApiServices<DocumentServices> {
   }
 
   public CompletableFuture<DocumentLink> createLink(
-      final String documentId,
-      final String storeId,
-      final DocumentLinkParams params) {
+      final String documentId, final String storeId, final DocumentLinkParams params) {
 
     if (!hasDocumentPermission(PermissionType.CREATE)) {
       return CompletableFuture.failedFuture(

--- a/service/src/main/java/io/camunda/service/DocumentServices.java
+++ b/service/src/main/java/io/camunda/service/DocumentServices.java
@@ -137,7 +137,7 @@ public class DocumentServices extends ApiServices<DocumentServices> {
   }
 
   public CompletableFuture<DocumentContentResponse> getDocumentContent(
-      final String documentId, final String storeId, final String contentHash) {
+      final String documentId, final String storeId) {
 
     if (!hasDocumentPermission(PermissionType.READ)) {
       return CompletableFuture.failedFuture(
@@ -147,7 +147,7 @@ public class DocumentServices extends ApiServices<DocumentServices> {
 
     final DocumentStore documentStore = getDocumentStore(storeId).instance();
     return documentStore
-        .verifyContentHash(documentId, contentHash)
+        .getDocument(documentId)
         .thenCompose(
             verification -> {
               if (verification.isLeft()) {
@@ -180,7 +180,6 @@ public class DocumentServices extends ApiServices<DocumentServices> {
   public CompletableFuture<DocumentLink> createLink(
       final String documentId,
       final String storeId,
-      final String contentHash,
       final DocumentLinkParams params) {
 
     if (!hasDocumentPermission(PermissionType.CREATE)) {
@@ -193,7 +192,7 @@ public class DocumentServices extends ApiServices<DocumentServices> {
 
     final DocumentStore documentStore = getDocumentStore(storeId).instance();
     return documentStore
-        .verifyContentHash(documentId, contentHash)
+        .getDocument(documentId)
         .thenCompose(
             verification ->
                 verification.isLeft()

--- a/service/src/test/java/io/camunda/service/DocumentServicesTest.java
+++ b/service/src/test/java/io/camunda/service/DocumentServicesTest.java
@@ -125,8 +125,7 @@ public class DocumentServicesTest {
         .thenReturn(Collections.emptySet());
 
     // when
-    final var future =
-        services.getDocumentContent("irrelevant-document-id", "irrelevant-store-id");
+    final var future = services.getDocumentContent("irrelevant-document-id", "irrelevant-store-id");
 
     assertThat(future.isCompletedExceptionally()).isTrue();
   }
@@ -314,8 +313,7 @@ public class DocumentServicesTest {
         .thenReturn(CompletableFuture.completedFuture(Either.right(documentContent)));
 
     // when
-    final var actualDocumentContent =
-        services.getDocumentContent(documentId, storeId).join();
+    final var actualDocumentContent = services.getDocumentContent(documentId, storeId).join();
 
     // then
     assertThat(actualDocumentContent).isNotNull();

--- a/service/src/test/java/io/camunda/service/DocumentServicesTest.java
+++ b/service/src/test/java/io/camunda/service/DocumentServicesTest.java
@@ -126,8 +126,7 @@ public class DocumentServicesTest {
 
     // when
     final var future =
-        services.getDocumentContent(
-            "irrelevant-document-id", "irrelevant-store-id", "irrelevant-hash");
+        services.getDocumentContent("irrelevant-document-id", "irrelevant-store-id");
 
     assertThat(future.isCompletedExceptionally()).isTrue();
   }
@@ -316,7 +315,7 @@ public class DocumentServicesTest {
 
     // when
     final var actualDocumentContent =
-        services.getDocumentContent(documentId, storeId, contentHash).join();
+        services.getDocumentContent(documentId, storeId).join();
 
     // then
     assertThat(actualDocumentContent).isNotNull();

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -4510,15 +4510,6 @@ paths:
           description: The ID of the document store to download the document from.
           schema:
             type: string
-        - name: contentHash
-          in: query
-          required: true
-          schema:
-            type: string
-          description: >
-            The hash of the document content that was computed by the document store during upload.
-            The hash is part of the document reference that is returned when uploading a document.
-            If the client fails to provide the correct hash, the request will be rejected.
       responses:
         "200":
           description: The document was downloaded successfully.
@@ -4595,15 +4586,6 @@ paths:
           description: The ID of the document store to link the document from.
           schema:
             type: string
-        - name: contentHash
-          in: query
-          required: true
-          schema:
-            type: string
-          description: >
-            The hash of the document content that was computed by the document store during upload.
-            The hash is part of the document reference that is returned when uploading a document.
-            If the client fails to provide the correct hash, the request will be rejected.
       requestBody:
         required: false
         content:
@@ -9897,9 +9879,6 @@ components:
         documentId:
           type: string
           description: The ID of the document.
-        contentHash:
-          type: string
-          description: The hash of the document.
         metadata:
           $ref: "#/components/schemas/DocumentMetadata"
 

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/ResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/ResponseMapper.java
@@ -355,7 +355,6 @@ public final class ResponseMapper {
         .camundaDocumentType(CamundaDocumentTypeEnum.CAMUNDA)
         .documentId(response.documentId())
         .storeId(response.storeId())
-        .contentHash(response.contentHash())
         .metadata(externalMetadata);
   }
 

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/DocumentController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/DocumentController.java
@@ -95,14 +95,13 @@ public class DocumentController {
       produces = {}) // produces arbitrary content type
   public ResponseEntity<StreamingResponseBody> getDocumentContent(
       @PathVariable final String documentId,
-      @RequestParam(required = false) final String storeId,
-      @RequestParam(required = false) final String contentHash) {
+      @RequestParam(required = false) final String storeId) {
 
     // handle the future explicitly here because a StreamingResponseBody is needed as result instead
     // of a future wrapping the stream response
     return documentServices
         .withAuthentication(authenticationProvider.getCamundaAuthentication())
-        .getDocumentContent(documentId, storeId, contentHash)
+        .getDocumentContent(documentId, storeId)
         // Any service exception that can occur is handled by the GlobalControllerExceptionHandler
         .thenApply(ResponseMapper::toDocumentContentResponse)
         .join();
@@ -123,26 +122,24 @@ public class DocumentController {
   public CompletableFuture<ResponseEntity<Object>> createDocumentLink(
       @PathVariable final String documentId,
       @RequestParam(required = false) final String storeId,
-      @RequestParam(required = false) final String contentHash,
       @RequestBody final DocumentLinkRequest linkRequest) {
 
     return RequestMapper.toDocumentLinkParams(linkRequest)
         .fold(
             RestErrorMapper::mapProblemToCompletedResponse,
-            params -> createDocumentLink(documentId, storeId, contentHash, params));
+            params -> createDocumentLink(documentId, storeId, params));
   }
 
   private CompletableFuture<ResponseEntity<Object>> createDocumentLink(
       final String documentId,
       final String storeId,
-      final String contentHash,
       final DocumentLinkParams params) {
 
     return RequestMapper.executeServiceMethod(
         () ->
             documentServices
                 .withAuthentication(authenticationProvider.getCamundaAuthentication())
-                .createLink(documentId, storeId, contentHash, params),
+                .createLink(documentId, storeId, params),
         ResponseMapper::toDocumentLinkResponse);
   }
 }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/DocumentController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/DocumentController.java
@@ -94,8 +94,7 @@ public class DocumentController {
       path = "/{documentId}",
       produces = {}) // produces arbitrary content type
   public ResponseEntity<StreamingResponseBody> getDocumentContent(
-      @PathVariable final String documentId,
-      @RequestParam(required = false) final String storeId) {
+      @PathVariable final String documentId, @RequestParam(required = false) final String storeId) {
 
     // handle the future explicitly here because a StreamingResponseBody is needed as result instead
     // of a future wrapping the stream response
@@ -131,9 +130,7 @@ public class DocumentController {
   }
 
   private CompletableFuture<ResponseEntity<Object>> createDocumentLink(
-      final String documentId,
-      final String storeId,
-      final DocumentLinkParams params) {
+      final String documentId, final String storeId, final DocumentLinkParams params) {
 
     return RequestMapper.executeServiceMethod(
         () ->

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DocumentControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DocumentControllerTest.java
@@ -99,7 +99,6 @@ public class DocumentControllerTest extends RestControllerTest {
                       "documentId": "documentId",
                       "storeId": "default",
                       "camunda.document.type": "camunda",
-                      "contentHash": "dummy_hash",
                       "metadata": {
                         "contentType": "application/octet-stream",
                         "fileName": "file.txt",
@@ -179,7 +178,6 @@ public class DocumentControllerTest extends RestControllerTest {
                       "documentId": "documentId",
                       "storeId": "default",
                       "camunda.document.type": "camunda",
-                      "contentHash": "dummy_hash",
                       "metadata": {
                         "contentType": "application/octet-stream",
                         "fileName": "file.txt",
@@ -284,8 +282,7 @@ public class DocumentControllerTest extends RestControllerTest {
                           },
                           "camunda.document.type": "camunda",
                           "storeId": "default",
-                          "documentId": "documentId",
-                          "contentHash": "dummy_hash"
+                          "documentId": "documentId"
                         },
                         {
                           "metadata": {
@@ -298,8 +295,7 @@ public class DocumentControllerTest extends RestControllerTest {
                           },
                           "camunda.document.type": "camunda",
                           "storeId": "default",
-                          "documentId": "documentId",
-                          "contentHash": "dummy_hash"
+                          "documentId": "documentId"
                         }
                       ],
                       "failedDocuments": []
@@ -338,7 +334,7 @@ public class DocumentControllerTest extends RestControllerTest {
     // given
     final var content = new byte[] {1, 2, 3};
 
-    when(documentServices.getDocumentContent("documentId", null, null))
+    when(documentServices.getDocumentContent("documentId", null))
         .thenReturn(
             CompletableFuture.completedFuture(
                 new DocumentContentResponse(new ByteArrayInputStream(content), "application/pdf")));
@@ -375,7 +371,7 @@ public class DocumentControllerTest extends RestControllerTest {
     // given
     final var content = new byte[] {1, 2, 3};
 
-    when(documentServices.getDocumentContent("documentId", null, null))
+    when(documentServices.getDocumentContent("documentId", null))
         .thenReturn(
             CompletableFuture.completedFuture(
                 new DocumentContentResponse(new ByteArrayInputStream(content), null)));
@@ -395,7 +391,7 @@ public class DocumentControllerTest extends RestControllerTest {
   @Test
   void shouldYieldBadRequestWhenNoHashDocumentForGetDocument() {
     // given
-    when(documentServices.getDocumentContent(any(), any(), any()))
+    when(documentServices.getDocumentContent(any(), any()))
         .thenReturn(
             CompletableFuture.failedFuture(
                 ErrorMapper.mapDocumentError(new DocumentHashMismatch("foo", null))));
@@ -426,7 +422,7 @@ public class DocumentControllerTest extends RestControllerTest {
   @Test
   void shouldYieldBadRequestWhenWrongHashForGetDocument() {
     // given
-    when(documentServices.getDocumentContent(any(), any(), any()))
+    when(documentServices.getDocumentContent(any(), any()))
         .thenReturn(
             CompletableFuture.failedFuture(
                 ErrorMapper.mapDocumentError(new DocumentHashMismatch("foo", "barbaz"))));


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Removing need of contentHash for Documents API as we now have a security concept around it.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #36687
