### PR TITLE
Add basic security module tests

### DIFF
--- a/security/security-core/pom.xml
+++ b/security/security-core/pom.xml
@@ -19,18 +19,6 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.springframework</groupId>
-      <artifactId>spring-core</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework</groupId>
-      <artifactId>spring-context</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-annotations</artifactId>
-    </dependency>
-    <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>camunda-security-protocol</artifactId>
     </dependency>
@@ -41,6 +29,19 @@
     <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>zeebe-auth</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-context</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
     </dependency>
     <dependency>
       <groupId>com.jayway.jsonpath</groupId>

--- a/security/security-core/pom.xml
+++ b/security/security-core/pom.xml
@@ -52,6 +52,12 @@
     </dependency>
 
     <dependency>
+      <groupId>net.jcip</groupId>
+      <artifactId>jcip-annotations</artifactId>
+      <scope>compile</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>
@@ -60,11 +66,6 @@
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>net.jcip</groupId>
-      <artifactId>jcip-annotations</artifactId>
-      <scope>compile</scope>
     </dependency>
   </dependencies>
 </project>

--- a/security/security-core/src/test/java/io/camunda/security/auth/MappingRuleMatcherTest.java
+++ b/security/security-core/src/test/java/io/camunda/security/auth/MappingRuleMatcherTest.java
@@ -1,0 +1,219 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.security.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class MappingRuleMatcherTest {
+
+  private record MappingRuleEntity(String mappingRuleId, String claimName, String claimValue)
+      implements MappingRuleMatcher.MappingRule {}
+
+  /** Tests for the {@link MappingRuleMatcher#matchingRules(Stream, Map)} method. */
+  @Nested
+  class MatchingRulesTest {
+
+    @Test
+    @DisplayName("returns empty when claims is null")
+    void returnsEmptyWhenClaimsNull() {
+      // given
+      final var rules = List.of(new MappingRuleEntity("r1", "$.sub", "alice"));
+
+      // when
+      final List<MappingRuleEntity> result =
+          MappingRuleMatcher.matchingRules(rules.stream(), null).toList();
+
+      // then
+      assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("returns empty when no mapping rules provided")
+    void returnsEmptyWhenNoRules() {
+      // given
+      final Map<String, Object> claims = Map.of("sub", "alice");
+
+      // when
+      final List<MappingRuleEntity> result =
+          MappingRuleMatcher.matchingRules(Stream.<MappingRuleEntity>empty(), claims).toList();
+
+      // then
+      assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("matches simple scalar claim and filters non-matching")
+    void matchesSimpleScalar() {
+      // given
+      final Map<String, Object> claims = Map.of("sub", "alice");
+      final var rules =
+          List.of(
+              new MappingRuleEntity("match", "$.sub", "alice"),
+              new MappingRuleEntity("nope", "$.sub", "bob"));
+
+      // when
+      final List<MappingRuleEntity> result =
+          MappingRuleMatcher.matchingRules(rules.stream(), claims).toList();
+
+      // then
+      assertThat(result).extracting(MappingRuleEntity::mappingRuleId).containsExactly("match");
+    }
+
+    @Test
+    @DisplayName("does not match when JSONPath points to missing leaf")
+    void doesNotMatchMissingLeaf() {
+      // given
+      final Map<String, Object> claims = Map.of("sub", "alice");
+      final var rules = List.of(new MappingRuleEntity("r1", "$.email", "alice"));
+
+      // when
+      final List<MappingRuleEntity> result =
+          MappingRuleMatcher.matchingRules(rules.stream(), claims).toList();
+
+      // then
+      assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("does not match when types differ")
+    void doesNotMatchTypeMismatch() {
+      // given
+      final Map<String, Object> claims = Map.of("age", 30); // Integer value
+      final var rules = List.of(new MappingRuleEntity("r1", "$.age", "30")); // String expected
+
+      // when
+      final List<MappingRuleEntity> result =
+          MappingRuleMatcher.matchingRules(rules.stream(), claims).toList();
+
+      // then
+      assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("matches when collection claim contains expected value")
+    void matchesCollectionContains() {
+      // given
+      final Map<String, Object> claims = Map.of("roles", List.of("admin", "operator"));
+      final var rules =
+          List.of(
+              new MappingRuleEntity("admin", "$.roles", "admin"),
+              new MappingRuleEntity("developer", "$.roles", "developer"));
+
+      // when
+      final List<MappingRuleEntity> result =
+          MappingRuleMatcher.matchingRules(rules.stream(), claims).toList();
+
+      // then
+      assertThat(result).extracting(MappingRuleEntity::mappingRuleId).containsExactly("admin");
+    }
+
+    @Test
+    @DisplayName("matches nested path inside object")
+    void matchesNestedPath() {
+      // given
+      final Map<String, Object> claims =
+          Map.of("realm", Map.of("roles", List.of("admin", "operator")));
+      final var rules = List.of(new MappingRuleEntity("operator", "$.realm.roles", "operator"));
+
+      // when
+      final List<MappingRuleEntity> result =
+          MappingRuleMatcher.matchingRules(rules.stream(), claims).toList();
+
+      // then
+      assertThat(result).extracting(MappingRuleEntity::mappingRuleId).containsExactly("operator");
+    }
+
+    @Test
+    @DisplayName("filters mixed results preserving order of matching rules")
+    void filtersMixedResultsPreservingOrder() {
+      // given
+      final Map<String, Object> claims =
+          Map.of(
+              "sub", "alice",
+              "roles", List.of("admin", "developer"),
+              "realm", Map.of("region", "eu"));
+      final var rules =
+          List.of(
+              new MappingRuleEntity("r1", "$.sub", "alice"),
+              new MappingRuleEntity("r2", "$.sub", "bob"),
+              new MappingRuleEntity("r3", "$.roles", "admin"),
+              new MappingRuleEntity("r4", "$.realm.region", "us"),
+              new MappingRuleEntity("r5", "$.realm.region", "eu"));
+
+      // when
+      final List<MappingRuleEntity> result =
+          MappingRuleMatcher.matchingRules(rules.stream(), claims).toList();
+
+      // then
+      assertThat(result)
+          .extracting(MappingRuleEntity::mappingRuleId)
+          .containsExactly("r1", "r3", "r5");
+    }
+
+    @Test
+    @DisplayName("invalid JSONPath expression is ignored (not matching)")
+    void invalidJsonPathIgnored() {
+      // given
+      final Map<String, Object> claims = Map.of("sub", "alice");
+      final var rules = List.of(new MappingRuleEntity("bad", "$.sub['", "alice")); // invalid path
+
+      // when
+      final List<MappingRuleEntity> result =
+          MappingRuleMatcher.matchingRules(rules.stream(), claims).toList();
+
+      // then
+      assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("collection claim where expected value not present")
+    void collectionClaimValueNotPresent() {
+      // given
+      final Map<String, Object> claims = Map.of("roles", List.of("user", "viewer"));
+      final var rules = List.of(new MappingRuleEntity("admin", "$.roles", "admin"));
+
+      // when
+      final List<MappingRuleEntity> result =
+          MappingRuleMatcher.matchingRules(rules.stream(), claims).toList();
+
+      // then
+      assertThat(result).isEmpty();
+    }
+
+    /**
+     * This test does not actually test new behavior, but covers the code path where the same
+     * expression is used multiples times, exercising the caching logic. It's not strictly
+     * necessary, but nice to have coverage of the cache.
+     */
+    @Test
+    @DisplayName("multiple rules share same expression (cache exercise)")
+    void multipleRulesSameExpression() {
+      // given
+      final Map<String, Object> claims = Map.of("dept", "sales");
+      final var rules =
+          List.of(
+              new MappingRuleEntity("sales", "$.dept", "sales"),
+              new MappingRuleEntity("engineering", "$.dept", "engineering"),
+              new MappingRuleEntity("support", "$.dept", "support"));
+
+      // when
+      final List<MappingRuleEntity> result =
+          MappingRuleMatcher.matchingRules(rules.stream(), claims).toList();
+
+      // then
+      assertThat(result).extracting(MappingRuleEntity::mappingRuleId).containsExactly("sales");
+    }
+  }
+}

--- a/security/security-protocol/pom.xml
+++ b/security/security-protocol/pom.xml
@@ -22,4 +22,18 @@
     <version.java>8</version.java>
   </properties>
 
+  <dependencies>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
 </project>

--- a/security/security-protocol/src/test/java/io/camunda/zeebe/protocol/record/value/AuthorizationScopeTest.java
+++ b/security/security-protocol/src/test/java/io/camunda/zeebe/protocol/record/value/AuthorizationScopeTest.java
@@ -5,13 +5,11 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.zeebe.protocol.impl;
+package io.camunda.zeebe.protocol.record.value;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
-import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
-import io.camunda.zeebe.protocol.record.value.AuthorizationScope;
 import org.junit.jupiter.api.Test;
 
 public class AuthorizationScopeTest {

--- a/security/security-protocol/src/test/java/io/camunda/zeebe/protocol/record/value/AuthorizationScopeTest.java
+++ b/security/security-protocol/src/test/java/io/camunda/zeebe/protocol/record/value/AuthorizationScopeTest.java
@@ -17,7 +17,7 @@ public class AuthorizationScopeTest {
   @Test
   public void shouldProvideWildcardScope() {
     // given
-    final var wildcardScope = AuthorizationScope.WILDCARD;
+    final AuthorizationScope wildcardScope = AuthorizationScope.WILDCARD;
 
     // then
     assertThat(wildcardScope.getMatcher()).isEqualTo(AuthorizationResourceMatcher.ANY);
@@ -27,10 +27,10 @@ public class AuthorizationScopeTest {
   @Test
   public void shouldDetectWildcardId() {
     // given
-    final var wildcardId = AuthorizationScope.WILDCARD_CHAR;
+    final String wildcardId = AuthorizationScope.WILDCARD_CHAR;
 
     // when
-    final var wildcardScope = AuthorizationScope.of(wildcardId);
+    final AuthorizationScope wildcardScope = AuthorizationScope.of(wildcardId);
 
     // then
     assertThat(wildcardScope.getMatcher()).isEqualTo(AuthorizationResourceMatcher.ANY);
@@ -40,10 +40,10 @@ public class AuthorizationScopeTest {
   @Test
   public void shouldProvideIdScope() {
     // given
-    final var resourceId = "resource-id";
+    final String resourceId = "resource-id";
 
     // when
-    final var idScope = AuthorizationScope.id(resourceId);
+    final AuthorizationScope idScope = AuthorizationScope.id(resourceId);
 
     // then
     assertThat(idScope.getMatcher()).isEqualTo(AuthorizationResourceMatcher.ID);
@@ -53,10 +53,10 @@ public class AuthorizationScopeTest {
   @Test
   public void shouldDetectIdScope() {
     // given
-    final var resourceId = "resource-id";
+    final String resourceId = "resource-id";
 
     // when
-    final var idScope = AuthorizationScope.of(resourceId);
+    final AuthorizationScope idScope = AuthorizationScope.of(resourceId);
 
     // then
     assertThat(idScope.getMatcher()).isEqualTo(AuthorizationResourceMatcher.ID);
@@ -66,13 +66,14 @@ public class AuthorizationScopeTest {
   @Test
   public void shouldThrowErrorForInvalidId() {
     // given
-    final var invalidResourceId = AuthorizationScope.WILDCARD_CHAR;
+    final String invalidResourceId = AuthorizationScope.WILDCARD_CHAR;
 
     // when / then
     assertThatThrownBy(() -> AuthorizationScope.id(invalidResourceId))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining(
-            ("Resource ID cannot be the wildcard character '%s'. For declaring WILDCARD access, please use the AuthorizationScope.WILDCARD constant.")
-                .formatted(invalidResourceId));
+            String.format(
+                "Resource ID cannot be the wildcard character '%s'. For declaring WILDCARD access, please use the AuthorizationScope.WILDCARD constant.",
+                invalidResourceId));
   }
 }

--- a/security/security-services/pom.xml
+++ b/security/security-services/pom.xml
@@ -47,11 +47,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>

--- a/security/security-services/pom.xml
+++ b/security/security-services/pom.xml
@@ -34,6 +34,18 @@
       <groupId>io.camunda</groupId>
       <artifactId>camunda-search-client-reader</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-auth</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-protocol</artifactId>
+      <scope>test</scope>
+    </dependency>
+
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
@@ -42,6 +54,11 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/security/security-services/src/test/java/io/camunda/security/impl/AuthorizationCheckerTest.java
+++ b/security/security-services/src/test/java/io/camunda/security/impl/AuthorizationCheckerTest.java
@@ -7,9 +7,6 @@
  */
 package io.camunda.security.impl;
 
-import static io.camunda.zeebe.protocol.record.value.AuthorizationResourceType.COMPONENT;
-import static org.assertj.core.api.Assertions.assertThat;
-
 import io.camunda.search.entities.AuthorizationEntity;
 import io.camunda.security.auth.Authorization;
 import io.camunda.security.auth.CamundaAuthentication;
@@ -35,6 +32,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -56,17 +54,18 @@ public class AuthorizationCheckerTest {
             SecurityContext.of(c -> c.withAuthentication(a -> a).withAuthorization(a -> a)));
 
     // then
-    assertThat(result).isEmpty();
+    Assertions.assertThat(result).isEmpty();
   }
 
   @Test
   public void noPermissionTypesReturnedWhenOwnerIdsIsEmpty() {
     // when
     final var result =
-        authorizationChecker.collectPermissionTypes("foo", COMPONENT, CamundaAuthentication.none());
+        authorizationChecker.collectPermissionTypes(
+            "foo", AuthorizationResourceType.COMPONENT, CamundaAuthentication.none());
 
     // then
-    assertThat(result).isEmpty();
+    Assertions.assertThat(result).isEmpty();
   }
 
   @Test
@@ -81,11 +80,11 @@ public class AuthorizationCheckerTest {
             SecurityContext.of(c -> c.withAuthentication(a -> a).withAuthorization(a -> a)));
 
     // then
-    assertThat(result).isFalse();
+    Assertions.assertThat(result).isFalse();
   }
 
   @Nested
-  @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+  @TestInstance(Lifecycle.PER_CLASS)
   class IsAuthorizedTests {
 
     public static final String WILDCARD_RESOURCE_ID = AuthorizationScope.WILDCARD.getResourceId();
@@ -435,7 +434,7 @@ public class AuthorizationCheckerTest {
   }
 
   @Nested
-  @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+  @TestInstance(Lifecycle.PER_CLASS)
   class CollectPermissionTypesTests {
 
     private static final String WILDCARD_RESOURCE_ID = AuthorizationScope.WILDCARD.getResourceId();
@@ -922,7 +921,7 @@ public class AuthorizationCheckerTest {
   }
 
   @Nested
-  @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+  @TestInstance(Lifecycle.PER_CLASS)
   class RetrieveAuthorizedAuthorizationScopesTests {
 
     private static final String WILDCARD_RESOURCE_ID = AuthorizationScope.WILDCARD.getResourceId();
@@ -952,7 +951,7 @@ public class AuthorizationCheckerTest {
         final var actual = checker.retrieveAuthorizedAuthorizationScopes(securityContext);
 
         // then
-        assertThat(actual)
+        Assertions.assertThat(actual)
             .describedAs(scenario.displayName())
             .containsExactlyElementsOf(scenario.expected());
       }

--- a/security/security-services/src/test/java/io/camunda/security/impl/AuthorizationCheckerTest.java
+++ b/security/security-services/src/test/java/io/camunda/security/impl/AuthorizationCheckerTest.java
@@ -185,7 +185,7 @@ public class AuthorizationCheckerTest {
       // then
       Assertions.assertThat(isAuthorized)
           .describedAs(displayName)
-          .isEqualTo(expected == Expected.ACCESS_ALLOWED);
+          .isEqualTo(expected.isAuthorized());
     }
 
     Stream<Arguments> anonymousAuthorizationScenarios() {
@@ -423,7 +423,14 @@ public class AuthorizationCheckerTest {
 
     private enum Expected {
       ACCESS_ALLOWED,
-      ACCESS_DENIED
+      ACCESS_DENIED;
+
+      boolean isAuthorized() {
+        return switch (this) {
+          case ACCESS_ALLOWED -> true;
+          case ACCESS_DENIED -> false;
+        };
+      }
     }
   }
 

--- a/security/security-services/src/test/java/io/camunda/security/impl/AuthorizationCheckerTest.java
+++ b/security/security-services/src/test/java/io/camunda/security/impl/AuthorizationCheckerTest.java
@@ -13,12 +13,29 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import io.camunda.search.clients.reader.AuthorizationReader;
+import io.camunda.search.entities.AuthorizationEntity;
 import io.camunda.security.auth.Authorization;
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.security.auth.SecurityContext;
+import io.camunda.zeebe.protocol.Protocol;
+import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.AuthorizationScope;
+import io.camunda.zeebe.protocol.record.value.PermissionType;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
 
 public class AuthorizationCheckerTest {
@@ -75,5 +92,348 @@ public class AuthorizationCheckerTest {
 
     // then
     assertThat(result).isFalse();
+  }
+
+  @Nested
+  @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+  class IsAuthorizedTests {
+
+    public final String WILDCARD_RESOURCE_ID = AuthorizationScope.WILDCARD.getResourceId();
+    public final String AUTHORIZED_USERNAME =
+        io.camunda.zeebe.auth.Authorization.AUTHORIZED_USERNAME;
+
+    private static final String RESOURCE_ID = "id";
+
+    private AuthorizationChecker authorizationChecker;
+    private FakeAuthorizationReader authorizationReader;
+
+    @BeforeAll
+    void beforeAll() {
+      authorizationReader = new FakeAuthorizationReader();
+      authorizationChecker = new AuthorizationChecker(authorizationReader);
+      // user based authorizations
+      authorizationReader.create(
+          new AuthorizationEntity(
+              Protocol.encodePartitionId(1, 1),
+              "userWithWildcard",
+              AuthorizationOwnerType.USER.name(),
+              AuthorizationResourceType.PROCESS_DEFINITION.name(),
+              AuthorizationResourceMatcher.ANY.value(),
+              WILDCARD_RESOURCE_ID,
+              Set.of(PermissionType.READ_PROCESS_INSTANCE)));
+      authorizationReader.create(
+          new AuthorizationEntity(
+              Protocol.encodePartitionId(1, 2),
+              "userWithResourceId",
+              AuthorizationOwnerType.USER.name(),
+              AuthorizationResourceType.PROCESS_DEFINITION.name(),
+              AuthorizationResourceMatcher.ID.value(),
+              RESOURCE_ID,
+              Set.of(PermissionType.READ_PROCESS_INSTANCE)));
+      // client based authorizations
+      authorizationReader.create(
+          new AuthorizationEntity(
+              Protocol.encodePartitionId(1, 3),
+              "clientWildcard",
+              AuthorizationOwnerType.CLIENT.name(),
+              AuthorizationResourceType.PROCESS_DEFINITION.name(),
+              AuthorizationResourceMatcher.ANY.value(),
+              WILDCARD_RESOURCE_ID,
+              Set.of(PermissionType.READ_PROCESS_INSTANCE)));
+      authorizationReader.create(
+          new AuthorizationEntity(
+              Protocol.encodePartitionId(1, 4),
+              "clientWithResourceId",
+              AuthorizationOwnerType.CLIENT.name(),
+              AuthorizationResourceType.PROCESS_DEFINITION.name(),
+              AuthorizationResourceMatcher.ID.value(),
+              RESOURCE_ID,
+              Set.of(PermissionType.READ_PROCESS_INSTANCE)));
+      // mapping rule based authorizations
+      authorizationReader.create(
+          new AuthorizationEntity(
+              Protocol.encodePartitionId(1, 5),
+              "mrWildcard",
+              AuthorizationOwnerType.MAPPING_RULE.name(),
+              AuthorizationResourceType.PROCESS_DEFINITION.name(),
+              AuthorizationResourceMatcher.ANY.value(),
+              WILDCARD_RESOURCE_ID,
+              Set.of(PermissionType.READ_PROCESS_INSTANCE)));
+      authorizationReader.create(
+          new AuthorizationEntity(
+              Protocol.encodePartitionId(1, 6),
+              "mrWithResourceId",
+              AuthorizationOwnerType.MAPPING_RULE.name(),
+              AuthorizationResourceType.PROCESS_DEFINITION.name(),
+              AuthorizationResourceMatcher.ID.value(),
+              RESOURCE_ID,
+              Set.of(PermissionType.READ_PROCESS_INSTANCE)));
+    }
+
+    @AfterAll
+    void afterAll() {
+      authorizationReader.close();
+    }
+
+    @ParameterizedTest(name = "{index} {0}")
+    @MethodSource("anonymousAuthorizationScenarios")
+    void anonymousAuthorizationScenariosTest(
+        final String displayName,
+        final CamundaAuthentication authentication,
+        final Authorization<?> authorization,
+        final AuthorizationScope attemptedScope,
+        final Expected expected) {
+      // given
+      final var securityContext =
+          SecurityContext.of(
+              c -> c.withAuthentication(authentication).withAuthorization(authorization));
+
+      // when
+      final boolean isAuthorized =
+          authorizationChecker.isAuthorized(attemptedScope, securityContext);
+
+      // then
+      Assertions.assertThat(isAuthorized)
+          .describedAs(displayName)
+          .isEqualTo(expected == Expected.ACCESS_ALLOWED);
+    }
+
+    Stream<Arguments> anonymousAuthorizationScenarios() {
+      return Stream.of(
+          Arguments.of(
+              "anonymous ID:id accessing id -> denied",
+              CamundaAuthentication.anonymous(),
+              Authorization.of(
+                  authorization ->
+                      authorization
+                          .resourceType(AuthorizationResourceType.PROCESS_DEFINITION)
+                          .permissionType(PermissionType.READ_PROCESS_INSTANCE)
+                          .resourceId(RESOURCE_ID)),
+              AuthorizationScope.id(RESOURCE_ID),
+              Expected.ACCESS_DENIED),
+          Arguments.of(
+              "anonymous ID:id accessing * -> denied",
+              CamundaAuthentication.anonymous(),
+              Authorization.of(
+                  authorization ->
+                      authorization
+                          .resourceType(AuthorizationResourceType.PROCESS_DEFINITION)
+                          .permissionType(PermissionType.READ_PROCESS_INSTANCE)
+                          .resourceId(RESOURCE_ID)),
+              AuthorizationScope.WILDCARD,
+              Expected.ACCESS_DENIED),
+          Arguments.of(
+              "anonymous ANY:* accessing id -> denied",
+              CamundaAuthentication.anonymous(),
+              Authorization.of(
+                  authorization ->
+                      authorization
+                          .resourceType(AuthorizationResourceType.PROCESS_DEFINITION)
+                          .permissionType(PermissionType.READ_PROCESS_INSTANCE)
+                          .resourceId(WILDCARD_RESOURCE_ID)),
+              AuthorizationScope.id(RESOURCE_ID),
+              Expected.ACCESS_DENIED),
+          Arguments.of(
+              "anonymous ANY:* accessing * -> denied",
+              CamundaAuthentication.anonymous(),
+              Authorization.of(
+                  authorization ->
+                      authorization
+                          .resourceType(AuthorizationResourceType.PROCESS_DEFINITION)
+                          .permissionType(PermissionType.READ_PROCESS_INSTANCE)
+                          .resourceId(WILDCARD_RESOURCE_ID)),
+              AuthorizationScope.WILDCARD,
+              Expected.ACCESS_DENIED));
+    }
+
+    @ParameterizedTest(name = "{index} {0}")
+    @MethodSource("authenticatedAuthorizationScenarios")
+    void authenticatedAuthorizationScenariosTest(
+        final String displayName,
+        final CamundaAuthentication authentication,
+        final Authorization<?> authorization,
+        final AuthorizationScope attemptedScope,
+        final Expected expected) {
+      // given
+      final var securityContext =
+          SecurityContext.of(
+              c -> c.withAuthentication(authentication).withAuthorization(authorization));
+
+      // when
+      final boolean isAuthorized =
+          authorizationChecker.isAuthorized(attemptedScope, securityContext);
+
+      // then
+      Assertions.assertThat(isAuthorized)
+          .describedAs(displayName)
+          .isEqualTo(expected == Expected.ACCESS_ALLOWED);
+    }
+
+    Stream<Arguments> authenticatedAuthorizationScenarios() {
+      return Stream.of(
+          // user based
+          Arguments.of(
+              "auth userWithWildcard ANY:* accessing * -> allowed",
+              CamundaAuthentication.of(
+                  authorization ->
+                      authorization
+                          .user("userWithWildcard")
+                          .claims(Map.of(AUTHORIZED_USERNAME, "userWithWildcard"))),
+              Authorization.of(
+                  authorization ->
+                      authorization
+                          .resourceType(AuthorizationResourceType.PROCESS_DEFINITION)
+                          .permissionType(PermissionType.READ_PROCESS_INSTANCE)
+                          .resourceId(WILDCARD_RESOURCE_ID)),
+              AuthorizationScope.WILDCARD,
+              Expected.ACCESS_ALLOWED),
+          Arguments.of(
+              "auth userWithWildcard ANY:* accessing id -> allowed",
+              CamundaAuthentication.of(
+                  authorization ->
+                      authorization
+                          .user("userWithWildcard")
+                          .claims(Map.of(AUTHORIZED_USERNAME, "userWithWildcard"))),
+              Authorization.of(
+                  authorization ->
+                      authorization
+                          .resourceType(AuthorizationResourceType.PROCESS_DEFINITION)
+                          .permissionType(PermissionType.READ_PROCESS_INSTANCE)
+                          .resourceId(WILDCARD_RESOURCE_ID)),
+              AuthorizationScope.id(RESOURCE_ID),
+              Expected.ACCESS_ALLOWED),
+          Arguments.of(
+              "auth userWithResourceId ID:id accessing id -> allowed",
+              CamundaAuthentication.of(
+                  authorization ->
+                      authorization
+                          .user("userWithResourceId")
+                          .claims(Map.of(AUTHORIZED_USERNAME, "userWithResourceId"))),
+              Authorization.of(
+                  authorization ->
+                      authorization
+                          .resourceType(AuthorizationResourceType.PROCESS_DEFINITION)
+                          .permissionType(PermissionType.READ_PROCESS_INSTANCE)
+                          .resourceId(RESOURCE_ID)),
+              AuthorizationScope.id(RESOURCE_ID),
+              Expected.ACCESS_ALLOWED),
+          Arguments.of(
+              "auth userWithResourceId ID:id accessing different id -> denied",
+              CamundaAuthentication.of(
+                  authorization ->
+                      authorization
+                          .user("userWithResourceId")
+                          .claims(Map.of(AUTHORIZED_USERNAME, "userWithResourceId"))),
+              Authorization.of(
+                  authorization ->
+                      authorization
+                          .resourceType(AuthorizationResourceType.PROCESS_DEFINITION)
+                          .permissionType(PermissionType.READ_PROCESS_INSTANCE)
+                          .resourceId(RESOURCE_ID)),
+              AuthorizationScope.id("a_different_id"),
+              Expected.ACCESS_DENIED),
+          Arguments.of(
+              "auth userWithResourceId ID:id accessing * -> denied",
+              CamundaAuthentication.of(
+                  authorization ->
+                      authorization
+                          .user("userWithResourceId")
+                          .claims(Map.of(AUTHORIZED_USERNAME, "userWithResourceId"))),
+              Authorization.of(
+                  authorization ->
+                      authorization
+                          .resourceType(AuthorizationResourceType.PROCESS_DEFINITION)
+                          .permissionType(PermissionType.READ_PROCESS_INSTANCE)
+                          .resourceId(RESOURCE_ID)),
+              AuthorizationScope.WILDCARD,
+              Expected.ACCESS_DENIED),
+          // client based
+          Arguments.of(
+              "auth clientWildcard ANY:* accessing * -> allowed",
+              CamundaAuthentication.of(a -> a.clientId("clientWildcard")),
+              Authorization.of(
+                  a ->
+                      a.resourceType(AuthorizationResourceType.PROCESS_DEFINITION)
+                          .permissionType(PermissionType.READ_PROCESS_INSTANCE)
+                          .resourceId(WILDCARD_RESOURCE_ID)),
+              AuthorizationScope.WILDCARD,
+              Expected.ACCESS_ALLOWED),
+          Arguments.of(
+              "auth clientWildcard ANY:* accessing id -> allowed",
+              CamundaAuthentication.of(a -> a.clientId("clientWildcard")),
+              Authorization.of(
+                  a ->
+                      a.resourceType(AuthorizationResourceType.PROCESS_DEFINITION)
+                          .permissionType(PermissionType.READ_PROCESS_INSTANCE)
+                          .resourceId(WILDCARD_RESOURCE_ID)),
+              AuthorizationScope.id(RESOURCE_ID),
+              Expected.ACCESS_ALLOWED),
+          Arguments.of(
+              "auth clientWithResourceId ID:id accessing id -> allowed",
+              CamundaAuthentication.of(a -> a.clientId("clientWithResourceId")),
+              Authorization.of(
+                  a ->
+                      a.resourceType(AuthorizationResourceType.PROCESS_DEFINITION)
+                          .permissionType(PermissionType.READ_PROCESS_INSTANCE)
+                          .resourceId(RESOURCE_ID)),
+              AuthorizationScope.id(RESOURCE_ID),
+              Expected.ACCESS_ALLOWED),
+          Arguments.of(
+              "auth clientWithResourceId ID:id accessing other id -> denied",
+              CamundaAuthentication.of(a -> a.clientId("clientWithResourceId")),
+              Authorization.of(
+                  a ->
+                      a.resourceType(AuthorizationResourceType.PROCESS_DEFINITION)
+                          .permissionType(PermissionType.READ_PROCESS_INSTANCE)
+                          .resourceId(RESOURCE_ID)),
+              AuthorizationScope.id("different"),
+              Expected.ACCESS_DENIED),
+          // mapping rule based
+          Arguments.of(
+              "auth mapping rule mrWildcard ANY:* accessing * -> allowed",
+              CamundaAuthentication.of(a -> a.mappingRule("mrWildcard")),
+              Authorization.of(
+                  a ->
+                      a.resourceType(AuthorizationResourceType.PROCESS_DEFINITION)
+                          .permissionType(PermissionType.READ_PROCESS_INSTANCE)
+                          .resourceId(WILDCARD_RESOURCE_ID)),
+              AuthorizationScope.WILDCARD,
+              Expected.ACCESS_ALLOWED),
+          Arguments.of(
+              "auth mapping rule mrWildcard ANY:* accessing id -> allowed",
+              CamundaAuthentication.of(a -> a.mappingRule("mrWildcard")),
+              Authorization.of(
+                  a ->
+                      a.resourceType(AuthorizationResourceType.PROCESS_DEFINITION)
+                          .permissionType(PermissionType.READ_PROCESS_INSTANCE)
+                          .resourceId(WILDCARD_RESOURCE_ID)),
+              AuthorizationScope.id(RESOURCE_ID),
+              Expected.ACCESS_ALLOWED),
+          Arguments.of(
+              "auth mapping rule mrWithResourceId ID:id accessing id -> allowed",
+              CamundaAuthentication.of(a -> a.mappingRule("mrWithResourceId")),
+              Authorization.of(
+                  a ->
+                      a.resourceType(AuthorizationResourceType.PROCESS_DEFINITION)
+                          .permissionType(PermissionType.READ_PROCESS_INSTANCE)
+                          .resourceId(RESOURCE_ID)),
+              AuthorizationScope.id(RESOURCE_ID),
+              Expected.ACCESS_ALLOWED),
+          Arguments.of(
+              "auth mapping rule mrWithResourceId ID:id accessing other id -> denied",
+              CamundaAuthentication.of(a -> a.mappingRule("mrWithResourceId")),
+              Authorization.of(
+                  a ->
+                      a.resourceType(AuthorizationResourceType.PROCESS_DEFINITION)
+                          .permissionType(PermissionType.READ_PROCESS_INSTANCE)
+                          .resourceId(RESOURCE_ID)),
+              AuthorizationScope.id("different"),
+              Expected.ACCESS_DENIED));
+    }
+
+    private enum Expected {
+      ACCESS_ALLOWED,
+      ACCESS_DENIED
+    }
   }
 }

--- a/security/security-services/src/test/java/io/camunda/security/impl/FakeAuthorizationReader.java
+++ b/security/security-services/src/test/java/io/camunda/security/impl/FakeAuthorizationReader.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.security.impl;
+
+import io.camunda.search.clients.reader.AuthorizationReader;
+import io.camunda.search.entities.AuthorizationEntity;
+import io.camunda.search.filter.AuthorizationFilter;
+import io.camunda.search.query.AuthorizationQuery;
+import io.camunda.search.query.SearchQueryResult;
+import io.camunda.security.reader.ResourceAccessChecks;
+import io.camunda.zeebe.protocol.record.value.EntityType;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * A fake implementation of the AuthorizationReader interface for testing purposes. It stores
+ * AuthorizationEntity objects in memory and allows searching and retrieving them by key.
+ */
+class FakeAuthorizationReader implements AuthorizationReader, AutoCloseable {
+
+  private final List<AuthorizationEntity> authorizations = new ArrayList<>();
+
+  /** Create a new AuthorizationEntity, so it can be found by search and getByKey. */
+  public void create(final AuthorizationEntity authorization) {
+    authorizations.add(authorization);
+  }
+
+  @Override
+  public AuthorizationEntity getByKey(
+      final long key, final ResourceAccessChecks resourceAccessChecks) {
+    return authorizations.stream()
+        .filter(a -> a.authorizationKey().equals(key))
+        .findAny()
+        .orElse(null);
+  }
+
+  /**
+   * Simple search algorithm by filtering the in-memory list of authorizations.
+   *
+   * <ul>
+   *   <li>if the filter is null, all authorizations match
+   *   <li>if a filter field is not null, the corresponding field must match (or contain, for lists)
+   *       the value in the filter
+   * </ul>
+   */
+  @Override
+  public SearchQueryResult<AuthorizationEntity> search(
+      final AuthorizationQuery query, final ResourceAccessChecks resourceAccessChecks) {
+    final var filter = query.filter();
+    final var matches = authorizations.stream().filter(a -> matches(a, filter)).toList();
+
+    if (matches.isEmpty()) {
+      return SearchQueryResult.empty();
+    }
+
+    final var first = matches.getFirst();
+    final var last = matches.getLast();
+    return new SearchQueryResult<>(
+        matches.size(), false, matches, first.toString(), last.toString());
+  }
+
+  private boolean matches(
+      final AuthorizationEntity authorization, final AuthorizationFilter filter) {
+    if (filter == null) {
+      return true;
+    }
+    if (filter.authorizationKey() != null
+        && !filter.authorizationKey().equals(authorization.authorizationKey())) {
+      return false;
+    }
+    if (filter.ownerType() != null && !filter.ownerType().equals(authorization.ownerType())) {
+      return false;
+    }
+    if (filter.ownerIds() != null && !filter.ownerIds().contains(authorization.ownerId())) {
+      return false;
+    }
+    if (filter.ownerTypeToOwnerIds() != null) {
+      final Set<String> filterOwnerIds =
+          filter
+              .ownerTypeToOwnerIds()
+              .get(EntityType.valueOf(EntityType.class, authorization.ownerType()));
+      if (filterOwnerIds == null || !filterOwnerIds.contains(authorization.ownerId())) {
+        return false;
+      }
+    }
+    if (filter.resourceMatcher() != null
+        && !filter.resourceMatcher().equals(authorization.resourceMatcher())) {
+      return false;
+    }
+    if (filter.resourceIds() != null
+        && !filter.resourceIds().contains(authorization.resourceId())) {
+      return false;
+    }
+    if (filter.resourceType() != null
+        && !filter.resourceType().equals(authorization.resourceType())) {
+      return false;
+    }
+    return filter.permissionTypes() == null
+        || filter.permissionTypes().containsAll(authorization.permissionTypes());
+  }
+
+  @Override
+  public void close() {
+    authorizations.clear();
+  }
+}


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Adds some basic tests to the security module that were still missing. In particular:
- Adds coverage of the `AuthorizationChecker`
- Adds coverage of the `MappingRuleMatcher`

It does not add coverage of the `ArgumentUtil` as these methods do not require unit testing.

This PR also re-organizes some security module code. In particular:
- Moves `AuthorizationScope` from `protocol-impl` to `security-protocol`
- Reorders security-core dependencies for keeping a better overview
- Removes some unnecessary mockito usage to test behavior rather than implementation

**Additional notes**

- Anonymous users are never authorized
- Authorized users are authorized if they have access to the resource by id or as wildcard

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #31766
