### PR TITLE
Move cluster ID config from `console.ping` to `zeebe.broker.cluster`

### DIFF
--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -532,6 +532,11 @@
       # Example:
       # clusterName: zeebe-cluster
 
+      # Allows to configure the cluster ID.
+      # This setting is used to identify the cluster and should be unique across clusters. If not set, it will be generated automatically.
+      # This setting can also be overridden using the environment variable ZEEBE_BROKER_CLUSTER_CLUSTERID.
+      # clusterId:
+
       # Configure heartbeatInterval. The leader sends a heartbeat to a follower every heartbeatInterval.
       # Note: This is an advanced setting.
       # This setting can also be overridden using the environment variable ZEEBE_BROKER_CLUSTER_HEARTBEATINTERVAL.

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -449,6 +449,11 @@
       # Example:
       # clusterName: zeebe-cluster
 
+      # Allows to configure the cluster ID.
+      # This setting is used to identify the cluster and should be unique across clusters. If not set, it will be generated automatically.
+      # This setting can also be overridden using the environment variable ZEEBE_BROKER_CLUSTER_CLUSTERID.
+      # clusterId:
+      
       # Configure heartbeatInterval. The leader sends a heartbeat to a follower every heartbeatInterval.
       # Note: This is an advanced setting.
       # This setting can also be overridden using the environment variable ZEEBE_BROKER_CLUSTER_HEARTBEATINTERVAL.

--- a/dist/src/main/java/io/camunda/application/commons/configuration/BrokerBasedConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/configuration/BrokerBasedConfiguration.java
@@ -99,4 +99,9 @@ public class BrokerBasedConfiguration {
     final var configFactory = new ClusterConfigFactory();
     return configFactory.mapConfiguration(properties);
   }
+
+  @Bean
+  public String clusterId() {
+    return properties.getCluster().getClusterId();
+  }
 }

--- a/dist/src/main/java/io/camunda/application/commons/console/ping/PingConsoleRunner.java
+++ b/dist/src/main/java/io/camunda/application/commons/console/ping/PingConsoleRunner.java
@@ -10,6 +10,7 @@ package io.camunda.application.commons.console.ping;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.application.Profile;
+import io.camunda.application.commons.configuration.BrokerBasedConfiguration;
 import io.camunda.application.commons.console.ping.PingConsoleRunner.ConsolePingConfiguration;
 import io.camunda.application.commons.console.ping.PingConsoleTask.LicensePayload;
 import io.camunda.service.ManagementServices;
