### PR TITLE
feat: add gateway endpoint for deleting an exporter

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterApiUtils.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterApiUtils.java
@@ -24,6 +24,7 @@ import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.MemberLeaveOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.MemberRemoveOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionBootstrapOperation;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionDeleteExporterOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionDisableExporterOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionEnableExporterOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionForceReconfigureOperation;
@@ -211,6 +212,12 @@ final class ClusterApiUtils {
               .brokerId(Integer.parseInt(enableExporterOperation.memberId().id()))
               .partitionId(enableExporterOperation.partitionId())
               .exporterId(enableExporterOperation.exporterId());
+      case final PartitionDeleteExporterOperation deleteExporterOperation ->
+          new Operation()
+              .operation(OperationEnum.PARTITION_DELETE_EXPORTER)
+              .brokerId(Integer.parseInt(deleteExporterOperation.memberId().id()))
+              .partitionId(deleteExporterOperation.partitionId())
+              .exporterId(deleteExporterOperation.exporterId());
       case final PartitionBootstrapOperation bootstrapOperation ->
           new Operation()
               .operation(OperationEnum.PARTITION_BOOTSTRAP)
@@ -454,6 +461,12 @@ final class ClusterApiUtils {
                   .brokerId(Integer.parseInt(enableExporterOperation.memberId().id()))
                   .partitionId(enableExporterOperation.partitionId())
                   .exporterId(enableExporterOperation.exporterId());
+          case final PartitionDeleteExporterOperation deleteExporterOperation ->
+              new TopologyChangeCompletedInner()
+                  .operation(TopologyChangeCompletedInner.OperationEnum.PARTITION_DELETE_EXPORTER)
+                  .brokerId(Integer.parseInt(deleteExporterOperation.memberId().id()))
+                  .partitionId(deleteExporterOperation.partitionId())
+                  .exporterId(deleteExporterOperation.exporterId());
           default ->
               new TopologyChangeCompletedInner()
                   .operation(TopologyChangeCompletedInner.OperationEnum.UNKNOWN);

--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ExportersEndpoint.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ExportersEndpoint.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.shared.management;
 
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ExporterDeleteRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ExporterDisableRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ExporterEnableRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequestSender;
@@ -19,6 +20,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.actuate.endpoint.web.annotation.RestControllerEndpoint;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -57,6 +59,16 @@ public class ExportersEndpoint {
                 exporterId,
                 Optional.ofNullable(initializeInfo).map(InitializationInfo::initializeFrom),
                 dryRun))
+        .handle(ClusterApiUtils::mapOperationResponse);
+  }
+
+  @DeleteMapping(path = "/{exporterId}")
+  public CompletableFuture<ResponseEntity<?>> deleteExporter(
+      @PathVariable("exporterId") final String exporterId,
+      @RequestParam(defaultValue = "false") final boolean dryRun) {
+
+    return requestSender
+        .deleteExporter(new ExporterDeleteRequest(exporterId, dryRun))
         .handle(ClusterApiUtils::mapOperationResponse);
   }
 

--- a/dist/src/main/resources/api/cluster/components.yaml
+++ b/dist/src/main/resources/api/cluster/components.yaml
@@ -322,6 +322,7 @@ schemas:
           - AWAIT_RELOCATION
           - UPDATE_ROUTING_STATE
           - DELETE_HISTORY
+          - PARTITION_DELETE_EXPORTER
       brokerId:
         $ref: "components.yaml#/schemas/BrokerId"
       partitionId:

--- a/dist/src/main/resources/api/cluster/exporter-api.yaml
+++ b/dist/src/main/resources/api/cluster/exporter-api.yaml
@@ -61,6 +61,26 @@ paths:
         '504':
           $ref: 'components.yaml#/responses/TimeoutError'
 
+  /{exporterId}:
+    delete:
+      summary: Delete an exporter
+      description: Delete the exporter with the given exporterId. This will remove the exporter configuration and stop all export operations for this exporter.
+      parameters:
+        - $ref: '#/components/parameters/ExporterId'
+      responses:
+        '202':
+          $ref: "#/components/responses/ExporterOperationResponse"
+        '400':
+          $ref: 'components.yaml#/responses/InvalidRequest'
+        '409':
+          $ref: 'components.yaml#/responses/ConcurrentChangeError'
+        '500':
+          $ref: 'components.yaml#/responses/InternalError'
+        '502':
+          $ref: 'components.yaml#/responses/GatewayError'
+        '504':
+          $ref: 'components.yaml#/responses/TimeoutError'
+
   /:
     get:
       summary: List all exporters
@@ -84,7 +104,7 @@ components:
 
   responses:
     ExporterOperationResponse:
-      description: Request to disable or enable exporter is accepted.
+      description: Request to disable, enable, or delete exporter is accepted.
       content:
         application.json:
           schema:
@@ -121,4 +141,3 @@ components:
           type: string
           description: Id of the exporter to initialize from
           example: "exporter-1"
