### PR TITLE
feat: spring sdk logs unset prefer-rest-over-grpc

### DIFF
--- a/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/properties/PropertiesPostProcessor.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/properties/PropertiesPostProcessor.java
@@ -58,7 +58,7 @@ public class PropertiesPostProcessor implements EnvironmentPostProcessor {
   private void createMessages(final ConfigurableEnvironment environment) {
     if (!environment.containsProperty("camunda.client.zeebe.prefer-rest-over-grpc")) {
       log.warn(
-          "No 'camunda.client.zeebe.prefer-rest-over-grpc' is set. Please set to 'true' or 'false' explicitly as the default behaviour will change in the next release.");
+          "No 'camunda.client.zeebe.prefer-rest-over-grpc' is set. Please set to 'true' or 'false' explicitly as the default behaviour will change from 'false' to 'true' in the next release.");
     }
   }
 

--- a/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/properties/PropertiesPostProcessor.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/properties/PropertiesPostProcessor.java
@@ -52,6 +52,14 @@ public class PropertiesPostProcessor implements EnvironmentPostProcessor {
     mapLegacyProperties(environment);
     mapLegacyOverrides(environment);
     processClientMode(environment);
+    createMessages(environment);
+  }
+
+  private void createMessages(final ConfigurableEnvironment environment) {
+    if (!environment.containsProperty("camunda.client.zeebe.prefer-rest-over-grpc")) {
+      log.warn(
+          "No 'camunda.client.zeebe.prefer-rest-over-grpc' is set. Please set to 'true' or 'false' explicitly as the default behaviour will change in the next release.");
+    }
   }
 
   private void mapLegacyOverrides(final ConfigurableEnvironment environment) {

--- a/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/properties/PropertiesPostProcessorLoggingTest.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/properties/PropertiesPostProcessorLoggingTest.java
@@ -17,21 +17,54 @@ package io.camunda.zeebe.spring.client.properties;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.system.CapturedOutput;
 import org.springframework.boot.test.system.OutputCaptureExtension;
 
-@SpringBootTest(
-    properties = "zeebe.client.broker.grpc-address=http://legacy:26500",
-    classes = CamundaClientPropertiesTestConfig.class)
-@ExtendWith(OutputCaptureExtension.class)
 public class PropertiesPostProcessorLoggingTest {
-  @Test
-  void shouldLogPropertyMapping(final CapturedOutput output) {
-    assertThat(output)
-        .contains(
-            "Legacy property 'zeebe.client.broker.grpc-address' found, setting to 'camunda.client.zeebe.grpc-address'. Please update your setup to use the latest property");
+
+  @Nested
+  @SpringBootTest(
+      properties = "zeebe.client.broker.grpc-address=http://legacy:26500",
+      classes = CamundaClientPropertiesTestConfig.class)
+  @ExtendWith(OutputCaptureExtension.class)
+  class DeprecatedPropertyMapping {
+    @Test
+    void shouldLogPropertyMapping(final CapturedOutput output) {
+      assertThat(output)
+          .contains(
+              "Legacy property 'zeebe.client.broker.grpc-address' found, setting to 'camunda.client.zeebe.grpc-address'. Please update your setup to use the latest property");
+    }
+  }
+
+  @Nested
+  @SpringBootTest(classes = CamundaClientPropertiesTestConfig.class)
+  @ExtendWith(OutputCaptureExtension.class)
+  class RestOverGrpcWarning {
+
+    @Test
+    void shouldLogRestOverGrpcWarning(final CapturedOutput output) {
+      assertThat(output)
+          .contains(
+              "No 'camunda.client.zeebe.prefer-rest-over-grpc' is set. Please set to 'true' or 'false' explicitly as the default behaviour will change in the next release.");
+    }
+  }
+
+  @Nested
+  @SpringBootTest(
+      properties = "camunda.client.zeebe.prefer-rest-over-grpc=true",
+      classes = CamundaClientPropertiesTestConfig.class)
+  @ExtendWith(OutputCaptureExtension.class)
+  class RestOverGrpcSet {
+
+    @Test
+    void shouldNotLogRestOverGrpcWarning(final CapturedOutput output) {
+      assertThat(output)
+          .doesNotContain(
+              "No 'camunda.client.zeebe.prefer-rest-over-grpc' is set. Please set to 'true' or 'false' explicitly as the default behaviour will change in the next release.");
+    }
   }
 }

--- a/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/properties/PropertiesPostProcessorLoggingTest.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/properties/PropertiesPostProcessorLoggingTest.java
@@ -49,7 +49,7 @@ public class PropertiesPostProcessorLoggingTest {
     void shouldLogRestOverGrpcWarning(final CapturedOutput output) {
       assertThat(output)
           .contains(
-              "No 'camunda.client.zeebe.prefer-rest-over-grpc' is set. Please set to 'true' or 'false' explicitly as the default behaviour will change in the next release.");
+              "No 'camunda.client.zeebe.prefer-rest-over-grpc' is set. Please set to 'true' or 'false' explicitly as the default behaviour will change from 'false' to 'true' in the next release.");
     }
   }
 
@@ -64,7 +64,7 @@ public class PropertiesPostProcessorLoggingTest {
     void shouldNotLogRestOverGrpcWarning(final CapturedOutput output) {
       assertThat(output)
           .doesNotContain(
-              "No 'camunda.client.zeebe.prefer-rest-over-grpc' is set. Please set to 'true' or 'false' explicitly as the default behaviour will change in the next release.");
+              "No 'camunda.client.zeebe.prefer-rest-over-grpc' is set. Please set to 'true' or 'false' explicitly as the default behaviour will change from 'false' to 'true' in the next release.");
     }
   }
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR adds a warning log to the spring sdk on startup if the `prefer-rest-over-grpc` property is not set.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
