### PR TITLE
fix: do not perform assignee check for m2m clients in Tasklist V1 APIs

### DIFF
--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/api/rest/v1/controllers/TaskControllerIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/api/rest/v1/controllers/TaskControllerIT.java
@@ -1096,7 +1096,7 @@ public class TaskControllerIT extends TasklistZeebeIntegrationTest {
       final var assignRequest =
           new TaskAssignRequest().setAssignee("bill_doe").setAllowOverrideAssignment(false);
 
-      setCurrentUser(CamundaAuthentication.of(b -> b.user("bob_doe")), true);
+      setCurrentUser(CamundaAuthentication.of(b -> b.clientId("bob_doe")));
 
       // when
       final var errorResult =
@@ -1409,7 +1409,7 @@ public class TaskControllerIT extends TasklistZeebeIntegrationTest {
       final String bpmnProcessId = "simpleTestProcess";
       final String flowNodeBpmnId = "taskD_".concat(UUID.randomUUID().toString());
       final var taskId = createTask(bpmnProcessId, flowNodeBpmnId, 1).getTaskId();
-      setCurrentUser(getDefaultCurrentUser(), true);
+      setCurrentUser(CamundaAuthentication.of(b -> b.clientId(DEFAULT_USER_ID)));
 
       // when
       final var result =
@@ -1646,7 +1646,7 @@ public class TaskControllerIT extends TasklistZeebeIntegrationTest {
               .setVariables(
                   List.of(
                       new VariableInputDTO().setName("object_var").setValue("{\"test\": true}")));
-      setCurrentUser(getDefaultCurrentUser(), true);
+      setCurrentUser(CamundaAuthentication.of(b -> b.clientId(DEFAULT_USER_ID)));
 
       // when
       final var errorResult =
@@ -1702,7 +1702,7 @@ public class TaskControllerIT extends TasklistZeebeIntegrationTest {
               .setVariables(
                   List.of(new VariableInputDTO().setName("array_var").setValue("[30, 8, 2022]")));
 
-      setCurrentUser(CamundaAuthentication.of(b -> b.user("user_B")), true);
+      setCurrentUser(CamundaAuthentication.of(b -> b.clientId("user_B")));
 
       // when
       final var errorResult =

--- a/tasklist/webapp/pom.xml
+++ b/tasklist/webapp/pom.xml
@@ -168,11 +168,6 @@
       <artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
     </dependency>
 
-    <dependency>
-      <groupId>org.springframework.security</groupId>
-      <artifactId>spring-security-oauth2-resource-server</artifactId>
-    </dependency>
-
     <!-- OpenAPI -->
     <dependency>
       <groupId>org.springdoc</groupId>
@@ -325,11 +320,6 @@
     <dependency>
       <groupId>jakarta.annotation</groupId>
       <artifactId>jakarta.annotation-api</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.springframework.security</groupId>
-      <artifactId>spring-security-core</artifactId>
     </dependency>
 
     <dependency>

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/api/rest/v1/controllers/TaskController.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/api/rest/v1/controllers/TaskController.java
@@ -221,7 +221,8 @@ public class TaskController extends ApiErrorController {
 
   private void checkTaskImplementation(final LazySupplier<TaskDTO> taskSupplier) {
     if (taskSupplier.get().getImplementation() != TaskImplementation.JOB_WORKER
-        && TasklistAuthenticationUtil.isApiUser()) {
+        && TasklistAuthenticationUtil.isApiUser(
+            authenticationProvider.getCamundaAuthentication())) {
       final TaskDTO task = taskSupplier.get();
       LOGGER.warn(
           "V1 API is used for task with id={} implementation={}",

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/es/TaskValidator.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/es/TaskValidator.java
@@ -28,6 +28,12 @@ public class TaskValidator {
   @Autowired private CamundaAuthenticationProvider authenticationProvider;
   @Autowired private TasklistProperties tasklistProperties;
 
+  public TaskValidator(
+      CamundaAuthenticationProvider authenticationProvider, TasklistProperties tasklistProperties) {
+    this.authenticationProvider = authenticationProvider;
+    this.tasklistProperties = tasklistProperties;
+  }
+
   public void validateCanPersistDraftTaskVariables(final TaskEntity task) {
     validateTaskStateAndAssignment(task);
   }
@@ -56,7 +62,7 @@ public class TaskValidator {
   private void validateTaskStateAndAssignment(final TaskEntity task) {
     validateTaskIsActive(task);
 
-    if (TasklistAuthenticationUtil.isApiUser()) {
+    if (TasklistAuthenticationUtil.isApiUser(authenticationProvider.getCamundaAuthentication())) {
       // JWT Token/API users are allowed to complete task assigned to anyone
       return;
     }
@@ -78,7 +84,7 @@ public class TaskValidator {
       final TaskEntity taskBefore, final boolean allowOverrideAssignment) {
     validateTaskIsActive(taskBefore);
 
-    if ((TasklistAuthenticationUtil.isApiUser()
+    if ((TasklistAuthenticationUtil.isApiUser(authenticationProvider.getCamundaAuthentication())
             || tasklistProperties.getFeatureFlag().getAllowNonSelfAssignment())
         && allowOverrideAssignment) {
       // JWT Token/API users can reassign task

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/security/TasklistAuthenticationUtil.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/security/TasklistAuthenticationUtil.java
@@ -16,13 +16,13 @@ public final class TasklistAuthenticationUtil {
 
   public static boolean isApiUser(CamundaAuthentication authenticatedUser) {
 
-    if (authenticatedUser.authenticatedUsername() != null) {
+    if (authenticatedUser.authenticatedUsername() != null || authenticatedUser.isAnonymous()) {
       return false;
     } else if (authenticatedUser.authenticatedClientId() != null) {
       return true;
     } else {
       throw new InvalidRequestException(
-          "Expecting authentication to either have username or client id");
+          "Expecting authentication to either be anonymous, or have username or client id");
     }
   }
 }

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/security/TasklistAuthenticationUtil.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/security/TasklistAuthenticationUtil.java
@@ -7,17 +7,22 @@
  */
 package io.camunda.tasklist.webapp.security;
 
-import java.util.Optional;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+import io.camunda.security.auth.CamundaAuthentication;
+import io.camunda.tasklist.webapp.rest.exception.InvalidRequestException;
 
 public final class TasklistAuthenticationUtil {
 
   private TasklistAuthenticationUtil() {}
 
-  public static boolean isApiUser() {
-    return Optional.ofNullable(SecurityContextHolder.getContext().getAuthentication())
-        .map(JwtAuthenticationToken.class::isInstance)
-        .orElse(false);
+  public static boolean isApiUser(CamundaAuthentication authenticatedUser) {
+
+    if (authenticatedUser.authenticatedUsername() != null) {
+      return false;
+    } else if (authenticatedUser.authenticatedClientId() != null) {
+      return true;
+    } else {
+      throw new InvalidRequestException(
+          "Expecting authentication to either have username or client id");
+    }
   }
 }

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/service/TaskService.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/service/TaskService.java
@@ -156,7 +156,8 @@ public class TaskService {
       allowOverrideAssignment = true;
     }
 
-    final var isApiUser = TasklistAuthenticationUtil.isApiUser();
+    final var isApiUser =
+        TasklistAuthenticationUtil.isApiUser(authenticationProvider.getCamundaAuthentication());
     if (StringUtils.isEmpty(assignee) && isApiUser) {
       throw new InvalidRequestException("Assignee must be specified");
     }
@@ -189,7 +190,9 @@ public class TaskService {
   }
 
   private String determineTaskAssignee(final String assignee, final String authenticatedUsername) {
-    return StringUtils.isEmpty(assignee) && !TasklistAuthenticationUtil.isApiUser()
+    return StringUtils.isEmpty(assignee)
+            && !TasklistAuthenticationUtil.isApiUser(
+                authenticationProvider.getCamundaAuthentication())
         ? authenticatedUsername
         : assignee;
   }
@@ -319,7 +322,7 @@ public class TaskService {
   private String[] getTaskMetricLabels(final TaskEntity task, final String username) {
     final String keyUserId;
 
-    if (TasklistAuthenticationUtil.isApiUser()) {
+    if (TasklistAuthenticationUtil.isApiUser(authenticationProvider.getCamundaAuthentication())) {
       if (task.getAssignee() != null) {
         keyUserId = task.getAssignee();
       } else {

--- a/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/api/rest/v1/controllers/TaskControllerTest.java
+++ b/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/api/rest/v1/controllers/TaskControllerTest.java
@@ -35,7 +35,6 @@ import io.camunda.tasklist.webapp.group.UserGroupService;
 import io.camunda.tasklist.webapp.mapper.TaskMapper;
 import io.camunda.tasklist.webapp.permission.TasklistPermissionServices;
 import io.camunda.tasklist.webapp.rest.exception.InvalidRequestException;
-import io.camunda.tasklist.webapp.security.TasklistAuthenticationUtil;
 import io.camunda.tasklist.webapp.security.TasklistURIs;
 import io.camunda.tasklist.webapp.service.TaskService;
 import io.camunda.tasklist.webapp.service.VariableService;
@@ -46,7 +45,6 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -54,7 +52,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Answers;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
@@ -84,7 +81,18 @@ class TaskControllerTest {
   @BeforeEach
   public void setUp() {
     mockMvc = MockMvcBuilders.standaloneSetup(instance).build();
-    final var authentication = mock(CamundaAuthentication.class);
+    setAuthenticatedClient("foo");
+  }
+
+  protected void setAuthenticatedUser(String name) {
+
+    final var authentication = CamundaAuthentication.of(b -> b.user(name));
+    when(authenticationProvider.getCamundaAuthentication()).thenReturn(authentication);
+  }
+
+  protected void setAuthenticatedClient(String id) {
+
+    final var authentication = CamundaAuthentication.of(b -> b.clientId(id));
     when(authenticationProvider.getCamundaAuthentication()).thenReturn(authentication);
   }
 
@@ -927,10 +935,7 @@ class TaskControllerTest {
       when(taskMapper.toTaskResponse(taskDTO)).thenReturn(expectedTaskResponse);
       when(tasklistProperties.getIdentity()).thenReturn(mock(IdentityProperties.class));
       when(tasklistProperties.getIdentity().isUserAccessRestrictionsEnabled()).thenReturn(true);
-      when(authenticationProvider.getCamundaAuthentication())
-          .thenReturn(mock(CamundaAuthentication.class));
-      when(authenticationProvider.getCamundaAuthentication().authenticatedUsername())
-          .thenReturn("demo");
+      setAuthenticatedUser("demo");
       when(userGroupService.getUserGroups()).thenReturn(List.of("Admins"));
       when(tasklistProperties.getIdentity().isUserAccessRestrictionsEnabled()).thenReturn(false);
 
@@ -970,10 +975,7 @@ class TaskControllerTest {
       when(taskMapper.toTaskResponse(taskDTO)).thenReturn(expectedTaskResponse);
       when(tasklistProperties.getIdentity()).thenReturn(mock(IdentityProperties.class));
       when(tasklistProperties.getIdentity().isUserAccessRestrictionsEnabled()).thenReturn(true);
-      when(authenticationProvider.getCamundaAuthentication())
-          .thenReturn(mock(CamundaAuthentication.class));
-      when(authenticationProvider.getCamundaAuthentication().authenticatedUsername())
-          .thenReturn("demo");
+      setAuthenticatedUser("demo");
       when(userGroupService.getUserGroups()).thenReturn(List.of("Admins"));
       when(tasklistProperties.getIdentity().isUserAccessRestrictionsEnabled()).thenReturn(false);
 
@@ -1005,10 +1007,7 @@ class TaskControllerTest {
       when(taskService.completeTask(taskId, variables, true)).thenThrow(NotFoundException.class);
       when(tasklistProperties.getIdentity()).thenReturn(mock(IdentityProperties.class));
       when(tasklistProperties.getIdentity().isUserAccessRestrictionsEnabled()).thenReturn(true);
-      when(authenticationProvider.getCamundaAuthentication())
-          .thenReturn(mock(CamundaAuthentication.class));
-      when(authenticationProvider.getCamundaAuthentication().authenticatedUsername())
-          .thenReturn("demo");
+      setAuthenticatedUser("demo");
       when(userGroupService.getUserGroups()).thenReturn(List.of("Admins"));
       when(tasklistProperties.getIdentity().isUserAccessRestrictionsEnabled()).thenReturn(false);
 
@@ -1059,10 +1058,7 @@ class TaskControllerTest {
 
         when(tasklistProperties.getIdentity()).thenReturn(mock(IdentityProperties.class));
         when(tasklistProperties.getIdentity().isUserAccessRestrictionsEnabled()).thenReturn(true);
-        when(authenticationProvider.getCamundaAuthentication())
-            .thenReturn(mock(CamundaAuthentication.class));
-        when(authenticationProvider.getCamundaAuthentication().authenticatedUsername())
-            .thenReturn("demo");
+        setAuthenticatedUser("demo");
         when(userGroupService.getUserGroups()).thenReturn(List.of("Admins"));
         when(taskMapper.toTaskQuery(searchRequest)).thenReturn(searchQuery);
         when(taskService.getTasks(searchQuery, Set.of(TASK_DESCRIPTION), false))
@@ -1121,10 +1117,7 @@ class TaskControllerTest {
 
         when(tasklistProperties.getIdentity()).thenReturn(mock(IdentityProperties.class));
         when(tasklistProperties.getIdentity().isUserAccessRestrictionsEnabled()).thenReturn(true);
-        when(authenticationProvider.getCamundaAuthentication())
-            .thenReturn(mock(CamundaAuthentication.class));
-        when(authenticationProvider.getCamundaAuthentication().authenticatedUsername())
-            .thenReturn(null);
+        setAuthenticatedClient("foo");
         when(taskMapper.toTaskQuery(searchRequest)).thenReturn(searchQuery);
         when(taskService.getTasks(searchQuery, Set.of(TASK_DESCRIPTION), false))
             .thenReturn(List.of(providedTask));
@@ -1182,10 +1175,7 @@ class TaskControllerTest {
 
         when(tasklistProperties.getIdentity()).thenReturn(mock(IdentityProperties.class));
         when(tasklistProperties.getIdentity().isUserAccessRestrictionsEnabled()).thenReturn(true);
-        when(authenticationProvider.getCamundaAuthentication())
-            .thenReturn(mock(CamundaAuthentication.class));
-        when(authenticationProvider.getCamundaAuthentication().authenticatedUsername())
-            .thenReturn("demo");
+        setAuthenticatedUser("demo");
         when(userGroupService.getUserGroups()).thenReturn(List.of("Admins"));
         when(taskMapper.toTaskQuery(searchRequest)).thenReturn(searchQuery);
         when(taskMapper.toTaskSearchResponse(providedTask)).thenReturn(taskResponse);
@@ -1248,10 +1238,7 @@ class TaskControllerTest {
 
         when(tasklistProperties.getIdentity()).thenReturn(mock(IdentityProperties.class));
         when(tasklistProperties.getIdentity().isUserAccessRestrictionsEnabled()).thenReturn(true);
-        when(authenticationProvider.getCamundaAuthentication())
-            .thenReturn(mock(CamundaAuthentication.class));
-        when(authenticationProvider.getCamundaAuthentication().authenticatedUsername())
-            .thenReturn("demo");
+        setAuthenticatedUser("demo");
         when(userGroupService.getUserGroups()).thenReturn(List.of("Admins"));
         when(taskMapper.toTaskQuery(searchRequest)).thenReturn(searchQuery);
         when(taskService.getTasks(searchQuery, Set.of(TASK_DESCRIPTION), false))
@@ -1290,10 +1277,7 @@ class TaskControllerTest {
 
         when(tasklistProperties.getIdentity()).thenReturn(mock(IdentityProperties.class));
         when(tasklistProperties.getIdentity().isUserAccessRestrictionsEnabled()).thenReturn(true);
-        when(authenticationProvider.getCamundaAuthentication())
-            .thenReturn(mock(CamundaAuthentication.class));
-        when(authenticationProvider.getCamundaAuthentication().authenticatedUsername())
-            .thenReturn("demo");
+        setAuthenticatedUser("demo");
         when(userGroupService.getUserGroups()).thenReturn(List.of("Admins"));
         when(taskMapper.toTaskQuery(searchRequest)).thenReturn(searchQuery);
 
@@ -1340,10 +1324,7 @@ class TaskControllerTest {
 
         when(tasklistProperties.getIdentity()).thenReturn(mock(IdentityProperties.class));
         when(tasklistProperties.getIdentity().isUserAccessRestrictionsEnabled()).thenReturn(true);
-        when(authenticationProvider.getCamundaAuthentication())
-            .thenReturn(mock(CamundaAuthentication.class));
-        when(authenticationProvider.getCamundaAuthentication().authenticatedUsername())
-            .thenReturn("demo");
+        setAuthenticatedUser("demo");
         when(userGroupService.getUserGroups()).thenReturn(List.of("Admins"));
         when(taskService.getTask(taskId)).thenReturn(taskDto);
         when(taskService.completeTask(taskId, variables, true)).thenReturn(taskDto);
@@ -1390,10 +1371,7 @@ class TaskControllerTest {
 
         when(tasklistProperties.getIdentity()).thenReturn(mock(IdentityProperties.class));
         when(tasklistProperties.getIdentity().isUserAccessRestrictionsEnabled()).thenReturn(true);
-        when(authenticationProvider.getCamundaAuthentication())
-            .thenReturn(mock(CamundaAuthentication.class));
-        when(authenticationProvider.getCamundaAuthentication().authenticatedUsername())
-            .thenReturn("demo");
+        setAuthenticatedUser("demo");
         when(userGroupService.getUserGroups()).thenReturn(List.of("Demo"));
         when(taskService.getTask(taskId)).thenReturn(taskDto);
         when(taskService.completeTask(taskId, variables, true)).thenReturn(taskDto);
@@ -1445,10 +1423,7 @@ class TaskControllerTest {
 
         when(tasklistProperties.getIdentity()).thenReturn(mock(IdentityProperties.class));
         when(tasklistProperties.getIdentity().isUserAccessRestrictionsEnabled()).thenReturn(true);
-        when(authenticationProvider.getCamundaAuthentication())
-            .thenReturn(mock(CamundaAuthentication.class));
-        when(authenticationProvider.getCamundaAuthentication().authenticatedUsername())
-            .thenReturn("demo");
+        setAuthenticatedUser("demo");
         when(userGroupService.getUserGroups()).thenReturn(List.of("Admins"));
         when(taskService.getTask(taskId)).thenReturn(providedTask);
         when(taskMapper.toTaskResponse(providedTask)).thenReturn(taskResponse);
@@ -1497,10 +1472,7 @@ class TaskControllerTest {
 
         when(tasklistProperties.getIdentity()).thenReturn(mock(IdentityProperties.class));
         when(tasklistProperties.getIdentity().isUserAccessRestrictionsEnabled()).thenReturn(true);
-        when(authenticationProvider.getCamundaAuthentication())
-            .thenReturn(mock(CamundaAuthentication.class));
-        when(authenticationProvider.getCamundaAuthentication().authenticatedUsername())
-            .thenReturn("demo");
+        setAuthenticatedUser("demo");
         when(userGroupService.getUserGroups()).thenReturn(List.of("Admins"));
         when(taskService.getTask(taskId)).thenReturn(providedTask);
         when(taskMapper.toTaskResponse(providedTask)).thenReturn(taskResponse);
@@ -1551,10 +1523,7 @@ class TaskControllerTest {
 
         when(tasklistProperties.getIdentity()).thenReturn(mock(IdentityProperties.class));
         when(tasklistProperties.getIdentity().isUserAccessRestrictionsEnabled()).thenReturn(true);
-        when(authenticationProvider.getCamundaAuthentication())
-            .thenReturn(mock(CamundaAuthentication.class));
-        when(authenticationProvider.getCamundaAuthentication().authenticatedUsername())
-            .thenReturn("demo");
+        setAuthenticatedUser("demo");
         when(userGroupService.getUserGroups()).thenReturn(List.of("Test"));
         when(taskService.getTask(taskId)).thenReturn(providedTask);
         when(taskMapper.toTaskResponse(providedTask)).thenReturn(taskResponse);
@@ -1607,10 +1576,7 @@ class TaskControllerTest {
         when(taskMapper.toTaskResponse(providedTask)).thenReturn(taskResponse);
         when(tasklistProperties.getIdentity()).thenReturn(mock(IdentityProperties.class));
         when(tasklistProperties.getIdentity().isUserAccessRestrictionsEnabled()).thenReturn(true);
-        when(authenticationProvider.getCamundaAuthentication())
-            .thenReturn(mock(CamundaAuthentication.class));
-        when(authenticationProvider.getCamundaAuthentication().authenticatedUsername())
-            .thenReturn("demo");
+        setAuthenticatedUser("demo");
         when(userGroupService.getUserGroups()).thenReturn(List.of("Admins"));
         when(tasklistPermissionServices.hasPermissionToUpdateUserTask(any())).thenReturn(true);
 
@@ -1660,10 +1626,7 @@ class TaskControllerTest {
         when(taskMapper.toTaskResponse(providedTask)).thenReturn(taskResponse);
         when(tasklistProperties.getIdentity()).thenReturn(mock(IdentityProperties.class));
         when(tasklistProperties.getIdentity().isUserAccessRestrictionsEnabled()).thenReturn(true);
-        when(authenticationProvider.getCamundaAuthentication())
-            .thenReturn(mock(CamundaAuthentication.class));
-        when(authenticationProvider.getCamundaAuthentication().authenticatedUsername())
-            .thenReturn("demo");
+        setAuthenticatedUser("demo");
         when(userGroupService.getUserGroups()).thenReturn(List.of("Demo"));
 
         // When
@@ -1937,7 +1900,6 @@ class TaskControllerTest {
         "This operation is not supported using Tasklist V1 API. Please use the latest API. For more information, refer to the documentation: https://docs.camunda.tasklist";
 
     private final String taskId = "taskId";
-    private MockedStatic<TasklistAuthenticationUtil> authenticationUtil;
 
     @BeforeEach
     public void setUp() {
@@ -1948,14 +1910,6 @@ class TaskControllerTest {
               new TaskDTO().setId(taskId).setImplementation(TaskImplementation.ZEEBE_USER_TASK));
       when(authenticationProvider.getCamundaAuthentication())
           .thenReturn(mock(CamundaAuthentication.class));
-
-      authenticationUtil = mockStatic(TasklistAuthenticationUtil.class);
-      authenticationUtil.when(TasklistAuthenticationUtil::isApiUser).thenReturn(true);
-    }
-
-    @AfterEach
-    public void tearDown() {
-      authenticationUtil.close();
     }
 
     @Test
@@ -1964,6 +1918,8 @@ class TaskControllerTest {
       final var completeRequest =
           new TaskCompleteRequest()
               .setVariables(List.of(new VariableInputDTO().setName("var_a").setValue("val_a")));
+
+      setAuthenticatedClient("foo");
 
       // When
       final var responseAsString =
@@ -1986,6 +1942,9 @@ class TaskControllerTest {
 
     @Test
     void assignUserTaskShouldReturnBadRequest() throws Exception {
+      // Given
+      setAuthenticatedClient("foo");
+
       // When
       final var responseAsString =
           mockMvc
@@ -2011,6 +1970,9 @@ class TaskControllerTest {
 
     @Test
     void unassignUserTaskShouldReturnBadRequest() throws Exception {
+      // Given
+      setAuthenticatedClient("foo");
+
       // When
       final var responseAsString =
           mockMvc

--- a/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/es/TaskValidatorTest.java
+++ b/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/es/TaskValidatorTest.java
@@ -214,6 +214,24 @@ public class TaskValidatorTest {
   }
 
   @Test
+  public void anonymousUserCannotCompleteAssignedTask() {
+    // given
+    final TaskEntity task = new TaskEntity().setAssignee(TEST_USER).setState(TaskState.CREATED);
+
+    setAnonymousUser();
+
+    // when - then
+    assertThatThrownBy(() -> instance.validateCanComplete(task))
+        .isInstanceOf(InvalidRequestException.class)
+        .hasMessage(
+            """
+          { "title": "TASK_NOT_ASSIGNED_TO_CURRENT_USER",
+            "detail": "Task is not assigned to null"
+          }
+          """);
+  }
+
+  @Test
   public void apiUserShouldBeAbleToCompleteOtherPersonTask() {
     // given
     final TaskEntity task =
@@ -386,5 +404,11 @@ public class TaskValidatorTest {
 
     final var authentication = CamundaAuthentication.of(b -> b.clientId(id));
     when(authenticationProvider.getCamundaAuthentication()).thenReturn(authentication);
+  }
+
+  protected void setAnonymousUser() {
+
+    when(authenticationProvider.getCamundaAuthentication())
+        .thenReturn(CamundaAuthentication.anonymous());
   }
 }

--- a/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/es/TaskValidatorTest.java
+++ b/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/es/TaskValidatorTest.java
@@ -9,8 +9,6 @@ package io.camunda.tasklist.webapp.es;
 
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
@@ -19,18 +17,14 @@ import io.camunda.security.auth.CamundaAuthenticationProvider;
 import io.camunda.tasklist.property.FeatureFlagProperties;
 import io.camunda.tasklist.property.TasklistProperties;
 import io.camunda.tasklist.webapp.rest.exception.InvalidRequestException;
-import io.camunda.tasklist.webapp.security.TasklistAuthenticationUtil;
 import io.camunda.webapps.schema.entities.usertask.TaskEntity;
 import io.camunda.webapps.schema.entities.usertask.TaskState;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
@@ -39,20 +33,18 @@ public class TaskValidatorTest {
   public static final String TEST_USER = "TestUser";
 
   @Mock private CamundaAuthenticationProvider authenticationProvider;
-  @Mock private TasklistProperties tasklistProperties;
+  private TasklistProperties tasklistProperties;
 
-  @InjectMocks private TaskValidator instance;
+  private TaskValidator instance;
 
-  private MockedStatic<TasklistAuthenticationUtil> authenticationUtil;
+  private FeatureFlagProperties featureFlagProperties;
 
   @BeforeEach
   public void setUp() {
-    authenticationUtil = mockStatic(TasklistAuthenticationUtil.class);
-  }
+    this.tasklistProperties = new TasklistProperties();
+    this.featureFlagProperties = tasklistProperties.getFeatureFlag();
 
-  @AfterEach
-  public void tearDown() {
-    authenticationUtil.close();
+    instance = new TaskValidator(authenticationProvider, tasklistProperties);
   }
 
   @ParameterizedTest
@@ -79,11 +71,8 @@ public class TaskValidatorTest {
   @Test
   public void userCanNotPersistDraftTaskVariablesIfAssignedToAnotherPerson() {
     // given
-    when(tasklistProperties.getFeatureFlag()).thenReturn(new FeatureFlagProperties());
-    authenticationUtil.when(TasklistAuthenticationUtil::isApiUser).thenReturn(false);
-    final var authentication = mock(CamundaAuthentication.class);
-    when(authentication.authenticatedUsername()).thenReturn(TEST_USER);
-    when(authenticationProvider.getCamundaAuthentication()).thenReturn(authentication);
+    setAuthenticatedUser(TEST_USER);
+
     final TaskEntity task =
         new TaskEntity().setAssignee("AnotherTestUser").setState(TaskState.CREATED);
 
@@ -101,8 +90,9 @@ public class TaskValidatorTest {
   @Test
   public void userCanNotPersistDraftTaskVariablesIfAssigneeIsNull() {
     // given
-    authenticationUtil.when(TasklistAuthenticationUtil::isApiUser).thenReturn(false);
     final TaskEntity task = new TaskEntity().setAssignee(null).setState(TaskState.CREATED);
+
+    setAuthenticatedUser(TEST_USER);
 
     // when - then
     assertThatThrownBy(() -> instance.validateCanPersistDraftTaskVariables(task))
@@ -118,10 +108,8 @@ public class TaskValidatorTest {
   @Test
   public void userCanPersistDraftTaskVariablesWhenTaskIsAssignedToItself() {
     // given
-    authenticationUtil.when(TasklistAuthenticationUtil::isApiUser).thenReturn(false);
-    final var authentication = mock(CamundaAuthentication.class);
-    when(authentication.authenticatedUsername()).thenReturn(TEST_USER);
-    when(authenticationProvider.getCamundaAuthentication()).thenReturn(authentication);
+    setAuthenticatedUser(TEST_USER);
+
     final TaskEntity task = new TaskEntity().setAssignee(TEST_USER).setState(TaskState.CREATED);
 
     // when - then
@@ -132,9 +120,10 @@ public class TaskValidatorTest {
   @Test
   public void apiUserShouldBeAbleToPersistDraftTaskVariablesEvenIfTaskIsAssignedToAnotherPerson() {
     // given
-    authenticationUtil.when(TasklistAuthenticationUtil::isApiUser).thenReturn(true);
     final TaskEntity task =
         new TaskEntity().setAssignee("AnotherTestUser").setState(TaskState.CREATED);
+
+    setAuthenticatedClient(TEST_USER);
 
     // when - then
     assertThatCode(() -> instance.validateCanPersistDraftTaskVariables(task))
@@ -164,11 +153,8 @@ public class TaskValidatorTest {
   @Test
   public void userCanNotCompleteTaskIfAssignedToAnotherPerson() {
     // given
-    when(tasklistProperties.getFeatureFlag()).thenReturn(new FeatureFlagProperties());
-    authenticationUtil.when(TasklistAuthenticationUtil::isApiUser).thenReturn(false);
-    final var authentication = mock(CamundaAuthentication.class);
-    when(authentication.authenticatedUsername()).thenReturn(TEST_USER);
-    when(authenticationProvider.getCamundaAuthentication()).thenReturn(authentication);
+    setAuthenticatedUser(TEST_USER);
+
     final TaskEntity task =
         new TaskEntity().setAssignee("AnotherTestUser").setState(TaskState.CREATED);
 
@@ -187,8 +173,9 @@ public class TaskValidatorTest {
   @Test
   public void userCanNotCompleteTaskIfAssigneeIsNull() {
     // given
-    authenticationUtil.when(TasklistAuthenticationUtil::isApiUser).thenReturn(false);
     final TaskEntity task = new TaskEntity().setAssignee(null).setState(TaskState.CREATED);
+
+    setAuthenticatedUser(TEST_USER);
 
     // when - then
     assertThatThrownBy(() -> instance.validateCanComplete(task))
@@ -205,10 +192,8 @@ public class TaskValidatorTest {
   public void userCanCompleteTheirOwnTask() {
     // given
 
-    authenticationUtil.when(TasklistAuthenticationUtil::isApiUser).thenReturn(false);
-    final var authentication = mock(CamundaAuthentication.class);
-    when(authentication.authenticatedUsername()).thenReturn(TEST_USER);
-    when(authenticationProvider.getCamundaAuthentication()).thenReturn(authentication);
+    setAuthenticatedUser(TEST_USER);
+
     final TaskEntity task = new TaskEntity().setAssignee(TEST_USER).setState(TaskState.CREATED);
 
     // when - then
@@ -218,12 +203,10 @@ public class TaskValidatorTest {
   @Test
   public void userCanCompleteOtherPersonTaskIfAllowNonSelfAssignment() {
     // given
-    when(tasklistProperties.getFeatureFlag())
-        .thenReturn(new FeatureFlagProperties().setAllowNonSelfAssignment(true));
-    authenticationUtil.when(TasklistAuthenticationUtil::isApiUser).thenReturn(false);
-    final var authentication = mock(CamundaAuthentication.class);
-    when(authentication.authenticatedUsername()).thenReturn("AnotherTestUser");
-    when(authenticationProvider.getCamundaAuthentication()).thenReturn(authentication);
+    featureFlagProperties.setAllowNonSelfAssignment(true);
+
+    setAuthenticatedUser("AnotherTestUser");
+
     final TaskEntity task = new TaskEntity().setAssignee(TEST_USER).setState(TaskState.CREATED);
 
     // when - then
@@ -233,9 +216,10 @@ public class TaskValidatorTest {
   @Test
   public void apiUserShouldBeAbleToCompleteOtherPersonTask() {
     // given
-    authenticationUtil.when(TasklistAuthenticationUtil::isApiUser).thenReturn(true);
     final TaskEntity task =
         new TaskEntity().setAssignee("AnotherTestUser").setState(TaskState.CREATED);
+
+    setAuthenticatedClient(TEST_USER);
 
     // when - then
     assertThatCode(() -> instance.validateCanComplete(task)).doesNotThrowAnyException();
@@ -244,8 +228,9 @@ public class TaskValidatorTest {
   @Test
   public void apiUserShouldBeAbleToAssignToDifferentUsers() {
     // given
-    authenticationUtil.when(TasklistAuthenticationUtil::isApiUser).thenReturn(true);
     final TaskEntity taskBefore = new TaskEntity().setAssignee(null).setState(TaskState.CREATED);
+
+    setAuthenticatedClient(TEST_USER);
 
     // when - then
     assertThatCode(() -> instance.validateCanAssign(taskBefore, true)).doesNotThrowAnyException();
@@ -254,9 +239,10 @@ public class TaskValidatorTest {
   @Test
   public void apiUserShouldBeAbleToReassignToAnotherUser() {
     // given
-    authenticationUtil.when(TasklistAuthenticationUtil::isApiUser).thenReturn(true);
     final TaskEntity taskBefore =
         new TaskEntity().setAssignee("previously assigned user").setState(TaskState.CREATED);
+
+    setAuthenticatedClient(TEST_USER);
 
     // when - then
     assertThatCode(() -> instance.validateCanAssign(taskBefore, true)).doesNotThrowAnyException();
@@ -265,9 +251,10 @@ public class TaskValidatorTest {
   @Test
   public void apiUserShouldBeAbleToReassignToAnotherUserWhenOverrideAllowed() {
     // given
-    authenticationUtil.when(TasklistAuthenticationUtil::isApiUser).thenReturn(true);
     final TaskEntity taskBefore =
         new TaskEntity().setAssignee("previously assigned user").setState(TaskState.CREATED);
+
+    setAuthenticatedClient(TEST_USER);
 
     // when - then
     assertThatCode(() -> instance.validateCanAssign(taskBefore, true)).doesNotThrowAnyException();
@@ -276,12 +263,13 @@ public class TaskValidatorTest {
   @Test
   public void apiUserShouldNoBeAbleToReassignToAnotherUserWhenOverrideForbidden() {
     // given
-    authenticationUtil.when(TasklistAuthenticationUtil::isApiUser).thenReturn(true);
     final TaskEntity taskBefore =
         new TaskEntity()
             .setAssignee("previously assigned user")
             .setState(TaskState.CREATED)
             .setId("123");
+
+    setAuthenticatedClient(TEST_USER);
 
     // when - then
     assertThatThrownBy(() -> instance.validateCanAssign(taskBefore, false))
@@ -316,10 +304,10 @@ public class TaskValidatorTest {
   @Test
   public void nonApiUserShouldNotBeAbleToReassignToAnotherUser() {
     // given
-    when(tasklistProperties.getFeatureFlag()).thenReturn(new FeatureFlagProperties());
-    authenticationUtil.when(TasklistAuthenticationUtil::isApiUser).thenReturn(false);
     final TaskEntity task =
         new TaskEntity().setAssignee("AnotherTestUser").setState(TaskState.CREATED);
+
+    setAuthenticatedUser(TEST_USER);
 
     // when - then
     assertThatThrownBy(() -> instance.validateCanAssign(task, true))
@@ -336,10 +324,10 @@ public class TaskValidatorTest {
   @Test
   public void nonApiUserShouldNotBeAbleToReassignToAnotherUserWhenOverrideAllowed() {
     // given
-    when(tasklistProperties.getFeatureFlag()).thenReturn(new FeatureFlagProperties());
-    authenticationUtil.when(TasklistAuthenticationUtil::isApiUser).thenReturn(false);
     final TaskEntity task =
         new TaskEntity().setAssignee("AnotherTestUser").setState(TaskState.CREATED);
+
+    setAuthenticatedUser(TEST_USER);
 
     // when - then
     assertThatThrownBy(() -> instance.validateCanAssign(task, true))
@@ -386,5 +374,17 @@ public class TaskValidatorTest {
               "detail": "Task is not active"
             }
             """);
+  }
+
+  protected void setAuthenticatedUser(String name) {
+
+    final var authentication = CamundaAuthentication.of(b -> b.user(name));
+    when(authenticationProvider.getCamundaAuthentication()).thenReturn(authentication);
+  }
+
+  protected void setAuthenticatedClient(String id) {
+
+    final var authentication = CamundaAuthentication.of(b -> b.clientId(id));
+    when(authenticationProvider.getCamundaAuthentication()).thenReturn(authentication);
   }
 }


### PR DESCRIPTION
- fix is to reuse the CamundaAuthentication object
- the tests are adjusted to actually cover the logic that determines if it's an API user and to not just mock it one way or the other

closes #33185