### PR TITLE
ci: Add QA team to medic lookup

### DIFF
--- a/.ci/scripts/ci/setup-medic-lookup.sh
+++ b/.ci/scripts/ci/setup-medic-lookup.sh
@@ -29,5 +29,8 @@ lookupTeamMedic["team-distributed-systems"]=$distributedSystemsMedic
 lookupTeamMedic["Distributed Systems"]=$distributedSystemsMedic
 lookupTeamMedic["DistributedSystems"]=$distributedSystemsMedic
 
+# failure in QA test
+lookupTeamMedic["QA"]="QA Acceptance Test, requires investigation"
+
 # catch all for tests without an assigned team
 lookupTeamMedic["General"]="General Test, requires investigation"


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
The QA team is the owner of the Root Acceptance Tests `qa/acceptance-tests`. A message should appear when one of these tests is flaky or faily

https://camunda.slack.com/archives/C071KP5BTHB/p1756101910839459

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
