### PR TITLE
Configure identity e2e tests to for OIDC mode

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityMappingRulesPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityMappingRulesPage.ts
@@ -51,7 +51,7 @@ export class IdentityMappingRulesPage {
       this.mappingRulesList.getByRole('cell', {name, exact: true});
 
     this.createMappingRuleButton = page.getByRole('button', {
-      name: 'Create a mapping rule',
+      name: 'Create mapping rule',
     });
     this.editMappingRuleButton = (rowName) =>
       this.mappingRulesList
@@ -91,7 +91,7 @@ export class IdentityMappingRulesPage {
       this.createMappingRuleModal.getByRole('button', {name: 'Cancel'});
     this.createMappingRuleModalCreateButton =
       this.createMappingRuleModal.getByRole('button', {
-        name: 'Create a mapping rule',
+        name: 'Create mapping rule',
       });
 
     this.editMappingRuleModal = page.getByRole('dialog', {
@@ -148,7 +148,7 @@ export class IdentityMappingRulesPage {
         name: 'Delete mapping rule',
       });
 
-    this.emptyState = page.getByText("You don't have any mapping rules yet");
+    this.emptyState = page.getByText('No mapping rules created yet');
     this.usersNavItem = page.getByText('Users');
   }
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityMappingRulesPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityMappingRulesPage.ts
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {Page, Locator} from '@playwright/test';
+import {Page, Locator, expect} from '@playwright/test';
 import {relativizePath, Paths} from 'utils/relativizePath';
 
 export class IdentityMappingRulesPage {
@@ -37,10 +37,19 @@ export class IdentityMappingRulesPage {
   readonly deleteMappingRuleModalDeleteButton: Locator;
   readonly emptyState: Locator;
   readonly usersNavItem: Locator;
+  readonly selectMappingRuleRow: (name: string) => Locator;
+  readonly mappingRuleCell: (name: string) => Locator;
 
   constructor(page: Page) {
     this.page = page;
     this.mappingRulesList = page.getByRole('table');
+
+    this.selectMappingRuleRow = (name) =>
+      this.mappingRulesList.getByRole('row', {name: name});
+
+    this.mappingRuleCell = (name) =>
+      this.mappingRulesList.getByRole('cell', {name, exact: true});
+
     this.createMappingRuleButton = page.getByRole('button', {
       name: 'Create a mapping rule',
     });
@@ -145,5 +154,48 @@ export class IdentityMappingRulesPage {
 
   async navigateToMappingRules() {
     await this.page.goto(relativizePath(Paths.mappingRules()));
+  }
+
+  async createMappingRule(
+    mappingRuleId: string,
+    mappingRuleName: string,
+    claimName: string,
+    claimValue: string,
+  ) {
+    await this.createMappingRuleButton.click();
+    await expect(this.createMappingRuleModal).toBeVisible();
+    await this.createMappingRuleIdField.fill(mappingRuleId);
+    await this.createMappingRuleNameField.fill(mappingRuleName);
+    await this.createMappingRuleClaimNameField.fill(claimName);
+    await this.createMappingRuleClaimValueField.fill(claimValue);
+
+    await this.createMappingRuleModalCreateButton.click();
+    await expect(this.createMappingRuleModal).toBeHidden();
+  }
+
+  async editMappingRule(
+    currentName: string,
+    newName: string,
+    newClaimName?: string,
+    newClaimValue?: string,
+  ) {
+    await this.editMappingRuleButton(currentName).click();
+    await expect(this.editMappingRuleModal).toBeVisible();
+    await this.editMappingRuleNameField.fill(newName);
+    if (newClaimName) {
+      await this.editMappingRuleClaimNameField.fill(newClaimName);
+    }
+    if (newClaimValue) {
+      await this.editMappingRuleClaimValueField.fill(newClaimValue);
+    }
+    await this.editMappingRuleModalUpdateButton.click();
+    await expect(this.editMappingRuleModal).toBeHidden();
+  }
+
+  async deleteMappingRule(mappingRuleName: string) {
+    await this.deleteMappingRuleButton(mappingRuleName).click();
+    await expect(this.deleteMappingRuleModal).toBeVisible();
+    await this.deleteMappingRuleModalDeleteButton.click();
+    await expect(this.deleteMappingRuleModal).toBeHidden();
   }
 }

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/mapping-rules.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/mapping-rules.spec.ts
@@ -1,0 +1,104 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {expect} from '@playwright/test';
+import {test} from 'fixtures';
+import {relativizePath, Paths} from 'utils/relativizePath';
+import {navigateToApp} from '@pages/UtilitiesPage';
+import {captureScreenshot, captureFailureVideo} from '@setup';
+import {LOGIN_CREDENTIALS, createTestData} from 'utils/constants';
+import {waitForItemInList} from 'utils/waitForItemInList';
+import {mockOIDCModeUI} from 'utils/mockOIDCModeUI';
+
+test.describe.serial('mapping rules CRUD', () => {
+  let NEW_MAPPING_RULE: NonNullable<
+    ReturnType<typeof createTestData>['mappingRule']
+  >;
+  let EDITED_MAPPING_RULE: NonNullable<
+    ReturnType<typeof createTestData>['editedMappingRule']
+  >;
+
+  test.beforeAll(() => {
+    const testData = createTestData({
+      mappingRule: true,
+      editedMappingRule: true,
+    });
+    NEW_MAPPING_RULE = testData.mappingRule!;
+    EDITED_MAPPING_RULE = testData.editedMappingRule!;
+  });
+
+  test.beforeEach(async ({page, loginPage}) => {
+    await navigateToApp(page, 'identity');
+    await mockOIDCModeUI(page);
+    await loginPage.login(
+      LOGIN_CREDENTIALS.username,
+      LOGIN_CREDENTIALS.password,
+    );
+    await expect(page).toHaveURL(relativizePath(Paths.mappingRules()));
+  });
+
+  test.afterEach(async ({page}, testInfo) => {
+    await captureScreenshot(page, testInfo);
+    await captureFailureVideo(page, testInfo);
+  });
+
+  test('creates a mapping rule', async ({page, identityMappingRulesPage}) => {
+    await identityMappingRulesPage.createMappingRule(
+      NEW_MAPPING_RULE.id,
+      NEW_MAPPING_RULE.name,
+      NEW_MAPPING_RULE.claimName,
+      NEW_MAPPING_RULE.claimValue,
+    );
+
+    const item = identityMappingRulesPage.mappingRuleCell(
+      NEW_MAPPING_RULE.name,
+    );
+
+    await waitForItemInList(page, item, {
+      emptyStateLocator: identityMappingRulesPage.emptyState,
+    });
+
+    await expect(item).toBeVisible();
+  });
+
+  test('edits a mapping rule', async ({page, identityMappingRulesPage}) => {
+    await expect(
+      identityMappingRulesPage.mappingRuleCell(NEW_MAPPING_RULE.name),
+    ).toBeVisible();
+
+    await identityMappingRulesPage.editMappingRule(
+      NEW_MAPPING_RULE.name,
+      EDITED_MAPPING_RULE.name,
+      EDITED_MAPPING_RULE.claimName,
+      EDITED_MAPPING_RULE.claimValue,
+    );
+
+    const item = identityMappingRulesPage.mappingRuleCell(
+      EDITED_MAPPING_RULE.name,
+    );
+
+    await waitForItemInList(page, item);
+  });
+
+  test('deletes a mapping rule', async ({page, identityMappingRulesPage}) => {
+    await expect(
+      identityMappingRulesPage.mappingRuleCell(EDITED_MAPPING_RULE.name),
+    ).toBeVisible();
+
+    await identityMappingRulesPage.deleteMappingRule(EDITED_MAPPING_RULE.name);
+
+    const item = identityMappingRulesPage.mappingRuleCell(
+      EDITED_MAPPING_RULE.name,
+    );
+
+    await waitForItemInList(page, item, {
+      shouldBeVisible: false,
+      emptyStateLocator: identityMappingRulesPage.emptyState,
+    });
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/constants.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/constants.ts
@@ -62,6 +62,27 @@ export const createUniqueTenant = (customId?: string) => {
   };
 };
 
+// Create unique mapping rule with optional custom ID
+export const createUniqueMappingRule = (customId?: string) => {
+  const id = customId || generateUniqueId();
+  return {
+    id: `mapping${id}`,
+    name: `Test Mapping Rule ${id}`,
+    claimName: `claim${id}`,
+    claimValue: `value${id}`,
+  };
+};
+
+// Create unique edited mapping rule data with optional custom ID
+export const createEditedMappingRule = (customId?: string) => {
+  const id = customId || generateUniqueId();
+  return {
+    name: `Edited Mapping Rule ${id}`,
+    claimName: `edited-claim${id}`,
+    claimValue: `edited-value${id}`,
+  };
+};
+
 // Generic function to create specific test data with shared ID
 
 export const createUserAuthorization = (authRole: {name: string}) => ({
@@ -89,6 +110,8 @@ export const createTestData = (options: {
   group?: boolean;
   editedGroup?: boolean;
   tenant?: boolean;
+  mappingRule?: boolean;
+  editedMappingRule?: boolean;
 }) => {
   const {
     user = false,
@@ -98,6 +121,8 @@ export const createTestData = (options: {
     group = false,
     editedGroup = false,
     tenant = false,
+    mappingRule = false,
+    editedMappingRule = false,
   } = options;
   const sharedId = generateUniqueId();
 
@@ -109,6 +134,8 @@ export const createTestData = (options: {
     group?: ReturnType<typeof createUniqueGroup>;
     editedGroup?: ReturnType<typeof createEditedGroup>;
     tenant?: ReturnType<typeof createUniqueTenant>;
+    mappingRule?: ReturnType<typeof createUniqueMappingRule>;
+    editedMappingRule?: ReturnType<typeof createEditedMappingRule>;
     id: string;
   } = {id: sharedId};
 
@@ -130,6 +157,14 @@ export const createTestData = (options: {
 
   if (tenant) {
     result.tenant = createUniqueTenant(sharedId);
+  }
+
+  if (mappingRule) {
+    result.mappingRule = createUniqueMappingRule(sharedId);
+  }
+
+  if (editedMappingRule) {
+    result.editedMappingRule = createEditedMappingRule(sharedId);
   }
 
   // Create authorizations only if authRole is also created

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/mockOIDCModeUI.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/mockOIDCModeUI.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {Page, Route} from '@playwright/test';
+
+export async function mockOIDCModeUI(page: Page): Promise<void> {
+  await page.route('**/config.js', async (route: Route) => {
+    const response = await route.fetch();
+    const originalBody = await response.text();
+
+    let config: Record<string, string> = {};
+
+    const match = originalBody.match(
+      /window\.clientConfig\s*=\s*(\{[\s\S]*\});?/,
+    );
+
+    if (match) {
+      config = eval('(' + match[1] + ')');
+    }
+
+    Object.keys(config).forEach((key) => {
+      if (key.includes('IS_OIDC')) {
+        config[key] = 'true';
+      }
+    });
+
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/javascript',
+      body: `window.clientConfig = ${JSON.stringify(config)};`,
+    });
+  });
+}

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/mockOIDCModeUI.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/mockOIDCModeUI.ts
@@ -24,7 +24,7 @@ export async function mockOIDCModeUI(page: Page): Promise<void> {
     }
 
     Object.keys(config).forEach((key) => {
-      if (key.includes('IS_OIDC')) {
+      if (key === 'isOidc') {
         config[key] = 'true';
       }
     });


### PR DESCRIPTION
## Description

- Creates utility that allows for FE/UI E2E testing by intercepting and modifying the `clientConfig.js` request's response to force the UI into OIDC mode (allowing, for example, testing of Mapping rules CRUD)
- Adds create, edit and delete test cases for Mapping Rules with UI in mocked OIDC mode
- Creates new fixtures for `IdentityMappingRulesPage.ts` (create, edit and delete utility functions) and modifies existing ones
- Fixes unrelated linting issues

IMPORTANT: As #31750 is an issue intended to address the ability of testing the UI, especially unblocking the creation of basic coverage for the Mapping Rules page. For those purposes the mock method used here is sufficient. 

If at some point we actually need to run the application in OIDC mode in a test environment the setup would be more complex due to having to configure Identity's environment itself with MS Entra. That setup also raises questions about possibly having a dedicated account added to that project to run the tests, as well as how to appropriately treatpotentially sensitive data (client ID, client secred, issuer URI for MS Entra) for this configuration.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #31750 
