### PR TITLE
[Backport stable/8.6] fix: make Tasklist and Operate updateSchemaSettings default to false

### DIFF
--- a/operate/common/src/main/java/io/camunda/operate/property/ElasticsearchProperties.java
+++ b/operate/common/src/main/java/io/camunda/operate/property/ElasticsearchProperties.java
@@ -38,7 +38,8 @@ public class ElasticsearchProperties {
   private Integer connectTimeout;
 
   private boolean createSchema = true;
-  private boolean updateSchemaSettings = true;
+  // default to false to avoid breaking change in 8.7 patch version. SM users need to opt-in
+  private boolean updateSchemaSettings = false;
 
   /** Indicates whether operate does a proper health check for ES clusters. */
   private boolean healthCheckEnabled = true;

--- a/operate/common/src/main/java/io/camunda/operate/property/ElasticsearchProperties.java
+++ b/operate/common/src/main/java/io/camunda/operate/property/ElasticsearchProperties.java
@@ -38,7 +38,7 @@ public class ElasticsearchProperties {
   private Integer connectTimeout;
 
   private boolean createSchema = true;
-  // default to false to avoid breaking change in 8.7 patch version. SM users need to opt-in
+  // default to false to avoid breaking change in 8.7 patch version
   private boolean updateSchemaSettings = false;
 
   /** Indicates whether operate does a proper health check for ES clusters. */

--- a/operate/common/src/main/java/io/camunda/operate/property/OpensearchProperties.java
+++ b/operate/common/src/main/java/io/camunda/operate/property/OpensearchProperties.java
@@ -38,7 +38,8 @@ public class OpensearchProperties {
   private Integer connectTimeout;
 
   private boolean createSchema = true;
-  private boolean updateSchemaSettings = true;
+  // default to false to avoid breaking change in 8.7 patch version. SM users need to opt-in
+  private boolean updateSchemaSettings = false;
 
   /** Indicates whether operate does a proper health check for ES/OS clusters. */
   private boolean healthCheckEnabled = true;

--- a/operate/common/src/main/java/io/camunda/operate/property/OpensearchProperties.java
+++ b/operate/common/src/main/java/io/camunda/operate/property/OpensearchProperties.java
@@ -38,7 +38,7 @@ public class OpensearchProperties {
   private Integer connectTimeout;
 
   private boolean createSchema = true;
-  // default to false to avoid breaking change in 8.7 patch version. SM users need to opt-in
+  // default to false to avoid breaking change in 8.7 patch version
   private boolean updateSchemaSettings = false;
 
   /** Indicates whether operate does a proper health check for ES/OS clusters. */

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/schema/SchemaStartupIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/schema/SchemaStartupIT.java
@@ -42,6 +42,8 @@ import io.camunda.operate.store.opensearch.OpensearchTaskStore;
 import java.util.Map;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
@@ -178,16 +180,23 @@ public class SchemaStartupIT extends AbstractSchemaIT {
         .isEqualTo(String.valueOf(updatedReplicas));
   }
 
-  @Test
-  public void shouldNotUpdateIndexSettingsWhenUpdateSchemaSettingsIsDisabled()
-      throws MigrationException {
+  /**
+   * @param useDefaultConfiguration when true, relies on default configuration where
+   *     updateSchemaSettings is false; when false, explicitly sets updateSchemaSettings to false
+   */
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  public void shouldNotUpdateIndexSettingsWhenUpdateSchemaSettingsIsDisabled(
+      final boolean useDefaultConfiguration) throws MigrationException {
     // given
     final int initialReplicas = 0;
     final int attemptedUpdatedReplicas = 2;
 
     // Set initial replica count and disable schema settings update
     setNumberOfReplicas(initialReplicas);
-    setUpdateSchemaSettings(false);
+    if (!useDefaultConfiguration) {
+      setUpdateSchemaSettings(false);
+    }
     migrationProperties.setMigrationEnabled(false);
 
     // Create initial schema

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/schema/SchemaStartupIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/schema/SchemaStartupIT.java
@@ -12,10 +12,12 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.entry;
 
 import io.camunda.operate.JacksonConfig;
+import io.camunda.operate.conditions.DatabaseInfo;
 import io.camunda.operate.connect.OperateDateTimeFormatter;
 import io.camunda.operate.exceptions.MigrationException;
 import io.camunda.operate.exceptions.OperateRuntimeException;
 import io.camunda.operate.property.MigrationProperties;
+import io.camunda.operate.property.OperateProperties;
 import io.camunda.operate.schema.IndexMapping.IndexMappingProperty;
 import io.camunda.operate.schema.elasticsearch.ElasticsearchSchemaManager;
 import io.camunda.operate.schema.indices.MigrationRepositoryIndex;
@@ -42,6 +44,7 @@ import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 
 @ContextConfiguration(
@@ -72,12 +75,17 @@ import org.springframework.test.context.ContextConfiguration;
       TestSchemaStartup.class
     })
 @SpringBootTest(properties = {"spring.profiles.active="})
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 public class SchemaStartupIT extends AbstractSchemaIT {
 
   @Autowired public SchemaManager schemaManager;
 
   @Autowired public TestSchemaStartup schemaStartup;
   @Autowired public TestIndex testIndex;
+
+  @Autowired private OperateProperties operateProperties;
+
+  @Autowired private MigrationProperties migrationProperties;
 
   @Test
   public void shouldAddMissingFieldToExistingIndex() throws MigrationException {
@@ -134,5 +142,90 @@ public class SchemaStartupIT extends AbstractSchemaIT {
     assertThatThrownBy(() -> schemaStartup.initializeSchemaOnDemand())
         .isInstanceOf(OperateRuntimeException.class)
         .hasMessageContaining("Not supported index changes are introduced");
+  }
+
+  @Test
+  public void shouldUpdateIndexSettingsWhenUpdateSchemaSettingsIsEnabled()
+      throws MigrationException {
+    // given
+    final int initialReplicas = 0;
+    final int updatedReplicas = 2;
+
+    // Set initial replica count and enable schema settings update
+    setNumberOfReplicas(initialReplicas);
+    setUpdateSchemaSettings(true);
+    migrationProperties.setMigrationEnabled(false);
+
+    // Create initial schema
+    schemaStartup.initializeSchemaOnDemand();
+
+    // Verify initial replica settings
+    final String indexName = testIndex.getFullQualifiedName();
+    final Map<String, String> initialSettings =
+        schemaManager.getIndexSettingsFor(indexName, SchemaManager.NUMBERS_OF_REPLICA);
+    assertThat(initialSettings.get(SchemaManager.NUMBERS_OF_REPLICA))
+        .isEqualTo(String.valueOf(initialReplicas));
+
+    // when
+    // Update replica count in properties and reinitialize schema
+    setNumberOfReplicas(updatedReplicas);
+    schemaStartup.initializeSchemaOnDemand();
+
+    // then
+    final Map<String, String> updatedSettings =
+        schemaManager.getIndexSettingsFor(indexName, SchemaManager.NUMBERS_OF_REPLICA);
+    assertThat(updatedSettings.get(SchemaManager.NUMBERS_OF_REPLICA))
+        .isEqualTo(String.valueOf(updatedReplicas));
+  }
+
+  @Test
+  public void shouldNotUpdateIndexSettingsWhenUpdateSchemaSettingsIsDisabled()
+      throws MigrationException {
+    // given
+    final int initialReplicas = 0;
+    final int attemptedUpdatedReplicas = 2;
+
+    // Set initial replica count and disable schema settings update
+    setNumberOfReplicas(initialReplicas);
+    setUpdateSchemaSettings(false);
+    migrationProperties.setMigrationEnabled(false);
+
+    // Create initial schema
+    schemaStartup.initializeSchemaOnDemand();
+
+    // Verify initial replica settings
+    final String indexName = testIndex.getFullQualifiedName();
+    final Map<String, String> initialSettings =
+        schemaManager.getIndexSettingsFor(indexName, SchemaManager.NUMBERS_OF_REPLICA);
+    assertThat(initialSettings.get(SchemaManager.NUMBERS_OF_REPLICA))
+        .isEqualTo(String.valueOf(initialReplicas));
+
+    // when
+    // Update replica count in properties and reinitialize schema
+    setNumberOfReplicas(attemptedUpdatedReplicas);
+    schemaStartup.initializeSchemaOnDemand();
+
+    // then
+    // Settings should remain unchanged
+    final Map<String, String> unchangedSettings =
+        schemaManager.getIndexSettingsFor(indexName, SchemaManager.NUMBERS_OF_REPLICA);
+    assertThat(unchangedSettings.get(SchemaManager.NUMBERS_OF_REPLICA))
+        .isEqualTo(String.valueOf(initialReplicas));
+  }
+
+  private void setNumberOfReplicas(final int numberOfReplicas) {
+    if (DatabaseInfo.isElasticsearch()) {
+      operateProperties.getElasticsearch().setNumberOfReplicas(numberOfReplicas);
+    } else {
+      operateProperties.getOpensearch().setNumberOfReplicas(numberOfReplicas);
+    }
+  }
+
+  private void setUpdateSchemaSettings(final boolean updateSchemaSettings) {
+    if (DatabaseInfo.isElasticsearch()) {
+      operateProperties.getElasticsearch().setUpdateSchemaSettings(updateSchemaSettings);
+    } else {
+      operateProperties.getOpensearch().setUpdateSchemaSettings(updateSchemaSettings);
+    }
   }
 }

--- a/tasklist/common/src/main/java/io/camunda/tasklist/property/ElasticsearchProperties.java
+++ b/tasklist/common/src/main/java/io/camunda/tasklist/property/ElasticsearchProperties.java
@@ -38,7 +38,7 @@ public class ElasticsearchProperties {
   private Integer connectTimeout;
 
   private boolean createSchema = true;
-  // default to false to avoid breaking change in 8.7 patch version. SM users need to opt-in
+  // default to false to avoid breaking change in 8.7 patch version
   private boolean updateSchemaSettings = false;
 
   private String url;

--- a/tasklist/common/src/main/java/io/camunda/tasklist/property/ElasticsearchProperties.java
+++ b/tasklist/common/src/main/java/io/camunda/tasklist/property/ElasticsearchProperties.java
@@ -38,7 +38,8 @@ public class ElasticsearchProperties {
   private Integer connectTimeout;
 
   private boolean createSchema = true;
-  private boolean updateSchemaSettings = true;
+  // default to false to avoid breaking change in 8.7 patch version. SM users need to opt-in
+  private boolean updateSchemaSettings = false;
 
   private String url;
   private String username;

--- a/tasklist/common/src/main/java/io/camunda/tasklist/property/OpenSearchProperties.java
+++ b/tasklist/common/src/main/java/io/camunda/tasklist/property/OpenSearchProperties.java
@@ -38,7 +38,8 @@ public class OpenSearchProperties {
   private Integer connectTimeout;
 
   private boolean createSchema = true;
-  private boolean updateSchemaSettings = true;
+  // default to false to avoid breaking change in 8.7 patch version. SM users need to opt-in
+  private boolean updateSchemaSettings = false;
 
   private String url;
   private String username;

--- a/tasklist/common/src/main/java/io/camunda/tasklist/property/OpenSearchProperties.java
+++ b/tasklist/common/src/main/java/io/camunda/tasklist/property/OpenSearchProperties.java
@@ -38,7 +38,7 @@ public class OpenSearchProperties {
   private Integer connectTimeout;
 
   private boolean createSchema = true;
-  // default to false to avoid breaking change in 8.7 patch version. SM users need to opt-in
+  // default to false to avoid breaking change in 8.7 patch version
   private boolean updateSchemaSettings = false;
 
   private String url;

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/schema/SchemaStartup.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/schema/SchemaStartup.java
@@ -7,8 +7,6 @@
  */
 package io.camunda.tasklist.schema;
 
-import io.camunda.tasklist.exceptions.MigrationException;
-import io.camunda.tasklist.property.MigrationProperties;
 import io.camunda.tasklist.property.TasklistProperties;
 import io.camunda.tasklist.schema.IndexMapping.IndexMappingProperty;
 import io.camunda.tasklist.schema.indices.IndexDescriptor;
@@ -38,10 +36,8 @@ public class SchemaStartup {
 
   @Autowired private TasklistProperties tasklistProperties;
 
-  @Autowired private MigrationProperties migrationProperties;
-
   @PostConstruct
-  public void initializeSchema() throws MigrationException, IOException {
+  public void initializeSchema() throws IOException {
     try {
       LOGGER.info("SchemaStartup started.");
       LOGGER.info("SchemaStartup: validate index versions.");

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/es/ElasticSearchSchemaManagementIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/es/ElasticSearchSchemaManagementIT.java
@@ -25,10 +25,10 @@ import io.camunda.tasklist.schema.indices.IndexDescriptor;
 import io.camunda.tasklist.schema.manager.ElasticsearchSchemaManager;
 import io.camunda.tasklist.schema.templates.TaskTemplate;
 import io.camunda.tasklist.schema.templates.TemplateDescriptor;
+import io.camunda.tasklist.util.DatabaseTestExtension;
 import io.camunda.tasklist.util.ElasticsearchHelper;
 import io.camunda.tasklist.util.ElasticsearchTestExtension;
-import io.camunda.tasklist.util.TasklistZeebeIntegrationTest;
-import io.camunda.tasklist.util.TestApplication;
+import io.camunda.tasklist.util.TasklistIntegrationTest;
 import io.camunda.tasklist.util.TestIndexDescriptor;
 import io.camunda.tasklist.util.TestTemplateDescriptor;
 import io.camunda.tasklist.util.apps.schema.TestIndexDescriptorConfiguration;
@@ -40,34 +40,23 @@ import java.util.Map;
 import java.util.Set;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 
-@SpringBootTest(
-    classes = {
-      TestApplication.class,
-      TestIndexDescriptorConfiguration.class,
-      TestTemplateDescriptorConfiguration.class
-    },
-    properties = {
-      TasklistProperties.PREFIX + ".importer.startLoadingDataOnStartup = false",
-      TasklistProperties.PREFIX + ".archiver.rolloverEnabled = false",
-      TasklistProperties.PREFIX + "importer.jobType = testJobType",
-      "camunda.webapps.enabled = true",
-      "camunda.webapps.default-app = tasklist",
-    },
-    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Import({TestIndexDescriptorConfiguration.class, TestTemplateDescriptorConfiguration.class})
 @DirtiesContext(classMode = AFTER_EACH_TEST_METHOD)
-public class ElasticSearchSchemaManagementIT extends TasklistZeebeIntegrationTest {
+public class ElasticSearchSchemaManagementIT extends TasklistIntegrationTest {
 
   private static final Logger LOGGER =
       LoggerFactory.getLogger(ElasticSearchSchemaManagementIT.class);
 
+  @RegisterExtension @Autowired public DatabaseTestExtension databaseTestExtension;
   @Autowired private TasklistProperties tasklistProperties;
   @Autowired private List<IndexDescriptor> indexDescriptors;
   @Autowired private List<TemplateDescriptor> templateDescriptors;

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/es/SchemaCreationIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/es/SchemaCreationIT.java
@@ -7,10 +7,13 @@
  */
 package io.camunda.tasklist.es;
 
+import static io.camunda.tasklist.es.RetryElasticsearchClient.NUMBERS_OF_REPLICA;
 import static io.camunda.tasklist.util.CollectionUtil.filter;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
+import io.camunda.tasklist.property.TasklistProperties;
+import io.camunda.tasklist.qa.util.TestSchemaStartup;
 import io.camunda.tasklist.qa.util.TestUtil;
 import io.camunda.tasklist.schema.IndexSchemaValidator;
 import io.camunda.tasklist.schema.indices.IndexDescriptor;
@@ -28,7 +31,9 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.DirtiesContext;
 
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 public class SchemaCreationIT extends TasklistIntegrationTest {
 
   @RegisterExtension @Autowired public DatabaseTestExtension databaseTestExtension;
@@ -36,6 +41,9 @@ public class SchemaCreationIT extends TasklistIntegrationTest {
   @Autowired private List<IndexDescriptor> indexDescriptors;
   @Autowired private IndexSchemaValidator indexSchemaValidator;
   @Autowired private NoSqlHelper noSqlHelper;
+  @Autowired private TasklistProperties tasklistProperties;
+  @Autowired private RetryElasticsearchClient retryElasticsearchClient;
+  @Autowired private TestSchemaStartup schemaStartup;
 
   @BeforeAll
   public static void beforeClass() {
@@ -90,6 +98,54 @@ public class SchemaCreationIT extends TasklistIntegrationTest {
 
     for (final IndexDescriptor indexDescriptor : strictMappingIndices) {
       assertThatIndexHasDynamicMappingOf(indexDescriptor, "strict");
+    }
+  }
+
+  @Test
+  public void testReplicasUpdatedWhenUpdateSchemaSettingsIsTrue() throws Exception {
+    // given
+    tasklistProperties.getElasticsearch().setUpdateSchemaSettings(true);
+    // Set a specific number of replicas in configuration
+    final int configuredReplicas = 2;
+    tasklistProperties.getElasticsearch().setNumberOfReplicas(configuredReplicas);
+
+    // when
+    // Schema startup should update the settings (trigger schema creation/update)
+    schemaStartup.initializeSchemaOnDemand();
+
+    // then
+    // Assert that number of replicas is updated with configuration
+    assertThat(indexDescriptors).isNotEmpty();
+    for (final IndexDescriptor indexDescriptor : indexDescriptors) {
+      final String replicasValue =
+          retryElasticsearchClient
+              .getIndexSettingsFor(indexDescriptor.getFullQualifiedName(), NUMBERS_OF_REPLICA)
+              .get(NUMBERS_OF_REPLICA);
+      assertThat(replicasValue).isEqualTo(String.valueOf(configuredReplicas));
+    }
+  }
+
+  @Test
+  public void testReplicasNotUpdatedWhenUpdateSchemaSettingsIsFalse() throws Exception {
+    // given
+    tasklistProperties.getElasticsearch().setUpdateSchemaSettings(false);
+    // Set a specific number of replicas in configuration
+    final int configuredReplicas = 3;
+    tasklistProperties.getElasticsearch().setNumberOfReplicas(configuredReplicas);
+
+    // when
+    // Schema startup should update the settings (trigger schema creation/update)
+    schemaStartup.initializeSchemaOnDemand();
+
+    // then
+    // Assert that number of replicas is updated with configuration
+    assertThat(indexDescriptors).isNotEmpty();
+    for (final IndexDescriptor indexDescriptor : indexDescriptors) {
+      final String replicasValue =
+          retryElasticsearchClient
+              .getIndexSettingsFor(indexDescriptor.getFullQualifiedName(), NUMBERS_OF_REPLICA)
+              .get(NUMBERS_OF_REPLICA);
+      assertThat(replicasValue).isEqualTo("0");
     }
   }
 

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/os/OpenSearchSchemaManagementIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/os/OpenSearchSchemaManagementIT.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.opensearch.client.opensearch._types.mapping.Property.Kind.Keyword;
+import static org.springframework.test.annotation.DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.tasklist.entities.TaskEntity;
@@ -23,10 +24,10 @@ import io.camunda.tasklist.schema.indices.IndexDescriptor;
 import io.camunda.tasklist.schema.manager.OpenSearchSchemaManager;
 import io.camunda.tasklist.schema.templates.TaskTemplate;
 import io.camunda.tasklist.schema.templates.TemplateDescriptor;
+import io.camunda.tasklist.util.DatabaseTestExtension;
 import io.camunda.tasklist.util.NoSqlHelper;
 import io.camunda.tasklist.util.OpenSearchTestExtension;
-import io.camunda.tasklist.util.TasklistZeebeIntegrationTest;
-import io.camunda.tasklist.util.TestApplication;
+import io.camunda.tasklist.util.TasklistIntegrationTest;
 import io.camunda.tasklist.util.TestIndexDescriptor;
 import io.camunda.tasklist.util.TestTemplateDescriptor;
 import io.camunda.tasklist.util.apps.schema.TestIndexDescriptorConfiguration;
@@ -38,34 +39,23 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.opensearch.client.opensearch._types.mapping.Property;
 import org.opensearch.client.opensearch._types.mapping.TypeMapping;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 
-@SpringBootTest(
-    classes = {
-      TestApplication.class,
-      TestIndexDescriptorConfiguration.class,
-      TestTemplateDescriptorConfiguration.class
-    },
-    properties = {
-      TasklistProperties.PREFIX + ".importer.startLoadingDataOnStartup = false",
-      TasklistProperties.PREFIX + ".archiver.rolloverEnabled = false",
-      TasklistProperties.PREFIX + "importer.jobType = testJobType",
-      "camunda.webapps.enabled = true",
-      "camunda.webapps.default-app = tasklist",
-    },
-    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
-public class OpenSearchSchemaManagementIT extends TasklistZeebeIntegrationTest {
+@Import({TestIndexDescriptorConfiguration.class, TestTemplateDescriptorConfiguration.class})
+@DirtiesContext(classMode = AFTER_EACH_TEST_METHOD)
+public class OpenSearchSchemaManagementIT extends TasklistIntegrationTest {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(OpenSearchSchemaManagementIT.class);
+  @RegisterExtension @Autowired public DatabaseTestExtension databaseTestExtension;
   @Autowired private TasklistProperties tasklistProperties;
   @Autowired private List<IndexDescriptor> indexDescriptors;
   @Autowired private List<TemplateDescriptor> templateDescriptors;

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/os/SchemaCreationIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/os/SchemaCreationIT.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.tasklist.os;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import io.camunda.tasklist.property.TasklistProperties;
+import io.camunda.tasklist.qa.util.TestSchemaStartup;
+import io.camunda.tasklist.qa.util.TestUtil;
+import io.camunda.tasklist.schema.indices.IndexDescriptor;
+import io.camunda.tasklist.util.DatabaseTestExtension;
+import io.camunda.tasklist.util.TasklistIntegrationTest;
+import java.util.List;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.DirtiesContext;
+
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+public class SchemaCreationIT extends TasklistIntegrationTest {
+
+  @RegisterExtension @Autowired public DatabaseTestExtension databaseTestExtension;
+
+  @Autowired private List<IndexDescriptor> indexDescriptors;
+  @Autowired private TasklistProperties tasklistProperties;
+  @Autowired private RetryOpenSearchClient retryOpenSearchClient;
+  @Autowired private TestSchemaStartup schemaStartup;
+
+  @BeforeAll
+  public static void beforeClass() {
+    assumeTrue(TestUtil.isOpenSearch());
+  }
+
+  @Test
+  public void testReplicasUpdatedWhenUpdateSchemaSettingsIsTrue() throws Exception {
+    // given
+    tasklistProperties.getOpenSearch().setUpdateSchemaSettings(true);
+    // Set a specific number of replicas in configuration
+    final int configuredReplicas = 2;
+    tasklistProperties.getOpenSearch().setNumberOfReplicas(configuredReplicas);
+
+    // when
+    // Schema startup should update the settings (trigger schema creation/update)
+    schemaStartup.initializeSchemaOnDemand();
+
+    // then
+    // Assert that number of replicas is updated with configuration
+    assertThat(indexDescriptors).isNotEmpty();
+    for (final IndexDescriptor indexDescriptor : indexDescriptors) {
+      final String replicasValue =
+          retryOpenSearchClient
+              .getIndexSettingsFor(indexDescriptor.getFullQualifiedName())
+              .numberOfReplicas();
+      assertThat(replicasValue).isEqualTo(String.valueOf(configuredReplicas));
+    }
+  }
+
+  @Test
+  public void testReplicasNotUpdatedWhenUpdateSchemaSettingsIsFalse() throws Exception {
+    // given
+    tasklistProperties.getOpenSearch().setUpdateSchemaSettings(false);
+    // Set a specific number of replicas in configuration
+    final int configuredReplicas = 3;
+    tasklistProperties.getOpenSearch().setNumberOfReplicas(configuredReplicas);
+
+    // when
+    // Schema startup should update the settings (trigger schema creation/update)
+    schemaStartup.initializeSchemaOnDemand();
+
+    // then
+    // Assert that number of replicas is updated with configuration
+    assertThat(indexDescriptors).isNotEmpty();
+    for (final IndexDescriptor indexDescriptor : indexDescriptors) {
+      final String replicasValue =
+          retryOpenSearchClient
+              .getIndexSettingsFor(indexDescriptor.getFullQualifiedName())
+              .numberOfReplicas();
+      assertThat(replicasValue).isEqualTo("0");
+    }
+  }
+}

--- a/tasklist/qa/util/src/main/java/io/camunda/tasklist/qa/util/TestSchemaStartup.java
+++ b/tasklist/qa/util/src/main/java/io/camunda/tasklist/qa/util/TestSchemaStartup.java
@@ -7,8 +7,8 @@
  */
 package io.camunda.tasklist.qa.util;
 
-import io.camunda.tasklist.exceptions.MigrationException;
 import io.camunda.tasklist.schema.SchemaStartup;
+import java.io.IOException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Profile;
@@ -21,7 +21,11 @@ public class TestSchemaStartup extends SchemaStartup {
   private static final Logger LOGGER = LoggerFactory.getLogger(TestSchemaStartup.class);
 
   @Override
-  public void initializeSchema() throws MigrationException {
+  public void initializeSchema() {
     LOGGER.info("No schema validation, creation and migration will be executed.");
+  }
+
+  public void initializeSchemaOnDemand() throws IOException {
+    super.initializeSchema();
   }
 }


### PR DESCRIPTION
# Description
Backport of #37132 to `stable/8.6`.

relates to #32872