### PR TITLE
fix: rename id validation property

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/security/CamundaSecurityConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/security/CamundaSecurityConfiguration.java
@@ -67,19 +67,18 @@ public class CamundaSecurityConfiguration {
                   true));
     }
 
-    final var initializationCfg = camundaSecurityProperties.getInitialization();
-    final var idRegex = initializationCfg.getIdentifierRegex();
+    final var idRegex = camundaSecurityProperties.getIdValidationPattern();
     try {
-      final var idPattern = initializationCfg.getIdentifierPattern();
+      final var idPattern = camundaSecurityProperties.getCompiledIdValidationPattern();
       if (idPattern != null && idPattern.matcher(AuthorizationScope.WILDCARD_CHAR).matches()) {
         throw new IllegalStateException(
             "The configured identifier pattern (%s=%s) allows the asterisk ('*') which is a reserved character. Please use a different pattern."
-                .formatted("camunda.security.initialization.identifierRegex", idRegex));
+                .formatted("camunda.security.id-validation-pattern", idRegex));
       }
     } catch (final PatternSyntaxException regEx) {
       throw new IllegalStateException(
           "The configured identifier pattern (%s=%s) is invalid. Please use a different pattern."
-              .formatted("camunda.security.initialization.identifierRegex", idRegex));
+              .formatted("camunda.security.id-validation-pattern", idRegex));
     }
   }
 

--- a/dist/src/test/java/io/camunda/application/commons/security/CamundaSecurityConfigurationTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/security/CamundaSecurityConfigurationTest.java
@@ -56,7 +56,7 @@ public class CamundaSecurityConfigurationTest {
 
   @Test
   public void shouldFailToStartWhenIdPatternIsInvalid() {
-    final var idPatternProperty = "camunda.security.initialization.identifierRegex";
+    final var idPatternProperty = "camunda.security.id-validation-pattern";
     final var idPatternValue = "[|";
     System.setProperty(idPatternProperty, idPatternValue);
 
@@ -80,7 +80,7 @@ public class CamundaSecurityConfigurationTest {
 
   @Test
   public void shouldFailToStartWhenIdPatternAllowsWildcardCharacter() {
-    final var idPatternProperty = "camunda.security.initialization.identifierRegex";
+    final var idPatternProperty = "camunda.security.id-validation-pattern";
     final var idPatternValue = "^[a-zA-Z0-9_@.+*-]+$";
     System.setProperty(idPatternProperty, idPatternValue);
 

--- a/security/security-core/src/main/java/io/camunda/security/configuration/InitializationConfiguration.java
+++ b/security/security-core/src/main/java/io/camunda/security/configuration/InitializationConfiguration.java
@@ -12,7 +12,6 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.regex.Pattern;
 
 public class InitializationConfiguration {
 
@@ -21,14 +20,9 @@ public class InitializationConfiguration {
   public static final String DEFAULT_USER_NAME = "Demo";
   public static final String DEFAULT_USER_EMAIL = "demo@example.com";
 
-  /** 1 or more alphanumeric characters, '_', '@', '.', '+', or '-'. */
-  public static final String DEFAULT_ID_REGEX = "^[a-zA-Z0-9_@.+-]+$";
-
   private List<ConfiguredUser> users = new ArrayList<>();
   private List<ConfiguredMappingRule> mappingRules = new ArrayList<>();
   private Map<String, Map<String, Collection<String>>> defaultRoles = new HashMap<>();
-  private String identifierRegex = DEFAULT_ID_REGEX;
-  private Pattern identifierPattern;
 
   public List<ConfiguredUser> getUsers() {
     return users;
@@ -52,20 +46,5 @@ public class InitializationConfiguration {
 
   public void setDefaultRoles(final Map<String, Map<String, Collection<String>>> defaultRoles) {
     this.defaultRoles = defaultRoles;
-  }
-
-  public String getIdentifierRegex() {
-    return identifierRegex;
-  }
-
-  public void setIdentifierRegex(final String identifierRegex) {
-    this.identifierRegex = identifierRegex;
-  }
-
-  public Pattern getIdentifierPattern() {
-    if (identifierPattern == null) {
-      identifierPattern = Pattern.compile(identifierRegex);
-    }
-    return identifierPattern;
   }
 }

--- a/security/security-core/src/main/java/io/camunda/security/configuration/SecurityConfiguration.java
+++ b/security/security-core/src/main/java/io/camunda/security/configuration/SecurityConfiguration.java
@@ -8,8 +8,12 @@
 package io.camunda.security.configuration;
 
 import io.camunda.security.configuration.headers.HeaderConfiguration;
+import java.util.regex.Pattern;
 
 public class SecurityConfiguration {
+
+  /** 1 or more alphanumeric characters, '_', '@', '.', '+', or '-'. */
+  public static final String DEFAULT_ID_REGEX = "^[a-zA-Z0-9_@.+-]+$";
 
   private AuthenticationConfiguration authentication = new AuthenticationConfiguration();
   private AuthorizationsConfiguration authorizations = new AuthorizationsConfiguration();
@@ -18,6 +22,9 @@ public class SecurityConfiguration {
   private CsrfConfiguration csrf = new CsrfConfiguration();
   private HeaderConfiguration httpHeaders = new HeaderConfiguration();
   private SaasConfiguration saas = new SaasConfiguration();
+
+  private String idValidationPattern = DEFAULT_ID_REGEX;
+  private Pattern compiledIdValidationPattern;
 
   public AuthenticationConfiguration getAuthentication() {
     return authentication;
@@ -77,5 +84,20 @@ public class SecurityConfiguration {
 
   public void setCsrf(final CsrfConfiguration csrf) {
     this.csrf = csrf;
+  }
+
+  public String getIdValidationPattern() {
+    return idValidationPattern;
+  }
+
+  public void setIdValidationPattern(final String idValidationPattern) {
+    this.idValidationPattern = idValidationPattern;
+  }
+
+  public Pattern getCompiledIdValidationPattern() {
+    if (compiledIdValidationPattern == null) {
+      compiledIdValidationPattern = Pattern.compile(idValidationPattern);
+    }
+    return compiledIdValidationPattern;
   }
 }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/setup/SetupController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/setup/SetupController.java
@@ -74,7 +74,7 @@ public class SetupController {
     }
 
     return RequestMapper.toUserRequest(
-            request, securityConfiguration.getInitialization().getIdentifierPattern())
+            request, securityConfiguration.getCompiledIdValidationPattern())
         .fold(
             RestErrorMapper::mapProblemToCompletedResponse,
             dto ->

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantController.java
@@ -15,7 +15,7 @@ import io.camunda.search.query.RoleQuery;
 import io.camunda.search.query.TenantQuery;
 import io.camunda.search.query.UserQuery;
 import io.camunda.security.auth.CamundaAuthenticationProvider;
-import io.camunda.security.configuration.InitializationConfiguration;
+import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.service.GroupServices;
 import io.camunda.service.MappingRuleServices;
 import io.camunda.service.RoleServices;
@@ -65,7 +65,7 @@ public class TenantController {
   private final GroupServices groupServices;
   private final RoleServices roleServices;
   private final CamundaAuthenticationProvider authenticationProvider;
-  private final InitializationConfiguration initializationConfiguration;
+  private final SecurityConfiguration securityConfiguration;
 
   public TenantController(
       final TenantServices tenantServices,
@@ -74,21 +74,21 @@ public class TenantController {
       final GroupServices groupServices,
       final RoleServices roleServices,
       final CamundaAuthenticationProvider authenticationProvider,
-      final InitializationConfiguration initializationConfiguration) {
+      final SecurityConfiguration securityConfiguration) {
     this.tenantServices = tenantServices;
     this.userServices = userServices;
     this.mappingRuleServices = mappingRuleServices;
     this.groupServices = groupServices;
     this.roleServices = roleServices;
     this.authenticationProvider = authenticationProvider;
-    this.initializationConfiguration = initializationConfiguration;
+    this.securityConfiguration = securityConfiguration;
   }
 
   @CamundaPostMapping
   public CompletableFuture<ResponseEntity<Object>> createTenant(
       @RequestBody final TenantCreateRequest createTenantRequest) {
     return RequestMapper.toTenantCreateDto(
-            createTenantRequest, initializationConfiguration.getIdentifierPattern())
+            createTenantRequest, securityConfiguration.getCompiledIdValidationPattern())
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::createTenant);
   }
 
@@ -127,7 +127,10 @@ public class TenantController {
   public CompletableFuture<ResponseEntity<Object>> assignUserToTenant(
       @PathVariable final String tenantId, @PathVariable final String username) {
     return RequestMapper.toTenantMemberRequest(
-            tenantId, username, EntityType.USER, initializationConfiguration.getIdentifierPattern())
+            tenantId,
+            username,
+            EntityType.USER,
+            securityConfiguration.getCompiledIdValidationPattern())
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::addMemberToTenant);
   }
 
@@ -149,7 +152,7 @@ public class TenantController {
             tenantId,
             clientId,
             EntityType.CLIENT,
-            initializationConfiguration.getIdentifierPattern())
+            securityConfiguration.getCompiledIdValidationPattern())
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::addMemberToTenant);
   }
 
@@ -160,7 +163,7 @@ public class TenantController {
             tenantId,
             mappingRuleId,
             EntityType.MAPPING_RULE,
-            initializationConfiguration.getIdentifierPattern())
+            securityConfiguration.getCompiledIdValidationPattern())
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::addMemberToTenant);
   }
 
@@ -168,7 +171,10 @@ public class TenantController {
   public CompletableFuture<ResponseEntity<Object>> assignGroupToTenant(
       @PathVariable final String tenantId, @PathVariable final String groupId) {
     return RequestMapper.toTenantMemberRequest(
-            tenantId, groupId, EntityType.GROUP, initializationConfiguration.getIdentifierPattern())
+            tenantId,
+            groupId,
+            EntityType.GROUP,
+            securityConfiguration.getCompiledIdValidationPattern())
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::addMemberToTenant);
   }
 
@@ -176,7 +182,10 @@ public class TenantController {
   public CompletableFuture<ResponseEntity<Object>> assignRoleToTenant(
       @PathVariable final String tenantId, @PathVariable final String roleId) {
     return RequestMapper.toTenantMemberRequest(
-            tenantId, roleId, EntityType.ROLE, initializationConfiguration.getIdentifierPattern())
+            tenantId,
+            roleId,
+            EntityType.ROLE,
+            securityConfiguration.getCompiledIdValidationPattern())
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::addMemberToTenant);
   }
 
@@ -194,7 +203,10 @@ public class TenantController {
   public CompletableFuture<ResponseEntity<Object>> unassignUserFromTenant(
       @PathVariable final String tenantId, @PathVariable final String username) {
     return RequestMapper.toTenantMemberRequest(
-            tenantId, username, EntityType.USER, initializationConfiguration.getIdentifierPattern())
+            tenantId,
+            username,
+            EntityType.USER,
+            securityConfiguration.getCompiledIdValidationPattern())
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::removeMemberFromTenant);
   }
 
