### PR TITLE
Add flaky tests summary comment feature

### DIFF
--- a/.github/actions/collect-flaky-tests/README.md
+++ b/.github/actions/collect-flaky-tests/README.md
@@ -1,0 +1,87 @@
+# Collect Flaky Tests Action
+
+## Purpose
+
+This composite action collects and aggregates flaky test results from multiple CI jobs in the Camunda orchestration cluster project. It processes results from various test suites including unit tests, integration tests with different databases (Elasticsearch, OpenSearch, RDBMS), and Docker checks.
+
+## Inputs
+
+| ···············Input················ | ·······················Description························ | ·Required· | ·Default· |
+|--------------------------------------|------------------------------------------------------------|------------|-----------|
+| `general-unit-tests-result`          | Result of the general unit tests job                       | true       | N/A       |
+| `general-unit-tests-flaky`           | Flaky tests from the general unit tests job                | true       | N/A       |
+| `elasticsearch-tests-result`         | Result of the Elasticsearch integration tests job          | true       | N/A       |
+| `elasticsearch-tests-flaky`          | Flaky tests from the Elasticsearch integration tests job   | true       | N/A       |
+| `opensearch-tests-result`            | Result of the OpenSearch integration tests job             | true       | N/A       |
+| `opensearch-tests-flaky`             | Flaky tests from the OpenSearch integration tests job      | true       | N/A       |
+| `rdbms-h2-tests-result`              | Result of the RDBMS H2 integration tests job               | true       | N/A       |
+| `rdbms-h2-tests-flaky`               | Flaky tests from the RDBMS H2 integration tests job        | true       | N/A       |
+| `rdbms-tests-result`                 | Result of the RDBMS integration tests job                  | true       | N/A       |
+| `rdbms-tests-flaky`                  | Flaky tests from the RDBMS integration tests job           | true       | N/A       |
+| `docker-checks-result`               | Result of the Docker checks job                            | true       | N/A       |
+| `docker-checks-flaky`                | Flaky tests from the Docker checks job                     | true       | N/A       |
+| `zeebe-tests-result`                 | Result of the Zeebe unit tests job                         | true       | N/A       |
+| `zeebe-matrix-output-result`         | Matrix output for Zeebe unit tests                         | true       | N/A       |
+| `integration-tests-result`           | Result of the integration tests job                        | true       | N/A       |
+| `integration-matrix-output-result`   | Matrix output for integration tests                        | true       | N/A       |
+
+## Outputs
+
+| ·······Output······· | ·····························································Description····························································· |
+|----------------------|---------------------------------------------------------------------------------------------------------------------------------------|
+| `flaky_tests_data`   | JSON array of flaky tests data aggregated from all test jobs. Each object contains `job` (string) and `flaky_tests` (string) fields   |
+
+### Output Format Example
+
+```json
+[
+  {
+    "job": "elasticsearch-integration-tests",
+    "flaky_tests": "io.camunda.it.auth.ProcessAuthorizationIT.shouldReturnProcessDefinitionStartForm(CamundaClient, CamundaClient)"
+  },
+  {
+    "job": "general-unit-tests",
+    "flaky_tests": "io.camunda.it.tenancy.VariableTenancyIT.getByKeyShouldReturnTenantOwnedVariable(CamundaClient, CamundaClient) io.camunda.it.tenancy.VariableTenancyIT.shouldReturnOnlyTenantAVariables(CamundaClient)"
+  },
+  {
+    "job": "general-unit-tests",
+    "flaky_tests": "io.camunda.it.rdbms.db.batchoperation.BatchOperationIT.shouldFindAllBatchOperationsPaged(CamundaRdbmsTestApplication)[1]"
+  },
+  {
+    "job": "integration-tests/Zeebe - [IT] Zeebe QA - Core Features",
+    "flaky_tests": "io.camunda.zeebe.it.clustering.AvailabilityTest.shouldCreateProcessWhenPartitionRecovers"
+  }
+]
+```
+
+## Example Usage
+
+```yaml
+- name: Collect flaky test results
+  uses: ./.github/actions/collect-flaky-tests
+  with:
+    general-unit-tests-result: ${{ needs.general-unit-tests.result }}
+    general-unit-tests-flaky: ${{ needs.general-unit-tests.outputs.flaky_tests }}
+    elasticsearch-tests-result: ${{ needs.elasticsearch-integration-tests.result }}
+    elasticsearch-tests-flaky: ${{ needs.elasticsearch-integration-tests.outputs.flaky_tests }}
+    opensearch-tests-result: ${{ needs.opensearch-integration-tests.result }}
+    opensearch-tests-flaky: ${{ needs.opensearch-integration-tests.outputs.flaky_tests }}
+    rdbms-h2-tests-result: ${{ needs.rdbms-h2-integration-tests.result }}
+    rdbms-h2-tests-flaky: ${{ needs.rdbms-h2-integration-tests.outputs.flaky_tests }}
+    rdbms-tests-result: ${{ needs.rdbms-integration-tests.result }}
+    rdbms-tests-flaky: ${{ needs.rdbms-integration-tests.outputs.flaky_tests }}
+    docker-checks-result: ${{ needs.docker-checks.result }}
+    docker-checks-flaky: ${{ needs.docker-checks.outputs.flaky_tests }}
+    zeebe-tests-result: ${{ needs.zeebe-unit-tests.result }}
+    zeebe-matrix-output-result: ${{ needs.zeebe-unit-tests.outputs.matrix_results }}
+    integration-tests-result: ${{ needs.integration-tests.result }}
+    integration-matrix-output-result: ${{ needs.integration-tests.outputs.matrix_results }}
+```
+
+## Internal Implementation
+
+- Uses bash shell scripts located in `scripts/collect-flaky-tests.sh`
+- Processes both single job results and matrix job results
+- Aggregates flaky test data into a unified JSON structure
+- Handles empty or skipped job results gracefully
+

