### PR TITLE
fix: handle exporter opening if record counters are not present in me…

### DIFF
--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporter.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporter.java
@@ -83,6 +83,7 @@ public class ElasticsearchExporter implements Exporter {
             .readMetadata()
             .map(this::deserializeExporterMetadata)
             .map(ElasticsearchExporterMetadata::getRecordCountersByValueType)
+            .filter(counters -> !counters.isEmpty())
             .map(ElasticsearchRecordCounters::new)
             .orElse(new ElasticsearchRecordCounters());
 

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterTest.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterTest.java
@@ -81,6 +81,19 @@ final class ElasticsearchExporterTest {
         .isInstanceOf(ElasticsearchExporterException.class);
   }
 
+  @Test
+  void shouldNotFailOnOpenIfElasticMetadataDoesNotContainRecordCounters() {
+    // given
+    final var exporter = new ElasticsearchExporter();
+    exporter.configure(context);
+    final var storedMetadataAsJSON = "{\"recordCountersByValueType\":{}}";
+    final var serializedMetadata = storedMetadataAsJSON.getBytes(StandardCharsets.UTF_8);
+    controller.updateLastExportedRecordPosition(1, serializedMetadata);
+
+    // when
+    assertThatCode(() -> exporter.open(controller)).doesNotThrowAnyException();
+  }
+
   @Nested
   final class RecordFilterTest {
 
@@ -602,7 +615,6 @@ final class ElasticsearchExporterTest {
       final var expectedMetadataAsJSON =
           "{\"recordCountersByValueType\":{\"PROCESS_INSTANCE\":2,\"VARIABLE\":1}}";
       assertThat(controller.readMetadata())
-          .isPresent()
           .map(metadata -> new String(metadata, StandardCharsets.UTF_8))
           .hasValue(expectedMetadataAsJSON);
     }

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/RecordCounterTest.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/RecordCounterTest.java
@@ -71,10 +71,11 @@ public class RecordCounterTest {
 
     // then the record counter should be 1
     final var counters = readMetadata();
-    assertThat(counters).describedAs("The counter is stored in the metadata").isNotEmpty();
-    assertThat(counters.get(valueType))
+    assertThat(counters)
+        .describedAs("The counter is stored in the metadata")
+        .isNotEmpty()
         .describedAs("The record counter should be 1 as only exported 1 record")
-        .isEqualTo(1);
+        .containsEntry(valueType, 1L);
   }
 
   @Test
@@ -118,10 +119,11 @@ public class RecordCounterTest {
 
     // then the record counter should be 1
     final var counters = readMetadata();
-    assertThat(counters).describedAs("The counter is stored in the metadata").isNotEmpty();
-    assertThat(counters.get(valueType))
+    assertThat(counters)
+        .describedAs("The counter is stored in the metadata")
+        .isNotEmpty()
         .describedAs("The record counter should be 1 as only exported 1 record")
-        .isEqualTo(1);
+        .containsEntry(valueType, 1L);
   }
 
   @Test
@@ -171,11 +173,12 @@ public class RecordCounterTest {
 
     // then the record counter should be 1
     final var counters = readMetadata();
-    assertThat(counters).describedAs("The counter is stored in the metadata").isNotEmpty();
-    assertThat(counters.get(valueType))
+    assertThat(counters)
+        .describedAs("The counter is stored in the metadata")
+        .isNotEmpty()
         .describedAs(
             "The record counter should be 1, as we have exported the record asynchronously")
-        .isEqualTo(1);
+        .containsEntry(valueType, 1L);
   }
 
   @Test
@@ -204,10 +207,11 @@ public class RecordCounterTest {
 
     // then the record counter should be 1
     final var counters = readMetadata();
-    assertThat(counters).describedAs("The counter is stored in the metadata").isNotEmpty();
-    assertThat(counters.get(valueType))
+    assertThat(counters)
+        .describedAs("The counter is stored in the metadata")
+        .isNotEmpty()
         .describedAs("The record counter should be 1, as we have exported the same record twice")
-        .isEqualTo(1);
+        .containsEntry(valueType, 1L);
   }
 
   @Test
@@ -234,10 +238,11 @@ public class RecordCounterTest {
 
     // then the record counter should be 2
     final var counters = readMetadata();
-    assertThat(counters).describedAs("The counter is stored in the metadata").isNotEmpty();
-    assertThat(counters.get(valueType))
+    assertThat(counters)
+        .describedAs("The counter is stored in the metadata")
+        .isNotEmpty()
         .describedAs("The record counter should be 2, as we have exported the two records")
-        .isEqualTo(2);
+        .containsEntry(valueType, 2L);
   }
 
   @Test

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporter.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporter.java
@@ -71,6 +71,7 @@ public class OpensearchExporter implements Exporter {
             .readMetadata()
             .map(this::deserializeExporterMetadata)
             .map(OpensearchExporterMetadata::getRecordCountersByValueType)
+            .filter(counters -> !counters.isEmpty())
             .map(OpensearchRecordCounters::new)
             .orElse(new OpensearchRecordCounters());
 

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterTest.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterTest.java
@@ -85,6 +85,19 @@ final class OpensearchExporterTest {
   }
 
   @Test
+  void shouldNotFailOnOpenIfElasticMetadataDoesNotContainRecordCounters() {
+    // given
+    final var exporter = new OpensearchExporter();
+    exporter.configure(context);
+    final var storedMetadataAsJSON = "{\"recordCountersByValueType\":{}}";
+    final var serializedMetadata = storedMetadataAsJSON.getBytes(StandardCharsets.UTF_8);
+    controller.updateLastExportedRecordPosition(1, serializedMetadata);
+
+    // when
+    assertThatCode(() -> exporter.open(controller)).doesNotThrowAnyException();
+  }
+
+  @Test
   void shouldCreateIndexStateManagementPolicy() {
     // given
     config.retention.setEnabled(true);


### PR DESCRIPTION
…tadata

## Description

<!-- Describe the goal and purpose of this PR. -->

We identified a case (maybe multiple cases) whereby the exporter metadata contained no record counters. This prevented the exporter from opening successfully and no data can be exported. [Context](https://camunda.slack.com/archives/C08MRKHJ0CD/p1755248222104019).

This PR adds a filter to handle this scenario and allow the Exporter to open successfully.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #37014
