### PR TITLE
feat: add cluster raft properties to unified configuration

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/Raft.java
+++ b/configuration/src/main/java/io/camunda/configuration/Raft.java
@@ -8,8 +8,15 @@
 
 package io.camunda.configuration;
 
+import static io.camunda.zeebe.broker.system.configuration.ClusterCfg.DEFAULT_ELECTION_TIMEOUT;
+import static io.camunda.zeebe.broker.system.configuration.ExperimentalCfg.DEFAULT_MAX_APPENDS_PER_FOLLOWER;
+import static io.camunda.zeebe.broker.system.configuration.ExperimentalCfg.DEFAULT_MAX_APPEND_BATCH_SIZE;
+import static io.camunda.zeebe.broker.system.configuration.ExperimentalRaftCfg.DEFAULT_SNAPSHOT_CHUNK_SIZE;
+import static io.camunda.zeebe.broker.system.configuration.ExperimentalRaftCfg.DEFAULT_SNAPSHOT_REQUEST_TIMEOUT;
+
 import java.time.Duration;
 import java.util.Set;
+import org.springframework.util.unit.DataSize;
 
 /**
  * Configuration for the Raft consensus protocol in the cluster. This class provides settings for
@@ -24,6 +31,26 @@ public class Raft {
       "zeebe.broker.cluster.raft.enablePriorityElection";
   private static final String LEGACY_FLUSH_ENABLED = "zeebe.broker.cluster.raft.flush.enabled";
   private static final String LEGACY_FLUSH_DELAY = "zeebe.broker.cluster.raft.flush.delay";
+  private static final String LEGACY_MAX_APPENDS_PER_FOLLOWER =
+      "zeebe.broker.experimental.maxAppendsPerFollower";
+  private static final String LEGACY_MAX_APPEND_BATCH_SIZE =
+      "zeebe.broker.experimental.maxAppendBatchSize";
+  private static final String LEGACY_REQUEST_TIMEOUT =
+      "zeebe.broker.experimental.raft.requestTimeout";
+  private static final String LEGACY_SNAPSHOT_REQUEST_TIMEOUT =
+      "zeebe.broker.experimental.raft.snapshotRequestTimeout";
+  private static final String LEGACY_SNAPSHOT_CHUNK_SIZE =
+      "zeebe.broker.experimental.raft.snapshotChunkSize";
+  private static final String LEGACY_CONFIGURATION_CHANGE_TIMEOUT =
+      "zeebe.broker.experimental.raft.configurationChangeTimeout";
+  private static final String LEGACY_MAX_QUORUM_RESPONSE_TIMEOUT =
+      "zeebe.broker.experimental.raft.maxQuorumResponseTimeout";
+  private static final String LEGACY_MIN_STEP_DOWN_FAILURE_COUNT =
+      "zeebe.broker.experimental.raft.minStepDownFailureCount";
+  private static final String LEGACY_PREFER_SNAPSHOT_REPLICATION_THRESHOLD =
+      "zeebe.broker.experimental.raft.preferSnapshotReplicationThreshold";
+  private static final String LEGACY_PREALLOCATE_SEGMENT_FILES =
+      "zeebe.broker.experimental.raft.preallocateSegmentFiles";
 
   /**
    * The heartbeat interval for Raft. The leader sends a heartbeat to a follower every
@@ -72,6 +99,71 @@ public class Raft {
    * follower append in a synchronous fashion.
    */
   private Duration flushDelay = Duration.ZERO;
