### PR TITLE
build: tasklist CI: upload test results on job cancel

### DIFF
--- a/.github/workflows/tasklist-ci-test-reusable.yml
+++ b/.github/workflows/tasklist-ci-test-reusable.yml
@@ -123,7 +123,7 @@ jobs:
 
       - name: Upload failed test results
         uses: ./.github/actions/collect-test-artifacts
-        if: failure()
+        if: failure() || cancelled()
         with:
           name: tasklist-test-results-${{ matrix.database }}
           path: |


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Sometimes, if the job fails and then is get canceled by timeout, the logs are gone.
This PR prevents that from happening.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