--- a/.github/actions/collect-flaky-tests/action.yml
+++ b/.github/actions/collect-flaky-tests/action.yml
@@ -1,0 +1,98 @@
+name: 'Collect Flaky Tests'
+description: 'Collects and aggregates flaky test results from multiple CI jobs'
+
+# owner: @camunda/monorepo-devops-team
+
+inputs:
+    general-unit-tests-result:
+        description: 'Result of the general unit tests job'
+        required: true
+    general-unit-tests-flaky:
+        description: 'Flaky tests from the general unit tests job'
+        required: true
+    elasticsearch-tests-result:
+        description: 'Result of the Elasticsearch integration tests job'
+        required: true
+    elasticsearch-tests-flaky:
+        description: 'Flaky tests from the Elasticsearch integration tests job'
+        required: true
+    opensearch-tests-result:
+        description: 'Result of the OpenSearch integration tests job'
+        required: true
+    opensearch-tests-flaky:
+        description: 'Flaky tests from the OpenSearch integration tests job'
+        required: true
+    rdbms-h2-tests-result:
+        description: 'Result of the RDBMS H2 integration tests job'
+        required: true
+    rdbms-h2-tests-flaky:
+        description: 'Flaky tests from the RDBMS H2 integration tests job'
+        required: true
+    rdbms-tests-result:
+        description: 'Result of the RDBMS integration tests job'
+        required: true
+    rdbms-tests-flaky:
+        description: 'Flaky tests from the RDBMS integration tests job'
+        required: true
+    docker-checks-result:
+        description: 'Result of the Docker checks job'
+        required: true
+    docker-checks-flaky:
+        description: 'Flaky tests from the Docker checks job'
+        required: true
+    zeebe-tests-result:
+        description: 'Result of the Zeebe unit tests job'
+        required: true
+    zeebe-matrix-output-result:
+        description: 'Matrix output for Zeebe unit tests'
+        required: true
+    integration-tests-result:
+        description: 'Result of the integration tests job'
+        required: true
+    integration-matrix-output-result:
+        description: 'Matrix output for integration tests'
+        required: true
+
+
+outputs:
+  flaky_tests_data:
+    description: 'JSON array of flaky tests data'
+    value: ${{ steps.collect-results.outputs.flaky_tests_data }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Collect flaky test results
+      id: collect-results
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        # Source helper functions
+        source ${{ github.action_path }}/scripts/collect-flaky-tests.sh
+
+        # Initialize flaky data array
+        flaky_data='[]'
+
+        # Collect from single jobs
+        collect_from_single_job "general-unit-tests" "${{ inputs.general-unit-tests-result }}" "${{ inputs.general-unit-tests-flaky }}"
+        collect_from_single_job "elasticsearch-integration-tests" "${{ inputs.elasticsearch-tests-result }}" "${{ inputs.elasticsearch-tests-flaky }}"
+        collect_from_single_job "opensearch-integration-tests" "${{ inputs.opensearch-tests-result }}" "${{ inputs.opensearch-tests-flaky }}"
+        collect_from_single_job "rdbms-h2-integration-tests" "${{ inputs.rdbms-h2-tests-result }}" "${{ inputs.rdbms-h2-tests-flaky }}"
+        collect_from_single_job "rdbms-integration-tests" "${{ inputs.rdbms-tests-result }}" "${{ inputs.rdbms-tests-flaky }}"
+        collect_from_single_job "docker-checks" "${{ inputs.docker-checks-result }}" "${{ inputs.docker-checks-flaky }}"
+
+        # Collect from matrix jobs
+        collect_from_matrix_job "zeebe-unit-tests" "${{ inputs.zeebe-tests-result }}" '${{ inputs.zeebe-matrix-output-result }}'
+        collect_from_matrix_job "integration-tests" "${{ inputs.integration-tests-result }}" '${{ inputs.integration-matrix-output-result }}'
+
+        # Output the collected data
+        {
+          echo "flaky_tests_data<<EOF"
+          echo "$flaky_data"
+          echo "EOF"
+        } >> "$GITHUB_OUTPUT"
+
+        # Log the collected data
+        echo "Collected flaky tests data:"
+        echo "$flaky_data" | jq '.'

--- a/.github/actions/collect-flaky-tests/scripts/collect-flaky-tests.sh
+++ b/.github/actions/collect-flaky-tests/scripts/collect-flaky-tests.sh
@@ -10,13 +10,13 @@ add_job_data() {
   local job_name="$1"
   local flaky_tests="$2"
   flaky_tests=$(echo "$flaky_tests" | xargs)
-    if [[ -n "$flaky_tests" ]]; then
-      # Escape double quotes for JSON
-      # Replace newlines with literal \n for JSON
-      escaped_flaky_tests=$(echo "$flaky_tests" | sed 's/"/\\"/g' | sed ':a;N;$!ba;s/\n/\\n/g')
-      echo "Adding job: $job_name with flaky test: $flaky_tests"
-      flaky_data=$(echo "$flaky_data" | jq --arg job "$job_name" --arg tests "$escaped_flaky_tests" '. += [{"job": $job, "flaky_tests": $tests}]')
-    fi
+  if [[ -n "$flaky_tests" ]]; then
+    echo "Adding job: $job_name with flaky test: $flaky_tests"
+
+    # Append to flaky_data JSON array safely using jq
+    flaky_data=$(echo "${flaky_data:-[]}" | jq --arg job "$job_name" --arg tests "$flaky_tests" \
+      '. += [{"job": $job, "flaky_tests": $tests}]')
+  fi
 }
 
 # Helper function to add job data from single jobs

--- a/.github/actions/collect-flaky-tests/scripts/collect-flaky-tests.sh
+++ b/.github/actions/collect-flaky-tests/scripts/collect-flaky-tests.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# Helper functions for collecting flaky test data
+# owner: @camunda/monorepo-devops-team
+
+set -euo pipefail
+flaky_data='[]'
+
+# Helper function to add job data to JSON array
+add_job_data() {
+  local job_name="$1"
+  local flaky_tests="$2"
+  flaky_tests=$(echo "$flaky_tests" | xargs)
+    if [[ -n "$flaky_tests" ]]; then
+      # Escape double quotes for JSON
+      # Replace newlines with literal \n for JSON
+      escaped_flaky_tests=$(echo "$flaky_tests" | sed 's/"/\\"/g' | sed ':a;N;$!ba;s/\n/\\n/g')
+      echo "Adding job: $job_name with flaky test: $flaky_tests"
+      flaky_data=$(echo "$flaky_data" | jq --arg job "$job_name" --arg tests "$escaped_flaky_tests" '. += [{"job": $job, "flaky_tests": $tests}]')
+    fi
+}
+
+# Helper function to add job data from single jobs
+collect_from_single_job() {
+  local job_id="$1"
+  local result="$2"
+  local flaky_tests="$3"
+
+  if [[ "$result" != "skipped" ]]; then
+  add_job_data "$job_id" "$flaky_tests"
+  fi
+}
+
+# Helper function to add job data from matrix jobs
+collect_from_matrix_job() {
+  local job_id="$1"
+  local result="$2"
+  local output_json="$3"
+
+  if [[ "$result" != "skipped" ]]; then
+    echo "Raw ${job_id} matrix JSON:" && echo "$output_json" | jq '.'
+
+    if echo "$output_json" | jq -e '.flakyTests and (.flakyTests | type == "object")' > /dev/null 2>&1; then
+      while IFS= read -r entry; do
+        local job_name
+        local flaky_tests
+        job_name=$(echo "$entry" | jq -r '.key')
+        flaky_tests=$(echo "$entry" | jq -r '.value // ""')
+        add_job_data "${job_id}/${job_name}" "$flaky_tests"
+      done < <(echo "$output_json" | jq -c '.flakyTests | to_entries[]')
+    else
+      echo "flakyTests is missing or not an object for $job_id"
+    fi
+  fi
+}

--- a/.github/actions/flaky-tests-summary-comment/README.md
+++ b/.github/actions/flaky-tests-summary-comment/README.md
@@ -1,0 +1,84 @@
+# Flaky Tests Summary Comment Action
+
+## Purpose
+
+Creates or updates a PR comment with a comprehensive summary of flaky tests across all test jobs.
+
+## Inputs
+
+| ·······Input······· | ·····················Description····················· | ·Required· | ·Default· |
+|---------------------|-------------------------------------------------------|------------|-----------|
+| `flaky-tests-data`  | JSON array containing processed flaky test data       | true       | N/A       |
+| `pr-number`         | Pull request number for the comment                   | true       | N/A       |
+| `branch-name`       | Branch name where the comment will be posted          | true       | N/A       |
+
+## Expected Data Structure
+
+### Example `flaky-tests-data` input:
+
+```json
+[
+  {
+    "job": "elasticsearch-integration-tests",
+    "flaky_tests": "io.camunda.it.auth.ProcessAuthorizationIT.shouldReturnProcessDefinitionStartForm(CamundaClient, CamundaClient)"
+  },
+  {
+    "job": "general-unit-tests",
+    "flaky_tests": "io.camunda.it.tenancy.VariableTenancyIT.getByKeyShouldReturnTenantOwnedVariable(CamundaClient, CamundaClient) io.camunda.it.tenancy.VariableTenancyIT.shouldReturnOnlyTenantAVariables(CamundaClient)"
+  }
+]
+```
+
+### Example internal data structure:
+
+```json
+[
+  {
+    "packageName": "io.camunda.it.auth",
+    "className": "ProcessAuthorizationIT",
+    "methodName": "shouldReturnProcessDefinitionStartForm(CamundaClient, CamundaClient)",
+    "jobs": [
+      "elasticsearch-integration-tests"
+    ],
+    "occurrences": 1
+  }
+]
+```
+
+## Outputs
+
+This action does not produce outputs. It creates or updates a PR comment directly.
+
+## Example Usage
+
+```yaml
+- name: Post flaky tests summary comment
+  uses: ./.github/actions/flaky-tests-summary-comment
+  with:
+    flaky-tests-data: ${{ steps.collect-flaky-tests.outputs.flaky_tests_data }}
+    pr-number: ${{ github.event.pull_request.number }}
+    branch-name: ${{ github.head_ref }}
+```
+
+## Features
+
+- Processes JSON array of flaky test data from multiple test jobs
+- Creates formatted PR comments with test failure summaries
+- Updates existing comments to avoid spam
+- Handles empty or invalid data gracefully
+- Provides detailed logging for debugging
+
+## Internal Implementation
+
+- Uses GitHub Script action for API interactions
+- Processes data through modular JavaScript files:
+  - `src/flaky-tests-data-processor.js` - Structures and processes raw flaky test data
+  - `src/flaky-tests-comment-generator.js` - Generates formatted comment content
+  - `src/github-api.js` - Handles GitHub API interactions
+  - `src/helpers.js` - Utility functions
+
+## Dependencies
+
+- `actions/github-script@v7` for GitHub API access
+- Modular JavaScript processors in `src/` directory
+

--- a/.github/actions/flaky-tests-summary-comment/action.yml
+++ b/.github/actions/flaky-tests-summary-comment/action.yml
@@ -1,0 +1,56 @@
+---
+name: Flaky Tests Summary Comment
+
+description: Creates or updates a PR comment with flaky test summary across all test jobs
+
+# owner: @camunda/monorepo-devops-team
+
+inputs:
+  flaky-tests-data:
+    description: 'JSON array containing flaky test data from all jobs'
+    required: true
+  pr-number:
+    description: 'Pull request number for the comment'
+    required: true
+  branch-name:
+    description: 'Branch name where the comment will be posted'
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Flaky Tests Summary Comment
+      uses: actions/github-script@v7
+      with:
+        github-token: ${{ github.token }}
+        script: |
+          const flakyTestsDataInput = `${{ inputs.flaky-tests-data }}`;
+
+          if (!flakyTestsDataInput) {
+            console.log('[flaky-tests] No flaky tests data provided - skipping flaky summary comment.');
+            return;
+          }
+
+          let flakyTestsData;
+          try {
+            flakyTestsData = JSON.parse(flakyTestsDataInput);
+            console.log('Received flaky tests data:', flakyTestsData);
+          } catch (error) {
+            console.error('[flaky-tests] Failed to parse flaky tests data:', error.message);
+            return;
+          }
+
+          // Exit if no flaky tests found
+          if (!Array.isArray(flakyTestsData) || flakyTestsData.length === 0) {
+            console.log('[flaky-tests] No flaky tests found - skipping flaky summary comment.');
+            return;
+          }
+
+          // Step 1: Process and structure the flaky test data
+          const { processFlakyTestsData } = require('./.github/actions/flaky-tests-summary-comment/src/flaky-tests-data-processor');
+          const processedData = processFlakyTestsData(flakyTestsData);
+          console.log('[flaky-tests] Processed data:', JSON.stringify(processedData, null, 2));
+
+          // Step 2: Generate and post the PR comment
+          const { createOrUpdateComment } = require('./.github/actions/flaky-tests-summary-comment/src/flaky-tests-comment-generator');
+          await createOrUpdateComment(context, github, processedData, ${{ inputs.pr-number }}, '${{ inputs.branch-name }}');

--- a/.github/actions/flaky-tests-summary-comment/src/flaky-tests-comment-generator.js
+++ b/.github/actions/flaky-tests-summary-comment/src/flaky-tests-comment-generator.js
@@ -11,8 +11,6 @@ async function createOrUpdateComment(context, github, currentData, prNumber, bra
 
   // Step 2: Parse existing comment to extract historical data
   const historicalData = existingComment ? helpers.parseComment(existingComment.body) : null;
-
-  console.log("Existing comment:", existingComment);
   console.log('Historical data:', historicalData);
 
   // Step 3: Merge current and historical data, or generate first run data

--- a/.github/actions/flaky-tests-summary-comment/src/flaky-tests-comment-generator.js
+++ b/.github/actions/flaky-tests-summary-comment/src/flaky-tests-comment-generator.js
@@ -1,0 +1,87 @@
+const helpers = require('./helpers');
+const githubApi = require('./github-api');
+
+async function createOrUpdateComment(context, github, currentData, prNumber, branchName) {
+  console.log(`[flaky-tests] Processing flaky test comment for PR #${prNumber}`);
+
+  const { owner, repo } = context.repo;
+
+  // Step 1: Fetch any existing flaky test comment
+  const existingComment = await githubApi.getExistingComment(github, owner, repo, prNumber);
+
+  // Step 2: Parse existing comment to extract historical data
+  const historicalData = existingComment ? helpers.parseComment(existingComment.body) : null;
+
+  console.log("Existing comment:", existingComment);
+  console.log('Historical data:', historicalData);
+
+  // Step 3: Merge current and historical data, or generate first run data
+  const mergedData = (!historicalData || historicalData.length === 0) ? helpers.prepareFirstRunData(currentData) : helpers.mergeFlakyData(currentData, historicalData);
+  console.log('Merged data:', JSON.stringify(mergedData, null, 2));
+
+  // Step 4: Generate comment content
+  const comment = await buildComment(mergedData, github, branchName);
+
+  // Step 5: Create or update comment
+  if (existingComment) {
+    console.log('[flaky-tests] Updating existing flaky test comment...');
+    await githubApi.updateComment(github, owner, repo, existingComment.id, comment);
+  } else {
+    console.log('[flaky-tests] Creating new flaky test comment...');
+    await githubApi.createComment(github, owner, repo, prNumber, comment);
+  }
+
+  console.log('[flaky-tests] Flaky test comment processed.');
+}
+
+async function buildComment(mergedData, github, branchName) {
+  const lines = [
+    `# 🧪 Flaky Tests Summary`,
+    `_👻 Haunted Tests — They Fail When No One's Watching_`,
+    ``
+  ];
+
+  mergedData.sort((a, b) => b.flakiness - a.flakiness);
+
+  for (const test of mergedData) {
+    const icon = getFlakyIcon(test.flakiness);
+    const url = await generateTestSourceUrl(test, github, branchName);
+
+    const testName = test.methodName || test.fullName;
+    const formattedName = url ? `[**${testName}**](${url})` : `**${testName}**`;
+    lines.push(`- ${formattedName} – ${icon} **${test.flakiness}% flakiness**`);
+    lines.push(`  - Jobs: \`${test.jobs.join(', ')}\``);
+    lines.push(`  - Package: \`${test.packageName}\``);
+    lines.push(`  - Class: \`${test.className ? test.className : "-"}\``);
+    lines.push(`  - Occurrences: ${test.occurrences} / ${test.totalRuns}`);
+    lines.push('');
+  }
+
+  lines.push(
+      `If the changes affect this area, **please check and fix before merging**.`,
+      `If not, **leave a quick comment** explaining why it's likely unrelated.`
+  );
+
+  return lines.join('\n');
+}
+
+function getFlakyIcon(percent) {
+  if (percent < 30) return '👀';
+  if (percent <= 80) return '⚠️';
+  return '💀';
+}
+
+async function generateTestSourceUrl(test, github, branchName) {
+    const originalUrl = await githubApi.getTestSourceUrl(test, github);
+    const testName = test.methodName || test.fullName;
+    console.log(`[flaky-tests] Original URL for test ${testName}: ${originalUrl}`);
+
+    if (!originalUrl || typeof originalUrl !== 'string') {
+        console.warn(`[flaky-tests] No valid source URL found for test: ${testName}`);
+        return '';
+    }
+
+    return originalUrl.replace(/blob\/[^/]+/, `tree/${branchName}`);
+}
+
+module.exports = { createOrUpdateComment };

--- a/.github/actions/flaky-tests-summary-comment/src/flaky-tests-data-processor.js
+++ b/.github/actions/flaky-tests-summary-comment/src/flaky-tests-data-processor.js
@@ -1,0 +1,39 @@
+const helpers = require('./helpers');
+
+function processFlakyTestsData(rawData) {
+  const testMap = new Map();
+
+  rawData.forEach(({ job, flaky_tests }) => {
+    if (!flaky_tests || flaky_tests.trim() === '') {
+      console.log(`[flaky-tests] Skipping job "${job}" - no flaky tests`);
+      return;
+    }
+
+    const testNames = [...flaky_tests.matchAll(
+        /[^\s\[(]+(?:\([^)]*\))?(?:\[[^\]]*])?/g
+    )].map(match => match[0]);
+
+    testNames.forEach(testName => {
+      const parsedTest = helpers.parseTestName(testName);
+      const key = helpers.getTestKey(parsedTest);
+      const existingTest = testMap.get(key);
+
+      if (existingTest) {
+        if (!existingTest.jobs.includes(job)) {
+          existingTest.jobs.push(job);
+        }
+        existingTest.occurrences++;
+      } else {
+        testMap.set(key, {
+          ...parsedTest,
+          jobs: [job],
+          occurrences: 1
+        });
+      }
+    });
+  });
+
+  return Array.from(testMap.values());
+}
+
+module.exports = { processFlakyTestsData };

--- a/.github/actions/flaky-tests-summary-comment/src/github-api.js
+++ b/.github/actions/flaky-tests-summary-comment/src/github-api.js
@@ -1,0 +1,69 @@
+async function getTestSourceUrl(test, github) {
+  const repo = 'camunda/camunda';
+  const query = `repo:${repo} ${test.className.replace(/\$/g, ' ')} ${test.methodName || test.fullName}`;
+
+  console.log(`[flaky-tests] Searching for test source with query: ${query}`);
+
+  const { data } = await github.rest.search.code({
+    q: `${query}`,
+  });
+
+  if (!data.items || data.items.length === 0) {
+    console.warn(`[flaky-tests] No match found for test: ${query}`);
+    return null;
+  }
+
+  return data.items[0].html_url;
+}
+
+async function getExistingComment(github, owner, repo, prNumber) {
+  try {
+    const { data: comments } = await github.rest.issues.listComments({
+      owner,
+      repo,
+      issue_number: prNumber,
+    });
+
+    return comments.find(c => c.body?.includes('🧪 Flaky Tests Summary')) || null;
+  } catch (error) {
+    console.error('[flaky-tests] Error finding existing comment:', error);
+    return null;
+  }
+}
+
+async function createComment(github, owner, repo, prNumber, body) {
+  try {
+    await github.rest.issues.createComment({
+      owner,
+      repo,
+      issue_number: prNumber,
+      body,
+    });
+    console.log('Successfully created flaky test comment');
+  } catch (error) {
+    console.error('[flaky-tests] Error creating comment:', error);
+    throw error;
+  }
+}
+
+async function updateComment(github, owner, repo, commentId, body) {
+  try {
+    await github.rest.issues.updateComment({
+      owner,
+      repo,
+      comment_id: commentId,
+      body,
+    });
+    console.log('[flaky-tests] Successfully updated flaky test comment');
+  } catch (error) {
+    console.error('[flaky-tests] Error updating comment:', error);
+    throw error;
+  }
+}
+
+module.exports = {
+  getTestSourceUrl,
+  getExistingComment,
+  createComment,
+  updateComment
+};

--- a/.github/actions/flaky-tests-summary-comment/src/helpers.js
+++ b/.github/actions/flaky-tests-summary-comment/src/helpers.js
@@ -134,10 +134,12 @@ function prepareFirstRunData(currentData) {
 }
 
 function getTestKey(test) {
-  const methodName = test.methodName.replace(/\[([^\]]+)]\([^)]+\)/g, '$1');
-  return test.fullName
-      ? `${test.fullName}`
-      : `${test.packageName}.${test.className}.${methodName}`;
+  if (test.fullName) {
+    return `${test.fullName}`;
+  }
+
+  const methodName = test.methodName ? test.methodName.replace(/\[([^\]]+)]\([^)]+\)/g, '$1') : '';
+  return `${test.packageName}.${test.className}.${methodName}`;
 }
 
 module.exports = {

--- a/.github/actions/flaky-tests-summary-comment/src/helpers.js
+++ b/.github/actions/flaky-tests-summary-comment/src/helpers.js
@@ -1,0 +1,149 @@
+function parseTestName(testName) {
+  const lastDotIndex = testName.lastIndexOf('.');
+
+  if (lastDotIndex === -1) {
+    console.warn(`[flaky-tests] Could not parse test name: ${testName}`);
+    return {
+      fullName: testName.trim()
+    };
+  }
+
+  const fullyQualifiedClass = testName.slice(0, lastDotIndex);
+  let methodName = testName.slice(lastDotIndex + 1);
+
+  // Remove trailing [index] if it exists
+  methodName = methodName.replace(/\[.*?]\s*$/, '');
+
+  // Remove parameter list if it exists
+  methodName = methodName.replace(/\(.*?\)\s*$/, '').trim();
+
+  const classParts = fullyQualifiedClass.split('.');
+  const className = classParts[classParts.length - 1];
+  const packageName = classParts.slice(0, -1).join('.');
+
+  return {
+    packageName,
+    className,
+    methodName
+  };
+}
+
+function parseComment(body) {
+  try {
+    const lines = body.split('\n');
+
+    const flakyTests = [];
+    let currentTest = {};
+
+    for (const line of lines) {
+      //Match method name
+      const methodMatch = line.match(/-\s(?:\[\*\*(.+?)\*\*\]\(.+?\)|(\S+?))\s–/);
+      if (methodMatch) {
+        // If no hyperlink exists
+        if (Object.keys(currentTest).length > 0) {
+          flakyTests.push(currentTest);
+          currentTest = {};
+        }
+        // methodMatch[1] is for the markdown link, methodMatch[2] for plain text
+        currentTest.methodName = methodMatch[1] || methodMatch[2];
+      }
+
+      // Match jobs
+      const jobsMatch = line.match(/Jobs:\s+`(.+?)`/);
+      if (jobsMatch) {
+        currentTest.jobs = jobsMatch[1].split(',').map(job => job.trim());
+      }
+
+      // Match package
+      const pkgMatch = line.match(/Package:\s+`(.+?)`/);
+      if (pkgMatch) {
+        currentTest.packageName = pkgMatch[1];
+      }
+
+      // Match class
+      const classMatch = line.match(/Class:\s+`(.+?)`/);
+      if (classMatch) {
+        currentTest.className = classMatch[1];
+      }
+
+      // Match occurrences
+      const occMatch = line.match(/Occurrences:\s+(\d+)\s*\/\s*(\d+)/);
+      if (occMatch) {
+        currentTest.occurrences = parseInt(occMatch[1], 10);
+        currentTest.totalRuns = parseInt(occMatch[2], 10);
+      }
+    }
+
+    // Push last test if any
+    if (Object.keys(currentTest).length > 0) {
+      flakyTests.push(currentTest);
+    }
+
+    return flakyTests;
+  } catch (err) {
+    console.error('[flaky-tests] Failed to parse comment:', err);
+    return null;
+  }
+}
+
+function mergeFlakyData(current, historical) {
+
+  const newTotal = historical[0].totalRuns + 1;
+  const merged = new Map();
+
+  historical.forEach(oldTest => {
+    merged.set(getTestKey(oldTest), {...oldTest, totalRuns: newTotal});
+  });
+
+  current.forEach(test => {
+    const key = getTestKey(test);
+    const existing = merged.get(key);
+
+    if (existing) {
+      const jobs = [...new Set([...existing.jobs, ...test.jobs])];
+      merged.set(key, {
+        ...existing,
+        jobs,
+        occurrences: existing.occurrences + 1,
+        totalRuns: newTotal
+      });
+    } else {
+      merged.set(key, {
+        ...test,
+        occurrences: 1,
+        totalRuns: newTotal
+      });
+    }
+  });
+
+  return Array.from(merged.values(), test => ({
+    ...test,
+    flakiness: Math.round((test.occurrences / test.totalRuns) * 100)
+  }));
+}
+
+function prepareFirstRunData(currentData) {
+  if (!currentData?.length) return [];
+
+  return currentData.map(test => ({
+    ...test,
+    occurrences: test.occurrences || 1,
+    totalRuns: 1,
+    flakiness: (test.occurrences || 1) * 100
+  }));
+}
+
+function getTestKey(test) {
+  const methodName = test.methodName.replace(/\[([^\]]+)]\([^)]+\)/g, '$1');
+  return test.fullName
+      ? `${test.fullName}`
+      : `${test.packageName}.${test.className}.${methodName}`;
+}
+
+module.exports = {
+  parseTestName,
+  getTestKey,
+  parseComment,
+  prepareFirstRunData,
+  mergeFlakyData
+};