@@ -47,15 +48,18 @@ public class PingConsoleRunner implements ApplicationRunner {
   private final ManagementServices managementServices;
   private final Either<Exception, String> licensePayload;
   private final ApplicationContext applicationContext;
+  private final String clusterId;
 
   @Autowired
   public PingConsoleRunner(
       final ConsolePingConfiguration pingConfigurationProperties,
       final ManagementServices managementServices,
-      final ApplicationContext applicationContext) {
+      final ApplicationContext applicationContext,
+      final BrokerBasedConfiguration brokerConfig) {
     pingConfiguration = pingConfigurationProperties;
     this.managementServices = managementServices;
     this.applicationContext = applicationContext;
+    clusterId = brokerConfig.config().getCluster().getClusterId();
     licensePayload = getLicensePayload();
   }
 
@@ -88,7 +92,7 @@ public class PingConsoleRunner implements ApplicationRunner {
       throw new IllegalArgumentException(
           String.format("Ping endpoint %s must be a valid URI.", pingConfiguration.endpoint));
     }
-    if (pingConfiguration.clusterId() == null || pingConfiguration.clusterId().isBlank()) {
+    if (clusterId == null || clusterId.isBlank()) {
       throw new IllegalArgumentException("Cluster ID must not be null or empty.");
     }
     if (pingConfiguration.clusterName() == null || pingConfiguration.clusterName().isBlank()) {
@@ -166,7 +170,7 @@ public class PingConsoleRunner implements ApplicationRunner {
     final LicensePayload payload =
         new LicensePayload(
             license,
-            pingConfiguration.clusterId(),
+            clusterId,
             pingConfiguration.clusterName(),
             VersionUtil.getVersion(),
             getActiveProfiles(),
@@ -182,7 +186,6 @@ public class PingConsoleRunner implements ApplicationRunner {
   public record ConsolePingConfiguration(
       boolean enabled,
       URI endpoint,
-      String clusterId,
       String clusterName,
       Duration pingPeriod,
       RetryConfiguration retry,

--- a/dist/src/main/java/io/camunda/application/commons/console/ping/PingConsoleRunner.java
+++ b/dist/src/main/java/io/camunda/application/commons/console/ping/PingConsoleRunner.java
@@ -10,7 +10,6 @@ package io.camunda.application.commons.console.ping;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.application.Profile;
-import io.camunda.application.commons.configuration.BrokerBasedConfiguration;
 import io.camunda.application.commons.console.ping.PingConsoleRunner.ConsolePingConfiguration;
 import io.camunda.application.commons.console.ping.PingConsoleTask.LicensePayload;
 import io.camunda.service.ManagementServices;
@@ -55,11 +54,11 @@ public class PingConsoleRunner implements ApplicationRunner {
       final ConsolePingConfiguration pingConfigurationProperties,
       final ManagementServices managementServices,
       final ApplicationContext applicationContext,
-      final BrokerBasedConfiguration brokerConfig) {
+      final String clusterId) {
     pingConfiguration = pingConfigurationProperties;
     this.managementServices = managementServices;
     this.applicationContext = applicationContext;
-    clusterId = brokerConfig.config().getCluster().getClusterId();
+    this.clusterId = clusterId;
     licensePayload = getLicensePayload();
   }
 

--- a/dist/src/test/java/io/camunda/application/commons/console/ping/PingConsoleConfigurationTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/console/ping/PingConsoleConfigurationTest.java
@@ -16,12 +16,9 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import io.camunda.application.commons.configuration.BrokerBasedConfiguration;
 import io.camunda.application.commons.console.ping.PingConsoleRunner.ConsolePingConfiguration;
 import io.camunda.service.ManagementServices;
 import io.camunda.service.license.LicenseType;
-import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
-import io.camunda.zeebe.broker.system.configuration.ClusterCfg;
 import io.camunda.zeebe.util.retry.RetryConfiguration;
 import java.io.IOException;
 import java.net.URI;
@@ -45,10 +42,6 @@ class PingConsoleConfigurationTest {
   private static final ManagementServices MANAGEMENT_SERVICES = mock(ManagementServices.class);
   private static final Environment ENVIRONMENT = mock(Environment.class);
   private static final ApplicationContext APPLICATION_CONTEXT = mock(ApplicationContext.class);
-  private static final BrokerBasedConfiguration BROKER_BASED_CFG =
-      mock(BrokerBasedConfiguration.class);
-  private static final BrokerCfg BROKER_CFG = mock(BrokerCfg.class);
-  private static final ClusterCfg CLUSTER_CONFIG = mock(ClusterCfg.class);
   private final ConsolePingConfiguration pingConfiguration =
       new ConsolePingConfiguration(
           true,
@@ -69,9 +62,6 @@ class PingConsoleConfigurationTest {
     when(MANAGEMENT_SERVICES.getCamundaLicenseExpiresAt()).thenReturn(null);
     when(APPLICATION_CONTEXT.getEnvironment()).thenReturn(ENVIRONMENT);
     when(ENVIRONMENT.getActiveProfiles()).thenReturn(new String[] {"broker"});
-    when(BROKER_BASED_CFG.config()).thenReturn(BROKER_CFG);
-    when(BROKER_CFG.getCluster()).thenReturn(CLUSTER_CONFIG);
-    when(CLUSTER_CONFIG.getClusterId()).thenReturn("clusterId");
   }
 
   @Test
@@ -89,7 +79,7 @@ class PingConsoleConfigurationTest {
                         consolePingConfiguration,
                         MANAGEMENT_SERVICES,
                         APPLICATION_CONTEXT,
-                        BROKER_BASED_CFG)
+                        "clusterId")
                     ::validateConfiguration)
             .actual();
     assertThat(exception.getMessage()).isEqualTo("Ping endpoint must not be null.");
@@ -115,7 +105,7 @@ class PingConsoleConfigurationTest {
                         consolePingConfiguration,
                         MANAGEMENT_SERVICES,
                         APPLICATION_CONTEXT,
-                        BROKER_BASED_CFG)
+                        "clusterId")
                     ::validateConfiguration)
             .actual();
     assertThat(exception.getMessage()).isEqualTo("Ping endpoint 123 must be a valid URI.");
@@ -124,7 +114,6 @@ class PingConsoleConfigurationTest {
   @Test
   void clusterIdShouldNotBeNullOrEmpty() {
     // given
-    when(CLUSTER_CONFIG.getClusterId()).thenReturn(null);
     final ConsolePingConfiguration consolePingConfiguration =
         new ConsolePingConfiguration(
             true,
@@ -139,16 +128,12 @@ class PingConsoleConfigurationTest {
         assertThatExceptionOfType(IllegalArgumentException.class)
             .isThrownBy(
                 new PingConsoleRunner(
-                        consolePingConfiguration,
-                        MANAGEMENT_SERVICES,
-                        APPLICATION_CONTEXT,
-                        BROKER_BASED_CFG)
+                        consolePingConfiguration, MANAGEMENT_SERVICES, APPLICATION_CONTEXT, null)
                     ::validateConfiguration)
             .actual();
     assertThat(exception.getMessage()).isEqualTo("Cluster ID must not be null or empty.");
 
     // reset
-    when(CLUSTER_CONFIG.getClusterId()).thenReturn("clusterId");
   }
 
   @Test
@@ -171,7 +156,7 @@ class PingConsoleConfigurationTest {
                         consolePingConfiguration,
                         MANAGEMENT_SERVICES,
                         APPLICATION_CONTEXT,
-                        BROKER_BASED_CFG)
+                        "clusterId")
                     ::validateConfiguration)
             .actual();
     assertThat(exception.getMessage()).isEqualTo("Cluster name must not be null or empty.");
@@ -197,7 +182,7 @@ class PingConsoleConfigurationTest {
                         consolePingConfiguration,
                         MANAGEMENT_SERVICES,
                         APPLICATION_CONTEXT,
-                        BROKER_BASED_CFG)
+                        "clusterId")
                     ::validateConfiguration)
             .actual();
     assertThat(exception.getMessage()).isEqualTo("Ping period must be greater than zero.");
@@ -226,7 +211,7 @@ class PingConsoleConfigurationTest {
                         consolePingConfiguration,
                         MANAGEMENT_SERVICES,
                         APPLICATION_CONTEXT,
-                        BROKER_BASED_CFG)
+                        "clusterId")
                     ::validateConfiguration)
             .actual();
     assertThat(exception.getMessage())
@@ -256,7 +241,7 @@ class PingConsoleConfigurationTest {
                         consolePingConfiguration,
                         MANAGEMENT_SERVICES,
                         APPLICATION_CONTEXT,
-                        BROKER_BASED_CFG)
+                        "clusterId")
                     ::validateConfiguration)
             .actual();
     assertThat(exception.getMessage())