@@ -205,7 +217,7 @@ public class TenantController {
             tenantId,
             clientId,
             EntityType.CLIENT,
-            initializationConfiguration.getIdentifierPattern())
+            securityConfiguration.getCompiledIdValidationPattern())
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::removeMemberFromTenant);
   }
 
@@ -227,7 +239,7 @@ public class TenantController {
             tenantId,
             mappingRuleId,
             EntityType.MAPPING_RULE,
-            initializationConfiguration.getIdentifierPattern())
+            securityConfiguration.getCompiledIdValidationPattern())
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::removeMemberFromTenant);
   }
 
@@ -235,7 +247,10 @@ public class TenantController {
   public CompletableFuture<ResponseEntity<Object>> unassignGroupFromTenant(
       @PathVariable final String tenantId, @PathVariable final String groupId) {
     return RequestMapper.toTenantMemberRequest(
-            tenantId, groupId, EntityType.GROUP, initializationConfiguration.getIdentifierPattern())
+            tenantId,
+            groupId,
+            EntityType.GROUP,
+            securityConfiguration.getCompiledIdValidationPattern())
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::removeMemberFromTenant);
   }
 
@@ -243,7 +258,10 @@ public class TenantController {
   public CompletableFuture<ResponseEntity<Object>> unassignRoleFromTenant(
       @PathVariable final String tenantId, @PathVariable final String roleId) {
     return RequestMapper.toTenantMemberRequest(
-            tenantId, roleId, EntityType.ROLE, initializationConfiguration.getIdentifierPattern())
+            tenantId,
+            roleId,
+            EntityType.ROLE,
+            securityConfiguration.getCompiledIdValidationPattern())
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::removeMemberFromTenant);
   }
 

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupController.java
@@ -15,7 +15,7 @@ import io.camunda.search.query.GroupQuery;
 import io.camunda.search.query.MappingRuleQuery;
 import io.camunda.search.query.RoleQuery;
 import io.camunda.security.auth.CamundaAuthenticationProvider;
-import io.camunda.security.configuration.InitializationConfiguration;
+import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.service.GroupServices;
 import io.camunda.service.GroupServices.GroupDTO;
 import io.camunda.service.GroupServices.GroupMemberDTO;
@@ -60,26 +60,26 @@ public class GroupController {
   private final MappingRuleServices mappingRuleServices;
   private final RoleServices roleServices;
   private final CamundaAuthenticationProvider authenticationProvider;
-  private final InitializationConfiguration initializationConfiguration;
+  private final SecurityConfiguration securityConfiguration;
 
   public GroupController(
       final GroupServices groupServices,
       final MappingRuleServices mappingRuleServices,
       final RoleServices roleServices,
       final CamundaAuthenticationProvider authenticationProvider,
-      final InitializationConfiguration initializationConfiguration) {
+      final SecurityConfiguration securityConfiguration) {
     this.groupServices = groupServices;
     this.mappingRuleServices = mappingRuleServices;
     this.roleServices = roleServices;
     this.authenticationProvider = authenticationProvider;
-    this.initializationConfiguration = initializationConfiguration;
+    this.securityConfiguration = securityConfiguration;
   }
 
   @CamundaPostMapping
   public CompletableFuture<ResponseEntity<Object>> createGroup(
       @RequestBody final GroupCreateRequest createGroupRequest) {
     return RequestMapper.toGroupCreateRequest(
-            createGroupRequest, initializationConfiguration.getIdentifierPattern())
+            createGroupRequest, securityConfiguration.getCompiledIdValidationPattern())
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::createGroup);
   }
 
@@ -88,7 +88,7 @@ public class GroupController {
       @PathVariable final String groupId,
       @RequestBody final GroupUpdateRequest groupUpdateRequest) {
     return RequestMapper.toGroupUpdateRequest(
-            groupUpdateRequest, groupId, initializationConfiguration.getIdentifierPattern())
+            groupUpdateRequest, groupId, securityConfiguration.getCompiledIdValidationPattern())
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::updateGroup);
   }
 
