### PR TITLE
test: accept snapshot at position 0 for no snapshot update test

### DIFF
--- a/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/NoSnapshotTest.java
+++ b/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/NoSnapshotTest.java
@@ -46,7 +46,7 @@ final class NoSnapshotTest {
     state.withNetwork(network).withOldBroker().start(true);
     final long processInstanceKey = testCase.setUp(state.client());
     final long key = testCase.runBefore(state);
-    assertThat(state).hasNoSnapshotAvailable(1);
+    assertThat(state).hasNoSnapshotAvailableOrHasSnapshotAtPosition0(1);
 
     // when
     state.close();


### PR DESCRIPTION
## Description

Due to migration that runs on cluster bootstrap, sometimes we may have snapshot after startup. So the pre-condition for this test do no always satisfy. Since the snapshot at position 0 do not actually have the state changes from StreamProcessor, it is ok to accept that snapshot for this test.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
