### PR TITLE
feat: group API testing for v2

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/group/group-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/group/group-api-tests.spec.ts
@@ -1,0 +1,282 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {test, expect} from '@playwright/test';
+import {
+  jsonHeaders,
+  extractAndStoreIds,
+  buildUrl,
+  assertRequiredFields,
+  assertEqualsForKeys,
+  paginatedResponseFields,
+} from '../../../../utils/http';
+import {
+  CREATE_NEW_GROUP,
+  groupRequiredFields,
+} from '../../../../utils/beans/request-beans';
+import {sleep} from '../../../../utils/sleep';
+
+test.describe('Groups API Tests', () => {
+  const state: Record<string, unknown> = {};
+
+  test('CRUD', async ({request}) => {
+    await test.step('Create Group', async () => {
+      const requestBody = CREATE_NEW_GROUP();
+
+      const res = await request.post(buildUrl('/groups'), {
+        headers: jsonHeaders(),
+        data: requestBody,
+      });
+
+      expect(res.status()).toBe(201);
+      const json = await res.json();
+      assertRequiredFields(json, groupRequiredFields);
+      assertEqualsForKeys(json, requestBody, groupRequiredFields);
+      await extractAndStoreIds(res, state);
+    });
+
+    await test.step('Create Group Unauthorized', async () => {
+      const requestBody = CREATE_NEW_GROUP();
+      const res = await request.post(buildUrl('/groups', {}), {
+        headers: {},
+        data: requestBody,
+      });
+      expect(res.status()).toBe(401);
+    });
+
+    await test.step('Create Group Bad Request', async () => {
+      const invalidRequest = {
+        name: 'x',
+      };
+
+      const res = await request.post(buildUrl('/groups'), {
+        headers: jsonHeaders(),
+        data: invalidRequest,
+      });
+      expect(res.status()).toBe(400);
+    });
+
+    await test.step('Search Groups By Name', async () => {
+      await sleep(10000);
+      const groupName = state['name'];
+      const body = {
+        filter: {
+          name: groupName,
+        },
+      };
+      const expectedBody = {
+        groupId: state['groupId'],
+        name: state['name'],
+        description: state['description'],
+      };
+
+      const res = await request.post(buildUrl('/groups/search'), {
+        headers: jsonHeaders(),
+        data: body,
+      });
+      expect(res.status()).toBe(200);
+      const json = await res.json();
+      assertRequiredFields(json, paginatedResponseFields);
+      expect(json.page.totalItems).toBe(1);
+      assertRequiredFields(json.items[0], groupRequiredFields);
+      assertEqualsForKeys(json.items[0], expectedBody, groupRequiredFields);
+    });
+
+    await test.step('Search Groups By Id', async () => {
+      const groupId = state['groupId'];
+      const body = {
+        filter: {
+          groupId: groupId,
+        },
+      };
+      const expectedBody = {
+        groupId: state['groupId'],
+        name: state['name'],
+        description: state['description'],
+      };
+
+      const res = await request.post(buildUrl('/groups/search'), {
+        headers: jsonHeaders(),
+        data: body,
+      });
+
+      expect(res.status()).toBe(200);
+      const json = await res.json();
+      assertRequiredFields(json, paginatedResponseFields);
+      expect(json.page.totalItems).toBe(1);
+      assertRequiredFields(json.items[0], groupRequiredFields);
+      assertEqualsForKeys(json.items[0], expectedBody, groupRequiredFields);
+    });
+
+    await test.step('Search Groups By Invalid Id', async () => {
+      const body = {
+        filter: {
+          groupId: 'invalidgroupid',
+        },
+      };
+
+      const res = await request.post(buildUrl('/groups/search'), {
+        headers: jsonHeaders(),
+        data: body,
+      });
+
+      expect(res.status()).toBe(200);
+      const json = await res.json();
+      assertRequiredFields(json, paginatedResponseFields);
+      expect(json.page.totalItems).toBe(0);
+      expect(json.items.length).toBe(0);
+    });
+
+    await test.step('Search Groups Unauthorized', async () => {
+      const groupName = state['name'];
+      const body = {
+        filter: {
+          name: groupName,
+        },
+      };
+
+      const res = await request.post(buildUrl('/groups/search'), {
+        headers: {},
+        data: body,
+      });
+      expect(res.status()).toBe(401);
+    });
+
+    await test.step('Get Group', async () => {
+      const param: Record<string, string> = {
+        groupId: state['groupId'] as string,
+      };
+      const expectedBody: Record<string, string> = {
+        groupId: state['groupId'] as string,
+        name: state['name'] as string,
+        description: state['description'] as string,
+      };
+
+      const res = await request.get(buildUrl('/groups/{groupId}', param), {
+        headers: jsonHeaders(),
+      });
+
+      expect(res.status()).toBe(200);
+      const json = await res.json();
+      assertRequiredFields(json, groupRequiredFields);
+      assertEqualsForKeys(json, expectedBody, groupRequiredFields);
+    });
+
+    await test.step('Get Group Not Found', async () => {
+      const param: Record<string, string> = {
+        groupId: 'invalidGroupName',
+      };
+      const res = await request.get(buildUrl('/groups/{groupId}', param), {
+        headers: jsonHeaders(),
+      });
+      expect(res.status()).toBe(404);
+    });
+
+    await test.step('Get Group Unauthorized', async () => {
+      const param: Record<string, string> = {
+        groupId: state['groupId'] as string,
+      };
+      const res = await request.get(buildUrl('/groups/{groupId}', param), {
+        headers: {},
+      });
+      expect(res.status()).toBe(401);
+    });
+
+    await test.step('Update Group', async () => {
+      const p = {groupId: state['groupId'] as string};
+      const body = {
+        name: `${state['name']}-updated`,
+        description: `${state['description']}-updated`,
+      };
+
+      const res = await request.put(buildUrl('/groups/{groupId}', p), {
+        headers: jsonHeaders(),
+        data: body,
+      });
+
+      expect(res.status()).toBe(200);
+      const json = await res.json();
+      assertRequiredFields(json, ['groupId', 'name']);
+      assertEqualsForKeys(json, {name: body.name}, ['name']);
+      assertEqualsForKeys(json, {description: body.description}, [
+        'description',
+      ]);
+      state['name'] = json.name;
+      state['description'] = json.description;
+    });
+
+    await test.step('Update Group Unauthorized', async () => {
+      const p = {groupId: state['groupId'] as string};
+      const body = {
+        name: `${state['name']}-updated`,
+        description: `${state['description']}-updated`,
+      };
+      const res = await request.put(buildUrl('/groups/{groupId}', p), {
+        headers: {},
+        data: body,
+      });
+      expect(res.status()).toBe(401);
+    });
+
+    await test.step('Update Group Bad Request', async () => {
+      const p = {groupId: state['groupId'] as string};
+      const invalid = {description: 'x'};
+      const res = await request.put(buildUrl('/groups/{groupId}', p), {
+        headers: jsonHeaders(),
+        data: invalid,
+      });
+      expect(res.status()).toBe(400);
+    });
+
+    await test.step('Update Group Not Found', async () => {
+      const p = {groupId: 'invalidGroupId'};
+      const body = {
+        name: `${state['name']}-updated`,
+        description: `${state['description']}-updated`,
+      };
+      const res = await request.put(buildUrl('/groups/{groupId}', p), {
+        headers: jsonHeaders(),
+        data: body,
+      });
+      expect(res.status()).toBe(404);
+    });
+
+    await test.step('Delete Group', async () => {
+      const p = {groupId: state['groupId'] as string};
+      const res = await request.delete(buildUrl('/groups/{groupId}', p), {
+        headers: jsonHeaders(),
+      });
+      expect(res.status()).toBe(204);
+    });
+
+    await test.step('Get Group After Deletion', async () => {
+      await sleep(10000);
+      const p = {groupId: state['groupId'] as string};
+      const after = await request.get(buildUrl('/groups/{groupId}', p), {
+        headers: jsonHeaders(),
+      });
+      expect(after.status()).toBe(404);
+    });
+
+    await test.step('Delete Group Unauthorized', async () => {
+      const p = {groupId: state['groupId'] as string};
+      const res = await request.delete(buildUrl('/groups/{groupId}', p), {
+        headers: {},
+      });
+      expect(res.status()).toBe(401);
+    });
+
+    await test.step('Delete Group Not Found', async () => {
+      const p = {groupId: 'invalidGroupId'};
+      const res = await request.delete(buildUrl('/groups/{groupId}', p), {
+        headers: jsonHeaders(),
+      });
+      expect(res.status()).toBe(404);
+    });
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/group/group-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/group/group-api-tests.spec.ts
@@ -116,7 +116,7 @@ test.describe('Groups API Tests', () => {
     await test.step('Search Groups By Invalid Id', async () => {
       const body = {
         filter: {
-          groupId: 'invalidgroupid',
+          groupId: 'invalidGroupId',
         },
       };
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/group/group-clients-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/group/group-clients-api-tests.spec.ts
@@ -86,7 +86,7 @@ test.describe('Groups Clients API Tests', () => {
     });
 
     await test.step('Search Clients For Group Not Found', async () => {
-      const p = {groupId: 'invalidgroup'};
+      const p = {groupId: 'invalidGroupId'};
 
       const res = await request.post(
         buildUrl('/groups/{groupId}/clients/search', p),

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/group/group-clients-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/group/group-clients-api-tests.spec.ts
@@ -1,0 +1,166 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {test, expect} from '@playwright/test';
+import {
+  jsonHeaders,
+  buildUrl,
+  assertRequiredFields,
+  assertEqualsForKeys,
+  paginatedResponseFields,
+} from '../../../../utils/http';
+import {
+  CREATE_NEW_GROUP,
+  groupRequiredFields,
+} from '../../../../utils/beans/request-beans';
+import {sleep} from '../../../../utils/sleep';
+
+test.describe('Groups Clients API Tests', () => {
+  const state: Record<string, unknown> = {};
+
+  test('CRUD', async ({request}) => {
+    await test.step('Create Group', async () => {
+      const requestBody = CREATE_NEW_GROUP();
+      const res = await request.post(buildUrl('/groups'), {
+        headers: jsonHeaders(),
+        data: requestBody,
+      });
+      expect(res.status()).toBe(201);
+      const json = await res.json();
+      assertRequiredFields(json, groupRequiredFields);
+      assertEqualsForKeys(json, requestBody, groupRequiredFields);
+      state['groupId'] = json.groupId;
+    });
+
+    await test.step('Assign Client To Group', async () => {
+      state['clientId'] = 'test-client';
+      const p = {
+        groupId: state['groupId'] as string,
+        clientId: state['clientId'] as string,
+      };
+      const res = await request.put(
+        buildUrl('/groups/{groupId}/clients/{clientId}', p),
+        {
+          headers: jsonHeaders(),
+        },
+      );
+      expect(res.status()).toBe(204);
+    });
+
+    await test.step('Search Clients For Group', async () => {
+      await sleep(10000);
+      const p = {groupId: state['groupId'] as string};
+      const expectedBody = {clientId: state['clientId'] as string};
+      const requiredFields = Object.keys(expectedBody);
+
+      const res = await request.post(
+        buildUrl('/groups/{groupId}/clients/search', p),
+        {
+          headers: jsonHeaders(),
+          data: {},
+        },
+      );
+      expect(res.status()).toBe(200);
+      const json = await res.json();
+      assertRequiredFields(json, paginatedResponseFields);
+      expect(json.page.totalItems).toBe(1);
+      assertRequiredFields(json.items[0], requiredFields);
+      assertEqualsForKeys(json.items[0], expectedBody, requiredFields);
+    });
+
+    await test.step('Search Clients For Group Unauthorized', async () => {
+      const p = {groupId: state['groupId'] as string};
+      const res = await request.post(
+        buildUrl('/groups/{groupId}/clients/search', p),
+        {
+          headers: {},
+          data: {},
+        },
+      );
+      expect(res.status()).toBe(401);
+    });
+
+    await test.step('Search Clients For Group Not Found', async () => {
+      const p = {groupId: 'invalidgroup'};
+
+      const res = await request.post(
+        buildUrl('/groups/{groupId}/clients/search', p),
+        {
+          headers: jsonHeaders(),
+          data: {},
+        },
+      );
+
+      expect(res.status()).toBe(200);
+      const json = await res.json();
+      assertRequiredFields(json, paginatedResponseFields);
+      expect(json.page.totalItems).toBe(0);
+      expect(json.items.length).toBe(0);
+    });
+
+    await test.step('Unassign Client From Group', async () => {
+      const p = {
+        groupId: state['groupId'] as string,
+        clientId: state['clientId'] as string,
+      };
+      const res = await request.delete(
+        buildUrl('/groups/{groupId}/clients/{clientId}', p),
+        {
+          headers: jsonHeaders(),
+        },
+      );
+      expect(res.status()).toBe(204);
+    });
+
+    await test.step('Search Clients After Deletion', async () => {
+      await sleep(10000);
+      const p = {groupId: state['groupId'] as string};
+
+      const res = await request.post(
+        buildUrl('/groups/{groupId}/clients/search', p),
+        {
+          headers: jsonHeaders(),
+          data: {},
+        },
+      );
+      expect(res.status()).toBe(200);
+      const json = await res.json();
+      assertRequiredFields(json, paginatedResponseFields);
+      expect(json.page.totalItems).toBe(0);
+      expect(json.items.length).toBe(0);
+    });
+
+    await test.step('Unassign Client From Group Unauthorized', async () => {
+      const p = {
+        groupId: state['groupId'] as string,
+        clientId: state['clientId'] as string,
+      };
+      const res = await request.delete(
+        buildUrl('/groups/{groupId}/clients/{clientId}', p),
+        {
+          headers: {},
+        },
+      );
+      expect(res.status()).toBe(401);
+    });
+
+    await test.step('Unassign Client From Group Not Found', async () => {
+      const p = {
+        groupId: state['groupId'] as string,
+        clientId: state['clientId'] as string,
+      };
+      const res = await request.delete(
+        buildUrl('/groups/{groupId}/clients/{clientId}', p),
+        {
+          headers: jsonHeaders(),
+        },
+      );
+      expect(res.status()).toBe(404);
+    });
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/group/group-mapping-rules-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/group/group-mapping-rules-api-tests.spec.ts
@@ -1,0 +1,184 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {test, expect} from '@playwright/test';
+import {
+  jsonHeaders,
+  extractAndStoreIds,
+  buildUrl,
+  assertRequiredFields,
+  assertEqualsForKeys,
+  paginatedResponseFields,
+} from '../../../../utils/http';
+import {
+  CREATE_NEW_GROUP,
+  groupRequiredFields,
+  mappingRuleRequiredFields,
+} from '../../../../utils/beans/request-beans';
+import {sleep} from '../../../../utils/sleep';
+import {CREATE_NEW_MAPPING_RULE} from '../../../../utils/beans/request-beans';
+
+test.describe('Group Mapping Rules API Tests', () => {
+  const state: Record<string, unknown> = {};
+
+  test('CRUD', async ({request}) => {
+    await test.step('Create Group', async () => {
+      const requestBody = CREATE_NEW_GROUP();
+      const res = await request.post(buildUrl('/groups'), {
+        headers: jsonHeaders(),
+        data: requestBody,
+      });
+      expect(res.status()).toBe(201);
+      const json = await res.json();
+      assertRequiredFields(json, groupRequiredFields);
+      assertEqualsForKeys(json, requestBody, groupRequiredFields);
+      await extractAndStoreIds(res, state);
+    });
+
+    await test.step('Create Mapping Rule', async () => {
+      const body = CREATE_NEW_MAPPING_RULE();
+      const res = await request.post(buildUrl('/mapping-rules'), {
+        headers: jsonHeaders(),
+        data: body,
+      });
+      expect(res.status()).toBe(201);
+      await extractAndStoreIds(res, state);
+    });
+
+    await test.step('Assign Mapping Rule To Group', async () => {
+      const p = {
+        groupId: state['groupId'] as string,
+        mappingRuleId: state['mappingRuleId'] as string,
+      };
+      const res = await request.put(
+        buildUrl('/groups/{groupId}/mapping-rules/{mappingRuleId}', p),
+        {
+          headers: jsonHeaders(),
+        },
+      );
+      expect(res.status()).toBe(204);
+    });
+
+    await test.step('Search Mapping Rules For Group', async () => {
+      await sleep(10000);
+      const p = {groupId: state['groupId'] as string};
+      const expectedBody: Record<string, string> = {
+        claimName: state['claimName'] as string,
+        claimValue: state['claimValue'] as string,
+        name: state['name'] as string,
+        mappingRuleId: state['mappingRuleId'] as string,
+      };
+
+      const res = await request.post(
+        buildUrl('/groups/{groupId}/mapping-rules/search', p),
+        {
+          headers: jsonHeaders(),
+          data: {},
+        },
+      );
+      expect(res.status()).toBe(200);
+      const json = await res.json();
+      assertRequiredFields(json, paginatedResponseFields);
+      expect(json.page.totalItems).toBe(1);
+      assertRequiredFields(json.items[0], mappingRuleRequiredFields);
+      assertEqualsForKeys(
+        json.items[0],
+        expectedBody,
+        mappingRuleRequiredFields,
+      );
+    });
+
+    await test.step('Search Mapping Rules For Group Unauthorized', async () => {
+      const p = {groupId: state['groupId'] as string};
+      const res = await request.post(
+        buildUrl('/groups/{groupId}/mapping-rules/search', p),
+        {
+          headers: {},
+          data: {},
+        },
+      );
+      expect(res.status()).toBe(401);
+    });
+
+    await test.step('Search Mapping Rules For Group Not Found', async () => {
+      const p = {groupId: 'invalidGroupId'};
+      const res = await request.post(
+        buildUrl('/groups/{groupId}/mapping-rules/search', p),
+        {
+          headers: jsonHeaders(),
+          data: {},
+        },
+      );
+      expect(res.status()).toBe(200);
+      const json = await res.json();
+      assertRequiredFields(json, paginatedResponseFields);
+      expect(json.page.totalItems).toBe(0);
+      expect(json.items.length).toBe(0);
+    });
+
+    await test.step('Unassign Mapping Rule From Group', async () => {
+      const p = {
+        groupId: state['groupId'] as string,
+        mappingRuleId: state['mappingRuleId'] as string,
+      };
+      const res = await request.delete(
+        buildUrl('/groups/{groupId}/mapping-rules/{mappingRuleId}', p),
+        {
+          headers: jsonHeaders(),
+        },
+      );
+      expect(res.status()).toBe(204);
+    });
+
+    await test.step('Search Mapping Rules After Deletion', async () => {
+      await sleep(10000);
+      const p = {groupId: state['groupId'] as string};
+
+      const res = await request.post(
+        buildUrl('/groups/{groupId}/mapping-rules/search', p),
+        {
+          headers: jsonHeaders(),
+          data: {},
+        },
+      );
+      expect(res.status()).toBe(200);
+      const json = await res.json();
+      assertRequiredFields(json, paginatedResponseFields);
+      expect(json.page.totalItems).toBe(0);
+      expect(json.items.length).toBe(0);
+    });
+
+    await test.step('Unassign Mapping Rule From Group Unauthorized', async () => {
+      const p = {
+        groupId: state['groupId'] as string,
+        mappingRuleId: state['mappingRuleId'] as string,
+      };
+      const res = await request.delete(
+        buildUrl('/groups/{groupId}/mapping-rules/{mappingRuleId}', p),
+        {
+          headers: {},
+        },
+      );
+      expect(res.status()).toBe(401);
+    });
+
+    await test.step('Unassign Mapping Rule From Group Not Found', async () => {
+      const p = {
+        groupId: state['groupId'] as string,
+        mappingRuleId: state['mappingRuleId'] as string,
+      };
+      const res = await request.delete(
+        buildUrl('/groups/{groupId}/mapping-rules/{mappingRuleId}', p),
+        {
+          headers: jsonHeaders(),
+        },
+      );
+      expect(res.status()).toBe(404);
+    });
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/group/group-roles-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/group/group-roles-api-tests.spec.ts
@@ -1,0 +1,185 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {test, expect} from '@playwright/test';
+import {
+  jsonHeaders,
+  extractAndStoreIds,
+  buildUrl,
+  assertRequiredFields,
+  assertEqualsForKeys,
+  paginatedResponseFields,
+} from '../../../../utils/http';
+import {
+  CREATE_NEW_GROUP,
+  CREATE_NEW_ROLE,
+  groupRequiredFields,
+  roleRequiredFields,
+} from '../../../../utils/beans/request-beans';
+import {sleep} from '../../../../utils/sleep';
+
+test.describe('Group Roles API Tests', () => {
+  const state: Record<string, unknown> = {};
+
+  test('CRUD', async ({request}) => {
+    await test.step('Create Group', async () => {
+      const requestBody = CREATE_NEW_GROUP();
+      const res = await request.post(buildUrl('/groups'), {
+        headers: jsonHeaders(),
+        data: requestBody,
+      });
+      expect(res.status()).toBe(201);
+      const json = await res.json();
+      assertRequiredFields(json, groupRequiredFields);
+      assertEqualsForKeys(json, requestBody, groupRequiredFields);
+      state['groupId'] = json.groupId;
+      await sleep(5000);
+    });
+
+    await test.step('Create Role', async () => {
+      const body = CREATE_NEW_ROLE();
+
+      const res = await request.post(buildUrl('/roles'), {
+        headers: jsonHeaders(),
+        data: body,
+      });
+
+      expect(res.status()).toBe(201);
+      await extractAndStoreIds(res, state);
+    });
+
+    await test.step('Assign Role To Group', async () => {
+      await sleep(5000);
+      const p = {
+        groupId: state['groupId'] as string,
+        roleId: state['roleId'] as string,
+      };
+      const res = await request.put(
+        buildUrl('/roles/{roleId}/groups/{groupId}', p),
+        {
+          headers: jsonHeaders(),
+        },
+      );
+      expect(res.status()).toBe(204);
+    });
+
+    await test.step('Search Roles For Group', async () => {
+      await sleep(10000);
+      const p = {groupId: state['groupId'] as string};
+      const expectedBody: Record<string, string> = {
+        name: state['name'] as string,
+        roleId: state['roleId'] as string,
+        description: state['description'] as string,
+      };
+
+      const res = await request.post(
+        buildUrl('/groups/{groupId}/roles/search', p),
+        {
+          headers: jsonHeaders(),
+          data: {},
+        },
+      );
+
+      expect(res.status()).toBe(200);
+      const json = await res.json();
+      assertRequiredFields(json, paginatedResponseFields);
+      expect(json.page.totalItems).toBe(1);
+      assertRequiredFields(json.items[0], roleRequiredFields);
+      assertEqualsForKeys(json.items[0], expectedBody, roleRequiredFields);
+    });
+
+    await test.step('Search Roles For Group Unauthorized', async () => {
+      const p = {groupId: state['groupId'] as string};
+      const res = await request.post(
+        buildUrl('/groups/{groupId}/roles/search', p),
+        {
+          headers: {},
+          data: {},
+        },
+      );
+      expect(res.status()).toBe(401);
+    });
+
+    await test.step('Search Roles For Group Not Found', async () => {
+      const p = {groupId: 'invalidgroupid'};
+
+      const res = await request.post(
+        buildUrl('/groups/{groupId}/roles/search', p),
+        {
+          headers: jsonHeaders(),
+          data: {},
+        },
+      );
+
+      const json = await res.json();
+      assertRequiredFields(json, paginatedResponseFields);
+      expect(json.page.totalItems).toBe(0);
+      expect(json.items.length).toBe(0);
+    });
+
+    await test.step('Unassign Role From Group', async () => {
+      const p = {
+        groupId: state['groupId'] as string,
+        roleId: state['roleId'] as string,
+      };
+      const res = await request.delete(
+        buildUrl('/roles/{roleId}/groups/{groupId}', p),
+        {
+          headers: jsonHeaders(),
+        },
+      );
+      expect(res.status()).toBe(204);
+    });
+
+    await test.step('Search Roles For Group After Deletion', async () => {
+      await sleep(5000);
+      const p = {groupId: state['groupId'] as string};
+
+      const res = await request.post(
+        buildUrl('/groups/{groupId}/roles/search', p),
+        {
+          headers: jsonHeaders(),
+          data: {},
+        },
+      );
+
+      expect(res.status()).toBe(200);
+      const json = await res.json();
+      assertRequiredFields(json, paginatedResponseFields);
+      expect(json.page.totalItems).toBe(0);
+    });
+
+    await test.step('Unassign Role From Group Unauthorized', async () => {
+      const p = {
+        groupId: state['groupId'] as string,
+        roleId: state['roleId'] as string,
+      };
+      const res = await request.delete(
+        buildUrl('/roles/{roleId}/groups/{groupId}', p),
+        {
+          headers: {},
+        },
+      );
+      expect(res.status()).toBe(401);
+    });
+
+    await test.step('Unassign Role From Group Not Found', async () => {
+      const p = {
+        groupId: state['groupId'] as string,
+        roleId: state['roleId'] as string,
+      };
+      const res = await request.delete(
+        buildUrl('/roles/{roleId}/groups/{groupId}', p),
+        {
+          headers: jsonHeaders(),
+        },
+      );
+      expect(res.status()).toBe(404);
+    });
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/group/group-roles-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/group/group-roles-api-tests.spec.ts
@@ -106,7 +106,7 @@ test.describe('Group Roles API Tests', () => {
     });
 
     await test.step('Search Roles For Group Not Found', async () => {
-      const p = {groupId: 'invalidgroupid'};
+      const p = {groupId: 'invalidGroupId'};
 
       const res = await request.post(
         buildUrl('/groups/{groupId}/roles/search', p),

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/group/group-users-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/group/group-users-api-tests.spec.ts
@@ -42,7 +42,7 @@ test.describe('Group Users API Tests', () => {
     await test.step('Assign User To Group Not Found', async () => {
       state['username'] = 'demo';
       const stateParams: Record<string, string> = {
-        groupId: 'invalidgroupid',
+        groupId: 'invalidGroupId',
         username: state['username'] as string,
       };
       const res = await request.put(

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/group/group-users-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/group/group-users-api-tests.spec.ts
@@ -1,0 +1,203 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {test, expect} from '@playwright/test';
+import {
+  jsonHeaders,
+  extractAndStoreIds,
+  buildUrl,
+  assertRequiredFields,
+  assertEqualsForKeys,
+  paginatedResponseFields,
+} from '../../../../utils/http';
+import {
+  CREATE_NEW_GROUP,
+  groupRequiredFields,
+} from '../../../../utils/beans/request-beans';
+import {sleep} from '../../../../utils/sleep';
+
+test.describe('Group Users API Tests', () => {
+  const state: Record<string, unknown> = {};
+
+  test('CRUD', async ({request}) => {
+    await test.step('Create Group', async () => {
+      const requestBody = CREATE_NEW_GROUP();
+      const res = await request.post(buildUrl('/groups'), {
+        headers: jsonHeaders(),
+        data: requestBody,
+      });
+      expect(res.status()).toBe(201);
+      const json = await res.json();
+      assertRequiredFields(json, groupRequiredFields);
+      assertEqualsForKeys(json, requestBody, groupRequiredFields);
+      await extractAndStoreIds(res, state);
+      await sleep(5000);
+    });
+
+    await test.step('Assign User To Group Not Found', async () => {
+      state['username'] = 'demo';
+      const stateParams: Record<string, string> = {
+        groupId: 'invalidgroupid',
+        username: state['username'] as string,
+      };
+      const res = await request.put(
+        buildUrl('/groups/{groupId}/users/{username}', stateParams),
+        {
+          headers: jsonHeaders(),
+        },
+      );
+      expect(res.status()).toBe(404);
+    });
+
+    await test.step('Assign User To Group', async () => {
+      state['username'] = 'demo';
+      const stateParams: Record<string, string> = {
+        groupId: state['groupId'] as string,
+        username: state['username'] as string,
+      };
+      const res = await request.put(
+        buildUrl('/groups/{groupId}/users/{username}', stateParams),
+        {
+          headers: jsonHeaders(),
+        },
+      );
+      expect(res.status()).toBe(204);
+    });
+
+    await test.step('Assign Already Added User To Group Conflict', async () => {
+      state['username'] = 'demo';
+      const stateParams: Record<string, string> = {
+        groupId: state['groupId'] as string,
+        username: state['username'] as string,
+      };
+      const res = await request.put(
+        buildUrl('/groups/{groupId}/users/{username}', stateParams),
+        {
+          headers: jsonHeaders(),
+        },
+      );
+      expect(res.status()).toBe(409);
+      const json = await res.json();
+      assertRequiredFields(json, ['title']);
+      expect(json['title']).toContain('ALREADY_EXISTS');
+    });
+
+    await test.step('Search Users For Group', async () => {
+      await sleep(10000);
+      const stateParams: Record<string, string> = {
+        groupId: state['groupId'] as string,
+        username: state['username'] as string,
+      };
+      const expectedBody = {username: state['username'] as string};
+      const requiredFields = Object.keys(expectedBody);
+
+      const res = await request.post(
+        buildUrl('/groups/{groupId}/users/search', stateParams),
+        {headers: jsonHeaders()},
+      );
+
+      expect(res.status()).toBe(200);
+      const json = await res.json();
+      assertRequiredFields(json, paginatedResponseFields);
+      expect(json.page.totalItems).toBe(1);
+      assertRequiredFields(json.items[0], requiredFields);
+      assertEqualsForKeys(json.items[0], expectedBody, requiredFields);
+    });
+
+    await test.step('Search Users For Group Unauthorized', async () => {
+      state['username'] = 'demo';
+      const stateParams: Record<string, string> = {
+        groupId: state['groupId'] as string,
+        username: state['username'] as string,
+      };
+      const res = await request.post(
+        buildUrl('/groups/{groupId}/users/search', stateParams),
+        {headers: {}},
+      );
+      expect(res.status()).toBe(401);
+    });
+
+    await test.step('Search Users For Group Not Found', async () => {
+      const stateParams: Record<string, string> = {
+        groupId: 'invalidGroupName',
+        username: state['username'] as string,
+      };
+
+      const res = await request.post(
+        buildUrl('/groups/{groupId}/users/search', stateParams),
+        {headers: jsonHeaders()},
+      );
+
+      expect(res.status()).toBe(200);
+      const json = await res.json();
+      assertRequiredFields(json, paginatedResponseFields);
+      expect(json.page.totalItems).toBe(0);
+      expect(json.items.length).toBe(0);
+    });
+
+    await test.step('Unassign User From Group', async () => {
+      const p = {
+        groupId: state['groupId'] as string,
+        username: state['username'] as string,
+      };
+      const res = await request.delete(
+        buildUrl('/groups/{groupId}/users/{username}', p),
+        {
+          headers: jsonHeaders(),
+        },
+      );
+      expect(res.status()).toBe(204);
+    });
+
+    await test.step('Search Users After Deletion', async () => {
+      await sleep(10000);
+      const p = {groupId: state['groupId'] as string};
+
+      const res = await request.post(
+        buildUrl('/groups/{groupId}/users/search', p),
+        {
+          headers: jsonHeaders(),
+          data: {},
+        },
+      );
+      expect(res.status()).toBe(200);
+      const json = await res.json();
+      assertRequiredFields(json, paginatedResponseFields);
+      expect(json.page.totalItems).toBe(0);
+      expect(json.items.length).toBe(0);
+    });
+
+    await test.step('Unassign User From Group Unauthorized', async () => {
+      const p = {
+        groupId: state['groupId'] as string,
+        username: state['username'] as string,
+      };
+      const res = await request.delete(
+        buildUrl('/groups/{groupId}/users/{username}', p),
+        {
+          headers: {},
+        },
+      );
+      expect(res.status()).toBe(401);
+    });
+
+    await test.step('Unassign User From Group Not Found', async () => {
+      const p = {
+        groupId: state['groupId'] as string,
+        username: state['username'] as string,
+      };
+      const res = await request.delete(
+        buildUrl('/groups/{groupId}/users/{username}', p),
+        {
+          headers: jsonHeaders(),
+        },
+      );
+      expect(res.status()).toBe(404);
+    });
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/beans/request-beans.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/beans/request-beans.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {generateUniqueId} from '../constants';
+
+export const groupRequiredFields: string[] = ['groupId', 'name', 'description'];
+export const mappingRuleRequiredFields: string[] = [
+  'claimName',
+  'claimValue',
+  'name',
+  'mappingRuleId',
+];
+export const roleRequiredFields: string[] = ['roleId', 'name', 'description'];
+
+export function CREATE_NEW_GROUP() {
+  return {
+    groupId: 'group' + generateUniqueId(),
+    name: 'new group' + generateUniqueId(),
+    description: 'Test group description',
+  };
+}
+
+export function CREATE_NEW_MAPPING_RULE() {
+  const uniqueName = generateUniqueId();
+  return {
+    claimName: 'claimName' + uniqueName,
+    claimValue: 'claimValue' + uniqueName,
+    name: 'name' + uniqueName,
+    mappingRuleId: 'rule' + uniqueName,
+  };
+}
+
+export function CREATE_NEW_ROLE() {
+  const uid = generateUniqueId();
+  return {
+    roleId: `role-${uid}`,
+    name: `Test Role ${uid}`,
+    description: 'E2E test role',
+  };
+}

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/http.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/http.ts
@@ -1,0 +1,171 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {expect, APIResponse} from '@playwright/test';
+
+export type Credentials = {
+  baseUrl: string;
+  accessToken: string;
+};
+
+export const credentials: Credentials = {
+  baseUrl: 'http://localhost:8080',
+  accessToken: Buffer.from(`demo:demo`).toString('base64'),
+};
+
+export const paginatedResponseFields: string[] = ['items', 'page'];
+
+export function authHeaders(token?: string): Record<string, string> {
+  const h: Record<string, string> = {};
+  if (token) h.Authorization = `Basic ${credentials.accessToken}`;
+  return h;
+}
+
+function has(obj: unknown, prop: string): boolean {
+  return (
+    obj != null && Object.prototype.hasOwnProperty.call(obj as object, prop)
+  );
+}
+
+export function assertRequiredFields(obj: unknown, required: string[]): void {
+  expect(obj).toBeTruthy();
+  for (const f of required) {
+    expect(has(obj, f)).toBe(true);
+    const v = (obj as Record<string, unknown>)[f];
+    expect(v).toBeDefined();
+  }
+}
+
+export function assertEqualsForKeys(
+  obj: unknown,
+  expected: Record<string, unknown>,
+  keys: readonly string[],
+): void {
+  if (obj == null || typeof obj !== 'object') {
+    throw new Error('Response is not an object');
+  }
+  const rec = obj as Record<string, unknown>;
+  const hasOwn = Object.prototype.hasOwnProperty;
+
+  const fmt = (v: unknown): string => {
+    try {
+      return JSON.stringify(v);
+    } catch {
+      return String(v);
+    }
+  };
+
+  for (const k of keys) {
+    if (!hasOwn.call(rec, k)) {
+      throw new Error(`Missing key '${k}' on response object`);
+    }
+    if (!hasOwn.call(expected, k)) {
+      throw new Error(`Missing key '${k}' in expected values`);
+    }
+
+    const actual = rec[k];
+    const exp = expected[k];
+
+    const bothObjects =
+      actual !== null &&
+      typeof actual === 'object' &&
+      exp !== null &&
+      typeof exp === 'object';
+
+    const equal = bothObjects
+      ? fmt(actual) === fmt(exp)
+      : Object.is(actual, exp);
+
+    if (!equal) {
+      throw new Error(
+        `Value mismatch for key '${k}': actual=${fmt(actual)} expected=${fmt(exp)}`,
+      );
+    }
+  }
+}
+
+export function jsonHeaders(): Record<string, string> {
+  return {
+    'Content-Type': 'application/json',
+    ...authHeaders(credentials.accessToken),
+  };
+}
+
+export function octetStreamHeaders(token?: string): Record<string, string> {
+  return {Accept: 'application/octet-stream', ...authHeaders(token)};
+}
+
+export function buildUrl(
+  pathTemplate: string, // e.g., "/tenants/{tenantId}"
+  params?: Record<string, string | number | undefined>,
+  query?: Record<string, string | number | undefined>,
+): string {
+  const version: string = 'v2';
+  const base = credentials.baseUrl;
+  let url = `${base}/${version}${pathTemplate}`.replace(
+    /\{(\w+)\}/g,
+    (_, k) => {
+      const v = params?.[k];
+      return v == null ? '__MISSING_PARAM__' : String(v);
+    },
+  );
+  if (query) {
+    const q = Object.entries(query)
+      .filter(([, v]) => v !== undefined)
+      .map(
+        ([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(String(v))}`,
+      )
+      .join('&');
+    if (q) url += (url.includes('?') ? '&' : '?') + q;
+  }
+  return url;
+}
+
+export async function extractAndStoreIds(
+  resp: APIResponse,
+  state: Record<string, any>,
+) {
+  try {
+    const ct = resp.headers()['content-type'] || '';
+    if (!ct.includes('application/json')) return;
+    const data = await resp.json();
+
+    const consider = (o: any) => {
+      if (o && typeof o === 'object') {
+        for (const [k, v] of Object.entries(o)) {
+          if (
+            /(Id|Key|username|documentId|clientId|groupId|roleId|name|mappingRuleId|contentHash|description|claimName|claimValue)$/.test(
+              k,
+            )
+          ) {
+            state[k] = v;
+          }
+        }
+      }
+    };
+    Array.isArray(data) ? data.forEach(consider) : consider(data);
+
+    const loc = resp.headers()['location'] || resp.headers()['Location'];
+    if (loc) {
+      const parts = String(loc).split('/').filter(Boolean);
+      for (let i = 0; i < parts.length - 1; i++) {
+        const seg = parts[i];
+        const val = parts[i + 1];
+        if (/^\w[\w-]*$/.test(val)) {
+          const base = seg.replace(/s$/, '');
+          const key = `${base}Id`;
+          if (state[key] == null) state[key] = val;
+        }
+      }
+    }
+  } catch (error) {
+    console.error(
+      'Error occurred while parsing response to extract IDs' + error,
+    );
+  }
+}


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR includes changes API testing for `Groups` endpoint using [this specification.](https://docs.camunda.io/docs/next/apis-tools/orchestration-cluster-api-rest/specifications/create-group/)

[Here](https://github.com/camunda/camunda/actions/runs/17203416438/job/48798689971) is the test run.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