@@ -105,7 +105,10 @@ public class GroupController {
   public CompletableFuture<ResponseEntity<Object>> assignUserToGroup(
       @PathVariable final String groupId, @PathVariable final String username) {
     return RequestMapper.toGroupMemberRequest(
-            groupId, username, EntityType.USER, initializationConfiguration.getIdentifierPattern())
+            groupId,
+            username,
+            EntityType.USER,
+            securityConfiguration.getCompiledIdValidationPattern())
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::assignMember);
   }
 
@@ -116,7 +119,7 @@ public class GroupController {
             groupId,
             clientId,
             EntityType.CLIENT,
-            initializationConfiguration.getIdentifierPattern())
+            securityConfiguration.getCompiledIdValidationPattern())
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::assignMember);
   }
 
@@ -127,7 +130,7 @@ public class GroupController {
             groupId,
             mappingRuleId,
             EntityType.MAPPING_RULE,
-            initializationConfiguration.getIdentifierPattern())
+            securityConfiguration.getCompiledIdValidationPattern())
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::assignMember);
   }
 
@@ -135,7 +138,10 @@ public class GroupController {
   public CompletableFuture<ResponseEntity<Object>> unassignUserFromGroup(
       @PathVariable final String groupId, @PathVariable final String username) {
     return RequestMapper.toGroupMemberRequest(
-            groupId, username, EntityType.USER, initializationConfiguration.getIdentifierPattern())
+            groupId,
+            username,
+            EntityType.USER,
+            securityConfiguration.getCompiledIdValidationPattern())
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::unassignMember);
   }
 
@@ -146,7 +152,7 @@ public class GroupController {
             groupId,
             clientId,
             EntityType.CLIENT,
-            initializationConfiguration.getIdentifierPattern())
+            securityConfiguration.getCompiledIdValidationPattern())
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::unassignMember);
   }
 
@@ -157,7 +163,7 @@ public class GroupController {
             groupId,
             mappingRuleId,
             EntityType.MAPPING_RULE,
-            initializationConfiguration.getIdentifierPattern())
+            securityConfiguration.getCompiledIdValidationPattern())
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::unassignMember);
   }
 

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/MappingRuleController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/MappingRuleController.java
@@ -11,7 +11,7 @@ import static io.camunda.zeebe.gateway.rest.RestErrorMapper.mapErrorToResponse;
 
 import io.camunda.search.query.MappingRuleQuery;
 import io.camunda.security.auth.CamundaAuthenticationProvider;
-import io.camunda.security.configuration.InitializationConfiguration;
+import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.service.MappingRuleServices;
 import io.camunda.service.MappingRuleServices.MappingRuleDTO;
 import io.camunda.zeebe.gateway.protocol.rest.MappingRuleCreateRequest;
@@ -41,22 +41,22 @@ import org.springframework.web.bind.annotation.RequestMapping;
 public class MappingRuleController {
   private final MappingRuleServices mappingRuleServices;
   private final CamundaAuthenticationProvider authenticationProvider;
-  private final InitializationConfiguration initializationConfiguration;
+  private final SecurityConfiguration securityConfiguration;
 
   public MappingRuleController(
       final MappingRuleServices mappingRuleServices,
       final CamundaAuthenticationProvider authenticationProvider,
-      final InitializationConfiguration initializationConfiguration) {
+      final SecurityConfiguration securityConfiguration) {
     this.mappingRuleServices = mappingRuleServices;
     this.authenticationProvider = authenticationProvider;
-    this.initializationConfiguration = initializationConfiguration;
+    this.securityConfiguration = securityConfiguration;
   }
 
   @CamundaPostMapping
   public CompletableFuture<ResponseEntity<Object>> create(
       @RequestBody final MappingRuleCreateRequest mappingRuleRequest) {
     return RequestMapper.toMappingRuleCreateRequest(
-            mappingRuleRequest, initializationConfiguration.getIdentifierPattern())
+            mappingRuleRequest, securityConfiguration.getCompiledIdValidationPattern())
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::createMappingRule);
   }
 

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleController.java
@@ -12,7 +12,7 @@ import static io.camunda.zeebe.gateway.rest.RestErrorMapper.mapErrorToResponse;
 import io.camunda.search.query.MappingRuleQuery;
 import io.camunda.search.query.RoleQuery;
 import io.camunda.security.auth.CamundaAuthenticationProvider;
-import io.camunda.security.configuration.InitializationConfiguration;
+import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.service.GroupServices;
 import io.camunda.service.MappingRuleServices;
 import io.camunda.service.RoleServices;
@@ -56,7 +56,7 @@ public class RoleController {
   private final RoleServices roleServices;
   private final MappingRuleServices mappingServices;
   private final CamundaAuthenticationProvider authenticationProvider;
-  private final InitializationConfiguration initializationConfiguration;
+  private final SecurityConfiguration securityConfiguration;
 
   public RoleController(
       final RoleServices roleServices,
@@ -64,18 +64,18 @@ public class RoleController {
       final MappingRuleServices mappingServices,
       final GroupServices groupServices,
       final CamundaAuthenticationProvider authenticationProvider,
-      final InitializationConfiguration initializationConfiguration) {
+      final SecurityConfiguration securityConfiguration) {
     this.roleServices = roleServices;
     this.mappingServices = mappingServices;
     this.authenticationProvider = authenticationProvider;
-    this.initializationConfiguration = initializationConfiguration;
+    this.securityConfiguration = securityConfiguration;
   }
 
   @CamundaPostMapping
   public CompletableFuture<ResponseEntity<Object>> createRole(
       @RequestBody final RoleCreateRequest createRoleRequest) {
     return RequestMapper.toRoleCreateRequest(
-            createRoleRequest, initializationConfiguration.getIdentifierPattern())
+            createRoleRequest, securityConfiguration.getCompiledIdValidationPattern())
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::createRole);
   }
 
@@ -241,7 +241,10 @@ public class RoleController {
   public CompletableFuture<ResponseEntity<Object>> assignRoleToUser(
       @PathVariable final String roleId, @PathVariable final String username) {
     return RequestMapper.toRoleMemberRequest(
-            roleId, username, EntityType.USER, initializationConfiguration.getIdentifierPattern())
+            roleId,
+            username,
+            EntityType.USER,
+            securityConfiguration.getCompiledIdValidationPattern())
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::addMemberToRole);
   }
 
@@ -249,7 +252,10 @@ public class RoleController {
   public CompletableFuture<ResponseEntity<Object>> assignRoleToClient(
       @PathVariable final String roleId, @PathVariable final String clientId) {
     return RequestMapper.toRoleMemberRequest(
-            roleId, clientId, EntityType.CLIENT, initializationConfiguration.getIdentifierPattern())
+            roleId,
+            clientId,
+            EntityType.CLIENT,
+            securityConfiguration.getCompiledIdValidationPattern())
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::addMemberToRole);
   }
 
@@ -257,7 +263,10 @@ public class RoleController {
   public CompletableFuture<ResponseEntity<Object>> assignRoleToGroup(
       @PathVariable final String roleId, @PathVariable final String groupId) {
     return RequestMapper.toRoleMemberRequest(
-            roleId, groupId, EntityType.GROUP, initializationConfiguration.getIdentifierPattern())
+            roleId,
+            groupId,
+            EntityType.GROUP,
+            securityConfiguration.getCompiledIdValidationPattern())
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::addMemberToRole);
   }
 
@@ -277,7 +286,7 @@ public class RoleController {
             roleId,
             mappingRuleId,
             EntityType.MAPPING_RULE,
-            initializationConfiguration.getIdentifierPattern())
+            securityConfiguration.getCompiledIdValidationPattern())
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::addMemberToRole);
   }
 
