### PR TITLE
fix: add RoleValidator and use jwt decoder in cookie filter

### DIFF
--- a/optimize/backend/src/main/java/io/camunda/optimize/rest/security/cloud/CCSaaSSecurityConfigurerAdapter.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/rest/security/cloud/CCSaaSSecurityConfigurerAdapter.java
@@ -25,6 +25,7 @@ import io.camunda.optimize.rest.security.AuthenticationCookieFilter;
 import io.camunda.optimize.rest.security.CustomPreAuthenticatedAuthenticationProvider;
 import io.camunda.optimize.rest.security.oauth.AudienceValidator;
 import io.camunda.optimize.rest.security.oauth.CustomClaimValidator;
+import io.camunda.optimize.rest.security.oauth.RoleValidator;
 import io.camunda.optimize.rest.security.oauth.ScopeValidator;
 import io.camunda.optimize.service.exceptions.OptimizeRuntimeException;
 import io.camunda.optimize.service.security.AuthCookieService;
@@ -36,6 +37,7 @@ import io.camunda.optimize.tomcat.CCSaasRequestAdjustmentFilter;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.time.Instant;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -80,6 +82,7 @@ import org.springframework.web.util.UriComponentsBuilder;
 public class CCSaaSSecurityConfigurerAdapter extends AbstractSecurityConfigurerAdapter {
 
   public static final String CAMUNDA_CLUSTER_ID_CLAIM_NAME = "https://camunda.com/clusterId";
+  private static final List<String> ALLOWED_ORG_ROLES = Arrays.asList("admin", "analyst", "owner");
 
   private static final Logger LOG = LoggerFactory.getLogger(CCSaaSSecurityConfigurerAdapter.class);
   private final ClientRegistrationRepository clientRegistrationRepository;
@@ -234,9 +237,11 @@ public class CCSaaSSecurityConfigurerAdapter extends AbstractSecurityConfigurerA
                 .getUserAccessTokenAudience()
                 .orElse(""));
     final OAuth2TokenValidator<Jwt> profileValidator = new ScopeValidator("profile");
+    final OAuth2TokenValidator<Jwt> roleValidator = new RoleValidator(ALLOWED_ORG_ROLES);
     // The default validator already contains validation for timestamp and X509 thumbprint
     final OAuth2TokenValidator<Jwt> combinedValidatorWithDefaults =
-        JwtValidators.createDefaultWithValidators(audienceValidator, profileValidator);
+        JwtValidators.createDefaultWithValidators(
+            audienceValidator, profileValidator, roleValidator);
     jwtDecoder.setJwtValidator(combinedValidatorWithDefaults);
     return jwtDecoder;
   }

--- a/optimize/backend/src/main/java/io/camunda/optimize/rest/security/cloud/CCSaaSSecurityConfigurerAdapter.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/rest/security/cloud/CCSaaSSecurityConfigurerAdapter.java
@@ -59,6 +59,8 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
+import org.springframework.security.oauth2.client.oidc.authentication.OidcIdTokenDecoderFactory;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestRedirectFilter;
 import org.springframework.security.oauth2.core.OAuth2AccessToken;
@@ -67,6 +69,7 @@ import org.springframework.security.oauth2.core.oidc.OidcUserInfo;
 import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtDecoderFactory;
 import org.springframework.security.oauth2.jwt.JwtValidators;
 import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
 import org.springframework.security.web.SecurityFilterChain;
@@ -223,26 +226,20 @@ public class CCSaaSSecurityConfigurerAdapter extends AbstractSecurityConfigurerA
         configurationService, new AuthorizationRequestCookieValueMapper());
   }
 