-

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/ExporterDeleteEndpointIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/ExporterDeleteEndpointIT.java
@@ -1,0 +1,125 @@
+/*
+Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+one or more contributor license agreements. See the NOTICE file distributed
+with this work for additional information regarding copyright ownership.
+Licensed under the Camunda License 1.0. You may not use this file
+except in compliance with the Camunda License 1.0. */
+
+package io.camunda.zeebe.it.management;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.management.cluster.ExporterStatus;
+import io.camunda.zeebe.management.cluster.Operation;
+import io.camunda.zeebe.management.cluster.Operation.OperationEnum;
+import io.camunda.zeebe.management.cluster.PlannedOperationsResponse;
+import io.camunda.zeebe.qa.util.actuator.ExportersActuator;
+import io.camunda.zeebe.qa.util.cluster.TestCluster;
+import io.camunda.zeebe.qa.util.topology.ClusterActuatorAssert;
+import java.nio.file.Path;
+import java.time.Duration;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
+
+@Timeout(2 * 60) // 2 minutes
+final class ExporterDeleteEndpointIT {
+  @Test
+  void shouldDeleteExporterAfterRestartWithMissingConfig(@TempDir final Path tempDir) {
+    // given - cluster with recording exporter restarted after removing the exporter config
+    final var restartedCluster = restartClusterWithExporterConfigRemoved(tempDir);
+
+    // exporter shows up as CONFIG_NOT_FOUND
+    final ExportersActuator exportersActuator = ExportersActuator.of(restartedCluster.anyGateway());
+
+    // it should still list the recording exporter once, but with CONFIG_NOT_FOUND
+    assertThat(exportersActuator.getExporters())
+        .hasSize(1)
+        .first()
+        .satisfies(
+            status -> {
+              assertThat(status.getExporterId()).isEqualTo("recordingExporter");
+              assertThat(status.getStatus()).isEqualTo(ExporterStatus.StatusEnum.CONFIG_NOT_FOUND);
+            });
+
+    // when: delete exporter
+    final var deleteResponse =
+        ExportersActuator.of(restartedCluster.anyGateway()).deleteExporter("recordingExporter");
+    assertThat(deleteResponse.getPlannedChanges())
+        .hasSize(1)
+        .first()
+        .extracting(Operation::getOperation)
+        .isEqualTo(OperationEnum.PARTITION_DELETE_EXPORTER);
+
+    waitUntilOperationIsApplied(restartedCluster, deleteResponse);
+
+    // then: exporter no longer appears
+    Awaitility.await()
+        .atMost(Duration.ofSeconds(30))
+        .untilAsserted(
+            () ->
+                assertThat(exportersActuator.getExporters())
+                    .describedAs("Exporter is deleted")
+                    .isEmpty());
+
+    restartedCluster.shutdown();
+  }
+
+  private TestCluster restartClusterWithExporterConfigRemoved(final Path tempDir) {
+    // first cluster with recording exporter enabled, persisted working directory
+    final var cluster =
+        TestCluster.builder()
+            .useRecordingExporter(true)
+            .withBrokersCount(1)
+            .withPartitionsCount(1)
+            .withReplicationFactor(1)
+            .withEmbeddedGateway(true)
+            .withBrokerConfig(
+                (memberId, broker) ->
+                    broker.withWorkingDirectory(resolveBrokerDir(tempDir, memberId)))
+            .build()
+            .start()
+            .awaitCompleteTopology();
+    // sanity: exporter is enabled initially
+    Awaitility.await()
+        .atMost(Duration.ofSeconds(30))
+        .untilAsserted(
+            () ->
+                assertThat(ExportersActuator.of(cluster.anyGateway()).getExporters())
+                    .hasSize(1)
+                    .first()
+                    .extracting(ExporterStatus::getStatus)
+                    .isEqualTo(ExporterStatus.StatusEnum.ENABLED));
+
+    cluster.shutdown();
+
+    // when: cluster restarted without recording exporter configured
+    final var restartedCluster =
+        TestCluster.builder()
+            .useRecordingExporter(false)
+            .withBrokersCount(1)
+            .withPartitionsCount(1)
+            .withReplicationFactor(1)
+            .withEmbeddedGateway(true)
+            .withBrokerConfig(
+                (memberId, broker) ->
+                    broker.withWorkingDirectory(resolveBrokerDir(tempDir, memberId)))
+            .build()
+            .start()
+            .awaitCompleteTopology();
+    return restartedCluster;
+  }
+
+  private Path resolveBrokerDir(final Path base, final MemberId memberId) {
+    return base.resolve("broker-" + memberId.id());
+  }
+
+  private void waitUntilOperationIsApplied(
+      final TestCluster cluster, final PlannedOperationsResponse response) {
+    Awaitility.await()
+        .timeout(Duration.ofSeconds(30))
+        .untilAsserted(() -> ClusterActuatorAssert.assertThat(cluster).hasAppliedChanges(response));
+  }
+}

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/ExportersActuator.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/ExportersActuator.java
@@ -104,6 +104,15 @@ public interface ExportersActuator {
   PlannedOperationsResponse enableExporter(@Param final String exporterId);
 
   /**
+   * Request to delete an exporter
+   *
+   * @throws feign.FeignException if the request is not successful (e.g. 4xx or 5xx)
+   */
+  @RequestLine("DELETE /{exporterId}")
+  @Headers({"Content-Type: application/json", "Accept: application/json"})
+  PlannedOperationsResponse deleteExporter(@Param final String exporterId);
+
+  /**
    * Returns the list of exporters with their status
    *
    * @throws feign.FeignException if the request is not successful (e.g. 4xx or 5xx)

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneBroker.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneBroker.java
@@ -47,7 +47,7 @@ public final class TestStandaloneBroker extends TestSpringApplication<TestStanda
   public static final String DEFAULT_MAPPING_RULE_ID = "default";
   public static final String DEFAULT_MAPPING_RULE_CLAIM_NAME = "client_id";
   public static final String DEFAULT_MAPPING_RULE_CLAIM_VALUE = "default";
-  private static final String RECORDING_EXPORTER_ID = "recordingExporter";
+  public static final String RECORDING_EXPORTER_ID = "recordingExporter";
   private final BrokerBasedProperties config;
   private final CamundaSecurityProperties securityConfig;
 


### PR DESCRIPTION
## Description

This PR implements the api for deleting an exporter permanently from the brokers, after the configuration of it is removed. 

The api is exposed via the existing endpoint for exporters.
```
DELETE actuator/exporters/{exporterId}
```

## Related issues

closes #35325 
closes #35321
