### PR TITLE
Feature/35308 cpt client configuration

### DIFF
--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/CamundaProcessTestExtension.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/CamundaProcessTestExtension.java
@@ -16,6 +16,7 @@
 package io.camunda.process.test.api;
 
 import io.camunda.client.CamundaClient;
+import io.camunda.client.CredentialsProvider;
 import io.camunda.process.test.api.coverage.ProcessCoverage;
 import io.camunda.process.test.api.coverage.ProcessCoverageBuilder;
 import io.camunda.process.test.impl.assertions.CamundaDataSource;
@@ -494,6 +495,29 @@ public class CamundaProcessTestExtension
   public CamundaProcessTestExtension withRemoteConnectorsRestApiAddress(
       final URI remoteConnectorsRestApiAddress) {
     runtimeBuilder.withRemoteConnectorsRestApiAddress(remoteConnectorsRestApiAddress);
+    return this;
+  }
+
+  /**
+   * Provide a custom credentials provider for a remote Camunda runtime.
+   *
+   * @param credentialsProvider the credentials provider for the remote runtime.
+   * @return the extension builder
+   */
+  public CamundaProcessTestExtension withRemoteCamundaClientCredentialsProvider(
+      final CredentialsProvider credentialsProvider) {
+    runtimeBuilder.withCredentialsProvider(credentialsProvider);
+    return this;
+  }
+
+  /**
+   * Configure the request timeout for the Camunda Client
+   *
+   * @param requestTimeout time to wait before the request times out
+   * @return the extension builder
+   */
+  public CamundaProcessTestExtension withClientRequestTimeout(final Duration requestTimeout) {
+    runtimeBuilder.withCamundaClientRequestTimeout(requestTimeout);
     return this;
   }
 

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/CamundaProcessTestContainerRuntime.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/CamundaProcessTestContainerRuntime.java
@@ -70,15 +70,18 @@ public class CamundaProcessTestContainerRuntime
   private final ConnectorsContainer connectorsContainer;
 
   private final boolean connectorsEnabled;
+  private final Duration camundaClientRequestTimeout;
 
   CamundaProcessTestContainerRuntime(
       final CamundaProcessTestRuntimeBuilder builder, final ContainerFactory containerFactory) {
     this.containerFactory = containerFactory;
-    connectorsEnabled = builder.isConnectorsEnabled();
-    network = Network.newNetwork();
 
+    network = Network.newNetwork();
     camundaContainer = createCamundaContainer(network, builder);
     connectorsContainer = createConnectorsContainer(network, builder);
+
+    connectorsEnabled = builder.isConnectorsEnabled();
+    camundaClientRequestTimeout = builder.getCamundaClientRequestTimeout();
   }
 
   /*
@@ -197,7 +200,8 @@ public class CamundaProcessTestContainerRuntime
         CamundaClient.newClientBuilder()
             .restAddress(getCamundaRestApiAddress())
             .grpcAddress(getCamundaGrpcApiAddress())
-            .usePlaintext();
+            .usePlaintext()
+            .defaultRequestTimeout(camundaClientRequestTimeout);
   }
 
   public CamundaContainer getCamundaContainer() {

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/CamundaProcessTestRuntimeBuilder.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/CamundaProcessTestRuntimeBuilder.java
@@ -21,6 +21,7 @@ import io.camunda.process.test.api.CamundaClientBuilderFactory;
 import io.camunda.process.test.api.CamundaProcessTestRuntimeMode;
 import io.camunda.process.test.impl.containers.ContainerFactory;
 import java.net.URI;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -97,6 +98,9 @@ public class CamundaProcessTestRuntimeBuilder {
       CamundaProcessTestRuntimeDefaults.REMOTE_CAMUNDA_MONITORING_API_ADDRESS;
   private URI remoteConnectorsRestApiAddress =
       CamundaProcessTestRuntimeDefaults.REMOTE_CONNECTORS_REST_API_ADDRESS;
+
+  private Duration camundaClientRequestTimeout =
+      CamundaProcessTestRuntimeDefaults.CAMUNDA_CLIENT_REQUEST_TIMEOUT;
 
   // ============ For testing =================
 
@@ -225,6 +229,11 @@ public class CamundaProcessTestRuntimeBuilder {
     return this;
   }
 
+  public CamundaProcessTestRuntimeBuilder withCamundaClientRequestTimeout(final Duration timeout) {
+    this.camundaClientRequestTimeout = timeout;
+    return this;
+  }
+
   public CamundaProcessTestRuntimeBuilder withRemoteCamundaClientBuilderFactory(
       final CamundaClientBuilderFactory remoteCamundaClientBuilderFactory) {
     this.remoteCamundaClientBuilderFactory = remoteCamundaClientBuilderFactory;
@@ -341,5 +350,9 @@ public class CamundaProcessTestRuntimeBuilder {
 
   public URI getRemoteConnectorsRestApiAddress() {
     return remoteConnectorsRestApiAddress;
+  }
+
+  public Duration getCamundaClientRequestTimeout() {
+    return camundaClientRequestTimeout;
   }
 }

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/CamundaProcessTestRuntimeBuilder.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/CamundaProcessTestRuntimeBuilder.java
@@ -15,8 +15,7 @@
  */
 package io.camunda.process.test.impl.runtime;
 
-import io.camunda.client.CamundaClient;
-import io.camunda.client.CamundaClientBuilder;
+import io.camunda.client.CredentialsProvider;
 import io.camunda.process.test.api.CamundaClientBuilderFactory;
 import io.camunda.process.test.api.CamundaProcessTestRuntimeMode;
 import io.camunda.process.test.impl.containers.ContainerFactory;
