### PR TITLE
fix: keep sorting on page for enriched views

### DIFF
--- a/identity/client/src/components/global/useEnrichGroups.tsx
+++ b/identity/client/src/components/global/useEnrichGroups.tsx
@@ -62,7 +62,20 @@ export function useEnrichedGroups<P>(
 
       const groupIds = members.map(({ groupId }) => groupId);
       const groupResult = await callSearchGroups({ groupIds });
-      setGroups(groupResult.data?.items || []);
+
+      const fullGroups = groupResult.data?.items || [];
+
+      // Hydrate members while keeping order from original request
+      const orderedGroups = members.map((member) => {
+        // Inefficient, but we don't care as we search <100 items
+        const group = fullGroups.find((u) => u.groupId === member.groupId);
+        return {
+          groupId: member.groupId,
+          name: group?.name || "",
+        };
+      });
+
+      setGroups(orderedGroups || []);
       setSuccess(true);
     } catch {
       setGroups([]);

--- a/identity/client/src/components/global/useEnrichUsers.tsx
+++ b/identity/client/src/components/global/useEnrichUsers.tsx
@@ -62,7 +62,21 @@ export function useEnrichedUsers<P>(
 
       const usernames = members.map(({ username }) => username);
       const userResult = await callSearchUser({ usernames });
-      setUsers(userResult.data?.items || []);
+
+      const fullUsers = userResult.data?.items || [];
+
+      // Hydrate members while keeping order from original request
+      const orderedUsers = members.map((member) => {
+        // Inefficient, but we don't care as we search <100 items
+        const user = fullUsers.find((u) => u.username === member.username);
+        return {
+          username: member.username,
+          name: user?.name || "",
+          email: user?.email || "",
+        };
+      });
+
+      setUsers(orderedUsers);
       setSuccess(true);
     } catch {
       setUsers([]);

--- a/identity/client/src/pages/groups/detail/roles/index.tsx
+++ b/identity/client/src/pages/groups/detail/roles/index.tsx
@@ -82,8 +82,8 @@ const Roles: FC<RolesProps> = ({ groupId }) => {
       <EntityList
         data={roles?.items}
         headers={[
-          { header: t("roleId"), key: "roleId" },
-          { header: t("roleName"), key: "name" },
+          { header: t("roleId"), key: "roleId", isSortable: true },
+          { header: t("roleName"), key: "name", isSortable: true },
         ]}
         loading={loading}
         addEntityLabel={t("assignRole")}


### PR DESCRIPTION
## Description
Keep sorting on pages that use multiple requests to show data

[screencap-2025-08-22-14-40-32.webm](https://github.com/user-attachments/assets/6c1fb455-fba6-4827-b3ca-b0952d1e2f9c)

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #37101
