### PR TITLE
test: Refactor backup restore test for tasklist

### DIFF
--- a/.github/workflows/tasklist-backup-restore-tests-reusable.yml
+++ b/.github/workflows/tasklist-backup-restore-tests-reusable.yml
@@ -46,6 +46,14 @@ jobs:
           dockerfile: tasklist.Dockerfile
           push: true
           distball: ${{ steps.build-zeebe.outputs.distball }}
+      - uses: ./.github/actions/build-platform-docker
+        id: build-zeebe-docker
+        with:
+          repository: localhost:5000/camunda/zeebe
+          version: ${{ env.DOCKER_IMAGE_TAG }}
+          dockerfile: Dockerfile
+          push: true
+          distball: ${{ steps.build-zeebe.outputs.distball }}
       - name: Run Tasklist backup restore Tests
         shell: bash
         run: ./mvnw -B -pl tasklist/qa/backup-restore-tests -DskipChecks -DtasklistDatabase=${{ inputs.database }} -DskipTests=false verify | tee "${BUILD_OUTPUT_FILE_PATH}"

--- a/tasklist/qa/backup-restore-tests/src/test/java/io/camunda/tasklist/qa/backup/BackupRestoreTest.java
+++ b/tasklist/qa/backup-restore-tests/src/test/java/io/camunda/tasklist/qa/backup/BackupRestoreTest.java
@@ -56,7 +56,8 @@ public class BackupRestoreTest {
   public static final String REPOSITORY_NAME = "testRepository";
   public static final Long BACKUP_ID = 123L;
   private static final Logger LOGGER = LoggerFactory.getLogger(BackupRestoreTest.class);
-  private static final String TASKLIST_TEST_DOCKER_IMAGE = "localhost:5000/camunda/tasklist";
+  private static final String IMAGE_REPO = "localhost:5000/";
+  private static final String TASKLIST_TEST_DOCKER_IMAGE = IMAGE_REPO + "camunda/tasklist";
 
   @Autowired private TasklistAPICaller tasklistAPICaller;
 
@@ -137,8 +138,7 @@ public class BackupRestoreTest {
                 new HttpHost(testContext.getExternalElsHost(), testContext.getExternalElsPort()))));
     createElsSnapshotRepository(testContext);
 
-    testContainerUtil.startZeebe(
-        ContainerVersionsUtil.readProperty(ZEEBE_CURRENTVERSION_DOCKER_PROPERTY_NAME), testContext);
+    testContainerUtil.startZeebe(IMAGE_REPO, VERSION, testContext);
     createZeebeClient(testContext.getExternalZeebeContactPoint());
   }
 

--- a/tasklist/qa/util/src/main/java/io/camunda/tasklist/qa/util/TestContainerUtil.java
+++ b/tasklist/qa/util/src/main/java/io/camunda/tasklist/qa/util/TestContainerUtil.java
@@ -483,11 +483,16 @@ public class TestContainerUtil {
     }
   }
 
-  public ZeebeContainer startZeebe(final String version, final TestContext testContext) {
+  public ZeebeContainer startZeebe(final String version, final TestContext<?> testContext) {
+    return startZeebe("", version, testContext);
+  }
+
+  public ZeebeContainer startZeebe(
+      final String host, final String version, final TestContext<?> testContext) {
     if (broker == null) {
       LOGGER.info("************ Starting Zeebe {} ************", version);
       broker =
-          new ZeebeContainer(DockerImageName.parse("camunda/zeebe:" + version))
+          new ZeebeContainer(DockerImageName.parse(host + "camunda/zeebe:" + version))
               .withNetwork(testContext.getNetwork())
               .withEnv("ZEEBE_BROKER_GATEWAY_ENABLE", "true")
               .withEnv("CAMUNDA_SECURITY_AUTHENTICATION_UNPROTECTEDAPI", "true")


### PR DESCRIPTION
## Description

Update Tasklist's backup restore test so it spins up a Zeebe image built with the branch's code instead of using `camunda/zeebe:SNAPSHOT`

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