+  @Bean
+  public JwtDecoderFactory<ClientRegistration> idTokenDecoderFactory() {
+    final var decoderFactory = new OidcIdTokenDecoderFactory();
+    decoderFactory.setJwtValidatorFactory(clientRegistration -> createWebappJwtValidators());
+    return decoderFactory;
+  }
+
   @SuppressWarnings("unchecked")
   private JwtDecoder jwtDecoder() {
     final NimbusJwtDecoder jwtDecoder =
         NimbusJwtDecoder.withJwkSetUri(
                 configurationService.getOptimizeApiConfiguration().getJwtSetUri())
             .build();
-    final OAuth2TokenValidator<Jwt> audienceValidator =
-        new AudienceValidator(
-            configurationService
-                .getAuthConfiguration()
-                .getCloudAuthConfiguration()
-                .getUserAccessTokenAudience()
-                .orElse(""));
-    final OAuth2TokenValidator<Jwt> profileValidator = new ScopeValidator("profile");
-    final OAuth2TokenValidator<Jwt> roleValidator = new RoleValidator(ALLOWED_ORG_ROLES);
-    // The default validator already contains validation for timestamp and X509 thumbprint
-    final OAuth2TokenValidator<Jwt> combinedValidatorWithDefaults =
-        JwtValidators.createDefaultWithValidators(
-            audienceValidator, profileValidator, roleValidator);
-    jwtDecoder.setJwtValidator(combinedValidatorWithDefaults);
+    jwtDecoder.setJwtValidator(createWebappJwtValidators());
     return jwtDecoder;
   }
 
@@ -253,16 +250,41 @@ public class CCSaaSSecurityConfigurerAdapter extends AbstractSecurityConfigurerA
         NimbusJwtDecoder.withJwkSetUri(
                 configurationService.getOptimizeApiConfiguration().getJwtSetUri())
             .build();
