### PR TITLE
[stable/8.7] revert: "fix: add qa module to root"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,6 @@
     <module>testing/camunda-process-test-spring</module>
     <module>testing/camunda-process-test-example</module>
     <module>document</module>
-    <module>qa</module>
   </modules>
 
   <scm>


### PR DESCRIPTION
## Description

This reverts commit 6a00dee147d204dd92bc8343b9d723417e3c4186.

This was necessary as it was breaking the release dry-run.

Note that his means that ArchUnit tests are no longer executed in the `General Unit Tests` section, as this is run with `-D skipQaBuild=true`. We'll fix that in a later PR.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

relates to https://camunda.slack.com/archives/C06UWQNCU7M/p1756114363166019?thread_ts=1755827877.666109&cid=C06UWQNCU7M