@@ -75,32 +74,15 @@ public class CamundaProcessTestRuntimeBuilder {
   private CamundaProcessTestRuntimeMode runtimeMode =
       CamundaProcessTestRuntimeDefaults.RUNTIME_MODE;
 
+  private Duration camundaClientRequestTimeout =
+      CamundaProcessTestRuntimeDefaults.CAMUNDA_CLIENT_REQUEST_TIMEOUT;
   private CamundaClientBuilderFactory remoteCamundaClientBuilderFactory =
-      () -> {
-        final CamundaClientBuilder camundaClientBuilder =
-            CamundaClient.newClientBuilder().usePlaintext();
-
-        // Make sure not to override the CamundaClient's default configuration
-        if (CamundaProcessTestRuntimeDefaults.REMOTE_CLIENT_GRPC_ADDRESS != null) {
-          camundaClientBuilder.grpcAddress(
-              CamundaProcessTestRuntimeDefaults.REMOTE_CLIENT_GRPC_ADDRESS);
-        }
-
-        if (CamundaProcessTestRuntimeDefaults.REMOTE_CLIENT_REST_ADDRESS != null) {
-          camundaClientBuilder.restAddress(
-              CamundaProcessTestRuntimeDefaults.REMOTE_CLIENT_REST_ADDRESS);
-        }
-
-        return camundaClientBuilder;
-      };
+      CamundaProcessTestRuntimeDefaults.CAMUNDA_CLIENT_BUILDER_FACTORY;
 
   private URI remoteCamundaMonitoringApiAddress =
       CamundaProcessTestRuntimeDefaults.REMOTE_CAMUNDA_MONITORING_API_ADDRESS;
   private URI remoteConnectorsRestApiAddress =
       CamundaProcessTestRuntimeDefaults.REMOTE_CONNECTORS_REST_API_ADDRESS;
-
-  private Duration camundaClientRequestTimeout =
-      CamundaProcessTestRuntimeDefaults.CAMUNDA_CLIENT_REQUEST_TIMEOUT;
 
   // ============ For testing =================
 
@@ -229,8 +211,11 @@ public class CamundaProcessTestRuntimeBuilder {
     return this;
   }
 
-  public CamundaProcessTestRuntimeBuilder withCamundaClientRequestTimeout(final Duration timeout) {
-    this.camundaClientRequestTimeout = timeout;
+  public CamundaProcessTestRuntimeBuilder withCamundaClientRequestTimeout(
+      final Duration requestTimeout) {
+    this.camundaClientRequestTimeout = requestTimeout;
+    this.remoteCamundaClientBuilderFactory =
+        () -> remoteCamundaClientBuilderFactory.get().defaultRequestTimeout(requestTimeout);
     return this;
   }
 
@@ -249,6 +234,13 @@ public class CamundaProcessTestRuntimeBuilder {
   public CamundaProcessTestRuntimeBuilder withRemoteConnectorsRestApiAddress(
       final URI remoteConnectorsRestApiAddress) {
     this.remoteConnectorsRestApiAddress = remoteConnectorsRestApiAddress;
+    return this;
+  }
+
+  public CamundaProcessTestRuntimeBuilder withCredentialsProvider(
+      final CredentialsProvider credentialsProvider) {
+    this.remoteCamundaClientBuilderFactory =
+        () -> remoteCamundaClientBuilderFactory.get().credentialsProvider(credentialsProvider);
     return this;
   }
 

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/CamundaProcessTestRuntimeDefaults.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/CamundaProcessTestRuntimeDefaults.java
@@ -15,6 +15,7 @@
  */
 package io.camunda.process.test.impl.runtime;
 
+import io.camunda.process.test.api.CamundaClientBuilderFactory;
 import io.camunda.process.test.api.CamundaProcessTestRuntimeMode;
 import java.net.URI;
 import java.time.Duration;
@@ -84,4 +85,7 @@ public class CamundaProcessTestRuntimeDefaults {
 
   public static final Duration CAMUNDA_CLIENT_REQUEST_TIMEOUT =
       PROPERTIES_UTIL.getCamundaClientRequestTimeout();
+
+  public static final CamundaClientBuilderFactory CAMUNDA_CLIENT_BUILDER_FACTORY =
+      PROPERTIES_UTIL.getCamundaClientBuilderFactory();
 }

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/CamundaProcessTestRuntimeDefaults.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/CamundaProcessTestRuntimeDefaults.java
@@ -17,6 +17,7 @@ package io.camunda.process.test.impl.runtime;
 
 import io.camunda.process.test.api.CamundaProcessTestRuntimeMode;
 import java.net.URI;
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 
@@ -33,6 +34,8 @@ public class CamundaProcessTestRuntimeDefaults {
   public static final String DEFAULT_ELASTICSEARCH_LOGGER_NAME = "tc.elasticsearch";
   public static final String DEFAULT_CAMUNDA_LOGGER_NAME = "tc.camunda";
   public static final String DEFAULT_CONNECTORS_LOGGER_NAME = "tc.connectors";
+
+  public static final Duration DEFAULT_CAMUNDA_CLIENT_REQUEST_TIMEOUT = Duration.ofSeconds(10);
 
   public static final URI LOCAL_CAMUNDA_MONITORING_API_ADDRESS =
       URI.create("http://0.0.0.0:" + ContainerRuntimePorts.CAMUNDA_MONITORING_API);
@@ -78,4 +81,7 @@ public class CamundaProcessTestRuntimeDefaults {
 
   public static final URI REMOTE_CLIENT_GRPC_ADDRESS = PROPERTIES_UTIL.getRemoteClientGrpcAddress();
   public static final URI REMOTE_CLIENT_REST_ADDRESS = PROPERTIES_UTIL.getRemoteClientRestAddress();
+
+  public static final Duration CAMUNDA_CLIENT_REQUEST_TIMEOUT =
+      PROPERTIES_UTIL.getCamundaClientRequestTimeout();
 }

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/ContainerRuntimePropertiesUtil.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/ContainerRuntimePropertiesUtil.java
@@ -24,6 +24,7 @@ import io.camunda.process.test.impl.runtime.properties.RemoteRuntimeProperties;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -39,7 +40,6 @@ public final class ContainerRuntimePropertiesUtil {
   public static final String USER_RUNTIME_PROPERTIES_FILE = "camunda-container-runtime.properties";
 
   public static final String PROPERTY_NAME_RUNTIME_MODE = "runtimeMode";
-
   public static final String PROPERTY_NAME_ELASTICSEARCH_VERSION = "elasticsearch.version";
 
   private static final String BASE_DIR = "/";
@@ -191,6 +191,10 @@ public final class ContainerRuntimePropertiesUtil {
 
   public URI getRemoteClientRestAddress() {
     return remoteRuntimeProperties.getRemoteClientProperties().getRestAddress();
+  }
+
+  public Duration getCamundaClientRequestTimeout() {
+    return remoteRuntimeProperties.getRemoteClientProperties().getCamundaClientRequestTimeout();
   }
 
   public CamundaProcessTestRuntimeMode getRuntimeMode() {

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/ContainerRuntimePropertiesUtil.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/ContainerRuntimePropertiesUtil.java
@@ -205,4 +205,8 @@ public final class ContainerRuntimePropertiesUtil {
   public CamundaClientBuilderFactory getCamundaClientBuilderFactory() {
     return remoteRuntimeProperties.getRemoteClientProperties().getClientBuilderFactory();
   }
+
+  public RemoteRuntimeProperties getRemoteRuntimeProperties() {
+    return remoteRuntimeProperties;
+  }
 }

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/ContainerRuntimePropertiesUtil.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/ContainerRuntimePropertiesUtil.java
@@ -17,6 +17,7 @@ package io.camunda.process.test.impl.runtime;
 
 import static io.camunda.process.test.impl.runtime.util.PropertiesUtil.getPropertyOrDefault;
 
+import io.camunda.process.test.api.CamundaClientBuilderFactory;
 import io.camunda.process.test.api.CamundaProcessTestRuntimeMode;
 import io.camunda.process.test.impl.runtime.properties.CamundaContainerRuntimeProperties;
 import io.camunda.process.test.impl.runtime.properties.ConnectorsContainerRuntimeProperties;
@@ -194,10 +195,14 @@ public final class ContainerRuntimePropertiesUtil {
   }
 
   public Duration getCamundaClientRequestTimeout() {
-    return remoteRuntimeProperties.getRemoteClientProperties().getCamundaClientRequestTimeout();
+    return remoteRuntimeProperties.getRemoteClientProperties().getRequestTimeout();
   }
 
   public CamundaProcessTestRuntimeMode getRuntimeMode() {
     return runtimeMode;
+  }
+
+  public CamundaClientBuilderFactory getCamundaClientBuilderFactory() {
+    return remoteRuntimeProperties.getRemoteClientProperties().getClientBuilderFactory();
   }
 }

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/properties/RemoteRuntimeClientAuthProperties.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/properties/RemoteRuntimeClientAuthProperties.java
@@ -96,33 +96,31 @@ public class RemoteRuntimeClientAuthProperties {
             v -> AuthMethod.valueOf(v.toLowerCase()),
             AuthMethod.none);
 
-    username = getPropertyOrDefault(properties, PROPERTY_NAME_USERNAME, null);
+    username = getPropertyOrNull(properties, PROPERTY_NAME_USERNAME);
 
-    password = getPropertyOrDefault(properties, PROPERTY_NAME_PASSWORD, null);
+    password = getPropertyOrNull(properties, PROPERTY_NAME_PASSWORD);
 
-    clientId = getPropertyOrDefault(properties, PROPERTY_NAME_CLIENT_ID, null);
+    clientId = getPropertyOrNull(properties, PROPERTY_NAME_CLIENT_ID);
 
-    clientSecret = getPropertyOrDefault(properties, PROPERTY_NAME_CLIENT_SECRET, null);
+    clientSecret = getPropertyOrNull(properties, PROPERTY_NAME_CLIENT_SECRET);
 
-    tokenUrl = getPropertyOrDefault(properties, PROPERTY_NAME_TOKEN_URL, URI::create, null);
+    tokenUrl = getPropertyOrNull(properties, PROPERTY_NAME_TOKEN_URL, URI::create);
 
-    audience = getPropertyOrDefault(properties, PROPERTY_NAME_AUDIENCE, null);
+    audience = getPropertyOrNull(properties, PROPERTY_NAME_AUDIENCE);
 
-    scope = getPropertyOrDefault(properties, PROPERTY_NAME_SCOPE, null);
+    scope = getPropertyOrNull(properties, PROPERTY_NAME_SCOPE);
 
-    resource = getPropertyOrDefault(properties, PROPERTY_NAME_RESOURCE, null);
+    resource = getPropertyOrNull(properties, PROPERTY_NAME_RESOURCE);
 
-    keystorePath = getPropertyOrDefault(properties, PROPERTY_NAME_KEYSTORE_PATH, Paths::get, null);
+    keystorePath = getPropertyOrNull(properties, PROPERTY_NAME_KEYSTORE_PATH, Paths::get);
 
-    keystorePassword = getPropertyOrDefault(properties, PROPERTY_NAME_KEYSTORE_PASSWORD, null);
+    keystorePassword = getPropertyOrNull(properties, PROPERTY_NAME_KEYSTORE_PASSWORD);
 
-    keystoreKeyPassword =
-        getPropertyOrDefault(properties, PROPERTY_NAME_KEYSTORE_KEY_PASSWORD, null);
+    keystoreKeyPassword = getPropertyOrNull(properties, PROPERTY_NAME_KEYSTORE_KEY_PASSWORD);
 
-    truststorePath =
-        getPropertyOrDefault(properties, PROPERTY_NAME_TRUSTSTORE_PATH, Paths::get, null);
+    truststorePath = getPropertyOrNull(properties, PROPERTY_NAME_TRUSTSTORE_PATH, Paths::get);
 
-    truststorePassword = getPropertyOrDefault(properties, PROPERTY_NAME_TRUSTSTORE_PASSWORD, null);
+    truststorePassword = getPropertyOrNull(properties, PROPERTY_NAME_TRUSTSTORE_PASSWORD);
 
     credentialsCachePath =
         getPropertyOrDefault(

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/properties/RemoteRuntimeClientAuthProperties.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/properties/RemoteRuntimeClientAuthProperties.java
@@ -19,6 +19,7 @@ import static io.camunda.client.impl.oauth.OAuthCredentialsProviderBuilder.DEFAU
 import static io.camunda.client.impl.oauth.OAuthCredentialsProviderBuilder.DEFAULT_CREDENTIALS_CACHE_PATH;
 import static io.camunda.client.impl.oauth.OAuthCredentialsProviderBuilder.DEFAULT_READ_TIMEOUT;
 import static io.camunda.process.test.impl.runtime.util.PropertiesUtil.getPropertyOrDefault;
+import static io.camunda.process.test.impl.runtime.util.PropertiesUtil.getPropertyOrNull;
 
 import java.net.URI;
 import java.nio.file.Path;
@@ -28,37 +29,26 @@ import java.util.Properties;
 
 public class RemoteRuntimeClientAuthProperties {
   public static final String PROPERTY_NAME_METHOD = "remote.client.auth.method";
-  public static final String PROPERTY_NAME_USERNAME =
-      "remote.client.auth.username";
-  public static final String PROPERTY_NAME_PASSWORD =
-      "remote.client.auth.password";
-  public static final String PROPERTY_NAME_CLIENT_ID =
-      "remote.client.auth.clientId";
-  public static final String PROPERTY_NAME_CLIENT_SECRET =
-      "remote.client.auth.clientSecret";
-  public static final String PROPERTY_NAME_TOKEN_URL =
-      "remote.client.auth.tokenUrl";
-  public static final String PROPERTY_NAME_AUDIENCE =
-      "remote.client.auth.audience";
+  public static final String PROPERTY_NAME_USERNAME = "remote.client.auth.username";
+  public static final String PROPERTY_NAME_PASSWORD = "remote.client.auth.password";
+  public static final String PROPERTY_NAME_CLIENT_ID = "remote.client.auth.clientId";
+  public static final String PROPERTY_NAME_CLIENT_SECRET = "remote.client.auth.clientSecret";
+  public static final String PROPERTY_NAME_TOKEN_URL = "remote.client.auth.tokenUrl";
+  public static final String PROPERTY_NAME_AUDIENCE = "remote.client.auth.audience";
   public static final String PROPERTY_NAME_SCOPE = "remote.client.auth.scope";
-  public static final String PROPERTY_NAME_RESOURCE =
-      "remote.client.auth.resource";
-  public static final String PROPERTY_NAME_KEYSTORE_PATH =
-      "remote.client.auth.keystorePath";
+  public static final String PROPERTY_NAME_RESOURCE = "remote.client.auth.resource";
+  public static final String PROPERTY_NAME_KEYSTORE_PATH = "remote.client.auth.keystorePath";
   public static final String PROPERTY_NAME_KEYSTORE_PASSWORD =
       "remote.client.auth.keystorePassword";
   public static final String PROPERTY_NAME_KEYSTORE_KEY_PASSWORD =
       "remote.client.auth.keystoreKeyPassword";
-  public static final String PROPERTY_NAME_TRUSTSTORE_PATH =
-      "remote.client.auth.truststorePath";
+  public static final String PROPERTY_NAME_TRUSTSTORE_PATH = "remote.client.auth.truststorePath";
   public static final String PROPERTY_NAME_TRUSTSTORE_PASSWORD =
       "remote.client.auth.truststorePassword";
   public static final String PROPERTY_NAME_CREDENTIALS_CACHE_PATH =
       "remote.client.auth.credentialsCachePath";
-  public static final String PROPERTY_NAME_CONNECT_TIMEOUT =
-      "remote.client.auth.connectTimeout";
-  public static final String PROPERTY_NAME_READ_TIMEOUT =
-      "remote.client.auth.readTimeout";
+  public static final String PROPERTY_NAME_CONNECT_TIMEOUT = "remote.client.auth.connectTimeout";
+  public static final String PROPERTY_NAME_READ_TIMEOUT = "remote.client.auth.readTimeout";
 
   public static final String PROPERTY_NAME_CLIENT_ASSERTION_KEYSTORE_PATH =
       "remote.client.auth.clientAssertion.keystorePath";
@@ -66,9 +56,8 @@ public class RemoteRuntimeClientAuthProperties {
       "remote.client.auth.clientAssertion.keystorePassword";
   public static final String PROPERTY_NAME_CLIENT_ASSERTION_KEYSTORE_KEY_ALIAS =
       "remote.client.auth.clientAssertion.keystoreKeyAlias";
-  public static final String
-      PROPERTY_NAME_CLIENT_ASSERTION_KEYSTORE_KEY_PASSWORD =
-          "remote.client.auth.clientAssertion.keystoreKeyPassword";
+  public static final String PROPERTY_NAME_CLIENT_ASSERTION_KEYSTORE_KEY_PASSWORD =
+      "remote.client.auth.clientAssertion.keystoreKeyPassword";
 
   private final AuthMethod method;
 
@@ -105,7 +94,7 @@ public class RemoteRuntimeClientAuthProperties {
             properties,
             PROPERTY_NAME_METHOD,
             v -> AuthMethod.valueOf(v.toLowerCase()),
-            null);
+            AuthMethod.none);
 
     username = getPropertyOrDefault(properties, PROPERTY_NAME_USERNAME, null);
 
@@ -113,12 +102,9 @@ public class RemoteRuntimeClientAuthProperties {
 
     clientId = getPropertyOrDefault(properties, PROPERTY_NAME_CLIENT_ID, null);
 
-    clientSecret =
-        getPropertyOrDefault(properties, PROPERTY_NAME_CLIENT_SECRET, null);
+    clientSecret = getPropertyOrDefault(properties, PROPERTY_NAME_CLIENT_SECRET, null);
 
-    tokenUrl =
-        getPropertyOrDefault(
-            properties, PROPERTY_NAME_TOKEN_URL, URI::create, null);
+    tokenUrl = getPropertyOrDefault(properties, PROPERTY_NAME_TOKEN_URL, URI::create, null);
 
     audience = getPropertyOrDefault(properties, PROPERTY_NAME_AUDIENCE, null);
 
@@ -126,65 +112,59 @@ public class RemoteRuntimeClientAuthProperties {
 
     resource = getPropertyOrDefault(properties, PROPERTY_NAME_RESOURCE, null);
 
-    keystorePath =
-        getPropertyOrDefault(
-            properties, PROPERTY_NAME_KEYSTORE_PATH, Paths::get, null);
+    keystorePath = getPropertyOrDefault(properties, PROPERTY_NAME_KEYSTORE_PATH, Paths::get, null);
 
-    keystorePassword =
-        getPropertyOrDefault(properties, PROPERTY_NAME_KEYSTORE_PASSWORD, null);
+    keystorePassword = getPropertyOrDefault(properties, PROPERTY_NAME_KEYSTORE_PASSWORD, null);
 
     keystoreKeyPassword =
-        getPropertyOrDefault(
-            properties, PROPERTY_NAME_KEYSTORE_KEY_PASSWORD, null);
+        getPropertyOrDefault(properties, PROPERTY_NAME_KEYSTORE_KEY_PASSWORD, null);
 
     truststorePath =
-        getPropertyOrDefault(
-            properties, PROPERTY_NAME_TRUSTSTORE_PATH, Paths::get, null);
+        getPropertyOrDefault(properties, PROPERTY_NAME_TRUSTSTORE_PATH, Paths::get, null);
 
-    truststorePassword =
-        getPropertyOrDefault(
-            properties, PROPERTY_NAME_TRUSTSTORE_PASSWORD, null);
+    truststorePassword = getPropertyOrDefault(properties, PROPERTY_NAME_TRUSTSTORE_PASSWORD, null);
 
     credentialsCachePath =
         getPropertyOrDefault(
-            properties,
-            PROPERTY_NAME_CREDENTIALS_CACHE_PATH,
-            DEFAULT_CREDENTIALS_CACHE_PATH);
+            properties, PROPERTY_NAME_CREDENTIALS_CACHE_PATH, DEFAULT_CREDENTIALS_CACHE_PATH);
 
     connectTimeout =
         getPropertyOrDefault(
             properties,
             PROPERTY_NAME_CONNECT_TIMEOUT,
-            Duration::parse,
+            v -> {
+              try {
+                return Duration.parse(v);
+              } catch (final Throwable t) {
+                return DEFAULT_CONNECT_TIMEOUT;
+              }
+            },
             DEFAULT_CONNECT_TIMEOUT);
 
     readTimeout =
         getPropertyOrDefault(
             properties,
             PROPERTY_NAME_READ_TIMEOUT,
-            Duration::parse,
+            v -> {
+              try {
+                return Duration.parse(v);
+              } catch (final Throwable t) {
+                return DEFAULT_READ_TIMEOUT;
+              }
+            },
             DEFAULT_READ_TIMEOUT);
 
     clientAssertionKeystorePath =
-        getPropertyOrDefault(
-            properties,
-            PROPERTY_NAME_CLIENT_ASSERTION_KEYSTORE_PATH,
-            Paths::get,
-            null);
+        getPropertyOrNull(properties, PROPERTY_NAME_CLIENT_ASSERTION_KEYSTORE_PATH, Paths::get);
 
     clientAssertionKeystorePassword =
-        getPropertyOrDefault(
-            properties, PROPERTY_NAME_CLIENT_ASSERTION_KEYSTORE_PASSWORD, null);
+        getPropertyOrNull(properties, PROPERTY_NAME_CLIENT_ASSERTION_KEYSTORE_PASSWORD);
 
     clientAssertionKeystoreKeyAlias =
-        getPropertyOrDefault(
-            properties, PROPERTY_NAME_CLIENT_ASSERTION_KEYSTORE_KEY_ALIAS, null);
+        getPropertyOrNull(properties, PROPERTY_NAME_CLIENT_ASSERTION_KEYSTORE_KEY_ALIAS);
 
     clientAssertionKeystoreKeyPassword =
-        getPropertyOrDefault(
-            properties,
-            PROPERTY_NAME_CLIENT_ASSERTION_KEYSTORE_KEY_PASSWORD,
-            null);
+        getPropertyOrNull(properties, PROPERTY_NAME_CLIENT_ASSERTION_KEYSTORE_KEY_PASSWORD);
   }
 
   public AuthMethod getMethod() {

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/properties/RemoteRuntimeClientAuthProperties.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/properties/RemoteRuntimeClientAuthProperties.java
@@ -1,0 +1,279 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.impl.runtime.properties;
+
+import static io.camunda.client.impl.oauth.OAuthCredentialsProviderBuilder.DEFAULT_CONNECT_TIMEOUT;
+import static io.camunda.client.impl.oauth.OAuthCredentialsProviderBuilder.DEFAULT_CREDENTIALS_CACHE_PATH;
+import static io.camunda.client.impl.oauth.OAuthCredentialsProviderBuilder.DEFAULT_READ_TIMEOUT;
+import static io.camunda.process.test.impl.runtime.util.PropertiesUtil.getPropertyOrDefault;
+
+import java.net.URI;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.Duration;
+import java.util.Properties;
+
+public class RemoteRuntimeClientAuthProperties {
+  public static final String PROPERTY_NAME_METHOD = "remote.client.auth.method";
+  public static final String PROPERTY_NAME_USERNAME =
+      "remote.client.auth.username";
+  public static final String PROPERTY_NAME_PASSWORD =
+      "remote.client.auth.password";
+  public static final String PROPERTY_NAME_CLIENT_ID =
+      "remote.client.auth.clientId";
+  public static final String PROPERTY_NAME_CLIENT_SECRET =
+      "remote.client.auth.clientSecret";
+  public static final String PROPERTY_NAME_TOKEN_URL =
+      "remote.client.auth.tokenUrl";
+  public static final String PROPERTY_NAME_AUDIENCE =
+      "remote.client.auth.audience";
+  public static final String PROPERTY_NAME_SCOPE = "remote.client.auth.scope";
+  public static final String PROPERTY_NAME_RESOURCE =
+      "remote.client.auth.resource";
+  public static final String PROPERTY_NAME_KEYSTORE_PATH =
+      "remote.client.auth.keystorePath";
+  public static final String PROPERTY_NAME_KEYSTORE_PASSWORD =
+      "remote.client.auth.keystorePassword";
+  public static final String PROPERTY_NAME_KEYSTORE_KEY_PASSWORD =
+      "remote.client.auth.keystoreKeyPassword";
+  public static final String PROPERTY_NAME_TRUSTSTORE_PATH =
+      "remote.client.auth.truststorePath";
+  public static final String PROPERTY_NAME_TRUSTSTORE_PASSWORD =
+      "remote.client.auth.truststorePassword";
+  public static final String PROPERTY_NAME_CREDENTIALS_CACHE_PATH =
+      "remote.client.auth.credentialsCachePath";
+  public static final String PROPERTY_NAME_CONNECT_TIMEOUT =
+      "remote.client.auth.connectTimeout";
+  public static final String PROPERTY_NAME_READ_TIMEOUT =
+      "remote.client.auth.readTimeout";
+
+  public static final String PROPERTY_NAME_CLIENT_ASSERTION_KEYSTORE_PATH =
+      "remote.client.auth.clientAssertion.keystorePath";
+  public static final String PROPERTY_NAME_CLIENT_ASSERTION_KEYSTORE_PASSWORD =
+      "remote.client.auth.clientAssertion.keystorePassword";
+  public static final String PROPERTY_NAME_CLIENT_ASSERTION_KEYSTORE_KEY_ALIAS =
+      "remote.client.auth.clientAssertion.keystoreKeyAlias";
+  public static final String
+      PROPERTY_NAME_CLIENT_ASSERTION_KEYSTORE_KEY_PASSWORD =
+          "remote.client.auth.clientAssertion.keystoreKeyPassword";
+
+  private final AuthMethod method;
+
+  // basic auth
+  private final String username;
+  private final String password;
+
+  // self-managed and saas
+  private final String clientId;
+  private final String clientSecret;
+  private final URI tokenUrl;
+  private final String audience;
+  private final String scope;
+  private final String resource;
+  private final Path keystorePath;
+  private final String keystorePassword;
+  private final String keystoreKeyPassword;
+  private final Path truststorePath;
+  private final String truststorePassword;
+  private final String credentialsCachePath;
+
+  private final Duration connectTimeout;
+  private final Duration readTimeout;
+
+  // client assertion
+  private final Path clientAssertionKeystorePath;
+  private final String clientAssertionKeystorePassword;
+  private final String clientAssertionKeystoreKeyAlias;
+  private final String clientAssertionKeystoreKeyPassword;
+
+  public RemoteRuntimeClientAuthProperties(final Properties properties) {
+    method =
+        getPropertyOrDefault(
+            properties,
+            PROPERTY_NAME_METHOD,
+            v -> AuthMethod.valueOf(v.toLowerCase()),
+            null);
+
+    username = getPropertyOrDefault(properties, PROPERTY_NAME_USERNAME, null);
+
+    password = getPropertyOrDefault(properties, PROPERTY_NAME_PASSWORD, null);
+
+    clientId = getPropertyOrDefault(properties, PROPERTY_NAME_CLIENT_ID, null);
+
+    clientSecret =
+        getPropertyOrDefault(properties, PROPERTY_NAME_CLIENT_SECRET, null);
+
+    tokenUrl =
+        getPropertyOrDefault(
+            properties, PROPERTY_NAME_TOKEN_URL, URI::create, null);
+
+    audience = getPropertyOrDefault(properties, PROPERTY_NAME_AUDIENCE, null);
+
+    scope = getPropertyOrDefault(properties, PROPERTY_NAME_SCOPE, null);
+
+    resource = getPropertyOrDefault(properties, PROPERTY_NAME_RESOURCE, null);
+
+    keystorePath =
+        getPropertyOrDefault(
+            properties, PROPERTY_NAME_KEYSTORE_PATH, Paths::get, null);
+
+    keystorePassword =
+        getPropertyOrDefault(properties, PROPERTY_NAME_KEYSTORE_PASSWORD, null);
+
+    keystoreKeyPassword =
+        getPropertyOrDefault(
+            properties, PROPERTY_NAME_KEYSTORE_KEY_PASSWORD, null);
+
+    truststorePath =
+        getPropertyOrDefault(
+            properties, PROPERTY_NAME_TRUSTSTORE_PATH, Paths::get, null);
+
+    truststorePassword =
+        getPropertyOrDefault(
+            properties, PROPERTY_NAME_TRUSTSTORE_PASSWORD, null);
+
+    credentialsCachePath =
+        getPropertyOrDefault(
+            properties,
+            PROPERTY_NAME_CREDENTIALS_CACHE_PATH,
+            DEFAULT_CREDENTIALS_CACHE_PATH);
+
+    connectTimeout =
+        getPropertyOrDefault(
+            properties,
+            PROPERTY_NAME_CONNECT_TIMEOUT,
+            Duration::parse,
+            DEFAULT_CONNECT_TIMEOUT);
+
+    readTimeout =
+        getPropertyOrDefault(
+            properties,
+            PROPERTY_NAME_READ_TIMEOUT,
+            Duration::parse,
+            DEFAULT_READ_TIMEOUT);
+
+    clientAssertionKeystorePath =
+        getPropertyOrDefault(
+            properties,
+            PROPERTY_NAME_CLIENT_ASSERTION_KEYSTORE_PATH,
+            Paths::get,
+            null);
+
+    clientAssertionKeystorePassword =
+        getPropertyOrDefault(
+            properties, PROPERTY_NAME_CLIENT_ASSERTION_KEYSTORE_PASSWORD, null);
+
+    clientAssertionKeystoreKeyAlias =
+        getPropertyOrDefault(
+            properties, PROPERTY_NAME_CLIENT_ASSERTION_KEYSTORE_KEY_ALIAS, null);
+
+    clientAssertionKeystoreKeyPassword =
+        getPropertyOrDefault(
+            properties,
+            PROPERTY_NAME_CLIENT_ASSERTION_KEYSTORE_KEY_PASSWORD,
+            null);
+  }
+
+  public AuthMethod getMethod() {
+    return method;
+  }
+
+  public String getUsername() {
+    return username;
+  }
+
+  public String getPassword() {
+    return password;
+  }
+
+  public String getClientId() {
+    return clientId;
+  }
+
+  public String getClientSecret() {
+    return clientSecret;
+  }
+
+  public URI getTokenUrl() {
+    return tokenUrl;
+  }
+
+  public String getAudience() {
+    return audience;
+  }
+
+  public String getScope() {
+    return scope;
+  }
+
+  public String getResource() {
+    return resource;
+  }
+
+  public Path getKeystorePath() {
+    return keystorePath;
+  }
+
+  public String getKeystorePassword() {
+    return keystorePassword;
+  }
+
+  public String getKeystoreKeyPassword() {
+    return keystoreKeyPassword;
+  }
+
+  public Path getTruststorePath() {
+    return truststorePath;
+  }
+
+  public String getTruststorePassword() {
+    return truststorePassword;
+  }
+
+  public String getCredentialsCachePath() {
+    return credentialsCachePath;
+  }
+
+  public Duration getConnectTimeout() {
+    return connectTimeout;
+  }
+
+  public Duration getReadTimeout() {
+    return readTimeout;
+  }
+
+  public Path getClientAssertionKeystorePath() {
+    return clientAssertionKeystorePath;
+  }
+
+  public String getClientAssertionKeystorePassword() {
+    return clientAssertionKeystorePassword;
+  }
+
+  public String getClientAssertionKeystoreKeyAlias() {
+    return clientAssertionKeystoreKeyAlias;
+  }
+
+  public String getClientAssertionKeystoreKeyPassword() {
+    return clientAssertionKeystoreKeyPassword;
+  }
+
+  public enum AuthMethod {
+    none,
+    oidc,
+    basic
+  }
+}

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/properties/RemoteRuntimeClientCloudProperties.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/properties/RemoteRuntimeClientCloudProperties.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.impl.runtime.properties;
+
+import static io.camunda.process.test.impl.runtime.util.PropertiesUtil.getPropertyOrDefault;
+
+import java.util.Properties;
+
+public class RemoteRuntimeClientCloudProperties {
+  public static final String PROPERTY_NAME_REGION =
+      "remote.client.cloud.region";
+  public static final String PROPERTY_NAME_CLUSTER_ID =
+      "remote.client.cloud.clusterId";
+
+  private final String region;
+  private final String clusterId;
+
+  public RemoteRuntimeClientCloudProperties(final Properties properties) {
+    region = getPropertyOrDefault(properties, PROPERTY_NAME_REGION, null);
+
+    clusterId =
+        getPropertyOrDefault(properties, PROPERTY_NAME_CLUSTER_ID, null);
+  }
+
+  public String getRegion() {
+    return region;
+  }
+
+  public String getClusterId() {
+    return clusterId;
+  }
+}

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/properties/RemoteRuntimeClientCloudProperties.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/properties/RemoteRuntimeClientCloudProperties.java
@@ -15,24 +15,21 @@
  */
 package io.camunda.process.test.impl.runtime.properties;
 
-import static io.camunda.process.test.impl.runtime.util.PropertiesUtil.getPropertyOrDefault;
+import static io.camunda.process.test.impl.runtime.util.PropertiesUtil.getPropertyOrNull;
 
 import java.util.Properties;
 
 public class RemoteRuntimeClientCloudProperties {
-  public static final String PROPERTY_NAME_REGION =
-      "remote.client.cloud.region";
-  public static final String PROPERTY_NAME_CLUSTER_ID =
-      "remote.client.cloud.clusterId";
+  public static final String PROPERTY_NAME_REGION = "remote.client.cloud.region";
+  public static final String PROPERTY_NAME_CLUSTER_ID = "remote.client.cloud.clusterId";
 
   private final String region;
   private final String clusterId;
 
   public RemoteRuntimeClientCloudProperties(final Properties properties) {
-    region = getPropertyOrDefault(properties, PROPERTY_NAME_REGION, null);
+    region = getPropertyOrNull(properties, PROPERTY_NAME_REGION);
 
-    clusterId =
-        getPropertyOrDefault(properties, PROPERTY_NAME_CLUSTER_ID, null);
+    clusterId = getPropertyOrNull(properties, PROPERTY_NAME_CLUSTER_ID);
   }
 
   public String getRegion() {

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/properties/RemoteRuntimeClientProperties.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/properties/RemoteRuntimeClientProperties.java
@@ -19,14 +19,18 @@ import static io.camunda.process.test.impl.runtime.util.PropertiesUtil.getProper
 
 import io.camunda.process.test.impl.runtime.CamundaProcessTestRuntimeDefaults;
 import java.net.URI;
+import java.time.Duration;
 import java.util.Properties;
 
 public class RemoteRuntimeClientProperties {
   public static final String PROPERTY_NAME_REMOTE_CLIENT_GRPC_ADDRESS = "remote.client.grpcAddress";
   public static final String PROPERTY_NAME_REMOTE_CLIENT_REST_ADDRESS = "remote.client.restAddress";
+  public static final String PROPERTY_NAME_CAMUNDA_CLIENT_REQUEST_TIMEOUT =
+      "remote.client.requestTimeout";
 
   private final URI grpcAddress;
   private final URI restAddress;
+  private final Duration camundaClientRequestTimeout;
 
   public RemoteRuntimeClientProperties(final Properties properties) {
     grpcAddress =
@@ -54,6 +58,13 @@ public class RemoteRuntimeClientProperties {
               }
             },
             null);
+
+    camundaClientRequestTimeout =
+        getPropertyOrDefault(
+            properties,
+            PROPERTY_NAME_CAMUNDA_CLIENT_REQUEST_TIMEOUT,
+            Duration::parse,
+            CamundaProcessTestRuntimeDefaults.DEFAULT_CAMUNDA_CLIENT_REQUEST_TIMEOUT);
   }
 
   public URI getGrpcAddress() {
@@ -62,5 +73,9 @@ public class RemoteRuntimeClientProperties {
 
   public URI getRestAddress() {
     return restAddress;
+  }
+
+  public Duration getCamundaClientRequestTimeout() {
+    return camundaClientRequestTimeout;
   }
 }

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/properties/RemoteRuntimeProperties.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/properties/RemoteRuntimeProperties.java
@@ -22,9 +22,9 @@ import java.net.URI;
 import java.util.Properties;
 
 public class RemoteRuntimeProperties {
-  public static final String PROPERTY_NAME_REMOTE_CAMUNDA_MONITORING_API_ADDRESS =
+  public static final String PROPERTY_NAME_CAMUNDA_MONITORING_API_ADDRESS =
       "remote.camundaMonitoringApiAddress";
-  public static final String PROPERTY_NAME_REMOTE_CONNECTORS_REST_API_ADDRESS =
+  public static final String PROPERTY_NAME_CONNECTORS_REST_API_ADDRESS =
       "remote.connectorsRestApiAddress";
 
   private final URI camundaMonitoringApiAddress;
@@ -36,7 +36,7 @@ public class RemoteRuntimeProperties {
     camundaMonitoringApiAddress =
         getPropertyOrDefault(
             properties,
-            PROPERTY_NAME_REMOTE_CAMUNDA_MONITORING_API_ADDRESS,
+            PROPERTY_NAME_CAMUNDA_MONITORING_API_ADDRESS,
             v -> {
               try {
                 return URI.create(v);
@@ -49,7 +49,7 @@ public class RemoteRuntimeProperties {
     connectorsRestApiAddress =
         getPropertyOrDefault(
             properties,
-            PROPERTY_NAME_REMOTE_CONNECTORS_REST_API_ADDRESS,
+            PROPERTY_NAME_CONNECTORS_REST_API_ADDRESS,
             v -> {
               try {
                 return URI.create(v);

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/util/CptCredentialsProviderConfigurer.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/util/CptCredentialsProviderConfigurer.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.impl.runtime.util;
+
+import static java.util.Optional.ofNullable;
+
+import io.camunda.client.CredentialsProvider;
+import io.camunda.client.impl.NoopCredentialsProvider;
+import io.camunda.client.impl.basicauth.BasicAuthCredentialsProviderBuilder;
+import io.camunda.client.impl.oauth.OAuthCredentialsProviderBuilder;
+import io.camunda.process.test.impl.runtime.properties.RemoteRuntimeClientAuthProperties.AuthMethod;
+import io.camunda.process.test.impl.runtime.properties.RemoteRuntimeClientProperties;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/*
+ * This is a near duplicate of the CredentialsProviderConfiguration found in the
+ * spring-boot-starter-camunda-sdk project. However, because that implementation is heavily
+ * reliant on spring boot's autoconfiguration, the decision was made to copy the implementation
+ * for the CPT context.
+ */
+/** Configures the CredentialsProvider for a CamundaCloudClient. */
+public class CptCredentialsProviderConfigurer {
+  private static final Logger LOG = LoggerFactory.getLogger(CptCredentialsProviderConfigurer.class);
+
+  public static CredentialsProvider configure(
+      final RemoteRuntimeClientProperties clientProperties) {
+    final AuthMethod authMethod = clientProperties.getAuthProperties().getMethod();
+
+    if (authMethod == null) {
+      return new NoopCredentialsProvider();
+    }
+
+    switch (authMethod) {
+      case basic:
+        return buildBasicAuthCredentialsProvider(clientProperties);
+      case oidc:
+        return buildOAuthCredentialsProvider(clientProperties);
+      default:
+        return new NoopCredentialsProvider();
+    }
+  }
+
+  private static CredentialsProvider buildBasicAuthCredentialsProvider(
+      final RemoteRuntimeClientProperties clientProperties) {
+    final String username = clientProperties.getAuthProperties().getUsername();
+    final String password = clientProperties.getAuthProperties().getPassword();
+
+    final BasicAuthCredentialsProviderBuilder builder =
+        new BasicAuthCredentialsProviderBuilder()
+            .applyEnvironmentOverrides(false)
+            .username(username)
+            .password(password);
+
+    try {
+      return builder.build();
+    } catch (final Exception e) {
+      LOG.warn(
+          "Failed to configure basic credential provider, falling back to use no authentication, cause: {}",
+          e.getMessage());
+      if (LOG.isDebugEnabled()) {
+        LOG.debug(e.getMessage(), e);
+      }
+      return new NoopCredentialsProvider();
+    }
+  }
+
+  private static CredentialsProvider buildOAuthCredentialsProvider(
+      final RemoteRuntimeClientProperties clientProperties) {
+
+    final OAuthCredentialsProviderBuilder credBuilder =
+        CredentialsProvider.newCredentialsProviderBuilder()
+            .applyEnvironmentOverrides(false)
+            .clientId(clientProperties.getAuthProperties().getClientId())
+            .clientSecret(clientProperties.getAuthProperties().getClientSecret())
+            .audience(clientProperties.getAuthProperties().getAudience())
+            .scope(clientProperties.getAuthProperties().getScope())
+            .resource(clientProperties.getAuthProperties().getResource())
+            .authorizationServerUrl(
+                ofNullable(clientProperties.getAuthProperties().getTokenUrl())
+                    .map(URI::toString)
+                    .orElse(null))
+            .credentialsCachePath(clientProperties.getAuthProperties().getCredentialsCachePath())
+            .connectTimeout(clientProperties.getAuthProperties().getConnectTimeout())
+            .readTimeout(clientProperties.getAuthProperties().getReadTimeout())
+            .clientAssertionKeystorePath(
+                clientProperties.getAuthProperties().getClientAssertionKeystorePath())
+            .clientAssertionKeystorePassword(
+                clientProperties.getAuthProperties().getClientAssertionKeystorePassword())
+            .clientAssertionKeystoreKeyAlias(
+                clientProperties.getAuthProperties().getClientAssertionKeystoreKeyAlias())
+            .clientAssertionKeystoreKeyPassword(
+                clientProperties.getAuthProperties().getClientAssertionKeystoreKeyPassword());
+
+    maybeConfigureIdentityProviderSSLConfig(credBuilder, clientProperties);
+    try {
+      return credBuilder.build();
+    } catch (final Exception e) {
+      LOG.warn(
+          "Failed to configure oidc credential provider, falling back to use no authentication, cause: {}",
+          e.getMessage());
+      if (LOG.isDebugEnabled()) {
+        LOG.debug(e.getMessage(), e);
+      }
+      return new NoopCredentialsProvider();
+    }
+  }
+
+  private static void maybeConfigureIdentityProviderSSLConfig(
+      final OAuthCredentialsProviderBuilder builder,
+      final RemoteRuntimeClientProperties clientProperties) {
+    if (clientProperties.getAuthProperties().getKeystorePath() != null) {
+      final Path keyStore = clientProperties.getAuthProperties().getKeystorePath();
+      if (Files.exists(keyStore)) {
+        LOG.debug("Using keystore {}", keyStore);
+        builder.keystorePath(keyStore);
+        builder.keystorePassword(clientProperties.getAuthProperties().getKeystorePassword());
+        builder.keystoreKeyPassword(clientProperties.getAuthProperties().getKeystoreKeyPassword());
+      } else {
+        LOG.debug("Keystore {} not found", keyStore);
+      }
+    }
+
+    if (clientProperties.getAuthProperties().getTruststorePath() != null) {
+      final Path trustStore = clientProperties.getAuthProperties().getTruststorePath();
+      if (Files.exists(trustStore)) {
+        LOG.debug("Using truststore {}", trustStore);
+        builder.truststorePath(trustStore);
+        builder.truststorePassword(clientProperties.getAuthProperties().getTruststorePassword());
+      } else {
+        LOG.debug("Truststore {} not found", trustStore);
+      }
+    }
+  }
+}

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/util/PropertiesUtil.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/util/PropertiesUtil.java
@@ -30,6 +30,18 @@ public class PropertiesUtil {
   private static final Pattern PLACEHOLDER_PATTERN = Pattern.compile("\\$\\{.*}");
 
   /**
+   * Reads a property and returns null if it doesn't exist or the value is a placeholder.
+   *
+   * @param properties the properties object containing the property
+   * @param propertyName the property key
+   * @return the property value or the default
+   */
+  public static String getPropertyOrNull(final Properties properties, final String propertyName) {
+
+    return getPropertyOrDefault(properties, propertyName, null);
+  }
+
+  /**
    * Reads a property and returns a default if it doesn't exist or the value is a placeholder.
    *
    * @param properties the properties object containing the property
@@ -49,6 +61,32 @@ public class PropertiesUtil {
     }
   }
 
+  /**
+   * Reads and transforms a property to a specific type. Returns null if it doesn't exist, the value
+   * is a placeholder or the conversion failed.
+   *
+   * @param properties the properties object containing the property
+   * @param propertyName the property key
+   * @param converter a mapping function converting the value from a String to another type
+   * @return the property value or the default
+   */
+  public static <T> T getPropertyOrNull(
+      final Properties properties, final String propertyName, final Function<String, T> converter) {
+
+    return getPropertyOrDefault(properties, propertyName, converter, null);
+  }
+
+  /**
+   * Reads and transforms a property to a specific type. Returns a default value if it doesn't exist
+   * or the value is a placeholder. This method will propagate any exceptions thrown by the
+   * converter to the caller.
+   *
+   * @param properties the properties object containing the property
+   * @param propertyName the property key
+   * @param converter a mapping function converting the value from a String to another type
+   * @param defaultValue if the property doesn't exist.
+   * @return the property value or the default
+   */
   public static <T> T getPropertyOrDefault(
       final Properties properties,
       final String propertyName,

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/JunitExtensionTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/JunitExtensionTest.java
@@ -18,11 +18,13 @@ package io.camunda.process.test.api;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.client.CamundaClientConfiguration;
+import io.camunda.client.impl.NoopCredentialsProvider;
 import io.camunda.process.test.api.coverage.ProcessCoverage;
 import io.camunda.process.test.api.coverage.ProcessCoverageBuilder;
 import io.camunda.process.test.impl.client.CamundaManagementClient;
@@ -34,6 +36,7 @@ import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.client.ZeebeClientConfiguration;
 import java.lang.reflect.Field;
 import java.net.URI;
+import java.time.Duration;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -270,7 +273,9 @@ public class JunitExtensionTest {
             .withCamundaEnv(camundaEnvVars)
             .withCamundaEnv("env-3", "test-3")
             .withCamundaExposedPort(100)
-            .withCamundaExposedPort(200);
+            .withCamundaExposedPort(200)
+            .withClientRequestTimeout(Duration.ofHours(1))
+            .withRemoteCamundaClientCredentialsProvider(new NoopCredentialsProvider());
 
     // when
     extension.beforeAll(extensionContext);
@@ -287,6 +292,9 @@ public class JunitExtensionTest {
 
     verify(camundaRuntimeBuilder).withCamundaExposedPort(100);
     verify(camundaRuntimeBuilder).withCamundaExposedPort(200);
+
+    verify(camundaRuntimeBuilder).withCamundaClientRequestTimeout(Duration.ofHours(1));
+    verify(camundaRuntimeBuilder, times(1)).withCredentialsProvider(any());
   }
 
   @Test

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/runtime/CamundaProcessTestContainerRuntimeTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/runtime/CamundaProcessTestContainerRuntimeTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.when;
 import io.camunda.process.test.impl.containers.CamundaContainer;
 import io.camunda.process.test.impl.containers.ConnectorsContainer;
 import io.camunda.process.test.impl.containers.ContainerFactory;
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
@@ -224,6 +225,7 @@ public class CamundaProcessTestContainerRuntimeTest {
         .withConnectorsSecrets(connectorSecrets)
         .withConnectorsSecret(additionalConnectorSecretKey, additionalConnectorSecretValue)
         .withConnectorsLogger("custom-logger")
+        .withCamundaClientRequestTimeout(Duration.ofHours(1))
         .build();
 
     // then

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/runtime/ContainerRuntimePropertiesUtilTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/runtime/ContainerRuntimePropertiesUtilTest.java
@@ -20,7 +20,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.camunda.process.test.api.CamundaProcessTestRuntimeMode;
 import io.camunda.process.test.impl.runtime.properties.CamundaContainerRuntimeProperties;
 import io.camunda.process.test.impl.runtime.properties.ConnectorsContainerRuntimeProperties;
+import io.camunda.process.test.impl.runtime.properties.RemoteRuntimeClientAuthProperties;
+import io.camunda.process.test.impl.runtime.properties.RemoteRuntimeClientAuthProperties.AuthMethod;
+import io.camunda.process.test.impl.runtime.properties.RemoteRuntimeClientCloudProperties;
+import io.camunda.process.test.impl.runtime.properties.RemoteRuntimeClientProperties.ClientMode;
 import java.net.URI;
+import java.nio.file.Paths;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -87,6 +93,15 @@ public class ContainerRuntimePropertiesUtilTest {
     assertThat(propertiesUtil.getConnectorsDockerImageName())
         .isEqualTo("camunda/connectors-bundle");
     assertThat(propertiesUtil.getConnectorsDockerImageVersion()).isEqualTo("SNAPSHOT");
+    assertThat(propertiesUtil.getRemoteRuntimeProperties().getRemoteClientProperties().getMode())
+        .isEqualTo(ClientMode.selfManaged);
+    assertThat(
+            propertiesUtil
+                .getRemoteRuntimeProperties()
+                .getRemoteClientProperties()
+                .getAuthProperties()
+                .getMethod())
+        .isEqualTo(AuthMethod.none);
   }
 
   @ParameterizedTest
@@ -306,6 +321,44 @@ public class ContainerRuntimePropertiesUtilTest {
           .isEqualTo("camunda/connectors-bundle");
       assertThat(propertiesUtil.getConnectorsDockerImageVersion()).isEqualTo("8.8.3");
       assertThat(propertiesUtil.getCamundaClientRequestTimeout()).hasHours(1);
+
+      final RemoteRuntimeClientCloudProperties cloudProps =
+          propertiesUtil
+              .getRemoteRuntimeProperties()
+              .getRemoteClientProperties()
+              .getCloudProperties();
+      assertThat(cloudProps.getClusterId()).isEqualTo("clusterId");
+      assertThat(cloudProps.getRegion()).isEqualTo("region");
+
+      final RemoteRuntimeClientAuthProperties authProps =
+          propertiesUtil
+              .getRemoteRuntimeProperties()
+              .getRemoteClientProperties()
+              .getAuthProperties();
+      assertThat(authProps.getMethod()).isEqualTo(AuthMethod.oidc);
+      assertThat(authProps.getUsername()).isEqualTo("username");
+      assertThat(authProps.getPassword()).isEqualTo("password");
+      assertThat(authProps.getClientId()).isEqualTo("clientId");
+      assertThat(authProps.getClientSecret()).isEqualTo("clientSecret");
+      assertThat(authProps.getTokenUrl()).isEqualTo(URI.create("http://example.com"));
+      assertThat(authProps.getAudience()).isEqualTo("audience");
+      assertThat(authProps.getScope()).isEqualTo("scope");
+      assertThat(authProps.getResource()).isEqualTo("resource");
+      assertThat(authProps.getKeystorePath()).isEqualTo(Paths.get("/path/to/keystore"));
+      assertThat(authProps.getKeystorePassword()).isEqualTo("keystorePassword");
+      assertThat(authProps.getKeystoreKeyPassword()).isEqualTo("keystoreKeyPassword");
+      assertThat(authProps.getTruststorePath()).isEqualTo(Paths.get("/path/to/truststore"));
+      assertThat(authProps.getTruststorePassword()).isEqualTo("truststorePassword");
+      assertThat(authProps.getCredentialsCachePath()).isEqualTo("/path/to/credentialsCache");
+      assertThat(authProps.getConnectTimeout()).isEqualTo(Duration.ofSeconds(5));
+      assertThat(authProps.getReadTimeout()).isEqualTo(Duration.ofSeconds(6));
+      assertThat(authProps.getCredentialsCachePath()).isEqualTo("/path/to/credentialsCache");
+      assertThat(authProps.getClientAssertionKeystorePath())
+          .isEqualTo(Paths.get("/path/to/assertion/keystore"));
+      assertThat(authProps.getClientAssertionKeystorePassword()).isEqualTo("keystorePassword");
+      assertThat(authProps.getClientAssertionKeystoreKeyAlias()).isEqualTo("keystoreKeyAlias");
+      assertThat(authProps.getClientAssertionKeystoreKeyPassword())
+          .isEqualTo("keystoreKeyPassword");
     }
 
     @Test

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/runtime/ContainerRuntimePropertiesUtilTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/runtime/ContainerRuntimePropertiesUtilTest.java
@@ -50,6 +50,7 @@ public class ContainerRuntimePropertiesUtilTest {
     assertThat(propertiesUtil.getConnectorsDockerImageName())
         .isEqualTo("camunda/connectors-bundle");
     assertThat(propertiesUtil.getConnectorsDockerImageVersion()).isEqualTo("SNAPSHOT");
+    assertThat(propertiesUtil.getCamundaClientRequestTimeout()).hasSeconds(10);
   }
 
   @Test
@@ -304,6 +305,7 @@ public class ContainerRuntimePropertiesUtilTest {
       assertThat(propertiesUtil.getConnectorsDockerImageName())
           .isEqualTo("camunda/connectors-bundle");
       assertThat(propertiesUtil.getConnectorsDockerImageVersion()).isEqualTo("8.8.3");
+      assertThat(propertiesUtil.getCamundaClientRequestTimeout()).hasHours(1);
     }
 
     @Test

--- a/testing/camunda-process-test-java/src/test/resources/containerRuntimePropertiesUtil/camunda-container-runtime.properties
+++ b/testing/camunda-process-test-java/src/test/resources/containerRuntimePropertiesUtil/camunda-container-runtime.properties
@@ -32,8 +32,33 @@ connectorsExposedPorts[2]=9088
 
 runtimeMode=remote
 
+remote.client.mode=saas
 remote.camundaMonitoringApiAddress=http://0.0.0.0:8080
 remote.connectorsRestApiAddress=http://0.0.0.0:8085
 remote.client.grpcAddress=http://0.0.0.0:8088
 remote.client.restAddress=http://0.0.0.0:8089
 remote.client.requestTimeout=PT1H
+remote.client.cloud.clusterId=clusterId
+remote.client.cloud.region=region
+
+remote.client.auth.method=none
+remote.client.auth.username=username
+remote.client.auth.password=password
+remote.client.auth.clientId=clientId
+remote.client.auth.clientSecret=clientSecret
+remote.client.auth.tokenUrl=http://example.com
+remote.client.auth.audience=audience
+remote.client.auth.scope=scope
+remote.client.auth.resource=resource
+remote.client.auth.keystorePath=/path/to/keystore
+remote.client.auth.keystorePassword=keystorePassword
+remote.client.auth.keystoreKeyPassword=keystoreKeyPassword
+remote.client.auth.truststorePath=/path/to/truststore
+remote.client.auth.truststorePassword=truststorePassword
+remote.client.auth.credentialsCachePath=/path/to/credentialsCache
+remote.client.auth.connectTimeout=PT5S
+remote.client.auth.readTimeout=PT5S
+remote.client.auth.clientAssertion.keystorePath=/path/to/assertion/keystore
+remote.client.auth.clientAssertion.keystorePassword=keystorePassword
+remote.client.auth.clientAssertion.keystoreKeyAlias=keystoreKeyAlias
+remote.client.auth.clientAssertion.keystoreKeyPassword=keystoreKeyPassword

--- a/testing/camunda-process-test-java/src/test/resources/containerRuntimePropertiesUtil/camunda-container-runtime.properties
+++ b/testing/camunda-process-test-java/src/test/resources/containerRuntimePropertiesUtil/camunda-container-runtime.properties
@@ -36,3 +36,4 @@ remote.camundaMonitoringApiAddress=http://0.0.0.0:8080
 remote.connectorsRestApiAddress=http://0.0.0.0:8085
 remote.client.grpcAddress=http://0.0.0.0:8088
 remote.client.restAddress=http://0.0.0.0:8089
+remote.client.requestTimeout=PT1H

--- a/testing/camunda-process-test-java/src/test/resources/containerRuntimePropertiesUtil/camunda-container-runtime.properties
+++ b/testing/camunda-process-test-java/src/test/resources/containerRuntimePropertiesUtil/camunda-container-runtime.properties
@@ -41,7 +41,7 @@ remote.client.requestTimeout=PT1H
 remote.client.cloud.clusterId=clusterId
 remote.client.cloud.region=region
 
-remote.client.auth.method=none
+remote.client.auth.method=oidc
 remote.client.auth.username=username
 remote.client.auth.password=password
 remote.client.auth.clientId=clientId
@@ -57,7 +57,7 @@ remote.client.auth.truststorePath=/path/to/truststore
 remote.client.auth.truststorePassword=truststorePassword
 remote.client.auth.credentialsCachePath=/path/to/credentialsCache
 remote.client.auth.connectTimeout=PT5S
-remote.client.auth.readTimeout=PT5S
+remote.client.auth.readTimeout=PT6S
 remote.client.auth.clientAssertion.keystorePath=/path/to/assertion/keystore
 remote.client.auth.clientAssertion.keystorePassword=keystorePassword
 remote.client.auth.clientAssertion.keystoreKeyAlias=keystoreKeyAlias

--- a/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/configuration/LegacyCamundaProcessTestRuntimeConfiguration.java
+++ b/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/configuration/LegacyCamundaProcessTestRuntimeConfiguration.java
@@ -17,11 +17,9 @@ package io.camunda.process.test.impl.configuration;
 
 import io.camunda.process.test.api.CamundaProcessTestRuntimeMode;
 import io.camunda.process.test.impl.runtime.CamundaProcessTestRuntimeDefaults;
-import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
 import org.springframework.context.annotation.Configuration;
@@ -47,10 +45,6 @@ public class LegacyCamundaProcessTestRuntimeConfiguration {
   private Map<String, String> connectorsSecrets = Collections.emptyMap();
 
   private CamundaProcessTestRuntimeMode runtimeMode = CamundaProcessTestRuntimeMode.MANAGED;
-
-  @Value("camunda-client.request-timeout")
-  private Duration camundaClientRequestTimeout =
-      CamundaProcessTestRuntimeDefaults.CAMUNDA_CLIENT_REQUEST_TIMEOUT;
 
   @NestedConfigurationProperty private RemoteConfiguration remote = new RemoteConfiguration();
 
@@ -140,13 +134,5 @@ public class LegacyCamundaProcessTestRuntimeConfiguration {
 
   public void setRemote(final RemoteConfiguration remote) {
     this.remote = remote;
-  }
-
-  public Duration getCamundaClientRequestTimeout() {
-    return camundaClientRequestTimeout;
-  }
-
-  public void setCamundaClientRequestTimeout(final Duration camundaClientRequestTimeout) {
-    this.camundaClientRequestTimeout = camundaClientRequestTimeout;
   }
 }

--- a/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/configuration/LegacyCamundaProcessTestRuntimeConfiguration.java
+++ b/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/configuration/LegacyCamundaProcessTestRuntimeConfiguration.java
@@ -17,9 +17,11 @@ package io.camunda.process.test.impl.configuration;
 
 import io.camunda.process.test.api.CamundaProcessTestRuntimeMode;
 import io.camunda.process.test.impl.runtime.CamundaProcessTestRuntimeDefaults;
+import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
 import org.springframework.context.annotation.Configuration;
@@ -45,6 +47,10 @@ public class LegacyCamundaProcessTestRuntimeConfiguration {
   private Map<String, String> connectorsSecrets = Collections.emptyMap();
 
   private CamundaProcessTestRuntimeMode runtimeMode = CamundaProcessTestRuntimeMode.MANAGED;
+
+  @Value("camunda-client.request-timeout")
+  private Duration camundaClientRequestTimeout =
+      CamundaProcessTestRuntimeDefaults.CAMUNDA_CLIENT_REQUEST_TIMEOUT;
 
   @NestedConfigurationProperty private RemoteConfiguration remote = new RemoteConfiguration();
 
@@ -134,5 +140,13 @@ public class LegacyCamundaProcessTestRuntimeConfiguration {
 
   public void setRemote(final RemoteConfiguration remote) {
     this.remote = remote;
+  }
+
+  public Duration getCamundaClientRequestTimeout() {
+    return camundaClientRequestTimeout;
+  }
+
+  public void setCamundaClientRequestTimeout(final Duration camundaClientRequestTimeout) {
+    this.camundaClientRequestTimeout = camundaClientRequestTimeout;
   }
 }

--- a/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/runtime/CamundaSpringProcessTestRuntimeBuilder.java
+++ b/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/runtime/CamundaSpringProcessTestRuntimeBuilder.java
@@ -36,6 +36,9 @@ public class CamundaSpringProcessTestRuntimeBuilder {
     final CamundaProcessTestRuntimeMode runtimeMode = runtimeConfiguration.getRuntimeMode();
     runtimeBuilder.withRuntimeMode(runtimeMode);
 
+    runtimeBuilder.withCamundaClientRequestTimeout(
+        runtimeConfiguration.getRemote().getClient().getRequestTimeout());
+
     if (runtimeMode == CamundaProcessTestRuntimeMode.MANAGED || runtimeMode == null) {
       configureManagedRuntime(runtimeBuilder, runtimeConfiguration);
 
@@ -92,6 +95,8 @@ public class CamundaSpringProcessTestRuntimeBuilder {
         runtimeConfiguration.getRemote().getClient();
 
     final CamundaClientBuilder clientBuilder = createCamundaClientBuilder(remoteClientProperties);
+    clientBuilder.defaultRequestTimeout(
+        runtimeConfiguration.getRemote().getClient().getRequestTimeout());
 
     if (remoteClientProperties.getRestAddress() != null) {
       clientBuilder.restAddress(remoteClientProperties.getRestAddress());

--- a/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/impl/CamundaSpringProcessTestRuntimeBuilderTest.java
+++ b/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/impl/CamundaSpringProcessTestRuntimeBuilderTest.java
@@ -38,6 +38,7 @@ import io.camunda.spring.client.properties.CamundaClientCloudProperties;
 import io.camunda.spring.client.properties.CamundaClientProperties;
 import io.camunda.spring.client.properties.CamundaClientProperties.ClientMode;
 import java.net.URI;
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -66,6 +67,7 @@ public class CamundaSpringProcessTestRuntimeBuilderTest {
     assertThat(runtimeBuilder.getCamundaExposedPorts()).isEmpty();
 
     assertThat(runtimeBuilder.isConnectorsEnabled()).isFalse();
+    assertThat(runtimeBuilder.getCamundaClientRequestTimeout()).hasSeconds(10);
   }
 
   @Test
@@ -87,6 +89,8 @@ public class CamundaSpringProcessTestRuntimeBuilderTest {
     runtimeConfiguration.setCamundaLoggerName("io.camunda.custom.logger.name");
     runtimeConfiguration.setConnectorsLoggerName("io.camunda.custom.logger.name");
 
+    runtimeConfiguration.getRemote().getClient().setRequestTimeout(Duration.ofHours(1));
+
     // when
     CamundaSpringProcessTestRuntimeBuilder.buildRuntime(runtimeBuilder, runtimeConfiguration);
 
@@ -97,6 +101,7 @@ public class CamundaSpringProcessTestRuntimeBuilderTest {
     assertThat(runtimeBuilder.getCamundaExposedPorts()).isEqualTo(camundaExposedPorts);
     assertThat(runtimeBuilder.getCamundaLoggerName()).isEqualTo("io.camunda.custom.logger.name");
     assertThat(runtimeBuilder.getConnectorsLoggerName()).isEqualTo("io.camunda.custom.logger.name");
+    assertThat(runtimeBuilder.getCamundaClientRequestTimeout()).isEqualTo(Duration.ofHours(1));
   }
 
   @Test
@@ -182,6 +187,7 @@ public class CamundaSpringProcessTestRuntimeBuilderTest {
     final URI remoteConnectorsRestApiAddress = URI.create("http://camunda.com:4000");
 
     runtimeConfiguration.setRuntimeMode(CamundaProcessTestRuntimeMode.REMOTE);
+    runtimeConfiguration.getRemote().getClient().setRequestTimeout(Duration.ofHours(1));
 
     final RemoteConfiguration remoteConfiguration = runtimeConfiguration.getRemote();
     remoteConfiguration.setCamundaMonitoringApiAddress(remoteCamundaMonitoringApiAddress);
@@ -210,6 +216,7 @@ public class CamundaSpringProcessTestRuntimeBuilderTest {
     assertThat(configuration.getRestAddress()).isEqualTo(remoteCamundaRestApiAddress);
     assertThat(configuration.getGrpcAddress()).isEqualTo(remoteCamundaGrpcApiAddress);
     assertThat(configuration.isPlaintextConnectionEnabled()).isTrue();
+    assertThat(configuration.getDefaultRequestTimeout()).isEqualTo(Duration.ofHours(1));
   }
 
   @Test


### PR DESCRIPTION
## Description

The CPT has been extended to allow a user to configure the camunda client's request timeout and authentication/authorization provider. This gives the user greater flexibility in successfully and easily configuring a test environment using a remote Camunda runtime such as the Camunda SaaS platform.

In addition to allowing a user to configure the CPT Extension in both the pure java and Spring context, the user can also add new auth and request timeout properties to the camunda-container-runtime.properties file.

## Related issues

closes #35308 
