### PR TITLE
UC: secondary storage properties

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/Elasticsearch.java
+++ b/configuration/src/main/java/io/camunda/configuration/Elasticsearch.java
@@ -7,21 +7,10 @@
  */
 package io.camunda.configuration;
 
-import java.util.Set;
-
 public class Elasticsearch extends SecondaryStorageDatabase {
 
   @Override
-  protected String prefix() {
-    return "camunda.data.secondary-storage.elasticsearch";
-  }
-
-  @Override
-  protected Set<String> legacyUrlProperties() {
-    return Set.of(
-        "camunda.database.url",
-        "camunda.operate.elasticsearch.url",
-        "camunda.tasklist.elasticsearch.url",
-        "zeebe.broker.exporters.camundaexporter.args.connect.url");
+  protected String databaseName() {
+    return "elasticsearch";
   }
 }

--- a/configuration/src/main/java/io/camunda/configuration/Opensearch.java
+++ b/configuration/src/main/java/io/camunda/configuration/Opensearch.java
@@ -7,21 +7,10 @@
  */
 package io.camunda.configuration;
 
-import java.util.Set;
-
 public class Opensearch extends SecondaryStorageDatabase {
 
   @Override
-  protected String prefix() {
-    return "camunda.data.secondary-storage.opensearch";
-  }
-
-  @Override
-  protected Set<String> legacyUrlProperties() {
-    return Set.of(
-        "camunda.database.url",
-        "camunda.operate.opensearch.url",
-        "camunda.tasklist.opensearch.url",
-        "zeebe.broker.exporters.camundaexporter.args.connect.url");
+  protected String databaseName() {
+    return "opensearch";
   }
 }

--- a/configuration/src/main/java/io/camunda/configuration/SecondaryStorageDatabase.java
+++ b/configuration/src/main/java/io/camunda/configuration/SecondaryStorageDatabase.java
@@ -15,6 +15,20 @@ public abstract class SecondaryStorageDatabase {
   /** Endpoint for the database configured as secondary storage. */
   private String url = "http://localhost:9200";
 
+  /** Name of the cluster */
+  private String clusterName = databaseName().toLowerCase();
+
+  private Security security = new Security(databaseName());
+
+  /** Username for the database configured as secondary storage. */
+  private String username = "";
+
+  /** Password for the database configured as secondary storage. */
+  private String password = "";
+
+  /** Prefix to apply to the indexes */
+  private String indexPrefix = "";
+
   public String getUrl() {
     return UnifiedConfigurationHelper.validateLegacyConfiguration(
         prefix() + ".url",
@@ -24,11 +38,118 @@ public abstract class SecondaryStorageDatabase {
         legacyUrlProperties());
   }
 
-  public void setUrl(String url) {
+  public void setUrl(final String url) {
     this.url = url;
   }
 
-  protected abstract String prefix();
+  public String getUsername() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        prefix() + ".username",
+        username,
+        String.class,
+        BackwardsCompatibilityMode.SUPPORTED_ONLY_IF_VALUES_MATCH,
+        legacyUsernameProperties());
+  }
 
-  protected abstract Set<String> legacyUrlProperties();
+  public void setUsername(final String username) {
+    this.username = username;
+  }
+
+  public String getPassword() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        prefix() + ".password",
+        password,
+        String.class,
+        BackwardsCompatibilityMode.SUPPORTED_ONLY_IF_VALUES_MATCH,
+        legacyPasswordProperties());
+  }
+
+  public void setPassword(final String password) {
+    this.password = password;
+  }
+
+  public Security getSecurity() {
+    return security;
+  }
+
+  public void setSecurity(final Security security) {
+    this.security = security;
+  }
+
+  public String getClusterName() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        prefix() + ".cluster-name",
+        clusterName,
+        String.class,
+        BackwardsCompatibilityMode.SUPPORTED_ONLY_IF_VALUES_MATCH,
+        legacyClusterNameProperties());
+  }
+
+  public void setClusterName(String clusterName) {
+    this.clusterName = clusterName;
+  }
+
+  public String getIndexPrefix() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        prefix() + ".index-prefix",
+        indexPrefix,
+        String.class,
+        BackwardsCompatibilityMode.SUPPORTED_ONLY_IF_VALUES_MATCH,
+        indexPrefixLegacyProperties());
+  }
+
+  public void setIndexPrefix(String indexPrefix) {
+    this.indexPrefix = indexPrefix;
+  }
+
+  private String prefix() {
+    return "camunda.data.secondary-storage." + databaseName().toLowerCase();
+  }
+
+  private Set<String> legacyUrlProperties() {
+    final String dbName = databaseName().toLowerCase();
+    return Set.of(
+        "camunda.database.url",
+        "camunda.operate." + dbName + ".url",
+        "camunda.tasklist." + dbName + ".url",
+        "zeebe.broker.exporters.camundaexporter.args.connect.url");
+  }
+
+  private Set<String> legacyClusterNameProperties() {
+    final String dbName = databaseName().toLowerCase();
+    return Set.of(
+        "camunda.database.clusterName",
+        "camunda.operate." + dbName + ".clusterName",
+        "camunda.tasklist." + dbName + ".clusterName",
+        "zeebe.broker.exporters.camundaexporter.args.connect.clusterName");
+  }
+
+  private Set<String> legacyUsernameProperties() {
+    final String dbName = databaseName().toLowerCase();
+    return Set.of(
+        "camunda.database.username",
+        "camunda.operate." + dbName + ".username",
+        "camunda.tasklist." + dbName + ".username",
+        "zeebe.broker.exporters.camundaexporter.args.connect.username");
+  }
+
+  private Set<String> legacyPasswordProperties() {
+    final String dbName = databaseName().toLowerCase();
+    return Set.of(
+        "camunda.database.password",
+        "camunda.operate." + dbName + ".password",
+        "camunda.tasklist." + dbName + ".password",
+        "zeebe.broker.exporters.camundaexporter.args.connect.password");
+  }
+
+  private Set<String> indexPrefixLegacyProperties() {
+    final String dbName = databaseName().toLowerCase();
+    return Set.of(
+        "camunda.database.indexPrefix",
+        "camunda.tasklist." + dbName + ".indexPrefix",
+        "camunda.operate." + dbName + ".indexPrefix",
+        "zeebe.broker.exporters.camundaexporter.args.index.indexPrefix");
+  }
+
+  protected abstract String databaseName();
 }

--- a/configuration/src/main/java/io/camunda/configuration/Security.java
+++ b/configuration/src/main/java/io/camunda/configuration/Security.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import io.camunda.configuration.UnifiedConfigurationHelper.BackwardsCompatibilityMode;
+import java.util.Set;
+
+public class Security {
+
+  private final String databaseName;
+
+  /** Enable security */
+  private boolean enabled = false;
+
+  /** Path to certificate used by Elasticsearch or Opensearch */
+  private String certificatePath;
+
+  /** Should the hostname be validated */
+  private boolean verifyHostname = true;
+
+  /** Certificate was self-signed */
+  private boolean selfSigned = false;
+
+  public Security(final String databaseName) {
+    this.databaseName = databaseName.toLowerCase();
+  }
+
+  public boolean isEnabled() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        prefix() + ".enabled",
+        enabled,
+        Boolean.class,
+        BackwardsCompatibilityMode.SUPPORTED_ONLY_IF_VALUES_MATCH,
+        legacyEnabledProperties());
+  }
+
+  public void setEnabled(final boolean enabled) {
+    this.enabled = enabled;
+  }
+
+  public String getCertificatePath() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        prefix() + ".certificate-path",
+        certificatePath,
+        String.class,
+        BackwardsCompatibilityMode.SUPPORTED_ONLY_IF_VALUES_MATCH,
+        legacyCertificatePathProperties());
+  }
+
+  public void setCertificatePath(final String certificatePath) {
+    this.certificatePath = certificatePath;
+  }
+
+  public boolean isVerifyHostname() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        prefix() + ".verify-hostname",
+        verifyHostname,
+        Boolean.class,
+        BackwardsCompatibilityMode.SUPPORTED_ONLY_IF_VALUES_MATCH,
+        legacyVerifyHostnameProperties());
+  }
+
+  public void setVerifyHostname(final boolean verifyHostname) {
+    this.verifyHostname = verifyHostname;
+  }
+
+  public boolean isSelfSigned() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        prefix() + ".self-signed",
+        selfSigned,
+        Boolean.class,
+        BackwardsCompatibilityMode.SUPPORTED_ONLY_IF_VALUES_MATCH,
+        legacySelfSignedProperties());
+  }
+
+  public void setSelfSigned(final boolean selfSigned) {
+    this.selfSigned = selfSigned;
+  }
+
+  private String prefix() {
+    return "camunda.data.secondary-storage." + databaseName + ".security";
+  }
+
+  private Set<String> legacyEnabledProperties() {
+    return Set.of(
+        "camunda.database.security.enabled",
+        "zeebe.broker.exporters.camundaexporter.args.connect.security.enabled");
+  }
+
+  private Set<String> legacyCertificatePathProperties() {
+    return Set.of(
+        "camunda.database.security.certificatePath",
+        "camunda.tasklist." + databaseName + ".ssl.certificatePath",
+        "camunda.operate." + databaseName + ".ssl.certificatePath",
+        "zeebe.broker.exporters.camundaexporter.args.connect.security.certificatePath");
+  }
+
+  private Set<String> legacyVerifyHostnameProperties() {
+    return Set.of(
+        "camunda.database.security.verifyHostname",
+        "camunda.tasklist." + databaseName + ".ssl.verifyHostname",
+        "camunda.operate." + databaseName + ".ssl.verifyHostname",
+        "zeebe.broker.exporters.camundaexporter.args.connect.security.verifyHostname");
+  }
+
+  private Set<String> legacySelfSignedProperties() {
+    return Set.of(
+        "camunda.database.security.selfSigned",
+        "camunda.tasklist." + databaseName + ".ssl.selfSigned",
+        "camunda.operate." + databaseName + ".ssl.selfSigned",
+        "zeebe.broker.exporters.camundaexporter.args.connect.security.selfSigned");
+  }
+}

--- a/configuration/src/main/java/io/camunda/configuration/UnifiedConfigurationHelper.java
+++ b/configuration/src/main/java/io/camunda/configuration/UnifiedConfigurationHelper.java
@@ -20,6 +20,7 @@ import org.springframework.boot.convert.ApplicationConversionService;
 import org.springframework.core.ResolvableType;
 import org.springframework.core.convert.ConversionService;
 import org.springframework.core.convert.TypeDescriptor;
+import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Component;
 
