### PR TITLE
feat: add cluster health endpoint

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
@@ -128,6 +128,7 @@ public class WebSecurityConfig {
           // these v2 endpoints are public
           "/v2/license",
           "/v2/setup/user",
+          "/v2/status",
           // deprecated Tasklist v1 Public Endpoints
           "/v1/external/process/**");
   public static final Set<String> WEBAPP_PATHS =

--- a/clients/java/src/main/java/io/camunda/client/CamundaClient.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClient.java
@@ -64,6 +64,7 @@ import io.camunda.client.api.command.ResetClockCommandStep1;
 import io.camunda.client.api.command.ResolveIncidentCommandStep1;
 import io.camunda.client.api.command.ResumeBatchOperationStep1;
 import io.camunda.client.api.command.SetVariablesCommandStep1;
+import io.camunda.client.api.command.StatusRequestStep1;
 import io.camunda.client.api.command.SuspendBatchOperationStep1;
 import io.camunda.client.api.command.TopologyRequestStep1;
 import io.camunda.client.api.command.UnassignClientFromGroupCommandStep1;
@@ -206,6 +207,22 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    * @return the request where you must call {@code send()}
    */
   TopologyRequestStep1 newTopologyRequest();
+
+  /**
+   * Request the current cluster status. Can be used to check if the cluster is healthy (has at
+   * least one partition with a healthy leader).
+   *
+   * <pre>
+   * boolean isHealthy = camundaClient
+   *  .newStatusRequest()
+   *  .send()
+   *  .join()
+   *  .isHealthy();
+   * </pre>
+   *
+   * @return the request where you must call {@code send()}
+   */
+  StatusRequestStep1 newStatusRequest();
 
   /**
    * @return the client's configuration

--- a/clients/java/src/main/java/io/camunda/client/api/command/StatusRequestStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/StatusRequestStep1.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.command;
+
+import io.camunda.client.api.response.StatusResponse;
+
+public interface StatusRequestStep1 extends FinalCommandStep<StatusResponse> {
+  // the place for new optional parameters
+}

--- a/clients/java/src/main/java/io/camunda/client/api/response/StatusResponse.java
+++ b/clients/java/src/main/java/io/camunda/client/api/response/StatusResponse.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.response;
+
+/**
+ * Response for cluster status request. The status endpoint returns 204 (No Content) when healthy
+ * and 503 (Service Unavailable) when unhealthy. The response body is always empty.
+ */
+public interface StatusResponse {
+  /**
+   * @return {@link Status#UP} if the cluster is healthy (has at least one partition with a healthy
+   *     leader), {@link Status#DOWN} otherwise
+   */
+  Status getStatus();
+
+  enum Status {
+    UP,
+    DOWN
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
@@ -73,6 +73,7 @@ import io.camunda.client.api.command.ResetClockCommandStep1;
 import io.camunda.client.api.command.ResolveIncidentCommandStep1;
 import io.camunda.client.api.command.ResumeBatchOperationStep1;
 import io.camunda.client.api.command.SetVariablesCommandStep1;
+import io.camunda.client.api.command.StatusRequestStep1;
 import io.camunda.client.api.command.StreamJobsCommandStep1;
 import io.camunda.client.api.command.SuspendBatchOperationStep1;
 import io.camunda.client.api.command.ThrowErrorCommandStep1;
@@ -209,6 +210,7 @@ import io.camunda.client.impl.command.ResetClockCommandImpl;
 import io.camunda.client.impl.command.ResolveIncidentCommandImpl;
 import io.camunda.client.impl.command.ResumeBatchOperationCommandImpl;
 import io.camunda.client.impl.command.SetVariablesCommandImpl;
+import io.camunda.client.impl.command.StatusRequestImpl;
 import io.camunda.client.impl.command.StreamJobsCommandImpl;
 import io.camunda.client.impl.command.SuspendBatchOperationCommandImpl;
 import io.camunda.client.impl.command.TopologyRequestImpl;
@@ -503,6 +505,11 @@ public final class CamundaClientImpl implements CamundaClient {
         config.getDefaultRequestTimeout(),
         credentialsProvider::shouldRetryRequest,
         config.preferRestOverGrpc());
+  }
+
+  @Override
+  public StatusRequestStep1 newStatusRequest() {
+    return new StatusRequestImpl(httpClient, config.getDefaultRequestTimeout());
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/client/impl/command/StatusRequestImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/StatusRequestImpl.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.command;
+
+import io.camunda.client.api.CamundaFuture;
+import io.camunda.client.api.command.FinalCommandStep;
+import io.camunda.client.api.command.StatusRequestStep1;
+import io.camunda.client.api.response.StatusResponse;
+import io.camunda.client.impl.http.HttpCamundaFuture;
+import io.camunda.client.impl.http.HttpClient;
+import io.camunda.client.impl.response.StatusResponseImpl;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
+import org.apache.hc.client5.http.config.RequestConfig;
+
+public final class StatusRequestImpl implements StatusRequestStep1 {
+
+  private final HttpClient httpClient;
+  private final RequestConfig.Builder httpRequestConfig;
+  private Duration requestTimeout;
+
+  public StatusRequestImpl(final HttpClient httpClient, final Duration requestTimeout) {
+    this.requestTimeout = requestTimeout;
+    this.httpClient = httpClient;
+    httpRequestConfig = httpClient.newRequestConfig();
+  }
+
+  @Override
+  public FinalCommandStep<StatusResponse> requestTimeout(final Duration requestTimeout) {
+    this.requestTimeout = requestTimeout;
+    return this;
+  }
+
+  @Override
+  public CamundaFuture<StatusResponse> send() {
+    final HttpCamundaFuture<StatusResponse> result = new HttpCamundaFuture<>();
+
+    final Predicate<Integer> successPredicate = status -> status == 204 || status == 503;
+    httpClient.get(
+        "/status",
+        httpRequestConfig
+            .setResponseTimeout(requestTimeout.toMillis(), TimeUnit.MILLISECONDS)
+            .build(),
+        successPredicate,
+        StatusResponseImpl::new,
+        result);
+
+    return result;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/response/StatusResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/StatusResponseImpl.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.response;
+
+import io.camunda.client.api.response.StatusResponse;
+
+public final class StatusResponseImpl implements StatusResponse {
+
+  private final Status status;
+
+  public StatusResponseImpl(final Void ignored, final Integer statusCode) {
+    status = statusCode == 204 ? Status.UP : Status.DOWN;
+  }
+
+  @Override
+  public Status getStatus() {
+    return status;
+  }
+}

--- a/clients/java/src/test/java/io/camunda/client/StatusRequestRestTest.java
+++ b/clients/java/src/test/java/io/camunda/client/StatusRequestRestTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.client.api.command.ClientException;
+import io.camunda.client.api.response.StatusResponse;
+import io.camunda.client.api.response.StatusResponse.Status;
+import io.camunda.client.util.ClientRestTest;
+import java.time.Duration;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import org.junit.jupiter.api.Test;
+
+public final class StatusRequestRestTest extends ClientRestTest {
+
+  @Test
+  void shouldRequestStatusWhenHealthy() throws ExecutionException, InterruptedException {
+    // given - cluster is healthy (returns 204 No Content)
+    gatewayService.onStatusRequestHealthy();
+
+    // when
+    final Future<StatusResponse> response = client.newStatusRequest().send();
+
+    // then
+    assertThat(response).succeedsWithin(Duration.ofSeconds(5));
+    final StatusResponse status = response.get();
+    assertThat(status.getStatus()).isEqualTo(Status.UP);
+  }
+
+  @Test
+  void shouldRequestStatusWhenUnhealthy() throws ExecutionException, InterruptedException {
+    // given - cluster is unhealthy (returns 503 Service Unavailable)
+    gatewayService.onStatusRequestUnhealthy();
+
+    // when
+    final Future<StatusResponse> response = client.newStatusRequest().send();
+
+    // then
+    assertThat(response).succeedsWithin(Duration.ofSeconds(5));
+    final StatusResponse status = response.get();
+    assertThat(status.getStatus()).isEqualTo(Status.DOWN);
+  }
+
+  @Test
+  void shouldHandleServerErrorAsClientException() {
+    // given - server returns 500 Internal Server Error
+    gatewayService.onStatusRequest(500);
+
+    // when & then - should throw ClientException for non-503 errors
+    assertThatThrownBy(() -> client.newStatusRequest().send().join())
+        .isInstanceOf(ClientException.class);
+  }
+
+  @Test
+  void shouldHandleBadRequestAsClientException() {
+    // given - server returns 400 Bad Request
+    gatewayService.onStatusRequest(400);
+
+    // when & then - should throw ClientException for non-503 errors
+    assertThatThrownBy(() -> client.newStatusRequest().send().join())
+        .isInstanceOf(ClientException.class);
+  }
+
+  @Test
+  void shouldHandleUnauthorizedAsClientException() {
+    // given - server returns 401 Unauthorized
+    gatewayService.onStatusRequest(401);
+
+    // when & then - should throw ClientException for authentication errors
+    assertThatThrownBy(() -> client.newStatusRequest().send().join())
+        .isInstanceOf(ClientException.class);
+  }
+
+  @Test
+  void shouldHandleForbiddenAsClientException() {
+    // given - server returns 403 Forbidden
+    gatewayService.onStatusRequest(403);
+
+    // when & then - should throw ClientException for authorization errors
+    assertThatThrownBy(() -> client.newStatusRequest().send().join())
+        .isInstanceOf(ClientException.class);
+  }
+
+  @Test
+  void shouldHandleNotFoundAsClientException() {
+    // given - server returns 404 Not Found
+    gatewayService.onStatusRequest(404);
+
+    // when & then - should throw ClientException for endpoint not found
+    assertThatThrownBy(() -> client.newStatusRequest().send().join())
+        .isInstanceOf(ClientException.class);
+  }
+}

--- a/clients/java/src/test/java/io/camunda/client/util/RestGatewayPaths.java
+++ b/clients/java/src/test/java/io/camunda/client/util/RestGatewayPaths.java
@@ -63,6 +63,7 @@ public class RestGatewayPaths {
   private static final String URL_TENANT = REST_API_PATH + "/tenants/%s";
   private static final String URL_TENANTS = REST_API_PATH + "/tenants";
   private static final String URL_TOPOLOGY = REST_API_PATH + "/topology";
+  private static final String URL_STATUS = REST_API_PATH + "/status";
   private static final String URL_USAGE_METRICS = REST_API_PATH + "/system/usage-metrics";
   private static final String URL_USER = REST_API_PATH + "/users/%s";
   private static final String URL_USERS = REST_API_PATH + "/users";
@@ -82,6 +83,13 @@ public class RestGatewayPaths {
    */
   public static String getTopologyUrl() {
     return URL_TOPOLOGY;
+  }
+
+  /**
+   * @return the status request URL
+   */
+  public static String getStatusUrl() {
+    return URL_STATUS;
   }
 
   /**

--- a/clients/java/src/test/java/io/camunda/client/util/RestGatewayService.java
+++ b/clients/java/src/test/java/io/camunda/client/util/RestGatewayService.java
@@ -340,4 +340,25 @@ public class RestGatewayService {
   public void onRoleRequest(final String roleId, final RoleResult response) {
     registerGet(RestGatewayPaths.getRoleUrl(roleId), response);
   }
+
+  public void onStatusRequestHealthy() {
+    onStatusRequest(204);
+  }
+
+  public void onStatusRequestUnhealthy() {
+    onStatusRequest(503);
+  }
+
+  /**
+   * Register a status response with a custom HTTP status code.
+   *
+   * @param statusCode the HTTP status code to return for status requests
+   */
+  public void onStatusRequest(final int statusCode) {
+    mockInfo
+        .getWireMock()
+        .register(
+            WireMock.get(RestGatewayPaths.getStatusUrl())
+                .willReturn(WireMock.aResponse().withStatus(statusCode)));
+  }
 }

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -71,6 +71,20 @@ paths:
                 $ref: "#/components/schemas/TopologyResponse"
         "500":
           $ref: "#/components/responses/InternalServerError"
+
+  /status:
+    get:
+      tags:
+        - Cluster
+      operationId: getStatus
+      summary: Get cluster status
+      description: Checks the health status of the cluster by verifying if there's at least one partition with a healthy leader.
+      responses:
+        "204":
+          description: The cluster is UP and has at least one partition with a healthy leader.
+        "503":
+          description: The cluster is DOWN and does not have any partition with a healthy leader.
+
   /license:
     get:
       tags:

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/StatusController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/StatusController.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.controller;
+
+import io.camunda.zeebe.broker.client.api.BrokerClient;
+import io.camunda.zeebe.broker.client.api.BrokerClusterState;
+import io.camunda.zeebe.gateway.rest.annotation.CamundaGetMapping;
+import io.camunda.zeebe.protocol.record.PartitionHealthStatus;
+import java.util.List;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@CamundaRestController
+@RequestMapping("/v2")
+public class StatusController {
+  private final BrokerClient client;
+
+  public StatusController(final BrokerClient client) {
+    this.client = client;
+  }
+
+  @CamundaGetMapping(path = "/status")
+  public ResponseEntity<Void> getStatus() {
+    if (!hasAPartitionWithAHealthyLeader()) {
+      return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).build();
+    }
+
+    return ResponseEntity.noContent().build();
+  }
+
+  private boolean hasAPartitionWithAHealthyLeader() {
+    final BrokerClusterState topology = client.getTopologyManager().getTopology();
+    final List<Integer> partitions = topology.getPartitions();
+
+    return partitions.stream()
+        .anyMatch(
+            partition -> {
+              final int leader = topology.getLeaderForPartition(partition);
+              return topology.getPartitionHealth(leader, partition)
+                  == PartitionHealthStatus.HEALTHY;
+            });
+  }
+}

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/StatusControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/StatusControllerTest.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.controller;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.http.HttpStatus.SERVICE_UNAVAILABLE;
+
+import io.camunda.zeebe.broker.client.api.BrokerClient;
+import io.camunda.zeebe.broker.client.api.BrokerClusterState;
+import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
+import io.camunda.zeebe.gateway.rest.RestControllerTest;
+import io.camunda.zeebe.protocol.record.PartitionHealthStatus;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.Mock;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+@WebMvcTest(StatusController.class)
+class StatusControllerTest extends RestControllerTest {
+
+  static final String STATUS_URL = "/v2/status";
+
+  @MockitoBean BrokerClient brokerClient;
+  @MockitoBean BrokerTopologyManager topologyManager;
+  @Mock BrokerClusterState clusterState;
+
+  @BeforeEach
+  void setUp() {
+    when(brokerClient.getTopologyManager()).thenReturn(topologyManager);
+    when(topologyManager.getTopology()).thenReturn(clusterState);
+  }
+
+  @Test
+  void shouldReturnNoContentWhenAtLeastOnePartitionHasHealthyLeader() {
+    // given
+    final int partitionId1 = 1;
+    final int partitionId2 = 2;
+    final int leaderId1 = 1;
+    final int leaderId2 = 2;
+
+    when(clusterState.getPartitions()).thenReturn(List.of(partitionId1, partitionId2));
+    when(clusterState.getLeaderForPartition(partitionId1)).thenReturn(leaderId1);
+    when(clusterState.getLeaderForPartition(partitionId2)).thenReturn(leaderId2);
+    when(clusterState.getPartitionHealth(leaderId1, partitionId1))
+        .thenReturn(PartitionHealthStatus.HEALTHY);
+    when(clusterState.getPartitionHealth(leaderId2, partitionId2))
+        .thenReturn(PartitionHealthStatus.UNHEALTHY);
+
+    // when / then
+    webClient
+        .get()
+        .uri(STATUS_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isNoContent()
+        .expectBody()
+        .isEmpty();
+
+    verify(brokerClient).getTopologyManager();
+    verify(topologyManager).getTopology();
+    verify(clusterState).getPartitions();
+    verify(clusterState).getLeaderForPartition(partitionId1);
+    verify(clusterState).getPartitionHealth(leaderId1, partitionId1);
+  }
+
+  @ParameterizedTest
+  @EnumSource(
+      value = PartitionHealthStatus.class,
+      names = {"HEALTHY"},
+      mode = EnumSource.Mode.EXCLUDE)
+  void shouldReturnServiceUnavailableWhenNoPartitionHasHealthyLeader(
+      final PartitionHealthStatus unhealthyStatus) {
+    // given
+    final int partitionId1 = 1;
+    final int partitionId2 = 2;
+    final int leaderId1 = 1;
+    final int leaderId2 = 2;
+
+    when(clusterState.getPartitions()).thenReturn(List.of(partitionId1, partitionId2));
+    when(clusterState.getLeaderForPartition(partitionId1)).thenReturn(leaderId1);
+    when(clusterState.getLeaderForPartition(partitionId2)).thenReturn(leaderId2);
+    when(clusterState.getPartitionHealth(leaderId1, partitionId1)).thenReturn(unhealthyStatus);
+    when(clusterState.getPartitionHealth(leaderId2, partitionId2)).thenReturn(unhealthyStatus);
+
+    // when / then
+    webClient
+        .get()
+        .uri(STATUS_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isEqualTo(SERVICE_UNAVAILABLE)
+        .expectBody()
+        .isEmpty();
+
+    verify(brokerClient).getTopologyManager();
+    verify(topologyManager).getTopology();
+    verify(clusterState).getPartitions();
+    verify(clusterState).getLeaderForPartition(partitionId1);
+    verify(clusterState).getPartitionHealth(leaderId1, partitionId1);
+    verify(clusterState).getLeaderForPartition(partitionId2);
+    verify(clusterState).getPartitionHealth(leaderId2, partitionId2);
+  }
+
+  @Test
+  void shouldReturnServiceUnavailableWhenNoPartitionsExist() {
+    // given
+    when(clusterState.getPartitions()).thenReturn(List.of());
+
+    // when / then
+    webClient
+        .get()
+        .uri(STATUS_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isEqualTo(SERVICE_UNAVAILABLE)
+        .expectBody()
+        .isEmpty();
+
+    verify(brokerClient).getTopologyManager();
+    verify(topologyManager).getTopology();
+    verify(clusterState).getPartitions();
+  }
+
+  @Test
+  void shouldHandleMixedPartitionHealthStatuses() {
+    // given
+    final int partitionId1 = 1;
+    final int partitionId2 = 2;
+    final int partitionId3 = 3;
+    final int leaderId1 = 1;
+    final int leaderId2 = 2;
+    final int leaderId3 = 3;
+
+    when(clusterState.getPartitions())
+        .thenReturn(List.of(partitionId1, partitionId2, partitionId3));
+    when(clusterState.getLeaderForPartition(partitionId1)).thenReturn(leaderId1);
+    when(clusterState.getLeaderForPartition(partitionId2)).thenReturn(leaderId2);
+    when(clusterState.getLeaderForPartition(partitionId3)).thenReturn(leaderId3);
+    when(clusterState.getPartitionHealth(leaderId1, partitionId1))
+        .thenReturn(PartitionHealthStatus.DEAD);
+    when(clusterState.getPartitionHealth(leaderId2, partitionId2))
+        .thenReturn(PartitionHealthStatus.UNHEALTHY);
+    when(clusterState.getPartitionHealth(leaderId3, partitionId3))
+        .thenReturn(PartitionHealthStatus.HEALTHY);
+
+    // when / then
+    webClient
+        .get()
+        .uri(STATUS_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isNoContent()
+        .expectBody()
+        .isEmpty();
+
+    verify(brokerClient).getTopologyManager();
+    verify(topologyManager).getTopology();
+    verify(clusterState).getPartitions();
+    verify(clusterState).getLeaderForPartition(partitionId1);
+    verify(clusterState).getPartitionHealth(leaderId1, partitionId1);
+    verify(clusterState).getLeaderForPartition(partitionId2);
+    verify(clusterState).getPartitionHealth(leaderId2, partitionId2);
+    verify(clusterState).getLeaderForPartition(partitionId3);
+    verify(clusterState).getPartitionHealth(leaderId3, partitionId3);
+  }
+}

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ClusterStatusTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ClusterStatusTest.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.clustering;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.response.StatusResponse.Status;
+import io.camunda.zeebe.qa.util.cluster.TestCluster;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.zeebe.test.util.asserts.TopologyAssert;
+import java.time.Duration;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Integration test to verify cluster status reporting.
+ *
+ * <p>Tests that the cluster status correctly reports healthy when at least one partition has a
+ * healthy leader, and unhealthy when no partitions have healthy leaders.
+ */
+@ZeebeIntegration
+public class ClusterStatusTest {
+
+  @TestZeebe(autoStart = false)
+  private static final TestCluster CLUSTER =
+      TestCluster.builder()
+          .withEmbeddedGateway(false)
+          .withGatewaysCount(1)
+          .withGatewayConfig(gateway -> gateway.withCreateSchema(false))
+          .withBrokersCount(3)
+          .withBrokerConfig(node -> node.withCreateSchema(false))
+          .withPartitionsCount(3)
+          .withReplicationFactor(1)
+          .build();
+
+  @BeforeEach
+  void beforeEach() {
+    CLUSTER.start().awaitCompleteTopology();
+  }
+
+  @Test
+  public void shouldReportHealthyStatusWhenClusterIsUp() {
+    // given - cluster is running with leaders
+
+    // when - requesting status
+    try (final var client = createCamundaClient()) {
+      final var status = client.newStatusRequest().send().join();
+
+      // then - status should be healthy
+      assertThat(status.getStatus()).isEqualTo(Status.UP);
+    }
+  }
+
+  @Test
+  public void shouldReportUnhealthyStatusWhenNoLeadersExist() {
+    // given - cluster is initially healthy
+    try (final var client = createCamundaClient()) {
+      final var initialResponse = client.newStatusRequest().send().join();
+      assertThat(initialResponse.getStatus()).isEqualTo(Status.UP);
+
+      // when - stopping all brokers to force no leaders for any partition
+      CLUSTER.brokers().values().forEach(TestStandaloneBroker::stop);
+
+      // then - status should eventually become unhealthy
+      Awaitility.await("Status should become unhealthy when no leaders exist")
+          .atMost(Duration.ofSeconds(30))
+          .pollInterval(Duration.ofSeconds(1))
+          .untilAsserted(
+              () -> {
+                final var status = client.newStatusRequest().send().join();
+                assertThat(status.getStatus()).isEqualTo(Status.DOWN);
+              });
+    }
+  }
+
+  @Test
+  public void shouldReportHealthyStatusWhenOnlyOnePartitionHasHealthyLeader() {
+    // given - cluster is initially healthy
+    try (final var client = createCamundaClient()) {
+      final var initialResponse = client.newStatusRequest().send().join();
+      assertThat(initialResponse.getStatus()).isEqualTo(Status.UP);
+
+      // when - stopping 2 out of 3 brokers, leaving at least one partition with a leader
+      stopBrokers(0, 1);
+      waitForNoLeaderForPartitions(client, 0, 1);
+
+      // then - status should remain healthy as long as one partition has a healthy leader
+      Awaitility.await("Status should remain healthy with partial cluster")
+          .pollInterval(Duration.ofMillis(100))
+          .atMost(Duration.ofSeconds(10))
+          .untilAsserted(
+              () -> {
+                final var status = client.newStatusRequest().send().join();
+                assertThat(status.getStatus()).isEqualTo(Status.UP);
+              });
+    }
+  }
+
+  private void stopBrokers(final int... brokers) {
+    for (final int broker : brokers) {
+      CLUSTER.brokers().get(MemberId.from(String.valueOf(broker))).stop();
+    }
+  }
+
+  private void waitForNoLeaderForPartitions(final CamundaClient client, final int... partitions) {
+    Awaitility.await()
+        .timeout(Duration.ofSeconds(30))
+        .untilAsserted(
+            () -> {
+              for (final var partition : partitions) {
+                TopologyAssert.assertThat(client.newTopologyRequest().send().join())
+                    .doesNotContainLeaderForPartition(partition);
+              }
+            });
+  }
+
+  private static CamundaClient createCamundaClient() {
+    final var gateway = CLUSTER.anyGateway();
+    return CLUSTER
+        .newClientBuilder()
+        .restAddress(gateway.restAddress())
+        .defaultRequestTimeout(Duration.ofSeconds(15))
+        .build();
+  }
+}


### PR DESCRIPTION
## Description

Adds a public endpoint to report if the orchestration cluster is `UP`.
Defines `UP` as: There's at least one partition with a healthy leader in the cluster

Returns no content, with the following status codes:
- `204` in case of `UP`
- `503` in case of `DOWN`

## Related issues

closes #20921
