### PR TITLE
refactor: unified config: better organization of SecondaryStorageDatabase

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/Elasticsearch.java
+++ b/configuration/src/main/java/io/camunda/configuration/Elasticsearch.java
@@ -7,21 +7,10 @@
  */
 package io.camunda.configuration;
 
-import java.util.Set;
-
 public class Elasticsearch extends SecondaryStorageDatabase {
 
   @Override
-  protected String prefix() {
-    return "camunda.data.secondary-storage.elasticsearch";
-  }
-
-  @Override
-  protected Set<String> legacyUrlProperties() {
-    return Set.of(
-        "camunda.database.url",
-        "camunda.operate.elasticsearch.url",
-        "camunda.tasklist.elasticsearch.url",
-        "zeebe.broker.exporters.camundaexporter.args.connect.url");
+  protected String databaseName() {
+    return "elasticsearch";
   }
 }

--- a/configuration/src/main/java/io/camunda/configuration/Opensearch.java
+++ b/configuration/src/main/java/io/camunda/configuration/Opensearch.java
@@ -7,21 +7,10 @@
  */
 package io.camunda.configuration;
 
-import java.util.Set;
-
 public class Opensearch extends SecondaryStorageDatabase {
 
   @Override
-  protected String prefix() {
-    return "camunda.data.secondary-storage.opensearch";
-  }
-
-  @Override
-  protected Set<String> legacyUrlProperties() {
-    return Set.of(
-        "camunda.database.url",
-        "camunda.operate.opensearch.url",
-        "camunda.tasklist.opensearch.url",
-        "zeebe.broker.exporters.camundaexporter.args.connect.url");
+  protected String databaseName() {
+    return "opensearch";
   }
 }

--- a/configuration/src/main/java/io/camunda/configuration/SecondaryStorageDatabase.java
+++ b/configuration/src/main/java/io/camunda/configuration/SecondaryStorageDatabase.java
@@ -28,7 +28,18 @@ public abstract class SecondaryStorageDatabase {
     this.url = url;
   }
 
-  protected abstract String prefix();
+  private String prefix() {
+    return "camunda.data.secondary-storage." + databaseName().toLowerCase();
+  }
 
-  protected abstract Set<String> legacyUrlProperties();
+  private Set<String> legacyUrlProperties() {
+    final String dbName = databaseName().toLowerCase();
+    return Set.of(
+        "camunda.database.url",
+        "camunda.operate." + dbName + ".url",
+        "camunda.tasklist." + dbName + ".url",
+        "zeebe.broker.exporters.camundaexporter.args.connect.url");
+  }
+
+  protected abstract String databaseName();
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
With this PR, the development of the secondary-storage DBs can happen in SecondaryStorageDatabase.java without excessive fork between Elasticsearch and Opensearch.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

Related to [#34902](https://github.com/camunda/camunda/issues/34902)