@@ -288,7 +297,7 @@ public class RoleController {
             roleId,
             mappingRuleId,
             EntityType.MAPPING_RULE,
-            initializationConfiguration.getIdentifierPattern())
+            securityConfiguration.getCompiledIdValidationPattern())
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::removeMemberFromRole);
   }
 
@@ -296,7 +305,10 @@ public class RoleController {
   public CompletableFuture<ResponseEntity<Object>> unassignRoleFromUser(
       @PathVariable final String roleId, @PathVariable final String username) {
     return RequestMapper.toRoleMemberRequest(
-            roleId, username, EntityType.USER, initializationConfiguration.getIdentifierPattern())
+            roleId,
+            username,
+            EntityType.USER,
+            securityConfiguration.getCompiledIdValidationPattern())
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::removeMemberFromRole);
   }
 
@@ -304,7 +316,10 @@ public class RoleController {
   public CompletableFuture<ResponseEntity<Object>> unassignRoleFromClient(
       @PathVariable final String roleId, @PathVariable final String clientId) {
     return RequestMapper.toRoleMemberRequest(
-            roleId, clientId, EntityType.CLIENT, initializationConfiguration.getIdentifierPattern())
+            roleId,
+            clientId,
+            EntityType.CLIENT,
+            securityConfiguration.getCompiledIdValidationPattern())
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::removeMemberFromRole);
   }
 
@@ -312,7 +327,10 @@ public class RoleController {
   public CompletableFuture<ResponseEntity<Object>> unassignRoleFromGroup(
       @PathVariable final String roleId, @PathVariable final String groupId) {
     return RequestMapper.toRoleMemberRequest(
-            roleId, groupId, EntityType.GROUP, initializationConfiguration.getIdentifierPattern())
+            roleId,
+            groupId,
+            EntityType.GROUP,
+            securityConfiguration.getCompiledIdValidationPattern())
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::removeMemberFromRole);
   }
 

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/UserController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/UserController.java
@@ -12,7 +12,7 @@ import static io.camunda.zeebe.gateway.rest.RestErrorMapper.mapErrorToResponse;
 import io.camunda.authentication.ConditionalOnInternalUserManagement;
 import io.camunda.search.query.UserQuery;
 import io.camunda.security.auth.CamundaAuthenticationProvider;
-import io.camunda.security.configuration.InitializationConfiguration;
+import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.service.UserServices;
 import io.camunda.service.UserServices.UserDTO;
 import io.camunda.zeebe.gateway.protocol.rest.UserRequest;
@@ -43,22 +43,22 @@ import org.springframework.web.bind.annotation.RequestMapping;
 public class UserController {
   private final UserServices userServices;
   private final CamundaAuthenticationProvider authenticationProvider;
-  private final InitializationConfiguration initializationConfiguration;
+  private final SecurityConfiguration securityConfiguration;
 
   public UserController(
       final UserServices userServices,
       final CamundaAuthenticationProvider authenticationProvider,
-      final InitializationConfiguration initializationConfiguration) {
+      final SecurityConfiguration securityConfiguration) {
     this.userServices = userServices;
     this.authenticationProvider = authenticationProvider;
-    this.initializationConfiguration = initializationConfiguration;
+    this.securityConfiguration = securityConfiguration;
   }
 
   @CamundaPostMapping
   public CompletableFuture<ResponseEntity<Object>> createUser(
       @RequestBody final UserRequest userRequest) {
     return RequestMapper.toUserRequest(
-            userRequest, initializationConfiguration.getIdentifierPattern())
+            userRequest, securityConfiguration.getCompiledIdValidationPattern())
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::createUser);
   }
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/setup/SetupControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/setup/SetupControllerTest.java
@@ -14,7 +14,6 @@ import static org.mockito.Mockito.when;
 
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.security.auth.CamundaAuthenticationProvider;
-import io.camunda.security.configuration.InitializationConfiguration;
 import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.security.entity.AuthenticationMethod;
 import io.camunda.service.RoleServices;
@@ -45,8 +44,7 @@ import org.springframework.test.json.JsonCompareMode;
 class SetupControllerTest extends RestControllerTest {
   private static final String BASE_PATH = "/v2/setup";
   private static final String USER_PATH = BASE_PATH + "/user";
-  private static final Pattern ID_PATTERN =
-      Pattern.compile(InitializationConfiguration.DEFAULT_ID_REGEX);
+  private static final Pattern ID_PATTERN = Pattern.compile(SecurityConfiguration.DEFAULT_ID_REGEX);
 
   @MockitoBean private UserServices userServices;
   @MockitoBean private RoleServices roleServices;
@@ -64,7 +62,7 @@ class SetupControllerTest extends RestControllerTest {
     when(roleServices.withAuthentication(anonymousAuthentication)).thenReturn(roleServices);
     when(securityConfiguration.getAuthentication().getMethod())
         .thenReturn(AuthenticationMethod.BASIC);
-    when(securityConfiguration.getInitialization().getIdentifierPattern()).thenReturn(ID_PATTERN);
+    when(securityConfiguration.getCompiledIdValidationPattern()).thenReturn(ID_PATTERN);
   }
 
   @ParameterizedTest
@@ -338,7 +336,7 @@ class SetupControllerTest extends RestControllerTest {
               "detail": "The provided username contains illegal characters. It must match the pattern '%s'.",
               "instance": "%s"
             }"""
-            .formatted(InitializationConfiguration.DEFAULT_ID_REGEX, USER_PATH));
+            .formatted(SecurityConfiguration.DEFAULT_ID_REGEX, USER_PATH));
     verifyNoInteractions(userServices);
   }
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantControllerTest.java
@@ -16,7 +16,7 @@ import static org.mockito.Mockito.when;
 
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.security.auth.CamundaAuthenticationProvider;
-import io.camunda.security.configuration.InitializationConfiguration;
+import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.service.GroupServices;
 import io.camunda.service.MappingRuleServices;
 import io.camunda.service.RoleServices;
@@ -57,8 +57,7 @@ import org.springframework.test.web.reactive.server.WebTestClient.ResponseSpec;
 public class TenantControllerTest {
 
   private static final String TENANT_BASE_URL = "/v2/tenants";
-  private static final Pattern ID_PATTERN =
-      Pattern.compile(InitializationConfiguration.DEFAULT_ID_REGEX);
+  private static final Pattern ID_PATTERN = Pattern.compile(SecurityConfiguration.DEFAULT_ID_REGEX);
 
   @Nested
   @WebMvcTest(TenantController.class)
@@ -69,7 +68,7 @@ public class TenantControllerTest {
     @MockitoBean private GroupServices groupServices;
     @MockitoBean private RoleServices roleServices;
     @MockitoBean private CamundaAuthenticationProvider authenticationProvider;
-    @MockitoBean private InitializationConfiguration initializationConfiguration;
+    @MockitoBean private SecurityConfiguration securityConfiguration;
 
     @BeforeEach
     void setup() {
@@ -77,7 +76,7 @@ public class TenantControllerTest {
           .thenReturn(AUTHENTICATION_WITH_DEFAULT_TENANT);
       when(tenantServices.withAuthentication(any(CamundaAuthentication.class)))
           .thenReturn(tenantServices);
-      when(initializationConfiguration.getIdentifierPattern()).thenReturn(ID_PATTERN);
+      when(securityConfiguration.getCompiledIdValidationPattern()).thenReturn(ID_PATTERN);
     }
 
     @ParameterizedTest
@@ -224,7 +223,7 @@ public class TenantControllerTest {
               "detail": "The provided tenantId contains illegal characters. It must match the pattern '%s'.",
               "instance": "%s"
             }"""
-                  .formatted(InitializationConfiguration.DEFAULT_ID_REGEX, TENANT_BASE_URL),
+                  .formatted(SecurityConfiguration.DEFAULT_ID_REGEX, TENANT_BASE_URL),
               JsonCompareMode.STRICT);
 
       // then
