### PR TITLE
ci: add distributed systems medic to daily alerting

### DIFF
--- a/.ci/scripts/ci/setup-medic-lookup.sh
+++ b/.ci/scripts/ci/setup-medic-lookup.sh
@@ -23,8 +23,8 @@ identityMedic="<!subteam^S053MF48SSH|identity-medic>"
 lookupTeamMedic["team-identity"]=$identityMedic
 lookupTeamMedic["Identity"]=$identityMedic
 
-# no current medic slack handle for this team
-distributedSystemsMedic="Distributed Systems Medic"
+# @distributed-systems-medic
+distributedSystemsMedic="<!subteam^S09B7LXB77D|distributed-systems-medic>"
 lookupTeamMedic["team-distributed-systems"]=$distributedSystemsMedic
 lookupTeamMedic["Distributed Systems"]=$distributedSystemsMedic
 lookupTeamMedic["DistributedSystems"]=$distributedSystemsMedic


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
- Adds the Distributed System Medic to the daily CI alerts, rather than just posting a message.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