@@ -282,7 +267,7 @@ class PingConsoleConfigurationTest {
                     consolePingConfiguration,
                     MANAGEMENT_SERVICES,
                     APPLICATION_CONTEXT,
-                    BROKER_BASED_CFG))
+                    "clusterId"))
         .doesNotThrowAnyException();
   }
 
@@ -309,7 +294,7 @@ class PingConsoleConfigurationTest {
                         consolePingConfiguration,
                         MANAGEMENT_SERVICES,
                         APPLICATION_CONTEXT,
-                        BROKER_BASED_CFG)
+                        "clusterId")
                     ::validateConfiguration)
             .actual();
     assertThat(exception.getMessage()).isEqualTo("Max retry delay must be greater than zero.");
@@ -338,7 +323,7 @@ class PingConsoleConfigurationTest {
                         consolePingConfiguration,
                         MANAGEMENT_SERVICES,
                         APPLICATION_CONTEXT,
-                        BROKER_BASED_CFG)
+                        "clusterId")
                     ::validateConfiguration)
             .actual();
     assertThat(exception.getMessage()).isEqualTo("Min retry delay must be greater than zero.");
@@ -368,7 +353,7 @@ class PingConsoleConfigurationTest {
                         consolePingConfiguration,
                         MANAGEMENT_SERVICES,
                         APPLICATION_CONTEXT,
-                        BROKER_BASED_CFG)
+                        "clusterId")
                     ::validateConfiguration)
             .actual();
     assertThat(exception.getMessage())