@@ -30,6 +31,7 @@ public class UnifiedConfigurationHelper {
   private static final ConversionService CONVERSION_SERVICE = new ApplicationConversionService();
 
   private static Environment environment;
+  private static ConfigurableEnvironment configurableEnvironment;
 
   public UnifiedConfigurationHelper(@Autowired final Environment environment) {
     // We need to pin the environment object statically so that it can be used to perform the

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
@@ -457,6 +457,19 @@ public class BrokerBasedPropertiesOverride {
     final Map<String, Object> args = exporter.getArgs();
     setArg(args, "connect.type", secondaryStorage.getType().name());
     setArg(args, "connect.url", database.getUrl());
+    setArg(args, "connect.clusterName", database.getClusterName());
+
+    // Add security configuration mapping
+    if (database.getSecurity() != null) {
+      setArg(args, "connect.security.enabled", database.getSecurity().isEnabled());
+      setArg(args, "connect.security.certificatePath", database.getSecurity().getCertificatePath());
+      setArg(args, "connect.security.verifyHostname", database.getSecurity().isVerifyHostname());
+      setArg(args, "connect.security.selfSigned", database.getSecurity().isSelfSigned());
+    }
+    setArg(args, "connect.username", database.getUsername());
+    setArg(args, "connect.password", database.getPassword());
+
+    setArg(args, "connect.indexPrefix", database.getIndexPrefix());
   }
 
   @SuppressWarnings("unchecked")

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/SearchEngineConnectPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/SearchEngineConnectPropertiesOverride.java
@@ -10,6 +10,7 @@ package io.camunda.configuration.beanoverrides;
 import io.camunda.configuration.SecondaryStorage;
 import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
 import io.camunda.configuration.SecondaryStorageDatabase;
+import io.camunda.configuration.Security;
 import io.camunda.configuration.UnifiedConfiguration;
 import io.camunda.configuration.beans.LegacySearchEngineConnectProperties;
 import io.camunda.configuration.beans.SearchEngineConnectProperties;
@@ -35,8 +36,8 @@ public class SearchEngineConnectPropertiesOverride {
   private final LegacySearchEngineConnectProperties legacySearchEngineConnectProperties;
 
   public SearchEngineConnectPropertiesOverride(
-      @Autowired UnifiedConfiguration unifiedConfiguration,
-      @Autowired LegacySearchEngineConnectProperties legacySearchEngineConnectProperties) {
+      @Autowired final UnifiedConfiguration unifiedConfiguration,
+      @Autowired final LegacySearchEngineConnectProperties legacySearchEngineConnectProperties) {
     this.unifiedConfiguration = unifiedConfiguration;
     this.legacySearchEngineConnectProperties = legacySearchEngineConnectProperties;
   }
@@ -57,7 +58,37 @@ public class SearchEngineConnectPropertiesOverride {
 
     override.setType(secondaryStorage.getType().name());
     override.setUrl(database.getUrl());
+    override.setClusterName(database.getClusterName());
+
+    populateFromSecurity(override);
+    override.setIndexPrefix(database.getIndexPrefix());
+
+    override.setUsername(database.getUsername());
+    override.setPassword(database.getPassword());
 
     return override;
+  }
+
+  private void populateFromSecurity(final SearchEngineConnectProperties override) {
+    final Security security = resolveSecurity(override);
+    if (security == null) {
+      return;
+    }
+
+    override.getSecurity().setEnabled(security.isEnabled());
+    override.getSecurity().setCertificatePath(security.getCertificatePath());
+    override.getSecurity().setVerifyHostname(security.isVerifyHostname());
+    override.getSecurity().setSelfSigned(security.isSelfSigned());
+  }
+
+  private Security resolveSecurity(final SearchEngineConnectProperties override) {
+    final SecondaryStorage secondaryStorage =
+        unifiedConfiguration.getCamunda().getData().getSecondaryStorage();
+
+    return switch (override.getTypeEnum()) {
+      case ELASTICSEARCH -> secondaryStorage.getElasticsearch().getSecurity();
+      case OPENSEARCH -> secondaryStorage.getOpensearch().getSecurity();
+      default -> null;
+    };
   }
 }

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/TasklistPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/TasklistPropertiesOverride.java
@@ -11,9 +11,14 @@ package io.camunda.configuration.beanoverrides;
 import io.camunda.configuration.Backup;
 import io.camunda.configuration.SecondaryStorage;
 import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
+import io.camunda.configuration.Security;
 import io.camunda.configuration.UnifiedConfiguration;
 import io.camunda.tasklist.property.BackupProperties;
+import io.camunda.tasklist.property.SslProperties;
 import io.camunda.tasklist.property.TasklistProperties;
+import java.util.Objects;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
 import org.springframework.beans.BeanUtils;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -50,17 +55,10 @@ public class TasklistPropertiesOverride {
         unifiedConfiguration.getCamunda().getData().getSecondaryStorage();
 
     if (SecondaryStorageType.elasticsearch == database.getType()) {
-      override.setDatabase("elasticsearch");
-      override.getElasticsearch().setUrl(database.getElasticsearch().getUrl());
-      override.getZeebeElasticsearch().setUrl(database.getElasticsearch().getUrl());
+      populateFromElasticsearch(override, database);
     } else if (SecondaryStorageType.opensearch == database.getType()) {
-      override.setDatabase("opensearch");
-      override.getOpenSearch().setUrl(database.getOpensearch().getUrl());
-      override.getZeebeOpenSearch().setUrl(database.getOpensearch().getUrl());
+      populateFromOpensearch(override, database);
     }
-
-    // TODO: Populate the rest of the bean using unifiedConfiguration
-    //  override.setSampleField(unifiedConfiguration.getSampleField());
 
     return override;
   }
@@ -70,5 +68,46 @@ public class TasklistPropertiesOverride {
         unifiedConfiguration.getCamunda().getData().getBackup().withTasklistBackupProperties();
     final BackupProperties backupProperties = override.getBackup();
     backupProperties.setRepositoryName(backup.getRepositoryName());
+  }
+
+  private void populateFromElasticsearch(
+      final TasklistProperties override, final SecondaryStorage database) {
+    override.setDatabase("elasticsearch");
+    override.getElasticsearch().setUrl(database.getElasticsearch().getUrl());
+    override.getElasticsearch().setUsername(database.getElasticsearch().getUsername());
+    override.getElasticsearch().setPassword(database.getElasticsearch().getPassword());
+    override.getElasticsearch().setClusterName(database.getElasticsearch().getClusterName());
+    override.getElasticsearch().setIndexPrefix(database.getElasticsearch().getIndexPrefix());
+
+    populateFromSecurity(
+        database.getElasticsearch().getSecurity(),
+        override.getElasticsearch()::getSsl,
+        override.getElasticsearch()::setSsl);
+  }
+
+  private void populateFromOpensearch(
+      final TasklistProperties override, final SecondaryStorage database) {
+    override.setDatabase("opensearch");
+    override.getOpenSearch().setUrl(database.getOpensearch().getUrl());
+    override.getOpenSearch().setUsername(database.getOpensearch().getUsername());
+    override.getOpenSearch().setPassword(database.getOpensearch().getPassword());
+    override.getOpenSearch().setClusterName(database.getOpensearch().getClusterName());
+    override.getOpenSearch().setIndexPrefix(database.getOpensearch().getIndexPrefix());
+
+    populateFromSecurity(
+        database.getOpensearch().getSecurity(),
+        override.getOpenSearch()::getSsl,
+        override.getOpenSearch()::setSsl);
+  }
+
+  private void populateFromSecurity(
+      final Security security,
+      final Supplier<SslProperties> getSsl,
+      final Consumer<SslProperties> setSsl) {
+    final SslProperties sslProps = Objects.requireNonNullElseGet(getSsl.get(), SslProperties::new);
+    sslProps.setCertificatePath(security.getCertificatePath());
+    sslProps.setVerifyHostname(security.isVerifyHostname());
+    sslProps.setSelfSigned(security.isSelfSigned());
+    setSsl.accept(sslProps);
   }
 }

--- a/configuration/src/test/java/io/camunda/configuration/SecondaryStorageTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/SecondaryStorageTest.java
@@ -38,12 +38,21 @@ import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
   SearchEngineConnectPropertiesOverride.class
 })
 public class SecondaryStorageTest {
+  private static final String EXPECTED_CLUSTER_NAME = "sample-cluster";
+  private static final String EXPECTED_INDEX_PREFIX = "sample-index-prefix";
+
+  private static final String EXPECTED_USERNAME = "testUsername";
+  private static final String EXPECTED_PASSWORD = "testPassword";
 
   @Nested
   @TestPropertySource(
       properties = {
         "camunda.data.secondary-storage.type=elasticsearch",
-        "camunda.data.secondary-storage.elasticsearch.url=http://expected-url:4321"
+        "camunda.data.secondary-storage.elasticsearch.url=http://expected-url:4321",
+        "camunda.data.secondary-storage.elasticsearch.username=" + EXPECTED_USERNAME,
+        "camunda.data.secondary-storage.elasticsearch.password=" + EXPECTED_PASSWORD,
+        "camunda.data.secondary-storage.elasticsearch.cluster-name=" + EXPECTED_CLUSTER_NAME,
+        "camunda.data.secondary-storage.elasticsearch.index-prefix=" + EXPECTED_INDEX_PREFIX
       })
   class WithOnlyUnifiedConfigSet {
     final OperateProperties operateProperties;
@@ -69,6 +78,12 @@ public class SecondaryStorageTest {
 
       assertThat(operateProperties.getDatabase()).isEqualTo(expectedOperateDatabaseType);
       assertThat(operateProperties.getElasticsearch().getUrl()).isEqualTo(expectedUrl);
+      assertThat(operateProperties.getElasticsearch().getUsername()).isEqualTo(EXPECTED_USERNAME);
+      assertThat(operateProperties.getElasticsearch().getPassword()).isEqualTo(EXPECTED_PASSWORD);
+      assertThat(operateProperties.getElasticsearch().getClusterName())
+          .isEqualTo(EXPECTED_CLUSTER_NAME);
+      assertThat(operateProperties.getElasticsearch().getIndexPrefix())
+          .isEqualTo(EXPECTED_INDEX_PREFIX);
     }
 
     @Test
@@ -78,6 +93,10 @@ public class SecondaryStorageTest {
 
       assertThat(tasklistProperties.getDatabase()).isEqualTo(expectedTasklistDatabaseType);
       assertThat(tasklistProperties.getElasticsearch().getUrl()).isEqualTo(expectedUrl);
+      assertThat(tasklistProperties.getElasticsearch().getUsername()).isEqualTo(EXPECTED_USERNAME);
+      assertThat(tasklistProperties.getElasticsearch().getPassword()).isEqualTo(EXPECTED_PASSWORD);
+      assertThat(tasklistProperties.getElasticsearch().getIndexPrefix())
+          .isEqualTo(EXPECTED_INDEX_PREFIX);
     }
 
     @Test
@@ -94,12 +113,17 @@ public class SecondaryStorageTest {
           UnifiedConfigurationHelper.argsToExporterConfiguration(args);
       assertThat(exporterConfiguration.getConnect().getType()).isEqualTo(expectedType);
       assertThat(exporterConfiguration.getConnect().getUrl()).isEqualTo(expectedUrl);
+      assertThat(exporterConfiguration.getConnect().getUsername()).isEqualTo(EXPECTED_USERNAME);
+      assertThat(exporterConfiguration.getConnect().getPassword()).isEqualTo(EXPECTED_PASSWORD);
+      assertThat(exporterConfiguration.getConnect().getIndexPrefix())
+          .isEqualTo(EXPECTED_INDEX_PREFIX);
     }
 
     @Test
     void testCamundaSearchEngineConnectProperties() {
       assertThat(searchEngineConnectProperties.getType().toLowerCase()).isEqualTo("elasticsearch");
       assertThat(searchEngineConnectProperties.getUrl()).isEqualTo("http://expected-url:4321");
+      assertThat(searchEngineConnectProperties.getIndexPrefix()).isEqualTo(EXPECTED_INDEX_PREFIX);
     }
   }
 
@@ -115,7 +139,37 @@ public class SecondaryStorageTest {
         "camunda.data.secondary-storage.elasticsearch.url=http://matching-url:4321",
         "camunda.database.url=http://matching-url:4321",
         "camunda.tasklist.elasticsearch.url=http://matching-url:4321",
-        "camunda.operate.elasticsearch.url=http://matching-url:4321"
+        "camunda.operate.elasticsearch.url=http://matching-url:4321",
+        // username
+        "camunda.data.secondary-storage.elasticsearch.username=" + EXPECTED_USERNAME,
+        "camunda.database.username=" + EXPECTED_USERNAME,
+        "camunda.operate.elasticsearch.username=" + EXPECTED_USERNAME,
+        "camunda.tasklist.elasticsearch.username=" + EXPECTED_USERNAME,
+        // password
+        "camunda.data.secondary-storage.elasticsearch.password=" + EXPECTED_PASSWORD,
+        "camunda.database.password=" + EXPECTED_PASSWORD,
+        "camunda.operate.elasticsearch.password=" + EXPECTED_PASSWORD,
+        "camunda.tasklist.elasticsearch.password=" + EXPECTED_PASSWORD,
+        // NOTE: In the following blocks, the camundaExporter doesn't have to be configured, as
+        //  it is default with StandaloneCamunda. Any attempt of configuration will fail unless
+        //  the className is also configured.
+
+        // cluster name
+        "camunda.data.secondary-storage.elasticsearch.cluster-name=" + EXPECTED_CLUSTER_NAME,
+        "camunda.data.clusterName=" + EXPECTED_CLUSTER_NAME,
+        "camunda.tasklist.elasticsearch.clusterName=" + EXPECTED_CLUSTER_NAME,
+        "camunda.operate.elasticsearch.clusterName=" + EXPECTED_CLUSTER_NAME,
+        "camunda.operate.elasticsearch.url=http://matching-url:4321",
+
+        // NOTE: In the following blocks, the camundaExporter doesn't have to be configured, as
+        //  it is default with StandaloneCamunda. Any attempt of configuration will fail unless
+        //  the className is also configured.
+
+        // index prefix
+        "camunda.data.secondary-storage.elasticsearch.index-prefix=" + EXPECTED_INDEX_PREFIX,
+        "camunda.database.indexPrefix=" + EXPECTED_INDEX_PREFIX,
+        "camunda.tasklist.elasticsearch.indexPrefix=" + EXPECTED_INDEX_PREFIX,
+        "camunda.operate.elasticsearch.indexPrefix=" + EXPECTED_INDEX_PREFIX,
       })
   class WithNewAndLegacySet {
     final OperateProperties operateProperties;
@@ -141,6 +195,12 @@ public class SecondaryStorageTest {
 
       assertThat(operateProperties.getDatabase()).isEqualTo(expectedOperateDatabaseType);
       assertThat(operateProperties.getElasticsearch().getUrl()).isEqualTo(expectedUrl);
+      assertThat(operateProperties.getElasticsearch().getClusterName())
+          .isEqualTo(EXPECTED_CLUSTER_NAME);
+      assertThat(operateProperties.getElasticsearch().getIndexPrefix())
+          .isEqualTo(EXPECTED_INDEX_PREFIX);
+      assertThat(operateProperties.getElasticsearch().getUsername()).isEqualTo(EXPECTED_USERNAME);
+      assertThat(operateProperties.getElasticsearch().getPassword()).isEqualTo(EXPECTED_PASSWORD);
     }
 
     @Test
@@ -150,6 +210,12 @@ public class SecondaryStorageTest {
 
       assertThat(tasklistProperties.getDatabase()).isEqualTo(expectedTasklistDatabaseType);
       assertThat(tasklistProperties.getElasticsearch().getUrl()).isEqualTo(expectedUrl);
+      assertThat(tasklistProperties.getElasticsearch().getUsername()).isEqualTo(EXPECTED_USERNAME);
+      assertThat(tasklistProperties.getElasticsearch().getPassword()).isEqualTo(EXPECTED_PASSWORD);
+      assertThat(tasklistProperties.getElasticsearch().getIndexPrefix())
+          .isEqualTo(EXPECTED_INDEX_PREFIX);
+      assertThat(tasklistProperties.getElasticsearch().getClusterName())
+          .isEqualTo(EXPECTED_CLUSTER_NAME);
     }
 
     @Test
@@ -166,12 +232,22 @@ public class SecondaryStorageTest {
           UnifiedConfigurationHelper.argsToExporterConfiguration(args);
       assertThat(exporterConfiguration.getConnect().getType()).isEqualTo(expectedType);
       assertThat(exporterConfiguration.getConnect().getUrl()).isEqualTo(expectedUrl);
+      assertThat(exporterConfiguration.getConnect().getUsername()).isEqualTo(EXPECTED_USERNAME);
+      assertThat(exporterConfiguration.getConnect().getPassword()).isEqualTo(EXPECTED_PASSWORD);
+      assertThat(exporterConfiguration.getConnect().getIndexPrefix())
+          .isEqualTo(EXPECTED_INDEX_PREFIX);
+      assertThat(exporterConfiguration.getConnect().getClusterName())
+          .isEqualTo(EXPECTED_CLUSTER_NAME);
     }
 
     @Test
     void testCamundaSearchEngineConnectProperties() {
       assertThat(searchEngineConnectProperties.getType().toLowerCase()).isEqualTo("elasticsearch");
       assertThat(searchEngineConnectProperties.getUrl()).isEqualTo("http://matching-url:4321");
+      assertThat(searchEngineConnectProperties.getIndexPrefix()).isEqualTo(EXPECTED_INDEX_PREFIX);
+      assertThat(searchEngineConnectProperties.getClusterName()).isEqualTo(EXPECTED_CLUSTER_NAME);
+      assertThat(searchEngineConnectProperties.getUsername()).isEqualTo(EXPECTED_USERNAME);
+      assertThat(searchEngineConnectProperties.getPassword()).isEqualTo(EXPECTED_PASSWORD);
     }
   }
 }

