### PR TITLE
feat: unified config: migrate secondary-storage cluster name

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/SecondaryStorageDatabase.java
+++ b/configuration/src/main/java/io/camunda/configuration/SecondaryStorageDatabase.java
@@ -15,6 +15,9 @@ public abstract class SecondaryStorageDatabase {
   /** Endpoint for the database configured as secondary storage. */
   private String url = "http://localhost:9200";
 
+  /** Name of the cluster */
+  private String clusterName = databaseName().toLowerCase();
+
   public String getUrl() {
     return UnifiedConfigurationHelper.validateLegacyConfiguration(
         prefix() + ".url",
@@ -28,6 +31,19 @@ public abstract class SecondaryStorageDatabase {
     this.url = url;
   }
 
+  public String getClusterName() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        prefix() + ".cluster-name",
+        clusterName,
+        String.class,
+        BackwardsCompatibilityMode.SUPPORTED_ONLY_IF_VALUES_MATCH,
+        legacyClusterNameProperties());
+  }
+
+  public void setClusterName(String clusterName) {
+    this.clusterName = clusterName;
+  }
+
   private String prefix() {
     return "camunda.data.secondary-storage." + databaseName().toLowerCase();
   }
@@ -39,6 +55,15 @@ public abstract class SecondaryStorageDatabase {
         "camunda.operate." + dbName + ".url",
         "camunda.tasklist." + dbName + ".url",
         "zeebe.broker.exporters.camundaexporter.args.connect.url");
+  }
+
+  private Set<String> legacyClusterNameProperties() {
+    final String dbName = databaseName().toLowerCase();
+    return Set.of(
+        "camunda.database.clusterName",
+        "camunda.operate." + dbName + ".clusterName",
+        "camunda.tasklist." + dbName + ".clusterName",
+        "zeebe.broker.exporters.camundaexporter.args.connect.clusterName");
   }
 
   protected abstract String databaseName();

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
@@ -457,6 +457,7 @@ public class BrokerBasedPropertiesOverride {
     final Map<String, Object> args = exporter.getArgs();
     setArg(args, "connect.type", secondaryStorage.getType().name());
     setArg(args, "connect.url", database.getUrl());
+    setArg(args, "connect.clusterName", database.getClusterName());
   }
 
   @SuppressWarnings("unchecked")

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/OperatePropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/OperatePropertiesOverride.java
@@ -53,10 +53,12 @@ public class OperatePropertiesOverride {
       override.setDatabase(DatabaseType.Elasticsearch);
       override.getElasticsearch().setUrl(database.getElasticsearch().getUrl());
       override.getZeebeElasticsearch().setUrl(database.getElasticsearch().getUrl());
+      override.getElasticsearch().setClusterName(database.getElasticsearch().getClusterName());
     } else if (SecondaryStorageType.opensearch == database.getType()) {
       override.setDatabase(DatabaseType.Opensearch);
       override.getOpensearch().setUrl(database.getOpensearch().getUrl());
       override.getZeebeOpensearch().setUrl(database.getOpensearch().getUrl());
+      override.getOpensearch().setClusterName(database.getOpensearch().getClusterName());
     }
 
     // TODO: Populate the rest of the bean using unifiedConfiguration

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/SearchEngineConnectPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/SearchEngineConnectPropertiesOverride.java
@@ -57,6 +57,7 @@ public class SearchEngineConnectPropertiesOverride {
 
     override.setType(secondaryStorage.getType().name());
     override.setUrl(database.getUrl());
+    override.setClusterName(database.getClusterName());
 
     return override;
   }

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/TasklistPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/TasklistPropertiesOverride.java
@@ -53,10 +53,12 @@ public class TasklistPropertiesOverride {
       override.setDatabase("elasticsearch");
       override.getElasticsearch().setUrl(database.getElasticsearch().getUrl());
       override.getZeebeElasticsearch().setUrl(database.getElasticsearch().getUrl());
+      override.getElasticsearch().setClusterName(database.getElasticsearch().getClusterName());
     } else if (SecondaryStorageType.opensearch == database.getType()) {
       override.setDatabase("opensearch");
       override.getOpenSearch().setUrl(database.getOpensearch().getUrl());
       override.getZeebeOpenSearch().setUrl(database.getOpensearch().getUrl());
+      override.getOpenSearch().setClusterName(database.getOpensearch().getClusterName());
     }
 
     // TODO: Populate the rest of the bean using unifiedConfiguration