@@ -393,7 +378,7 @@ class PingConsoleConfigurationTest {
                     consolePingConfiguration,
                     MANAGEMENT_SERVICES,
                     APPLICATION_CONTEXT,
-                    BROKER_BASED_CFG))
+                    "clusterId"))
         .doesNotThrowAnyException();
   }
 
@@ -416,7 +401,7 @@ class PingConsoleConfigurationTest {
                     consolePingConfiguration,
                     MANAGEMENT_SERVICES,
                     APPLICATION_CONTEXT,
-                    BROKER_BASED_CFG))
+                    "clusterId"))
         .doesNotThrowAnyException();
   }
 

--- a/dist/src/test/java/io/camunda/application/commons/console/ping/PingConsoleRunnerIT.java
+++ b/dist/src/test/java/io/camunda/application/commons/console/ping/PingConsoleRunnerIT.java
@@ -21,12 +21,9 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
-import io.camunda.application.commons.configuration.BrokerBasedConfiguration;
 import io.camunda.application.commons.console.ping.PingConsoleRunner.ConsolePingConfiguration;
 import io.camunda.service.ManagementServices;
 import io.camunda.service.license.LicenseType;
-import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
-import io.camunda.zeebe.broker.system.configuration.ClusterCfg;
 import io.camunda.zeebe.util.VersionUtil;
 import io.camunda.zeebe.util.retry.RetryConfiguration;
 import java.net.URI;
