### PR TITLE
refactor: do not print out record in error responses

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.engine.state.EventApplier;
 import io.camunda.zeebe.engine.state.appliers.EventAppliers;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.engine.state.processing.DbBannedInstanceState;
+import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
 import io.camunda.zeebe.protocol.impl.record.value.error.ErrorRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
@@ -217,7 +218,17 @@ public class Engine implements RecordProcessor {
       writers.rejection().appendRejection(record, RejectionType.PROCESSING_ERROR, errorMessage);
       writers
           .response()
-          .writeRejectionOnCommand(record, RejectionType.PROCESSING_ERROR, errorMessage);
+          .writeRejectionOnCommand(
+              record,
+              RejectionType.PROCESSING_ERROR,
+              """
+                Expected to process command %d (%s.%s) without errors, but unexpected error occurred. \
+                Check your broker logs (partition %d), or ask your operator, for more details."""
+                  .formatted(
+                      Protocol.encodePartitionId(record.getPartitionId(), record.getKey()),
+                      record.getValueType(),
+                      record.getIntent(),
+                      record.getPartitionId()));
     }
     errorRecord.initErrorRecord(processingException, record.getPosition());
 

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.logstreams.log.LogStreamReader;
 import io.camunda.zeebe.logstreams.log.LogStreamWriter;
 import io.camunda.zeebe.logstreams.log.LoggedEvent;
 import io.camunda.zeebe.logstreams.log.WriteContext;
+import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.impl.record.value.error.ErrorRecord;
 import io.camunda.zeebe.protocol.record.RecordType;
@@ -463,20 +464,26 @@ public final class ProcessingStateMachine {
   }
 
   private boolean tryExitOutOfErrorLoop(final Throwable error) {
+    final var rejectionReason =
+        """
+            Expected to process command %d (%s.%s), but caught an exception. Check broker logs \
+            (partition %s) for details, or ask your operator to do so."""
+            .formatted(
+                Protocol.encodePartitionId(context.getPartitionId(), currentRecord.getKey()),
+                metadata.getValueType(),
+                metadata.getIntent(),
+                context.getPartitionId());
     try {
       // If in error loop and the processing record is a user command
       if (errorHandlingPhase == ErrorHandlingPhase.USER_COMMAND_PROCESSING_ERROR_FAILED) {
         // First try to reject with proper error message
         LOG.debug(ERROR_MESSAGE_HANDLING_PROCESSING_ERROR_FAILED, currentRecord, metadata, error);
-        tryRejectingIfUserCommand(error.getMessage());
+        tryRejectingIfUserCommand(rejectionReason);
         return true;
       } else if (errorHandlingPhase == ErrorHandlingPhase.USER_COMMAND_REJECT_FAILED) {
         LOG.warn(ERROR_MESSAGE_HANDLING_PROCESSING_ERROR_FAILED, currentRecord, metadata, error);
         // try to reject with a generic error message
-        tryRejectingIfUserCommand(
-            String.format(
-                "Expected to process command, but caught an exception. Check broker logs (partition %s) for details.",
-                context.getPartitionId()));
+        tryRejectingIfUserCommand(rejectionReason);
         return true;
       }
     } catch (final Exception e) {


### PR DESCRIPTION
## Description

This PR updates the error messages sent as rejection **responses** back to user when we face a processing error (i.e. an unexpected error).

Previously, there was a good chance that we would leak the complete record as part of it, which is generally something users do not understand and do not know what to do with it. 

Note that the original error is still logged, so we have access to it via the logs, but the response is much more lightweight. The "actionable" part of the error is to look at logs or ask your operator to do so, with the command key, partition, value type, and intent.

## Related issues

related to #35177 

In the sense that this highlighted we just leak the complete record all the way through the client.
