### PR TITLE
[Backport stable/operate-8.5] ArchUnit rule to support both camelCase and kebab-case in ConditionalOnProperty

### DIFF
--- a/operate/archiver/src/main/java/io/camunda/operate/ArchiverModuleConfiguration.java
+++ b/operate/archiver/src/main/java/io/camunda/operate/ArchiverModuleConfiguration.java
@@ -33,7 +33,7 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
     basePackages = "io.camunda.operate.archiver",
     nameGenerator = FullyQualifiedAnnotationBeanNameGenerator.class)
 @ConditionalOnProperty(
-    name = "camunda.operate.archiverEnabled",
+    name = "camunda.operate.archiver-enabled",
     havingValue = "true",
     matchIfMissing = true)
 public class ArchiverModuleConfiguration {

--- a/operate/importer/src/main/java/io/camunda/operate/ImportModuleConfiguration.java
+++ b/operate/importer/src/main/java/io/camunda/operate/ImportModuleConfiguration.java
@@ -29,7 +29,7 @@ import org.springframework.context.annotation.FullyQualifiedAnnotationBeanNameGe
     basePackages = "io.camunda.operate.zeebeimport",
     nameGenerator = FullyQualifiedAnnotationBeanNameGenerator.class)
 @ConditionalOnProperty(
-    name = "camunda.operate.importerEnabled",
+    name = "camunda.operate.importer-enabled",
     havingValue = "true",
     matchIfMissing = true)
 public class ImportModuleConfiguration {

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/ElasticsearchChecks.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/ElasticsearchChecks.java
@@ -63,7 +63,7 @@ import org.springframework.context.annotation.Configuration;
 @Conditional(ElasticsearchCondition.class)
 @ConditionalOnProperty(
     prefix = OperateProperties.PREFIX,
-    name = "webappEnabled",
+    name = "webapp-enabled",
     havingValue = "true",
     matchIfMissing = true)
 public class ElasticsearchChecks {

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/OpensearchChecks.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/OpensearchChecks.java
@@ -62,7 +62,7 @@ import org.springframework.context.annotation.Configuration;
 @Conditional(OpensearchCondition.class)
 @ConditionalOnProperty(
     prefix = OperateProperties.PREFIX,
-    name = "webappEnabled",
+    name = "webapp-enabled",
     havingValue = "true",
     matchIfMissing = true)
 public class OpensearchChecks {

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/j5templates/SearchCheckPredicatesHolder.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/j5templates/SearchCheckPredicatesHolder.java
@@ -26,7 +26,7 @@ import org.springframework.stereotype.Component;
 @Component
 @ConditionalOnProperty(
     prefix = OperateProperties.PREFIX,
-    name = "webappEnabled",
+    name = "webapp-enabled",
     havingValue = "true",
     matchIfMissing = true)
 public class SearchCheckPredicatesHolder {

--- a/operate/webapp/src/main/java/io/camunda/operate/WebappModuleConfiguration.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/WebappModuleConfiguration.java
@@ -29,7 +29,7 @@ import org.springframework.context.annotation.FullyQualifiedAnnotationBeanNameGe
     basePackages = "io.camunda.operate.webapp",
     nameGenerator = FullyQualifiedAnnotationBeanNameGenerator.class)
 @ConditionalOnProperty(
-    name = "camunda.operate.webappEnabled",
+    name = "camunda.operate.webapp-enabled",
     havingValue = "true",
     matchIfMissing = true)
 public class WebappModuleConfiguration {

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/security/identity/IdentityConfigurer.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/security/identity/IdentityConfigurer.java
@@ -33,7 +33,7 @@ public class IdentityConfigurer {
   @Profile(OperateProfileService.SSO_AUTH_PROFILE)
   @ConditionalOnProperty(
       prefix = OperateProperties.PREFIX,
-      name = "identity.resourcePermissionsEnabled",
+      name = "identity.resource-permissions-enabled",
       havingValue = "true")
   public Identity getSaaSIdentity(final OperateProperties operateProperties) {
     return new Identity(


### PR DESCRIPTION
# Description
Backport of #36872 to `stable/operate-8.5`.

Note that this is not a full backport. It does not copy the ArchUnit rule, but it does apply the associated bug fix.

relates to #36869