+
+  /** Sets the maximum of appends which are send per follower. */
+  private int maxAppendsPerFollower = DEFAULT_MAX_APPENDS_PER_FOLLOWER;
+
+  /** Sets the maximum batch size, which is send per append request to a follower. */
+  private DataSize maxAppendBatchSize = DEFAULT_MAX_APPEND_BATCH_SIZE;
+
+  /**
+   * Sets the timeout for all requests send by raft leaders and followers.When modifying the values
+   * for requestTimeout, it might also be useful to update snapshotTimeout.
+   */
+  private Duration requestTimeout = DEFAULT_ELECTION_TIMEOUT;
+
+  /**
+   * Sets the timeout for all snapshot requests sent by raft leaders to the followers. If the
+   * network latency between brokers is high, it would help to set a higher timeout here.
+   */
+  private Duration snapshotRequestTimeout = DEFAULT_SNAPSHOT_REQUEST_TIMEOUT;
+
+  /** Sets the maximum size of snapshot chunks sent by raft leaders to the followers. */
+  private DataSize snapshotChunkSize = DEFAULT_SNAPSHOT_CHUNK_SIZE;
+
+  /**
+   * Sets the timeout for configuration change requests such as joining or leaving. Since changes
+   * are usually a multi-step process with multiple commits, a higher timeout than the default
+   * requestTimeout is recommended.
+   */
+  private Duration configurationChangeTimeout = Duration.ofSeconds(10);
+
+  /**
+   * If the leader is not able to reach the quorum, the leader may step down. This is triggered if
+   * the leader is not able to reach the quorum of the followers for maxQuorumResponseTimeout. The
+   * minStepDownFailureCount also influences when the leader step down. Higher the timeout, slower
+   * the leader reacts to a partial network partition. When the timeout is lower, there might be
+   * false positives, and the leader might step down too quickly. When this value is 0, it will use
+   * a default value of electionTimeout * 2.
+   */
+  private Duration maxQuorumResponseTimeout = Duration.ofSeconds(0);
+
+  /**
+   * If the leader is not able to reach the quorum, the leader may step down. This is triggered
+   * after a number of requests, to a quorum of followers, has failed, and the number of failures
+   * reached minStepDownFailureCount. The maxQuorumResponseTime also influences when the leader step
+   * down.
+   */
+  private int minStepDownFailureCount = 3;
+
+  /**
+   * Threshold used by the leader to decide between replicating a snapshot or records. The unit is
+   * number of records by which the follower may lag behind before the leader prefers replicating
+   * snapshots instead of records.
+   */
+  private int preferSnapshotReplicationThreshold = 100;
+
+  /**
+   * Defines whether segment files are pre-allocated to their full size on creation or not. If true,
+   * when a new segment is created on demand, disk space will be reserved for its full maximum size.
+   * This helps avoid potential out of disk space errors which can be fatal when using memory mapped
+   * files, especially when running on network storage. In the best cases, it will also allocate
+   * contiguous blocks, giving a small performance boost.
+   *
+   * <p>You may want to turn this off if your system does not support efficient file allocation via
+   * system calls, or if you notice an I/O penalty when creating segments.
+   */
+  private boolean preallocateSegmentFiles = true;
 
   public Duration getHeartbeatInterval() {
     return UnifiedConfigurationHelper.validateLegacyConfiguration(
@@ -136,5 +228,135 @@ public class Raft {
 
   public void setFlushDelay(final Duration flushDelay) {
     this.flushDelay = flushDelay;
+  }
+
+  public int getMaxAppendsPerFollower() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + ".max-appends-per-follower",
+        maxAppendsPerFollower,
+        Integer.class,
+        UnifiedConfigurationHelper.BackwardsCompatibilityMode.SUPPORTED,
+        Set.of(LEGACY_MAX_APPENDS_PER_FOLLOWER));
+  }
+
+  public void setMaxAppendsPerFollower(final int maxAppendsPerFollower) {
+    this.maxAppendsPerFollower = maxAppendsPerFollower;
+  }
+
+  public DataSize getMaxAppendBatchSize() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + ".max-append-batch-size",
+        maxAppendBatchSize,
+        DataSize.class,
+        UnifiedConfigurationHelper.BackwardsCompatibilityMode.SUPPORTED,
+        Set.of(LEGACY_MAX_APPEND_BATCH_SIZE));
+  }
+
+  public void setMaxAppendBatchSize(final DataSize maxAppendBatchSize) {
+    this.maxAppendBatchSize = maxAppendBatchSize;
+  }
+
+  public Duration getRequestTimeout() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + ".request-timeout",
+        requestTimeout,
+        Duration.class,
+        UnifiedConfigurationHelper.BackwardsCompatibilityMode.SUPPORTED,
+        Set.of(LEGACY_REQUEST_TIMEOUT));
+  }
+
+  public void setRequestTimeout(final Duration requestTimeout) {
+    this.requestTimeout = requestTimeout;
+  }
+
+  public Duration getSnapshotRequestTimeout() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + ".snapshot-request-timeout",
+        snapshotRequestTimeout,
+        Duration.class,
+        UnifiedConfigurationHelper.BackwardsCompatibilityMode.SUPPORTED,
+        Set.of(LEGACY_SNAPSHOT_REQUEST_TIMEOUT));
+  }
+
+  public void setSnapshotRequestTimeout(final Duration snapshotRequestTimeout) {
+    this.snapshotRequestTimeout = snapshotRequestTimeout;
+  }
+
+  public DataSize getSnapshotChunkSize() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + ".snapshot-chunk-size",
+        snapshotChunkSize,
+        DataSize.class,
+        UnifiedConfigurationHelper.BackwardsCompatibilityMode.SUPPORTED,
+        Set.of(LEGACY_SNAPSHOT_CHUNK_SIZE));
+  }
+
+  public void setSnapshotChunkSize(final DataSize snapshotChunkSize) {
+    this.snapshotChunkSize = snapshotChunkSize;
+  }
+
+  public Duration getConfigurationChangeTimeout() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + ".configuration-change-timeout",
+        configurationChangeTimeout,
+        Duration.class,
+        UnifiedConfigurationHelper.BackwardsCompatibilityMode.SUPPORTED,
+        Set.of(LEGACY_CONFIGURATION_CHANGE_TIMEOUT));
+  }
+
+  public void setConfigurationChangeTimeout(final Duration configurationChangeTimeout) {
+    this.configurationChangeTimeout = configurationChangeTimeout;
+  }
+
+  public Duration getMaxQuorumResponseTimeout() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + ".max-quorum-response-timeout",
+        maxQuorumResponseTimeout,
+        Duration.class,
+        UnifiedConfigurationHelper.BackwardsCompatibilityMode.SUPPORTED,
+        Set.of(LEGACY_MAX_QUORUM_RESPONSE_TIMEOUT));
+  }
+
+  public void setMaxQuorumResponseTimeout(final Duration maxQuorumResponseTimeout) {
+    this.maxQuorumResponseTimeout = maxQuorumResponseTimeout;
+  }
+
+  public int getMinStepDownFailureCount() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + ".min-step-down-failure-count",
+        minStepDownFailureCount,
+        Integer.class,
+        UnifiedConfigurationHelper.BackwardsCompatibilityMode.SUPPORTED,
+        Set.of(LEGACY_MIN_STEP_DOWN_FAILURE_COUNT));
+  }
+
+  public void setMinStepDownFailureCount(final int minStepDownFailureCount) {
+    this.minStepDownFailureCount = minStepDownFailureCount;
+  }
+
+  public int getPreferSnapshotReplicationThreshold() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + ".prefer-snapshot-replication-threshold",
+        preferSnapshotReplicationThreshold,
+        Integer.class,
+        UnifiedConfigurationHelper.BackwardsCompatibilityMode.SUPPORTED,
+        Set.of(LEGACY_PREFER_SNAPSHOT_REPLICATION_THRESHOLD));
+  }
+
+  public void setPreferSnapshotReplicationThreshold(final int preferSnapshotReplicationThreshold) {
+    this.preferSnapshotReplicationThreshold = preferSnapshotReplicationThreshold;
+  }
+
+  public boolean isPreallocateSegmentFiles() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + ".preallocate-segment-files",
+        preallocateSegmentFiles,
+        Boolean.class,
+        UnifiedConfigurationHelper.BackwardsCompatibilityMode.SUPPORTED,
+        Set.of(LEGACY_PREALLOCATE_SEGMENT_FILES));
+  }
+
+  public void setPreallocateSegmentFiles(final boolean preallocateSegmentFiles) {
+    this.preallocateSegmentFiles = preallocateSegmentFiles;
   }
 }

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
@@ -210,6 +210,35 @@ public class BrokerBasedPropertiesOverride {
     // Set flush configuration
     final var flushConfig = new FlushConfig(raft.isFlushEnabled(), raft.getFlushDelay());
     override.getCluster().getRaft().setFlush(flushConfig);
+
+    override.getExperimental().setMaxAppendsPerFollower(raft.getMaxAppendsPerFollower());
+    override.getExperimental().setMaxAppendBatchSize(raft.getMaxAppendBatchSize());
+    override.getExperimental().getRaft().setRequestTimeout(raft.getRequestTimeout());
+    override
+        .getExperimental()
+        .getRaft()
+        .setSnapshotRequestTimeout(raft.getSnapshotRequestTimeout());
+    override.getExperimental().getRaft().setSnapshotChunkSize(raft.getSnapshotChunkSize());
+    override
+        .getExperimental()
+        .getRaft()
+        .setConfigurationChangeTimeout(raft.getConfigurationChangeTimeout());
+    override
+        .getExperimental()
+        .getRaft()
+        .setMaxQuorumResponseTimeout(raft.getMaxQuorumResponseTimeout());
+    override
+        .getExperimental()
+        .getRaft()
+        .setMinStepDownFailureCount(raft.getMinStepDownFailureCount());
+    override
+        .getExperimental()
+        .getRaft()
+        .setPreferSnapshotReplicationThreshold(raft.getPreferSnapshotReplicationThreshold());
+    override
+        .getExperimental()
+        .getRaft()
+        .setPreallocateSegmentFiles(raft.isPreallocateSegmentFiles());
   }
 
   private void populateFromClusterMetadata(final BrokerBasedProperties override) {


### PR DESCRIPTION
## Description

This PR adds the properties from section camunda.cluster.raft in unified config.

Note: Cluster section is scheduled for 8.9.

The legacy properties are:
zeebe.broker.experimental.maxAppendsPerFollower
zeebe.broker.experimental.maxAppendBatchSize
zeebe.broker.experimental.raft.requestTimeout
zeebe.broker.experimental.raft.snapshotRequestTimeout
zeebe.broker.experimental.raft.snapshotChunkSize
zeebe.broker.experimental.raft.configurationChangeTimeout
zeebe.broker.experimental.raft.maxQuorumResponseTimeout
zeebe.broker.experimental.raft.minStepDownFailureCount
zeebe.broker.experimental.raft.preferSnapshotReplicationThreshold
zeebe.broker.experimental.raft.preallocateSegmentFiles

The new properties are:
camunda.cluster.raft.max-appends-per-follower
camunda.cluster.raft.max-append-batch-size
camunda.cluster.raft.request-timeout
camunda.cluster.raft.snapshot-request-timeout
camunda.cluster.raft.snapshot-chunk-size
camunda.cluster.raft.configuration-change-timeout
camunda.cluster.raft.max-quorum-response-timeout
camunda.cluster.raft.min-step-down-failure-count
camunda.cluster.raft.prefer-snapshot-replication-threshold
camunda.cluster.raft.preallocate-segment-files

Backwards compatibility is supported for these properties. That means, if legacy is set and new property is not set, legacy value will be used.

## Checklist

- [x] The legacy properties and the backwards compatibility strategy are updated in [schema doc](https://docs.google.com/spreadsheets/d/1R4epsy6DWemA8_76cUE6zOGUFbrXCXlM2reXnKFuz7Y/edit?gid=818158292#gid=818158292)
- [x] The new property fields are documented in the code
## Related issues

related to #34906