### PR TITLE
fix: set elasticsearch url in integration tests

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/migration/KeycloakIdentityMigrationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/migration/KeycloakIdentityMigrationIT.java
@@ -169,7 +169,12 @@ public class KeycloakIdentityMigrationIT {
 
   @BeforeAll
   static void init() {
-    BROKER.withCamundaExporter("http://" + ELASTIC.getHttpHostAddress()).start();
+    BROKER
+        .withCamundaExporter("http://" + ELASTIC.getHttpHostAddress())
+        .withProperty(
+            "camunda.data.secondary-storage.elasticsearch.url",
+            "http://" + ELASTIC.getHttpHostAddress())
+        .start();
 
     IDENTITY
         .withEnv(

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/migration/OidcIdentityMigrationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/migration/OidcIdentityMigrationIT.java
@@ -125,7 +125,12 @@ public class OidcIdentityMigrationIT {
     }
 
     IDENTITY.start();
-    BROKER.withCamundaExporter("http://" + ELASTIC.getHttpHostAddress()).start();
+    BROKER
+        .withCamundaExporter("http://" + ELASTIC.getHttpHostAddress())
+        .withProperty(
+            "camunda.data.secondary-storage.elasticsearch.url",
+            "http://" + ELASTIC.getHttpHostAddress())
+        .start();
   }
 
   @BeforeEach

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/migration/SaaSIdentityMigrationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/migration/SaaSIdentityMigrationIT.java
@@ -123,7 +123,12 @@ public class SaaSIdentityMigrationIT {
 
   @BeforeAll
   static void init(final WireMockRuntimeInfo wmRuntimeInfo) {
-    BROKER.withCamundaExporter("http://" + ELASTIC.getHttpHostAddress()).start();
+    BROKER
+        .withCamundaExporter("http://" + ELASTIC.getHttpHostAddress())
+        .withProperty(
+            "camunda.data.secondary-storage.elasticsearch.url",
+            "http://" + ELASTIC.getHttpHostAddress())
+        .start();
 
     org.testcontainers.Testcontainers.exposeHostPorts(wmRuntimeInfo.getHttpPort());
     IDENTITY.withEnv(

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/BasicAuthOverGrpcIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/BasicAuthOverGrpcIT.java
@@ -52,7 +52,11 @@ public class BasicAuthOverGrpcIT {
 
   @BeforeEach
   void beforeEach() {
-    broker.withCamundaExporter("http://" + CONTAINER.getHttpHostAddress());
+    broker
+        .withCamundaExporter("http://" + CONTAINER.getHttpHostAddress())
+        .withProperty(
+            "camunda.data.secondary-storage.elasticsearch.url",
+            "http://" + CONTAINER.getHttpHostAddress());
     broker.start();
 
     final var defaultUsername = "demo";

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/BasicAuthOverRestIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/BasicAuthOverRestIT.java
@@ -43,7 +43,7 @@ final class BasicAuthOverRestIT {
   @AutoClose private static CamundaClient defaultUserClient;
 
   @TestZeebe(autoStart = false)
-  private TestStandaloneBroker broker =
+  private final TestStandaloneBroker broker =
       new TestStandaloneBroker()
           .withRecordingExporter(true)
           .withAuthorizationsEnabled()
@@ -51,7 +51,11 @@ final class BasicAuthOverRestIT {
 
   @BeforeEach
   void beforeEach() {
-    broker.withCamundaExporter("http://" + CONTAINER.getHttpHostAddress());
+    broker
+        .withCamundaExporter("http://" + CONTAINER.getHttpHostAddress())
+        .withProperty(
+            "camunda.data.secondary-storage.elasticsearch.url",
+            "http://" + CONTAINER.getHttpHostAddress());
     broker.start();
 
     final var defaultUsername = "demo";

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/OidcAuthOverGrpcIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/OidcAuthOverGrpcIT.java
@@ -72,6 +72,9 @@ public class OidcAuthOverGrpcIT {
           .withAuthenticatedAccess()
           .withAuthenticationMethod(AuthenticationMethod.OIDC)
           .withCamundaExporter("http://" + CONTAINER.getHttpHostAddress())
+          .withProperty(
+              "camunda.data.secondary-storage.elasticsearch.url",
+              "http://" + CONTAINER.getHttpHostAddress())
           .withSecurityConfig(
               c -> {
                 c.getAuthorizations().setEnabled(true);

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/OidcAuthOverRestIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/OidcAuthOverRestIT.java
@@ -72,6 +72,9 @@ public class OidcAuthOverRestIT {
           .withAuthenticatedAccess()
           .withAuthenticationMethod(AuthenticationMethod.OIDC)
           .withCamundaExporter("http://" + CONTAINER.getHttpHostAddress())
+          .withProperty(
+              "camunda.data.secondary-storage.elasticsearch.url",
+              "http://" + CONTAINER.getHttpHostAddress())
           .withSecurityConfig(
               c -> {
                 c.getAuthorizations().setEnabled(true);

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/multitenancy/MultiTenancyIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/multitenancy/MultiTenancyIT.java
@@ -120,7 +120,12 @@ public class MultiTenancyIT {
 
   @BeforeAll
   static void init() {
-    BROKER.withCamundaExporter("http://" + CONTAINER.getHttpHostAddress()).start();
+    BROKER
+        .withCamundaExporter("http://" + CONTAINER.getHttpHostAddress())
+        .withProperty(
+            "camunda.data.secondary-storage.elasticsearch.url",
+            "http://" + CONTAINER.getHttpHostAddress())
+        .start();
 
     // We can do the setup with any user. We pick user A for convenience.
     try (final var client = createCamundaClient(USER_TENANT_A)) {

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/security/headers/SecurityHeadersBasicAuthIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/security/headers/SecurityHeadersBasicAuthIT.java
@@ -57,7 +57,10 @@ public class SecurityHeadersBasicAuthIT extends SecurityHeadersBaseIT {
 
   @BeforeEach
   void beforeEach() {
-    broker.withCamundaExporter("http://" + CONTAINER.getHttpHostAddress());
+    broker
+        .withCamundaExporter("http://" + CONTAINER.getHttpHostAddress())
+        .withProperty(
+            "camunda.data.secondary-storage.elasticsearch.url", CONTAINER.getHttpHostAddress());
     broker.start();
 
     camundaClient = createClient(broker, USERNAME, PASSWORD);

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/security/headers/SecurityHeadersOidcIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/security/headers/SecurityHeadersOidcIT.java
@@ -95,6 +95,9 @@ public class SecurityHeadersOidcIT extends SecurityHeadersBaseIT {
           .withAuthenticatedAccess()
           .withAuthenticationMethod(AuthenticationMethod.OIDC)
           .withCamundaExporter("http://" + CONTAINER.getHttpHostAddress())
+          .withProperty(
+              "camunda.data.secondary-storage.elasticsearch.url",
+              "http://" + CONTAINER.getHttpHostAddress())
           .withSecurityConfig(
               c -> {
                 c.getAuthorizations().setEnabled(true);

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/startup/IdentitySetupOnStartupTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/startup/IdentitySetupOnStartupTest.java
@@ -25,7 +25,7 @@ import org.springframework.util.unit.DataSize;
 final class IdentitySetupOnStartupTest {
 
   @Test
-  @Timeout(unit = TimeUnit.SECONDS, value = 30)
+  @Timeout(unit = TimeUnit.SECONDS, value = 60)
   void shouldInitializeIdentitySetup() {
     try (final LogCapturer logCapturer = new LogCapturer(Loggers.PROCESSOR_LOGGER.getName());
         final TestCluster cluster =
@@ -46,7 +46,8 @@ final class IdentitySetupOnStartupTest {
                       cfg.brokerConfig().getProcessing().setMaxCommandsInBatch(100);
                     })
                 .build()
-                .start()) {
+                .start()
+                .awaitCompleteTopology()) {
 
       Assertions.assertThat(
               RecordingExporter.identitySetupRecords(IdentitySetupIntent.INITIALIZED).getFirst())


### PR DESCRIPTION
## Description

This PR fixes integrations tests by setting the correct Elasticsearch url.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
