### PR TITLE
feat: unified config: patch zeebe DB URL

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/OperatePropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/OperatePropertiesOverride.java
@@ -48,9 +48,11 @@ public class OperatePropertiesOverride {
     if (SecondaryStorageType.elasticsearch.equals(database.getType())) {
       override.setDatabase(DatabaseType.Elasticsearch);
       override.getElasticsearch().setUrl(database.getElasticsearch().getUrl());
+      override.getZeebeElasticsearch().setUrl(database.getElasticsearch().getUrl());
     } else if (SecondaryStorageType.opensearch == database.getType()) {
       override.setDatabase(DatabaseType.Opensearch);
       override.getOpensearch().setUrl(database.getOpensearch().getUrl());
+      override.getZeebeOpensearch().setUrl(database.getOpensearch().getUrl());
     }
 
     // TODO: Populate the rest of the bean using unifiedConfiguration

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/TasklistPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/TasklistPropertiesOverride.java
@@ -48,9 +48,11 @@ public class TasklistPropertiesOverride {
     if (SecondaryStorageType.elasticsearch == database.getType()) {
       override.setDatabase("elasticsearch");
       override.getElasticsearch().setUrl(database.getElasticsearch().getUrl());
+      override.getZeebeElasticsearch().setUrl(database.getElasticsearch().getUrl());
     } else if (SecondaryStorageType.opensearch == database.getType()) {
       override.setDatabase("opensearch");
       override.getOpenSearch().setUrl(database.getOpensearch().getUrl());
+      override.getZeebeOpenSearch().setUrl(database.getOpensearch().getUrl());
     }
 
     // TODO: Populate the rest of the bean using unifiedConfiguration

--- a/dist/src/main/config/application.yaml
+++ b/dist/src/main/config/application.yaml
@@ -108,8 +108,6 @@ camunda:
     zeebeElasticsearch:
       # Cluster name
       clusterName: elasticsearch
-      # URL
-      url: http://localhost:9200
       # Index prefix, configured in Zeebe Elasticsearch exporter
       prefix: zeebe-record
   # Tasklist configuration properties
@@ -133,8 +131,6 @@ camunda:
     zeebeElasticsearch:
       # Cluster name
       clusterName: elasticsearch
-      # Url
-      url: http://localhost:9200
       # Index prefix, configured in Zeebe Elasticsearch exporter
       prefix: zeebe-record
   security:


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
The zeebeElasticsearch or the zeebeOpensearch URL should also be read from the unified configuration, as the case of having a different secondary storage for Zeebe is no longer supported.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

Related to [#34902](https://github.com/camunda/camunda/issues/34902)