### PR TITLE
revert: "fix: add qa module to root"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,6 @@
     <module>security</module>
     <module>migration</module>
     <module>configuration</module>
-    <module>qa</module>
   </modules>
 
   <scm>


### PR DESCRIPTION
## Description

This reverts commit 3a39089dd2e5b382b1f3b6d946411d74453ea02c.

This is necessary as it was breaking the release dry-run.

Note that his means that ArchUnit tests are no longer executed in the `General Unit Tests` section, as this is run with `-D skipQaBuild=true`. We'll fix that in a later PR.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

relates to https://camunda.slack.com/archives/C06UWQNCU7M/p1756114363166019?thread_ts=1755827877.666109&cid=C06UWQNCU7M