--- a/configuration/src/test/java/io/camunda/configuration/SecondaryStorageTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/SecondaryStorageTest.java
@@ -38,12 +38,14 @@ import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
   SearchEngineConnectPropertiesOverride.class
 })
 public class SecondaryStorageTest {
+  private static final String EXPECTED_CLUSTER_NAME = "sample-cluster";
 
   @Nested
   @TestPropertySource(
       properties = {
         "camunda.data.secondary-storage.type=elasticsearch",
-        "camunda.data.secondary-storage.elasticsearch.url=http://expected-url:4321"
+        "camunda.data.secondary-storage.elasticsearch.url=http://expected-url:4321",
+        "camunda.data.secondary-storage.elasticsearch.cluster-name=" + EXPECTED_CLUSTER_NAME
       })
   class WithOnlyUnifiedConfigSet {
     final OperateProperties operateProperties;
@@ -69,6 +71,8 @@ public class SecondaryStorageTest {
 
       assertThat(operateProperties.getDatabase()).isEqualTo(expectedOperateDatabaseType);
       assertThat(operateProperties.getElasticsearch().getUrl()).isEqualTo(expectedUrl);
+      assertThat(operateProperties.getElasticsearch().getClusterName())
+          .isEqualTo(EXPECTED_CLUSTER_NAME);
     }
 
     @Test
@@ -115,7 +119,17 @@ public class SecondaryStorageTest {
         "camunda.data.secondary-storage.elasticsearch.url=http://matching-url:4321",
         "camunda.database.url=http://matching-url:4321",
         "camunda.tasklist.elasticsearch.url=http://matching-url:4321",
-        "camunda.operate.elasticsearch.url=http://matching-url:4321"
+        "camunda.operate.elasticsearch.url=http://matching-url:4321",
+
+        // NOTE: In the following blocks, the camundaExporter doesn't have to be configured, as
+        //  it is default with StandaloneCamunda. Any attempt of configuration will fail unless
+        //  the className is also configured.
+
+        // cluster name
+        "camunda.data.secondary-storage.elasticsearch.cluster-name=" + EXPECTED_CLUSTER_NAME,
+        "camunda.data.clusterName=" + EXPECTED_CLUSTER_NAME,
+        "camunda.tasklist.elasticsearch.clusterName=" + EXPECTED_CLUSTER_NAME,
+        "camunda.operate.elasticsearch.clusterName=" + EXPECTED_CLUSTER_NAME,
       })
   class WithNewAndLegacySet {
     final OperateProperties operateProperties;
@@ -141,6 +155,8 @@ public class SecondaryStorageTest {
 
       assertThat(operateProperties.getDatabase()).isEqualTo(expectedOperateDatabaseType);
       assertThat(operateProperties.getElasticsearch().getUrl()).isEqualTo(expectedUrl);
+      assertThat(operateProperties.getElasticsearch().getClusterName())
+          .isEqualTo(EXPECTED_CLUSTER_NAME);
     }
 
     @Test
@@ -150,6 +166,8 @@ public class SecondaryStorageTest {
 
       assertThat(tasklistProperties.getDatabase()).isEqualTo(expectedTasklistDatabaseType);
       assertThat(tasklistProperties.getElasticsearch().getUrl()).isEqualTo(expectedUrl);
+      assertThat(tasklistProperties.getElasticsearch().getClusterName())
+          .isEqualTo(EXPECTED_CLUSTER_NAME);
     }
 
     @Test
@@ -166,12 +184,15 @@ public class SecondaryStorageTest {
           UnifiedConfigurationHelper.argsToExporterConfiguration(args);
       assertThat(exporterConfiguration.getConnect().getType()).isEqualTo(expectedType);
       assertThat(exporterConfiguration.getConnect().getUrl()).isEqualTo(expectedUrl);
+      assertThat(exporterConfiguration.getConnect().getClusterName())
+          .isEqualTo(EXPECTED_CLUSTER_NAME);
     }
 
     @Test
     void testCamundaSearchEngineConnectProperties() {
       assertThat(searchEngineConnectProperties.getType().toLowerCase()).isEqualTo("elasticsearch");
       assertThat(searchEngineConnectProperties.getUrl()).isEqualTo("http://matching-url:4321");
+      assertThat(searchEngineConnectProperties.getClusterName()).isEqualTo(EXPECTED_CLUSTER_NAME);
     }
   }
 }

