### PR TITLE
feat: support handling get requests with empty responses in the java client

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/impl/http/ApiEntityConsumer.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/http/ApiEntityConsumer.java
@@ -64,10 +64,12 @@ final class ApiEntityConsumer<T> extends AbstractBinAsyncEntityConsumer<ApiEntit
 
   @Override
   protected void streamStart(final ContentType contentType) throws IOException {
-    if (ContentType.APPLICATION_JSON.isSameMimeType(contentType)) {
-      entityConsumer = new JsonApiEntityConsumer<>(json, type, true);
-    } else if (ContentType.APPLICATION_PROBLEM_JSON.isSameMimeType(contentType)) {
+    if (ContentType.APPLICATION_PROBLEM_JSON.isSameMimeType(contentType)) {
       entityConsumer = new JsonApiEntityConsumer<>(json, type, false);
+    } else if (Void.class.equals(type)) {
+      entityConsumer = new RawApiEntityConsumer<>(true, chunkSize);
+    } else if (ContentType.APPLICATION_JSON.isSameMimeType(contentType)) {
+      entityConsumer = new JsonApiEntityConsumer<>(json, type, true);
     } else {
       final boolean isResponse =
           String.class.equals(type)

--- a/clients/java/src/main/java/io/camunda/client/impl/http/JsonResponseAndStatusCodeTransformer.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/http/JsonResponseAndStatusCodeTransformer.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.http;
+
+@FunctionalInterface
+public interface JsonResponseAndStatusCodeTransformer<HttpT, RespT> {
+  RespT transform(final HttpT entity, final int statusCode) throws Exception;
+}


### PR DESCRIPTION
## Description
This PR enhances the Java client to support handling GET requests with empty responses by implementing status code-based response handling. The enhancement allows the client to process HTTP responses based on their status codes rather than requiring a response body, which is particularly useful for endpoints that return empty content on success.

Key Changes:
- Introduces a new `JsonResponseAndStatusCodeTransformer` interface to handle both response entities and status codes
- Adds support for `Void` entity types in the API entity consumer for processing empty responses
- Refactors the HTTP client to support both traditional response parsing and status code-based handling with customizable success predicates

## Related issues

closes #37243
relates to #20921
