### PR TITLE
[Backport stable/8.7] test: remove pre-condition that snapshot do not exists

### DIFF
--- a/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/NoSnapshotTest.java
+++ b/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/NoSnapshotTest.java
@@ -46,7 +46,6 @@ final class NoSnapshotTest {
     state.withNetwork(network).withOldBroker().start(true);
     final long processInstanceKey = testCase.setUp(state.client());
     final long key = testCase.runBefore(state);
-    assertThat(state).hasNoSnapshotAvailable(1);
 
     // when
     state.close();


### PR DESCRIPTION
# Description
Backport of #37203 to `stable/8.7`.

relates to 