--- a/configuration/src/test/java/io/camunda/configuration/SecurityElasticsearchTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/SecurityElasticsearchTest.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.configuration.beanoverrides.BrokerBasedPropertiesOverride;
+import io.camunda.configuration.beanoverrides.OperatePropertiesOverride;
+import io.camunda.configuration.beanoverrides.SearchEngineConnectPropertiesOverride;
+import io.camunda.configuration.beanoverrides.TasklistPropertiesOverride;
+import io.camunda.configuration.beans.BrokerBasedProperties;
+import io.camunda.configuration.beans.SearchEngineConnectProperties;
+import io.camunda.exporter.config.ExporterConfiguration;
+import io.camunda.operate.property.OperateProperties;
+import io.camunda.search.connect.configuration.SecurityConfiguration;
+import io.camunda.tasklist.property.SslProperties;
+import io.camunda.tasklist.property.TasklistProperties;
+import io.camunda.zeebe.broker.system.configuration.ExporterCfg;
+import java.util.Map;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+@ActiveProfiles({"broker"})
+@SpringJUnitConfig({
+  UnifiedConfiguration.class,
+  UnifiedConfigurationHelper.class,
+  SearchEngineConnectPropertiesOverride.class,
+  BrokerBasedPropertiesOverride.class,
+  TasklistPropertiesOverride.class,
+  OperatePropertiesOverride.class,
+})
+public class SecurityElasticsearchTest {
+
+  private ExporterConfiguration getExporterConfiguration(
+      final BrokerBasedProperties brokerBasedProperties) {
+
+    final ExporterCfg camundaExporter = brokerBasedProperties.getCamundaExporter();
+    assertThat(camundaExporter).isNotNull();
+
+    final Map<String, Object> args = camundaExporter.getArgs();
+    assertThat(args).isNotNull();
+
+    return UnifiedConfigurationHelper.argsToExporterConfiguration(args);
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "camunda.data.secondary-storage.type=elasticsearch",
+        "camunda.data.secondary-storage.elasticsearch.security.enabled=true",
+        "camunda.data.secondary-storage.elasticsearch.security.certificate-path=certificatePath",
+        "camunda.data.secondary-storage.elasticsearch.security.verify-hostname=false",
+        "camunda.data.secondary-storage.elasticsearch.security.self-signed=true"
+      })
+  class WithOnlyUnifiedConfigSet {
+    final SearchEngineConnectProperties searchEngineConnectProperties;
+    final BrokerBasedProperties brokerBasedProperties;
+    final TasklistProperties tasklistProperties;
+    final OperateProperties operateProperties;
+
+    WithOnlyUnifiedConfigSet(
+        @Autowired final SearchEngineConnectProperties searchEngineConnectProperties,
+        @Autowired final BrokerBasedProperties brokerBasedProperties,
+        @Autowired final TasklistProperties tasklistProperties,
+        @Autowired final OperateProperties operateProperties) {
+      this.searchEngineConnectProperties = searchEngineConnectProperties;
+      this.brokerBasedProperties = brokerBasedProperties;
+      this.tasklistProperties = tasklistProperties;
+      this.operateProperties = operateProperties;
+    }
+
+    @Test
+    void testCamundaSearchEngineConnectProperties() {
+      assertThat(searchEngineConnectProperties.getSecurity())
+          .returns(true, SecurityConfiguration::isEnabled)
+          .returns("certificatePath", SecurityConfiguration::getCertificatePath)
+          .returns(false, SecurityConfiguration::isVerifyHostname)
+          .returns(true, SecurityConfiguration::isSelfSigned);
+    }
+
+    @Test
+    void testCamundaExporterProperties() {
+      final ExporterConfiguration exporterConfiguration =
+          getExporterConfiguration(brokerBasedProperties);
+
+      assertThat(exporterConfiguration.getConnect().getSecurity())
+          .returns(true, SecurityConfiguration::isEnabled)
+          .returns("certificatePath", SecurityConfiguration::getCertificatePath)
+          .returns(false, SecurityConfiguration::isVerifyHostname)
+          .returns(true, SecurityConfiguration::isSelfSigned);
+    }
+
+    @Test
+    void testCamundaTasklistProperties() {
+      assertThat(tasklistProperties.getElasticsearch().getSsl())
+          .returns("certificatePath", SslProperties::getCertificatePath)
+          .returns(false, SslProperties::isVerifyHostname)
+          .returns(true, SslProperties::isSelfSigned);
+    }
+
+    @Test
+    void testCamundaOperateProperties() {
+      assertThat(operateProperties.getElasticsearch().getSsl())
+          .returns("certificatePath", io.camunda.operate.property.SslProperties::getCertificatePath)
+          .returns(false, io.camunda.operate.property.SslProperties::isVerifyHostname)
+          .returns(true, io.camunda.operate.property.SslProperties::isSelfSigned);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "camunda.data.secondary-storage.type=elasticsearch",
+        // enabled
+        "camunda.data.secondary-storage.elasticsearch.security.enabled=true",
+        "camunda.database.security.enabled=true",
+        // certificate path
+        "camunda.data.secondary-storage.elasticsearch.security.certificate-path=certificatePath",
+        "camunda.database.security.certificatePath=certificatePath",
+        "camunda.tasklist.elasticsearch.ssl.certificatePath=certificatePath",
+        "camunda.operate.elasticsearch.ssl.certificatePath=certificatePath",
+        // verify hostname
+        "camunda.data.secondary-storage.elasticsearch.security.verify-hostname=false",
+        "camunda.database.security.verifyHostname=false",
+        "camunda.tasklist.elasticsearch.ssl.verifyHostname=false",
+        "camunda.operate.elasticsearch.ssl.verifyHostname=false",
+        // self signed
+        "camunda.data.secondary-storage.elasticsearch.security.self-signed=true",
+        "camunda.database.security.selfSigned=true",
+        "camunda.tasklist.elasticsearch.ssl.selfSigned=true",
+        "camunda.operate.elasticsearch.ssl.selfSigned=true"
+      })
+  class WithNewAndLegacySet {
+    final SearchEngineConnectProperties searchEngineConnectProperties;
+    final BrokerBasedProperties brokerBasedProperties;
+    final TasklistProperties tasklistProperties;
+    final OperateProperties operateProperties;
+
+    WithNewAndLegacySet(
+        @Autowired final SearchEngineConnectProperties searchEngineConnectProperties,
+        @Autowired final BrokerBasedProperties brokerBasedProperties,
+        @Autowired final TasklistProperties tasklistProperties,
+        @Autowired final OperateProperties operateProperties) {
+      this.searchEngineConnectProperties = searchEngineConnectProperties;
+      this.brokerBasedProperties = brokerBasedProperties;
+      this.tasklistProperties = tasklistProperties;
+      this.operateProperties = operateProperties;
+    }
+
+    @Test
+    void testCamundaSearchEngineConnectProperties() {
+      assertThat(searchEngineConnectProperties.getSecurity())
+          .returns(true, SecurityConfiguration::isEnabled)
+          .returns("certificatePath", SecurityConfiguration::getCertificatePath)
+          .returns(false, SecurityConfiguration::isVerifyHostname)
+          .returns(true, SecurityConfiguration::isSelfSigned);
+    }
+
+    @Test
+    void testCamundaExporterProperties() {
+      final ExporterConfiguration exporterConfiguration =
+          getExporterConfiguration(brokerBasedProperties);
+
+      assertThat(exporterConfiguration.getConnect().getSecurity())
+          .returns(true, SecurityConfiguration::isEnabled)
+          .returns("certificatePath", SecurityConfiguration::getCertificatePath)
+          .returns(false, SecurityConfiguration::isVerifyHostname)
+          .returns(true, SecurityConfiguration::isSelfSigned);
+    }
+
+    @Test
+    void testCamundaTasklistProperties() {
+      assertThat(tasklistProperties.getElasticsearch().getSsl())
+          .returns("certificatePath", SslProperties::getCertificatePath)
+          .returns(false, SslProperties::isVerifyHostname)
+          .returns(true, SslProperties::isSelfSigned);
+    }
+
+    @Test
+    void testCamundaOperateProperties() {
+      assertThat(operateProperties.getElasticsearch().getSsl())
+          .returns("certificatePath", io.camunda.operate.property.SslProperties::getCertificatePath)
+          .returns(false, io.camunda.operate.property.SslProperties::isVerifyHostname)
+          .returns(true, io.camunda.operate.property.SslProperties::isSelfSigned);
+    }
+  }
+}