--- a/dist/src/main/config/application.yaml
+++ b/dist/src/main/config/application.yaml
@@ -83,23 +83,11 @@ camunda:
       type: 'elasticsearch'
       elasticsearch:
         url: 'http://localhost:9200'
+        cluster-name: 'elasticsearch'
   # ---
 
-  database:
-    # Sets the name of the cluster, default name is "elasticsearch"
-    # This setting can also be overridden using the environment variable CAMUNDA_DATABASE_CLUSTERNAME
-    clusterName: elasticsearch
   # Operate configuration properties
   operate:
-    # Set operate username and password.
-    # If user with <username> does not exist it will be created.
-    # Default: demo/demo
-    #username:
-    #password:
-    # ELS instance to store Operate data
-    elasticsearch:
-      # Cluster name
-      clusterName: elasticsearch
     # Zeebe instance
     zeebe:
       # Gateway address
@@ -112,15 +100,6 @@ camunda:
       prefix: zeebe-record
   # Tasklist configuration properties
   tasklist:
-    # Set Tasklist username and password.
-    # If user with <username> does not exist it will be created.
-    # Default: demo/demo
-    #username:
-    #password:
-    # ELS instance to store Tasklist data
-    elasticsearch:
-      # Cluster name
-      clusterName: elasticsearch
     # Zeebe instance
     zeebe:
       # Gateway address

--- a/dist/src/main/resources/application-elasticsearch.yaml
+++ b/dist/src/main/resources/application-elasticsearch.yaml
@@ -75,7 +75,6 @@ zeebe:
         className: io.camunda.exporter.CamundaExporter
         args:
           connect:
-            clusterName: elasticsearch
             dateFormat: yyyy-MM-dd'T'HH:mm:ss.SSSZZ
             socketTimeout: 1000
             connectTimeout: 1000
@@ -126,23 +125,11 @@ camunda:
       type: 'elasticsearch'
       elasticsearch:
         url: 'http://localhost:9200'
+        cluster-name: 'elasticsearch'
   # -----
 
-  database:
-    # Sets the name of the cluster, default name is "elasticsearch"
-    # This setting can also be overridden using the environment variable CAMUNDA_DATABASE_CLUSTERNAME
-    clusterName: elasticsearch
   # Operate configuration properties
   operate:
-    # Set operate username and password.
-    # If user with <username> does not exists it will be created.
-    # Default: demo/demo
-    #username:
-    #password:
-    # ELS instance to store Operate data
-    elasticsearch:
-      # Cluster name
-      clusterName: elasticsearch
     # Zeebe instance
     zeebe:
       # Gateway address
@@ -155,15 +142,6 @@ camunda:
       prefix: zeebe-record
   # Tasklist configuration properties
   tasklist:
-    # Set Tasklist username and password.
-    # If user with <username> does not exists it will be created.
-    # Default: demo/demo
-    #username:
-    #password:
-    # ELS instance to store Tasklist data
-    elasticsearch:
-      # Cluster name
-      clusterName: elasticsearch
     # Zeebe instance
     zeebe:
       # Gateway address

--- a/dist/src/main/resources/application-opensearch.yaml
+++ b/dist/src/main/resources/application-opensearch.yaml
@@ -75,7 +75,6 @@ zeebe:
         className: io.camunda.exporter.CamundaExporter
         args:
           connect:
-            clusterName: opensearch
             dateFormat: yyyy-MM-dd'T'HH:mm:ss.SSSZZ
             socketTimeout: 1000
             connectTimeout: 1000
@@ -127,23 +126,11 @@ camunda:
       type: 'opensearch'
       opensearch:
         url: 'http://localhost:9200'
+        cluster-name: 'opensearch'
   # -----
 
-  database:
-    # Sets the name of the cluster, default name is "elasticsearch"
-    # This setting can also be overridden using the environment variable CAMUNDA_DATABASE_CLUSTERNAME
-    clusterName: opensearch
   # Operate configuration properties
   operate:
