### PR TITLE
fix: improve and cleanup usage metric API validations

### DIFF
--- a/service/src/main/java/io/camunda/service/UsageMetricsServices.java
+++ b/service/src/main/java/io/camunda/service/UsageMetricsServices.java
@@ -45,7 +45,6 @@ public final class UsageMetricsServices
     if (query == null) {
       throw new IllegalArgumentException("Query must not be null");
     }
-    validateStartAndEndTime(query);
     final UsageMetricsSearchClient authUsageMetricsSearchClient =
         usageMetricsSearchClient.withSecurityContext(
             securityContextProvider.provideSecurityContext(
@@ -61,21 +60,6 @@ public final class UsageMetricsServices
                     mapToUsageMetricsTUQuery(query)));
 
     return SearchQueryResult.of(Tuple.of(statsFuture.join(), tuStatsFuture.join()));
-  }
-
-  private void validateStartAndEndTime(final UsageMetricsQuery query) {
-    final var filter = query.filter();
-    if (filter.startTime() == null || filter.endTime() == null) {
-      throw new IllegalArgumentException("Query must have a start AND end time");
-    }
-    final var startTime = filter.startTime();
-    final var endTime = filter.endTime();
-    if (endTime.isBefore(startTime)) {
-      throw new IllegalArgumentException("End time must be after start time");
-    }
-    if (startTime.isAfter(endTime)) {
-      throw new IllegalArgumentException("Start time must be before end time");
-    }
   }
 
   @Override

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
@@ -121,7 +121,7 @@ public final class SearchQueryRequestMapper {
     return getResult(
         validate(
             violations -> {
-              if (startTime == null || endTime == null) {
+              if (StringUtils.isAnyBlank(startTime, endTime)) {
                 violations.add("The startTime and endTime must both be specified");
               }
               validateDate(startTime, "startTime", violations);

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
@@ -124,8 +124,13 @@ public final class SearchQueryRequestMapper {
               if (StringUtils.isAnyBlank(startTime, endTime)) {
                 violations.add("The startTime and endTime must both be specified");
               }
-              validateDate(startTime, "startTime", violations);
-              validateDate(endTime, "endTime", violations);
+              final var startDateTime = validateDate(startTime, "startTime", violations);
+              final var endDateTime = validateDate(endTime, "endTime", violations);
+              if (startDateTime != null
+                  && endDateTime != null
+                  && endDateTime.isBefore(startDateTime)) {
+                violations.add("The endTime must be after startTime");
+              }
             }),
         () ->
             new UsageMetricsQuery.Builder()

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/RequestValidator.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/RequestValidator.java
@@ -35,15 +35,16 @@ public final class RequestValidator {
                 HttpStatus.BAD_REQUEST, problems, INVALID_ARGUMENT.name()));
   }
 
-  public static void validateDate(
+  public static OffsetDateTime validateDate(
       final String dateString, final String attributeName, final List<String> violations) {
     if (dateString != null && !dateString.isEmpty()) {
       try {
-        OffsetDateTime.parse(dateString);
+        return OffsetDateTime.parse(dateString);
       } catch (final DateTimeParseException ex) {
         violations.add(ERROR_MESSAGE_DATE_PARSING.formatted(attributeName, dateString));
       }
     }
+    return null;
   }
 
   public static boolean isEmpty(final Changeset changeset) {

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/system/UsageMetricsControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/system/UsageMetricsControllerTest.java
@@ -290,4 +290,33 @@ public class UsageMetricsControllerTest extends RestControllerTest {
         .expectBody()
         .json(expectedResponse, JsonCompareMode.STRICT);
   }
+
+  @Test
+  void shouldYieldBadRequestIfStartTimeIsAfterEndTime() {
+    // given
+    final var expectedResponse =
+        """
+        {
+          "type":"about:blank",
+          "title":"INVALID_ARGUMENT",
+          "status":400,
+          "detail":"The endTime must be after startTime.",
+          "instance":"/v2/system/usage-metrics"
+        }
+        """;
+    // when/then
+    webClient
+        .get()
+        .uri(
+            USAGE_METRICS_URL
+                + "?startTime=2024-12-31T10:50:26.000Z&endTime=2024-12-30T10:50:26.000Z")
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isBadRequest()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON_VALUE)
+        .expectBody()
+        .json(expectedResponse, JsonCompareMode.STRICT);
+  }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/system/UsageMetricsControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/system/UsageMetricsControllerTest.java
@@ -211,6 +211,33 @@ public class UsageMetricsControllerTest extends RestControllerTest {
   }
 
   @Test
+  void shouldYieldBadRequestIfEmptyStartAndEndTimeAreGiven() {
+    // given
+    final var expectedResponse =
+        """
+        {
+          "type":"about:blank",
+          "title":"INVALID_ARGUMENT",
+          "status":400,
+          "detail":"The startTime and endTime must both be specified.",
+          "instance":"/v2/system/usage-metrics"
+        }
+        """;
+    // when/then
+    webClient
+        .get()
+        .uri(USAGE_METRICS_URL + "?startTime=&endTime=")
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isBadRequest()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON_VALUE)
+        .expectBody()
+        .json(expectedResponse, JsonCompareMode.STRICT);
+  }
+
+  @Test
   void shouldYieldBadRequestIfNoStartTimeIsGiven() {
     // given
     final var expectedResponse =


### PR DESCRIPTION
## Description

- Validate empty start and end time inputs in usage metrics
- Ensure endTime is after startTime in usage metrics validation
- Remove redundant start and end time validation in usage metric service

## Related issues

closes https://github.com/camunda/camunda/issues/36738
closes https://github.com/camunda/camunda/issues/36773