--- a/configuration/src/test/java/io/camunda/configuration/SecurityOpensearchTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/SecurityOpensearchTest.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.configuration.beanoverrides.BrokerBasedPropertiesOverride;
+import io.camunda.configuration.beanoverrides.OperatePropertiesOverride;
+import io.camunda.configuration.beanoverrides.SearchEngineConnectPropertiesOverride;
+import io.camunda.configuration.beanoverrides.TasklistPropertiesOverride;
+import io.camunda.configuration.beans.BrokerBasedProperties;
+import io.camunda.configuration.beans.SearchEngineConnectProperties;
+import io.camunda.exporter.config.ExporterConfiguration;
+import io.camunda.operate.property.OperateProperties;
+import io.camunda.search.connect.configuration.SecurityConfiguration;
+import io.camunda.tasklist.property.SslProperties;
+import io.camunda.tasklist.property.TasklistProperties;
+import io.camunda.zeebe.broker.system.configuration.ExporterCfg;
+import java.util.Map;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+@ActiveProfiles({"broker"})
+@SpringJUnitConfig({
+  UnifiedConfiguration.class,
+  UnifiedConfigurationHelper.class,
+  SearchEngineConnectPropertiesOverride.class,
+  BrokerBasedPropertiesOverride.class,
+  TasklistPropertiesOverride.class,
+  OperatePropertiesOverride.class,
+})
+public class SecurityOpensearchTest {
+
+  private ExporterConfiguration getExporterConfiguration(
+      final BrokerBasedProperties brokerBasedProperties) {
+
+    final ExporterCfg camundaExporter = brokerBasedProperties.getCamundaExporter();
+    assertThat(camundaExporter).isNotNull();
+
+    final Map<String, Object> args = camundaExporter.getArgs();
+    assertThat(args).isNotNull();
+
+    return UnifiedConfigurationHelper.argsToExporterConfiguration(args);
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "camunda.data.secondary-storage.type=opensearch",
+        "camunda.data.secondary-storage.opensearch.security.enabled=true",
+        "camunda.data.secondary-storage.opensearch.security.certificate-path=certificatePath",
+        "camunda.data.secondary-storage.opensearch.security.verify-hostname=false",
+        "camunda.data.secondary-storage.opensearch.security.self-signed=true"
+      })
+  class WithOnlyUnifiedConfigSet {
+    final SearchEngineConnectProperties searchEngineConnectProperties;
+    final BrokerBasedProperties brokerBasedProperties;
+    final TasklistProperties tasklistProperties;
+    final OperateProperties operateProperties;
+
+    WithOnlyUnifiedConfigSet(
+        @Autowired final SearchEngineConnectProperties searchEngineConnectProperties,
+        @Autowired final BrokerBasedProperties brokerBasedProperties,
+        @Autowired final TasklistProperties tasklistProperties,
+        @Autowired final OperateProperties operateProperties) {
+      this.searchEngineConnectProperties = searchEngineConnectProperties;
+      this.brokerBasedProperties = brokerBasedProperties;
+      this.tasklistProperties = tasklistProperties;
+      this.operateProperties = operateProperties;
+    }
+
+    @Test
+    void testCamundaSearchEngineConnectProperties() {
+      assertThat(searchEngineConnectProperties.getSecurity())
+          .returns(true, SecurityConfiguration::isEnabled)
+          .returns("certificatePath", SecurityConfiguration::getCertificatePath)
+          .returns(false, SecurityConfiguration::isVerifyHostname)
+          .returns(true, SecurityConfiguration::isSelfSigned);
+    }
+
+    @Test
+    void testCamundaExporterProperties() {
+      final ExporterConfiguration exporterConfiguration =
+          getExporterConfiguration(brokerBasedProperties);
+
+      assertThat(exporterConfiguration.getConnect().getSecurity())
+          .returns(true, SecurityConfiguration::isEnabled)
+          .returns("certificatePath", SecurityConfiguration::getCertificatePath)
+          .returns(false, SecurityConfiguration::isVerifyHostname)
+          .returns(true, SecurityConfiguration::isSelfSigned);
+    }
+
+    @Test
+    void testCamundaTasklistProperties() {
+      assertThat(tasklistProperties.getOpenSearch().getSsl())
+          .returns("certificatePath", SslProperties::getCertificatePath)
+          .returns(false, SslProperties::isVerifyHostname)
+          .returns(true, SslProperties::isSelfSigned);
+    }
+
+    @Test
+    void testCamundaOperateProperties() {
+      assertThat(operateProperties.getOpensearch().getSsl())
+          .returns("certificatePath", io.camunda.operate.property.SslProperties::getCertificatePath)
+          .returns(false, io.camunda.operate.property.SslProperties::isVerifyHostname)
+          .returns(true, io.camunda.operate.property.SslProperties::isSelfSigned);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "camunda.data.secondary-storage.type=opensearch",
+        // enabled
+        "camunda.data.secondary-storage.opensearch.security.enabled=true",
+        "camunda.database.security.enabled=true",
+        // certificate path
+        "camunda.data.secondary-storage.opensearch.security.certificate-path=certificatePath",
+        "camunda.database.security.certificatePath=certificatePath",
+        "camunda.tasklist.opensearch.ssl.certificatePath=certificatePath",
+        "camunda.operate.opensearch.ssl.certificatePath=certificatePath",
+        // verify hostname
+        "camunda.data.secondary-storage.opensearch.security.verify-hostname=false",
+        "camunda.database.security.verifyHostname=false",
+        "camunda.tasklist.opensearch.ssl.verifyHostname=false",
+        "camunda.operate.opensearch.ssl.verifyHostname=false",
+        // self signed
+        "camunda.data.secondary-storage.opensearch.security.self-signed=true",
+        "camunda.database.security.selfSigned=true",
+        "camunda.tasklist.opensearch.ssl.selfSigned=true",
+        "camunda.operate.opensearch.ssl.selfSigned=true"
+      })
+  class WithNewAndLegacySet {
+    final SearchEngineConnectProperties searchEngineConnectProperties;
+    final BrokerBasedProperties brokerBasedProperties;
+    final TasklistProperties tasklistProperties;
+    final OperateProperties operateProperties;
+
+    WithNewAndLegacySet(
+        @Autowired final SearchEngineConnectProperties searchEngineConnectProperties,
+        @Autowired final BrokerBasedProperties brokerBasedProperties,
+        @Autowired final TasklistProperties tasklistProperties,
+        @Autowired final OperateProperties operateProperties) {
+      this.searchEngineConnectProperties = searchEngineConnectProperties;
+      this.brokerBasedProperties = brokerBasedProperties;
+      this.tasklistProperties = tasklistProperties;
+      this.operateProperties = operateProperties;
+    }
+
+    @Test
+    void testCamundaSearchEngineConnectProperties() {
+      assertThat(searchEngineConnectProperties.getSecurity())
+          .returns(true, SecurityConfiguration::isEnabled)
+          .returns("certificatePath", SecurityConfiguration::getCertificatePath)
+          .returns(false, SecurityConfiguration::isVerifyHostname)
+          .returns(true, SecurityConfiguration::isSelfSigned);
+    }
+
+    @Test
+    void testCamundaExporterProperties() {
+      final ExporterConfiguration exporterConfiguration =
+          getExporterConfiguration(brokerBasedProperties);
+
+      assertThat(exporterConfiguration.getConnect().getSecurity())
+          .returns(true, SecurityConfiguration::isEnabled)
+          .returns("certificatePath", SecurityConfiguration::getCertificatePath)
+          .returns(false, SecurityConfiguration::isVerifyHostname)
+          .returns(true, SecurityConfiguration::isSelfSigned);
+    }
+
+    @Test
+    void testCamundaTasklistProperties() {
+      assertThat(tasklistProperties.getOpenSearch().getSsl())
+          .returns("certificatePath", SslProperties::getCertificatePath)
+          .returns(false, SslProperties::isVerifyHostname)
+          .returns(true, SslProperties::isSelfSigned);
+    }
+
+    @Test
+    void testCamundaOperateProperties() {
+      assertThat(operateProperties.getOpensearch().getSsl())
+          .returns("certificatePath", io.camunda.operate.property.SslProperties::getCertificatePath)
+          .returns(false, io.camunda.operate.property.SslProperties::isVerifyHostname)
+          .returns(true, io.camunda.operate.property.SslProperties::isSelfSigned);
+    }
+  }
+}

--- a/dist/src/main/config/application.yaml
+++ b/dist/src/main/config/application.yaml
@@ -83,23 +83,12 @@ camunda:
       type: 'elasticsearch'
       elasticsearch:
         url: 'http://localhost:9200'
+        cluster-name: 'elasticsearch'
+        index-prefix: ''
   # ---
 
-  database:
-    # Sets the name of the cluster, default name is "elasticsearch"
-    # This setting can also be overridden using the environment variable CAMUNDA_DATABASE_CLUSTERNAME
-    clusterName: elasticsearch
   # Operate configuration properties
   operate:
-    # Set operate username and password.
-    # If user with <username> does not exist it will be created.
-    # Default: demo/demo
-    #username:
-    #password:
-    # ELS instance to store Operate data
-    elasticsearch:
-      # Cluster name
-      clusterName: elasticsearch
     # Zeebe instance
     zeebe:
       # Gateway address
@@ -112,15 +101,6 @@ camunda:
       prefix: zeebe-record
   # Tasklist configuration properties
   tasklist:
