### PR TITLE
fix: use react-router links in Navbar

### DIFF
--- a/identity/client/src/components/layout/AppHeader.tsx
+++ b/identity/client/src/components/layout/AppHeader.tsx
@@ -8,7 +8,7 @@
 
 import { C3Navigation } from "@camunda/camunda-composite-components";
 import { useGlobalRoutes } from "src/components/global/useGlobalRoutes";
-import { useNavigate } from "react-router";
+import { Link } from "react-router";
 import { useApi } from "src/utility/api";
 import { checkLicense, License } from "src/utility/api/headers";
 import { getAuthentication } from "src/utility/api/authentication";
@@ -19,7 +19,6 @@ import { isSaaS } from "src/configuration";
 
 const AppHeader = ({ hideNavLinks = false }) => {
   const routes = useGlobalRoutes();
-  const navigate = useNavigate();
   const { data: license } = useApi(checkLicense);
   const { data: camundaUser } = useApi(getAuthentication);
   const [isAppBarOpen, setIsAppBarOpen] = useState(false);
@@ -31,9 +30,10 @@ const AppHeader = ({ hideNavLinks = false }) => {
         name: "Identity",
         ariaLabel: "Identity",
         routeProps: {
-          href: "/",
+          to: "/",
         },
       }}
+      forwardRef={Link}
       appBar={{
         ariaLabel: "App panel",
         isOpen: isAppBarOpen,
@@ -46,7 +46,7 @@ const AppHeader = ({ hideNavLinks = false }) => {
           : routes.map((route) => ({
               ...route,
               routeProps: {
-                onClick: () => navigate(route.key),
+                to: route.key,
               },
             })),
         licenseTag: getLicenseTag(license),


### PR DESCRIPTION
## Description

This PR ensures we use ReactRouter Links in the App Header. This fixes a broken redirect on the Header Logo.

[screencap-2025-08-22-11-25-58.webm](https://github.com/user-attachments/assets/2dfe024f-cc9a-4ac1-8837-91dcbfc56515)


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #37100
