### PR TITLE
fix: add missing metadata name to Maven module

### DIFF
--- a/migration/commons/pom.xml
+++ b/migration/commons/pom.xml
@@ -17,6 +17,7 @@
 
   <groupId>io.camunda.migration</groupId>
   <artifactId>migration-commons</artifactId>
+  <name>Migration Commons</name>
 
   <properties>
     <maven.compiler.source>21</maven.compiler.source>


### PR DESCRIPTION
## Description

Fix Maven Central validation error due to missing `name` tag in pom.xml of newly added module: https://github.com/camunda/camunda/actions/runs/17233844247

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

None
