### PR TITLE
fix: update index template settings only when they change

### DIFF
--- a/schema-manager/src/main/java/io/camunda/search/schema/SearchEngineClient.java
+++ b/schema-manager/src/main/java/io/camunda/search/schema/SearchEngineClient.java
@@ -20,12 +20,12 @@ public interface SearchEngineClient extends CloseableSilently {
 
   /**
    * @param indexDescriptor indexDescriptor
-   * @param settings settings
+   * @param indexConfiguration indexConfiguration
    * @param create If true, this request cannot replace or update existing index templates.
    */
   void createIndexTemplate(
       final IndexTemplateDescriptor indexDescriptor,
-      final IndexConfiguration settings,
+      final IndexConfiguration indexConfiguration,
       final boolean create);
 
   /**
@@ -48,7 +48,7 @@ public interface SearchEngineClient extends CloseableSilently {
 
   void updateIndexTemplateSettings(
       final IndexTemplateDescriptor indexTemplateDescriptor,
-      final IndexConfiguration configuredSettings);
+      final IndexConfiguration indexConfiguration);
 
   void deleteIndex(final String indexName);
 

--- a/schema-manager/src/main/java/io/camunda/search/schema/SearchEngineClient.java
+++ b/schema-manager/src/main/java/io/camunda/search/schema/SearchEngineClient.java
@@ -48,7 +48,7 @@ public interface SearchEngineClient extends CloseableSilently {
 
   void updateIndexTemplateSettings(
       final IndexTemplateDescriptor indexTemplateDescriptor,
-      final IndexConfiguration currentSettings);
+      final IndexConfiguration configuredSettings);
 
   void deleteIndex(final String indexName);
 

--- a/schema-manager/src/main/java/io/camunda/search/schema/utils/SearchEngineClientUtils.java
+++ b/schema-manager/src/main/java/io/camunda/search/schema/utils/SearchEngineClientUtils.java
@@ -34,6 +34,10 @@ public class SearchEngineClientUtils {
         .collect(Collectors.joining(","));
   }
 
+  public static <T, U> U convertValue(final T fromValue, final Function<T, U> converter) {
+    return fromValue != null ? converter.apply(fromValue) : null;
+  }
+
   public <T> T mapToSettings(
       final Map<String, String> settingsMap, final Function<InputStream, T> settingsDeserializer) {
     try (final var settingsStream =
@@ -69,17 +73,21 @@ public class SearchEngineClientUtils {
     }
 
     public SchemaSettingsAppender withNumberOfShards(final int numberOfShards) {
-      indexBlock.put("number_of_shards", numberOfShards);
+      indexBlock.put("number_of_shards", String.valueOf(numberOfShards));
       return this;
     }
 
     public SchemaSettingsAppender withNumberOfReplicas(final int numberOfReplicas) {
-      indexBlock.put("number_of_replicas", numberOfReplicas);
+      indexBlock.put("number_of_replicas", String.valueOf(numberOfReplicas));
       return this;
     }
 
     public InputStream build() throws IOException {
       return new ByteArrayInputStream(objectMapper.writeValueAsBytes(map));
+    }
+
+    public boolean equalsSettings(final Map<String, Object> otherSettings) {
+      return settingsBlock.equals(otherSettings);
     }
   }
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Skip redundant index template settings PUTs for Elasticsearch/OpenSearch. 
Adds parallel execution of index settings updates  to cut overhead.

## Problem
Every startup overwrote template settings (priority, shards, replicas) even when unchanged. This wasted requests, bumped ES/OS cluster.

## Solution
* Compare desired vs current template priority + serialized settings.
* Only send PUT if something changed; otherwise log debug skip.
* Run settings updates in parallel (virtual threads).

## Effects
* No unnecessary template PUTs on steady restarts.
* Faster startup with many templates.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes [#37240](https://github.com/camunda/camunda/issues/37240)
