### PR TITLE
Revert "deps: Update version.lucene to v8.11.4"

### DIFF
--- a/operate/pom.xml
+++ b/operate/pom.xml
@@ -95,7 +95,7 @@
     <version.elasticsearch7>7.17.29</version.elasticsearch7>
     <version.elasticsearch>8.9.2</version.elasticsearch>
     <!-- the lucene version must be coupled with version.elasticsearch7 -->
-    <version.lucene>8.11.4</version.lucene>
+    <version.lucene>8.11.3</version.lucene>
     <version.error-prone>2.25.0</version.error-prone>
     <version.guava>33.0.0-jre</version.guava>
     <version.android-json>0.0.20131108.vaadin1</version.android-json>


### PR DESCRIPTION
This reverts commit 2353d324c30a4c812887a5ea0f5dafa966ba4d08.

## Description

<!-- Describe the goal and purpose of this PR. -->
Reverting lucene update (we can't update lucene because it needs to be in line with the used ES7 version).

Still unsure why this is happening because we [disabled it in our config](https://github.com/camunda/camunda/blob/stable/operate-8.5/.github/renovate.json#L57-L65).

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
