### PR TITLE
Allow to filter process instances by tags filter

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/ProcessInstanceFilterBase.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/ProcessInstanceFilterBase.java
@@ -27,6 +27,7 @@ import io.camunda.client.api.search.request.TypedFilterableRequest.SearchRequest
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Consumer;
 
 public interface ProcessInstanceFilterBase extends SearchRequestFilter {
@@ -148,4 +149,10 @@ public interface ProcessInstanceFilterBase extends SearchRequestFilter {
 
   /** Filter by incidentErrorHashCode using {@link IntegerProperty} */
   ProcessInstanceFilterBase incidentErrorHashCode(final Consumer<IntegerProperty> fn);
+
+  /** Filter by tags */
+  ProcessInstanceFilterBase tags(final Set<String> tags);
+
+  /** Filter by tags */
+  ProcessInstanceFilterBase tags(final String... tags);
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/ProcessInstanceFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/ProcessInstanceFilterImpl.java
@@ -34,10 +34,14 @@ import io.camunda.client.impl.search.filter.builder.ProcessInstanceStateProperty
 import io.camunda.client.impl.search.filter.builder.StringPropertyImpl;
 import io.camunda.client.impl.search.request.TypedSearchRequestPropertyProvider;
 import io.camunda.client.impl.util.ProcessInstanceFilterMapper;
+import io.camunda.client.impl.util.TagUtil;
 import io.camunda.client.protocol.rest.ProcessInstanceFilterFields;
 import java.time.OffsetDateTime;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Consumer;
 
 public class ProcessInstanceFilterImpl
@@ -337,6 +341,18 @@ public class ProcessInstanceFilterImpl
       filter.add$OrItem(protocolFilterFields);
     }
     return this;
+  }
+
+  @Override
+  public ProcessInstanceFilterBase tags(final Set<String> tags) {
+    TagUtil.ensureValidTags("tags", tags);
+    filter.setTags(tags);
+    return this;
+  }
+
+  @Override
+  public ProcessInstanceFilterBase tags(final String... tags) {
+    return tags(new HashSet<>(Arrays.asList(tags)));
   }
 
   @Override

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceSearchWithTagsTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceSearchWithTagsTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.client;
+
+import static io.camunda.it.util.TestHelper.deployProcessAndWaitForIt;
+import static io.camunda.it.util.TestHelper.startProcessInstanceWithTags;
+import static io.camunda.it.util.TestHelper.waitForProcessInstancesToStart;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.response.ProcessInstanceEvent;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+
+@MultiDbTest
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms")
+public class ProcessInstanceSearchWithTagsTest {
+
+  private static CamundaClient client;
+  private static final List<ProcessInstanceEvent> PROCESS_INSTANCES = new ArrayList<>();
+
+  @BeforeAll
+  public static void setUp() {
+    final var process =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .serviceTask("my-task", t -> t.zeebeJobType("my-job"))
+            .endEvent()
+            .done();
+    deployProcessAndWaitForIt(client, process, "process.bpmn");
+
+    PROCESS_INSTANCES.add(startProcessInstanceWithTags(client, "process", Set.of("a", "b", "c")));
+    PROCESS_INSTANCES.add(startProcessInstanceWithTags(client, "process", Set.of("a", "b")));
+    PROCESS_INSTANCES.add(startProcessInstanceWithTags(client, "process", Set.of("a", "c")));
+    waitForProcessInstancesToStart(client, PROCESS_INSTANCES.size());
+  }
+
+  @AfterAll
+  static void afterAll() {
+    PROCESS_INSTANCES.clear();
+  }
+
+  @Test
+  void shouldReturnProcessInstancesWithMatchingTag() {
+    final var result =
+        client.newProcessInstanceSearchRequest().filter(f -> f.tags("a")).send().join();
+
+    assertThat(result.items())
+        .hasSize(3)
+        .allSatisfy(
+            item -> {
+              assertThat(item.getTags()).contains("a");
+            });
+  }
+
+  @Test
+  void shouldReturnNoProcessInstancesWithNotMatchingTags() {
+    final var result =
+        client.newProcessInstanceSearchRequest().filter(f -> f.tags("a", "d")).send().join();
+
+    assertThat(result.items()).isEmpty();
+  }
+
+  @Test
+  void shouldReturnProcessInstancesWithMatchingTags() {
+    final var result =
+        client.newProcessInstanceSearchRequest().filter(f -> f.tags("a", "b")).send().join();
+
+    assertThat(result.items())
+        .hasSize(2)
+        .allSatisfy(
+            item -> {
+              assertThat(item.getTags()).contains("a", "b");
+            });
+  }
+
+  @Test
+  void shouldReturnProcessInstancesWithMatchingTagsAndOtherFilter() {
+    final var result =
+        client
+            .newProcessInstanceSearchRequest()
+            .filter(f -> f.tags("a", "c").processDefinitionId("process"))
+            .send()
+            .join();
+
+    assertThat(result.items()).isNotEmpty();
+    assertThat(result.items())
+        .hasSize(2)
+        .allSatisfy(
+            item -> {
+              assertThat(item.getTags()).contains("a", "c");
+              assertThat(item.getProcessDefinitionId()).isEqualTo("process");
+            });
+  }
+
+  @Test
+  void shouldReturnNoProcessInstancesWithNotMatchingTagsAndOtherFilter() {
+    final var processInstanceKey = PROCESS_INSTANCES.getFirst().getProcessInstanceKey();
+    final var result =
+        client
+            .newProcessInstanceSearchRequest()
+            .filter(f -> f.tags("a", "c").processDefinitionId("otherProcess"))
+            .send()
+            .join();
+
+    assertThat(result.items()).isEmpty();
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/util/TestHelper.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/util/TestHelper.java
@@ -165,6 +165,17 @@ public final class TestHelper {
         .join();
   }
 
+  public static ProcessInstanceEvent startProcessInstanceWithTags(
+      final CamundaClient camundaClient, final String bpmnProcessId, final Set<String> tags) {
+    return camundaClient
+        .newCreateInstanceCommand()
+        .bpmnProcessId(bpmnProcessId)
+        .latestVersion()
+        .tags(tags)
+        .send()
+        .join();
+  }
+
   public static ProcessInstanceEvent startProcessInstance(
       final CamundaClient camundaClient, final String bpmnProcessId, final String payload) {
     final CreateProcessInstanceCommandStep1.CreateProcessInstanceCommandStep3

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/ProcessInstanceFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/ProcessInstanceFilterTransformer.java
@@ -30,6 +30,7 @@ import static io.camunda.webapps.schema.descriptors.template.ListViewTemplate.PR
 import static io.camunda.webapps.schema.descriptors.template.ListViewTemplate.PROCESS_VERSION_TAG;
 import static io.camunda.webapps.schema.descriptors.template.ListViewTemplate.START_DATE;
 import static io.camunda.webapps.schema.descriptors.template.ListViewTemplate.STATE;
+import static io.camunda.webapps.schema.descriptors.template.ListViewTemplate.TAGS;
 import static java.util.Optional.ofNullable;
 
 import io.camunda.search.clients.query.SearchQuery;
@@ -95,6 +96,10 @@ public final class ProcessInstanceFilterTransformer
 
     if (filter.partitionId() != null) {
       queries.add(term(PARTITION_ID, filter.partitionId()));
+    }
+
+    if (filter.tags() != null && !filter.tags().isEmpty()) {
+      queries.add(and(filter.tags().stream().map(tag -> term(TAGS, tag)).toList()));
     }
 
     return queries;

--- a/search/search-domain/src/main/java/io/camunda/search/filter/ProcessInstanceFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/ProcessInstanceFilter.java
@@ -17,6 +17,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 
 public record ProcessInstanceFilter(
     List<Operation<Long>> processInstanceKeyOperations,
@@ -41,6 +42,7 @@ public record ProcessInstanceFilter(
     List<Operation<String>> flowNodeInstanceStateOperations,
     List<Operation<Integer>> incidentErrorHashCodeOperations,
     Integer partitionId,
+    Set<String> tags,
     List<ProcessInstanceFilter> orFilters)
     implements FilterBase {
 
@@ -64,6 +66,7 @@ public record ProcessInstanceFilter(
         .errorMessageOperations(errorMessageOperations)
         .incidentErrorHashCodeOperations(incidentErrorHashCodeOperations)
         .partitionId(partitionId)
+        .tags(tags)
         .orFilters(orFilters);
   }
 
@@ -91,6 +94,7 @@ public record ProcessInstanceFilter(
     private List<Operation<String>> flowNodeInstanceStateOperations;
     private List<Operation<Integer>> incidentErrorHashCodeOperations;
     private Integer partitionId;
+    private Set<String> tags;
     private List<ProcessInstanceFilter> orFilters;
 
     public Builder processInstanceKeyOperations(final List<Operation<Long>> operations) {
@@ -378,6 +382,11 @@ public record ProcessInstanceFilter(
       return this;
     }
 
+    public Builder tags(final Set<String> value) {
+      tags = value;
+      return this;
+    }
+
     public Builder addOrOperation(final ProcessInstanceFilter orOperation) {
       if (orFilters == null) {
         orFilters = new ArrayList<>();
@@ -417,6 +426,7 @@ public record ProcessInstanceFilter(
           Objects.requireNonNullElse(flowNodeInstanceStateOperations, Collections.emptyList()),
           Objects.requireNonNullElse(incidentErrorHashCodeOperations, Collections.emptyList()),
           partitionId,
+          Objects.requireNonNullElse(tags, Collections.emptySet()),
           orFilters);
     }
   }

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -6460,6 +6460,8 @@ components:
           description: The process definition key.
           allOf:
             - $ref: "#/components/schemas/BasicStringFilterProperty"
+        tags:
+          $ref: '#/components/schemas/TagSet'
     ProcessInstanceFilter:
       description: Process instance search filter.
       allOf:

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
@@ -91,6 +91,7 @@ import io.camunda.zeebe.gateway.protocol.rest.*;
 import io.camunda.zeebe.gateway.rest.util.KeyUtil;
 import io.camunda.zeebe.gateway.rest.util.ProcessInstanceStateConverter;
 import io.camunda.zeebe.gateway.rest.validator.RequestValidator;
+import io.camunda.zeebe.gateway.rest.validator.TagsValidator;
 import io.camunda.zeebe.protocol.record.value.EntityType;
 import io.camunda.zeebe.util.Either;
 import jakarta.validation.constraints.NotNull;
@@ -1038,6 +1039,16 @@ public final class SearchQueryRequestMapper {
       ofNullable(filter.getIncidentErrorHashCode())
           .map(mapToOperations(Integer.class))
           .ifPresent(builder::incidentErrorHashCodeOperations);
+
+      if (!CollectionUtils.isEmpty(filter.getTags())) {
+        final var tagErrors = TagsValidator.validate(filter.getTags());
+        if (tagErrors.isEmpty()) {
+          ofNullable(filter.getTags()).ifPresent(builder::tags);
+        } else {
+          validationErrors.addAll(tagErrors);
+        }
+      }
+
       if (!CollectionUtils.isEmpty(filter.getVariables())) {
         final Either<List<String>, List<VariableValueFilter>> either =
             toVariableValueFilters(filter.getVariables());

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/ProcessInstanceRequestValidator.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/ProcessInstanceRequestValidator.java
@@ -57,7 +57,7 @@ public class ProcessInstanceRequestValidator {
   }
 
   private static void validateTags(final Set<String> tags, final List<String> violations) {
-    TagsValidator.validate(tags, violations);
+    violations.addAll(TagsValidator.validate(tags));
   }
 
   public static Optional<ProblemDetail> validateCancelProcessInstanceRequest(

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/TagsValidator.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/TagsValidator.java
@@ -11,26 +11,28 @@ import static io.camunda.zeebe.gateway.rest.validator.ErrorMessages.ERROR_MESSAG
 import static io.camunda.zeebe.gateway.rest.validator.ErrorMessages.ERROR_MESSAGE_INVALID_TAG_FORMAT;
 
 import io.camunda.zeebe.util.TagUtil;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
 public class TagsValidator {
 
-  public static void validate(final Set<String> tags, final List<String> violations) {
+  public static List<String> validate(final Set<String> tags) {
+    final List<String> errors = new ArrayList<>();
     if (tags == null || tags.isEmpty()) {
-      return;
+      return errors;
     }
 
     if (tags.size() > TagUtil.MAX_NUMBER_OF_TAGS) {
-      violations.add(
+      errors.add(
           ERROR_MESSAGE_INVALID_TAGS_COUNT.formatted(tags.size(), TagUtil.MAX_NUMBER_OF_TAGS));
     }
 
     for (final String tag : tags) {
       if (!TagUtil.isValidTag(tag)) {
-        violations.add(
-            ERROR_MESSAGE_INVALID_TAG_FORMAT.formatted(tag, TagUtil.TAG_FORMAT_DESCRIPTION));
+        errors.add(ERROR_MESSAGE_INVALID_TAG_FORMAT.formatted(tag, TagUtil.TAG_FORMAT_DESCRIPTION));
       }
     }
+    return errors;
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceQueryControllerTest.java
@@ -793,4 +793,29 @@ public class ProcessInstanceQueryControllerTest extends RestControllerTest {
     // Verify that the service was called with the valid key
     verify(processInstanceServices).callHierarchy(processInstanceKey);
   }
+
+  @Test
+  void shouldReturnBadRequestWhenTagsAreInvalid() {
+    // given
+    final var request =
+        """
+            {
+                "filter": { "tags": ["1 invalid tag", "tag2"] }
+            }""";
+
+    // when / then
+    webClient
+        .post()
+        .uri(PROCESS_INSTANCES_SEARCH_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isBadRequest()
+        .expectBody()
+        .consumeWith(
+            result ->
+                new String(result.getResponseBody()).contains("Tags must start with a letter"));
+  }
 }


### PR DESCRIPTION
## Description

This PR allows filtering process instances by tags. It filters all process instances that contain at least ALL GIVEN tags in the filter object.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes https://github.com/camunda/camunda/issues/36952
