### PR TITLE
Integrate Quality Board action for bug issues

### DIFF
--- a/.github/workflows/add-to-projects.yml
+++ b/.github/workflows/add-to-projects.yml
@@ -100,9 +100,8 @@ jobs:
           # any of the following labels:
           labeled: component/clients, component/spring-sdk, component/camunda-process-test, component/c8-api
       - id: add-to-qualityboard
-        name: Add to Quality Board project
-        uses: actions/add-to-project@v1.0.2
+        name: Add Bugs to Quality Board project
+        uses: camunda/team-qa-engineering/automation/actions/add-to-quality-board@v1
         with:
-          project-url: https://github.com/orgs/camunda/projects/187
           github-token: ${{ secrets.GH_PROJECT_AUTOMATION_TOKEN }}
-          labeled: kind/bug
+        if: contains(github.event.issue.labels.*.name, 'kind/bug')


### PR DESCRIPTION
This PR adds the new action to add issues with label kind/bug to the Quality Board project, in parallel to existing project assignments. In addition to adding the issue to a project it also extracts component and severity labels to use them as custom fields in the Quality Board. The action is hosted and maintained by thr QA Engineering team  https://github.com/camunda/team-qa-engineering/tree/main/automation/actions/add-to-quality-board