### PR TITLE
test: remove pre-condition that snapshot do not exists

### DIFF
--- a/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/NoSnapshotTest.java
+++ b/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/NoSnapshotTest.java
@@ -46,7 +46,6 @@ final class NoSnapshotTest {
     state.withNetwork(network).withOldBroker().start(true);
     final long processInstanceKey = testCase.setUp(state.client());
     final long key = testCase.runBefore(state);
-    assertThat(state).hasNoSnapshotAvailable(1);
 
     // when
     state.close();


### PR DESCRIPTION
## Description

Due to migration that runs on cluster bootstrap, sometimes we may have snapshot after startup. So the pre-condition for this test that a snapshot does not exist might not always satisfy.

Since the snapshot at position 0 do not actually have the state changes from StreamProcessor, this test still has value. So we keep the test to cover such cases, but only remove the pre-condition.

Alternately, we can verify that if the snapshot exists it is at position 0. But I think we don't need to be that strict for this test.

Context: [slack thread](https://camunda.slack.com/archives/C06UWQNCU7M/p1756128830978939?thread_ts=1756116064.852049&cid=C06UWQNCU7M)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