-    # Set operate username and password.
-    # If user with <username> does not exists it will be created.
-    # Default: demo/demo
-    #username:
-    #password:
-    # ELS instance to store Operate data
-    opensearch:
-      # Cluster name
-      clusterName: opensearch
     # Zeebe instance
     zeebe:
       # Gateway address
@@ -156,15 +143,6 @@ camunda:
       prefix: zeebe-record
   # Tasklist configuration properties
   tasklist:
-    # Set Tasklist username and password.
-    # If user with <username> does not exists it will be created.
-    # Default: demo/demo
-    #username:
-    #password:
-    # ELS instance to store Tasklist data
-    opensearch:
-      # Cluster name
-      clusterName: opensearch
     # Zeebe instance
     zeebe:
       # Gateway address

--- a/operate/qa/integration-tests/src/test/resources/config/application-test-properties.yml
+++ b/operate/qa/integration-tests/src/test/resources/config/application-test-properties.yml
@@ -1,14 +1,16 @@
 camunda:
+  # Unified Configuration
   data:
     secondary-storage:
       type: 'elasticsearch'
       elasticsearch:
         url: 'http://someHost:12345'
+        cluster-name: 'clusterName'
+  # ---
+
   operate:
     batchOperationMaxSize: 500
     elasticsearch:
-      clusterName: clusterName
-      url: http://someHost:12345
       dateFormat: yyyy-MM-dd
       batchSize: 111
     zeebeElasticsearch:

--- a/operate/qa/integration-tests/src/test/resources/config/application-test.yml
+++ b/operate/qa/integration-tests/src/test/resources/config/application-test.yml
@@ -2,14 +2,22 @@ testcontainers:
   elasticsearch: "docker.elastic.co/elasticsearch/elasticsearch:8.16.6"
   opensearch: "opensearchproject/opensearch:2.5.0"
 
+# Unified Configuration
+camunda:
+  data:
+    secondary-storage:
+      type: 'elasticsearch'
+      elasticsearch:
+        url: 'http://localhost:9200'
+        cluster-name: 'docker-cluster'
+# ---
+
 camunda.operate:
   username: demo
   password: demo
   backup:
     repositoryName: repoName
   elasticsearch:
-    clusterName: docker-cluster
-    url: http://localhost:9200
     dateFormat: yyyy-MM-dd'T'HH:mm:ss.SSSZ
   zeebe:
     gatewayAddress: localhost:26500

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/os/OpenSearchConnectorBasicAuthIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/os/OpenSearchConnectorBasicAuthIT.java
@@ -98,24 +98,24 @@ public class OpenSearchConnectorBasicAuthIT extends TasklistIntegrationTest {
       final String osUrl =
           String.format("http://%s:%s", opensearch.getHost(), opensearch.getMappedPort(9200));
       TestPropertyValues.of(
-              // Unified Config compatibility: DB type
+              // Unified Configuration
               "camunda.data.secondary-storage.type=opensearch",
-              "camunda.database.type=opensearch",
-              "camunda.operate.database=opensearch",
-              "camunda.tasklist.database=opensearch",
-              // Unified Config compatibility: DB URL
               "camunda.data.secondary-storage.opensearch.url=" + osUrl,
+              "camunda.data.secondary-storage.opensearch.cluster-name=docker-cluster",
+
+              // TODO: The following legacy values are set somewhere equal to http://localhost:9200.
+              //  We should find them and unset them, so that they don't cause conflicts. In the
+              //  meantime, this test can run in double configuration mode.
               "camunda.database.url=" + osUrl,
               "camunda.tasklist.opensearch.url=" + osUrl,
               "camunda.operate.opensearch.url=" + osUrl,
               // ---
+
               "camunda.tasklist.opensearch.username=opensearch",
               "camunda.tasklist.opensearch.password=changeme",
-              "camunda.tasklist.opensearch.clusterName=docker-cluster",
               "camunda.tasklist.zeebeOpensearch.url=" + osUrl,
               "camunda.tasklist.zeebeOpensearch.username=opensearch",
               "camunda.tasklist.zeebeOpensearch.password=changeme",
-              "camunda.tasklist.zeebeOpensearch.clusterName=docker-cluster",
               "camunda.tasklist.zeebeOpensearch.prefix=zeebe-record")
           .applyTo(applicationContext.getEnvironment());
     }

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/properties/PropertiesTest.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/properties/PropertiesTest.java
@@ -8,7 +8,9 @@
 package io.camunda.tasklist.properties;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