-    # Set Tasklist username and password.
-    # If user with <username> does not exist it will be created.
-    # Default: demo/demo
-    #username:
-    #password:
-    # ELS instance to store Tasklist data
-    elasticsearch:
-      # Cluster name
-      clusterName: elasticsearch
     # Zeebe instance
     zeebe:
       # Gateway address

--- a/dist/src/main/resources/application-elasticsearch.yaml
+++ b/dist/src/main/resources/application-elasticsearch.yaml
@@ -75,7 +75,6 @@ zeebe:
         className: io.camunda.exporter.CamundaExporter
         args:
           connect:
-            clusterName: elasticsearch
             dateFormat: yyyy-MM-dd'T'HH:mm:ss.SSSZZ
             socketTimeout: 1000
             connectTimeout: 1000
@@ -126,23 +125,12 @@ camunda:
       type: 'elasticsearch'
       elasticsearch:
         url: 'http://localhost:9200'
+        cluster-name: 'elasticsearch'
+        index-prefix: ''
   # -----
 
-  database:
-    # Sets the name of the cluster, default name is "elasticsearch"
-    # This setting can also be overridden using the environment variable CAMUNDA_DATABASE_CLUSTERNAME
-    clusterName: elasticsearch
   # Operate configuration properties
   operate:
-    # Set operate username and password.
-    # If user with <username> does not exists it will be created.
-    # Default: demo/demo
-    #username:
-    #password:
-    # ELS instance to store Operate data
-    elasticsearch:
-      # Cluster name
-      clusterName: elasticsearch
     # Zeebe instance
     zeebe:
       # Gateway address
@@ -155,15 +143,6 @@ camunda:
       prefix: zeebe-record
   # Tasklist configuration properties
   tasklist:
-    # Set Tasklist username and password.
-    # If user with <username> does not exists it will be created.
-    # Default: demo/demo
-    #username:
-    #password:
-    # ELS instance to store Tasklist data
-    elasticsearch:
-      # Cluster name
-      clusterName: elasticsearch
     # Zeebe instance
     zeebe:
       # Gateway address

--- a/dist/src/main/resources/application-opensearch.yaml
+++ b/dist/src/main/resources/application-opensearch.yaml
@@ -75,7 +75,6 @@ zeebe:
         className: io.camunda.exporter.CamundaExporter
         args:
           connect:
-            clusterName: opensearch
             dateFormat: yyyy-MM-dd'T'HH:mm:ss.SSSZZ
             socketTimeout: 1000
             connectTimeout: 1000
@@ -127,23 +126,12 @@ camunda:
       type: 'opensearch'
       opensearch:
         url: 'http://localhost:9200'
+        cluster-name: 'opensearch'
+        index-prefix: ''
   # -----
 
-  database:
-    # Sets the name of the cluster, default name is "elasticsearch"
-    # This setting can also be overridden using the environment variable CAMUNDA_DATABASE_CLUSTERNAME
-    clusterName: opensearch
   # Operate configuration properties
   operate:
-    # Set operate username and password.
-    # If user with <username> does not exists it will be created.
-    # Default: demo/demo
-    #username:
-    #password:
-    # ELS instance to store Operate data
-    opensearch:
-      # Cluster name
-      clusterName: opensearch
     # Zeebe instance
     zeebe:
       # Gateway address
@@ -156,15 +144,6 @@ camunda:
       prefix: zeebe-record
   # Tasklist configuration properties
   tasklist:
-    # Set Tasklist username and password.
-    # If user with <username> does not exists it will be created.
-    # Default: demo/demo
-    #username:
-    #password:
-    # ELS instance to store Tasklist data
-    opensearch:
-      # Cluster name
-      clusterName: opensearch
     # Zeebe instance
     zeebe:
       # Gateway address