@@ -478,7 +477,7 @@ public class TenantControllerTest {
               "detail": "The provided tenantId contains illegal characters. It must match the pattern '%s'.",
               "instance": "%s"
             }"""
-                  .formatted(InitializationConfiguration.DEFAULT_ID_REGEX, uri),
+                  .formatted(SecurityConfiguration.DEFAULT_ID_REGEX, uri),
               JsonCompareMode.STRICT);
 
       // then
@@ -515,7 +514,7 @@ public class TenantControllerTest {
               "detail": "The provided %s contains illegal characters. It must match the pattern '%s'.",
               "instance": "%s"
             }"""
-                  .formatted(entityIdName, InitializationConfiguration.DEFAULT_ID_REGEX, uri),
+                  .formatted(entityIdName, SecurityConfiguration.DEFAULT_ID_REGEX, uri),
               JsonCompareMode.STRICT);
 
       // then
@@ -577,7 +576,7 @@ public class TenantControllerTest {
               "detail": "The provided tenantId contains illegal characters. It must match the pattern '%s'.",
               "instance": "%s"
             }"""
-                  .formatted(InitializationConfiguration.DEFAULT_ID_REGEX, uri),
+                  .formatted(SecurityConfiguration.DEFAULT_ID_REGEX, uri),
               JsonCompareMode.STRICT);
 
       // then
@@ -615,7 +614,7 @@ public class TenantControllerTest {
               "detail": "The provided %s contains illegal characters. It must match the pattern '%s'.",
               "instance": "%s"
             }"""
-                  .formatted(entityIdName, InitializationConfiguration.DEFAULT_ID_REGEX, uri),
+                  .formatted(entityIdName, SecurityConfiguration.DEFAULT_ID_REGEX, uri),
               JsonCompareMode.STRICT);
 
       // then
