### PR TITLE
ci: add missed $ to properly access variable in setup-medic-lookup.sh

### DIFF
--- a/.ci/scripts/ci/setup-medic-lookup.sh
+++ b/.ci/scripts/ci/setup-medic-lookup.sh
@@ -9,14 +9,14 @@ declare -A lookupTeamMedic
 # @core-features-medic
 coreFeaturesMedic="<!subteam^S08P2CU9V8W|core-features-medic>"
 lookupTeamMedic["team-core-features"]=$coreFeaturesMedic
-lookupTeamMedic["Core Features"]=coreFeaturesMedic
-lookupTeamMedic["CoreFeatures"]=coreFeaturesMedic
+lookupTeamMedic["Core Features"]=$coreFeaturesMedic
+lookupTeamMedic["CoreFeatures"]=$coreFeaturesMedic
 
 # @data-layer-medic
 dataLayerMedic="<!subteam^S08P2CSC06S|data-layer-medic>"
 lookupTeamMedic["team-data-layer"]=$dataLayerMedic
-lookupTeamMedic["Data Layer"]=dataLayerMedic
-lookupTeamMedic["DataLayer"]=dataLayerMedic
+lookupTeamMedic["Data Layer"]=$dataLayerMedic
+lookupTeamMedic["DataLayer"]=$dataLayerMedic
 
 # @identity-medic
 identityMedic="<!subteam^S053MF48SSH|identity-medic>"

--- a/.github/workflows/statistics-daily.yml
+++ b/.github/workflows/statistics-daily.yml
@@ -9,6 +9,7 @@ on:
   pull_request:
     paths:
       - '.github/workflows/statistics-daily.yml'
+      - '.ci/scripts/setup-medic-lookup.sh'
   workflow_dispatch: {}
 
 env:

--- a/.github/workflows/statistics-weekly.yml
+++ b/.github/workflows/statistics-weekly.yml
@@ -11,6 +11,7 @@ on:
   pull_request:
     paths:
       - '.github/workflows/statistics-weekly.yml'
+      - '.ci/scripts/setup-medic-lookup.sh'
   workflow_dispatch: {}
 
 env:


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
- Adds a missed `$` to the `setup-medic-lookup.sh` script
- Modifies the test run trigger for the faily/flaky tests so that they will run when the setup script is modified

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
