### PR TITLE
chore(mapper): add input and output insert methods

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/DecisionInstanceMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/DecisionInstanceMapper.java
@@ -16,6 +16,10 @@ public interface DecisionInstanceMapper extends ProcessBasedHistoryCleanupMapper
 
   void insert(DecisionInstanceDbModel decisionInstance);
 
+  void insertInput(DecisionInstanceDbModel decisionInstance);
+
+  void insertOutput(DecisionInstanceDbModel decisionInstance);
+
   Long count(DecisionInstanceDbQuery filter);
 
   List<DecisionInstanceEntity> search(DecisionInstanceDbQuery filter);


### PR DESCRIPTION
related to #37083

## Description
Adds insertion methods for input and outputs of decision instances to the decision instance mapper [to be used by C7  to C8 data migrator.](https://github.com/camunda/camunda-bpm-platform-maintenance/issues/1638)
Uses already existing insertInput and insertOutput queries from `DecisionInstanceMapper.xml`.
Input and output insertion methods already have some test coverage in `DecisionInstanceIT`. 


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #37083