@@ -663,7 +662,7 @@ public class TenantControllerTest {
     @MockitoBean private GroupServices groupServices;
     @MockitoBean private RoleServices roleServices;
     @MockitoBean private CamundaAuthenticationProvider authenticationProvider;
-    @MockitoBean private InitializationConfiguration initializationConfiguration;
+    @MockitoBean private SecurityConfiguration securityConfiguration;
 
     @ParameterizedTest
     @MethodSource("tenantControllerRequests")

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantQueryControllerTest.java
@@ -26,7 +26,7 @@ import io.camunda.search.query.TenantQuery;
 import io.camunda.search.sort.TenantSort;
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.security.auth.CamundaAuthenticationProvider;
-import io.camunda.security.configuration.InitializationConfiguration;
+import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.service.GroupServices;
 import io.camunda.service.MappingRuleServices;
 import io.camunda.service.RoleServices;
@@ -52,8 +52,7 @@ import org.springframework.test.json.JsonCompareMode;
 public class TenantQueryControllerTest extends RestControllerTest {
   private static final String TENANT_BASE_URL = "/v2/tenants";
   private static final String SEARCH_TENANT_URL = "%s/search".formatted(TENANT_BASE_URL);
-  private static final Pattern ID_PATTERN =
-      Pattern.compile(InitializationConfiguration.DEFAULT_ID_REGEX);
+  private static final Pattern ID_PATTERN = Pattern.compile(SecurityConfiguration.DEFAULT_ID_REGEX);
 
   private static final List<TenantEntity> TENANT_ENTITIES =
       List.of(
@@ -225,7 +224,7 @@ public class TenantQueryControllerTest extends RestControllerTest {
   @MockitoBean private GroupServices groupServices;
   @MockitoBean private RoleServices roleServices;
   @MockitoBean private CamundaAuthenticationProvider authenticationProvider;
-  @MockitoBean private InitializationConfiguration initializationConfiguration;
+  @MockitoBean private SecurityConfiguration securityConfiguration;
 
   @BeforeEach
   void setup() {
@@ -241,7 +240,7 @@ public class TenantQueryControllerTest extends RestControllerTest {
         .thenReturn(groupServices);
     when(roleServices.withAuthentication(any(CamundaAuthentication.class)))
         .thenReturn(roleServices);
-    when(initializationConfiguration.getIdentifierPattern()).thenReturn(ID_PATTERN);
+    when(securityConfiguration.getCompiledIdValidationPattern()).thenReturn(ID_PATTERN);
   }
 
   @Test

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantRequestValidatorTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantRequestValidatorTest.java
@@ -11,7 +11,7 @@ import static io.camunda.zeebe.gateway.rest.validator.ErrorMessages.ERROR_MESSAG
 import static io.camunda.zeebe.gateway.rest.validator.ErrorMessages.ERROR_MESSAGE_ILLEGAL_CHARACTER;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.camunda.security.configuration.InitializationConfiguration;
+import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.zeebe.gateway.protocol.rest.TenantCreateRequest;
 import io.camunda.zeebe.gateway.rest.validator.TenantRequestValidator;
 import io.camunda.zeebe.protocol.record.value.EntityType;
@@ -23,8 +23,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 public class TenantRequestValidatorTest {
 
-  private static final Pattern ID_PATTERN =
-      Pattern.compile(InitializationConfiguration.DEFAULT_ID_REGEX);
+  private static final Pattern ID_PATTERN = Pattern.compile(SecurityConfiguration.DEFAULT_ID_REGEX);
 
   @ParameterizedTest
   @MethodSource("validTenantIds")

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupControllerTest.java
@@ -16,7 +16,7 @@ import static org.mockito.Mockito.when;
 
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.security.auth.CamundaAuthenticationProvider;
-import io.camunda.security.configuration.InitializationConfiguration;
+import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.service.GroupServices;
 import io.camunda.service.GroupServices.GroupDTO;
 import io.camunda.service.GroupServices.GroupMemberDTO;
@@ -51,8 +51,7 @@ import org.springframework.test.json.JsonCompareMode;
 public class GroupControllerTest {
 
   private static final String GROUP_BASE_URL = "/v2/groups";
-  private static final Pattern ID_PATTERN =
-      Pattern.compile(InitializationConfiguration.DEFAULT_ID_REGEX);
+  private static final Pattern ID_PATTERN = Pattern.compile(SecurityConfiguration.DEFAULT_ID_REGEX);
 
   @Nested
   @WebMvcTest(GroupController.class)
@@ -216,7 +215,7 @@ public class GroupControllerTest {
     @MockitoBean private RoleServices roleServices;
     @MockitoBean private MappingRuleServices mappingRuleServices;
     @MockitoBean private CamundaAuthenticationProvider authenticationProvider;
-    @MockitoBean private InitializationConfiguration initializationConfiguration;
+    @MockitoBean private SecurityConfiguration securityConfiguration;
 
     @BeforeEach
     void setup() {
@@ -224,7 +223,7 @@ public class GroupControllerTest {
           .thenReturn(AUTHENTICATION_WITH_DEFAULT_TENANT);
       when(groupServices.withAuthentication(any(CamundaAuthentication.class)))
           .thenReturn(groupServices);
-      when(initializationConfiguration.getIdentifierPattern()).thenReturn(ID_PATTERN);
+      when(securityConfiguration.getCompiledIdValidationPattern()).thenReturn(ID_PATTERN);
     }
 
     @ParameterizedTest
@@ -405,7 +404,7 @@ public class GroupControllerTest {
                 "detail": "The provided groupId contains illegal characters. It must match the pattern '%s'.",
                 "instance": "%s"
               }"""
-                  .formatted(InitializationConfiguration.DEFAULT_ID_REGEX, GROUP_BASE_URL),
+                  .formatted(SecurityConfiguration.DEFAULT_ID_REGEX, GROUP_BASE_URL),
               JsonCompareMode.STRICT);
       verifyNoInteractions(groupServices);
     }
@@ -573,7 +572,7 @@ public class GroupControllerTest {
                 "detail": "The provided groupId contains illegal characters. It must match the pattern '%s'.",
                 "instance": "%s"
               }"""
-                  .formatted(InitializationConfiguration.DEFAULT_ID_REGEX, path),
+                  .formatted(SecurityConfiguration.DEFAULT_ID_REGEX, path),
               JsonCompareMode.STRICT);
       verifyNoInteractions(groupServices);
     }
@@ -787,7 +786,7 @@ public class GroupControllerTest {
                 "detail": "The provided mappingRuleId contains illegal characters. It must match the pattern '%s'.",
                 "instance": "%s"
               }"""
-                  .formatted(InitializationConfiguration.DEFAULT_ID_REGEX, path),
+                  .formatted(SecurityConfiguration.DEFAULT_ID_REGEX, path),
               JsonCompareMode.STRICT);
       verifyNoInteractions(groupServices);
     }
@@ -818,7 +817,7 @@ public class GroupControllerTest {
                 "detail": "The provided groupId contains illegal characters. It must match the pattern '%s'.",
                 "instance": "%s"
               }"""
-                  .formatted(InitializationConfiguration.DEFAULT_ID_REGEX, path),
+                  .formatted(SecurityConfiguration.DEFAULT_ID_REGEX, path),
               JsonCompareMode.STRICT);
       verifyNoInteractions(groupServices);
     }
@@ -1008,7 +1007,7 @@ public class GroupControllerTest {
                   "detail": "The provided mappingRuleId contains illegal characters. It must match the pattern '%s'.",
                   "instance": "%s"
                 }"""
-                  .formatted(InitializationConfiguration.DEFAULT_ID_REGEX, path),
+                  .formatted(SecurityConfiguration.DEFAULT_ID_REGEX, path),
               JsonCompareMode.STRICT);
       verifyNoInteractions(groupServices);
     }
@@ -1038,7 +1037,7 @@ public class GroupControllerTest {
                   "detail": "The provided groupId contains illegal characters. It must match the pattern '%s'.",
                   "instance": "%s"
                 }"""
-                  .formatted(InitializationConfiguration.DEFAULT_ID_REGEX, path),
+                  .formatted(SecurityConfiguration.DEFAULT_ID_REGEX, path),
               JsonCompareMode.STRICT);
       verifyNoInteractions(groupServices);
     }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupQueryControllerTest.java
@@ -27,7 +27,7 @@ import io.camunda.search.query.SearchQueryResult;
 import io.camunda.search.sort.GroupSort;
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.security.auth.CamundaAuthenticationProvider;
-import io.camunda.security.configuration.InitializationConfiguration;
+import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.service.GroupServices;
 import io.camunda.service.MappingRuleServices;
 import io.camunda.service.RoleServices;
@@ -81,8 +81,7 @@ public class GroupQueryControllerTest extends RestControllerTest {
       """;
   private static final String GROUP_BASE_URL = "/v2/groups";
   private static final String GROUP_SEARCH_URL = GROUP_BASE_URL + "/search";
-  private static final Pattern ID_PATTERN =
-      Pattern.compile(InitializationConfiguration.DEFAULT_ID_REGEX);
+  private static final Pattern ID_PATTERN = Pattern.compile(SecurityConfiguration.DEFAULT_ID_REGEX);
 
   private static final List<GroupMemberEntity> GROUP_USER_ENTITIES =
       List.of(
@@ -236,7 +235,7 @@ public class GroupQueryControllerTest extends RestControllerTest {
   @MockitoBean private MappingRuleServices mappingServices;
   @MockitoBean private RoleServices roleServices;
   @MockitoBean private CamundaAuthenticationProvider authenticationProvider;
-  @MockitoBean private InitializationConfiguration initializationConfiguration;
+  @MockitoBean private SecurityConfiguration securityConfiguration;
 
   @BeforeEach
   void setup() {
@@ -248,7 +247,7 @@ public class GroupQueryControllerTest extends RestControllerTest {
         .thenReturn(roleServices);
     when(mappingServices.withAuthentication(any(CamundaAuthentication.class)))
         .thenReturn(mappingServices);
-    when(initializationConfiguration.getIdentifierPattern()).thenReturn(ID_PATTERN);
+    when(securityConfiguration.getCompiledIdValidationPattern()).thenReturn(ID_PATTERN);
   }
 
   @Test

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/MappingRuleControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/MappingRuleControllerTest.java
@@ -15,7 +15,7 @@ import static org.mockito.Mockito.when;
 
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.security.auth.CamundaAuthenticationProvider;
-import io.camunda.security.configuration.InitializationConfiguration;
+import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.service.MappingRuleServices;
 import io.camunda.service.MappingRuleServices.MappingRuleDTO;
 import io.camunda.zeebe.gateway.protocol.rest.MappingRuleCreateRequest;
@@ -37,12 +37,11 @@ import org.springframework.test.json.JsonCompareMode;
 public class MappingRuleControllerTest extends RestControllerTest {
 
   private static final String MAPPING_RULES_PATH = "/v2/mapping-rules";
-  private static final Pattern ID_PATTERN =
-      Pattern.compile(InitializationConfiguration.DEFAULT_ID_REGEX);
+  private static final Pattern ID_PATTERN = Pattern.compile(SecurityConfiguration.DEFAULT_ID_REGEX);
 
   @MockitoBean private MappingRuleServices mappingRuleServices;
   @MockitoBean private CamundaAuthenticationProvider authenticationProvider;
-  @MockitoBean private InitializationConfiguration initializationConfiguration;
+  @MockitoBean private SecurityConfiguration securityConfiguration;
 
   @BeforeEach
   void setup() {
@@ -50,7 +49,7 @@ public class MappingRuleControllerTest extends RestControllerTest {
         .thenReturn(AUTHENTICATION_WITH_DEFAULT_TENANT);
     when(mappingRuleServices.withAuthentication(any(CamundaAuthentication.class)))
         .thenReturn(mappingRuleServices);
-    when(initializationConfiguration.getIdentifierPattern()).thenReturn(ID_PATTERN);
+    when(securityConfiguration.getCompiledIdValidationPattern()).thenReturn(ID_PATTERN);
   }
 
   @ParameterizedTest
@@ -276,7 +275,7 @@ public class MappingRuleControllerTest extends RestControllerTest {
               "detail": "The provided mappingRuleId contains illegal characters. It must match the pattern '%s'.",
               "instance": "%s"
             }"""
-            .formatted(InitializationConfiguration.DEFAULT_ID_REGEX, MAPPING_RULES_PATH));
+            .formatted(SecurityConfiguration.DEFAULT_ID_REGEX, MAPPING_RULES_PATH));
     verifyNoInteractions(mappingRuleServices);
   }
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/MappingRuleQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/MappingRuleQueryControllerTest.java
@@ -20,7 +20,7 @@ import io.camunda.search.query.SearchQueryResult;
 import io.camunda.search.sort.MappingRuleSort;
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.security.auth.CamundaAuthenticationProvider;
-import io.camunda.security.configuration.InitializationConfiguration;
+import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.service.MappingRuleServices;
 import io.camunda.service.exception.ErrorMapper;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
@@ -36,12 +36,11 @@ import org.springframework.test.json.JsonCompareMode;
 @WebMvcTest(value = MappingRuleController.class)
 public class MappingRuleQueryControllerTest extends RestControllerTest {
   private static final String MAPPING_RULE_BASE_URL = "/v2/mapping-rules";
-  private static final Pattern ID_PATTERN =
-      Pattern.compile(InitializationConfiguration.DEFAULT_ID_REGEX);
+  private static final Pattern ID_PATTERN = Pattern.compile(SecurityConfiguration.DEFAULT_ID_REGEX);
 
   @MockitoBean private MappingRuleServices mappingRuleServices;
   @MockitoBean private CamundaAuthenticationProvider authenticationProvider;
-  @MockitoBean private InitializationConfiguration initializationConfiguration;
+  @MockitoBean private SecurityConfiguration securityConfiguration;
 
   @BeforeEach
   void setup() {
@@ -49,7 +48,7 @@ public class MappingRuleQueryControllerTest extends RestControllerTest {
         .thenReturn(AUTHENTICATION_WITH_DEFAULT_TENANT);
     when(mappingRuleServices.withAuthentication(any(CamundaAuthentication.class)))
         .thenReturn(mappingRuleServices);
-    when(initializationConfiguration.getIdentifierPattern()).thenReturn(ID_PATTERN);
+    when(securityConfiguration.getCompiledIdValidationPattern()).thenReturn(ID_PATTERN);
   }
 
   @Test

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleControllerTest.java
@@ -15,7 +15,7 @@ import static org.mockito.Mockito.when;
 
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.security.auth.CamundaAuthenticationProvider;
-import io.camunda.security.configuration.InitializationConfiguration;
+import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.service.GroupServices;
 import io.camunda.service.MappingRuleServices;
 import io.camunda.service.RoleServices;
@@ -48,15 +48,14 @@ import org.springframework.test.json.JsonCompareMode;
 public class RoleControllerTest extends RestControllerTest {
 
   private static final String ROLE_BASE_URL = "/v2/roles";
-  private static final Pattern ID_PATTERN =
-      Pattern.compile(InitializationConfiguration.DEFAULT_ID_REGEX);
+  private static final Pattern ID_PATTERN = Pattern.compile(SecurityConfiguration.DEFAULT_ID_REGEX);
 
   @MockitoBean private RoleServices roleServices;
   @MockitoBean private UserServices userServices;
   @MockitoBean private MappingRuleServices mappingRuleServices;
   @MockitoBean private GroupServices groupServices;
   @MockitoBean private CamundaAuthenticationProvider authenticationProvider;
-  @MockitoBean private InitializationConfiguration initializationConfiguration;
+  @MockitoBean private SecurityConfiguration securityConfiguration;
 
   @BeforeEach
   void setup() {
@@ -70,7 +69,7 @@ public class RoleControllerTest extends RestControllerTest {
         .thenReturn(mappingRuleServices);
     when(groupServices.withAuthentication(any(CamundaAuthentication.class)))
         .thenReturn(groupServices);
-    when(initializationConfiguration.getIdentifierPattern()).thenReturn(ID_PATTERN);
+    when(securityConfiguration.getCompiledIdValidationPattern()).thenReturn(ID_PATTERN);
   }
 
   @ParameterizedTest
@@ -259,7 +258,7 @@ public class RoleControllerTest extends RestControllerTest {
                 "detail": "The provided roleId contains illegal characters. It must match the pattern '%s'.",
                 "instance": "%s"
               }"""
-                .formatted(InitializationConfiguration.DEFAULT_ID_REGEX, ROLE_BASE_URL),
+                .formatted(SecurityConfiguration.DEFAULT_ID_REGEX, ROLE_BASE_URL),
             JsonCompareMode.STRICT);
     verifyNoInteractions(roleServices);
   }
@@ -552,7 +551,7 @@ public class RoleControllerTest extends RestControllerTest {
                 "detail": "The provided mappingRuleId contains illegal characters. It must match the pattern '%s'.",
                 "instance": "%s"
               }"""
-                .formatted(InitializationConfiguration.DEFAULT_ID_REGEX, path),
+                .formatted(SecurityConfiguration.DEFAULT_ID_REGEX, path),
             JsonCompareMode.STRICT);
     verifyNoInteractions(roleServices);
   }
@@ -583,7 +582,7 @@ public class RoleControllerTest extends RestControllerTest {
                 "detail": "The provided roleId contains illegal characters. It must match the pattern '%s'.",
                 "instance": "%s"
               }"""
-                .formatted(InitializationConfiguration.DEFAULT_ID_REGEX, path),
+                .formatted(SecurityConfiguration.DEFAULT_ID_REGEX, path),
             JsonCompareMode.STRICT);
     verifyNoInteractions(roleServices);
   }
@@ -747,7 +746,7 @@ public class RoleControllerTest extends RestControllerTest {
                 "detail": "The provided username contains illegal characters. It must match the pattern '%s'.",
                 "instance": "%s"
               }"""
-                .formatted(InitializationConfiguration.DEFAULT_ID_REGEX, path),
+                .formatted(SecurityConfiguration.DEFAULT_ID_REGEX, path),
             JsonCompareMode.STRICT);
     verifyNoInteractions(roleServices);
   }
@@ -778,7 +777,7 @@ public class RoleControllerTest extends RestControllerTest {
                 "detail": "The provided roleId contains illegal characters. It must match the pattern '%s'.",
                 "instance": "%s"
               }"""
-                .formatted(InitializationConfiguration.DEFAULT_ID_REGEX, path),
+                .formatted(SecurityConfiguration.DEFAULT_ID_REGEX, path),
             JsonCompareMode.STRICT);
     verifyNoInteractions(roleServices);
   }
@@ -884,7 +883,7 @@ public class RoleControllerTest extends RestControllerTest {
                   "detail": "The provided username contains illegal characters. It must match the pattern '%s'.",
                   "instance": "%s"
                 }"""
-                .formatted(InitializationConfiguration.DEFAULT_ID_REGEX, path),
+                .formatted(SecurityConfiguration.DEFAULT_ID_REGEX, path),
             JsonCompareMode.STRICT);
     verifyNoInteractions(roleServices);
   }