@@ -41,9 +38,6 @@ import org.springframework.core.env.Environment;
 
 public class PingConsoleRunnerIT {
 
-  private final BrokerBasedConfiguration brokerBasedConfig = mock(BrokerBasedConfiguration.class);
-  private final BrokerCfg brokerCfg = mock(BrokerCfg.class);
-  private final ClusterCfg clusterCfg = mock(ClusterCfg.class);
   private ApplicationContext applicationContext;
   private WireMockServer wireMockServer;
   private ManagementServices managementServices;
@@ -90,9 +84,6 @@ public class PingConsoleRunnerIT {
     when(managementServices.isCommercialCamundaLicense()).thenReturn(true);
     when(managementServices.isCamundaLicenseValid()).thenReturn(true);
     when(applicationContext.getEnvironment()).thenReturn(environment);
-    when(brokerBasedConfig.config()).thenReturn(brokerCfg);
-    when(brokerCfg.getCluster()).thenReturn(clusterCfg);
-    when(clusterCfg.getClusterId()).thenReturn("test-cluster-id");
     when(environment.getActiveProfiles())
         .thenReturn(new String[] {"gateway", "broker", "identity"});
 
@@ -101,7 +92,7 @@ public class PingConsoleRunnerIT {
             true, URI.create(mockUrl), "test-cluster-name", pingPeriod, retryConfig, null);
 
     final PingConsoleRunner pingConsoleRunner =
-        new PingConsoleRunner(config, managementServices, applicationContext, brokerBasedConfig);
+        new PingConsoleRunner(config, managementServices, applicationContext, "test-cluster-id");
 
     // when
     pingConsoleRunner.run(null);

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ClusterCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ClusterCfg.java
@@ -46,6 +46,7 @@ public final class ClusterCfg implements ConfigurationEntry {
 
   private List<Integer> partitionIds;
   private int nodeId = DEFAULT_NODE_ID;
+  private String clusterId;
   private int partitionsCount = DEFAULT_PARTITIONS_COUNT;
   private int replicationFactor = DEFAULT_REPLICATION_FACTOR;
   private int clusterSize = DEFAULT_CLUSTER_SIZE;
@@ -115,6 +116,14 @@ public final class ClusterCfg implements ConfigurationEntry {
 
   public void setNodeId(final int nodeId) {
     this.nodeId = nodeId;
+  }
+
+  public String getClusterId() {
+    return clusterId;
+  }
+
+  public void setClusterId(final String clusterId) {
+    this.clusterId = clusterId;
   }
 
   public int getPartitionsCount() {

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/ClusterCfgTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/ClusterCfgTest.java
@@ -40,6 +40,7 @@ public final class ClusterCfgTest {
       "zeebe.broker.cluster.configManager.gossip.syncRequestTimeout";
   private static final String ZEEBE_BROKER_CLUSTER_CONFIG_MANAGER_GOSSIP_GOSSIP_FANOUT =
       "zeebe.broker.cluster.configManager.gossip.gossipFanout";
+  private static final String ZEEBE_BROKER_CLUSTER_CLUSTER_ID = "zeebe.broker.cluster.clusterId";
 
   @Test
   public void shouldUseDefaults() {
@@ -64,6 +65,7 @@ public final class ClusterCfgTest {
     assertThat(defaultCfg.getClusterSize()).isEqualTo(1);
     assertThat(defaultCfg.getInitialContactPoints()).isEqualTo(List.of());
     assertThat(defaultCfg.getConfigManager()).isEqualTo(ConfigManagerCfg.defaultConfig());
+    assertThat(defaultCfg.getClusterId()).isNull();
   }
 
   @Test
@@ -74,6 +76,7 @@ public final class ClusterCfgTest {
     environment.put(ZEEBE_BROKER_CLUSTER_PARTITIONS_COUNT, "2");
     environment.put(ZEEBE_BROKER_CLUSTER_REPLICATION_FACTOR, "3");
     environment.put(ZEEBE_BROKER_CLUSTER_NODE_ID, "2");
+    environment.put(ZEEBE_BROKER_CLUSTER_CLUSTER_ID, "cluster-id");
 
     // when
     final BrokerCfg cfg = TestConfigReader.readConfig("cluster-cfg", environment);
@@ -84,6 +87,7 @@ public final class ClusterCfgTest {
     assertThat(cfgCluster.getPartitionsCount()).isEqualTo(2);
     assertThat(cfgCluster.getReplicationFactor()).isEqualTo(3);
     assertThat(cfgCluster.getNodeId()).isEqualTo(2);
+    assertThat(cfgCluster.getClusterId()).isEqualTo("cluster-id");
   }
 
   @Test


### PR DESCRIPTION
## Description

This PR is to be merged before the code freeze tomorrow to maintain backwards compatibility for the 8.8 release in relation to the configuration of the cluster ID.

This PR only moves the configuration of the cluster ID from `console.ping` to `zeebe.broker.cluster`, which is the intended location for this configuration when we implement the Cluster ID being available in the broker topology (implemented in this PR https://github.com/camunda/camunda/pull/36725). 

Therefore for the PingConsole feature, this is only a temporary change since this will be fetched from the broker topology in the future, as shown in the PR above. 

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