--- a/.github/conftest-unified-ci-rules.rego
+++ b/.github/conftest-unified-ci-rules.rego
@@ -88,6 +88,35 @@ deny[msg] {
         [concat(", ", get_jobs_after_checkresults_without_ifalways(input.jobs))])
 }
 
+deny[msg] {
+    # only enforced on Unified CI since it is specific to utils-flaky-tests-summary job
+    input.name == "CI"
+    input.jobs["utils-flaky-tests-summary"]
+
+    jobs_with_flaky_outputs := get_jobs_with_flaky_outputs(input.jobs)
+    flaky_summary_needs := {need | need := input.jobs["utils-flaky-tests-summary"].needs[_]}
+
+    missing_jobs := jobs_with_flaky_outputs - flaky_summary_needs
+    count(missing_jobs) > 0
+
+    msg := sprintf("The utils-flaky-tests-summary job is missing dependencies on jobs with flakyTests outputs! Missing job IDs: %s",
+        [concat(", ", missing_jobs)])
+}
+
+deny[msg] {
+    # only enforced on Unified CI since it is specific to utils-flaky-tests-summary job
+    input.name == "CI"
+    input.jobs["utils-flaky-tests-summary"]
+
+    needs_list := input.jobs["utils-flaky-tests-summary"].needs
+    sorted_needs := sort(needs_list)
+
+    needs_list != sorted_needs
+
+    msg := sprintf("The utils-flaky-tests-summary job \"needs\" list is not alphabetically ordered! Expected: [%s], Got: [%s]",
+        [concat(", ", sorted_needs), concat(", ", needs_list)])
+}
+
 ###########################   RULE HELPERS   ##################################
 
 get_jobs_without_timeoutminutes(jobInput) = jobs_without_timeoutminutes {
@@ -191,5 +220,14 @@ get_jobs_after_checkresults_without_ifalways(jobInput) = jobs_after_checkresults
         #
         job_if := object.get(job, "if", "")  # get with empty default value
         not contains(job_if, "always() && needs.check-results.result == 'success'")
+    }
+}
+
+get_jobs_with_flaky_outputs(jobInput) = jobs_with_flaky_outputs {
+    jobs_with_flaky_outputs := { job_id |
+        job := jobInput[job_id]
+
+        # check if job has flakyTests output
+        job.outputs.flakyTests
     }
 }

