### PR TITLE
feat: add operate post importer queue size metric

### DIFF
--- a/operate/common/src/main/java/io/camunda/operate/Metrics.java
+++ b/operate/common/src/main/java/io/camunda/operate/Metrics.java
@@ -109,6 +109,14 @@ public class Metrics {
     Gauge.builder(name, gaugeSupplier).tags(tags).register(registry);
   }
 
+  public void registerGaugeSupplier(
+      final String name,
+      final String description,
+      final Supplier<Number> gaugeSupplier,
+      final String... tags) {
+    Gauge.builder(name, gaugeSupplier).tags(tags).description(description).register(registry);
+  }
+
   public <E> void registerGaugeQueueSize(
       final String name, final Queue<E> queue, final String... tags) {
     registerGauge(name, queue, q -> q.size(), tags);

--- a/operate/common/src/main/java/io/camunda/operate/Metrics.java
+++ b/operate/common/src/main/java/io/camunda/operate/Metrics.java
@@ -57,6 +57,8 @@ public class Metrics {
 
   // Gauges:
   public static final String GAUGE_IMPORT_QUEUE_SIZE = OPERATE_NAMESPACE + "import.queue.size";
+  public static final String GAUGE_POST_IMPORTER_QUEUE_SIZE =
+      OPERATE_NAMESPACE + "post.importer.queue.size";
   public static final String GAUGE_BPMN_MODEL_COUNT = OPERATE_NAMESPACE + "model.bpmn.count";
   public static final String GAUGE_DMN_MODEL_COUNT = OPERATE_NAMESPACE + "model.dmn.count";
 
@@ -114,6 +116,10 @@ public class Metrics {
 
   public Timer getTimer(final String name, final String... tags) {
     return registry.timer(name, tags);
+  }
+
+  public MeterRegistry getMeterRegistry() {
+    return registry;
   }
 
   public Timer getHistogram(final String name, final String... tags) {

--- a/operate/importer/pom.xml
+++ b/operate/importer/pom.xml
@@ -40,6 +40,11 @@
     </dependency>
 
     <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-util</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.elasticsearch</groupId>
       <artifactId>elasticsearch-core</artifactId>
     </dependency>

--- a/operate/importer/src/main/java/io/camunda/operate/zeebeimport/post/AbstractIncidentPostImportAction.java
+++ b/operate/importer/src/main/java/io/camunda/operate/zeebeimport/post/AbstractIncidentPostImportAction.java
@@ -18,11 +18,11 @@ import io.camunda.operate.property.OperateProperties;
 import io.camunda.operate.util.BackoffIdleStrategy;
 import io.camunda.operate.zeebe.ImportValueType;
 import io.camunda.operate.zeebeimport.ImportPositionHolder;
-import io.micrometer.core.instrument.Gauge;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -49,7 +49,7 @@ public abstract class AbstractIncidentPostImportAction implements PostImportActi
 
   protected ImportPositionEntity lastProcessedPosition;
   private final BackoffIdleStrategy errorStrategy;
-  private volatile long lastKnownQueueSize = 0;
+  private final AtomicLong lastKnownQueueSize = new AtomicLong(0);
 
   public AbstractIncidentPostImportAction(final int partitionId) {
     this.partitionId = partitionId;
@@ -57,19 +57,19 @@ public abstract class AbstractIncidentPostImportAction implements PostImportActi
   }
 
   protected void initializeMetrics() {
-    if (metrics != null) {
-      final var metricDoc = PostImporterMetricsDoc.PostImporterQueueSize.NAME;
-      final var description = PostImporterMetricsDoc.PostImporterQueueSize.DESCRIPTION;
+    final var metricDoc = PostImporterMetricsDoc.POST_IMPORTER_QUEUE_SIZE.getName();
+    final var description = PostImporterMetricsDoc.POST_IMPORTER_QUEUE_SIZE.getDescription();
 
-      Gauge.builder(metricDoc, () -> lastKnownQueueSize)
-          .description(description)
-          .tag(Metrics.TAG_KEY_PARTITION, String.valueOf(partitionId))
-          .register(metrics.getMeterRegistry());
-    }
+    metrics.registerGaugeSupplier(
+        metricDoc,
+        description,
+        () -> lastKnownQueueSize,
+        Metrics.TAG_KEY_PARTITION,
+        String.valueOf(partitionId));
   }
 
   protected void updateQueueSizeMetric(final long queueSize) {
-    lastKnownQueueSize = queueSize;
+    lastKnownQueueSize.set(queueSize);
   }
 
   @Override

--- a/operate/importer/src/main/java/io/camunda/operate/zeebeimport/post/PostImporterMetricsDoc.java
+++ b/operate/importer/src/main/java/io/camunda/operate/zeebeimport/post/PostImporterMetricsDoc.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.operate.zeebeimport.post;
+
+import io.camunda.operate.Metrics;
+
+/**
+ * Documentation for post importer metrics following the Camunda metrics guide.
+ *
+ * <p>This class serves as documentation for all metrics related to the post importer functionality,
+ * providing clear descriptions and usage guidelines for each metric.
+ */
+public final class PostImporterMetricsDoc {
+
+  private PostImporterMetricsDoc() {
+    // Utility class
+  }
+
+  /**
+   * Post importer queue size metric documentation.
+   *
+   * <p>This gauge metric tracks the current size of the post importer queue for each partition. It
+   * helps monitor if the post importer is stuck or overloaded, which is critical for operational
+   * monitoring.
+   *
+   * <p><strong>Use case:</strong> Quickly determine if the post importer is experiencing issues
+   * without requiring manual polling. This was identified as a need in support case SUPPORT-27255.
+   *
+   * <p><strong>Type:</strong> Gauge (current value at a specific moment)
+   *
+   * <p><strong>Tags:</strong>
+   *
+   * <ul>
+   *   <li>partition - The partition ID for which the queue size is measured
+   * </ul>
+   *
+   * <p><strong>Update frequency:</strong> Updated on each processing batch request when {@code
+   * getPendingIncidents()} is called.
+   *
+   * <p><strong>Alerting considerations:</strong> High values may indicate that the post importer is
+   * unable to keep up with the incoming incident processing workload.
+   */
+  public static final class PostImporterQueueSize {
+    public static final String NAME = Metrics.GAUGE_POST_IMPORTER_QUEUE_SIZE;
+    public static final String DESCRIPTION =
+        "Current size of the post importer queue for processing pending incidents";
+
+    private PostImporterQueueSize() {
+      // Utility class
+    }
+
+    public String getName() {
+      return NAME;
+    }
+
+    public String getDescription() {
+      return DESCRIPTION;
+    }
+  }
+}

--- a/operate/importer/src/main/java/io/camunda/operate/zeebeimport/post/PostImporterMetricsDoc.java
+++ b/operate/importer/src/main/java/io/camunda/operate/zeebeimport/post/PostImporterMetricsDoc.java
@@ -8,21 +8,18 @@
 package io.camunda.operate.zeebeimport.post;
 
 import io.camunda.operate.Metrics;
+import io.camunda.zeebe.util.micrometer.ExtendedMeterDocumentation;
+import io.micrometer.core.instrument.Meter.Type;
 
 /**
- * Documentation for post importer metrics following the Camunda metrics guide.
- *
- * <p>This class serves as documentation for all metrics related to the post importer functionality,
- * providing clear descriptions and usage guidelines for each metric.
+ * {@link PostImporterMetricsDoc} documents all post importer specific metrics following the Camunda
+ * metrics guide.
  */
-public final class PostImporterMetricsDoc {
-
-  private PostImporterMetricsDoc() {
-    // Utility class
-  }
+@SuppressWarnings("NullableProblems")
+public enum PostImporterMetricsDoc implements ExtendedMeterDocumentation {
 
   /**
-   * Post importer queue size metric documentation.
+   * Post importer queue size metric.
    *
    * <p>This gauge metric tracks the current size of the post importer queue for each partition. It
    * helps monitor if the post importer is stuck or overloaded, which is critical for operational
@@ -31,35 +28,26 @@ public final class PostImporterMetricsDoc {
    * <p><strong>Use case:</strong> Quickly determine if the post importer is experiencing issues
    * without requiring manual polling. This was identified as a need in support case SUPPORT-27255.
    *
-   * <p><strong>Type:</strong> Gauge (current value at a specific moment)
-   *
-   * <p><strong>Tags:</strong>
-   *
-   * <ul>
-   *   <li>partition - The partition ID for which the queue size is measured
-   * </ul>
-   *
    * <p><strong>Update frequency:</strong> Updated on each processing batch request when {@code
    * getPendingIncidents()} is called.
    *
    * <p><strong>Alerting considerations:</strong> High values may indicate that the post importer is
    * unable to keep up with the incoming incident processing workload.
    */
-  public static final class PostImporterQueueSize {
-    public static final String NAME = Metrics.GAUGE_POST_IMPORTER_QUEUE_SIZE;
-    public static final String DESCRIPTION =
-        "Current size of the post importer queue for processing pending incidents";
-
-    private PostImporterQueueSize() {
-      // Utility class
-    }
-
+  POST_IMPORTER_QUEUE_SIZE {
+    @Override
     public String getName() {
-      return NAME;
+      return Metrics.GAUGE_POST_IMPORTER_QUEUE_SIZE;
     }
 
-    public String getDescription() {
-      return DESCRIPTION;
+    @Override
+    public Type getType() {
+      return Type.GAUGE;
     }
-  }
+
+    @Override
+    public String getDescription() {
+      return "Current size of the post importer queue for processing pending incidents";
+    }
+  };
 }

--- a/operate/importer/src/main/java/io/camunda/operate/zeebeimport/post/elasticsearch/ElasticsearchIncidentPostImportAction.java
+++ b/operate/importer/src/main/java/io/camunda/operate/zeebeimport/post/elasticsearch/ElasticsearchIncidentPostImportAction.java
@@ -88,6 +88,13 @@ public class ElasticsearchIncidentPostImportAction extends AbstractIncidentPostI
     super(partitionId);
   }
 
+  @Override
+  public void run() {
+    // Initialize metrics when the component is fully loaded
+    initializeMetrics();
+    super.run();
+  }
+
   /**
    * Returns map incident key -> intent (CRAETED|RESOLVED)
    *
@@ -123,6 +130,11 @@ public class ElasticsearchIncidentPostImportAction extends AbstractIncidentPostI
                     .size(operateProperties.getZeebeElasticsearch().getBatchSize()));
     try {
       final SearchResponse response = esClient.search(listViewRequest, RequestOptions.DEFAULT);
+
+      // Update the queue size metric with the total hits count
+      final long queueSize = response.getHits().getTotalHits().value;
+      updateQueueSizeMetric(queueSize);
+
       incidents2Process =
           Arrays.stream(response.getHits().getHits())
               .map(sh -> sh.getSourceAsMap())

--- a/operate/importer/src/main/java/io/camunda/operate/zeebeimport/post/opensearch/OpensearchIncidentPostImportAction.java
+++ b/operate/importer/src/main/java/io/camunda/operate/zeebeimport/post/opensearch/OpensearchIncidentPostImportAction.java
@@ -82,6 +82,13 @@ public class OpensearchIncidentPostImportAction extends AbstractIncidentPostImpo
     super(partitionId);
   }
 
+  @Override
+  public void run() {
+    // Initialize metrics when the component is fully loaded
+    initializeMetrics();
+    super.run();
+  }
+
   /**
    * Returns map incident key -> intent (CRAETED|RESOLVED)
    *
@@ -114,6 +121,11 @@ public class OpensearchIncidentPostImportAction extends AbstractIncidentPostImpo
             .size(operateProperties.getZeebeOpensearch().getBatchSize());
 
     final var response = richOpenSearchClient.doc().search(postImporterQueueRequest, Result.class);
+
+    // Update the queue size metric with the total hits count
+    final long queueSize = response.hits().total().value();
+    updateQueueSizeMetric(queueSize);
+
     incidents2Process =
         response.hits().hits().stream()
             .map(Hit::source)

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/elasticsearch/ElasticsearchPostImportActionIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/elasticsearch/ElasticsearchPostImportActionIT.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.databind.ObjectReader;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
 import io.camunda.operate.JacksonConfig;
+import io.camunda.operate.Metrics;
 import io.camunda.operate.conditions.DatabaseInfo;
 import io.camunda.operate.connect.ElasticsearchConnector;
 import io.camunda.operate.connect.OperateDateTimeFormatter;
@@ -47,6 +48,8 @@ import io.camunda.operate.zeebeimport.ImportPositionHolder;
 import io.camunda.operate.zeebeimport.post.PostImportAction;
 import io.camunda.operate.zeebeimport.post.elasticsearch.ElasticsearchIncidentPostImportAction;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -84,7 +87,9 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
       DatabaseInfo.class,
       ElasticsearchSchemaTestHelper.class,
       ElasticsearchClientTestHelper.class,
-      ElasticsearchIncidentPostImportAction.class
+      ElasticsearchIncidentPostImportAction.class,
+      Metrics.class,
+      SimpleMeterRegistry.class
     },
     properties = {"spring.profiles.active=", OperateProperties.PREFIX + ".database=elasticsearch"})
 @EnableConfigurationProperties(OperateProperties.class)
@@ -101,6 +106,7 @@ public class ElasticsearchPostImportActionIT extends AbstractElasticsearchConnec
   @Autowired protected FlowNodeInstanceTemplate flowNodeInstanceTemplate;
   @Autowired protected PostImporterQueueTemplate postImporterQueueTemplate;
   @Autowired protected IncidentTemplate incidentTemplate;
+  @Autowired protected Metrics metrics;
 
   // not needed for the test but to satisfy our auto wirings
   @MockitoBean("postImportThreadPoolScheduler")
@@ -125,7 +131,8 @@ public class ElasticsearchPostImportActionIT extends AbstractElasticsearchConnec
     schemaTestHelper.dropSchema();
   }
 
-  private void createProcessInstance(String key, Consumer<Map<String, Object>> propertiesCreator) {
+  private void createProcessInstance(
+      final String key, final Consumer<Map<String, Object>> propertiesCreator) {
 
     final Map<String, Object> processInstance = new HashMap<String, Object>();
     propertiesCreator.accept(processInstance);
@@ -140,10 +147,10 @@ public class ElasticsearchPostImportActionIT extends AbstractElasticsearchConnec
   }
 
   private void createFlowNodeInstance(
-      String key,
-      String processInstanceKey,
-      Consumer<Map<String, Object>> listViewPropertiesCreator,
-      Consumer<Map<String, Object>> flowNodeInstancePropertiesCreator) {
+      final String key,
+      final String processInstanceKey,
+      final Consumer<Map<String, Object>> listViewPropertiesCreator,
+      final Consumer<Map<String, Object>> flowNodeInstancePropertiesCreator) {
 
     final Map<String, Object> listViewFlowNodeInstance = new HashMap<String, Object>();
     listViewPropertiesCreator.accept(listViewFlowNodeInstance);
@@ -263,10 +270,10 @@ public class ElasticsearchPostImportActionIT extends AbstractElasticsearchConnec
   }
 
   private void assertUpdateWasRoutedTo(
-      List<JsonNode> bulkActions,
-      IndexDescriptor index,
-      String documentId,
-      String expectedRountingKey) {
+      final List<JsonNode> bulkActions,
+      final IndexDescriptor index,
+      final String documentId,
+      final String expectedRountingKey) {
     final List<JsonNode> updatesForDocument =
         filterUpdatesToIndexAndDocument(bulkActions, index, documentId);
 
@@ -284,7 +291,7 @@ public class ElasticsearchPostImportActionIT extends AbstractElasticsearchConnec
   }
 
   private List<JsonNode> filterUpdatesToIndexAndDocument(
-      List<JsonNode> bulkActions, IndexDescriptor index, String documentId) {
+      final List<JsonNode> bulkActions, final IndexDescriptor index, final String documentId) {
     return bulkActions.stream()
         .filter(n -> n.has("update")) // only updates
         .map(n -> n.get("update"))
@@ -295,7 +302,7 @@ public class ElasticsearchPostImportActionIT extends AbstractElasticsearchConnec
         .collect(Collectors.toList());
   }
 
-  private List<JsonNode> parseActions(String bulkRequestBody) throws IOException {
+  private List<JsonNode> parseActions(final String bulkRequestBody) throws IOException {
     final ObjectMapper objectMapper = new ObjectMapper();
     final ObjectReader reader = objectMapper.readerFor(JsonNode.class);
 
@@ -318,5 +325,37 @@ public class ElasticsearchPostImportActionIT extends AbstractElasticsearchConnec
     }
 
     return actions;
+  }
+
+  @Test
+  public void shouldEmitPostImporterQueueSizeMetrics() throws IOException {
+    // given
+    schemaManager.createSchema();
+
+    final String postImporterQueueKey = "1";
+    final Map<String, Object> postImporterQueueEntry = new HashMap<String, Object>();
+    postImporterQueueEntry.put("key", 123L);
+    postImporterQueueEntry.put("position", 1L);
+    postImporterQueueEntry.put("actionType", PostImporterActionType.INCIDENT);
+    postImporterQueueEntry.put("intent", IncidentIntent.CREATED);
+    postImporterQueueEntry.put("partitionId", PARTITION_ID);
+
+    searchClientTestHelper.createDocument(
+        postImporterQueueTemplate.getFullQualifiedName(),
+        postImporterQueueKey,
+        postImporterQueueEntry);
+
+    // refresh so that the post importer sees the queue entry
+    searchClientTestHelper.refreshAllIndexes();
+
+    // when
+    postImportAction.performOneRound();
+
+    // then - verify that the post importer queue size metric is registered and has correct value
+    final Gauge queueSizeGauge =
+        metrics.getMeterRegistry().find(Metrics.GAUGE_POST_IMPORTER_QUEUE_SIZE).gauge();
+    assertThat(queueSizeGauge).isNotNull();
+    assertThat(queueSizeGauge.getId().getTag("partition")).isEqualTo(String.valueOf(PARTITION_ID));
+    assertThat(queueSizeGauge.value()).isEqualTo(1.0); // One entry in the queue
   }
 }

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/opensearch/OpensearchPostImportActionIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/opensearch/OpensearchPostImportActionIT.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.databind.ObjectReader;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
 import io.camunda.operate.JacksonConfig;
+import io.camunda.operate.Metrics;
 import io.camunda.operate.conditions.DatabaseInfo;
 import io.camunda.operate.connect.OpensearchConnector;
 import io.camunda.operate.connect.OperateDateTimeFormatter;
@@ -48,6 +49,8 @@ import io.camunda.operate.zeebeimport.ImportPositionHolder;
 import io.camunda.operate.zeebeimport.post.PostImportAction;
 import io.camunda.operate.zeebeimport.post.opensearch.OpensearchIncidentPostImportAction;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -85,7 +88,9 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
       DatabaseInfo.class,
       OpenSearchSchemaTestHelper.class,
       OpenSearchClientTestHelper.class,
-      OpensearchIncidentPostImportAction.class
+      OpensearchIncidentPostImportAction.class,
+      Metrics.class,
+      SimpleMeterRegistry.class
     },
     properties = {"spring.profiles.active=", OperateProperties.PREFIX + ".database=opensearch"})
 @EnableConfigurationProperties(OperateProperties.class)
@@ -102,6 +107,7 @@ public class OpensearchPostImportActionIT extends AbstractOpensearchConnectorPro
   @Autowired protected FlowNodeInstanceTemplate flowNodeInstanceTemplate;
   @Autowired protected PostImporterQueueTemplate postImporterQueueTemplate;
   @Autowired protected IncidentTemplate incidentTemplate;
+  @Autowired protected Metrics metrics;
 
   // not needed for the test but to satisfy our auto wirings
   @MockitoBean("postImportThreadPoolScheduler")
@@ -126,7 +132,8 @@ public class OpensearchPostImportActionIT extends AbstractOpensearchConnectorPro
     schemaTestHelper.dropSchema();
   }
 
-  private void createProcessInstance(String key, Consumer<Map<String, Object>> propertiesCreator) {
+  private void createProcessInstance(
+      final String key, final Consumer<Map<String, Object>> propertiesCreator) {
 
     final Map<String, Object> processInstance = new HashMap<String, Object>();
     propertiesCreator.accept(processInstance);
@@ -141,10 +148,10 @@ public class OpensearchPostImportActionIT extends AbstractOpensearchConnectorPro
   }
 
   private void createFlowNodeInstance(
-      String key,
-      String processInstanceKey,
-      Consumer<Map<String, Object>> listViewPropertiesCreator,
-      Consumer<Map<String, Object>> flowNodeInstancePropertiesCreator) {
+      final String key,
+      final String processInstanceKey,
+      final Consumer<Map<String, Object>> listViewPropertiesCreator,
+      final Consumer<Map<String, Object>> flowNodeInstancePropertiesCreator) {
 
     final Map<String, Object> listViewFlowNodeInstance = new HashMap<String, Object>();
     listViewPropertiesCreator.accept(listViewFlowNodeInstance);
@@ -264,10 +271,10 @@ public class OpensearchPostImportActionIT extends AbstractOpensearchConnectorPro
   }
 
   private void assertUpdateWasRoutedTo(
-      List<JsonNode> bulkActions,
-      IndexDescriptor index,
-      String documentId,
-      String expectedRountingKey) {
+      final List<JsonNode> bulkActions,
+      final IndexDescriptor index,
+      final String documentId,
+      final String expectedRountingKey) {
     final List<JsonNode> updatesForDocument =
         filterUpdatesToIndexAndDocument(bulkActions, index, documentId);
 
@@ -285,7 +292,7 @@ public class OpensearchPostImportActionIT extends AbstractOpensearchConnectorPro
   }
 
   private List<JsonNode> filterUpdatesToIndexAndDocument(
-      List<JsonNode> bulkActions, IndexDescriptor index, String documentId) {
+      final List<JsonNode> bulkActions, final IndexDescriptor index, final String documentId) {
     return bulkActions.stream()
         .filter(n -> n.has("update")) // only updates
         .map(n -> n.get("update"))
@@ -296,7 +303,7 @@ public class OpensearchPostImportActionIT extends AbstractOpensearchConnectorPro
         .collect(Collectors.toList());
   }
 
-  private List<JsonNode> parseActions(String bulkRequestBody) throws IOException {
+  private List<JsonNode> parseActions(final String bulkRequestBody) throws IOException {
     final ObjectMapper objectMapper = new ObjectMapper();
     final ObjectReader reader = objectMapper.readerFor(JsonNode.class);
 
@@ -319,5 +326,37 @@ public class OpensearchPostImportActionIT extends AbstractOpensearchConnectorPro
     }
 
     return actions;
+  }
+
+  @Test
+  public void shouldEmitPostImporterQueueSizeMetrics() throws IOException {
+    // given
+    schemaManager.createSchema();
+
+    final String postImporterQueueKey = "1";
+    final Map<String, Object> postImporterQueueEntry = new HashMap<String, Object>();
+    postImporterQueueEntry.put("key", 123L);
+    postImporterQueueEntry.put("position", 1L);
+    postImporterQueueEntry.put("actionType", PostImporterActionType.INCIDENT);
+    postImporterQueueEntry.put("intent", IncidentIntent.CREATED);
+    postImporterQueueEntry.put("partitionId", PARTITION_ID);
+
+    searchClientTestHelper.createDocument(
+        postImporterQueueTemplate.getFullQualifiedName(),
+        postImporterQueueKey,
+        postImporterQueueEntry);
+
+    // refresh so that the post importer sees the queue entry
+    searchClientTestHelper.refreshAllIndexes();
+
+    // when
+    postImportAction.performOneRound();
+
+    // then - verify that the post importer queue size metric is registered and has correct value
+    final Gauge queueSizeGauge =
+        metrics.getMeterRegistry().find(Metrics.GAUGE_POST_IMPORTER_QUEUE_SIZE).gauge();
+    assertThat(queueSizeGauge).isNotNull();
+    assertThat(queueSizeGauge.getId().getTag("partition")).isEqualTo(String.valueOf(PARTITION_ID));
+    assertThat(queueSizeGauge.value()).isEqualTo(1.0); // One entry in the queue
   }
 }


### PR DESCRIPTION
## Description

This PR adds a new `post.importer.queue.size` metric that uses the ES/OS response when the next processing batch is requested. Since this is queue size metric and we only care a bout the size at a given time, I'm using a Gauge.

Also adding metric docs and updating existing ITs to verify that the new metric are correctly emitted.

For 8.8, I will need to check how this is implemented (IIRC exporters have been reworked and `ElasticsearchIncidentPostImportAction` no longer exists) and will open a separate PR.

## Related issues

related to #32396
