### PR TITLE
fix: ensure backup manager uses dynamic partition count

### DIFF
--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/api/BackupManager.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/api/BackupManager.java
@@ -14,17 +14,19 @@ import java.util.Collection;
 public interface BackupManager {
 
   /**
-   * Takes backup with id checkpointId. The method returns immediately after triggering the backup.
-   * {@link BackupManager#getBackupStatus(long)} must be used to check if the backup is completed or
-   * not. If a completed backup with same id already exists, no new backup will be taken.
+   * Takes backup with id checkpointId using the provided partition count. The method returns
+   * immediately after triggering the backup. {@link BackupManager#getBackupStatus(long)} must be
+   * used to check if the backup is completed or not. If a completed backup with same id already
+   * exists, no new backup will be taken.
    *
    * <p>The implementation of this method should be non-blocking to not block the caller.
    *
    * @param checkpointId id of the backup
    * @param checkpointPosition position of the record until which must be included in the backup.
+   * @param partitionCount the current number of partitions to store in the backup
    * @return an ActorFuture with the result of the backup
    */
-  ActorFuture<Void> takeBackup(long checkpointId, long checkpointPosition);
+  ActorFuture<Void> takeBackup(long checkpointId, long checkpointPosition, int partitionCount);
 
   /**
    * Get the status of the backup

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/management/BackupService.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/management/BackupService.java
@@ -72,7 +72,8 @@ public final class BackupService extends Actor implements BackupManager {
   }
 
   @Override
-  public ActorFuture<Void> takeBackup(final long checkpointId, final long checkpointPosition) {
+  public ActorFuture<Void> takeBackup(
+      final long checkpointId, final long checkpointPosition, final int partitionCount) {
     final ActorFuture<Void> result = createFuture();
     actor.run(
         () -> {
@@ -81,7 +82,7 @@ public final class BackupService extends Actor implements BackupManager {
                   snapshotStore,
                   getBackupId(checkpointId),
                   checkpointPosition,
-                  numberOfPartitions,
+                  partitionCount,
                   actor,
                   segmentsDirectory,
                   journalInfoProvider);
@@ -100,9 +101,10 @@ public final class BackupService extends Actor implements BackupManager {
                       error);
                 } else {
                   LOG.info(
-                      "Backup {} at position {} completed",
+                      "Backup {} at position {} completed with {} partitions",
                       inProgressBackup.checkpointId(),
-                      inProgressBackup.checkpointPosition());
+                      inProgressBackup.checkpointPosition(),
+                      partitionCount);
                 }
               });
           backupResult.onComplete(result);

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/management/NoopBackupManager.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/management/NoopBackupManager.java
@@ -30,9 +30,11 @@ public class NoopBackupManager implements BackupManager {
   }
 
   @Override
-  public ActorFuture<Void> takeBackup(final long checkpointId, final long checkpointPosition) {
-    LOG.warn("Attempted to take backup, but cannot take backup. {}", errorMessage);
-    return CompletableActorFuture.completedExceptionally(new Exception(errorMessage));
+  public ActorFuture<Void> takeBackup(
+      final long checkpointId, final long checkpointPosition, final int partitionCount) {
+    final var result = new CompletableActorFuture<Void>();
+    result.completeExceptionally(new UnsupportedOperationException(errorMessage));
+    return result;
   }
 
   @Override

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/PartitionCountSupplier.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/PartitionCountSupplier.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.backup.processing;
+
+@FunctionalInterface
+public interface PartitionCountSupplier {
+  int getCurrentPartitionCount();
+}

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/StreamProcessorTransitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/StreamProcessorTransitionStep.java
@@ -144,6 +144,14 @@ public final class StreamProcessorTransitionStep implements PartitionTransitionS
     // Set the scaling progress supplier to prevent checkpointing during scaling
     context.getCheckpointProcessor().setScalingInProgressSupplier(engine::isScalingInProgress);
 
+    // Set the partition count supplier to use dynamic partition counts from routing information
+    context
+        .getCheckpointProcessor()
+        .setPartitionCountSupplier(
+            () ->
+                engine.getCurrentPartitionCount(
+                    context.getBrokerCfg().getCluster().getPartitionsCount()));
+
     final var scheduledCommandCache =
         BoundedScheduledCommandCache.ofIntent(
             new BoundedCommandCacheMetrics(context.getPartitionTransitionMeterRegistry()),

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/backup/ConcurrentBackupCompactionTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/backup/ConcurrentBackupCompactionTest.java
@@ -148,7 +148,7 @@ public class ConcurrentBackupCompactionTest extends DynamicAutoCloseable {
     // when
     // a backup is taken (but the snapshot store does not complete it,
     // because the BackupStore it's blocked)
-    final var backupResultFut = backupService.takeBackup(backupIdx, backupIdx);
+    final var backupResultFut = backupService.takeBackup(backupIdx, backupIdx, 1);
 
     Awaitility.await("snapshot is reserved")
         .until(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.engine.state.EventApplier;
 import io.camunda.zeebe.engine.state.appliers.EventAppliers;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.engine.state.processing.DbBannedInstanceState;
+import io.camunda.zeebe.engine.state.routing.RoutingInfo;
 import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
 import io.camunda.zeebe.protocol.impl.record.value.error.ErrorRecord;
@@ -97,6 +98,22 @@ public class Engine implements RecordProcessor {
     final var desiredPartitions = routingState.desiredPartitions();
 
     return !currentPartitions.equals(desiredPartitions);
+  }
+
+  /**
+   * Returns the current partition count from routing information. If routing state is not
+   * initialized, returns the fallback partition count.
+   *
+   * @param fallBackPartitionCount the fallback partition count to use if dynamic routing state is
+   *     not initialized
+   * @return the current partition count
+   */
+  public int getCurrentPartitionCount(final int fallBackPartitionCount) {
+    return RoutingInfo.dynamic(
+            processingState.getRoutingState(),
+            RoutingInfo.forStaticPartitions(fallBackPartitionCount))
+        .partitions()
+        .size();
   }
 
   @Override

--- a/zeebe/restore/src/test/java/io/camunda/zeebe/restore/PartitionRestoreServiceTest.java
+++ b/zeebe/restore/src/test/java/io/camunda/zeebe/restore/PartitionRestoreServiceTest.java
@@ -249,7 +249,7 @@ class PartitionRestoreServiceTest {
   private Backup takeBackup(final long backupId, final long checkpointPosition) {
     final var backup =
         backupStore.waitForBackup(new BackupIdentifierImpl(nodeId, partitionId, backupId));
-    backupService.takeBackup(backupId, checkpointPosition);
+    backupService.takeBackup(backupId, checkpointPosition, 1); // Use partition count of 1 for tests
     return backup.orTimeout(30, TimeUnit.SECONDS).join();
   }
 


### PR DESCRIPTION
## Description

To store the correct partition count in the backup, `CheckpointCreateProcessor` gets the current partition count from the runtime state and provide it to the backup manager. 

To avoid having the module depends on the engine module, we provide this information via a supplier. This is not ideal. We also have a supplier to provide the scaling information. At the moment, it is not clear what is the best way to refactor the modules to handle this dependency clearly. My first idea is to move all scaling related classes out of the engine. However, it would be good to consider this when implementing message relocation. 

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #21470 