--- a/.github/conftest-unified-ci-rules.rego
+++ b/.github/conftest-unified-ci-rules.rego
@@ -125,6 +125,7 @@ get_jobs_without_cihealth(jobInput) = jobs_without_cihealth {
         job_id != "get-concurrency-group-dynamically"
         job_id != "get-snapshot-docker-version-tag"
         job_id != "setup-unit-tests"
+        job_id != "utils-flaky-tests-summary"
 
         # not enforced on jobs that invoke other reusable workflows (instead enforced there)
         not job.uses

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -252,6 +252,8 @@ jobs:
     timeout-minutes: 10
     permissions: { }  # GITHUB_TOKEN unused in this job
     runs-on: gcp-perf-core-16-default
+    outputs:
+      flakyTests: ${{ steps.analyze-test-run.outputs.flakyTests }}
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-build
@@ -316,6 +318,8 @@ jobs:
     timeout-minutes: 10
     permissions: { }  # GITHUB_TOKEN unused in this job
     runs-on: gcp-perf-core-16-default
+    outputs:
+      flakyTests: ${{ steps.analyze-test-run.outputs.flakyTests }}
     strategy:
       fail-fast: false
       matrix:
@@ -382,6 +386,15 @@ jobs:
         if: ${{ failure() || cancelled() || steps.analyze-test-run.outputs.flakyTests != '' }}
         with:
           name: "[UT] Zeebe - ${{ matrix.component }} - ${{matrix.suiteName}}"
+      - name: Write matrix outputs for test analysis
+        uses: cloudposse/github-action-matrix-outputs-write@v1
+        id: matrix-write
+        with:
+          matrix-step-name: ${{ github.job }}
+          matrix-key: ${{ matrix.component }}-${{ matrix.suiteName }}
+          outputs: |-
+            flakyTests: ${{ toJson(steps.analyze-test-run.outputs.flakyTests) }}
+            hasFlaky: ${{ steps.analyze-test-run.outputs.flakyTests != '' }}
       - name: Observe build status
         if: always()
         continue-on-error: true
@@ -403,6 +416,8 @@ jobs:
     timeout-minutes: 15
     permissions: { }  # GITHUB_TOKEN unused in this job
     runs-on: gcp-perf-core-16-default
+    outputs:
+      flakyTests: ${{ steps.analyze-test-run.outputs.flakyTests }}
     env:
       ZEEBE_TEST_DOCKER_IMAGE: localhost:5000/camunda/zeebe:current-test
     services:
@@ -496,6 +511,8 @@ jobs:
     timeout-minutes: 15
     permissions: { }  # GITHUB_TOKEN unused in this job
     runs-on: gcp-perf-core-16-default
+    outputs:
+      flakyTests: ${{ steps.analyze-test-run.outputs.flakyTests }}
     env:
       ZEEBE_TEST_DOCKER_IMAGE: localhost:5000/camunda/zeebe:current-test
     services:
@@ -595,6 +612,8 @@ jobs:
     timeout-minutes: 15
     permissions: { }  # GITHUB_TOKEN unused in this job
     runs-on: gcp-perf-core-8-default
+    outputs:
+      flakyTests: ${{ steps.analyze-test-run.outputs.flakyTests }}
     env:
       ZEEBE_TEST_DOCKER_IMAGE: localhost:5000/camunda/zeebe:current-test
     steps:
@@ -661,6 +680,8 @@ jobs:
     name: "[IT] RDBMS"
     timeout-minutes: 7
     runs-on: gcp-perf-core-8-default
+    outputs:
+      flakyTests: ${{ steps.analyze-test-run.outputs.flakyTests }}
     permissions: { }  # no GITHUB_TOKEN is needed
     steps:
       - uses: actions/checkout@v4
@@ -720,6 +741,8 @@ jobs:
     timeout-minutes: 25
     permissions: { }  # GITHUB_TOKEN unused in this job
     runs-on: ${{ matrix.runs-on }}
+    outputs:
+      flakyTests: ${{ steps.analyze-test-run.outputs.flakyTests }}
     strategy:
       fail-fast: false
       matrix:
@@ -870,6 +893,15 @@ jobs:
         if: ${{ failure() || cancelled() || steps.analyze-test-run.outputs.flakyTests != '' }}
         with:
           name: "[IT] ${{ matrix.name }}"
+      - name: Write matrix outputs for test analysis
+        uses: cloudposse/github-action-matrix-outputs-write@v1
+        id: matrix-write
+        with:
+          matrix-step-name: ${{ github.job }}
+          matrix-key: ${{ matrix.module }} - [IT] ${{ matrix.name }} - ${{ matrix.owner }}
+          outputs: |-
+            flakyTests: ${{ toJson(steps.analyze-test-run.outputs.flakyTests) }}
+            hasFlaky: ${{ steps.analyze-test-run.outputs.flakyTests != '' }}
       - name: Observe build status
         if: always()
         continue-on-error: true
@@ -889,6 +921,8 @@ jobs:
     name: Camunda docker tests
     needs: [ detect-changes ]
     runs-on: ubuntu-latest
+    outputs:
+      flakyTests: ${{ steps.analyze-test-run.outputs.flakyTests }}
     timeout-minutes: 20
     permissions:
       security-events: write
@@ -988,6 +1022,68 @@ jobs:
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
           user_description: "General"
 
+  utils-flaky-tests-summary:
+    name: flaky tests summary comment
+    if: always() && github.event_name == 'pull_request'
+    needs:
+      - general-unit-tests
+      - zeebe-unit-tests
+      - elasticsearch-integration-tests
+      - opensearch-integration-tests
+      - rdbms-h2-integration-tests
+      - rdbms-integration-tests
+      - integration-tests
+      - docker-checks
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      pull-requests: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - name: Read Zeebe unit tests matrix outputs
+        uses: cloudposse/github-action-matrix-outputs-read@v1
+        id: zeebe-matrix-read
+        with:
+          matrix-step-name: zeebe-unit-tests
+      - name: Read Integration tests matrix outputs
+        uses: cloudposse/github-action-matrix-outputs-read@v1
+        id: integration-matrix-read
+        with:
+          matrix-step-name: integration-tests
+      - name: Collect flaky test results
+        id: collect-results
+        uses: ./.github/actions/collect-flaky-tests
+        with:
+          general-unit-tests-result: ${{ needs.general-unit-tests.result }}
+          general-unit-tests-flaky: ${{ needs.general-unit-tests.outputs.flakyTests }}
+          elasticsearch-tests-result: ${{ needs.elasticsearch-integration-tests.result }}
+          elasticsearch-tests-flaky: ${{ needs.elasticsearch-integration-tests.outputs.flakyTests }}
+          opensearch-tests-result: ${{ needs.opensearch-integration-tests.result }}
+          opensearch-tests-flaky: ${{ needs.opensearch-integration-tests.outputs.flakyTests }}
+          rdbms-h2-tests-result: ${{ needs.rdbms-h2-integration-tests.result }}
+          rdbms-h2-tests-flaky: ${{ needs.rdbms-h2-integration-tests.outputs.flakyTests }}
+          rdbms-tests-result: ${{ needs.rdbms-integration-tests.result }}
+          rdbms-tests-flaky: ${{ needs.rdbms-integration-tests.outputs.flakyTests }}
+          docker-checks-result: ${{ needs.docker-checks.result }}
+          docker-checks-flaky: ${{ needs.docker-checks.outputs.flakyTests }}
+          zeebe-tests-result: ${{ needs.zeebe-unit-tests.result }}
+          zeebe-matrix-output-result: ${{ steps.zeebe-matrix-read.outputs.result }}
+          integration-tests-result: ${{ needs.integration-tests.result }}
+          integration-matrix-output-result: ${{ steps.integration-matrix-read.outputs.result }}
+      - name: Update flaky tests comment
+        uses: ./.github/actions/flaky-tests-summary-comment
+        with:
+          flaky-tests-data: '${{ steps.collect-results.outputs.flaky_tests_data }}'
+          pr-number: ${{ github.event.pull_request.number }}
+          branch-name: ${{ github.event.pull_request.head.ref }}
+      - name: Delete matrix job generated artifacts
+        uses: geekyeggo/delete-artifact@v5
+        with:
+          name: |
+            zeebe-unit-tests-*
+            integration-tests-*
+
   identity-frontend-tests:
     if: needs.detect-changes.outputs.identity-frontend-tests == 'true'
     needs: [ detect-changes ]
@@ -1027,7 +1123,6 @@ jobs:
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           user_description: "Identity"
-
 
   tasklist-ci:
     if: needs.detect-changes.outputs.java-code-changes == 'true' || needs.detect-changes.outputs.frontend-changes == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1026,14 +1026,14 @@ jobs:
     name: flaky tests summary comment
     if: always() && github.event_name == 'pull_request'
     needs:
-      - general-unit-tests
-      - zeebe-unit-tests
+      - docker-checks
       - elasticsearch-integration-tests
+      - general-unit-tests
+      - integration-tests
       - opensearch-integration-tests
       - rdbms-h2-integration-tests
       - rdbms-integration-tests
-      - integration-tests
-      - docker-checks
+      - zeebe-unit-tests
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:


### PR DESCRIPTION
## Description
This PR introduces the final, cleaned-up implementation of flakiness reporting in CI via GitHub Checks. Its goal is to enhance CI visibility by automatically identifying and surfacing flaky tests in pull requests, as described here https://github.com/camunda/camunda/issues/28981

**What’s Included:**
- New `ci.yml` job to gather flaky tests data
- Usage of `cloudposse/github-action-matrix-outputs-read@v1` and `cloudposse/github-action-matrix-outputs-write@v1` to gather flaky tests from matrix jobs
- Introduction of `collect-flaky-tests` action to gather all data in a single object
- Introduction of `flaky-tests-summary-comment` action to create/update flaky tests summary comment
- Usage of `geekyeggo/delete-artifact@v5` to tear down artifacts generated while collecting data from matrix jobs
- Comment with flaky tests found + statistics.
<img width="971" height="689" alt="image" src="https://github.com/user-attachments/assets/ba5434fa-848c-40a3-9722-9117f4b568ff" />


> [!NOTE]
>  Copilot helped me generating most of the code + docs.

> [!NOTE]
> If you are curious about the process and conception of this code check out here https://github.com/camunda/camunda/pull/36161

## Related issues

closes #