+import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
 import io.camunda.configuration.UnifiedConfiguration;
 import io.camunda.configuration.UnifiedConfigurationHelper;
 import io.camunda.configuration.beanoverrides.TasklistPropertiesOverride;
@@ -34,9 +36,16 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 public class PropertiesTest {
 
   @Autowired private TasklistProperties tasklistProperties;
+  @Autowired private UnifiedConfiguration unifiedConfiguration;
 
   @Test
   public void testProperties() {
+    // The file application-test-properties.yml only has data related to Elasticsearch.
+    assumeTrue(
+        unifiedConfiguration.getCamunda().getData().getSecondaryStorage().getType()
+            == SecondaryStorageType.elasticsearch,
+        "Skipping because DB is not Elasticsearch");
+
     assertThat(tasklistProperties.getImporter().isStartLoadingDataOnStartup()).isFalse();
     assertThat(tasklistProperties.getImporter().getCompletedReaderMinEmptyBatches()).isEqualTo(10);
     assertThat(tasklistProperties.getElasticsearch().getClusterName()).isEqualTo("clusterName");

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/api/rest/v1/controllers/internal/ProcessInternalControllerIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/api/rest/v1/controllers/internal/ProcessInternalControllerIT.java
@@ -64,6 +64,11 @@ public class ProcessInternalControllerIT extends TasklistZeebeIntegrationTest {
     registry.add("camunda.tasklist.cloud.clusterId", () -> "449ac2ad-d3c6-4c73-9c68-7752e39ae616");
     registry.add("camunda.tasklist.client.clusterId", () -> "449ac2ad-d3c6-4c73-9c68-7752e39ae616");
     registry.add("camunda.tasklist.featureFlag.processPublicEndpoints", () -> true);
+
+    // TODO: Some legacy configs are setting this to docker-cluster. I couldn't find them. We should
+    //  remove them eventually. For the moment, the test will work in compatibility mode.
+    registry.add(
+        "camunda.data.secondary-storage.elasticsearch.cluster-name", () -> "docker-cluster");
   }
 
   @BeforeEach

--- a/tasklist/qa/integration-tests/src/test/resources/config/application-test-properties.yml
+++ b/tasklist/qa/integration-tests/src/test/resources/config/application-test-properties.yml
@@ -1,15 +1,16 @@
 camunda:
+  # Unified Configuration
   data:
     secondary-storage:
       type: 'elasticsearch'
       elasticsearch:
         url: 'http://localhost:9200'
+        cluster-name: 'clusterName'
+  # ---
   tasklist:
     csrfPreventionEnabled: false
     batchOperationMaxSize: 500
     elasticsearch:
-      clusterName: clusterName
-      url: http://localhost:9200
       dateFormat: yyyy-MM-dd
       batchSize: 111
     zeebeElasticsearch:

--- a/tasklist/qa/integration-tests/src/test/resources/config/application-test.yml
+++ b/tasklist/qa/integration-tests/src/test/resources/config/application-test.yml
@@ -1,9 +1,17 @@
+# Unified Configuration
+camunda:
+  data:
+    secondary-storage:
+      type: 'elasticsearch'
+      elasticsearch:
+        url: 'http://localhost:9200'
+        cluster-name: 'docker-cluster'
+# ---
+
 camunda.tasklist:
   username: demo
   password: demo
   elasticsearch:
-    clusterName: docker-cluster
-    url: http://localhost:9200
     dateFormat: yyyy-MM-dd'T'HH:mm:ss.SSSZ
   zeebe:
     gatewayAddress: localhost:26500


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
**Description**
Migrates to the Unified Config the following legacy properties:
* `camunda.database.clusterName`
* `zeebe.broker.exporters.camundaexporter.args.connect.clusterName`
* `camunda.operate.elasticsearch.clusterName`
* `camunda.tasklist.elasticsearch.clusterName`
* `zeebe.broker.exporters.camundaexporter.args.connect.clusterName`

in favor of the new `camunda.data.secondary-storage.elasticsearch.cluster-name`, as well as

* `camunda.operate.opensearch.clusterName`
* `camunda.tasklist.opensearch.clusterName`

in favor of the new `camunda.data.secondary-storage.opensearch.cluster-name`

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

Related to [#34902](https://github.com/camunda/camunda/issues/34902)
