### PR TITLE
fix: Reduce the noise in schema-manager logs for nominal cases

### DIFF
--- a/schema-manager/src/main/java/io/camunda/search/schema/elasticsearch/ElasticsearchEngineClient.java
+++ b/schema-manager/src/main/java/io/camunda/search/schema/elasticsearch/ElasticsearchEngineClient.java
@@ -238,7 +238,7 @@ public class ElasticsearchEngineClient implements SearchEngineClient {
           String.format(
               "Failed to search documents in the import position index for partition [%s]",
               partitionId);
-      LOG.error(errMsg, e);
+      LOG.warn(errMsg, e);
       return false;
     }
   }

--- a/schema-manager/src/main/java/io/camunda/search/schema/opensearch/OpensearchEngineClient.java
+++ b/schema-manager/src/main/java/io/camunda/search/schema/opensearch/OpensearchEngineClient.java
@@ -253,7 +253,7 @@ public class OpensearchEngineClient implements SearchEngineClient {
           String.format(
               "Failed to search documents in the import position index for partition [%s]",
               partitionId);
-      LOG.error(errMsg, e);
+      LOG.warn(errMsg, e);
       return false;
     }
   }

--- a/schema-manager/src/test/java/io/camunda/search/schema/SchemaManagerConcurrencyIT.java
+++ b/schema-manager/src/test/java/io/camunda/search/schema/SchemaManagerConcurrencyIT.java
@@ -105,9 +105,9 @@ public class SchemaManagerConcurrencyIT {
 
     // then
     assertThat(exceptions).isEmpty();
-    // assert that both schema managers detected missing index
-    assertThat(PostMethodPauseAdvice.getReturnedValueBeforePause(thread1, List.class)).hasSize(1);
-    assertThat(PostMethodPauseAdvice.getReturnedValueBeforePause(thread2, List.class)).hasSize(1);
+    // assert that both schema managers detected missing indices ("index_name" and "template_name")
+    assertThat(PostMethodPauseAdvice.getReturnedValueBeforePause(thread1, List.class)).hasSize(2);
+    assertThat(PostMethodPauseAdvice.getReturnedValueBeforePause(thread2, List.class)).hasSize(2);
     // assert that the schema was correctly created
     final var retrievedIndex = clientAdapter.getIndexAsNode(index.getFullQualifiedName());
     final var retrievedIndexTemplate =

--- a/schema-manager/src/test/java/io/camunda/search/schema/utils/SchemaManagerITInvocationProvider.java
+++ b/schema-manager/src/test/java/io/camunda/search/schema/utils/SchemaManagerITInvocationProvider.java
@@ -70,6 +70,7 @@ public class SchemaManagerITInvocationProvider
     }
     config.connect().setClusterName(connectionType.name());
     config.connect().setType(connectionType.toString());
+    config.schemaManager().getRetry().setMaxRetries(3); // cap the retries to avoid long test runs
     return config;
   }
 

--- a/search/search-test-utils/src/main/java/io/camunda/search/test/utils/SearchClientAdapter.java
+++ b/search/search-test-utils/src/main/java/io/camunda/search/test/utils/SearchClientAdapter.java
@@ -221,6 +221,22 @@ public class SearchClientAdapter {
     }
   }
 
+  public void deleteIndex(final String indexName) throws IOException {
+    if (elsClient != null) {
+      elsClient.indices().delete(d -> d.index(indexName));
+    } else if (osClient != null) {
+      osClient.indices().delete(d -> d.index(indexName));
+    }
+  }
+
+  public void deleteIndexTemplate(final String templateName) throws IOException {
+    if (elsClient != null) {
+      elsClient.indices().deleteIndexTemplate(d -> d.name(templateName));
+    } else if (osClient != null) {
+      osClient.indices().deleteIndexTemplate(d -> d.name(templateName));
+    }
+  }
+
   public void refresh() throws IOException {
     if (elsClient != null) {
       elsClient.indices().refresh();


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

**1 . Many INFO logs are useless logs to the end user,** example:
```
2025-08-08 08:00:15.111] [] INFO 
	io.camunda.search.schema.SchemaManager - Index template 'tasklist-task-variable-8.3.0_template', has been created / already exists
```
* Reduced logging verbosity from `info` to `debug` in several places to avoid noisy logs during index and template creation and updates.


**2. Even when they exist, Index templates are always created with create=true and also their related indices** which causes these logs:
```
[2025-08-24 18:37:57.948] [] DEBUG
	io.camunda.search.schema.elasticsearch.ElasticsearchEngineClient - index template [tasklist-draft-task-variable-8.3.0_template] already exists
[2025-08-24 18:37:57.959] [] DEBUG
	io.camunda.search.schema.elasticsearch.ElasticsearchEngineClient - Expected to create index [operate-event-8.3.0_], but already exist. Will continue, likely was created by a different instance.
co.elastic.clients.elasticsearch._types.ElasticsearchException: [es/indices.create] failed: [resource_already_exists_exception] index [operate-event-8.3.0_/T0gpoKM8TmG7ulUawe5Yqg] already exists
	at co.elastic.clients.transport.ElasticsearchTransportBase.getApiResponse(ElasticsearchTransportBase.java:349)
	at co.elastic.clients.transport.ElasticsearchTransportBase.performRequest(ElasticsearchTransportBase.java:148)
	at co.elastic.clients.elasticsearch.indices.ElasticsearchIndicesClient.create(ElasticsearchIndicesClient.java:285
```

* Avoid re-creating the existing index templates **=> avoids 15 create index template calls to ES/OS**
* Handle the related indices creation as part of `initialiseIndices()`, so that they are handled the same way as the other indices (create only the non-existing ones) **=> avoids 15 create index calls to ES/OS**
* Replace the single `indexDescriptors` collection with two: `indexOnlyDescriptors` and `allIndexDescriptors`. The latter now combines both index and template descriptors, which is used throughout schema initialization and update logic.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #37164