+    jwtDecoder.setJwtValidator(createPublicApiJwtValidators());
+    return jwtDecoder;
+  }
+
+  /**
+   * Creates JWT validators for webapp endpoints (both oauth2Login and oauth2ResourceServer).
+   * Includes audience, scope, and role validation for comprehensive security.
+   */
+  private OAuth2TokenValidator<Jwt> createWebappJwtValidators() {
+    final OAuth2TokenValidator<Jwt> audienceValidator =
+        new AudienceValidator(
+            configurationService
+                .getAuthConfiguration()
+                .getCloudAuthConfiguration()
+                .getUserAccessTokenAudience()
+                .orElse(""));
+    final OAuth2TokenValidator<Jwt> profileValidator = new ScopeValidator("profile");
+    final OAuth2TokenValidator<Jwt> roleValidator = new RoleValidator(ALLOWED_ORG_ROLES);
+
+    return JwtValidators.createDefaultWithValidators(
+        audienceValidator, profileValidator, roleValidator);
+  }
+
+  /**
+   * Creates JWT validators for public API endpoints. Includes audience and cluster ID validation
+   * for API access control.
+   */
+  private OAuth2TokenValidator<Jwt> createPublicApiJwtValidators() {
     final OAuth2TokenValidator<Jwt> audienceValidator =
         new AudienceValidator(getAuth0Configuration().getAudience());
     final OAuth2TokenValidator<Jwt> clusterIdValidator =
         new CustomClaimValidator(
             CAMUNDA_CLUSTER_ID_CLAIM_NAME, getAuth0Configuration().getClusterId());
-    // The default validator already contains validation for timestamp and X509 thumbprint
-    final OAuth2TokenValidator<Jwt> combinedValidatorWithDefaults =
-        JwtValidators.createDefaultWithValidators(audienceValidator, clusterIdValidator);
-    jwtDecoder.setJwtValidator(combinedValidatorWithDefaults);
-    return jwtDecoder;
+
+    return JwtValidators.createDefaultWithValidators(audienceValidator, clusterIdValidator);
   }
 
   private AuthenticationSuccessHandler getAuthenticationSuccessHandler() {

--- a/optimize/backend/src/main/java/io/camunda/optimize/rest/security/oauth/RoleValidator.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/rest/security/oauth/RoleValidator.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.rest.security.oauth;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.oauth2.core.OAuth2Error;
+import org.springframework.security.oauth2.core.OAuth2ErrorCodes;
+import org.springframework.security.oauth2.core.OAuth2TokenValidator;
+import org.springframework.security.oauth2.core.OAuth2TokenValidatorResult;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+public class RoleValidator implements OAuth2TokenValidator<Jwt> {
+
+  static final String ORGANIZATION_CLAIM_KEY = "https://camunda.com/orgs";
+  private static final Logger LOG = LoggerFactory.getLogger(RoleValidator.class);
+
+  private final List<String> allowedRoles;
+
+  public RoleValidator(final List<String> allowedRoles) {
+    this.allowedRoles = Objects.requireNonNull(allowedRoles, "allowedRoles must not be null");
+  }
+
+  @Override
+  public OAuth2TokenValidatorResult validate(final Jwt token) {
+    final var claimValue = token.getClaims().get(ORGANIZATION_CLAIM_KEY);
+    if (claimValue == null) {
+      LOG.debug("Rejected token: missing organization claim '{}'", ORGANIZATION_CLAIM_KEY);
+      return OAuth2TokenValidatorResult.failure(
+          new OAuth2Error(
+              OAuth2ErrorCodes.INVALID_TOKEN,
+              "Token does not contain required organization claim for Optimize access.",
+              null));
+    }
+
+    if (claimValue instanceof final Collection<?> claimedOrgs) {
+      if (hasAllowedRole(claimedOrgs)) {
+        return OAuth2TokenValidatorResult.success();
+      }
+    }
+
+    LOG.debug(
+        "Rejected token with organizations '{}', required roles: {}", claimValue, allowedRoles);
+    return OAuth2TokenValidatorResult.failure(
+        new OAuth2Error(
+            OAuth2ErrorCodes.INVALID_TOKEN,
+            "Token does not contain required organization role for Optimize access. Required roles: %s"
+                .formatted(allowedRoles),
+            null));
+  }
+
+  private boolean hasAllowedRole(final Collection<?> claimedOrgs) {
+    for (final Object claimedOrg : claimedOrgs) {
+      if (claimedOrg instanceof final Map<?, ?> orgDetails) {
+        final Object rolesObj = orgDetails.get("roles");
+        if (rolesObj instanceof final Collection<?> userRoles) {
+          for (final Object userRole : userRoles) {
+            if (userRole instanceof String && allowedRoles.contains(userRole)) {
+              LOG.debug("User has allowed role '{}' for Optimize access", userRole);
+              return true;
+            }
+          }
+        }
+      }
+    }
+    return false;
+  }
+}

--- a/optimize/backend/src/test/java/io/camunda/optimize/rest/security/oauth/RoleValidatorTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/rest/security/oauth/RoleValidatorTest.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.rest.security.oauth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.oauth2.core.OAuth2TokenValidatorResult;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+class RoleValidatorTest {
+
+  private final List<String> allowedRoles = Arrays.asList("admin", "analyst", "owner");
+  private final RoleValidator validator = new RoleValidator(allowedRoles);
+
+  @Test
+  void shouldFailWhenTokenHasNoOrganizationClaim() {
+    // given
+    final Jwt token = mock(Jwt.class);
+    final Map<String, Object> claims = new HashMap<>();
+    when(token.getClaims()).thenReturn(claims);
+
+    // when
+    final OAuth2TokenValidatorResult result = validator.validate(token);
+
+    // then
+    assertThat(result.hasErrors()).isTrue();
+  }
+
+  @Test
+  void shouldSucceedWhenUserHasAllowedRole() {
+    // given
+    final Jwt token = mock(Jwt.class);
+    final Map<String, Object> claims = new HashMap<>();
+    final Map<String, Object> org = new HashMap<>();
+    org.put("id", "org1");
+    org.put("roles", Arrays.asList("admin", "developer"));
+    claims.put("https://camunda.com/orgs", List.of(org));
+    when(token.getClaims()).thenReturn(claims);
+
+    // when
+    final OAuth2TokenValidatorResult result = validator.validate(token);
+
+    // then
+    assertThat(result.hasErrors()).isFalse();
+  }
+
+  @Test
+  void shouldSucceedWhenUserHasAllowedRoleInAnyOrg() {
+    // given
+    final Jwt token = mock(Jwt.class);
+    final Map<String, Object> claims = new HashMap<>();
+    final Map<String, Object> org1 = new HashMap<>();
+    org1.put("id", "org1");
+    org1.put("roles", List.of("developer"));
+    final Map<String, Object> org2 = new HashMap<>();
+    org2.put("id", "org2");
+    org2.put("roles", List.of("analyst"));
+    claims.put("https://camunda.com/orgs", Arrays.asList(org1, org2));
+    when(token.getClaims()).thenReturn(claims);
+
+    // when
+    final OAuth2TokenValidatorResult result = validator.validate(token);
+
+    // then
+    assertThat(result.hasErrors()).isFalse();
+  }
+
+  @Test
+  void shouldFailWhenUserHasNoAllowedRole() {
+    // given
+    final Jwt token = mock(Jwt.class);
+    final Map<String, Object> claims = new HashMap<>();
+    final Map<String, Object> org = new HashMap<>();
+    org.put("id", "org1");
+    org.put("roles", Arrays.asList("developer", "viewer"));
+    claims.put("https://camunda.com/orgs", List.of(org));
+    when(token.getClaims()).thenReturn(claims);
+
+    // when
+    final OAuth2TokenValidatorResult result = validator.validate(token);
+
+    // then
+    assertThat(result.hasErrors()).isTrue();
+    assertThat(result.getErrors().iterator().next().getErrorCode()).isEqualTo("invalid_token");
+  }
+
+  @Test
+  void shouldFailWhenOrganizationHasNoRoles() {
+    // given
+    final Jwt token = mock(Jwt.class);
+    final Map<String, Object> claims = new HashMap<>();
+    final Map<String, Object> org = new HashMap<>();
+    org.put("id", "org1");
+    org.put("roles", Collections.emptyList());
+    claims.put("https://camunda.com/orgs", List.of(org));
+    when(token.getClaims()).thenReturn(claims);
+
+    // when
+    final OAuth2TokenValidatorResult result = validator.validate(token);
+
+    // then
+    assertThat(result.hasErrors()).isTrue();
+  }
+
+  @Test
+  void shouldFailWhenOrganizationClaimIsEmpty() {
+    // given
+    final Jwt token = mock(Jwt.class);
+    final Map<String, Object> claims = new HashMap<>();
+    claims.put("https://camunda.com/orgs", Collections.emptyList());
+    when(token.getClaims()).thenReturn(claims);
+
+    // when
+    final OAuth2TokenValidatorResult result = validator.validate(token);
+
+    // then
+    assertThat(result.hasErrors()).isTrue();
+  }
+
+  @Test
+  void shouldFailWhenOrganizationClaimHasInvalidStructure() {
+    // given
+    final Jwt token = mock(Jwt.class);
+    final Map<String, Object> claims = new HashMap<>();
+    claims.put("https://camunda.com/orgs", "invalid-structure");
+    when(token.getClaims()).thenReturn(claims);
+
+    // when
+    final OAuth2TokenValidatorResult result = validator.validate(token);
+
+    // then
+    assertThat(result.hasErrors()).isTrue();
+  }
+}


### PR DESCRIPTION
## Description

We previously reverted role validator changes in [this PR](https://github.com/camunda/camunda/pull/36987) because it was breaking [public API auth logic](https://camunda.slack.com/archives/C08MRKHJ0CD/p1755590527480099). This PR is a follow-up to the original issue to implement role validation in Optimize SaaS, see #31600

This PR is doing 2 things
- Adding back role validation into the `jwtDecoder()` as described [here](https://camunda.slack.com/archives/C06UYJMMETZ/p1755691076970439?thread_ts=1755616581.351389&cid=C06UYJMMETZ) 
- Adding the `jwtDecoder()` to the AuthenticationCookieFilter so the jwt claims don't get bypassed when a user has a valid OAuth session, see slack [thread](https://camunda.slack.com/archives/C06UYJMMETZ/p1755616581351389)

## Related issues

related to #31600
