### PR TITLE
Fixing flaky `shouldInitializeIdentitySetup` test

### DIFF
--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/startup/IdentitySetupOnStartupTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/startup/IdentitySetupOnStartupTest.java
@@ -25,7 +25,7 @@ import org.springframework.util.unit.DataSize;
 final class IdentitySetupOnStartupTest {
 
   @Test
-  @Timeout(unit = TimeUnit.SECONDS, value = 30)
+  @Timeout(unit = TimeUnit.SECONDS, value = 60)
   void shouldInitializeIdentitySetup() {
     try (final LogCapturer logCapturer = new LogCapturer(Loggers.PROCESSOR_LOGGER.getName());
         final TestCluster cluster =
@@ -46,7 +46,8 @@ final class IdentitySetupOnStartupTest {
                       cfg.brokerConfig().getProcessing().setMaxCommandsInBatch(100);
                     })
                 .build()
-                .start()) {
+                .start()
+                .awaitCompleteTopology()) {
 
       Assertions.assertThat(
               RecordingExporter.identitySetupRecords(IdentitySetupIntent.INITIALIZED).getFirst())


### PR DESCRIPTION
## Description

As `shouldInitializeIdentitySetup` is flaky, the following changes were made in order to make it more stable:

1. Extending timeout to 60 sec in to accommodate for slow CI
2. Adding `awaitCompleteTopology` to make sure assertions are executed when the cluster is ready

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