@@ -914,7 +913,7 @@ public class RoleControllerTest extends RestControllerTest {
                   "detail": "The provided roleId contains illegal characters. It must match the pattern '%s'.",
                   "instance": "%s"
                 }"""
-                .formatted(InitializationConfiguration.DEFAULT_ID_REGEX, path),
+                .formatted(SecurityConfiguration.DEFAULT_ID_REGEX, path),
             JsonCompareMode.STRICT);
     verifyNoInteractions(roleServices);
   }
@@ -1021,7 +1020,7 @@ public class RoleControllerTest extends RestControllerTest {
                 "detail": "The provided groupId contains illegal characters. It must match the pattern '%s'.",
                 "instance": "%s"
               }"""
-                .formatted(InitializationConfiguration.DEFAULT_ID_REGEX, path),
+                .formatted(SecurityConfiguration.DEFAULT_ID_REGEX, path),
             JsonCompareMode.STRICT);
     verifyNoInteractions(roleServices);
   }
@@ -1052,7 +1051,7 @@ public class RoleControllerTest extends RestControllerTest {
                 "detail": "The provided roleId contains illegal characters. It must match the pattern '%s'.",
                 "instance": "%s"
               }"""
-                .formatted(InitializationConfiguration.DEFAULT_ID_REGEX, path),
+                .formatted(SecurityConfiguration.DEFAULT_ID_REGEX, path),
             JsonCompareMode.STRICT);
     verifyNoInteractions(roleServices);
   }
@@ -1161,7 +1160,7 @@ public class RoleControllerTest extends RestControllerTest {
                   "detail": "The provided groupId contains illegal characters. It must match the pattern '%s'.",
                   "instance": "%s"
                 }"""
