### PR TITLE
Exporters should use `decisionEvaluationInstanceKey` as id

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/DecisionEvaluationHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/DecisionEvaluationHandlerTest.java
@@ -68,6 +68,7 @@ public class DecisionEvaluationHandlerTest {
     final ImmutableEvaluatedDecisionValue decisionValue =
         ImmutableEvaluatedDecisionValue.builder()
             .from(factory.generateObject(EvaluatedDecisionValue.class))
+            .withDecisionEvaluationInstanceKey("123-1")
             .build();
     final long expectedId = 123;
     final DecisionEvaluationRecordValue decisionRecordValue =
@@ -124,6 +125,7 @@ public class DecisionEvaluationHandlerTest {
     final ImmutableEvaluatedDecisionValue evaluatedDecision =
         ImmutableEvaluatedDecisionValue.builder()
             .from(factory.generateObject(EvaluatedDecisionValue.class))
+            .withDecisionEvaluationInstanceKey(recordKey + "-1")
             .withDecisionType(decisionType.name())
             .withMatchedRules(
                 List.of(
@@ -247,6 +249,7 @@ public class DecisionEvaluationHandlerTest {
         ImmutableEvaluatedDecisionValue.builder()
             .from(factory.generateObject(EvaluatedDecisionValue.class))
             .withDecisionType(DecisionType.DECISION_TABLE.name())
+            .withDecisionEvaluationInstanceKey(recordKey + "-1")
             .build();
 
     final DecisionEvaluationRecordValue decisionRecordValue =
@@ -283,8 +286,14 @@ public class DecisionEvaluationHandlerTest {
             .from(factory.generateObject(DecisionEvaluationRecordValue.class))
             .withEvaluatedDecisions(
                 List.of(
-                    factory.generateObject(EvaluatedDecisionValue.class),
-                    factory.generateObject(EvaluatedDecisionValue.class)))
+                    ImmutableEvaluatedDecisionValue.builder()
+                        .from(factory.generateObject(EvaluatedDecisionValue.class))
+                        .withDecisionEvaluationInstanceKey(recordKey + "-1")
+                        .build(),
+                    ImmutableEvaluatedDecisionValue.builder()
+                        .from(factory.generateObject(EvaluatedDecisionValue.class))
+                        .withDecisionEvaluationInstanceKey(recordKey + "-2")
+                        .build()))
             .build();
 
     final Record<DecisionEvaluationRecordValue> decisionRecord =
@@ -296,6 +305,7 @@ public class DecisionEvaluationHandlerTest {
                     .withKey(recordKey));
 
     // when
+
     DecisionInstanceEntity decisionInstanceEntity =
         new DecisionInstanceEntity().setId(recordKey + "-1");
     underTest.updateEntity(decisionRecord, decisionInstanceEntity);
@@ -321,6 +331,7 @@ public class DecisionEvaluationHandlerTest {
     final ImmutableEvaluatedDecisionValue evaluatedDecision =
         ImmutableEvaluatedDecisionValue.builder()
             .from(factory.generateObject(EvaluatedDecisionValue.class))
+            .withDecisionEvaluationInstanceKey(recordKey + "-1")
             .withDecisionType(DecisionType.DECISION_TABLE.name())
             .withMatchedRules(
                 List.of(

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/DecisionInstanceExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/DecisionInstanceExportHandler.java
@@ -74,7 +74,7 @@ public class DecisionInstanceExportHandler
     final DecisionEvaluationRecordValue value = record.getValue();
     final var state = getState(record, value, index);
     final var key = record.getKey();
-    final var id = record.getKey() + "-" + index;
+    final var id = evaluatedDecision.getDecisionEvaluationInstanceKey();
 
     return new DecisionInstanceDbModel.Builder()
         .decisionInstanceId(id)


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Refactor both exporters (Camunda and RDBMS) to use `decisionEvaluationInstanceKey` as value of the ID

## Related issues

closes #36732 
