### PR TITLE
fix: add timeout to Interaction between diagram and filters test

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstancesFilters.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstancesFilters.spec.ts
@@ -18,7 +18,7 @@ type ProcessInstance = {processInstanceKey: number};
 let callActivityProcessInstance: ProcessInstance;
 let orderProcessInstance: ProcessInstance;
 
-test.beforeAll(async ({request}) => {
+test.beforeAll(async () => {
   await deploy([
     './resources/processWithMultipleVersions_v_1.bpmn',
     './resources/processWithAnError.bpmn',
@@ -189,9 +189,9 @@ test.describe('Process Instances Filters', () => {
       await expect(operateFiltersPanelPage.flowNodeFilter).toHaveValue('');
 
       await operateFiltersPanelPage.selectFlowNode('StartEvent_1');
-      await expect(
-        operateProcessesPage.noMatchingInstancesMessage,
-      ).toBeVisible();
+      await expect(operateProcessesPage.noMatchingInstancesMessage).toBeVisible(
+        {timeout: 60000},
+      );
     });
 
     await test.step('Select another flow node from the diagram', async () => {


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
This test was flaky in the nightly runs, added a timeout to stabilise it


🧪 Successful test run [here](https://github.com/camunda/camunda/actions/runs/17201053141)
      Tests failed due to below issues:
          - [Variable Editing Spinner issue](https://github.com/camunda/camunda/issues/34148)
          - [Variable Editing bug](https://github.com/camunda/camunda/issues/36368)
## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
