### PR TITLE
[Backport stable/8.6] test: disable ExporterDisableTest. exporterStaysDisabledAfterRestart

### DIFF
--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/exporter/ExporterDisableTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/exporter/ExporterDisableTest.java
@@ -26,6 +26,7 @@ import io.camunda.zeebe.test.util.record.RecordingExporter;
 import java.time.Duration;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
@@ -97,6 +98,7 @@ final class ExporterDisableTest {
   }
 
   @Test
+  @Disabled("https://github.com/camunda/camunda/issues/37046")
   void exporterStaysDisabledAfterRestart() {
     // given
     generateEventsOnAllPartitions();


### PR DESCRIPTION
# Description
Backport of #37047 to `stable/8.6`.

relates to camunda/camunda#37046 camunda/camunda#37046