-                .formatted(InitializationConfiguration.DEFAULT_ID_REGEX, path),
+                .formatted(SecurityConfiguration.DEFAULT_ID_REGEX, path),
             JsonCompareMode.STRICT);
     verifyNoInteractions(roleServices);
   }
@@ -1191,7 +1190,7 @@ public class RoleControllerTest extends RestControllerTest {
                   "detail": "The provided roleId contains illegal characters. It must match the pattern '%s'.",
                   "instance": "%s"
                 }"""
-                .formatted(InitializationConfiguration.DEFAULT_ID_REGEX, path),
+                .formatted(SecurityConfiguration.DEFAULT_ID_REGEX, path),
             JsonCompareMode.STRICT);
     verifyNoInteractions(roleServices);
   }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleQueryControllerTest.java
@@ -23,7 +23,7 @@ import io.camunda.search.query.SearchQueryResult;
 import io.camunda.search.sort.RoleSort;
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.security.auth.CamundaAuthenticationProvider;
-import io.camunda.security.configuration.InitializationConfiguration;
+import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.service.GroupServices;
 import io.camunda.service.MappingRuleServices;
 import io.camunda.service.RoleServices;
@@ -44,15 +44,14 @@ import org.springframework.test.json.JsonCompareMode;
 @WebMvcTest(value = RoleController.class)
 public class RoleQueryControllerTest extends RestControllerTest {
   private static final String ROLE_BASE_URL = "/v2/roles";
-  private static final Pattern ID_PATTERN =
-      Pattern.compile(InitializationConfiguration.DEFAULT_ID_REGEX);
+  private static final Pattern ID_PATTERN = Pattern.compile(SecurityConfiguration.DEFAULT_ID_REGEX);
 
   @MockitoBean private RoleServices roleServices;
   @MockitoBean private UserServices userServices;
   @MockitoBean private MappingRuleServices mappingRuleServices;
   @MockitoBean private GroupServices groupServices;
   @MockitoBean private CamundaAuthenticationProvider authenticationProvider;
-  @MockitoBean private InitializationConfiguration initializationConfiguration;
+  @MockitoBean private SecurityConfiguration securityConfiguration;
 
   @BeforeEach
   void setup() {
@@ -66,7 +65,7 @@ public class RoleQueryControllerTest extends RestControllerTest {
         .thenReturn(mappingRuleServices);
     when(groupServices.withAuthentication(any(CamundaAuthentication.class)))
         .thenReturn(groupServices);
-    when(initializationConfiguration.getIdentifierPattern()).thenReturn(ID_PATTERN);
+    when(securityConfiguration.getCompiledIdValidationPattern()).thenReturn(ID_PATTERN);
   }
 
   @Test

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/UserControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/UserControllerTest.java
@@ -16,7 +16,7 @@ import static org.mockito.Mockito.when;
 
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.security.auth.CamundaAuthenticationProvider;
-import io.camunda.security.configuration.InitializationConfiguration;
+import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.service.UserServices;
 import io.camunda.service.UserServices.UserDTO;
 import io.camunda.service.exception.ErrorMapper;
@@ -48,8 +48,7 @@ import org.springframework.test.json.JsonCompareMode;
 public class UserControllerTest {
 
   private static final String USER_BASE_URL = "/v2/users";
-  private static final Pattern ID_PATTERN =
-      Pattern.compile(InitializationConfiguration.DEFAULT_ID_REGEX);
+  private static final Pattern ID_PATTERN = Pattern.compile(SecurityConfiguration.DEFAULT_ID_REGEX);
 
   @Nested
   @WebMvcTest(UserController.class)
@@ -58,7 +57,7 @@ public class UserControllerTest {
 
     @MockitoBean private UserServices userServices;
     @MockitoBean private CamundaAuthenticationProvider authenticationProvider;
-    @MockitoBean private InitializationConfiguration initializationConfiguration;
+    @MockitoBean private SecurityConfiguration securityConfiguration;
 
     @BeforeEach
     void setup() {
@@ -66,7 +65,7 @@ public class UserControllerTest {
           .thenReturn(AUTHENTICATION_WITH_DEFAULT_TENANT);
       when(userServices.withAuthentication(any(CamundaAuthentication.class)))
           .thenReturn(userServices);
-      when(initializationConfiguration.getIdentifierPattern()).thenReturn(ID_PATTERN);
+      when(securityConfiguration.getCompiledIdValidationPattern()).thenReturn(ID_PATTERN);
     }
 
     @ParameterizedTest
@@ -329,7 +328,7 @@ public class UserControllerTest {
               "detail": "The provided username contains illegal characters. It must match the pattern '%s'.",
               "instance": "%s"
             }"""
-              .formatted(InitializationConfiguration.DEFAULT_ID_REGEX, USER_BASE_URL));
+              .formatted(SecurityConfiguration.DEFAULT_ID_REGEX, USER_BASE_URL));
       verifyNoInteractions(userServices);
     }
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/UserQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/UserQueryControllerTest.java
@@ -21,7 +21,7 @@ import io.camunda.search.query.UserQuery;
 import io.camunda.search.sort.UserSort;
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.security.auth.CamundaAuthenticationProvider;
-import io.camunda.security.configuration.InitializationConfiguration;
+import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.service.RoleServices;
 import io.camunda.service.UserServices;
 import io.camunda.service.exception.ErrorMapper;
@@ -61,8 +61,7 @@ public class UserQueryControllerTest extends RestControllerTest {
               }
           }""";
   private static final String USERS_SEARCH_URL = "/v2/users/search";
-  private static final Pattern ID_PATTERN =
-      Pattern.compile(InitializationConfiguration.DEFAULT_ID_REGEX);
+  private static final Pattern ID_PATTERN = Pattern.compile(SecurityConfiguration.DEFAULT_ID_REGEX);
 
   private static final SearchQueryResult<UserEntity> SEARCH_QUERY_RESULT =
       new Builder<UserEntity>()
@@ -76,7 +75,7 @@ public class UserQueryControllerTest extends RestControllerTest {
   @MockitoBean RoleServices roleServices;
   @MockitoBean PasswordEncoder passwordEncoder;
   @MockitoBean CamundaAuthenticationProvider authenticationProvider;
-  @MockitoBean private InitializationConfiguration initializationConfiguration;
+  @MockitoBean private SecurityConfiguration securityConfiguration;
 
   @BeforeEach
   void setup() {
@@ -84,7 +83,7 @@ public class UserQueryControllerTest extends RestControllerTest {
         .thenReturn(AUTHENTICATION_WITH_DEFAULT_TENANT);
     when(userServices.withAuthentication(any(CamundaAuthentication.class)))
         .thenReturn(userServices);
-    when(initializationConfiguration.getIdentifierPattern()).thenReturn(ID_PATTERN);
+    when(securityConfiguration.getCompiledIdValidationPattern()).thenReturn(ID_PATTERN);
   }
 
   @Test


### PR DESCRIPTION
- move out of initialization config because it is not for initializing the system

related to #37000