--- a/dist/src/test/java/io/camunda/application/CamundaDockerIT.java
+++ b/dist/src/test/java/io/camunda/application/CamundaDockerIT.java
@@ -29,13 +29,18 @@ import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
 import org.testcontainers.elasticsearch.ElasticsearchContainer;
 
 @EnabledIfSystemProperty(named = "camunda.docker.test.enabled", matches = "true")
 public class CamundaDockerIT {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(CamundaDockerIT.class);
 
   private static final int SERVER_PORT = 8080;
   private static final int MANAGEMENT_PORT = 9600;
@@ -191,6 +196,7 @@ public class CamundaDockerIT {
 
   private GenericContainer createUnauthenticatedUnifiedConfigCamundaContainer() {
     return new GenericContainer<>(CAMUNDA_TEST_DOCKER_IMAGE)
+        .withLogConsumer(new Slf4jLogConsumer(LOGGER))
         .withExposedPorts(SERVER_PORT, MANAGEMENT_PORT, GATEWAY_GRPC_PORT)
         .withNetwork(Network.SHARED)
         .withNetworkAliases(CAMUNDA_NETWORK_ALIAS)
@@ -203,6 +209,8 @@ public class CamundaDockerIT {
         // Unified Configuration
         .withEnv("CAMUNDA_DATA_SECONDARYSTORAGE_TYPE", DATABASE_TYPE)
         .withEnv("CAMUNDA_DATA_SECONDARYSTORAGE_ELASTICSEARCH_URL", elasticsearchUrl())
+        .withEnv("CAMUNDA_OPERATE_ZEEBEELASTICSEARCH_URL", elasticsearchUrl())
+        .withEnv("CAMUNDA_TASKLIST_ZEEBEELASTICSEARCH_URL", elasticsearchUrl())
         // ---
         .withEnv("CAMUNDA_SECURITY_AUTHENTICATION_UNPROTECTED_API", "true")
         .withEnv("CAMUNDA_SECURITY_AUTHORIZATIONS_ENABLED", "false");
@@ -210,6 +218,7 @@ public class CamundaDockerIT {
 
   private GenericContainer createCamundaContainer() {
     return new GenericContainer<>(CAMUNDA_TEST_DOCKER_IMAGE)
+        .withLogConsumer(new Slf4jLogConsumer(LOGGER))
         .withExposedPorts(SERVER_PORT, MANAGEMENT_PORT, GATEWAY_GRPC_PORT)
         .withNetwork(Network.SHARED)
         .withNetworkAliases(CAMUNDA_NETWORK_ALIAS)
@@ -230,6 +239,8 @@ public class CamundaDockerIT {
         .withEnv("CAMUNDA_DATA_SECONDARYSTORAGE_ELASTICSEARCH_URL", elasticsearchUrl())
         .withEnv("CAMUNDA_DATA_SECONDARYSTORAGE_TYPE", DATABASE_TYPE)
         // ---
+        .withEnv("CAMUNDA_OPERATE_ZEEBEELASTICSEARCH_URL", elasticsearchUrl())
+        .withEnv("CAMUNDA_TASKLIST_ZEEBEELASTICSEARCH_URL", elasticsearchUrl())
         .withEnv("CAMUNDA_OPERATE_ZEEBE_GATEWAYADDRESS", gatewayAddress())
         .withEnv("ZEEBE_BROKER_GATEWAY_ENABLE", "true");
   }

--- a/operate/qa/backup-restore-tests/src/test/java/io/camunda/operate/qa/backup/BackupRestoreTest.java
+++ b/operate/qa/backup-restore-tests/src/test/java/io/camunda/operate/qa/backup/BackupRestoreTest.java
@@ -66,6 +66,7 @@ public class BackupRestoreTest {
   @Before
   public void setup() {
     testContext = new BackupRestoreTestContext().setZeebeIndexPrefix(INDEX_PREFIX);
+    testContext.setConnectionType("elasticsearch");
   }
 
   @Test
@@ -147,6 +148,7 @@ public class BackupRestoreTest {
             .withLogConsumer(new Slf4jLogConsumer(LOGGER))
             .withEnv("CAMUNDA_DATABASE_INDEXPREFIX", INDEX_PREFIX)
             .withEnv("CAMUNDA_OPERATE_ELASTICSEARCH_INDEXPREFIX", INDEX_PREFIX)
+            .withEnv("CAMUNDA_DATA_SECONDARYSTORAGE_ELASTICSEARCH_INDEXPREFIX", INDEX_PREFIX)
             .withEnv("CAMUNDA_OPERATE_IMPORTERENABLED", "false")
             .withEnv("CAMUNDA_OPERATE_BACKUP_REPOSITORYNAME", REPOSITORY_NAME);
 

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/ProbesTestIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/ProbesTestIT.java
@@ -13,7 +13,9 @@ import io.camunda.operate.management.IndicesCheck;
 import io.camunda.operate.qa.util.TestSchemaManager;
 import io.camunda.operate.util.TestApplication;
 import io.camunda.operate.util.TestUtil;
+import java.util.Optional;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -24,6 +26,16 @@ import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 class ProbesTestIT {
+
+  private static String indexPrefixConfig;
+
+  @BeforeAll
+  public static void init() {
+    final String dbType =
+        (Optional.ofNullable("camunda.data.secondary-storage.type").orElse("elasticsearch"))
+            .toLowerCase();
+    indexPrefixConfig = "camunda.data.secondary-storage." + dbType + ".index-prefix";
+  }
 
   @Nested
   @ExtendWith(SpringExtension.class)
@@ -39,7 +51,7 @@ class ProbesTestIT {
 
     @DynamicPropertySource
     static void setProperties(final DynamicPropertyRegistry registry) {
-      registry.add("camunda.database.indexPrefix", () -> TestUtil.createRandomString(10));
+      registry.add(indexPrefixConfig, () -> TestUtil.createRandomString(10));
       registry.add("camunda.database.schema-manager.createSchema", () -> true);
       registry.add("camunda.operate.zeebe.compatibility.enabled", () -> true);
     }
@@ -65,7 +77,7 @@ class ProbesTestIT {
 
     @DynamicPropertySource
     static void setProperties(final DynamicPropertyRegistry registry) {
-      registry.add("camunda.database.indexPrefix", () -> TestUtil.createRandomString(10));
+      registry.add(indexPrefixConfig, () -> TestUtil.createRandomString(10));
       registry.add("camunda.database.schema-manager.createSchema", () -> false);
       registry.add("camunda.operate.zeebe.compatibility.enabled", () -> true);
     }

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/opensearch/OpensearchFinishedImportingIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/opensearch/OpensearchFinishedImportingIT.java
@@ -47,10 +47,14 @@ import org.springframework.test.context.TestPropertySource;
 @TestPropertySource(
     properties = {
       "camunda.data.secondary-storage.type=opensearch",
+
+      // TODO: Some property sources are setting the following legacy variables equal to
+      //  'elasticsearch', causing a conflict. I couldn't find where this setting is happening,
+      //  therefore, for the moment, I'm overriding them here to let the tests work.
+      //  We need to identify these sources and remove them.
       "camunda.database.type=opensearch",
       "camunda.tasklist.database=opensearch",
       "camunda.operate.database=opensearch",
-      "zeebe.broker.exporters.camundaexporter.args.connect.type=opensearch"
     })
 public class OpensearchFinishedImportingIT extends OperateZeebeAbstractIT {
 

--- a/operate/qa/integration-tests/src/test/resources/config/application-test-properties.yml
+++ b/operate/qa/integration-tests/src/test/resources/config/application-test-properties.yml
@@ -1,14 +1,16 @@
 camunda:
+  # Unified Configuration
   data:
     secondary-storage:
       type: 'elasticsearch'
       elasticsearch:
         url: 'http://someHost:12345'
+        cluster-name: 'clusterName'
+  # ---
+
   operate:
     batchOperationMaxSize: 500
     elasticsearch:
-      clusterName: clusterName
-      url: http://someHost:12345
       dateFormat: yyyy-MM-dd
       batchSize: 111
     zeebeElasticsearch:

--- a/operate/qa/integration-tests/src/test/resources/config/application-test.yml
+++ b/operate/qa/integration-tests/src/test/resources/config/application-test.yml
@@ -2,14 +2,22 @@ testcontainers:
   elasticsearch: "docker.elastic.co/elasticsearch/elasticsearch:8.16.6"
   opensearch: "opensearchproject/opensearch:2.5.0"
 
+# Unified Configuration
+camunda:
+  data:
+    secondary-storage:
+      type: 'elasticsearch'
+      elasticsearch:
+        url: 'http://localhost:9200'
+        cluster-name: 'docker-cluster'
+# ---
+
 camunda.operate:
   username: demo
   password: demo
   backup:
     repositoryName: repoName
   elasticsearch:
-    clusterName: docker-cluster
-    url: http://localhost:9200
     dateFormat: yyyy-MM-dd'T'HH:mm:ss.SSSZ
   zeebe:
     gatewayAddress: localhost:26500

--- a/operate/qa/util/src/main/java/io/camunda/operate/qa/util/TestContainerUtil.java
+++ b/operate/qa/util/src/main/java/io/camunda/operate/qa/util/TestContainerUtil.java
@@ -625,8 +625,11 @@ public class TestContainerUtil {
         .withEnv("CAMUNDA_OPERATE_ZEEBEOPENSEARCH_URL", dbUrl)
         .withEnv("CAMUNDA_TASKLIST_OPENSEARCH_URL", dbUrl)
         .withEnv("CAMUNDA_TASKLIST_ZEEBEOPENSEARCH_URL", dbUrl);
-    if (testContext.getZeebeIndexPrefix() != null) {
+    if (testContext.getZeebeIndexPrefix() != null && dbType != null) {
       broker
+          .withEnv(
+              "CAMUNDA_DATA_SECONDARYSTORAGE_" + dbType.toUpperCase() + "_INDEXPREFIX",
+              testContext.getZeebeIndexPrefix())
           .withEnv(
               "ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_ARGS_CONNECT_INDEXPREFIX",
               testContext.getZeebeIndexPrefix())

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/backup/StandaloneBackupManagerIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/backup/StandaloneBackupManagerIT.java
@@ -75,7 +75,9 @@ final class StandaloneBackupManagerIT {
       new TestStandaloneBackupManager()
           .withProperty("camunda.database.username", ADMIN_USER)
           .withProperty("camunda.database.password", ADMIN_PASSWORD)
-          .withProperty("camunda.data.backup.repository-name", "els-test");
+          .withProperty("camunda.data.backup.repository-name", "els-test")
+          .withProperty("camunda.data.secondary-storage.elasticsearch.username", ADMIN_USER)
+          .withProperty("camunda.data.secondary-storage.elasticsearch.password", ADMIN_PASSWORD);
 
   // Configure the schema manager to create indices and templates in test setup
   @TestZeebe(autoStart = false)
@@ -83,6 +85,8 @@ final class StandaloneBackupManagerIT {
       new TestStandaloneSchemaManager()
           .withProperty("camunda.database.username", ADMIN_USER)
           .withProperty("camunda.database.password", ADMIN_PASSWORD)
+          .withProperty("camunda.data.secondary-storage.elasticsearch.username", ADMIN_USER)
+          .withProperty("camunda.data.secondary-storage.elasticsearch.password", ADMIN_PASSWORD)
           .withProperty("camunda.database.retention.enabled", "true");
 
   // Configure the Camunda single application with restricted access to the Elasticsearch
@@ -104,6 +108,8 @@ final class StandaloneBackupManagerIT {
           .withProperty("camunda.tasklist.zeebeelasticsearch.username", APP_USER)
           .withProperty("camunda.tasklist.zeebeelasticsearch.password", APP_PASSWORD)
           .withProperty("camunda.tasklist.elasticsearch.healthCheckEnabled", "false")
+          .withProperty("camunda.data.secondary-storage.elasticsearch.username", APP_USER)
+          .withProperty("camunda.data.secondary-storage.elasticsearch.password", APP_PASSWORD)
           .withExporter(
               CamundaExporter.class.getSimpleName(),
               cfg -> {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/network/SecuredClusterMessagingIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/network/SecuredClusterMessagingIT.java
@@ -80,6 +80,8 @@ final class SecuredClusteredMessagingIT {
               "/tmp/certificate.pem")
           .withCopyToContainer(
               MountableFile.forHostPath(CERTIFICATE.privateKey().toPath(), 0777), "/tmp/key.pem")
+          // unified configuration: index prefix
+          .withEnv("CAMUNDA_DATA_SECONDARYSTORAGE_ELASTICSEARCH_INDEXPREFIX", testPrefix)
           // unified configuration: type
           .withEnv("CAMUNDA_DATA_SECONDARYSTORAGE_TYPE", DB_TYPE_ELASTICSEARCH)
           .withEnv("CAMUNDA_DATABASE_TYPE", DB_TYPE_ELASTICSEARCH)
@@ -92,9 +94,7 @@ final class SecuredClusteredMessagingIT {
           .withEnv("CAMUNDA_OPERATE_ELASTICSEARCH_URL", esUrl)
           .withEnv("CAMUNDA_TASKLIST_ELASTICSEARCH_URL", esUrl)
           .withEnv("CAMUNDA_TASKLIST_ZEEBEELASTICSEARCH_URL", esUrl)
-          // ---
-          .withEnv("CAMUNDA_DATABASE_INDEXPREFIX", testPrefix)
-          .withEnv("ZEEBE_BROKER_NETWORK_ADVERTISEDHOST", "zeebe")
+          // ---.withEnv("ZEEBE_BROKER_NETWORK_ADVERTISEDHOST", "zeebe")
           .withEnv(
               "ZEEBE_BROKER_EXPORTERS_CAMUNDA_CLASSNAME", "io.camunda.exporter.CamundaExporter")
           .withEnv("ZEEBE_BROKER_EXPORTERS_CAMUNDA_ARGS_CONNECT_URL", esUrl)
@@ -121,7 +121,8 @@ final class SecuredClusteredMessagingIT {
               "/tmp/certificate.pem")
           .withCopyToContainer(
               MountableFile.forHostPath(CERTIFICATE.privateKey().toPath(), 0777), "/tmp/key.pem")
-          .withEnv("CAMUNDA_OPERATE_ELASTICSEARCH_INDEXPREFIX", testPrefix)
+          // Unified Configuration: index prefix
+          .withEnv("CAMUNDA_DATA_SECONDARYSTORAGE_ELASTICSEARCH_INDEXPREFIX", testPrefix)
           // Unified Configuration: db type
           .withEnv("CAMUNDA_DATA_SECONDARYSTORAGE_TYPE", DB_TYPE_ELASTICSEARCH)
           .withEnv("CAMUNDA_DATABASE_TYPE", DB_TYPE_ELASTICSEARCH)
@@ -135,7 +136,6 @@ final class SecuredClusteredMessagingIT {
           .withEnv("CAMUNDA_TASKLIST_ELASTICSEARCH_URL", esUrl)
           .withEnv("CAMUNDA_TASKLIST_ZEEBEELASTICSEARCH_URL", esUrl)
           // ---
-          .withEnv("CAMUNDA_DATABASE_INDEXPREFIX", testPrefix)
           .withEnv("CAMUNDA_OPERATE_ZEEBEELASTICSEARCH_INDEXPREFIX", testPrefix)
           .withEnv("CAMUNDA_OPERATE_ZEEBE_GATEWAYADDRESS", zeebe.getInternalGatewayAddress())
           .withEnv("CAMUNDA_LOG_LEVEL", "DEBUG")
@@ -164,7 +164,8 @@ final class SecuredClusteredMessagingIT {
               "/tmp/certificate.pem")
           .withCopyToContainer(
               MountableFile.forHostPath(CERTIFICATE.privateKey().toPath(), 0777), "/tmp/key.pem")
-          .withEnv("CAMUNDA_TASKLIST_ELASTICSEARCH_INDEXPREFIX", testPrefix)
+          // Unified Configuration: index prefix
+          .withEnv("CAMUNDA_DATA_SECONDARYSTORAGE_ELASTICSEARCH_INDEXPREFIX", testPrefix)
           // Unified Configuration: db type
           .withEnv("CAMUNDA_DATA_SECONDARYSTORAGE_TYPE", DB_TYPE_ELASTICSEARCH)
           .withEnv("CAMUNDA_DATABASE_TYPE", DB_TYPE_ELASTICSEARCH)
@@ -178,7 +179,6 @@ final class SecuredClusteredMessagingIT {
           .withEnv("CAMUNDA_TASKLIST_ELASTICSEARCH_URL", esUrl)
           .withEnv("CAMUNDA_TASKLIST_ZEEBEELASTICSEARCH_URL", esUrl)
           // ---
-          .withEnv("CAMUNDA_DATABASE_INDEXPREFIX", testPrefix)
           .withEnv("CAMUNDA_TASKLIST_ZEEBEELASTICSEARCH_INDEXPREFIX", testPrefix)
           .withEnv("CAMUNDA_TASKLIST_ZEEBE_GATEWAYADDRESS", zeebe.getInternalGatewayAddress())
           .withEnv(

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/schema/StandaloneSchemaManagerIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/schema/StandaloneSchemaManagerIT.java
@@ -74,6 +74,8 @@ final class StandaloneSchemaManagerIT {
               "zeebe.broker.exporters.elasticsearch.args.authentication.password", ADMIN_PASSWORD)
           .withProperty("camunda.database.username", ADMIN_USER)
           .withProperty("camunda.database.password", ADMIN_PASSWORD)
+          .withProperty("camunda.data.secondary-storage.elasticsearch.username", ADMIN_USER)
+          .withProperty("camunda.data.secondary-storage.elasticsearch.password", ADMIN_PASSWORD)
           .withProperty("camunda.database.retention.enabled", "true");
 
   @TestZeebe(autoStart = false)
@@ -98,6 +100,8 @@ final class StandaloneSchemaManagerIT {
           .withProperty("camunda.tasklist.elasticsearch.password", APP_PASSWORD)
           .withProperty("camunda.tasklist.zeebeelasticsearch.username", APP_USER)
           .withProperty("camunda.tasklist.zeebeelasticsearch.password", APP_PASSWORD)
+          .withProperty("camunda.data.secondary-storage.elasticsearch.username", APP_USER)
+          .withProperty("camunda.data.secondary-storage.elasticsearch.password", APP_PASSWORD)
           .withProperty("camunda.tasklist.elasticsearch.healthCheckEnabled", "false")
           .withExporter(
               CamundaExporter.class.getSimpleName(),

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/MultiDbConfigurator.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/MultiDbConfigurator.java
@@ -63,13 +63,14 @@ public class MultiDbConfigurator {
     final Map<String, Object> elasticsearchProperties = new HashMap<>();
 
     /* Tasklist */
-    elasticsearchProperties.put("camunda.tasklist.elasticsearch.indexPrefix", indexPrefix);
     elasticsearchProperties.put("camunda.tasklist.zeebeElasticsearch.prefix", zeebeIndexPrefix());
 
     /* Operate */
-    elasticsearchProperties.put("camunda.operate.elasticsearch.indexPrefix", indexPrefix);
     elasticsearchProperties.put("camunda.operate.zeebeElasticsearch.prefix", zeebeIndexPrefix());
 
+    // indexPrefix
+    elasticsearchProperties.put(
+        "camunda.data.secondary-storage.elasticsearch.index-prefix", indexPrefix);
     // db type
     elasticsearchProperties.put(PROPERTY_CAMUNDA_DATABASE_TYPE, DB_TYPE_ELASTICSEARCH);
     elasticsearchProperties.put(
@@ -86,7 +87,6 @@ public class MultiDbConfigurator {
     elasticsearchProperties.put("camunda.operate.zeebeElasticsearch.url", elasticsearchUrl);
 
     /* Camunda */
-    elasticsearchProperties.put("camunda.database.indexPrefix", indexPrefix);
     elasticsearchProperties.put(
         "camunda.database.retention.enabled", Boolean.toString(retentionEnabled));
     elasticsearchProperties.put("camunda.database.retention.policyName", indexPrefix + "-ilm");
@@ -179,17 +179,17 @@ public class MultiDbConfigurator {
     final Map<String, Object> opensearchProperties = new HashMap<>();
 
     /* Tasklist */
-    opensearchProperties.put("camunda.tasklist.opensearch.indexPrefix", indexPrefix);
     opensearchProperties.put("camunda.tasklist.zeebeOpensearch.prefix", zeebeIndexPrefix());
     opensearchProperties.put("camunda.tasklist.opensearch.username", userName);
     opensearchProperties.put("camunda.tasklist.opensearch.password", userPassword);
 
     /* Operate */
-    opensearchProperties.put("camunda.operate.opensearch.indexPrefix", indexPrefix);
     opensearchProperties.put("camunda.operate.zeebeOpensearch.prefix", zeebeIndexPrefix());
     opensearchProperties.put("camunda.operate.opensearch.username", userName);
     opensearchProperties.put("camunda.operate.opensearch.password", userPassword);
 
+    // index prefix
+    opensearchProperties.put("camunda.data.secondary-storage.opensearch.index-prefix", indexPrefix);
     // db url
     opensearchProperties.put("camunda.data.secondary-storage.opensearch.url", opensearchUrl);
     opensearchProperties.put("camunda.tasklist.opensearch.url", opensearchUrl);
@@ -203,7 +203,6 @@ public class MultiDbConfigurator {
     opensearchProperties.put("camunda.tasklist.database", DB_TYPE_OPENSEARCH);
 
     /* Camunda */
-    opensearchProperties.put("camunda.database.indexPrefix", indexPrefix);
     opensearchProperties.put("camunda.database.username", userName);
     opensearchProperties.put("camunda.database.password", userPassword);
     opensearchProperties.put("camunda.database.url", opensearchUrl);
@@ -212,6 +211,10 @@ public class MultiDbConfigurator {
     opensearchProperties.put("camunda.database.retention.policyName", indexPrefix + "-ilm");
     opensearchProperties.put("camunda.database.retention.minimumAge", "0s");
     opensearchProperties.put(CREATE_SCHEMA_PROPERTY, true);
+
+    /* Unified Config */
+    opensearchProperties.put("camunda.data.secondary-storage.opensearch.username", userName);
+    opensearchProperties.put("camunda.data.secondary-storage.opensearch.password", userPassword);
 
     testApplication.withAdditionalProperties(opensearchProperties);
 

--- a/schema-manager/src/test/java/io/camunda/search/schema/SchemaUpdateIT.java
+++ b/schema-manager/src/test/java/io/camunda/search/schema/SchemaUpdateIT.java
@@ -86,7 +86,13 @@ class SchemaUpdateIT {
             .withEnv("CAMUNDA_DATABASE_INDEXPREFIX", indexPrefix)
             .withEnv("CAMUNDA_DATABASE_INDEX_NUMBEROFREPLICAS", "1")
             .withEnv("CAMUNDA_DATABASE_RETENTION_ENABLED", "true")
-            .withEnv("CAMUNDA_DATABASE_RETENTION_ENABLED", "true")) {
+            .withEnv("CAMUNDA_DATABASE_RETENTION_ENABLED", "true")
+            .withEnv(
+                "CAMUNDA_DATA_SECONDARY_STORAGE_%s_INDEX_PREFIX".formatted(databaseType.name()),
+                indexPrefix)
+            .withEnv(
+                "CAMUNDA_DATA_SECONDARY_STORAGE_%s_INDEX_PREFIX".formatted(databaseType.name()),
+                indexPrefix)) {
       previousVersionContainer.start();
       previousVersionContainer.followOutput(new Slf4jLogConsumer(LOG));
     }

--- a/tasklist/qa/backup-restore-tests/src/test/java/io/camunda/tasklist/qa/backup/BackupRestoreTest.java
+++ b/tasklist/qa/backup-restore-tests/src/test/java/io/camunda/tasklist/qa/backup/BackupRestoreTest.java
@@ -111,15 +111,14 @@ public class BackupRestoreTest {
             // Unified Configuration: DB type + compatibility
             .withEnv("CAMUNDA_DATA_SECONDARYSTORAGE_TYPE", dbType)
             .withEnv("CAMUNDA_TASKLIST_DATABASE", dbType)
-            // Unified Configuration: DB URL + compatibility
-            // ---
-            .withEnv("CAMUNDA_TASKLIST_BACKUP_REPOSITORYNAME", REPOSITORY_NAME)
-            .withEnv("CAMUNDA_DATABASE_INDEXPREFIX", INDEX_PREFIX)
+            // Unified Configuration: index prefix
             .withEnv(
                 TestUtil.isOpenSearch()
-                    ? "CAMUNDA_TASKLIST_OPENSEARCH_INDEXPREFIX"
-                    : "CAMUNDA_TASKLIST_ELASTICSEARCH_INDEXPREFIX",
+                    ? "CAMUNDA_DATA_SECONDARYSTORAGE_OPENSEARCH_INDEXPREFIX"
+                    : "CAMUNDA_DATA_SECONDARYSTORAGE_ELASTICSEARCH_INDEXPREFIX",
                 INDEX_PREFIX)
+            // ---
+            .withEnv("CAMUNDA_TASKLIST_BACKUP_REPOSITORYNAME", REPOSITORY_NAME)
             .withEnv("CAMUNDA_TASKLIST_CSRF_PREVENTION_ENABLED", "false")
             .withEnv("CAMUNDA_TASKLIST_ZEEBE_COMPATIBILITY_ENABLED", "true")
             .withEnv("CAMUNDA_TASKLIST_IMPORTERENABLED", "false")

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/ProbesTestIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/ProbesTestIT.java
@@ -16,7 +16,9 @@ import io.camunda.tasklist.qa.util.TestUtil;
 import io.camunda.tasklist.schema.IndexSchemaValidator;
 import io.camunda.tasklist.util.TasklistIntegrationTest;
 import io.camunda.tasklist.util.TestApplication;
+import java.util.Optional;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -27,6 +29,16 @@ import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 public class ProbesTestIT extends TasklistIntegrationTest {
+
+  private static String indexPrefixConfig;
+
+  @BeforeAll
+  public static void init() {
+    final String dbType =
+        (Optional.ofNullable("camunda.data.secondary-storage.type").orElse("elasticsearch"))
+            .toLowerCase();
+    indexPrefixConfig = "camunda.data.secondary-storage." + dbType + ".index-prefix";
+  }
 
   @Nested
   @ExtendWith(SpringExtension.class)
@@ -40,7 +52,7 @@ public class ProbesTestIT extends TasklistIntegrationTest {
 
     @DynamicPropertySource
     static void setProperties(final DynamicPropertyRegistry registry) {
-      registry.add("camunda.database.indexPrefix", () -> TestUtil.createRandomString(10));
+      registry.add(indexPrefixConfig, () -> TestUtil.createRandomString(10));
       registry.add("camunda.database.schema-manager.createSchema", () -> true);
     }
 
@@ -69,7 +81,7 @@ public class ProbesTestIT extends TasklistIntegrationTest {
 
     @DynamicPropertySource
     static void setProperties(final DynamicPropertyRegistry registry) {
-      registry.add("camunda.database.indexPrefix", () -> TestUtil.createRandomString(10));
+      registry.add(indexPrefixConfig, () -> TestUtil.createRandomString(10));
       registry.add("camunda.database.schema-manager.createSchema", () -> false);
     }
 

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/es/ElasticsearchConnectorBasicAuthIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/es/ElasticsearchConnectorBasicAuthIT.java
@@ -109,6 +109,9 @@ public class ElasticsearchConnectorBasicAuthIT extends TasklistIntegrationTest {
               "camunda.database.type=elasticsearch",
               "camunda.tasklist.database=elasticsearch",
               "camunda.operate.database=elasticsearch",
+              // Unified config
+              "camunda.data.secondary-storage.elasticsearch.username=elastic",
+              "camunda.data.secondary-storage.elasticsearch.password=changeme",
               //
               "camunda.tasklist.zeebeElasticsearch.username=elastic",
               "camunda.tasklist.zeebeElasticsearch.password=changeme",

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/es/ElasticsearchConnectorBasicAuthNoClusterPrivilegesIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/es/ElasticsearchConnectorBasicAuthNoClusterPrivilegesIT.java
@@ -129,6 +129,9 @@ public class ElasticsearchConnectorBasicAuthNoClusterPrivilegesIT extends Taskli
               "camunda.database.type=elasticsearch",
               "camunda.tasklist.database=elasticsearch",
               "camunda.operate.database=elasticsearch",
+              // Unified config
+              "camunda.data.secondary-storage.elasticsearch.username=" + TASKLIST_ES_USER,
+              "camunda.data.secondary-storage.elasticsearch.password=" + TASKLIST_ES_PASSWORD,
               //
               "camunda.tasklist.zeebeElasticsearch.username=" + TASKLIST_ES_USER,
               "camunda.tasklist.zeebeElasticsearch.password=" + TASKLIST_ES_PASSWORD,

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/es/ElasticsearchConnectorSSLAuthIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/es/ElasticsearchConnectorSSLAuthIT.java
@@ -118,6 +118,9 @@ public class ElasticsearchConnectorSSLAuthIT extends TasklistIntegrationTest {
               // "camunda.tasklist.elasticsearch.ssl.verifyHostname=true",
               "camunda.tasklist.zeebeElasticsearch.username=elastic",
               "camunda.tasklist.zeebeElasticsearch.password=elastic",
+              // Unified config
+              "camunda.data.secondary-storage.elasticsearch.username=elastic",
+              "camunda.data.secondary-storage.elasticsearch.password=elastic",
               // "camunda.tasklist.zeebeElasticsearch.ssl.certificatePath="+certDir+"/elastic-stack-ca.p12",
               // "camunda.tasklist.zeebeElasticsearch.ssl.selfSigned=true",
               // "camunda.tasklist.zeebeElasticsearch.ssl.verifyHostname=true",

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/os/OpenSearchConnectorBasicAuthIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/os/OpenSearchConnectorBasicAuthIT.java
@@ -98,24 +98,28 @@ public class OpenSearchConnectorBasicAuthIT extends TasklistIntegrationTest {
       final String osUrl =
           String.format("http://%s:%s", opensearch.getHost(), opensearch.getMappedPort(9200));
       TestPropertyValues.of(
-              // Unified Config compatibility: DB type
+              // Unified Configuration
               "camunda.data.secondary-storage.type=opensearch",
-              "camunda.database.type=opensearch",
-              "camunda.operate.database=opensearch",
-              "camunda.tasklist.database=opensearch",
-              // Unified Config compatibility: DB URL
               "camunda.data.secondary-storage.opensearch.url=" + osUrl,
+              "camunda.data.secondary-storage.opensearch.cluster-name=docker-cluster",
+
+              // TODO: The following legacy values are set somewhere equal to http://localhost:9200.
+              //  We should find them and unset them, so that they don't cause conflicts. In the
+              //  meantime, this test can run in double configuration mode.
               "camunda.database.url=" + osUrl,
               "camunda.tasklist.opensearch.url=" + osUrl,
               "camunda.operate.opensearch.url=" + osUrl,
+              // Unified config
+              "camunda.data.secondary-storage.opensearch.username=opensearch",
+              "camunda.data.secondary-storage.opensearch.password=changeme",
+
               // ---
+
               "camunda.tasklist.opensearch.username=opensearch",
               "camunda.tasklist.opensearch.password=changeme",
-              "camunda.tasklist.opensearch.clusterName=docker-cluster",
               "camunda.tasklist.zeebeOpensearch.url=" + osUrl,
               "camunda.tasklist.zeebeOpensearch.username=opensearch",
               "camunda.tasklist.zeebeOpensearch.password=changeme",
-              "camunda.tasklist.zeebeOpensearch.clusterName=docker-cluster",
               "camunda.tasklist.zeebeOpensearch.prefix=zeebe-record")
           .applyTo(applicationContext.getEnvironment());
     }

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/os/OpenSearchConnectorSSLAuthIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/os/OpenSearchConnectorSSLAuthIT.java
@@ -97,7 +97,9 @@ public class OpenSearchConnectorSSLAuthIT extends TasklistIntegrationTest {
               "camunda.tasklist.zeebeOpensearch.username=elastic",
               "camunda.tasklist.zeebeOpensearch.password=elastic",
               "camunda.tasklist.zeebeOpensearch.clusterName=docker-cluster",
-              "camunda.tasklist.zeebeOpensearch.prefix=zeebe-record")
+              "camunda.tasklist.zeebeOpensearch.prefix=zeebe-record",
+              "camunda.data.secondary-storage.opensearch.username=elastic",
+              "camunda.data.secondary-storage.opensearch.password=elastic")
           .applyTo(applicationContext.getEnvironment());
     }
   }

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/properties/PropertiesTest.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/properties/PropertiesTest.java
@@ -8,7 +8,9 @@
 package io.camunda.tasklist.properties;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
+import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
 import io.camunda.configuration.UnifiedConfiguration;
 import io.camunda.configuration.UnifiedConfigurationHelper;
 import io.camunda.configuration.beanoverrides.TasklistPropertiesOverride;
@@ -34,9 +36,16 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 public class PropertiesTest {
 
   @Autowired private TasklistProperties tasklistProperties;
+  @Autowired private UnifiedConfiguration unifiedConfiguration;
 
   @Test
   public void testProperties() {
+    // The file application-test-properties.yml only has data related to Elasticsearch.
+    assumeTrue(
+        unifiedConfiguration.getCamunda().getData().getSecondaryStorage().getType()
+            == SecondaryStorageType.elasticsearch,
+        "Skipping because DB is not Elasticsearch");
+
     assertThat(tasklistProperties.getImporter().isStartLoadingDataOnStartup()).isFalse();
     assertThat(tasklistProperties.getImporter().getCompletedReaderMinEmptyBatches()).isEqualTo(10);
     assertThat(tasklistProperties.getElasticsearch().getClusterName()).isEqualTo("clusterName");

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TasklistZeebeExtensionElasticSearch.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TasklistZeebeExtensionElasticSearch.java
@@ -87,6 +87,7 @@ public class TasklistZeebeExtensionElasticSearch extends TasklistZeebeExtension 
         Map.entry("CAMUNDA_OPERATE_DATABASE", dbType),
         Map.entry("CAMUNDA_TASKLIST_DATABASE", dbType),
         Map.entry("CAMUNDA_DATABASE_TYPE", dbType),
+        Map.entry("CAMUNDA_DATA_SECONDARYSTORAGE_ELASTICSEARCH_INDEXPREFIX", indexPrefix),
         // ---
         Map.entry("ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_ARGS_BULK_SIZE", "1"),
         Map.entry("ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_ARGS_CONNECT_INDEXPREFIX", indexPrefix),

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TasklistZeebeExtensionOpenSearch.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TasklistZeebeExtensionOpenSearch.java
@@ -79,6 +79,7 @@ public class TasklistZeebeExtensionOpenSearch extends TasklistZeebeExtension {
         Map.entry("CAMUNDA_OPERATE_DATABASE", dbType),
         Map.entry("CAMUNDA_TASKLIST_DATABASE", dbType),
         Map.entry("ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_ARGS_CONNECT_TYPE", dbType),
+        Map.entry("CAMUNDA_DATA_SECONDARYSTORAGE_OPENSEARCH_INDEXPREFIX", indexPrefix),
         // Unified Config: db url + compatibility vars
         Map.entry("CAMUNDA_DATABASE_URL", dbUrl),
         Map.entry("CAMUNDA_DATA_SECONDARYSTORAGE_OPENSEARCH_URL", dbUrl),

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/api/rest/v1/controllers/internal/ProcessInternalControllerIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/api/rest/v1/controllers/internal/ProcessInternalControllerIT.java
@@ -64,6 +64,11 @@ public class ProcessInternalControllerIT extends TasklistZeebeIntegrationTest {
     registry.add("camunda.tasklist.cloud.clusterId", () -> "449ac2ad-d3c6-4c73-9c68-7752e39ae616");
     registry.add("camunda.tasklist.client.clusterId", () -> "449ac2ad-d3c6-4c73-9c68-7752e39ae616");
     registry.add("camunda.tasklist.featureFlag.processPublicEndpoints", () -> true);
+
+    // TODO: Some legacy configs are setting this to docker-cluster. I couldn't find them. We should
+    //  remove them eventually. For the moment, the test will work in compatibility mode.
+    registry.add(
+        "camunda.data.secondary-storage.elasticsearch.cluster-name", () -> "docker-cluster");
   }
 
   @BeforeEach

--- a/tasklist/qa/integration-tests/src/test/resources/config/application-test-properties.yml
+++ b/tasklist/qa/integration-tests/src/test/resources/config/application-test-properties.yml
@@ -1,15 +1,16 @@
 camunda:
+  # Unified Configuration
   data:
     secondary-storage:
       type: 'elasticsearch'
       elasticsearch:
         url: 'http://localhost:9200'
+        cluster-name: 'clusterName'
+  # ---
   tasklist:
     csrfPreventionEnabled: false
     batchOperationMaxSize: 500
     elasticsearch:
-      clusterName: clusterName
-      url: http://localhost:9200
       dateFormat: yyyy-MM-dd
       batchSize: 111
     zeebeElasticsearch:

--- a/tasklist/qa/integration-tests/src/test/resources/config/application-test.yml
+++ b/tasklist/qa/integration-tests/src/test/resources/config/application-test.yml
@@ -1,9 +1,17 @@
+# Unified Configuration
+camunda:
+  data:
+    secondary-storage:
+      type: 'elasticsearch'
+      elasticsearch:
+        url: 'http://localhost:9200'
+        cluster-name: 'docker-cluster'
+# ---
+
 camunda.tasklist:
   username: demo
   password: demo
   elasticsearch:
-    clusterName: docker-cluster
-    url: http://localhost:9200
     dateFormat: yyyy-MM-dd'T'HH:mm:ss.SSSZ
   zeebe:
     gatewayAddress: localhost:26500

--- a/tasklist/qa/util/src/main/java/io/camunda/tasklist/qa/util/TestContainerUtil.java
+++ b/tasklist/qa/util/src/main/java/io/camunda/tasklist/qa/util/TestContainerUtil.java
@@ -573,11 +573,9 @@ public class TestContainerUtil {
         .withEnv(
             "ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_ARGS_HISTORY_WAITPERIODBEFOREARCHIVING", "1s");
     if (testContext.getZeebeIndexPrefix() != null) {
-      zeebeBroker
-          .withEnv("CAMUNDA_DATABASE_INDEXPREFIX", testContext.getZeebeIndexPrefix())
-          .withEnv(
-              "ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_ARGS_CONNECT_INDEXPREFIX",
-              testContext.getZeebeIndexPrefix());
+      zeebeBroker.withEnv(
+          "CAMUNDA_DATA_SECONDARY_STORAGE_" + type.toUpperCase() + "_INDEX_PREFIX",
+          testContext.getZeebeIndexPrefix());
     }
   }
 


### PR DESCRIPTION
## Description

This branch introduces the following unified configuration properties:

- `camunda.data.secondary-storage.elasticsearch.cluster-name`, `camunda.data.secondary-storage.opensearch.cluster-name` deprecate `camunda.database.clusterName`, `zeebe.broker.exporters.camundaexporter.args.connect.clusterName`, `camunda.operate.elasticsearch.clusterName`, `camunda.tasklist.elasticsearch.clusterName`, `zeebe.broker.exporters.camundaexporter.args.connect.clusterName`
- `camunda.data.secondary-storage.elasticsearch.username`, `camunda.data.secondary-storage.elasticsearch.password` deprecate `camunda.database.username`, `camunda.operate.elasticsearch.username`, `camunda.tasklist.elasticsearch.username`, `zeebe.broker.exporters.camundaexporter.args.connect.username`, `camunda.database.password`, `camunda.operate.elasticsearch.password`, `camunda.tasklist.elasticsearch.password`, `zeebe.broker.exporters.camundaexporter.args.connect.password`, `camunda.operate.opensearch.username`, `camunda.tasklist.opensearch.username`, `camunda.operate.opensearch.password`, `camunda.tasklist.opensearch.password`
- `camunda.data.secondary-storage.elasticsearch.index-prefix`, `camunda.data.secondary-storage.opensearch.index-prefix` deprecate `camunda.database.indexPrefix`, `camunda.tasklist.elasticsearch.indexPrefix`, `camunda.operate.elasticsearch.indexPrefix`, `zeebe.broker.exporters.camundaexporter.args.index.indexPrefix`, `camunda.tasklist.opensearch.indexPrefix`, `camunda.operate.opensearch.indexPrefix`
- `camunda.data.secondary-storage.elasticsearch.security.enabled`, `camunda.data.secondary-storage.opensearch.security.enabled` deprecate `camunda.database.security.enabled`, `zeebe.broker.exporters.camundaexporter.args.connect.security.enabled`
- `camunda.data.secondary-storage.elasticsearch.security.certificate-path`, `camunda.data.secondary-storage.opensearch.security.certificate-path` deprecate `camunda.database.security.certificatePath`, `camunda.tasklist.elasticsearch.ssl.certificatePath`, `camunda.operate.elasticsearch.ssl.certificatePath`, `zeebe.broker.exporters.camundaexporter.args.connect.security.certificatePath`, `camunda.tasklist.opensearch.ssl.certificatePath`, `camunda.operate.opensearch.ssl.certificatePath`
- `camunda.data.secondary-storage.elasticsearch.security.verify-hostname`, `camunda.data.secondary-storage.opensearch.security.verify-hostname` deprecate `camunda.database.security.verifyHostname`, `camunda.tasklist.opensearch.ssl.verifyHostname`, `camunda.operate.opensearch.ssl.verifyHostname`, `zeebe.broker.exporters.camundaexporter.args.connect.security.verifyHostname`, `camunda.tasklist.elasticsearch.ssl.verifyHostname`, `camunda.operate.elasticsearch.ssl.verifyHostname`
- `camunda.data.secondary-storage.elasticsearch.security.self-signed`, `camunda.data.secondary-storage.opensearch.security.self-signed` deprecate `camunda.database.security.selfSigned`, `camunda.tasklist.elasticsearch.ssl.selfSigned`, `camunda.operate.elasticsearch.ssl.selfSigned`, `zeebe.broker.exporters.camundaexporter.args.connect.security.selfSigned`, `camunda.tasklist.elasticsearch.ssl.selfSigned`, `camunda.operate.elasticsearch.ssl.selfSigned`

