### PR TITLE
fix: adapt SaaS/SM role permissions to spec 

### DIFF
--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/saas/StaticEntities.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/saas/StaticEntities.java
@@ -81,6 +81,12 @@ public class StaticEntities {
               "*",
               AuthorizationResourceType.BATCH,
               Set.of(PermissionType.CREATE, PermissionType.READ, PermissionType.UPDATE)),
+          new CreateAuthorizationRequest(
+              DEVELOPER_ROLE_ID,
+              AuthorizationOwnerType.ROLE,
+              "*",
+              AuthorizationResourceType.MESSAGE,
+              Set.of(PermissionType.READ)),
           // OPERATIONS ENGINEER
           new CreateAuthorizationRequest(
               OPERATIONS_ENGINEER_ROLE_ID,
@@ -94,10 +100,12 @@ public class StaticEntities {
               "*",
               AuthorizationResourceType.PROCESS_DEFINITION,
               Set.of(
+                  PermissionType.CREATE_PROCESS_INSTANCE,
                   PermissionType.READ_PROCESS_DEFINITION,
                   PermissionType.READ_PROCESS_INSTANCE,
                   PermissionType.UPDATE_PROCESS_INSTANCE,
-                  PermissionType.CREATE_PROCESS_INSTANCE,
+                  PermissionType.MODIFY_PROCESS_INSTANCE,
+                  PermissionType.CANCEL_PROCESS_INSTANCE,
                   PermissionType.DELETE_PROCESS_INSTANCE)),
           new CreateAuthorizationRequest(
               OPERATIONS_ENGINEER_ROLE_ID,
@@ -129,6 +137,12 @@ public class StaticEntities {
               "*",
               AuthorizationResourceType.BATCH,
               Set.of(PermissionType.CREATE, PermissionType.READ, PermissionType.UPDATE)),
+          new CreateAuthorizationRequest(
+              OPERATIONS_ENGINEER_ROLE_ID,
+              AuthorizationOwnerType.ROLE,
+              "*",
+              AuthorizationResourceType.MESSAGE,
+              Set.of(PermissionType.READ)),
           // TASK USER
           new CreateAuthorizationRequest(
               TASK_USER_ROLE_ID,
@@ -186,6 +200,18 @@ public class StaticEntities {
               AuthorizationOwnerType.ROLE,
               "*",
               AuthorizationResourceType.BATCH,
+              Set.of(PermissionType.READ)),
+          new CreateAuthorizationRequest(
+              VISITOR_ROLE_ID,
+              AuthorizationOwnerType.ROLE,
+              "*",
+              AuthorizationResourceType.MESSAGE,
+              Set.of(PermissionType.READ)),
+          new CreateAuthorizationRequest(
+              VISITOR_ROLE_ID,
+              AuthorizationOwnerType.ROLE,
+              "*",
+              AuthorizationResourceType.RESOURCE,
               Set.of(PermissionType.READ)));
 
   public static List<CreateAuthorizationRequest> getZeebeClientPermissions(final String clientId) {

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/sm/StaticEntities.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/sm/StaticEntities.java
@@ -208,17 +208,22 @@ public class StaticEntities {
                         AuthorizationResourceType.RESOURCE,
                         Set.of(
                             PermissionType.READ,
+                            PermissionType.DELETE_DRD,
+                            PermissionType.DELETE_FORM,
                             PermissionType.DELETE_PROCESS,
-                            PermissionType.DELETE_DRD)),
+                            PermissionType.DELETE_RESOURCE)),
                     new CreateAuthorizationRequest(
                         ownerId,
                         ownerType,
                         "*",
                         AuthorizationResourceType.PROCESS_DEFINITION,
                         Set.of(
+                            PermissionType.CREATE_PROCESS_INSTANCE,
                             PermissionType.READ_PROCESS_DEFINITION,
                             PermissionType.READ_PROCESS_INSTANCE,
                             PermissionType.UPDATE_PROCESS_INSTANCE,
+                            PermissionType.MODIFY_PROCESS_INSTANCE,
+                            PermissionType.CANCEL_PROCESS_INSTANCE,
                             PermissionType.DELETE_PROCESS_INSTANCE)),
                     new CreateAuthorizationRequest(
                         ownerId,

--- a/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/saas/StaticConsoleRoleAuthorizationMigrationHandlerTest.java
+++ b/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/saas/StaticConsoleRoleAuthorizationMigrationHandlerTest.java
@@ -55,7 +55,7 @@ public class StaticConsoleRoleAuthorizationMigrationHandlerTest {
     migrationHandler.migrate();
 
     final var results = ArgumentCaptor.forClass(CreateAuthorizationRequest.class);
-    verify(authorizationServices, times(21)).createAuthorization(results.capture());
+    verify(authorizationServices, times(26)).createAuthorization(results.capture());
     final var requests = results.getAllValues();
     assertThat(requests).containsExactlyElementsOf(ROLE_PERMISSIONS);
   }
@@ -75,6 +75,6 @@ public class StaticConsoleRoleAuthorizationMigrationHandlerTest {
     migrationHandler.migrate();
 
     // then
-    verify(authorizationServices, times(22)).createAuthorization(any());
+    verify(authorizationServices, times(26)).createAuthorization(any());
   }
 }

--- a/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/sm/ClientMigrationHandlerTest.java
+++ b/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/sm/ClientMigrationHandlerTest.java
@@ -163,12 +163,14 @@ public class ClientMigrationHandlerTest {
                 "*",
                 AuthorizationResourceType.PROCESS_DEFINITION,
                 Set.of(
-                    PermissionType.UPDATE_USER_TASK,
-                    PermissionType.DELETE_PROCESS_INSTANCE,
-                    PermissionType.UPDATE_PROCESS_INSTANCE,
                     PermissionType.CREATE_PROCESS_INSTANCE,
+                    PermissionType.READ_PROCESS_DEFINITION,
                     PermissionType.READ_PROCESS_INSTANCE,
-                    PermissionType.READ_PROCESS_DEFINITION)),
+                    PermissionType.UPDATE_PROCESS_INSTANCE,
+                    PermissionType.UPDATE_USER_TASK,
+                    PermissionType.MODIFY_PROCESS_INSTANCE,
+                    PermissionType.CANCEL_PROCESS_INSTANCE,
+                    PermissionType.DELETE_PROCESS_INSTANCE)),
             tuple(
                 "ClientTwo",
                 AuthorizationOwnerType.CLIENT,

--- a/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/sm/KeycloakRoleMigrationHandlerTest.java
+++ b/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/sm/KeycloakRoleMigrationHandlerTest.java
@@ -167,7 +167,11 @@ public class KeycloakRoleMigrationHandlerTest {
                 AuthorizationOwnerType.ROLE,
                 AuthorizationResourceType.RESOURCE,
                 Set.of(
-                    PermissionType.READ, PermissionType.DELETE_PROCESS, PermissionType.DELETE_DRD)),
+                    PermissionType.READ,
+                    PermissionType.DELETE_PROCESS,
+                    PermissionType.DELETE_DRD,
+                    PermissionType.DELETE_FORM,
+                    PermissionType.DELETE_RESOURCE)),
             tuple(
                 "role_1",
                 AuthorizationOwnerType.ROLE,
@@ -178,10 +182,13 @@ public class KeycloakRoleMigrationHandlerTest {
                 AuthorizationOwnerType.ROLE,
                 AuthorizationResourceType.PROCESS_DEFINITION,
                 Set.of(
+                    PermissionType.CREATE_PROCESS_INSTANCE,
                     PermissionType.READ_PROCESS_DEFINITION,
                     PermissionType.READ_PROCESS_INSTANCE,
-                    PermissionType.DELETE_PROCESS_INSTANCE,
-                    PermissionType.UPDATE_PROCESS_INSTANCE)),
+                    PermissionType.UPDATE_PROCESS_INSTANCE,
+                    PermissionType.MODIFY_PROCESS_INSTANCE,
+                    PermissionType.CANCEL_PROCESS_INSTANCE,
+                    PermissionType.DELETE_PROCESS_INSTANCE)),
             tuple(
                 "role_1",
                 AuthorizationOwnerType.ROLE,

--- a/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/sm/OidcRoleMigrationHandlerTest.java
+++ b/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/sm/OidcRoleMigrationHandlerTest.java
@@ -171,7 +171,11 @@ public class OidcRoleMigrationHandlerTest {
                 AuthorizationOwnerType.ROLE,
                 AuthorizationResourceType.RESOURCE,
                 Set.of(
-                    PermissionType.READ, PermissionType.DELETE_PROCESS, PermissionType.DELETE_DRD)),
+                    PermissionType.READ,
+                    PermissionType.DELETE_PROCESS,
+                    PermissionType.DELETE_DRD,
+                    PermissionType.DELETE_FORM,
+                    PermissionType.DELETE_RESOURCE)),
             tuple(
                 "role_1",
                 AuthorizationOwnerType.ROLE,
@@ -182,10 +186,13 @@ public class OidcRoleMigrationHandlerTest {
                 AuthorizationOwnerType.ROLE,
                 AuthorizationResourceType.PROCESS_DEFINITION,
                 Set.of(
+                    PermissionType.CREATE_PROCESS_INSTANCE,
                     PermissionType.READ_PROCESS_DEFINITION,
                     PermissionType.READ_PROCESS_INSTANCE,
-                    PermissionType.DELETE_PROCESS_INSTANCE,
-                    PermissionType.UPDATE_PROCESS_INSTANCE)),
+                    PermissionType.UPDATE_PROCESS_INSTANCE,
+                    PermissionType.MODIFY_PROCESS_INSTANCE,
+                    PermissionType.CANCEL_PROCESS_INSTANCE,
+                    PermissionType.DELETE_PROCESS_INSTANCE)),
             tuple(
                 "role_1",
                 AuthorizationOwnerType.ROLE,
@@ -489,7 +496,11 @@ public class OidcRoleMigrationHandlerTest {
                 AuthorizationOwnerType.ROLE,
                 AuthorizationResourceType.RESOURCE,
                 Set.of(
-                    PermissionType.READ, PermissionType.DELETE_PROCESS, PermissionType.DELETE_DRD)),
+                    PermissionType.READ,
+                    PermissionType.DELETE_PROCESS,
+                    PermissionType.DELETE_DRD,
+                    PermissionType.DELETE_FORM,
+                    PermissionType.DELETE_RESOURCE)),
             tuple(
                 "role_1",
                 AuthorizationOwnerType.ROLE,
@@ -500,10 +511,13 @@ public class OidcRoleMigrationHandlerTest {
                 AuthorizationOwnerType.ROLE,
                 AuthorizationResourceType.PROCESS_DEFINITION,
                 Set.of(
+                    PermissionType.CREATE_PROCESS_INSTANCE,
                     PermissionType.READ_PROCESS_DEFINITION,
                     PermissionType.READ_PROCESS_INSTANCE,
-                    PermissionType.DELETE_PROCESS_INSTANCE,
-                    PermissionType.UPDATE_PROCESS_INSTANCE)),
+                    PermissionType.UPDATE_PROCESS_INSTANCE,
+                    PermissionType.MODIFY_PROCESS_INSTANCE,
+                    PermissionType.CANCEL_PROCESS_INSTANCE,
+                    PermissionType.DELETE_PROCESS_INSTANCE)),
             tuple(
                 "role_1",
                 AuthorizationOwnerType.ROLE,

--- a/qa/migration-tests/src/test/java/io/camunda/it/migration/KeycloakIdentityMigrationIT.java
+++ b/qa/migration-tests/src/test/java/io/camunda/it/migration/KeycloakIdentityMigrationIT.java
@@ -261,7 +261,11 @@ public class KeycloakIdentityMigrationIT {
                 "operate",
                 ResourceType.RESOURCE,
                 Set.of(
-                    PermissionType.READ, PermissionType.DELETE_PROCESS, PermissionType.DELETE_DRD)),
+                    PermissionType.READ,
+                    PermissionType.DELETE_PROCESS,
+                    PermissionType.DELETE_DRD,
+                    PermissionType.DELETE_FORM,
+                    PermissionType.DELETE_RESOURCE)),
             tuple(
                 "operate",
                 ResourceType.DECISION_DEFINITION,
@@ -279,10 +283,13 @@ public class KeycloakIdentityMigrationIT {
                 "operate",
                 ResourceType.PROCESS_DEFINITION,
                 Set.of(
+                    PermissionType.CREATE_PROCESS_INSTANCE,
                     PermissionType.READ_PROCESS_DEFINITION,
-                    PermissionType.DELETE_PROCESS_INSTANCE,
+                    PermissionType.READ_PROCESS_INSTANCE,
                     PermissionType.UPDATE_PROCESS_INSTANCE,
-                    PermissionType.READ_PROCESS_INSTANCE)),
+                    PermissionType.MODIFY_PROCESS_INSTANCE,
+                    PermissionType.CANCEL_PROCESS_INSTANCE,
+                    PermissionType.DELETE_PROCESS_INSTANCE)),
             tuple(
                 "operate",
                 ResourceType.BATCH,

--- a/qa/migration-tests/src/test/java/io/camunda/it/migration/OidcIdentityMigrationIT.java
+++ b/qa/migration-tests/src/test/java/io/camunda/it/migration/OidcIdentityMigrationIT.java
@@ -228,7 +228,11 @@ public class OidcIdentityMigrationIT {
                 "operate",
                 ResourceType.RESOURCE,
                 Set.of(
-                    PermissionType.READ, PermissionType.DELETE_PROCESS, PermissionType.DELETE_DRD)),
+                    PermissionType.READ,
+                    PermissionType.DELETE_PROCESS,
+                    PermissionType.DELETE_DRD,
+                    PermissionType.DELETE_FORM,
+                    PermissionType.DELETE_RESOURCE)),
             tuple(
                 "operate",
                 ResourceType.DECISION_DEFINITION,
@@ -246,10 +250,13 @@ public class OidcIdentityMigrationIT {
                 "operate",
                 ResourceType.PROCESS_DEFINITION,
                 Set.of(
+                    PermissionType.CREATE_PROCESS_INSTANCE,
                     PermissionType.READ_PROCESS_DEFINITION,
-                    PermissionType.DELETE_PROCESS_INSTANCE,
+                    PermissionType.READ_PROCESS_INSTANCE,
                     PermissionType.UPDATE_PROCESS_INSTANCE,
-                    PermissionType.READ_PROCESS_INSTANCE)),
+                    PermissionType.MODIFY_PROCESS_INSTANCE,
+                    PermissionType.CANCEL_PROCESS_INSTANCE,
+                    PermissionType.DELETE_PROCESS_INSTANCE)),
             tuple(
                 "operate",
                 ResourceType.BATCH,

--- a/qa/migration-tests/src/test/java/io/camunda/it/migration/SaaSIdentityMigrationIT.java
+++ b/qa/migration-tests/src/test/java/io/camunda/it/migration/SaaSIdentityMigrationIT.java
@@ -275,7 +275,7 @@ public class SaaSIdentityMigrationIT {
   }
 
   @Test
-  public void canMigratePermissions() throws URISyntaxException, IOException, InterruptedException {
+  public void canMigratePermissions() {
     // when
     migration.start();
 
@@ -370,6 +370,12 @@ public class SaaSIdentityMigrationIT {
                 ResourceType.BATCH,
                 Set.of(PermissionType.CREATE, PermissionType.READ, PermissionType.UPDATE)),
             tuple(
+                DEVELOPER_ROLE_ID,
+                OwnerType.ROLE,
+                "*",
+                ResourceType.MESSAGE,
+                Set.of(PermissionType.READ)),
+            tuple(
                 OPERATIONS_ENGINEER_ROLE_ID,
                 OwnerType.ROLE,
                 "operate",
@@ -381,10 +387,12 @@ public class SaaSIdentityMigrationIT {
                 "*",
                 ResourceType.PROCESS_DEFINITION,
                 Set.of(
+                    PermissionType.CREATE_PROCESS_INSTANCE,
                     PermissionType.READ_PROCESS_DEFINITION,
                     PermissionType.READ_PROCESS_INSTANCE,
                     PermissionType.UPDATE_PROCESS_INSTANCE,
-                    PermissionType.CREATE_PROCESS_INSTANCE,
+                    PermissionType.MODIFY_PROCESS_INSTANCE,
+                    PermissionType.CANCEL_PROCESS_INSTANCE,
                     PermissionType.DELETE_PROCESS_INSTANCE)),
             tuple(
                 OPERATIONS_ENGINEER_ROLE_ID,
@@ -419,6 +427,12 @@ public class SaaSIdentityMigrationIT {
                 "*",
                 ResourceType.BATCH,
                 Set.of(PermissionType.CREATE, PermissionType.READ, PermissionType.UPDATE)),
+            tuple(
+                OPERATIONS_ENGINEER_ROLE_ID,
+                OwnerType.ROLE,
+                "*",
+                ResourceType.MESSAGE,
+                Set.of(PermissionType.READ)),
             tuple(
                 TASK_USER_ROLE_ID,
                 OwnerType.ROLE,
@@ -475,6 +489,18 @@ public class SaaSIdentityMigrationIT {
                 OwnerType.ROLE,
                 "*",
                 ResourceType.BATCH,
+                Set.of(PermissionType.READ)),
+            tuple(
+                VISITOR_ROLE_ID,
+                OwnerType.ROLE,
+                "*",
+                ResourceType.MESSAGE,
+                Set.of(PermissionType.READ)),
+            tuple(
+                VISITOR_ROLE_ID,
+                OwnerType.ROLE,
+                "*",
+                ResourceType.RESOURCE,
                 Set.of(PermissionType.READ)));
   }
 


### PR DESCRIPTION
## Description

This adapts the permission migration to be aligned with the current state of the spec:
* [SaaS permission mapping spec](https://docs.google.com/document/d/1XqG9Y9SXvakwcJ7ZheE8lgd6X0PMWSuyH4IbYTzLYeE/edit?pli=1&tab=t.0#heading=h.9od5xy5791xv)
* [SM permission mapping spec](https://docs.google.com/document/d/1XqG9Y9SXvakwcJ7ZheE8lgd6X0PMWSuyH4IbYTzLYeE/edit?pli=1&tab=t.0#bookmark=kix.lqp4lg18i3nl)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

